### PR TITLE
improve(nextcloud-talk): avoid room credential reads on sends

### DIFF
--- a/extensions/nextcloud-talk/src/accounts.ts
+++ b/extensions/nextcloud-talk/src/accounts.ts
@@ -120,20 +120,6 @@ export function resolveNextcloudTalkAccount(params: {
     const accountEnabled = merged.enabled !== false;
     const enabled = baseEnabled && accountEnabled;
     const secretResolution = resolveNextcloudTalkSecret(accountId, merged);
-    const apiCredentialResolution = resolveNextcloudTalkApiCredentialsResult({
-      apiUser: merged.apiUser,
-      apiPassword: merged.apiPassword,
-      apiPasswordFile: merged.apiPasswordFile,
-      configPath: `channels.nextcloud-talk.accounts.${accountId}.apiPasswordFile`,
-    });
-    const diagnostics = [
-      secretResolution.diagnostic,
-      apiCredentialResolution.status === "configured_unavailable"
-        ? apiCredentialResolution.diagnostic
-        : undefined,
-    ].filter((diagnostic): diagnostic is NextcloudTalkCredentialUnavailableDiagnostic =>
-      Boolean(diagnostic),
-    );
     const baseUrl = merged.baseUrl?.trim()?.replace(/\/$/, "") ?? "";
 
     debugAccounts("resolve", {
@@ -151,8 +137,9 @@ export function resolveNextcloudTalkAccount(params: {
       secret: secretResolution.secret,
       secretSource: secretResolution.source,
       tokenStatus: secretResolution.status,
-      apiCredentialStatus: apiCredentialResolution.status,
-      ...(diagnostics.length > 0 ? { credentialDiagnostics: diagnostics } : {}),
+      ...(secretResolution.diagnostic
+        ? { credentialDiagnostics: [secretResolution.diagnostic] }
+        : {}),
       config: merged,
     } satisfies ResolvedNextcloudTalkAccount;
   };
@@ -164,4 +151,28 @@ export function resolveNextcloudTalkAccount(params: {
     hasCredential: (account) => account.tokenStatus !== "missing",
     resolveDefaultAccountId: () => resolveDefaultNextcloudTalkAccountId(params.cfg),
   });
+}
+
+export function inspectNextcloudTalkAccount(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+}): ResolvedNextcloudTalkAccount {
+  const account = resolveNextcloudTalkAccount(params);
+  const apiCredentialResolution = resolveNextcloudTalkApiCredentialsResult({
+    apiUser: account.config.apiUser,
+    apiPassword: account.config.apiPassword,
+    apiPasswordFile: account.config.apiPasswordFile,
+    configPath: `channels.nextcloud-talk.accounts.${account.accountId}.apiPasswordFile`,
+  });
+  const credentialDiagnostics = [
+    ...(account.credentialDiagnostics ?? []),
+    ...(apiCredentialResolution.status === "configured_unavailable"
+      ? [apiCredentialResolution.diagnostic]
+      : []),
+  ];
+  return {
+    ...account,
+    apiCredentialStatus: apiCredentialResolution.status,
+    ...(credentialDiagnostics.length > 0 ? { credentialDiagnostics } : {}),
+  };
 }

--- a/extensions/nextcloud-talk/src/channel.adapters.ts
+++ b/extensions/nextcloud-talk/src/channel.adapters.ts
@@ -11,6 +11,7 @@ import {
   inspectNextcloudTalkAccount,
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,
+  resolveNextcloudTalkAccount,
   type ResolvedNextcloudTalkAccount,
 } from "./accounts.js";
 import type { CoreConfig } from "./types.js";
@@ -22,7 +23,8 @@ export const nextcloudTalkConfigAdapter = createScopedChannelConfigAdapter<
 >({
   sectionKey: "nextcloud-talk",
   listAccountIds: listNextcloudTalkAccountIds,
-  resolveAccount: adaptScopedAccountAccessor(inspectNextcloudTalkAccount),
+  resolveAccount: adaptScopedAccountAccessor(resolveNextcloudTalkAccount),
+  inspectAccount: adaptScopedAccountAccessor(inspectNextcloudTalkAccount),
   defaultAccountId: resolveDefaultNextcloudTalkAccountId,
   clearBaseFields: ["botSecret", "botSecretFile", "baseUrl", "name"],
   resolveAllowFrom: (account) => account.config.allowFrom,

--- a/extensions/nextcloud-talk/src/channel.adapters.ts
+++ b/extensions/nextcloud-talk/src/channel.adapters.ts
@@ -8,9 +8,9 @@ import {
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  inspectNextcloudTalkAccount,
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,
-  resolveNextcloudTalkAccount,
   type ResolvedNextcloudTalkAccount,
 } from "./accounts.js";
 import type { CoreConfig } from "./types.js";
@@ -22,7 +22,7 @@ export const nextcloudTalkConfigAdapter = createScopedChannelConfigAdapter<
 >({
   sectionKey: "nextcloud-talk",
   listAccountIds: listNextcloudTalkAccountIds,
-  resolveAccount: adaptScopedAccountAccessor(resolveNextcloudTalkAccount),
+  resolveAccount: adaptScopedAccountAccessor(inspectNextcloudTalkAccount),
   defaultAccountId: resolveDefaultNextcloudTalkAccountId,
   clearBaseFields: ["botSecret", "botSecretFile", "baseUrl", "name"],
   resolveAllowFrom: (account) => account.config.allowFrom,

--- a/extensions/nextcloud-talk/src/channel.status.test.ts
+++ b/extensions/nextcloud-talk/src/channel.status.test.ts
@@ -1,6 +1,7 @@
 // Nextcloud Talk tests cover channel.status plugin behavior.
 import { describe, expect, it } from "vitest";
 import { nextcloudTalkPlugin } from "./channel.js";
+import type { CoreConfig } from "./types.js";
 
 describe("nextcloud-talk channel status", () => {
   it("classifies room tokens as groups", () => {
@@ -31,5 +32,25 @@ describe("nextcloud-talk channel status", () => {
         fix: "Add --feature response to the Talk bot.",
       },
     ]);
+  });
+
+  it("preserves API credential availability on the account status surface", () => {
+    const cfg = {
+      channels: {
+        "nextcloud-talk": {
+          baseUrl: "https://cloud.example.com",
+          botSecret: "bot-secret",
+          apiUser: "bot",
+          apiPassword: "api-password",
+        },
+      },
+    } satisfies CoreConfig;
+
+    const account = nextcloudTalkPlugin.config.resolveAccount(cfg, "default");
+
+    expect(nextcloudTalkPlugin.config.describeAccount?.(account, cfg)).toMatchObject({
+      configured: true,
+      apiCredentialStatus: "available",
+    });
   });
 });

--- a/extensions/nextcloud-talk/src/channel.status.test.ts
+++ b/extensions/nextcloud-talk/src/channel.status.test.ts
@@ -1,4 +1,7 @@
 // Nextcloud Talk tests cover channel.status plugin behavior.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { nextcloudTalkPlugin } from "./channel.js";
 import type { CoreConfig } from "./types.js";
@@ -34,23 +37,36 @@ describe("nextcloud-talk channel status", () => {
     ]);
   });
 
-  it("preserves API credential availability on the account status surface", () => {
+  it("keeps API credential inspection off runtime resolution", async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), "nextcloud-talk-status-"));
+    const apiPasswordFile = path.join(directory, "api-password");
     const cfg = {
       channels: {
         "nextcloud-talk": {
           baseUrl: "https://cloud.example.com",
           botSecret: "bot-secret",
           apiUser: "bot",
-          apiPassword: "api-password",
+          apiPasswordFile,
         },
       },
     } satisfies CoreConfig;
 
-    const account = nextcloudTalkPlugin.config.resolveAccount(cfg, "default");
+    try {
+      const account = nextcloudTalkPlugin.config.resolveAccount(cfg, "default");
+      expect(account.apiCredentialStatus).toBeUndefined();
+      expect(account.credentialDiagnostics).toBeUndefined();
 
-    expect(nextcloudTalkPlugin.config.describeAccount?.(account, cfg)).toMatchObject({
-      configured: true,
-      apiCredentialStatus: "available",
-    });
+      fs.writeFileSync(apiPasswordFile, "api-password\n", "utf8");
+      const inspected = (await nextcloudTalkPlugin.config.inspectAccount?.(
+        cfg,
+        "default",
+      )) as typeof account;
+      expect(nextcloudTalkPlugin.config.describeAccount?.(inspected, cfg)).toMatchObject({
+        configured: true,
+        apiCredentialStatus: "available",
+      });
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Nextcloud Talk ordinary outbound sends inspected optional room-lookup API password files even though sending requires only the bot secret and base URL. When `apiPasswordFile` was configured, every send therefore performed unrelated synchronous file inspection during outbound preparation.

## Why This Change Was Made

Runtime account resolution now prepares only bot-send facts. The config/status adapter uses a separate inspection path that preserves API credential availability and diagnostics, while room-info continues to resolve those credentials at its existing use boundary.

## User Impact

Nextcloud Talk sends no longer pay file-inspection overhead for unrelated room lookup credentials. Config and status reporting continue to expose the same API credential state.

## Evidence

- Exact-base alternating benchmark, 11 samples × 50,000 resolutions: configured API password file overhead fell from +24.108 µs/op to +0.200 µs/op (99.2% reduction); the defective path improved 86.2%.
- Status regression preserves `apiCredentialStatus: "available"` through the config adapter.
- Owner and sibling verification: 6 files / 36 tests passed.
- Full Nextcloud Talk extension: 24 files / 154 tests passed.
- `node scripts/check-changed.mjs -- extensions/nextcloud-talk/src/accounts.ts extensions/nextcloud-talk/src/channel.adapters.ts extensions/nextcloud-talk/src/channel.status.test.ts` passed all selected format, boundary, dead-export, typecheck, lint, guard, and import-cycle checks.
- `git diff --check` passed.
- Fresh autoreview: TruffleHog clean; Codex `gpt-5.6-sol` with high reasoning reported no P0/P1 findings (correctness confidence 0.96).
- Live provider mutation was not run because no Nextcloud credentials are available; the defect and repair are pre-provider synchronous file-inspection behavior, covered by exact-base call-count/timing proof and unchanged provider-path tests.
