### PR TITLE
refactor(protocol): rely on synthesized Swift coding keys

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -667,11 +667,6 @@ public struct BoardWidgetRemoveOp: Codable, Sendable {
         self.kind = kind
         self.name = name
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case kind
-        case name
-    }
 }
 
 public struct BoardMcpAppDescriptor: Codable, Sendable {
@@ -711,11 +706,6 @@ public struct BoardWidgetHtmlContent: Codable, Sendable {
         self.kind = kind
         self.html = html
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case kind
-        case html
-    }
 }
 
 public struct BoardWidgetMcpAppContent: Codable, Sendable {
@@ -728,11 +718,6 @@ public struct BoardWidgetMcpAppContent: Codable, Sendable {
     {
         self.kind = kind
         self.descriptor = descriptor
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case kind
-        case descriptor
     }
 }
 
@@ -1077,11 +1062,6 @@ public struct BoardTicketEventParams: Codable, Sendable {
         self.ticket = ticket
         self.payload = payload
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case ticket
-        case payload
-    }
 }
 
 public struct BoardPromptAuthorizeParams: Codable, Sendable {
@@ -1091,10 +1071,6 @@ public struct BoardPromptAuthorizeParams: Codable, Sendable {
         ticket: String)
     {
         self.ticket = ticket
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ticket
     }
 }
 
@@ -1171,11 +1147,6 @@ public struct BoardSetChatDockCommand: Codable, Sendable {
         self.kind = kind
         self.dock = dock
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case kind
-        case dock
-    }
 }
 
 public struct BoardCommandEvent: Codable, Sendable {
@@ -1206,11 +1177,6 @@ public struct ProgressCardStep: Codable, Sendable {
     {
         self.step = step
         self.status = status
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case step
-        case status
     }
 }
 
@@ -1266,10 +1232,6 @@ public struct ProgressCardGetResult: Codable, Sendable {
     {
         self.card = card
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case card
-    }
 }
 
 public struct ProgressCardPutParams: Codable, Sendable {
@@ -1305,10 +1267,6 @@ public struct ProgressCardPutResult: Codable, Sendable {
         card: AnyCodable)
     {
         self.card = card
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case card
     }
 }
 
@@ -1496,14 +1454,6 @@ public struct RequestFrame: Codable, Sendable {
         self.params = params
         self.traceparent = traceparent
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case id
-        case method
-        case params
-        case traceparent
-    }
 }
 
 public struct ResponseFrame: Codable, Sendable {
@@ -1525,14 +1475,6 @@ public struct ResponseFrame: Codable, Sendable {
         self.ok = ok
         self.payload = payload
         self.error = error
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case id
-        case ok
-        case payload
-        case error
     }
 }
 
@@ -1658,11 +1600,6 @@ public struct StateVersion: Codable, Sendable {
     {
         self.presence = presence
         self.health = health
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case presence
-        case health
     }
 }
 
@@ -1798,10 +1735,6 @@ public struct McpAppViewExpiredErrorDetails: Codable, Sendable {
     {
         self.code = code
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case code
-    }
 }
 
 public struct OutboundDeliveryQueuedErrorDetails: Codable, Sendable {
@@ -1811,10 +1744,6 @@ public struct OutboundDeliveryQueuedErrorDetails: Codable, Sendable {
         code: String)
     {
         self.code = code
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case code
     }
 }
 
@@ -1866,10 +1795,6 @@ public struct WizardNotFoundErrorDetails: Codable, Sendable {
     {
         self.code = code
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case code
-    }
 }
 
 public struct ProjectCloneErrorDetails: Codable, Sendable {
@@ -1882,11 +1807,6 @@ public struct ProjectCloneErrorDetails: Codable, Sendable {
     {
         self.code = code
         self.cause = cause
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case code
-        case cause
     }
 }
 
@@ -1940,13 +1860,6 @@ public struct GatewaySuspendBlocker: Codable, Sendable {
         self.count = count
         self.message = message
         self.task = task
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case kind
-        case count
-        case message
-        case task
     }
 }
 
@@ -2050,10 +1963,6 @@ public struct GatewaySuspendStatusRunningResult: Codable, Sendable {
     {
         self.status = status
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case status
-    }
 }
 
 public struct GatewaySuspendStatusReadyResult: Codable, Sendable {
@@ -2101,12 +2010,6 @@ public struct GatewaySuspendResumeResult: Codable, Sendable {
         self.ok = ok
         self.status = status
         self.resumed = resumed
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case status
-        case resumed
     }
 }
 
@@ -2192,11 +2095,6 @@ public struct WorkerSlotSummary: Codable, Sendable {
     {
         self.total = total
         self.available = available
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case total
-        case available
     }
 }
 
@@ -2495,11 +2393,6 @@ public struct EnvironmentsListResult: Codable, Sendable {
         self.environments = environments
         self.profiles = profiles
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case environments
-        case profiles
-    }
 }
 
 public struct EnvironmentsStatusParams: Codable, Sendable {
@@ -2675,11 +2568,6 @@ public struct WorkerDesktopLaunchResult: Codable, Sendable {
         self.app = app
         self.status = status
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case app
-        case status
-    }
 }
 
 public struct ProjectCheckout: Codable, Sendable {
@@ -2774,11 +2662,6 @@ public struct DesktopLaunchParams: Codable, Sendable {
     {
         self.source = source
         self.app = app
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case source
-        case app
     }
 }
 
@@ -3056,10 +2939,6 @@ public struct ConversationListResult: Codable, Sendable {
     {
         self.conversations = conversations
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case conversations
-    }
 }
 
 public struct ConversationTurnCancelParams: Codable, Sendable {
@@ -3087,10 +2966,6 @@ public struct ConversationTurnCancelResult: Codable, Sendable {
         cancelled: Bool)
     {
         self.cancelled = cancelled
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case cancelled
     }
 }
 
@@ -3819,11 +3694,6 @@ public struct ProjectsRegisterParams: Codable, Sendable {
         self.path = path
         self.name = name
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case path
-        case name
-    }
 }
 
 public struct ProjectsRegisterResult: Codable, Sendable {
@@ -3954,10 +3824,6 @@ public struct ProjectsSearchRemoteParams: Codable, Sendable {
     {
         self.query = query
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case query
-    }
 }
 
 public struct ProjectsSearchRemoteResult: Codable, Sendable {
@@ -3970,11 +3836,6 @@ public struct ProjectsSearchRemoteResult: Codable, Sendable {
     {
         self.credential = credential
         self.projects = projects
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case credential
-        case projects
     }
 }
 
@@ -4003,10 +3864,6 @@ public struct ProjectsRemoveResult: Codable, Sendable {
         removed: Bool)
     {
         self.removed = removed
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case removed
     }
 }
 
@@ -4086,10 +3943,6 @@ public struct WorktreesListResult: Codable, Sendable {
     {
         self.worktrees = worktrees
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case worktrees
-    }
 }
 
 public struct WorktreesCreateParams: Codable, Sendable {
@@ -4125,11 +3978,6 @@ public struct WorktreesRemoveParams: Codable, Sendable {
         self.id = id
         self.force = force
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case force
-    }
 }
 
 public struct WorktreesRemoveResult: Codable, Sendable {
@@ -4161,10 +4009,6 @@ public struct WorktreesRestoreParams: Codable, Sendable {
         id: String)
     {
         self.id = id
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
     }
 }
 
@@ -4202,11 +4046,6 @@ public struct WorktreeBranch: Codable, Sendable {
     {
         self.name = name
         self.kind = kind
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case kind
     }
 }
 
@@ -4268,12 +4107,6 @@ public struct FsDirEntry: Codable, Sendable {
         self.path = path
         self.hidden = hidden
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case path
-        case hidden
-    }
 }
 
 public struct FsListDirParams: Codable, Sendable {
@@ -4310,13 +4143,6 @@ public struct FsListDirResult: Codable, Sendable {
         self.parent = parent
         self.home = home
         self.entries = entries
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case path
-        case parent
-        case home
-        case entries
     }
 }
 
@@ -4426,10 +4252,6 @@ public struct NodePluginToolsUpdateParams: Codable, Sendable {
     {
         self.tools = tools
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case tools
-    }
 }
 
 public struct NodeSkillDescriptor: Codable, Sendable {
@@ -4446,12 +4268,6 @@ public struct NodeSkillDescriptor: Codable, Sendable {
         self.description = description
         self.content = content
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case description
-        case content
-    }
 }
 
 public struct NodeSkillsUpdateParams: Codable, Sendable {
@@ -4462,10 +4278,6 @@ public struct NodeSkillsUpdateParams: Codable, Sendable {
     {
         self.skills = skills
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case skills
-    }
 }
 
 public struct NodePendingAckParams: Codable, Sendable {
@@ -4475,10 +4287,6 @@ public struct NodePendingAckParams: Codable, Sendable {
         ids: [String])
     {
         self.ids = ids
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ids
     }
 }
 
@@ -4704,13 +4512,6 @@ public struct NodeEventResult: Codable, Sendable {
         self.event = event
         self.handled = handled
         self.reason = reason
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case event
-        case handled
-        case reason
     }
 }
 
@@ -4989,11 +4790,6 @@ public struct UiSidebarCommand: Codable, Sendable {
         self.kind = kind
         self.visible = visible
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case kind
-        case visible
-    }
 }
 
 public struct UiPanelCommand: Codable, Sendable {
@@ -5073,10 +4869,6 @@ public struct UiCommandResult: Codable, Sendable {
         ok: Bool)
     {
         self.ok = ok
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
     }
 }
 
@@ -5176,10 +4968,6 @@ public struct SecretsStoreListResult: Codable, Sendable {
     {
         self.entries = entries
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case entries
-    }
 }
 
 public struct SecretsStoreSetParams: Codable, Sendable {
@@ -5215,10 +5003,6 @@ public struct SecretsStoreDeleteParams: Codable, Sendable {
         name: String)
     {
         self.name = name
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
     }
 }
 
@@ -5452,12 +5236,6 @@ public struct SessionCatalogDescriptor: Codable, Sendable {
         self.label = label
         self.capabilities = capabilities
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case label
-        case capabilities
-    }
 }
 
 public struct SessionCatalogPullRequestSummary: Codable, Sendable {
@@ -5470,11 +5248,6 @@ public struct SessionCatalogPullRequestSummary: Codable, Sendable {
     {
         self.numbers = numbers
         self.state = state
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case numbers
-        case state
     }
 }
 
@@ -5630,14 +5403,6 @@ public struct SessionCatalog: Codable, Sendable {
         self.hosts = hosts
         self.error = error
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case label
-        case capabilities
-        case hosts
-        case error
-    }
 }
 
 public struct SessionCatalogTranscriptItem: Codable, Sendable {
@@ -5665,16 +5430,6 @@ public struct SessionCatalogTranscriptItem: Codable, Sendable {
         self.model = model
         self.truncated = truncated
         self.raw = raw
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case type
-        case text
-        case timestamp
-        case model
-        case truncated
-        case raw
     }
 }
 
@@ -5723,10 +5478,6 @@ public struct SessionsCatalogListResult: Codable, Sendable {
         catalogs: [SessionCatalog])
     {
         self.catalogs = catalogs
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case catalogs
     }
 }
 
@@ -5883,10 +5634,6 @@ public struct SessionsCatalogArchiveResult: Codable, Sendable {
         ok: Bool)
     {
         self.ok = ok
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
     }
 }
 
@@ -6160,12 +5907,6 @@ public struct SessionsSearchResult: Codable, Sendable {
         self.indexing = indexing
         self.truncated = truncated
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case results
-        case indexing
-        case truncated
-    }
 }
 
 public struct SessionCompactionCheckpoint: Codable, Sendable {
@@ -6327,11 +6068,6 @@ public struct SessionObserverPlanProgress: Codable, Sendable {
         self.completed = completed
         self.total = total
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case completed
-        case total
-    }
 }
 
 public struct SessionObserverDigest: Codable, Sendable {
@@ -6393,12 +6129,6 @@ public struct SessionCompanionExchange: Codable, Sendable {
         self.question = question
         self.answer = answer
         self.ts = ts
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case question
-        case answer
-        case ts
     }
 }
 
@@ -6721,11 +6451,6 @@ public struct SessionsCompanionAskResult: Codable, Sendable {
         self.answer = answer
         self.ts = ts
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case answer
-        case ts
-    }
 }
 
 public struct SessionsCompanionResetParams: Codable, Sendable {
@@ -6753,10 +6478,6 @@ public struct SessionsCompanionResetResult: Codable, Sendable {
         ok: Bool)
     {
         self.ok = ok
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
     }
 }
 
@@ -6786,10 +6507,6 @@ public struct SessionsCompanionStateResult: Codable, Sendable {
     {
         self.exchanges = exchanges
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case exchanges
-    }
 }
 
 public struct SessionsObserverVisibilityParams: Codable, Sendable {
@@ -6800,10 +6517,6 @@ public struct SessionsObserverVisibilityParams: Codable, Sendable {
     {
         self.visible = visible
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case visible
-    }
 }
 
 public struct SessionsObserverVisibilityResult: Codable, Sendable {
@@ -6813,10 +6526,6 @@ public struct SessionsObserverVisibilityResult: Codable, Sendable {
         ok: Bool)
     {
         self.ok = ok
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
     }
 }
 
@@ -7270,10 +6979,6 @@ public struct SessionSuggestionsAddResult: Codable, Sendable {
     {
         self.suggestion = suggestion
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case suggestion
-    }
 }
 
 public struct SessionSuggestionsListParams: Codable, Sendable {
@@ -7304,11 +7009,6 @@ public struct SessionSuggestionsListResult: Codable, Sendable {
     {
         self.suggestions = suggestions
         self.role = role
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case suggestions
-        case role
     }
 }
 
@@ -7346,10 +7046,6 @@ public struct SessionSuggestionsResolveResult: Codable, Sendable {
     {
         self.suggestion = suggestion
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case suggestion
-    }
 }
 
 public struct SessionSuggestionEvent: Codable, Sendable {
@@ -7362,11 +7058,6 @@ public struct SessionSuggestionEvent: Codable, Sendable {
     {
         self.action = action
         self.suggestion = suggestion
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case action
-        case suggestion
     }
 }
 
@@ -7410,11 +7101,6 @@ public struct SessionTypingResult: Codable, Sendable {
     {
         self.ok = ok
         self.broadcast = broadcast
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case broadcast
     }
 }
 
@@ -7492,11 +7178,6 @@ public struct SessionPlacementRunner: Codable, Sendable {
     {
         self.kind = kind
         self.status = status
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case kind
-        case status
     }
 }
 
@@ -8358,11 +8039,6 @@ public struct SessionMovePlacement: Codable, Sendable {
         self.state = state
         self.generation = generation
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case state
-        case generation
-    }
 }
 
 public struct SessionsMoveResult: Codable, Sendable {
@@ -8569,12 +8245,6 @@ public struct SessionsCompactionListResult: Codable, Sendable {
         self.key = key
         self.checkpoints = checkpoints
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case key
-        case checkpoints
-    }
 }
 
 public struct SessionsCompactionBranchResult: Codable, Sendable {
@@ -8780,10 +8450,6 @@ public struct SessionsBranchesListResult: Codable, Sendable {
         branches: [SessionBranch])
     {
         self.branches = branches
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case branches
     }
 }
 
@@ -9065,12 +8731,6 @@ public struct SessionsFilesRevealResult: Codable, Sendable {
         self.path = path
         self.error = error
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case path
-        case error
-    }
 }
 
 public struct SessionsFilesSetParams: Codable, Sendable {
@@ -9182,11 +8842,6 @@ public struct SessionDiffCommit: Codable, Sendable {
         self.sha = sha
         self.subject = subject
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case sha
-        case subject
-    }
 }
 
 public struct SessionsDiffParams: Codable, Sendable {
@@ -9286,12 +8941,6 @@ public struct SessionWorktreeInfo: Codable, Sendable {
         self.id = id
         self.path = path
         self.branch = branch
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case path
-        case branch
     }
 }
 
@@ -9956,11 +9605,6 @@ public struct SessionsPatchManyParams: Codable, Sendable {
         self.targets = targets
         self.patch = patch
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case targets
-        case patch
-    }
 }
 
 public struct SessionsPatchManyResult: Codable, Sendable {
@@ -9970,10 +9614,6 @@ public struct SessionsPatchManyResult: Codable, Sendable {
         outcomes: [AnyCodable])
     {
         self.outcomes = outcomes
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case outcomes
     }
 }
 
@@ -10024,12 +9664,6 @@ public struct SessionsPluginPatchResult: Codable, Sendable {
         self.ok = ok
         self.key = key
         self.value = value
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case key
-        case value
     }
 }
 
@@ -10114,13 +9748,6 @@ public struct PreservedSessionWorktree: Codable, Sendable {
         self.path = path
         self.reason = reason
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case branch
-        case path
-        case reason
-    }
 }
 
 public struct SessionsDeleteResult: Codable, Sendable {
@@ -10189,12 +9816,6 @@ public struct SessionsAssignOwnerResult: Codable, Sendable {
         self.key = key
         self.owner = owner
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case key
-        case owner
-    }
 }
 
 public struct SessionGroup: Codable, Sendable {
@@ -10207,11 +9828,6 @@ public struct SessionGroup: Codable, Sendable {
     {
         self.name = name
         self.position = position
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case position
     }
 }
 
@@ -10228,12 +9844,6 @@ public struct SessionGroupDefaults: Codable, Sendable {
         self.name = name
         self.cwd = cwd
         self.worktree = worktree
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case cwd
-        case worktree
     }
 }
 
@@ -10267,10 +9877,6 @@ public struct SessionsGroupsDefaultsResult: Codable, Sendable {
     {
         self.defaults = defaults
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case defaults
-    }
 }
 
 public struct SessionsGroupsPutParams: Codable, Sendable {
@@ -10302,11 +9908,6 @@ public struct SessionsGroupsRenameParams: Codable, Sendable {
         self.name = name
         self.to = to
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case to
-    }
 }
 
 public struct SessionsGroupsUpdateParams: Codable, Sendable {
@@ -10323,12 +9924,6 @@ public struct SessionsGroupsUpdateParams: Codable, Sendable {
         self.cwd = cwd
         self.worktree = worktree
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case cwd
-        case worktree
-    }
 }
 
 public struct SessionsGroupsUpdateResult: Codable, Sendable {
@@ -10342,11 +9937,6 @@ public struct SessionsGroupsUpdateResult: Codable, Sendable {
         self.ok = ok
         self.defaults = defaults
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case defaults
-    }
 }
 
 public struct SessionsGroupsDeleteParams: Codable, Sendable {
@@ -10356,10 +9946,6 @@ public struct SessionsGroupsDeleteParams: Codable, Sendable {
         name: String)
     {
         self.name = name
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
     }
 }
 
@@ -11130,11 +10716,6 @@ public struct AuditRunIdentityPresentV1: Codable, Sendable {
         self.state = state
         self.context = context
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case state
-        case context
-    }
 }
 
 public struct AuditRunIdentityUnknownV1: Codable, Sendable {
@@ -11625,10 +11206,6 @@ public struct TaskSuggestionsListResult: Codable, Sendable {
     {
         self.suggestions = suggestions
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case suggestions
-    }
 }
 
 public struct TaskSummary: Codable, Sendable {
@@ -11827,10 +11404,6 @@ public struct TasksGetResult: Codable, Sendable {
     {
         self.task = task
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case task
-    }
 }
 
 public struct TasksCancelParams: Codable, Sendable {
@@ -11868,13 +11441,6 @@ public struct TasksCancelResult: Codable, Sendable {
         self.reason = reason
         self.task = task
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case found
-        case cancelled
-        case reason
-        case task
-    }
 }
 
 public struct TasksRecoveryParams: Codable, Sendable {
@@ -11898,10 +11464,6 @@ public struct TasksRecoveryResult: Codable, Sendable {
         results: [[String: AnyCodable]])
     {
         self.results = results
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case results
     }
 }
 
@@ -12006,10 +11568,6 @@ public struct ConfigSchemaLookupParams: Codable, Sendable {
         path: String)
     {
         self.path = path
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case path
     }
 }
 
@@ -12177,10 +11735,6 @@ public struct SystemAgentChatHistoryParams: Codable, Sendable {
     {
         self.limit = limit
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case limit
-    }
 }
 
 public struct SystemAgentChatHistoryTurn: Codable, Sendable {
@@ -12197,12 +11751,6 @@ public struct SystemAgentChatHistoryTurn: Codable, Sendable {
         self.text = text
         self.at = at
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case role
-        case text
-        case at
-    }
 }
 
 public struct SystemAgentChatHistoryResult: Codable, Sendable {
@@ -12212,10 +11760,6 @@ public struct SystemAgentChatHistoryResult: Codable, Sendable {
         turns: [SystemAgentChatHistoryTurn])
     {
         self.turns = turns
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case turns
     }
 }
 
@@ -12535,14 +12079,6 @@ public struct WizardStartParams: Codable, Sendable {
         self.flow = flow
         self.channel = channel
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case mode
-        case workspace
-        case installDaemon
-        case flow
-        case channel
-    }
 }
 
 public struct WizardNextParams: Codable, Sendable {
@@ -12740,11 +12276,6 @@ public struct WizardStatusResult: Codable, Sendable {
         self.status = status
         self.error = error
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case status
-        case error
-    }
 }
 
 public struct TalkModeParams: Codable, Sendable {
@@ -12757,11 +12288,6 @@ public struct TalkModeParams: Codable, Sendable {
     {
         self.enabled = enabled
         self.phase = phase
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case enabled
-        case phase
     }
 }
 
@@ -12864,15 +12390,6 @@ public struct TalkCatalogResult: Codable, Sendable {
         self.transcription = transcription
         self.realtime = realtime
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case modes
-        case transports
-        case brains
-        case speech
-        case transcription
-        case realtime
-    }
 }
 
 public struct TalkClientCreateParams: Codable, Sendable {
@@ -12962,10 +12479,6 @@ public struct TalkClientMutationResult: Codable, Sendable {
         ok: Bool)
     {
         self.ok = ok
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
     }
 }
 
@@ -13172,10 +12685,6 @@ public struct TalkConfigResult: Codable, Sendable {
         config: [String: AnyCodable])
     {
         self.config = config
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case config
     }
 }
 
@@ -13473,10 +12982,6 @@ public struct TalkSessionOkResult: Codable, Sendable {
     {
         self.ok = ok
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-    }
 }
 
 public struct TalkSpeakParams: Codable, Sendable {
@@ -13586,10 +13091,6 @@ public struct TtsSpeakParams: Codable, Sendable {
         text: String)
     {
         self.text = text
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case text
     }
 }
 
@@ -14030,14 +13531,6 @@ public struct AgentsCreateParams: Codable, Sendable {
         self.model = model
         self.emoji = emoji
         self.avatar = avatar
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case workspace
-        case model
-        case emoji
-        case avatar
     }
 }
 
@@ -14629,10 +14122,6 @@ public struct ArtifactsListResult: Codable, Sendable {
     {
         self.artifacts = artifacts
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case artifacts
-    }
 }
 
 public struct ArtifactsGetParams: Codable, Sendable {
@@ -14672,10 +14161,6 @@ public struct ArtifactsGetResult: Codable, Sendable {
         artifact: ArtifactSummary)
     {
         self.artifact = artifact
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case artifact
     }
 }
 
@@ -15115,10 +14600,6 @@ public struct CommandsListResult: Codable, Sendable {
     {
         self.commands = commands
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case commands
-    }
 }
 
 public struct SkillsStatusParams: Codable, Sendable {
@@ -15163,11 +14644,6 @@ public struct GitHubAuthor: Codable, Sendable {
     {
         self.name = name
         self.email = email
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case name
-        case email
     }
 }
 
@@ -15234,12 +14710,6 @@ public struct GitHubSelectedIdentity: Codable, Sendable {
         self.scope = scope
         self.configured = configured
         self.identity = identity
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case scope
-        case configured
-        case identity
     }
 }
 
@@ -15445,10 +14915,6 @@ public struct ToolsGitHubAuthorizeAccessDeniedResult: Codable, Sendable {
     {
         self.status = status
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case status
-    }
 }
 
 public struct ToolsGitHubAuthorizeExpiredResult: Codable, Sendable {
@@ -15459,10 +14925,6 @@ public struct ToolsGitHubAuthorizeExpiredResult: Codable, Sendable {
     {
         self.status = status
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case status
-    }
 }
 
 public struct ToolsGitHubAuthorizeIncorrectDeviceCodeResult: Codable, Sendable {
@@ -15472,10 +14934,6 @@ public struct ToolsGitHubAuthorizeIncorrectDeviceCodeResult: Codable, Sendable {
         status: String)
     {
         self.status = status
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case status
     }
 }
 
@@ -15507,11 +14965,6 @@ public struct ToolsGitHubAuthorizeFailedResult: Codable, Sendable {
     {
         self.status = status
         self.reason = reason
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case status
-        case reason
     }
 }
 
@@ -15555,10 +15008,6 @@ public struct ToolsGitHubAuthorizeCancelResult: Codable, Sendable {
     {
         self.cancelled = cancelled
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case cancelled
-    }
 }
 
 public struct ToolCatalogProfile: Codable, Sendable {
@@ -15571,11 +15020,6 @@ public struct ToolCatalogProfile: Codable, Sendable {
     {
         self.id = id
         self.label = label
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case label
     }
 }
 
@@ -15770,13 +15214,6 @@ public struct ToolsEffectiveGroup: Codable, Sendable {
         self.source = source
         self.tools = tools
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case label
-        case source
-        case tools
-    }
 }
 
 public struct ToolsEffectiveNotice: Codable, Sendable {
@@ -15795,13 +15232,6 @@ public struct ToolsEffectiveNotice: Codable, Sendable {
         self.severity = severity
         self.message = message
         self.servers = servers
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case severity
-        case message
-        case servers
     }
 }
 
@@ -15883,12 +15313,6 @@ public struct ToolsInvokeError: Codable, Sendable {
         self.message = message
         self.details = details
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case code
-        case message
-        case details
-    }
 }
 
 public struct ToolsInvokeResult: Codable, Sendable {
@@ -15939,10 +15363,6 @@ public struct SkillsBinsResult: Codable, Sendable {
     {
         self.bins = bins
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case bins
-    }
 }
 
 public struct SkillsSearchParams: Codable, Sendable {
@@ -15956,11 +15376,6 @@ public struct SkillsSearchParams: Codable, Sendable {
         self.query = query
         self.limit = limit
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case query
-        case limit
-    }
 }
 
 public struct SkillsSearchResult: Codable, Sendable {
@@ -15971,10 +15386,6 @@ public struct SkillsSearchResult: Codable, Sendable {
     {
         self.results = results
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case results
-    }
 }
 
 public struct SkillsDetailParams: Codable, Sendable {
@@ -15984,10 +15395,6 @@ public struct SkillsDetailParams: Codable, Sendable {
         slug: String)
     {
         self.slug = slug
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case slug
     }
 }
 
@@ -16024,10 +15431,6 @@ public struct SkillsCuratorActionParams: Codable, Sendable {
         skill: String)
     {
         self.skill = skill
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case skill
     }
 }
 
@@ -16189,11 +15592,6 @@ public struct SkillsProposalEvaluateResult: Codable, Sendable {
     {
         self.record = record
         self.evaluation = evaluation
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case record
-        case evaluation
     }
 }
 
@@ -16758,11 +16156,6 @@ public struct SkillsSecurityVerdictsResult: Codable, Sendable {
         self.schema = schema
         self.items = items
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case schema
-        case items
-    }
 }
 
 public struct SkillsSkillCardParams: Codable, Sendable {
@@ -17185,12 +16578,6 @@ public struct CronDeclarativeAddResult: Codable, Sendable {
         self.updated = updated
         self.job = job
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case created
-        case updated
-        case job
-    }
 }
 
 public struct CronRunsParams: Codable, Sendable {
@@ -17432,15 +16819,6 @@ public struct LogsTailResult: Codable, Sendable {
         self.truncated = truncated
         self.reset = reset
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case file
-        case cursor
-        case size
-        case lines
-        case truncated
-        case reset
-    }
 }
 
 public struct MemoryMigrationItem: Codable, Sendable {
@@ -17469,16 +16847,6 @@ public struct MemoryMigrationItem: Codable, Sendable {
         self.reason = reason
         self.details = details
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case status
-        case source
-        case target
-        case message
-        case reason
-        case details
-    }
 }
 
 public struct MemoryMigrationSummary: Codable, Sendable {
@@ -17506,16 +16874,6 @@ public struct MemoryMigrationSummary: Codable, Sendable {
         self.conflicts = conflicts
         self.errors = errors
         self.sensitive = sensitive
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case total
-        case planned
-        case migrated
-        case skipped
-        case conflicts
-        case errors
-        case sensitive
     }
 }
 
@@ -17917,10 +17275,6 @@ public struct TerminalListResult: Codable, Sendable {
     {
         self.sessions = sessions
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case sessions
-    }
 }
 
 public struct TerminalUploadParams: Codable, Sendable {
@@ -17956,11 +17310,6 @@ public struct TerminalUploadResult: Codable, Sendable {
         self.path = path
         self.size = size
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case path
-        case size
-    }
 }
 
 public struct TerminalAckResult: Codable, Sendable {
@@ -17970,10 +17319,6 @@ public struct TerminalAckResult: Codable, Sendable {
         ok: Bool)
     {
         self.ok = ok
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
     }
 }
 
@@ -18401,10 +17746,6 @@ public struct ApprovalGetParams: Codable, Sendable {
     {
         self.id = id
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-    }
 }
 
 public struct ApprovalGetResult: Codable, Sendable {
@@ -18414,10 +17755,6 @@ public struct ApprovalGetResult: Codable, Sendable {
         approval: ApprovalSnapshot)
     {
         self.approval = approval
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case approval
     }
 }
 
@@ -18434,12 +17771,6 @@ public struct ApprovalHistoryParams: Codable, Sendable {
         self.cursor = cursor
         self.limit = limit
         self.kind = kind
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case cursor
-        case limit
-        case kind
     }
 }
 
@@ -18478,13 +17809,6 @@ public struct ApprovalResolveParams: Codable, Sendable {
         self.decision = decision
         self.reviewer = reviewer
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case kind
-        case decision
-        case reviewer
-    }
 }
 
 public struct ApprovalResolveResult: Codable, Sendable {
@@ -18497,11 +17821,6 @@ public struct ApprovalResolveResult: Codable, Sendable {
     {
         self.applied = applied
         self.approval = approval
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case applied
-        case approval
     }
 }
 
@@ -18743,10 +18062,6 @@ public struct ExecApprovalGetParams: Codable, Sendable {
     {
         self.id = id
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-    }
 }
 
 public struct ExecApprovalRequestParams: Codable, Sendable {
@@ -18885,12 +18200,6 @@ public struct ExecApprovalResolveParams: Codable, Sendable {
         self.decision = decision
         self.reviewer = reviewer
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case decision
-        case reviewer
-    }
 }
 
 public struct QuestionOption: Codable, Sendable {
@@ -18903,11 +18212,6 @@ public struct QuestionOption: Codable, Sendable {
     {
         self.label = label
         self.description = description
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case label
-        case description
     }
 }
 
@@ -18994,10 +18298,6 @@ public struct QuestionAnswers: Codable, Sendable {
         answers: [String: AnyCodable])
     {
         self.answers = answers
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case answers
     }
 }
 
@@ -19129,10 +18429,6 @@ public struct QuestionGetParams: Codable, Sendable {
     {
         self.id = id
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-    }
 }
 
 public struct QuestionGetResult: Codable, Sendable {
@@ -19142,10 +18438,6 @@ public struct QuestionGetResult: Codable, Sendable {
         question: QuestionRecord)
     {
         self.question = question
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case question
     }
 }
 
@@ -19158,10 +18450,6 @@ public struct QuestionListResult: Codable, Sendable {
         questions: [QuestionRecord])
     {
         self.questions = questions
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case questions
     }
 }
 
@@ -19270,12 +18558,6 @@ public struct PluginApprovalResolveParams: Codable, Sendable {
         self.id = id
         self.decision = decision
         self.reviewer = reviewer
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-        case decision
-        case reviewer
     }
 }
 
@@ -19504,11 +18786,6 @@ public struct PluginSearchResultEntry: Codable, Sendable {
         self.score = score
         self.package = package
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case score
-        case package
-    }
 }
 
 public struct PluginsInstallResult: Codable, Sendable {
@@ -19571,10 +18848,6 @@ public struct PluginsRefreshResult: Codable, Sendable {
     {
         self.ok = ok
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-    }
 }
 
 public struct PluginsSearchParams: Codable, Sendable {
@@ -19588,11 +18861,6 @@ public struct PluginsSearchParams: Codable, Sendable {
         self.query = query
         self.limit = limit
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case query
-        case limit
-    }
 }
 
 public struct PluginsSearchResult: Codable, Sendable {
@@ -19602,10 +18870,6 @@ public struct PluginsSearchResult: Codable, Sendable {
         results: [PluginSearchResultEntry])
     {
         self.results = results
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case results
     }
 }
 
@@ -19819,11 +19083,6 @@ public struct PluginsUiDescriptorsResult: Codable, Sendable {
     {
         self.ok = ok
         self.descriptors = descriptors
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case descriptors
     }
 }
 
@@ -20130,10 +19389,6 @@ public struct ScopeUpgradeRequest: Codable, Sendable {
         scopes: [String])
     {
         self.scopes = scopes
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case scopes
     }
 }
 
@@ -20471,10 +19726,6 @@ public struct ChatHistoryResetResult: Codable, Sendable {
     {
         self.kind = kind
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case kind
-    }
 }
 
 public struct ChatMetadataParams: Codable, Sendable {
@@ -20571,11 +19822,6 @@ public struct ChatToolTitlesResult: Codable, Sendable {
     {
         self.titles = titles
         self.disabled = disabled
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case titles
-        case disabled
     }
 }
 
@@ -21147,11 +20393,6 @@ public struct UpdateHoldResult: Codable, Sendable {
         self.ok = ok
         self.schedule = schedule
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case ok
-        case schedule
-    }
 }
 
 public struct UpdateRunParams: Codable, Sendable {
@@ -21195,10 +20436,6 @@ public struct TickEvent: Codable, Sendable {
         ts: Int)
     {
         self.ts = ts
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case ts
     }
 }
 
@@ -21280,10 +20517,6 @@ public struct PortalListResult: Codable, Sendable {
     {
         self.portals = portals
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case portals
-    }
 }
 
 public struct PortalOpenParams: Codable, Sendable {
@@ -21302,13 +20535,6 @@ public struct PortalOpenParams: Codable, Sendable {
         self.title = title
         self.description = description
         self.path = path
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case port
-        case title
-        case description
-        case path
     }
 }
 
@@ -21370,10 +20596,6 @@ public struct PortalCloseParams: Codable, Sendable {
     {
         self.id = id
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case id
-    }
 }
 
 public struct PortalCloseResult: Codable, Sendable {
@@ -21384,10 +20606,6 @@ public struct PortalCloseResult: Codable, Sendable {
     {
         self.closed = closed
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case closed
-    }
 }
 
 public struct PortalChangedEvent: Codable, Sendable {
@@ -21397,10 +20615,6 @@ public struct PortalChangedEvent: Codable, Sendable {
         portals: [PortalSummary])
     {
         self.portals = portals
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case portals
     }
 }
 

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -9,6 +9,7 @@ import {
   MIN_NODE_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
 } from "../packages/gateway-protocol/src/version.js";
+import { writeGeneratedOutput } from "./lib/generated-output-utils.mts";
 
 type JsonSchema = {
   type?: string | string[];
@@ -37,21 +38,6 @@ const outPaths = [
     "GatewayModels.swift",
   ),
 ];
-const { writeGeneratedOutput } = (await import(
-  new URL("./lib/generated-output-utils.mjs", import.meta.url).href
-)) as {
-  writeGeneratedOutput: (params: {
-    repoRoot: string;
-    outputPath: string;
-    next: string;
-    check?: boolean;
-  }) => {
-    changed: boolean;
-    wrote: boolean;
-    outputPath: string;
-  };
-};
-
 const STRICT_LITERAL_STRUCTS = new Set([
   "PluginsSessionActionSuccessResult",
   "PluginsSessionActionFailureResult",
@@ -383,17 +369,20 @@ function emitStruct(name: string, schema: JsonSchema): string {
   }
   lines.push(`public struct ${name}: Codable, Sendable {`);
   const codingKeys: string[] = [];
+  let needsCodingKeys = false;
   for (const [key, propSchema] of Object.entries(props)) {
     const propName = swiftStoredPropertyName(name, key);
     const propType = swiftType(propSchema, required.has(key), true);
     lines.push(`    public let ${propName}: ${propType}`);
     lines.push(...swiftCompatibilityPropertyLines(name, key));
     if (propName !== key) {
+      needsCodingKeys = true;
       codingKeys.push(`        case ${propName} = "${key}"`);
     } else {
       codingKeys.push(`        case ${propName}`);
     }
   }
+  const customCodable = emitStructCustomCodable(name, props, required);
   lines.push(
     "\n    public init(\n" +
       Object.entries(props)
@@ -422,11 +411,12 @@ function emitStruct(name: string, schema: JsonSchema): string {
         .join("\n") +
       "\n    }" +
       emitStructCompatibilityInitializer(name, props, required) +
-      "\n\n" +
-      "    private enum CodingKeys: String, CodingKey {\n" +
-      codingKeys.join("\n") +
-      "\n    }" +
-      emitStructCustomCodable(name, props, required) +
+      (needsCodingKeys || customCodable.length > 0
+        ? "\n\n    private enum CodingKeys: String, CodingKey {\n" +
+          codingKeys.join("\n") +
+          "\n    }"
+        : "") +
+      customCodable +
       "\n}",
   );
   lines.push("");


### PR DESCRIPTION
## What Problem This Solves

The Swift Gateway model generator emitted hundreds of redundant identity `CodingKeys` blocks even though Swift synthesizes the same Codable mapping for unchanged property names.

## Why This Change Was Made

The generator now emits `CodingKeys` only for renamed properties and custom Codable implementations, then canonically regenerates the current-main model. Current upstream models, strict literal handling, explicit-null codecs, unknown-frame behavior, and protocol versions remain unchanged.

AI-assisted maintainer cleanup. I reviewed the final generator, generated output, and exact landing diff.

## User Impact

No wire or public model behavior changes. The generated Swift surface is 786 lines smaller and easier to audit while retaining the same public declarations and serialization behavior.

## Evidence

- Generator net LOC: `-10`; generated Swift net LOC: `-786`; total `+13/-809` (net `-796`) across exactly two files.
- Current-main base: `b977ccb21e2b4b8bff05729548ea1b1558a74a33`; exact head: `ad7d029e7f5d99829f45652ff04042d2800e50d6`.
- Exact diff SHA-256: `c8ac81b47be5756e2cff28594b88f4d69ce306f05c01f6c9b99bf7f5403d2324`.
- Canonical Swift protocol generation check passed and is deterministic.
- Native Swift 6.4 OpenClawProtocol build and six preservation guards passed.
- All 5,024 public declaration/property/init/case lines are byte-identical to current main; current upstream model additions are retained.
- Renamed/custom Codable blocks, strict-literal guards, unknown handlers, explicit-null behavior, and protocol versions `4/4/3` are unchanged.
- Mandatory exact-source autoreview: secret scan clean; isolated Codex review reported no actionable findings (0.99 patch-correctness confidence).
