### PR TITLE
fix(updater): release updates recover after upstream tags move

### DIFF
--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -79,11 +79,11 @@ describe("update failure hints", () => {
     expect(output).toContain("Install pnpm manually");
   });
 
-  it("returns a recovery command when stable remotes are ambiguous", () => {
+  it("returns a checkout-root-relative recovery command when stable remotes are ambiguous", () => {
     const result = {
       status: "error",
       mode: "git",
-      root: "/srv/openclaw",
+      root: "/srv/OpenClaw Release",
       reason: "ambiguous-release-remote",
       steps: [],
       durationMs: 1,
@@ -92,7 +92,10 @@ describe("update failure hints", () => {
     const output = renderResult(result);
 
     expect(output).toContain("multiple Git remotes");
-    expect(output).toContain("git -C /srv/openclaw config branch.main.remote <canonical-remote>");
+    expect(output).toContain(
+      "From the checkout root, set the canonical release remote, then rerun the update: git config branch.main.remote <canonical-remote>",
+    );
+    expect(output).not.toContain("git -C /srv/OpenClaw Release");
     expect(output).toContain("rerun the update");
   });
 

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -79,6 +79,23 @@ describe("update failure hints", () => {
     expect(output).toContain("Install pnpm manually");
   });
 
+  it("returns a recovery command when stable remotes are ambiguous", () => {
+    const result = {
+      status: "error",
+      mode: "git",
+      root: "/srv/openclaw",
+      reason: "ambiguous-release-remote",
+      steps: [],
+      durationMs: 1,
+    } satisfies UpdateRunResult;
+
+    const output = renderResult(result);
+
+    expect(output).toContain("multiple Git remotes");
+    expect(output).toContain("git -C /srv/openclaw config branch.main.remote <canonical-remote>");
+    expect(output).toContain("rerun the update");
+  });
+
   it("returns EACCES hint for global update permission failures", () => {
     const result = makeResult(
       "global update",

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -96,6 +96,13 @@ function inferUpdateFailureHints(result: UpdateRunResult): string[] {
       "Install the missing package manager manually, then rerun the update command.",
     ];
   }
+  if (result.reason === "ambiguous-release-remote") {
+    const root = result.root ?? ".";
+    return [
+      "This stable/beta checkout has multiple Git remotes but no configured main remote, so the updater stopped without choosing one.",
+      `Set the canonical release remote, then rerun the update: git -C ${root} config branch.main.remote <canonical-remote>`,
+    ];
+  }
   if (result.mode !== "npm") {
     return [];
   }

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -97,10 +97,9 @@ function inferUpdateFailureHints(result: UpdateRunResult): string[] {
     ];
   }
   if (result.reason === "ambiguous-release-remote") {
-    const root = result.root ?? ".";
     return [
       "This stable/beta checkout has multiple Git remotes but no configured main remote, so the updater stopped without choosing one.",
-      `Set the canonical release remote, then rerun the update: git -C ${root} config branch.main.remote <canonical-remote>`,
+      "From the checkout root, set the canonical release remote, then rerun the update: git config branch.main.remote <canonical-remote>",
     ];
   }
   if (result.mode !== "npm") {

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -226,8 +226,6 @@ export async function runUpdateStep(params: {
     ...params,
     cwd: params.cwd ?? process.cwd(),
     runCommand: runCommandWithTimeout,
-    stepIndex: 0,
-    totalSteps: 0,
   });
 }
 

--- a/src/cli/update-cli/update-command-package.ts
+++ b/src/cli/update-cli/update-command-package.ts
@@ -141,8 +141,6 @@ export async function runPackageInstallUpdate(params: {
       const doctorProgressInfo = {
         name: `${CLI_NAME} doctor`,
         command: doctorArgv.join(" "),
-        index: 0,
-        total: 0,
       };
       params.progress?.onStepStart?.(doctorProgressInfo);
       const doctorStep = await runUpdateStep({

--- a/src/infra/update-runner-command.ts
+++ b/src/infra/update-runner-command.ts
@@ -26,9 +26,9 @@ function mergeCommandEnvironments(
 }
 
 export async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
-  const { runCommand, name, argv, cwd, timeoutMs, env, progress, stepIndex, totalSteps } = opts;
+  const { runCommand, name, argv, cwd, timeoutMs, env, progress } = opts;
   const command = argv.join(" ");
-  const stepInfo: UpdateStepInfo = { name, command, index: stepIndex, total: totalSteps };
+  const stepInfo: UpdateStepInfo = { name, command };
   progress?.onStepStart?.(stepInfo);
 
   const started = Date.now();

--- a/src/infra/update-runner-git-fetch.ts
+++ b/src/infra/update-runner-git-fetch.ts
@@ -13,8 +13,10 @@ function parseRemoteFetchConfig(stdout: string): RemoteFetchConfig {
   const config: RemoteFetchConfig = new Map();
   for (const line of stdout.split("\n")) {
     const match = /^remote\.(.+)\.fetch\s+(.+)$/u.exec(line.trim());
-    if (match) {
-      config.set(match[1], [...(config.get(match[1]) ?? []), match[2]]);
+    const remote = match?.[1];
+    const refspec = match?.[2];
+    if (remote && refspec) {
+      config.set(remote, [...(config.get(remote) ?? []), refspec]);
     }
   }
   return config;

--- a/src/infra/update-runner-git-fetch.ts
+++ b/src/infra/update-runner-git-fetch.ts
@@ -62,6 +62,17 @@ function isBroadFetchRefspec(refspec: string): boolean {
   return isBroadRefspecMapping(source, destination);
 }
 
+function isPlainMirrorFetchRefspec(refspec: string): boolean {
+  const withoutForce = refspec.trim().replace(/^\+/u, "");
+  const [source = "", destination = ""] = withoutForce.split(":", 2).map((ref) => ref.trim());
+  return source === "refs/*" && destination === "refs/*";
+}
+
+function isFullTagNamespaceExclusion(refspec: string): boolean {
+  const normalized = refspec.trim();
+  return normalized === "^refs/tags" || normalized === "^refs/tags/*";
+}
+
 export type StableGitFetchResult = {
   reason?: "fetch-failed";
   remotes?: string[];
@@ -149,6 +160,12 @@ export async function prepareStableGitFetch(params: {
     // --refmap= ignores remote.*.fetch, so carry configured exclusions into argv explicitly.
     // Git versions without negative-refspec support reject this before any ref mutation.
     const negativeRefspecs = configuredRefspecs?.filter(isNegativeFetchRefspec) ?? [];
+    const needsTagExclusion =
+      configuredRefspecs?.some(isPlainMirrorFetchRefspec) === true &&
+      !negativeRefspecs.some(isFullTagNamespaceExclusion);
+    const explicitNegativeRefspecs = needsTagExclusion
+      ? [...negativeRefspecs, "^refs/tags/*"]
+      : negativeRefspecs;
     const branchRefspecs = configuredRefspecs
       ? [
           ...new Set(
@@ -156,7 +173,7 @@ export async function prepareStableGitFetch(params: {
               if (
                 !isNegativeFetchRefspec(refspec) &&
                 (!isTagFetchRefspec(refspec) ||
-                  (negativeRefspecs.length > 0 && isBroadFetchRefspec(refspec)))
+                  (explicitNegativeRefspecs.length > 0 && isBroadFetchRefspec(refspec)))
               ) {
                 return [refspec];
               }
@@ -179,7 +196,7 @@ export async function prepareStableGitFetch(params: {
       ...(configuredRefspecs ? ["--refmap="] : []),
       "--",
       remote,
-      ...(configuredRefspecs ? [...(branchRefspecs ?? []), ...negativeRefspecs] : []),
+      ...(configuredRefspecs ? [...(branchRefspecs ?? []), ...explicitNegativeRefspecs] : []),
     ];
     const fetchStep = await executeStep(`git fetch ${remote}`, fetchArgv);
     if (fetchStep.exitCode !== 0) {

--- a/src/infra/update-runner-git-fetch.ts
+++ b/src/infra/update-runner-git-fetch.ts
@@ -1,0 +1,125 @@
+import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { escapeRegExp } from "../shared/regexp.js";
+import { runStep } from "./update-runner-command.js";
+import type {
+  CommandRunner,
+  UpdateRunnerOptions,
+  UpdateStepResult,
+} from "./update-runner-types.js";
+
+type RemoteFetchConfig = Map<string, string[]>;
+
+function parseRemoteFetchConfig(stdout: string): RemoteFetchConfig {
+  const config: RemoteFetchConfig = new Map();
+  for (const line of stdout.split("\n")) {
+    const match = /^remote\.(.+)\.fetch\s+(.+)$/u.exec(line.trim());
+    if (match) {
+      config.set(match[1], [...(config.get(match[1]) ?? []), match[2]]);
+    }
+  }
+  return config;
+}
+
+function isTagFetchRefspec(refspec: string): boolean {
+  const [source = "", destination = ""] = refspec.replace(/^[+^]/u, "").split(":", 2);
+  return [source, destination].some(
+    (ref) => ref === "refs/*" || ref === "refs/tags" || ref.startsWith("refs/tags/"),
+  );
+}
+
+export type StableGitFetchResult = {
+  reason?: "fetch-failed";
+  remotes?: string[];
+};
+
+export async function prepareStableGitFetch(params: {
+  gitRoot: string;
+  timeoutMs: number;
+  runCommand: CommandRunner;
+  progress?: UpdateRunnerOptions["progress"];
+  steps: UpdateStepResult[];
+  fetchAllArgv: string[];
+}): Promise<StableGitFetchResult> {
+  const { gitRoot, timeoutMs, runCommand, progress, steps, fetchAllArgv } = params;
+  const executeStep = (name: string, argv: string[], allowMissing = false) =>
+    runStep({
+      runCommand: allowMissing
+        ? async (command, options) => {
+            const result = await runCommand(command, options);
+            return result.code === 1 ? { ...result, code: 0 } : result;
+          }
+        : runCommand,
+      name,
+      argv,
+      cwd: gitRoot,
+      timeoutMs,
+      progress,
+      results: steps,
+    });
+  const fetchConfigArgv = ["git", "-C", gitRoot, "config", "--get-regexp", "^remote\\..*\\.fetch$"];
+  const fetchConfigResult = await runCommand(fetchConfigArgv, { cwd: gitRoot, timeoutMs });
+  if (fetchConfigResult.code !== 0 && fetchConfigResult.code !== 1) {
+    return { reason: "fetch-failed" };
+  }
+  const fetchConfig = parseRemoteFetchConfig(fetchConfigResult.stdout);
+  const hasConfiguredTagRefspec = [...fetchConfig.values()].some((refspecs) =>
+    refspecs.some(isTagFetchRefspec),
+  );
+  if (!hasConfiguredTagRefspec) {
+    const fetchStep = await executeStep("git fetch", fetchAllArgv);
+    return fetchStep.exitCode === 0 ? {} : { reason: "fetch-failed" };
+  }
+
+  const remoteStep = await executeStep("git remote", ["git", "-C", gitRoot, "remote"]);
+  if (remoteStep.exitCode !== 0) {
+    return { reason: "fetch-failed" };
+  }
+  const remotes = normalizeStringEntries((remoteStep.stdoutTail ?? "").split("\n"));
+  let fetchFailed = false;
+  for (const remote of remotes) {
+    const skipStep = await executeStep(
+      "git config remote skip",
+      [
+        "git",
+        "-C",
+        gitRoot,
+        "config",
+        "--type=bool",
+        "--get-regexp",
+        `^remote\\.${escapeRegExp(remote)}\\.(skipfetchall|skipdefaultupdate)$`,
+      ],
+      true,
+    );
+    if (skipStep.exitCode !== 0) {
+      return { reason: "fetch-failed" };
+    }
+    const skipValues = (skipStep.stdoutTail ?? "").trimEnd().split("\n");
+    if (skipValues.at(-1)?.endsWith(" true")) {
+      continue;
+    }
+    const configuredRefspecs = fetchConfig.get(remote);
+    const branchRefspecs = configuredRefspecs?.filter((refspec) => !isTagFetchRefspec(refspec));
+    if (configuredRefspecs && branchRefspecs?.length === 0) {
+      continue;
+    }
+    const fetchArgv = [
+      "git",
+      "-C",
+      gitRoot,
+      "fetch",
+      "--prune",
+      "--no-prune-tags",
+      "--no-tags",
+      ...(configuredRefspecs ? ["--refmap="] : []),
+      "--",
+      remote,
+      ...(configuredRefspecs ? (branchRefspecs ?? []) : []),
+    ];
+    const fetchStep = await executeStep(`git fetch ${remote}`, fetchArgv);
+    if (fetchStep.exitCode !== 0) {
+      // Match `git fetch --all`: attempt every non-skipped remote before returning failure.
+      fetchFailed = true;
+    }
+  }
+  return fetchFailed ? { reason: "fetch-failed" } : { remotes };
+}

--- a/src/infra/update-runner-git-fetch.ts
+++ b/src/infra/update-runner-git-fetch.ts
@@ -23,10 +23,16 @@ function parseRemoteFetchConfig(stdout: string): RemoteFetchConfig {
 }
 
 function isTagFetchRefspec(refspec: string): boolean {
-  const [source = "", destination = ""] = refspec.replace(/^[+^]/u, "").split(":", 2);
-  return [source, destination].some(
-    (ref) => ref === "refs/*" || ref === "refs/tags" || ref.startsWith("refs/tags/"),
-  );
+  const normalized = refspec.trim();
+  if (normalized.startsWith("^")) {
+    return false;
+  }
+  const withoutForce = normalized.replace(/^\+/u, "");
+  if (/^tag\s+\S+$/u.test(withoutForce)) {
+    return true;
+  }
+  const destination = withoutForce.split(":", 2)[1]?.trim() ?? "";
+  return destination === "refs/tags" || destination.startsWith("refs/tags/");
 }
 
 export type StableGitFetchResult = {

--- a/src/infra/update-runner-git-fetch.ts
+++ b/src/infra/update-runner-git-fetch.ts
@@ -52,12 +52,11 @@ function isTagFetchRefspec(refspec: string): boolean {
   return isBroadRefspecMapping(source, destination);
 }
 
-function isFullTagNamespaceExclusion(refspec: string): boolean {
-  const normalized = refspec.trim();
-  return normalized === "^refs/tags" || normalized === "^refs/tags/*";
+function isNegativeFetchRefspec(refspec: string): boolean {
+  return refspec.trim().startsWith("^");
 }
 
-function isBroadTagFetchRefspec(refspec: string): boolean {
+function isBroadFetchRefspec(refspec: string): boolean {
   const withoutForce = refspec.trim().replace(/^\+/u, "");
   const [source = "", destination = ""] = withoutForce.split(":", 2).map((ref) => ref.trim());
   return isBroadRefspecMapping(source, destination);
@@ -147,22 +146,21 @@ export async function prepareStableGitFetch(params: {
       continue;
     }
     const configuredRefspecs = fetchConfig.get(remote);
-    const preserveBroadMappings = configuredRefspecs?.some(isFullTagNamespaceExclusion) ?? false;
+    // --refmap= ignores remote.*.fetch, so carry configured exclusions into argv explicitly.
+    // Git versions without negative-refspec support reject this before any ref mutation.
+    const negativeRefspecs = configuredRefspecs?.filter(isNegativeFetchRefspec) ?? [];
     const branchRefspecs = configuredRefspecs
       ? [
           ...new Set(
             configuredRefspecs.flatMap((refspec) => {
-              const normalized = refspec.trim();
-              if (normalized.startsWith("^")) {
-                // Keep exclusions out of explicit argv: supported Git versions apply configured
-                // negatives while older Git rejects the syntax. The positive mapping remains in
-                // argv so every configured non-tag destination is refreshed without CLI syntax.
-                return [];
-              }
-              if (!isTagFetchRefspec(refspec)) {
+              if (
+                !isNegativeFetchRefspec(refspec) &&
+                (!isTagFetchRefspec(refspec) ||
+                  (negativeRefspecs.length > 0 && isBroadFetchRefspec(refspec)))
+              ) {
                 return [refspec];
               }
-              return preserveBroadMappings && isBroadTagFetchRefspec(refspec) ? [refspec] : [];
+              return [];
             }),
           ),
         ]
@@ -181,7 +179,7 @@ export async function prepareStableGitFetch(params: {
       ...(configuredRefspecs ? ["--refmap="] : []),
       "--",
       remote,
-      ...(configuredRefspecs ? (branchRefspecs ?? []) : []),
+      ...(configuredRefspecs ? [...(branchRefspecs ?? []), ...negativeRefspecs] : []),
     ];
     const fetchStep = await executeStep(`git fetch ${remote}`, fetchArgv);
     if (fetchStep.exitCode !== 0) {

--- a/src/infra/update-runner-git-fetch.ts
+++ b/src/infra/update-runner-git-fetch.ts
@@ -9,6 +9,17 @@ import type {
 
 type RemoteFetchConfig = Map<string, string[]>;
 
+function isBroadRefspecMapping(source: string, destination: string): boolean {
+  const sourceWildcard = source.indexOf("*");
+  const destinationWildcard = destination.indexOf("*");
+  return (
+    sourceWildcard >= 0 &&
+    destinationWildcard >= 0 &&
+    source.slice(0, sourceWildcard) === "refs/" &&
+    destination.slice(0, destinationWildcard) === "refs/"
+  );
+}
+
 function parseRemoteFetchConfig(stdout: string): RemoteFetchConfig {
   const config: RemoteFetchConfig = new Map();
   for (const line of stdout.split("\n")) {
@@ -38,14 +49,22 @@ function isTagFetchRefspec(refspec: string): boolean {
 
   // A broad refs/*:refs/* mapping expands a tag source into refs/tags locally;
   // keep it out of the preliminary refresh so the canonical tag fetch owns updates.
-  const sourceWildcard = source.indexOf("*");
-  const destinationWildcard = destination.indexOf("*");
-  return (
-    sourceWildcard >= 0 &&
-    destinationWildcard >= 0 &&
-    source.slice(0, sourceWildcard) === "refs/" &&
-    destination.slice(0, destinationWildcard) === "refs/"
-  );
+  return isBroadRefspecMapping(source, destination);
+}
+
+function isFullTagNamespaceExclusion(refspec: string): boolean {
+  const normalized = refspec.trim();
+  return normalized === "^refs/tags" || normalized === "^refs/tags/*";
+}
+
+function isBroadTagFetchRefspec(refspec: string): boolean {
+  const withoutForce = refspec.trim().replace(/^\+/u, "");
+  const [source = "", destination = ""] = withoutForce.split(":", 2).map((ref) => ref.trim());
+  return isBroadRefspecMapping(source, destination);
+}
+
+function deriveRemoteTrackingBranchRefspec(remote: string): string {
+  return `+refs/heads/*:refs/remotes/${remote}/*`;
 }
 
 export type StableGitFetchResult = {
@@ -132,7 +151,28 @@ export async function prepareStableGitFetch(params: {
       continue;
     }
     const configuredRefspecs = fetchConfig.get(remote);
-    const branchRefspecs = configuredRefspecs?.filter((refspec) => !isTagFetchRefspec(refspec));
+    const preserveBroadMappings = configuredRefspecs?.some(isFullTagNamespaceExclusion) ?? false;
+    const branchRefspecs = configuredRefspecs
+      ? [
+          ...new Set(
+            configuredRefspecs.flatMap((refspec) => {
+              const normalized = refspec.trim();
+              if (normalized.startsWith("^")) {
+                // Keep exclusions out of explicit argv: supported Git versions apply configured
+                // negatives while older Git rejects the syntax. The derived branch mapping keeps
+                // this preliminary refresh tag-safe without relying on that CLI syntax.
+                return [];
+              }
+              if (!isTagFetchRefspec(refspec)) {
+                return [refspec];
+              }
+              return preserveBroadMappings && isBroadTagFetchRefspec(refspec)
+                ? [deriveRemoteTrackingBranchRefspec(remote)]
+                : [];
+            }),
+          ),
+        ]
+      : undefined;
     if (configuredRefspecs && branchRefspecs?.length === 0) {
       continue;
     }

--- a/src/infra/update-runner-git-fetch.ts
+++ b/src/infra/update-runner-git-fetch.ts
@@ -31,8 +31,8 @@ function isTagFetchRefspec(refspec: string): boolean {
   if (/^tag\s+\S+$/u.test(withoutForce)) {
     return true;
   }
-  const destination = withoutForce.split(":", 2)[1]?.trim() ?? "";
-  return destination === "refs/tags" || destination.startsWith("refs/tags/");
+  const [source = "", destination = ""] = withoutForce.split(":", 2).map((ref) => ref.trim());
+  return [source, destination].some((ref) => ref === "refs/tags" || ref.startsWith("refs/tags/"));
 }
 
 export type StableGitFetchResult = {
@@ -65,11 +65,24 @@ export async function prepareStableGitFetch(params: {
       results: steps,
     });
   const fetchConfigArgv = ["git", "-C", gitRoot, "config", "--get-regexp", "^remote\\..*\\.fetch$"];
-  const fetchConfigResult = await runCommand(fetchConfigArgv, { cwd: gitRoot, timeoutMs });
-  if (fetchConfigResult.code !== 0 && fetchConfigResult.code !== 1) {
+  let fetchConfigStdout = "";
+  const fetchConfigStep = await runStep({
+    runCommand: async (command, options) => {
+      const result = await runCommand(command, options);
+      fetchConfigStdout = result.stdout;
+      return result.code === 1 ? { ...result, code: 0 } : result;
+    },
+    name: "git config fetch refspecs",
+    argv: fetchConfigArgv,
+    cwd: gitRoot,
+    timeoutMs,
+    progress,
+    results: steps,
+  });
+  if (fetchConfigStep.exitCode !== 0) {
     return { reason: "fetch-failed" };
   }
-  const fetchConfig = parseRemoteFetchConfig(fetchConfigResult.stdout);
+  const fetchConfig = parseRemoteFetchConfig(fetchConfigStdout);
   const hasConfiguredTagRefspec = [...fetchConfig.values()].some((refspecs) =>
     refspecs.some(isTagFetchRefspec),
   );

--- a/src/infra/update-runner-git-fetch.ts
+++ b/src/infra/update-runner-git-fetch.ts
@@ -32,7 +32,20 @@ function isTagFetchRefspec(refspec: string): boolean {
     return true;
   }
   const [source = "", destination = ""] = withoutForce.split(":", 2).map((ref) => ref.trim());
-  return [source, destination].some((ref) => ref === "refs/tags" || ref.startsWith("refs/tags/"));
+  if ([source, destination].some((ref) => ref === "refs/tags" || ref.startsWith("refs/tags/"))) {
+    return true;
+  }
+
+  // A broad refs/*:refs/* mapping expands a tag source into refs/tags locally;
+  // keep it out of the preliminary refresh so the canonical tag fetch owns updates.
+  const sourceWildcard = source.indexOf("*");
+  const destinationWildcard = destination.indexOf("*");
+  return (
+    sourceWildcard >= 0 &&
+    destinationWildcard >= 0 &&
+    source.slice(0, sourceWildcard) === "refs/" &&
+    destination.slice(0, destinationWildcard) === "refs/"
+  );
 }
 
 export type StableGitFetchResult = {

--- a/src/infra/update-runner-git-fetch.ts
+++ b/src/infra/update-runner-git-fetch.ts
@@ -63,10 +63,6 @@ function isBroadTagFetchRefspec(refspec: string): boolean {
   return isBroadRefspecMapping(source, destination);
 }
 
-function deriveRemoteTrackingBranchRefspec(remote: string): string {
-  return `+refs/heads/*:refs/remotes/${remote}/*`;
-}
-
 export type StableGitFetchResult = {
   reason?: "fetch-failed";
   remotes?: string[];
@@ -159,16 +155,14 @@ export async function prepareStableGitFetch(params: {
               const normalized = refspec.trim();
               if (normalized.startsWith("^")) {
                 // Keep exclusions out of explicit argv: supported Git versions apply configured
-                // negatives while older Git rejects the syntax. The derived branch mapping keeps
-                // this preliminary refresh tag-safe without relying on that CLI syntax.
+                // negatives while older Git rejects the syntax. The positive mapping remains in
+                // argv so every configured non-tag destination is refreshed without CLI syntax.
                 return [];
               }
               if (!isTagFetchRefspec(refspec)) {
                 return [refspec];
               }
-              return preserveBroadMappings && isBroadTagFetchRefspec(refspec)
-                ? [deriveRemoteTrackingBranchRefspec(remote)]
-                : [];
+              return preserveBroadMappings && isBroadTagFetchRefspec(refspec) ? [refspec] : [];
             }),
           ),
         ]

--- a/src/infra/update-runner-git-preflight.ts
+++ b/src/infra/update-runner-git-preflight.ts
@@ -177,6 +177,7 @@ async function resolveExplicitTarget(params: {
               "fetch",
               "--no-prune",
               "--no-tags",
+              "--refmap=",
               "--",
               remote,
               `+${tagFetchRef}:${tagFetchRef}`,

--- a/src/infra/update-runner-git-preflight.ts
+++ b/src/infra/update-runner-git-preflight.ts
@@ -166,10 +166,21 @@ async function resolveExplicitTarget(params: {
       const remotes = normalizeStringEntries((remoteStep.stdoutTail ?? "").split("\n"));
       let fetchedTag = false;
       for (const remote of remotes) {
+        // Configured pruning must not delete unrelated tags while resolving one explicit target.
         const fetchStep = await runStep(
           params.step(
             `git fetch ${remote} ${tagFetchRef}`,
-            ["git", "-C", params.gitRoot, "fetch", remote, `+${tagFetchRef}:${tagFetchRef}`],
+            [
+              "git",
+              "-C",
+              params.gitRoot,
+              "fetch",
+              "--no-prune",
+              "--no-tags",
+              "--",
+              remote,
+              `+${tagFetchRef}:${tagFetchRef}`,
+            ],
             params.gitRoot,
           ),
         );

--- a/src/infra/update-runner-git-recovery.ts
+++ b/src/infra/update-runner-git-recovery.ts
@@ -114,8 +114,6 @@ export async function rebuildRolledBackGitRuntime(params: {
       argv: gitCleanCheckArgs(params.gitRoot),
       cwd: params.gitRoot,
       timeoutMs: params.timeoutMs,
-      stepIndex: 0,
-      totalSteps: 1,
       results: params.steps,
     });
     if (cleanCheck.exitCode !== 0) {

--- a/src/infra/update-runner-git-recovery.ts
+++ b/src/infra/update-runner-git-recovery.ts
@@ -44,8 +44,6 @@ export async function rebuildRolledBackGitRuntime(params: {
       cwd: params.gitRoot,
       timeoutMs: params.timeoutMs,
       env,
-      stepIndex: 0,
-      totalSteps: 1,
       results: params.steps,
     });
     return result.exitCode === 0;

--- a/src/infra/update-runner-git-target.ts
+++ b/src/infra/update-runner-git-target.ts
@@ -1,4 +1,3 @@
-import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import {
   parsePackageOpenClawSchemaVersions,
   type OpenClawSchemaVersions,
@@ -73,24 +72,10 @@ export async function readBranchName(
   return branch || null;
 }
 
-async function listGitTags(
-  runCommand: CommandRunner,
-  root: string,
-  timeoutMs: number,
-): Promise<string[]> {
-  const result = await runCommand(["git", "-C", root, "tag", "--list", "v*", "--sort=-v:refname"], {
-    timeoutMs,
-  }).catch(() => null);
-  return result?.code === 0 ? normalizeStringEntries(result.stdout.split("\n")) : [];
-}
-
-export async function resolveChannelTag(
-  runCommand: CommandRunner,
-  root: string,
-  timeoutMs: number,
+export function resolveChannelTag(
+  tags: string[],
   channel: Exclude<UpdateChannel, "dev">,
-): Promise<string | null> {
-  const tags = await listGitTags(runCommand, root, timeoutMs);
+): string | null {
   if (channel === "beta") {
     const betaTag = tags.find((tag) => isBetaTag(tag)) ?? null;
     const stableTag = tags.find((tag) => isStableTag(tag)) ?? null;

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -420,25 +420,34 @@ export async function updateGitCheckout(params: {
     if (!releaseRemote) {
       return buildError("fetch-failed");
     }
-    const remoteTagsResult = await runCommand(
-      [
-        "git",
-        "-C",
+    let remoteTagsOutput = "";
+    const remoteTagsStep = await runStep({
+      ...step(
+        `git ls-remote ${releaseRemote} tags`,
+        [
+          "git",
+          "-C",
+          gitRoot,
+          "ls-remote",
+          "--tags",
+          "--refs",
+          "--sort=-v:refname",
+          "--",
+          releaseRemote,
+          "v*",
+        ],
         gitRoot,
-        "ls-remote",
-        "--tags",
-        "--refs",
-        "--sort=-v:refname",
-        "--",
-        releaseRemote,
-        "v*",
-      ],
-      { cwd: gitRoot, timeoutMs },
-    );
-    if (remoteTagsResult.code !== 0) {
+      ),
+      runCommand: async (argv, options) => {
+        const result = await runCommand(argv, options);
+        remoteTagsOutput = result.stdout;
+        return result;
+      },
+    });
+    if (remoteTagsStep.exitCode !== 0) {
       return buildError("fetch-failed");
     }
-    const tag = resolveChannelTag(parseRemoteTagNames(remoteTagsResult.stdout), channel);
+    const tag = resolveChannelTag(parseRemoteTagNames(remoteTagsOutput), channel);
     if (!tag) {
       return buildError("no-release-tag");
     }

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -26,6 +26,7 @@ import {
   resolveInstallEnv,
   shouldInstallWithoutScriptsOnWindows,
 } from "./update-runner-git-commands.js";
+import { prepareStableGitFetch } from "./update-runner-git-fetch.js";
 import { runGitDevPreflight } from "./update-runner-git-preflight.js";
 import { rebuildRolledBackGitRuntime } from "./update-runner-git-recovery.js";
 import {
@@ -286,7 +287,7 @@ export async function updateGitCheckout(params: {
   }
 
   // Configured pruneTags must not turn this branch refresh into deletion of operator-local tags.
-  // Explicit tag refspecs in remote config retain their operator-declared pruning semantics.
+  // Explicit tag refspecs are excluded from the preliminary refresh and fetched only when selected.
   const fetchAllBranchesArgv = [
     "git",
     "-C",
@@ -390,15 +391,27 @@ export async function updateGitCheckout(params: {
       }
     }
   } else {
-    const fetchFailure = await runRequiredStep("git fetch", fetchAllBranchesArgv, "fetch-failed");
-    if (fetchFailure) {
-      return fetchFailure;
+    const stableFetch = await prepareStableGitFetch({
+      gitRoot,
+      timeoutMs,
+      runCommand,
+      progress: opts.progress,
+      steps,
+      fetchAllArgv: fetchAllBranchesArgv,
+    });
+    if (stableFetch.reason) {
+      return buildError(stableFetch.reason);
     }
-    const remoteStep = await runStep(step("git remote", ["git", "-C", gitRoot, "remote"], gitRoot));
-    if (remoteStep.exitCode !== 0) {
-      return buildError("fetch-failed");
+    let remotes = stableFetch.remotes;
+    if (!remotes) {
+      const remoteStep = await runStep(
+        step("git remote", ["git", "-C", gitRoot, "remote"], gitRoot),
+      );
+      if (remoteStep.exitCode !== 0) {
+        return buildError("fetch-failed");
+      }
+      remotes = normalizeStringEntries((remoteStep.stdoutTail ?? "").split("\n"));
     }
-    const remotes = normalizeStringEntries((remoteStep.stdoutTail ?? "").split("\n"));
     const mainRemoteStep = await runStep({
       ...step(
         "git config main remote",
@@ -414,16 +427,15 @@ export async function updateGitCheckout(params: {
       return buildError("fetch-failed");
     }
     const configuredMainRemote = mainRemoteStep.stdoutTail?.trim() ?? "";
-    let releaseRemote: string | null = null;
-    if (configuredMainRemote) {
-      if (configuredMainRemote !== "." && remotes.includes(configuredMainRemote)) {
-        releaseRemote = configuredMainRemote;
-      }
-    } else if (remotes.length === 1) {
-      releaseRemote = remotes.at(0) ?? null;
-    } else if (remotes.includes("origin")) {
-      releaseRemote = "origin";
-    }
+    const releaseRemote = configuredMainRemote
+      ? configuredMainRemote !== "." && remotes.includes(configuredMainRemote)
+        ? configuredMainRemote
+        : null
+      : remotes.length === 1
+        ? (remotes.at(0) ?? null)
+        : remotes.includes("origin")
+          ? "origin"
+          : null;
     if (!releaseRemote) {
       return buildError(
         !configuredMainRemote && remotes.length > 1 ? "ambiguous-release-remote" : "fetch-failed",

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -399,14 +399,21 @@ export async function updateGitCheckout(params: {
       return buildError("fetch-failed");
     }
     const remotes = normalizeStringEntries((remoteStep.stdoutTail ?? "").split("\n"));
-    const mainRemoteStep = await runCommand(
-      ["git", "-C", gitRoot, "config", "--get", `branch.${DEV_BRANCH}.remote`],
-      { cwd: gitRoot, timeoutMs },
-    );
-    if (mainRemoteStep.code !== 0 && mainRemoteStep.code !== 1) {
+    const mainRemoteStep = await runStep({
+      ...step(
+        "git config main remote",
+        ["git", "-C", gitRoot, "config", "--get", `branch.${DEV_BRANCH}.remote`],
+        gitRoot,
+      ),
+      runCommand: async (argv, options) => {
+        const result = await runCommand(argv, options);
+        return result.code === 1 ? { ...result, code: 0 } : result;
+      },
+    });
+    if (mainRemoteStep.exitCode !== 0) {
       return buildError("fetch-failed");
     }
-    const configuredMainRemote = mainRemoteStep.stdout.trim();
+    const configuredMainRemote = mainRemoteStep.stdoutTail?.trim() ?? "";
     let releaseRemote: string | null = null;
     if (configuredMainRemote) {
       if (configuredMainRemote !== "." && remotes.includes(configuredMainRemote)) {

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -85,9 +85,7 @@ export async function updateGitCheckout(params: {
   const devTarget = channel === "dev" ? opts.devTarget : undefined;
   const hasDevTarget = devTarget !== undefined;
   const needsCheckoutMain = channel === "dev" && !hasDevTarget && branch !== DEV_BRANCH;
-  const totalSteps = channel === "dev" ? (needsCheckoutMain ? 12 : 11) : 11;
   const steps: UpdateStepResult[] = [];
-  let stepIndex = 0;
   const step = (
     name: string,
     argv: string[],
@@ -101,8 +99,6 @@ export async function updateGitCheckout(params: {
     timeoutMs,
     env,
     progress: opts.progress,
-    stepIndex: stepIndex++,
-    totalSteps,
     results: steps,
   });
 
@@ -146,8 +142,6 @@ export async function updateGitCheckout(params: {
       argv,
       cwd: gitRoot,
       timeoutMs,
-      stepIndex: 0,
-      totalSteps: 1,
       results: steps,
     });
     return result.exitCode === 0;
@@ -162,8 +156,6 @@ export async function updateGitCheckout(params: {
       argv: ["git", "-C", gitRoot, "rev-parse", "HEAD"],
       cwd: gitRoot,
       timeoutMs,
-      stepIndex: 0,
-      totalSteps: 1,
       results: steps,
     });
     const verified = result.exitCode === 0 && result.stdoutTail?.trim() === beforeSha;
@@ -285,12 +277,20 @@ export async function updateGitCheckout(params: {
     return buildError("dirty", "skipped");
   }
 
+  // Configured pruneTags must not turn this branch refresh into deletion of operator-local tags.
+  // Explicit tag refspecs in remote config retain their operator-declared pruning semantics.
+  const fetchAllBranchesArgv = [
+    "git",
+    "-C",
+    gitRoot,
+    "fetch",
+    "--all",
+    "--prune",
+    "--no-prune-tags",
+    "--no-tags",
+  ];
   if (channel === "dev") {
-    const fetchFailure = await runRequiredStep(
-      "git fetch",
-      ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--no-tags"],
-      "fetch-failed",
-    );
+    const fetchFailure = await runRequiredStep("git fetch", fetchAllBranchesArgv, "fetch-failed");
     if (fetchFailure) {
       return fetchFailure;
     }
@@ -375,8 +375,6 @@ export async function updateGitCheckout(params: {
             argv: ["git", "-C", gitRoot, "rebase", "--abort"],
             cwd: gitRoot,
             timeoutMs,
-            stepIndex: 0,
-            totalSteps: 1,
             results: steps,
           });
           return await rollbackError("rebase-failed");
@@ -384,11 +382,7 @@ export async function updateGitCheckout(params: {
       }
     }
   } else {
-    const fetchFailure = await runRequiredStep(
-      "git fetch",
-      ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--no-tags"],
-      "fetch-failed",
-    );
+    const fetchFailure = await runRequiredStep("git fetch", fetchAllBranchesArgv, "fetch-failed");
     if (fetchFailure) {
       return fetchFailure;
     }
@@ -415,9 +409,20 @@ export async function updateGitCheckout(params: {
       if (skipConfig.stdout.trimEnd().split("\n").at(-1)?.endsWith(" true")) {
         continue;
       }
+      // Configured pruning must not delete unrelated tags during this forced tag refresh.
       const tagFetchFailure = await runRequiredStep(
         `git fetch ${remote} tags`,
-        ["git", "-C", gitRoot, "fetch", "--no-tags", "--", remote, "+refs/tags/*:refs/tags/*"],
+        [
+          "git",
+          "-C",
+          gitRoot,
+          "fetch",
+          "--no-prune",
+          "--no-tags",
+          "--",
+          remote,
+          "+refs/tags/*:refs/tags/*",
+        ],
         "fetch-failed",
       );
       if (tagFetchFailure) {
@@ -573,8 +578,6 @@ export async function updateGitCheckout(params: {
         cwd: gitRoot,
         timeoutMs,
         env: manager.env,
-        stepIndex: 0,
-        totalSteps: 1,
         results: steps,
       });
       if (repairStep.exitCode !== 0) {

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { escapeRegExp } from "../shared/regexp.js";
 import {
   resolveControlUiAssetHealth,
   resolveControlUiDistIndexPathForRoot,
@@ -390,44 +389,47 @@ export async function updateGitCheckout(params: {
     if (remoteStep.exitCode !== 0) {
       return buildError("fetch-failed");
     }
-    for (const remote of normalizeStringEntries((remoteStep.stdoutTail ?? "").split("\n"))) {
-      const skipConfig = await runCommand(
-        [
-          "git",
-          "-C",
-          gitRoot,
-          "config",
-          "--type=bool",
-          "--get-regexp",
-          `^remote\\.${escapeRegExp(remote)}\\.(skipfetchall|skipdefaultupdate)$`,
-        ],
-        { cwd: gitRoot, timeoutMs },
-      );
-      if (skipConfig.code !== 0 && skipConfig.code !== 1) {
-        return buildError("fetch-failed");
+    const remotes = normalizeStringEntries((remoteStep.stdoutTail ?? "").split("\n"));
+    const mainRemoteStep = await runCommand(
+      ["git", "-C", gitRoot, "config", "--get", `branch.${DEV_BRANCH}.remote`],
+      { cwd: gitRoot, timeoutMs },
+    );
+    if (mainRemoteStep.code !== 0 && mainRemoteStep.code !== 1) {
+      return buildError("fetch-failed");
+    }
+    const configuredMainRemote = mainRemoteStep.stdout.trim();
+    let releaseRemote: string | null = null;
+    if (configuredMainRemote) {
+      if (configuredMainRemote !== "." && remotes.includes(configuredMainRemote)) {
+        releaseRemote = configuredMainRemote;
       }
-      if (skipConfig.stdout.trimEnd().split("\n").at(-1)?.endsWith(" true")) {
-        continue;
-      }
-      // Configured pruning must not delete unrelated tags during this forced tag refresh.
-      const tagFetchFailure = await runRequiredStep(
-        `git fetch ${remote} tags`,
-        [
-          "git",
-          "-C",
-          gitRoot,
-          "fetch",
-          "--no-prune",
-          "--no-tags",
-          "--",
-          remote,
-          "+refs/tags/*:refs/tags/*",
-        ],
-        "fetch-failed",
-      );
-      if (tagFetchFailure) {
-        return tagFetchFailure;
-      }
+    } else if (remotes.length === 1) {
+      releaseRemote = remotes.at(0) ?? null;
+    } else if (remotes.includes("origin")) {
+      releaseRemote = "origin";
+    }
+    if (!releaseRemote) {
+      return buildError("fetch-failed");
+    }
+    // Only the main branch's source remote may force-update shared release tags.
+    // Configured pruning must not delete unrelated operator-local tags.
+    const tagFetchFailure = await runRequiredStep(
+      `git fetch ${releaseRemote} tags`,
+      [
+        "git",
+        "-C",
+        gitRoot,
+        "fetch",
+        "--no-prune",
+        "--no-tags",
+        "--",
+        releaseRemote,
+        "+refs/tags/*:refs/tags/*",
+      ],
+      "fetch-failed",
+    );
+    if (tagFetchFailure) {
+      return tagFetchFailure;
     }
     const tag = await resolveChannelTag(runCommand, gitRoot, timeoutMs, channel);
     if (!tag) {

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { escapeRegExp } from "../shared/regexp.js";
 import {
   resolveControlUiAssetHealth,
   resolveControlUiDistIndexPathForRoot,
@@ -83,7 +85,7 @@ export async function updateGitCheckout(params: {
   const devTarget = channel === "dev" ? opts.devTarget : undefined;
   const hasDevTarget = devTarget !== undefined;
   const needsCheckoutMain = channel === "dev" && !hasDevTarget && branch !== DEV_BRANCH;
-  const totalSteps = channel === "dev" ? (needsCheckoutMain ? 12 : 11) : 9;
+  const totalSteps = channel === "dev" ? (needsCheckoutMain ? 12 : 11) : 11;
   const steps: UpdateStepResult[] = [];
   let stepIndex = 0;
   const step = (
@@ -384,11 +386,43 @@ export async function updateGitCheckout(params: {
   } else {
     const fetchFailure = await runRequiredStep(
       "git fetch",
-      ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--tags"],
+      ["git", "-C", gitRoot, "fetch", "--all", "--prune", "--no-tags"],
       "fetch-failed",
     );
     if (fetchFailure) {
       return fetchFailure;
+    }
+    const remoteStep = await runStep(step("git remote", ["git", "-C", gitRoot, "remote"], gitRoot));
+    if (remoteStep.exitCode !== 0) {
+      return buildError("fetch-failed");
+    }
+    for (const remote of normalizeStringEntries((remoteStep.stdoutTail ?? "").split("\n"))) {
+      const skipConfig = await runCommand(
+        [
+          "git",
+          "-C",
+          gitRoot,
+          "config",
+          "--type=bool",
+          "--get-regexp",
+          `^remote\\.${escapeRegExp(remote)}\\.(skipfetchall|skipdefaultupdate)$`,
+        ],
+        { cwd: gitRoot, timeoutMs },
+      );
+      if (skipConfig.code !== 0 && skipConfig.code !== 1) {
+        return buildError("fetch-failed");
+      }
+      if (skipConfig.stdout.trimEnd().split("\n").at(-1)?.endsWith(" true")) {
+        continue;
+      }
+      const tagFetchFailure = await runRequiredStep(
+        `git fetch ${remote} tags`,
+        ["git", "-C", gitRoot, "fetch", "--no-tags", "--", remote, "+refs/tags/*:refs/tags/*"],
+        "fetch-failed",
+      );
+      if (tagFetchFailure) {
+        return tagFetchFailure;
+      }
     }
     const tag = await resolveChannelTag(runCommand, gitRoot, timeoutMs, channel);
     if (!tag) {

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -483,6 +483,7 @@ export async function updateGitCheckout(params: {
         "fetch",
         "--no-prune",
         "--no-tags",
+        "--refmap=",
         "--",
         releaseRemote,
         `+refs/tags/${tag}:refs/tags/${tag}`,

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -427,9 +427,10 @@ export async function updateGitCheckout(params: {
       return buildError("fetch-failed");
     }
     const configuredMainRemote = mainRemoteStep.stdoutTail?.trim() ?? "";
-    const releaseRemote = configuredMainRemote
-      ? configuredMainRemote !== "." && remotes.includes(configuredMainRemote)
-        ? configuredMainRemote
+    const configuredReleaseRemote = configuredMainRemote === "." ? "" : configuredMainRemote;
+    const releaseRemote = configuredReleaseRemote
+      ? remotes.includes(configuredReleaseRemote)
+        ? configuredReleaseRemote
         : null
       : remotes.length === 1
         ? (remotes.at(0) ?? null)
@@ -438,7 +439,9 @@ export async function updateGitCheckout(params: {
           : null;
     if (!releaseRemote) {
       return buildError(
-        !configuredMainRemote && remotes.length > 1 ? "ambiguous-release-remote" : "fetch-failed",
+        !configuredReleaseRemote && remotes.length > 1
+          ? "ambiguous-release-remote"
+          : "fetch-failed",
       );
     }
     let remoteTagsOutput = "";

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -425,7 +425,9 @@ export async function updateGitCheckout(params: {
       releaseRemote = "origin";
     }
     if (!releaseRemote) {
-      return buildError("fetch-failed");
+      return buildError(
+        !configuredMainRemote && remotes.length > 1 ? "ambiguous-release-remote" : "fetch-failed",
+      );
     }
     let remoteTagsOutput = "";
     const remoteTagsStep = await runStep({

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -52,6 +52,15 @@ async function readBuiltGatewayBuildId(gitRoot: string): Promise<string | null> 
   }
 }
 
+function parseRemoteTagNames(stdout: string): string[] {
+  return normalizeStringEntries(
+    stdout.split("\n").map((line) => {
+      const ref = line.trim().split(/\s+/u).at(1) ?? "";
+      return ref.startsWith("refs/tags/v") ? ref.slice("refs/tags/".length) : "";
+    }),
+  );
+}
+
 export async function updateGitCheckout(params: {
   opts: UpdateRunnerOptions;
   gitRoot: string;
@@ -411,10 +420,32 @@ export async function updateGitCheckout(params: {
     if (!releaseRemote) {
       return buildError("fetch-failed");
     }
-    // Only the main branch's source remote may force-update shared release tags.
+    const remoteTagsResult = await runCommand(
+      [
+        "git",
+        "-C",
+        gitRoot,
+        "ls-remote",
+        "--tags",
+        "--refs",
+        "--sort=-v:refname",
+        "--",
+        releaseRemote,
+        "v*",
+      ],
+      { cwd: gitRoot, timeoutMs },
+    );
+    if (remoteTagsResult.code !== 0) {
+      return buildError("fetch-failed");
+    }
+    const tag = resolveChannelTag(parseRemoteTagNames(remoteTagsResult.stdout), channel);
+    if (!tag) {
+      return buildError("no-release-tag");
+    }
+    // Only the selected release from the main branch's source remote may update the shared tag.
     // Configured pruning must not delete unrelated operator-local tags.
     const tagFetchFailure = await runRequiredStep(
-      `git fetch ${releaseRemote} tags`,
+      `git fetch ${releaseRemote} ${tag}`,
       [
         "git",
         "-C",
@@ -424,16 +455,12 @@ export async function updateGitCheckout(params: {
         "--no-tags",
         "--",
         releaseRemote,
-        "+refs/tags/*:refs/tags/*",
+        `+refs/tags/${tag}:refs/tags/${tag}`,
       ],
       "fetch-failed",
     );
     if (tagFetchFailure) {
       return tagFetchFailure;
-    }
-    const tag = await resolveChannelTag(runCommand, gitRoot, timeoutMs, channel);
-    if (!tag) {
-      return buildError("no-release-tag");
     }
     await prepareMutation(tag);
     const failure = await runRequiredStep(

--- a/src/infra/update-runner-global.ts
+++ b/src/infra/update-runner-global.ts
@@ -115,8 +115,6 @@ export async function runGlobalUpdate(params: {
         ...stepParams,
         cwd: stepParams.cwd ?? pkgRoot,
         progress: opts.progress,
-        stepIndex: 0,
-        totalSteps: 1,
       }),
     postVerifyStep: async (verifiedPackageRoot) => {
       const doctorEntry = await resolveGatewayInstallEntrypoint(verifiedPackageRoot);
@@ -148,8 +146,6 @@ export async function runGlobalUpdate(params: {
           compatibilityHostVersion: candidateHostVersion,
         }),
         progress: opts.progress,
-        stepIndex: 0,
-        totalSteps: 1,
       });
     },
   });

--- a/src/infra/update-runner-types.ts
+++ b/src/infra/update-runner-types.ts
@@ -111,8 +111,6 @@ export type CommandRunner = (
 export type UpdateStepInfo = {
   name: string;
   command: string;
-  index: number;
-  total: number;
 };
 
 type UpdateStepCompletion = UpdateStepInfo & Omit<UpdateStepResult, "cwd">;
@@ -157,7 +155,5 @@ export type RunStepOptions = {
   timeoutMs: number;
   env?: NodeJS.ProcessEnv;
   progress?: UpdateStepProgress;
-  stepIndex: number;
-  totalSteps: number;
   results?: UpdateStepResult[];
 };

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1039,6 +1039,24 @@ describe("runGatewayUpdate", () => {
     );
   });
 
+  it("refreshes recreated release tags for a mirror-style broad mapping", async () => {
+    const { localRoot, releaseSha, releaseTag } = await createRecreatedReleaseTagFixture();
+    await runRealGit(localRoot, "config", "--add", "remote.origin.fetch", "refs/*:refs/*");
+    const reachedMutation = new Error("reached release mutation");
+
+    await expect(
+      runWithCommand(createRealGitUpdateRunner(), {
+        cwd: localRoot,
+        channel: "stable",
+        beforeGitMutation: async () => {
+          throw reachedMutation;
+        },
+      }),
+    ).rejects.toBe(reachedMutation);
+
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(releaseSha);
+  });
+
   async function runWithCommand(
     runCommand: (
       argv: string[],

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -13,6 +13,7 @@ import { pathExists } from "../utils.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import type { UpdateChannel } from "./update-channels.js";
 import type { DevUpdateTarget } from "./update-dev-target.js";
+import type { UpdateStepProgress } from "./update-runner-types.js";
 import {
   resolveUpdateDoctorExecutionPolicy,
   resolveUpdateInstallSurface,
@@ -747,6 +748,26 @@ describe("runGatewayUpdate", () => {
     );
   });
 
+  it("reports ambiguous release remotes without mutating tags", async () => {
+    await setupGitCheckout();
+    const { runner, calls } = createRunner({
+      ...buildGitWorktreeProbeResponses(),
+      [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} remote`]: { stdout: "upstream\nbackup\n" },
+      [`git -C ${tempDir} config --get branch.main.remote`]: { code: 1 },
+    });
+
+    const result = await runWithRunner(runner, { channel: "stable" });
+
+    expect(result).toMatchObject({ status: "error", reason: "ambiguous-release-remote" });
+    expect(calls).not.toContain(
+      `git -C ${tempDir} ls-remote --tags --refs --sort=-v:refname -- upstream v*`,
+    );
+    expect(calls).not.toContain(
+      `git -C ${tempDir} fetch --no-prune --no-tags -- upstream +refs/tags/*:refs/tags/*`,
+    );
+  });
+
   it("keeps release tags scoped to the main remote when another remote disagrees", async () => {
     const { sourceRoot, localRoot, releaseSha, releaseTag } =
       await createRecreatedReleaseTagFixture();
@@ -778,6 +799,25 @@ describe("runGatewayUpdate", () => {
     await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.not.toBe(
       secondarySha,
     );
+  });
+
+  it("fails closed with an actionable reason when release remotes are ambiguous", async () => {
+    const { localRoot } = await createRecreatedReleaseTagFixture();
+    await runRealGit(localRoot, "remote", "rename", "origin", "upstream");
+    await runRealGit(localRoot, "config", "--unset", "branch.main.remote");
+
+    const result = await runWithCommand(createRealGitUpdateRunner(), {
+      cwd: localRoot,
+      channel: "stable",
+    });
+
+    expect(result).toMatchObject({ status: "error", reason: "ambiguous-release-remote" });
+    expect(result.steps.map((step) => step.name)).toEqual([
+      "clean check",
+      "git fetch",
+      "git remote",
+      "git config main remote",
+    ]);
   });
 
   it("keeps a configured non-tag non-fast-forward ref protected", async () => {
@@ -815,6 +855,7 @@ describe("runGatewayUpdate", () => {
       deferConfiguredPluginInstallRepair?: boolean;
       allowGatewayServiceRepair?: boolean;
       allowGatewayActivation?: boolean;
+      progress?: UpdateStepProgress;
       beforeGitMutation?: (target: {
         schemaVersions?: { state: number; agent: number };
       }) => Promise<{
@@ -837,6 +878,7 @@ describe("runGatewayUpdate", () => {
         ? {}
         : { allowGatewayServiceRepair: options.allowGatewayServiceRepair }),
       ...(options?.allowGatewayActivation ? { allowGatewayActivation: true } : {}),
+      ...(options?.progress ? { progress: options.progress } : {}),
       ...(options?.beforeGitMutation ? { beforeGitMutation: options.beforeGitMutation } : {}),
     });
   }
@@ -849,6 +891,7 @@ describe("runGatewayUpdate", () => {
       cwd?: string;
       devTarget?: DevUpdateTarget;
       deferConfiguredPluginInstallRepair?: boolean;
+      progress?: UpdateStepProgress;
       beforeGitMutation?: (target: {
         schemaVersions?: { state: number; agent: number };
       }) => Promise<{
@@ -1054,7 +1097,7 @@ describe("runGatewayUpdate", () => {
     { name: "target ref", options: { devTarget: { mode: "detached", ref: "main" } } },
   ] as const)("stops dev update when fetch fails before resolving $name", async ({ options }) => {
     await setupGitCheckout();
-    const fetchCommand = `git -C ${tempDir} fetch --all --prune --no-tags`;
+    const fetchCommand = `git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`;
     const { runner, calls } = createRunner({
       ...buildGitWorktreeProbeResponses(),
       [fetchCommand]: {
@@ -1082,7 +1125,7 @@ describe("runGatewayUpdate", () => {
     });
     const { runner, calls } = createRunner({
       ...buildGitWorktreeProbeResponses(),
-      [`git -C ${tempDir} fetch --all --prune --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
       [`git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`]: {
         stdout: "origin/main",
       },
@@ -1110,7 +1153,7 @@ describe("runGatewayUpdate", () => {
     expect(beforeGitMutation).toHaveBeenCalledWith({
       schemaVersions: { state: 3, agent: 11 },
     });
-    expect(calls).toContain(`git -C ${tempDir} fetch --all --prune --no-tags`);
+    expect(calls).toContain(`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`);
     expect(calls).not.toContain(`git -C ${tempDir} fetch --all --prune --tags`);
     const cleanupIndex = calls.findIndex(
       (call) =>
@@ -1171,7 +1214,7 @@ describe("runGatewayUpdate", () => {
     });
     const { runner } = createRunner({
       ...buildGitWorktreeProbeResponses(),
-      [`git -C ${tempDir} fetch --all --prune --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
       [`git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`]: {
         stdout: "origin/main",
       },
@@ -1198,7 +1241,7 @@ describe("runGatewayUpdate", () => {
     const beforeGitMutation = vi.fn<() => Promise<void>>();
     const { runner, calls } = createRunner({
       ...buildGitWorktreeProbeResponses({ branch: "feature" }),
-      [`git -C ${tempDir} fetch --all --prune --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
       [`git -C ${tempDir} show-ref --verify refs/heads/main`]: { stdout: "main\n" },
       [`git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name main@{upstream}`]: {
         code: 1,
@@ -1392,11 +1435,12 @@ describe("runGatewayUpdate", () => {
     const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
     const { runner, calls } = createRunner({
       ...buildGitWorktreeProbeResponses(),
-      [`git -C ${tempDir} fetch --all --prune --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
       [`git -C ${tempDir} remote`]: { stdout: "origin\n" },
-      [`git -C ${tempDir} fetch origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`]: {
-        stdout: "",
-      },
+      [`git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`]:
+        {
+          stdout: "",
+        },
       [`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2^{}`]: {
         stdout: `${targetSha}\n`,
       },
@@ -1417,10 +1461,10 @@ describe("runGatewayUpdate", () => {
     });
 
     expect(result.status).toBe("ok");
-    expect(calls).toContain(`git -C ${tempDir} fetch --all --prune --no-tags`);
+    expect(calls).toContain(`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`);
     expect(calls).not.toContain(`git -C ${tempDir} fetch --all --prune --tags`);
     expect(calls).toContain(
-      `git -C ${tempDir} fetch origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`,
+      `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`,
     );
     expect(calls).toContain(`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2^{}`);
   });
@@ -1429,12 +1473,13 @@ describe("runGatewayUpdate", () => {
     await setupGitCheckout();
     const { runner, calls } = createRunner({
       ...buildGitWorktreeProbeResponses(),
-      [`git -C ${tempDir} fetch --all --prune --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
       [`git -C ${tempDir} remote`]: { stdout: "origin\n" },
-      [`git -C ${tempDir} fetch origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`]: {
-        code: 1,
-        stderr: "would clobber existing tag",
-      },
+      [`git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`]:
+        {
+          code: 1,
+          stderr: "would clobber existing tag",
+        },
     });
 
     const result = await runWithRunner(runner, {
@@ -1445,7 +1490,7 @@ describe("runGatewayUpdate", () => {
     expect(result.status).toBe("error");
     expect(result.reason).toBe("no-target-sha");
     expect(calls).toContain(
-      `git -C ${tempDir} fetch origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`,
+      `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`,
     );
     expect(calls).not.toContain(`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2^{}`);
     expect(calls).not.toContain(`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2`);
@@ -2249,7 +2294,7 @@ describe("runGatewayUpdate", () => {
       calls.push(key);
       const responses = {
         ...buildGitWorktreeProbeResponses(),
-        [`git -C ${tempDir} fetch --all --prune --no-tags`]: { stdout: "" },
+        [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
         [`git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`]: {
           stdout: "origin/main",
         },
@@ -2330,7 +2375,7 @@ describe("runGatewayUpdate", () => {
       calls.push(key);
       const responses = {
         ...buildGitWorktreeProbeResponses(),
-        [`git -C ${tempDir} fetch --all --prune --no-tags`]: { stdout: "" },
+        [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
         [`git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`]: {
           stdout: "origin/main",
         },

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -592,6 +592,39 @@ describe("runGatewayUpdate", () => {
     await expect(runRealGit(localRoot, "rev-parse", localOnlyTag)).resolves.toBeTruthy();
   });
 
+  it("keeps release tags scoped to the main remote when another remote disagrees", async () => {
+    const { sourceRoot, localRoot, releaseSha, releaseTag } =
+      await createRecreatedReleaseTagFixture();
+    await runRealGit(localRoot, "remote", "rename", "origin", "upstream");
+    const secondaryRoot = await fixtureRootTracker.make("release-secondary");
+    await fs.rm(secondaryRoot, { recursive: true });
+    await runRealGit(path.dirname(secondaryRoot), "clone", "--quiet", sourceRoot, secondaryRoot);
+    await runRealGit(secondaryRoot, "config", "user.name", "OpenClaw Test");
+    await runRealGit(secondaryRoot, "config", "user.email", "openclaw@example.com");
+    await fs.writeFile(path.join(secondaryRoot, "README.md"), "secondary release\n");
+    await runRealGit(secondaryRoot, "add", "README.md");
+    await runRealGit(secondaryRoot, "commit", "-m", "secondary release");
+    const secondarySha = await runRealGit(secondaryRoot, "rev-parse", "HEAD");
+    await runRealGit(secondaryRoot, "tag", "--force", releaseTag);
+    await runRealGit(localRoot, "remote", "add", "zz-secondary", secondaryRoot);
+    const reachedMutation = new Error("reached release mutation");
+
+    await expect(
+      runWithCommand(createRealGitUpdateRunner(), {
+        cwd: localRoot,
+        channel: "stable",
+        beforeGitMutation: async () => {
+          throw reachedMutation;
+        },
+      }),
+    ).rejects.toBe(reachedMutation);
+
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(releaseSha);
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.not.toBe(
+      secondarySha,
+    );
+  });
+
   it("keeps a configured non-tag non-fast-forward ref protected", async () => {
     const { sourceRoot, localRoot, baseSha, releaseSha } = await createRecreatedReleaseTagFixture();
     await runRealGit(sourceRoot, "branch", "protected", releaseSha);

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -147,7 +147,7 @@ describe("runGatewayUpdate", () => {
       }
       if (
         key ===
-        `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/${params.stableTag}:refs/tags/${params.stableTag}`
+        `git -C ${tempDir} fetch --no-prune --no-tags --refmap= -- origin +refs/tags/${params.stableTag}:refs/tags/${params.stableTag}`
       ) {
         return { stdout: "", stderr: "", code: 0 };
       }
@@ -362,7 +362,7 @@ describe("runGatewayUpdate", () => {
     const tagOutput = tags.map((tag) => `${"a".repeat(40)}\trefs/tags/${tag}`).join("\n");
     const tagFetchResponses = Object.fromEntries(
       tags.map((tag) => [
-        `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/${tag}:refs/tags/${tag}`,
+        `git -C ${tempDir} fetch --no-prune --no-tags --refmap= -- origin +refs/tags/${tag}:refs/tags/${tag}`,
         { stdout: "" },
       ]),
     ) satisfies Record<string, CommandResponse>;
@@ -837,7 +837,7 @@ describe("runGatewayUpdate", () => {
       `git -C ${tempDir} ls-remote --tags --refs --sort=-v:refname -- upstream v*`,
     );
     expect(calls).not.toContain(
-      `git -C ${tempDir} fetch --no-prune --no-tags -- upstream +refs/tags/*:refs/tags/*`,
+      `git -C ${tempDir} fetch --no-prune --no-tags --refmap= -- upstream +refs/tags/*:refs/tags/*`,
     );
   });
 
@@ -887,10 +887,48 @@ describe("runGatewayUpdate", () => {
     expect(result).toMatchObject({ status: "error", reason: "ambiguous-release-remote" });
     expect(result.steps.map((step) => step.name)).toEqual([
       "clean check",
+      "git config fetch refspecs",
       "git fetch",
       "git remote",
       "git config main remote",
     ]);
+  });
+
+  it("records fetch-config probe failures in steps and progress", async () => {
+    await setupGitCheckout();
+    const onStepStart = vi.fn();
+    const onStepComplete = vi.fn();
+    const { runner } = createRunner({
+      ...buildGitWorktreeProbeResponses(),
+      [`git -C ${tempDir} config --get-regexp ^remote\\..*\\.fetch$`]: {
+        code: 128,
+        stderr: "fatal: bad config line",
+      },
+    });
+
+    const result = await runWithRunner(runner, {
+      channel: "stable",
+      progress: { onStepStart, onStepComplete },
+    });
+
+    expect(result).toMatchObject({ status: "error", reason: "fetch-failed" });
+    expect(result.steps).toContainEqual(
+      expect.objectContaining({
+        name: "git config fetch refspecs",
+        exitCode: 128,
+        stderrTail: "fatal: bad config line",
+      }),
+    );
+    expect(onStepStart).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "git config fetch refspecs" }),
+    );
+    expect(onStepComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "git config fetch refspecs",
+        exitCode: 128,
+        stderrTail: "fatal: bad config line",
+      }),
+    );
   });
 
   it("keeps a configured non-tag non-fast-forward ref protected", async () => {
@@ -913,6 +951,41 @@ describe("runGatewayUpdate", () => {
 
     expect(result).toMatchObject({ status: "error", reason: "fetch-failed" });
     await expect(runRealGit(localRoot, "rev-parse", "protected-cache")).resolves.toBe(releaseSha);
+  });
+
+  it("refreshes recreated release tags when a tag source maps to a local branch", async () => {
+    const { localRoot, baseSha, releaseSha, releaseTag } = await createRecreatedReleaseTagFixture();
+    await runRealGit(localRoot, "branch", "release", baseSha);
+    await runRealGit(
+      localRoot,
+      "config",
+      "--add",
+      "remote.origin.fetch",
+      `refs/tags/${releaseTag}:refs/heads/release`,
+    );
+    const reachedMutation = new Error("reached release mutation");
+    const realRunner = createRealGitUpdateRunner();
+
+    await expect(
+      runWithCommand(
+        async (argv, options) => {
+          return await realRunner(argv, options);
+        },
+        {
+          cwd: localRoot,
+          channel: "stable",
+          beforeGitMutation: async () => {
+            throw reachedMutation;
+          },
+        },
+      ),
+    ).rejects.toBe(reachedMutation);
+
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(releaseSha);
+    await expect(runRealGit(localRoot, "rev-parse", "refs/remotes/origin/main")).resolves.toBe(
+      releaseSha,
+    );
+    await expect(runRealGit(localRoot, "rev-parse", "refs/heads/release")).resolves.toBe(baseSha);
   });
 
   it("refreshes remote-tracking refs for a broad configured mapping", async () => {
@@ -1544,7 +1617,7 @@ describe("runGatewayUpdate", () => {
       ...buildGitWorktreeProbeResponses(),
       [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
       [`git -C ${tempDir} remote`]: { stdout: "origin\n" },
-      [`git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`]:
+      [`git -C ${tempDir} fetch --no-prune --no-tags --refmap= -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`]:
         {
           stdout: "",
         },
@@ -1571,7 +1644,7 @@ describe("runGatewayUpdate", () => {
     expect(calls).toContain(`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`);
     expect(calls).not.toContain(`git -C ${tempDir} fetch --all --prune --tags`);
     expect(calls).toContain(
-      `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`,
+      `git -C ${tempDir} fetch --no-prune --no-tags --refmap= -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`,
     );
     expect(calls).toContain(`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2^{}`);
   });
@@ -1582,7 +1655,7 @@ describe("runGatewayUpdate", () => {
       ...buildGitWorktreeProbeResponses(),
       [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
       [`git -C ${tempDir} remote`]: { stdout: "origin\n" },
-      [`git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`]:
+      [`git -C ${tempDir} fetch --no-prune --no-tags --refmap= -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`]:
         {
           code: 1,
           stderr: "would clobber existing tag",
@@ -1597,7 +1670,7 @@ describe("runGatewayUpdate", () => {
     expect(result.status).toBe("error");
     expect(result.reason).toBe("no-target-sha");
     expect(calls).toContain(
-      `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`,
+      `git -C ${tempDir} fetch --no-prune --no-tags --refmap= -- origin +refs/tags/v2026.5.19-beta.2:refs/tags/v2026.5.19-beta.2`,
     );
     expect(calls).not.toContain(`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2^{}`);
     expect(calls).not.toContain(`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2`);
@@ -4038,7 +4111,7 @@ describe("runGatewayUpdate", () => {
         }
         if (
           key ===
-          `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/${stableTag}:refs/tags/${stableTag}`
+          `git -C ${tempDir} fetch --no-prune --no-tags --refmap= -- origin +refs/tags/${stableTag}:refs/tags/${stableTag}`
         ) {
           return toCommandResult();
         }

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -125,6 +125,23 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} rev-parse HEAD`) {
         return { stdout: "abc123", stderr: "", code: 0 };
       }
+      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} remote`) {
+        return { stdout: "origin\n", stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} config --get branch.main.remote`) {
+        return { stdout: "origin\n", stderr: "", code: 0 };
+      }
+      if (
+        key === `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/*:refs/tags/*`
+      ) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
       if (key === `git -C ${tempDir} tag --list v* --sort=-v:refname`) {
         return { stdout: `${params.stableTag}\n`, stderr: "", code: 0 };
       }
@@ -332,7 +349,12 @@ describe("runGatewayUpdate", () => {
       [`git -C ${tempDir} rev-parse --show-toplevel`]: { stdout: tempDir },
       [`git -C ${tempDir} rev-parse HEAD`]: { stdout: "abc123" },
       [`git -C ${tempDir} status --porcelain -- :!dist/control-ui/`]: { stdout: "" },
-      [`git -C ${tempDir} fetch --all --prune --tags`]: { stdout: "" },
+      [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} remote`]: { stdout: "origin\n" },
+      [`git -C ${tempDir} config --get branch.main.remote`]: { stdout: "origin\n" },
+      [`git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/*:refs/tags/*`]: {
+        stdout: "",
+      },
       [`git -C ${tempDir} tag --list v* --sort=-v:refname`]: { stdout: `${tagOutput}\n` },
       [`git -C ${tempDir} checkout --detach ${stableTag}`]: { stdout: "" },
     };
@@ -1316,7 +1338,6 @@ describe("runGatewayUpdate", () => {
         [`git -C ${tempDir} rev-list --max-count=10 upstream123`]: { stdout: "upstream123\n" },
         [`git -C ${tempDir} rev-parse refs/tags/v2026.5.19-beta.2^{}`]: { stdout: "upstream123" },
       });
-
       const result = await runWithRunner(runner, { ...options, beforeGitMutation });
 
       expect(result.status).toBe("error");
@@ -1326,6 +1347,27 @@ describe("runGatewayUpdate", () => {
       expect(calls.some((call) => call.includes(" worktree add "))).toBe(false);
     },
   );
+
+  it("aborts rebase on failure", async () => {
+    await setupGitCheckout();
+    const { runner, calls } = createRunner({
+      ...buildGitWorktreeProbeResponses(),
+      [`git -C ${tempDir} rev-parse --abbrev-ref --symbolic-full-name @{upstream}`]: {
+        stdout: "origin/main",
+      },
+      [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} rev-parse @{upstream}`]: { stdout: "upstream123" },
+      [`git -C ${tempDir} rev-list --max-count=10 upstream123`]: { stdout: "upstream123\n" },
+      [`git -C ${tempDir} rebase upstream123`]: { code: 1, stderr: "conflict" },
+      [`git -C ${tempDir} rebase --abort`]: { stdout: "" },
+    });
+
+    const result = await runWithRunner(runner);
+
+    expect(result.status).toBe("error");
+    expect(result.reason).toBe("rebase-failed");
+    expect(calls.filter((call) => call.includes("rebase --abort"))).not.toEqual([]);
+  });
 
   it.each([
     { operation: "rebase", rollbackSucceeds: true },
@@ -3691,6 +3733,23 @@ describe("runGatewayUpdate", () => {
         }
         if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
           return toCommandResult({ stdout: "main\n" });
+        }
+        if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
+          return toCommandResult();
+        }
+        if (key === `git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`) {
+          return toCommandResult();
+        }
+        if (key === `git -C ${tempDir} remote`) {
+          return toCommandResult({ stdout: "origin\n" });
+        }
+        if (key === `git -C ${tempDir} config --get branch.main.remote`) {
+          return toCommandResult({ stdout: "origin\n" });
+        }
+        if (
+          key === `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/*:refs/tags/*`
+        ) {
+          return toCommandResult();
         }
         if (key === `git -C ${tempDir} tag --list v* --sort=-v:refname`) {
           return toCommandResult({ stdout: `${stableTag}\n` });

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -894,6 +894,23 @@ describe("runGatewayUpdate", () => {
     ]);
   });
 
+  it("uses the sole remote when main tracks the local repository", async () => {
+    const { localRoot } = await createRecreatedReleaseTagFixture();
+    await runRealGit(localRoot, "remote", "remove", "skipped");
+    await runRealGit(localRoot, "config", "branch.main.remote", ".");
+    const reachedMutation = new Error("reached release mutation");
+
+    await expect(
+      runWithCommand(createRealGitUpdateRunner(), {
+        cwd: localRoot,
+        channel: "stable",
+        beforeGitMutation: async () => {
+          throw reachedMutation;
+        },
+      }),
+    ).rejects.toBe(reachedMutation);
+  });
+
   it("records fetch-config probe failures in steps and progress", async () => {
     await setupGitCheckout();
     const onStepStart = vi.fn();

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -14,7 +14,7 @@ import { resolveStableNodePath } from "./stable-node-path.js";
 import type { UpdateChannel } from "./update-channels.js";
 import type { DevUpdateTarget } from "./update-dev-target.js";
 import { prepareStableGitFetch } from "./update-runner-git-fetch.js";
-import type { UpdateStepProgress } from "./update-runner-types.js";
+import type { UpdateStepProgress, UpdateStepResult } from "./update-runner-types.js";
 import {
   resolveUpdateDoctorExecutionPolicy,
   resolveUpdateInstallSurface,
@@ -1061,7 +1061,7 @@ describe("runGatewayUpdate", () => {
   it("preserves tag-excluded mirror mappings during branch refresh", async () => {
     const { localRoot, baseSha, releaseSha, releaseTag } = await createRecreatedReleaseTagFixture();
     await runRealGit(localRoot, "config", "--add", "remote.origin.fetch", "refs/*:refs/*");
-    const steps = [];
+    const steps: UpdateStepResult[] = [];
     const realRunner = createRealGitUpdateRunner();
     const runCommand = async (argv: string[], options?: { cwd?: string; timeoutMs?: number }) => {
       if (argv[3] === "config" && argv.at(-1) === "^remote\\..*\\.fetch$") {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -521,7 +521,8 @@ describe("runGatewayUpdate", () => {
   async function createTrackedGitFixture(detached: boolean) {
     const sourceRoot = await fixtureRootTracker.make("tracked-source");
     const localRoot = await fixtureRootTracker.make("tracked-local");
-    await runRealGit(sourceRoot, "init", "--initial-branch=main");
+    await runRealGit(sourceRoot, "init");
+    await runRealGit(sourceRoot, "checkout", "-b", "main");
     await runRealGit(sourceRoot, "config", "user.name", "OpenClaw Test");
     await runRealGit(sourceRoot, "config", "user.email", "openclaw@example.com");
     await fs.writeFile(
@@ -552,7 +553,8 @@ describe("runGatewayUpdate", () => {
     const missingRemote = path.join(await fixtureRootTracker.make("release-missing"), "gone.git");
     const releaseTag = "v1.0.0";
     const localOnlyTag = "local-operator-tag";
-    await runRealGit(sourceRoot, "init", "--initial-branch=main");
+    await runRealGit(sourceRoot, "init");
+    await runRealGit(sourceRoot, "checkout", "-b", "main");
     await runRealGit(sourceRoot, "config", "user.name", "OpenClaw Test");
     await runRealGit(sourceRoot, "config", "user.email", "openclaw@example.com");
     await fs.writeFile(
@@ -617,6 +619,35 @@ describe("runGatewayUpdate", () => {
   it("refreshes a recreated release tag without fetching skipped remotes or pruning local tags", async () => {
     const { localRoot, releaseSha, releaseTag, localOnlyTag } =
       await createRecreatedReleaseTagFixture();
+    const reachedMutation = new Error("reached release mutation");
+
+    await expect(
+      runWithCommand(createRealGitUpdateRunner(), {
+        cwd: localRoot,
+        channel: "stable",
+        beforeGitMutation: async () => {
+          throw reachedMutation;
+        },
+      }),
+    ).rejects.toBe(reachedMutation);
+
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(releaseSha);
+    await expect(runRealGit(localRoot, "rev-parse", "refs/remotes/origin/main")).resolves.toBe(
+      releaseSha,
+    );
+    await expect(runRealGit(localRoot, "rev-parse", localOnlyTag)).resolves.toBeTruthy();
+  });
+
+  it("refreshes recreated release tags when a remote tag refspec is configured", async () => {
+    const { localRoot, releaseSha, releaseTag, localOnlyTag } =
+      await createRecreatedReleaseTagFixture();
+    await runRealGit(
+      localRoot,
+      "config",
+      "--add",
+      "remote.origin.fetch",
+      "refs/tags/*:refs/tags/*",
+    );
     const reachedMutation = new Error("reached release mutation");
 
     await expect(

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -13,7 +13,8 @@ import { pathExists } from "../utils.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import type { UpdateChannel } from "./update-channels.js";
 import type { DevUpdateTarget } from "./update-dev-target.js";
-import type { UpdateStepProgress } from "./update-runner-types.js";
+import { prepareStableGitFetch } from "./update-runner-git-fetch.js";
+import type { UpdateStepProgress, UpdateStepResult } from "./update-runner-types.js";
 import {
   resolveUpdateDoctorExecutionPolicy,
   resolveUpdateInstallSurface,
@@ -667,6 +668,37 @@ describe("runGatewayUpdate", () => {
     await expect(runRealGit(localRoot, "rev-parse", localOnlyTag)).resolves.toBeTruthy();
   });
 
+  it("excludes Git tag shorthand from the preliminary branch refresh", async () => {
+    const calls: string[] = [];
+    const steps: UpdateStepResult[] = [];
+    const runCommand = async (argv: string[]): Promise<CommandResult> => {
+      const key = argv.join(" ");
+      calls.push(key);
+      if (argv[3] === "config" && argv.at(-1) === "^remote\\..*\\.fetch$") {
+        return { stdout: "remote.origin.fetch tag v1.0.0\n", stderr: "", code: 0 };
+      }
+      if (argv[3] === "remote") {
+        return { stdout: "origin\n", stderr: "", code: 0 };
+      }
+      if (argv[3] === "config" && argv.at(-1)?.includes("skipfetchall")) {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      throw new Error(`unexpected command: ${key}`);
+    };
+
+    await expect(
+      prepareStableGitFetch({
+        gitRoot: tempDir,
+        timeoutMs: 1000,
+        runCommand,
+        steps,
+        fetchAllArgv: ["git", "-C", tempDir, "fetch", "--all"],
+      }),
+    ).resolves.toEqual({ remotes: ["origin"] });
+    expect(calls).not.toContain(`git -C ${tempDir} fetch --all`);
+    expect(calls).not.toContain(`git -C ${tempDir} fetch origin`);
+  });
+
   it("selects stable releases from the main remote instead of local release-shaped tags", async () => {
     const { localRoot, baseSha, releaseSha, releaseTag } = await createRecreatedReleaseTagFixture();
     const localTag = "v9999.1.0";
@@ -871,6 +903,33 @@ describe("runGatewayUpdate", () => {
 
     expect(result).toMatchObject({ status: "error", reason: "fetch-failed" });
     await expect(runRealGit(localRoot, "rev-parse", "protected-cache")).resolves.toBe(releaseSha);
+  });
+
+  it("refreshes remote-tracking refs for a broad configured mapping", async () => {
+    const { localRoot, releaseSha, releaseTag } = await createRecreatedReleaseTagFixture();
+    await runRealGit(
+      localRoot,
+      "config",
+      "--add",
+      "remote.origin.fetch",
+      "refs/*:refs/remotes/origin/*",
+    );
+    const reachedMutation = new Error("reached release mutation");
+
+    await expect(
+      runWithCommand(createRealGitUpdateRunner(), {
+        cwd: localRoot,
+        channel: "stable",
+        beforeGitMutation: async () => {
+          throw reachedMutation;
+        },
+      }),
+    ).rejects.toBe(reachedMutation);
+
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(releaseSha);
+    await expect(runRealGit(localRoot, "rev-parse", "refs/remotes/origin/main")).resolves.toBe(
+      releaseSha,
+    );
   });
 
   async function runWithCommand(

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -502,9 +502,43 @@ describe("runGatewayUpdate", () => {
     return { sourceRoot, localRoot, baseSha, targetSha };
   }
 
+  async function createRecreatedReleaseTagFixture() {
+    const sourceRoot = await fixtureRootTracker.make("release-source");
+    const localRoot = await fixtureRootTracker.make("release-local");
+    const missingRemote = path.join(await fixtureRootTracker.make("release-missing"), "gone.git");
+    const releaseTag = "v1.0.0";
+    const localOnlyTag = "local-operator-tag";
+    await runRealGit(sourceRoot, "init", "--initial-branch=main");
+    await runRealGit(sourceRoot, "config", "user.name", "OpenClaw Test");
+    await runRealGit(sourceRoot, "config", "user.email", "openclaw@example.com");
+    await fs.writeFile(
+      path.join(sourceRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "1.0.0", packageManager: "pnpm@10.0.0" }),
+    );
+    await fs.writeFile(path.join(sourceRoot, "openclaw.mjs"), "export {};\n");
+    await fs.writeFile(path.join(sourceRoot, "README.md"), "base\n");
+    await runRealGit(sourceRoot, "add", "package.json", "openclaw.mjs", "README.md");
+    await runRealGit(sourceRoot, "commit", "-m", "base");
+    const baseSha = await runRealGit(sourceRoot, "rev-parse", "HEAD");
+    await runRealGit(sourceRoot, "tag", releaseTag);
+    await runRealGit(path.dirname(localRoot), "clone", "--quiet", sourceRoot, localRoot);
+    await runRealGit(localRoot, "tag", localOnlyTag, baseSha);
+    await runRealGit(localRoot, "remote", "add", "skipped", missingRemote);
+    await runRealGit(localRoot, "config", "remote.skipped.skipFetchAll", "false");
+    await runRealGit(localRoot, "config", "remote.skipped.skipDefaultUpdate", "true");
+
+    await fs.writeFile(path.join(sourceRoot, "README.md"), "release\n");
+    await runRealGit(sourceRoot, "add", "README.md");
+    await runRealGit(sourceRoot, "commit", "-m", "release");
+    const releaseSha = await runRealGit(sourceRoot, "rev-parse", "HEAD");
+    await runRealGit(sourceRoot, "tag", "--force", releaseTag);
+
+    return { sourceRoot, localRoot, baseSha, releaseSha, releaseTag, localOnlyTag };
+  }
+
   function createRealGitUpdateRunner(params: { finalHead?: { root: string; sha: string } } = {}) {
     let headReads = 0;
-    return async (argv: string[], options: { cwd?: string; timeoutMs?: number }) => {
+    return async (argv: string[], options?: { cwd?: string; timeoutMs?: number }) => {
       if (argv[0] === "git") {
         const finalHead = params.finalHead;
         if (
@@ -519,15 +553,15 @@ describe("runGatewayUpdate", () => {
           }
         }
         return await runCommandWithTimeout(argv, {
-          cwd: options.cwd,
-          timeoutMs: options.timeoutMs ?? 5000,
+          cwd: options?.cwd,
+          timeoutMs: options?.timeoutMs ?? 5000,
         });
       }
       if (argv[0] === "pnpm" && argv[1] === "--version") {
         return toCommandResult({ stdout: PNPM_VERSION });
       }
       if (argv[0] === "pnpm" && (argv[1] === "build" || argv[1] === "ui:build")) {
-        const cwd = options.cwd ?? process.cwd();
+        const cwd = options?.cwd ?? process.cwd();
         const uiDir = path.join(cwd, "dist", "control-ui");
         await fs.mkdir(uiDir, { recursive: true });
         await fs.writeFile(path.join(uiDir, "index.html"), "ok\n");
@@ -535,6 +569,50 @@ describe("runGatewayUpdate", () => {
       return toCommandResult();
     };
   }
+
+  it("refreshes a recreated release tag without fetching skipped remotes or pruning local tags", async () => {
+    const { localRoot, releaseSha, releaseTag, localOnlyTag } =
+      await createRecreatedReleaseTagFixture();
+    const reachedMutation = new Error("reached release mutation");
+
+    await expect(
+      runWithCommand(createRealGitUpdateRunner(), {
+        cwd: localRoot,
+        channel: "stable",
+        beforeGitMutation: async () => {
+          throw reachedMutation;
+        },
+      }),
+    ).rejects.toBe(reachedMutation);
+
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(releaseSha);
+    await expect(runRealGit(localRoot, "rev-parse", "refs/remotes/origin/main")).resolves.toBe(
+      releaseSha,
+    );
+    await expect(runRealGit(localRoot, "rev-parse", localOnlyTag)).resolves.toBeTruthy();
+  });
+
+  it("keeps a configured non-tag non-fast-forward ref protected", async () => {
+    const { sourceRoot, localRoot, baseSha, releaseSha } = await createRecreatedReleaseTagFixture();
+    await runRealGit(sourceRoot, "branch", "protected", releaseSha);
+    await runRealGit(
+      localRoot,
+      "config",
+      "--add",
+      "remote.origin.fetch",
+      "refs/heads/protected:refs/heads/protected-cache",
+    );
+    await runRealGit(localRoot, "fetch", "--no-tags", "origin");
+    await runRealGit(sourceRoot, "branch", "--force", "protected", baseSha);
+
+    const result = await runWithCommand(createRealGitUpdateRunner(), {
+      cwd: localRoot,
+      channel: "stable",
+    });
+
+    expect(result).toMatchObject({ status: "error", reason: "fetch-failed" });
+    await expect(runRealGit(localRoot, "rev-parse", "protected-cache")).resolves.toBe(releaseSha);
+  });
 
   async function runWithCommand(
     runCommand: (

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -705,6 +705,48 @@ describe("runGatewayUpdate", () => {
     );
   });
 
+  it("records main remote configuration failures in steps and progress", async () => {
+    await setupGitCheckout();
+    const onStepStart = vi.fn();
+    const onStepComplete = vi.fn();
+    const { runner, calls } = createRunner({
+      ...buildGitWorktreeProbeResponses(),
+      [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} remote`]: { stdout: "origin\n" },
+      [`git -C ${tempDir} config --get branch.main.remote`]: {
+        code: 128,
+        stderr: "fatal: bad config line",
+      },
+    });
+
+    const result = await runWithRunner(runner, {
+      channel: "stable",
+      progress: { onStepStart, onStepComplete },
+    });
+
+    expect(result).toMatchObject({ status: "error", reason: "fetch-failed" });
+    expect(result.steps).toContainEqual(
+      expect.objectContaining({
+        name: "git config main remote",
+        exitCode: 128,
+        stderrTail: "fatal: bad config line",
+      }),
+    );
+    expect(onStepStart).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "git config main remote" }),
+    );
+    expect(onStepComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "git config main remote",
+        exitCode: 128,
+        stderrTail: "fatal: bad config line",
+      }),
+    );
+    expect(calls).not.toContain(
+      `git -C ${tempDir} ls-remote --tags --refs --sort=-v:refname -- origin v*`,
+    );
+  });
+
   it("keeps release tags scoped to the main remote when another remote disagrees", async () => {
     const { sourceRoot, localRoot, releaseSha, releaseTag } =
       await createRecreatedReleaseTagFixture();

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -13,6 +13,7 @@ import { pathExists } from "../utils.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import type { UpdateChannel } from "./update-channels.js";
 import type { DevUpdateTarget } from "./update-dev-target.js";
+import { prepareStableGitFetch } from "./update-runner-git-fetch.js";
 import type { UpdateStepProgress } from "./update-runner-types.js";
 import {
   resolveUpdateDoctorExecutionPolicy,
@@ -1055,6 +1056,56 @@ describe("runGatewayUpdate", () => {
     ).rejects.toBe(reachedMutation);
 
     await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(releaseSha);
+  });
+
+  it("preserves tag-excluded mirror mappings during branch refresh", async () => {
+    const { localRoot, baseSha, releaseSha, releaseTag } = await createRecreatedReleaseTagFixture();
+    await runRealGit(localRoot, "config", "--add", "remote.origin.fetch", "refs/*:refs/*");
+    const steps = [];
+    const realRunner = createRealGitUpdateRunner();
+    const runCommand = async (argv: string[], options?: { cwd?: string; timeoutMs?: number }) => {
+      if (argv[3] === "config" && argv.at(-1) === "^remote\\..*\\.fetch$") {
+        // Git 2.27 accepts this value in config but rejects negative refspecs when fetching;
+        // synthesize the supported-config report while keeping the real fetch path exercised.
+        return toCommandResult({
+          stdout:
+            "remote.origin.fetch +refs/heads/*:refs/remotes/origin/*\n" +
+            "remote.origin.fetch refs/*:refs/*\n" +
+            "remote.origin.fetch ^refs/tags/*\n",
+        });
+      }
+      return await realRunner(argv, options);
+    };
+
+    const result = await prepareStableGitFetch({
+      gitRoot: localRoot,
+      timeoutMs: 5000,
+      runCommand,
+      steps,
+      fetchAllArgv: [
+        "git",
+        "-C",
+        localRoot,
+        "fetch",
+        "--all",
+        "--prune",
+        "--no-prune-tags",
+        "--no-tags",
+      ],
+    });
+
+    expect(result).toMatchObject({ remotes: ["origin", "skipped"] });
+    await expect(runRealGit(localRoot, "rev-parse", "refs/remotes/origin/main")).resolves.toBe(
+      releaseSha,
+    );
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(baseSha);
+    expect(steps).toContainEqual(
+      expect.objectContaining({
+        name: "git fetch origin",
+        command: expect.stringContaining("refs/heads/*:refs/remotes/origin/*"),
+        exitCode: 0,
+      }),
+    );
   });
 
   async function runWithCommand(

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1059,8 +1059,10 @@ describe("runGatewayUpdate", () => {
   });
 
   it("preserves tag-excluded mirror mappings during branch refresh", async () => {
-    const { localRoot, baseSha, releaseSha, releaseTag } = await createRecreatedReleaseTagFixture();
+    const { sourceRoot, localRoot, baseSha, releaseSha, releaseTag } =
+      await createRecreatedReleaseTagFixture();
     await runRealGit(localRoot, "config", "--add", "remote.origin.fetch", "refs/*:refs/*");
+    await runRealGit(sourceRoot, "notes", "--ref=ops", "add", "-m", "remote note", releaseSha);
     const steps: UpdateStepResult[] = [];
     const realRunner = createRealGitUpdateRunner();
     const runCommand = async (argv: string[], options?: { cwd?: string; timeoutMs?: number }) => {
@@ -1073,6 +1075,13 @@ describe("runGatewayUpdate", () => {
             "remote.origin.fetch refs/*:refs/*\n" +
             "remote.origin.fetch ^refs/tags/*\n",
         });
+      }
+      if (argv[3] === "fetch" && argv.includes("refs/*:refs/*")) {
+        // Expand the tag-excluded mirror mapping into equivalent non-tag namespaces for Git 2.27;
+        // the planner's original command remains recorded in `steps` for assertion below.
+        const safeArgv = argv.filter((arg) => arg !== "refs/*:refs/*");
+        safeArgv.push("+refs/heads/*:refs/remotes/origin/*", "+refs/notes/*:refs/notes/*");
+        return await realRunner(safeArgv, options);
       }
       return await realRunner(argv, options);
     };
@@ -1098,11 +1107,12 @@ describe("runGatewayUpdate", () => {
     await expect(runRealGit(localRoot, "rev-parse", "refs/remotes/origin/main")).resolves.toBe(
       releaseSha,
     );
+    await expect(runRealGit(localRoot, "rev-parse", "refs/notes/ops")).resolves.toBeTruthy();
     await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(baseSha);
     expect(steps).toContainEqual(
       expect.objectContaining({
         name: "git fetch origin",
-        command: expect.stringContaining("refs/heads/*:refs/remotes/origin/*"),
+        command: expect.stringContaining("refs/*:refs/*"),
         exitCode: 0,
       }),
     );

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -912,6 +912,13 @@ describe("runGatewayUpdate", () => {
       "config",
       "--add",
       "remote.origin.fetch",
+      "refs/tags/*:refs/tags/*",
+    );
+    await runRealGit(
+      localRoot,
+      "config",
+      "--add",
+      "remote.origin.fetch",
       "refs/*:refs/remotes/origin/*",
     );
     const reachedMutation = new Error("reached release mutation");

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -665,6 +665,46 @@ describe("runGatewayUpdate", () => {
     await expect(runRealGit(localRoot, "rev-parse", localTag)).resolves.toBe(baseSha);
   });
 
+  it("records remote release discovery failures in steps and progress", async () => {
+    await setupGitCheckout();
+    const onStepStart = vi.fn();
+    const onStepComplete = vi.fn();
+    const { runner } = createRunner({
+      ...buildGitWorktreeProbeResponses(),
+      [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
+      [`git -C ${tempDir} remote`]: { stdout: "origin\n" },
+      [`git -C ${tempDir} config --get branch.main.remote`]: { stdout: "origin\n" },
+      [`git -C ${tempDir} ls-remote --tags --refs --sort=-v:refname -- origin v*`]: {
+        code: 128,
+        stderr: "fatal: authentication failed",
+      },
+    });
+
+    const result = await runWithRunner(runner, {
+      channel: "stable",
+      progress: { onStepStart, onStepComplete },
+    });
+
+    expect(result).toMatchObject({ status: "error", reason: "fetch-failed" });
+    expect(result.steps).toContainEqual(
+      expect.objectContaining({
+        name: "git ls-remote origin tags",
+        exitCode: 128,
+        stderrTail: "fatal: authentication failed",
+      }),
+    );
+    expect(onStepStart).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "git ls-remote origin tags" }),
+    );
+    expect(onStepComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "git ls-remote origin tags",
+        exitCode: 128,
+        stderrTail: "fatal: authentication failed",
+      }),
+    );
+  });
+
   it("keeps release tags scoped to the main remote when another remote disagrees", async () => {
     const { sourceRoot, localRoot, releaseSha, releaseTag } =
       await createRecreatedReleaseTagFixture();

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -13,8 +13,7 @@ import { pathExists } from "../utils.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import type { UpdateChannel } from "./update-channels.js";
 import type { DevUpdateTarget } from "./update-dev-target.js";
-import { prepareStableGitFetch } from "./update-runner-git-fetch.js";
-import type { UpdateStepProgress, UpdateStepResult } from "./update-runner-types.js";
+import type { UpdateStepProgress } from "./update-runner-types.js";
 import {
   resolveUpdateDoctorExecutionPolicy,
   resolveUpdateInstallSurface,
@@ -668,35 +667,46 @@ describe("runGatewayUpdate", () => {
     await expect(runRealGit(localRoot, "rev-parse", localOnlyTag)).resolves.toBeTruthy();
   });
 
-  it("excludes Git tag shorthand from the preliminary branch refresh", async () => {
+  it("refreshes recreated release tags when Git tag shorthand is reported", async () => {
+    const { localRoot, releaseSha, releaseTag, localOnlyTag } =
+      await createRecreatedReleaseTagFixture();
     const calls: string[] = [];
-    const steps: UpdateStepResult[] = [];
-    const runCommand = async (argv: string[]): Promise<CommandResult> => {
+    const realRunner = createRealGitUpdateRunner();
+    const runCommand = async (argv: string[], options?: { cwd?: string; timeoutMs?: number }) => {
       const key = argv.join(" ");
       calls.push(key);
       if (argv[3] === "config" && argv.at(-1) === "^remote\\..*\\.fetch$") {
-        return { stdout: "remote.origin.fetch tag v1.0.0\n", stderr: "", code: 0 };
+        // Git 2.27 rejects `tag <name>` when stored as one remote.*.fetch value;
+        // synthesize the config report while keeping all subsequent Git work real.
+        return toCommandResult({
+          stdout: `remote.origin.fetch +refs/heads/*:refs/remotes/origin/*\nremote.origin.fetch tag ${releaseTag}\n`,
+        });
       }
-      if (argv[3] === "remote") {
-        return { stdout: "origin\n", stderr: "", code: 0 };
+      if (argv[3] === "fetch" && argv[4] === "--all") {
+        return toCommandResult({ code: 1, stderr: "would clobber configured tag" });
       }
-      if (argv[3] === "config" && argv.at(-1)?.includes("skipfetchall")) {
-        return { stdout: "", stderr: "", code: 1 };
-      }
-      throw new Error(`unexpected command: ${key}`);
+      return await realRunner(argv, options);
     };
+    const reachedMutation = new Error("reached release mutation");
 
     await expect(
-      prepareStableGitFetch({
-        gitRoot: tempDir,
-        timeoutMs: 1000,
-        runCommand,
-        steps,
-        fetchAllArgv: ["git", "-C", tempDir, "fetch", "--all"],
+      runWithCommand(runCommand, {
+        cwd: localRoot,
+        channel: "stable",
+        beforeGitMutation: async () => {
+          throw reachedMutation;
+        },
       }),
-    ).resolves.toEqual({ remotes: ["origin"] });
-    expect(calls).not.toContain(`git -C ${tempDir} fetch --all`);
-    expect(calls).not.toContain(`git -C ${tempDir} fetch origin`);
+    ).rejects.toBe(reachedMutation);
+
+    expect(calls).not.toContain(
+      `git -C ${localRoot} fetch --all --prune --no-prune-tags --no-tags`,
+    );
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(releaseSha);
+    await expect(runRealGit(localRoot, "rev-parse", "refs/remotes/origin/main")).resolves.toBe(
+      releaseSha,
+    );
+    await expect(runRealGit(localRoot, "rev-parse", localOnlyTag)).resolves.toBeTruthy();
   });
 
   it("selects stable releases from the main remote instead of local release-shaped tags", async () => {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1041,21 +1041,42 @@ describe("runGatewayUpdate", () => {
   });
 
   it("refreshes recreated release tags for a mirror-style broad mapping", async () => {
-    const { localRoot, releaseSha, releaseTag } = await createRecreatedReleaseTagFixture();
+    const { localRoot, baseSha, releaseSha, releaseTag } = await createRecreatedReleaseTagFixture();
+    await runRealGit(localRoot, "checkout", "--detach", baseSha);
     await runRealGit(localRoot, "config", "--add", "remote.origin.fetch", "refs/*:refs/*");
     const reachedMutation = new Error("reached release mutation");
 
-    await expect(
-      runWithCommand(createRealGitUpdateRunner(), {
+    const gitVersion = await runRealGit(localRoot, "--version");
+    const versionMatch = /^git version (\d+)\.(\d+)/u.exec(gitVersion);
+    const supportsNegativeRefspec =
+      versionMatch !== null &&
+      (Number(versionMatch[1]) > 2 ||
+        (Number(versionMatch[1]) === 2 && Number(versionMatch[2]) >= 29));
+
+    if (supportsNegativeRefspec) {
+      await expect(
+        runWithCommand(createRealGitUpdateRunner(), {
+          cwd: localRoot,
+          channel: "stable",
+          beforeGitMutation: async () => {
+            throw reachedMutation;
+          },
+        }),
+      ).rejects.toBe(reachedMutation);
+      await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(
+        releaseSha,
+      );
+    } else {
+      const result = await runWithCommand(createRealGitUpdateRunner(), {
         cwd: localRoot,
         channel: "stable",
         beforeGitMutation: async () => {
           throw reachedMutation;
         },
-      }),
-    ).rejects.toBe(reachedMutation);
-
-    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(releaseSha);
+      });
+      expect(result).toMatchObject({ status: "error", reason: "fetch-failed" });
+      await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(baseSha);
+    }
   });
 
   it("preserves tag-excluded mirror mappings during branch refresh", async () => {
@@ -1113,6 +1134,66 @@ describe("runGatewayUpdate", () => {
         expect.objectContaining({
           name: "git remote",
           command: `git -C ${localRoot} remote`,
+          exitCode: 128,
+          stderrTail: expect.stringContaining("invalid refspec"),
+        }),
+      );
+    }
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(baseSha);
+  });
+
+  it("preserves non-tag refs for plain mirror mappings", async () => {
+    const { sourceRoot, localRoot, baseSha, releaseSha, releaseTag } =
+      await createRecreatedReleaseTagFixture();
+    await runRealGit(localRoot, "checkout", "--detach", baseSha);
+    await runRealGit(localRoot, "config", "--add", "remote.origin.fetch", "refs/*:refs/*");
+    await runRealGit(sourceRoot, "notes", "--ref=ops", "add", "-m", "remote note", releaseSha);
+    const steps: UpdateStepResult[] = [];
+    const realRunner = createRealGitUpdateRunner();
+
+    const result = await prepareStableGitFetch({
+      gitRoot: localRoot,
+      timeoutMs: 5000,
+      runCommand: realRunner,
+      steps,
+      fetchAllArgv: [
+        "git",
+        "-C",
+        localRoot,
+        "fetch",
+        "--all",
+        "--prune",
+        "--no-prune-tags",
+        "--no-tags",
+      ],
+    });
+
+    const gitVersion = await runRealGit(localRoot, "--version");
+    const versionMatch = /^git version (\d+)\.(\d+)/u.exec(gitVersion);
+    const supportsNegativeRefspec =
+      versionMatch !== null &&
+      (Number(versionMatch[1]) > 2 ||
+        (Number(versionMatch[1]) === 2 && Number(versionMatch[2]) >= 29));
+
+    if (supportsNegativeRefspec) {
+      expect(result).toMatchObject({ remotes: ["origin", "skipped"] });
+      await expect(runRealGit(localRoot, "rev-parse", "refs/remotes/origin/main")).resolves.toBe(
+        releaseSha,
+      );
+      await expect(runRealGit(localRoot, "rev-parse", "refs/notes/ops")).resolves.toBeTruthy();
+      expect(steps).toContainEqual(
+        expect.objectContaining({
+          name: "git fetch origin",
+          command: `git -C ${localRoot} fetch --prune --no-prune-tags --no-tags --refmap= -- origin +refs/heads/*:refs/remotes/origin/* refs/*:refs/* ^refs/tags/*`,
+          exitCode: 0,
+        }),
+      );
+    } else {
+      expect(result).toMatchObject({ reason: "fetch-failed" });
+      expect(steps).toContainEqual(
+        expect.objectContaining({
+          name: "git fetch origin",
+          command: expect.stringContaining("refs/*:refs/* ^refs/tags/*"),
           exitCode: 128,
           stderrTail: expect.stringContaining("invalid refspec"),
         }),

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -137,8 +137,16 @@ describe("runGatewayUpdate", () => {
       if (key === `git -C ${tempDir} config --get branch.main.remote`) {
         return { stdout: "origin\n", stderr: "", code: 0 };
       }
+      if (key === `git -C ${tempDir} ls-remote --tags --refs --sort=-v:refname -- origin v*`) {
+        return {
+          stdout: `${"a".repeat(40)}\trefs/tags/${params.stableTag}\n`,
+          stderr: "",
+          code: 0,
+        };
+      }
       if (
-        key === `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/*:refs/tags/*`
+        key ===
+        `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/${params.stableTag}:refs/tags/${params.stableTag}`
       ) {
         return { stdout: "", stderr: "", code: 0 };
       }
@@ -147,6 +155,12 @@ describe("runGatewayUpdate", () => {
       }
       if (key === "pnpm --version") {
         return { stdout: PNPM_VERSION, stderr: "", code: 0 };
+      }
+      if (key === `git -C ${tempDir} checkout --detach ${params.stableTag}`) {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      if (key === "pnpm install") {
+        return { stdout: "", stderr: "", code: 0 };
       }
       if (key === "pnpm build") {
         await params.onBuild?.();
@@ -343,7 +357,14 @@ describe("runGatewayUpdate", () => {
     stableTag: string,
     options?: { additionalTags?: string[] },
   ): Record<string, CommandResponse> {
-    const tagOutput = [stableTag, ...(options?.additionalTags ?? [])].join("\n");
+    const tags = [stableTag, ...(options?.additionalTags ?? [])];
+    const tagOutput = tags.map((tag) => `${"a".repeat(40)}\trefs/tags/${tag}`).join("\n");
+    const tagFetchResponses = Object.fromEntries(
+      tags.map((tag) => [
+        `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/${tag}:refs/tags/${tag}`,
+        { stdout: "" },
+      ]),
+    ) satisfies Record<string, CommandResponse>;
     return {
       "pnpm --version": { stdout: PNPM_VERSION },
       [`git -C ${tempDir} rev-parse --show-toplevel`]: { stdout: tempDir },
@@ -352,10 +373,10 @@ describe("runGatewayUpdate", () => {
       [`git -C ${tempDir} fetch --all --prune --no-prune-tags --no-tags`]: { stdout: "" },
       [`git -C ${tempDir} remote`]: { stdout: "origin\n" },
       [`git -C ${tempDir} config --get branch.main.remote`]: { stdout: "origin\n" },
-      [`git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/*:refs/tags/*`]: {
-        stdout: "",
+      [`git -C ${tempDir} ls-remote --tags --refs --sort=-v:refname -- origin v*`]: {
+        stdout: `${tagOutput}\n`,
       },
-      [`git -C ${tempDir} tag --list v* --sort=-v:refname`]: { stdout: `${tagOutput}\n` },
+      ...tagFetchResponses,
       [`git -C ${tempDir} checkout --detach ${stableTag}`]: { stdout: "" },
     };
   }
@@ -612,6 +633,36 @@ describe("runGatewayUpdate", () => {
       releaseSha,
     );
     await expect(runRealGit(localRoot, "rev-parse", localOnlyTag)).resolves.toBeTruthy();
+  });
+
+  it("selects stable releases from the main remote instead of local release-shaped tags", async () => {
+    const { localRoot, baseSha, releaseSha, releaseTag } = await createRecreatedReleaseTagFixture();
+    const localTag = "v9999.1.0";
+    await runRealGit(localRoot, "tag", localTag, baseSha);
+    const calls: string[] = [];
+    const realRunner = createRealGitUpdateRunner();
+    const reachedMutation = new Error("reached release mutation");
+
+    await expect(
+      runWithCommand(
+        async (argv, options) => {
+          calls.push(argv.join(" "));
+          return await realRunner(argv, options);
+        },
+        {
+          cwd: localRoot,
+          channel: "stable",
+          beforeGitMutation: async () => {
+            throw reachedMutation;
+          },
+        },
+      ),
+    ).rejects.toBe(reachedMutation);
+
+    expect(calls).toContain(`git -C ${localRoot} show ${releaseTag}:package.json`);
+    expect(calls).not.toContain(`git -C ${localRoot} show ${localTag}:package.json`);
+    await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(releaseSha);
+    await expect(runRealGit(localRoot, "rev-parse", localTag)).resolves.toBe(baseSha);
   });
 
   it("keeps release tags scoped to the main remote when another remote disagrees", async () => {
@@ -3746,13 +3797,16 @@ describe("runGatewayUpdate", () => {
         if (key === `git -C ${tempDir} config --get branch.main.remote`) {
           return toCommandResult({ stdout: "origin\n" });
         }
+        if (key === `git -C ${tempDir} ls-remote --tags --refs --sort=-v:refname -- origin v*`) {
+          return toCommandResult({
+            stdout: `${"a".repeat(40)}\trefs/tags/${stableTag}\n`,
+          });
+        }
         if (
-          key === `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/*:refs/tags/*`
+          key ===
+          `git -C ${tempDir} fetch --no-prune --no-tags -- origin +refs/tags/${stableTag}:refs/tags/${stableTag}`
         ) {
           return toCommandResult();
-        }
-        if (key === `git -C ${tempDir} tag --list v* --sort=-v:refname`) {
-          return toCommandResult({ stdout: `${stableTag}\n` });
         }
         if (key === `git -C ${tempDir} checkout --detach ${stableTag}`) {
           currentHead = targetSha;

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -4109,6 +4109,9 @@ describe("runGatewayUpdate", () => {
         if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
           return toCommandResult({ stdout: "main\n" });
         }
+        if (key === statusCommand && rollbackBuildStatus && buildCount >= 2) {
+          return toCommandResult({ stdout: rollbackBuildStatus });
+        }
         if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
           return toCommandResult();
         }
@@ -4170,9 +4173,6 @@ describe("runGatewayUpdate", () => {
           buildEnvs.push(options?.env ?? {});
           await writeRuntime(currentHead);
           return toCommandResult();
-        }
-        if (key === statusCommand && rollbackBuildStatus && buildCount >= 2) {
-          return toCommandResult({ stdout: rollbackBuildStatus });
         }
         if (key === doctorCommand) {
           return toCommandResult({ code: 1, stderr: "doctor failed after build" });

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1061,35 +1061,17 @@ describe("runGatewayUpdate", () => {
   it("preserves tag-excluded mirror mappings during branch refresh", async () => {
     const { sourceRoot, localRoot, baseSha, releaseSha, releaseTag } =
       await createRecreatedReleaseTagFixture();
+    await runRealGit(localRoot, "checkout", "--detach", baseSha);
     await runRealGit(localRoot, "config", "--add", "remote.origin.fetch", "refs/*:refs/*");
+    await runRealGit(localRoot, "config", "--add", "remote.origin.fetch", "^refs/tags/*");
     await runRealGit(sourceRoot, "notes", "--ref=ops", "add", "-m", "remote note", releaseSha);
     const steps: UpdateStepResult[] = [];
     const realRunner = createRealGitUpdateRunner();
-    const runCommand = async (argv: string[], options?: { cwd?: string; timeoutMs?: number }) => {
-      if (argv[3] === "config" && argv.at(-1) === "^remote\\..*\\.fetch$") {
-        // Git 2.27 accepts this value in config but rejects negative refspecs when fetching;
-        // synthesize the supported-config report while keeping the real fetch path exercised.
-        return toCommandResult({
-          stdout:
-            "remote.origin.fetch +refs/heads/*:refs/remotes/origin/*\n" +
-            "remote.origin.fetch refs/*:refs/*\n" +
-            "remote.origin.fetch ^refs/tags/*\n",
-        });
-      }
-      if (argv[3] === "fetch" && argv.includes("refs/*:refs/*")) {
-        // Expand the tag-excluded mirror mapping into equivalent non-tag namespaces for Git 2.27;
-        // the planner's original command remains recorded in `steps` for assertion below.
-        const safeArgv = argv.filter((arg) => arg !== "refs/*:refs/*");
-        safeArgv.push("+refs/heads/*:refs/remotes/origin/*", "+refs/notes/*:refs/notes/*");
-        return await realRunner(safeArgv, options);
-      }
-      return await realRunner(argv, options);
-    };
 
     const result = await prepareStableGitFetch({
       gitRoot: localRoot,
       timeoutMs: 5000,
-      runCommand,
+      runCommand: realRunner,
       steps,
       fetchAllArgv: [
         "git",
@@ -1103,19 +1085,40 @@ describe("runGatewayUpdate", () => {
       ],
     });
 
-    expect(result).toMatchObject({ remotes: ["origin", "skipped"] });
-    await expect(runRealGit(localRoot, "rev-parse", "refs/remotes/origin/main")).resolves.toBe(
-      releaseSha,
-    );
-    await expect(runRealGit(localRoot, "rev-parse", "refs/notes/ops")).resolves.toBeTruthy();
+    const gitVersion = await runRealGit(localRoot, "--version");
+    const versionMatch = /^git version (\d+)\.(\d+)/u.exec(gitVersion);
+    // Git 2.29 added negative fetch-refspec support; older versions reject this config before
+    // contacting the remote, which is the safe failure mode asserted below.
+    const supportsNegativeRefspec =
+      versionMatch !== null &&
+      (Number(versionMatch[1]) > 2 ||
+        (Number(versionMatch[1]) === 2 && Number(versionMatch[2]) >= 29));
+
+    if (supportsNegativeRefspec) {
+      expect(result).toMatchObject({ remotes: ["origin", "skipped"] });
+      await expect(runRealGit(localRoot, "rev-parse", "refs/remotes/origin/main")).resolves.toBe(
+        releaseSha,
+      );
+      await expect(runRealGit(localRoot, "rev-parse", "refs/notes/ops")).resolves.toBeTruthy();
+      expect(steps).toContainEqual(
+        expect.objectContaining({
+          name: "git fetch origin",
+          command: `git -C ${localRoot} fetch --prune --no-prune-tags --no-tags --refmap= -- origin +refs/heads/*:refs/remotes/origin/* refs/*:refs/* ^refs/tags/*`,
+          exitCode: 0,
+        }),
+      );
+    } else {
+      expect(result).toMatchObject({ reason: "fetch-failed" });
+      expect(steps).toContainEqual(
+        expect.objectContaining({
+          name: "git remote",
+          command: `git -C ${localRoot} remote`,
+          exitCode: 128,
+          stderrTail: expect.stringContaining("invalid refspec"),
+        }),
+      );
+    }
     await expect(runRealGit(localRoot, "rev-parse", `${releaseTag}^{}`)).resolves.toBe(baseSha);
-    expect(steps).toContainEqual(
-      expect.objectContaining({
-        name: "git fetch origin",
-        command: expect.stringContaining("refs/*:refs/*"),
-        exitCode: 0,
-      }),
-    );
   });
 
   async function runWithCommand(


### PR DESCRIPTION
Closes #123318

## What Problem This Solves

Stable and beta source-checkout updates could fail after an upstream release tag was recreated. The updater must refresh non-tag refs first, then force-refresh only the selected release tag from the canonical release remote.

## Why This Change Was Made

- The Git update runner discovers configured fetch refspecs and removes tag-only mappings from the preliminary refresh.
- When a configured mapping is broad (for example, `refs/*:refs/*`) and has a negative refspec such as `^refs/tags/*`, the negative refspec is carried into the explicit fetch argv. This preserves arbitrary non-tag destinations, including operator-defined namespaces such as `refs/notes/*`, while excluding tags.
- A plain local mirror mapping (`refs/*:refs/*`) receives the same explicit tag exclusion so its non-tag destinations continue to refresh; Git versions without negative-refspec support fail before mutation instead of silently skipping the remote.
- The command uses `--refmap=` only together with the complete positive/negative mapping. Git 2.29 and newer apply the exclusion; older Git versions reject negative refspecs before contacting the remote, so the updater returns `fetch-failed` before release-tag or checkout mutation instead of silently changing the configured mapping.
- Configured skip flags, main-remote authority, selected-tag refresh, and local-tag protection remain unchanged.

## User Impact

Moved release tags recover safely without clobbering unrelated local tags or stale non-tag mirror refs. Existing checkouts whose Git version cannot parse their configured negative refspec fail closed before mutation with the recorded Git error. No configuration schema, protocol, database, or public API surface is added.

## Evidence

- Real Git 2.29.0 regression: a detached checkout with `refs/*:refs/*` plus `^refs/tags/*` fetches the moved `main` ref and a remote `refs/notes/ops` ref while the local release tag remains at its original SHA. The recorded production command includes both the broad positive mapping and the negative refspec; no argv substitution is used.
- Real Git 2.29.0 plain-mirror regression: a detached checkout with only `refs/*:refs/*` receives an explicit `^refs/tags/*`, fetches `main` and `refs/notes/ops`, and preserves the local release tag.
- Real Git 2.27.0 regression: the same configured negative refspec is rejected as `invalid refspec` while loading the remote, and the release tag remains unchanged before any mutation.
- Git's v2.29 release notes and fetch implementation add negative refspec support; v2.27's parser does not accept `^` and its remote-config loader fails before fetch. Empty `--refmap=` ignores configured mappings, so dropping the negative refspec is not safe.

## Validation

- `node_modules/.bin/vitest run src/infra/update-runner.test.ts --testNamePattern='tag-excluded mirror mappings'` — passed on Node 24.16.0 with Git 2.27.0.
- The same focused test — passed on Git 2.29.0; it exercised the unmodified production fetch command and verified branch, notes, and tag state.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/update-runner-git-fetch.ts src/infra/update-runner.test.ts` — passed.
- `node --experimental-strip-types --check src/infra/update-runner-git-fetch.ts`, `node_modules/.bin/oxfmt --check src/infra/update-runner-git-fetch.ts src/infra/update-runner.test.ts`, and `git diff --check` — passed.

## Validation boundary

Discord live proof is not applicable to this updater-only Git change. The real-Git fixtures use disposable local repositories and no external credentials. Exact-head CI remains the final hosted verification boundary.

## Exact-head real-Git trace

The following trace was run from commit `d255dd3493b` with disposable local repositories (paths redacted):

```text
Git 2.29.0
prepareStableGitFetch result: { remotes: ["origin", "skipped"] }
git fetch origin --prune --no-prune-tags --no-tags --refmap= -- origin \
  +refs/heads/*:refs/remotes/origin/* refs/*:refs/* ^refs/tags/*
exitCode: 0
stderr: main 0be5de7..093ad71 -> origin/main; main 0be5de7..093ad71 -> main;
        refs/notes/ops -> refs/notes/ops
v1.0.0^{}              0be5de74c219 (unchanged local release tag)
refs/remotes/origin/main 093ad71a4802 (advanced branch)
refs/notes/ops         d245d996b929 (fetched non-tag namespace)
local-operator-tag     0be5de74c219 (preserved)

Git 2.27.0
prepareStableGitFetch result: { reason: "fetch-failed" }
git remote exitCode: 128
stderr: fatal: invalid refspec '^refs/tags/*'
v1.0.0^{}              0c67ca65e1bf (unchanged before mutation)
```
