### PR TITLE
test(qa-lab): release cached databases before removing fixture temp dirs

### DIFF
--- a/extensions/qa-lab/src/runtime-parity-cache-diagnostics.test.ts
+++ b/extensions/qa-lab/src/runtime-parity-cache-diagnostics.test.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveStorePath, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { formatSqliteSessionFileMarker } from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  formatSqliteSessionFileMarker,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it } from "vitest";
 import { buildRuntimeParityCacheDiagnostics } from "./runtime-parity-cache-diagnostics.js";
 import { captureRuntimeParityCell, type RuntimeParityUsage } from "./runtime-parity.js";
@@ -10,6 +14,11 @@ import { createTempDirHarness } from "./temp-dir.test-helper.js";
 const tempDirs = createTempDirHarness();
 
 afterEach(async () => {
+  // Fixtures point a state dir at these temp workspaces, so the shared and per-agent
+  // SQLite handles stay cached and Windows fails the removal with EBUSY. The agent close
+  // releases its leases through shared state and reopens it, so the store is released second.
+  closeOpenClawAgentDatabasesForTest();
+  resetPluginStateStoreForTests();
   await tempDirs.cleanup();
 });
 

--- a/extensions/qa-lab/src/runtime-parity-session-selection.test.ts
+++ b/extensions/qa-lab/src/runtime-parity-session-selection.test.ts
@@ -1,8 +1,10 @@
 import path from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveStorePath, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import {
   appendSqliteTrajectoryRuntimeEvents,
+  closeOpenClawAgentDatabasesForTest,
   formatSqliteSessionFileMarker,
 } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it } from "vitest";
@@ -12,6 +14,11 @@ import { createTempDirHarness } from "./temp-dir.test-helper.js";
 const tempDirs = createTempDirHarness();
 
 afterEach(async () => {
+  // Fixtures point a state dir at these temp workspaces, so the shared and per-agent
+  // SQLite handles stay cached and Windows fails the removal with EBUSY. The agent close
+  // releases its leases through shared state and reopens it, so the store is released second.
+  closeOpenClawAgentDatabasesForTest();
+  resetPluginStateStoreForTests();
   await tempDirs.cleanup();
 });
 

--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -2,10 +2,12 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { resolveStorePath, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import {
   appendSqliteTrajectoryRuntimeEvents,
+  closeOpenClawAgentDatabasesForTest,
   formatSqliteSessionFileMarker,
 } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -25,6 +27,11 @@ const tempDirs = createTempDirHarness();
 
 afterEach(async () => {
   vi.unstubAllGlobals();
+  // Fixtures point a state dir at these temp workspaces, so the shared and per-agent
+  // SQLite handles stay cached and Windows fails the removal with EBUSY. The agent close
+  // releases its leases through shared state and reopens it, so the store is released second.
+  closeOpenClawAgentDatabasesForTest();
+  resetPluginStateStoreForTests();
   await tempDirs.cleanup();
 });
 

--- a/extensions/qa-lab/src/runtime-tool-fixture.test.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.test.ts
@@ -2,8 +2,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { QaSuiteInfraError } from "./errors.js";
 import { runRuntimeToolFixture } from "./runtime-tool-fixture.js";
@@ -437,6 +439,10 @@ async function runMockRuntimeToolFixtureWithOutputs(params: {
 }
 
 afterEach(async () => {
+  // The session store keeps the state database open under the temporary root, so
+  // Windows fails the removal with EBUSY unless the cached handle is released first.
+  closeOpenClawAgentDatabasesForTest();
+  resetPluginStateStoreForTests();
   await Promise.all(
     tempRoots.splice(0).map((tempRoot) => fs.rm(tempRoot, { recursive: true, force: true })),
   );

--- a/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-session.test.ts
@@ -1,12 +1,16 @@
 // Qa Lab tests cover suite runtime agent session plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import {
   loadTranscriptEventsSync,
   upsertSessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { appendSqliteSessionTranscriptEventForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  appendSqliteSessionTranscriptEventForTest,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createSession,
@@ -22,6 +26,11 @@ const { cleanup, makeTempDir } = createTempDirHarness();
 
 afterEach(async () => {
   vi.useRealTimers();
+  // Fixtures point a state dir at these temp workspaces, so the shared and per-agent
+  // SQLite handles stay cached and Windows fails the removal with EBUSY. The agent close
+  // releases its leases through shared state and reopens it, so the store is released second.
+  closeOpenClawAgentDatabasesForTest();
+  resetPluginStateStoreForTests();
   await cleanup();
 });
 


### PR DESCRIPTION
Related: #119796

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where contributors on Windows cannot run the `extension-qa` shard to a meaningful
result: five `extensions/qa-lab` suites fail in teardown with `EBUSY: resource busy or locked`,
never in an assertion. Each fixture points a state directory at a temporary workspace and then
removes that workspace while the shared and per-agent SQLite handles opened underneath it are
still cached, so the removal fails and the suite is reported as failed even though the behavior
under test passed. On Linux, unlinking an open file succeeds, so CI never sees it.

```
Error: EBUSY: resource busy or locked, unlink
  'C:\...\Temp\openclaw\qa-runtime-parity-XXXXXX\state\openclaw.sqlite'
```

## Why This Change Was Made

Each fixture releases the databases it leaves open immediately before the removal, in the ordering
merged for this class in #127201: close the cached per-agent databases first, then the shared
state store.

The order is what makes the pair work, and each half is load-bearing in the strongest sense — with
either call alone the same 66 teardowns still fail, only against the other database (measured
below).

The release is added to each fixture's own `afterEach`, not to the shared
`createTempDirHarness()` helper in `src/temp-dir.test-helper.ts`. That helper is also reached from
`test-file-scenario-runner.test-support.ts`, which runs inside the QA suite child process that
`suite-process-lifecycle.test.ts` spawns; closing the process-wide caches there kills the running
suite (`QA suite process exited before writing a completed summary: {"code":1}`). Putting the
release in the harness fixes the same eleven teardowns but breaks that lifecycle test, so it is
deliberately not done.

Tests only; no production file is touched.

## User Impact

Contributors on Windows can run these five `extensions/qa-lab` suites to completion instead of
reading teardown failures unrelated to the code under test. Behavior on Linux and macOS is
unchanged.

## Evidence

Windows 11, Node 24.18.1, `main` `000aea1d7a3` (this branch's base), both arms on the same tree.

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-qa.config.ts \
  --configLoader runner extensions/qa-lab extensions/qa-channel
```

| whole `extension-qa` shard | `main` | with this branch |
|---|---|---|
| test files | 23 failed / 186 passed | **18 failed / 191 passed** |
| tests | 115 failed / 2733 passed | **49 failed / 2799 passed** |
| `EBUSY` occurrences | **86** | **20** |

Per suite, all `EBUSY`, all cleared:

| suite | `main` | with this branch |
|---|---|---|
| `src/runtime-tool-fixture.test.ts` | 27 failed | **0** |
| `src/runtime-parity.test.ts` | 19 failed | **0** |
| `src/suite-runtime-agent-session.test.ts` | 14 failed | **0** |
| `src/runtime-parity-cache-diagnostics.test.ts` | 4 failed | **0** |
| `src/runtime-parity-session-selection.test.ts` | 2 failed | **0** |

Both calls are load-bearing, same command over the five suites, only the teardown mutated:

| arm | result |
|---|---|
| this branch | 125 passed, 0 `EBUSY` |
| drop `closeOpenClawAgentDatabasesForTest()` | 66 failed, **66** `EBUSY`, every one on `openclaw-agent.sqlite` |
| drop `resetPluginStateStoreForTests()` | 66 failed, **66** `EBUSY`, every one on `openclaw.sqlite` |

The lock does not disappear with one call, it moves — which is the same dependency this class
already documented in #127201.

No test that passes on `main` fails on this branch: the set of non-`EBUSY` failures is identical
on both arms (31 cases, all pre-existing), and the two arms were diffed test-by-test rather than
compared by count.

- `./node_modules/.bin/tsgo -p test/tsconfig/tsconfig.extensions.test.json --noEmit` -> output
  identical to `main` (the same six pre-existing `extensions/acpx` errors, none in these files)
- `./node_modules/.bin/oxlint <the five files>` -> exit 0
- `./node_modules/.bin/oxfmt --check <the five files>` -> exit 0

## What this PR does not fix

Three suites in the same shard still fail with `EBUSY` after this change and are **not** touched
here, because the handle that survives is not one of the caches these helpers clear:

```
src/gateway-child.test.ts                10 failed
src/codex-plugin-lifecycle.test.ts        6 failed
src/providers/shared/auth-store.test.ts   4 failed
```

Adding the same pair to `gateway-child.test.ts` and `codex-plugin-lifecycle.test.ts` was measured
and moves their lock from `openclaw.sqlite` to `openclaw-agent.sqlite` without making either suite
green (10 -> 8 and 6 -> 6), so those edits were dropped rather than shipped as noise.
`auth-store.test.ts` already closes both databases in its own teardown and still fails on the
per-agent file. Those three look like a separate mechanism — a handle opened outside the cached
paths, likely through the auth-profile lock or a child process — and deserve their own change.

## Relationship to the other repairs in this class

Disjoint from every open or merged repair of the same Windows teardown class:

```
#119809 (merged)  lifecycle fixtures
#126352 (merged)  eight extensions/ files
#127201 (merged)  src/gateway/github-publication.test-support.ts
#127236 (merged)  two extensions/nostr suites
#119964 (open)    three extensions/zalouser/ files
#128310 (open)    eight extensions/memory-core files
this PR           five extensions/qa-lab files
```
