### PR TITLE
improve(msteams): avoid repeated activity preparation on retries

### DIFF
--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -508,13 +508,14 @@ describe("msteams messenger", () => {
       expect(retryEvents).toEqual([{ nextAttempt: 2, delayMs: 0 }]);
     });
 
-    it("retries full activity preparation when media upload fails transiently", async () => {
+    it("retries media preparation but reuses it after provider dispatch starts", async () => {
       const tmpDir = await mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "msteams-retry-"));
       const localFile = path.join(tmpDir, "retry.txt");
       await writeFile(localFile, "hello");
 
       try {
         const attempts: string[] = [];
+        const providerPayloads: string[] = [];
         const retryEvents: Array<{ nextAttempt: number; delayMs: number }> = [];
         let uploadAttempts = 0;
         graphUploadMockState.uploadAndShareSharePoint.mockImplementation(async () => {
@@ -535,8 +536,12 @@ describe("msteams messenger", () => {
           name: "retry.txt",
         });
 
+        const sendActivity = createRecordedSendActivity(attempts, 429);
         const ctx = {
-          sendActivity: createRecordedSendActivity(attempts),
+          sendActivity: async (activity: unknown) => {
+            providerPayloads.push(JSON.stringify(activity));
+            return await sendActivity(activity);
+          },
         };
         const ids = await sendMSTeamsMessages({
           replyStyle: "thread",
@@ -555,14 +560,18 @@ describe("msteams messenger", () => {
             getAccessToken: async () => "token",
           },
           sharePointSiteId: "site-123",
-          retry: { maxAttempts: 2, baseDelayMs: 0, maxDelayMs: 0 },
+          retry: { maxAttempts: 3, baseDelayMs: 0, maxDelayMs: 0 },
           onRetry: (e) => retryEvents.push({ nextAttempt: e.nextAttempt, delayMs: e.delayMs }),
         });
 
         expect(uploadAttempts).toBe(2);
-        expect(attempts).toEqual(["one"]);
+        expect(attempts).toEqual(["one", "one"]);
+        expect(providerPayloads[1]).toBe(providerPayloads[0]);
         expect(ids).toEqual(["id:one"]);
-        expect(retryEvents).toEqual([{ nextAttempt: 2, delayMs: 0 }]);
+        expect(retryEvents).toEqual([
+          { nextAttempt: 2, delayMs: 0 },
+          { nextAttempt: 3, delayMs: 0 },
+        ]);
       } finally {
         await rm(tmpDir, { recursive: true, force: true });
       }

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -452,12 +452,15 @@ export async function sendMSTeamsMessages(params: {
     message: MSTeamsRenderedMessage,
     messageIndex: number,
   ): Promise<string> => {
+    let activity: Record<string, unknown> | undefined;
     let pendingUploadId: string | undefined;
     let response: unknown;
     try {
       response = await sendWithRetry(
         async () => {
-          const activity = await buildActivity(
+          // Retry failed preparation, but keep its successful I/O and SharePoint work
+          // out of subsequent provider retries.
+          activity ??= await buildActivity(
             message,
             params.conversationRef,
             params.tokenProvider,
@@ -466,14 +469,11 @@ export async function sendMSTeamsMessages(params: {
             { feedbackLoopEnabled: params.feedbackLoopEnabled },
           );
 
-          // Extract and strip the internal-only pending upload tag before sending.
-          pendingUploadId =
+          pendingUploadId ??=
             typeof activity["_pendingUploadId"] === "string"
               ? activity["_pendingUploadId"]
               : undefined;
-          if (pendingUploadId) {
-            delete activity["_pendingUploadId"];
-          }
+          delete activity["_pendingUploadId"];
 
           providerDispatchStarted = true;
           return await sendFn(activity);


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams replay-safe provider retries repeated already-successful activity preparation. For media messages, a transient provider 429 could reread and re-encode the attachment or repeat SharePoint upload and drive-item projection before retrying the same send.

## Why This Change Was Made

Successful preparation is retained only for the current message and reused across provider retries. Preparation failures still leave the activity unset, so replay-safe preparation errors retry exactly as before; retry policy, payload projection, and pending-upload bookkeeping are unchanged.

## User Impact

Teams sends recover from transient provider failures without repeating completed media or SharePoint work. Ordinary sends and failure behavior are unchanged.

## Evidence

- Mixed preparation/provider retry regression: transient upload 429 → successful upload → provider 429 → successful send now performs 2 uploads instead of the baseline 3, while both provider attempts serialize to the same payload.
- Controlled 100 ms/upload reproduction: 358 ms before → 244 ms after (31.8% lower in this retry scenario).
- Focused regression: 1 passed / 45 skipped.
- Owner and sibling verification: 6 files / 148 tests passed.
- `node scripts/check-changed.mjs -- extensions/msteams/src/messenger.ts extensions/msteams/src/messenger.test.ts` passed all selected format, boundary, dead-export, typecheck, lint, guard, and import-cycle checks.
- `git diff --check` passed.
- Fresh autoreview: TruffleHog clean; Codex `gpt-5.6-sol` with high reasoning reported no P0/P1 findings (correctness confidence 0.96).
