### PR TITLE
refactor(cli): centralize onboarding and setup option ownership

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2473,8 +2473,8 @@ src/cli/program/register.audit.ts	12
 src/cli/program/register.backup.ts	14
 src/cli/program/register.configure.ts	1
 src/cli/program/register.migrate.ts	12
-src/cli/program/register.onboard.ts	37
-src/cli/program/register.setup.ts	10
+src/cli/program/register.onboard.ts	28
+src/cli/program/register.setup.ts	2
 src/cli/program/register.status-health-sessions.ts	29
 src/cli/program/route-specs.ts	1
 src/cli/run-main.ts	1

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -23,7 +23,7 @@ import { formatCliCommand } from "../command-format.js";
 import { listExplicitOptionFlagsExcept } from "../command-options.js";
 import { parseGatewayPortOption } from "../gateway-port-option.js";
 
-export function resolveInstallDaemonFlag(command: Command): boolean | undefined {
+function resolveInstallDaemonFlag(command: Command): boolean | undefined {
   // Commander doesn't support option conflicts natively; keep original behavior.
   // If --skip-daemon is explicitly passed, it wins.
   if (command.getOptionValueSource("skipDaemon") === "cli") {
@@ -147,9 +147,61 @@ export function registerOnboardAuthOptions(command: Command): Command {
     .option("--custom-text-input", "Mark the custom provider model as text-only");
 }
 
-export function pickOnboardAuthOptionValues(
-  opts: Record<string, unknown>,
-): Partial<OnboardOptions> {
+export function registerOnboardGatewayOptions(command: Command): Command {
+  return command
+    .option("--gateway-port <port>", "Gateway port")
+    .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")
+    .option("--gateway-auth <mode>", "Gateway auth: token|password")
+    .option("--gateway-token <token>", "Gateway token (token auth)")
+    .option(
+      "--gateway-token-ref-env <name>",
+      "Gateway token SecretRef env var name (token auth; e.g. OPENCLAW_GATEWAY_TOKEN)",
+    )
+    .option("--gateway-password <password>", "Gateway password (password auth)");
+}
+
+export function registerOnboardRemoteOptions(command: Command): Command {
+  return command
+    .option("--remote-url <url>", "Remote Gateway WebSocket URL")
+    .option("--remote-token <token>", "Remote Gateway token (optional)")
+    .option("--remote-password <password>", "Remote Gateway password (optional)");
+}
+
+export function registerOnboardRuntimeOptions(
+  command: Command,
+  variant: "onboard" | "setup",
+): Command {
+  return command
+    .option("--tailscale <mode>", "Tailscale: off|serve|funnel")
+    .addOption(new Option("--tailscale-reset-on-exit").hideHelp())
+    .addOption(new Option("--no-tailscale-reset-on-exit").hideHelp())
+    .option("--install-daemon", "Install gateway service")
+    .option("--no-install-daemon", "Skip gateway service install")
+    .option("--skip-daemon", "Skip gateway service install")
+    .option("--daemon-runtime <runtime>", "Daemon runtime: node")
+    .option("--skip-channels", "Skip channel setup")
+    .option("--skip-skills", "Skip skills setup")
+    .option("--skip-bootstrap", "Skip creating default agent workspace files")
+    .option("--skip-search", "Skip search provider setup")
+    .option("--skip-health", "Skip health check")
+    .option(
+      "--skip-ui",
+      variant === "setup" ? "Skip Control UI/TUI launch" : "Skip Control UI/TUI prompts",
+    )
+    .option("--suppress-gateway-token-output", "Disable the guided Control UI handoff")
+    .option(
+      "--skip-hooks",
+      variant === "setup"
+        ? "Accepted for onboard compatibility; hooks setup is skipped"
+        : "Skip hook setup",
+    )
+    .option("--node-manager <name>", "Node manager for skills: npm|pnpm|bun")
+    .option("--import-from <provider>", "Migration provider to run during onboarding")
+    .option("--import-source <path>", "Source agent home for --import-from")
+    .option("--import-secrets", "Import supported secrets during onboarding migration", false);
+}
+
+function pickOnboardAuthOptionValues(opts: Record<string, unknown>): Partial<OnboardOptions> {
   const customTextInput = opts.customTextInput === true;
   return {
     authChoice: opts.authChoice as AuthChoice | undefined,
@@ -171,6 +223,50 @@ export function pickOnboardAuthOptionValues(
       | "anthropic"
       | undefined,
     customImageInput: customTextInput ? false : opts.customImageInput === true ? true : undefined,
+  };
+}
+
+export function resolveOnboardCommandOptions(
+  opts: Record<string, unknown>,
+  command: Command,
+): OnboardOptions {
+  return {
+    workspace: readStringValue(opts.workspace),
+    agentName: readStringValue(opts.agentName),
+    nonInteractive: Boolean(opts.nonInteractive),
+    acceptRisk: Boolean(opts.acceptRisk),
+    classic: Boolean(opts.classic),
+    tui: Boolean(opts.tui),
+    flow: opts.flow as "quickstart" | "advanced" | "manual" | "import" | undefined,
+    mode: opts.mode as "local" | "remote" | undefined,
+    ...pickOnboardAuthOptionValues(opts),
+    gatewayPort: parseGatewayPortOption(opts.gatewayPort, "--gateway-port"),
+    gatewayBind: opts.gatewayBind as GatewayBind | undefined,
+    gatewayAuth: opts.gatewayAuth as GatewayAuthChoice | undefined,
+    gatewayToken: readStringValue(opts.gatewayToken),
+    gatewayTokenRefEnv: readStringValue(opts.gatewayTokenRefEnv),
+    gatewayPassword: readStringValue(opts.gatewayPassword),
+    remoteUrl: readStringValue(opts.remoteUrl),
+    remoteToken: readStringValue(opts.remoteToken),
+    remotePassword: readStringValue(opts.remotePassword),
+    tailscale: opts.tailscale as TailscaleMode | undefined,
+    reset: Boolean(opts.reset),
+    resetScope: opts.resetScope as ResetScope | undefined,
+    installDaemon: resolveInstallDaemonFlag(command),
+    daemonRuntime: opts.daemonRuntime as GatewayDaemonRuntime | undefined,
+    skipChannels: Boolean(opts.skipChannels),
+    skipSkills: Boolean(opts.skipSkills),
+    skipBootstrap: Boolean(opts.skipBootstrap),
+    skipSearch: Boolean(opts.skipSearch),
+    skipHealth: Boolean(opts.skipHealth),
+    skipUi: Boolean(opts.skipUi),
+    suppressGatewayTokenOutput: Boolean(opts.suppressGatewayTokenOutput),
+    skipHooks: Boolean(opts.skipHooks),
+    nodeManager: opts.nodeManager as NodeManagerChoice | undefined,
+    importFrom: readStringValue(opts.importFrom),
+    importSource: readStringValue(opts.importSource),
+    importSecrets: Boolean(opts.importSecrets),
+    json: Boolean(opts.json),
   };
 }
 
@@ -218,40 +314,10 @@ export function registerOnboardCommand(program: Command): void {
     .option("--mode <mode>", "Onboard mode: local|remote");
 
   registerOnboardAuthOptions(command);
-
-  command
-    .option("--gateway-port <port>", "Gateway port")
-    .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")
-    .option("--gateway-auth <mode>", "Gateway auth: token|password")
-    .option("--gateway-token <token>", "Gateway token (token auth)")
-    .option(
-      "--gateway-token-ref-env <name>",
-      "Gateway token SecretRef env var name (token auth; e.g. OPENCLAW_GATEWAY_TOKEN)",
-    )
-    .option("--gateway-password <password>", "Gateway password (password auth)")
-    .option("--remote-url <url>", "Remote Gateway WebSocket URL")
-    .option("--remote-token <token>", "Remote Gateway token (optional)")
-    .option("--remote-password <password>", "Remote Gateway password (optional)")
-    .option("--tailscale <mode>", "Tailscale: off|serve|funnel")
-    .addOption(new Option("--tailscale-reset-on-exit").hideHelp())
-    .addOption(new Option("--no-tailscale-reset-on-exit").hideHelp())
-    .option("--install-daemon", "Install gateway service")
-    .option("--no-install-daemon", "Skip gateway service install")
-    .option("--skip-daemon", "Skip gateway service install")
-    .option("--daemon-runtime <runtime>", "Daemon runtime: node")
-    .option("--skip-channels", "Skip channel setup")
-    .option("--skip-skills", "Skip skills setup")
-    .option("--skip-bootstrap", "Skip creating default agent workspace files")
-    .option("--skip-search", "Skip search provider setup")
-    .option("--skip-health", "Skip health check")
-    .option("--skip-ui", "Skip Control UI/TUI prompts")
-    .option("--suppress-gateway-token-output", "Disable the guided Control UI handoff")
-    .option("--skip-hooks", "Skip hook setup")
-    .option("--node-manager <name>", "Node manager for skills: npm|pnpm|bun")
-    .option("--import-from <provider>", "Migration provider to run during onboarding")
-    .option("--import-source <path>", "Source agent home for --import-from")
-    .option("--import-secrets", "Import supported secrets during onboarding migration", false)
-    .option("--json", "Output JSON summary", false);
+  registerOnboardGatewayOptions(command);
+  registerOnboardRemoteOptions(command);
+  registerOnboardRuntimeOptions(command, "onboard");
+  command.option("--json", "Output JSON summary", false);
 
   const recommendations = command
     .command("recommendations")
@@ -363,50 +429,12 @@ export function registerOnboardCommand(program: Command): void {
       if (!validateOnboardAuthOptionValues(opts as Record<string, unknown>, defaultRuntime)) {
         return;
       }
-      const installDaemon = resolveInstallDaemonFlag(commandRuntime);
-      const gatewayPort = parseGatewayPortOption(opts.gatewayPort, "--gateway-port");
-      const { setupWizardCommand } = await import("../../commands/onboard.js");
-      await setupWizardCommand(
-        {
-          workspace: opts.workspace as string | undefined,
-          agentName: opts.agentName as string | undefined,
-          nonInteractive: Boolean(opts.nonInteractive),
-          acceptRisk: Boolean(opts.acceptRisk),
-          classic: Boolean(opts.classic),
-          tui: Boolean(opts.tui),
-          flow: opts.flow as "quickstart" | "advanced" | "manual" | "import" | undefined,
-          mode: opts.mode as "local" | "remote" | undefined,
-          ...pickOnboardAuthOptionValues(opts as Record<string, unknown>),
-          gatewayPort,
-          gatewayBind: opts.gatewayBind as GatewayBind | undefined,
-          gatewayAuth: opts.gatewayAuth as GatewayAuthChoice | undefined,
-          gatewayToken: opts.gatewayToken as string | undefined,
-          gatewayTokenRefEnv: opts.gatewayTokenRefEnv as string | undefined,
-          gatewayPassword: opts.gatewayPassword as string | undefined,
-          remoteUrl: opts.remoteUrl as string | undefined,
-          remoteToken: opts.remoteToken as string | undefined,
-          remotePassword: readStringValue(opts.remotePassword),
-          tailscale: opts.tailscale as TailscaleMode | undefined,
-          reset: Boolean(opts.reset),
-          resetScope: opts.resetScope as ResetScope | undefined,
-          installDaemon,
-          daemonRuntime: opts.daemonRuntime as GatewayDaemonRuntime | undefined,
-          skipChannels: Boolean(opts.skipChannels),
-          skipSkills: Boolean(opts.skipSkills),
-          skipBootstrap: Boolean(opts.skipBootstrap),
-          skipSearch: Boolean(opts.skipSearch),
-          skipHealth: Boolean(opts.skipHealth),
-          skipUi: Boolean(opts.skipUi),
-          suppressGatewayTokenOutput: Boolean(opts.suppressGatewayTokenOutput),
-          skipHooks: Boolean(opts.skipHooks),
-          nodeManager: opts.nodeManager as NodeManagerChoice | undefined,
-          importFrom: opts.importFrom as string | undefined,
-          importSource: opts.importSource as string | undefined,
-          importSecrets: Boolean(opts.importSecrets),
-          json: Boolean(opts.json),
-        },
-        defaultRuntime,
+      const onboardingOptions = resolveOnboardCommandOptions(
+        opts as Record<string, unknown>,
+        commandRuntime,
       );
+      const { setupWizardCommand } = await import("../../commands/onboard.js");
+      await setupWizardCommand(onboardingOptions, defaultRuntime);
     });
   });
 }

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -1,6 +1,7 @@
 // Register setup tests cover setup command registration and option wiring.
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerOnboardCommand } from "./register.onboard.js";
 import { registerSetupCommand, resolveSetupCommandRoute } from "./register.setup.js";
 
 const mocks = vi.hoisted(() => ({
@@ -97,6 +98,45 @@ describe("registerSetupCommand", () => {
       path: "/tmp/openclaw.json",
       sourceConfig: {},
     });
+  });
+
+  it("keeps shared onboarding flags aligned while preserving command-specific help", () => {
+    const program = new Command();
+    registerOnboardCommand(program);
+    registerSetupCommand(program);
+    const onboard = program.commands.find((command) => command.name() === "onboard")!;
+    const setup = program.commands.find((command) => command.name() === "setup")!;
+    const setupOptions = new Map(setup.options.map((option) => [option.flags, option]));
+    const distinctHelp = new Set([
+      "workspace",
+      "reset",
+      "nonInteractive",
+      "skipUi",
+      "skipHooks",
+      "json",
+    ]);
+
+    for (const option of onboard.options) {
+      const sibling = setupOptions.get(option.flags);
+      if (!sibling) {
+        continue;
+      }
+      expect([sibling.flags, sibling.defaultValue, sibling.hidden]).toEqual([
+        option.flags,
+        option.defaultValue,
+        option.hidden,
+      ]);
+      if (!distinctHelp.has(option.attributeName())) {
+        expect(sibling.description).toBe(option.description);
+      }
+    }
+
+    const optionIndex = (command: Command, name: string) =>
+      command.options.findIndex((option) => option.attributeName() === name);
+    expect(optionIndex(onboard, "remoteUrl")).toBeLessThan(optionIndex(onboard, "tailscale"));
+    expect(optionIndex(setup, "remoteUrl")).toBeGreaterThan(optionIndex(setup, "importSecrets"));
+    expect(setupOptions.get("--tailscale-reset-on-exit")?.hidden).toBe(true);
+    expect(setupOptions.get("--no-tailscale-reset-on-exit")?.hidden).toBe(true);
   });
 
   it("keeps routing precedence explicit", () => {

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -1,25 +1,18 @@
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 // Setup command registration: system-agent chat for configured systems, onboarding otherwise.
-import { Option, type Command } from "commander";
+import type { Command } from "commander";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
-import type { GatewayDaemonRuntime } from "../../commands/daemon-runtime.js";
-import type {
-  GatewayAuthChoice,
-  GatewayBind,
-  NodeManagerChoice,
-  ResetScope,
-  TailscaleMode,
-} from "../../commands/onboard-types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions, listExplicitOptionFlagsExcept } from "../command-options.js";
 import { isUnconfiguredConfigSource } from "../fresh-install-config.js";
-import { parseGatewayPortOption } from "../gateway-port-option.js";
 import {
-  pickOnboardAuthOptionValues,
   registerOnboardAuthOptions,
-  resolveInstallDaemonFlag,
+  registerOnboardGatewayOptions,
+  registerOnboardRemoteOptions,
+  registerOnboardRuntimeOptions,
+  resolveOnboardCommandOptions,
   validateOnboardAuthOptionValues,
 } from "./register.onboard.js";
 
@@ -113,50 +106,9 @@ async function runOnboardingEntry(
   if (!validateOnboardAuthOptionValues(options, runtime)) {
     return;
   }
-  const installDaemon = resolveInstallDaemonFlag(commandRuntime);
-  const gatewayPort = parseGatewayPortOption(options.gatewayPort, "--gateway-port");
+  const onboardingOptions = resolveOnboardCommandOptions(options, commandRuntime);
   const { setupWizardCommand } = await import("../../commands/onboard.js");
-  await setupWizardCommand(
-    {
-      workspace: readStringValue(options.workspace),
-      agentName: readStringValue(options.agentName),
-      nonInteractive: Boolean(options.nonInteractive),
-      acceptRisk: Boolean(options.acceptRisk),
-      classic: Boolean(options.classic),
-      tui: Boolean(options.tui),
-      flow: options.flow as "quickstart" | "advanced" | "manual" | "import" | undefined,
-      mode: options.mode as "local" | "remote" | undefined,
-      ...pickOnboardAuthOptionValues(options),
-      reset: Boolean(options.reset),
-      resetScope: options.resetScope as ResetScope | undefined,
-      gatewayPort,
-      gatewayBind: options.gatewayBind as GatewayBind | undefined,
-      gatewayAuth: options.gatewayAuth as GatewayAuthChoice | undefined,
-      gatewayToken: readStringValue(options.gatewayToken),
-      gatewayTokenRefEnv: readStringValue(options.gatewayTokenRefEnv),
-      gatewayPassword: readStringValue(options.gatewayPassword),
-      tailscale: options.tailscale as TailscaleMode | undefined,
-      installDaemon,
-      daemonRuntime: options.daemonRuntime as GatewayDaemonRuntime | undefined,
-      skipChannels: Boolean(options.skipChannels),
-      skipSkills: Boolean(options.skipSkills),
-      skipBootstrap: Boolean(options.skipBootstrap),
-      skipSearch: Boolean(options.skipSearch),
-      skipHealth: Boolean(options.skipHealth),
-      skipUi: Boolean(options.skipUi),
-      suppressGatewayTokenOutput: Boolean(options.suppressGatewayTokenOutput),
-      skipHooks: Boolean(options.skipHooks),
-      nodeManager: options.nodeManager as NodeManagerChoice | undefined,
-      importFrom: readStringValue(options.importFrom),
-      importSource: readStringValue(options.importSource),
-      importSecrets: Boolean(options.importSecrets),
-      remoteUrl: readStringValue(options.remoteUrl),
-      remoteToken: readStringValue(options.remoteToken),
-      remotePassword: readStringValue(options.remotePassword),
-      json: Boolean(options.json),
-    },
-    runtime,
-  );
+  await setupWizardCommand(onboardingOptions, runtime);
 }
 
 function addSystemAgentOptions(command: Command): Command {
@@ -211,39 +163,9 @@ export function registerSetupCommand(program: Command): void {
     .option("--mode <mode>", "Onboard mode: local|remote");
 
   registerOnboardAuthOptions(command);
-
-  command
-    .option("--gateway-port <port>", "Gateway port")
-    .option("--gateway-bind <mode>", "Gateway bind: loopback|tailnet|lan|auto|custom")
-    .option("--gateway-auth <mode>", "Gateway auth: token|password")
-    .option("--gateway-token <token>", "Gateway token (token auth)")
-    .option(
-      "--gateway-token-ref-env <name>",
-      "Gateway token SecretRef env var name (token auth; e.g. OPENCLAW_GATEWAY_TOKEN)",
-    )
-    .option("--gateway-password <password>", "Gateway password (password auth)")
-    .option("--tailscale <mode>", "Tailscale: off|serve|funnel")
-    .addOption(new Option("--tailscale-reset-on-exit").hideHelp())
-    .addOption(new Option("--no-tailscale-reset-on-exit").hideHelp())
-    .option("--install-daemon", "Install gateway service")
-    .option("--no-install-daemon", "Skip gateway service install")
-    .option("--skip-daemon", "Skip gateway service install")
-    .option("--daemon-runtime <runtime>", "Daemon runtime: node")
-    .option("--skip-channels", "Skip channel setup")
-    .option("--skip-skills", "Skip skills setup")
-    .option("--skip-bootstrap", "Skip creating default agent workspace files")
-    .option("--skip-search", "Skip search provider setup")
-    .option("--skip-health", "Skip health check")
-    .option("--skip-ui", "Skip Control UI/TUI launch")
-    .option("--suppress-gateway-token-output", "Disable the guided Control UI handoff")
-    .option("--skip-hooks", "Accepted for onboard compatibility; hooks setup is skipped")
-    .option("--node-manager <name>", "Node manager for skills: npm|pnpm|bun")
-    .option("--import-from <provider>", "Migration provider to run during onboarding")
-    .option("--import-source <path>", "Source agent home for --import-from")
-    .option("--import-secrets", "Import supported secrets during onboarding migration", false)
-    .option("--remote-url <url>", "Remote Gateway WebSocket URL")
-    .option("--remote-token <token>", "Remote Gateway token (optional)")
-    .option("--remote-password <password>", "Remote Gateway password (optional)");
+  registerOnboardGatewayOptions(command);
+  registerOnboardRuntimeOptions(command, "setup");
+  registerOnboardRemoteOptions(command);
 
   addSystemAgentOptions(command).action(async (rawOptions, commandRuntime: Command) => {
     const { defaultRuntime } = await import("../../runtime.js");


### PR DESCRIPTION
## Summary

- centralize shared onboarding Gateway, remote-Gateway, and runtime flag registration in the existing onboarding command owner
- route both `openclaw onboard` and `openclaw setup` through one canonical onboarding-options projection while preserving daemon flag precedence, provider-auth flags, lazy dispatch, route selection, and command-specific help
- remove 50 production lines and 17 grandfathered unsafe type assertions; add real-Commander parity coverage for shared flags, defaults, hidden retired aliases, and intentionally different public option ordering

## Compatibility proof

Complete public option surfaces were fingerprinted before and after the refactor across flag spelling, description, default, hidden state, and registration order:

- `onboard`: 115 options, unchanged SHA-256 `7b41facf445973e8587c16a45e50dbf1ff28f6ef455cf0ddee36d931eee154fb`
- `setup`: 118 options, unchanged SHA-256 `3730f5717ccf85b64a211a0f05778b98c39536312479842a443e29b2679957f5`

## Verification

- Complete onboarding, setup, and cold-help import suites: **93 tests passed** across 3 files.
- Assertion-safety ratchet: passed with both touched production baselines tightened (`37 -> 28`; `10 -> 2`).
- Maximum-lines ratchet, focused lint, formatting validation, and `git diff --check`: passed.
- Independent structured code review: no actionable findings.
- Production LOC: `+119/-169` (**net -50**); tests: `+40/-0`; assertion baseline: `+2/-2`.
