### PR TITLE
fix(discord): resolve omitted set-presence accountId through the configured default account

### DIFF
--- a/extensions/discord/src/actions/runtime.presence.test.ts
+++ b/extensions/discord/src/actions/runtime.presence.test.ts
@@ -1,8 +1,8 @@
 // Discord tests cover runtime.presence plugin behavior.
-import type { DiscordActionConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { DiscordActionConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayPlugin } from "../internal/gateway.js";
-import { clearGateways, registerGateway } from "../monitor/gateway-registry.js";
+import { clearGateways, getGateway, registerGateway } from "../monitor/gateway-registry.js";
 import type { ActionGate } from "../runtime-api.js";
 import { handleDiscordPresenceAction } from "./runtime.presence.js";
 
@@ -14,19 +14,22 @@ function createMockGateway(connected = true): GatewayPlugin {
 
 const presenceEnabled: ActionGate<DiscordActionConfig> = (key) => key === "presence";
 const presenceDisabled: ActionGate<DiscordActionConfig> = () => false;
+const discordCfg = { channels: { discord: {} } } as OpenClawConfig;
 
 describe("handleDiscordPresenceAction", () => {
   async function setPresence(
     params: Record<string, unknown>,
     actionGate: ActionGate<DiscordActionConfig> = presenceEnabled,
   ) {
-    return await handleDiscordPresenceAction("setPresence", params, actionGate);
+    return await handleDiscordPresenceAction("setPresence", params, actionGate, discordCfg);
   }
 
   beforeEach(() => {
     mockUpdatePresence.mockClear();
     clearGateways();
-    registerGateway(undefined, createMockGateway());
+    // Production registers gateways under concrete normalized account ids;
+    // registering under "default" mirrors runDiscordGatewayLifecycle.
+    registerGateway("default", createMockGateway());
   });
 
   it("sets playing activity", async () => {
@@ -34,6 +37,7 @@ describe("handleDiscordPresenceAction", () => {
       "setPresence",
       { activityType: "playing", activityName: "with fire", status: "online" },
       presenceEnabled,
+      discordCfg,
     );
     expect(mockUpdatePresence).toHaveBeenCalledWith({
       since: null,
@@ -47,6 +51,30 @@ describe("handleDiscordPresenceAction", () => {
     );
     expect(payload.ok).toBe(true);
     expect(payload.activities[0]).toEqual({ type: 0, name: "with fire" });
+  });
+
+  it("resolves an omitted accountId to the configured default account", async () => {
+    await setPresence({ status: "online" });
+    expect(getGateway("default")).toBeDefined();
+    expect(mockUpdatePresence).toHaveBeenCalled();
+  });
+
+  it("resolves the configured defaultAccount when accountId is omitted", async () => {
+    clearGateways();
+    registerGateway("ops-bot", createMockGateway());
+    const cfg = {
+      channels: {
+        discord: {
+          defaultAccount: "ops-bot",
+          accounts: { "ops-bot": {} },
+        },
+      },
+    } as OpenClawConfig;
+
+    await handleDiscordPresenceAction("setPresence", { status: "idle" }, presenceEnabled, cfg);
+
+    expect(getGateway("default")).toBeUndefined();
+    expect(mockUpdatePresence).toHaveBeenCalled();
   });
 
   it.each([
@@ -141,7 +169,7 @@ describe("handleDiscordPresenceAction", () => {
 
   it("errors when gateway is not connected", async () => {
     clearGateways();
-    registerGateway(undefined, createMockGateway(false));
+    registerGateway("default", createMockGateway(false));
     await expect(setPresence({ status: "dnd" })).rejects.toThrow(/not connected/);
   });
 
@@ -159,8 +187,8 @@ describe("handleDiscordPresenceAction", () => {
   });
 
   it("rejects unknown presence actions", async () => {
-    await expect(handleDiscordPresenceAction("unknownAction", {}, presenceEnabled)).rejects.toThrow(
-      /Unknown presence action/,
-    );
+    await expect(
+      handleDiscordPresenceAction("unknownAction", {}, presenceEnabled, discordCfg),
+    ).rejects.toThrow(/Unknown presence action/);
   });
 });

--- a/extensions/discord/src/actions/runtime.presence.ts
+++ b/extensions/discord/src/actions/runtime.presence.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements runtime.presence behavior.
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveDefaultDiscordAccountId } from "../accounts.js";
 import type { Activity, UpdatePresenceData } from "../internal/gateway.js";
 import { getGateway } from "../monitor/gateway-registry.js";
 import {
@@ -8,6 +9,7 @@ import {
   jsonResult,
   readStringParam,
   type DiscordActionConfig,
+  type OpenClawConfig,
 } from "../runtime-api.js";
 
 const ACTIVITY_TYPE_MAP: Record<string, number> = {
@@ -25,6 +27,7 @@ export async function handleDiscordPresenceAction(
   action: string,
   params: Record<string, unknown>,
   isActionEnabled: ActionGate<DiscordActionConfig>,
+  cfg: OpenClawConfig,
 ): Promise<AgentToolResult<unknown>> {
   if (action !== "setPresence") {
     throw new Error(`Unknown presence action: ${action}`);
@@ -34,7 +37,10 @@ export async function handleDiscordPresenceAction(
     throw new Error("Discord presence changes are disabled.");
   }
 
-  const accountId = readStringParam(params, "accountId");
+  // Production gateways register under concrete normalized account ids, so an
+  // omitted accountId must resolve through the configured default (matching
+  // messaging/guild actions) instead of the registry's omitted-id sentinel.
+  const accountId = readStringParam(params, "accountId") ?? resolveDefaultDiscordAccountId(cfg);
   const gateway = getGateway(accountId);
   if (!gateway) {
     throw new Error(

--- a/extensions/discord/src/actions/runtime.ts
+++ b/extensions/discord/src/actions/runtime.ts
@@ -75,7 +75,7 @@ export async function handleDiscordAction(
     return await handleDiscordModerationAction(action, params, isActionEnabled, cfg);
   }
   if (presenceActions.has(action)) {
-    return await handleDiscordPresenceAction(action, params, isActionEnabled);
+    return await handleDiscordPresenceAction(action, params, isActionEnabled, cfg);
   }
   throw new Error(`Unknown action: ${action}`);
 }


### PR DESCRIPTION
Closes #127702

## What Problem This Solves

`set-presence` failed from a default (`main:main`) account setup whenever `accountId` was omitted: `handleDiscordPresenceAction` passed the raw optional param into the gateway registry, whose omitted-id sentinel key is never registered in production (gateways always register under normalized concrete ids such as `default`). The result was "Discord gateway not available... The bot may not be connected." even while the bot was connected. Messaging and guild actions resolve the configured default when the id is omitted; presence was the outlier.

## Why This Change Was Made

- `runtime.presence.ts` now resolves `readStringParam(params, "accountId") ?? resolveDefaultDiscordAccountId(cfg)`, mirroring `runtime.guild.ts` / `runtime.messaging.shared.ts`.
- `handleDiscordAction` threads its existing `cfg` into the presence handler, matching the moderation handler signature.

## User Impact

- `set-presence` without an explicit accountId now targets the configured/default Discord account, consistent with every other Discord action.
- Explicit-accountId behavior is unchanged; multi-account setups using `defaultAccount` resolve correctly.

## Evidence

Focused proof (Windows, Node v24.15.0): `node node_modules/vitest/vitest.mjs run extensions/discord/src/actions/runtime.presence.test.ts` -> 20 passed.

Test updates close the masking gap: gateways now register under `"default"` (production-realistic) instead of the omitted-id sentinel, plus two regression tests - omitted id reaches the default gateway, and a configured `defaultAccount: "ops-bot"` (with listed account) routes there.
