### PR TITLE
fix(google): isolate web search header credentials

### DIFF
--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -30,6 +30,7 @@ import {
   resolveGeminiConfig,
   resolveGeminiBaseUrl,
   resolveGeminiModel,
+  isGeminiProviderOwnedHeader,
   type GeminiConfig,
 } from "./gemini-web-search-provider.shared.js";
 
@@ -62,12 +63,6 @@ type GeminiGroundingResponse = {
     status?: string;
   };
 };
-
-const GEMINI_PROVIDER_OWNED_HEADER_NAMES = new Set([
-  "content-type",
-  "x-goog-api-client",
-  "x-goog-api-key",
-]);
 
 // Headers validates field syntax, but Undici does not implement Fetch's
 // forbidden-request-header checks. These names can otherwise be consumed,
@@ -214,6 +209,9 @@ function resolveGeminiWebSearchHeaders(gemini?: GeminiConfig): Record<string, st
   }
   const headers = new Headers();
   for (const [name, input] of Object.entries(gemini.headers)) {
+    if (isGeminiProviderOwnedHeader(name)) {
+      continue;
+    }
     const path = `plugins.entries.google.config.webSearch.headers[${JSON.stringify(name)}]`;
     const value =
       typeof input === "string"
@@ -236,9 +234,6 @@ function resolveGeminiWebSearchHeaders(gemini?: GeminiConfig): Record<string, st
     }
     if (GEMINI_UNSAFE_REQUEST_HEADER_NAMES.has(normalizedName)) {
       throw new Error(`${path} uses a reserved or framing HTTP header.`);
-    }
-    if (GEMINI_PROVIDER_OWNED_HEADER_NAMES.has(normalizedName)) {
-      continue;
     }
     headers.set(normalizedName, normalizedValue);
   }

--- a/extensions/google/src/gemini-web-search-provider.shared.ts
+++ b/extensions/google/src/gemini-web-search-provider.shared.ts
@@ -6,6 +6,11 @@ import {
 import { normalizeGoogleApiBaseUrl } from "./google-api-base-url.js";
 
 const DEFAULT_GEMINI_WEB_SEARCH_MODEL = "gemini-2.5-flash";
+const GEMINI_PROVIDER_OWNED_HEADER_NAMES = new Set([
+  "content-type",
+  "x-goog-api-client",
+  "x-goog-api-key",
+]);
 
 export type GeminiConfig = {
   apiKey?: unknown;
@@ -29,4 +34,8 @@ export function resolveGeminiBaseUrl(gemini?: GeminiConfig): string {
   return normalizeGoogleApiBaseUrl(
     trimToUndefined(gemini?.baseUrl) ?? trimToUndefined(gemini?.providerBaseUrl),
   );
+}
+
+export function isGeminiProviderOwnedHeader(name: string): boolean {
+  return GEMINI_PROVIDER_OWNED_HEADER_NAMES.has(name.toLowerCase());
 }

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -9,6 +9,10 @@ import {
   type WebSearchProviderToolDefinition,
 } from "openclaw/plugin-sdk/provider-web-search-config-contract";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  isGeminiProviderOwnedHeader,
+  resolveGeminiBaseUrl,
+} from "./gemini-web-search-provider.shared.js";
 
 const GEMINI_CREDENTIAL_PATH = "plugins.entries.google.config.webSearch.apiKey";
 const GOOGLE_PROVIDER_CREDENTIAL_PATH = "models.providers.google.apiKey";
@@ -129,6 +133,30 @@ export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
     credentialPath: GEMINI_CREDENTIAL_PATH,
     ...contractFields,
     getConfiguredCredentialFallback: getGoogleModelProviderCredentialFallback,
+    getSecretOwnerContract: (config) => ({
+      baseUrl: resolveGeminiBaseUrl({
+        baseUrl: resolveProviderWebSearchPluginConfig(config, "google")?.baseUrl,
+        providerBaseUrl: resolveGoogleModelProviderConfig(config)?.baseUrl,
+      }),
+    }),
+    getConfiguredSecretInputs: (config) => {
+      const headers = resolveProviderWebSearchPluginConfig(config, "google")?.headers;
+      if (!isRecord(headers)) {
+        return [];
+      }
+      return Object.entries(headers)
+        .filter(([name]) => !isGeminiProviderOwnedHeader(name))
+        .map(([name, value]) => ({
+          path: `plugins.entries.google.config.webSearch.headers[${JSON.stringify(name)}]`,
+          value,
+          setResolvedValue: (target: OpenClawConfig, resolved: string) => {
+            const targetHeaders = resolveProviderWebSearchPluginConfig(target, "google")?.headers;
+            if (isRecord(targetHeaders)) {
+              targetHeaders[name] = resolved;
+            }
+          },
+        }));
+    },
     createTool: (ctx) =>
       createGeminiToolDefinition(
         withGoogleModelProviderFallbacks(

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -166,8 +166,23 @@ describe("google web search provider", () => {
     const mockFetch = installGeminiFetch();
     const tool = createGeminiToolWithHeaders({
       "X-Routing-Target": "staging",
+      "X.Routing.Token": "resolved-dotted-token",
       "X-Gateway-Token": "resolved-gateway-token",
-      "X-Goog-Api-Key": "operator-value",
+      "X-Goog-Api-Key": {
+        source: "env",
+        provider: "default",
+        id: "MISSING_IGNORED_GOOGLE_API_KEY",
+      },
+      "X-Goog-Api-Client": {
+        source: "env",
+        provider: "default",
+        id: "MISSING_IGNORED_GOOGLE_API_CLIENT",
+      },
+      "Content-Type": {
+        source: "env",
+        provider: "default",
+        id: "MISSING_IGNORED_CONTENT_TYPE",
+      },
     });
 
     await tool?.execute({ query: "OpenClaw operator headers" });
@@ -177,6 +192,7 @@ describe("google web search provider", () => {
       "x-gateway-token": "resolved-gateway-token",
       "x-goog-api-key": "AIza-plugin-test",
       "x-routing-target": "staging",
+      "x.routing.token": "resolved-dotted-token",
     });
   });
 

--- a/src/plugins/web-provider-types.ts
+++ b/src/plugins/web-provider-types.ts
@@ -51,6 +51,12 @@ type WebSearchProviderConfiguredCredentialFallback = {
   value: unknown;
 };
 
+type WebSearchProviderConfiguredSecretInput = {
+  path: string;
+  value: unknown;
+  setResolvedValue: (configTarget: OpenClawConfig, value: string) => void;
+};
+
 type WebFetchProviderConfiguredCredentialFallback = {
   path: string;
   value: unknown;
@@ -113,6 +119,12 @@ export type WebSearchProviderPlugin = {
   getConfiguredCredentialFallback?: (
     config?: OpenClawConfig,
   ) => WebSearchProviderConfiguredCredentialFallback | undefined;
+  /** Additional provider-owned SecretRefs resolved only after this search provider wins selection. */
+  getConfiguredSecretInputs?: (
+    config?: OpenClawConfig,
+  ) => readonly WebSearchProviderConfiguredSecretInput[];
+  /** Non-secret provider-owned routing facts that bind last-known-good credential reuse. */
+  getSecretOwnerContract?: (config?: OpenClawConfig) => unknown;
   applySelectionConfig?: (config: OpenClawConfig) => OpenClawConfig;
   runSetup?: (ctx: WebSearchProviderSetupContext) => OpenClawConfig | Promise<OpenClawConfig>;
   resolveRuntimeMetadata?: (

--- a/src/secrets/runtime-config-collectors-plugins.bundled.test.ts
+++ b/src/secrets/runtime-config-collectors-plugins.bundled.test.ts
@@ -5,9 +5,8 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import type { OpenClawConfig } from "../config/config.js";
 import { findBundledPluginMetadataById } from "../plugins/bundled-plugin-metadata.js";
 import { resolvePluginConfigContractsById } from "../plugins/config-contracts.js";
-import { resolveSecretRefValues } from "./resolve.js";
 import { collectPluginConfigAssignments } from "./runtime-config-collectors-plugins.js";
-import { applyResolvedAssignments, createResolverContext } from "./runtime-shared.js";
+import { createResolverContext } from "./runtime-shared.js";
 
 function envRef(id: string) {
   return { source: "env" as const, provider: "default", id };
@@ -144,7 +143,7 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
     });
   });
 
-  it("resolves only explicitly referenced Google web-search headers", async () => {
+  it("leaves Google web-search headers to their selected capability owner", () => {
     expect(
       findBundledPluginMetadataById("google", {
         includeChannelConfigs: false,
@@ -169,8 +168,7 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
         },
       },
     } as OpenClawConfig;
-    const env = { GEMINI_GATEWAY_TOKEN: "resolved-gateway-token" };
-    const context = createResolverContext({ sourceConfig: config, env });
+    const context = createResolverContext({ sourceConfig: config, env: {} });
 
     collectPluginConfigAssignments({
       config,
@@ -179,22 +177,7 @@ describe("collectPluginConfigAssignments bundled plugin manifests", () => {
       loadablePluginOrigins: new Map([["google", "bundled"]]),
     });
 
-    expect(context.assignments.map((assignment) => assignment.path)).toEqual([
-      "plugins.entries.google.config.webSearch.headers.X-Gateway-Token",
-    ]);
-    const resolved = await resolveSecretRefValues(
-      context.assignments.map((assignment) => assignment.ref),
-      { config, env, cache: context.cache },
-    );
-    applyResolvedAssignments({ assignments: context.assignments, resolved });
-    expect(config.plugins?.entries?.google?.config).toMatchObject({
-      webSearch: {
-        headers: {
-          "X-Routing-Target": "staging",
-          "X-Gateway-Token": "resolved-gateway-token",
-        },
-      },
-    });
+    expect(context.assignments).toEqual([]);
   });
 
   it("collects voice-call SecretRef assignments from bundled manifest contracts", () => {

--- a/src/secrets/runtime-config-collectors-plugins.test.ts
+++ b/src/secrets/runtime-config-collectors-plugins.test.ts
@@ -242,6 +242,46 @@ describe("collectPluginConfigAssignments", () => {
     expect(loadPluginManifestRegistryForPluginRegistryMock).not.toHaveBeenCalled();
   });
 
+  it("keeps unrelated web-search SecretRefs with the generic plugin owner", () => {
+    const config = createPluginConfig("custom-search", {
+      webSearch: {
+        headers: { "X.Routing.Token": envRef("CUSTOM_ROUTING_TOKEN") },
+        proxyToken: envRef("CUSTOM_PROXY_TOKEN"),
+      },
+    });
+    const context = makeContext(config, {
+      plugins: [
+        {
+          id: "custom-search",
+          origin: "config",
+          contracts: { webSearchProviders: [{ id: "custom-search" }] },
+          configContracts: {
+            secretInputs: {
+              paths: [
+                { path: "webSearch.headers.*", expected: "string" },
+                { path: "webSearch.proxyToken", expected: "string" },
+              ],
+            },
+          },
+        } as never,
+      ],
+    });
+
+    collectPluginConfigAssignments({
+      config,
+      defaults: undefined,
+      context,
+      loadablePluginOrigins: loadablePluginOrigins([["custom-search", "config"]]),
+    });
+
+    expect(context.assignments).toMatchObject([
+      {
+        path: "plugins.entries.custom-search.config.webSearch.proxyToken",
+        ownerKind: "unknown",
+      },
+    ]);
+  });
+
   it("resolves assignments via apply callback", () => {
     const config = createPluginConfig("acpx", {
       mcpServers: {

--- a/src/secrets/runtime-config-collectors-plugins.ts
+++ b/src/secrets/runtime-config-collectors-plugins.ts
@@ -72,7 +72,15 @@ export function collectPluginConfigAssignments(params: {
       }).entries(),
     ].flatMap(([pluginId, metadata]) => {
       const secretInputs = metadata.configContracts.secretInputs;
-      if (!secretInputs?.paths.length) {
+      const ownsWebSearch = manifestRegistry.plugins.some(
+        (plugin) =>
+          plugin.id === pluginId && (plugin.contracts?.webSearchProviders?.length ?? 0) > 0,
+      );
+      // Selection owns only supplemental headers; other declared plugin secrets remain generic.
+      const paths = secretInputs?.paths.filter(
+        ({ path }) => !ownsWebSearch || path !== "webSearch.headers.*",
+      );
+      if (!paths?.length) {
         return [];
       }
       return [
@@ -80,8 +88,8 @@ export function collectPluginConfigAssignments(params: {
           pluginId,
           {
             origin: metadata.origin,
-            bundledDefaultEnabled: secretInputs.bundledDefaultEnabled,
-            paths: secretInputs.paths,
+            bundledDefaultEnabled: secretInputs?.bundledDefaultEnabled,
+            paths,
           },
         ] as const,
       ];

--- a/src/secrets/runtime-google-web-search-headers.test.ts
+++ b/src/secrets/runtime-google-web-search-headers.test.ts
@@ -1,0 +1,367 @@
+/** Selected Google web-search headers share their provider's SecretRef owner. */
+import { createServer } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { createWebSearchTool } from "../agents/tools/web-search.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isSecretValueRegisteredForRedaction } from "../logging/secret-redaction-registry.js";
+import {
+  activateSecretsRuntimeSnapshotState,
+  clearSecretsRuntimeSnapshotState,
+} from "./runtime-state.js";
+import { prepareSecretsRuntimeSnapshot } from "./runtime.js";
+
+const envRef = (id: string) => ({ source: "env" as const, provider: "default", id });
+const origins = new Map([
+  ["brave", "bundled"],
+  ["google", "bundled"],
+] as const);
+
+function createConfig(params: {
+  provider?: "brave" | "gemini";
+  enabled?: boolean;
+  headers?: Record<string, unknown>;
+  googleBaseUrl?: string;
+  otherBaseUrl?: string;
+  searchBaseUrl?: string;
+}): OpenClawConfig {
+  return {
+    agents: { list: [{ id: "main", default: true }] },
+    ...(params.googleBaseUrl || params.otherBaseUrl
+      ? {
+          models: {
+            providers: {
+              ...(params.googleBaseUrl
+                ? { google: { baseUrl: params.googleBaseUrl, models: [] } }
+                : {}),
+              ...(params.otherBaseUrl
+                ? { openai: { baseUrl: params.otherBaseUrl, models: [] } }
+                : {}),
+            },
+          },
+        }
+      : {}),
+    tools: {
+      web: {
+        search: {
+          ...(params.provider ? { provider: params.provider } : {}),
+          ...(params.enabled === false ? { enabled: false } : {}),
+        },
+      },
+    },
+    plugins: {
+      entries: {
+        brave: { enabled: true, config: { webSearch: { apiKey: "brave-fixture-key" } } },
+        google: {
+          enabled: true,
+          config: {
+            webSearch: {
+              apiKey: envRef("GOOGLE_SEARCH_API_REF"),
+              headers: params.headers ?? { "X.Routing.Token": envRef("GOOGLE_ROUTING_REF") },
+              ...(params.searchBaseUrl ? { baseUrl: params.searchBaseUrl } : {}),
+            },
+          },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function prepare(config: OpenClawConfig, env: NodeJS.ProcessEnv = {}) {
+  return prepareSecretsRuntimeSnapshot({
+    config,
+    env,
+    includeAuthStoreRefs: false,
+    allowUnavailableSecretOwners: true,
+    loadablePluginOrigins: origins,
+  });
+}
+
+function readGoogleConfig(config: OpenClawConfig) {
+  return config.plugins?.entries?.google?.config as {
+    webSearch: { apiKey: unknown; headers: Record<string, unknown> };
+  };
+}
+
+afterEach(() => clearSecretsRuntimeSnapshotState());
+
+describe("Google web-search supplemental SecretRefs", () => {
+  it("resolves dotted headers into the selected API-key owner's single ref set", async () => {
+    const headerValue = "google-routing-secret-value";
+    const snapshot = await prepare(createConfig({ provider: "gemini" }), {
+      GOOGLE_SEARCH_API_REF: "google-api-secret-value",
+      GOOGLE_ROUTING_REF: headerValue,
+    });
+
+    expect(snapshot.webTools.search.selectedProvider).toBe("gemini");
+    expect(readGoogleConfig(snapshot.config).webSearch).toEqual({
+      apiKey: "google-api-secret-value",
+      headers: { "X.Routing.Token": headerValue },
+    });
+    expect(snapshot.secretOwners?.filter((owner) => owner.ownerId === "web-search:gemini")).toEqual(
+      [
+        expect.objectContaining({
+          ownerKind: "capability",
+          refKeys: ["env:default:GOOGLE_ROUTING_REF", "env:default:GOOGLE_SEARCH_API_REF"],
+          resolvedValues: expect.arrayContaining([
+            { refKey: "env:default:GOOGLE_ROUTING_REF", value: headerValue },
+            { refKey: "env:default:GOOGLE_SEARCH_API_REF", value: "google-api-secret-value" },
+          ]),
+        }),
+      ],
+    );
+    expect(isSecretValueRegisteredForRedaction(headerValue)).toBe(true);
+  });
+
+  it.each([
+    { label: "explicit Brave", provider: "brave" as const, selected: "brave" },
+    { label: "auto-detected Brave", provider: undefined, selected: "brave" },
+    { label: "disabled search", provider: "gemini" as const, enabled: false, selected: undefined },
+  ])(
+    "does not resolve inactive Google headers for $label",
+    async ({ provider, enabled, selected }) => {
+      const snapshot = await prepare(createConfig({ provider, enabled }));
+
+      expect(snapshot.webTools.search.selectedProvider).toBe(selected);
+      expect(snapshot.degradedOwners).toEqual([]);
+      expect(readGoogleConfig(snapshot.config).webSearch.headers["X.Routing.Token"]).toEqual(
+        envRef("GOOGLE_ROUTING_REF"),
+      );
+    },
+  );
+
+  it("ignores missing provider-owned header refs before resolution", async () => {
+    const snapshot = await prepare(
+      createConfig({
+        provider: "gemini",
+        headers: {
+          "X-Goog-Api-Key": envRef("MISSING_IGNORED_GOOGLE_API_KEY"),
+          "x-GOOG-api-client": envRef("MISSING_IGNORED_GOOGLE_API_CLIENT"),
+          "Content-Type": envRef("MISSING_IGNORED_CONTENT_TYPE"),
+        },
+      }),
+      { GOOGLE_SEARCH_API_REF: "google-api-secret-value" },
+    );
+
+    expect(snapshot.webTools.search.selectedProvider).toBe("gemini");
+    expect(snapshot.degradedOwners).toEqual([]);
+    expect(snapshot.secretOwners).toEqual([
+      expect.objectContaining({
+        ownerId: "web-search:gemini",
+        refKeys: ["env:default:GOOGLE_SEARCH_API_REF"],
+      }),
+    ]);
+  });
+
+  it("isolates an unavailable selected header without credential fallback", async () => {
+    const snapshot = await prepare(createConfig({ provider: "gemini" }), {
+      GOOGLE_SEARCH_API_REF: "google-api-secret-value",
+      GEMINI_API_KEY: "must-not-bypass-missing-header",
+    });
+
+    expect(snapshot.webTools.search.selectedProvider).toBeUndefined();
+    expect(snapshot.degradedOwners).toEqual([
+      expect.objectContaining({
+        ownerKind: "capability",
+        ownerId: "web-search:gemini",
+        degradationState: "cold",
+        paths: ['plugins.entries.google.config.webSearch.headers["X.Routing.Token"]'],
+        refKeys: ["env:default:GOOGLE_ROUTING_REF", "env:default:GOOGLE_SEARCH_API_REF"],
+        reason: "secret reference was not found",
+      }),
+    ]);
+    expect(snapshot.warnings.map((warning) => warning.message).join("\n")).not.toContain(
+      "GOOGLE_ROUTING_REF",
+    );
+    expect(
+      snapshot.secretOwners?.filter((owner) => owner.ownerId === "web-search:gemini"),
+    ).toHaveLength(1);
+  });
+
+  it("never restores or sends stale credentials to a changed inherited destination", async () => {
+    const authenticatedRequests: string[] = [];
+    const previousHost = createServer((_request, response) => response.end("previous"));
+    const changedHost = createServer((request, response) => {
+      if (request.headers["x-goog-api-key"] || request.headers["x-gateway-token"]) {
+        authenticatedRequests.push(request.url ?? "");
+      }
+      response.end("changed");
+    });
+    const hosts = [previousHost, changedHost];
+    await Promise.all(
+      hosts.map(
+        (host) =>
+          new Promise<void>((resolve, reject) => {
+            host.once("error", reject);
+            host.listen(0, "127.0.0.1", resolve);
+          }),
+      ),
+    );
+
+    try {
+      const urls = hosts.map((host) => {
+        const address = host.address();
+        if (!address || typeof address === "string") {
+          throw new Error("security proof host did not bind");
+        }
+        return `http://127.0.0.1:${address.port}/v1beta`;
+      });
+      const headers = { "X-Gateway-Token": envRef("GOOGLE_ROUTING_REF") };
+      const active = await prepare(
+        createConfig({ provider: "gemini", googleBaseUrl: urls[0], headers }),
+        {
+          GOOGLE_SEARCH_API_REF: "previous-api-key",
+          GOOGLE_ROUTING_REF: "previous-gateway-token",
+        },
+      );
+      activateSecretsRuntimeSnapshotState({
+        snapshot: active,
+        refreshContext: null,
+        refreshHandler: null,
+      });
+
+      const candidate = await prepare(
+        createConfig({ provider: "gemini", googleBaseUrl: urls[1], headers }),
+        { GOOGLE_SEARCH_API_REF: "candidate-api-key" },
+      );
+      expect(candidate.degradedOwners).toEqual([
+        expect.objectContaining({ ownerId: "web-search:gemini", degradationState: "cold" }),
+      ]);
+      expect(candidate.webTools.search.selectedProvider).toBeUndefined();
+      expect(readGoogleConfig(candidate.config).webSearch).toEqual({
+        apiKey: "candidate-api-key",
+        headers,
+      });
+
+      activateSecretsRuntimeSnapshotState({
+        snapshot: candidate,
+        refreshContext: null,
+        refreshHandler: null,
+      });
+      const tool = createWebSearchTool({
+        config: candidate.config,
+        runtimeWebSearch: candidate.webTools.search,
+      });
+      await expect(
+        tool?.execute("security-proof", { query: "blocked" }, undefined),
+      ).rejects.toMatchObject({
+        code: "SECRET_SURFACE_UNAVAILABLE",
+        ownerId: "web-search:gemini",
+      });
+      expect(authenticatedRequests).toEqual([]);
+    } finally {
+      await Promise.all(
+        hosts.map(
+          (host) =>
+            new Promise<void>((resolve) => {
+              host.close(() => resolve());
+            }),
+        ),
+      );
+    }
+  });
+
+  it.each([
+    {
+      label: "normalized unchanged inherited destination",
+      initial: { googleBaseUrl: "https://google.example.invalid/v1beta/" },
+      candidate: { googleBaseUrl: "https://google.example.invalid/v1beta" },
+      state: "stale",
+    },
+    {
+      label: "unrelated provider destination change",
+      initial: {
+        googleBaseUrl: "https://google.example.invalid/v1beta",
+        otherBaseUrl: "https://old.example.invalid/v1",
+      },
+      candidate: {
+        googleBaseUrl: "https://google.example.invalid/v1beta",
+        otherBaseUrl: "https://new.example.invalid/v1",
+      },
+      state: "stale",
+    },
+    {
+      label: "changed plugin-owned destination",
+      initial: { searchBaseUrl: "https://old.example.invalid/v1beta" },
+      candidate: { searchBaseUrl: "https://new.example.invalid/v1beta" },
+      state: "cold",
+    },
+    {
+      label: "inherited destination shadowed by plugin override",
+      initial: {
+        googleBaseUrl: "https://old.example.invalid/v1beta",
+        searchBaseUrl: "https://fixed.example.invalid/v1beta",
+      },
+      candidate: {
+        googleBaseUrl: "https://changed.example.invalid/v1beta",
+        searchBaseUrl: "https://fixed.example.invalid/v1beta",
+      },
+      state: "stale",
+    },
+  ] as const)("classifies $label as $state", async ({ initial, candidate, state }) => {
+    const active = await prepare(createConfig({ provider: "gemini", ...initial }), {
+      GOOGLE_SEARCH_API_REF: "original-google-api-key",
+      GOOGLE_ROUTING_REF: "original-routing-header",
+    });
+    activateSecretsRuntimeSnapshotState({
+      snapshot: active,
+      refreshContext: null,
+      refreshHandler: null,
+    });
+
+    const failed = await prepare(createConfig({ provider: "gemini", ...candidate }), {
+      GOOGLE_SEARCH_API_REF: "rotated-google-api-key",
+    });
+    expect(failed.degradedOwners).toEqual([
+      expect.objectContaining({ ownerId: "web-search:gemini", degradationState: state }),
+    ]);
+    expect(failed.webTools.search.selectedProvider).toBe(state === "stale" ? "gemini" : undefined);
+  });
+
+  it.each([
+    { label: "unchanged owner", changed: false, state: "stale" },
+    { label: "changed header ref", changed: true, state: "cold" },
+    { label: "incomplete previous owner", changed: false, state: "cold" },
+  ] as const)(
+    "keeps $label $state when a header becomes unavailable",
+    async ({ changed, label, state }) => {
+      const config = createConfig({ provider: "gemini" });
+      const active = await prepare(config, {
+        GOOGLE_SEARCH_API_REF: "original-google-api-key",
+        GOOGLE_ROUTING_REF: "original-routing-header",
+      });
+      if (label === "incomplete previous owner") {
+        active.secretOwners![0]!.resolvedValues = active.secretOwners![0]!.resolvedValues?.filter(
+          ({ refKey }) => refKey !== "env:default:GOOGLE_ROUTING_REF",
+        );
+      }
+      activateSecretsRuntimeSnapshotState({
+        snapshot: active,
+        refreshContext: null,
+        refreshHandler: null,
+      });
+
+      const candidate = changed
+        ? createConfig({
+            provider: "gemini",
+            headers: { "X.Routing.Token": envRef("CHANGED_GOOGLE_ROUTING_REF") },
+          })
+        : config;
+      const failed = await prepare(candidate, {
+        GOOGLE_SEARCH_API_REF: "rotated-google-api-key",
+      });
+
+      expect(failed.degradedOwners).toEqual([
+        expect.objectContaining({ ownerId: "web-search:gemini", degradationState: state }),
+      ]);
+      if (state === "stale") {
+        expect(readGoogleConfig(failed.config).webSearch).toEqual({
+          apiKey: "original-google-api-key",
+          headers: { "X.Routing.Token": "original-routing-header" },
+        });
+        expect(failed.webTools.search.selectedProvider).toBe("gemini");
+      } else if (!changed) {
+        expect(readGoogleConfig(failed.config).webSearch.apiKey).toBe("rotated-google-api-key");
+      }
+    },
+  );
+});

--- a/src/secrets/runtime-owner-contract.test.ts
+++ b/src/secrets/runtime-owner-contract.test.ts
@@ -38,4 +38,39 @@ describe("runtime owner contracts", () => {
 
     expect(digestWebContract(shorthand)).toBe(digestWebContract(canonical));
   });
+
+  it("binds only the selected provider's canonical owner contribution", () => {
+    const digest = (sourceConfig: OpenClawConfig) =>
+      digestRuntimeWebOwnerContract({
+        scopePath: "tools.web.search",
+        configuredProvider: "first",
+        toolConfig: sourceConfig.tools?.web?.search,
+        providers: ["first", "other"].map((id) => ({
+          id,
+          getSecretOwnerContract: (config?: OpenClawConfig) => config?.models?.providers?.[id],
+        })),
+        providerId: "first",
+        sourceConfig,
+      });
+    const config = (firstUrl: string, otherUrl: string, apiKey: unknown): OpenClawConfig =>
+      ({
+        models: {
+          providers: {
+            first: { baseUrl: firstUrl, models: [], apiKey },
+            other: { baseUrl: otherUrl, models: [] },
+          },
+        },
+      }) as OpenClawConfig;
+    const first = config("https://first.invalid/v1", "https://other.invalid/v1", "$FIRST_KEY");
+    const equivalent = config("https://first.invalid/v1", "https://changed.invalid/v1", {
+      source: "env",
+      provider: "default",
+      id: "FIRST_KEY",
+    });
+
+    expect(digest(first)).toBe(digest(equivalent));
+    expect(digest(first)).not.toBe(
+      digest(config("https://changed.invalid/v1", "https://other.invalid/v1", "$FIRST_KEY")),
+    );
+  });
 });

--- a/src/secrets/runtime-owner-contract.ts
+++ b/src/secrets/runtime-owner-contract.ts
@@ -50,7 +50,11 @@ export function digestRuntimeWebOwnerContract(params: {
   scopePath: string;
   configuredProvider?: string;
   toolConfig: unknown;
-  providers: Array<{ id: string; pluginId?: string }>;
+  providers: Array<{
+    id: string;
+    pluginId?: string;
+    getSecretOwnerContract?: (config?: OpenClawConfig) => unknown;
+  }>;
   providerId: string;
   sourceConfig: OpenClawConfig;
 }): string {
@@ -63,6 +67,7 @@ export function digestRuntimeWebOwnerContract(params: {
         configuredProvider: params.configuredProvider,
         toolConfig: params.toolConfig,
         provider,
+        providerContract: provider?.getSecretOwnerContract?.(params.sourceConfig),
         pluginConfig: pluginId
           ? params.sourceConfig.plugins?.entries?.[pluginId]?.config
           : undefined,

--- a/src/secrets/runtime-web-tools-selection.types.ts
+++ b/src/secrets/runtime-web-tools-selection.types.ts
@@ -1,4 +1,5 @@
 /** Typed credential ownership and unavailable-provider results for runtime web tools. */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretRef, SecretRefSource } from "../config/types.secrets.js";
 import type { SecretDegradationReason } from "./runtime-degraded-state.js";
 import type { SecretResolverWarningCode } from "./runtime-shared.js";
@@ -24,25 +25,36 @@ export type SecretResolutionResult<TSource extends string> = {
   fallbackEnvVar?: string;
 };
 
-export type RuntimeWebSecretOwner = {
-  providerId: string;
+export type RuntimeWebSecretRef = {
   path: string;
   ref: SecretRef;
   refKey: string;
-  contractDigest: string;
   resolvedValue?: string;
-  reason?: SecretDegradationReason;
-  providerFailure?: { source: SecretRefSource; provider: string };
   restoreResolvedValue?: (value: string) => void;
 };
 
-export type RuntimeWebUnavailableProvider = RuntimeWebSecretOwner & {
+export type RuntimeWebSecretOwner = {
+  providerId: string;
+  contractDigest: string;
+  refs: RuntimeWebSecretRef[];
+};
+
+export type RuntimeWebUnavailableProvider = RuntimeWebSecretRef & {
+  providerId: string;
+  contractDigest: string;
   reason: SecretDegradationReason;
+  providerFailure?: { source: SecretRefSource; provider: string };
 };
 
 export type RuntimeWebProviderSelectionResult = {
   secretOwners: RuntimeWebSecretOwner[];
   unavailableProviders: RuntimeWebUnavailableProvider[];
+};
+
+export type RuntimeWebConfiguredSecretInput = {
+  path: string;
+  value: unknown;
+  setResolvedValue: (configTarget: OpenClawConfig, value: string) => void;
 };
 
 /** Carries typed web-provider ownership through strict reload failures. */

--- a/src/secrets/runtime-web-tools.shared.ts
+++ b/src/secrets/runtime-web-tools.shared.ts
@@ -10,8 +10,10 @@ import type { ResolverContext, SecretDefaults } from "./runtime-shared.js";
 import { pushInactiveSurfaceWarning, pushWarning } from "./runtime-shared.js";
 import {
   RuntimeWebProviderUnavailableError,
+  type RuntimeWebConfiguredSecretInput,
   type RuntimeWebResolveSecretInputParams,
   type RuntimeWebProviderSelectionResult,
+  type RuntimeWebSecretOwner,
   type RuntimeWebUnavailableProvider,
   type RuntimeWebWarningCode,
   type SecretResolutionResult,
@@ -83,6 +85,10 @@ type RuntimeWebProviderSelectionParams<
     config: OpenClawConfig;
     toolConfig: TToolConfig;
   }) => { path: string; value: unknown } | undefined;
+  getConfiguredSecretInputs?: (params: {
+    provider: TProvider;
+    config: OpenClawConfig;
+  }) => readonly RuntimeWebConfiguredSecretInput[];
   /** Resolves inline/env/SecretRef credentials and reports the winning source. */
   resolveSecretInput: (
     params: RuntimeWebResolveSecretInputParams,
@@ -379,6 +385,7 @@ export async function resolveRuntimeWebProviderSelection<
   const unavailableProviders: RuntimeWebUnavailableProvider[] = [];
   const resolveProviderContractDigest = (providerId: string) =>
     digestRuntimeWebOwnerContract({ ...params, providerId });
+  let selectedOwner: RuntimeWebSecretOwner | undefined;
   let selectedProvider: string | undefined;
   let selectedPath: string | undefined;
   let selectedResolution: SecretResolutionResult<TSource> | undefined;
@@ -505,7 +512,7 @@ export async function resolveRuntimeWebProviderSelection<
         continue;
       }
 
-      if (params.configuredProvider) {
+      if (params.configuredProvider || isKeyless || selectedCandidateResolution.value) {
         selectedProvider = provider.id;
         selectedPath = selectedCandidatePath;
         selectedResolution = selectedCandidateResolution;
@@ -521,42 +528,6 @@ export async function resolveRuntimeWebProviderSelection<
             value: selectedCandidateResolution.value,
           });
         }
-        break;
-      }
-
-      if (isKeyless) {
-        selectedProvider = provider.id;
-        selectedPath = selectedCandidatePath;
-        selectedResolution = selectedCandidateResolution;
-        if (selectedCandidateResolution.value) {
-          setResolvedCredentialPath({
-            resolvedConfig: params.resolvedConfig,
-            path: selectedCandidatePath,
-            value: selectedCandidateResolution.value,
-          });
-          params.setResolvedCredential({
-            resolvedConfig: params.resolvedConfig,
-            provider,
-            value: selectedCandidateResolution.value,
-          });
-        }
-        break;
-      }
-
-      if (selectedCandidateResolution.value) {
-        selectedProvider = provider.id;
-        selectedPath = selectedCandidatePath;
-        selectedResolution = selectedCandidateResolution;
-        setResolvedCredentialPath({
-          resolvedConfig: params.resolvedConfig,
-          path: selectedCandidatePath,
-          value: selectedCandidateResolution.value,
-        });
-        params.setResolvedCredential({
-          resolvedConfig: params.resolvedConfig,
-          provider,
-          value: selectedCandidateResolution.value,
-        });
         break;
       }
     }
@@ -567,6 +538,73 @@ export async function resolveRuntimeWebProviderSelection<
         source: "missing" as TSource,
         secretRefConfigured: false,
       };
+    }
+
+    const selectedEntry = params.providers.find((provider) => provider.id === selectedProvider);
+    if (selectedEntry) {
+      const contractDigest = resolveProviderContractDigest(selectedEntry.id);
+      if (selectedPath && selectedResolution?.secretRef && selectedResolution.secretRefKey) {
+        selectedOwner = {
+          providerId: selectedEntry.id,
+          contractDigest,
+          refs: [
+            {
+              path: selectedPath,
+              ref: selectedResolution.secretRef,
+              refKey: selectedResolution.secretRefKey,
+              ...(selectedResolution.value ? { resolvedValue: selectedResolution.value } : {}),
+              restoreResolvedValue: (value) =>
+                params.setResolvedCredential({
+                  resolvedConfig: params.resolvedConfig,
+                  provider: selectedEntry,
+                  value,
+                }),
+            },
+          ],
+        };
+      }
+      for (const input of params.getConfiguredSecretInputs?.({
+        provider: selectedEntry,
+        config: params.sourceConfig,
+      }) ?? []) {
+        if (!params.hasConfiguredSecretRef(input.value, params.defaults)) {
+          continue;
+        }
+        const resolution = await params.resolveSecretInput({
+          providerId: selectedEntry.id,
+          value: input.value,
+          path: input.path,
+          envVars: [],
+          contractDigest,
+        });
+        if (!resolution.secretRef || !resolution.secretRefKey) {
+          continue;
+        }
+        const owner = (selectedOwner ??= {
+          providerId: selectedEntry.id,
+          contractDigest,
+          refs: [],
+        });
+        const secret = {
+          path: input.path,
+          ref: resolution.secretRef,
+          refKey: resolution.secretRefKey,
+          ...(resolution.value ? { resolvedValue: resolution.value } : {}),
+          restoreResolvedValue: (value: string) =>
+            input.setResolvedValue(params.resolvedConfig, value),
+        };
+        owner.refs.push(secret);
+        if (resolution.value) {
+          secret.restoreResolvedValue(resolution.value);
+        } else if (resolution.unresolvedRefReason) {
+          unresolvedWithoutFallback.push({
+            ...secret,
+            provider: selectedEntry.id,
+            reason: resolution.unresolvedRefReason,
+            contractDigest,
+          });
+        }
+      }
     }
 
     const recordUnresolvedNoFallback = (unresolved: {
@@ -586,26 +624,16 @@ export async function resolveRuntimeWebProviderSelection<
         message: unresolved.reason,
       });
     };
+    const toUnavailableProviders = (entries: UnresolvedProvider[]) =>
+      entries.flatMap(({ provider, ref, refKey, ...failure }) =>
+        ref && refKey ? [{ providerId: provider, ref, refKey, ...failure }] : [],
+      );
     const failUnresolvedNoFallback = (
       unresolved: UnresolvedProvider,
       related: UnresolvedProvider[] = [unresolved],
     ): never => {
       recordUnresolvedNoFallback(unresolved);
-      const relatedUnavailableProviders = related.flatMap((entry) =>
-        entry.ref && entry.refKey
-          ? [
-              {
-                providerId: entry.provider,
-                path: entry.path,
-                ref: entry.ref,
-                refKey: entry.refKey,
-                reason: entry.reason,
-                contractDigest: entry.contractDigest,
-                restoreResolvedValue: entry.restoreResolvedValue,
-              },
-            ]
-          : [],
-      );
+      const relatedUnavailableProviders = toUnavailableProviders(related);
       if (relatedUnavailableProviders.length > 0) {
         const error = new RuntimeWebProviderUnavailableError(
           params.noFallbackCode,
@@ -618,31 +646,19 @@ export async function resolveRuntimeWebProviderSelection<
       throw new Error(`[${params.noFallbackCode}] ${unresolved.reason}`);
     };
 
-    if (params.configuredProvider) {
-      const unresolved = unresolvedWithoutFallback[0];
-      if (unresolved) {
-        const refKey = unresolved.refKey;
-        const ref = unresolved.ref;
-        if (refKey && ref) {
-          const unavailable = {
-            providerId: params.configuredProvider,
-            path: unresolved.path,
-            ref,
-            refKey,
-            reason: unresolved.reason,
-            contractDigest: unresolved.contractDigest,
-            restoreResolvedValue: unresolved.restoreResolvedValue,
-          };
-          if (params.allowUnavailableProviders) {
-            unavailableProviders.push(unavailable);
-          } else {
-            failUnresolvedNoFallback(unresolved);
-          }
-        } else {
-          failUnresolvedNoFallback(unresolved);
-        }
+    const selectedUnresolved = unresolvedWithoutFallback.filter(
+      (entry) => entry.provider === (selectedProvider ?? params.configuredProvider),
+    );
+    if (selectedUnresolved.length > 0) {
+      const firstUnresolved = expectDefined(selectedUnresolved[0], "selected unresolved provider");
+      const unavailable = toUnavailableProviders(selectedUnresolved);
+      if (!params.allowUnavailableProviders || unavailable.length !== selectedUnresolved.length) {
+        failUnresolvedNoFallback(firstUnresolved, selectedUnresolved);
       }
-    } else {
+      unavailableProviders.push(...unavailable);
+    }
+
+    if (!params.configuredProvider) {
       if (!selectedProvider && unresolvedWithoutFallback.length > 0) {
         const firstUnresolved = expectDefined(
           unresolvedWithoutFallback[0],
@@ -651,28 +667,14 @@ export async function resolveRuntimeWebProviderSelection<
         if (!params.allowUnavailableProviders) {
           failUnresolvedNoFallback(firstUnresolved, unresolvedWithoutFallback);
         }
-        const unavailable = unresolvedWithoutFallback.flatMap((entry) =>
-          entry.ref && entry.refKey
-            ? [
-                {
-                  providerId: entry.provider,
-                  path: entry.path,
-                  ref: entry.ref,
-                  refKey: entry.refKey,
-                  reason: entry.reason,
-                  contractDigest: entry.contractDigest,
-                  restoreResolvedValue: entry.restoreResolvedValue,
-                },
-              ]
-            : [],
-        );
+        const unavailable = toUnavailableProviders(unresolvedWithoutFallback);
         if (unavailable.length !== unresolvedWithoutFallback.length) {
           failUnresolvedNoFallback(firstUnresolved, unresolvedWithoutFallback);
         }
         unavailableProviders.push(...unavailable);
       }
 
-      if (selectedProvider) {
+      if (selectedProvider && unavailableProviders.length === 0) {
         const selectedProviderEntry = params.providers.find(
           (entry) => entry.id === selectedProvider,
         );
@@ -729,22 +731,14 @@ export async function resolveRuntimeWebProviderSelection<
     });
   }
 
-  const selectedSecretOwner =
-    selectedProvider &&
-    selectedPath &&
-    selectedResolution?.secretRef &&
-    selectedResolution.secretRefKey
-      ? {
-          providerId: selectedProvider,
-          path: selectedPath,
-          ref: selectedResolution.secretRef,
-          refKey: selectedResolution.secretRefKey,
-          contractDigest: resolveProviderContractDigest(selectedProvider),
-          ...(selectedResolution.value ? { resolvedValue: selectedResolution.value } : {}),
-        }
-      : undefined;
   return {
-    secretOwners: selectedSecretOwner ? [selectedSecretOwner] : unavailableProviders,
+    secretOwners: selectedOwner
+      ? [selectedOwner]
+      : unavailableProviders.map((unavailable) => ({
+          providerId: unavailable.providerId,
+          contractDigest: unavailable.contractDigest,
+          refs: [unavailable],
+        })),
     unavailableProviders,
   };
 }

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "../plugins/installed-plugin-index-records.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import type {
@@ -110,6 +111,8 @@ function createUnavailableWebProviderOwner(params: {
     RuntimeWebUnavailableProvider,
     "providerId" | "path" | "refKey" | "reason" | "providerFailure"
   >;
+  relatedUnavailable?: RuntimeWebUnavailableProvider[];
+  owner?: RuntimeWebSecretOwner;
   degradationState?: "cold" | "stale";
 }): DegradedSecretOwner {
   return {
@@ -117,8 +120,10 @@ function createUnavailableWebProviderOwner(params: {
     ownerId: runtimeWebSecretOwnerId(params.kind, params.unavailable.providerId),
     state: "unavailable",
     degradationState: params.degradationState ?? "cold",
-    paths: [params.unavailable.path],
-    refKeys: [params.unavailable.refKey],
+    paths: (params.relatedUnavailable ?? [params.unavailable]).map((entry) => entry.path),
+    refKeys: sortUniqueStrings(
+      (params.owner?.refs ?? [params.unavailable]).map((entry) => entry.refKey),
+    ),
     reason: params.unavailable.reason,
     ...(params.unavailable.providerFailure
       ? { providerFailures: [params.unavailable.providerFailure] }
@@ -144,11 +149,18 @@ function collectUnavailableWebProviders(params: {
   degradedOwners: DegradedSecretOwner[];
   forceColdRefKeys?: ReadonlySet<string>;
 }): void {
-  for (const unavailable of params.result.unavailableProviders) {
+  for (const owner of params.result.secretOwners) {
+    const relatedUnavailable = params.result.unavailableProviders.filter(
+      (unavailable) => unavailable.providerId === owner.providerId,
+    );
+    const unavailable = relatedUnavailable[0];
+    if (!unavailable) {
+      continue;
+    }
     let degradationState = classifySecretOwnerDegradationState({
       ownerKind: "capability",
       ownerId: runtimeWebSecretOwnerId(params.kind, unavailable.providerId),
-      refs: [unavailable.ref],
+      refs: owner.refs.map((secret) => secret.ref),
       config: params.sourceConfig,
       contractDigest: unavailable.contractDigest,
       forceColdRefKeys: params.forceColdRefKeys,
@@ -160,21 +172,23 @@ function collectUnavailableWebProviders(params: {
           entry.ownerKind === "capability" &&
           entry.ownerId === runtimeWebSecretOwnerId(params.kind, unavailable.providerId),
       );
-      const value = activeOwner?.resolvedValues?.find(
-        (entry) => entry.refKey === unavailable.refKey,
-      )?.value;
       try {
-        if (typeof value !== "string" || !unavailable.restoreResolvedValue) {
-          throw new Error("last-known-good web credential is unavailable");
-        }
-        unavailable.restoreResolvedValue(value);
-        unavailable.resolvedValue = value;
-        const selectedOwner = params.result.secretOwners.find(
-          (entry) =>
-            entry.providerId === unavailable.providerId && entry.refKey === unavailable.refKey,
-        );
-        if (selectedOwner) {
-          selectedOwner.resolvedValue = value;
+        const restored = owner.refs.map((secret) => {
+          const value = activeOwner?.resolvedValues?.find(
+            (entry) => entry.refKey === secret.refKey,
+          )?.value;
+          if (typeof value !== "string" || !secret.restoreResolvedValue) {
+            throw new Error("last-known-good web credential is unavailable");
+          }
+          return { secret, value, restore: secret.restoreResolvedValue };
+        });
+        for (const { secret, value, restore } of restored) {
+          restore(value);
+          secret.resolvedValue = value;
+          const failure = relatedUnavailable.find((entry) => entry.refKey === secret.refKey);
+          if (failure) {
+            failure.resolvedValue = value;
+          }
         }
         const activeMetadata =
           params.kind === "search" ? active?.webTools.search : active?.webTools.fetch;
@@ -189,13 +203,15 @@ function collectUnavailableWebProviders(params: {
         degradationState = "cold";
       }
     }
-    const owner = createUnavailableWebProviderOwner({
+    const degradedOwner = createUnavailableWebProviderOwner({
       kind: params.kind,
       unavailable,
+      relatedUnavailable,
+      owner,
       degradationState,
     });
-    params.degradedOwners.push(owner);
-    warnDegradedSecretOwner(params.context, owner);
+    params.degradedOwners.push(degradedOwner);
+    warnDegradedSecretOwner(params.context, degradedOwner);
   }
 }
 
@@ -203,13 +219,20 @@ function toWebSecretOwnerRefState(
   kind: "search" | "fetch",
   owner: RuntimeWebSecretOwner,
 ): SecretOwnerRefState {
+  const resolvedValues = new Map(
+    owner.refs.flatMap((entry) =>
+      entry.resolvedValue ? [[entry.refKey, entry.resolvedValue] as const] : [],
+    ),
+  );
   return {
     ownerKind: "capability",
     ownerId: runtimeWebSecretOwnerId(kind, owner.providerId),
-    refKeys: [owner.refKey],
+    refKeys: sortUniqueStrings(owner.refs.map((entry) => entry.refKey)),
     contractDigest: owner.contractDigest,
-    ...(owner.resolvedValue
-      ? { resolvedValues: [{ refKey: owner.refKey, value: owner.resolvedValue }] }
+    ...(resolvedValues.size > 0
+      ? {
+          resolvedValues: [...resolvedValues].map(([refKey, value]) => ({ refKey, value })),
+        }
       : {}),
   };
 }
@@ -539,6 +562,7 @@ async function resolveSecretInputWithEnvFallback(params: {
   }
 
   if (resolvedFromRef) {
+    registerSecretValueForRedaction(resolvedFromRef);
     return {
       value: resolvedFromRef,
       source: "secretRef",
@@ -925,6 +949,8 @@ export async function resolveRuntimeWebTools(params: {
           config,
           search: toolConfig,
         }),
+      getConfiguredSecretInputs: ({ provider, config }) =>
+        provider.getConfiguredSecretInputs?.(config) ?? [],
       resolveSecretInput: ({ providerId, value, path, envVars, contractDigest }) =>
         resolveSecretInputWithEnvFallback({
           kind: "search",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google web-search supplemental header SecretRefs were advertised but collected as unknown plugin secrets before provider selection. A missing Google header could abort the Gateway even when Brave was selected or search was disabled, while dotted header names could be written to the wrong config location.

## Why This Change Was Made

Applicable Gemini supplemental headers now join the selected `capability:web-search:gemini` owner with the API key as one atomic owner record. Resolution happens only after Gemini wins selection. Provider-owned authentication headers are filtered before resolution, exact header keys are preserved, and stale restoration is bound to the normalized effective request destination, including inherited model-provider URLs.

The generic collector handoff is limited to the exact `webSearch.headers.*` contract; unrelated third-party plugin SecretRefs remain strict and generic.

## User Impact

Missing Google-only header credentials no longer affect Brave or disabled search. Gemini requests can use environment-, file-, exec-, or store-backed supplemental headers, including names containing dots, without overriding provider authentication. Credentials are never restored to a changed proxy host.

AI-assisted implementation; I reviewed the owner boundary, live requests, tests, and two security-review rounds.

## Evidence

- Pre-fix coverage reproduced unknown-owner startup failures, inactive Google references affecting other selections, dotted-key loss, and ignored provider-auth references being resolved.
- 130 focused tests passed after rebasing onto current `main`; 794 passed before rebase.
- Two autoreview passes, including post-rebase review, reported no actionable findings.
- Initial security review found stale proxy credential replay after inherited host changes. The owner contract now includes the provider's normalized effective destination; final security review found no qualifying vulnerabilities.
- Isolated real dev Gateways and loopback mock provider:
  - Brave selected with missing Google headers: `/readyz` `200`, no Gemini degradation;
  - Gemini selected: dotted supplemental header reached the mock request, provider `x-goog-api-key` remained authoritative, ignored provider-owned refs caused no degradation;
  - inherited host changed during header outage: owner became cold, no API key or old header was restored, invocation was blocked, and the changed host received zero authenticated requests.

Production LOC: +239/-150 (net +89). Tests: +463/-22 (net +441).
