### PR TITLE
refactor(providers): deduplicate failover and streaming fixtures

### DIFF
--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -107,6 +107,22 @@ function createSseResponse(events: Record<string, unknown>[] = []): Response {
   });
 }
 
+function anthropicMessageStart(message: Record<string, unknown>) {
+  return { type: "message_start", message };
+}
+
+function anthropicMessageDelta(delta: Record<string, unknown>, usage: Record<string, unknown>) {
+  return { type: "message_delta", delta, usage };
+}
+
+function anthropicContentBlockStart(index: number, content_block: Record<string, unknown>) {
+  return { type: "content_block_start", index, content_block };
+}
+
+function anthropicContentBlockDelta(index: number, delta: Record<string, unknown>) {
+  return { type: "content_block_delta", index, delta };
+}
+
 function serializeSseEvents(events: Record<string, unknown>[]): string {
   return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
 }
@@ -132,20 +148,9 @@ function createFailingSseResponse(events: Record<string, unknown>[], error: Erro
 
 function createInterruptedThinkingEvents(): Record<string, unknown>[] {
   return [
-    {
-      type: "message_start",
-      message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
-    },
-    {
-      type: "content_block_start",
-      index: 0,
-      content_block: { type: "thinking", thinking: "step by step", signature: "" },
-    },
-    {
-      type: "content_block_delta",
-      index: 0,
-      delta: { type: "signature_delta", signature: "partial-signature" },
-    },
+    anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } }),
+    anthropicContentBlockStart(0, { type: "thinking", thinking: "step by step", signature: "" }),
+    anthropicContentBlockDelta(0, { type: "signature_delta", signature: "partial-signature" }),
   ];
 }
 
@@ -247,6 +252,10 @@ function findRecord(items: unknown, predicate: (record: Record<string, unknown>)
     }
   }
   throw new Error("Expected matching record");
+}
+
+function latestAnthropicUserMessage() {
+  return findRecord(latestAnthropicRequest().payload.messages, (record) => record.role === "user");
 }
 
 function makeAnthropicTransportModel(
@@ -355,15 +364,8 @@ describe("anthropic transport stream", () => {
     });
     guardedFetchMock.mockResolvedValue(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_default", usage: { input_tokens: 0, output_tokens: 0 } },
-        },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 0, output_tokens: 0 },
-        },
+        anthropicMessageStart({ id: "msg_default", usage: { input_tokens: 0, output_tokens: 0 } }),
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 0, output_tokens: 0 }),
         { type: "message_stop" },
       ]),
     );
@@ -514,19 +516,16 @@ describe("anthropic transport stream", () => {
   ])("$name", async (testCase) => {
     const textEvents = testCase.content
       ? [
-          { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
-          { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Done." } },
+          anthropicContentBlockStart(0, { type: "text", text: "" }),
+          anthropicContentBlockDelta(0, { type: "text_delta", text: "Done." }),
           { type: "content_block_stop", index: 0 },
         ]
       : [];
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: testCase.id, model: testCase.model, usage: testCase.initial },
-        },
+        anthropicMessageStart({ id: testCase.id, model: testCase.model, usage: testCase.initial }),
         ...textEvents,
-        { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: testCase.final },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, testCase.final),
         { type: "message_stop" },
       ]),
     );
@@ -548,50 +547,27 @@ describe("anthropic transport stream", () => {
     guardedFetchMock
       .mockResolvedValueOnce(
         createSseResponse([
-          {
-            type: "message_start",
-            message: {
-              id: "msg_compaction",
-              model: "claude-sonnet-4-6",
-              usage: { input_tokens: 50_001, output_tokens: 0 },
-            },
-          },
-          {
-            type: "content_block_start",
-            index: 0,
-            content_block: { type: "compaction", content: null },
-          },
-          {
-            type: "content_block_delta",
-            index: 0,
-            delta: { type: "compaction_delta", content: "summary checkpoint" },
-          },
+          anthropicMessageStart({
+            id: "msg_compaction",
+            model: "claude-sonnet-4-6",
+            usage: { input_tokens: 50_001, output_tokens: 0 },
+          }),
+          anthropicContentBlockStart(0, { type: "compaction", content: null }),
+          anthropicContentBlockDelta(0, {
+            type: "compaction_delta",
+            content: "summary checkpoint",
+          }),
           { type: "content_block_stop", index: 0 },
-          {
-            type: "content_block_start",
-            index: 1,
-            content_block: { type: "text", text: "Done." },
-          },
+          anthropicContentBlockStart(1, { type: "text", text: "Done." }),
           { type: "content_block_stop", index: 1 },
-          {
-            type: "message_delta",
-            delta: { stop_reason: "end_turn" },
-            usage: { input_tokens: 1, output_tokens: 1 },
-          },
+          anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 1, output_tokens: 1 }),
           { type: "message_stop" },
         ]),
       )
       .mockResolvedValueOnce(
         createSseResponse([
-          {
-            type: "message_start",
-            message: { id: "msg_replay", usage: { input_tokens: 1, output_tokens: 0 } },
-          },
-          {
-            type: "message_delta",
-            delta: { stop_reason: "end_turn" },
-            usage: { input_tokens: 1, output_tokens: 1 },
-          },
+          anthropicMessageStart({ id: "msg_replay", usage: { input_tokens: 1, output_tokens: 0 } }),
+          anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 1, output_tokens: 1 }),
           { type: "message_stop" },
         ]),
       );
@@ -693,22 +669,19 @@ describe("anthropic transport stream", () => {
   it("prices one-hour cache writes at the same rate as the direct Anthropic provider", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: {
-            id: "msg_cache_ttl_usage",
-            usage: {
-              input_tokens: 100,
-              output_tokens: 0,
-              cache_creation_input_tokens: 1_000_000,
-              cache_creation: {
-                ephemeral_5m_input_tokens: 600_000,
-                ephemeral_1h_input_tokens: 400_000,
-              },
+        anthropicMessageStart({
+          id: "msg_cache_ttl_usage",
+          usage: {
+            input_tokens: 100,
+            output_tokens: 0,
+            cache_creation_input_tokens: 1_000_000,
+            cache_creation: {
+              ephemeral_5m_input_tokens: 600_000,
+              ephemeral_1h_input_tokens: 400_000,
             },
           },
-        },
-        { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } },
+        }),
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { output_tokens: 5 }),
         { type: "message_stop" },
       ]),
     );
@@ -734,33 +707,25 @@ describe("anthropic transport stream", () => {
     // 💬 lane — exactly the pioneer commentary gap.
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_pio", usage: { input_tokens: 10, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "text", text: "I'll start by checking the current date." },
-        },
+        anthropicMessageStart({ id: "msg_pio", usage: { input_tokens: 10, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, {
+          type: "text",
+          text: "I'll start by checking the current date.",
+        }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "content_block_start",
-          index: 1,
-          content_block: { type: "tool_use", id: "toolu_vrtx_01S4", name: "exec", input: {} },
-        },
-        {
-          type: "content_block_delta",
-          index: 1,
-          delta: { type: "input_json_delta", partial_json: '{"command":"date"}' },
-        },
+        anthropicContentBlockStart(1, {
+          type: "tool_use",
+          id: "toolu_vrtx_01S4",
+          name: "exec",
+          input: {},
+        }),
+        anthropicContentBlockDelta(1, {
+          type: "input_json_delta",
+          partial_json: '{"command":"date"}',
+        }),
         { type: "content_block_stop", index: 1 },
-        {
-          // The proxy mislabel: a tool-using turn reported as end_turn, NOT tool_use.
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 10, output_tokens: 7 },
-        },
+        // The proxy mislabel: a tool-using turn reported as end_turn, NOT tool_use.
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 10, output_tokens: 7 }),
       ]),
     );
 
@@ -835,15 +800,8 @@ describe("anthropic transport stream", () => {
     async (model) => {
       guardedFetchMock.mockResolvedValueOnce(
         createSseResponse([
-          {
-            type: "message_start",
-            message: { id: "msg_fb", usage: { input_tokens: 1, output_tokens: 0 } },
-          },
-          {
-            type: "message_delta",
-            delta: { stop_reason: "end_turn" },
-            usage: { input_tokens: 1, output_tokens: 1 },
-          },
+          anthropicMessageStart({ id: "msg_fb", usage: { input_tokens: 1, output_tokens: 0 } }),
+          anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 1, output_tokens: 1 }),
           { type: "message_stop" },
         ]),
       );
@@ -888,15 +846,8 @@ describe("anthropic transport stream", () => {
   ])("omits server-side fallback params for $label", async ({ model, apiKey }) => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_no_fb", usage: { input_tokens: 1, output_tokens: 0 } },
-        },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 1, output_tokens: 1 },
-        },
+        anthropicMessageStart({ id: "msg_no_fb", usage: { input_tokens: 1, output_tokens: 0 } }),
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 1, output_tokens: 1 }),
         { type: "message_stop" },
       ]),
     );
@@ -920,65 +871,38 @@ describe("anthropic transport stream", () => {
   it("rebuilds Fable output at a mid-stream server-side fallback boundary", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: {
-            id: "msg_fb",
-            model: "claude-fable-5",
-            usage: { input_tokens: 5, output_tokens: 0 },
-          },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "thinking", thinking: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "thinking_delta", thinking: "pre-boundary reasoning" },
-        },
+        anthropicMessageStart({
+          id: "msg_fb",
+          model: "claude-fable-5",
+          usage: { input_tokens: 5, output_tokens: 0 },
+        }),
+        anthropicContentBlockStart(0, { type: "thinking", thinking: "" }),
+        anthropicContentBlockDelta(0, {
+          type: "thinking_delta",
+          thinking: "pre-boundary reasoning",
+        }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "content_block_start",
-          index: 1,
-          content_block: { type: "text", text: "partial " },
-        },
+        anthropicContentBlockStart(1, { type: "text", text: "partial " }),
         { type: "content_block_stop", index: 1 },
-        {
-          // Starting a tool call tags the preceding text as commentary before
-          // the classifier declines mid-turn.
-          type: "content_block_start",
-          index: 2,
-          content_block: { type: "tool_use", id: "call_1", name: "lookup", input: {} },
-        },
+        // Starting a tool call tags the preceding text as commentary before
+        // the classifier declines mid-turn.
+        anthropicContentBlockStart(2, {
+          type: "tool_use",
+          id: "call_1",
+          name: "lookup",
+          input: {},
+        }),
         { type: "content_block_stop", index: 2 },
-        {
-          type: "content_block_start",
-          index: 3,
-          content_block: {
-            type: "fallback",
-            from: { model: "claude-fable-5" },
-            to: { model: "claude-opus-4-8" },
-          },
-        },
+        anthropicContentBlockStart(3, {
+          type: "fallback",
+          from: { model: "claude-fable-5" },
+          to: { model: "claude-opus-4-8" },
+        }),
         { type: "content_block_stop", index: 3 },
-        {
-          type: "content_block_start",
-          index: 4,
-          content_block: { type: "text", text: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 4,
-          delta: { type: "text_delta", text: "continued" },
-        },
+        anthropicContentBlockStart(4, { type: "text", text: "" }),
+        anthropicContentBlockDelta(4, { type: "text_delta", text: "continued" }),
         { type: "content_block_stop", index: 4 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 5, output_tokens: 9 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 5, output_tokens: 9 }),
         { type: "message_stop" },
       ]),
     );
@@ -1023,40 +947,21 @@ describe("anthropic transport stream", () => {
   it("records and prices a pre-output server-side fallback boundary", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: {
-            id: "msg_pre_output_fb",
-            model: "claude-fable-5",
-            usage: { input_tokens: 5, output_tokens: 0 },
-          },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: {
-            type: "fallback",
-            from: { model: "claude-fable-5" },
-            to: { model: "claude-opus-5" },
-          },
-        },
+        anthropicMessageStart({
+          id: "msg_pre_output_fb",
+          model: "claude-fable-5",
+          usage: { input_tokens: 5, output_tokens: 0 },
+        }),
+        anthropicContentBlockStart(0, {
+          type: "fallback",
+          from: { model: "claude-fable-5" },
+          to: { model: "claude-opus-5" },
+        }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "content_block_start",
-          index: 1,
-          content_block: { type: "text", text: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 1,
-          delta: { type: "text_delta", text: "continued" },
-        },
+        anthropicContentBlockStart(1, { type: "text", text: "" }),
+        anthropicContentBlockDelta(1, { type: "text_delta", text: "continued" }),
         { type: "content_block_stop", index: 1 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 5, output_tokens: 2 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 5, output_tokens: 2 }),
         { type: "message_stop" },
       ]),
     );
@@ -1685,24 +1590,12 @@ describe("anthropic transport stream", () => {
   ])("surfaces structured %s streaming refusals for %s", async (id, name, provider) => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_refusal", usage: { input_tokens: 3, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "text", text: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "text_delta", text: "discard this partial output" },
-        },
+        anthropicMessageStart({ id: "msg_refusal", usage: { input_tokens: 3, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, { type: "text", text: "" }),
+        anthropicContentBlockDelta(0, { type: "text_delta", text: "discard this partial output" }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "message_delta",
-          delta: {
+        anthropicMessageDelta(
+          {
             stop_reason: "refusal",
             stop_details: {
               type: "refusal",
@@ -1710,8 +1603,8 @@ describe("anthropic transport stream", () => {
               explanation: "This request is not allowed.",
             },
           },
-          usage: { input_tokens: 3, output_tokens: 2 },
-        },
+          { input_tokens: 3, output_tokens: 2 },
+        ),
         { type: "message_stop" },
       ]),
     );
@@ -1756,16 +1649,8 @@ describe("anthropic transport stream", () => {
   it("discards buffered Fable output when the transport ends before terminal status", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "text", text: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "text_delta", text: "unsafe partial output" },
-        },
+        anthropicContentBlockStart(0, { type: "text", text: "" }),
+        anthropicContentBlockDelta(0, { type: "text_delta", text: "unsafe partial output" }),
       ]),
     );
     const streamFn = createAnthropicMessagesTransportStreamFn();
@@ -1794,22 +1679,11 @@ describe("anthropic transport stream", () => {
   it("rejects ordinary Anthropic output when the stream ends before message_stop", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_partial", usage: { input_tokens: 3, output_tokens: 0 } },
-        },
-        { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "text_delta", text: "truncated answer" },
-        },
+        anthropicMessageStart({ id: "msg_partial", usage: { input_tokens: 3, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, { type: "text", text: "" }),
+        anthropicContentBlockDelta(0, { type: "text_delta", text: "truncated answer" }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 3, output_tokens: 2 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 3, output_tokens: 2 }),
       ]),
     );
 
@@ -1826,22 +1700,11 @@ describe("anthropic transport stream", () => {
   it("accepts proxy provider streams that end without message_stop", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_proxy", usage: { input_tokens: 3, output_tokens: 0 } },
-        },
-        { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "text_delta", text: "proxy answer" },
-        },
+        anthropicMessageStart({ id: "msg_proxy", usage: { input_tokens: 3, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, { type: "text", text: "" }),
+        anthropicContentBlockDelta(0, { type: "text_delta", text: "proxy answer" }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 3, output_tokens: 2 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 3, output_tokens: 2 }),
       ]),
     );
 
@@ -1863,28 +1726,13 @@ describe("anthropic transport stream", () => {
   it("defers a pre-tool text block's text_end until it carries the commentary phase", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_defer", usage: { input_tokens: 5, output_tokens: 0 } },
-        },
-        { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "text_delta", text: "I'll check the repo." },
-        },
+        anthropicMessageStart({ id: "msg_defer", usage: { input_tokens: 5, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, { type: "text", text: "" }),
+        anthropicContentBlockDelta(0, { type: "text_delta", text: "I'll check the repo." }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "content_block_start",
-          index: 1,
-          content_block: { type: "tool_use", id: "tool_1", name: "exec", input: {} },
-        },
+        anthropicContentBlockStart(1, { type: "tool_use", id: "tool_1", name: "exec", input: {} }),
         { type: "content_block_stop", index: 1 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "tool_use" },
-          usage: { input_tokens: 5, output_tokens: 7 },
-        },
+        anthropicMessageDelta({ stop_reason: "tool_use" }, { input_tokens: 5, output_tokens: 7 }),
         { type: "message_stop" },
       ]),
     );
@@ -1923,22 +1771,11 @@ describe("anthropic transport stream", () => {
   it("emits a non-tool text block's text_end as unphased answer text", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_answer", usage: { input_tokens: 5, output_tokens: 0 } },
-        },
-        { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "text_delta", text: "Here is the answer." },
-        },
+        anthropicMessageStart({ id: "msg_answer", usage: { input_tokens: 5, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, { type: "text", text: "" }),
+        anthropicContentBlockDelta(0, { type: "text_delta", text: "Here is the answer." }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 5, output_tokens: 4 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 5, output_tokens: 4 }),
         { type: "message_stop" },
       ]),
     );
@@ -1979,35 +1816,20 @@ describe("anthropic transport stream", () => {
   it("preserves unsafe integer Anthropic tool-use input deltas", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_unsafe", usage: { input_tokens: 10, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: {
-            type: "tool_use",
-            id: "tool_unsafe",
-            name: "send_message",
-            input: {},
-          },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: {
-            type: "input_json_delta",
-            partial_json:
-              '{"to":1481220477346119781,"safe":42,"maxSafe":9007199254740991,"nested":{"ids":[9007199254740993,-9007199254740992]}}',
-          },
-        },
+        anthropicMessageStart({ id: "msg_unsafe", usage: { input_tokens: 10, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, {
+          type: "tool_use",
+          id: "tool_unsafe",
+          name: "send_message",
+          input: {},
+        }),
+        anthropicContentBlockDelta(0, {
+          type: "input_json_delta",
+          partial_json:
+            '{"to":1481220477346119781,"safe":42,"maxSafe":9007199254740991,"nested":{"ids":[9007199254740993,-9007199254740992]}}',
+        }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "tool_use" },
-          usage: { input_tokens: 10, output_tokens: 5 },
-        },
+        anthropicMessageDelta({ stop_reason: "tool_use" }, { input_tokens: 10, output_tokens: 5 }),
         { type: "message_stop" },
       ]),
     );
@@ -2037,37 +1859,33 @@ describe("anthropic transport stream", () => {
   it("rejects malformed terminal tool JSON before completing any sibling call", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_malformed_tools", usage: { input_tokens: 2, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "tool_use", id: "call_valid", name: "read", input: {} },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "input_json_delta", partial_json: '{"path":"README.md"}' },
-        },
+        anthropicMessageStart({
+          id: "msg_malformed_tools",
+          usage: { input_tokens: 2, output_tokens: 0 },
+        }),
+        anthropicContentBlockStart(0, {
+          type: "tool_use",
+          id: "call_valid",
+          name: "read",
+          input: {},
+        }),
+        anthropicContentBlockDelta(0, {
+          type: "input_json_delta",
+          partial_json: '{"path":"README.md"}',
+        }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "content_block_start",
-          index: 1,
-          content_block: { type: "tool_use", id: "call_invalid", name: "read", input: {} },
-        },
-        {
-          type: "content_block_delta",
-          index: 1,
-          delta: { type: "input_json_delta", partial_json: '{"path":"SECRET.md"' },
-        },
+        anthropicContentBlockStart(1, {
+          type: "tool_use",
+          id: "call_invalid",
+          name: "read",
+          input: {},
+        }),
+        anthropicContentBlockDelta(1, {
+          type: "input_json_delta",
+          partial_json: '{"path":"SECRET.md"',
+        }),
         { type: "content_block_stop", index: 1 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "tool_use" },
-          usage: { input_tokens: 2, output_tokens: 2 },
-        },
+        anthropicMessageDelta({ stop_reason: "tool_use" }, { input_tokens: 2, output_tokens: 2 }),
         { type: "message_stop" },
       ]),
     );
@@ -2095,25 +1913,18 @@ describe("anthropic transport stream", () => {
   it("rejects an active tool call that never receives content_block_stop", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_unsealed", usage: { input_tokens: 2, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "tool_use", id: "call_unsealed", name: "read", input: {} },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "input_json_delta", partial_json: '{"path":"README.md"' },
-        },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "tool_use" },
-          usage: { input_tokens: 2, output_tokens: 1 },
-        },
+        anthropicMessageStart({ id: "msg_unsealed", usage: { input_tokens: 2, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, {
+          type: "tool_use",
+          id: "call_unsealed",
+          name: "read",
+          input: {},
+        }),
+        anthropicContentBlockDelta(0, {
+          type: "input_json_delta",
+          partial_json: '{"path":"README.md"',
+        }),
+        anthropicMessageDelta({ stop_reason: "tool_use" }, { input_tokens: 2, output_tokens: 1 }),
         { type: "message_stop" },
       ]),
     );
@@ -2260,26 +2071,18 @@ describe("anthropic transport stream", () => {
   it("uses seeded Anthropic tool input when no argument deltas arrive", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_seeded_tool", usage: { input_tokens: 2, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: {
-            type: "tool_use",
-            id: "call_seeded",
-            name: "read",
-            input: { path: "README.md" },
-          },
-        },
+        anthropicMessageStart({
+          id: "msg_seeded_tool",
+          usage: { input_tokens: 2, output_tokens: 0 },
+        }),
+        anthropicContentBlockStart(0, {
+          type: "tool_use",
+          id: "call_seeded",
+          name: "read",
+          input: { path: "README.md" },
+        }),
         { type: "content_block_stop", index: 0 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "tool_use" },
-          usage: { input_tokens: 2, output_tokens: 1 },
-        },
+        anthropicMessageDelta({ stop_reason: "tool_use" }, { input_tokens: 2, output_tokens: 1 }),
         { type: "message_stop" },
       ]),
     );
@@ -2298,29 +2101,18 @@ describe("anthropic transport stream", () => {
   it("preserves Anthropic OAuth identity and tool-name remapping with transport overrides", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 10, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: {
-            type: "tool_use",
-            id: "tool_1",
-            name: "Read",
-            input: { path: "/tmp/a" },
-          },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 10, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, {
+          type: "tool_use",
+          id: "tool_1",
+          name: "Read",
+          input: { path: "/tmp/a" },
+        }),
         {
           type: "content_block_stop",
           index: 0,
         },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "tool_use" },
-          usage: { input_tokens: 10, output_tokens: 5 },
-        },
+        anthropicMessageDelta({ stop_reason: "tool_use" }, { input_tokens: 10, output_tokens: 5 }),
         { type: "message_stop" },
       ]),
     );
@@ -2402,38 +2194,23 @@ describe("anthropic transport stream", () => {
   it("preserves text seeded on a text block after a thinking block", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "thinking", thinking: "checking", signature: "sig_1" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "signature_delta", signature: "sig_2" },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, {
+          type: "thinking",
+          thinking: "checking",
+          signature: "sig_1",
+        }),
+        anthropicContentBlockDelta(0, { type: "signature_delta", signature: "sig_2" }),
         {
           type: "content_block_stop",
           index: 0,
         },
-        {
-          type: "content_block_start",
-          index: 1,
-          content_block: { type: "text", text: "NO_REPLY" },
-        },
+        anthropicContentBlockStart(1, { type: "text", text: "NO_REPLY" }),
         {
           type: "content_block_stop",
           index: 1,
         },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 6, output_tokens: 9 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 6, output_tokens: 9 }),
       ]),
     );
     const streamFn = createAnthropicMessagesTransportStreamFn();
@@ -2477,34 +2254,19 @@ describe("anthropic transport stream", () => {
     const signedThinking = `keep${highSurrogate}signed`;
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "thinking", thinking: signedThinking, signature: "sig_1" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "signature_delta", signature: "sig_2" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "signature_delta", signature: "sig_3" },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, {
+          type: "thinking",
+          thinking: signedThinking,
+          signature: "sig_1",
+        }),
+        anthropicContentBlockDelta(0, { type: "signature_delta", signature: "sig_2" }),
+        anthropicContentBlockDelta(0, { type: "signature_delta", signature: "sig_3" }),
         {
           type: "content_block_stop",
           index: 0,
         },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 6, output_tokens: 9 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 6, output_tokens: 9 }),
       ]),
     );
 
@@ -2528,37 +2290,17 @@ describe("anthropic transport stream", () => {
   it("routes interleaved active content blocks by their event indexes", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_interleaved", usage: { input_tokens: 1, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "text", text: "" },
-        },
-        {
-          type: "content_block_start",
-          index: 1,
-          content_block: { type: "text", text: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 1,
-          delta: { type: "text_delta", text: "second" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "text_delta", text: "first" },
-        },
+        anthropicMessageStart({
+          id: "msg_interleaved",
+          usage: { input_tokens: 1, output_tokens: 0 },
+        }),
+        anthropicContentBlockStart(0, { type: "text", text: "" }),
+        anthropicContentBlockStart(1, { type: "text", text: "" }),
+        anthropicContentBlockDelta(1, { type: "text_delta", text: "second" }),
+        anthropicContentBlockDelta(0, { type: "text_delta", text: "first" }),
         { type: "content_block_stop", index: 1 },
         { type: "content_block_stop", index: 0 },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 1, output_tokens: 2 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 1, output_tokens: 2 }),
         { type: "message_stop" },
       ]),
     );
@@ -2578,24 +2320,17 @@ describe("anthropic transport stream", () => {
   it("preserves provider-seeded thinking signatures when no signature_delta follows", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "thinking", thinking: "seeded", signature: "seed_signature" },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, {
+          type: "thinking",
+          thinking: "seeded",
+          signature: "seed_signature",
+        }),
         {
           type: "content_block_stop",
           index: 0,
         },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 6, output_tokens: 5 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 6, output_tokens: 5 }),
       ]),
     );
 
@@ -2619,39 +2354,20 @@ describe("anthropic transport stream", () => {
   it("concatenates multiple signature_delta events instead of overwriting", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "thinking", thinking: "step by step", signature: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "signature_delta", signature: "chunk1" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "signature_delta", signature: "chunk2" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "signature_delta", signature: "chunk3" },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, {
+          type: "thinking",
+          thinking: "step by step",
+          signature: "",
+        }),
+        anthropicContentBlockDelta(0, { type: "signature_delta", signature: "chunk1" }),
+        anthropicContentBlockDelta(0, { type: "signature_delta", signature: "chunk2" }),
+        anthropicContentBlockDelta(0, { type: "signature_delta", signature: "chunk3" }),
         {
           type: "content_block_stop",
           index: 0,
         },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 6, output_tokens: 5 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 6, output_tokens: 5 }),
       ]),
     );
 
@@ -2742,30 +2458,11 @@ describe("anthropic transport stream", () => {
   it("commits only stopped signatures across interleaved thinking blocks", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "thinking", thinking: "first", signature: "" },
-        },
-        {
-          type: "content_block_start",
-          index: 1,
-          content_block: { type: "thinking", thinking: "second", signature: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 1,
-          delta: { type: "signature_delta", signature: "complete-second" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "signature_delta", signature: "partial-first" },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, { type: "thinking", thinking: "first", signature: "" }),
+        anthropicContentBlockStart(1, { type: "thinking", thinking: "second", signature: "" }),
+        anthropicContentBlockDelta(1, { type: "signature_delta", signature: "complete-second" }),
+        anthropicContentBlockDelta(0, { type: "signature_delta", signature: "partial-first" }),
         { type: "content_block_stop", index: 1 },
       ]),
     );
@@ -2793,39 +2490,16 @@ describe("anthropic transport stream", () => {
   it("captures OpenAI-style reasoning_content deltas from Anthropic-compatible streams", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { content: "", reasoning_content: "Need " },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { content: "", reasoning_content: "context." },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { content: "Visible answer.", reasoning_content: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { content: " Continued.", reasoning_content: null },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } }),
+        anthropicContentBlockDelta(0, { content: "", reasoning_content: "Need " }),
+        anthropicContentBlockDelta(0, { content: "", reasoning_content: "context." }),
+        anthropicContentBlockDelta(0, { content: "Visible answer.", reasoning_content: "" }),
+        anthropicContentBlockDelta(0, { content: " Continued.", reasoning_content: null }),
         {
           type: "content_block_stop",
           index: 0,
         },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 6, output_tokens: 2 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 6, output_tokens: 2 }),
       ]),
     );
     const model = makeAnthropicTransportModel({
@@ -2894,34 +2568,15 @@ describe("anthropic transport stream", () => {
   it("captures reasoning_content after compatible streams start a text block", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "text", text: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { content: "Visible ", reasoning_content: "Need " },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { content: "answer.", reasoning_content: null },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, { type: "text", text: "" }),
+        anthropicContentBlockDelta(0, { content: "Visible ", reasoning_content: "Need " }),
+        anthropicContentBlockDelta(0, { content: "answer.", reasoning_content: null }),
         {
           type: "content_block_stop",
           index: 0,
         },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 6, output_tokens: 2 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 6, output_tokens: 2 }),
       ]),
     );
 
@@ -2957,39 +2612,20 @@ describe("anthropic transport stream", () => {
   it("preserves native text_delta chunks that also carry reasoning_content", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_start",
-          index: 0,
-          content_block: { type: "text", text: "" },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: {
-            type: "text_delta",
-            content: "Visible ",
-            text: "Visible ",
-            reasoning_content: "Need ",
-          },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "text_delta", text: "answer." },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } }),
+        anthropicContentBlockStart(0, { type: "text", text: "" }),
+        anthropicContentBlockDelta(0, {
+          type: "text_delta",
+          content: "Visible ",
+          text: "Visible ",
+          reasoning_content: "Need ",
+        }),
+        anthropicContentBlockDelta(0, { type: "text_delta", text: "answer." }),
         {
           type: "content_block_stop",
           index: 0,
         },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 6, output_tokens: 2 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 6, output_tokens: 2 }),
       ]),
     );
 
@@ -3025,24 +2661,13 @@ describe("anthropic transport stream", () => {
   it("recovers orphan text deltas when an Anthropic-compatible provider omits block start", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
-        },
-        {
-          type: "content_block_delta",
-          index: 0,
-          delta: { type: "text_delta", text: "你好" },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } }),
+        anthropicContentBlockDelta(0, { type: "text_delta", text: "你好" }),
         {
           type: "content_block_stop",
           index: 0,
         },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 6, output_tokens: 1 },
-        },
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 6, output_tokens: 1 }),
       ]),
     );
     const streamFn = createAnthropicMessagesTransportStreamFn();
@@ -3635,10 +3260,7 @@ describe("anthropic transport stream", () => {
       } as AnthropicStreamOptions,
     );
 
-    const userMessage = findRecord(
-      latestAnthropicRequest().payload.messages,
-      (record) => record.role === "user",
-    );
+    const userMessage = latestAnthropicUserMessage();
     const toolResult = findRecord(
       userMessage.content,
       (record) => record.type === "tool_result" && record.tool_use_id === "tool_1",
@@ -3673,10 +3295,7 @@ describe("anthropic transport stream", () => {
       { apiKey: "fake" } as AnthropicStreamOptions,
     );
 
-    const userMessage = findRecord(
-      latestAnthropicRequest().payload.messages,
-      (record) => record.role === "user",
-    );
+    const userMessage = latestAnthropicUserMessage();
     const toolResult = findRecord(
       userMessage.content,
       (record) => record.type === "tool_result" && record.tool_use_id === "tool_husk",
@@ -3718,10 +3337,7 @@ describe("anthropic transport stream", () => {
       } as AnthropicStreamOptions,
     );
 
-    const userMessage = findRecord(
-      latestAnthropicRequest().payload.messages,
-      (record) => record.role === "user",
-    );
+    const userMessage = latestAnthropicUserMessage();
     const toolResult = findRecord(
       userMessage.content,
       (record) => record.type === "tool_result" && record.tool_use_id === "tool_1",
@@ -3762,10 +3378,7 @@ describe("anthropic transport stream", () => {
       { apiKey: "test-api-key" } as AnthropicStreamOptions,
     );
 
-    const userMessage = findRecord(
-      latestAnthropicRequest().payload.messages,
-      (record) => record.role === "user",
-    );
+    const userMessage = latestAnthropicUserMessage();
     const imageBlock = findRecord(userMessage.content, (record) => record.type === "image");
     expect(imageBlock).toMatchObject({
       type: "image",
@@ -3795,10 +3408,7 @@ describe("anthropic transport stream", () => {
 
     expect(result.stopReason).toBe("stop");
     expect(normalizer).not.toHaveBeenCalled();
-    const userMessage = findRecord(
-      latestAnthropicRequest().payload.messages,
-      (record) => record.role === "user",
-    );
+    const userMessage = latestAnthropicUserMessage();
     expect(JSON.stringify(userMessage.content)).toContain("image omitted");
   });
 
@@ -3840,10 +3450,7 @@ describe("anthropic transport stream", () => {
       { apiKey: "test-api-key" } as AnthropicStreamOptions,
     );
 
-    const userMessage = findRecord(
-      latestAnthropicRequest().payload.messages,
-      (record) => record.role === "user",
-    );
+    const userMessage = latestAnthropicUserMessage();
     const toolResult = findRecord(userMessage.content, (record) => record.type === "tool_result");
     const imageBlock = findRecord(toolResult.content, (record) => record.type === "image");
     expect(imageBlock).toMatchObject({
@@ -3888,10 +3495,7 @@ describe("anthropic transport stream", () => {
       } as AnthropicStreamOptions,
     );
 
-    const userMessage = findRecord(
-      latestAnthropicRequest().payload.messages,
-      (record) => record.role === "user",
-    );
+    const userMessage = latestAnthropicUserMessage();
     const toolResult = findRecord(
       userMessage.content,
       (record) => record.type === "tool_result" && record.tool_use_id === "tool_1",
@@ -3944,10 +3548,7 @@ describe("anthropic transport stream", () => {
       } as AnthropicStreamOptions,
     );
 
-    const userMessage = findRecord(
-      latestAnthropicRequest().payload.messages,
-      (record) => record.role === "user",
-    );
+    const userMessage = latestAnthropicUserMessage();
     const toolResult = findRecord(
       userMessage.content,
       (record) => record.type === "tool_result" && record.tool_use_id === "tool_1",
@@ -3998,10 +3599,7 @@ describe("anthropic transport stream", () => {
       { apiKey: "fixture" } as AnthropicStreamOptions,
     );
 
-    const userMessage = findRecord(
-      latestAnthropicRequest().payload.messages,
-      (record) => record.role === "user",
-    );
+    const userMessage = latestAnthropicUserMessage();
     const toolResult = findRecord(
       userMessage.content,
       (record) => record.type === "tool_result" && record.tool_use_id === "tool_1",
@@ -4314,19 +3912,12 @@ describe("anthropic transport stream", () => {
 
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: {
-            id: "msg_1",
-            model: "claude-fable-5",
-            usage: { input_tokens: 1, output_tokens: 0 },
-          },
-        },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 1, output_tokens: 1 },
-        },
+        anthropicMessageStart({
+          id: "msg_1",
+          model: "claude-fable-5",
+          usage: { input_tokens: 1, output_tokens: 0 },
+        }),
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 1, output_tokens: 1 }),
         { type: "message_stop" },
       ]),
     );
@@ -4628,15 +4219,8 @@ describe("anthropic transport stream", () => {
   it("emits start event only after message_start so pre-stream SSE errors arrive before any non-error event", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
-        {
-          type: "message_start",
-          message: { id: "msg_1", usage: { input_tokens: 1, output_tokens: 0 } },
-        },
-        {
-          type: "message_delta",
-          delta: { stop_reason: "end_turn" },
-          usage: { input_tokens: 1, output_tokens: 1 },
-        },
+        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 1, output_tokens: 0 } }),
+        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 1, output_tokens: 1 }),
       ]),
     );
     const streamFn = createAnthropicMessagesTransportStreamFn();

--- a/src/agents/failover/failover-classification.auth-format.cases.ts
+++ b/src/agents/failover/failover-classification.auth-format.cases.ts
@@ -5,6 +5,7 @@ import {
   httpSource,
   matchesSource,
   messageRows,
+  failoverSignalRows,
   openRouterSource,
   patternsSource,
   reason,
@@ -13,163 +14,109 @@ import {
 } from "./failover-classification.corpus.test-support.js";
 export const authFormatCases = [
   // Authentication and authorization.
-  {
-    id: "billing-no-anthropic-credentials",
-    source: billingSource,
-    signal: { message: 'No credentials found for profile "anthropic:default".' },
-    expected: reason("auth"),
-  },
-  {
-    id: "billing-no-openai-api-key",
-    source: billingSource,
-    signal: { provider: "openai", message: "No API key found for profile openai." },
-    expected: reason("auth"),
-  },
-  {
-    id: "billing-oauth-refresh-failed",
-    source: billingSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        "OAuth token refresh failed for anthropic: Failed to refresh OAuth token for anthropic. Please try again or re-authenticate.",
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "billing-could-not-authenticate-key",
-    source: billingSource,
-    signal: { message: "could not authenticate api key" },
-    expected: reason("auth"),
-  },
-  {
-    id: "billing-token-account-id",
-    source: billingSource,
-    signal: { message: "Failed to extract accountId from token" },
-    expected: reason("auth"),
-  },
-  {
-    id: "billing-insufficient-permissions",
-    source: billingSource,
-    signal: { message: "You have insufficient permissions for this operation." },
-    expected: reason("auth"),
-  },
-  {
-    id: "billing-missing-scope",
-    source: billingSource,
-    signal: { message: "Missing scopes: model.request" },
-    expected: reason("auth"),
-  },
-  {
-    id: "billing-api-key-revoked",
-    source: billingSource,
-    signal: { message: "Your api key has been revoked" },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "billing-oauth-org-disabled",
-    source: billingSource,
-    signal: { message: "OAuth authentication is currently not allowed for this organization" },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "billing-chinese-model-denied",
-    source: billingSource,
-    signal: { message: "403 您无权访问glm-5.1。" },
-    expected: reason("auth"),
-  },
-  {
-    id: "billing-chinese-key-banned",
-    source: billingSource,
-    signal: { message: "当前ak因违规请求被禁止访问该模型" },
-    expected: reason("auth"),
-  },
-  {
-    id: "billing-chinese-ce-011",
-    source: billingSource,
-    signal: { message: '{"success":false,"code":"CE-011"}' },
-    expected: reason("auth"),
-  },
-  {
-    id: "billing-chinese-auth-failed",
-    source: billingSource,
-    signal: { message: "鉴权失败，请检查API Key" },
-    expected: reason("auth"),
-  },
-  {
+  ...failoverSignalRows(billingSource, reason("auth"), [
+    [
+      "billing-no-anthropic-credentials",
+      { message: 'No credentials found for profile "anthropic:default".' },
+    ],
+    [
+      "billing-no-openai-api-key",
+      { provider: "openai", message: "No API key found for profile openai." },
+    ],
+    [
+      "billing-oauth-refresh-failed",
+      {
+        provider: "anthropic",
+        message:
+          "OAuth token refresh failed for anthropic: Failed to refresh OAuth token for anthropic. Please try again or re-authenticate.",
+      },
+    ],
+    ["billing-could-not-authenticate-key", { message: "could not authenticate api key" }],
+    ["billing-token-account-id", { message: "Failed to extract accountId from token" }],
+    [
+      "billing-insufficient-permissions",
+      { message: "You have insufficient permissions for this operation." },
+    ],
+    ["billing-missing-scope", { message: "Missing scopes: model.request" }],
+  ]),
+  ...failoverSignalRows(billingSource, reason("auth_permanent"), [
+    ["billing-api-key-revoked", { message: "Your api key has been revoked" }],
+    [
+      "billing-oauth-org-disabled",
+      { message: "OAuth authentication is currently not allowed for this organization" },
+    ],
+  ]),
+  ...failoverSignalRows(billingSource, reason("auth"), [
+    ["billing-chinese-model-denied", { message: "403 您无权访问glm-5.1。" }],
+    ["billing-chinese-key-banned", { message: "当前ak因违规请求被禁止访问该模型" }],
+    ["billing-chinese-ce-011", { message: '{"success":false,"code":"CE-011"}' }],
+    ["billing-chinese-auth-failed", { message: "鉴权失败，请检查API Key" }],
+  ]),
+  ...failoverSignalRows(matchesSource, reason("auth"), [
     // #48988
-    id: "matches-zai-1113",
-    source: matchesSource,
-    signal: {
-      provider: "zai",
-      message: '{"code":1113,"message":"invalid api endpoint or credentials"}',
-    },
-    expected: reason("auth"),
-  },
-  {
+    [
+      "matches-zai-1113",
+      {
+        provider: "zai",
+        message: '{"code":1113,"message":"invalid api endpoint or credentials"}',
+      },
+    ],
     // #114784
-    id: "matches-google-invalid-key",
-    source: matchesSource,
-    signal: {
-      provider: "google",
-      message:
-        "Google Generative AI API error (400): API key not valid. Please pass a valid API key. [code=INVALID_ARGUMENT]",
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "matches-google-api-key-invalid-code",
-    source: matchesSource,
-    signal: { provider: "google", message: '{"code":"API_KEY_INVALID"}' },
-    expected: reason("auth"),
-  },
-  {
-    id: "patterns-html-401",
-    source: patternsSource,
-    signal: {
-      status: 401,
-      message:
-        "<!doctype html><html><head><title>401 Unauthorized</title></head><body><h1>Unauthorized</h1></body></html>",
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "patterns-html-403",
-    source: patternsSource,
-    signal: {
-      status: 403,
-      message:
-        "<!doctype html><html><head><title>403 Forbidden</title></head><body><h1>Forbidden</h1></body></html>",
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "structured-403-quota-without-hook",
-    source: structuredSource,
-    signal: {
-      provider: "demo-provider",
-      status: 403,
-      code: "PROVIDER_QUOTA_EXHAUSTED",
-      message: "Forbidden",
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "structured-403-rate-without-hook",
-    source: structuredSource,
-    signal: {
-      provider: "demo-provider",
-      status: 403,
-      code: "PROVIDER_RATE_LIMITED",
-      message: "Forbidden",
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "structured-message-prefix-403",
-    source: structuredSource,
-    signal: { provider: "demo-provider", message: "403 concurrency limit breached" },
-    expected: reason("auth"),
-  },
+    [
+      "matches-google-invalid-key",
+      {
+        provider: "google",
+        message:
+          "Google Generative AI API error (400): API key not valid. Please pass a valid API key. [code=INVALID_ARGUMENT]",
+      },
+    ],
+    [
+      "matches-google-api-key-invalid-code",
+      { provider: "google", message: '{"code":"API_KEY_INVALID"}' },
+    ],
+  ]),
+  ...failoverSignalRows(patternsSource, reason("auth"), [
+    [
+      "patterns-html-401",
+      {
+        status: 401,
+        message:
+          "<!doctype html><html><head><title>401 Unauthorized</title></head><body><h1>Unauthorized</h1></body></html>",
+      },
+    ],
+    [
+      "patterns-html-403",
+      {
+        status: 403,
+        message:
+          "<!doctype html><html><head><title>403 Forbidden</title></head><body><h1>Forbidden</h1></body></html>",
+      },
+    ],
+  ]),
+  ...failoverSignalRows(structuredSource, reason("auth"), [
+    [
+      "structured-403-quota-without-hook",
+      {
+        provider: "demo-provider",
+        status: 403,
+        code: "PROVIDER_QUOTA_EXHAUSTED",
+        message: "Forbidden",
+      },
+    ],
+    [
+      "structured-403-rate-without-hook",
+      {
+        provider: "demo-provider",
+        status: 403,
+        code: "PROVIDER_RATE_LIMITED",
+        message: "Forbidden",
+      },
+    ],
+    [
+      "structured-message-prefix-403",
+      { provider: "demo-provider", message: "403 concurrency limit breached" },
+    ],
+  ]),
   {
     id: "http-invalid-api-key",
     source: httpSource,
@@ -284,27 +231,17 @@ export const authFormatCases = [
     expected: reason("auth"),
   },
   // Request shape and replay format.
-  {
-    id: "billing-invalid-request-format",
-    source: billingSource,
-    signal: { message: "invalid request format" },
-    expected: reason("format"),
-  },
-  {
-    id: "billing-prefill-unsupported",
-    source: billingSource,
-    signal: {
-      message:
-        "This model does not support assistant message prefill. The conversation must end with a user message.",
-    },
-    expected: reason("format"),
-  },
-  {
-    id: "billing-pattern-string",
-    source: billingSource,
-    signal: { message: "string should match pattern" },
-    expected: reason("format"),
-  },
+  ...failoverSignalRows(billingSource, reason("format"), [
+    ["billing-invalid-request-format", { message: "invalid request format" }],
+    [
+      "billing-prefill-unsupported",
+      {
+        message:
+          "This model does not support assistant message prefill. The conversation must end with a user message.",
+      },
+    ],
+    ["billing-pattern-string", { message: "string should match pattern" }],
+  ]),
   {
     // #91710
     id: "matches-harness-provider",
@@ -315,47 +252,41 @@ export const authFormatCases = [
     },
     expected: reason("format"),
   },
-  {
-    id: "structured-invalid-request-raw",
-    source: structuredSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        '{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: thinking blocks cannot be modified"}}',
-    },
-    expected: reason("format"),
-  },
-  {
-    id: "structured-invalid-request-typed",
-    source: structuredSource,
-    signal: {
-      provider: "anthropic",
-      errorType: "invalid_request_error",
-      message: "thinking blocks cannot be modified",
-    },
-    expected: reason("format"),
-  },
-  {
+  ...failoverSignalRows(structuredSource, reason("format"), [
+    [
+      "structured-invalid-request-raw",
+      {
+        provider: "anthropic",
+        message:
+          '{"type":"error","error":{"type":"invalid_request_error","message":"messages.27.content.1: thinking blocks cannot be modified"}}',
+      },
+    ],
+    [
+      "structured-invalid-request-typed",
+      {
+        provider: "anthropic",
+        errorType: "invalid_request_error",
+        message: "thinking blocks cannot be modified",
+      },
+    ],
     // #118615, #116967
-    id: "structured-invalid-signature",
-    source: structuredSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        '{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.1: Invalid `signature` in `thinking` block"}}',
-    },
-    expected: reason("format"),
-  },
-  {
-    id: "structured-invalid-signature-carrier",
-    source: structuredSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        'Validation error: The model returned the following errors: {"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.1: Invalid `signature` in `thinking` block"}}',
-    },
-    expected: reason("format"),
-  },
+    [
+      "structured-invalid-signature",
+      {
+        provider: "anthropic",
+        message:
+          '{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.1: Invalid `signature` in `thinking` block"}}',
+      },
+    ],
+    [
+      "structured-invalid-signature-carrier",
+      {
+        provider: "anthropic",
+        message:
+          'Validation error: The model returned the following errors: {"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.1: Invalid `signature` in `thinking` block"}}',
+      },
+    ],
+  ]),
   {
     id: "openrouter-image-input",
     source: openRouterSource,

--- a/src/agents/failover/failover-classification.billing.cases.ts
+++ b/src/agents/failover/failover-classification.billing.cases.ts
@@ -4,6 +4,7 @@ import {
   httpSource,
   matchesSource,
   messageRows,
+  failoverSignalRows,
   patternsSource,
   reason,
   retrySource,
@@ -11,226 +12,146 @@ import {
 } from "./failover-classification.corpus.test-support.js";
 export const billingCases = [
   // Billing and account entitlement.
-  {
+  ...failoverSignalRows(retrySource, reason("billing"), [
     // FIXED(refactor-06): legacy retry policy recognized this provider limit class as permanent.
-    id: "retry-go-usage-limit",
-    source: retrySource,
-    signal: { message: "GoUsageLimitError: usage is unavailable for this account" },
-    expected: reason("billing"),
-  },
-  {
+    [
+      "retry-go-usage-limit",
+      { message: "GoUsageLimitError: usage is unavailable for this account" },
+    ],
     // FIXED(refactor-06): legacy retry policy recognized this provider limit class as permanent.
-    id: "retry-free-usage-limit",
-    source: retrySource,
-    signal: { message: "FreeUsageLimitError: free usage is exhausted" },
-    expected: reason("billing"),
-  },
-  {
+    ["retry-free-usage-limit", { message: "FreeUsageLimitError: free usage is exhausted" }],
     // FIXED(refactor-06): preserve the retry deny-list's account-balance semantics centrally.
-    id: "retry-no-available-balance",
-    source: retrySource,
-    signal: { message: "Your account has no available balance" },
-    expected: reason("billing"),
-  },
-  {
+    ["retry-no-available-balance", { message: "Your account has no available balance" }],
     // FIXED(refactor-06): preserve the retry deny-list's provider-budget semantics centrally.
-    id: "retry-out-of-budget",
-    source: retrySource,
-    signal: { message: "Provider account is out of budget" },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-anthropic-low-credit",
-    source: billingSource,
-    signal: { message: "Your credit balance is too low to access the Anthropic API." },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-insufficient-credits",
-    source: billingSource,
-    signal: { message: "insufficient credits" },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-openrouter-payment-required",
-    source: billingSource,
-    signal: { provider: "openrouter", message: "Payment Required: insufficient credits" },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-openai-insufficient-quota-json",
-    source: billingSource,
-    signal: {
-      provider: "openai",
-      message:
-        '{"type":"error","error":{"type":"insufficient_quota","message":"Your account has insufficient quota balance to run this request."}}',
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-together-payment-required",
-    source: billingSource,
-    signal: {
-      provider: "together",
-      message:
-        "402 Payment Required: The account associated with this API key has reached its maximum allowed monthly spending limit.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-venice-balance",
-    source: billingSource,
-    signal: {
-      provider: "venice",
-      message:
-        "Insufficient USD or Diem balance to complete request. Visit https://venice.ai/settings/api to add credits.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-more-credits-model",
-    source: billingSource,
-    signal: { message: "This model requires more credits to use" },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-more-credits-endpoint",
-    source: billingSource,
-    signal: { message: "This endpoint require more credits" },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-anthropic-extra-usage",
-    source: billingSource,
-    signal: {
-      provider: "anthropic",
-      message: "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-anthropic-extra-usage-required",
-    source: billingSource,
-    signal: {
-      provider: "anthropic",
-      message: "Extra usage is required for long context requests.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-anthropic-third-party-extra-usage",
-    source: billingSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        "Third-party apps now draw from your extra usage, not your plan limits. We've added a $200 credit to get you started. Claim it at claude.ai/settings/usage and keep going.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-insufficient-balance-code",
-    source: billingSource,
-    signal: { message: "insufficient_balance" },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-mbt-balance",
-    source: billingSource,
-    signal: {
-      message: "Insufficient MBT balance. Top up or upgrade your subscription to continue.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-team-credits-spend",
-    source: billingSource,
-    signal: {
-      message:
-        "Your team has either used all available credits or reached its monthly spending limit.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-mbt-flat-json",
-    source: billingSource,
-    signal: {
-      message:
-        '{"error":"insufficient_balance","message":"Insufficient MBT balance. Top up or upgrade your subscription to continue.","upgradeUrl":"/settings/billing"}',
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-poe-points",
-    source: billingSource,
-    signal: {
-      provider: "poe",
-      message: "402 You've used up your points! Visit https://poe.com/api/keys to get more.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-proxy-subscription",
-    source: billingSource,
-    signal: { message: "402 No available asset for API access, please purchase a subscription" },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-upgrade-plan",
-    source: billingSource,
-    signal: {
-      message:
-        "HTTP 402 Payment Required: Your usage limit has been reached. Please upgrade your plan.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-chinese-balance",
-    source: billingSource,
-    signal: { message: "余额不足，请充值" },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-chinese-account-balance",
-    source: billingSource,
-    signal: { message: "账户余额不足" },
-    expected: reason("billing"),
-  },
-  {
-    id: "billing-chinese-arrears",
-    source: billingSource,
-    signal: { message: "账户已欠费" },
-    expected: reason("billing"),
-  },
-  {
-    id: "matches-zai-1311",
-    source: matchesSource,
-    signal: {
-      provider: "zai",
-      message:
-        '{"code":1311,"message":"The model you requested is not available in your current plan"}',
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "matches-zai-plan-access",
-    source: matchesSource,
-    signal: {
-      provider: "zai",
-      message:
-        "FailoverError: Your current subscription plan does not yet include access to GLM-5V-Turbo",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "matches-volcengine-subscription",
-    source: matchesSource,
-    signal: {
-      provider: "volcengine",
-      message:
-        '{"error":{"code":"InvalidSubscription","message":"Your account does not have a valid CodingPlan subscription, or your subscription has expired."}}',
-    },
-    expected: reason("billing"),
-  },
+    ["retry-out-of-budget", { message: "Provider account is out of budget" }],
+  ]),
+  ...failoverSignalRows(billingSource, reason("billing"), [
+    [
+      "billing-anthropic-low-credit",
+      { message: "Your credit balance is too low to access the Anthropic API." },
+    ],
+    ["billing-insufficient-credits", { message: "insufficient credits" }],
+    [
+      "billing-openrouter-payment-required",
+      { provider: "openrouter", message: "Payment Required: insufficient credits" },
+    ],
+    [
+      "billing-openai-insufficient-quota-json",
+      {
+        provider: "openai",
+        message:
+          '{"type":"error","error":{"type":"insufficient_quota","message":"Your account has insufficient quota balance to run this request."}}',
+      },
+    ],
+    [
+      "billing-together-payment-required",
+      {
+        provider: "together",
+        message:
+          "402 Payment Required: The account associated with this API key has reached its maximum allowed monthly spending limit.",
+      },
+    ],
+    [
+      "billing-venice-balance",
+      {
+        provider: "venice",
+        message:
+          "Insufficient USD or Diem balance to complete request. Visit https://venice.ai/settings/api to add credits.",
+      },
+    ],
+    ["billing-more-credits-model", { message: "This model requires more credits to use" }],
+    ["billing-more-credits-endpoint", { message: "This endpoint require more credits" }],
+    [
+      "billing-anthropic-extra-usage",
+      {
+        provider: "anthropic",
+        message: "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+      },
+    ],
+    [
+      "billing-anthropic-extra-usage-required",
+      {
+        provider: "anthropic",
+        message: "Extra usage is required for long context requests.",
+      },
+    ],
+    [
+      "billing-anthropic-third-party-extra-usage",
+      {
+        provider: "anthropic",
+        message:
+          "Third-party apps now draw from your extra usage, not your plan limits. We've added a $200 credit to get you started. Claim it at claude.ai/settings/usage and keep going.",
+      },
+    ],
+    ["billing-insufficient-balance-code", { message: "insufficient_balance" }],
+    [
+      "billing-mbt-balance",
+      {
+        message: "Insufficient MBT balance. Top up or upgrade your subscription to continue.",
+      },
+    ],
+    [
+      "billing-team-credits-spend",
+      {
+        message:
+          "Your team has either used all available credits or reached its monthly spending limit.",
+      },
+    ],
+    [
+      "billing-mbt-flat-json",
+      {
+        message:
+          '{"error":"insufficient_balance","message":"Insufficient MBT balance. Top up or upgrade your subscription to continue.","upgradeUrl":"/settings/billing"}',
+      },
+    ],
+    [
+      "billing-poe-points",
+      {
+        provider: "poe",
+        message: "402 You've used up your points! Visit https://poe.com/api/keys to get more.",
+      },
+    ],
+    [
+      "billing-proxy-subscription",
+      { message: "402 No available asset for API access, please purchase a subscription" },
+    ],
+    [
+      "billing-upgrade-plan",
+      {
+        message:
+          "HTTP 402 Payment Required: Your usage limit has been reached. Please upgrade your plan.",
+      },
+    ],
+    ["billing-chinese-balance", { message: "余额不足，请充值" }],
+    ["billing-chinese-account-balance", { message: "账户余额不足" }],
+    ["billing-chinese-arrears", { message: "账户已欠费" }],
+  ]),
+  ...failoverSignalRows(matchesSource, reason("billing"), [
+    [
+      "matches-zai-1311",
+      {
+        provider: "zai",
+        message:
+          '{"code":1311,"message":"The model you requested is not available in your current plan"}',
+      },
+    ],
+    [
+      "matches-zai-plan-access",
+      {
+        provider: "zai",
+        message:
+          "FailoverError: Your current subscription plan does not yet include access to GLM-5V-Turbo",
+      },
+    ],
+    [
+      "matches-volcengine-subscription",
+      {
+        provider: "volcengine",
+        message:
+          '{"error":{"code":"InvalidSubscription","message":"Your account does not have a valid CodingPlan subscription, or your subscription has expired."}}',
+      },
+    ],
+  ]),
   {
     id: "patterns-xai-spending-limit",
     source: patternsSource,
@@ -241,38 +162,34 @@ export const billingCases = [
     },
     expected: reason("billing"),
   },
-  {
-    id: "structured-billing-raw-extra-usage",
-    source: structuredSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        '{"type":"error","error":{"type":"invalid_request_error","message":"You are out of extra usage. Add more at claude.ai/settings/usage"}}',
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "structured-billing-typed-extra-usage",
-    source: structuredSource,
-    signal: {
-      provider: "anthropic",
-      errorType: "invalid_request_error",
-      message: "You are out of extra usage. Add more at claude.ai/settings/usage",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "structured-billing-openai-details",
-    source: structuredSource,
-    signal: {
-      provider: "openai",
-      message: "You exceeded your current quota, please check your plan and billing details.",
-      code: "insufficient_quota",
-      errorType: "insufficient_quota",
-      details: ['{"error":{"code":"insufficient_quota","type":"insufficient_quota"}}'],
-    },
-    expected: reason("billing"),
-  },
+  ...failoverSignalRows(structuredSource, reason("billing"), [
+    [
+      "structured-billing-raw-extra-usage",
+      {
+        provider: "anthropic",
+        message:
+          '{"type":"error","error":{"type":"invalid_request_error","message":"You are out of extra usage. Add more at claude.ai/settings/usage"}}',
+      },
+    ],
+    [
+      "structured-billing-typed-extra-usage",
+      {
+        provider: "anthropic",
+        errorType: "invalid_request_error",
+        message: "You are out of extra usage. Add more at claude.ai/settings/usage",
+      },
+    ],
+    [
+      "structured-billing-openai-details",
+      {
+        provider: "openai",
+        message: "You exceeded your current quota, please check your plan and billing details.",
+        code: "insufficient_quota",
+        errorType: "insufficient_quota",
+        details: ['{"error":{"code":"insufficient_quota","type":"insufficient_quota"}}'],
+      },
+    ],
+  ]),
   {
     id: "http-structured-insufficient-quota",
     source: httpSource,
@@ -306,18 +223,16 @@ export const billingCases = [
     },
     expected: reason("billing"),
   },
-  {
-    id: "xai-out-of-credits",
-    source: "extensions/xai/index.test.ts",
-    signal: { provider: "xai", message: '403 {"error":"You have run out of credits"}' },
-    expected: reason("auth"),
-  },
-  {
-    id: "xai-subscription-required",
-    source: "extensions/xai/index.test.ts",
-    signal: { provider: "xai", message: '403 {"error":"You need a Grok subscription"}' },
-    expected: reason("auth"),
-  },
+  ...failoverSignalRows("extensions/xai/index.test.ts", reason("auth"), [
+    [
+      "xai-out-of-credits",
+      { provider: "xai", message: '403 {"error":"You have run out of credits"}' },
+    ],
+    [
+      "xai-subscription-required",
+      { provider: "xai", message: '403 {"error":"You need a Grok subscription"}' },
+    ],
+  ]),
   ...messageRows(billingSource, reason("billing"), [
     { id: "billing-http-402", message: "HTTP 402 Payment Required" },
     { id: "billing-status-402", message: "status: 402" },

--- a/src/agents/failover/failover-classification.corpus.test-support.ts
+++ b/src/agents/failover/failover-classification.corpus.test-support.ts
@@ -13,6 +13,40 @@ export const reason = (value: FailoverReason): FailoverClassification => ({
 });
 export const contextOverflow: FailoverClassification = { kind: "context_overflow" };
 
+type LegacyFailoverCorpusCase = readonly [
+  caseNumber: number,
+  matcher: string | readonly [source: string, matcher: string],
+  message: string,
+  expected: FailoverReason | "context_overflow" | null,
+  provider?: string,
+];
+
+export function legacyFailoverCorpusRows(
+  prefix: string,
+  source: string,
+  rows: readonly LegacyFailoverCorpusCase[],
+): FailoverClassificationCorpusRow[] {
+  return rows.map(([caseNumber, matcher, message, expected, provider]) => ({
+    id: `${prefix}-${String(caseNumber).padStart(3, "0")}`,
+    source: typeof matcher === "string" ? `${source}#${matcher}` : `${matcher[0]}#${matcher[1]}`,
+    signal: provider ? { provider, message } : { message },
+    expected:
+      expected === null
+        ? null
+        : expected === "context_overflow"
+          ? contextOverflow
+          : reason(expected),
+  }));
+}
+
+export function failoverSignalRows(
+  source: string,
+  expected: FailoverClassification | null,
+  rows: readonly (readonly [id: string, signal: FailoverSignal])[],
+): FailoverClassificationCorpusRow[] {
+  return rows.map(([id, signal]) => ({ id, source, signal, expected }));
+}
+
 export function messageRows(
   source: string,
   expected: FailoverClassification | null,

--- a/src/agents/failover/failover-classification.legacy-billing-a.cases.ts
+++ b/src/agents/failover/failover-classification.legacy-billing-a.cases.ts
@@ -1,616 +1,230 @@
 import {
-  contextOverflow,
-  reason,
-  type FailoverClassificationCorpusRow,
+  billingSource,
+  legacyFailoverCorpusRows,
 } from "./failover-classification.corpus.test-support.js";
 
 // Distinct real inputs preserved from matcher-specific suites retired by refactor-02.
-export const legacyBillingACases = [
-  {
-    id: "legacy-billing-a-001",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "  An unknown error occurred  " },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-002",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "  Request failed  " },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-003",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "  stream_read_error  " },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-004",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "  terminated  " },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-005",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: {
-      message:
-        '{"error":{"code":402,"message":"payment required","details":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}',
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-006",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message: '{"type":"error","error":{"type":"api_error","message":"invalid input format"}}',
-    },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-007",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        '{"type":"error","error":{"type":"api_error","message":"messages.1.content.1.tool_use.id should match pattern"}}',
-    },
-    expected: reason("format"),
-  },
-  {
-    id: "legacy-billing-a-008",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        '{"type":"error","error":{"type":"api_error","message":"Request size exceeds model context window"}}',
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "legacy-billing-a-009",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError,isLikelyContextOverflowError",
-    signal: {
-      message:
-        '{"type":"error","error":{"type":"invalid_request_error","message":"Reasoning is mandatory for this endpoint and cannot be disabled."}}',
-    },
-    expected: reason("format"),
-  },
-  {
-    id: "legacy-billing-a-010",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage,classifyFailoverReason",
-    signal: { message: "402 items found in the database" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-011",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        '402 Payment Required Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-012",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage,isLikelyContextOverflowError",
-    signal: { message: "402 Payment Required: request token limit exceeded for this billing plan" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-013",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "402 records processed" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-014",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "402 room is available" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-015",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "404 status code (no body)" },
-    expected: reason("model_not_found"),
-  },
-  {
-    id: "legacy-billing-a-016",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "410" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-017",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "410 conversation expired" },
-    expected: reason("session_expired"),
-  },
-  {
-    id: "legacy-billing-a-018",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "410 Gone" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-019",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "410: No body" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-020",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "422 status code (no body)" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-021",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      provider: "openai",
-      message:
-        '429 {"type":"error","error":{"type":"rate_limit_error","message":"You\\u0027ve hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), try again after 11:34 AM."}}',
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-a-022",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isFailoverErrorMessage",
-    signal: { message: "429 rate limit exceeded" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-a-023",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "access denied" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-a-024",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "all credentials for model x are cooling down" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-025",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "an unknown error occurred" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-026",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "AN UNKNOWN ERROR OCCURRED" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-027",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "An unknown error occurred." },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-028",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "api key deactivated" },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "legacy-billing-a-029",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "api key revoked" },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "legacy-billing-a-030",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "api_key_deleted" },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "legacy-billing-a-031",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "API_KEY_REVOKED" },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "legacy-billing-a-032",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage,isContextOverflowError",
-    signal: { message: "authentication failed" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-a-033",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "bad request" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-034",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthErrorMessage",
-    signal: { message: "billing issue detected" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-035",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "Book a 402 room" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-036",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isLikelyContextOverflowError,classifyFailoverReason",
-    signal: { message: "Context window exceeded: too many tokens per request." },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-037",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isLikelyContextOverflowError",
-    signal: { message: "Context window too small: minimum is 1000 tokens" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-038",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "conversation must end with a user message" },
-    expected: reason("format"),
-  },
-  {
-    id: "legacy-billing-a-039",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "deactivated workspace" },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "legacy-billing-a-040",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "deactivated_workspace" },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "legacy-billing-a-041",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "Error code 403 was returned, not 402-related" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-a-042",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        'ERROR provider=google model=gemini-3.1-flash-lite-preview: got status: INTERNAL, details: {"code":500,"status":"INTERNAL"}',
-    },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-043",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "Error: HTTP 422: No response body" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-044",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isLikelyContextOverflowError",
-    signal: { message: "exceeded your current quota" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-a-045",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "finish_reason: error" },
-    expected: reason("server_error"),
-  },
-  {
-    id: "legacy-billing-a-046",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "Fixed issue CHE-402 in the latest release" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-047",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "forbidden" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-a-048",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "got a 402 from the API" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-049",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: {
-      message:
-        'got status: INTERNAL. {"error":{"code":400,"message":"Request malformed","status":"INTERNAL"}}',
-    },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-050",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        'got status: INTERNAL. {"error":{"code":500,"message":"Internal error encountered.","status":"INTERNAL"}}',
-    },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-051",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        'HTTP 400: {"type":"error","error":{"type":"insufficient_quota","message":"Your account has insufficient quota balance to run this request."}}',
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-052",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 400: INVALID_ARGUMENT: input exceeds the maximum number of tokens" },
-    expected: contextOverflow,
-  },
-  {
-    id: "legacy-billing-a-053",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 400: No body" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-a-054",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 400: ThrottlingException: Too many concurrent requests" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-a-055",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message: 'HTTP 401: {"type":"error","error":{"type":"server_error","code":"server_error"}}',
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-a-057",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "http 402" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-058",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 402" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-059",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message: 'HTTP 402: {"type":"error","error":{"type":"server_error","code":"server_error"}}',
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-060",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 402: 402: rate limit exceeded" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-a-061",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 402: Daily limit reached, resets tomorrow." },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-a-062",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 402: Insufficient credits. Organization limit reached." },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-063",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message: "HTTP 402: Monthly spend limit reached. Please visit your billing settings.",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-a-064",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 402: Payment required" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-065",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 402: rate limit exceeded" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-a-066",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        "HTTP 402: The account associated with this API key has reached its maximum allowed monthly spending limit.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-067",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 402: Weekly usage limit exhausted." },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-a-068",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        "HTTP 402: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx insufficient credits. Monthly spend limit reached.",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-069",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 402: Your credit balance is too low. Monthly limit exceeded." },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-070",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 402: Your usage limit has been reached. Please upgrade your plan." },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-072",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 404: insufficient credits" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-073",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 404: invalid_api_key" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-a-074",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 404: No body" },
-    expected: reason("model_not_found"),
-  },
-  {
-    id: "legacy-billing-a-075",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 404: session not found" },
-    expected: reason("session_expired"),
-  },
-  {
-    id: "legacy-billing-a-076",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 410" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-077",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 410: conversation expired" },
-    expected: reason("session_expired"),
-  },
-  {
-    id: "legacy-billing-a-078",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 410: insufficient credits" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-a-079",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 410: invalid_api_key" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-a-080",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 410: No body" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-081",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 410: No body response" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-a-082",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message: 'HTTP 422: {"type":"error","error":{"type":"server_error","code":"server_error"}}',
-    },
-    expected: reason("format"),
-  },
-  {
-    id: "legacy-billing-a-083",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 422: check open ai req parameter error" },
-    expected: reason("format"),
-  },
-] satisfies readonly FailoverClassificationCorpusRow[];
+export const legacyBillingACases = legacyFailoverCorpusRows("legacy-billing-a", billingSource, [
+  [1, "classifyFailoverReason,isFailoverErrorMessage", "  An unknown error occurred  ", "timeout"],
+  [
+    2,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "  Request failed  ",
+    "timeout",
+  ],
+  [
+    3,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "  stream_read_error  ",
+    "timeout",
+  ],
+  [
+    4,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "  terminated  ",
+    "timeout",
+  ],
+  [
+    5,
+    "isBillingErrorMessage",
+    '{"error":{"code":402,"message":"payment required","details":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}',
+    "billing",
+  ],
+  [
+    6,
+    "classifyFailoverReason",
+    '{"type":"error","error":{"type":"api_error","message":"invalid input format"}}',
+    null,
+  ],
+  [
+    7,
+    "classifyFailoverReason",
+    '{"type":"error","error":{"type":"api_error","message":"messages.1.content.1.tool_use.id should match pattern"}}',
+    "format",
+  ],
+  [
+    8,
+    "classifyFailoverReason",
+    '{"type":"error","error":{"type":"api_error","message":"Request size exceeds model context window"}}',
+    "context_overflow",
+  ],
+  [
+    9,
+    "isContextOverflowError,isLikelyContextOverflowError",
+    '{"type":"error","error":{"type":"invalid_request_error","message":"Reasoning is mandatory for this endpoint and cannot be disabled."}}',
+    "format",
+  ],
+  [10, "isBillingErrorMessage,classifyFailoverReason", "402 items found in the database", null],
+  [
+    11,
+    "classifyFailoverReason",
+    '402 Payment Required Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
+    "billing",
+  ],
+  [
+    12,
+    "isBillingErrorMessage,isLikelyContextOverflowError",
+    "402 Payment Required: request token limit exceeded for this billing plan",
+    "billing",
+  ],
+  [13, "classifyFailoverReason", "402 records processed", null],
+  [14, "classifyFailoverReason", "402 room is available", null],
+  [15, "classifyFailoverReason", "404 status code (no body)", "model_not_found"],
+  [16, "classifyFailoverReason", "410", "timeout"],
+  [17, "classifyFailoverReason", "410 conversation expired", "session_expired"],
+  [18, "classifyFailoverReason", "410 Gone", "timeout"],
+  [19, "classifyFailoverReason", "410: No body", "timeout"],
+  [20, "classifyFailoverReason", "422 status code (no body)", null],
+  [
+    21,
+    "classifyFailoverReason",
+    '429 {"type":"error","error":{"type":"rate_limit_error","message":"You\\u0027ve hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), try again after 11:34 AM."}}',
+    "rate_limit",
+    "openai",
+  ],
+  [22, "isFailoverErrorMessage", "429 rate limit exceeded", "rate_limit"],
+  [23, "isAuthPermanentErrorMessage", "access denied", "auth"],
+  [24, "classifyFailoverReason", "all credentials for model x are cooling down", null],
+  [25, "classifyFailoverReason,isFailoverErrorMessage", "an unknown error occurred", "timeout"],
+  [26, "classifyFailoverReason,isFailoverErrorMessage", "AN UNKNOWN ERROR OCCURRED", "timeout"],
+  [27, "classifyFailoverReason,isFailoverErrorMessage", "An unknown error occurred.", "timeout"],
+  [28, "isAuthPermanentErrorMessage", "api key deactivated", "auth_permanent"],
+  [29, "isAuthPermanentErrorMessage", "api key revoked", "auth_permanent"],
+  [30, "isAuthPermanentErrorMessage", "api_key_deleted", "auth_permanent"],
+  [31, "isAuthPermanentErrorMessage", "API_KEY_REVOKED", "auth_permanent"],
+  [32, "isAuthPermanentErrorMessage,isContextOverflowError", "authentication failed", "auth"],
+  [33, "classifyFailoverReason", "bad request", null],
+  [34, "isAuthErrorMessage", "billing issue detected", null],
+  [35, "isBillingErrorMessage", "Book a 402 room", null],
+  [
+    36,
+    "isLikelyContextOverflowError,classifyFailoverReason",
+    "Context window exceeded: too many tokens per request.",
+    null,
+  ],
+  [37, "isLikelyContextOverflowError", "Context window too small: minimum is 1000 tokens", null],
+  [38, "classifyFailoverReason", "conversation must end with a user message", "format"],
+  [39, "isAuthPermanentErrorMessage", "deactivated workspace", "auth_permanent"],
+  [40, "isAuthPermanentErrorMessage", "deactivated_workspace", "auth_permanent"],
+  [41, "isBillingErrorMessage", "Error code 403 was returned, not 402-related", "auth"],
+  [
+    42,
+    "classifyFailoverReason",
+    'ERROR provider=google model=gemini-3.1-flash-lite-preview: got status: INTERNAL, details: {"code":500,"status":"INTERNAL"}',
+    "timeout",
+  ],
+  [43, "classifyFailoverReason", "Error: HTTP 422: No response body", null],
+  [44, "isLikelyContextOverflowError", "exceeded your current quota", "rate_limit"],
+  [
+    45,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "finish_reason: error",
+    "server_error",
+  ],
+  [46, "isBillingErrorMessage", "Fixed issue CHE-402 in the latest release", null],
+  [47, "isAuthPermanentErrorMessage", "forbidden", "auth"],
+  [48, "isBillingErrorMessage", "got a 402 from the API", "billing"],
+  [
+    49,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    'got status: INTERNAL. {"error":{"code":400,"message":"Request malformed","status":"INTERNAL"}}',
+    null,
+  ],
+  [
+    50,
+    "classifyFailoverReason",
+    'got status: INTERNAL. {"error":{"code":500,"message":"Internal error encountered.","status":"INTERNAL"}}',
+    "timeout",
+  ],
+  [
+    51,
+    "classifyFailoverReason",
+    'HTTP 400: {"type":"error","error":{"type":"insufficient_quota","message":"Your account has insufficient quota balance to run this request."}}',
+    "billing",
+  ],
+  [
+    52,
+    "classifyFailoverReason",
+    "HTTP 400: INVALID_ARGUMENT: input exceeds the maximum number of tokens",
+    "context_overflow",
+  ],
+  [53, "classifyFailoverReason", "HTTP 400: No body", null],
+  [
+    54,
+    "classifyFailoverReason",
+    "HTTP 400: ThrottlingException: Too many concurrent requests",
+    "rate_limit",
+  ],
+  [
+    55,
+    "classifyFailoverReason",
+    'HTTP 401: {"type":"error","error":{"type":"server_error","code":"server_error"}}',
+    "auth",
+  ],
+  [57, "isBillingErrorMessage", "http 402", "billing"],
+  [58, "classifyFailoverReason", "HTTP 402", "billing"],
+  [
+    59,
+    "classifyFailoverReason",
+    'HTTP 402: {"type":"error","error":{"type":"server_error","code":"server_error"}}',
+    "billing",
+  ],
+  [60, "classifyFailoverReason", "HTTP 402: 402: rate limit exceeded", "rate_limit"],
+  [61, "classifyFailoverReason", "HTTP 402: Daily limit reached, resets tomorrow.", "rate_limit"],
+  [
+    62,
+    "classifyFailoverReason",
+    "HTTP 402: Insufficient credits. Organization limit reached.",
+    "billing",
+  ],
+  [
+    63,
+    "classifyFailoverReason",
+    "HTTP 402: Monthly spend limit reached. Please visit your billing settings.",
+    "rate_limit",
+  ],
+  [64, "classifyFailoverReason", "HTTP 402: Payment required", "billing"],
+  [65, "classifyFailoverReason", "HTTP 402: rate limit exceeded", "rate_limit"],
+  [
+    66,
+    "classifyFailoverReason",
+    "HTTP 402: The account associated with this API key has reached its maximum allowed monthly spending limit.",
+    "billing",
+  ],
+  [67, "classifyFailoverReason", "HTTP 402: Weekly usage limit exhausted.", "rate_limit"],
+  [
+    68,
+    "classifyFailoverReason",
+    "HTTP 402: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx insufficient credits. Monthly spend limit reached.",
+    "billing",
+  ],
+  [
+    69,
+    "classifyFailoverReason",
+    "HTTP 402: Your credit balance is too low. Monthly limit exceeded.",
+    "billing",
+  ],
+  [
+    70,
+    "classifyFailoverReason",
+    "HTTP 402: Your usage limit has been reached. Please upgrade your plan.",
+    "billing",
+  ],
+  [72, "classifyFailoverReason", "HTTP 404: insufficient credits", "billing"],
+  [73, "classifyFailoverReason", "HTTP 404: invalid_api_key", "auth"],
+  [74, "classifyFailoverReason", "HTTP 404: No body", "model_not_found"],
+  [75, "classifyFailoverReason", "HTTP 404: session not found", "session_expired"],
+  [76, "classifyFailoverReason", "HTTP 410", "timeout"],
+  [77, "classifyFailoverReason", "HTTP 410: conversation expired", "session_expired"],
+  [78, "classifyFailoverReason", "HTTP 410: insufficient credits", "billing"],
+  [79, "classifyFailoverReason", "HTTP 410: invalid_api_key", "auth"],
+  [80, "classifyFailoverReason", "HTTP 410: No body", "timeout"],
+  [81, "classifyFailoverReason", "HTTP 410: No body response", "timeout"],
+  [
+    82,
+    "classifyFailoverReason",
+    'HTTP 422: {"type":"error","error":{"type":"server_error","code":"server_error"}}',
+    "format",
+  ],
+  [83, "classifyFailoverReason", "HTTP 422: check open ai req parameter error", "format"],
+]);

--- a/src/agents/failover/failover-classification.legacy-billing-b.cases.ts
+++ b/src/agents/failover/failover-classification.legacy-billing-b.cases.ts
@@ -1,613 +1,300 @@
 import {
-  contextOverflow,
-  reason,
-  type FailoverClassificationCorpusRow,
+  billingSource,
+  legacyFailoverCorpusRows,
 } from "./failover-classification.corpus.test-support.js";
 
 // Distinct real inputs preserved from matcher-specific suites retired by refactor-02.
-export const legacyBillingBCases = [
-  {
-    id: "legacy-billing-b-001",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 422: insufficient credits" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-b-002",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 422: No body" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-003",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 422: No response body" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-004",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 422: Unprocessable Entity" },
-    expected: reason("format"),
-  },
-  {
-    id: "legacy-billing-b-005",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 499" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-006",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        'HTTP 499: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
-    },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "legacy-billing-b-007",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 499: 499 Client Closed Request" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-008",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "HTTP 500" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-009",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        'HTTP 500: Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
-    },
-    expected: reason("server_error"),
-  },
-  {
-    id: "legacy-billing-b-010",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        'HTTP 502: Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
-    },
-    expected: reason("server_error"),
-  },
-  {
-    id: "legacy-billing-b-011",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        'HTTP 504: Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
-    },
-    expected: reason("server_error"),
-  },
-  {
-    id: "legacy-billing-b-012",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage,isLikelyContextOverflowError",
-    signal: { message: "insufficient credits: request size exceeds your current plan limits" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-b-013",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage,isFailoverErrorMessage,classifyFailoverReason; src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#matchesProviderContextOverflow",
-    signal: { message: "invalid api key" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-b-014",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "invalid token" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-b-015",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "ISSUE-402 has been resolved" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-016",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "key has been revoked" },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "legacy-billing-b-018",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "Let's investigate the context overflow bug" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-019",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "LLM request failed with an unknown error." },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-020",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "LLM request rejected: does not support assistant message prefill" },
-    expected: reason("format"),
-  },
-  {
-    id: "legacy-billing-b-021",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        "messages.84.content.1.image.source.base64.data: At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels",
-    },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-022",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isLikelyContextOverflowError",
-    signal: { message: "Model context window too small (minimum is 128k tokens)" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-023",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "model not found" },
-    expected: reason("model_not_found"),
-  },
-  {
-    id: "legacy-billing-b-024",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "model_context_window_exceeded" },
-    expected: contextOverflow,
-  },
-  {
-    id: "legacy-billing-b-025",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "no api key found" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-b-026",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        'No API key found for provider "openai". Auth store: /tmp/openclaw-agent-abc/auth-profiles.json (agentDir: /tmp/openclaw-agent-abc).',
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-b-027",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "no credentials found" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-b-028",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      provider: "openai",
-      message:
-        "OAuth token refresh failed for openai: file lock timeout for /tmp/agent/auth-profiles.json. Please try again or re-authenticate.",
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-b-029",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      provider: "openai",
-      message:
-        "OAuth token refresh failed for openai: invalid_grant. Please try again or re-authenticate.",
-    },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "legacy-billing-b-030",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "Payment Required" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-b-031",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "port 402 is open" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-032",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "processed 402 records" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-033",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "Prompt is too long" },
-    expected: contextOverflow,
-  },
-  {
-    id: "legacy-billing-b-034",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage; src/agents/embedded-agent-helpers/failover-matches.test.ts#isServerErrorMessage",
-    signal: { message: "Proxy notice: Status: Internal Server Error" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-035",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "Proxy notice: Status: Internal Server Error; code:500" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-036",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "Proxy notice: Status: Internal Server Error; upstream connect error" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-037",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: {
-      message:
-        "Quarterly report summary: subsystem A returned 402 records after retry. This is an analytics count, not an HTTP/API billing failure. Notes: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-b-038",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "reason: abort" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-039",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "reason: network_error" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-040",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "received a 402 response" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-b-041",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "request failed" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-042",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "request size exceeds model context window" },
-    expected: contextOverflow,
-  },
-  {
-    id: "legacy-billing-b-043",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "request size exceeds upload limit" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-044",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isFailoverErrorMessage",
-    signal: { message: "request timed out" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-045",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "Room 402 is available" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-046",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "See ticket #402 for details" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-047",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "Something is causing context overflow messages" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-048",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "status=402 payment required" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-b-049",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "stop reason: abort" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-050",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "stop reason: error" },
-    expected: reason("server_error"),
-  },
-  {
-    id: "legacy-billing-b-051",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "stop reason: MALFORMED_RESPONSE" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-052",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "stop reason: network_error" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-053",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "stream aborted" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-054",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "stream closed" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-055",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: {
-      message:
-        "Sure! Here's how to set up billing for your SaaS application.\n\n## Payment Integration\n\nFirst, you'll need to configure your payment gateway. Most providers offer a dashboard where you can manage credits, view invoices, and upgrade your plan. The billing page typically shows your current balance and payment history.\n\n## Managing Credits\n\nUsers can purchase credits through the billing portal. When their credit balance runs low, send them a notification to upgrade their plan or add more credits. You should also handle insufficient balance cases gracefully.\n\n## Subscription Plans\n\nOffer multiple plan tiers with different features. Allow users to upgrade or downgrade their plan at any time. Make sure the billing cycle is clear.\n\nLet me know if you need more details on any of these topics!",
-    },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-056",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "Terminated" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-057",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "The building at 402 Main Street" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-058",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage,classifyFailoverReason",
-    signal: {
-      message: "The evidence is insufficient to reconcile the final balance after compaction.",
-    },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-059",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "The mystery context overflow errors are strange" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-060",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "the operation was aborted" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-061",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "The user terminated the session manually." },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-062",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "There is a 402 near me" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-063",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isLikelyContextOverflowError",
-    signal: { message: "This endpoint requires reasoning" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-064",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "This model requires reasoning to be enabled" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-065",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "This operation was aborted" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-066",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "token has expired" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-b-067",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isAuthPermanentErrorMessage",
-    signal: { message: "unauthorized" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-billing-b-068",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "UND_ERR_SOCKET" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-069",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "Unhandled stop reason: context_window_exceeded" },
-    expected: contextOverflow,
-  },
-  {
-    id: "legacy-billing-b-070",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "Unhandled stop reason: error" },
-    expected: reason("server_error"),
-  },
-  {
-    id: "legacy-billing-b-071",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "Unhandled stop reason: malformed_response" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-billing-b-072",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason,isFailoverErrorMessage",
-    signal: { message: "Unknown error (no error details in response)" },
-    expected: reason("no_error_details"),
-  },
-  {
-    id: "legacy-billing-b-073",
-    source: "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage",
-    signal: { message: "Use a 402 stainless bolt" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-074",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: { message: "user reported that an unknown error occurred during sync" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-075",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "We're debugging context overflow issues" },
-    expected: null,
-  },
-  {
-    id: "legacy-billing-b-076",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      provider: "openai",
-      message:
-        "You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), try again after 11:34 AM.",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-b-077",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      provider: "openai",
-      message:
-        "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits, try again later.",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-billing-b-078",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      provider: "openai",
-      message:
-        "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.",
-    },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "legacy-billing-b-079",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#classifyFailoverReason",
-    signal: {
-      provider: "openai",
-      message:
-        "Your authentication session could not be refreshed automatically. Please log out and sign in again.",
-    },
-    expected: reason("auth_permanent"),
-  },
-  {
-    id: "legacy-billing-b-080",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isFailoverErrorMessage",
-    signal: { message: "Your credit balance is too low" },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-b-081",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isBillingErrorMessage,isLikelyContextOverflowError",
-    signal: { message: "Your credit balance is too low. Maximum request token limit exceeded." },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-billing-b-082",
-    source:
-      "src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts#isContextOverflowError",
-    signal: { message: "上下文过长" },
-    expected: contextOverflow,
-  },
-] satisfies readonly FailoverClassificationCorpusRow[];
+export const legacyBillingBCases = legacyFailoverCorpusRows("legacy-billing-b", billingSource, [
+  [1, "classifyFailoverReason", "HTTP 422: insufficient credits", "billing"],
+  [2, "classifyFailoverReason", "HTTP 422: No body", null],
+  [3, "classifyFailoverReason", "HTTP 422: No response body", null],
+  [4, "classifyFailoverReason", "HTTP 422: Unprocessable Entity", "format"],
+  [5, "classifyFailoverReason", "HTTP 499", "timeout"],
+  [
+    6,
+    "classifyFailoverReason",
+    'HTTP 499: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
+    "overloaded",
+  ],
+  [7, "classifyFailoverReason", "HTTP 499: 499 Client Closed Request", "timeout"],
+  [8, "classifyFailoverReason", "HTTP 500", "timeout"],
+  [
+    9,
+    "classifyFailoverReason",
+    'HTTP 500: Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
+    "server_error",
+  ],
+  [
+    10,
+    "classifyFailoverReason",
+    'HTTP 502: Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
+    "server_error",
+  ],
+  [
+    11,
+    "classifyFailoverReason",
+    'HTTP 504: Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
+    "server_error",
+  ],
+  [
+    12,
+    "isBillingErrorMessage,isLikelyContextOverflowError",
+    "insufficient credits: request size exceeds your current plan limits",
+    "billing",
+  ],
+  [
+    13,
+    "isBillingErrorMessage,isFailoverErrorMessage,classifyFailoverReason; src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#matchesProviderContextOverflow",
+    "invalid api key",
+    "auth",
+  ],
+  [14, "isAuthPermanentErrorMessage", "invalid token", "auth"],
+  [15, "isBillingErrorMessage", "ISSUE-402 has been resolved", null],
+  [16, "isAuthPermanentErrorMessage", "key has been revoked", "auth_permanent"],
+  [18, "isContextOverflowError", "Let's investigate the context overflow bug", null],
+  [19, "classifyFailoverReason", "LLM request failed with an unknown error.", null],
+  [
+    20,
+    "classifyFailoverReason",
+    "LLM request rejected: does not support assistant message prefill",
+    "format",
+  ],
+  [
+    21,
+    "classifyFailoverReason",
+    "messages.84.content.1.image.source.base64.data: At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels",
+    null,
+  ],
+  [
+    22,
+    "isLikelyContextOverflowError",
+    "Model context window too small (minimum is 128k tokens)",
+    null,
+  ],
+  [23, "isContextOverflowError", "model not found", "model_not_found"],
+  [24, "isContextOverflowError", "model_context_window_exceeded", "context_overflow"],
+  [25, "classifyFailoverReason", "no api key found", "auth"],
+  [
+    26,
+    "classifyFailoverReason",
+    'No API key found for provider "openai". Auth store: /tmp/openclaw-agent-abc/auth-profiles.json (agentDir: /tmp/openclaw-agent-abc).',
+    "auth",
+  ],
+  [27, "classifyFailoverReason", "no credentials found", "auth"],
+  [
+    28,
+    "classifyFailoverReason",
+    "OAuth token refresh failed for openai: file lock timeout for /tmp/agent/auth-profiles.json. Please try again or re-authenticate.",
+    "auth",
+    "openai",
+  ],
+  [
+    29,
+    "classifyFailoverReason",
+    "OAuth token refresh failed for openai: invalid_grant. Please try again or re-authenticate.",
+    "auth_permanent",
+    "openai",
+  ],
+  [30, "isBillingErrorMessage", "Payment Required", "billing"],
+  [31, "isBillingErrorMessage", "port 402 is open", null],
+  [32, "isBillingErrorMessage", "processed 402 records", null],
+  [33, "classifyFailoverReason", "Prompt is too long", "context_overflow"],
+  [
+    34,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage; src/agents/embedded-agent-helpers/failover-matches.test.ts#isServerErrorMessage",
+    "Proxy notice: Status: Internal Server Error",
+    null,
+  ],
+  [
+    35,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "Proxy notice: Status: Internal Server Error; code:500",
+    "timeout",
+  ],
+  [
+    36,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "Proxy notice: Status: Internal Server Error; upstream connect error",
+    "timeout",
+  ],
+  [
+    37,
+    "isBillingErrorMessage",
+    "Quarterly report summary: subsystem A returned 402 records after retry. This is an analytics count, not an HTTP/API billing failure. Notes: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "billing",
+  ],
+  [
+    38,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "reason: abort",
+    "timeout",
+  ],
+  [
+    39,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "reason: network_error",
+    "timeout",
+  ],
+  [40, "isBillingErrorMessage", "received a 402 response", "billing"],
+  [
+    41,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "request failed",
+    "timeout",
+  ],
+  [42, "isContextOverflowError", "request size exceeds model context window", "context_overflow"],
+  [43, "isContextOverflowError", "request size exceeds upload limit", null],
+  [44, "isFailoverErrorMessage", "request timed out", "timeout"],
+  [45, "isBillingErrorMessage", "Room 402 is available", null],
+  [46, "isBillingErrorMessage", "See ticket #402 for details", null],
+  [47, "isContextOverflowError", "Something is causing context overflow messages", null],
+  [48, "isBillingErrorMessage", "status=402 payment required", "billing"],
+  [
+    49,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "stop reason: abort",
+    "timeout",
+  ],
+  [
+    50,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "stop reason: error",
+    "server_error",
+  ],
+  [
+    51,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "stop reason: MALFORMED_RESPONSE",
+    "timeout",
+  ],
+  [
+    52,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "stop reason: network_error",
+    "timeout",
+  ],
+  [
+    53,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "stream aborted",
+    "timeout",
+  ],
+  [
+    54,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "stream closed",
+    "timeout",
+  ],
+  [
+    55,
+    "isBillingErrorMessage",
+    "Sure! Here's how to set up billing for your SaaS application.\n\n## Payment Integration\n\nFirst, you'll need to configure your payment gateway. Most providers offer a dashboard where you can manage credits, view invoices, and upgrade your plan. The billing page typically shows your current balance and payment history.\n\n## Managing Credits\n\nUsers can purchase credits through the billing portal. When their credit balance runs low, send them a notification to upgrade their plan or add more credits. You should also handle insufficient balance cases gracefully.\n\n## Subscription Plans\n\nOffer multiple plan tiers with different features. Allow users to upgrade or downgrade their plan at any time. Make sure the billing cycle is clear.\n\nLet me know if you need more details on any of these topics!",
+    null,
+  ],
+  [
+    56,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "Terminated",
+    "timeout",
+  ],
+  [57, "isBillingErrorMessage", "The building at 402 Main Street", null],
+  [
+    58,
+    "isBillingErrorMessage,classifyFailoverReason",
+    "The evidence is insufficient to reconcile the final balance after compaction.",
+    null,
+  ],
+  [59, "isContextOverflowError", "The mystery context overflow errors are strange", null],
+  [
+    60,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "the operation was aborted",
+    "timeout",
+  ],
+  [
+    61,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "The user terminated the session manually.",
+    null,
+  ],
+  [62, "isBillingErrorMessage", "There is a 402 near me", null],
+  [63, "isLikelyContextOverflowError", "This endpoint requires reasoning", null],
+  [64, "isContextOverflowError", "This model requires reasoning to be enabled", null],
+  [
+    65,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "This operation was aborted",
+    "timeout",
+  ],
+  [66, "isAuthPermanentErrorMessage", "token has expired", "auth"],
+  [67, "isAuthPermanentErrorMessage", "unauthorized", "auth"],
+  [
+    68,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "UND_ERR_SOCKET",
+    "timeout",
+  ],
+  [
+    69,
+    "isContextOverflowError",
+    "Unhandled stop reason: context_window_exceeded",
+    "context_overflow",
+  ],
+  [
+    70,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "Unhandled stop reason: error",
+    "server_error",
+  ],
+  [
+    71,
+    "isTimeoutErrorMessage,classifyFailoverReason,isFailoverErrorMessage",
+    "Unhandled stop reason: malformed_response",
+    "timeout",
+  ],
+  [
+    72,
+    "classifyFailoverReason,isFailoverErrorMessage",
+    "Unknown error (no error details in response)",
+    "no_error_details",
+  ],
+  [73, "isBillingErrorMessage", "Use a 402 stainless bolt", null],
+  [74, "classifyFailoverReason", "user reported that an unknown error occurred during sync", null],
+  [75, "isContextOverflowError", "We're debugging context overflow issues", null],
+  [
+    76,
+    "classifyFailoverReason",
+    "You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), try again after 11:34 AM.",
+    "rate_limit",
+    "openai",
+  ],
+  [
+    77,
+    "classifyFailoverReason",
+    "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits, try again later.",
+    "rate_limit",
+    "openai",
+  ],
+  [
+    78,
+    "classifyFailoverReason",
+    "Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.",
+    "auth_permanent",
+    "openai",
+  ],
+  [
+    79,
+    "classifyFailoverReason",
+    "Your authentication session could not be refreshed automatically. Please log out and sign in again.",
+    "auth_permanent",
+    "openai",
+  ],
+  [80, "isFailoverErrorMessage", "Your credit balance is too low", "billing"],
+  [
+    81,
+    "isBillingErrorMessage,isLikelyContextOverflowError",
+    "Your credit balance is too low. Maximum request token limit exceeded.",
+    "billing",
+  ],
+  [82, "isContextOverflowError", "上下文过长", "context_overflow"],
+]);

--- a/src/agents/failover/failover-classification.legacy-provider-matchers.cases.ts
+++ b/src/agents/failover/failover-classification.legacy-provider-matchers.cases.ts
@@ -1,191 +1,112 @@
 import {
-  reason,
-  type FailoverClassificationCorpusRow,
+  legacyFailoverCorpusRows,
+  matchesSource,
+  patternsSource,
 } from "./failover-classification.corpus.test-support.js";
 
 // Distinct real inputs preserved from matcher-specific suites retired by refactor-02.
-export const legacyProviderMatcherCases = [
-  {
-    id: "legacy-provider-matchers-001",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#isAuthErrorMessage",
-    signal: { message: '{"code": 1113, "message": "invalid api endpoint or credentials"}' },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-provider-matchers-002",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#isBillingErrorMessage",
-    signal: {
-      message:
-        '{"code":1311,"message":"The model you requested is not available in your current plan","details":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}',
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-provider-matchers-003",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#isBillingErrorMessage",
-    signal: {
-      message:
-        '{"error":{"code":"InvalidSubscription","message":"Your account does not have a valid coding plan subscription, or your subscription has expired.","details":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}',
-    },
-    expected: reason("billing"),
-  },
-  {
-    id: "legacy-provider-matchers-004",
-    source:
-      "src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        "401 <!doctype html><html><head><title>401 Unauthorized</title></head><body><h1>Unauthorized</h1></body></html>",
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-provider-matchers-005",
-    source:
-      "src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        "403 <!doctype html><html><head><title>403 Forbidden</title></head><body><h1>Forbidden</h1></body></html>",
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-provider-matchers-006",
-    source:
-      "src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        "502 <!doctype html><html><head><title>502 Bad Gateway</title></head><body><h1>502 Bad Gateway</h1><p>cloudflare-nginx</p></body></html>",
-    },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-provider-matchers-007",
-    source:
-      "src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        "503 <!doctype html><html><head><title>503</title></head><body><h1>Service Unavailable</h1><p>Please try again. Rate limit exceeded.</p></body></html>",
-    },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-provider-matchers-008",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#isAuthErrorMessage",
-    signal: { message: "API key invalidation policy updated" },
-    expected: null,
-  },
-  {
-    id: "legacy-provider-matchers-009",
-    source:
-      "src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#classifyProviderSpecificError",
-    signal: { message: "concurrency limit reached" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-provider-matchers-010",
-    source:
-      "src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        "Error: 401 <!doctype html><html><head><title>401 Unauthorized</title></head><body><h1>Unauthorized</h1></body></html>",
-    },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-provider-matchers-011",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        'HTTP 429: 429 status code (exceeded limit)\n{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}',
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "legacy-provider-matchers-012",
-    source:
-      "src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#matchesProviderContextOverflow",
-    signal: { message: "internal server error" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-provider-matchers-013",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#isAuthErrorMessage",
-    signal: { message: "invalid api key provided" },
-    expected: reason("auth"),
-  },
-  {
-    id: "legacy-provider-matchers-014",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#isAuthErrorMessage",
-    signal: { message: "INVALID API KEYSTORE configuration" },
-    expected: null,
-  },
-  {
-    id: "legacy-provider-matchers-015",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#isTimeoutErrorMessage",
-    signal: { message: "LLM request failed: connection refused by the provider endpoint." },
-    expected: null,
-  },
-  {
-    id: "legacy-provider-matchers-016",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#isTimeoutErrorMessage",
-    signal: {
-      message: "LLM request failed: provider rejected the request schema or tool payload.",
-    },
-    expected: null,
-  },
-  {
-    id: "legacy-provider-matchers-017",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#classifyFailoverReason",
-    signal: { message: "llm request failed." },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-provider-matchers-018",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#classifyFailoverReason",
-    signal: { message: "LLM request failed." },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-provider-matchers-019",
-    source:
-      "src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#classifyProviderSpecificError",
-    signal: { message: "model_is_deactivated" },
-    expected: reason("model_not_found"),
-  },
-  {
-    id: "legacy-provider-matchers-020",
-    source:
-      "src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#matchesProviderContextOverflow",
-    signal: { message: "Permission denied for /root/oc-acp-write-should-fail.txt." },
-    expected: null,
-  },
-  {
-    id: "legacy-provider-matchers-021",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#isServerErrorMessage",
-    signal: { message: "provider failed (HTTP 500): upstream apiKey is empty" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "legacy-provider-matchers-022",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#classifyFailoverReason",
-    signal: {
-      message:
-        'Requested agent harness "codex" does not support openrouter/gpt-5.4 (provider is not one of: codex, openai).',
-    },
-    expected: reason("format"),
-  },
-  {
-    id: "legacy-provider-matchers-023",
-    source:
-      "src/agents/embedded-agent-helpers/provider-error-patterns.test.ts#classifyProviderSpecificError",
-    signal: { message: "some random error" },
-    expected: null,
-  },
-  {
-    id: "legacy-provider-matchers-024",
-    source: "src/agents/embedded-agent-helpers/failover-matches.test.ts#isServerErrorMessage",
-    signal: { message: "status: internal server error" },
-    expected: reason("timeout"),
-  },
-] satisfies readonly FailoverClassificationCorpusRow[];
+export const legacyProviderMatcherCases = legacyFailoverCorpusRows(
+  "legacy-provider-matchers",
+  matchesSource,
+  [
+    [
+      1,
+      "isAuthErrorMessage",
+      '{"code": 1113, "message": "invalid api endpoint or credentials"}',
+      "auth",
+    ],
+    [
+      2,
+      "isBillingErrorMessage",
+      '{"code":1311,"message":"The model you requested is not available in your current plan","details":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}',
+      "billing",
+    ],
+    [
+      3,
+      "isBillingErrorMessage",
+      '{"error":{"code":"InvalidSubscription","message":"Your account does not have a valid coding plan subscription, or your subscription has expired.","details":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}',
+      "billing",
+    ],
+    [
+      4,
+      [patternsSource, "classifyFailoverReason"],
+      "401 <!doctype html><html><head><title>401 Unauthorized</title></head><body><h1>Unauthorized</h1></body></html>",
+      "auth",
+    ],
+    [
+      5,
+      [patternsSource, "classifyFailoverReason"],
+      "403 <!doctype html><html><head><title>403 Forbidden</title></head><body><h1>Forbidden</h1></body></html>",
+      "auth",
+    ],
+    [
+      6,
+      [patternsSource, "classifyFailoverReason"],
+      "502 <!doctype html><html><head><title>502 Bad Gateway</title></head><body><h1>502 Bad Gateway</h1><p>cloudflare-nginx</p></body></html>",
+      "timeout",
+    ],
+    [
+      7,
+      [patternsSource, "classifyFailoverReason"],
+      "503 <!doctype html><html><head><title>503</title></head><body><h1>Service Unavailable</h1><p>Please try again. Rate limit exceeded.</p></body></html>",
+      "timeout",
+    ],
+    [8, "isAuthErrorMessage", "API key invalidation policy updated", null],
+    [
+      9,
+      [patternsSource, "classifyProviderSpecificError"],
+      "concurrency limit reached",
+      "rate_limit",
+    ],
+    [
+      10,
+      [patternsSource, "classifyFailoverReason"],
+      "Error: 401 <!doctype html><html><head><title>401 Unauthorized</title></head><body><h1>Unauthorized</h1></body></html>",
+      "auth",
+    ],
+    [
+      11,
+      "classifyFailoverReason",
+      'HTTP 429: 429 status code (exceeded limit)\n{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}',
+      "rate_limit",
+    ],
+    [12, [patternsSource, "matchesProviderContextOverflow"], "internal server error", "timeout"],
+    [13, "isAuthErrorMessage", "invalid api key provided", "auth"],
+    [14, "isAuthErrorMessage", "INVALID API KEYSTORE configuration", null],
+    [
+      15,
+      "isTimeoutErrorMessage",
+      "LLM request failed: connection refused by the provider endpoint.",
+      null,
+    ],
+    [
+      16,
+      "isTimeoutErrorMessage",
+      "LLM request failed: provider rejected the request schema or tool payload.",
+      null,
+    ],
+    [17, "classifyFailoverReason", "llm request failed.", "timeout"],
+    [18, "classifyFailoverReason", "LLM request failed.", "timeout"],
+    [
+      19,
+      [patternsSource, "classifyProviderSpecificError"],
+      "model_is_deactivated",
+      "model_not_found",
+    ],
+    [
+      20,
+      [patternsSource, "matchesProviderContextOverflow"],
+      "Permission denied for /root/oc-acp-write-should-fail.txt.",
+      null,
+    ],
+    [21, "isServerErrorMessage", "provider failed (HTTP 500): upstream apiKey is empty", "timeout"],
+    [
+      22,
+      "classifyFailoverReason",
+      'Requested agent harness "codex" does not support openrouter/gpt-5.4 (provider is not one of: codex, openai).',
+      "format",
+    ],
+    [23, [patternsSource, "classifyProviderSpecificError"], "some random error", null],
+    [24, "isServerErrorMessage", "status: internal server error", "timeout"],
+  ],
+);

--- a/src/agents/failover/failover-classification.overflow-server-misc.cases.ts
+++ b/src/agents/failover/failover-classification.overflow-server-misc.cases.ts
@@ -5,6 +5,7 @@ import {
   httpSource,
   matchesSource,
   messageRows,
+  failoverSignalRows,
   openRouterSource,
   patternsSource,
   reason,
@@ -12,220 +13,110 @@ import {
 } from "./failover-classification.corpus.test-support.js";
 export const overflowServerMiscCases = [
   // Transient transport and provider failures.
-  {
-    id: "billing-deadline-exceeded",
-    source: billingSource,
-    signal: { message: "deadline exceeded" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-no-stream-chunks",
-    source: billingSource,
-    signal: { message: "request ended without sending any chunks" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-connection-error",
-    source: billingSource,
-    signal: { message: "Connection error." },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-fetch-failed",
-    source: billingSource,
-    signal: { message: "fetch failed" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-econnrefused",
-    source: billingSource,
-    signal: { message: "network error: ECONNREFUSED" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-enotfound",
-    source: billingSource,
-    signal: { message: "dial tcp: lookup api.example.com: no such host (ENOTFOUND)" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-dns-eai-again",
-    source: billingSource,
-    signal: { message: "temporary dns failure EAI_AGAIN" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-cloudflare-521",
-    source: billingSource,
-    signal: {
-      message:
-        "521 <!DOCTYPE html><html><head><title>Web server is down</title></head><body>Cloudflare</body></html>",
-    },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-openai-retry-guidance",
-    source: billingSource,
-    signal: {
-      provider: "openai",
-      message:
-        "An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID synthetic-provider-request-001 in your message.",
-    },
-    expected: reason("timeout"),
-  },
-  {
+  ...failoverSignalRows(billingSource, reason("timeout"), [
+    ["billing-deadline-exceeded", { message: "deadline exceeded" }],
+    ["billing-no-stream-chunks", { message: "request ended without sending any chunks" }],
+    ["billing-connection-error", { message: "Connection error." }],
+    ["billing-fetch-failed", { message: "fetch failed" }],
+    ["billing-econnrefused", { message: "network error: ECONNREFUSED" }],
+    [
+      "billing-enotfound",
+      { message: "dial tcp: lookup api.example.com: no such host (ENOTFOUND)" },
+    ],
+    ["billing-dns-eai-again", { message: "temporary dns failure EAI_AGAIN" }],
+    [
+      "billing-cloudflare-521",
+      {
+        message:
+          "521 <!DOCTYPE html><html><head><title>Web server is down</title></head><body>Cloudflare</body></html>",
+      },
+    ],
+    [
+      "billing-openai-retry-guidance",
+      {
+        provider: "openai",
+        message:
+          "An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID synthetic-provider-request-001 in your message.",
+      },
+    ],
     // #71620
-    id: "billing-shared-runtime-unknown-error",
-    source: billingSource,
-    signal: { message: "An unknown error occurred" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-generic-410",
-    source: billingSource,
-    signal: { message: "HTTP 410 Gone" },
-    expected: reason("timeout"),
-  },
-  {
+    ["billing-shared-runtime-unknown-error", { message: "An unknown error occurred" }],
+    ["billing-generic-410", { message: "HTTP 410 Gone" }],
     // #42149
-    id: "billing-gemini-malformed-response",
-    source: billingSource,
-    signal: { provider: "google", message: "Unhandled stop reason: MALFORMED_RESPONSE" },
-    expected: reason("timeout"),
-  },
-  {
+    [
+      "billing-gemini-malformed-response",
+      { provider: "google", message: "Unhandled stop reason: MALFORMED_RESPONSE" },
+    ],
     // #58315
-    id: "billing-operation-aborted",
-    source: billingSource,
-    signal: { message: "The operation was aborted" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-stream-aborted",
-    source: billingSource,
-    signal: { message: "stream was aborted" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-etimedout",
-    source: billingSource,
-    signal: { message: "Error: connect ETIMEDOUT 10.0.0.1:443" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-ehostunreach",
-    source: billingSource,
-    signal: { message: "Error: connect EHOSTUNREACH 10.0.0.1:443" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-epipe",
-    source: billingSource,
-    signal: { message: "Error: write EPIPE" },
-    expected: reason("timeout"),
-  },
-  {
+    ["billing-operation-aborted", { message: "The operation was aborted" }],
+    ["billing-stream-aborted", { message: "stream was aborted" }],
+    ["billing-etimedout", { message: "Error: connect ETIMEDOUT 10.0.0.1:443" }],
+    ["billing-ehostunreach", { message: "Error: connect EHOSTUNREACH 10.0.0.1:443" }],
+    ["billing-epipe", { message: "Error: write EPIPE" }],
     // #61281
-    id: "billing-provider-network-finish-reason",
-    source: billingSource,
-    signal: { message: "Provider finish_reason: network_error" },
-    expected: reason("timeout"),
-  },
-  {
+    [
+      "billing-provider-network-finish-reason",
+      { message: "Provider finish_reason: network_error" },
+    ],
     // #69368
-    id: "billing-undici-socket",
-    source: billingSource,
-    signal: { message: "Error: UND_ERR_SOCKET other side closed" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-undici-connect-timeout",
-    source: billingSource,
-    signal: { message: "UND_ERR_CONNECT_TIMEOUT" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-request-failed-retries",
-    source: billingSource,
-    signal: { message: "Request failed after repeated internal retries." },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-google-internal-500",
-    source: billingSource,
-    signal: {
-      provider: "google",
-      message:
-        "provider=google model=gemini-3.1-flash-lite-preview got status: INTERNAL upstream failure code:500",
-    },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-mini-max-520",
-    source: billingSource,
-    signal: { message: '{"type":"api_error","message":"unknown error, 520 (1000)"}' },
-    expected: reason("timeout"),
-  },
-  {
+    ["billing-undici-socket", { message: "Error: UND_ERR_SOCKET other side closed" }],
+    ["billing-undici-connect-timeout", { message: "UND_ERR_CONNECT_TIMEOUT" }],
+    [
+      "billing-request-failed-retries",
+      { message: "Request failed after repeated internal retries." },
+    ],
+    [
+      "billing-google-internal-500",
+      {
+        provider: "google",
+        message:
+          "provider=google model=gemini-3.1-flash-lite-preview got status: INTERNAL upstream failure code:500",
+      },
+    ],
+    [
+      "billing-mini-max-520",
+      { message: '{"type":"api_error","message":"unknown error, 520 (1000)"}' },
+    ],
     // #57010
-    id: "billing-anthropic-unexpected-error",
-    source: billingSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        '{"type":"error","error":{"type":"api_error","message":"An unexpected error occurred while processing the response"}}',
-    },
-    expected: reason("timeout"),
-  },
-  {
+    [
+      "billing-anthropic-unexpected-error",
+      {
+        provider: "anthropic",
+        message:
+          '{"type":"error","error":{"type":"api_error","message":"An unexpected error occurred while processing the response"}}',
+      },
+    ],
     // #56242
-    id: "billing-zhipu-network-1234",
-    source: billingSource,
-    signal: {
-      provider: "zai",
-      message:
-        "LLM error 1234: 网络错误，错误id：202603281427587491f4467f1c4712，请联系客服。 (request_id: 202603281427587491f4467f1c4712)",
-    },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-chinese-network-abnormal",
-    source: billingSource,
-    signal: { message: "网络异常，请稍后重试" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-chinese-service-busy",
-    source: billingSource,
-    signal: { message: "服务繁忙，请稍后再试" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "billing-chinese-system-error",
-    source: billingSource,
-    signal: { message: "系统错误，请稍后重试" },
-    expected: reason("timeout"),
-  },
-  {
-    id: "patterns-cloudflare-html-502",
-    source: patternsSource,
-    signal: {
-      status: 502,
-      message:
-        "<!doctype html><html><head><title>502 Bad Gateway</title></head><body><h1>502 Bad Gateway</h1><p>cloudflare-nginx</p></body></html>",
-    },
-    expected: reason("timeout"),
-  },
-  {
-    id: "patterns-cloudflare-html-503",
-    source: patternsSource,
-    signal: {
-      status: 503,
-      message:
-        "<!doctype html><html><head><title>503</title></head><body><h1>Service Unavailable</h1><p>Please try again. Rate limit exceeded.</p></body></html>",
-    },
-    expected: reason("timeout"),
-  },
+    [
+      "billing-zhipu-network-1234",
+      {
+        provider: "zai",
+        message:
+          "LLM error 1234: 网络错误，错误id：202603281427587491f4467f1c4712，请联系客服。 (request_id: 202603281427587491f4467f1c4712)",
+      },
+    ],
+    ["billing-chinese-network-abnormal", { message: "网络异常，请稍后重试" }],
+    ["billing-chinese-service-busy", { message: "服务繁忙，请稍后再试" }],
+    ["billing-chinese-system-error", { message: "系统错误，请稍后重试" }],
+  ]),
+  ...failoverSignalRows(patternsSource, reason("timeout"), [
+    [
+      "patterns-cloudflare-html-502",
+      {
+        status: 502,
+        message:
+          "<!doctype html><html><head><title>502 Bad Gateway</title></head><body><h1>502 Bad Gateway</h1><p>cloudflare-nginx</p></body></html>",
+      },
+    ],
+    [
+      "patterns-cloudflare-html-503",
+      {
+        status: 503,
+        message:
+          "<!doctype html><html><head><title>503</title></head><body><h1>Service Unavailable</h1><p>Please try again. Rate limit exceeded.</p></body></html>",
+      },
+    ],
+  ]),
   {
     id: "retry-explicit-retry-guidance",
     source: retrySource,
@@ -385,23 +276,18 @@ export const overflowServerMiscCases = [
     },
   ]),
   // Provider-completed server errors.
-  {
-    id: "billing-openai-structured-server-error",
-    source: billingSource,
-    signal: {
-      provider: "openai",
-      message:
-        'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
-    },
-    expected: reason("server_error"),
-  },
-  {
+  ...failoverSignalRows(billingSource, reason("server_error"), [
+    [
+      "billing-openai-structured-server-error",
+      {
+        provider: "openai",
+        message:
+          'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}',
+      },
+    ],
     // #109218
-    id: "billing-provider-finish-error",
-    source: billingSource,
-    signal: { message: "Provider finish_reason: error" },
-    expected: reason("server_error"),
-  },
+    ["billing-provider-finish-error", { message: "Provider finish_reason: error" }],
+  ]),
   {
     id: "matches-provider-finish-error",
     source: matchesSource,
@@ -437,36 +323,21 @@ export const overflowServerMiscCases = [
     },
     expected: reason("model_not_found"),
   },
-  {
-    id: "retry-mistral-model-not-found",
-    source: retrySource,
-    signal: { provider: "mistral", message: "Mistral API error (404): model not found" },
-    expected: reason("model_not_found"),
-  },
-  {
-    id: "retry-gpt-preview-not-found",
-    source: retrySource,
-    signal: { message: "model gpt-5.5-preview-0429 not found" },
+  ...failoverSignalRows(retrySource, reason("model_not_found"), [
+    [
+      "retry-mistral-model-not-found",
+      { provider: "mistral", message: "Mistral API error (404): model not found" },
+    ],
     // FIXED(refactor-02): was rate_limit, now model_not_found
-    expected: reason("model_not_found"),
-  },
-  {
-    id: "retry-model-preview-not-found",
-    source: retrySource,
-    signal: { message: "model model-x-500-preview not found" },
+    ["retry-gpt-preview-not-found", { message: "model gpt-5.5-preview-0429 not found" }],
     // FIXED(refactor-02): was null, now model_not_found
-    expected: reason("model_not_found"),
-  },
-  {
-    id: "billing-session-not-found",
-    source: billingSource,
-    signal: { message: "HTTP 410: session not found" },
-    expected: reason("session_expired"),
-  },
-  {
-    id: "billing-claude-conversation-missing",
-    source: billingSource,
-    signal: { provider: "claude-cli", message: "No conversation found with session ID: abc123" },
-    expected: reason("session_expired"),
-  },
+    ["retry-model-preview-not-found", { message: "model model-x-500-preview not found" }],
+  ]),
+  ...failoverSignalRows(billingSource, reason("session_expired"), [
+    ["billing-session-not-found", { message: "HTTP 410: session not found" }],
+    [
+      "billing-claude-conversation-missing",
+      { provider: "claude-cli", message: "No conversation found with session ID: abc123" },
+    ],
+  ]),
 ] satisfies readonly FailoverClassificationCorpusRow[];

--- a/src/agents/failover/failover-classification.overflow.cases.ts
+++ b/src/agents/failover/failover-classification.overflow.cases.ts
@@ -4,244 +4,159 @@ import {
   contextOverflow,
   errorsSource,
   messageRows,
+  failoverSignalRows,
   patternsSource,
   structuredSource,
 } from "./failover-classification.corpus.test-support.js";
 export const overflowCases = [
   // Context overflow.
-  {
-    id: "billing-context-request-too-large",
-    source: billingSource,
-    signal: { message: "request_too_large" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-maximum-size",
-    source: billingSource,
-    signal: { message: "Request exceeds the maximum size" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-length-exceeded",
-    source: billingSource,
-    signal: { message: "context length exceeded" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-maximum-length",
-    source: billingSource,
-    signal: { message: "Maximum context length" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-prompt-token-count",
-    source: billingSource,
-    signal: { message: "prompt is too long: 208423 tokens > 200000 maximum" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-compaction-failed",
-    source: billingSource,
-    signal: { message: "Context overflow: Summarization failed" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-413",
-    source: billingSource,
-    signal: { message: "413 Request Entity Too Large" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-anthropic-json",
-    source: billingSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        '{"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}',
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-anthropic-400-json",
-    source: billingSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        '400 {"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}',
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-kimi-limit",
-    source: billingSource,
-    signal: {
-      message:
-        "Invalid request: Your request exceeded model token limit: 262144 (requested: 291351)",
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-kimi-status",
-    source: billingSource,
-    signal: {
-      message:
-        "error, status code: 400, message: Invalid request: Your request exceeded model token limit: 262144 (requested: 291351)",
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-max-tokens-sum",
-    source: billingSource,
-    signal: {
-      message: "input length and max_tokens exceed context limit (i.e 156321 + 48384 > 200000)",
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-model-maximum",
-    source: billingSource,
-    signal: { message: "This request exceeds the model's maximum context length" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-max-tokens-window",
-    source: billingSource,
-    signal: { message: "LLM request rejected: max_tokens would exceed context window" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-input-budget",
-    source: billingSource,
-    signal: { message: "input length would exceed context budget for this model" },
-    expected: contextOverflow,
-  },
-  {
+  ...failoverSignalRows(billingSource, contextOverflow, [
+    ["billing-context-request-too-large", { message: "request_too_large" }],
+    ["billing-context-maximum-size", { message: "Request exceeds the maximum size" }],
+    ["billing-context-length-exceeded", { message: "context length exceeded" }],
+    ["billing-context-maximum-length", { message: "Maximum context length" }],
+    [
+      "billing-context-prompt-token-count",
+      { message: "prompt is too long: 208423 tokens > 200000 maximum" },
+    ],
+    ["billing-context-compaction-failed", { message: "Context overflow: Summarization failed" }],
+    ["billing-context-413", { message: "413 Request Entity Too Large" }],
+    [
+      "billing-context-anthropic-json",
+      {
+        provider: "anthropic",
+        message:
+          '{"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}',
+      },
+    ],
+    [
+      "billing-context-anthropic-400-json",
+      {
+        provider: "anthropic",
+        message:
+          '400 {"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}',
+      },
+    ],
+    [
+      "billing-context-kimi-limit",
+      {
+        message:
+          "Invalid request: Your request exceeded model token limit: 262144 (requested: 291351)",
+      },
+    ],
+    [
+      "billing-context-kimi-status",
+      {
+        message:
+          "error, status code: 400, message: Invalid request: Your request exceeded model token limit: 262144 (requested: 291351)",
+      },
+    ],
+    [
+      "billing-context-max-tokens-sum",
+      {
+        message: "input length and max_tokens exceed context limit (i.e 156321 + 48384 > 200000)",
+      },
+    ],
+    [
+      "billing-context-model-maximum",
+      { message: "This request exceeds the model's maximum context length" },
+    ],
+    [
+      "billing-context-max-tokens-window",
+      { message: "LLM request rejected: max_tokens would exceed context window" },
+    ],
+    [
+      "billing-context-input-budget",
+      { message: "input length would exceed context budget for this model" },
+    ],
     // FIXED(refactor-06): PR 2 removed the embedded-429 false positive; the provider wording is overflow.
-    id: "billing-context-input-length-model-limit",
-    source: billingSource,
-    signal: { message: "input length 14295 tokens exceeds the model limit" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-stop-reason",
-    source: billingSource,
-    signal: { message: "Unhandled stop reason: model_context_window_exceeded" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-chinese-too-long",
-    source: billingSource,
-    signal: { message: "错误：上下文过长，请减少输入" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-chinese-compress",
-    source: billingSource,
-    signal: { message: "请压缩上下文后重试" },
-    expected: contextOverflow,
-  },
-  {
-    id: "billing-context-404-vertex",
-    source: billingSource,
-    signal: { message: "HTTP 404: INVALID_ARGUMENT: input exceeds the maximum number of tokens" },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-bedrock-validation",
-    source: patternsSource,
-    signal: { message: "ValidationException: The input is too long for the model" },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-bedrock-token-count",
-    source: patternsSource,
-    signal: {
-      message: "ValidationException: Input token count exceeds the maximum number of input tokens",
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-bedrock-stream",
-    source: patternsSource,
-    signal: { message: "ModelStreamErrorException: Input is too long for this model" },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-vertex",
-    source: patternsSource,
-    signal: { message: "INVALID_ARGUMENT: input exceeds the maximum number of tokens" },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-ollama",
-    source: patternsSource,
-    signal: { message: "ollama error: context length exceeded, too many tokens" },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-mistral",
-    source: patternsSource,
-    signal: { message: "mistral: input is too long for this model" },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-cohere",
-    source: patternsSource,
-    signal: { message: "total tokens exceeds the model's maximum limit of 4096" },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-llamacpp-available",
-    source: patternsSource,
-    signal: {
-      message:
-        "400 request (66202 tokens) exceeds the available context size (65536 tokens), try increasing it",
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-llamacpp-no-the",
-    source: patternsSource,
-    signal: { message: "request (130000 tokens) exceeds available context size (131072 tokens)" },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-llamacpp-prompt",
-    source: patternsSource,
-    signal: {
-      message:
-        "prompt (8500 tokens) exceeds the available context size (8192 tokens), try increasing it",
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "patterns-context-ds4",
-    source: patternsSource,
-    signal: {
-      message: "400 Prompt has 256468 tokens, but the configured context size is 256000 tokens",
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "structured-context-raw-invalid-request",
-    source: structuredSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        '{"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}',
-    },
-    expected: contextOverflow,
-  },
-  {
-    id: "structured-context-typed-invalid-request",
-    source: structuredSource,
-    signal: {
-      provider: "anthropic",
-      errorType: "invalid_request_error",
-      message: "Request size exceeds model context window",
-    },
-    expected: contextOverflow,
-  },
+    [
+      "billing-context-input-length-model-limit",
+      { message: "input length 14295 tokens exceeds the model limit" },
+    ],
+    [
+      "billing-context-stop-reason",
+      { message: "Unhandled stop reason: model_context_window_exceeded" },
+    ],
+    ["billing-context-chinese-too-long", { message: "错误：上下文过长，请减少输入" }],
+    ["billing-context-chinese-compress", { message: "请压缩上下文后重试" }],
+    [
+      "billing-context-404-vertex",
+      { message: "HTTP 404: INVALID_ARGUMENT: input exceeds the maximum number of tokens" },
+    ],
+  ]),
+  ...failoverSignalRows(patternsSource, contextOverflow, [
+    [
+      "patterns-context-bedrock-validation",
+      { message: "ValidationException: The input is too long for the model" },
+    ],
+    [
+      "patterns-context-bedrock-token-count",
+      {
+        message:
+          "ValidationException: Input token count exceeds the maximum number of input tokens",
+      },
+    ],
+    [
+      "patterns-context-bedrock-stream",
+      { message: "ModelStreamErrorException: Input is too long for this model" },
+    ],
+    [
+      "patterns-context-vertex",
+      { message: "INVALID_ARGUMENT: input exceeds the maximum number of tokens" },
+    ],
+    [
+      "patterns-context-ollama",
+      { message: "ollama error: context length exceeded, too many tokens" },
+    ],
+    ["patterns-context-mistral", { message: "mistral: input is too long for this model" }],
+    [
+      "patterns-context-cohere",
+      { message: "total tokens exceeds the model's maximum limit of 4096" },
+    ],
+    [
+      "patterns-context-llamacpp-available",
+      {
+        message:
+          "400 request (66202 tokens) exceeds the available context size (65536 tokens), try increasing it",
+      },
+    ],
+    [
+      "patterns-context-llamacpp-no-the",
+      { message: "request (130000 tokens) exceeds available context size (131072 tokens)" },
+    ],
+    [
+      "patterns-context-llamacpp-prompt",
+      {
+        message:
+          "prompt (8500 tokens) exceeds the available context size (8192 tokens), try increasing it",
+      },
+    ],
+    [
+      "patterns-context-ds4",
+      {
+        message: "400 Prompt has 256468 tokens, but the configured context size is 256000 tokens",
+      },
+    ],
+  ]),
+  ...failoverSignalRows(structuredSource, contextOverflow, [
+    [
+      "structured-context-raw-invalid-request",
+      {
+        provider: "anthropic",
+        message:
+          '{"type":"error","error":{"type":"invalid_request_error","message":"Request size exceeds model context window"}}',
+      },
+    ],
+    [
+      "structured-context-typed-invalid-request",
+      {
+        provider: "anthropic",
+        errorType: "invalid_request_error",
+        message: "Request size exceeds model context window",
+      },
+    ],
+  ]),
   {
     id: "errors-context-codex-prompt-window",
     source: errorsSource,

--- a/src/agents/failover/failover-classification.rate-limit-overload.cases.ts
+++ b/src/agents/failover/failover-classification.rate-limit-overload.cases.ts
@@ -3,6 +3,7 @@ import {
   billingSource,
   matchesSource,
   messageRows,
+  failoverSignalRows,
   openRouterSource,
   patternsSource,
   reason,
@@ -11,235 +12,151 @@ import {
 } from "./failover-classification.corpus.test-support.js";
 export const rateLimitOverloadCases = [
   // Rate limits and temporary quotas.
-  {
-    id: "billing-openai-rate-limit",
-    source: billingSource,
-    signal: {
-      provider: "openai",
-      message:
-        "Rate limit reached for gpt-4.1-mini in organization org_test on requests per min. Limit: 3.000000 / min. Current: 3.000000 / min.",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "billing-gemini-resource-exhausted",
-    source: billingSource,
-    signal: {
-      provider: "google",
-      message: "RESOURCE_EXHAUSTED: Resource has been exhausted (e.g. check quota).",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "billing-groq-too-many-requests",
-    source: billingSource,
-    signal: {
-      provider: "groq",
-      message: "429 Too Many Requests: Too many requests were sent in a given timeframe.",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "billing-model-cooldown",
-    source: billingSource,
-    signal: { message: "model_cooldown: All credentials for model gpt-5 are cooling down" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "billing-chatgpt-usage-limit",
-    source: billingSource,
-    signal: { provider: "openai", message: "You have hit your ChatGPT usage limit (plus plan)" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "billing-bedrock-tokens-per-day",
-    source: billingSource,
-    signal: {
-      provider: "amazon-bedrock",
-      message: "AWS Bedrock: Too many tokens per day. Please try again tomorrow.",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
+  ...failoverSignalRows(billingSource, reason("rate_limit"), [
+    [
+      "billing-openai-rate-limit",
+      {
+        provider: "openai",
+        message:
+          "Rate limit reached for gpt-4.1-mini in organization org_test on requests per min. Limit: 3.000000 / min. Current: 3.000000 / min.",
+      },
+    ],
+    [
+      "billing-gemini-resource-exhausted",
+      {
+        provider: "google",
+        message: "RESOURCE_EXHAUSTED: Resource has been exhausted (e.g. check quota).",
+      },
+    ],
+    [
+      "billing-groq-too-many-requests",
+      {
+        provider: "groq",
+        message: "429 Too Many Requests: Too many requests were sent in a given timeframe.",
+      },
+    ],
+    [
+      "billing-model-cooldown",
+      { message: "model_cooldown: All credentials for model gpt-5 are cooling down" },
+    ],
+    [
+      "billing-chatgpt-usage-limit",
+      { provider: "openai", message: "You have hit your ChatGPT usage limit (plus plan)" },
+    ],
+    [
+      "billing-bedrock-tokens-per-day",
+      {
+        provider: "amazon-bedrock",
+        message: "AWS Bedrock: Too many tokens per day. Please try again tomorrow.",
+      },
+    ],
     // #33785
-    id: "billing-zhipu-periodic-limit",
-    source: billingSource,
-    signal: {
-      provider: "zai",
-      message:
-        "LLM error 1310: Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-03-06 22:19:54 (request_id: 20260303141547610b7f574d1b44cb)",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "billing-subscription-quota-refresh",
-    source: billingSource,
-    signal: {
-      message:
-        "402 You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access.",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "billing-chinese-too-frequent",
-    source: billingSource,
-    signal: { message: "请求过于频繁，请稍后重试" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "billing-chinese-frequency-limit",
-    source: billingSource,
-    signal: { message: "调用频率超限" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "billing-chinese-quota-exhausted",
-    source: billingSource,
-    signal: { message: "配额已用尽" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "billing-chinese-top-up",
-    source: billingSource,
-    signal: { message: "额度不足，请充值" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "matches-rate-limit",
-    source: matchesSource,
-    signal: { message: "rate limit exceeded" },
-    expected: reason("rate_limit"),
-  },
-  {
+    [
+      "billing-zhipu-periodic-limit",
+      {
+        provider: "zai",
+        message:
+          "LLM error 1310: Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-03-06 22:19:54 (request_id: 20260303141547610b7f574d1b44cb)",
+      },
+    ],
+    [
+      "billing-subscription-quota-refresh",
+      {
+        message:
+          "402 You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access.",
+      },
+    ],
+    ["billing-chinese-too-frequent", { message: "请求过于频繁，请稍后重试" }],
+    ["billing-chinese-frequency-limit", { message: "调用频率超限" }],
+    ["billing-chinese-quota-exhausted", { message: "配额已用尽" }],
+    ["billing-chinese-top-up", { message: "额度不足，请充值" }],
+  ]),
+  ...failoverSignalRows(matchesSource, reason("rate_limit"), [
+    ["matches-rate-limit", { message: "rate limit exceeded" }],
     // #98101
-    id: "matches-zai-1305-429",
-    source: matchesSource,
-    signal: {
-      provider: "zai",
-      message:
-        '429 status code (exceeded limit)\n{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}',
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "patterns-bedrock-throttling",
-    source: patternsSource,
-    signal: { provider: "amazon-bedrock", message: "ThrottlingException: Too many requests" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "patterns-bedrock-concurrency",
-    source: patternsSource,
-    signal: {
-      provider: "amazon-bedrock",
-      message: "ThrottlingException: Too many concurrent requests",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "patterns-concurrency-limit",
-    source: patternsSource,
-    signal: { message: "concurrency limit has been reached" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "patterns-concurrency-limit-breached",
-    source: patternsSource,
-    signal: { message: "concurrency limit breached" },
+    [
+      "matches-zai-1305-429",
+      {
+        provider: "zai",
+        message:
+          '429 status code (exceeded limit)\n{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}',
+      },
+    ],
+  ]),
+  ...failoverSignalRows(patternsSource, reason("rate_limit"), [
+    [
+      "patterns-bedrock-throttling",
+      { provider: "amazon-bedrock", message: "ThrottlingException: Too many requests" },
+    ],
+    [
+      "patterns-bedrock-concurrency",
+      {
+        provider: "amazon-bedrock",
+        message: "ThrottlingException: Too many concurrent requests",
+      },
+    ],
+    ["patterns-concurrency-limit", { message: "concurrency limit has been reached" }],
     // FIXED(refactor-02): was null, now rate_limit
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "patterns-concurrency-limit-was-reached",
-    source: patternsSource,
-    signal: { message: "concurrency limit was reached" },
+    ["patterns-concurrency-limit-breached", { message: "concurrency limit breached" }],
     // FIXED(refactor-02): was null, now rate_limit
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "patterns-cloudflare-workers-quota",
-    source: patternsSource,
-    signal: { message: "workers_ai gateway error: quota limit exceeded" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "patterns-json-rate-limit",
-    source: patternsSource,
-    signal: {
-      message: '429 {"error":{"type":"rate_limit_error","message":"Rate limit exceeded"}}',
-    },
-    expected: reason("rate_limit"),
-  },
+    ["patterns-concurrency-limit-was-reached", { message: "concurrency limit was reached" }],
+    [
+      "patterns-cloudflare-workers-quota",
+      { message: "workers_ai gateway error: quota limit exceeded" },
+    ],
+    [
+      "patterns-json-rate-limit",
+      {
+        message: '429 {"error":{"type":"rate_limit_error","message":"Rate limit exceeded"}}',
+      },
+    ],
+  ]),
   {
     id: "structured-unstructured-rate-limit",
     source: structuredSource,
     signal: { provider: "demo-provider", message: "invalid_api_key" },
     expected: reason("auth"),
   },
-  {
-    id: "retry-429-temporary",
-    source: retrySource,
-    signal: { message: "429 temporary provider response" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "retry-resource-exhausted-worker",
-    source: retrySource,
-    signal: { message: "ResourceExhausted: Worker local total request limit reached" },
+  ...failoverSignalRows(retrySource, reason("rate_limit"), [
+    ["retry-429-temporary", { message: "429 temporary provider response" }],
     // FIXED(refactor-06): separator-free provider code now shares the canonical rate-limit path.
-    expected: reason("rate_limit"),
-  },
-  {
+    [
+      "retry-resource-exhausted-worker",
+      { message: "ResourceExhausted: Worker local total request limit reached" },
+    ],
+  ]),
+  ...failoverSignalRows("src/agents/live-auth-keys.ts", reason("rate_limit"), [
     // FIXED(refactor-06): live key rotation already treated the spaced form as rate limiting.
-    id: "live-auth-resource-exhausted-spaced",
-    source: "src/agents/live-auth-keys.ts",
-    signal: { message: "resource exhausted" },
-    expected: reason("rate_limit"),
-  },
-  {
+    ["live-auth-resource-exhausted-spaced", { message: "resource exhausted" }],
     // FIXED(refactor-06): preserve the provider-code spelling used by live key rotation.
-    id: "live-auth-quota-exceeded-code",
-    source: "src/agents/live-auth-keys.ts",
-    signal: { message: "quota_exceeded" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "retry-resource-exhausted-capacity",
-    source: retrySource,
-    signal: { message: "resource_exhausted: transient worker capacity exhausted" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "retry-daily-limit",
-    source: retrySource,
-    signal: { message: "429 You exceeded your daily request limit. Please try again in 24 hours." },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "retry-retry-after-hours",
-    source: retrySource,
-    signal: { message: "429 RPM limit exceeded; Retry-After: 2 hours" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "retry-resource-exhausted-quota",
-    source: retrySource,
-    signal: {
-      message:
-        "429 RESOURCE_EXHAUSTED: Quota exceeded for quota metric requests per minute; please retry your request",
-    },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "retry-openai-resource-exhausted",
-    source: retrySource,
-    signal: {
-      provider: "openai",
-      message:
-        "OpenAI API error (429): RESOURCE_EXHAUSTED: Quota exceeded for requests per minute; please retry your request",
-    },
-    expected: reason("rate_limit"),
-  },
+    ["live-auth-quota-exceeded-code", { message: "quota_exceeded" }],
+  ]),
+  ...failoverSignalRows(retrySource, reason("rate_limit"), [
+    [
+      "retry-resource-exhausted-capacity",
+      { message: "resource_exhausted: transient worker capacity exhausted" },
+    ],
+    [
+      "retry-daily-limit",
+      { message: "429 You exceeded your daily request limit. Please try again in 24 hours." },
+    ],
+    ["retry-retry-after-hours", { message: "429 RPM limit exceeded; Retry-After: 2 hours" }],
+    [
+      "retry-resource-exhausted-quota",
+      {
+        message:
+          "429 RESOURCE_EXHAUSTED: Quota exceeded for quota metric requests per minute; please retry your request",
+      },
+    ],
+    [
+      "retry-openai-resource-exhausted",
+      {
+        provider: "openai",
+        message:
+          "OpenAI API error (429): RESOURCE_EXHAUSTED: Quota exceeded for requests per minute; please retry your request",
+      },
+    ],
+  ]),
   {
     id: "openrouter-stream-rate-limit",
     source: openRouterSource,
@@ -251,18 +168,10 @@ export const rateLimitOverloadCases = [
     },
     expected: reason("rate_limit"),
   },
-  {
-    id: "mantle-rate-limit",
-    source: "extensions/amazon-bedrock-mantle/index.test.ts",
-    signal: { provider: "amazon-bedrock-mantle", message: "rate_limit exceeded" },
-    expected: reason("rate_limit"),
-  },
-  {
-    id: "mantle-429",
-    source: "extensions/amazon-bedrock-mantle/index.test.ts",
-    signal: { provider: "amazon-bedrock-mantle", message: "429 Too Many Requests" },
-    expected: reason("rate_limit"),
-  },
+  ...failoverSignalRows("extensions/amazon-bedrock-mantle/index.test.ts", reason("rate_limit"), [
+    ["mantle-rate-limit", { provider: "amazon-bedrock-mantle", message: "rate_limit exceeded" }],
+    ["mantle-429", { provider: "amazon-bedrock-mantle", message: "429 Too Many Requests" }],
+  ]),
   {
     id: "xai-rate-limit-payload",
     source: "extensions/xai/index.test.ts",
@@ -337,99 +246,67 @@ export const rateLimitOverloadCases = [
     expected: reason("rate_limit"),
   },
   // Provider overload.
-  {
-    id: "billing-anthropic-overloaded",
-    source: billingSource,
-    signal: {
-      provider: "anthropic",
-      message:
-        '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_test"}',
-    },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "billing-together-overloaded",
-    source: billingSource,
-    signal: {
-      provider: "together",
-      message:
-        "503 Engine Overloaded: The server is experiencing a high volume of requests and is temporarily overloaded.",
-    },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "billing-groq-service-unavailable",
-    source: billingSource,
-    signal: {
-      provider: "groq",
-      message:
-        "503 Service Unavailable: The server is temporarily unable to handle the request due to overloading or maintenance.",
-    },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "billing-high-demand",
-    source: billingSource,
-    signal: {
-      message: "This model is currently experiencing high demand. Please try again later.",
-    },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "billing-service-capacity",
-    source: billingSource,
-    signal: { message: "service unavailable due to capacity limits" },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "billing-json-model-overloaded",
-    source: billingSource,
-    signal: {
-      message:
-        '{"error":{"code":503,"message":"The model is overloaded. Please try later","status":"UNAVAILABLE"}}',
-    },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "billing-529-busy",
-    source: billingSource,
-    signal: { message: "529 API is busy" },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "billing-chinese-overload",
-    source: billingSource,
-    signal: { message: "服务过载，请稍后重试" },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "billing-chinese-high-load",
-    source: billingSource,
-    signal: { message: "当前负载过高" },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "matches-openai-capacity",
-    source: matchesSource,
-    signal: { message: "Selected model is at capacity. Please try a different model." },
-    expected: reason("overloaded"),
-  },
-  {
-    id: "matches-openrouter-high-load",
-    source: matchesSource,
-    signal: {
-      provider: "openrouter",
-      message: "The service is currently experiencing high load and cannot process your request.",
-    },
-    expected: reason("overloaded"),
-  },
-  {
+  ...failoverSignalRows(billingSource, reason("overloaded"), [
+    [
+      "billing-anthropic-overloaded",
+      {
+        provider: "anthropic",
+        message:
+          '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_test"}',
+      },
+    ],
+    [
+      "billing-together-overloaded",
+      {
+        provider: "together",
+        message:
+          "503 Engine Overloaded: The server is experiencing a high volume of requests and is temporarily overloaded.",
+      },
+    ],
+    [
+      "billing-groq-service-unavailable",
+      {
+        provider: "groq",
+        message:
+          "503 Service Unavailable: The server is temporarily unable to handle the request due to overloading or maintenance.",
+      },
+    ],
+    [
+      "billing-high-demand",
+      {
+        message: "This model is currently experiencing high demand. Please try again later.",
+      },
+    ],
+    ["billing-service-capacity", { message: "service unavailable due to capacity limits" }],
+    [
+      "billing-json-model-overloaded",
+      {
+        message:
+          '{"error":{"code":503,"message":"The model is overloaded. Please try later","status":"UNAVAILABLE"}}',
+      },
+    ],
+    ["billing-529-busy", { message: "529 API is busy" }],
+    ["billing-chinese-overload", { message: "服务过载，请稍后重试" }],
+    ["billing-chinese-high-load", { message: "当前负载过高" }],
+  ]),
+  ...failoverSignalRows(matchesSource, reason("overloaded"), [
+    [
+      "matches-openai-capacity",
+      { message: "Selected model is at capacity. Please try a different model." },
+    ],
+    [
+      "matches-openrouter-high-load",
+      {
+        provider: "openrouter",
+        message: "The service is currently experiencing high load and cannot process your request.",
+      },
+    ],
     // #48988
-    id: "matches-zhipu-overload-cn",
-    source: matchesSource,
-    signal: { provider: "zai", message: "[1305][该模型当前访问量过大，请您稍后再试]" },
-    expected: reason("overloaded"),
-  },
+    [
+      "matches-zhipu-overload-cn",
+      { provider: "zai", message: "[1305][该模型当前访问量过大，请您稍后再试]" },
+    ],
+  ]),
   {
     id: "patterns-bedrock-model-not-ready",
     source: patternsSource,

--- a/src/agents/failover/failover-classification.structured-misc.cases.ts
+++ b/src/agents/failover/failover-classification.structured-misc.cases.ts
@@ -5,6 +5,7 @@ import {
   httpSource,
   matchesSource,
   messageRows,
+  failoverSignalRows,
   patternsSource,
   reason,
   retrySource,
@@ -22,24 +23,14 @@ export const structuredMiscCases = [
     },
     expected: reason("format"),
   },
-  {
-    id: "billing-image-size",
-    source: billingSource,
-    signal: { message: "image exceeds 5 MB maximum" },
-    expected: null,
-  },
-  {
-    id: "billing-malformed-function-call",
-    source: billingSource,
-    signal: { message: "Unhandled stop reason: MALFORMED_FUNCTION_CALL" },
-    expected: null,
-  },
-  {
-    id: "billing-bare-400",
-    source: billingSource,
-    signal: { message: "400 status code (no body)" },
-    expected: null,
-  },
+  ...failoverSignalRows(billingSource, null, [
+    ["billing-image-size", { message: "image exceeds 5 MB maximum" }],
+    [
+      "billing-malformed-function-call",
+      { message: "Unhandled stop reason: MALFORMED_FUNCTION_CALL" },
+    ],
+    ["billing-bare-400", { message: "400 status code (no body)" }],
+  ]),
   {
     id: "matches-google-invalid-argument",
     source: matchesSource,
@@ -56,30 +47,21 @@ export const structuredMiscCases = [
     signal: { message: "model is not ready" },
     expected: null,
   },
-  {
-    id: "structured-rate-limit-type-without-hook",
-    source: structuredSource,
-    signal: { provider: "anthropic", errorType: "rate_limit_error", message: "" },
-    expected: null,
-  },
-  {
-    id: "structured-api-error-type-without-hook",
-    source: structuredSource,
-    signal: { provider: "anthropic", errorType: "api_error", message: "" },
-    expected: null,
-  },
-  {
-    id: "structured-non-owner-server-code",
-    source: structuredSource,
-    signal: { provider: "google", code: "SERVER_ERROR", message: "" },
-    expected: null,
-  },
-  {
-    id: "structured-non-owner-insufficient-quota",
-    source: structuredSource,
-    signal: { provider: "anthropic", code: "INSUFFICIENT_QUOTA", message: "" },
-    expected: null,
-  },
+  ...failoverSignalRows(structuredSource, null, [
+    [
+      "structured-rate-limit-type-without-hook",
+      { provider: "anthropic", errorType: "rate_limit_error", message: "" },
+    ],
+    [
+      "structured-api-error-type-without-hook",
+      { provider: "anthropic", errorType: "api_error", message: "" },
+    ],
+    ["structured-non-owner-server-code", { provider: "google", code: "SERVER_ERROR", message: "" }],
+    [
+      "structured-non-owner-insufficient-quota",
+      { provider: "anthropic", code: "INSUFFICIENT_QUOTA", message: "" },
+    ],
+  ]),
   {
     id: "http-bad-request",
     source: httpSource,
@@ -179,173 +161,126 @@ export const structuredMiscCases = [
     },
     { id: "retry-image-width", message: "Image width 500 exceeds the maximum allowed size" },
   ]),
-  {
-    id: "structured-openai-internal-non-owner",
-    source: structuredSource,
-    signal: { provider: "openai", code: "INTERNAL", message: "" },
-    expected: null,
-  },
-  {
-    id: "structured-openai-deadline-non-owner",
-    source: structuredSource,
-    signal: { provider: "openai", code: "DEADLINE_EXCEEDED", message: "" },
-    expected: null,
-  },
-  {
-    id: "structured-anthropic-unavailable-non-owner",
-    source: structuredSource,
-    signal: { provider: "anthropic", code: "UNAVAILABLE", message: "" },
-    expected: null,
-  },
-  {
-    id: "structured-google-api-error-non-owner",
-    source: structuredSource,
-    signal: { provider: "google", code: "API_ERROR", message: "" },
-    expected: null,
-  },
-  {
-    id: "structured-google-rate-limit-error-non-owner",
-    source: structuredSource,
-    signal: { provider: "google", code: "RATE_LIMIT_ERROR", message: "" },
-    expected: null,
-  },
-  {
-    id: "structured-generic-sdk-type",
-    source: structuredSource,
-    signal: { provider: "demo-provider", message: "unclassified provider failure" },
-    expected: null,
-  },
+  ...failoverSignalRows(structuredSource, null, [
+    ["structured-openai-internal-non-owner", { provider: "openai", code: "INTERNAL", message: "" }],
+    [
+      "structured-openai-deadline-non-owner",
+      { provider: "openai", code: "DEADLINE_EXCEEDED", message: "" },
+    ],
+    [
+      "structured-anthropic-unavailable-non-owner",
+      { provider: "anthropic", code: "UNAVAILABLE", message: "" },
+    ],
+    [
+      "structured-google-api-error-non-owner",
+      { provider: "google", code: "API_ERROR", message: "" },
+    ],
+    [
+      "structured-google-rate-limit-error-non-owner",
+      { provider: "google", code: "RATE_LIMIT_ERROR", message: "" },
+    ],
+    [
+      "structured-generic-sdk-type",
+      { provider: "demo-provider", message: "unclassified provider failure" },
+    ],
+  ]),
   // Structured provider codes with hooks intentionally disabled for determinism.
-  {
-    id: "anthropic-rate-limit-error-type-core-fallback",
-    source: "extensions/anthropic/index.test.ts",
-    signal: { provider: "anthropic", errorType: "rate_limit_error", message: "" },
-    expected: null,
-  },
-  {
-    id: "anthropic-api-error-type-core-fallback",
-    source: "extensions/anthropic/index.test.ts",
-    signal: { provider: "anthropic", errorType: "api_error", message: "" },
-    expected: null,
-  },
-  {
-    id: "anthropic-rate-limit-code-core-fallback",
-    source: "extensions/anthropic/index.test.ts",
-    signal: { provider: "anthropic", code: "RATE_LIMIT_ERROR", message: "" },
-    expected: null,
-  },
-  {
-    id: "anthropic-api-error-code-core-fallback",
-    source: "extensions/anthropic/index.test.ts",
-    signal: { provider: "anthropic", code: "API_ERROR", message: "" },
-    expected: null,
-  },
-  {
-    id: "openai-server-code-core-fallback",
-    source: "extensions/openai/openai-provider.test.ts",
-    signal: { provider: "openai", code: "SERVER_ERROR", message: "" },
-    expected: null,
-  },
-  {
-    id: "openai-insufficient-quota-code-core-fallback",
-    source: "extensions/openai/openai-provider.test.ts",
-    signal: { provider: "openai", code: "INSUFFICIENT_QUOTA", message: "" },
-    expected: null,
-  },
-  {
-    id: "google-unavailable-code-core-fallback",
-    source: "extensions/google/provider-hooks.test.ts",
-    signal: { provider: "google", code: "UNAVAILABLE", message: "" },
-    expected: null,
-  },
-  {
-    id: "google-deadline-code-core-fallback",
-    source: "extensions/google/provider-hooks.test.ts",
-    signal: { provider: "google-vertex", code: "DEADLINE_EXCEEDED", message: "" },
-    expected: null,
-  },
-  {
-    id: "google-internal-code-core-fallback",
-    source: "extensions/google/provider-hooks.test.ts",
-    signal: { provider: "google-antigravity", code: "INTERNAL", message: "" },
-    expected: null,
-  },
-  {
-    id: "anthropic-claude-cli-rate-limit-type-core-fallback",
-    source: "extensions/anthropic/index.test.ts",
-    signal: { provider: "claude-cli", errorType: "rate_limit_error", message: "" },
-    expected: null,
-  },
-  {
-    id: "anthropic-claude-cli-api-error-type-core-fallback",
-    source: "extensions/anthropic/index.test.ts",
-    signal: { provider: "claude-cli", errorType: "api_error", message: "" },
-    expected: null,
-  },
-  {
-    id: "anthropic-rate-limit-type-api-code-core-fallback",
-    source: "extensions/anthropic/index.test.ts",
-    signal: {
-      provider: "anthropic",
-      errorType: "rate_limit_error",
-      code: "API_ERROR",
-      message: "",
-    },
-    expected: null,
-  },
-  {
-    id: "anthropic-insufficient-quota-code-core-fallback",
-    source: "extensions/anthropic/index.test.ts",
-    signal: {
-      provider: "anthropic",
-      errorType: "UNKNOWN_ERROR",
-      code: "INSUFFICIENT_QUOTA",
-      message: "",
-    },
-    expected: null,
-  },
-  {
-    id: "azure-openai-server-code-core-fallback",
-    source: "extensions/openai/openai-provider.test.ts",
-    signal: { provider: "azure-openai", code: "SERVER_ERROR", message: "" },
-    expected: null,
-  },
-  {
-    id: "azure-openai-insufficient-quota-code-core-fallback",
-    source: "extensions/openai/openai-provider.test.ts",
-    signal: { provider: "azure-openai", code: "INSUFFICIENT_QUOTA", message: "" },
-    expected: null,
-  },
-  {
-    id: "azure-openai-responses-server-code-core-fallback",
-    source: "extensions/openai/openai-provider.test.ts",
-    signal: { provider: "azure-openai-responses", code: "SERVER_ERROR", message: "" },
-    expected: null,
-  },
-  {
-    id: "azure-openai-responses-insufficient-quota-code-core-fallback",
-    source: "extensions/openai/openai-provider.test.ts",
-    signal: { provider: "azure-openai-responses", code: "INSUFFICIENT_QUOTA", message: "" },
-    expected: null,
-  },
-  {
-    id: "openai-api-error-code-core-fallback",
-    source: "extensions/openai/openai-provider.test.ts",
-    signal: { provider: "openai", code: "API_ERROR", message: "" },
-    expected: null,
-  },
-  {
-    id: "google-gemini-cli-unavailable-core-fallback",
-    source: "extensions/google/provider-hooks.test.ts",
-    signal: { provider: "google-gemini-cli", code: "UNAVAILABLE", message: "" },
-    expected: null,
-  },
-  {
-    id: "google-insufficient-quota-core-fallback",
-    source: "extensions/google/provider-hooks.test.ts",
-    signal: { provider: "google-vertex", code: "INSUFFICIENT_QUOTA", message: "" },
-    expected: null,
-  },
+  ...failoverSignalRows("extensions/anthropic/index.test.ts", null, [
+    [
+      "anthropic-rate-limit-error-type-core-fallback",
+      { provider: "anthropic", errorType: "rate_limit_error", message: "" },
+    ],
+    [
+      "anthropic-api-error-type-core-fallback",
+      { provider: "anthropic", errorType: "api_error", message: "" },
+    ],
+    [
+      "anthropic-rate-limit-code-core-fallback",
+      { provider: "anthropic", code: "RATE_LIMIT_ERROR", message: "" },
+    ],
+    [
+      "anthropic-api-error-code-core-fallback",
+      { provider: "anthropic", code: "API_ERROR", message: "" },
+    ],
+  ]),
+  ...failoverSignalRows("extensions/openai/openai-provider.test.ts", null, [
+    ["openai-server-code-core-fallback", { provider: "openai", code: "SERVER_ERROR", message: "" }],
+    [
+      "openai-insufficient-quota-code-core-fallback",
+      { provider: "openai", code: "INSUFFICIENT_QUOTA", message: "" },
+    ],
+  ]),
+  ...failoverSignalRows("extensions/google/provider-hooks.test.ts", null, [
+    [
+      "google-unavailable-code-core-fallback",
+      { provider: "google", code: "UNAVAILABLE", message: "" },
+    ],
+    [
+      "google-deadline-code-core-fallback",
+      { provider: "google-vertex", code: "DEADLINE_EXCEEDED", message: "" },
+    ],
+    [
+      "google-internal-code-core-fallback",
+      { provider: "google-antigravity", code: "INTERNAL", message: "" },
+    ],
+  ]),
+  ...failoverSignalRows("extensions/anthropic/index.test.ts", null, [
+    [
+      "anthropic-claude-cli-rate-limit-type-core-fallback",
+      { provider: "claude-cli", errorType: "rate_limit_error", message: "" },
+    ],
+    [
+      "anthropic-claude-cli-api-error-type-core-fallback",
+      { provider: "claude-cli", errorType: "api_error", message: "" },
+    ],
+    [
+      "anthropic-rate-limit-type-api-code-core-fallback",
+      {
+        provider: "anthropic",
+        errorType: "rate_limit_error",
+        code: "API_ERROR",
+        message: "",
+      },
+    ],
+    [
+      "anthropic-insufficient-quota-code-core-fallback",
+      {
+        provider: "anthropic",
+        errorType: "UNKNOWN_ERROR",
+        code: "INSUFFICIENT_QUOTA",
+        message: "",
+      },
+    ],
+  ]),
+  ...failoverSignalRows("extensions/openai/openai-provider.test.ts", null, [
+    [
+      "azure-openai-server-code-core-fallback",
+      { provider: "azure-openai", code: "SERVER_ERROR", message: "" },
+    ],
+    [
+      "azure-openai-insufficient-quota-code-core-fallback",
+      { provider: "azure-openai", code: "INSUFFICIENT_QUOTA", message: "" },
+    ],
+    [
+      "azure-openai-responses-server-code-core-fallback",
+      { provider: "azure-openai-responses", code: "SERVER_ERROR", message: "" },
+    ],
+    [
+      "azure-openai-responses-insufficient-quota-code-core-fallback",
+      { provider: "azure-openai-responses", code: "INSUFFICIENT_QUOTA", message: "" },
+    ],
+    ["openai-api-error-code-core-fallback", { provider: "openai", code: "API_ERROR", message: "" }],
+  ]),
+  ...failoverSignalRows("extensions/google/provider-hooks.test.ts", null, [
+    [
+      "google-gemini-cli-unavailable-core-fallback",
+      { provider: "google-gemini-cli", code: "UNAVAILABLE", message: "" },
+    ],
+    [
+      "google-insufficient-quota-core-fallback",
+      { provider: "google-vertex", code: "INSUFFICIENT_QUOTA", message: "" },
+    ],
+  ]),
   {
     id: "ollama-cloud-incomplete-stream",
     source: "extensions/ollama/index.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Provider failover and Anthropic streaming tests repeated thousands of lines of classification cases and SSE event objects, making coverage drift difficult to audit.

## Why This Change Was Made

This maintainer-requested test refactor consolidates those fixtures while preserving every current failover corpus row, retry expectation, stream event, comment, and current-main preview case. Production provider code is untouched.

AI-assisted maintainer cleanup. I reviewed the final code, proof, and exact landing diff.

## User Impact

No runtime behavior changes. Contributors get smaller provider regression fixtures with the same billing, auth, overload, rate-limit, legacy matcher, and streaming coverage.

## Evidence

- Test/test-support LOC: `+1897/-3613` (net `-1716`) across exactly eleven files; production runtime LOC: `+0/-0`.
- Current-main base: `b977ccb21e2b4b8bff05729548ea1b1558a74a33`; exact head: `e018ce1f111b68e726b139309efc196b07cb931d`.
- Exact diff SHA-256: `2ced9ef50ad77a066180ead4bebde9a213d1c44e8beb39339a6e618cc38b6f1c`.
- Failover: all 584 corpus rows remain unique and hash-identical; fresh corpus 605 and broader owner 784 tests passed.
- Anthropic transport: 132/132 passed; all 95 titles, 267 expectations, SSE semantics, comments, and current-main preview coverage are preserved.
- Focused typegraphs, production typing, typed lint, formatting, and diff checks passed.
- Independent verification found no production, provider-policy, authority, or security change.
- Mandatory exact-source autoreview: secret scan clean; isolated Codex review reported no actionable findings (0.99 patch-correctness confidence).
