### PR TITLE
fix(ai): record provider-returned model in managed openai completions stream

### DIFF
--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -414,6 +414,12 @@ export async function processCompletionsStream(
     notifyLlmRequestActivity(options?.signal);
     const chunk = rawChunk as OpenAICompatibleChatCompletionChunk;
     output.responseId ||= chunk.id;
+    // Retain the provider-returned model when it differs from the requested id so
+    // routed/alias responses are not misattributed, matching the direct provider
+    // stream and the anthropic/responses managed transports.
+    if (typeof chunk.model === "string" && chunk.model.length > 0 && chunk.model !== model.id) {
+      output.responseModel ||= chunk.model;
+    }
     let hasReasoningUsageActivity = false;
     if (chunk.usage) {
       output.usage = parseOpenAICompletionsUsage(chunk.usage, model);

--- a/packages/ai/test/fixtures/provider-transport-parity/openai-success.snap.txt
+++ b/packages/ai/test/fixtures/provider-transport-parity/openai-success.snap.txt
@@ -207,6 +207,7 @@
       "provider": "openai",
       "model": "gpt-5.5",
       "responseId": "chatcmpl-parity",
+      "responseModel": "gpt-5.5-response",
       "openclawDelivery": {
         "textPhaseRequiresTerminal": true
       },


### PR DESCRIPTION
Closes #127624

## What Problem This Solves

Managed OpenAI Chat Completions preserved response ID and usage but never copied the required `ChatCompletionChunk.model` into `AssistantMessage.responseModel`, so routed/alias requests lost the concrete upstream model and terminal receipts falsely reported the requested model with `rerouted:false`. Direct OpenAI Completions already records a differing returned model; managed transport was the sole divergent sibling (Anthropic direct/transport and OpenAI Responses transports all preserve it).

## Why This Change Was Made

`processCompletionsStream` in `packages/ai/src/transports/openai-completions-stream.ts` now applies the exact guard the direct provider uses (`packages/ai/src/providers/openai-completions.ts:472-474`) right after response-ID ownership:

```ts
if (typeof chunk.model === "string" && chunk.model.length > 0 && chunk.model !== model.id) {
  output.responseModel ||= chunk.model;
}
```

The shared mutable output flows into the terminal via `finalizeTransportStream`, and `MutableAssistantOutput` already carries optional `responseModel`.

## User Impact

- Managed completions runs now report the provider-returned effective model; reroute/effective-model diagnostics stop misattributing routed responses.
- Same-model streams are unchanged (guard requires a differing nonempty value), so no snapshot or transcript churn beyond the intended parity fix.

## Evidence

- The checked-in parity fixture (`requested gpt-5.5` / returned `gpt-5.5-response`) previously codified the divergence: direct snapshot had `"responseModel": "gpt-5.5-response"`, transport snapshot omitted it. After this change the parity snapshot gains exactly one line - `"responseModel": "gpt-5.5-response"` on the transport terminal - matching the anthropic snapshot shape.
- Focused proof (Windows, Node v24.15.0): `node node_modules/vitest/vitest.mjs run packages/ai/src/provider-transport-parity.test.ts -u` -> 8 passed, 1 snapshot updated (diff verified to contain only the expected line).

### Independently verified managed HTTP/SSE behavior

Trusted current-main source was exercised against a real loopback OpenAI-compatible HTTP/SSE server, the installed OpenAI SDK, and the public LLM runtime registry explicitly configured with the actual managed completions transport. Registering the built-in direct provider instead would incorrectly bypass the affected owner.

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs packages/ai/src/transports/openai-completions-stream.integration.test.ts --testNamePattern 'managed HTTP/SSE transport'

Before owner fix: 1 failed, 1 passed
  Requested model: gpt-requested
  Provider-returned model: gpt-effective-first
  Expected responseModel: gpt-effective-first
  Actual responseModel: undefined

After applying this PR's exact owner guard: 2 passed, exit 0
  First differing provider model retained despite a later differing model.
  Same-model and empty-model chunks retain an absent responseModel.
  The outbound requested model and delivered assistant text both remain unchanged.
```

This is genuine local HTTP/SSE plus installed-SDK managed-runtime proof; it is not an authenticated external OpenAI request. The installed OpenAI SDK declares `ChatCompletionChunk.model` as required. Responses/Codex streaming has a distinct header-authoritative model contract and is intentionally untouched.
