### PR TITLE
fix(slack): prevent stale debounce state after duplicate events

### DIFF
--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -563,6 +563,47 @@ describe("createSlackMessageHandler", () => {
     expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
   });
 
+  it("retires a buffered key when replay filtering drops every entry", async () => {
+    const handler = createSlackMessageHandler({
+      ctx: createContext(),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+    const bufferedMessage = {
+      type: "message" as const,
+      channel: "C111",
+      user: "U111",
+      ts: "1709000000.000300",
+      text: "duplicate buffered text",
+    };
+
+    await handler(bufferedMessage as never, { source: "message" });
+    const first = enqueueMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    await runOnFlush([first]);
+
+    await handler(bufferedMessage as never, { source: "message" });
+    const duplicate = enqueueMock.mock.calls[1]?.[0] as Record<string, unknown>;
+    await runOnFlush([duplicate]);
+    expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(1);
+    flushKeyMock.mockClear();
+
+    await handler(
+      {
+        type: "message",
+        subtype: "file_share",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000400",
+        text: "file follows",
+        files: [{ id: "F1" }],
+      } as never,
+      { source: "message" },
+    );
+
+    expect(flushKeyMock).not.toHaveBeenCalled();
+  });
+
   it("waits for debounced dispatch completion when requested by relay delivery", async () => {
     const { handler } = createHandlerWithTracker();
     const handled = handler(

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -208,6 +208,29 @@ export function createSlackMessageHandler(params: {
             .filter((completion) => completion !== undefined);
           try {
             await (async () => {
+              const flushedEntry = entries.at(-1);
+              if (flushedEntry) {
+                const teamId = flushedEntry.opts.eventScope?.teamId;
+                const flushedKey = buildSlackDebounceKey(
+                  flushedEntry.message,
+                  ctx.accountId,
+                  teamId,
+                );
+                const topLevelConversationKey = buildTopLevelSlackConversationKey(
+                  flushedEntry.message,
+                  ctx.accountId,
+                  teamId,
+                );
+                if (flushedKey && topLevelConversationKey) {
+                  const pendingKeys = pendingTopLevelDebounceKeys.get(topLevelConversationKey);
+                  if (pendingKeys) {
+                    pendingKeys.delete(flushedKey);
+                    if (pendingKeys.size === 0) {
+                      pendingTopLevelDebounceKeys.delete(topLevelConversationKey);
+                    }
+                  }
+                }
+              }
               // Logical-identity claims: Slack sends message + app_mention twins with
               // distinct event_ids for one post, so the durable queue cannot dedupe
               // them. Same-flush twins share one claim and one logical message while
@@ -270,22 +293,6 @@ export function createSlackMessageHandler(params: {
               if (!last) {
                 releaseClaims();
                 return;
-              }
-              const teamId = last.opts.eventScope?.teamId;
-              const flushedKey = buildSlackDebounceKey(last.message, ctx.accountId, teamId);
-              const topLevelConversationKey = buildTopLevelSlackConversationKey(
-                last.message,
-                ctx.accountId,
-                teamId,
-              );
-              if (flushedKey && topLevelConversationKey) {
-                const pendingKeys = pendingTopLevelDebounceKeys.get(topLevelConversationKey);
-                if (pendingKeys) {
-                  pendingKeys.delete(flushedKey);
-                  if (pendingKeys.size === 0) {
-                    pendingTopLevelDebounceKeys.delete(topLevelConversationKey);
-                  }
-                }
               }
               const combinedText =
                 surviving.length === 1


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where duplicate Slack message events that were correctly filtered during a debounce flush left their private pending-key registration behind. Over time, unique duplicate events could grow that registry and make every later immediate same-conversation message perform increasing no-op flush work.

## Why This Change Was Made

The Slack debounce owner now retires its top-level pending key as soon as the flush begins, before replay claims and every early-return path. Ordinary aggregation, replay dedupe, and immediate follow-up ordering remain unchanged.

## User Impact

Long-running Slack monitors no longer retain stale per-message debounce keys or repeatedly revisit them when files, controls, and other immediate messages arrive.

## Evidence

- Regression-first: the new duplicate-only flush case failed before the fix because `flushKey` was called once with stale key `slack:default:C111:1709000000.000300:U111`.
- Focused owner suite: `OPENCLAW_VITEST_MAX_WORKERS=4 node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler.test.ts` — 25/25 passed.
- Full changed-files gate: `node scripts/check-changed.mjs -- extensions/slack/src/monitor/message-handler.ts extensions/slack/src/monitor/message-handler.test.ts` — passed all extension production/test typecheck, lint, format, boundary, dead-code, database-first, media helper, sidecar-loader, and import-cycle checks.
- `git diff --check` — passed.
- Autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings; correctness confidence 0.98.
