### PR TITLE
fix(gateway): streamed tool calls silently omit assistant commentary

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -2831,6 +2831,24 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(res.status).toBe(200);
     const text = await res.text();
     const events = parseSseEvents(text);
+    const commentaryDeltas = events.filter((event) => event.event === "response.output_text.delta");
+    expect(
+      commentaryDeltas.map((event) => (parseSseData(event) as { delta?: string }).delta),
+    ).toEqual(["Let me check that."]);
+    expect(
+      collectSseEventTypes(events).filter((event) =>
+        [
+          "response.output_text.delta",
+          "response.output_text.done",
+          "response.output_item.done",
+        ].includes(event),
+      ),
+    ).toEqual([
+      "response.output_text.delta",
+      "response.output_text.done",
+      "response.output_item.done",
+      "response.output_item.done",
+    ]);
     const outputTextDone = findSseEvent(events, "response.output_text.done");
     expect((parseSseData(outputTextDone) as { text?: string }).text).toBe("Let me check that.");
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1266,7 +1266,7 @@ export async function handleOpenResponsesHttpRequest(
         const finalText =
           accumulatedText || resultPayloadText || bufferedReplaceableAssistantContent;
 
-        if (toolChoiceConstraint && finalText && !sawAssistantDelta) {
+        if (finalText && !sawAssistantDelta) {
           sawAssistantDelta = true;
           writeSseEvent(res, {
             type: "response.output_text.delta",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where applications streaming Gateway `/v1/responses` tool calls would receive no assistant commentary delta when the model returned its explanation only in the final payload. The completed response contained the text, but live stream consumers saw nothing before the function call.

## Why This Change Was Made

Remove an incorrect condition that limited pending-tool commentary emission to explicitly required or pinned tools. Every successful tool-call response now flushes its existing commentary exactly once when it has not already streamed, matching the sibling chat-completions endpoint.

## User Impact

Responses API clients now receive live assistant text such as “Let me check that.” before the corresponding function-call events when tools are selected automatically. Required/pinned tool enforcement, already-streamed text, empty commentary, and final event ordering remain unchanged.

## Evidence

- Pre-fix red: the existing real Gateway HTTP streaming regression fails in both normal and isolated server projects because `response.output_text.delta` is absent.
- Post-fix green: all 260 Responses and sibling chat-completions real Gateway/official-SDK tests pass, including tool-choice validation, replacement safety, ordinary/required tools, and terminal event consistency.
- Core and Gateway-test TypeScript, focused oxlint/oxfmt, and assertion-safety/max-lines ratchets pass.
- Production change removes one unnecessary condition without adding any production lines or public protocol/configuration surface.
- Fresh independent in-session source-aware review checks exact SSE event ordering, required-tool enforcement, duplicate prevention, SDK accumulation, and sibling endpoint behavior; the external review CLI was unavailable under the session approval boundary.
