### PR TITLE
fix: Code Mode exec approvals stop polling

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -484,11 +484,16 @@ type CodeModeFailedResult = {
 `exec` returns `waiting` when the guest suspends with resumable state that still
 needs a model-visible continuation — an explicit `yield_control(...)`, or a
 bridge tool call that has not resolved within the exec deadline. The result
-includes a `runId` for `wait`. Bridge requests — `catalog.search`, handle
-`describe()`, callable tool handles, and namespace calls including MCP — are auto-drained
-inside the same `exec`/`wait` call while they resolve within the deadline, so a
-compact code block that awaits several tools runs to completion in one model
-turn instead of forcing one model tool call per await.
+includes a `runId` for `wait`. Native-channel exec approvals are different:
+while the operator decision is pending, OpenClaw suspends both the Code Mode
+execution budget and the owning agent-run budget. The original `exec` remains
+in flight, then resumes with exactly its unused budget after approval resolves;
+it does not return `pending_tools` or require model polling through `wait`.
+Bridge requests — `catalog.search`, handle `describe()`, callable tool handles,
+and namespace calls including MCP — are auto-drained inside the same
+`exec`/`wait` call while they resolve within the deadline, so a compact code
+block that awaits several tools runs to completion in one model turn instead of
+forcing one model tool call per await.
 
 `exec` returns `completed` only when the guest VM has no pending work and the
 final value is JSON-compatible after OpenClaw's output adapter runs.
@@ -507,9 +512,11 @@ type CodeModeWaitInput = {
 
 Output is the same `CodeModeResult` union returned by `exec`.
 
-`wait` exists because nested OpenClaw tools can be slow, interactive, approval
-gated, or stream partial updates; the model should not need to keep one long
-`exec` call open while the host waits for external work.
+`wait` exists because nested OpenClaw tools can be slow, interactive, or stream
+partial updates; the model should not need to keep one long `exec` call open
+while the host waits for ordinary external work. Native-channel exec approvals
+are the exception: they stay inside the original `exec` so approval authority
+remains bound to the admitted run.
 
 QuickJS-WASI snapshot/restore is the resume mechanism:
 

--- a/src/agents/agent-run-approval-wait.ts
+++ b/src/agents/agent-run-approval-wait.ts
@@ -1,0 +1,61 @@
+import { onAgentEvent } from "../infra/agent-events.js";
+
+export type AgentRunApprovalWait = {
+  pending: boolean;
+  pausedMs: number;
+  onChange?: (pending: boolean) => void;
+  dispose: () => void;
+};
+
+export function observeAgentRunApprovalWait(params: {
+  runId?: string;
+  sessionId?: string;
+}): AgentRunApprovalWait {
+  const approvals = new Set<string>();
+  let pausedAtMs = 0;
+  let unsubscribe = () => {};
+  const state: AgentRunApprovalWait = {
+    pending: false,
+    pausedMs: 0,
+    dispose: () => {
+      unsubscribe();
+      state.onChange = undefined;
+    },
+  };
+  if (!params.runId) {
+    return state;
+  }
+  // Lifecycle facts pause scheduling only; the original admitted run retains all authority.
+  unsubscribe = onAgentEvent((event) => {
+    if (
+      event.runId !== params.runId ||
+      event.stream !== "lifecycle" ||
+      (params.sessionId && event.sessionId && event.sessionId !== params.sessionId)
+    ) {
+      return;
+    }
+    const approvalId = event.data.approvalId;
+    if (typeof approvalId !== "string" || !approvalId) {
+      return;
+    }
+    if (event.data.phase === "waiting-approval") {
+      approvals.add(approvalId);
+    } else if (event.data.phase === "approval-resolved") {
+      approvals.delete(approvalId);
+    } else {
+      return;
+    }
+    const pending = approvals.size > 0;
+    if (pending === state.pending) {
+      return;
+    }
+    if (pending) {
+      pausedAtMs = Date.now();
+    } else {
+      state.pausedMs += Date.now() - pausedAtMs;
+    }
+    state.pending = pending;
+    state.onChange?.(pending);
+  });
+  return state;
+}

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from "node:crypto";
+import {
+  observeAgentRunApprovalWait,
+  type AgentRunApprovalWait,
+} from "./agent-run-approval-wait.js";
 import { codeModeReplayIdForToolCall } from "./code-mode-bridge.js";
 import {
   createCodeModeCatalogProjection,
@@ -112,6 +116,7 @@ export async function runCodeModeExec(params: {
     reservedNames: namespaceRuntime.descriptors.map((descriptor) => descriptor.globalName),
   });
   const apiFiles = createCodeModeApiFilesForRun(namespaceRuntime, swarmEnabled);
+  const approvalWait = observeAgentRunApprovalWait(params.ctx);
   try {
     const source = await awaitCodeModeDeadline({
       operation: () => prepareSource({ code: params.code, language: params.language, config }),
@@ -153,6 +158,7 @@ export async function runCodeModeExec(params: {
       catalogProjection,
       namespaceRuntime,
       bridgeDispatch,
+      approvalWait,
       signal: params.signal,
       onUpdate: params.onUpdate,
     });
@@ -172,6 +178,8 @@ export async function runCodeModeExec(params: {
       replaySafe: params.restartSafe,
       telemetry: telemetry(runtime),
     };
+  } finally {
+    approvalWait.dispose();
   }
 }
 
@@ -188,6 +196,7 @@ async function waitForPending(
   pending: readonly PendingBridgeState[],
   settlementMode: CodeModeSettlementMode,
   timeoutMs: number,
+  approvalWait: AgentRunApprovalWait,
   signal?: AbortSignal,
 ): Promise<boolean> {
   // Abort wins even over already-settled requests: callers treat `false` as
@@ -210,7 +219,24 @@ async function waitForPending(
     return await Promise.race([
       bridgeReady,
       new Promise<boolean>((resolve) => {
-        timer = setTimeout(() => resolve(false), timeoutMs);
+        let remainingMs = timeoutMs;
+        let resumedAtMs = Date.now();
+        const arm = () => {
+          resumedAtMs = Date.now();
+          timer = setTimeout(() => resolve(false), Math.max(1, remainingMs));
+        };
+        approvalWait.onChange = (approvalPending) => {
+          if (approvalPending) {
+            // Preserve the unused guest budget while its owning approval remains inline.
+            clearTimeout(timer);
+            remainingMs = Math.max(1, remainingMs - (Date.now() - resumedAtMs));
+          } else {
+            arm();
+          }
+        };
+        if (!approvalWait.pending) {
+          arm();
+        }
       }),
       ...(signal
         ? [
@@ -228,6 +254,7 @@ async function waitForPending(
     if (signal && onAbort) {
       signal.removeEventListener("abort", onAbort);
     }
+    approvalWait.onChange = undefined;
   }
 }
 
@@ -248,6 +275,7 @@ async function settleCodeModeResult(params: {
   activeRunId?: string;
   reservedActiveRunSlot?: boolean;
   bridgeDispatch: CodeModeBridgeDispatchState;
+  approvalWait: AgentRunApprovalWait;
   signal?: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
 }) {
@@ -265,7 +293,7 @@ async function settleCodeModeResult(params: {
   // produced them. The deadline is also the only bound on sequential drain
   // rounds; maxPendingToolCalls stays a per-batch concurrency cap enforced in
   // the worker.
-  const settleDeadline = params.deadlineMs;
+  const settleDeadline = () => params.deadlineMs + params.approvalWait.pausedMs;
   const abortedResult = () => ({
     status: "failed" as const,
     error: "code mode execution aborted",
@@ -305,7 +333,7 @@ async function settleCodeModeResult(params: {
       }
       break;
     }
-    const remainingMs = settleDeadline - Date.now();
+    const remainingMs = settleDeadline() - Date.now();
     if (remainingMs <= 0) {
       break;
     }
@@ -335,7 +363,7 @@ async function settleCodeModeResult(params: {
           namespaceRuntime: params.namespaceRuntime,
           parentToolCallId: params.parentToolCallId,
           codeModeRunId: params.codeModeReplayId,
-          deadlineMs: settleDeadline,
+          deadlineMs: settleDeadline(),
           activeRunId,
           ctx: params.ctx,
           signal: params.signal,
@@ -347,10 +375,11 @@ async function settleCodeModeResult(params: {
         pending,
         result.settlementMode,
         remainingMs,
+        params.approvalWait,
         params.signal,
       );
       const resumeBudgetMs = ready
-        ? usableResumeBudgetMs(settleDeadline, params.config)
+        ? usableResumeBudgetMs(settleDeadline(), params.config)
         : undefined;
       if (!ready || resumeBudgetMs === undefined) {
         // Abort drops the run instead of parking it: a suspended snapshot for a
@@ -470,7 +499,7 @@ async function settleCodeModeResult(params: {
             namespaceRuntime: params.namespaceRuntime,
             parentToolCallId: params.parentToolCallId,
             codeModeRunId: params.codeModeReplayId,
-            deadlineMs: settleDeadline,
+            deadlineMs: settleDeadline(),
             activeRunId,
             ctx: params.ctx,
             signal: params.signal,
@@ -513,7 +542,7 @@ async function settleCodeModeResult(params: {
       catalogProjection: params.catalogProjection,
       namespaceRuntime: params.namespaceRuntime,
       output,
-      deadlineMs: settleDeadline,
+      deadlineMs: settleDeadline(),
       deliveredOutputCount,
       reservedActiveRunSlot: params.reservedActiveRunSlot,
       replaySafe: params.replaySafe,
@@ -581,15 +610,19 @@ export async function runWait(params: {
   // One wait call shares a single wall-clock deadline across draining the prior
   // pending calls, the resume worker, and the inline settle phase.
   const deadlineMs = Date.now() + state.config.timeoutMs;
+  const approvalWait = observeAgentRunApprovalWait(state.ctx);
   let releaseActiveRunSlot: (() => void) | undefined;
   try {
     const ready = await waitForPending(
       state.pending,
       state.settlementMode,
       Math.max(1, deadlineMs - Date.now()),
+      approvalWait,
       params.signal,
     );
-    const resumeBudgetMs = ready ? usableResumeBudgetMs(deadlineMs, state.config) : undefined;
+    const resumeBudgetMs = ready
+      ? usableResumeBudgetMs(deadlineMs + approvalWait.pausedMs, state.config)
+      : undefined;
     if (!ready || resumeBudgetMs === undefined) {
       // An aborted wait drops the suspended run: nothing will resume it, and
       // parking it would pin a process-global active-run slot until TTL expiry.
@@ -662,6 +695,7 @@ export async function runWait(params: {
       catalogProjection: state.catalogProjection,
       namespaceRuntime: state.namespaceRuntime,
       bridgeDispatch: state.bridgeDispatch,
+      approvalWait,
       deliveredOutputCount: outputTruncated ? 0 : state.deliveredOutputCount,
       pending,
       activeRunId: state.runId,
@@ -686,6 +720,7 @@ export async function runWait(params: {
       telemetry: telemetry(state.runtime),
     };
   } finally {
+    approvalWait.dispose();
     releaseActiveRunSlot?.();
     resumingRunIds.delete(state.runId);
   }

--- a/src/agents/code-mode.wait.test.ts
+++ b/src/agents/code-mode.wait.test.ts
@@ -3,6 +3,13 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { runWithAgentToolExecutionContext } from "../../packages/agent-core/src/tool-execution-context.js";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  createOperationalRunInstanceRef,
+  getAdmittedRunDelegatedAuthority,
+  prepareAgentRunAdmission,
+} from "./admitted-run-context.js";
 import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
 import {
   resetCodeModeTestState,
@@ -14,6 +21,10 @@ import {
 } from "./code-mode.test-support.js";
 import { createToolSearchCatalogRef } from "./tool-search.js";
 import { jsonResult } from "./tools/common.js";
+import {
+  createAdmittedGatewayToolCallerIdentity,
+  withGatewayToolCallerIdentity,
+} from "./tools/gateway-caller-context.js";
 
 function createTerminalBridgeHarness() {
   const harness = createCodeModeHarness();
@@ -75,6 +86,79 @@ describe("Code Mode wait, scope, and suspended runs", () => {
     expect(resumed.status).toBe("completed");
     expect(resumed.value).toBe("done");
     expect(resumed.output).toEqual([{ type: "text", text: "after" }]);
+  });
+
+  it("keeps inline nested approval inside the original admitted run beyond the Code Mode budget", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const runId = "run-code-mode-inline-approval";
+    const sessionId = "session-inline-approval";
+    const sessionKey = "agent:main:inline-approval";
+    const requested = createDeferred();
+    const decision = createDeferred();
+    const admission = prepareAgentRunAdmission({
+      cfg: {},
+      facts: {
+        runId,
+        agentId: "main",
+        ingress: { kind: "system", boundary: "code-mode-approval", state: "present" },
+      },
+      operationalRunInstance: createOperationalRunInstanceRef(runId),
+    });
+    const admittedRunContext = await admission.admit("embedded");
+    const identity = createAdmittedGatewayToolCallerIdentity({
+      admittedRunContext,
+      agentId: "main",
+      sessionKey,
+      turnSourceChannel: "telegram",
+    });
+    const timeoutMs = 1_000;
+    const config = { tools: { codeMode: { enabled: true, timeoutMs } } } as never;
+    const catalogRef = createToolSearchCatalogRef();
+    const context = { config, runtimeConfig: config, sessionId, sessionKey, runId, catalogRef };
+    const controls = createCodeModeTools(context);
+    const shell = pluginToolWithExecute("exec", "Run shell", async (toolCallId) => {
+      const event = { runId, sessionId, stream: "lifecycle" as const };
+      emitAgentEvent({
+        ...event,
+        data: { phase: "waiting-approval", approvalId: "approval-inline", toolCallId },
+      });
+      requested.resolve();
+      await decision.promise;
+      emitAgentEvent({
+        ...event,
+        data: { phase: "approval-resolved", approvalId: "approval-inline", toolCallId },
+      });
+      return jsonResult({ status: "completed", aggregated: "approved" });
+    });
+    applyCodeModeCatalog({ tools: [...controls, shell], ...context });
+
+    let settled = false;
+    try {
+      const execution = withGatewayToolCallerIdentity(identity, async () => {
+        const result = await expectDefined(controls[0], "Code Mode exec test invariant").execute(
+          "inline-approval",
+          { code: `return await exec({ value: "approval" });` },
+        );
+        settled = true;
+        return result;
+      });
+      await requested.promise;
+      await vi.advanceTimersByTimeAsync(timeoutMs + 1);
+
+      expect(settled).toBe(false);
+      expect(getAdmittedRunDelegatedAuthority(admittedRunContext)).toBeDefined();
+
+      decision.resolve();
+      expect(resultDetails(await execution)).toMatchObject({
+        status: "completed",
+        value: { status: "completed", aggregated: "approved" },
+      });
+      expect(getAdmittedRunDelegatedAuthority(admittedRunContext)).toBeDefined();
+    } finally {
+      decision.resolve();
+      admission.close();
+    }
+    expect(getAdmittedRunDelegatedAuthority(admittedRunContext)).toBeUndefined();
   });
 
   it("retains terminal bridge evidence until a yielded run completes through wait", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts
@@ -1,5 +1,6 @@
 // Coverage for attempt timeout ownership and cleanup.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent } from "../../../infra/agent-events.js";
 import { createEmbeddedAttemptRunAbort } from "./attempt-finalize.js";
 import { prepareEmbeddedAttemptTimeout } from "./attempt-timeout-prepare.js";
 
@@ -117,6 +118,64 @@ describe("prepareEmbeddedAttemptTimeout", () => {
       expect.objectContaining({ name: "TimeoutError", message: "request timed out" }),
     );
     timeout.clearTimers();
+  });
+
+  it("pauses exactly the original run budget until all scoped approvals resolve", async () => {
+    const harness = createTimeoutHarness();
+    const emitApproval = (
+      phase: string,
+      approvalId: string,
+      runId = "run-1",
+      sessionId = "session-1",
+    ) => emitAgentEvent({ runId, sessionId, stream: "lifecycle", data: { phase, approvalId } });
+
+    await vi.advanceTimersByTimeAsync(30);
+    emitApproval("waiting-approval", "first");
+    emitApproval("waiting-approval", "second");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(harness.abortRun).not.toHaveBeenCalled();
+
+    emitApproval("approval-resolved", "first", "another-run");
+    emitApproval("approval-resolved", "first", "run-1", "another-session");
+    emitApproval("approval-resolved", "first");
+    await vi.advanceTimersByTimeAsync(100);
+    expect(harness.abortRun).not.toHaveBeenCalled();
+
+    emitApproval("approval-resolved", "second");
+    await vi.advanceTimersByTimeAsync(69);
+    expect(harness.abortRun).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(harness.markTimedOutByRunBudget).toHaveBeenCalledOnce();
+    expect(harness.abortRun).toHaveBeenCalledWith(true);
+    harness.timeout.clearTimers();
+  });
+
+  it("pauses only the unused compaction grace budget during inline approval", async () => {
+    const harness = createTimeoutHarness({ pendingCompaction: true });
+    await vi.advanceTimersByTimeAsync(120);
+    emitAgentEvent({
+      runId: "run-1",
+      sessionId: "session-1",
+      stream: "lifecycle",
+      data: { phase: "waiting-approval", approvalId: "grace" },
+    });
+    await vi.advanceTimersByTimeAsync(500);
+    expect(harness.abortRun).not.toHaveBeenCalled();
+
+    harness.state.pendingCompaction = false;
+    emitAgentEvent({
+      runId: "run-1",
+      sessionId: "session-1",
+      stream: "lifecycle",
+      data: { phase: "approval-resolved", approvalId: "grace" },
+    });
+    await vi.advanceTimersByTimeAsync(29);
+    expect(harness.abortRun).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(harness.abortRun).toHaveBeenCalledWith(true);
+    harness.timeout.clearTimers();
   });
 
   it("grants one compaction grace window before aborting", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-timeout-prepare.ts
@@ -1,6 +1,7 @@
 /**
  * Owns the run deadline and compaction grace.
  */
+import { observeAgentRunApprovalWait } from "../../agent-run-approval-wait.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { log } from "../logger.js";
 import {
@@ -33,6 +34,8 @@ export function prepareEmbeddedAttemptTimeout(input: {
   let abortTimer: NodeJS.Timeout | undefined;
   let runAbortDeadlineAtMs = Date.now() + attempt.timeoutMs;
   let compactionGraceUsed = false;
+  let pausedRemainingMs = 0;
+  const approvalWait = observeAgentRunApprovalWait(attempt);
 
   const scheduleAbortTimer = (delayMs: number, reason: "initial" | "compaction-grace") => {
     runAbortDeadlineAtMs = Date.now() + Math.max(1, delayMs);
@@ -92,12 +95,22 @@ export function prepareEmbeddedAttemptTimeout(input: {
     );
   };
 
+  approvalWait.onChange = (pending) => {
+    if (pending) {
+      // Human review consumes neither the run budget nor an active compaction grace window.
+      pausedRemainingMs = Math.max(1, runAbortDeadlineAtMs - Date.now());
+      clearTimeout(abortTimer);
+    } else {
+      scheduleAbortTimer(pausedRemainingMs, compactionGraceUsed ? "compaction-grace" : "initial");
+    }
+  };
   scheduleAbortTimer(attempt.timeoutMs, "initial");
   attempt.onAttemptTimeoutArmed?.();
 
   return {
     getRunAbortDeadlineAtMs: () => runAbortDeadlineAtMs,
     clearTimers: () => {
+      approvalWait.dispose();
       if (abortTimer) {
         clearTimeout(abortTimer);
       }


### PR DESCRIPTION
Related: #93918

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running an approval-required nested shell command through OpenClaw Code Mode could see repeated model `wait` calls followed by the original agent run aborting and its pending approval being canceled while an operator was still deciding.

## Why This Change Was Made

The nested gateway-hosted shell command already waits inline inside its original admitted run, but both Code Mode's bridge deadline and the embedded agent attempt deadline continued spending wall-clock budget during the human approval. Observe the existing authoritative `waiting-approval` and `approval-resolved` lifecycle events per run, session, and approval ID, and pause exactly the unused Code Mode execution budget, agent-run budget, and any active compaction grace window until all overlapping approvals resolve. The original run and its closure-bound delegated authority remain alive; no approval authority is transferred, copied, detached, or recreated.

**Best-fix rationale:** Both independent deadline owners must observe the same producer-owned approval lifecycle. A detached approval or follow-up run loses closure-bound authority when the original admitted run ends; a downstream `pending_tools` guard or a larger timeout only hides the owner-boundary failure without preserving the original authority or exact remaining budget. Ordinary slow tools still retain the existing resumable `wait` behavior, and abort or closure continues to win.

**Provenance:** This is a latent incompatibility between two independently valid owner paths. The current Code Mode execution timeout path was introduced/carried forward by #113669 (`refactor(agents): split code mode execution`), authored and merged by @steipete on 2026-07-25. Native inline chat approval behavior was introduced by #93949, authored by @NianJiuZst and merged by @sallyom on 2026-06-18, related to #93918. Commit `7329a8d` changed shell-yield timing only and is not the root cause; the observed incident explicitly used `yieldMs=1000`.

## User Impact

Approval-required nested shell commands remain actionable while the human decides, without spending model turns polling `wait` or losing the pending approval. Allow-once or denial resumes the same admitted run with exactly its remaining execution budget. Normal slow non-approval tools still suspend and resume through `wait` as before, overlapping approvals remain scoped to the correct run/session, and compaction grace does not silently expire during review.

## Evidence

Failing-first owner-boundary regressions, captured before the production changes:

- `node scripts/run-vitest.mjs src/agents/code-mode.wait.test.ts` failed `keeps inline nested approval inside the original admitted run beyond the Code Mode budget`: expected the original execution to remain unsettled, received a settled execution.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts` failed both exact remaining run-budget and compaction-grace suspension cases because `abortRun` fired during approval.

Final focused and sibling proof:

- `node scripts/run-vitest.mjs src/agents/code-mode.wait.test.ts` — **20 passed**.
- `node scripts/run-vitest.mjs src/agents/code-mode.bridge.test.ts` — **22 passed**.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts` — **6 passed**.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-gateway.test.ts` — **95 passed**.
- `node scripts/run-vitest.mjs src/agents/tool-search-runtime.test.ts` — **65 passed**.
- `node scripts/check-changed.mjs -- src/agents/agent-run-approval-wait.ts src/agents/code-mode-execution.ts src/agents/code-mode.wait.test.ts src/agents/embedded-agent-runner/run/attempt-timeout-prepare.ts src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts` — all format, type, lint, guard, and import-cycle lanes passed.
- `pnpm build` — passed.
- `pnpm docs:check-mdx` — passed, **777 files**.
- `pnpm docs:check-links` — passed, **6,532 links / 0 broken**.
- `git diff --check` — passed.
- Fresh independent Codex-backed autoreview of the complete final code, tests, and documentation diff — clean, with no accepted or actionable findings.

**Direct live proof:** A built Gateway running a real Anthropic embedded Code Mode turn executed a harmless `/usr/bin/printf` command whose native approval intentionally remained pending beyond the 10-second Code Mode deadline. The original admitted run stayed active, the approval remained listed, allow-once resumed and completed that same run, command output appeared, outer Code Mode calls remained `exec=1, wait=0` throughout, and pending approvals returned to zero. One initial run resumed correctly but its final model turn hit a transient `ECONNRESET`; the exact rerun completed successfully.

**Change size:** Production `+117/-8` (net `+109`), tests `+143/-0`, docs `+15/-8`. Production growth is required for the shared run/session-scoped overlapping-approval lifecycle observer and coordinated exact-budget suspension in the two independent existing deadline owners; no detached path, compatibility shim, expanded timeout, or new configuration surface was added.

**AI-assisted:** yes.
