### PR TITLE
fix(agents): streamed replies and generated media disappear when delivery fails

### DIFF
--- a/src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts
+++ b/src/agents/embedded-agent-subscribe.block-reply-rejections.test.ts
@@ -54,7 +54,7 @@ describe("subscribeEmbeddedAgentSession block reply rejections", () => {
   it("contains rejected async text_end block replies", async () => {
     process.on("unhandledRejection", onUnhandledRejection);
     const onBlockReply = vi.fn().mockRejectedValue(new Error("boom"));
-    const { emit } = createSubscribedSessionHarness({
+    const { emit, subscription } = createSubscribedSessionHarness({
       runId: "run",
       onBlockReply,
       blockReplyBreak: "text_end",
@@ -65,13 +65,14 @@ describe("subscribeEmbeddedAgentSession block reply rejections", () => {
     await waitForAsyncCallbacks();
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(subscription.getVisibleBlockReplyCount()).toBe(0);
     expect(unhandledRejections).toHaveLength(0);
   });
 
   it("contains rejected async message_end block replies", async () => {
     process.on("unhandledRejection", onUnhandledRejection);
     const onBlockReply = vi.fn().mockRejectedValue(new Error("boom"));
-    const { emit } = createSubscribedSessionHarness({
+    const { emit, subscription } = createSubscribedSessionHarness({
       runId: "run",
       onBlockReply,
       blockReplyBreak: "message_end",
@@ -81,7 +82,183 @@ describe("subscribeEmbeddedAgentSession block reply rejections", () => {
     await waitForAsyncCallbacks();
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(subscription.getVisibleBlockReplyCount()).toBe(0);
     expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it("does not count deferred block replies rejected after terminal approval", async () => {
+    const onBlockReply = vi.fn().mockRejectedValue(new Error("terminal transport failed"));
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "deferred-block-rejection",
+      onBlockReply,
+      onBeforeTerminalDelivery: async () => undefined,
+      blockReplyBreak: "message_end",
+    });
+
+    emitMessageStartAndEndForAssistantText({ emit, text: "Deferred answer" });
+    emit({ type: "agent_end", messages: [], willRetry: false });
+    await subscription.waitForPendingEvents();
+
+    expect(onBlockReply).toHaveBeenCalledOnce();
+    expect(subscription.getVisibleBlockReplyCount()).toBe(0);
+  });
+
+  it.each([
+    { mode: "synchronous failure", failure: "throw" },
+    { mode: "asynchronous failure", failure: "reject" },
+    { mode: "successful delivery", failure: "none" },
+  ] as const)("preserves accurate tool-media ownership after $mode", async ({ failure }) => {
+    const onBlockReply = vi.fn(() => {
+      if (failure === "throw") {
+        throw new Error("synchronous media delivery failed");
+      }
+      if (failure === "reject") {
+        return Promise.reject(new Error("asynchronous media delivery failed"));
+      }
+      return Promise.resolve();
+    });
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: `tool-media-${failure}`,
+      onBlockReply,
+      builtinToolNames: new Set(["tts"]),
+    });
+    const expectedMedia = {
+      mediaUrls: ["/tmp/reply.opus"],
+      audioAsVoice: true,
+    };
+
+    emitToolRun({
+      emit,
+      toolName: "tts",
+      toolCallId: `tts-${failure}`,
+      result: { details: { media: { mediaUrl: "/tmp/reply.opus", audioAsVoice: true } } },
+    });
+    await subscription.waitForPendingEvents();
+    expect(subscription.getPendingToolMediaReply()).toEqual(expectedMedia);
+
+    emit({ type: "agent_end", messages: [], willRetry: false });
+    await subscription.waitForPendingEvents();
+
+    const delivered = failure === "none";
+    expect(onBlockReply).toHaveBeenCalledOnce();
+    expect(subscription.getPendingToolMediaReply()).toEqual(delivered ? null : expectedMedia);
+    expect(subscription.getVisibleBlockReplyCount()).toBe(delivered ? 1 : 0);
+    expect(subscription.hasToolMediaBlockReply()).toBe(delivered);
+  });
+
+  it.each([false, true])(
+    "retains rejected assistant media without retrying during terminal delivery (deferred: %s)",
+    async (deferred) => {
+      const onBlockReply = vi.fn().mockRejectedValue(new Error("assistant media rejected"));
+      const { emit, subscription } = createSubscribedSessionHarness({
+        runId: `assistant-media-${deferred}`,
+        onBlockReply,
+        blockReplyBreak: "message_end",
+        ...(deferred ? { onBeforeTerminalDelivery: async () => undefined } : {}),
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "music_generation",
+            childSessionKey: "music_generate:task-123",
+            announceType: "music generation task",
+            taskLabel: "generated track",
+            status: "ok",
+            statusLabel: "completed successfully",
+            result: "Generated a track.",
+            mediaUrls: ["/tmp/generated.opus"],
+            attachments: [
+              { path: "/tmp/generated.opus", mimeType: "audio/ogg", name: "generated.opus" },
+            ],
+            replyInstruction: "Reply normally.",
+          },
+        ],
+      });
+      const expectedMedia = subscription.getPendingToolMediaReply();
+      expect(expectedMedia).toEqual({
+        mediaUrls: ["/tmp/generated.opus"],
+        attachments: [
+          {
+            path: "/tmp/generated.opus",
+            mimeType: "audio/ogg",
+            name: "generated.opus",
+            trustedLocalMedia: true,
+          },
+        ],
+        audioAsVoice: undefined,
+        trustedLocalMedia: true,
+      });
+
+      emitMessageStartAndEndForAssistantText({ emit, text: "Here is your track." });
+      emit({ type: "agent_end", messages: [], willRetry: false });
+      await subscription.waitForPendingEvents();
+
+      expect(onBlockReply).toHaveBeenCalledOnce();
+      expect(subscription.getPendingToolMediaReply()).toEqual(expectedMedia);
+      expect(subscription.getVisibleBlockReplyCount()).toBe(0);
+      expect(subscription.hasToolMediaBlockReply()).toBe(false);
+    },
+  );
+
+  it("retains accepted delivery evidence when a later block is rejected", async () => {
+    const onBlockReply = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("second block rejected"));
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "partially-accepted-block-replies",
+      onBlockReply,
+      blockReplyBreak: "message_end",
+    });
+
+    emitMessageStartAndEndForAssistantText({ emit, text: "First delivered answer." });
+    await subscription.waitForPendingEvents();
+    emitMessageStartAndEndForAssistantText({ emit, text: "Second rejected answer." });
+    emit({ type: "agent_end", messages: [], willRetry: false });
+    await subscription.waitForPendingEvents();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(2);
+    expect(subscription.getVisibleBlockReplyCount()).toBe(1);
+  });
+
+  it("delivers queued media after an unrelated reasoning callback is rejected", async () => {
+    const onBlockReply = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("reasoning delivery failed"))
+      .mockResolvedValueOnce(undefined);
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "failed-reasoning-pending-media",
+      onBlockReply,
+      reasoningMode: "on",
+      thinkingLevel: "medium",
+      blockReplyBreak: "message_end",
+      builtinToolNames: new Set(["tts"]),
+    });
+    emitToolRun({
+      emit,
+      toolName: "tts",
+      toolCallId: "reasoning-tts",
+      result: { details: { media: { mediaUrl: "/tmp/reply.opus", audioAsVoice: true } } },
+    });
+    await subscription.waitForPendingEvents();
+
+    const reasoningMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "Considering the reply" }],
+      stopReason: "stop",
+    };
+    emit({ type: "message_start", message: reasoningMessage });
+    emit({ type: "message_end", message: reasoningMessage });
+    emit({ type: "agent_end", messages: [reasoningMessage], willRetry: false });
+    await subscription.waitForPendingEvents();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(2);
+    expect(onBlockReply).toHaveBeenLastCalledWith({
+      mediaUrls: ["/tmp/reply.opus"],
+      audioAsVoice: true,
+    });
+    expect(subscription.getPendingToolMediaReply()).toBeNull();
+    expect(subscription.getVisibleBlockReplyCount()).toBe(1);
+    expect(subscription.hasToolMediaBlockReply()).toBe(true);
   });
 
   it("contains rejected assistant progress callbacks", async () => {

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -10,6 +10,7 @@ import {
   handleAgentStart,
 } from "./embedded-agent-subscribe.handlers.lifecycle.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
+import { createReplyDelivery } from "./embedded-agent-subscribe.reply-delivery.js";
 
 const { emitAgentEventMock } = vi.hoisted(() => ({
   emitAgentEventMock: vi.fn(),
@@ -937,6 +938,9 @@ describe("handleAgentEnd", () => {
     const ctx = createContext(undefined);
     ctx.state.pendingToolMediaUrls = ["/tmp/reply.opus"];
     ctx.state.pendingToolAudioAsVoice = true;
+    vi.mocked(ctx.emitBlockReply).mockImplementation(
+      createReplyDelivery({ params: ctx.params, state: ctx.state, log: ctx.log }).emitBlockReply,
+    );
 
     await handleAgentEnd(ctx);
 

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -22,8 +22,8 @@ import { resolveFinalAssistantVisibleText } from "./embedded-agent-runner/run/he
 import { isIncompleteTerminalAssistantTurn } from "./embedded-agent-runner/run/incomplete-turn-classification.js";
 import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import {
-  consumePendingToolMediaReply,
   hasAssistantVisibleReply,
+  readPendingToolMediaReply,
 } from "./embedded-agent-subscribe.handlers.messages.replies.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 import { isAssistantMessage } from "./embedded-agent-utils.js";
@@ -271,14 +271,10 @@ export function handleAgentEnd(
   };
 
   const flushPendingMediaAndChannel = () => {
-    if (ctx.params.onBlockReply) {
-      const pendingToolMediaReply = consumePendingToolMediaReply(ctx.state);
+    if (ctx.params.onBlockReply && !ctx.state.pendingToolMediaDeliveryFailed) {
+      const pendingToolMediaReply = readPendingToolMediaReply(ctx.state);
       if (pendingToolMediaReply && hasAssistantVisibleReply(pendingToolMediaReply)) {
-        const visibleReplyCountBefore = ctx.state.visibleBlockReplyCount;
         ctx.emitBlockReply(pendingToolMediaReply);
-        if (ctx.state.visibleBlockReplyCount > visibleReplyCountBefore) {
-          ctx.state.hasToolMediaBlockReply = true;
-        }
       }
     }
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.replies.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.replies.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   consumePendingToolMediaIntoReply,
-  consumePendingToolMediaReply,
   readPendingToolMediaReply,
+  restorePendingToolMediaReply,
 } from "./embedded-agent-subscribe.handlers.messages.replies.js";
 
 describe("consumePendingToolMediaIntoReply", () => {
@@ -173,7 +173,7 @@ describe("consumePendingToolMediaIntoReply", () => {
   });
 });
 
-describe("consumePendingToolMediaReply", () => {
+describe("pending tool-media reply ownership", () => {
   it("reads a media-only reply without consuming queued tool media", () => {
     const state = {
       pendingToolMediaUrls: ["/tmp/reply.opus"],
@@ -189,18 +189,40 @@ describe("consumePendingToolMediaReply", () => {
     expect(state.pendingToolAudioAsVoice).toBe(true);
   });
 
-  it("builds a media-only reply for orphaned tool media", () => {
+  it("restores rejected media before newer pending media without widening trust", () => {
     const state = {
-      pendingToolMediaUrls: ["/tmp/reply.opus"],
-      pendingToolMediaTrustByUrl: new Map([["/tmp/reply.opus", false]]),
-      pendingToolAudioAsVoice: true,
+      pendingToolMediaUrls: ["/tmp/newer.png"],
+      pendingToolMediaAttachments: [{ type: "image" as const, path: "/tmp/newer.png" }],
+      pendingToolMediaTrustByUrl: new Map([["/tmp/newer.png", false]]),
+      pendingToolAudioAsVoice: false,
+      pendingToolMediaDeliveryFailed: false,
     };
 
-    expect(consumePendingToolMediaReply(state)).toEqual({
-      mediaUrls: ["/tmp/reply.opus"],
+    restorePendingToolMediaReply(state, {
+      mediaUrls: ["/tmp/trusted.opus", "/tmp/untrusted.opus"],
+      attachments: [
+        { path: "/tmp/trusted.opus", mimeType: "audio/ogg", trustedLocalMedia: true },
+        { path: "/tmp/untrusted.opus", mimeType: "audio/ogg" },
+      ],
       audioAsVoice: true,
     });
-    expect(state.pendingToolMediaUrls).toStrictEqual([]);
-    expect(state.pendingToolAudioAsVoice).toBe(false);
+
+    expect(readPendingToolMediaReply(state)).toEqual({
+      mediaUrls: ["/tmp/trusted.opus", "/tmp/untrusted.opus", "/tmp/newer.png"],
+      attachments: [
+        { path: "/tmp/trusted.opus", mimeType: "audio/ogg", trustedLocalMedia: true },
+        { path: "/tmp/untrusted.opus", mimeType: "audio/ogg" },
+        { type: "image", path: "/tmp/newer.png" },
+      ],
+      audioAsVoice: true,
+    });
+    expect(state.pendingToolMediaTrustByUrl).toEqual(
+      new Map([
+        ["/tmp/newer.png", false],
+        ["/tmp/trusted.opus", true],
+        ["/tmp/untrusted.opus", false],
+      ]),
+    );
+    expect(state.pendingToolMediaDeliveryFailed).toBe(true);
   });
 });

--- a/src/agents/embedded-agent-subscribe.handlers.messages.replies.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.replies.ts
@@ -160,22 +160,39 @@ export function consumePendingToolMediaIntoReply(
   return mergedPayload;
 }
 
-/** Consumes queued tool media as a standalone reply payload. */
-export function consumePendingToolMediaReply(
+/** Restores reserved tool media after its outbound delivery was rejected. */
+export function restorePendingToolMediaReply(
   state: Pick<
     EmbeddedAgentSubscribeState,
     | "pendingToolMediaUrls"
     | "pendingToolMediaAttachments"
     | "pendingToolMediaTrustByUrl"
     | "pendingToolAudioAsVoice"
+    | "pendingToolMediaDeliveryFailed"
   >,
-): BlockReplyPayload | null {
-  const payload = readPendingToolMediaReply(state);
-  if (!payload) {
-    return null;
+  payload: BlockReplyPayload,
+): void {
+  const pendingUrls = state.pendingToolMediaUrls;
+  const pendingAttachments = state.pendingToolMediaAttachments ?? [];
+  const restoredUrls = payload.mediaUrls ?? [];
+  const restoredAttachments = payload.attachments ?? [];
+  const seen = new Set(restoredUrls);
+  state.pendingToolMediaUrls = [...restoredUrls, ...pendingUrls.filter((url) => !seen.has(url))];
+  state.pendingToolMediaAttachments = [
+    ...restoredUrls.map((_, index) => restoredAttachments[index] ?? {}),
+    ...pendingUrls.flatMap((url, index) =>
+      seen.has(url) ? [] : [pendingAttachments[index] ?? {}],
+    ),
+  ];
+  for (const [index, url] of restoredUrls.entries()) {
+    if (payload.trustedLocalMedia || restoredAttachments[index]?.trustedLocalMedia) {
+      state.pendingToolMediaTrustByUrl.set(url, true);
+    } else if (!state.pendingToolMediaTrustByUrl.has(url)) {
+      state.pendingToolMediaTrustByUrl.set(url, false);
+    }
   }
-  clearPendingToolMedia(state);
-  return payload;
+  state.pendingToolAudioAsVoice ||= payload.audioAsVoice === true;
+  state.pendingToolMediaDeliveryFailed = true;
 }
 
 /** Reads queued tool media without clearing it. */

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -212,6 +212,7 @@ export type EmbeddedAgentSubscribeState = {
   /** Per-URL local-media trust; keys are normalized pending media URLs. */
   pendingToolMediaTrustByUrl: Map<string, boolean>;
   pendingToolAudioAsVoice: boolean;
+  pendingToolMediaDeliveryFailed: boolean;
   hasToolMediaBlockReply: boolean;
   visibleBlockReplyCount: number;
   pendingAssistantReplyDirectives?: Pick<

--- a/src/agents/embedded-agent-subscribe.reply-delivery.ts
+++ b/src/agents/embedded-agent-subscribe.reply-delivery.ts
@@ -10,6 +10,7 @@ import {
   consumePendingToolMediaIntoReply,
   hasAssistantVisibleReply,
   readPendingToolMediaReply,
+  restorePendingToolMediaReply,
 } from "./embedded-agent-subscribe.handlers.messages.replies.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 import type { SubscribeEmbeddedAgentSessionParams } from "./embedded-agent-subscribe.types.js";
@@ -88,14 +89,29 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
   const clearDeferredAssistantEvents = () => {
     state.deferredAssistantEvents.length = 0;
   };
-  const deferredToolMediaReplies = new WeakSet<BlockReplyPayload>();
+  const deferredToolMediaReplies = new WeakMap<BlockReplyPayload, BlockReplyPayload>();
   const emitBlockReplySafely = (
     payload: Parameters<NonNullable<SubscribeEmbeddedAgentSessionParams["onBlockReply"]>>[0],
-    options?: { assistantMessageIndex?: number },
-  ): boolean => {
+    options?: { assistantMessageIndex?: number; pendingToolMedia?: BlockReplyPayload | null },
+  ): void => {
     if (!params.onBlockReply) {
-      return false;
+      return;
     }
+    const recordDeliveredReply = () => {
+      if (!payload.isReasoning && hasAssistantVisibleReply(payload)) {
+        state.visibleBlockReplyCount += 1;
+        if (options?.pendingToolMedia) {
+          state.pendingToolMediaDeliveryFailed = false;
+          state.hasToolMediaBlockReply = true;
+        }
+      }
+    };
+    const recordDeliveryFailure = (error: unknown) => {
+      if (options?.pendingToolMedia) {
+        restorePendingToolMediaReply(state, options.pendingToolMedia);
+      }
+      log.warn(`block reply callback failed: ${String(error)}`);
+    };
     try {
       const taggedPayload =
         options?.assistantMessageIndex !== undefined
@@ -111,19 +127,16 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
         ? params.onBlockReply(taggedPayload, context)
         : params.onBlockReply(taggedPayload);
       if (!isPromiseLike<void>(maybeTask)) {
-        return true;
+        recordDeliveredReply();
+        return;
       }
-      const task = Promise.resolve(maybeTask).catch((err: unknown) => {
-        log.warn(`block reply callback failed: ${String(err)}`);
-      });
+      const task = Promise.resolve(maybeTask).then(recordDeliveredReply, recordDeliveryFailure);
       pendingBlockReplyTasks.add(task);
       void task.finally(() => {
         pendingBlockReplyTasks.delete(task);
       });
-      return true;
     } catch (err) {
-      log.warn(`block reply callback failed: ${String(err)}`);
-      return false;
+      recordDeliveryFailure(err);
     }
   };
   const emitBlockReply = (
@@ -131,8 +144,10 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
     options?: { assistantMessageIndex?: number; consumePendingToolMedia?: boolean },
   ) => {
     const withAssistantDirectives = consumePendingAssistantReplyDirectivesIntoReply(state, payload);
-    const consumesPendingToolMedia =
-      options?.consumePendingToolMedia !== false && readPendingToolMediaReply(state) !== null;
+    const pendingToolMedia =
+      payload.isReasoning || options?.consumePendingToolMedia === false
+        ? null
+        : readPendingToolMediaReply(state);
     const withToolMedia =
       options?.consumePendingToolMedia === false
         ? withAssistantDirectives
@@ -146,19 +161,13 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
           })
         : withToolMedia;
     if (state.deferBlockReplyDelivery) {
-      if (consumesPendingToolMedia) {
-        deferredToolMediaReplies.add(taggedPayload);
+      if (pendingToolMedia) {
+        deferredToolMediaReplies.set(taggedPayload, pendingToolMedia);
       }
       state.deferredBlockReplies.push(taggedPayload);
       return;
     }
-    const emitted = emitBlockReplySafely(taggedPayload, options);
-    if (emitted && !taggedPayload.isReasoning && hasAssistantVisibleReply(taggedPayload)) {
-      state.visibleBlockReplyCount += 1;
-      if (consumesPendingToolMedia) {
-        state.hasToolMediaBlockReply = true;
-      }
-    }
+    emitBlockReplySafely(taggedPayload, { ...options, pendingToolMedia });
   };
   const flushDeferredBlockReplies = () => {
     if (state.deferredBlockReplies.length === 0) {
@@ -166,13 +175,7 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
     }
     const deferred = state.deferredBlockReplies.splice(0);
     for (const payload of deferred) {
-      const emitted = emitBlockReplySafely(payload);
-      if (emitted && !payload.isReasoning && hasAssistantVisibleReply(payload)) {
-        state.visibleBlockReplyCount += 1;
-        if (deferredToolMediaReplies.has(payload)) {
-          state.hasToolMediaBlockReply = true;
-        }
-      }
+      emitBlockReplySafely(payload, { pendingToolMedia: deferredToolMediaReplies.get(payload) });
     }
   };
   const clearDeferredBlockReplies = () => {

--- a/src/agents/embedded-agent-subscribe.run-state.ts
+++ b/src/agents/embedded-agent-subscribe.run-state.ts
@@ -91,6 +91,7 @@ export function createEmbeddedAgentSubscribeState(
     pendingToolMediaAttachments: initialPendingToolMedia.attachments,
     pendingToolMediaTrustByUrl: initialPendingToolMedia.trustByUrl,
     pendingToolAudioAsVoice: false,
+    pendingToolMediaDeliveryFailed: false,
     hasToolMediaBlockReply: false,
     visibleBlockReplyCount: 0,
     pendingAssistantReplyDirectives: undefined,

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -442,6 +442,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.pendingToolMediaAttachments = [];
     state.pendingToolMediaTrustByUrl.clear();
     state.pendingToolAudioAsVoice = false;
+    state.pendingToolMediaDeliveryFailed = false;
     state.visibleBlockReplyCount = 0;
     state.deferBlockReplyDelivery = typeof params.onBeforeTerminalDelivery === "function";
     clearDeferredAssistantEvents();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receiving streamed agent replies or generated voice/image attachments could silently lose a reply when the channel transport rejected delivery. Failed asynchronous sends were incorrectly recorded as successful, and pending generated media was discarded before the delivery outcome was known.

## Why This Change Was Made

The private embedded-agent reply owner now commits visible-delivery and media-delivery facts only after the actual callback succeeds. Failed reserved media is restored with its original attachment metadata, voice presentation, per-item trust, and ordering; the terminal lifecycle avoids retrying an ambiguous failed delivery and leaves recoverable media available for final assembly. Direct replies, deferred terminal replies, reasoning-only blocks, partially accepted runs, and successful orphan-media delivery share that canonical lifecycle.

No public plugin SDK, configuration, authentication, persistent storage, channel protocol, or provider contract changes are introduced. Production growth is +19 lines, justified by preserving authoritative queued attachments and successful-delivery evidence across asynchronous failures; tests grow by +203 lines.

## User Impact

Failed streamed replies no longer masquerade as delivered, and rejected generated voice, image, and other attachments remain available for recovery instead of disappearing. Successfully accepted replies retain existing ordering, terminal behavior, attachment trust, and duplicate-send protections.

## Evidence

- Exact reviewed head: `cb4e611f41c4dd478d8392e70d94939e82eafe04`.
- Authentic pre-fix owner regressions: five failing cases for rejected direct/deferred replies and synchronous/asynchronous orphan-media loss; successful delivery control passed.
- An independently discovered reasoning-versus-media regression was captured failing before the owner-boundary correction and passes afterward.
- 245 focused owner/sibling tests pass across subscription delivery, terminal lifecycle, reasoning, tool-media ownership, pending replies, chunk flushing, and terminal gates.
- Separate first-class independent review passed 243 tests and reported no actionable findings; all three discovered sibling issues were corrected.
- Fresh authenticated full committed-branch Codex review: clean.
- Real ephemeral localhost channel proof: HTTP 503 makes exactly one request, records zero delivered replies, and retains the voice attachment; HTTP 204 records one delivered reply and clears the attachment queue.
- Production core typecheck, scoped lint, formatting, and `git diff --check` pass. Full test-typecheck additionally encounters existing unrelated local dependency gaps for `@panzoom/panzoom` and `@types/pako`; there are no touched-file type diagnostics.
