### PR TITLE
fix(cli): keep automation JSON clean with parent connection options

### DIFF
--- a/src/cli/cron-cli/output-mode.ts
+++ b/src/cli/cron-cli/output-mode.ts
@@ -1,8 +1,22 @@
 import type { Command } from "commander";
+import { getCommandPositionalsWithRootOptions } from "../../infra/cli-root-options.js";
 import {
   getMachineOutputCommandPath,
   MACHINE_OUTPUT_JSON_OPTION_DESCRIPTION,
 } from "../machine-output-argv.js";
+
+export const CRON_GATEWAY_OPTION_NAMES = [
+  "url",
+  "port",
+  "token",
+  "password",
+  "timeout",
+  "expectFinal",
+] as const;
+
+const CRON_GATEWAY_VALUE_FLAGS = CRON_GATEWAY_OPTION_NAMES.filter(
+  (name) => name !== "expectFinal",
+).map((name) => `--${name}`);
 
 const CRON_SCRATCH_JSON_OPTION_DESCRIPTION =
   "Output scratch plus revision metadata as JSON; writes return JSON by default";
@@ -46,9 +60,16 @@ export function createCronOutputCommand(parent: Command, name: CronOutputCommand
 }
 
 export function isCronMachineOutput(argv: readonly string[]): boolean {
-  const [, command] = getMachineOutputCommandPath(argv, 2);
-  if (!command) {
+  const [root] = getMachineOutputCommandPath(argv, 1);
+  if (!root) {
     return false;
   }
-  return MACHINE_OUTPUT_COMMANDS.has(command);
+  const [command] =
+    getCommandPositionalsWithRootOptions(argv, {
+      commandPath: [root],
+      booleanFlags: ["--expect-final"],
+      valueFlags: CRON_GATEWAY_VALUE_FLAGS,
+      maxPositionals: 1,
+    }) ?? [];
+  return command !== undefined && MACHINE_OUTPUT_COMMANDS.has(command);
 }

--- a/src/cli/cron-cli/register.cron-simple.test.ts
+++ b/src/cli/cron-cli/register.cron-simple.test.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CronJob } from "../../cron/types.js";
 import { defaultRuntime } from "../../runtime.js";
+import { isCommandJsonOutputMode } from "../program/json-mode.js";
 
 const callGatewayFromCli = vi.fn();
 
@@ -106,6 +107,18 @@ describe("cron machine-output help", () => {
 
   it("keeps registered command output declarations aligned with early stdout routing", () => {
     const cron = createRegisteredCronCommand();
+    const gatewayOptions = [
+      [],
+      ["--url", "ws://127.0.0.1:18789"],
+      ["--port", "18789"],
+      ["--token", "test-token"],
+      ["--password", "test-password"],
+      ["--timeout", "250"],
+      ["--expect-final"],
+      ["--port=18789"],
+      ["--timeout", "250", "--expect-final"],
+      ["--log-level", "debug", "--port", "18789"],
+    ];
     for (const command of cron.commands) {
       const jsonOption = command.options.find((option) => option.long === "--json");
       const alwaysJson =
@@ -113,10 +126,43 @@ describe("cron machine-output help", () => {
         "Explicit machine-output spelling (command results are JSON by default)";
       const reservesMachineOutput = command.name() === "scratch" || alwaysJson;
       for (const commandName of [command.name(), ...command.aliases()]) {
-        expect(isCronMachineOutput(["node", "openclaw", "cron", commandName]), commandName).toBe(
-          reservesMachineOutput,
-        );
+        for (const root of ["cron", "automations"]) {
+          for (const parentOptions of gatewayOptions) {
+            const argv = ["node", "openclaw", root, ...parentOptions, commandName];
+            expect(isCronMachineOutput(argv), argv.join(" ")).toBe(reservesMachineOutput);
+          }
+        }
       }
+    }
+  });
+
+  it.each([
+    { root: "cron", option: "--timeout", value: "250" },
+    { root: "automations", option: "--port", value: "18789" },
+    { root: "automations", option: "--url", value: "ws://127.0.0.1:18789" },
+    { root: "cron", option: "--token", value: "test-token" },
+    { root: "cron", option: "--password", value: "test-password" },
+  ])("preserves JSON mode for $root $option before status", async ({ root, option, value }) => {
+    const program = new Command().name("openclaw");
+    registerCronCli(program);
+    const argv = ["node", "openclaw", root, option, value, "status"];
+    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+    callGatewayFromCli.mockResolvedValueOnce({ enabled: true });
+    program.hook("preAction", (_parent, command) => {
+      expect(isCommandJsonOutputMode(command, argv)).toBe(true);
+    });
+
+    try {
+      await program.parseAsync(argv);
+      expect(callGatewayFromCli).toHaveBeenCalledWith(
+        "cron.status",
+        expect.objectContaining({ [option.slice(2)]: value }),
+        {},
+      );
+      expect(writeJson).toHaveBeenCalledWith({ enabled: true });
+    } finally {
+      callGatewayFromCli.mockReset();
+      writeJson.mockRestore();
     }
   });
 });

--- a/src/cli/cron-cli/register.ts
+++ b/src/cli/cron-cli/register.ts
@@ -6,7 +6,7 @@ import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayClientOptions } from "../gateway-rpc.js";
 import { setCommandJsonMode } from "../program/json-mode.js";
 import { applyParentDefaultHelpAction } from "../program/parent-default-help.js";
-import { isCronMachineOutput } from "./output-mode.js";
+import { CRON_GATEWAY_OPTION_NAMES, isCronMachineOutput } from "./output-mode.js";
 import {
   registerCronAddCommand,
   registerCronListCommand,
@@ -15,15 +15,6 @@ import {
 import { registerCronEditCommand } from "./register.cron-edit.js";
 import { registerCronScratchCommand } from "./register.cron-scratch.js";
 import { registerCronSimpleCommands } from "./register.cron-simple.js";
-
-const CRON_GATEWAY_OPTION_NAMES = [
-  "url",
-  "port",
-  "token",
-  "password",
-  "timeout",
-  "expectFinal",
-] as const;
 
 function inheritCronGatewayOptions(command: Command): void {
   for (const name of CRON_GATEWAY_OPTION_NAMES) {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2531,6 +2531,8 @@ describe("runCli exit behavior", () => {
 
   it.each([
     ["cron", ["node", "openclaw", "cron", "status"]],
+    ["cron parent timeout", ["node", "openclaw", "cron", "--timeout", "250", "status"]],
+    ["automations parent port", ["node", "openclaw", "automations", "--port", "18789", "status"]],
     ["cron alias", ["node", "openclaw", "cron", "create", "daily", "message"]],
     ["cron removal alias", ["node", "openclaw", "cron", "delete", "job"]],
     ["cron scratch equals", ["node", "openclaw", "cron", "scratch", "job", "--set=text"]],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using a documented Gateway connection option before an automation subcommand would lose machine-readable output handling. Commands such as `openclaw automations --port 18789 status` and `openclaw cron --timeout 250 status` incorrectly treated the option value as the subcommand, allowing startup diagnostics to pollute JSON stdout and producing human-readable failures for commands that promise JSON by default.

## Why This Change Was Made

Automation output ownership now resolves its command path through the existing root-aware positional parser while consuming the same authoritative Gateway option list already used for parent-option inheritance. This preserves both command spellings, subcommand aliases, root options, boolean options, equals-form values, non-machine commands, and existing public CLI contracts without introducing another parser or duplicate option policy.

Production code grows by 12 lines because early output ownership must understand the arity of the existing five value options and one boolean option; their shared declaration replaces the former registration-only copy. The existing strict early-parser treatment of uncommon empty or leading-hyphen option values remains unchanged rather than widening shared parsing behavior.

## User Impact

Automation commands retain clean, predictable machine-readable stdout and structured error ownership regardless of whether documented Gateway connection options appear before or after the subcommand. Existing option names, authentication behavior, configuration, output schemas, and human-readable commands are unchanged.

## Evidence

- Before the fix, six checked-in owner/real-Commander regressions failed across `--url`, `--port`, `--token`, `--password`, and `--timeout`, and two actual `runCli` startup regressions proved diagnostics were not routed away from JSON stdout.
- After the fix, 482 tests pass across eight focused automation, Commander, machine-output, root-option, pre-action, and full CLI-startup suites.
- Independent review passed 177 owner/parser tests, 16 actual CLI startup-routing scenarios, and 423 generated combinations of command spellings, subcommand aliases, parent/root options, equals values, boolean values, and non-machine siblings.
- Fresh authenticated review of the complete committed branch reported no actionable findings. Production type checking, focused formatting/lint, max-lines and assertion-safety ratchets, and `git diff --check` passed.
- Full core-test type checking reaches two existing shared-workspace dependency gaps unrelated to this change: missing `@panzoom/panzoom` and `@types/pako`; no changed CLI file reports a type error.
- Exact reviewed head: `fca2930bbc14022acf0ad006743f7ad8f0b93a1a`.
