### PR TITLE
refactor(agents): consolidate generation and runtime fixtures

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -77,6 +77,10 @@ type RuntimeFactoryOptions = NonNullable<
   Parameters<typeof testing.createSessionMcpRuntimeManager>[0]
 >;
 type RuntimeFactory = NonNullable<RuntimeFactoryOptions["createRuntime"]>;
+type RuntimeParams = Parameters<typeof getOrCreateSessionMcpRuntime>[0];
+type ConfiguredMcpServer = NonNullable<
+  NonNullable<NonNullable<RuntimeParams["cfg"]>["mcp"]>["servers"]
+>[string];
 const LIST_TOOLS_SERVER_LOG_TIMEOUT_MS = 2_000;
 const LIST_TOOLS_TEST_DEADLINE_MS = 4_000;
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
@@ -577,6 +581,66 @@ function makeRuntime(
       isError: false,
     }),
     dispose: async () => {},
+  };
+}
+
+function makeManagedRuntime(
+  params: Parameters<RuntimeFactory>[0],
+  tools = [{ toolName: "probe", description: "probe" }],
+  serverName?: string,
+): SessionMcpRuntime {
+  return {
+    ...makeRuntime(tools, serverName),
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    workspaceDir: params.workspaceDir,
+    configFingerprint: params.configFingerprint ?? "fingerprint",
+    requesterScope: params.requesterScope,
+  };
+}
+
+async function makeStdioRuntime(
+  sessionId: string,
+  serverName: string,
+  serverPath: string,
+  options: {
+    workspaceDir?: string;
+    server?: Omit<ConfiguredMcpServer, "command" | "args">;
+    toolOverrides?: RuntimeParams["toolOverrides"];
+  } = {},
+): Promise<SessionMcpRuntime> {
+  return await getOrCreateSessionMcpRuntime({
+    sessionId,
+    sessionKey: `agent:test:${sessionId}`,
+    workspaceDir: options.workspaceDir ?? "/workspace",
+    cfg: {
+      mcp: {
+        servers: {
+          [serverName]: {
+            command: process.execPath,
+            args: [serverPath],
+            ...options.server,
+          },
+        },
+      },
+    },
+    ...(options.toolOverrides ? { toolOverrides: options.toolOverrides } : {}),
+  });
+}
+
+function makeRequesterParams(
+  sessionId: string,
+  cfg: RuntimeParams["cfg"],
+  requesterSenderId: string,
+  overrides: Partial<RuntimeParams> = {},
+): RuntimeParams {
+  return {
+    sessionId,
+    workspaceDir: "/workspace",
+    cfg,
+    requesterSenderId,
+    messageChannel: "telegram",
+    ...overrides,
   };
 }
 
@@ -1158,22 +1222,12 @@ describe("session MCP runtime", () => {
       delayMs: 100,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-slow-listtools-server-timeout",
-      sessionKey: "agent:test:session-slow-listtools-server-timeout",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            slowListTools: {
-              command: process.execPath,
-              args: [serverPath],
-              connectionTimeoutMs: 1_000,
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime(
+      "session-slow-listtools-server-timeout",
+      "slowListTools",
+      serverPath,
+      { server: { connectionTimeoutMs: 1_000 } },
+    );
 
     try {
       const catalog = await runtime.getCatalog();
@@ -1270,21 +1324,11 @@ describe("session MCP runtime", () => {
     testing.setBundleMcpCatalogListTimeoutMsForTest(50);
     await writeListToolsMcpServer({ filePath: serverPath, logPath, hang: true });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-listtools-server-timeout",
-      sessionKey: "agent:test:session-listtools-server-timeout",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            hangingListTools: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime(
+      "session-listtools-server-timeout",
+      "hangingListTools",
+      serverPath,
+    );
     const catalogResult = runtime.getCatalog().then(
       (catalog) => ({ status: "resolved" as const, catalog }),
       (error: unknown) => ({ status: "rejected" as const, error }),
@@ -1324,21 +1368,7 @@ describe("session MCP runtime", () => {
       inputSchema: { type: "array", items: { type: "number" } },
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-invalid-schema",
-      sessionKey: "agent:test:session-invalid-schema",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            fuzzplugin: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime("session-invalid-schema", "fuzzplugin", serverPath);
 
     try {
       const catalog = await runtime.getCatalog();
@@ -1365,21 +1395,11 @@ describe("session MCP runtime", () => {
       listToolsJsonRpcErrorMessage: `Authorization: Bearer ${secret}`,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-diagnostic-redaction",
-      sessionKey: "agent:test:session-diagnostic-redaction",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            diagnostic: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime(
+      "session-diagnostic-redaction",
+      "diagnostic",
+      serverPath,
+    );
 
     try {
       const catalog = await runtime.getCatalog();
@@ -1540,17 +1560,8 @@ describe("session MCP runtime", () => {
       },
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-structured-content",
-      sessionKey: "agent:test:session-structured-content",
+    const runtime = await makeStdioRuntime("session-structured-content", "capture", serverPath, {
       workspaceDir: tempDir,
-      cfg: {
-        mcp: {
-          servers: {
-            capture: { command: process.execPath, args: [serverPath] },
-          },
-        },
-      },
     });
 
     try {
@@ -1591,23 +1602,9 @@ describe("session MCP runtime", () => {
       ],
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-tool-filter",
-      sessionKey: "agent:test:session-tool-filter",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            docs: {
-              command: process.execPath,
-              args: [serverPath],
-              toolFilter: {
-                include: ["*_docs", "admin_*"],
-                exclude: ["admin_*"],
-              },
-            },
-          },
-        },
+    const runtime = await makeStdioRuntime("session-tool-filter", "docs", serverPath, {
+      server: {
+        toolFilter: { include: ["*_docs", "admin_*"], exclude: ["admin_*"] },
       },
     });
 
@@ -1640,18 +1637,9 @@ describe("session MCP runtime", () => {
       ],
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-tool-deny",
-      sessionKey: "agent:test:session-tool-deny",
+    const runtime = await makeStdioRuntime("session-tool-deny", "docs", serverPath, {
       workspaceDir: tempDir,
-      cfg: {
-        mcp: {
-          servers: { docs: { command: process.execPath, args: [serverPath] } },
-        },
-      },
-      toolOverrides: {
-        mcpToolsDeny: { docs: ["read_docs", "resources_read"] },
-      },
+      toolOverrides: { mcpToolsDeny: { docs: ["read_docs", "resources_read"] } },
     });
 
     try {
@@ -1710,21 +1698,7 @@ describe("session MCP runtime", () => {
       ],
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-utf16-metadata",
-      sessionKey: "agent:test:session-utf16-metadata",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            metadata: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime("session-utf16-metadata", "metadata", serverPath);
 
     try {
       const catalog = await runtime.getCatalog();
@@ -1748,21 +1722,7 @@ describe("session MCP runtime", () => {
       tools: [{ name: "legacy_tool", inputSchema: { type: "object", properties: {} } }],
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-unadvertised-tools",
-      sessionKey: "agent:test:session-unadvertised-tools",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            legacy: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime("session-unadvertised-tools", "legacy", serverPath);
 
     try {
       const catalog = await runtime.getCatalog();
@@ -1870,21 +1830,8 @@ process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);`,
     );
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-refresh-diagnostic",
-      sessionKey: "agent:test:session-refresh-diagnostic",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            volatile: {
-              command: process.execPath,
-              args: [serverPath],
-              requestTimeoutMs: 123_456,
-            },
-          },
-        },
-      },
+    const runtime = await makeStdioRuntime("session-refresh-diagnostic", "volatile", serverPath, {
+      server: { requestTimeoutMs: 123_456 },
     });
 
     try {
@@ -2003,18 +1950,7 @@ process.on("SIGINT", shutdown);`,
       exitOnListCall: 2,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-refresh-exit",
-      sessionKey: "agent:test:session-refresh-exit",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            child: { command: process.execPath, args: [serverPath] },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime("session-refresh-exit", "child", serverPath);
 
     try {
       expect((await runtime.getCatalog()).tools).toHaveLength(1);
@@ -2121,21 +2057,7 @@ process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);`,
     );
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-inflight-invalidated",
-      sessionKey: "agent:test:session-inflight-invalidated",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            changing: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime("session-inflight-invalidated", "changing", serverPath);
 
     try {
       const firstCatalog = await runtime.getCatalog();
@@ -2234,21 +2156,7 @@ process.on("SIGINT", shutdown);`,
       listToolsJsonRpcErrorMessage: testCase.listToolsJsonRpcErrorMessage,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-resource-only",
-      sessionKey: "agent:test:session-resource-only",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            notes: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime("session-resource-only", "notes", serverPath);
 
     try {
       const catalog = await runtime.getCatalog();
@@ -2278,21 +2186,7 @@ process.on("SIGINT", shutdown);`,
       listToolsJsonRpcErrorMessage: "Unknown method",
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-tools-unknown-method",
-      sessionKey: "agent:test:session-tools-unknown-method",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            notes: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime("session-tools-unknown-method", "notes", serverPath);
 
     try {
       const catalog = await runtime.getCatalog();
@@ -2320,21 +2214,7 @@ process.on("SIGINT", shutdown);`,
       callToolIsError: true,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-error-backoff",
-      sessionKey: "agent:test:session-error-backoff",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            failing: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime("session-error-backoff", "failing", serverPath);
 
     try {
       await expect(runtime.callTool("failing", "slow_tool", {})).resolves.toMatchObject({
@@ -2434,21 +2314,11 @@ process.on("SIGINT", shutdown);`,
       callToolJsonRpcError: true,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-request-failure-backoff",
-      sessionKey: "agent:test:session-request-failure-backoff",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            failing: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime(
+      "session-request-failure-backoff",
+      "failing",
+      serverPath,
+    );
 
     try {
       await expect(runtime.callTool("failing", "slow_tool", {})).rejects.toThrow(
@@ -2482,18 +2352,7 @@ process.on("SIGINT", shutdown);`,
       callToolJsonRpcErrorCode: -32001,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-remote-timeout-code",
-      sessionKey: "agent:test:session-remote-timeout-code",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            responsive: { command: process.execPath, args: [serverPath] },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime("session-remote-timeout-code", "responsive", serverPath);
 
     try {
       await runtime.getCatalog();
@@ -2527,21 +2386,8 @@ process.on("SIGINT", shutdown);`,
       hangToolCallsUntilRestartMarkerPath: markerPath,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-timeout-recycle",
-      sessionKey: "agent:test:session-timeout-recycle",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            hanging: {
-              command: process.execPath,
-              args: [serverPath],
-              requestTimeoutMs: 500,
-            },
-          },
-        },
-      },
+    const runtime = await makeStdioRuntime("session-timeout-recycle", "hanging", serverPath, {
+      server: { requestTimeoutMs: 500 },
     });
 
     try {
@@ -2747,21 +2593,8 @@ process.on("SIGINT", shutdown);`,
       resourcePageCount: 2,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-resource-pages",
-      sessionKey: "agent:test:session-resource-pages",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            paged: {
-              command: process.execPath,
-              args: [serverPath],
-              requestTimeoutMs: 150,
-            },
-          },
-        },
-      },
+    const runtime = await makeStdioRuntime("session-resource-pages", "paged", serverPath, {
+      server: { requestTimeoutMs: 150 },
     });
 
     try {
@@ -2789,21 +2622,11 @@ process.on("SIGINT", shutdown);`,
       resourceListJsonRpcError: true,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-utility-failure-backoff",
-      sessionKey: "agent:test:session-utility-failure-backoff",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            failing: {
-              command: process.execPath,
-              args: [serverPath],
-            },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime(
+      "session-utility-failure-backoff",
+      "failing",
+      serverPath,
+    );
 
     try {
       if (!runtime.listResources) {
@@ -2832,18 +2655,7 @@ process.on("SIGINT", shutdown);`,
       resourceReadJsonRpcError: true,
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-preview-failure",
-      sessionKey: "agent:test:session-preview-failure",
-      workspaceDir: "/workspace",
-      cfg: {
-        mcp: {
-          servers: {
-            failing: { command: process.execPath, args: [serverPath] },
-          },
-        },
-      },
-    });
+    const runtime = await makeStdioRuntime("session-preview-failure", "failing", serverPath);
 
     try {
       const readResource = runtime.readResource;
@@ -2870,14 +2682,12 @@ process.on("SIGINT", shutdown);`,
     const disposed: string[] = [];
     const createRuntime: RuntimeFactory = (params) => {
       createdManifestRegistries.push(params.manifestRegistry);
-      const runtime = makeRuntime([{ toolName: "bundle_probe", description: "Bundle MCP probe" }]);
+      const runtime = makeManagedRuntime(params, [
+        { toolName: "bundle_probe", description: "Bundle MCP probe" },
+      ]);
       created.push(runtime);
       return {
         ...runtime,
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
         dispose: async () => {
           disposed.push(params.sessionId);
         },
@@ -2946,14 +2756,11 @@ process.on("SIGINT", shutdown);`,
     const disposed: Array<{ sessionId: string; agentDir?: string }> = [];
     const createRuntime: RuntimeFactory = (params) => {
       created.push({ sessionId: params.sessionId, agentDir: params.agentDir });
-      const runtime = makeRuntime([{ toolName: "bundle_probe", description: "Bundle MCP probe" }]);
       return {
-        ...runtime,
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        workspaceDir: params.workspaceDir,
+        ...makeManagedRuntime(params, [
+          { toolName: "bundle_probe", description: "Bundle MCP probe" },
+        ]),
         agentDir: params.agentDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
         dispose: async () => {
           disposed.push({ sessionId: params.sessionId, agentDir: params.agentDir });
         },
@@ -2994,14 +2801,12 @@ process.on("SIGINT", shutdown);`,
   it("peeks existing runtimes and populated catalogs without creating new runtimes", async () => {
     let catalogReady = false;
     const createRuntime: RuntimeFactory = (params) => {
-      const base = makeRuntime([{ toolName: "bundle_probe", description: "Bundle MCP probe" }]);
+      const base = makeManagedRuntime(params, [
+        { toolName: "bundle_probe", description: "Bundle MCP probe" },
+      ]);
       let cachedCatalog: ReturnType<SessionMcpRuntime["peekCatalog"]> = null;
       return {
         ...base,
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
         peekCatalog: () => cachedCatalog,
         getCatalog: async () => {
           const catalog = await base.getCatalog();
@@ -3037,11 +2842,9 @@ process.on("SIGINT", shutdown);`,
         params.cfg?.mcp?.servers?.configuredProbe?.env?.BUNDLE_PROBE_TEXT ?? "FROM-CONFIG",
       );
       return {
-        ...makeRuntime([{ toolName: "bundle_probe", description: "Bundle MCP probe" }]),
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
+        ...makeManagedRuntime(params, [
+          { toolName: "bundle_probe", description: "Bundle MCP probe" },
+        ]),
         callTool: async () => ({
           content: [{ type: "text", text: probeText }],
           isError: false,
@@ -3122,11 +2925,9 @@ process.on("SIGINT", shutdown);`,
     });
     let rejectCatalog: ((error: Error) => void) | undefined;
     const createRuntime: RuntimeFactory = (params) => ({
-      ...makeRuntime([{ toolName: "bundle_probe", description: "Bundle MCP probe" }]),
-      sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
-      workspaceDir: params.workspaceDir,
-      configFingerprint: params.configFingerprint ?? "fingerprint",
+      ...makeManagedRuntime(params, [
+        { toolName: "bundle_probe", description: "Bundle MCP probe" },
+      ]),
       getCatalog: async () => {
         if (!notifyCatalogStarted) {
           throw new Error("Expected bundle MCP catalog start callback to be initialized");
@@ -3538,14 +3339,7 @@ describe("requester-scoped MCP connection resolution", () => {
         include: params.includeServerNames ? [...params.includeServerNames] : undefined,
         exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
       });
-      return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
-      };
+      return makeManagedRuntime(params);
     };
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
@@ -3557,33 +3351,14 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    await manager.getOrCreate({
-      sessionId: "session-shared",
-      sessionKey: "agent:test:session-shared",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-      agentAccountId: "bot-1",
-    });
-    await manager.getOrCreate({
-      sessionId: "session-shared",
-      sessionKey: "agent:test:session-shared",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-      agentAccountId: "bot-1",
-    });
-    await manager.getOrCreate({
-      sessionId: "session-shared",
-      sessionKey: "agent:test:session-shared",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-b",
-      messageChannel: "telegram",
-      agentAccountId: "bot-1",
-    });
+    const params = (sender: string) =>
+      makeRequesterParams("session-shared", cfg as never, sender, {
+        sessionKey: "agent:test:session-shared",
+        agentAccountId: "bot-1",
+      });
+    await manager.getOrCreate(params("sender-a"));
+    await manager.getOrCreate(params("sender-a"));
+    await manager.getOrCreate(params("sender-b"));
 
     // Same requester reuses both static and requester-scoped entries; other sender adds one.
     expect(created).toEqual([
@@ -3694,13 +3469,7 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     ]);
 
-    const createRuntime: RuntimeFactory = (params) => ({
-      ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-      sessionId: params.sessionId,
-      workspaceDir: params.workspaceDir,
-      configFingerprint: params.configFingerprint ?? "fingerprint",
-      requesterScope: params.requesterScope,
-    });
+    const createRuntime: RuntimeFactory = makeManagedRuntime;
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
@@ -3710,20 +3479,9 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    await manager.getOrCreate({
-      sessionId: "session-resolve-once",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
-    await manager.getOrCreate({
-      sessionId: "session-resolve-once",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const params = makeRequesterParams("session-resolve-once", cfg as never, "sender-a");
+    await manager.getOrCreate(params);
+    await manager.getOrCreate(params);
 
     expect(resolveCalls).toBe(1);
     await manager.disposeAll();
@@ -3747,12 +3505,7 @@ describe("requester-scoped MCP connection resolution", () => {
         include: params.includeServerNames ? [...params.includeServerNames] : undefined,
         exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
       });
-      return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-      };
+      return makeManagedRuntime(params);
     };
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
@@ -3796,12 +3549,7 @@ describe("requester-scoped MCP connection resolution", () => {
         include: params.includeServerNames ? [...params.includeServerNames] : undefined,
         exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
       });
-      return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-      };
+      return makeManagedRuntime(params);
     };
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
@@ -3818,20 +3566,16 @@ describe("requester-scoped MCP connection resolution", () => {
       workspaceDir: "/workspace",
       cfg: cfg as never,
     });
-    await manager.getOrCreate({
-      sessionId: "session-fail-closed",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "denied",
-      messageChannel: "slack",
-    });
-    await manager.getOrCreate({
-      sessionId: "session-fail-closed",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "allowed",
-      messageChannel: "slack",
-    });
+    await manager.getOrCreate(
+      makeRequesterParams("session-fail-closed", cfg as never, "denied", {
+        messageChannel: "slack",
+      }),
+    );
+    await manager.getOrCreate(
+      makeRequesterParams("session-fail-closed", cfg as never, "allowed", {
+        messageChannel: "slack",
+      }),
+    );
 
     // Static entry is reused; only the allowed requester materializes a scoped runtime.
     expect(created).toEqual([
@@ -3857,13 +3601,7 @@ describe("requester-scoped MCP connection resolution", () => {
     const fingerprints: string[] = [];
     const createRuntime: RuntimeFactory = (params) => {
       fingerprints.push(params.configFingerprint ?? "missing");
-      return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
-      };
+      return makeManagedRuntime(params);
     };
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
@@ -3877,27 +3615,9 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    await manager.getOrCreate({
-      sessionId: "session-fingerprint",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "alice",
-      messageChannel: "telegram",
-    });
-    await manager.getOrCreate({
-      sessionId: "session-fingerprint",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "bob",
-      messageChannel: "telegram",
-    });
-    await manager.getOrCreate({
-      sessionId: "session-fingerprint",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "alice",
-      messageChannel: "telegram",
-    });
+    await manager.getOrCreate(makeRequesterParams("session-fingerprint", cfg as never, "alice"));
+    await manager.getOrCreate(makeRequesterParams("session-fingerprint", cfg as never, "bob"));
+    await manager.getOrCreate(makeRequesterParams("session-fingerprint", cfg as never, "alice"));
 
     // Empty static reconcile + two requester creates; requester fingerprints match.
     expect(fingerprints).toHaveLength(3);
@@ -3927,12 +3647,7 @@ describe("requester-scoped MCP connection resolution", () => {
         include: params.includeServerNames ? [...params.includeServerNames] : undefined,
         exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
       });
-      return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-      };
+      return makeManagedRuntime(params);
     };
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
@@ -3945,13 +3660,9 @@ describe("requester-scoped MCP connection resolution", () => {
     };
 
     vi.useFakeTimers();
-    const pending = manager.getOrCreate({
-      sessionId: "session-timeout",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const pending = manager.getOrCreate(
+      makeRequesterParams("session-timeout", cfg as never, "sender-a"),
+    );
     await vi.advanceTimersByTimeAsync(25);
     await expect(pending).resolves.toBeDefined();
     expect(created).toEqual([{ include: undefined, exclude: ["user-mail"] }]);
@@ -3980,13 +3691,7 @@ describe("requester-scoped MCP connection resolution", () => {
       if (params.includeServerNames) {
         createdIncludes.push([...params.includeServerNames].toSorted());
       }
-      return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
-      };
+      return makeManagedRuntime(params);
     };
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
@@ -3999,22 +3704,11 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    await manager.getOrCreate({
-      sessionId: "session-partial",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const params = makeRequesterParams("session-partial", cfg as never, "sender-a");
+    await manager.getOrCreate(params);
     expect(createdIncludes).toEqual([["mail-a"]]);
 
-    await manager.getOrCreate({
-      sessionId: "session-partial",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    await manager.getOrCreate(params);
     expect(createdIncludes).toEqual([["mail-a"], ["mail-a", "mail-b"]]);
     // Static part was created once and not rebuilt when the requester side upgraded.
     expect(manager.listRuntimeKeys().filter((key) => !key.startsWith("{"))).toEqual([
@@ -4040,13 +3734,8 @@ describe("requester-scoped MCP connection resolution", () => {
           ? "shared"
           : "shared";
       const toolName = serverName === "user-mail" ? "send" : "shared_tool";
-      const base = makeRuntime([{ toolName, description: toolName }], serverName);
       return {
-        ...base,
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
+        ...makeManagedRuntime(params, [{ toolName, description: toolName }], serverName),
         getCatalog: async () => ({
           version: 1,
           generatedAt: 0,
@@ -4118,15 +3807,10 @@ describe("requester-scoped MCP connection resolution", () => {
       let syntheticLastUsedAt = 100_000;
       const createRuntime: RuntimeFactory = (params) => {
         const sender = params.requesterScope?.requesterSenderId;
-        const base = makeRuntime([{ toolName: "probe", description: "probe" }]);
         // Distinct ascending lastUsedAt per runtime so LRU ordering is deterministic.
         const lastUsedAt = (syntheticLastUsedAt += 1_000);
         return {
-          ...base,
-          sessionId: params.sessionId,
-          workspaceDir: params.workspaceDir,
-          configFingerprint: params.configFingerprint ?? "fingerprint",
-          requesterScope: params.requesterScope,
+          ...makeManagedRuntime(params),
           get lastUsedAt() {
             return lastUsedAt;
           },
@@ -4150,13 +3834,7 @@ describe("requester-scoped MCP connection resolution", () => {
       };
 
       for (const sender of ["sender-a", "sender-b", "sender-c"]) {
-        const runtimeParams = {
-          sessionId: "session-cap",
-          workspaceDir: "/workspace",
-          cfg: cfg as never,
-          requesterSenderId: sender,
-          messageChannel: "telegram",
-        };
+        const runtimeParams = makeRequesterParams("session-cap", cfg as never, sender);
         if (entrypoint === "full") {
           await manager.getOrCreate(runtimeParams);
         } else {
@@ -4213,11 +3891,7 @@ describe("requester-scoped MCP connection resolution", () => {
         current = makeCatalog(serverName, toolName);
       });
       return {
-        ...makeRuntime([{ toolName: "unused", description: "unused" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
+        ...makeManagedRuntime(params, [{ toolName: "unused", description: "unused" }]),
         peekCatalog: () => current,
         getCatalog: async () => current,
         getServerRequestTimeoutMs: () => (serverName === "user-mail" ? 90_000 : 60_000),
@@ -4280,11 +3954,7 @@ describe("requester-scoped MCP connection resolution", () => {
     const createRuntime: RuntimeFactory = (params) => {
       const label = params.requesterScope ? "scoped" : "static";
       return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
+        ...makeManagedRuntime(params),
         dispose: async () => {
           disposed.push(label);
         },
@@ -4304,24 +3974,13 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    await manager.getOrCreate({
-      sessionId: "session-revoke",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const params = makeRequesterParams("session-revoke", cfg as never, "sender-a");
+    await manager.getOrCreate(params);
     expect(manager.listRuntimeKeys().some((key) => key.startsWith("{"))).toBe(true);
 
     allow = false;
     nowMs += 2_000;
-    const after = await manager.getOrCreate({
-      sessionId: "session-revoke",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const after = await manager.getOrCreate(params);
 
     expect(disposed).toContain("scoped");
     expect(manager.listRuntimeKeys().some((key) => key.startsWith("{"))).toBe(false);
@@ -4349,13 +4008,7 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     ]);
 
-    const createRuntime: RuntimeFactory = (params) => ({
-      ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-      sessionId: params.sessionId,
-      workspaceDir: params.workspaceDir,
-      configFingerprint: params.configFingerprint ?? "fingerprint",
-      requesterScope: params.requesterScope,
-    });
+    const createRuntime: RuntimeFactory = makeManagedRuntime;
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const pending = manager.getOrCreate({
       sessionId: "session-race-dispose",
@@ -4420,13 +4073,7 @@ describe("requester-scoped MCP connection resolution", () => {
       if (params.connectionOverrides) {
         builtHashes.push(hashMcpResolvedConnections(params.connectionOverrides));
       }
-      return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
-      };
+      return makeManagedRuntime(params);
     };
     const manager = testing.createSessionMcpRuntimeManager({
       createRuntime,
@@ -4444,24 +4091,13 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    const first = manager.getOrCreate({
-      sessionId: "session-serialize",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const params = makeRequesterParams("session-serialize", cfg as never, "sender-a");
+    const first = manager.getOrCreate(params);
     await new Promise((resolve) => {
       setTimeout(resolve, 20);
     });
 
-    const second = manager.getOrCreate({
-      sessionId: "session-serialize",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const second = manager.getOrCreate(params);
 
     // Second is queued behind the first exclusive section. First installs the first credential, then
     // second re-resolves the rotated credential and replaces — last serialized resolution wins.
@@ -4489,13 +4125,7 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     ]);
     const manager = testing.createSessionMcpRuntimeManager({
-      createRuntime: (params) => ({
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
-      }),
+      createRuntime: makeManagedRuntime,
     });
     await manager.getOrCreate({
       sessionId: "session-bookkeeping",
@@ -4542,13 +4172,7 @@ describe("requester-scoped MCP connection resolution", () => {
     let createCount = 0;
     const createRuntime: RuntimeFactory = (params) => {
       createCount += 1;
-      return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
-      };
+      return makeManagedRuntime(params);
     };
     const manager = testing.createSessionMcpRuntimeManager({
       createRuntime,
@@ -4563,50 +4187,27 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    await manager.getOrCreate({
-      sessionId: "session-revalidate",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const params = makeRequesterParams("session-revalidate", cfg as never, "sender-a");
+    await manager.getOrCreate(params);
     expect(resolveCalls).toBe(1);
     expect(createCount).toBe(2); // empty static + requester
 
     // Within revalidation window: no resolver call.
     nowMs += 500;
-    await manager.getOrCreate({
-      sessionId: "session-revalidate",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    await manager.getOrCreate(params);
     expect(resolveCalls).toBe(1);
     expect(createCount).toBe(2);
 
     // Past window, unchanged credentials: resolve once, no rebuild.
     nowMs += 1_000;
-    await manager.getOrCreate({
-      sessionId: "session-revalidate",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    await manager.getOrCreate(params);
     expect(resolveCalls).toBe(2);
     expect(createCount).toBe(2);
 
     // Past window with rotated header: rebuild requester runtime.
     token = "secret-token";
     nowMs += 1_000;
-    await manager.getOrCreate({
-      sessionId: "session-revalidate",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    await manager.getOrCreate(params);
     expect(resolveCalls).toBe(3);
     expect(createCount).toBe(3);
 
@@ -4638,11 +4239,7 @@ describe("requester-scoped MCP connection resolution", () => {
       const serverName = isScoped ? "mail-prod" : "mail.prod";
       const safe = params.safeServerNamesByServer?.get(serverName) ?? serverName;
       return {
-        ...makeRuntime([{ toolName: "send", description: "send" }], serverName),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
+        ...makeManagedRuntime(params, [{ toolName: "send", description: "send" }], serverName),
         getCatalog: async () => ({
           version: 1,
           generatedAt: 0,
@@ -4676,21 +4273,13 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    const runtimeA = await manager.getOrCreate({
-      sessionId: "session-safe-names",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const runtimeA = await manager.getOrCreate(
+      makeRequesterParams("session-safe-names", cfg as never, "sender-a"),
+    );
     resolveBoth = false;
-    const runtimeB = await manager.getOrCreate({
-      sessionId: "session-safe-names",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-b",
-      messageChannel: "telegram",
-    });
+    const runtimeB = await manager.getOrCreate(
+      makeRequesterParams("session-safe-names", cfg as never, "sender-b"),
+    );
 
     // Every create for this session received the same full-set assignments;
     // declaration order gives "mail.prod" (declared first) the unsuffixed base.
@@ -4719,11 +4308,7 @@ describe("requester-scoped MCP connection resolution", () => {
   it("reconciles a stale bare runtime when every server becomes requester-scoped", async () => {
     const disposed: string[] = [];
     const createRuntime: RuntimeFactory = (params) => ({
-      ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-      sessionId: params.sessionId,
-      workspaceDir: params.workspaceDir,
-      configFingerprint: params.configFingerprint ?? "fingerprint",
-      requesterScope: params.requesterScope,
+      ...makeManagedRuntime(params),
       dispose: async () => {
         disposed.push(
           params.includeServerNames
@@ -4866,13 +4451,7 @@ describe("requester-scoped MCP connection resolution", () => {
     const fingerprints: string[] = [];
     const createRuntime: RuntimeFactory = (params) => {
       fingerprints.push(params.configFingerprint ?? "");
-      return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }]),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
-      };
+      return makeManagedRuntime(params);
     };
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
@@ -4950,11 +4529,7 @@ describe("requester-scoped MCP connection resolution", () => {
         exclude: params.excludeServerNames ? [...params.excludeServerNames] : undefined,
       });
       return {
-        ...makeRuntime([{ toolName: "probe", description: "probe" }], "user-mail"),
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
+        ...makeManagedRuntime(params, [{ toolName: "probe", description: "probe" }], "user-mail"),
         get lastUsedAt() {
           return createdAt;
         },
@@ -4975,14 +4550,9 @@ describe("requester-scoped MCP connection resolution", () => {
 
     const sessionId = "session-scoped-only";
     const sessionKey = "agent:main:session-scoped-only";
-    const scoped = await manager.getOrCreateRequesterScoped({
-      sessionId,
-      sessionKey,
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const scoped = await manager.getOrCreateRequesterScoped(
+      makeRequesterParams(sessionId, cfg as never, "sender-a", { sessionKey }),
+    );
     expect(scoped?.requesterScope?.requesterSenderId).toBe("sender-a");
     await vi.waitFor(() =>
       expect(testing.getBookkeepingSizes(manager).requesterWorkChains).toBe(0),
@@ -5052,13 +4622,8 @@ describe("requester-scoped MCP connection resolution", () => {
         },
       },
     ]);
-    const createRuntime: RuntimeFactory = (params) => ({
-      ...makeRuntime([{ toolName: "probe", description: "probe" }], "user-mail"),
-      sessionId: params.sessionId,
-      workspaceDir: params.workspaceDir,
-      configFingerprint: params.configFingerprint ?? "fingerprint",
-      requesterScope: params.requesterScope,
-    });
+    const createRuntime: RuntimeFactory = (params) =>
+      makeManagedRuntime(params, [{ toolName: "probe", description: "probe" }], "user-mail");
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
@@ -5068,21 +4633,10 @@ describe("requester-scoped MCP connection resolution", () => {
       },
     };
 
-    const full = await manager.getOrCreate({
-      sessionId: "session-reuse",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const params = makeRequesterParams("session-reuse", cfg as never, "sender-a");
+    const full = await manager.getOrCreate(params);
     const fullRuntimeKey = manager.listRuntimeKeys().find((key) => key.startsWith("{"));
-    const requesterOnly = await manager.getOrCreateRequesterScoped({
-      sessionId: "session-reuse",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "sender-a",
-      messageChannel: "telegram",
-    });
+    const requesterOnly = await manager.getOrCreateRequesterScoped(params);
     const requesterOnlyRuntimeKey = manager.listRuntimeKeys().find((key) => key.startsWith("{"));
     expect(requesterOnly).toBe(full);
     expect(resolveCount).toBe(1);
@@ -5102,16 +4656,8 @@ describe("requester-scoped MCP connection resolution", () => {
           ctx.requesterSenderId === "authed" ? { url: "https://mcp.example.test/authed" } : null,
       },
     ]);
-    const createRuntime: RuntimeFactory = (params) => {
-      const runtime = makeRuntime([{ toolName: "inbox", description: "read inbox" }], "user-mail");
-      return {
-        ...runtime,
-        sessionId: params.sessionId,
-        workspaceDir: params.workspaceDir,
-        configFingerprint: params.configFingerprint ?? "fingerprint",
-        requesterScope: params.requesterScope,
-      };
-    };
+    const createRuntime: RuntimeFactory = (params) =>
+      makeManagedRuntime(params, [{ toolName: "inbox", description: "read inbox" }], "user-mail");
     const manager = testing.createSessionMcpRuntimeManager({ createRuntime });
     const cfg = {
       mcp: {
@@ -5123,13 +4669,9 @@ describe("requester-scoped MCP connection resolution", () => {
 
     expect(manager.getAdvertisedScopedCatalog("session-adv")).toBeNull();
 
-    const authed = await manager.getOrCreateRequesterScoped({
-      sessionId: "session-adv",
-      workspaceDir: "/workspace",
-      cfg: cfg as never,
-      requesterSenderId: "authed",
-      messageChannel: "telegram",
-    });
+    const authed = await manager.getOrCreateRequesterScoped(
+      makeRequesterParams("session-adv", cfg as never, "authed"),
+    );
     expect(authed).toBeDefined();
     const catalog = await authed!.getCatalog();
     manager.rememberAdvertisedScopedCatalog("session-adv", catalog);
@@ -5222,21 +4764,11 @@ process.stdin.on("end", () => {
 });`,
       );
 
-      const runtime = await getOrCreateSessionMcpRuntime({
-        sessionId: "session-force-close-timeout",
-        sessionKey: "agent:test:session-force-close-timeout",
-        workspaceDir: "/workspace",
-        cfg: {
-          mcp: {
-            servers: {
-              hangingTerminate: {
-                command: process.execPath,
-                args: [serverPath],
-              },
-            },
-          },
-        },
-      });
+      const runtime = await makeStdioRuntime(
+        "session-force-close-timeout",
+        "hangingTerminate",
+        serverPath,
+      );
 
       const catalog = await runtime.getCatalog();
       expect(catalog.tools).toHaveLength(1);
@@ -5319,21 +4851,7 @@ process.stdin.on("end", () => {
 });`,
       );
 
-      const runtime = await getOrCreateSessionMcpRuntime({
-        sessionId: "session-dispose-timeout",
-        sessionKey: "agent:test:session-dispose-timeout",
-        workspaceDir: "/workspace",
-        cfg: {
-          mcp: {
-            servers: {
-              hangingClose: {
-                command: process.execPath,
-                args: [serverPath],
-              },
-            },
-          },
-        },
-      });
+      const runtime = await makeStdioRuntime("session-dispose-timeout", "hangingClose", serverPath);
 
       const catalog = await runtime.getCatalog();
       expect(catalog.tools).toHaveLength(1);
@@ -6453,21 +5971,11 @@ process.on("SIGTERM", shutdown);
 process.on("SIGINT", shutdown);`,
       );
 
-      const runtime = await getOrCreateSessionMcpRuntime({
-        sessionId: "session-overlap-generation-test",
-        sessionKey: "agent:test:session-overlap-generation-test",
-        workspaceDir: "/workspace",
-        cfg: {
-          mcp: {
-            servers: {
-              overlap: {
-                command: process.execPath,
-                args: [serverPath],
-              },
-            },
-          },
-        },
-      });
+      const runtime = await makeStdioRuntime(
+        "session-overlap-generation-test",
+        "overlap",
+        serverPath,
+      );
 
       try {
         const firstCatalog = runtime.getCatalog();

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -46,10 +46,7 @@ import {
   sanitizeGeneratedMediaDisplayText,
   type AgentGeneratedAttachment,
 } from "../generated-attachments.js";
-import {
-  buildMediaGenerationRequestKey,
-  recordRecentMediaGenerationTaskStartForSession,
-} from "../media-generation-task-status-shared.js";
+import { buildMediaGenerationRequestKey } from "../media-generation-task-status-shared.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { optionalStringEnum } from "../schema/string-enum.js";
 import {
@@ -66,20 +63,13 @@ import {
 } from "./image-generate-tool.actions.js";
 import { decodeDataUrl } from "./image-tool.helpers.js";
 import {
-  buildMediaGenerationStartedToolResult,
   createDefaultMediaGenerateBackgroundScheduler,
-  notifyMediaGenerationAsyncTaskStarted,
-  scheduleMediaGenerationTaskCompletion,
-  shouldDetachMediaGenerationTask,
   type MediaGenerateAsyncStartCallback,
   type MediaGenerateBackgroundScheduler,
 } from "./media-generate-background-shared.js";
 import {
-  completeImageGenerationTaskRun,
-  createImageGenerationTaskRun,
-  failImageGenerationTaskRun,
   imageGenerationTaskLifecycle,
-  recordImageGenerationTaskProgress,
+  runMediaGenerationTask,
   type ImageGenerationTaskHandle,
 } from "./media-generate-background.js";
 import {
@@ -718,7 +708,7 @@ async function executeImageGenerationJob(params: {
   providers?: ImageGenerationProvider[];
 }) {
   if (params.taskHandle) {
-    recordImageGenerationTaskProgress({
+    imageGenerationTaskLifecycle.recordTaskProgress({
       handle: params.taskHandle,
       progressSummary: "Generating image",
     });
@@ -746,7 +736,7 @@ async function executeImageGenerationJob(params: {
     createCapabilityProviderRuntimeDeps(params.providers),
   );
   if (params.taskHandle) {
-    recordImageGenerationTaskProgress({
+    imageGenerationTaskLifecycle.recordTaskProgress({
       handle: params.taskHandle,
       progressSummary: "Saving generated image",
     });
@@ -1071,139 +1061,61 @@ export function createImageGenerateTool(options?: {
       });
       // Accepted tasks own their paid work independently; cancellation applies only before admission.
       signal?.throwIfAborted();
-      const taskHandle = createImageGenerationTaskRun({
+      return runMediaGenerationTask({
+        lifecycle: imageGenerationTaskLifecycle,
+        generationLabel: "image",
         sessionKey: options?.agentSessionKey,
         requesterAgentId: options?.requesterAgentId,
         requesterOrigin: options?.requesterOrigin,
         prompt,
+        requestKey,
         providerId: selectedProvider?.id,
+        config: effectiveCfg,
+        scheduleBackgroundWork,
+        onAsyncTaskStarted: options?.onAsyncTaskStarted,
+        onFailure: (message, meta) => log.warn(message, meta),
+        detailExtras: {
+          ...buildMediaReferenceDetails({
+            entries: loadedReferenceImages,
+            singleKey: "image",
+            pluralKey: "images",
+            getResolvedInput: (entry) => entry.resolvedImage,
+          }),
+          ...(model ? { model } : {}),
+          ...(resolution ? { resolution } : {}),
+          ...(size ? { size } : {}),
+          ...(aspectRatio ? { aspectRatio } : {}),
+          ...(quality ? { quality } : {}),
+          ...(outputFormat ? { outputFormat } : {}),
+          ...(background ? { background } : {}),
+          ...(filename ? { filename } : {}),
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+        },
+        run: (taskHandle) =>
+          executeImageGenerationJob({
+            effectiveCfg,
+            prompt,
+            agentDir: options?.agentDir,
+            model,
+            size,
+            aspectRatio,
+            resolution: explicitResolution,
+            inferredResolution,
+            quality,
+            outputFormat,
+            background,
+            count,
+            inputImages,
+            timeoutMs,
+            providerOptions,
+            ssrfPolicy: remoteMediaSsrfPolicy,
+            filename,
+            loadedReferenceImages,
+            taskHandle,
+            autoProviderFallback: explicitModelConfig ? false : undefined,
+            providers: imageGenerationProviders,
+          }),
       });
-      const shouldDetach = Boolean(
-        taskHandle &&
-        shouldDetachMediaGenerationTask(options?.agentSessionKey, options?.requesterAgentId),
-      );
-
-      if (shouldDetach && taskHandle) {
-        recordRecentMediaGenerationTaskStartForSession({
-          sessionKey: options?.agentSessionKey,
-          agentId: options?.requesterAgentId,
-          taskKind: "image_generation",
-          sourcePrefix: "image_generate",
-          taskId: taskHandle.taskId,
-          runId: taskHandle.runId,
-          taskLabel: prompt,
-          requestKey,
-          providerId: selectedProvider?.id,
-          progressSummary: "Generating image",
-        });
-        scheduleMediaGenerationTaskCompletion({
-          lifecycle: imageGenerationTaskLifecycle,
-          handle: taskHandle,
-          scheduleBackgroundWork,
-          progressSummary: "Generating image",
-          config: effectiveCfg,
-          toolName: "Image generation",
-          onWakeFailure: (message, meta) => log.warn(message, meta),
-          run: () =>
-            executeImageGenerationJob({
-              effectiveCfg,
-              prompt,
-              agentDir: options?.agentDir,
-              model,
-              size,
-              aspectRatio,
-              resolution: explicitResolution,
-              inferredResolution,
-              quality,
-              outputFormat,
-              background,
-              count,
-              inputImages,
-              timeoutMs,
-              providerOptions,
-              ssrfPolicy: remoteMediaSsrfPolicy,
-              filename,
-              loadedReferenceImages,
-              taskHandle,
-              autoProviderFallback: explicitModelConfig ? false : undefined,
-              providers: imageGenerationProviders,
-            }),
-        });
-
-        await notifyMediaGenerationAsyncTaskStarted({
-          callback: options?.onAsyncTaskStarted,
-          message: "Image generation started; wait for the generated image completion event.",
-          toolName: "image_generate",
-          handle: taskHandle,
-          onFailure: (message, meta) => log.warn(message, meta),
-        });
-
-        return buildMediaGenerationStartedToolResult({
-          toolName: "image_generate",
-          generationLabel: "image",
-          completionLabel: "image",
-          taskHandle,
-          detailExtras: {
-            ...buildMediaReferenceDetails({
-              entries: loadedReferenceImages,
-              singleKey: "image",
-              pluralKey: "images",
-              getResolvedInput: (entry) => entry.resolvedImage,
-            }),
-            ...(model ? { model } : {}),
-            ...(resolution ? { resolution } : {}),
-            ...(size ? { size } : {}),
-            ...(aspectRatio ? { aspectRatio } : {}),
-            ...(quality ? { quality } : {}),
-            ...(outputFormat ? { outputFormat } : {}),
-            ...(background ? { background } : {}),
-            ...(filename ? { filename } : {}),
-            ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-          },
-        });
-      }
-
-      try {
-        const executed = await executeImageGenerationJob({
-          effectiveCfg,
-          prompt,
-          agentDir: options?.agentDir,
-          model,
-          size,
-          aspectRatio,
-          resolution: explicitResolution,
-          inferredResolution,
-          quality,
-          outputFormat,
-          background,
-          count,
-          inputImages,
-          timeoutMs,
-          providerOptions,
-          ssrfPolicy: remoteMediaSsrfPolicy,
-          filename,
-          loadedReferenceImages,
-          taskHandle,
-          autoProviderFallback: explicitModelConfig ? false : undefined,
-          providers: imageGenerationProviders,
-        });
-        completeImageGenerationTaskRun({
-          handle: taskHandle,
-          provider: executed.provider,
-          model: executed.model,
-          count: executed.count,
-        });
-        return {
-          content: [{ type: "text", text: executed.contentText }],
-          details: executed.details,
-        };
-      } catch (error) {
-        failImageGenerationTaskRun({
-          handle: taskHandle,
-          error,
-        });
-        throw error;
-      }
     },
   };
 }

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -98,7 +98,7 @@ export function shouldDetachMediaGenerationTask(
 }
 
 /** Successful media generation output used to complete and wake detached tasks. */
-type MediaGenerationExecutionResult = {
+export type MediaGenerationExecutionResult = {
   provider: string;
   model: string;
   count: number;

--- a/src/agents/tools/media-generate-background.test.ts
+++ b/src/agents/tools/media-generate-background.test.ts
@@ -23,18 +23,8 @@ vi.mock("../../tasks/detached-task-runtime.js", () => taskExecutorMocks);
 vi.mock("../../tasks/task-registry-delivery-runtime.js", () => taskDeliveryRuntimeMocks);
 vi.mock("../subagents/announce/subagent-announce-delivery.js", () => announceDeliveryMocks);
 
-const {
-  createImageGenerationTaskRun,
-  createMusicGenerationTaskRun,
-  createVideoGenerationTaskRun,
-  failVideoGenerationTaskRun,
-  imageGenerationTaskLifecycle,
-  musicGenerationTaskLifecycle,
-  recordImageGenerationTaskProgress,
-  recordMusicGenerationTaskProgress,
-  recordVideoGenerationTaskProgress,
-  videoGenerationTaskLifecycle,
-} = await import("./media-generate-background.js");
+const { imageGenerationTaskLifecycle, musicGenerationTaskLifecycle, videoGenerationTaskLifecycle } =
+  await import("./media-generate-background.js");
 
 describe("image generate background helpers", () => {
   beforeEach(() => {
@@ -50,7 +40,7 @@ describe("image generate background helpers", () => {
       taskId: "task-123",
     });
 
-    const handle = createImageGenerationTaskRun({
+    const handle = imageGenerationTaskLifecycle.createTaskRun({
       sessionKey: "agent:main:discord:direct:123",
       requesterOrigin: {
         channel: "discord",
@@ -75,7 +65,7 @@ describe("image generate background helpers", () => {
   });
 
   it("records task progress updates", () => {
-    recordImageGenerationTaskProgress({
+    imageGenerationTaskLifecycle.recordTaskProgress({
       handle: {
         taskId: "task-123",
         runId: "tool:image_generate:abc",
@@ -176,7 +166,7 @@ describe("music generate background helpers", () => {
       taskId: "task-123",
     });
 
-    const handle = createMusicGenerationTaskRun({
+    const handle = musicGenerationTaskLifecycle.createTaskRun({
       sessionKey: "agent:main:discord:direct:123",
       requesterOrigin: {
         channel: "discord",
@@ -201,7 +191,7 @@ describe("music generate background helpers", () => {
   });
 
   it("records task progress updates", () => {
-    recordMusicGenerationTaskProgress({
+    musicGenerationTaskLifecycle.recordTaskProgress({
       handle: {
         taskId: "task-123",
         runId: "tool:music_generate:abc",
@@ -338,7 +328,7 @@ describe("video generate background helpers", () => {
       taskId: "task-123",
     });
 
-    const handle = createVideoGenerationTaskRun({
+    const handle = videoGenerationTaskLifecycle.createTaskRun({
       sessionKey: "agent:main:discord:direct:123",
       requesterOrigin: {
         channel: "discord",
@@ -360,7 +350,7 @@ describe("video generate background helpers", () => {
   });
 
   it("records task progress updates", () => {
-    recordVideoGenerationTaskProgress({
+    videoGenerationTaskLifecycle.recordTaskProgress({
       handle: {
         taskId: "task-123",
         runId: "tool:video_generate:abc",
@@ -382,7 +372,7 @@ describe("video generate background helpers", () => {
       taskId: "task-123",
     });
 
-    const handle = createVideoGenerationTaskRun({
+    const handle = videoGenerationTaskLifecycle.createTaskRun({
       sessionKey: "agent:main:discord:channel:123",
       prompt: "friendly lobster surfing",
       providerId: "fal",
@@ -395,14 +385,14 @@ describe("video generate background helpers", () => {
     expect(getAgentRunContext(handle.runId)?.sessionKey).toBe("agent:main:discord:channel:123");
 
     const beforeProgress = Date.now();
-    recordVideoGenerationTaskProgress({
+    videoGenerationTaskLifecycle.recordTaskProgress({
       handle,
       progressSummary: "Generating video",
     });
 
     expect(getAgentRunContext(handle.runId)?.lastActiveAt).toBeGreaterThanOrEqual(beforeProgress);
 
-    failVideoGenerationTaskRun({
+    videoGenerationTaskLifecycle.failTaskRun({
       handle,
       error: new Error("provider failed"),
     });

--- a/src/agents/tools/media-generate-background.ts
+++ b/src/agents/tools/media-generate-background.ts
@@ -3,15 +3,115 @@
  *
  * Binds shared detached media-task lifecycle behavior to image_generate labels and completion messages.
  */
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { DeliveryContext } from "../../utils/delivery-context.types.js";
+import { recordRecentMediaGenerationTaskStartForSession } from "../media-generation-task-status-shared.js";
 import {
   IMAGE_GENERATION_TASK_KIND,
   MUSIC_GENERATION_TASK_KIND,
   VIDEO_GENERATION_TASK_KIND,
 } from "../media-generation-task-status.js";
 import {
+  buildMediaGenerationStartedToolResult,
   createMediaGenerationTaskLifecycle,
+  notifyMediaGenerationAsyncTaskStarted,
+  scheduleMediaGenerationTaskCompletion,
+  shouldDetachMediaGenerationTask,
+  type MediaGenerateAsyncStartCallback,
+  type MediaGenerateBackgroundScheduler,
+  type MediaGenerationExecutionResult,
   type MediaGenerationTaskHandle,
 } from "./media-generate-background-shared.js";
+
+/** Owns task admission and the shared foreground or detached generation lifecycle. */
+export async function runMediaGenerationTask<T extends MediaGenerationExecutionResult>(params: {
+  lifecycle: ReturnType<typeof createMediaGenerationTaskLifecycle>;
+  generationLabel: "image" | "video" | "music";
+  sessionKey?: string;
+  requesterAgentId?: string;
+  requesterOrigin?: DeliveryContext;
+  prompt: string;
+  requestKey: string;
+  providerId?: string;
+  config?: OpenClawConfig;
+  scheduleBackgroundWork: MediaGenerateBackgroundScheduler;
+  onAsyncTaskStarted?: MediaGenerateAsyncStartCallback;
+  onFailure: (message: string, meta?: Record<string, unknown>) => void;
+  detailExtras?: Record<string, unknown>;
+  messages?: Array<string | undefined>;
+  run: (
+    handle: MediaGenerationTaskHandle | null,
+  ) => Promise<T & { contentText: string; details: Record<string, unknown> }>;
+}) {
+  const { generationLabel, lifecycle } = params;
+  const toolName = `${generationLabel}_generate`;
+  const progressSummary = `Generating ${generationLabel}`;
+  const title = `${generationLabel.charAt(0).toUpperCase()}${generationLabel.slice(1)}`;
+  const handle = lifecycle.createTaskRun({
+    sessionKey: params.sessionKey,
+    requesterAgentId: params.requesterAgentId,
+    requesterOrigin: params.requesterOrigin,
+    prompt: params.prompt,
+    providerId: params.providerId,
+  });
+
+  if (handle && shouldDetachMediaGenerationTask(params.sessionKey, params.requesterAgentId)) {
+    recordRecentMediaGenerationTaskStartForSession({
+      sessionKey: params.sessionKey,
+      agentId: params.requesterAgentId,
+      taskKind: `${generationLabel}_generation`,
+      sourcePrefix: toolName,
+      taskId: handle.taskId,
+      runId: handle.runId,
+      taskLabel: params.prompt,
+      requestKey: params.requestKey,
+      providerId: params.providerId,
+      progressSummary,
+    });
+    scheduleMediaGenerationTaskCompletion({
+      lifecycle,
+      handle,
+      scheduleBackgroundWork: params.scheduleBackgroundWork,
+      progressSummary,
+      config: params.config,
+      toolName: `${title} generation`,
+      onWakeFailure: params.onFailure,
+      run: () => params.run(handle),
+    });
+    await notifyMediaGenerationAsyncTaskStarted({
+      callback: params.onAsyncTaskStarted,
+      message: `${title} generation started; wait for the generated ${generationLabel} completion event.`,
+      toolName,
+      handle,
+      onFailure: params.onFailure,
+    });
+    return buildMediaGenerationStartedToolResult({
+      toolName,
+      generationLabel,
+      completionLabel: generationLabel,
+      taskHandle: handle,
+      detailExtras: params.detailExtras,
+      messages: params.messages,
+    });
+  }
+
+  try {
+    const executed = await params.run(handle);
+    lifecycle.completeTaskRun({
+      handle,
+      provider: executed.provider,
+      model: executed.model,
+      count: executed.count,
+    });
+    return {
+      content: [{ type: "text" as const, text: executed.contentText }],
+      details: executed.details,
+    };
+  } catch (error) {
+    lifecycle.failTaskRun({ handle, error });
+    throw error;
+  }
+}
 
 /** Detached image generation task handle. */
 export type ImageGenerationTaskHandle = MediaGenerationTaskHandle;
@@ -28,18 +128,6 @@ export const imageGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
   announceType: "image generation task",
   completionLabel: "image",
 });
-
-/** Creates an image generation task ledger run. */
-export const createImageGenerationTaskRun = imageGenerationTaskLifecycle.createTaskRun;
-
-/** Records progress for an image generation task. */
-export const recordImageGenerationTaskProgress = imageGenerationTaskLifecycle.recordTaskProgress;
-
-/** Completes an image generation task ledger run. */
-export const completeImageGenerationTaskRun = imageGenerationTaskLifecycle.completeTaskRun;
-
-/** Marks an image generation task ledger run as failed. */
-export const failImageGenerationTaskRun = imageGenerationTaskLifecycle.failTaskRun;
 
 /**
  * Music generation background task facade.
@@ -62,18 +150,6 @@ export const musicGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
   completionLabel: "music",
 });
 
-/** Creates a queued music-generation background task run. */
-export const createMusicGenerationTaskRun = musicGenerationTaskLifecycle.createTaskRun;
-
-/** Records progress for an active music-generation task. */
-export const recordMusicGenerationTaskProgress = musicGenerationTaskLifecycle.recordTaskProgress;
-
-/** Marks a music-generation task complete and stores generated attachment metadata. */
-export const completeMusicGenerationTaskRun = musicGenerationTaskLifecycle.completeTaskRun;
-
-/** Marks a music-generation task failed and emits task status updates. */
-export const failMusicGenerationTaskRun = musicGenerationTaskLifecycle.failTaskRun;
-
 /**
  * Video-generation background task lifecycle adapters.
  *
@@ -94,15 +170,3 @@ export const videoGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
   announceType: "video generation task",
   completionLabel: "video",
 });
-
-/** Creates a queued video-generation background task run. */
-export const createVideoGenerationTaskRun = videoGenerationTaskLifecycle.createTaskRun;
-
-/** Records progress for an active video-generation task. */
-export const recordVideoGenerationTaskProgress = videoGenerationTaskLifecycle.recordTaskProgress;
-
-/** Marks a video-generation task complete and stores generated attachment metadata. */
-export const completeVideoGenerationTaskRun = videoGenerationTaskLifecycle.completeTaskRun;
-
-/** Marks a video-generation task failed and emits task status updates. */
-export const failVideoGenerationTaskRun = videoGenerationTaskLifecycle.failTaskRun;

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -67,77 +67,89 @@ const musicGenerateBackgroundMocks = vi.hoisted(() => ({
   // Mirror the background lifecycle contract so tool tests can assert task-run
   // effects without spawning detached completion workers.
   musicGenerationTaskLifecycle: {
-    createTaskRun: (
-      params: Parameters<typeof musicGenerateBackground.createMusicGenerationTaskRun>[0],
-    ) => musicGenerateBackgroundMocks.createMusicGenerationTaskRun(params),
-    recordTaskProgress: (
-      params: Parameters<typeof musicGenerateBackground.recordMusicGenerationTaskProgress>[0],
-    ) => musicGenerateBackgroundMocks.recordMusicGenerationTaskProgress(params),
-    completeTaskRun: (
-      params: Parameters<typeof musicGenerateBackground.completeMusicGenerationTaskRun>[0],
-    ) => musicGenerateBackgroundMocks.completeMusicGenerationTaskRun(params),
-    failTaskRun: (
-      params: Parameters<typeof musicGenerateBackground.failMusicGenerationTaskRun>[0],
-    ) => musicGenerateBackgroundMocks.failMusicGenerationTaskRun(params),
+    completeTaskRun: vi.fn(
+      (
+        params: Parameters<
+          typeof musicGenerateBackground.musicGenerationTaskLifecycle.completeTaskRun
+        >[0],
+      ) => {
+        if (!params.handle) {
+          return;
+        }
+        taskExecutorMocks.completeTaskRunByRunId({
+          runId: params.handle.runId,
+          runtime: "cli",
+          sessionKey: params.handle.requesterSessionKey,
+        });
+      },
+    ),
+    createTaskRun: vi.fn(
+      (
+        params: Parameters<
+          typeof musicGenerateBackground.musicGenerationTaskLifecycle.createTaskRun
+        >[0],
+      ) => {
+        const sessionKey = params.sessionKey?.trim();
+        if (!sessionKey) {
+          return null;
+        }
+        const runId = "tool:music_generate:test-run";
+        const task = taskExecutorMocks.createRunningTaskRun({
+          runId,
+          runtime: "cli",
+          requesterSessionKey: sessionKey,
+          ownerKey: sessionKey,
+          scopeKind: "session",
+          task: params.prompt,
+          deliveryStatus: "not_applicable",
+          notifyPolicy: "silent",
+          createdAt: Date.now(),
+        });
+        return {
+          taskId: task.taskId,
+          runId,
+          requesterSessionKey: sessionKey,
+          requesterOrigin: params.requesterOrigin,
+          taskLabel: params.prompt,
+        };
+      },
+    ),
+    failTaskRun: vi.fn(
+      (
+        params: Parameters<
+          typeof musicGenerateBackground.musicGenerationTaskLifecycle.failTaskRun
+        >[0],
+      ) => {
+        if (!params.handle) {
+          return;
+        }
+        taskExecutorMocks.failTaskRunByRunId({
+          runId: params.handle.runId,
+          runtime: "cli",
+          sessionKey: params.handle.requesterSessionKey,
+        });
+      },
+    ),
+    recordTaskProgress: vi.fn(
+      (
+        params: Parameters<
+          typeof musicGenerateBackground.musicGenerationTaskLifecycle.recordTaskProgress
+        >[0],
+      ) => {
+        if (!params.handle) {
+          return;
+        }
+        taskExecutorMocks.recordTaskRunProgressByRunId({
+          runId: params.handle.runId,
+          runtime: "cli",
+          sessionKey: params.handle.requesterSessionKey,
+          progressSummary: params.progressSummary,
+          eventSummary: params.eventSummary,
+        });
+      },
+    ),
     wakeTaskCompletion: vi.fn(),
   },
-  completeMusicGenerationTaskRun: vi.fn((params) => {
-    if (!params.handle) {
-      return;
-    }
-    taskExecutorMocks.completeTaskRunByRunId({
-      runId: params.handle.runId,
-      runtime: "cli",
-      sessionKey: params.handle.requesterSessionKey,
-    });
-  }),
-  createMusicGenerationTaskRun: vi.fn((params) => {
-    const sessionKey = params.sessionKey?.trim();
-    if (!sessionKey) {
-      return null;
-    }
-    const runId = "tool:music_generate:test-run";
-    const task = taskExecutorMocks.createRunningTaskRun({
-      runId,
-      runtime: "cli",
-      requesterSessionKey: sessionKey,
-      ownerKey: sessionKey,
-      scopeKind: "session",
-      task: params.prompt,
-      deliveryStatus: "not_applicable",
-      notifyPolicy: "silent",
-      createdAt: Date.now(),
-    });
-    return {
-      taskId: task.taskId,
-      runId,
-      requesterSessionKey: sessionKey,
-      requesterOrigin: params.requesterOrigin,
-      taskLabel: params.prompt,
-    };
-  }),
-  failMusicGenerationTaskRun: vi.fn((params) => {
-    if (!params.handle) {
-      return;
-    }
-    taskExecutorMocks.failTaskRunByRunId({
-      runId: params.handle.runId,
-      runtime: "cli",
-      sessionKey: params.handle.requesterSessionKey,
-    });
-  }),
-  recordMusicGenerationTaskProgress: vi.fn((params) => {
-    if (!params.handle) {
-      return;
-    }
-    taskExecutorMocks.recordTaskRunProgressByRunId({
-      runId: params.handle.runId,
-      runtime: "cli",
-      sessionKey: params.handle.requesterSessionKey,
-      progressSummary: params.progressSummary,
-      eventSummary: params.eventSummary,
-    });
-  }),
 }));
 
 vi.mock("../../config/config.js", async (importOriginal) => ({
@@ -167,7 +179,10 @@ vi.mock("../../utils/fetch-timeout.js", async () => {
     buildTimeoutAbortSignal: vi.fn(actual.buildTimeoutAbortSignal),
   };
 });
-vi.mock("./media-generate-background.js", () => musicGenerateBackgroundMocks);
+vi.mock("./media-generate-background.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./media-generate-background.js")>()),
+  ...musicGenerateBackgroundMocks,
+}));
 vi.mock("../../tasks/runtime-internal.js", () => taskRuntimeInternalMocks);
 vi.mock("../../tasks/detached-task-runtime.js", () => taskExecutorMocks);
 

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -34,29 +34,19 @@ import {
   sanitizeGeneratedMediaDisplayText,
   type AgentGeneratedAttachment,
 } from "../generated-attachments.js";
-import {
-  buildMediaGenerationRequestKey,
-  recordRecentMediaGenerationTaskStartForSession,
-} from "../media-generation-task-status-shared.js";
+import { buildMediaGenerationRequestKey } from "../media-generation-task-status-shared.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { ToolInputError, readNumberParam, readToolStringParam } from "./common.js";
 import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
 import { decodeDataUrl } from "./image-tool.helpers.js";
 import {
-  buildMediaGenerationStartedToolResult,
   createDefaultMediaGenerateBackgroundScheduler,
-  notifyMediaGenerationAsyncTaskStarted,
-  scheduleMediaGenerationTaskCompletion,
-  shouldDetachMediaGenerationTask,
   type MediaGenerateAsyncStartCallback,
   type MediaGenerateBackgroundScheduler,
 } from "./media-generate-background-shared.js";
 import {
-  completeMusicGenerationTaskRun,
-  createMusicGenerationTaskRun,
-  failMusicGenerationTaskRun,
   musicGenerationTaskLifecycle,
-  recordMusicGenerationTaskProgress,
+  runMediaGenerationTask,
   type MusicGenerationTaskHandle,
 } from "./media-generate-background.js";
 import {
@@ -426,7 +416,7 @@ async function executeMusicGenerationJob(params: {
   providers?: MusicGenerationProvider[];
 }): Promise<ExecutedMusicGeneration> {
   if (params.taskHandle) {
-    recordMusicGenerationTaskProgress({
+    musicGenerationTaskLifecycle.recordTaskProgress({
       handle: params.taskHandle,
       progressSummary: "Generating music",
     });
@@ -448,7 +438,7 @@ async function executeMusicGenerationJob(params: {
     createCapabilityProviderRuntimeDeps(params.providers),
   );
   if (params.taskHandle) {
-    recordMusicGenerationTaskProgress({
+    musicGenerationTaskLifecycle.recordTaskProgress({
       handle: params.taskHandle,
       progressSummary: "Saving generated music",
     });
@@ -773,133 +763,61 @@ export function createMusicGenerateTool(options?: {
       });
       // Accepted tasks own their paid work independently; cancellation applies only before admission.
       signal?.throwIfAborted();
-      const taskHandle = createMusicGenerationTaskRun({
+      return runMediaGenerationTask({
+        lifecycle: musicGenerationTaskLifecycle,
+        generationLabel: "music",
         sessionKey: options?.agentSessionKey,
         requesterAgentId: options?.requesterAgentId,
         requesterOrigin: options?.requesterOrigin,
         prompt,
-        providerId: selectedProvider?.id ?? selectedModelRef?.provider,
+        requestKey,
+        providerId: selectedProviderId,
+        config: effectiveCfg,
+        scheduleBackgroundWork,
+        onAsyncTaskStarted: options?.onAsyncTaskStarted,
+        onFailure: (message, meta) => log.warn(message, meta),
+        messages: [timeout.message],
+        detailExtras: {
+          ...buildMediaReferenceDetails({
+            entries: loadedReferenceImages,
+            singleKey: "image",
+            pluralKey: "images",
+            getResolvedInput: (entry) => entry.resolvedInput,
+          }),
+          ...(model ? { model } : {}),
+          ...(lyrics ? { requestedLyrics: lyrics } : {}),
+          ...(typeof instrumental === "boolean" ? { instrumental } : {}),
+          ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
+          ...(format ? { format } : {}),
+          ...(filename ? { filename } : {}),
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+          ...(timeout.normalization
+            ? {
+                requestedTimeoutMs: timeout.normalization.requested,
+                timeoutNormalization: timeout.normalization,
+                warning: timeout.message,
+              }
+            : {}),
+        },
+        run: (taskHandle) =>
+          executeMusicGenerationJob({
+            effectiveCfg,
+            prompt,
+            agentDir: options?.agentDir,
+            lyrics,
+            instrumental,
+            durationSeconds,
+            model,
+            format,
+            filename,
+            loadedReferenceImages,
+            taskHandle,
+            autoProviderFallback: explicitModelConfig ? false : undefined,
+            timeoutMs,
+            timeoutNormalization: timeout.normalization,
+            providers: preparedProviders,
+          }),
       });
-      const shouldDetach = Boolean(
-        taskHandle &&
-        shouldDetachMediaGenerationTask(options?.agentSessionKey, options?.requesterAgentId),
-      );
-
-      if (shouldDetach && taskHandle) {
-        recordRecentMediaGenerationTaskStartForSession({
-          sessionKey: options?.agentSessionKey,
-          agentId: options?.requesterAgentId,
-          taskKind: "music_generation",
-          sourcePrefix: "music_generate",
-          taskId: taskHandle.taskId,
-          runId: taskHandle.runId,
-          taskLabel: prompt,
-          requestKey,
-          providerId: selectedProviderId,
-          progressSummary: "Generating music",
-        });
-        scheduleMediaGenerationTaskCompletion({
-          lifecycle: musicGenerationTaskLifecycle,
-          handle: taskHandle,
-          scheduleBackgroundWork,
-          progressSummary: "Generating music",
-          config: effectiveCfg,
-          toolName: "Music generation",
-          onWakeFailure: (message, meta) => log.warn(message, meta),
-          run: () =>
-            executeMusicGenerationJob({
-              effectiveCfg,
-              prompt,
-              agentDir: options?.agentDir,
-              model,
-              lyrics,
-              instrumental,
-              durationSeconds,
-              format,
-              filename,
-              loadedReferenceImages,
-              taskHandle,
-              autoProviderFallback: explicitModelConfig ? false : undefined,
-              timeoutMs,
-              timeoutNormalization: timeout.normalization,
-              providers: preparedProviders,
-            }),
-        });
-
-        await notifyMediaGenerationAsyncTaskStarted({
-          callback: options?.onAsyncTaskStarted,
-          message: "Music generation started; wait for the generated music completion event.",
-          toolName: "music_generate",
-          handle: taskHandle,
-          onFailure: (message, meta) => log.warn(message, meta),
-        });
-
-        return buildMediaGenerationStartedToolResult({
-          toolName: "music_generate",
-          generationLabel: "music",
-          completionLabel: "music",
-          taskHandle,
-          messages: [timeout.message],
-          detailExtras: {
-            ...buildMediaReferenceDetails({
-              entries: loadedReferenceImages,
-              singleKey: "image",
-              pluralKey: "images",
-              getResolvedInput: (entry) => entry.resolvedInput,
-            }),
-            ...(model ? { model } : {}),
-            ...(lyrics ? { requestedLyrics: lyrics } : {}),
-            ...(typeof instrumental === "boolean" ? { instrumental } : {}),
-            ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
-            ...(format ? { format } : {}),
-            ...(filename ? { filename } : {}),
-            ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-            ...(timeout.normalization
-              ? {
-                  requestedTimeoutMs: timeout.normalization.requested,
-                  timeoutNormalization: timeout.normalization,
-                  warning: timeout.message,
-                }
-              : {}),
-          },
-        });
-      }
-
-      try {
-        const executed = await executeMusicGenerationJob({
-          effectiveCfg,
-          prompt,
-          agentDir: options?.agentDir,
-          lyrics,
-          instrumental,
-          durationSeconds,
-          model,
-          format,
-          filename,
-          loadedReferenceImages,
-          taskHandle,
-          autoProviderFallback: explicitModelConfig ? false : undefined,
-          timeoutMs,
-          timeoutNormalization: timeout.normalization,
-          providers: preparedProviders,
-        });
-        completeMusicGenerationTaskRun({
-          handle: taskHandle,
-          provider: executed.provider,
-          model: executed.model,
-          count: executed.count,
-        });
-        return {
-          content: [{ type: "text", text: executed.contentText }],
-          details: executed.details,
-        };
-      } catch (error) {
-        failMusicGenerationTaskRun({
-          handle: taskHandle,
-          error,
-        });
-        throw error;
-      }
     },
   };
 }

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -34,10 +34,7 @@ import {
   sanitizeGeneratedMediaDisplayText,
   type AgentGeneratedAttachment,
 } from "../generated-attachments.js";
-import {
-  buildMediaGenerationRequestKey,
-  recordRecentMediaGenerationTaskStartForSession,
-} from "../media-generation-task-status-shared.js";
+import { buildMediaGenerationRequestKey } from "../media-generation-task-status-shared.js";
 import { getCustomProviderApiKey } from "../model-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
@@ -49,19 +46,12 @@ import {
   loadCapabilityMetadataSnapshot,
 } from "./manifest-capability-availability.js";
 import {
-  buildMediaGenerationStartedToolResult,
   createDefaultMediaGenerateBackgroundScheduler,
-  notifyMediaGenerationAsyncTaskStarted,
-  scheduleMediaGenerationTaskCompletion,
-  shouldDetachMediaGenerationTask,
   type MediaGenerateAsyncStartCallback,
   type MediaGenerateBackgroundScheduler,
 } from "./media-generate-background-shared.js";
 import {
-  completeVideoGenerationTaskRun,
-  createVideoGenerationTaskRun,
-  failVideoGenerationTaskRun,
-  recordVideoGenerationTaskProgress,
+  runMediaGenerationTask,
   videoGenerationTaskLifecycle,
   type VideoGenerationTaskHandle,
 } from "./media-generate-background.js";
@@ -620,7 +610,7 @@ async function executeVideoGenerationJob(params: {
   providers?: VideoGenerationProvider[];
 }): Promise<ExecutedVideoGeneration> {
   if (params.taskHandle) {
-    recordVideoGenerationTaskProgress({
+    videoGenerationTaskLifecycle.recordTaskProgress({
       handle: params.taskHandle,
       progressSummary: "Generating video",
     });
@@ -647,7 +637,7 @@ async function executeVideoGenerationJob(params: {
     createCapabilityProviderRuntimeDeps(params.providers),
   );
   if (params.taskHandle) {
-    recordVideoGenerationTaskProgress({
+    videoGenerationTaskLifecycle.recordTaskProgress({
       handle: params.taskHandle,
       progressSummary: "Saving generated video",
     });
@@ -1146,143 +1136,66 @@ export function createVideoGenerateTool(options?: {
       }
       // Accepted tasks own their paid work independently; cancellation applies only before admission.
       signal?.throwIfAborted();
-      const taskHandle = createVideoGenerationTaskRun({
+      return runMediaGenerationTask({
+        lifecycle: videoGenerationTaskLifecycle,
+        generationLabel: "video",
         sessionKey: options?.agentSessionKey,
         requesterAgentId: options?.requesterAgentId,
         requesterOrigin: options?.requesterOrigin,
         prompt,
+        requestKey,
         providerId: selectedProvider?.id,
+        config: effectiveCfg,
+        scheduleBackgroundWork,
+        onAsyncTaskStarted: options?.onAsyncTaskStarted,
+        onFailure: (message, meta) => log.warn(message, meta),
+        detailExtras: {
+          ...buildMediaReferenceDetails({
+            entries: loadedReferenceImages,
+            singleKey: "image",
+            pluralKey: "images",
+            getResolvedInput: (entry) => entry.resolvedInput,
+          }),
+          ...buildMediaReferenceDetails({
+            entries: loadedReferenceVideos,
+            singleKey: "video",
+            pluralKey: "videos",
+            getResolvedInput: (entry) => entry.resolvedInput,
+            singleRewriteKey: "videoRewrittenFrom",
+          }),
+          ...(model ? { model } : {}),
+          ...(size ? { size } : {}),
+          ...(aspectRatio ? { aspectRatio } : {}),
+          ...(resolution ? { resolution } : {}),
+          ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
+          ...(typeof audio === "boolean" ? { audio } : {}),
+          ...(typeof watermark === "boolean" ? { watermark } : {}),
+          ...(filename ? { filename } : {}),
+          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+        },
+        run: (taskHandle) =>
+          executeVideoGenerationJob({
+            effectiveCfg,
+            prompt,
+            agentDir: options?.agentDir,
+            model,
+            size,
+            aspectRatio,
+            resolution,
+            durationSeconds,
+            audio,
+            watermark,
+            filename,
+            loadedReferenceImages,
+            loadedReferenceVideos,
+            loadedReferenceAudios,
+            taskHandle,
+            providerOptions,
+            autoProviderFallback: explicitModelConfig ? false : undefined,
+            timeoutMs,
+            providers: preparedProviders,
+          }),
       });
-      const shouldDetach = Boolean(
-        taskHandle &&
-        shouldDetachMediaGenerationTask(options?.agentSessionKey, options?.requesterAgentId),
-      );
-
-      if (shouldDetach && taskHandle) {
-        recordRecentMediaGenerationTaskStartForSession({
-          sessionKey: options?.agentSessionKey,
-          agentId: options?.requesterAgentId,
-          taskKind: "video_generation",
-          sourcePrefix: "video_generate",
-          taskId: taskHandle.taskId,
-          runId: taskHandle.runId,
-          taskLabel: prompt,
-          requestKey,
-          providerId: selectedProvider?.id,
-          progressSummary: "Generating video",
-        });
-        scheduleMediaGenerationTaskCompletion({
-          lifecycle: videoGenerationTaskLifecycle,
-          handle: taskHandle,
-          scheduleBackgroundWork,
-          progressSummary: "Generating video",
-          config: effectiveCfg,
-          toolName: "Video generation",
-          onWakeFailure: (message, meta) => log.warn(message, meta),
-          run: () =>
-            executeVideoGenerationJob({
-              effectiveCfg,
-              prompt,
-              agentDir: options?.agentDir,
-              model,
-              size,
-              aspectRatio,
-              resolution,
-              durationSeconds,
-              audio,
-              watermark,
-              filename,
-              loadedReferenceImages,
-              loadedReferenceVideos,
-              loadedReferenceAudios,
-              taskHandle,
-              providerOptions,
-              autoProviderFallback: explicitModelConfig ? false : undefined,
-              timeoutMs,
-              providers: preparedProviders,
-            }),
-        });
-
-        await notifyMediaGenerationAsyncTaskStarted({
-          callback: options?.onAsyncTaskStarted,
-          message: "Video generation started; wait for the generated video completion event.",
-          toolName: "video_generate",
-          handle: taskHandle,
-          onFailure: (message, meta) => log.warn(message, meta),
-        });
-
-        return buildMediaGenerationStartedToolResult({
-          toolName: "video_generate",
-          generationLabel: "video",
-          completionLabel: "video",
-          taskHandle,
-          detailExtras: {
-            ...buildMediaReferenceDetails({
-              entries: loadedReferenceImages,
-              singleKey: "image",
-              pluralKey: "images",
-              getResolvedInput: (entry) => entry.resolvedInput,
-            }),
-            ...buildMediaReferenceDetails({
-              entries: loadedReferenceVideos,
-              singleKey: "video",
-              pluralKey: "videos",
-              getResolvedInput: (entry) => entry.resolvedInput,
-              singleRewriteKey: "videoRewrittenFrom",
-            }),
-            ...(model ? { model } : {}),
-            ...(size ? { size } : {}),
-            ...(aspectRatio ? { aspectRatio } : {}),
-            ...(resolution ? { resolution } : {}),
-            ...(typeof durationSeconds === "number" ? { durationSeconds } : {}),
-            ...(typeof audio === "boolean" ? { audio } : {}),
-            ...(typeof watermark === "boolean" ? { watermark } : {}),
-            ...(filename ? { filename } : {}),
-            ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-          },
-        });
-      }
-
-      try {
-        const executed = await executeVideoGenerationJob({
-          effectiveCfg,
-          prompt,
-          agentDir: options?.agentDir,
-          model,
-          size,
-          aspectRatio,
-          resolution,
-          durationSeconds,
-          audio,
-          watermark,
-          filename,
-          loadedReferenceImages,
-          loadedReferenceVideos,
-          loadedReferenceAudios,
-          taskHandle,
-          providerOptions,
-          autoProviderFallback: explicitModelConfig ? false : undefined,
-          timeoutMs,
-          providers: preparedProviders,
-        });
-        completeVideoGenerationTaskRun({
-          handle: taskHandle,
-          provider: executed.provider,
-          model: executed.model,
-          count: executed.count,
-        });
-
-        return {
-          content: [{ type: "text", text: executed.contentText }],
-          details: executed.details,
-        };
-      } catch (error) {
-        failVideoGenerationTaskRun({
-          handle: taskHandle,
-          error,
-        });
-        throw error;
-      }
     },
   };
 }

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -20,6 +20,7 @@ import { resolveSessionStorePathForScope } from "../../config/sessions/session-s
 import {
   clearMemoryPluginState,
   registerMemoryCapability,
+  type MemoryFlushPlan,
   type MemoryFlushPlanResolver,
 } from "../../plugins/memory-state.test-fixtures.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
@@ -85,7 +86,7 @@ async function runPreflightCompactionIfNeeded(params: PreflightCompactionTestPar
   });
 }
 
-function createMemoryFlushPlan() {
+function createMemoryFlushPlan(): MemoryFlushPlan {
   return {
     softThresholdTokens: 4_000,
     forceFlushTranscriptBytes: 1_000_000_000,
@@ -93,6 +94,22 @@ function createMemoryFlushPlan() {
     prompt: "Pre-compaction memory flush.\nNO_REPLY",
     systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
     relativePath: "memory/2023-11-14.md",
+  };
+}
+
+function createModifiedMemoryFlushPlan(overrides: Partial<MemoryFlushPlan>): MemoryFlushPlan {
+  return { ...createMemoryFlushPlan(), ...overrides };
+}
+
+function createFlushSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "session",
+    updatedAt: Date.now(),
+    totalTokens: 80_000,
+    totalTokensFresh: true,
+    totalTokensVersion: 1,
+    compactionCount: 1,
+    ...overrides,
   };
 }
 
@@ -309,17 +326,51 @@ function requireCompactEmbeddedAgentSessionCall(index = 0) {
 describe("runMemoryFlushIfNeeded", () => {
   let rootDir = "";
 
+  async function runDefaultMemoryFlush(
+    sessionEntry: SessionEntry,
+    overrides: Partial<MemoryFlushTestParams> = {},
+  ) {
+    const sessionKey = overrides.sessionKey ?? "main";
+    return await runMemoryFlushIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun(),
+      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      modelContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+      ...overrides,
+    });
+  }
+
+  async function runDefaultPreflight(
+    sessionEntry: SessionEntry,
+    overrides: Partial<PreflightCompactionTestParams> = {},
+  ) {
+    const sessionKey = overrides.sessionKey ?? "main";
+    return await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({ sessionId: "session", sessionKey }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      modelContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+      ...overrides,
+    });
+  }
+
   async function runProjectedCompaction(completed: boolean, followupRun = createTestFollowupRun()) {
     const storePath = path.join(rootDir, "sessions.json");
     const sessionKey = "main";
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
     const sessionStore = { [sessionKey]: sessionEntry };
     await writeTestSessionStore(storePath, sessionKey, sessionEntry);
     runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
@@ -329,19 +380,11 @@ describe("runMemoryFlushIfNeeded", () => {
         meta: { agentMeta: { sessionId: "session-rotated" } },
       };
     });
-    const result = await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    const result = await runDefaultMemoryFlush(sessionEntry, {
       followupRun,
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
       sessionStore,
       sessionKey,
       storePath,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
     return { followupRun, result, sessionKey, storePath };
   }
@@ -560,27 +603,10 @@ describe("runMemoryFlushIfNeeded", () => {
       });
       return { payloads: [], meta: {} };
     });
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
 
-    await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    await runDefaultMemoryFlush(sessionEntry, {
       followupRun: createTestFollowupRun({ workspaceDir: rootDir, senderIsOwner: false }),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledWith(
@@ -631,33 +657,18 @@ describe("runMemoryFlushIfNeeded", () => {
       });
       return { payloads: [], meta: {} };
     });
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
 
-    await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    await runDefaultMemoryFlush(sessionEntry, {
       followupRun: createTestFollowupRun({
         workspaceDir: rootDir,
         sessionId: "session",
         sessionKey,
         senderIsOwner: true,
       }),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
       sessionStore: { [sessionKey]: sessionEntry },
       sessionKey,
       storePath,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(runEmbeddedAgentMock).toHaveBeenCalledWith(
@@ -823,14 +834,7 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("counts resolved error payloads as failed memory flushes", async () => {
     const storePath = path.join(rootDir, "sessions.json");
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
     const sessionStore = { main: sessionEntry };
     await writeTestSessionStore(storePath, "main", sessionEntry);
     const visibleErrorPayloads: Array<{ text?: string; isError?: boolean }> = [];
@@ -859,19 +863,10 @@ describe("runMemoryFlushIfNeeded", () => {
     );
     const followupRun = createTestFollowupRun();
 
-    const result = await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    const result = await runDefaultMemoryFlush(sessionEntry, {
       followupRun,
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
       sessionStore,
-      sessionKey: "main",
       storePath,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
       onVisibleErrorPayloads: (payloads) => {
         visibleErrorPayloads.push(...payloads);
       },
@@ -894,14 +889,7 @@ describe("runMemoryFlushIfNeeded", () => {
   });
 
   it("reports restricted memory-flush write failures for visible delivery", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
     const visibleErrorPayloads: Array<{ text?: string; isError?: boolean }> = [];
     runWithModelFallbackMock.mockRejectedValueOnce(
       new Error(
@@ -909,21 +897,11 @@ describe("runMemoryFlushIfNeeded", () => {
       ),
     );
 
-    await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    await runDefaultMemoryFlush(sessionEntry, {
       followupRun: createTestFollowupRun({
         authProfileId: "anthropic:auto",
         authProfileIdSource: "auto",
       }),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
       onVisibleErrorPayloads: (payloads) => {
         visibleErrorPayloads.push(...payloads);
       },
@@ -938,31 +916,14 @@ describe("runMemoryFlushIfNeeded", () => {
   });
 
   it("surfaces generic non-abort memory-flush failures so cron meta.error is populated (regression: #80755)", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
     const visibleErrorPayloads: Array<{ text?: string; isError?: boolean }> = [];
     runWithModelFallbackMock.mockRejectedValueOnce(
       new Error("provider timed out after 60s while flushing memory"),
     );
 
-    await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
+    await runDefaultMemoryFlush(sessionEntry, {
       defaultModel: "anthropic/claude-opus-4-7",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
       onVisibleErrorPayloads: (payloads) => {
         visibleErrorPayloads.push(...payloads);
       },
@@ -977,32 +938,15 @@ describe("runMemoryFlushIfNeeded", () => {
   });
 
   it("redacts and caps generic visible memory-flush failures before delivery", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
     const visibleErrorPayloads: Array<{ text?: string; isError?: boolean }> = [];
     const token = "sk-abcdefghijklmnopqrstuv";
     runWithModelFallbackMock.mockRejectedValueOnce(
       new Error(`provider failed with Authorization: Bearer ${token} ${"🚀".repeat(400)}`),
     );
 
-    await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
+    await runDefaultMemoryFlush(sessionEntry, {
       defaultModel: "anthropic/claude-opus-4-7",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
       onVisibleErrorPayloads: (payloads) => {
         visibleErrorPayloads.push(...payloads);
       },
@@ -1017,31 +961,14 @@ describe("runMemoryFlushIfNeeded", () => {
   });
 
   it("does not surface user-abort errors as visible payloads (regression: #80755)", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
     const visibleErrorPayloads: Array<{ text?: string; isError?: boolean }> = [];
     const abortErr = new Error("operation aborted by user");
     abortErr.name = "AbortError";
     runWithModelFallbackMock.mockRejectedValueOnce(abortErr);
 
-    await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
+    await runDefaultMemoryFlush(sessionEntry, {
       defaultModel: "anthropic/claude-opus-4-7",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
       onVisibleErrorPayloads: (payloads) => {
         visibleErrorPayloads.push(...payloads);
       },
@@ -1052,31 +979,14 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("increments and UTF-16-safely persists a capped non-abort flush failure", async () => {
     const storePath = path.join(rootDir, "sessions.json");
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
     await writeTestSessionStore(storePath, "main", sessionEntry);
     const failureMessage = `${"a".repeat(198)}🚀tail`;
     runWithModelFallbackMock.mockRejectedValueOnce(new Error(failureMessage));
 
-    const result = await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
+    const result = await runDefaultMemoryFlush(sessionEntry, {
       defaultModel: "anthropic/claude-opus-4-7",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
       storePath,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     const persisted = loadMainSessionEntry(storePath);
@@ -1128,14 +1038,7 @@ describe("runMemoryFlushIfNeeded", () => {
     },
   ])("records a failed $stage attempt, cleans up, and retries", async (failure) => {
     const storePath = path.join(rootDir, "sessions.json");
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
     const sessionStore = { main: sessionEntry };
     await writeTestSessionStore(storePath, "main", sessionEntry);
     const message = `${failure.stage} failed`;
@@ -1210,27 +1113,11 @@ describe("runMemoryFlushIfNeeded", () => {
       .mockImplementationOnce(createMemoryFlushPlan)
       .mockReturnValueOnce(null);
     registerMemoryFlushPlanResolverForTest(resolver);
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
 
-    const result = await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    const result = await runDefaultMemoryFlush(sessionEntry, {
       followupRun: createTestFollowupRun({ workspaceDir: rootDir }),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
       defaultModel: "anthropic/claude-opus-4-7",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(result).toEqual({ sessionEntry, outcome: "skipped" });
@@ -1241,32 +1128,15 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("does not track failure on abort error", async () => {
     const storePath = path.join(rootDir, "sessions.json");
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
     await writeTestSessionStore(storePath, "main", sessionEntry);
     const abortErr = new Error("operation aborted by user");
     abortErr.name = "AbortError";
     runWithModelFallbackMock.mockRejectedValueOnce(abortErr);
 
-    const result = await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
+    const result = await runDefaultMemoryFlush(sessionEntry, {
       defaultModel: "anthropic/claude-opus-4-7",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
       storePath,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     const persisted = loadMainSessionEntry(storePath);
@@ -1276,30 +1146,14 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("clears failure counters on successful flush", async () => {
     const storePath = path.join(rootDir, "sessions.json");
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
+    const sessionEntry = createFlushSessionEntry({
       memoryFlush: { kind: "failed", failureCount: 2 },
-    };
+    });
     await writeTestSessionStore(storePath, "main", sessionEntry);
 
-    const result = await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
+    const result = await runDefaultMemoryFlush(sessionEntry, {
       defaultModel: "anthropic/claude-opus-4-7",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
       storePath,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     const persisted = loadMainSessionEntry(storePath);
@@ -1309,32 +1163,16 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("marks flush as completed after MAX_FLUSH_FAILURES to break retry loop", async () => {
     const storePath = path.join(rootDir, "sessions.json");
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
+    const sessionEntry = createFlushSessionEntry({
       memoryFlush: { kind: "failed", failureCount: TEST_MAX_FLUSH_FAILURES - 1 },
-    };
+    });
     await writeTestSessionStore(storePath, "main", sessionEntry);
     runWithModelFallbackMock.mockRejectedValueOnce(new Error("provider crashed during flush"));
 
     const visibleErrorPayloads: ReplyPayload[] = [];
-    const result = await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
-      sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
+    const result = await runDefaultMemoryFlush(sessionEntry, {
       defaultModel: "anthropic/claude-opus-4-7",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
       storePath,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
       onVisibleErrorPayloads: (payloads) => {
         visibleErrorPayloads.push(...payloads);
       },
@@ -1352,23 +1190,10 @@ describe("runMemoryFlushIfNeeded", () => {
   });
 
   it("runs memory flush on the configured maintenance model without active fallbacks", async () => {
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 4_000,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 20_000,
-      model: "ollama/qwen3:8b",
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ model: "ollama/qwen3:8b" }),
+    );
+    const sessionEntry = createFlushSessionEntry();
 
     const replyOperation = createReplyOperation();
     await runMemoryFlushIfNeeded({
@@ -1575,28 +1400,13 @@ describe("runMemoryFlushIfNeeded", () => {
   });
 
   it("skips memory flush for incognito sessions", async () => {
-    const sessionEntry: SessionEntry = {
+    const sessionEntry = createFlushSessionEntry({
       incognito: true,
       sessionId: "incognito-session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    });
 
-    const result = await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
+    const result = await runDefaultMemoryFlush(sessionEntry, {
       sessionCtx: createTestTemplateContext({ Provider: "webchat" }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(result).toEqual({ sessionEntry, outcome: "skipped" });
@@ -1606,27 +1416,14 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it("skips memory flush for an incognito key after process-local state is gone", async () => {
     const sessionKey = "agent:main:dashboard:incognito-deleted-memory";
-    const sessionEntry: SessionEntry = {
+    const sessionEntry = createFlushSessionEntry({
       sessionId: "rematerialized-session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    });
 
-    const result = await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
+    const result = await runDefaultMemoryFlush(sessionEntry, {
       sessionCtx: createTestTemplateContext({ Provider: "webchat" }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
       sessionStore: { [sessionKey]: sessionEntry },
       sessionKey,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(result).toEqual({ sessionEntry, outcome: "skipped" });
@@ -1667,14 +1464,7 @@ describe("runMemoryFlushIfNeeded", () => {
   });
 
   it("uses runtime policy session key when checking memory-flush sandbox writability", async () => {
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      totalTokensFresh: true,
-      totalTokensVersion: 1,
-      compactionCount: 1,
-    };
+    const sessionEntry = createFlushSessionEntry();
 
     const result = await runMemoryFlushIfNeeded({
       cfg: {
@@ -1718,14 +1508,9 @@ describe("runMemoryFlushIfNeeded", () => {
       `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
       "utf8",
     );
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 1,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ softThresholdTokens: 1, reserveTokensFloor: 0 }),
+    );
     compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
       ok: true,
       compacted: false,
@@ -1742,21 +1527,14 @@ describe("runMemoryFlushIfNeeded", () => {
     };
     const onCompactionNotice = vi.fn();
 
-    const entry = await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    const entry = await runDefaultPreflight(sessionEntry, {
       followupRun: createTestFollowupRun({
         sessionId: "session",
         sessionFile,
         sessionKey: "agent:main:main",
       }),
-      defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100,
-      sessionEntry,
-      sessionStore: { "agent:main:main": sessionEntry },
       sessionKey: "agent:main:main",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
       onCompactionNotice,
     });
 
@@ -1813,14 +1591,9 @@ describe("runMemoryFlushIfNeeded", () => {
       `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
       "utf8",
     );
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 1,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ softThresholdTokens: 1, reserveTokensFloor: 0 }),
+    );
     compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
       ok: true,
       compacted: false,
@@ -1866,14 +1639,9 @@ describe("runMemoryFlushIfNeeded", () => {
       `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
       "utf8",
     );
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 1,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ softThresholdTokens: 1, reserveTokensFloor: 0 }),
+    );
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
@@ -1884,8 +1652,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionRoot: "/tmp/workspace",
     };
 
-    await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    await runDefaultPreflight(sessionEntry, {
       followupRun: createTestFollowupRun({
         sessionId: "session",
         sessionFile,
@@ -1893,15 +1660,9 @@ describe("runMemoryFlushIfNeeded", () => {
         cwd: "/tmp/task-repo",
         runtimePolicySessionKey: "agent:main:telegram:default:direct:12345",
       }),
-      defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100,
-      sessionEntry,
-      sessionStore: { "agent:main:main": sessionEntry },
       sessionKey: "agent:main:main",
       runtimePolicySessionKey: "agent:main:telegram:default:direct:12345",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
@@ -2115,14 +1876,9 @@ describe("runMemoryFlushIfNeeded", () => {
     },
   );
   it("preflight compacts a fresh session when the current prompt estimate pushes the next request over budget", async () => {
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 0,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 10,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ softThresholdTokens: 0, reserveTokensFloor: 10 }),
+    );
     const storePath = path.join(rootDir, "preflight-fresh-sessions.json");
     const sessionKey = "agent:main:main";
     const sessionEntry: SessionEntry = {
@@ -2135,8 +1891,7 @@ describe("runMemoryFlushIfNeeded", () => {
     };
     await upsertSessionEntryCore({ agentId: "main", sessionKey, storePath }, sessionEntry);
 
-    await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    await runDefaultPreflight(sessionEntry, {
       followupRun: createTestFollowupRun({
         provider: "anthropic",
         model: "claude",
@@ -2145,25 +1900,16 @@ describe("runMemoryFlushIfNeeded", () => {
       promptForEstimate: "Please summarize the entire design discussion above. ".repeat(8),
       defaultModel: "anthropic/claude",
       modelContextTokens: 1000,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
       sessionKey,
       storePath,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
   });
   it("does not preflight compact a fresh session when only accumulated output tokens are large and the latest output keeps the request under budget", async () => {
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 0,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 10,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ softThresholdTokens: 0, reserveTokensFloor: 10 }),
+    );
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
@@ -2353,14 +2099,9 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey: "agent:main:main",
       events: [{ type: "message", message: { role: "user", content: "x".repeat(5_000) } }],
     });
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 1,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ softThresholdTokens: 1, reserveTokensFloor: 0 }),
+    );
     compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
       ok: true,
       compacted: true,
@@ -2383,16 +2124,11 @@ describe("runMemoryFlushIfNeeded", () => {
     });
     const replyOperation = createReplyOperation();
 
-    const entry = await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    const entry = await runDefaultPreflight(sessionEntry, {
       followupRun,
-      defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 100,
-      sessionEntry,
       sessionStore,
       sessionKey: "agent:main:main",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
       replyOperation,
     });
 
@@ -2424,35 +2160,21 @@ describe("runMemoryFlushIfNeeded", () => {
         },
       ],
     });
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 4_000,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ reserveTokensFloor: 0 }),
+    );
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
 
-    await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    await runDefaultPreflight(sessionEntry, {
       followupRun: createTestFollowupRun({
         sessionId: "session",
         sessionFile,
         sessionKey: "main",
       }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     const compactCall = requireCompactEmbeddedAgentSessionCall();
@@ -2487,18 +2209,8 @@ describe("runMemoryFlushIfNeeded", () => {
       totalTokensVersion: 1,
     };
 
-    await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun({ sessionId: "session", sessionKey: "main" }),
+    await runDefaultPreflight(sessionEntry, {
       promptForEstimate: "continue",
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(requireCompactEmbeddedAgentSessionCall().currentTokenCount).toBeGreaterThanOrEqual(
@@ -2525,32 +2237,18 @@ describe("runMemoryFlushIfNeeded", () => {
         },
       ],
     });
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 0,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ softThresholdTokens: 0, reserveTokensFloor: 0 }),
+    );
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
 
-    await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun({ sessionId: "session", sessionKey: "main" }),
+    await runDefaultPreflight(sessionEntry, {
       promptForEstimate: "",
-      defaultModel: "anthropic/claude-opus-4-6",
       modelContextTokens: 1_000,
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
@@ -2583,23 +2281,13 @@ describe("runMemoryFlushIfNeeded", () => {
 
     let directTranscriptStats: unknown[];
     try {
-      await runMemoryFlushIfNeeded({
-        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      await runDefaultMemoryFlush(sessionEntry, {
         followupRun: createTestFollowupRun({
           sessionId: "session",
           sessionFile,
           sessionKey: "main",
         }),
-        sessionCtx: createTestTemplateContext({ Provider: "whatsapp" }),
-        defaultModel: "anthropic/claude-opus-4-6",
-        modelContextTokens: 100_000,
-        resolvedVerboseLevel: "off",
-        sessionEntry,
-        sessionStore: { main: sessionEntry },
-        sessionKey: "main",
         storePath: path.join(rootDir, "sessions.json"),
-        isHeartbeat: false,
-        replyOperation: createReplyOperation(),
       });
       directTranscriptStats = statSpy.mock.calls.filter(
         ([target]) => String(target) === sessionFile,
@@ -3078,35 +2766,21 @@ describe("runMemoryFlushIfNeeded", () => {
       })}\n`,
       "utf8",
     );
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 4_000,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ reserveTokensFloor: 0 }),
+    );
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
 
-    await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    await runDefaultPreflight(sessionEntry, {
       followupRun: createTestFollowupRun({
         sessionId: "session",
         sessionFile,
         sessionKey: "main",
       }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
@@ -3134,35 +2808,21 @@ describe("runMemoryFlushIfNeeded", () => {
         },
       ],
     });
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 4_000,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ reserveTokensFloor: 0 }),
+    );
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
 
-    await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    await runDefaultPreflight(sessionEntry, {
       followupRun: createTestFollowupRun({
         sessionId: "session",
         sessionFile,
         sessionKey: "main",
       }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
@@ -3190,35 +2850,21 @@ describe("runMemoryFlushIfNeeded", () => {
         },
       ],
     });
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 4_000,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ reserveTokensFloor: 0 }),
+    );
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
 
-    await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    await runDefaultPreflight(sessionEntry, {
       followupRun: createTestFollowupRun({
         sessionId: "session",
         sessionFile,
         sessionKey: "main",
       }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     const compactCall = requireCompactEmbeddedAgentSessionCall();
@@ -3247,35 +2893,21 @@ describe("runMemoryFlushIfNeeded", () => {
         },
       ],
     });
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 4_000,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ reserveTokensFloor: 0 }),
+    );
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
 
-    await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    await runDefaultPreflight(sessionEntry, {
       followupRun: createTestFollowupRun({
         sessionId: "session",
         sessionFile,
         sessionKey: "main",
       }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      modelContextTokens: 100_000,
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
     });
 
     const compactCall = requireCompactEmbeddedAgentSessionCall();
@@ -3297,33 +2929,21 @@ describe("runMemoryFlushIfNeeded", () => {
         },
       ],
     });
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 4_000,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ reserveTokensFloor: 0 }),
+    );
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       totalTokensFresh: false,
     };
-    const entry = await runPreflightCompactionIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+    const entry = await runDefaultPreflight(sessionEntry, {
       followupRun: createTestFollowupRun({
         sessionId: "session",
         sessionFile,
         sessionKey: "main",
       }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      storePath: path.join(rootDir, "sessions.json"),
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      modelContextTokens: undefined,
     });
 
     expect(entry).toBe(sessionEntry);
@@ -3349,14 +2969,9 @@ describe("runMemoryFlushIfNeeded", () => {
         },
       ],
     });
-    registerMemoryFlushPlanResolverForTest(() => ({
-      softThresholdTokens: 4_000,
-      forceFlushTranscriptBytes: 1_000_000_000,
-      reserveTokensFloor: 0,
-      prompt: "Pre-compaction memory flush.\nNO_REPLY",
-      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
-      relativePath: "memory/2023-11-14.md",
-    }));
+    registerMemoryFlushPlanResolverForTest(() =>
+      createModifiedMemoryFlushPlan({ reserveTokensFloor: 0 }),
+    );
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
@@ -3370,7 +2985,7 @@ describe("runMemoryFlushIfNeeded", () => {
     let entry: SessionEntry | undefined;
     let directTranscriptStats: unknown[];
     try {
-      entry = await runPreflightCompactionIfNeeded({
+      entry = await runDefaultPreflight(sessionEntry, {
         cfg: {
           agents: {
             defaults: {
@@ -3386,14 +3001,6 @@ describe("runMemoryFlushIfNeeded", () => {
           sessionFile,
           sessionKey: "main",
         }),
-        defaultModel: "anthropic/claude-opus-4-6",
-        modelContextTokens: 100_000,
-        sessionEntry,
-        sessionStore: { main: sessionEntry },
-        sessionKey: "main",
-        storePath: path.join(rootDir, "sessions.json"),
-        isHeartbeat: false,
-        replyOperation: createReplyOperation(),
       });
       directTranscriptStats = statSpy.mock.calls.filter(
         ([target]) => String(target) === sessionFile,

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -56,8 +56,28 @@ function enqueueTestRun(
   key: string,
   params: Parameters<typeof createRun>[0],
   settings: QueueSettings,
+  runOverrides?: Partial<FollowupRun["run"]>,
 ) {
-  return enqueueFollowupRun(key, createRun(params), settings);
+  const run = createRun(params);
+  if (runOverrides) {
+    run.run = { ...run.run, ...runOverrides };
+  }
+  return enqueueFollowupRun(key, run, settings);
+}
+
+function enqueueSlackRun(
+  key: string,
+  settings: QueueSettings,
+  prompt: string,
+  runOverrides: Partial<FollowupRun["run"]>,
+  routeOverrides: Partial<Parameters<typeof createRun>[0]> = {},
+) {
+  return enqueueTestRun(
+    key,
+    { prompt, originatingChannel: "slack", originatingTo: "channel:A", ...routeOverrides },
+    settings,
+    runOverrides,
+  );
 }
 
 function createDrainRecorder(expectedCalls = 1) {
@@ -83,6 +103,17 @@ function enqueueTestRuns(
 ) {
   for (const run of runs) {
     enqueueTestRun(key, run, settings);
+  }
+}
+
+function enqueueRoutedRuns(
+  key: string,
+  settings: QueueSettings,
+  route: Omit<Parameters<typeof createRun>[0], "prompt">,
+  ...prompts: string[]
+) {
+  for (const prompt of prompts) {
+    enqueueTestRun(key, { prompt, ...route }, settings);
   }
 }
 
@@ -289,21 +320,12 @@ describe("followup queue collect routing", () => {
       `test-collect-same-to-${Date.now()}`,
     );
 
-    enqueueTestRuns(
+    enqueueRoutedRuns(
       key,
       settings,
-      {
-        prompt: "one",
-        originatingChannel: "slack",
-        originatingTo: "channel:A",
-        originatingChatType: "channel",
-      },
-      {
-        prompt: "two",
-        originatingChannel: "slack",
-        originatingTo: "channel:A",
-        originatingChatType: "channel",
-      },
+      { originatingChannel: "slack", originatingTo: "channel:A", originatingChatType: "channel" },
+      "one",
+      "two",
     );
 
     await drainRecordedQueue(key, runFollowup, done);
@@ -516,27 +538,15 @@ describe("followup queue collect routing", () => {
       {},
       2,
     );
-    const createPolicyRun = (
-      prompt: string,
-      sourceReplyDeliveryMode: NonNullable<FollowupRun["run"]["sourceReplyDeliveryMode"]>,
-    ) => {
-      const base = createRun({
-        prompt,
-        originatingChannel: "slack",
-        originatingTo: "channel:A",
-        originatingChatType: "channel",
-      });
-      return {
-        ...base,
-        run: {
-          ...base.run,
-          sourceReplyDeliveryMode,
-        },
-      };
-    };
-
-    enqueueFollowupRun(key, createPolicyRun("automatic", "automatic"), settings);
-    enqueueFollowupRun(key, createPolicyRun("private", "message_tool_only"), settings);
+    const route = { originatingChatType: "channel" };
+    enqueueSlackRun(key, settings, "automatic", { sourceReplyDeliveryMode: "automatic" }, route);
+    enqueueSlackRun(
+      key,
+      settings,
+      "private",
+      { sourceReplyDeliveryMode: "message_tool_only" },
+      route,
+    );
     await drainRecordedQueue(key, runFollowup, done);
 
     expect(calls.map((call) => call.prompt)).toEqual([
@@ -555,24 +565,17 @@ describe("followup queue collect routing", () => {
       {},
       2,
     );
-    const createTaskRun = (prompt: string, taskSuggestionDeliveryMode?: "gateway") => {
-      const base = createRun({
-        prompt,
-        originatingChannel: "webchat",
-        originatingTo: "same-target",
-        originatingChatType: "direct",
-      });
-      return {
-        ...base,
-        run: {
-          ...base.run,
-          taskSuggestionDeliveryMode,
-        },
-      };
+    const route = {
+      originatingChannel: "webchat" as const,
+      originatingTo: "same-target",
+      originatingChatType: "direct",
     };
-
-    enqueueFollowupRun(key, createTaskRun("legacy client"), settings);
-    enqueueFollowupRun(key, createTaskRun("actionable client", "gateway"), settings);
+    enqueueTestRun(key, { prompt: "legacy client", ...route }, settings, {
+      taskSuggestionDeliveryMode: undefined,
+    });
+    enqueueTestRun(key, { prompt: "actionable client", ...route }, settings, {
+      taskSuggestionDeliveryMode: "gateway",
+    });
     await drainRecordedQueue(key, runFollowup, done);
 
     expect(calls.map((call) => call.run.taskSuggestionDeliveryMode)).toEqual([
@@ -691,9 +694,11 @@ describe("followup queue collect routing", () => {
   });
 
   it("keeps content in every context-isolated overflow summary", async () => {
-    const key = `test-collect-overflow-all-context-lines-${Date.now()}`;
-    const { calls, done, runFollowup } = createDrainRecorder(6);
-    const settings = createQueueSettings({ cap: 3 });
+    const { key, calls, done, runFollowup, settings } = createQueueCase(
+      `test-collect-overflow-all-context-lines-${Date.now()}`,
+      { cap: 3 },
+      6,
+    );
     const queued = [
       ["dropped A", "A"],
       ["dropped B", "B"],
@@ -719,8 +724,7 @@ describe("followup queue collect routing", () => {
       );
     }
 
-    scheduleFollowupDrain(key, runFollowup);
-    await done.promise;
+    await drainRecordedQueue(key, runFollowup, done);
 
     expect(calls).toHaveLength(6);
     const overflowPrompts = calls.slice(0, 5).map((run) => run.prompt);
@@ -877,42 +881,19 @@ describe("followup queue collect routing", () => {
       { cap: 1 },
       2,
     );
-    const dropped = createRun({
-      prompt: "guest content",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
-      originatingChatType: "channel",
-    });
-    const survivor = createRun({
-      prompt: "owner content",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
-      originatingChatType: "channel",
-    });
-
-    enqueueFollowupRun(
+    enqueueSlackRun(
       key,
-      {
-        ...dropped,
-        run: {
-          ...dropped.run,
-          senderId: "guest",
-          senderIsOwner: false,
-        },
-      },
       settings,
+      "guest content",
+      { senderId: "guest", senderIsOwner: false },
+      { originatingChatType: "channel" },
     );
-    enqueueFollowupRun(
+    enqueueSlackRun(
       key,
-      {
-        ...survivor,
-        run: {
-          ...survivor.run,
-          senderId: "owner",
-          senderIsOwner: true,
-        },
-      },
       settings,
+      "owner content",
+      { senderId: "owner", senderIsOwner: true },
+      { originatingChatType: "channel" },
     );
 
     await drainRecordedQueue(key, runFollowup, done);
@@ -932,42 +913,16 @@ describe("followup queue collect routing", () => {
       { mode: "followup", cap: 2 },
       3,
     );
-    const guestRun = (prompt: string) => {
-      const base = createRun({
-        prompt,
-        originatingChannel: "slack",
-        originatingTo: "channel:A",
-        originatingChatType: "channel",
-      });
-      return {
-        ...base,
-        run: {
-          ...base.run,
-          senderId: "guest",
-          senderIsOwner: false,
-        },
-      };
-    };
-    const owner = createRun({
-      prompt: "owner content",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
-      originatingChatType: "channel",
-    });
-
-    enqueueFollowupRun(key, guestRun("dropped guest"), settings);
-    enqueueFollowupRun(key, guestRun("surviving guest"), settings);
-    enqueueFollowupRun(
+    const route = { originatingChatType: "channel" };
+    const guest = { senderId: "guest", senderIsOwner: false };
+    enqueueSlackRun(key, settings, "dropped guest", guest, route);
+    enqueueSlackRun(key, settings, "surviving guest", guest, route);
+    enqueueSlackRun(
       key,
-      {
-        ...owner,
-        run: {
-          ...owner.run,
-          senderId: "owner",
-          senderIsOwner: true,
-        },
-      },
       settings,
+      "owner content",
+      { senderId: "owner", senderIsOwner: true },
+      route,
     );
 
     await drainRecordedQueue(key, runFollowup, done);
@@ -992,22 +947,12 @@ describe("followup queue collect routing", () => {
     );
 
     for (const prompt of ["direct A", "direct B", "direct C"] as const) {
-      const source = createRun({
-        prompt,
-        originatingChannel: "slack",
-        originatingTo: "same-target",
-        originatingChatType: "direct",
-      });
-      enqueueFollowupRun(
+      enqueueSlackRun(
         key,
-        {
-          ...source,
-          run: {
-            ...source.run,
-            model: "model-c",
-          },
-        },
         settings,
+        prompt,
+        { model: "model-c" },
+        { originatingTo: "same-target", originatingChatType: "direct" },
       );
     }
     for (const prompt of ["channel D", "channel E", "channel F"]) {
@@ -1107,28 +1052,16 @@ describe("followup queue collect routing", () => {
       ["retained", "model-c", "auth-c", "channel"],
       ["survivor", "model-d", "auth-d", "channel"],
     ] as const) {
-      const source = createRun({
-        prompt,
-        originatingChannel: "slack",
-        originatingTo: "same-target",
-        originatingChatType: chatType,
-      });
-      enqueueFollowupRun(
+      enqueueSlackRun(
         key,
-        {
-          ...source,
-          run: {
-            ...source.run,
-            model,
-            authProfileId,
-          },
-        },
         settings,
+        prompt,
+        { model, authProfileId },
+        { originatingTo: "same-target", originatingChatType: chatType },
       );
     }
 
-    scheduleFollowupDrain(key, runFollowup);
-    await done.promise;
+    await drainRecordedQueue(key, runFollowup, done);
 
     expect(calls[0]?.prompt).toContain("Dropped 1 message");
     expect(calls[0]?.prompt).toContain("- second");
@@ -1144,27 +1077,21 @@ describe("followup queue collect routing", () => {
       { cap: 2 },
       3,
     );
-    const createSource = (
-      prompt: string,
-      sourceReplyDeliveryMode: NonNullable<FollowupRun["run"]["sourceReplyDeliveryMode"]>,
-    ) => {
-      const base = createRun({
-        prompt,
-        originatingChannel: "slack",
-        originatingTo: "channel:A",
-        originatingChatType: "channel",
-      });
-      return {
-        ...base,
-        run: {
-          ...base.run,
-          sourceReplyDeliveryMode,
-        },
-      };
-    };
-
-    enqueueFollowupRun(key, createSource("automatic source", "automatic"), settings);
-    enqueueFollowupRun(key, createSource("private source", "message_tool_only"), settings);
+    const route = { originatingChatType: "channel" };
+    enqueueSlackRun(
+      key,
+      settings,
+      "automatic source",
+      { sourceReplyDeliveryMode: "automatic" },
+      route,
+    );
+    enqueueSlackRun(
+      key,
+      settings,
+      "private source",
+      { sourceReplyDeliveryMode: "message_tool_only" },
+      route,
+    );
     for (const prompt of ["survivor one", "survivor two"]) {
       enqueueTestRun(
         key,
@@ -1195,24 +1122,9 @@ describe("followup queue collect routing", () => {
       { cap: 2 },
       3,
     );
-    const createSource = (prompt: string, runtimePolicySessionKey: string) => {
-      const base = createRun({
-        prompt,
-        originatingChannel: "slack",
-        originatingTo: "channel:A",
-        originatingChatType: "channel",
-      });
-      return {
-        ...base,
-        run: {
-          ...base.run,
-          runtimePolicySessionKey,
-        },
-      };
-    };
-
-    enqueueFollowupRun(key, createSource("policy one", "policy:one"), settings);
-    enqueueFollowupRun(key, createSource("policy two", "policy:two"), settings);
+    const route = { originatingChatType: "channel" };
+    enqueueSlackRun(key, settings, "policy one", { runtimePolicySessionKey: "policy:one" }, route);
+    enqueueSlackRun(key, settings, "policy two", { runtimePolicySessionKey: "policy:two" }, route);
     for (const prompt of ["survivor one", "survivor two"]) {
       enqueueTestRun(
         key,
@@ -1308,8 +1220,10 @@ describe("followup queue collect routing", () => {
   );
 
   it("drops an aborted split summary before running the surviving item", async () => {
-    const key = `test-collect-overflow-current-run-${Date.now()}`;
-    const { calls, done, runFollowup } = createDrainRecorder();
+    const { key, calls, done, runFollowup, settings } = createQueueCase(
+      `test-collect-overflow-current-run-${Date.now()}`,
+      { cap: 1 },
+    );
     const controller = new AbortController();
     const droppedBase = createRun({
       prompt: "private direct content",
@@ -1317,14 +1231,6 @@ describe("followup queue collect routing", () => {
       originatingTo: "same-target",
       originatingChatType: "direct",
     });
-    const survivingBase = createRun({
-      prompt: "public channel content",
-      originatingChannel: "slack",
-      originatingTo: "same-target",
-      originatingChatType: "channel",
-    });
-    const settings = createQueueSettings({ cap: 1 });
-
     enqueueFollowupRun(
       key,
       {
@@ -1340,18 +1246,12 @@ describe("followup queue collect routing", () => {
       },
       settings,
     );
-    enqueueFollowupRun(
+    enqueueSlackRun(
       key,
-      {
-        ...survivingBase,
-        run: {
-          ...survivingBase.run,
-          model: "old-model",
-          senderId: "owner",
-          senderIsOwner: true,
-        },
-      },
       settings,
+      "public channel content",
+      { model: "old-model", senderId: "owner", senderIsOwner: true },
+      { originatingTo: "same-target", originatingChatType: "channel" },
     );
     controller.abort();
     refreshQueuedFollowupSession({
@@ -1621,22 +1521,13 @@ describe("followup queue collect routing", () => {
       2,
     );
 
-    enqueueFollowupRun(key, createRun({ prompt: "unresolved origin" }), settings);
-    enqueueTestRuns(
+    enqueueTestRun(key, { prompt: "unresolved origin" }, settings);
+    enqueueRoutedRuns(
       key,
       settings,
-      {
-        prompt: "keyed one",
-        originatingChannel: "slack",
-        originatingTo: "channel:B",
-        originatingChatType: "channel",
-      },
-      {
-        prompt: "keyed two",
-        originatingChannel: "slack",
-        originatingTo: "channel:B",
-        originatingChatType: "channel",
-      },
+      { originatingChannel: "slack", originatingTo: "channel:B", originatingChatType: "channel" },
+      "keyed one",
+      "keyed two",
     );
 
     await drainRecordedQueue(key, runFollowup, done);
@@ -1696,21 +1587,16 @@ describe("followup queue collect routing", () => {
       `test-collect-user-request-kind-${Date.now()}`,
     );
 
-    enqueueTestRuns(
+    enqueueRoutedRuns(
       key,
       settings,
       {
-        prompt: "one",
         currentInboundEventKind: "user_request",
         originatingChannel: "slack",
         originatingTo: "channel:A",
       },
-      {
-        prompt: "two",
-        currentInboundEventKind: "user_request",
-        originatingChannel: "slack",
-        originatingTo: "channel:A",
-      },
+      "one",
+      "two",
     );
 
     await drainRecordedQueue(key, runFollowup, done);
@@ -2013,32 +1899,20 @@ describe("followup queue collect routing", () => {
     const firstImage = { type: "image" as const, data: "first", mimeType: "image/png" };
     const secondImage = { type: "image" as const, data: "second", mimeType: "image/png" };
 
-    enqueueFollowupRun(
-      key,
-      {
-        ...createRun({
-          prompt: "one",
-          originatingChannel: "slack",
-          originatingTo: "channel:A",
-        }),
-        images: [firstImage],
-        imageOrder: ["inline"],
-      },
-      settings,
-    );
-    enqueueFollowupRun(
-      key,
-      {
-        ...createRun({
-          prompt: "two",
-          originatingChannel: "slack",
-          originatingTo: "channel:A",
-        }),
-        images: [secondImage],
-        imageOrder: ["inline"],
-      },
-      settings,
-    );
+    for (const [prompt, image] of [
+      ["one", firstImage],
+      ["two", secondImage],
+    ] as const) {
+      enqueueFollowupRun(
+        key,
+        {
+          ...createRun({ prompt, originatingChannel: "slack", originatingTo: "channel:A" }),
+          images: [image],
+          imageOrder: ["inline"],
+        },
+        settings,
+      );
+    }
 
     await drainRecordedQueue(key, runFollowup, done);
 
@@ -2047,9 +1921,9 @@ describe("followup queue collect routing", () => {
   });
 
   it("preserves prepared empty image state across collected batches", async () => {
-    const key = `test-collect-prepared-empty-images-${Date.now()}`;
-    const { calls, done, runFollowup } = createDrainRecorder();
-    const settings = createQueueSettings();
+    const { key, calls, done, runFollowup, settings } = createQueueCase(
+      `test-collect-prepared-empty-images-${Date.now()}`,
+    );
     const missingMedia = {
       path: "/openclaw-test-missing/current.png",
       contentType: "image/png",
@@ -2072,8 +1946,7 @@ describe("followup queue collect routing", () => {
       enqueueFollowupRun(key, preparedRun, settings);
     }
 
-    scheduleFollowupDrain(key, runFollowup);
-    await done.promise;
+    await drainRecordedQueue(key, runFollowup, done);
 
     const collected = calls[0] as InternalFollowupRun | undefined;
     expect(collected?.currentTurnImagesPrepared).toBe(true);
@@ -2087,9 +1960,9 @@ describe("followup queue collect routing", () => {
   });
 
   it("offsets prepared media layout fact indexes across collected batches", async () => {
-    const key = `test-collect-prepared-image-layout-${Date.now()}`;
-    const { calls, done, runFollowup } = createDrainRecorder();
-    const settings = createQueueSettings();
+    const { key, calls, done, runFollowup, settings } = createQueueCase(
+      `test-collect-prepared-image-layout-${Date.now()}`,
+    );
 
     for (const [index, prompt] of ["one", "two"].entries()) {
       const preparedRun: InternalFollowupRun = {
@@ -2110,8 +1983,7 @@ describe("followup queue collect routing", () => {
       enqueueFollowupRun(key, preparedRun, settings);
     }
 
-    scheduleFollowupDrain(key, runFollowup);
-    await done.promise;
+    await drainRecordedQueue(key, runFollowup, done);
 
     expect((calls[0] as InternalFollowupRun | undefined)?.mediaImageLayout).toEqual({
       slots: [
@@ -2129,42 +2001,16 @@ describe("followup queue collect routing", () => {
       2,
     );
 
-    const nonOwner = createRun({
-      prompt: "use the gateway tool",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
+    enqueueSlackRun(key, settings, "use the gateway tool", {
+      senderId: "user-1",
+      senderName: "Guest",
+      senderIsOwner: false,
     });
-    enqueueFollowupRun(
-      key,
-      {
-        ...nonOwner,
-        run: {
-          ...nonOwner.run,
-          senderId: "user-1",
-          senderName: "Guest",
-          senderIsOwner: false,
-        },
-      },
-      settings,
-    );
-    const owner = createRun({
-      prompt: "what's the weather?",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
+    enqueueSlackRun(key, settings, "what's the weather?", {
+      senderId: "owner-1",
+      senderName: "Owner",
+      senderIsOwner: true,
     });
-    enqueueFollowupRun(
-      key,
-      {
-        ...owner,
-        run: {
-          ...owner.run,
-          senderId: "owner-1",
-          senderName: "Owner",
-          senderIsOwner: true,
-        },
-      },
-      settings,
-    );
 
     await drainRecordedQueue(key, runFollowup, done);
 
@@ -2381,45 +2227,14 @@ describe("followup queue collect routing", () => {
       `test-collect-auth-match-${Date.now()}`,
     );
 
-    const first = createRun({
-      prompt: "first",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
-    });
-    const second = createRun({
-      prompt: "second",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
-    });
-
-    enqueueFollowupRun(
-      key,
-      {
-        ...first,
-        run: {
-          ...first.run,
-          senderId: "user-1",
-          senderName: "Guest",
-          senderUsername: "guest",
-          senderIsOwner: false,
-        },
-      },
-      settings,
-    );
-    enqueueFollowupRun(
-      key,
-      {
-        ...second,
-        run: {
-          ...second.run,
-          senderId: "user-1",
-          senderName: "Guest",
-          senderUsername: "guest",
-          senderIsOwner: false,
-        },
-      },
-      settings,
-    );
+    const sender = {
+      senderId: "user-1",
+      senderName: "Guest",
+      senderUsername: "guest",
+      senderIsOwner: false,
+    };
+    enqueueSlackRun(key, settings, "first", sender);
+    enqueueSlackRun(key, settings, "second", sender);
 
     await drainRecordedQueue(key, runFollowup, done);
 
@@ -2435,45 +2250,18 @@ describe("followup queue collect routing", () => {
       `test-collect-auth-display-drift-${Date.now()}`,
     );
 
-    const first = createRun({
-      prompt: "first",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
+    enqueueSlackRun(key, settings, "first", {
+      senderId: "user-1",
+      senderName: "Guest",
+      senderUsername: "guest",
+      senderIsOwner: false,
     });
-    const second = createRun({
-      prompt: "second",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
+    enqueueSlackRun(key, settings, "second", {
+      senderId: "user-1",
+      senderName: "Guest User",
+      senderUsername: "guest-renamed",
+      senderIsOwner: false,
     });
-
-    enqueueFollowupRun(
-      key,
-      {
-        ...first,
-        run: {
-          ...first.run,
-          senderId: "user-1",
-          senderName: "Guest",
-          senderUsername: "guest",
-          senderIsOwner: false,
-        },
-      },
-      settings,
-    );
-    enqueueFollowupRun(
-      key,
-      {
-        ...second,
-        run: {
-          ...second.run,
-          senderId: "user-1",
-          senderName: "Guest User",
-          senderUsername: "guest-renamed",
-          senderIsOwner: false,
-        },
-      },
-      settings,
-    );
 
     await drainRecordedQueue(key, runFollowup, done);
 
@@ -2491,43 +2279,17 @@ describe("followup queue collect routing", () => {
       2,
     );
 
-    const base = createRun({
-      prompt: "first",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
+    enqueueSlackRun(key, settings, "first", {
+      senderId: "owner-1",
+      senderIsOwner: true,
+      bashElevated: { enabled: false, allowed: true, defaultLevel: "off" },
     });
-
-    enqueueFollowupRun(
-      key,
-      {
-        ...base,
-        run: {
-          ...base.run,
-          senderId: "owner-1",
-          senderIsOwner: true,
-          bashElevated: { enabled: false, allowed: true, defaultLevel: "off" },
-        },
-      },
-      settings,
-    );
-    enqueueFollowupRun(
-      key,
-      {
-        ...createRun({
-          prompt: "second",
-          originatingChannel: "slack",
-          originatingTo: "channel:A",
-        }),
-        run: {
-          ...base.run,
-          senderId: "owner-1",
-          senderIsOwner: true,
-          bashElevated: { enabled: true, allowed: true, defaultLevel: "on" },
-          execOverrides: { ask: "always" },
-        },
-      },
-      settings,
-    );
+    enqueueSlackRun(key, settings, "second", {
+      senderId: "owner-1",
+      senderIsOwner: true,
+      bashElevated: { enabled: true, allowed: true, defaultLevel: "on" },
+      execOverrides: { ask: "always" },
+    });
 
     await drainRecordedQueue(key, runFollowup, done);
 
@@ -2543,42 +2305,20 @@ describe("followup queue collect routing", () => {
       `test-collect-latest-run-${Date.now()}`,
     );
 
-    const first = createRun({ prompt: "first", originatingChannel: "slack", originatingTo: "A" });
-    const second = createRun({
-      prompt: "second",
-      originatingChannel: "slack",
-      originatingTo: "A",
-    });
-
-    enqueueFollowupRun(
+    const run = { provider: "openai", model: "gpt-5.4", senderId: "user-1", senderIsOwner: false };
+    enqueueSlackRun(
       key,
-      {
-        ...first,
-        run: {
-          ...first.run,
-          provider: "openai",
-          model: "gpt-5.4",
-          senderId: "user-1",
-          senderName: "First Name",
-          senderIsOwner: false,
-        },
-      },
       settings,
+      "first",
+      { ...run, senderName: "First Name" },
+      { originatingTo: "A" },
     );
-    enqueueFollowupRun(
+    enqueueSlackRun(
       key,
-      {
-        ...second,
-        run: {
-          ...second.run,
-          provider: "openai",
-          model: "gpt-5.4",
-          senderId: "user-1",
-          senderName: "Newest Name",
-          senderIsOwner: false,
-        },
-      },
       settings,
+      "second",
+      { ...run, senderName: "Newest Name" },
+      { originatingTo: "A" },
     );
 
     await drainRecordedQueue(key, runFollowup, done);
@@ -2633,34 +2373,17 @@ describe("followup queue collect routing", () => {
       3,
     );
 
-    const first = createRun({ prompt: "first", originatingChannel: "slack", originatingTo: "A" });
-    const second = createRun({ prompt: "second", originatingChannel: "slack", originatingTo: "A" });
-    const third = createRun({ prompt: "third", originatingChannel: "slack", originatingTo: "A" });
-
-    enqueueFollowupRun(
+    const route = { originatingTo: "A" };
+    const guest = { senderId: "user-a", senderName: "A", senderIsOwner: false };
+    enqueueSlackRun(key, settings, "first", guest, route);
+    enqueueSlackRun(
       key,
-      {
-        ...first,
-        run: { ...first.run, senderId: "user-a", senderName: "A", senderIsOwner: false },
-      },
       settings,
+      "second",
+      { senderId: "owner-1", senderName: "Owner", senderIsOwner: true },
+      route,
     );
-    enqueueFollowupRun(
-      key,
-      {
-        ...second,
-        run: { ...second.run, senderId: "owner-1", senderName: "Owner", senderIsOwner: true },
-      },
-      settings,
-    );
-    enqueueFollowupRun(
-      key,
-      {
-        ...third,
-        run: { ...third.run, senderId: "user-a", senderName: "A", senderIsOwner: false },
-      },
-      settings,
-    );
+    enqueueSlackRun(key, settings, "third", guest, route);
 
     await drainRecordedQueue(key, runFollowup, done);
 
@@ -2676,21 +2399,16 @@ describe("followup queue collect routing", () => {
       `test-collect-slack-thread-same-${Date.now()}`,
     );
 
-    enqueueTestRuns(
+    enqueueRoutedRuns(
       key,
       settings,
       {
-        prompt: "one",
         originatingChannel: "slack",
         originatingTo: "channel:A",
         originatingThreadId: "1706000000.000001",
       },
-      {
-        prompt: "two",
-        originatingChannel: "slack",
-        originatingTo: "channel:A",
-        originatingThreadId: "1706000000.000001",
-      },
+      "one",
+      "two",
     );
 
     await drainRecordedQueue(key, runFollowup, done);
@@ -2827,43 +2545,16 @@ describe("followup queue collect routing", () => {
     };
     const settings = createQueueSettings();
 
-    const guest = createRun({
-      prompt: "guest message",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
+    enqueueSlackRun(key, settings, "guest message", {
+      senderId: "user-1",
+      senderName: "Guest",
+      senderIsOwner: false,
     });
-    const owner = createRun({
-      prompt: "owner message",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
+    enqueueSlackRun(key, settings, "owner message", {
+      senderId: "owner-1",
+      senderName: "Owner",
+      senderIsOwner: true,
     });
-
-    enqueueFollowupRun(
-      key,
-      {
-        ...guest,
-        run: {
-          ...guest.run,
-          senderId: "user-1",
-          senderName: "Guest",
-          senderIsOwner: false,
-        },
-      },
-      settings,
-    );
-    enqueueFollowupRun(
-      key,
-      {
-        ...owner,
-        run: {
-          ...owner.run,
-          senderId: "owner-1",
-          senderName: "Owner",
-          senderIsOwner: true,
-        },
-      },
-      settings,
-    );
 
     await drainRecordedQueue(key, runFollowup, done);
 
@@ -3005,61 +2696,14 @@ describe("followup queue collect routing", () => {
       3,
     );
 
-    const droppedGuest = createRun({
-      prompt: "dropped guest message",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
+    const guest = { senderId: "user-1", senderName: "Guest", senderIsOwner: false };
+    enqueueSlackRun(key, settings, "dropped guest message", guest);
+    enqueueSlackRun(key, settings, "guest message", guest);
+    enqueueSlackRun(key, settings, "owner message", {
+      senderId: "owner-1",
+      senderName: "Owner",
+      senderIsOwner: true,
     });
-    const guest = createRun({
-      prompt: "guest message",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
-    });
-    const owner = createRun({
-      prompt: "owner message",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
-    });
-
-    enqueueFollowupRun(
-      key,
-      {
-        ...droppedGuest,
-        run: {
-          ...droppedGuest.run,
-          senderId: "user-1",
-          senderName: "Guest",
-          senderIsOwner: false,
-        },
-      },
-      settings,
-    );
-    enqueueFollowupRun(
-      key,
-      {
-        ...guest,
-        run: {
-          ...guest.run,
-          senderId: "user-1",
-          senderName: "Guest",
-          senderIsOwner: false,
-        },
-      },
-      settings,
-    );
-    enqueueFollowupRun(
-      key,
-      {
-        ...owner,
-        run: {
-          ...owner.run,
-          senderId: "owner-1",
-          senderName: "Owner",
-          senderIsOwner: true,
-        },
-      },
-      settings,
-    );
 
     await drainRecordedQueue(key, runFollowup, done);
 
@@ -3090,61 +2734,14 @@ describe("followup queue collect routing", () => {
     };
     const settings = createQueueSettings({ cap: 2 });
 
-    const droppedGuest = createRun({
-      prompt: "dropped guest message",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
+    const guest = { senderId: "user-1", senderName: "Guest", senderIsOwner: false };
+    enqueueSlackRun(key, settings, "dropped guest message", guest);
+    enqueueSlackRun(key, settings, "guest message", guest);
+    enqueueSlackRun(key, settings, "owner message", {
+      senderId: "owner-1",
+      senderName: "Owner",
+      senderIsOwner: true,
     });
-    const guest = createRun({
-      prompt: "guest message",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
-    });
-    const owner = createRun({
-      prompt: "owner message",
-      originatingChannel: "slack",
-      originatingTo: "channel:A",
-    });
-
-    enqueueFollowupRun(
-      key,
-      {
-        ...droppedGuest,
-        run: {
-          ...droppedGuest.run,
-          senderId: "user-1",
-          senderName: "Guest",
-          senderIsOwner: false,
-        },
-      },
-      settings,
-    );
-    enqueueFollowupRun(
-      key,
-      {
-        ...guest,
-        run: {
-          ...guest.run,
-          senderId: "user-1",
-          senderName: "Guest",
-          senderIsOwner: false,
-        },
-      },
-      settings,
-    );
-    enqueueFollowupRun(
-      key,
-      {
-        ...owner,
-        run: {
-          ...owner.run,
-          senderId: "owner-1",
-          senderName: "Owner",
-          senderIsOwner: true,
-        },
-      },
-      settings,
-    );
 
     await drainRecordedQueue(key, runFollowup, done);
 
@@ -3164,23 +2761,17 @@ describe("followup queue collect routing", () => {
       { mode: "followup", cap: 1 },
     );
 
-    enqueueTestRuns(
+    enqueueRoutedRuns(
       key,
       settings,
       {
-        prompt: "first",
         originatingChannel: "discord",
         originatingTo: "channel:C1",
         originatingAccountId: "work",
         originatingThreadId: "1739142736.000100",
       },
-      {
-        prompt: "second",
-        originatingChannel: "discord",
-        originatingTo: "channel:C1",
-        originatingAccountId: "work",
-        originatingThreadId: "1739142736.000100",
-      },
+      "first",
+      "second",
     );
 
     await drainRecordedQueue(key, runFollowup, done);


### PR DESCRIPTION
## What Problem This Solves

Image, video, and music tools duplicated foreground and detached generation lifecycle policy, while adjacent MCP, runner-memory, and queue tests repeated large fixture blocks.

## Why This Change Was Made

One agent-owned media generation task now handles admission, cancellation, completion, failure, wake delivery, and transcript outcomes for all three tools. The exact adjacent regression fixtures are consolidated without changing their cases. The extension-runner cleanup is intentionally excluded from this PR.

AI-assisted maintainer cleanup. I reviewed the final code, proof, and exact landing diff.

## User Impact

Media generation keeps the same model-visible schemas and outcomes through a smaller canonical lifecycle. Contributors get substantially smaller MCP, memory, and queue regression fixtures.

## Evidence

- Production net LOC: `-193`; tests net LOC: `-1289`; total net `-1482` across exactly ten files.
- Current-main base: `b977ccb21e2b4b8bff05729548ea1b1558a74a33`; exact head: `560aef262e4db8c41d75ab61a655f867631a66fd`.
- Exact diff SHA-256: `dd85450f408206c7358de4327d1090f0122b1d45f2f7aa2e87650b4f0f62bd50`.
- Fresh combined owner proof: 470/470 passed; assertion-safety ratchet passes without a baseline edit.
- Production typing, touched agent test shards, typed lint, formatting, and diff checks passed.
- Current-main MCP timeout/security and runner-memory terminal expectations remain intact.
- Independent verification confirmed cancellation placement, provider/SSRF inputs, detached/foreground lifecycle, wake delivery, authority/privacy, and model-visible schemas are preserved.
- Mandatory exact-source autoreview: secret scan clean; isolated Codex review reported no actionable findings (0.94 patch-correctness confidence).
