### PR TITLE
refactor(tests): deduplicate platform and runtime fixtures

### DIFF
--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1443,83 +1443,15 @@ describe("runGatewayUpdate", () => {
 
   it("uses pnpm highest resolution mode for dev preflight installs", async () => {
     await setupGitPackageManagerFixture();
-    const upstreamSha = "upstream123";
     const installEnvs: NodeJS.ProcessEnv[] = [];
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
-
-    const runCommand = async (
-      argv: string[],
-      options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-    ) => {
-      const key = argv.join(" ");
-      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-        return { stdout: tempDir, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return { stdout: "abc123", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-        return { stdout: "main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
-        return { stdout: "origin/main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
-        return { stdout: upstreamSha, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`) {
-        return { stdout: `${upstreamSha}\n`, stderr: "", code: 0 };
-      }
-      if (key === "pnpm --version") {
-        return { stdout: "10.0.0", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-        key.endsWith(` ${upstreamSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-        return { stdout: `HEAD is now at ${upstreamSha}`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith("git -C ") &&
-        preflightPrefixPattern.test(key) &&
-        key.includes(" checkout --detach ") &&
-        key.endsWith(upstreamSha)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm install") {
-        installEnvs.push(options?.env ?? {});
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm build" || key === "pnpm ui:build") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rebase ${upstreamSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === doctorCommand) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      return { stdout: "", stderr: "", code: 0 };
-    };
+    const { runCommand } = await createDevGitRunner({
+      onCommand: (key, options) => {
+        if (key === "pnpm install") {
+          installEnvs.push(options?.env ?? {});
+        }
+        return undefined;
+      },
+    });
 
     const result = await runWithCommand(runCommand, { channel: "dev" });
 
@@ -1537,85 +1469,22 @@ describe("runGatewayUpdate", () => {
   it("resolves the dev preflight package manager from the checked-out candidate worktree", async () => {
     await setupGitCheckout({ packageManager: "npm@10.0.0" });
     await setupUiIndex();
-    const upstreamSha = "upstream123";
     const preflightInstallCommands: string[] = [];
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
-
-    const runCommand = async (
-      argv: string[],
-      options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-    ) => {
-      const key = argv.join(" ");
-      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-        return { stdout: tempDir, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return { stdout: "abc123", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-        return { stdout: "main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
-        return { stdout: "origin/main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
-        return { stdout: upstreamSha, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`) {
-        return { stdout: `${upstreamSha}\n`, stderr: "", code: 0 };
-      }
-      if (key === "pnpm --version" || key === "npm --version") {
-        return { stdout: "10.0.0", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-        key.endsWith(` ${upstreamSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        await writePreflightPackageManagerFixtureFromWorktreeAdd(key, "pnpm@8.0.0");
-        return { stdout: `HEAD is now at ${upstreamSha}`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith("git -C ") &&
-        preflightPrefixPattern.test(key) &&
-        key.includes(" checkout --detach ") &&
-        key.endsWith(upstreamSha)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm install" || key === "npm install") {
-        if (options?.cwd && preflightPrefixPattern.test(options.cwd)) {
+    const { runCommand } = await createDevGitRunner({
+      onCommand: (key, options) => {
+        if (key === "npm --version") {
+          return { stdout: "10.0.0" };
+        }
+        if (
+          (key === "pnpm install" || key === "npm install") &&
+          options?.cwd &&
+          preflightPrefixPattern.test(options.cwd)
+        ) {
           preflightInstallCommands.push(key);
         }
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm build" || key === "npm run build" || key === "npm run ui:build") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rebase ${upstreamSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === doctorCommand) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      return { stdout: "", stderr: "", code: 0 };
-    };
+        return undefined;
+      },
+    });
 
     const result = await runWithCommand(runCommand, { channel: "dev" });
 
@@ -2001,106 +1870,37 @@ describe("runGatewayUpdate", () => {
 
   it("uses npm-bootstrapped pnpm for dev preflight when pnpm and corepack are missing", async () => {
     await setupGitPackageManagerFixture();
-    const calls: string[] = [];
     const pnpmEnvPaths: string[] = [];
-    const upstreamSha = "upstream123";
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
-
-    const runCommand = async (
-      argv: string[],
-      options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-    ) => {
-      const key = argv.join(" ");
-      calls.push(key);
-
-      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-        return { stdout: tempDir, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return { stdout: "abc123", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-        return { stdout: "main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
-        return { stdout: "origin/main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
-        return { stdout: upstreamSha, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`) {
-        return { stdout: `${upstreamSha}\n`, stderr: "", code: 0 };
-      }
-      if (key === "pnpm --version") {
-        const envPath = options?.env?.PATH ?? options?.env?.Path ?? "";
-        if (envPath.includes("openclaw-update-pnpm-")) {
-          pnpmEnvPaths.push(envPath);
-          return { stdout: "11.0.0", stderr: "", code: 0 };
+    const { calls, runCommand } = await createDevGitRunner({
+      onCommand: (key, options) => {
+        if (key === "pnpm --version") {
+          const envPath = options?.env?.PATH ?? options?.env?.Path ?? "";
+          if (envPath.includes("openclaw-update-pnpm-")) {
+            pnpmEnvPaths.push(envPath);
+            return { stdout: "11.0.0" };
+          }
+          throw new Error("spawn pnpm ENOENT");
         }
-        throw new Error("spawn pnpm ENOENT");
-      }
-      if (key === "corepack --version") {
-        throw new Error("spawn corepack ENOENT");
-      }
-      if (key === "npm --version") {
-        return { stdout: "10.0.0", stderr: "", code: 0 };
-      }
-      if (key.startsWith("npm install --prefix ") && key.endsWith(" pnpm@11")) {
-        return { stdout: "added 1 package", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-        key.endsWith(` ${upstreamSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-        return { stdout: `HEAD is now at ${upstreamSha}`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith("git -C ") &&
-        preflightPrefixPattern.test(key) &&
-        key.includes(" checkout --detach ") &&
-        key.endsWith(upstreamSha)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm install" || key === "pnpm build" || key === "pnpm lint") {
-        const envPath = options?.env?.PATH ?? options?.env?.Path ?? "";
-        pnpmEnvPaths.push(envPath);
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rebase ${upstreamSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm ui:build") {
-        const envPath = options?.env?.PATH ?? options?.env?.Path ?? "";
-        pnpmEnvPaths.push(envPath);
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === doctorCommand) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return { stdout: upstreamSha, stderr: "", code: 0 };
-      }
-      return { stdout: "", stderr: "", code: 0 };
-    };
+        if (key === "corepack --version") {
+          throw new Error("spawn corepack ENOENT");
+        }
+        if (key === "npm --version") {
+          return { stdout: "10.0.0" };
+        }
+        if (key.startsWith("npm install --prefix ") && key.endsWith(" pnpm@11")) {
+          return { stdout: "added 1 package" };
+        }
+        if (
+          key === "pnpm install" ||
+          key === "pnpm build" ||
+          key === "pnpm lint" ||
+          key === "pnpm ui:build"
+        ) {
+          pnpmEnvPaths.push(options?.env?.PATH ?? options?.env?.Path ?? "");
+        }
+        return undefined;
+      },
+    });
 
     const result = await runWithCommand(runCommand, { channel: "dev" });
 
@@ -2266,75 +2066,8 @@ describe("runGatewayUpdate", () => {
 
   it("pins dev updates to an explicit target ref when requested", async () => {
     await setupGitPackageManagerFixture();
-    const calls: string[] = [];
     const targetSha = "f2fdb9d1253ce3f227ccaa6cb0e3b664a32be4ee";
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
-
-    const runCommand = async (
-      argv: string[],
-      _options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-    ) => {
-      const key = argv.join(" ");
-      calls.push(key);
-
-      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-        return { stdout: tempDir, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return {
-          stdout: `${calls.includes(`git -C ${tempDir} checkout --detach ${targetSha}`) ? targetSha : "abc123"}\n`,
-          stderr: "",
-          code: 0,
-        };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-        return { stdout: "main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse ${targetSha}`) {
-        return { stdout: `${targetSha}\n`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-        key.endsWith(` ${targetSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-        return { stdout: `HEAD is now at ${targetSha}`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith("git -C ") &&
-        key.includes(` checkout --detach ${targetSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm install" || key === "pnpm build" || key === "pnpm lint") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm ui:build") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === doctorCommand) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} checkout --detach ${targetSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      return { stdout: "", stderr: "", code: 0 };
-    };
+    const { calls, runCommand } = await createDevGitRunner({ targetSha, targetRef: targetSha });
 
     const result = await runWithCommand(runCommand, {
       channel: "dev",
@@ -2456,75 +2189,8 @@ describe("runGatewayUpdate", () => {
 
   it("resolves symbolic dev target refs from the fetched remote branch", async () => {
     await setupGitPackageManagerFixture();
-    const calls: string[] = [];
     const targetSha = "2222222222222222222222222222222222222222";
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
-
-    const runCommand = async (
-      argv: string[],
-      _options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-    ) => {
-      const key = argv.join(" ");
-      calls.push(key);
-
-      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-        return { stdout: tempDir, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return {
-          stdout: `${calls.includes(`git -C ${tempDir} checkout --detach ${targetSha}`) ? targetSha : "abc123"}\n`,
-          stderr: "",
-          code: 0,
-        };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-        return { stdout: "main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse refs/remotes/origin/main`) {
-        return { stdout: `${targetSha}\n`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-        key.endsWith(` ${targetSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-        return { stdout: `HEAD is now at ${targetSha}`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith("git -C ") &&
-        key.includes(` checkout --detach ${targetSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm install" || key === "pnpm build" || key === "pnpm lint") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm ui:build") {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === doctorCommand) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} checkout --detach ${targetSha}`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      return { stdout: "", stderr: "", code: 0 };
-    };
+    const { calls, runCommand } = await createDevGitRunner({ targetSha, targetRef: "main" });
 
     const result = await runWithCommand(runCommand, {
       channel: "dev",
@@ -2626,79 +2292,23 @@ describe("runGatewayUpdate", () => {
 
   it("does not fall back to npm scripts when a pnpm repo cannot bootstrap pnpm", async () => {
     await setupGitPackageManagerFixture();
-    const calls: string[] = [];
-    const upstreamSha = "upstream123";
-
-    const runCommand = async (
-      argv: string[],
-      _options?: { env?: NodeJS.ProcessEnv; cwd?: string; timeoutMs?: number },
-    ) => {
-      const key = argv.join(" ");
-      calls.push(key);
-
-      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-        return { stdout: tempDir, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return { stdout: "abc123", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-        return { stdout: "main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`) {
-        return { stdout: "origin/main", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --no-tags`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-parse @{upstream}`) {
-        return { stdout: upstreamSha, stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} rev-list --max-count=10 ${upstreamSha}`) {
-        return { stdout: `${upstreamSha}\n`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree add --detach `) &&
-        key.endsWith(` ${upstreamSha}`) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        await writePreflightPackageManagerFixtureFromWorktreeAdd(key);
-        return { stdout: `HEAD is now at ${upstreamSha}`, stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith("git -C ") &&
-        preflightPrefixPattern.test(key) &&
-        key.includes(" checkout --detach ") &&
-        key.endsWith(upstreamSha)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (
-        key.startsWith(`git -C ${tempDir} worktree remove --force `) &&
-        preflightPrefixPattern.test(key)
-      ) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === `git -C ${tempDir} worktree prune`) {
-        return { stdout: "", stderr: "", code: 0 };
-      }
-      if (key === "pnpm --version") {
-        throw new Error("spawn pnpm ENOENT");
-      }
-      if (key === "corepack --version") {
-        throw new Error("spawn corepack ENOENT");
-      }
-      if (key === "npm --version") {
-        return { stdout: "10.0.0", stderr: "", code: 0 };
-      }
-      if (key.startsWith("npm install --prefix ") && key.endsWith(" pnpm@11")) {
-        return { stdout: "", stderr: "network exploded", code: 1 };
-      }
-      return { stdout: "", stderr: "", code: 0 };
-    };
+    const { calls, runCommand } = await createDevGitRunner({
+      onCommand: (key) => {
+        if (key === "pnpm --version") {
+          throw new Error("spawn pnpm ENOENT");
+        }
+        if (key === "corepack --version") {
+          throw new Error("spawn corepack ENOENT");
+        }
+        if (key === "npm --version") {
+          return { stdout: "10.0.0" };
+        }
+        if (key.startsWith("npm install --prefix ") && key.endsWith(" pnpm@11")) {
+          return { stderr: "network exploded", code: 1 };
+        }
+        return undefined;
+      },
+    });
 
     const result = await runWithCommand(runCommand, { channel: "dev" });
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -71,6 +71,12 @@ function startDiagnosticHeartbeat(
   });
 }
 
+function startEnabledDiagnosticHeartbeat(
+  opts?: Parameters<typeof startDiagnosticHeartbeatImpl>[1],
+) {
+  return startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, opts);
+}
+
 function createEmitMemorySampleMock() {
   return vi.fn(() => ({
     rssBytes: 100,
@@ -340,18 +346,9 @@ describe("stuck session diagnostics threshold", () => {
   it("uses the heartbeat test timing without runtime config tuning", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       vi.advanceTimersByTime(61_000);
     } finally {
@@ -375,18 +372,9 @@ describe("stuck session diagnostics threshold", () => {
   it("does not count a single in-flight turn as queued work without an active run", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       vi.advanceTimersByTime(61_000);
@@ -428,10 +416,7 @@ describe("stuck session diagnostics threshold", () => {
         { message: { role: "assistant", content: "the reimbursement was approved" } },
       );
 
-      startDiagnosticHeartbeat(
-        { diagnostics: { enabled: true } },
-        { recoverStuckSession: vi.fn() },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession: vi.fn() });
       logSessionStateChange({ sessionId, sessionKey, state: "processing" });
       vi.advanceTimersByTime(61_000);
 
@@ -461,10 +446,7 @@ describe("stuck session diagnostics threshold", () => {
         { message: { role: "assistant", content: privateReply } },
       );
 
-      startDiagnosticHeartbeat(
-        { diagnostics: { enabled: true } },
-        { recoverStuckSession: vi.fn() },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession: vi.fn() });
       logSessionStateChange({ sessionId, sessionKey, state: "processing" });
       vi.advanceTimersByTime(61_000);
 
@@ -480,14 +462,7 @@ describe("stuck session diagnostics threshold", () => {
     const recoverStuckSession = vi.fn();
     const sessionFile = "/tmp/openclaw-heartbeat-session.jsonl";
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { recoverStuckSession },
-    );
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
     logSessionStateChange({
       sessionId: "s1",
       sessionKey: "main",
@@ -508,14 +483,7 @@ describe("stuck session diagnostics threshold", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
     vi.setSystemTime(0);
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { recoverStuckSession },
-    );
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
     vi.setSystemTime(120_001);
@@ -544,14 +512,7 @@ describe("stuck session diagnostics threshold", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
     vi.setSystemTime(0);
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { recoverStuckSession },
-    );
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
     markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
 
@@ -584,14 +545,7 @@ describe("stuck session diagnostics threshold", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
     vi.setSystemTime(0);
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { recoverStuckSession },
-    );
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
     markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
 
@@ -621,15 +575,9 @@ describe("stuck session diagnostics threshold", () => {
 
   it("does not warn while a processing session continues reporting progress", () => {
     const events: DiagnosticEventPayload[] = [];
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat({
-        diagnostics: {
-          enabled: true,
-        },
-      });
+      startEnabledDiagnosticHeartbeat();
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       vi.advanceTimersByTime(45_000);
       markDiagnosticSessionProgress({ sessionId: "s1", sessionKey: "main" });
@@ -652,14 +600,7 @@ describe("stuck session diagnostics threshold", () => {
       }
     });
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       vi.advanceTimersByTime(91_000);
       // One warning emitted (60s); the 90s tick is throttled but still recovers.
@@ -689,14 +630,7 @@ describe("stuck session diagnostics threshold", () => {
       }
     });
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
       // First warn tick (60s): emit the stuck warning and request recovery once.
@@ -723,21 +657,12 @@ describe("stuck session diagnostics threshold", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        {
-          recoverStuckSession,
-          testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs: 5 * 60_000 },
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        recoverStuckSession,
+        testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs: 5 * 60_000 },
+      });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
       vi.advanceTimersByTime(61_000);
@@ -761,9 +686,7 @@ describe("stuck session diagnostics threshold", () => {
   it("flags stale terminal bridge progress in stalled session diagnostics", () => {
     const events: DiagnosticEventPayload[] = [];
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
@@ -772,11 +695,7 @@ describe("stuck session diagnostics threshold", () => {
         sessionKey: "main",
         reason: "codex_app_server:notification:rawResponseItem/completed",
       });
-      startDiagnosticHeartbeat({
-        diagnostics: {
-          enabled: true,
-        },
-      });
+      startEnabledDiagnosticHeartbeat();
 
       vi.advanceTimersByTime(61_000);
     } finally {
@@ -801,21 +720,12 @@ describe("stuck session diagnostics threshold", () => {
     const recoverStuckSession = vi.fn();
     const stuckSessionWarnMs = 30_000;
     const stuckSessionAbortMs = resolveStuckSessionAbortMs(stuckSessionWarnMs);
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        {
-          recoverStuckSession,
-          testTimings: { stuckSessionWarnMs, stuckSessionAbortMs },
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        recoverStuckSession,
+        testTimings: { stuckSessionWarnMs, stuckSessionAbortMs },
+      });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
 
@@ -850,14 +760,7 @@ describe("stuck session diagnostics threshold", () => {
     logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
     vi.advanceTimersByTime(122_000);
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { recoverStuckSession },
-    );
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
 
     vi.advanceTimersByTime(30_000);
 
@@ -880,14 +783,7 @@ describe("stuck session diagnostics threshold", () => {
       reason: "embedded_run:progress",
     });
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { recoverStuckSession },
-    );
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
 
     vi.advanceTimersByTime(30_000);
 
@@ -907,18 +803,9 @@ describe("stuck session diagnostics threshold", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionAbortMs = 60_000;
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
       markDiagnosticToolStartedForTest({
@@ -960,18 +847,9 @@ describe("stuck session diagnostics threshold", () => {
   it("does not classify active tool calls stalled while real progress frames arrive", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
       markDiagnosticToolStartedForTest({
@@ -1004,18 +882,9 @@ describe("stuck session diagnostics threshold", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionAbortMs = 60_000;
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
       markDiagnosticModelStartedForTest({
@@ -1058,17 +927,12 @@ describe("stuck session diagnostics threshold", () => {
     const recoverStuckSession = vi.fn(() => new Promise<never>(() => {}));
     const stuckSessionWarnMs = 30_000;
     const stuckSessionAbortMs = 90_000;
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        { diagnostics: { enabled: true } },
-        {
-          recoverStuckSession,
-          testTimings: { stuckSessionWarnMs, stuckSessionAbortMs },
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        recoverStuckSession,
+        testTimings: { stuckSessionWarnMs, stuckSessionAbortMs },
+      });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main", runId: "run-1" });
       markDiagnosticModelStartedForTest({
@@ -1124,17 +988,12 @@ describe("stuck session diagnostics threshold", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionAbortMs = 90_000;
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        { diagnostics: { enabled: true } },
-        {
-          recoverStuckSession,
-          testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs },
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        recoverStuckSession,
+        testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs },
+      });
       const ref = { sessionId: "s1", sessionKey: "main", runId: "run-1" };
       logSessionStateChange({ ...ref, state: "processing" });
       markDiagnosticEmbeddedRunStarted(ref);
@@ -1184,21 +1043,12 @@ describe("stuck session diagnostics threshold", () => {
     const recoverStuckSession = vi.fn();
     const stuckSessionWarnMs = 30_000;
     const stuckSessionAbortMs = 90_000;
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        {
-          recoverStuckSession,
-          testTimings: { stuckSessionWarnMs, stuckSessionAbortMs },
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        recoverStuckSession,
+        testTimings: { stuckSessionWarnMs, stuckSessionAbortMs },
+      });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
       markDiagnosticModelStartedForTest({
@@ -1234,18 +1084,9 @@ describe("stuck session diagnostics threshold", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionAbortMs = 60_000;
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
       markDiagnosticModelStartedForTest({
@@ -1285,18 +1126,9 @@ describe("stuck session diagnostics threshold", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionAbortMs = 60_000;
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
       markDiagnosticModelStartedForTest({
@@ -1337,13 +1169,10 @@ describe("stuck session diagnostics threshold", () => {
     const runId = "allowance-run";
     const requestTimeoutMs = 150_000;
     const owner = createDiagnosticEmbeddedRunOwner({ ...ref, runId });
-    startDiagnosticHeartbeat(
-      { diagnostics: { enabled: true } },
-      {
-        recoverStuckSession,
-        testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs: 60_000 },
-      },
-    );
+    startEnabledDiagnosticHeartbeat({
+      recoverStuckSession,
+      testTimings: { stuckSessionWarnMs: 30_000, stuckSessionAbortMs: 60_000 },
+    });
     logSessionStateChange({ ...ref, state: "processing" });
     markDiagnosticEmbeddedRunStarted({ ...ref, runId, owner });
     emitCoreModelRequestStartedDiagnosticEvent(
@@ -1389,18 +1218,9 @@ describe("stuck session diagnostics threshold", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const stuckSessionAbortMs = 60_000;
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticModelStartedForTest({
         sessionId: "s1",
@@ -1438,14 +1258,7 @@ describe("stuck session diagnostics threshold", () => {
     const recoverStuckSession = vi.fn();
     const stuckSessionAbortMs = 90_000;
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { recoverStuckSession },
-    );
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
     getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" }).lastActivity =
       Date.now() - 120_000;
@@ -1474,14 +1287,7 @@ describe("stuck session diagnostics threshold", () => {
   it("uses the built-in abort threshold for stalled active-work recovery", () => {
     const recoverStuckSession = vi.fn();
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { recoverStuckSession },
-    );
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
     logSessionStateChange({
       sessionId: "s1",
       sessionKey: "main",
@@ -1519,18 +1325,9 @@ describe("stuck session diagnostics threshold", () => {
       forceCleared: false,
       released: 0,
     });
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
@@ -1580,14 +1377,7 @@ describe("stuck session diagnostics threshold", () => {
       forceCleared: false,
       released: 0,
     });
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { recoverStuckSession },
-    );
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
     markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
     markDiagnosticModelStartedForTest({
@@ -1626,18 +1416,9 @@ describe("stuck session diagnostics threshold", () => {
       sessionKey: "main",
       released: 0,
     });
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticModelStartedForTest({
         sessionId: "s1",
@@ -1693,18 +1474,9 @@ describe("stuck session diagnostics threshold", () => {
       sessionKey: "main",
       released: 0,
     });
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticToolStartedForTest({
         sessionId: "s1",
@@ -1751,14 +1523,7 @@ describe("stuck session diagnostics threshold", () => {
         released: 0,
       }),
     );
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { recoverStuckSession },
-    );
+    startEnabledDiagnosticHeartbeat({ recoverStuckSession });
 
     // Set up two independent sessions that both stall with orphaned model activity.
     logSessionStateChange({ sessionId: "s1", sessionKey: "agent-a", state: "processing" });
@@ -1827,18 +1592,9 @@ describe("stuck session diagnostics threshold", () => {
         queuedCount: 1,
         ...outcome,
       });
-      const unsubscribe = onDiagnosticEvent((event) => {
-        events.push(event);
-      });
+      const unsubscribe = onDiagnosticEvent((event) => events.push(event));
       try {
-        startDiagnosticHeartbeat(
-          {
-            diagnostics: {
-              enabled: true,
-            },
-          },
-          { recoverStuckSession },
-        );
+        startEnabledDiagnosticHeartbeat({ recoverStuckSession });
         logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
         markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
         logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
@@ -1874,18 +1630,9 @@ describe("stuck session diagnostics threshold", () => {
       sessionId: "s1",
       sessionKey: "main",
     });
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
@@ -1915,18 +1662,9 @@ describe("stuck session diagnostics threshold", () => {
       sessionId: "s1",
       sessionKey: "main",
     });
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
@@ -1958,18 +1696,9 @@ describe("stuck session diagnostics threshold", () => {
         sessionKey: "main",
       };
     });
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
       vi.advanceTimersByTime(61_000);
@@ -2014,18 +1743,9 @@ describe("stuck session diagnostics threshold", () => {
           resolveRecovery = resolve;
         }),
     );
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
       vi.advanceTimersByTime(61_000);
@@ -2083,18 +1803,9 @@ describe("stuck session diagnostics threshold", () => {
           resolveRecovery = resolve;
         }),
     );
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       // idle-queued-recoverable-stall setup: embedded run ownership + idle + queued.
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
@@ -2142,18 +1853,9 @@ describe("stuck session diagnostics threshold", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       vi.advanceTimersByTime(45_000);
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
@@ -2178,18 +1880,9 @@ describe("stuck session diagnostics threshold", () => {
   it("throttles repeated long-running active-work warnings", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       vi.advanceTimersByTime(45_000);
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
@@ -2219,18 +1912,9 @@ describe("stuck session diagnostics threshold", () => {
   it("keeps queued sessions non-recoverable while active work is making progress", () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn();
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       vi.advanceTimersByTime(45_000);
@@ -2259,18 +1943,9 @@ describe("stuck session diagnostics threshold", () => {
     const stuckSessionWarnMs = 30_000;
     const stuckSessionAbortMs = 60_000;
     const terminalReason = "codex_app_server:notification:rawResponseItem/completed";
-    const unsubscribe = onDiagnosticEvent((event) => {
-      events.push(event);
-    });
+    const unsubscribe = onDiagnosticEvent((event) => events.push(event));
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        { recoverStuckSession },
-      );
+      startEnabledDiagnosticHeartbeat({ recoverStuckSession });
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
@@ -2309,11 +1984,7 @@ describe("stuck session diagnostics threshold", () => {
   });
 
   it("starts and stops the stability recorder with the heartbeat lifecycle", () => {
-    startDiagnosticHeartbeat({
-      diagnostics: {
-        enabled: true,
-      },
-    });
+    startEnabledDiagnosticHeartbeat();
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
 
     requireMatchingRecord(
@@ -2348,14 +2019,7 @@ describe("stuck session diagnostics threshold", () => {
   it("checks memory pressure every tick without recording idle samples", () => {
     const emitMemorySample = createEmitMemorySampleMock();
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      { emitMemorySample, sampleLiveness: () => null },
-    );
+    startEnabledDiagnosticHeartbeat({ emitMemorySample, sampleLiveness: () => null });
 
     vi.advanceTimersByTime(30_000);
     expect(emitMemorySample).toHaveBeenLastCalledWith({ emitSample: false });
@@ -2373,27 +2037,20 @@ describe("stuck session diagnostics threshold", () => {
     const unsubscribe = onDiagnosticEvent((event) => events.push(event.type));
 
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        {
-          emitMemorySample,
-          sampleLiveness: () => ({
-            reasons: ["cpu"],
-            intervalMs: 30_000,
-            eventLoopDelayP99Ms: 12,
-            eventLoopDelayMaxMs: 22,
-            eventLoopUtilization: 0.99,
-            cpuUserMs: 29_000,
-            cpuSystemMs: 1_000,
-            cpuTotalMs: 30_000,
-            cpuCoreRatio: 1,
-          }),
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        emitMemorySample,
+        sampleLiveness: () => ({
+          reasons: ["cpu"],
+          intervalMs: 30_000,
+          eventLoopDelayP99Ms: 12,
+          eventLoopDelayMaxMs: 22,
+          eventLoopUtilization: 0.99,
+          cpuUserMs: 29_000,
+          cpuSystemMs: 1_000,
+          cpuTotalMs: 30_000,
+          cpuCoreRatio: 1,
+        }),
+      });
 
       vi.advanceTimersByTime(30_000);
     } finally {
@@ -2429,19 +2086,16 @@ describe("stuck session diagnostics threshold", () => {
     const unsubscribe = onDiagnosticEvent((event) => events.push(event));
 
     try {
-      startDiagnosticHeartbeat(
-        { diagnostics: { enabled: true } },
-        {
-          emitMemorySample: createEmitMemorySampleMock(),
-          sampleLiveness: () => ({
-            reasons: ["event_loop_delay"],
-            intervalMs: 30_000,
-            degradedSinceMs: 60_000,
-            eventLoopDelayP99Ms: 1_200,
-            eventLoopDelayMaxMs: 1_500,
-          }),
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        emitMemorySample: createEmitMemorySampleMock(),
+        sampleLiveness: () => ({
+          reasons: ["event_loop_delay"],
+          intervalMs: 30_000,
+          degradedSinceMs: 60_000,
+          eventLoopDelayP99Ms: 1_200,
+          eventLoopDelayMaxMs: 1_500,
+        }),
+      });
 
       vi.advanceTimersByTime(30_000);
     } finally {
@@ -2477,20 +2131,13 @@ describe("stuck session diagnostics threshold", () => {
 
     try {
       vi.setSystemTime(0);
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        {
-          emitMemorySample: createEmitMemorySampleMock(),
-          recoverStuckSession,
-          sampleLiveness,
-          startupGraceMs: 60_000,
-          testTimings: { stuckSessionWarnMs: 1_000, stuckSessionAbortMs: 1_000 },
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        emitMemorySample: createEmitMemorySampleMock(),
+        recoverStuckSession,
+        sampleLiveness,
+        startupGraceMs: 60_000,
+        testTimings: { stuckSessionWarnMs: 1_000, stuckSessionAbortMs: 1_000 },
+      });
 
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
@@ -2522,22 +2169,15 @@ describe("stuck session diagnostics threshold", () => {
   it("warns for liveness samples when diagnostic work is open", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      {
-        emitMemorySample: createEmitMemorySampleMock(),
-        sampleLiveness: () => ({
-          reasons: ["event_loop_delay"],
-          intervalMs: 30_000,
-          eventLoopDelayP99Ms: 1_500,
-          eventLoopDelayMaxMs: 2_000,
-        }),
-      },
-    );
+    startEnabledDiagnosticHeartbeat({
+      emitMemorySample: createEmitMemorySampleMock(),
+      sampleLiveness: () => ({
+        reasons: ["event_loop_delay"],
+        intervalMs: 30_000,
+        eventLoopDelayP99Ms: 1_500,
+        eventLoopDelayMaxMs: 2_000,
+      }),
+    });
 
     logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
     vi.advanceTimersByTime(30_000);
@@ -2574,22 +2214,15 @@ describe("stuck session diagnostics threshold", () => {
     const completePhase = finishPhase;
 
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        {
-          emitMemorySample: createEmitMemorySampleMock(),
-          sampleLiveness: () => ({
-            reasons: ["event_loop_delay"],
-            intervalMs: 30_000,
-            eventLoopDelayP99Ms: 1_500,
-            eventLoopDelayMaxMs: 2_000,
-          }),
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        emitMemorySample: createEmitMemorySampleMock(),
+        sampleLiveness: () => ({
+          reasons: ["event_loop_delay"],
+          intervalMs: 30_000,
+          eventLoopDelayP99Ms: 1_500,
+          eventLoopDelayMaxMs: 2_000,
+        }),
+      });
 
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "telegram" });
       vi.advanceTimersByTime(30_000);
@@ -2626,22 +2259,15 @@ describe("stuck session diagnostics threshold", () => {
     await withDiagnosticPhase("recent.phase", () => undefined);
 
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        {
-          emitMemorySample: createEmitMemorySampleMock(),
-          sampleLiveness: () => ({
-            reasons: ["event_loop_delay"],
-            intervalMs: 30_000,
-            eventLoopDelayP99Ms: 1_500,
-            eventLoopDelayMaxMs: 2_000,
-          }),
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        emitMemorySample: createEmitMemorySampleMock(),
+        sampleLiveness: () => ({
+          reasons: ["event_loop_delay"],
+          intervalMs: 30_000,
+          eventLoopDelayP99Ms: 1_500,
+          eventLoopDelayMaxMs: 2_000,
+        }),
+      });
 
       logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
       vi.advanceTimersByTime(30_000);
@@ -2665,22 +2291,15 @@ describe("stuck session diagnostics threshold", () => {
   it("keeps transient event-loop max spikes debug-only when only background work is active", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      {
-        emitMemorySample: createEmitMemorySampleMock(),
-        sampleLiveness: () => ({
-          reasons: ["event_loop_delay"],
-          intervalMs: 30_000,
-          eventLoopDelayP99Ms: 21,
-          eventLoopDelayMaxMs: 1_500,
-        }),
-      },
-    );
+    startEnabledDiagnosticHeartbeat({
+      emitMemorySample: createEmitMemorySampleMock(),
+      sampleLiveness: () => ({
+        reasons: ["event_loop_delay"],
+        intervalMs: 30_000,
+        eventLoopDelayP99Ms: 21,
+        eventLoopDelayMaxMs: 1_500,
+      }),
+    });
 
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
     vi.advanceTimersByTime(30_000);
@@ -2702,24 +2321,17 @@ describe("stuck session diagnostics threshold", () => {
   it("does not count the active processing message as queued liveness backlog", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      {
-        emitMemorySample: createEmitMemorySampleMock(),
-        sampleLiveness: () => ({
-          reasons: ["event_loop_delay"],
-          intervalMs: 30_000,
-          eventLoopDelayP99Ms: 53.6,
-          eventLoopDelayMaxMs: 2_761.9,
-          eventLoopUtilization: 0.785,
-          cpuCoreRatio: 0.378,
-        }),
-      },
-    );
+    startEnabledDiagnosticHeartbeat({
+      emitMemorySample: createEmitMemorySampleMock(),
+      sampleLiveness: () => ({
+        reasons: ["event_loop_delay"],
+        intervalMs: 30_000,
+        eventLoopDelayP99Ms: 53.6,
+        eventLoopDelayMaxMs: 2_761.9,
+        eventLoopUtilization: 0.785,
+        cpuCoreRatio: 0.378,
+      }),
+    });
 
     logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "discord" });
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
@@ -2742,24 +2354,17 @@ describe("stuck session diagnostics threshold", () => {
   it("counts messages queued behind already active work as liveness backlog", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      {
-        emitMemorySample: createEmitMemorySampleMock(),
-        sampleLiveness: () => ({
-          reasons: ["event_loop_delay"],
-          intervalMs: 30_000,
-          eventLoopDelayP99Ms: 53.6,
-          eventLoopDelayMaxMs: 2_761.9,
-          eventLoopUtilization: 0.785,
-          cpuCoreRatio: 0.378,
-        }),
-      },
-    );
+    startEnabledDiagnosticHeartbeat({
+      emitMemorySample: createEmitMemorySampleMock(),
+      sampleLiveness: () => ({
+        reasons: ["event_loop_delay"],
+        intervalMs: 30_000,
+        eventLoopDelayP99Ms: 53.6,
+        eventLoopDelayMaxMs: 2_761.9,
+        eventLoopUtilization: 0.785,
+        cpuCoreRatio: 0.378,
+      }),
+    });
 
     logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
     logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "discord" });
@@ -2782,22 +2387,15 @@ describe("stuck session diagnostics threshold", () => {
   it("does not let idle liveness samples suppress later active-work warnings", () => {
     const warnSpy = vi.spyOn(diagnosticLogger, "warn").mockImplementation(() => undefined);
 
-    startDiagnosticHeartbeat(
-      {
-        diagnostics: {
-          enabled: true,
-        },
-      },
-      {
-        emitMemorySample: createEmitMemorySampleMock(),
-        sampleLiveness: () => ({
-          reasons: ["event_loop_delay"],
-          intervalMs: 30_000,
-          eventLoopDelayP99Ms: 1_500,
-          eventLoopDelayMaxMs: 2_000,
-        }),
-      },
-    );
+    startEnabledDiagnosticHeartbeat({
+      emitMemorySample: createEmitMemorySampleMock(),
+      sampleLiveness: () => ({
+        reasons: ["event_loop_delay"],
+        intervalMs: 30_000,
+        eventLoopDelayP99Ms: 1_500,
+        eventLoopDelayMaxMs: 2_000,
+      }),
+    });
 
     vi.advanceTimersByTime(30_000);
     expect(warnSpy).not.toHaveBeenCalled();
@@ -2813,23 +2411,16 @@ describe("stuck session diagnostics threshold", () => {
     const unsubscribe = onDiagnosticEvent((event) => events.push(event.type));
 
     try {
-      startDiagnosticHeartbeat(
-        {
-          diagnostics: {
-            enabled: true,
-          },
-        },
-        {
-          emitMemorySample: createEmitMemorySampleMock(),
-          sampleLiveness: () => ({
-            reasons: ["event_loop_delay"],
-            intervalMs: 30_000,
-            degradedSinceMs: 60_000,
-            eventLoopDelayP99Ms: 1_500,
-            eventLoopDelayMaxMs: 2_000,
-          }),
-        },
-      );
+      startEnabledDiagnosticHeartbeat({
+        emitMemorySample: createEmitMemorySampleMock(),
+        sampleLiveness: () => ({
+          reasons: ["event_loop_delay"],
+          intervalMs: 30_000,
+          degradedSinceMs: 60_000,
+          eventLoopDelayP99Ms: 1_500,
+          eventLoopDelayMaxMs: 2_000,
+        }),
+      });
 
       vi.advanceTimersByTime(30_000);
       vi.advanceTimersByTime(90_000);
@@ -2951,10 +2542,27 @@ describe("stuck session recovery activity reconciliation", () => {
     };
   }
 
-  function flush(): Promise<void> {
-    return new Promise((resolve) => {
-      setImmediate(resolve);
+  async function recoverStalledSession(params: {
+    stateGeneration: number | undefined;
+    sessionId?: string;
+    recover?: () => Promise<StuckSessionRecoveryOutcome>;
+  }): Promise<void> {
+    const recoverySessionId = params.sessionId ?? sessionId;
+    requestStuckSessionRecovery({
+      recover: params.recover ?? (() => Promise.resolve(abortedOutcome())),
+      classification: stalledClassification,
+      request: {
+        sessionId: recoverySessionId,
+        sessionKey,
+        ageMs: 139_014,
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+        stateGeneration: params.stateGeneration,
+      },
     });
+    await flushDiagnosticEvents();
+    await flushDiagnosticEvents();
   }
 
   beforeEach(() => {
@@ -2980,21 +2588,7 @@ describe("stuck session recovery activity reconciliation", () => {
     // The aborted run was removed without markDiagnosticEmbeddedRunEnded, so the
     // activity flag survives the idle transition and otherwise resurfaces as
     // idle/embedded_run on every later liveness sweep.
-    requestStuckSessionRecovery({
-      recover: () => Promise.resolve(abortedOutcome()),
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: state.generation,
-      },
-    });
-    await flush();
-    await flush();
+    await recoverStalledSession({ stateGeneration: state.generation });
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
@@ -3013,21 +2607,7 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId, sessionKey });
     state.queueDepth = 2;
 
-    requestStuckSessionRecovery({
-      recover: () => Promise.resolve(abortedOutcome()),
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: state.generation,
-      },
-    });
-    await flush();
-    await flush();
+    await recoverStalledSession({ stateGeneration: state.generation });
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
@@ -3051,21 +2631,7 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId, sessionKey });
     state.queueDepth = 2;
 
-    requestStuckSessionRecovery({
-      recover: () => Promise.resolve(abortedOutcome()),
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: state.generation,
-      },
-    });
-    await flush();
-    await flush();
+    await recoverStalledSession({ stateGeneration: state.generation });
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
@@ -3096,21 +2662,7 @@ describe("stuck session recovery activity reconciliation", () => {
       model: "gpt-5.5",
     });
 
-    requestStuckSessionRecovery({
-      recover: () => Promise.resolve(abortedOutcome()),
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: state.generation,
-      },
-    });
-    await flush();
-    await flush();
+    await recoverStalledSession({ stateGeneration: state.generation });
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
@@ -3144,21 +2696,7 @@ describe("stuck session recovery activity reconciliation", () => {
       model: "gpt-5.5",
     });
 
-    requestStuckSessionRecovery({
-      recover: () => Promise.resolve(abortedOutcome()),
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: state.generation,
-      },
-    });
-    await flush();
-    await flush();
+    await recoverStalledSession({ stateGeneration: state.generation });
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
@@ -3172,7 +2710,8 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId, sessionKey });
     const staleGeneration = state.generation;
 
-    requestStuckSessionRecovery({
+    await recoverStalledSession({
+      stateGeneration: staleGeneration,
       recover: () => {
         // A requeued run started before the coordinator applied the outcome,
         // advancing the generation past the captured one.
@@ -3185,19 +2724,7 @@ describe("stuck session recovery activity reconciliation", () => {
         markDiagnosticEmbeddedRunStarted({ sessionId: "wa-run-2", sessionKey });
         return Promise.resolve(abortedOutcome());
       },
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: staleGeneration,
-      },
     });
-    await flush();
-    await flush();
 
     // Generation guard bails: the live run keeps processing and its activity flag.
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
@@ -3212,7 +2739,8 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId, sessionKey });
     const staleGeneration = state.generation;
 
-    requestStuckSessionRecovery({
+    await recoverStalledSession({
+      stateGeneration: staleGeneration,
       recover: () => {
         markDiagnosticEmbeddedRunStarted({
           sessionId: "reply-run-1",
@@ -3221,19 +2749,7 @@ describe("stuck session recovery activity reconciliation", () => {
         });
         return Promise.resolve(abortedOutcome());
       },
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: staleGeneration,
-      },
     });
-    await flush();
-    await flush();
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
@@ -3255,7 +2771,8 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId, sessionKey });
     const staleGeneration = state.generation;
 
-    requestStuckSessionRecovery({
+    await recoverStalledSession({
+      stateGeneration: staleGeneration,
       recover: () => {
         markDiagnosticEmbeddedRunStarted({
           sessionId: "reply-run-1",
@@ -3264,19 +2781,7 @@ describe("stuck session recovery activity reconciliation", () => {
         });
         return Promise.resolve(abortedOutcome());
       },
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: staleGeneration,
-      },
     });
-    await flush();
-    await flush();
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
@@ -3301,26 +2806,16 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId: replySessionId, sessionKey });
     state.queueDepth = 2;
 
-    requestStuckSessionRecovery({
+    await recoverStalledSession({
+      sessionId: replySessionId,
+      stateGeneration: state.generation,
       recover: () =>
         Promise.resolve({
           ...abortedOutcome(),
           sessionId: replySessionId,
           activeSessionId: replySessionId,
         }),
-      classification: stalledClassification,
-      request: {
-        sessionId: replySessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: state.generation,
-      },
     });
-    await flush();
-    await flush();
 
     expect(peekDiagnosticSessionState({ sessionId: replySessionId, sessionKey })?.state).toBe(
       "idle",
@@ -3340,21 +2835,7 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId, sessionKey });
     state.queueDepth = 2;
 
-    requestStuckSessionRecovery({
-      recover: () => Promise.resolve(abortedOutcome()),
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: state.generation,
-      },
-    });
-    await flush();
-    await flush();
+    await recoverStalledSession({ stateGeneration: state.generation });
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("idle");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
@@ -3368,24 +2849,13 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId, sessionKey });
     const staleGeneration = state.generation;
 
-    requestStuckSessionRecovery({
+    await recoverStalledSession({
+      stateGeneration: staleGeneration,
       recover: () => {
         markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
         return Promise.resolve(abortedOutcome());
       },
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: staleGeneration,
-      },
     });
-    await flush();
-    await flush();
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
@@ -3406,24 +2876,13 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId, sessionKey });
     const staleGeneration = state.generation;
 
-    requestStuckSessionRecovery({
+    await recoverStalledSession({
+      stateGeneration: staleGeneration,
       recover: () => {
         markDiagnosticEmbeddedRunStarted({ sessionId: "reply-run-1", sessionKey });
         return Promise.resolve(abortedOutcome());
       },
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: staleGeneration,
-      },
     });
-    await flush();
-    await flush();
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
     expect(getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey }).activeWorkKind).toBe(
@@ -3446,7 +2905,8 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId, sessionKey });
     const staleGeneration = state.generation;
 
-    requestStuckSessionRecovery({
+    await recoverStalledSession({
+      stateGeneration: staleGeneration,
       recover: () => {
         markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
         emitDiagnosticEvent({
@@ -3459,19 +2919,7 @@ describe("stuck session recovery activity reconciliation", () => {
         });
         return Promise.resolve(abortedOutcome());
       },
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: staleGeneration,
-      },
     });
-    await flush();
-    await flush();
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
@@ -3487,7 +2935,8 @@ describe("stuck session recovery activity reconciliation", () => {
     const state = getDiagnosticSessionState({ sessionId, sessionKey });
     const staleGeneration = state.generation;
 
-    requestStuckSessionRecovery({
+    await recoverStalledSession({
+      stateGeneration: staleGeneration,
       recover: () => {
         markDiagnosticEmbeddedRunStarted({ sessionId: "reply-run-1", sessionKey });
         emitDiagnosticEvent({
@@ -3499,19 +2948,7 @@ describe("stuck session recovery activity reconciliation", () => {
         });
         return Promise.resolve(abortedOutcome());
       },
-      classification: stalledClassification,
-      request: {
-        sessionId,
-        sessionKey,
-        ageMs: 139_014,
-        queueDepth: 2,
-        allowActiveAbort: true,
-        expectedState: "processing",
-        stateGeneration: staleGeneration,
-      },
     });
-    await flush();
-    await flush();
 
     expect(peekDiagnosticSessionState({ sessionId, sessionKey })?.state).toBe("processing");
     const activity = getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -13,6 +13,14 @@ import { defaultRuntime } from "../runtime.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../sessions/agent-harness-session-key.js";
 import { notifyListeners } from "../shared/listeners.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import type { EmbeddedTuiBackend as EmbeddedTuiBackendType } from "./embedded-backend.js";
+
+type EmbeddedAgentResult = {
+  payloads: Array<{ text: string }>;
+  meta: Record<string, unknown>;
+};
+
+let EmbeddedTuiBackend: typeof EmbeddedTuiBackendType;
 
 const agentCommandFromIngressMock = vi.fn();
 const queueEmbeddedAgentMessageWithOutcomeAsyncMock = vi.fn();
@@ -308,12 +316,24 @@ function emitRegisteredAgentEvent(evt: unknown) {
   }
 }
 
+function captureBackendEvents(backend: EmbeddedTuiBackendType) {
+  const events: Array<{ event: string; payload: unknown }> = [];
+  backend.onEvent = ({ event, payload }) => {
+    events.push({ event, payload });
+  };
+  return events;
+}
+
+function sendMainChat(backend: EmbeddedTuiBackendType, message: string, runId: string) {
+  return backend.sendChat({ sessionKey: "agent:main:main", message, runId });
+}
+
 describe("EmbeddedTuiBackend", () => {
   const originalRuntimeLog = defaultRuntime.log;
   const originalRuntimeError = defaultRuntime.error;
 
   beforeAll(async () => {
-    await import("./embedded-backend.js");
+    ({ EmbeddedTuiBackend } = await import("./embedded-backend.js"));
   });
 
   beforeEach(() => {
@@ -428,7 +448,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("creates TUI sessions through the shared gateway lifecycle", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     const result = await backend.createSession({
@@ -458,7 +477,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("returns the resolved model from the shared reset lifecycle", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(backend.resetSession("main", "new")).resolves.toEqual({
@@ -470,11 +488,7 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("bridges assistant and lifecycle events into chat events", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
@@ -489,11 +503,7 @@ describe("EmbeddedTuiBackend", () => {
     await flushMicrotasks();
     expect(onConnected).toHaveBeenCalledTimes(1);
 
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "hello",
-      runId: "run-local-1",
-    });
+    await sendMainChat(backend, "hello", "run-local-1");
 
     registeredListener?.({
       runId: "run-local-1",
@@ -564,11 +574,7 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("isolates TUI event consumer failures in the agent event bus", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
@@ -576,11 +582,7 @@ describe("EmbeddedTuiBackend", () => {
       throw new Error("render failed");
     };
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "hello",
-      runId: "run-listener-error",
-    });
+    await sendMainChat(backend, "hello", "run-listener-error");
 
     expect(() =>
       emitRegisteredAgentEvent({
@@ -598,12 +600,8 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("bridges local plugin approvals without a Gateway", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (event) => {
-      events.push({ event: event.event, payload: event.payload });
-    };
+    const events = captureBackendEvents(backend);
 
     backend.start();
     await flushMicrotasks();
@@ -657,7 +655,6 @@ describe("EmbeddedTuiBackend", () => {
       },
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(backend.listModels()).resolves.toEqual([
@@ -680,7 +677,6 @@ describe("EmbeddedTuiBackend", () => {
       },
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(backend.listModels()).resolves.toEqual([]);
@@ -713,7 +709,6 @@ describe("EmbeddedTuiBackend", () => {
       },
     ]);
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(backend.listModels()).resolves.toEqual([
@@ -747,7 +742,6 @@ describe("EmbeddedTuiBackend", () => {
       },
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await backend.listModels({ agentId: "work" });
@@ -793,7 +787,6 @@ describe("EmbeddedTuiBackend", () => {
       },
     );
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(
@@ -820,7 +813,6 @@ describe("EmbeddedTuiBackend", () => {
         message: AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE,
       },
     });
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(backend.patchSession({ key: sessionKey, label: "squat" })).rejects.toThrow(
@@ -869,7 +861,6 @@ describe("EmbeddedTuiBackend", () => {
       ok: true,
       entry: { ...existingEntry, label: "kept" },
     });
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(backend.patchSession({ key: sessionKey, label: "kept" })).resolves.toMatchObject({
@@ -883,7 +874,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("scopes local session lists to the selected agent store", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await backend.listSessions({ agentId: "work", includeGlobal: true, search: "global" });
@@ -907,7 +897,6 @@ describe("EmbeddedTuiBackend", () => {
     });
     runSessionStartupMigrationMock.mockReturnValueOnce(migrationDone);
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
     backend.start();
 
@@ -934,7 +923,6 @@ describe("EmbeddedTuiBackend", () => {
     const publication = deferred<void>();
     refreshPreparedModelRuntimeSnapshotsMock.mockReturnValueOnce(publication.promise);
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
     backend.start();
 
@@ -961,7 +949,6 @@ describe("EmbeddedTuiBackend", () => {
     const nextConfig = { agents: { list: [{ id: "main" }], defaults: { model: "openai/next" } } };
     getRuntimeConfigMock.mockReturnValue(initialConfig);
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
     backend.start();
     await vi.waitFor(() => expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledOnce());
@@ -1003,7 +990,6 @@ describe("EmbeddedTuiBackend", () => {
       .mockReturnValueOnce(middle.promise)
       .mockReturnValueOnce(latest.promise);
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
     backend.start();
     await vi.waitFor(() => expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledOnce());
@@ -1028,10 +1014,7 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("rechecks runtime publication when a queued turn reaches model admission", async () => {
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockResolvedValueOnce({ payloads: [{ text: "second done" }], meta: {} });
@@ -1043,7 +1026,6 @@ describe("EmbeddedTuiBackend", () => {
       entry: { queueDebounceMs: 0 },
     }));
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
     backend.start();
     await backend.sendChat({
@@ -1079,7 +1061,6 @@ describe("EmbeddedTuiBackend", () => {
       storePath: "/tmp/openclaw-sessions.json",
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(
@@ -1111,7 +1092,6 @@ describe("EmbeddedTuiBackend", () => {
       entry: { sessionId: "session-work", updatedAt: embeddedEventTimestamp },
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(
@@ -1138,7 +1118,6 @@ describe("EmbeddedTuiBackend", () => {
       storePath: "/tmp/openclaw-work-sessions.json",
       entry: sessionEntry,
     });
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(
@@ -1174,7 +1153,6 @@ describe("EmbeddedTuiBackend", () => {
       entry: {},
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(backend.loadHistory({ sessionKey: "agent:main:main" })).resolves.toMatchObject({
@@ -1193,7 +1171,6 @@ describe("EmbeddedTuiBackend", () => {
       entry: { sessionId: "session-work-global" },
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(
@@ -1222,7 +1199,6 @@ describe("EmbeddedTuiBackend", () => {
     });
     runBtwSideQuestionMock.mockResolvedValueOnce({ text: "side done" });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
     backend.start();
     await backend.sendChat({
@@ -1254,7 +1230,6 @@ describe("EmbeddedTuiBackend", () => {
       .mockReturnValueOnce(second.promise);
     runBtwSideQuestionMock.mockReturnValueOnce(side.promise);
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
     backend.start();
     await backend.sendChat({
@@ -1298,7 +1273,6 @@ describe("EmbeddedTuiBackend", () => {
       entry: { sessionId: "sess-main" },
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await backend.loadHistory({ sessionKey: "agent:main:main" });
@@ -1327,7 +1301,6 @@ describe("EmbeddedTuiBackend", () => {
       entry: { spawnedWorkspaceDir: "/tmp/openclaw-custom-workspace" },
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(backend.loadHistory({ sessionKey: "agent:main:main" })).resolves.toMatchObject({
@@ -1350,7 +1323,6 @@ describe("EmbeddedTuiBackend", () => {
       entry: {},
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await expect(backend.loadHistory({ sessionKey: "agent:main:main" })).resolves.toMatchObject({
@@ -1370,7 +1342,6 @@ describe("EmbeddedTuiBackend", () => {
       canonicalKey: "agent:main:main",
       entry: {},
     });
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await backend.loadHistory({ sessionKey: "agent:main:main" });
@@ -1396,7 +1367,6 @@ describe("EmbeddedTuiBackend", () => {
       canonicalKey: "agent:main:main",
       entry: {},
     });
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await backend.loadHistory({ sessionKey: "agent:main:main" });
@@ -1416,7 +1386,6 @@ describe("EmbeddedTuiBackend", () => {
       meta: {},
     });
 
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
     backend.start();
     try {
@@ -1451,13 +1420,9 @@ describe("EmbeddedTuiBackend", () => {
       store: {},
       entry: { sessionId: "session-work-global" },
     }));
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
     runBtwSideQuestionMock.mockResolvedValueOnce({ text: "side done" });
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
     const events: Array<{ event: string; payload: unknown }> = [];
     backend.onEvent = (event) => events.push({ event: event.event, payload: event.payload });
@@ -1497,18 +1462,11 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("waits for local post-turn maintenance before emitting chat final", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
 
     backend.start();
     await backend.sendChat({
@@ -1547,11 +1505,7 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("waits for local post-turn maintenance during stop", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     const abortListener = vi.fn();
     agentCommandFromIngressMock.mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
       opts.abortSignal?.addEventListener("abort", abortListener);
@@ -1559,10 +1513,7 @@ describe("EmbeddedTuiBackend", () => {
     });
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    captureBackendEvents(backend);
     backend.start();
     await backend.sendChat({
       sessionKey: "agent:main:main",
@@ -1601,11 +1552,7 @@ describe("EmbeddedTuiBackend", () => {
 
   it("aborts local post-turn maintenance when stop grace elapses", async () => {
     await withEnvAsync({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: "5" }, async () => {
-      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-      const pending = deferred<{
-        payloads: Array<{ text: string }>;
-        meta: Record<string, unknown>;
-      }>();
+      const pending = deferred<EmbeddedAgentResult>();
       const abortListener = vi.fn();
       agentCommandFromIngressMock.mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
         opts.abortSignal?.addEventListener("abort", abortListener);
@@ -1643,15 +1590,8 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("queues same-session sends behind local post-turn maintenance", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const second = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
+    const second = deferred<EmbeddedAgentResult>();
     const firstAbortListener = vi.fn();
     agentCommandFromIngressMock
       .mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
@@ -1662,11 +1602,7 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
 
     registeredListener?.({
       runId: "run-local-first",
@@ -1679,11 +1615,7 @@ describe("EmbeddedTuiBackend", () => {
       data: { phase: "finishing", stopReason: "stop" },
     });
 
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "second",
-      runId: "run-local-second",
-    });
+    await sendMainChat(backend, "second", "run-local-second");
 
     expect(firstAbortListener).not.toHaveBeenCalled();
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
@@ -1699,15 +1631,8 @@ describe("EmbeddedTuiBackend", () => {
 
   it("queues same-session sends behind active local runs", async () => {
     await withEnvAsync({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: "5" }, async () => {
-      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-      const first = deferred<{
-        payloads: Array<{ text: string }>;
-        meta: Record<string, unknown>;
-      }>();
-      const second = deferred<{
-        payloads: Array<{ text: string }>;
-        meta: Record<string, unknown>;
-      }>();
+      const first = deferred<EmbeddedAgentResult>();
+      const second = deferred<EmbeddedAgentResult>();
       const firstAbortListener = vi.fn();
       agentCommandFromIngressMock
         .mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
@@ -1718,11 +1643,7 @@ describe("EmbeddedTuiBackend", () => {
 
       const backend = new EmbeddedTuiBackend();
       backend.start();
-      await backend.sendChat({
-        sessionKey: "agent:main:main",
-        message: "first",
-        runId: "run-local-first",
-      });
+      await sendMainChat(backend, "first", "run-local-first");
 
       registeredListener?.({
         runId: "run-local-first",
@@ -1730,11 +1651,7 @@ describe("EmbeddedTuiBackend", () => {
         data: { text: "first response", delta: "first response" },
       });
 
-      await backend.sendChat({
-        sessionKey: "agent:main:main",
-        message: "second",
-        runId: "run-local-second",
-      });
+      await sendMainChat(backend, "second", "run-local-second");
       await vi.advanceTimersByTimeAsync(5);
       await flushMicrotasks();
 
@@ -1752,7 +1669,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("cancels a queued local turn without waiting for the active provider", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const active = deferred<{ payloads: Array<{ text: string }>; meta: Record<string, unknown> }>();
     let activeSignal: AbortSignal | undefined;
     agentCommandFromIngressMock.mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
@@ -1767,19 +1683,10 @@ describe("EmbeddedTuiBackend", () => {
       entry: { queueDebounceMs: 0 },
     }));
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    const events = captureBackendEvents(backend);
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "the active provider does not settle",
-      runId: "active-provider",
-    });
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "cancel this queued turn",
-      runId: "queued-provider",
-    });
+    await sendMainChat(backend, "the active provider does not settle", "active-provider");
+    await sendMainChat(backend, "cancel this queued turn", "queued-provider");
 
     await backend.abortChat({ sessionKey: "agent:main:main", runId: "queued-provider" });
     await flushMicrotasks();
@@ -1802,7 +1709,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("keeps later queued turns behind the active provider when intermediate turns are canceled", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const active = deferred<{ payloads: Array<{ text: string }>; meta: Record<string, unknown> }>();
     let activeSignal: AbortSignal | undefined;
     agentCommandFromIngressMock
@@ -1819,30 +1725,13 @@ describe("EmbeddedTuiBackend", () => {
       entry: { queueDebounceMs: 0 },
     }));
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    const events = captureBackendEvents(backend);
     backend.start();
 
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "queue-first",
-    });
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "second",
-      runId: "queue-second",
-    });
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "third",
-      runId: "queue-third",
-    });
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "fourth",
-      runId: "queue-fourth",
-    });
+    await sendMainChat(backend, "first", "queue-first");
+    await sendMainChat(backend, "second", "queue-second");
+    await sendMainChat(backend, "third", "queue-third");
+    await sendMainChat(backend, "fourth", "queue-fourth");
     await backend.abortChat({ sessionKey: "agent:main:main", runId: "queue-second" });
     await flushMicrotasks();
 
@@ -1882,11 +1771,7 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("steers same-session sends into the active local run", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(first.promise);
     resolveActiveEmbeddedRunSessionIdMock.mockReturnValue("active-session");
     loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
@@ -1905,11 +1790,7 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
 
     const result = await backend.sendChat({
       sessionKey: "agent:main:main",
@@ -1930,15 +1811,8 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("queues local sends when active-runtime steering rejects them", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const second = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
+    const second = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
@@ -1959,16 +1833,8 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "queue on rejection",
-      runId: "run-local-second",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
+    await sendMainChat(backend, "queue on rejection", "run-local-second");
 
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
     first.resolve({ payloads: [{ text: "first done" }], meta: {} });
@@ -1980,15 +1846,8 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("honors a persisted local followup queue override", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const second = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
+    const second = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
@@ -2003,16 +1862,8 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "follow up later",
-      runId: "run-local-second",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
+    await sendMainChat(backend, "follow up later", "run-local-second");
 
     expect(resolveActiveEmbeddedRunSessionIdMock).not.toHaveBeenCalled();
     expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).not.toHaveBeenCalled();
@@ -2026,15 +1877,8 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("collects pending local messages into one followup turn", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const collected = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
+    const collected = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(collected.promise);
@@ -2048,11 +1892,7 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
     const second = await backend.sendChat({
       sessionKey: "agent:main:main",
       message: "collect alpha",
@@ -2086,15 +1926,8 @@ describe("EmbeddedTuiBackend", () => {
   it.each(["old", "new"] as const)(
     "keeps a local overflow summary after future drops switch to %s",
     async (nextDropPolicy) => {
-      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-      const active = deferred<{
-        payloads: Array<{ text: string }>;
-        meta: Record<string, unknown>;
-      }>();
-      const collected = deferred<{
-        payloads: Array<{ text: string }>;
-        meta: Record<string, unknown>;
-      }>();
+      const active = deferred<EmbeddedAgentResult>();
+      const collected = deferred<EmbeddedAgentResult>();
       agentCommandFromIngressMock
         .mockReturnValueOnce(active.promise)
         .mockReturnValueOnce(collected.promise);
@@ -2111,29 +1944,25 @@ describe("EmbeddedTuiBackend", () => {
       const backend = new EmbeddedTuiBackend();
       backend.start();
       try {
-        await backend.sendChat({
-          sessionKey: "agent:main:main",
-          message: "active turn",
-          runId: `run-local-policy-active-${nextDropPolicy}`,
-        });
-        await backend.sendChat({
-          sessionKey: "agent:main:main",
-          message: "first overflowed message",
-          runId: `run-local-policy-first-${nextDropPolicy}`,
-        });
-        await backend.sendChat({
-          sessionKey: "agent:main:main",
-          message: "second queued message",
-          runId: `run-local-policy-second-${nextDropPolicy}`,
-        });
+        await sendMainChat(backend, "active turn", `run-local-policy-active-${nextDropPolicy}`);
+        await sendMainChat(
+          backend,
+          "first overflowed message",
+          `run-local-policy-first-${nextDropPolicy}`,
+        );
+        await sendMainChat(
+          backend,
+          "second queued message",
+          `run-local-policy-second-${nextDropPolicy}`,
+        );
 
         dropPolicy = nextDropPolicy;
         cap = 2;
-        await backend.sendChat({
-          sessionKey: "agent:main:main",
-          message: "third queued message",
-          runId: `run-local-policy-third-${nextDropPolicy}`,
-        });
+        await sendMainChat(
+          backend,
+          "third queued message",
+          `run-local-policy-third-${nextDropPolicy}`,
+        );
 
         active.resolve({ payloads: [{ text: "active done" }], meta: {} });
         await vi.waitFor(() => {
@@ -2159,15 +1988,8 @@ describe("EmbeddedTuiBackend", () => {
   );
 
   it("applies the local queue cap and drop-new policy", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const second = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
+    const second = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
@@ -2183,16 +2005,8 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "kept followup",
-      runId: "run-local-second",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
+    await sendMainChat(backend, "kept followup", "run-local-second");
     const dropped = await backend.sendChat({
       sessionKey: "agent:main:main",
       message: "dropped followup",
@@ -2212,11 +2026,7 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("interrupts the active local run before starting its replacement", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
     const firstAbortListener = vi.fn(() => {
       first.resolve({ payloads: [{ text: "first aborted" }], meta: {} });
     });
@@ -2236,16 +2046,8 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "replace it",
-      runId: "run-local-second",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
+    await sendMainChat(backend, "replace it", "run-local-second");
 
     expect(firstAbortListener).toHaveBeenCalledTimes(1);
     await vi.waitFor(() => {
@@ -2254,11 +2056,7 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("does not inject local queue directives into an active run", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
     const firstAbortListener = vi.fn();
     agentCommandFromIngressMock
       .mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
@@ -2277,11 +2075,7 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
     await backend.sendChat({
       sessionKey: "agent:main:main",
       message: "/queue followup",
@@ -2296,11 +2090,7 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("does not queue stop commands behind active local runs", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
     const firstAbortListener = vi.fn(() => {
       first.resolve({ payloads: [{ text: "first aborted" }], meta: {} });
     });
@@ -2311,11 +2101,7 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
 
     registeredListener?.({
       runId: "run-local-first",
@@ -2335,11 +2121,7 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("stops terminal local runs while post-turn maintenance is pending", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
     const firstAbortListener = vi.fn(() => {
       first.resolve({ payloads: [{ text: "first aborted" }], meta: {} });
     });
@@ -2349,10 +2131,7 @@ describe("EmbeddedTuiBackend", () => {
     });
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
     backend.start();
     await backend.sendChat({
       sessionKey: "agent:main:main",
@@ -2387,18 +2166,11 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("retains the latest tool validation summary for an aborted chat event", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockImplementationOnce(() => pending.promise);
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
     backend.start();
     await backend.sendChat({
       sessionKey: "agent:main:main",
@@ -2520,15 +2292,13 @@ describe("EmbeddedTuiBackend", () => {
   ])(
     "projects $label as an actionable terminal failure",
     async ({ lifecycle, meta, text, partialText, abortBeforeLifecycle, secret }) => {
-      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
       const pending = deferred<{
         payloads: Array<{ text: string; mediaUrl: null }>;
         meta: Record<string, unknown>;
       }>();
       agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
       const backend = new EmbeddedTuiBackend();
-      const events: Array<{ event: string; payload: unknown }> = [];
-      backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+      const events = captureBackendEvents(backend);
       backend.start();
       await backend.sendChat({
         sessionKey: "agent:main:main",
@@ -2618,10 +2388,8 @@ describe("EmbeddedTuiBackend", () => {
       payloads: [{ text: partialText }],
       meta,
     });
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    const events = captureBackendEvents(backend);
     backend.start();
 
     await backend.sendChat({
@@ -2652,10 +2420,8 @@ describe("EmbeddedTuiBackend", () => {
         status: "error",
       }),
     );
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    const events = captureBackendEvents(backend);
     backend.start();
 
     await backend.sendChat({
@@ -2686,10 +2452,8 @@ describe("EmbeddedTuiBackend", () => {
         status: "error",
       }),
     );
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    const events = captureBackendEvents(backend);
     backend.start();
 
     await backend.sendChat({
@@ -2727,15 +2491,10 @@ describe("EmbeddedTuiBackend", () => {
       terminal: { state: "error", errorMessage: "real provider failure" },
     },
   ])("ignores $label in open lifecycle event data", async ({ data, terminal }) => {
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    const events = captureBackendEvents(backend);
     backend.start();
     await backend.sendChat({
       sessionKey: "agent:main:main",
@@ -2760,15 +2519,13 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("preserves a yielded parent turn in the embedded session projection", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const pending = deferred<{
       payloads: Array<{ text: string; mediaUrl: null }>;
       meta: Record<string, unknown>;
     }>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+    const events = captureBackendEvents(backend);
     backend.start();
     await backend.sendChat({
       sessionKey: "agent:main:main",
@@ -2804,18 +2561,11 @@ describe("EmbeddedTuiBackend", () => {
   ] as const)(
     "clears stale validation diagnostics on local $stream progress",
     async (progressEvent) => {
-      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-      const pending = deferred<{
-        payloads: Array<{ text: string }>;
-        meta: Record<string, unknown>;
-      }>();
+      const pending = deferred<EmbeddedAgentResult>();
       agentCommandFromIngressMock.mockImplementationOnce(() => pending.promise);
 
       const backend = new EmbeddedTuiBackend();
-      const events: Array<{ event: string; payload: unknown }> = [];
-      backend.onEvent = (evt) => {
-        events.push({ event: evt.event, payload: evt.payload });
-      };
+      const events = captureBackendEvents(backend);
       backend.start();
       await backend.sendChat({
         sessionKey: "agent:main:main",
@@ -2856,18 +2606,11 @@ describe("EmbeddedTuiBackend", () => {
   );
 
   it("drops unsafe lifecycle tool-error summaries", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockImplementationOnce(() => pending.promise);
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
     backend.start();
     await backend.sendChat({
       sessionKey: "agent:main:main",
@@ -2898,20 +2641,12 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("sends broad stop-like text as a normal prompt when idle", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "do not do that",
-      runId: "run-local-normal-stop-like-text",
-    });
+    await sendMainChat(backend, "do not do that", "run-local-normal-stop-like-text");
 
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
 
@@ -2920,18 +2655,11 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("sends idle slash stop as a normal prompt so the TUI receives a terminal event", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
     backend.start();
     await backend.sendChat({
       sessionKey: "agent:main:main",
@@ -2961,26 +2689,15 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("queues same-session sends behind terminal local runs until maintenance settles", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const second = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
+    const second = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
 
     registeredListener?.({
       runId: "run-local-first",
@@ -2988,11 +2705,7 @@ describe("EmbeddedTuiBackend", () => {
       data: { phase: "end", stopReason: "stop" },
     });
 
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "second",
-      runId: "run-local-second",
-    });
+    await sendMainChat(backend, "second", "run-local-second");
     expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
 
     first.resolve({ payloads: [{ text: "first done" }], meta: {} });
@@ -3005,15 +2718,8 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("runs selected-agent global sends independently across agents", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const second = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
+    const second = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
@@ -3041,15 +2747,8 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("does not stop another agent's selected global local run", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const first = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const stop = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const first = deferred<EmbeddedAgentResult>();
+    const stop = deferred<EmbeddedAgentResult>();
     const firstAbortListener = vi.fn(() => {
       first.resolve({ payloads: [{ text: "main aborted" }], meta: {} });
     });
@@ -3084,18 +2783,11 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("does not abort selected-global run ids across default-agent boundaries", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     getRuntimeConfigMock.mockReturnValue({
       agents: { list: [{ id: "main", default: true }, { id: "work" }] },
     });
-    const defaultRun = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
-    const workRun = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const defaultRun = deferred<EmbeddedAgentResult>();
+    const workRun = deferred<EmbeddedAgentResult>();
     const defaultAbortListener = vi.fn(() => {
       defaultRun.resolve({ payloads: [{ text: "default aborted" }], meta: {} });
     });
@@ -3149,7 +2841,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("scopes selected global patches to the selected agent", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const backend = new EmbeddedTuiBackend();
 
     await backend.patchSession({
@@ -3173,24 +2864,13 @@ describe("EmbeddedTuiBackend", () => {
 
   it("fails a queued local send when the previous finishing run does not settle", async () => {
     await withEnvAsync({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: "5" }, async () => {
-      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-      const first = deferred<{
-        payloads: Array<{ text: string }>;
-        meta: Record<string, unknown>;
-      }>();
+      const first = deferred<EmbeddedAgentResult>();
       agentCommandFromIngressMock.mockReturnValueOnce(first.promise);
 
       const backend = new EmbeddedTuiBackend();
-      const events: Array<{ event: string; payload: unknown }> = [];
-      backend.onEvent = (evt) => {
-        events.push({ event: evt.event, payload: evt.payload });
-      };
+      const events = captureBackendEvents(backend);
       backend.start();
-      await backend.sendChat({
-        sessionKey: "agent:main:main",
-        message: "first",
-        runId: "run-local-first",
-      });
+      await sendMainChat(backend, "first", "run-local-first");
 
       registeredListener?.({
         runId: "run-local-first",
@@ -3203,11 +2883,7 @@ describe("EmbeddedTuiBackend", () => {
         data: { phase: "finishing", stopReason: "stop" },
       });
 
-      await backend.sendChat({
-        sessionKey: "agent:main:main",
-        message: "second",
-        runId: "run-local-second",
-      });
+      await sendMainChat(backend, "second", "run-local-second");
 
       await vi.advanceTimersByTimeAsync(5);
       await flushMicrotasks();
@@ -3230,11 +2906,7 @@ describe("EmbeddedTuiBackend", () => {
 
   it("keeps the bounded post-turn timeout visible through canceled queue predecessors", async () => {
     await withEnvAsync({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: "5" }, async () => {
-      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-      const active = deferred<{
-        payloads: Array<{ text: string }>;
-        meta: Record<string, unknown>;
-      }>();
+      const active = deferred<EmbeddedAgentResult>();
       agentCommandFromIngressMock.mockReturnValueOnce(active.promise);
       loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
         cfg: { messages: { queue: { mode: "followup" } } },
@@ -3244,8 +2916,7 @@ describe("EmbeddedTuiBackend", () => {
         entry: { queueDebounceMs: 0 },
       }));
       const backend = new EmbeddedTuiBackend();
-      const events: Array<{ event: string; payload: unknown }> = [];
-      backend.onEvent = ({ event, payload }) => events.push({ event, payload });
+      const events = captureBackendEvents(backend);
       backend.start();
       await backend.sendChat({
         sessionKey: "agent:main:main",
@@ -3287,24 +2958,13 @@ describe("EmbeddedTuiBackend", () => {
 
   it("fails a queued local send immediately when shutdown grace is zero", async () => {
     await withEnvAsync({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: "0" }, async () => {
-      const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-      const first = deferred<{
-        payloads: Array<{ text: string }>;
-        meta: Record<string, unknown>;
-      }>();
+      const first = deferred<EmbeddedAgentResult>();
       agentCommandFromIngressMock.mockReturnValueOnce(first.promise);
 
       const backend = new EmbeddedTuiBackend();
-      const events: Array<{ event: string; payload: unknown }> = [];
-      backend.onEvent = (evt) => {
-        events.push({ event: evt.event, payload: evt.payload });
-      };
+      const events = captureBackendEvents(backend);
       backend.start();
-      await backend.sendChat({
-        sessionKey: "agent:main:main",
-        message: "first",
-        runId: "run-local-first",
-      });
+      await sendMainChat(backend, "first", "run-local-first");
 
       registeredListener?.({
         runId: "run-local-first",
@@ -3312,11 +2972,7 @@ describe("EmbeddedTuiBackend", () => {
         data: { phase: "finishing", stopReason: "stop" },
       });
 
-      await backend.sendChat({
-        sessionKey: "agent:main:main",
-        message: "second",
-        runId: "run-local-second",
-      });
+      await sendMainChat(backend, "second", "run-local-second");
       await flushMicrotasks();
 
       expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
@@ -3336,7 +2992,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("clears local finishing state before surfacing a post-turn failure", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     agentCommandFromIngressMock
       .mockImplementationOnce(() => {
         registeredListener?.({
@@ -3366,11 +3021,7 @@ describe("EmbeddedTuiBackend", () => {
     };
 
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "first",
-      runId: "run-local-first",
-    });
+    await sendMainChat(backend, "first", "run-local-first");
 
     await vi.waitFor(() => {
       expect(sentDuringError).toBeDefined();
@@ -3402,25 +3053,14 @@ describe("EmbeddedTuiBackend", () => {
       expectedText: "Draft answer",
     },
   ])("$name", async ({ finalPayloads, expectedText }) => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (event) => {
-      events.push({ event: event.event, payload: event.payload });
-    };
+    const events = captureBackendEvents(backend);
 
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "finish the draft",
-      runId: "run-local-authoritative-final",
-    });
+    await sendMainChat(backend, "finish the draft", "run-local-authoritative-final");
 
     registeredListener?.({
       runId: "run-local-authoritative-final",
@@ -3455,25 +3095,14 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("keeps final short replies like No after suppressing lead-fragment deltas", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
 
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "answer shortly",
-      runId: "run-local-no",
-    });
+    await sendMainChat(backend, "answer shortly", "run-local-no");
 
     registeredListener?.({
       runId: "run-local-no",
@@ -3520,25 +3149,14 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("marks local embedded replacement deltas", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
 
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "replace",
-      runId: "run-local-replace",
-    });
+    await sendMainChat(backend, "replace", "run-local-replace");
 
     registeredListener?.({
       runId: "run-local-replace",
@@ -3579,24 +3197,13 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("keeps internal context private when local deltas split its delimiters", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "split internal context",
-      runId: "run-local-split-context",
-    });
+    await sendMainChat(backend, "split internal context", "run-local-split-context");
 
     const deltas = [
       `Visible\n${INTERNAL_RUNTIME_CONTEXT_BEGIN}\n`,
@@ -3629,25 +3236,14 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("keeps a fallback response deliverable after a retryable lifecycle error", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
 
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "recover after timeout",
-      runId: "run-local-fallback",
-    });
+    await sendMainChat(backend, "recover after timeout", "run-local-fallback");
 
     registeredListener?.({
       runId: "run-local-fallback",
@@ -3700,7 +3296,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("emits side-result events for local /btw runs", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     loadSessionEntryMock.mockReturnValueOnce({
       cfg: {},
       canonicalKey: "agent:main:main",
@@ -3719,10 +3314,7 @@ describe("EmbeddedTuiBackend", () => {
     runBtwSideQuestionMock.mockResolvedValueOnce({ text: "nothing important" });
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
 
     backend.start();
     await backend.sendChat({
@@ -3774,7 +3366,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("emits side-result events for local /side alias runs", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     loadSessionEntryMock.mockReturnValueOnce({
       cfg: {},
       canonicalKey: "agent:main:main",
@@ -3793,10 +3384,7 @@ describe("EmbeddedTuiBackend", () => {
     runBtwSideQuestionMock.mockResolvedValueOnce({ text: "alias answer" });
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
 
     backend.start();
     await backend.sendChat({
@@ -3841,25 +3429,14 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("registers tool-first local runs before forwarding agent events", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-    const pending = deferred<{
-      payloads: Array<{ text: string }>;
-      meta: Record<string, unknown>;
-    }>();
+    const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
     const backend = new EmbeddedTuiBackend();
-    const events: Array<{ event: string; payload: unknown }> = [];
-    backend.onEvent = (evt) => {
-      events.push({ event: evt.event, payload: evt.payload });
-    };
+    const events = captureBackendEvents(backend);
 
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "run tool first",
-      runId: "run-tool-first",
-    });
+    await sendMainChat(backend, "run tool first", "run-tool-first");
 
     registeredListener?.({
       runId: "run-tool-first",
@@ -3913,7 +3490,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("aborts active local runs", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     let capturedSignal: AbortSignal | undefined;
     agentCommandFromIngressMock.mockImplementationOnce((opts: { abortSignal?: AbortSignal }) => {
       capturedSignal = opts.abortSignal;
@@ -3926,11 +3502,7 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "long task",
-      runId: "run-abort-1",
-    });
+    await sendMainChat(backend, "long task", "run-abort-1");
 
     const result = await backend.abortChat({
       sessionKey: "agent:main:main",
@@ -3943,7 +3515,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("keeps local BTW runs alive during a session-scoped abort", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     loadSessionEntryMock.mockReturnValue({
       cfg: {},
       canonicalKey: "agent:main:main",
@@ -3973,11 +3544,7 @@ describe("EmbeddedTuiBackend", () => {
 
     const backend = new EmbeddedTuiBackend();
     backend.start();
-    await backend.sendChat({
-      sessionKey: "agent:main:main",
-      message: "long task",
-      runId: "run-main-abort",
-    });
+    await sendMainChat(backend, "long task", "run-main-abort");
     await backend.sendChat({
       sessionKey: "agent:main:main",
       message: "/btw what changed?",
@@ -3999,7 +3566,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("passes explicit chat timeouts to the agent command as seconds", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     agentCommandFromIngressMock.mockResolvedValueOnce({
       payloads: [{ text: "hello" }],
       meta: {},
@@ -4027,8 +3593,6 @@ describe("EmbeddedTuiBackend", () => {
   });
 
   it("restores embedded mode and runtime loggers on stop", async () => {
-    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
-
     const backend = new EmbeddedTuiBackend();
     backend.start();
 

--- a/test/scripts/mac-elevation-host.test.ts
+++ b/test/scripts/mac-elevation-host.test.ts
@@ -185,6 +185,49 @@ function runInstaller(
   });
 }
 
+function runAuthenticatedMigrationInstall(
+  harness: ReturnType<typeof createInstallRollbackHarness>,
+  env: NodeJS.ProcessEnv = harness.env,
+) {
+  return runInstaller(
+    harness.installerPath,
+    [
+      "install",
+      "--archive",
+      harness.archivePath,
+      "--receipt",
+      harness.receiptPath,
+      ...receiptDigestArgs(harness.receiptPath),
+      "--app",
+      harness.appPath,
+      "--migrate-launch-agent",
+      harness.sourcePlist,
+    ],
+    env,
+  );
+}
+
+function runAuthenticatedElevationRecovery(
+  harness: ReturnType<typeof createInstallRollbackHarness>,
+) {
+  return runInstaller(
+    harness.installerPath,
+    [
+      "recover",
+      "--archive",
+      harness.archivePath,
+      "--receipt",
+      harness.receiptPath,
+      ...receiptDigestArgs(harness.receiptPath),
+      "--app",
+      harness.appPath,
+      "--state-dir",
+      harness.stateDir,
+    ],
+    harness.env,
+  );
+}
+
 function writeAppInfoPlist(appPath: string, sourceCommit: string, peekabooCommit: string): void {
   mkdirSync(path.join(appPath, "Contents", "MacOS"), { recursive: true });
   writeFileSync(
@@ -1493,22 +1536,7 @@ describe("mac elevation host command contract", () => {
       const harness = createInstallRollbackHarness();
       const pendingPath = path.join(harness.stateDir, "elevation-host-install.pending.json");
       writeFileSync(pendingPath, "other-install-transaction\n", "utf8");
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("incomplete elevation install transaction exists");
       expect(readFileSync(pendingPath, "utf8")).toBe("other-install-transaction\n");
@@ -1660,22 +1688,10 @@ describe("mac elevation host command contract", () => {
       expect(rejectedVerify.stderr).toContain("must not contain bundled CUA driver");
 
       const installation = createInstallRollbackHarness();
-      const rejectedInstall = runInstaller(
-        installation.installerPath,
-        [
-          "install",
-          "--archive",
-          installation.archivePath,
-          "--receipt",
-          installation.receiptPath,
-          ...receiptDigestArgs(installation.receiptPath),
-          "--app",
-          installation.appPath,
-          "--migrate-launch-agent",
-          installation.sourcePlist,
-        ],
-        { ...installation.env, TEST_CUA_DRIVER_KIND: "symlink" },
-      );
+      const rejectedInstall = runAuthenticatedMigrationInstall(installation, {
+        ...installation.env,
+        TEST_CUA_DRIVER_KIND: "symlink",
+      });
       expect(rejectedInstall.status).toBe(1);
       expect(rejectedInstall.stderr).toContain("must not contain bundled CUA driver");
     },
@@ -1986,22 +2002,7 @@ describe("mac elevation host command contract", () => {
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
       const priorFailedPath = `${harness.appPath}.failed-elevation-host-${"a".repeat(40)}`;
       mkdirSync(priorFailedPath);
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("could not bootstrap elevation host");
@@ -2183,22 +2184,7 @@ describe("mac elevation host command contract", () => {
           rollbackCuaDriverKind: "file",
           unsafeEntryEvidence: evidence,
         });
-        const result = runInstaller(
-          harness.installerPath,
-          [
-            "install",
-            "--archive",
-            harness.archivePath,
-            "--receipt",
-            harness.receiptPath,
-            ...receiptDigestArgs(harness.receiptPath),
-            "--app",
-            harness.appPath,
-            "--migrate-launch-agent",
-            harness.sourcePlist,
-          ],
-          harness.env,
-        );
+        const result = runAuthenticatedMigrationInstall(harness);
 
         expect(result.status).toBe(1);
         expect(result.stderr).toContain("Quarantined CUA-bearing elevation app");
@@ -2222,22 +2208,7 @@ describe("mac elevation host command contract", () => {
         rollbackCuaDriverKind: "file",
         unsafeEntryEvidence: "job",
       });
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("Quarantined CUA-bearing elevation app");
@@ -2255,22 +2226,7 @@ describe("mac elevation host command contract", () => {
           rollbackCuaDriverKind: "file",
           unsafeEntryEvidence: evidence,
         });
-        const result = runInstaller(
-          harness.installerPath,
-          [
-            "install",
-            "--archive",
-            harness.archivePath,
-            "--receipt",
-            harness.receiptPath,
-            ...receiptDigestArgs(harness.receiptPath),
-            "--app",
-            harness.appPath,
-            "--migrate-launch-agent",
-            harness.sourcePlist,
-          ],
-          harness.env,
-        );
+        const result = runAuthenticatedMigrationInstall(harness);
 
         expect(result.status).toBe(1);
         expect(result.stderr).not.toContain("Quarantined CUA-bearing elevation app");
@@ -2377,22 +2333,7 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
         migrationRestoreBootstrapFails: true,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const currentReceipt = readFileSync(
         path.join(harness.stateDir, "elevation-host-install.json"),
@@ -2402,22 +2343,7 @@ describe("mac elevation host command contract", () => {
       mkdirSync(resources, { recursive: true });
       writeExecutable(path.join(resources, "cua-driver"), "#!/bin/sh\nexit 0\n");
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
 
       expect(recovered.status).toBe(1);
       expect(recovered.stderr).toContain("Preserved current elevation app with bundled CUA driver");
@@ -2456,22 +2382,7 @@ describe("mac elevation host command contract", () => {
         "invalid\n",
         "utf8",
       );
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(
@@ -2491,22 +2402,7 @@ describe("mac elevation host command contract", () => {
         recreateSourceDuringBootout: true,
       });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(
@@ -2532,22 +2428,7 @@ describe("mac elevation host command contract", () => {
     "restores exact source ownership when termination arrives during custody transfer",
     () => {
       const harness = createInstallRollbackHarness({ signalDuringCustody: true });
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.signal).toBe("SIGTERM");
       expect(readFileSync(harness.sourcePlist, "utf8")).toBe(harness.sourceContents);
@@ -2564,22 +2445,7 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ raceMigrationCustodyDestination: true });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("could not take exact custody");
@@ -2605,22 +2471,7 @@ describe("mac elevation host command contract", () => {
       const harness = createInstallRollbackHarness({
         replaceMigrationSourceSameContentBeforeInitialCustody: true,
       });
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("could not take exact custody");
@@ -2663,22 +2514,7 @@ describe("mac elevation host command contract", () => {
         true,
       );
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status, recovered.stderr).toBe(0);
       expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
         oldBinary,
@@ -2695,41 +2531,11 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ killAfterPendingReceipt: true });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const interrupted = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const interrupted = runAuthenticatedMigrationInstall(harness);
       expect(interrupted.signal).toBe("SIGKILL");
       expect(readFileSync(harness.sourcePlist, "utf8")).toBe(harness.sourceContents);
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status, recovered.stderr).toBe(0);
       expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
         oldBinary,
@@ -2742,41 +2548,11 @@ describe("mac elevation host command contract", () => {
     "rejects a same-content migration source replacement after install process death",
     () => {
       const harness = createInstallRollbackHarness({ killAfterInitialMigrationCustody: true });
-      const interrupted = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const interrupted = runAuthenticatedMigrationInstall(harness);
       expect(interrupted.signal).toBe("SIGKILL");
       writeFileSync(harness.sourcePlist, harness.sourceContents, "utf8");
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status).toBe(1);
       expect(recovered.stderr).toContain(
         "pending migration source identity no longer matches the prepared transaction",
@@ -2793,41 +2569,11 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ killAfterRollbackAppCustody: true });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const interrupted = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const interrupted = runAuthenticatedMigrationInstall(harness);
       expect(interrupted.signal).toBe("SIGKILL");
       expect(existsSync(harness.appPath)).toBe(false);
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status, recovered.stderr).toBe(0);
       expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
         oldBinary,
@@ -2846,22 +2592,7 @@ describe("mac elevation host command contract", () => {
         replaceAuthenticatedRenameHelperBeforeUse: true,
       });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("authenticated elevation helper could not sync");
@@ -2877,22 +2608,7 @@ describe("mac elevation host command contract", () => {
     "restores exact source ownership when hangup arrives during custody transfer",
     () => {
       const harness = createInstallRollbackHarness({ hupDuringCustody: true });
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.signal).toBe("SIGHUP");
       expect(readFileSync(harness.sourcePlist, "utf8")).toBe(harness.sourceContents);
@@ -2912,22 +2628,7 @@ describe("mac elevation host command contract", () => {
         signalBeforeRollbackAppMove: true,
       });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.signal).toBe("SIGTERM");
       expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
@@ -2944,22 +2645,7 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ danglingRollbackDuringMove: true });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("could not take verified custody");
@@ -2976,22 +2662,7 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ restartAppDuringBootout: true });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("an OpenClaw app process survived owner shutdown");
@@ -3017,22 +2688,7 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ transientAppRestartReloadsJob: true });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("migration LaunchAgent reloaded during owner shutdown");
@@ -3050,22 +2706,7 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ failLsofInspection: true });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("an OpenClaw app process survived owner shutdown");
@@ -3089,22 +2730,7 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ failPgrepInspection: true });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("an OpenClaw app process survived owner shutdown");
@@ -3127,22 +2753,7 @@ describe("mac elevation host command contract", () => {
     "rejects a rollback app whose non-native architecture fails signature validation",
     () => {
       const harness = createInstallRollbackHarness({ rollbackNonNativeSignatureInvalid: true });
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(
@@ -3158,22 +2769,7 @@ describe("mac elevation host command contract", () => {
     "preserves rollback evidence when automatic recovery cannot restore the source owner",
     () => {
       const harness = createInstallRollbackHarness({ recreateSourceOnFailure: true });
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("automatic elevation-host rollback was incomplete");
@@ -3192,22 +2788,7 @@ describe("mac elevation host command contract", () => {
     "commits only after the exact macOS computer-use node reconnects through the new app",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status, result.stderr).toBe(0);
       expect(result.stdout).toContain("Elevation host installed: pid=555555");
@@ -3235,22 +2816,7 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
         sameSourceExistingApp: true,
       });
-      const first = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const first = runAuthenticatedMigrationInstall(harness);
       expect(first.status, first.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const firstReceipt = JSON.parse(readFileSync(installReceiptPath, "utf8")) as {
@@ -3296,22 +2862,7 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
       });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("artifact receipt x86_64 CDHash mismatch");
@@ -3332,22 +2883,7 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
       });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
@@ -3367,22 +2903,7 @@ describe("mac elevation host command contract", () => {
         removeInstalledExecutableAfterReadiness: true,
       });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
@@ -3406,22 +2927,7 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
         signalDuringReceiptCommit: true,
       });
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.signal).toBe("SIGTERM");
       expect(existsSync(harness.sourcePlist)).toBe(false);
@@ -3441,22 +2947,7 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
       });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const result = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const result = runAuthenticatedMigrationInstall(harness);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain("could not atomically publish the install receipt");
@@ -3473,22 +2964,7 @@ describe("mac elevation host command contract", () => {
     "rejects managed upgrades that change the recorded config or node profile",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
 
       const mismatchedConfig = runInstaller(
@@ -3546,22 +3022,7 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
 
       const recovered = runInstaller(
@@ -3589,22 +3050,7 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       rmSync(harness.appPath, { recursive: true });
@@ -3620,22 +3066,7 @@ describe("mac elevation host command contract", () => {
       );
       expect(existsSync(installReceiptPath)).toBe(true);
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status, recovered.stderr).toBe(0);
       expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
         oldBinary,
@@ -3654,22 +3085,7 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
       });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
 
@@ -3706,22 +3122,7 @@ describe("mac elevation host command contract", () => {
         killAfterMigrationRestoreBootstrapOnce: true,
         launchdBootstrapFails: false,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
 
       const interrupted = runInstaller(
@@ -3758,22 +3159,7 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
       });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       rmSync(harness.appPath, { recursive: true });
@@ -3814,22 +3200,7 @@ describe("mac elevation host command contract", () => {
         killDuringMigrationRestoreBootstrapOnce: true,
         launchdBootstrapFails: false,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const recoveryArgs = ["recover", "--app", harness.appPath, "--state-dir", harness.stateDir];
       const interrupted = runInstaller(harness.installerPath, recoveryArgs, harness.env);
@@ -3854,22 +3225,7 @@ describe("mac elevation host command contract", () => {
     "rejects a symlinked current app before recovery mutation",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const receiptContents = readFileSync(installReceiptPath, "utf8");
@@ -3877,22 +3233,7 @@ describe("mac elevation host command contract", () => {
       rmSync(harness.appPath, { recursive: true });
       symlinkSync(backupPath, harness.appPath);
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status).toBe(1);
       expect(recovered.stderr).toContain("current OpenClaw app has an unsupported entry type");
       expect(readFileSync(installReceiptPath, "utf8")).toBe(receiptContents);
@@ -3905,41 +3246,11 @@ describe("mac elevation host command contract", () => {
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       rmSync(path.join(harness.appPath, "Contents", "Info.plist"));
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status, recovered.stderr).toBe(0);
       expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
         oldBinary,
@@ -3960,43 +3271,13 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
         recreateAppDuringDamagedCustody: true,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const receiptContents = readFileSync(installReceiptPath, "utf8");
       rmSync(path.join(harness.appPath, "Contents", "Info.plist"));
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status).toBe(1);
       expect(recovered.stderr).toContain("Preserved damaged current app at");
       expect(existsSync(path.join(harness.appPath, "Contents", "replacement"))).toBe(true);
@@ -4016,44 +3297,14 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
         replaceDamagedAppDirectoryBeforeCustody: true,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const receiptContents = readFileSync(installReceiptPath, "utf8");
       const backupPath = (JSON.parse(receiptContents) as { backupPath: string }).backupPath;
       rmSync(path.join(harness.appPath, "Contents", "Info.plist"));
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status).toBe(1);
       expect(recovered.stderr).toContain("Restored replacement app entry at");
       expect(recovered.stderr).toContain(
@@ -4076,43 +3327,13 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
         symlinkDamagedAppBeforeCustody: true,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const receiptContents = readFileSync(installReceiptPath, "utf8");
       rmSync(path.join(harness.appPath, "Contents", "Info.plist"));
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status).toBe(1);
       expect(lstatSync(harness.appPath).isSymbolicLink()).toBe(true);
       expect(readFileSync(installReceiptPath, "utf8")).toBe(receiptContents);
@@ -4126,44 +3347,14 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
         migrationRestoreBootstrapFails: true,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const receiptContents = readFileSync(installReceiptPath, "utf8");
       const backupPath = (JSON.parse(receiptContents) as { backupPath: string }).backupPath;
       rmSync(harness.appPath, { recursive: true });
 
-      const recovered = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const recovered = runAuthenticatedElevationRecovery(harness);
       expect(recovered.status).toBe(1);
       expect(existsSync(harness.appPath)).toBe(false);
       expect(existsSync(backupPath)).toBe(true);
@@ -4184,22 +3375,7 @@ describe("mac elevation host command contract", () => {
         migrationRestoreBootstrapFails: true,
         replaceMigrationSourceDuringReversalCustody: true,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const receiptContents = readFileSync(installReceiptPath, "utf8");
@@ -4230,22 +3406,7 @@ describe("mac elevation host command contract", () => {
         migrationRestoreBootstrapFails: true,
         replaceMigrationSourceSameContentBeforeCustody: true,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const receiptContents = readFileSync(installReceiptPath, "utf8");
@@ -4283,22 +3444,7 @@ describe("mac elevation host command contract", () => {
         migrationRestoreBootstrapFails: true,
         symlinkMigrationSourceDuringReversalCustody: true,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const receiptContents = readFileSync(installReceiptPath, "utf8");
@@ -4318,22 +3464,7 @@ describe("mac elevation host command contract", () => {
     "refuses recovery before mutation when process inspection tools are unavailable",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const binDir = path.join(harness.env.HOME, "bin");
       rmSync(path.join(binDir, "lsof"));
@@ -4364,22 +3495,7 @@ describe("mac elevation host command contract", () => {
     "preserves recovery custody across uninstall until explicit recovery",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
 
@@ -4407,22 +3523,10 @@ describe("mac elevation host command contract", () => {
     "recovers across simulated native and Rosetta host selection using both architecture CDHashes",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        { ...harness.env, TEST_NATIVE_ARCH: "arm64" },
-      );
+      const installed = runAuthenticatedMigrationInstall(harness, {
+        ...harness.env,
+        TEST_NATIVE_ARCH: "arm64",
+      });
       expect(installed.status, installed.stderr).toBe(0);
 
       const receipt = JSON.parse(
@@ -4464,22 +3568,7 @@ describe("mac elevation host command contract", () => {
         signalDuringRecoveryAppMove: true,
       });
       const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
 
       const recovered = runInstaller(
@@ -4502,22 +3591,7 @@ describe("mac elevation host command contract", () => {
     "recovers a migrated source owner when no prior app existed",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const receipt = JSON.parse(readFileSync(installReceiptPath, "utf8")) as {
@@ -4551,22 +3625,7 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
         migrationRestoreBootstrapFails: true,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const currentReceipt = readFileSync(installReceiptPath, "utf8");
@@ -4603,22 +3662,7 @@ describe("mac elevation host command contract", () => {
         launchdBootstrapFails: false,
         migrationRestoreBootstrapFails: true,
       });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const currentReceipt = readFileSync(installReceiptPath, "utf8");
@@ -4642,22 +3686,7 @@ describe("mac elevation host command contract", () => {
     "refuses recovery before mutation when the recorded app backup is missing",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const currentReceipt = readFileSync(installReceiptPath, "utf8");
@@ -4689,22 +3718,7 @@ describe("mac elevation host command contract", () => {
     "refuses recovery before mutation when the app backup signature is invalid",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const currentReceipt = readFileSync(installReceiptPath, "utf8");
@@ -4736,22 +3750,7 @@ describe("mac elevation host command contract", () => {
     "refuses a corrupt migration backup before stopping the current generation",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const currentReceipt = readFileSync(installReceiptPath, "utf8");
@@ -4790,22 +3789,7 @@ describe("mac elevation host command contract", () => {
       const originalBinary = readFileSync(
         path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"),
       );
-      const firstInstall = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const firstInstall = runAuthenticatedMigrationInstall(harness);
       expect(firstInstall.status, firstInstall.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const currentReceipt = JSON.parse(readFileSync(installReceiptPath, "utf8")) as Record<
@@ -4881,22 +3865,7 @@ describe("mac elevation host command contract", () => {
       );
       expect(readFileSync(installReceiptPath, "utf8")).toBe(firstReceipt);
 
-      const legacyRecovery = runInstaller(
-        harness.installerPath,
-        [
-          "recover",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--state-dir",
-          harness.stateDir,
-        ],
-        harness.env,
-      );
+      const legacyRecovery = runAuthenticatedElevationRecovery(harness);
       expect(legacyRecovery.status, legacyRecovery.stderr).toBe(0);
       expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
         originalBinary,
@@ -4910,22 +3879,7 @@ describe("mac elevation host command contract", () => {
     "inherits legacy managed-upgrade config from the installed elevation plist",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const currentReceipt = JSON.parse(readFileSync(installReceiptPath, "utf8")) as Record<
@@ -4989,22 +3943,7 @@ describe("mac elevation host command contract", () => {
     "refuses recovery when another owner recreates the source LaunchAgent path",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       writeFileSync(harness.sourcePlist, "replacement owner\n", "utf8");
       const installedBinary = readFileSync(
@@ -5038,22 +3977,7 @@ describe("mac elevation host command contract", () => {
       expect(restoreBody).not.toContain('ln "$restore_tmp" "$destination"');
 
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
       const installedBinary = readFileSync(
         path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"),
@@ -5077,22 +4001,7 @@ describe("mac elevation host command contract", () => {
     "rejects a receipt backup path that lexically escapes the canonical state directory",
     () => {
       const harness = createInstallRollbackHarness({ launchdBootstrapFails: false });
-      const installed = runInstaller(
-        harness.installerPath,
-        [
-          "install",
-          "--archive",
-          harness.archivePath,
-          "--receipt",
-          harness.receiptPath,
-          ...receiptDigestArgs(harness.receiptPath),
-          "--app",
-          harness.appPath,
-          "--migrate-launch-agent",
-          harness.sourcePlist,
-        ],
-        harness.env,
-      );
+      const installed = runAuthenticatedMigrationInstall(harness);
       expect(installed.status, installed.stderr).toBe(0);
 
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");


### PR DESCRIPTION
## What Problem This Solves

The macOS elevation, embedded TUI, update-runner, and diagnostic suites repeated large command, recovery, logging, and module fixtures. That duplication made security-sensitive test intent harder to audit and current-main cases harder to extend safely.

## Why This Change Was Made

This maintainer-requested test refactor consolidates the repeated fixtures inside their owning suites while preserving every existing behavior assertion. Current-main update and diagnostic cases are retained; production code is untouched.

AI-assisted maintainer cleanup. I reviewed the final code, proof, and exact landing diff.

## User Impact

No runtime behavior changes. Contributors get substantially smaller test fixtures with the same platform, security, recovery, routing, and privacy coverage.

## Evidence

- Test-only LOC: `+598/-3078` (net `-2480`) across exactly four files; production LOC: `+0/-0`.
- Current-main base: `b977ccb21e2b4b8bff05729548ea1b1558a74a33`; exact head: `c60510488126f63bd228215fd243bd65721a2d4e`.
- Exact binary diff SHA-256: `19fb3be4224ccf4e93aa55965991744bb7994aec29a4a8516aeac061e242af06`.
- Fresh owner proof: macOS elevation 107/107, embedded TUI 96/96, diagnostics 84/84, update runner 74/74.
- Current-main update timeout/install-root and diagnostic recovery-outcome cases are preserved; macOS and TUI candidates remain byte-identical to their independently verified frozen versions.
- Formatting, targeted typed lint, script lint, scope audit, and `git diff --check` passed.
- Independent verification found no weakened timeout, security, transaction, redaction, session, or routing assertion.
- Mandatory exact-source autoreview: secret scan clean; isolated Codex review reported no actionable findings (0.99 patch-correctness confidence).
