### PR TITLE
feat(ui): search sessions and catalogs from command palette

### DIFF
--- a/ui/src/components/command-palette-catalog-search.test.ts
+++ b/ui/src/components/command-palette-catalog-search.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import {
+  getStaticCommandPaletteCatalogItems,
+  loadCommandPaletteCatalogItems,
+} from "./command-palette-catalog-search.ts";
+
+describe("command palette catalog search", () => {
+  it("exposes app cards and permission-filtered settings sections without RPCs", () => {
+    const regular = getStaticCommandPaletteCatalogItems(false);
+    const admin = getStaticCommandPaletteCatalogItems(true);
+
+    expect(regular).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ category: "apps", label: "iPhone" }),
+        expect.objectContaining({ category: "settings", routeId: "profile" }),
+      ]),
+    );
+    expect(regular.some((item) => item.routeId === "security")).toBe(false);
+    expect(admin.some((item) => item.routeId === "security")).toBe(true);
+  });
+
+  it("loads bounded name and description catalogs in parallel", async () => {
+    const request = vi.fn(async (method: string) => {
+      switch (method) {
+        case "cron.list":
+          return {
+            jobs: [
+              {
+                id: "nightly",
+                name: "Nightly invoices",
+                description: "Reconciles customer billing",
+              },
+            ],
+          };
+        case "skills.status":
+          return {
+            skills: [
+              {
+                skillKey: "forecast-brief",
+                name: "Forecast brief",
+                description: "Summarizes the weather",
+                source: "workspace",
+              },
+            ],
+          };
+        case "plugins.list":
+          return {
+            plugins: [
+              {
+                id: "weather-helper",
+                name: "Weather helper",
+                description: "Adds forecast tools",
+                packageName: "@openclaw/weather-helper",
+              },
+            ],
+          };
+        case "models.list":
+          return {
+            models: [
+              {
+                id: "gpt-search",
+                name: "Search model",
+                provider: "openai",
+                tags: ["fast"],
+              },
+            ],
+          };
+        default:
+          throw new Error(`Unexpected method: ${method}`);
+      }
+    });
+
+    const items = await loadCommandPaletteCatalogItems({
+      client: { request } as unknown as GatewayBrowserClient,
+      agentId: "main",
+      agents: async () => ({
+        defaultId: "main",
+        mainKey: "main",
+        scope: "global",
+        agents: [{ id: "main", name: "Main assistant", workspace: "/workspace" }],
+      }),
+      methodAvailable: () => true,
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ category: "agents", label: "Main assistant" }),
+        expect.objectContaining({ category: "automations", label: "Nightly invoices" }),
+        expect.objectContaining({ category: "skills", label: "Forecast brief" }),
+        expect.objectContaining({ category: "plugins", label: "Weather helper" }),
+        expect.objectContaining({ category: "models", label: "Search model" }),
+      ]),
+    );
+    expect(request).toHaveBeenCalledWith(
+      "cron.list",
+      expect.objectContaining({ includeDisabled: true, limit: 200, offset: 0, compact: true }),
+    );
+    expect(request).toHaveBeenCalledWith("skills.status", { agentId: "main" });
+    expect(request).toHaveBeenCalledWith("plugins.list", {});
+    expect(request).toHaveBeenCalledWith("models.list", {
+      view: "configured",
+      agentId: "main",
+      preparedOnly: true,
+    });
+  });
+});

--- a/ui/src/components/command-palette-catalog-search.ts
+++ b/ui/src/components/command-palette-catalog-search.ts
@@ -1,0 +1,347 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type {
+  AgentsListResult,
+  CronJobsListResult,
+  ModelCatalogEntry,
+  SkillStatusReport,
+} from "../api/types.ts";
+import {
+  SETTINGS_SEARCHABLE_SUBPAGE_ROUTES,
+  settingsNavigationLabelForRoute,
+  subtitleForRoute,
+  visibleSettingsNavigationGroups,
+} from "../app-navigation.ts";
+import type { RouteId } from "../app-route-paths.ts";
+import { t } from "../i18n/index.ts";
+import type { PluginListResult } from "../lib/plugins/index.ts";
+import type { IconName } from "./icons.ts";
+
+type CommandPaletteCatalogCategory =
+  | "agents"
+  | "apps"
+  | "automations"
+  | "models"
+  | "plugins"
+  | "settings"
+  | "skills";
+
+type CommandPaletteCatalogItem = {
+  id: string;
+  label: string;
+  icon: IconName;
+  category: CommandPaletteCatalogCategory;
+  routeId: RouteId;
+  description?: string;
+  searchText?: string;
+};
+
+export type CommandPaletteItem = Omit<CommandPaletteCatalogItem, "routeId" | "category"> & {
+  category: "search" | "navigation" | "chats" | CommandPaletteCatalogCategory;
+  action: string;
+};
+
+export function commandPaletteCategoryLabel(category: string): string {
+  switch (category) {
+    case "search":
+      return t("palette.categories.search");
+    case "navigation":
+      return t("palette.categories.navigation");
+    case "skills":
+      return t("palette.categories.skills");
+    case "agents":
+      return t("palette.items.agents");
+    case "apps":
+      return t("palette.items.apps");
+    case "automations":
+      return t("palette.items.scheduled");
+    case "models":
+      return t("routeTitles.modelProviders");
+    case "plugins":
+      return t("palette.items.plugins");
+    case "settings":
+      return t("palette.items.settings");
+    case "chats":
+      return t("sessionsView.title");
+    default:
+      return category;
+  }
+}
+
+const CATALOG_SEARCH_LIMIT = 10;
+
+function getCommandPaletteBaseItems(
+  desktopAvailable: boolean,
+  custodianAvailable: boolean,
+): CommandPaletteItem[] {
+  return [
+    {
+      id: "nav-new-session",
+      label: t("newSession.title"),
+      icon: "plus",
+      category: "navigation",
+      action: "nav:new-session",
+    },
+    {
+      id: "nav-sessions",
+      label: t("palette.items.sessions"),
+      icon: "fileText",
+      category: "navigation",
+      action: "nav:sessions",
+    },
+    {
+      id: "nav-cron",
+      label: t("palette.items.scheduled"),
+      icon: "scrollText",
+      category: "navigation",
+      action: "nav:cron",
+    },
+    {
+      id: "nav-skills",
+      label: t("palette.items.skills"),
+      icon: "zap",
+      category: "navigation",
+      action: "nav:skills",
+    },
+    {
+      id: "nav-plugins",
+      label: t("palette.items.plugins"),
+      icon: "puzzle",
+      category: "navigation",
+      action: "nav:plugins",
+    },
+    {
+      id: "nav-apps",
+      label: t("palette.items.apps"),
+      icon: "layoutGrid",
+      category: "navigation",
+      action: "nav:apps",
+    },
+    {
+      id: "nav-config",
+      label: t("palette.items.settings"),
+      icon: "settings",
+      category: "navigation",
+      action: "nav:config",
+    },
+    {
+      id: "nav-agents",
+      label: t("palette.items.agents"),
+      icon: "folder",
+      category: "navigation",
+      action: "nav:agents",
+    },
+    {
+      id: "slash:verbose",
+      label: "/verbose",
+      icon: "terminal",
+      category: "search",
+      action: "/verbose full",
+      description: t("palette.descriptions.verboseMode"),
+    },
+    ...(desktopAvailable
+      ? [
+          {
+            id: "panel-desktop",
+            label: t("palette.items.desktop"),
+            icon: "monitor" as const,
+            category: "navigation" as const,
+            action: "panel:desktop",
+          },
+        ]
+      : []),
+    ...(custodianAvailable
+      ? [
+          {
+            id: "panel-custodian",
+            label: t("nav.askOpenClaw"),
+            icon: "lobster" as const,
+            category: "navigation" as const,
+            action: "panel:custodian",
+          },
+        ]
+      : []),
+  ];
+}
+
+export function filterCommandPaletteItems(params: {
+  query: string;
+  includeSlashCommands: boolean;
+  sessionItems: readonly CommandPaletteItem[];
+  catalogItems: readonly CommandPaletteItem[];
+  desktopAvailable: boolean;
+  custodianAvailable: boolean;
+}): CommandPaletteItem[] {
+  const baseItems = getCommandPaletteBaseItems(
+    params.desktopAvailable,
+    params.custodianAvailable,
+  ).filter((item) => params.includeSlashCommands || item.category !== "search");
+  if (!params.query) {
+    return baseItems;
+  }
+  const query = normalizeLowercaseStringOrEmpty(params.query);
+  const matchRank = (item: CommandPaletteItem) => {
+    const label = normalizeLowercaseStringOrEmpty(item.label);
+    if (label === query) {
+      return 3;
+    }
+    if (label.startsWith(query)) {
+      return 2;
+    }
+    return label.includes(query) ||
+      normalizeLowercaseStringOrEmpty(item.description).includes(query) ||
+      normalizeLowercaseStringOrEmpty(item.searchText).includes(query)
+      ? 1
+      : 0;
+  };
+  const baseMatches = baseItems.filter((item) => matchRank(item) > 0);
+  const catalogMatches = params.catalogItems
+    .map((item) => ({ item, rank: matchRank(item) }))
+    .filter(({ rank }) => rank > 0)
+    .toSorted(
+      (left, right) => right.rank - left.rank || left.item.label.localeCompare(right.item.label),
+    )
+    .slice(0, CATALOG_SEARCH_LIMIT)
+    .map(({ item }) => item);
+  return [...params.sessionItems, ...baseMatches, ...catalogMatches];
+}
+
+export function toCommandPaletteItems(
+  items: readonly CommandPaletteCatalogItem[],
+): CommandPaletteItem[] {
+  return items.map((item) => ({
+    id: item.id,
+    label: item.label,
+    icon: item.icon,
+    category: item.category,
+    action: `nav:${item.routeId}`,
+    description: item.description,
+    searchText: item.searchText,
+  }));
+}
+
+const APP_CARDS = [
+  "ios",
+  "android",
+  "appleWatch",
+  "wearOs",
+  "macos",
+  "windows",
+  "linux",
+  "chrome",
+  "plugins",
+] as const;
+
+export function getStaticCommandPaletteCatalogItems(
+  canAdmin: boolean,
+): CommandPaletteCatalogItem[] {
+  const settings = visibleSettingsNavigationGroups(canAdmin)
+    .flatMap((group) => group.routes)
+    .concat(SETTINGS_SEARCHABLE_SUBPAGE_ROUTES)
+    .map((routeId) => ({
+      id: `settings-${routeId}`,
+      label: settingsNavigationLabelForRoute(routeId),
+      icon: "settings" as const,
+      category: "settings" as const,
+      routeId,
+      description: subtitleForRoute(routeId),
+      searchText: routeId,
+    }));
+  const apps = APP_CARDS.map((card) => ({
+    id: `app-${card}`,
+    label: t(`appsPage.cards.${card}.title`),
+    icon: "layoutGrid" as const,
+    category: "apps" as const,
+    routeId: "apps" as const,
+    description: t(`appsPage.cards.${card}.desc`),
+    searchText: card,
+  }));
+  return [...settings, ...apps];
+}
+
+export async function loadCommandPaletteCatalogItems(params: {
+  client: GatewayBrowserClient;
+  agentId: string;
+  agents: () => Promise<AgentsListResult | null>;
+  methodAvailable: (method: string) => boolean;
+}): Promise<CommandPaletteCatalogItem[]> {
+  const requestIfAvailable = async <T>(
+    method: string,
+    requestParams: unknown,
+  ): Promise<T | null> =>
+    params.methodAvailable(method)
+      ? params.client.request<T>(method, requestParams).catch(() => null)
+      : null;
+  const [agents, automations, skills, plugins, models] = await Promise.all([
+    params.agents().catch(() => null),
+    requestIfAvailable<CronJobsListResult>("cron.list", {
+      includeDisabled: true,
+      limit: 200,
+      offset: 0,
+      sortBy: "name",
+      sortDir: "asc",
+      compact: true,
+    }),
+    requestIfAvailable<SkillStatusReport>("skills.status", { agentId: params.agentId }),
+    requestIfAvailable<PluginListResult>("plugins.list", {}),
+    requestIfAvailable<{ models: ModelCatalogEntry[] }>("models.list", {
+      view: "configured",
+      agentId: params.agentId,
+      preparedOnly: true,
+    }),
+  ]);
+
+  return [
+    ...(agents?.agents ?? []).map((agent) => ({
+      id: `agent-${agent.id}`,
+      label: agent.identity?.name ?? agent.name ?? agent.id,
+      icon: "bot" as const,
+      category: "agents" as const,
+      routeId: "agents" as const,
+      description: agent.id,
+      searchText: [agent.id, agent.workspace, agent.model?.primary, agent.identity?.theme]
+        .filter(Boolean)
+        .join(" "),
+    })),
+    ...(automations?.jobs ?? []).map((job) => ({
+      id: `automation-${job.id}`,
+      label: job.displayName ?? job.name,
+      icon: "calendarClock" as const,
+      category: "automations" as const,
+      routeId: "cron" as const,
+      description: job.description,
+      searchText: [job.id, job.declarationKey, job.name, job.agentId].filter(Boolean).join(" "),
+    })),
+    ...(skills?.skills ?? []).map((skill) => ({
+      id: `skill-${skill.skillKey}`,
+      label: skill.name,
+      icon: "zap" as const,
+      category: "skills" as const,
+      routeId: "skills" as const,
+      description: skill.description,
+      searchText: [skill.skillKey, skill.source].filter(Boolean).join(" "),
+    })),
+    ...(plugins?.plugins ?? []).map((plugin) => ({
+      id: `plugin-${plugin.id}`,
+      label: plugin.name,
+      icon: "puzzle" as const,
+      category: "plugins" as const,
+      routeId: "plugins" as const,
+      description: plugin.description,
+      searchText: [plugin.id, plugin.packageName, plugin.category, plugin.kind?.join(" ")]
+        .filter(Boolean)
+        .join(" "),
+    })),
+    ...(models?.models ?? []).map((model) => ({
+      id: `model-${model.provider}-${model.id}`,
+      label: model.name || model.id,
+      icon: "brain" as const,
+      category: "models" as const,
+      routeId: "model-providers" as const,
+      description: model.provider,
+      searchText: [model.id, model.provider, model.alias, model.tags?.join(" ")]
+        .filter(Boolean)
+        .join(" "),
+    })),
+  ];
+}

--- a/ui/src/components/command-palette-session-search.ts
+++ b/ui/src/components/command-palette-session-search.ts
@@ -1,0 +1,40 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { GatewaySessionRow } from "../api/types.ts";
+import { resolveSessionDisplayName } from "../lib/session-display.ts";
+
+const SESSION_SEARCH_SNIPPET_MAX_CHARS = 160;
+
+export function sessionMetadataMatchRank(row: GatewaySessionRow, search: string): number {
+  const normalizedSearch = normalizeLowercaseStringOrEmpty(search);
+  const fields = [
+    resolveSessionDisplayName(row.key, row),
+    row.key,
+    row.label,
+    row.subject,
+    row.category,
+    row.kind,
+    row.model,
+    row.modelProvider,
+    row.owner?.actor.label,
+    row.owner?.actor.id,
+    row.createdActor?.label,
+    row.createdActor?.id,
+  ]
+    .map((value) => normalizeLowercaseStringOrEmpty(value))
+    .filter(Boolean);
+  if (fields.some((field) => field === normalizedSearch)) {
+    return 3;
+  }
+  if (fields.some((field) => field.startsWith(normalizedSearch))) {
+    return 2;
+  }
+  return fields.some((field) => field.includes(normalizedSearch)) ? 1 : 0;
+}
+
+export function transcriptSearchSnippet(snippet: string): string {
+  const compact = snippet.replace(/\s+/gu, " ").trim();
+  return compact.length > SESSION_SEARCH_SNIPPET_MAX_CHARS
+    ? `${truncateUtf16Safe(compact, SESSION_SEARCH_SNIPPET_MAX_CHARS - 1)}…`
+    : compact;
+}

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -334,6 +334,30 @@ describe("CommandPalette lifecycle", () => {
     expect(palette.textContent).not.toContain("Chat search failed");
   });
 
+  it.each([
+    { state: "indexing", response: { indexing: true } },
+    { state: "truncated", response: { truncated: true } },
+  ])("shows a partial-search notice when transcript results are $state", async ({ response }) => {
+    const metadata = createSessionResult("agent:main:metadata", "Needle planning");
+    const list = vi.fn<ApplicationContext<RouteId>["sessions"]["list"]>(async () => metadata);
+    const request = vi.fn(async () => ({ results: [], ...response }));
+    const { gateway } = createGateway(true, {
+      methods: ["sessions.search"],
+      request: request as GatewayBrowserClient["request"],
+    });
+    const { palette } = await mountPalette(createContext(gateway, list));
+
+    await enterQuery(palette, "needle");
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await palette.updateComplete;
+
+    expect(palette.textContent).toContain(
+      "Transcript search unavailable — showing chat titles and metadata",
+    );
+    expect(palette.textContent).toContain("Needle planning");
+  });
+
   it("lazily searches automation names and descriptions once per connection", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "cron.list") {

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -263,6 +263,74 @@ describe("CommandPalette lifecycle", () => {
     expect(palette.querySelectorAll(".cmd-palette__input")).toHaveLength(1);
   });
 
+  it("searches a bare default session key in the selected agent scope", async () => {
+    const roster = createSessionResult("main", "Default chat");
+    const list = vi.fn<ApplicationContext<RouteId>["sessions"]["list"]>(async (options) =>
+      options?.search ? { ...roster, count: 0, sessions: [] } : roster,
+    );
+    const request = vi.fn(async () => ({
+      results: [
+        {
+          sessionKey: "main",
+          sessionId: "default",
+          messageId: "message-default",
+          role: "assistant" as const,
+          timestamp: 42,
+          snippet: "The needle is in the default chat body.",
+          score: 10,
+        },
+      ],
+    }));
+    const { gateway } = createGateway(true, {
+      methods: ["sessions.search"],
+      request: request as GatewayBrowserClient["request"],
+    });
+    const { palette } = await mountPalette(createContext(gateway, list));
+
+    await enterQuery(palette, "needle");
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await palette.updateComplete;
+
+    expect(request).toHaveBeenCalledWith("sessions.search", {
+      agentId: "main",
+      sessionKeys: ["main"],
+      query: "needle",
+      limit: 25,
+    });
+    expect(palette.textContent).toContain("Default chat");
+    expect(palette.textContent).toContain("needle is in the default chat body");
+  });
+
+  it("keeps metadata matches selectable when transcript search fails", async () => {
+    const metadata = createSessionResult("agent:main:metadata", "Needle planning");
+    const list = vi.fn<ApplicationContext<RouteId>["sessions"]["list"]>(async () => metadata);
+    const request = vi.fn(async () => {
+      throw new Error("transcript index unavailable");
+    });
+    const { gateway } = createGateway(true, {
+      methods: ["sessions.search"],
+      request: request as GatewayBrowserClient["request"],
+    });
+    const { palette } = await mountPalette(createContext(gateway, list));
+
+    await enterQuery(palette, "needle");
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await palette.updateComplete;
+
+    const metadataItem = palette.querySelector<HTMLElement>(
+      "#cmd-palette-option-session-agent-main-metadata",
+    );
+    expect(metadataItem?.textContent).toContain("Needle planning");
+    metadataItem?.click();
+    expect(palette.onSelectSession).toHaveBeenCalledWith("agent:main:metadata");
+    expect(palette.textContent).toContain(
+      "Transcript search unavailable — showing chat titles and metadata",
+    );
+    expect(palette.textContent).not.toContain("Chat search failed");
+  });
+
   it("waits for two characters before searching sessions", async () => {
     const { gateway } = createGateway(true, { methods: ["sessions.search"] });
     const list = vi.fn(async () => createSessionResult("agent:main:test", "Test"));

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionsSearchResult } from "../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { SessionsListResult } from "../api/types.ts";
@@ -26,14 +27,17 @@ type GatewayHarness = {
   setConnected: (connected: boolean) => void;
 };
 
-function createGateway(connected: boolean): GatewayHarness {
-  const client = {} as GatewayBrowserClient;
+function createGateway(
+  connected: boolean,
+  options: { methods?: string[]; request?: GatewayBrowserClient["request"] } = {},
+): GatewayHarness {
+  const client = { request: options.request } as GatewayBrowserClient;
   let snapshot: ApplicationGatewaySnapshot = {
     client,
     phase: connected ? "connected" : "reconnecting",
     offlineStable: false,
     canvasPluginSurfaceUrl: null,
-    hello: null,
+    hello: options.methods ? ({ features: { methods: options.methods } } as never) : null,
     assistantAgentId: "main",
     sessionKey: "main",
     lastError: null,
@@ -79,6 +83,7 @@ function createContext(
     gateway,
     sessions: {
       list,
+      state: { result: null },
     },
   } as unknown as ApplicationContext<RouteId>;
 }
@@ -136,7 +141,7 @@ describe("CommandPalette lifecycle", () => {
     const list = vi.fn(async () => createSessionResult("agent:main:old", "Old chat"));
     const { palette, provider } = await mountPalette(createContext(gateway, list));
     await enterQuery(palette, "old");
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(50);
     await palette.updateComplete;
     expect(palette.textContent).toContain("Old chat");
 
@@ -165,7 +170,7 @@ describe("CommandPalette lifecycle", () => {
       .mockResolvedValueOnce(createSessionResult("agent:main:retry", "Retry chat"));
     const { palette } = await mountPalette(createContext(harness.gateway, list));
     await enterQuery(palette, "retry");
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(50);
     expect(list).toHaveBeenCalledOnce();
 
     harness.setConnected(false);
@@ -175,7 +180,7 @@ describe("CommandPalette lifecycle", () => {
 
     harness.setConnected(true);
     await palette.updateComplete;
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(50);
     await palette.updateComplete;
 
     expect(list).toHaveBeenCalledTimes(2);
@@ -193,18 +198,135 @@ describe("CommandPalette lifecycle", () => {
     );
     const { palette, provider } = await mountPalette(createContext(initial.gateway, initialList));
     await enterQuery(palette, "chat");
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(50);
     expect(initialList).toHaveBeenCalledOnce();
 
     stale.resolve(createSessionResult("agent:main:stale", "Stale chat"));
     provider.setContext(createContext(replacement.gateway, replacementList));
     await palette.updateComplete;
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(50);
     await palette.updateComplete;
 
     expect(replacementList).toHaveBeenCalledOnce();
     expect(palette.textContent).toContain("Fresh chat");
     expect(palette.textContent).not.toContain("Stale chat");
+  });
+
+  it("merges full-context matches after metadata matches without adding another search field", async () => {
+    const metadata = createSessionResult("agent:main:metadata", "needle");
+    const contextOnly = createSessionResult("agent:main:context", "Unrelated title");
+    const roster = {
+      ...metadata,
+      count: 2,
+      totalCount: 2,
+      sessions: [...metadata.sessions, ...contextOnly.sessions],
+    } as SessionsListResult;
+    const list = vi.fn<ApplicationContext<RouteId>["sessions"]["list"]>(async (options) =>
+      options?.search ? metadata : roster,
+    );
+    const searchResult: SessionsSearchResult = {
+      results: [
+        {
+          sessionKey: "agent:main:context",
+          sessionId: "context",
+          messageId: "message-context",
+          role: "assistant",
+          timestamp: 42,
+          snippet: "The needle appears only in the conversation body.",
+          score: 10,
+        },
+      ],
+    };
+    const request = vi.fn(async () => searchResult);
+    const { gateway } = createGateway(true, {
+      methods: ["sessions.search"],
+      request: request as GatewayBrowserClient["request"],
+    });
+    const { palette } = await mountPalette(createContext(gateway, list));
+
+    await enterQuery(palette, "needle");
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await palette.updateComplete;
+
+    expect(request).toHaveBeenCalledWith("sessions.search", {
+      agentId: "main",
+      sessionKeys: ["agent:main:metadata", "agent:main:context"],
+      query: "needle",
+      limit: 25,
+    });
+    const chatItems = [...palette.querySelectorAll<HTMLElement>(".cmd-palette__item")];
+    expect(chatItems).toHaveLength(2);
+    expect(chatItems[0]?.textContent).toContain("needle");
+    expect(chatItems[1]?.textContent).toContain("Unrelated title");
+    expect(chatItems[1]?.textContent).toContain("needle appears only in the conversation body");
+    expect(palette.querySelectorAll(".cmd-palette__input")).toHaveLength(1);
+  });
+
+  it("waits for two characters before searching sessions", async () => {
+    const { gateway } = createGateway(true, { methods: ["sessions.search"] });
+    const list = vi.fn(async () => createSessionResult("agent:main:test", "Test"));
+    const { palette } = await mountPalette(createContext(gateway, list));
+
+    await enterQuery(palette, "n");
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("keeps bounded metadata pagination when transcript search is unavailable", async () => {
+    const list = vi.fn<ApplicationContext<RouteId>["sessions"]["list"]>(async (options) => {
+      const offset = options?.offset ?? 0;
+      return {
+        ...createSessionResult(`agent:main:hidden-${offset}`, `Hidden ${offset}`),
+        totalCount: 250,
+        hasMore: true,
+        nextOffset: offset + 50,
+        sessions: [
+          {
+            key: `agent:main:hidden-${offset}`,
+            kind: "direct",
+            displayName: `Hidden ${offset}`,
+            spawnedBy: "agent:main:main",
+            updatedAt: 1,
+          },
+        ],
+      } as SessionsListResult;
+    });
+    const { gateway } = createGateway(true);
+    const { palette } = await mountPalette(createContext(gateway, list));
+
+    await enterQuery(palette, "hidden");
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.waitFor(() => expect(list).toHaveBeenCalledTimes(4));
+
+    expect(list.mock.calls.map(([options]) => options?.offset ?? 0)).toEqual([0, 50, 100, 150]);
+  });
+
+  it("matches category metadata from the full visible roster", async () => {
+    const categorized = createSessionResult("agent:main:categorized", "Unrelated title");
+    const categorizedRow = categorized.sessions.at(0);
+    if (!categorizedRow) {
+      throw new Error("Expected categorized session fixture");
+    }
+    categorized.sessions[0] = { ...categorizedRow, category: "Tak" };
+    const empty = { ...categorized, count: 0, sessions: [] } as SessionsListResult;
+    const list = vi.fn<ApplicationContext<RouteId>["sessions"]["list"]>(async (options) =>
+      options?.search ? empty : categorized,
+    );
+    const request = vi.fn(async () => ({ results: [] }) satisfies SessionsSearchResult);
+    const { gateway } = createGateway(true, {
+      methods: ["sessions.search"],
+      request: request as GatewayBrowserClient["request"],
+    });
+    const { palette } = await mountPalette(createContext(gateway, list));
+
+    await enterQuery(palette, "tak");
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    await palette.updateComplete;
+
+    expect(palette.textContent).toContain("Unrelated title");
   });
 
   it("shows a search failure instead of a false empty result", async () => {
@@ -217,7 +339,7 @@ describe("CommandPalette lifecycle", () => {
     // The query matches no navigation item, so a swallowed search failure
     // would render the plain "No results" empty state.
     await enterQuery(palette, "zzz-unmatched");
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(50);
     await palette.updateComplete;
 
     expect(list).toHaveBeenCalledOnce();
@@ -228,7 +350,7 @@ describe("CommandPalette lifecycle", () => {
     await enterQuery(palette, "zz");
     await palette.updateComplete;
     expect(palette.textContent).not.toContain("Chat search failed");
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(50);
     await palette.updateComplete;
     expect(palette.textContent).toContain("Recovered chat");
   });

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -81,6 +81,9 @@ function createContext(
 ): ApplicationContext<RouteId> {
   return {
     gateway,
+    agents: {
+      ensureList: async () => null,
+    },
     sessions: {
       list,
       state: { result: null },
@@ -329,6 +332,48 @@ describe("CommandPalette lifecycle", () => {
       "Transcript search unavailable — showing chat titles and metadata",
     );
     expect(palette.textContent).not.toContain("Chat search failed");
+  });
+
+  it("lazily searches automation names and descriptions once per connection", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.list") {
+        return {
+          jobs: [
+            {
+              id: "nightly-invoices",
+              name: "Nightly invoices",
+              description: "Reconciles customer billing",
+            },
+          ],
+        };
+      }
+      throw new Error(`Unexpected method: ${method}`);
+    });
+    const { gateway } = createGateway(true, {
+      methods: ["cron.list"],
+      request: request as GatewayBrowserClient["request"],
+    });
+    const empty = { ...createSessionResult("agent:main:none", "None"), sessions: [] };
+    const { palette } = await mountPalette(
+      createContext(
+        gateway,
+        vi.fn(async () => empty),
+      ),
+    );
+
+    await enterQuery(palette, "reconciles");
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.waitFor(() => expect(palette.textContent).toContain("Nightly invoices"));
+    const item = palette.querySelector<HTMLElement>(
+      "#cmd-palette-option-automation-nightly-invoices",
+    );
+    item?.click();
+    expect(palette.onNavigate).toHaveBeenCalledWith("cron");
+
+    await enterQuery(palette, "invoices");
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.waitFor(() => expect(palette.textContent).toContain("Nightly invoices"));
+    expect(request.mock.calls.filter(([method]) => method === "cron.list")).toHaveLength(1);
   });
 
   it("waits for two characters before searching sessions", async () => {

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -339,8 +339,30 @@ describe("CommandPalette lifecycle", () => {
     { state: "truncated", response: { truncated: true } },
   ])("shows a partial-search notice when transcript results are $state", async ({ response }) => {
     const metadata = createSessionResult("agent:main:metadata", "Needle planning");
-    const list = vi.fn<ApplicationContext<RouteId>["sessions"]["list"]>(async () => metadata);
-    const request = vi.fn(async () => ({ results: [], ...response }));
+    const contextOnly = createSessionResult("agent:main:context", "Unrelated title");
+    const roster = {
+      ...metadata,
+      count: 2,
+      totalCount: 2,
+      sessions: [...metadata.sessions, ...contextOnly.sessions],
+    } as SessionsListResult;
+    const list = vi.fn<ApplicationContext<RouteId>["sessions"]["list"]>(async (options) =>
+      options?.search ? metadata : roster,
+    );
+    const request = vi.fn(async () => ({
+      results: [
+        {
+          sessionKey: "agent:main:context",
+          sessionId: "context",
+          messageId: "message-context",
+          role: "assistant" as const,
+          timestamp: 42,
+          snippet: "The needle also appears in this transcript.",
+          score: 10,
+        },
+      ],
+      ...response,
+    }));
     const { gateway } = createGateway(true, {
       methods: ["sessions.search"],
       request: request as GatewayBrowserClient["request"],
@@ -353,9 +375,11 @@ describe("CommandPalette lifecycle", () => {
     await palette.updateComplete;
 
     expect(palette.textContent).toContain(
-      "Transcript search unavailable — showing chat titles and metadata",
+      "Transcript matches may be incomplete — indexing or search limits apply",
     );
     expect(palette.textContent).toContain("Needle planning");
+    expect(palette.textContent).toContain("Unrelated title");
+    expect(palette.textContent).toContain("needle also appears in this transcript");
   });
 
   it("lazily searches automation names and descriptions once per connection", async () => {

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -1,15 +1,13 @@
 // Control UI component renders the command palette.
 import { consume } from "@lit/context";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ref } from "lit/directives/ref.js";
 import type { SessionsSearchHit } from "../../../packages/gateway-protocol/src/index.js";
 import type { RouteId } from "../app-route-paths.ts";
 import { applicationContext, type ApplicationContext } from "../app/context.ts";
+import { hasOperatorAdminAccess } from "../app/operator-access.ts";
 import { t } from "../i18n/index.ts";
 import { formatRelativeTimestamp } from "../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
@@ -22,26 +20,27 @@ import {
 import { searchVisibleSessionTranscripts } from "../lib/sessions/transcript-search.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
+import {
+  commandPaletteCategoryLabel,
+  filterCommandPaletteItems,
+  getStaticCommandPaletteCatalogItems,
+  loadCommandPaletteCatalogItems,
+  toCommandPaletteItems,
+  type CommandPaletteItem,
+} from "./command-palette-catalog-search.ts";
 import { isCommandPaletteShortcut } from "./command-palette-contract.ts";
 import {
   sessionMetadataMatchRank,
   transcriptSearchSnippet,
 } from "./command-palette-session-search.ts";
-import { icons, type IconName } from "./icons.ts";
+import { icons } from "./icons.ts";
 import "./modal-dialog.ts";
 import {
   CUSTODIAN_PANEL_TOGGLE_EVENT,
   DESKTOP_PANEL_TOGGLE_EVENT,
 } from "./panel-toggle-contract.ts";
 
-type PaletteItem = {
-  id: string;
-  label: string;
-  icon: IconName;
-  category: "search" | "navigation" | "skills" | "chats";
-  action: string;
-  description?: string;
-};
+type PaletteItem = CommandPaletteItem;
 
 const SESSION_ACTION_PREFIX = "session:";
 const SESSION_SEARCH_DEBOUNCE_MS = 50;
@@ -52,113 +51,14 @@ const SESSION_SEARCH_PAGE_SIZE = 50;
 const SESSION_TRANSCRIPT_MAX_LIST_PAGES = 4;
 const SESSION_TRANSCRIPT_MAX_REQUESTS = 4;
 const SESSION_TRANSCRIPT_MAX_SESSION_KEYS = 200;
-
-function getPaletteBaseItems(
-  desktopAvailable: boolean,
-  custodianAvailable: boolean,
-): PaletteItem[] {
-  return [
-    {
-      id: "nav-new-session",
-      label: t("newSession.title"),
-      icon: "plus",
-      category: "navigation",
-      action: "nav:new-session",
-    },
-    {
-      id: "nav-sessions",
-      label: t("palette.items.sessions"),
-      icon: "fileText",
-      category: "navigation",
-      action: "nav:sessions",
-    },
-    {
-      id: "nav-cron",
-      label: t("palette.items.scheduled"),
-      icon: "scrollText",
-      category: "navigation",
-      action: "nav:cron",
-    },
-    {
-      id: "nav-skills",
-      label: t("palette.items.skills"),
-      icon: "zap",
-      category: "navigation",
-      action: "nav:skills",
-    },
-    {
-      id: "nav-plugins",
-      label: t("palette.items.plugins"),
-      icon: "puzzle",
-      category: "navigation",
-      action: "nav:plugins",
-    },
-    {
-      id: "nav-apps",
-      label: t("palette.items.apps"),
-      icon: "layoutGrid",
-      category: "navigation",
-      action: "nav:apps",
-    },
-    {
-      id: "nav-config",
-      label: t("palette.items.settings"),
-      icon: "settings",
-      category: "navigation",
-      action: "nav:config",
-    },
-    {
-      id: "nav-agents",
-      label: t("palette.items.agents"),
-      icon: "folder",
-      category: "navigation",
-      action: "nav:agents",
-    },
-    {
-      id: "slash:verbose",
-      label: "/verbose",
-      icon: "terminal",
-      category: "search",
-      action: "/verbose full",
-      description: t("palette.descriptions.verboseMode"),
-    },
-    ...(desktopAvailable
-      ? [
-          {
-            id: "panel-desktop",
-            label: t("palette.items.desktop"),
-            icon: "monitor" as const,
-            category: "navigation" as const,
-            action: "panel:desktop",
-          },
-        ]
-      : []),
-    ...(custodianAvailable
-      ? [
-          {
-            id: "panel-custodian",
-            label: t("nav.askOpenClaw"),
-            icon: "lobster" as const,
-            category: "navigation" as const,
-            action: "panel:custodian",
-          },
-        ]
-      : []),
-  ];
-}
-
-function getPaletteItemsInternal(
-  desktopAvailable: boolean,
-  custodianAvailable: boolean,
-): PaletteItem[] {
-  return getPaletteBaseItems(desktopAvailable, custodianAvailable);
-}
+const CATALOG_CACHE_TTL_MS = 30_000;
 
 type CommandPaletteProps = {
   open: boolean;
   query: string;
   activeIndex: number;
   sessionItems: readonly PaletteItem[];
+  catalogItems: readonly PaletteItem[];
   sessionSearchFailed: boolean;
   sessionSearchPartial: boolean;
   onToggle: () => void;
@@ -176,24 +76,18 @@ function filteredItems(
   query: string,
   includeSlashCommands = true,
   sessionItems: readonly PaletteItem[] = [],
+  catalogItems: readonly PaletteItem[] = [],
   desktopAvailable = false,
   custodianAvailable = false,
 ): PaletteItem[] {
-  const items = getPaletteItemsInternal(desktopAvailable, custodianAvailable).filter(
-    (item) => includeSlashCommands || item.category !== "search",
-  );
-  if (!query) {
-    return items;
-  }
-  const q = normalizeLowercaseStringOrEmpty(query);
-  const matches = items.filter(
-    (item) =>
-      normalizeLowercaseStringOrEmpty(item.label).includes(q) ||
-      normalizeLowercaseStringOrEmpty(item.description).includes(q),
-  );
-  // Gateway search already matched the chat rows, so lead with those before
-  // local navigation and slash-command matches.
-  return [...sessionItems, ...matches];
+  return filterCommandPaletteItems({
+    query,
+    includeSlashCommands,
+    sessionItems,
+    catalogItems,
+    desktopAvailable,
+    custodianAvailable,
+  });
 }
 
 function groupItems(items: PaletteItem[]): Array<[string, PaletteItem[]]> {
@@ -241,6 +135,7 @@ function handleKeydown(e: KeyboardEvent, props: CommandPaletteProps) {
     props.query,
     Boolean(props.onSlashCommand),
     props.sessionItems,
+    props.catalogItems,
     props.desktopAvailable,
     props.custodianAvailable,
   );
@@ -275,21 +170,6 @@ function handleKeydown(e: KeyboardEvent, props: CommandPaletteProps) {
   }
 }
 
-function getCategoryLabel(category: string): string {
-  switch (category) {
-    case "search":
-      return t("palette.categories.search");
-    case "navigation":
-      return t("palette.categories.navigation");
-    case "skills":
-      return t("palette.categories.skills");
-    case "chats":
-      return t("sessionsView.title");
-    default:
-      return category;
-  }
-}
-
 function getOptionId(item: PaletteItem): string {
   return `cmd-palette-option-${item.id.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
 }
@@ -312,6 +192,7 @@ function renderCommandPalette(props: CommandPaletteProps) {
     props.query,
     Boolean(props.onSlashCommand),
     props.sessionItems,
+    props.catalogItems,
     props.desktopAvailable,
     props.custodianAvailable,
   );
@@ -371,7 +252,9 @@ function renderCommandPalette(props: CommandPaletteProps) {
               </div>`
             : grouped.map(
                 ([category, groupedItems]) => html`
-                  <div class="cmd-palette__group-label">${getCategoryLabel(category)}</div>
+                  <div class="cmd-palette__group-label">
+                    ${commandPaletteCategoryLabel(category)}
+                  </div>
                   ${groupedItems.map((item) => {
                     const globalIndex = items.indexOf(item);
                     const isActive = globalIndex === props.activeIndex;
@@ -422,12 +305,19 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
   @state() private query = "";
   @state() private activeIndex = 0;
   @state() private sessionItems: readonly PaletteItem[] = [];
+  @state() private catalogItems: readonly PaletteItem[] = [];
   @state() private sessionSearchFailed = false;
   @state() private sessionSearchPartial = false;
 
   private readonly subscriptions = new SubscriptionsController(this);
   private sessionSearchTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   private sessionSearchId = 0;
+  private catalogLoad?: {
+    client: NonNullable<ApplicationContext<RouteId>["gateway"]["snapshot"]["client"]>;
+    agentId: string;
+    promise: Promise<void>;
+    loadedAt?: number;
+  };
   private sessionSearchSource?: {
     gateway: ApplicationContext<RouteId>["gateway"];
     client: ApplicationContext<RouteId>["gateway"]["snapshot"]["client"];
@@ -454,6 +344,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     this.query = "";
     this.activeIndex = 0;
     this.clearSessionSearch();
+    this.clearCatalogSearch();
     this.sessionSearchSource = undefined;
     super.disconnectedCallback();
   }
@@ -500,6 +391,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       // Query results belong to one runtime/client connection. Discard them as
       // soon as that owner changes so detached or reconnecting rows stay inert.
       this.clearSessionSearch();
+      this.clearCatalogSearch();
     }
     if (snapshot.phase === "connected" && (sourceChanged || clientChanged || reconnected)) {
       this.scheduleSessionSearch(this.query);
@@ -517,6 +409,47 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     this.sessionSearchPartial = false;
   }
 
+  private clearCatalogSearch() {
+    this.catalogLoad = undefined;
+    this.catalogItems = [];
+  }
+
+  private ensureCatalogItems(): Promise<void> {
+    const context = this.context;
+    const gateway = context?.gateway;
+    const client = gateway?.snapshot.client;
+    if (!context || gateway?.snapshot.phase !== "connected" || !client) {
+      return Promise.resolve();
+    }
+    const agentId = resolveUiSelectedGlobalAgentId(gateway.snapshot);
+    const current = this.catalogLoad;
+    if (
+      current?.client === client &&
+      current.agentId === agentId &&
+      (current.loadedAt === undefined || Date.now() - current.loadedAt < CATALOG_CACHE_TTL_MS)
+    ) {
+      return current.promise;
+    }
+    const snapshot = gateway.snapshot;
+    const promise = loadCommandPaletteCatalogItems({
+      client,
+      agentId,
+      agents: () => context.agents?.ensureList?.() ?? Promise.resolve(null),
+      methodAvailable: (method) => Boolean(isGatewayMethodAdvertised(snapshot, method)),
+    }).then((items) => {
+      if (
+        this.catalogLoad?.promise === promise &&
+        this.context?.gateway === gateway &&
+        gateway.snapshot.client === client
+      ) {
+        this.catalogItems = toCommandPaletteItems(items);
+        this.catalogLoad.loadedAt = Date.now();
+      }
+    });
+    this.catalogLoad = { client, agentId, promise };
+    return promise;
+  }
+
   private scheduleSessionSearch(query: string) {
     if (this.sessionSearchTimer !== null) {
       globalThis.clearTimeout(this.sessionSearchTimer);
@@ -529,17 +462,15 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     this.sessionSearchFailed = false;
     this.sessionSearchPartial = false;
     const search = normalizeOptionalString(query);
-    if (
-      !this.open ||
-      !search ||
-      search.length < SESSION_SEARCH_MIN_CHARS ||
-      !this.onSelectSession
-    ) {
+    if (!this.open || !search || search.length < SESSION_SEARCH_MIN_CHARS) {
       return;
     }
     this.sessionSearchTimer = globalThis.setTimeout(() => {
       this.sessionSearchTimer = null;
-      void this.searchSessions(search);
+      void this.ensureCatalogItems();
+      if (this.onSelectSession) {
+        void this.searchSessions(search);
+      }
     }, SESSION_SEARCH_DEBOUNCE_MS);
   }
 
@@ -716,6 +647,14 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       query: this.query,
       activeIndex: this.activeIndex,
       sessionItems: this.sessionItems,
+      catalogItems: [
+        ...toCommandPaletteItems(
+          getStaticCommandPaletteCatalogItems(
+            hasOperatorAdminAccess(this.context?.gateway.snapshot.hello?.auth ?? null),
+          ),
+        ),
+        ...this.catalogItems,
+      ],
       sessionSearchFailed: this.sessionSearchFailed,
       sessionSearchPartial: this.sessionSearchPartial,
       desktopAvailable: this.desktopAvailable,

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -354,7 +354,7 @@ function renderCommandPalette(props: CommandPaletteProps) {
         />
         <div id=${paletteListboxId} class="cmd-palette__results" role="listbox">
           ${props.sessionSearchPartial
-            ? html`<div class="cmd-palette__search-notice" role="status">
+            ? html`<div class="cmd-palette__empty" role="status">
                 ${t("palette.searchPartial")}
               </div>`
             : nothing}

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -61,6 +61,7 @@ type CommandPaletteProps = {
   catalogItems: readonly PaletteItem[];
   sessionSearchFailed: boolean;
   sessionSearchPartial: boolean;
+  sessionSearchIncomplete: boolean;
   onToggle: () => void;
   onQueryChange: (query: string) => void;
   onActiveIndexChange: (index: number) => void;
@@ -234,9 +235,13 @@ function renderCommandPalette(props: CommandPaletteProps) {
           }}
         />
         <div id=${paletteListboxId} class="cmd-palette__results" role="listbox">
-          ${props.sessionSearchPartial
+          ${props.sessionSearchPartial || props.sessionSearchIncomplete
             ? html`<div class="cmd-palette__empty" role="status">
-                ${t("palette.searchPartial")}
+                ${t(
+                  props.sessionSearchIncomplete
+                    ? "palette.searchIncomplete"
+                    : "palette.searchPartial",
+                )}
               </div>`
             : nothing}
           ${grouped.length === 0
@@ -308,6 +313,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
   @state() private catalogItems: readonly PaletteItem[] = [];
   @state() private sessionSearchFailed = false;
   @state() private sessionSearchPartial = false;
+  @state() private sessionSearchIncomplete = false;
 
   private readonly subscriptions = new SubscriptionsController(this);
   private sessionSearchTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
@@ -407,6 +413,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     this.sessionItems = [];
     this.sessionSearchFailed = false;
     this.sessionSearchPartial = false;
+    this.sessionSearchIncomplete = false;
   }
 
   private clearCatalogSearch() {
@@ -461,6 +468,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     this.sessionItems = [];
     this.sessionSearchFailed = false;
     this.sessionSearchPartial = false;
+    this.sessionSearchIncomplete = false;
     const search = normalizeOptionalString(query);
     if (!this.open || !search || search.length < SESSION_SEARCH_MIN_CHARS) {
       return;
@@ -572,10 +580,10 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
         return;
       }
       const transcriptResult = transcriptOutcome?.result ?? null;
-      this.sessionSearchPartial =
-        transcriptOutcome?.error === true ||
-        transcriptResult?.indexing === true ||
-        transcriptResult?.truncated === true;
+      this.sessionSearchPartial = transcriptOutcome?.error === true;
+      this.sessionSearchIncomplete =
+        transcriptOutcome?.error !== true &&
+        (transcriptResult?.indexing === true || transcriptResult?.truncated === true);
       const transcriptHitByKey = new Map<string, SessionsSearchHit>();
       for (const hit of transcriptResult?.results ?? []) {
         if (!transcriptHitByKey.has(hit.sessionKey)) {
@@ -660,6 +668,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       ],
       sessionSearchFailed: this.sessionSearchFailed,
       sessionSearchPartial: this.sessionSearchPartial,
+      sessionSearchIncomplete: this.sessionSearchIncomplete,
       desktopAvailable: this.desktopAvailable,
       custodianAvailable: this.custodianAvailable,
       onToggle: this.togglePalette,

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -572,7 +572,10 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
         return;
       }
       const transcriptResult = transcriptOutcome?.result ?? null;
-      this.sessionSearchPartial = transcriptOutcome?.error === true;
+      this.sessionSearchPartial =
+        transcriptOutcome?.error === true ||
+        transcriptResult?.indexing === true ||
+        transcriptResult?.truncated === true;
       const transcriptHitByKey = new Map<string, SessionsSearchHit>();
       for (const hit of transcriptResult?.results ?? []) {
         if (!transcriptHitByKey.has(hit.sessionKey)) {

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -15,7 +15,10 @@ import { formatRelativeTimestamp } from "../lib/format.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { resolveSessionDisplayName } from "../lib/session-display.ts";
 import { filterVisibleSessionRows, getVisibleSessionRows } from "../lib/sessions/index.ts";
-import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
+import {
+  parseAgentSessionKey,
+  resolveUiSelectedGlobalAgentId,
+} from "../lib/sessions/session-key.ts";
 import { searchVisibleSessionTranscripts } from "../lib/sessions/transcript-search.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
@@ -46,6 +49,9 @@ const SESSION_SEARCH_MIN_CHARS = 2;
 const SESSION_SEARCH_LIMIT = 10;
 const SESSION_SEARCH_MAX_PAGES = 4;
 const SESSION_SEARCH_PAGE_SIZE = 50;
+const SESSION_TRANSCRIPT_MAX_LIST_PAGES = 4;
+const SESSION_TRANSCRIPT_MAX_REQUESTS = 4;
+const SESSION_TRANSCRIPT_MAX_SESSION_KEYS = 200;
 
 function getPaletteBaseItems(
   desktopAvailable: boolean,
@@ -154,6 +160,7 @@ type CommandPaletteProps = {
   activeIndex: number;
   sessionItems: readonly PaletteItem[];
   sessionSearchFailed: boolean;
+  sessionSearchPartial: boolean;
   onToggle: () => void;
   onQueryChange: (query: string) => void;
   onActiveIndexChange: (index: number) => void;
@@ -346,6 +353,11 @@ function renderCommandPalette(props: CommandPaletteProps) {
           }}
         />
         <div id=${paletteListboxId} class="cmd-palette__results" role="listbox">
+          ${props.sessionSearchPartial
+            ? html`<div class="cmd-palette__search-notice" role="status">
+                ${t("palette.searchPartial")}
+              </div>`
+            : nothing}
           ${grouped.length === 0
             ? html`<div class="cmd-palette__empty">
                 <span class="nav-item__icon" style="opacity:0.3;width:20px;height:20px"
@@ -411,6 +423,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
   @state() private activeIndex = 0;
   @state() private sessionItems: readonly PaletteItem[] = [];
   @state() private sessionSearchFailed = false;
+  @state() private sessionSearchPartial = false;
 
   private readonly subscriptions = new SubscriptionsController(this);
   private sessionSearchTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
@@ -501,6 +514,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     this.sessionSearchId += 1;
     this.sessionItems = [];
     this.sessionSearchFailed = false;
+    this.sessionSearchPartial = false;
   }
 
   private scheduleSessionSearch(query: string) {
@@ -513,6 +527,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     this.sessionSearchId += 1;
     this.sessionItems = [];
     this.sessionSearchFailed = false;
+    this.sessionSearchPartial = false;
     const search = normalizeOptionalString(query);
     if (
       !this.open ||
@@ -548,6 +563,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       gateway.snapshot,
       "sessions.search",
     );
+    const defaultAgentId = resolveUiSelectedGlobalAgentId(gateway.snapshot);
     const transcriptSearch = transcriptSearchAvailable
       ? searchVisibleSessionTranscripts({
           client,
@@ -559,15 +575,21 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
             includeUnknown: false,
             configuredAgentsOnly: true,
           },
-          resolveAgentId: (sessionKey) => parseAgentSessionKey(sessionKey)?.agentId,
+          resolveAgentId: (sessionKey) =>
+            parseAgentSessionKey(sessionKey)?.agentId ?? defaultAgentId,
           isCurrent,
+          maxListPages: SESSION_TRANSCRIPT_MAX_LIST_PAGES,
+          maxSearchRequests: SESSION_TRANSCRIPT_MAX_REQUESTS,
+          maxSessionKeys: SESSION_TRANSCRIPT_MAX_SESSION_KEYS,
           mapPageRows: (rows) =>
             filterVisibleSessionRows(rows, {
               agentId: "",
-              defaultAgentId: "",
+              defaultAgentId,
               filterByAgent: false,
             }),
         })
+          .then((result) => ({ error: false as const, result }))
+          .catch(() => ({ error: true as const, result: null }))
       : Promise.resolve(null);
     const visibleRows: ReturnType<typeof getVisibleSessionRows> = [];
     const visibleKeys = new Set<string>();
@@ -575,54 +597,51 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     let pagesLoaded = 0;
     let offset: number | undefined;
     try {
-      if (!transcriptSearchAvailable) {
-        while (
-          visibleRows.length < SESSION_SEARCH_LIMIT &&
-          pagesLoaded < SESSION_SEARCH_MAX_PAGES
-        ) {
-          const result = await sessions.list({
-            search,
-            limit: SESSION_SEARCH_PAGE_SIZE,
-            ...(offset === undefined ? {} : { offset }),
-            includeGlobal: false,
-            includeUnknown: false,
-          });
-          pagesLoaded += 1;
-          if (!isCurrent() || !result) {
-            return;
-          }
-          const pageRows = getVisibleSessionRows(result, {
-            agentId: "",
-            defaultAgentId: "",
-            filterByAgent: false,
-          });
-          for (const row of pageRows) {
-            if (!visibleKeys.has(row.key)) {
-              visibleKeys.add(row.key);
-              visibleRows.push(row);
-            }
-          }
-          if (visibleRows.length >= SESSION_SEARCH_LIMIT || !result.hasMore) {
-            break;
-          }
-          const nextOffset =
-            typeof result.nextOffset === "number" && Number.isFinite(result.nextOffset)
-              ? Math.max(0, Math.floor(result.nextOffset))
-              : result.sessions.length > 0
-                ? (offset ?? 0) + result.sessions.length
-                : null;
-          // Malformed pagination must not turn a palette query into an RPC loop.
-          if (nextOffset === null || seenOffsets.has(nextOffset)) {
-            break;
-          }
-          seenOffsets.add(nextOffset);
-          offset = nextOffset;
+      while (visibleRows.length < SESSION_SEARCH_LIMIT && pagesLoaded < SESSION_SEARCH_MAX_PAGES) {
+        const result = await sessions.list({
+          search,
+          limit: SESSION_SEARCH_PAGE_SIZE,
+          ...(offset === undefined ? {} : { offset }),
+          includeGlobal: false,
+          includeUnknown: false,
+        });
+        pagesLoaded += 1;
+        if (!isCurrent() || !result) {
+          return;
         }
+        const pageRows = getVisibleSessionRows(result, {
+          agentId: "",
+          defaultAgentId,
+          filterByAgent: false,
+        });
+        for (const row of pageRows) {
+          if (!visibleKeys.has(row.key)) {
+            visibleKeys.add(row.key);
+            visibleRows.push(row);
+          }
+        }
+        if (visibleRows.length >= SESSION_SEARCH_LIMIT || !result.hasMore) {
+          break;
+        }
+        const nextOffset =
+          typeof result.nextOffset === "number" && Number.isFinite(result.nextOffset)
+            ? Math.max(0, Math.floor(result.nextOffset))
+            : result.sessions.length > 0
+              ? (offset ?? 0) + result.sessions.length
+              : null;
+        // Malformed pagination must not turn a palette query into an RPC loop.
+        if (nextOffset === null || seenOffsets.has(nextOffset)) {
+          break;
+        }
+        seenOffsets.add(nextOffset);
+        offset = nextOffset;
       }
-      const transcriptResult = await transcriptSearch;
+      const transcriptOutcome = await transcriptSearch;
       if (!isCurrent()) {
         return;
       }
+      const transcriptResult = transcriptOutcome?.result ?? null;
+      this.sessionSearchPartial = transcriptOutcome?.error === true;
       const transcriptHitByKey = new Map<string, SessionsSearchHit>();
       for (const hit of transcriptResult?.results ?? []) {
         if (!transcriptHitByKey.has(hit.sessionKey)) {
@@ -656,14 +675,14 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
           return transcriptDiff || (right.row.updatedAt ?? 0) - (left.row.updatedAt ?? 0);
         })
         .slice(0, SESSION_SEARCH_LIMIT)
-        .map(({ row, metadataRank, transcriptHit }) => ({
+        .map(({ row, transcriptHit }) => ({
           id: `session-${row.key}`,
           label: resolveSessionDisplayName(row.key, row),
           icon: "messageSquare" as const,
           category: "chats" as const,
           action: `${SESSION_ACTION_PREFIX}${row.key}`,
           description:
-            metadataRank === 0 && transcriptHit
+            transcriptHit && sessionMetadataMatchRank(row, search) === 0
               ? transcriptSearchSnippet(transcriptHit.snippet)
               : formatRelativeTimestamp(row.updatedAt, { fallback: "" }),
         }));
@@ -698,6 +717,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       activeIndex: this.activeIndex,
       sessionItems: this.sessionItems,
       sessionSearchFailed: this.sessionSearchFailed,
+      sessionSearchPartial: this.sessionSearchPartial,
       desktopAvailable: this.desktopAvailable,
       custodianAvailable: this.custodianAvailable,
       onToggle: this.togglePalette,

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -7,15 +7,23 @@ import {
 import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { ref } from "lit/directives/ref.js";
+import type { SessionsSearchHit } from "../../../packages/gateway-protocol/src/index.js";
 import type { RouteId } from "../app-route-paths.ts";
 import { applicationContext, type ApplicationContext } from "../app/context.ts";
 import { t } from "../i18n/index.ts";
 import { formatRelativeTimestamp } from "../lib/format.ts";
+import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { resolveSessionDisplayName } from "../lib/session-display.ts";
-import { getVisibleSessionRows } from "../lib/sessions/index.ts";
+import { filterVisibleSessionRows, getVisibleSessionRows } from "../lib/sessions/index.ts";
+import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
+import { searchVisibleSessionTranscripts } from "../lib/sessions/transcript-search.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { isCommandPaletteShortcut } from "./command-palette-contract.ts";
+import {
+  sessionMetadataMatchRank,
+  transcriptSearchSnippet,
+} from "./command-palette-session-search.ts";
 import { icons, type IconName } from "./icons.ts";
 import "./modal-dialog.ts";
 import {
@@ -33,7 +41,8 @@ type PaletteItem = {
 };
 
 const SESSION_ACTION_PREFIX = "session:";
-const SESSION_SEARCH_DEBOUNCE_MS = 250;
+const SESSION_SEARCH_DEBOUNCE_MS = 50;
+const SESSION_SEARCH_MIN_CHARS = 2;
 const SESSION_SEARCH_LIMIT = 10;
 const SESSION_SEARCH_MAX_PAGES = 4;
 const SESSION_SEARCH_PAGE_SIZE = 50;
@@ -505,7 +514,12 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
     this.sessionItems = [];
     this.sessionSearchFailed = false;
     const search = normalizeOptionalString(query);
-    if (!this.open || !search || !this.onSelectSession) {
+    if (
+      !this.open ||
+      !search ||
+      search.length < SESSION_SEARCH_MIN_CHARS ||
+      !this.onSelectSession
+    ) {
       return;
     }
     this.sessionSearchTimer = globalThis.setTimeout(() => {
@@ -523,67 +537,136 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       return;
     }
     const requestId = ++this.sessionSearchId;
+    const isCurrent = () =>
+      requestId === this.sessionSearchId &&
+      this.open &&
+      this.context?.sessions === sessions &&
+      this.context?.gateway === gateway &&
+      gateway.snapshot.client === client &&
+      gateway.snapshot.phase === "connected";
+    const transcriptSearchAvailable = isGatewayMethodAdvertised(
+      gateway.snapshot,
+      "sessions.search",
+    );
+    const transcriptSearch = transcriptSearchAvailable
+      ? searchVisibleSessionTranscripts({
+          client,
+          query: search,
+          result: undefined,
+          listSessions: sessions.list,
+          listOptions: {
+            includeGlobal: false,
+            includeUnknown: false,
+            configuredAgentsOnly: true,
+          },
+          resolveAgentId: (sessionKey) => parseAgentSessionKey(sessionKey)?.agentId,
+          isCurrent,
+          mapPageRows: (rows) =>
+            filterVisibleSessionRows(rows, {
+              agentId: "",
+              defaultAgentId: "",
+              filterByAgent: false,
+            }),
+        })
+      : Promise.resolve(null);
     const visibleRows: ReturnType<typeof getVisibleSessionRows> = [];
     const visibleKeys = new Set<string>();
     const seenOffsets = new Set<number>([0]);
     let pagesLoaded = 0;
     let offset: number | undefined;
     try {
-      while (visibleRows.length < SESSION_SEARCH_LIMIT && pagesLoaded < SESSION_SEARCH_MAX_PAGES) {
-        const result = await sessions.list({
-          search,
-          limit: SESSION_SEARCH_PAGE_SIZE,
-          ...(offset === undefined ? {} : { offset }),
-          includeGlobal: false,
-          includeUnknown: false,
-        });
-        pagesLoaded += 1;
-        if (
-          requestId !== this.sessionSearchId ||
-          !this.open ||
-          this.context?.sessions !== sessions ||
-          this.context?.gateway !== gateway ||
-          gateway.snapshot.client !== client ||
-          gateway.snapshot.phase !== "connected" ||
-          !result
+      if (!transcriptSearchAvailable) {
+        while (
+          visibleRows.length < SESSION_SEARCH_LIMIT &&
+          pagesLoaded < SESSION_SEARCH_MAX_PAGES
         ) {
-          return;
-        }
-        const pageRows = getVisibleSessionRows(result, {
-          agentId: "",
-          defaultAgentId: "",
-          filterByAgent: false,
-        });
-        for (const row of pageRows) {
-          if (!visibleKeys.has(row.key)) {
-            visibleKeys.add(row.key);
-            visibleRows.push(row);
+          const result = await sessions.list({
+            search,
+            limit: SESSION_SEARCH_PAGE_SIZE,
+            ...(offset === undefined ? {} : { offset }),
+            includeGlobal: false,
+            includeUnknown: false,
+          });
+          pagesLoaded += 1;
+          if (!isCurrent() || !result) {
+            return;
           }
+          const pageRows = getVisibleSessionRows(result, {
+            agentId: "",
+            defaultAgentId: "",
+            filterByAgent: false,
+          });
+          for (const row of pageRows) {
+            if (!visibleKeys.has(row.key)) {
+              visibleKeys.add(row.key);
+              visibleRows.push(row);
+            }
+          }
+          if (visibleRows.length >= SESSION_SEARCH_LIMIT || !result.hasMore) {
+            break;
+          }
+          const nextOffset =
+            typeof result.nextOffset === "number" && Number.isFinite(result.nextOffset)
+              ? Math.max(0, Math.floor(result.nextOffset))
+              : result.sessions.length > 0
+                ? (offset ?? 0) + result.sessions.length
+                : null;
+          // Malformed pagination must not turn a palette query into an RPC loop.
+          if (nextOffset === null || seenOffsets.has(nextOffset)) {
+            break;
+          }
+          seenOffsets.add(nextOffset);
+          offset = nextOffset;
         }
-        if (visibleRows.length >= SESSION_SEARCH_LIMIT || !result.hasMore) {
-          break;
-        }
-        const nextOffset =
-          typeof result.nextOffset === "number" && Number.isFinite(result.nextOffset)
-            ? Math.max(0, Math.floor(result.nextOffset))
-            : result.sessions.length > 0
-              ? (offset ?? 0) + result.sessions.length
-              : null;
-        // Malformed pagination must not turn a palette query into an RPC loop.
-        if (nextOffset === null || seenOffsets.has(nextOffset)) {
-          break;
-        }
-        seenOffsets.add(nextOffset);
-        offset = nextOffset;
       }
-      this.sessionItems = visibleRows.slice(0, SESSION_SEARCH_LIMIT).map((row) => ({
-        id: `session-${row.key}`,
-        label: resolveSessionDisplayName(row.key, row),
-        icon: "messageSquare" as const,
-        category: "chats" as const,
-        action: `${SESSION_ACTION_PREFIX}${row.key}`,
-        description: formatRelativeTimestamp(row.updatedAt, { fallback: "" }),
-      }));
+      const transcriptResult = await transcriptSearch;
+      if (!isCurrent()) {
+        return;
+      }
+      const transcriptHitByKey = new Map<string, SessionsSearchHit>();
+      for (const hit of transcriptResult?.results ?? []) {
+        if (!transcriptHitByKey.has(hit.sessionKey)) {
+          transcriptHitByKey.set(hit.sessionKey, hit);
+        }
+      }
+      const rowsByKey = new Map(visibleRows.map((row) => [row.key, row] as const));
+      for (const row of transcriptResult?.sessions ?? []) {
+        if (!rowsByKey.has(row.key)) {
+          rowsByKey.set(row.key, row);
+        }
+      }
+      this.sessionItems = [...rowsByKey.values()]
+        .map((row) => ({
+          row,
+          metadataRank: Math.max(
+            visibleKeys.has(row.key) ? 1 : 0,
+            sessionMetadataMatchRank(row, search),
+          ),
+          transcriptHit: transcriptHitByKey.get(row.key),
+        }))
+        .filter(({ metadataRank, transcriptHit }) => metadataRank > 0 || transcriptHit)
+        .toSorted((left, right) => {
+          const metadataDiff = right.metadataRank - left.metadataRank;
+          if (metadataDiff !== 0) {
+            return metadataDiff;
+          }
+          const transcriptDiff =
+            (right.transcriptHit?.score ?? Number.NEGATIVE_INFINITY) -
+            (left.transcriptHit?.score ?? Number.NEGATIVE_INFINITY);
+          return transcriptDiff || (right.row.updatedAt ?? 0) - (left.row.updatedAt ?? 0);
+        })
+        .slice(0, SESSION_SEARCH_LIMIT)
+        .map(({ row, metadataRank, transcriptHit }) => ({
+          id: `session-${row.key}`,
+          label: resolveSessionDisplayName(row.key, row),
+          icon: "messageSquare" as const,
+          category: "chats" as const,
+          action: `${SESSION_ACTION_PREFIX}${row.key}`,
+          description:
+            metadataRank === 0 && transcriptHit
+              ? transcriptSearchSnippet(transcriptHit.snippet)
+              : formatRelativeTimestamp(row.updatedAt, { fallback: "" }),
+        }));
       this.activeIndex = 0;
     } catch {
       // Session search is best-effort; navigation commands stay usable. But a

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { defaultControlUiFeatureMethods } from "../test-helpers/control-ui-e2e.ts";
 import {
   actionOpacity,
   activateSelfRemovingControl,
@@ -175,7 +176,23 @@ suite.define(() => {
     const page = await context.newPage();
     await page.clock.install();
     const gateway = await installMockGateway(page, {
+      featureMethods: [...defaultControlUiFeatureMethods, "cron.list"],
       methodResponses: {
+        "cron.list": {
+          jobs: [
+            {
+              id: "nightly-invoices",
+              name: "Nightly invoices",
+              description: "Reconciles customer billing",
+            },
+          ],
+          snapshotRevision: "1",
+          total: 1,
+          limit: 200,
+          offset: 0,
+          nextOffset: null,
+          hasMore: false,
+        },
         "sessions.list": {
           cases: [
             {
@@ -309,10 +326,23 @@ suite.define(() => {
         )
         .toBe(true);
 
+      // The same palette lazily loads small non-session catalogs once and
+      // matches both item names and descriptions without involving FTS.
+      const cronRequestsBeforePalette = (await gateway.getRequests("cron.list")).length;
+      const transcriptRequestsBeforePalette = (await gateway.getRequests("sessions.search")).length;
+      await page.getByRole("button", { name: "Open command palette" }).click();
+      const paletteInput = page.locator(".cmd-palette__input");
+      await paletteInput.waitFor({ state: "visible", timeout: 10_000 });
+      await paletteInput.fill("reconciles customer billing");
+      await page.clock.runFor(50);
+      const automationOption = page.getByRole("option", { name: /Nightly invoices/u });
+      await automationOption.waitFor({ state: "visible", timeout: 10_000 });
+      expect(await gateway.getRequests("cron.list")).toHaveLength(cronRequestsBeforePalette + 1);
+      await page.keyboard.press("Escape");
+
       // Command palette is the single search surface: metadata and indexed
       // conversation text share one field, and selecting either navigates.
       await page.getByRole("button", { name: "Open command palette" }).click();
-      const paletteInput = page.locator(".cmd-palette__input");
       await paletteInput.waitFor({ state: "visible", timeout: 10_000 });
       await paletteInput.fill("view-only handshake");
       await page.clock.runFor(50);
@@ -321,9 +351,10 @@ suite.define(() => {
         .filter({ hasText: "Release planning" });
       await paletteOption.waitFor({ state: "visible", timeout: 10_000 });
       await expect.poll(() => paletteOption.textContent()).toContain("view-only handshake");
+      expect(await gateway.getRequests("cron.list")).toHaveLength(cronRequestsBeforePalette + 1);
       const transcriptRequests = await gateway.getRequests("sessions.search");
-      expect(transcriptRequests).toHaveLength(1);
-      expect(requireRecord(transcriptRequests[0]?.params)).toMatchObject({
+      expect(transcriptRequests).toHaveLength(transcriptRequestsBeforePalette + 2);
+      expect(requireRecord(transcriptRequests.at(-1)?.params)).toMatchObject({
         agentId: "main",
         query: "view-only handshake",
       });

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -178,55 +178,6 @@ suite.define(() => {
       methodResponses: {
         "sessions.list": {
           cases: [
-            ...[50, 100, 150].map((offset) => ({
-              match: { offset, search: "helpers" },
-              response: sessionsListResponse(
-                Array.from({ length: 50 }, (_, index) =>
-                  sessionRow(
-                    `agent:main:hidden-helper-${offset + index}`,
-                    `Hidden helper ${offset + index}`,
-                    baseTime - offset - index,
-                    { spawnedBy: "agent:main:main" },
-                  ),
-                ),
-                { hasMore: true, nextOffset: offset + 50, offset, totalCount: 250 },
-              ),
-            })),
-            {
-              match: { search: "helpers" },
-              response: sessionsListResponse(
-                Array.from({ length: 50 }, (_, index) =>
-                  sessionRow(
-                    `agent:main:hidden-helper-${index}`,
-                    `Hidden helper ${index}`,
-                    baseTime - index,
-                    { spawnedBy: "agent:main:main" },
-                  ),
-                ),
-                { hasMore: true, nextOffset: 50, totalCount: 250 },
-              ),
-            },
-            {
-              match: { offset: 50, search: "release" },
-              response: sessionsListResponse(
-                [sessionRow("agent:main:release", "Release planning", baseTime - 60_000)],
-                { offset: 50, totalCount: 51 },
-              ),
-            },
-            {
-              match: { search: "release" },
-              response: sessionsListResponse(
-                Array.from({ length: 50 }, (_, index) =>
-                  sessionRow(
-                    `agent:main:release-helper-${index}`,
-                    `Release helper ${index}`,
-                    baseTime - index,
-                    { spawnedBy: "agent:main:main" },
-                  ),
-                ),
-                { hasMore: true, nextOffset: 50, totalCount: 51 },
-              ),
-            },
             {
               match: {},
               response: sessionsListResponse([
@@ -241,6 +192,19 @@ suite.define(() => {
                 }),
                 sessionRow("agent:main:research", "Research notes", baseTime - 120_000),
               ]),
+            },
+          ],
+        },
+        "sessions.search": {
+          results: [
+            {
+              messageId: "message-release-context",
+              role: "assistant",
+              score: 4.2,
+              sessionId: "release",
+              sessionKey: "agent:main:release",
+              snippet: "The view-only handshake is ready for final review.",
+              timestamp: baseTime - 45_000,
             },
           ],
         },
@@ -345,48 +309,24 @@ suite.define(() => {
         )
         .toBe(true);
 
-      // Command palette is the single search surface: querying lists matching
-      // chats from the gateway and selecting one navigates to it.
+      // Command palette is the single search surface: metadata and indexed
+      // conversation text share one field, and selecting either navigates.
       await page.getByRole("button", { name: "Open command palette" }).click();
       const paletteInput = page.locator(".cmd-palette__input");
       await paletteInput.waitFor({ state: "visible", timeout: 10_000 });
-      // Automatic search is intentionally bounded: an all-hidden result set
-      // must not scan the entire session store from one palette query.
-      await paletteInput.fill("helpers");
-      await expect
-        .poll(async () => {
-          const requests = await gateway.getRequests("sessions.list");
-          return requests.filter((request) => requireRecord(request.params).search === "helpers")
-            .length;
-        })
-        .toBe(4);
-      await page.clock.runFor(400);
-      const boundedSearchRequests = await gateway.getRequests("sessions.list");
-      expect(
-        boundedSearchRequests.filter(
-          (request) => requireRecord(request.params).search === "helpers",
-        ),
-      ).toHaveLength(4);
-
-      await paletteInput.fill("release");
+      await paletteInput.fill("view-only handshake");
+      await page.clock.runFor(50);
       const paletteOption = page
         .locator(".cmd-palette__item")
         .filter({ hasText: "Release planning" });
       await paletteOption.waitFor({ state: "visible", timeout: 10_000 });
-      // The first result page contains 50 hidden child sessions; search must
-      // follow nextOffset before exposing the visible chat on page two.
-      await expect
-        .poll(() =>
-          page.locator(".cmd-palette__item").filter({ hasText: "Release helper" }).count(),
-        )
-        .toBe(0);
-      const searchRequests = await gateway.getRequests("sessions.list");
-      expect(
-        searchRequests.some((request) => {
-          const params = requireRecord(request.params);
-          return params.search === "release" && params.offset === 50;
-        }),
-      ).toBe(true);
+      await expect.poll(() => paletteOption.textContent()).toContain("view-only handshake");
+      const transcriptRequests = await gateway.getRequests("sessions.search");
+      expect(transcriptRequests).toHaveLength(1);
+      expect(requireRecord(transcriptRequests[0]?.params)).toMatchObject({
+        agentId: "main",
+        query: "view-only handshake",
+      });
       await captureUiProof(page, "command-palette-session-search.png");
       await paletteOption.click();
       await expect

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -101,17 +101,17 @@
     },
     {
       "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/components/command-palette-catalog-search.ts",
+      "text": "/verbose"
+    },
+    {
+      "count": 1,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/components/command-palette.ts",
       "text": "esc"
-    },
-    {
-      "count": 1,
-      "kind": "object-property",
-      "name": "label",
-      "path": "ui/src/components/command-palette.ts",
-      "text": "/verbose"
     },
     {
       "count": 1,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4331,6 +4331,7 @@ export const en: TranslationMap = {
     noResults: "No results",
     searchFailed: "Chat search failed — check the gateway logs and retry",
     searchPartial: "Transcript search unavailable — showing chat titles and metadata",
+    searchIncomplete: "Transcript matches may be incomplete — indexing or search limits apply",
     categories: {
       search: "Search",
       navigation: "Navigation",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4330,6 +4330,7 @@ export const en: TranslationMap = {
     placeholder: "Search chats and commands…",
     noResults: "No results",
     searchFailed: "Chat search failed — check the gateway logs and retry",
+    searchPartial: "Transcript search unavailable — showing chat titles and metadata",
     categories: {
       search: "Search",
       navigation: "Navigation",

--- a/ui/src/lib/sessions/transcript-search.ts
+++ b/ui/src/lib/sessions/transcript-search.ts
@@ -43,13 +43,17 @@ export async function searchVisibleSessionTranscripts(params: {
           }
           const rows = params.mapPageRows?.(result.sessions) ?? result.sessions;
           for (const row of rows) {
-            rowsByKey.set(row.key, row);
-            if (rowsByKey.size >= maxSessionKeys) {
+            if (!rowsByKey.has(row.key) && rowsByKey.size >= maxSessionKeys) {
               rosterTruncated = true;
               return [...rowsByKey.values()];
             }
+            rowsByKey.set(row.key, row);
           }
           if (!result.hasMore) {
+            return [...rowsByKey.values()];
+          }
+          if (rowsByKey.size >= maxSessionKeys) {
+            rosterTruncated = true;
             return [...rowsByKey.values()];
           }
           const nextOffset = result.nextOffset ?? offset + result.sessions.length;

--- a/ui/src/lib/sessions/transcript-search.ts
+++ b/ui/src/lib/sessions/transcript-search.ts
@@ -1,0 +1,72 @@
+import type { SessionsSearchResult } from "../../../../packages/gateway-protocol/src/index.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
+import type { SessionListOptions } from "./index.ts";
+import { fetchPagedSessionRows } from "./paged-session-rows.ts";
+
+type VisibleSessionTranscriptSearchResult = SessionsSearchResult & {
+  sessions: GatewaySessionRow[];
+};
+
+export async function searchVisibleSessionTranscripts(params: {
+  client: GatewayBrowserClient;
+  query: string;
+  result?: SessionsListResult | null;
+  listSessions: (options: SessionListOptions) => Promise<SessionsListResult | null>;
+  listOptions: SessionListOptions;
+  resolveAgentId: (sessionKey: string) => string | undefined;
+  isCurrent?: () => boolean;
+  mapPageRows?: (rows: GatewaySessionRow[]) => GatewaySessionRow[];
+}): Promise<VisibleSessionTranscriptSearchResult> {
+  const protocolKeyLimit = 200;
+  const sessions = await fetchPagedSessionRows({
+    initialResult: params.result,
+    list: (offset) =>
+      params.listSessions({
+        ...params.listOptions,
+        limit: protocolKeyLimit,
+        offset,
+      }),
+    isCurrent: params.isCurrent,
+    mapPageRows: params.mapPageRows,
+    missingResultError: "Unable to load all sessions for transcript search.",
+    stalledPaginationError: "Session pagination did not advance during transcript search.",
+  });
+  const visibleSessions = sessions ?? [];
+  const keysByAgent = new Map<string, string[]>();
+  for (const row of visibleSessions) {
+    const agentId = params.resolveAgentId(row.key);
+    if (!agentId) {
+      continue;
+    }
+    const keys = keysByAgent.get(agentId) ?? [];
+    keys.push(row.key);
+    keysByAgent.set(agentId, keys);
+  }
+  const requests: Array<Promise<SessionsSearchResult>> = [];
+  for (const [agentId, sessionKeys] of keysByAgent) {
+    for (let index = 0; index < sessionKeys.length; index += protocolKeyLimit) {
+      requests.push(
+        params.client.request<SessionsSearchResult>("sessions.search", {
+          agentId,
+          sessionKeys: sessionKeys.slice(index, index + protocolKeyLimit),
+          query: params.query,
+          limit: 25,
+        }),
+      );
+    }
+  }
+  const pages = await Promise.all(requests);
+  const results = pages
+    .flatMap((page) => page.results)
+    .toSorted((left, right) => right.score - left.score || right.timestamp - left.timestamp)
+    .slice(0, 25);
+  return {
+    sessions: visibleSessions,
+    results,
+    indexing: pages.some((page) => page.indexing === true),
+    truncated:
+      pages.some((page) => page.truncated === true) ||
+      pages.reduce((total, page) => total + page.results.length, 0) > results.length,
+  };
+}

--- a/ui/src/lib/sessions/transcript-search.ts
+++ b/ui/src/lib/sessions/transcript-search.ts
@@ -17,22 +17,63 @@ export async function searchVisibleSessionTranscripts(params: {
   resolveAgentId: (sessionKey: string) => string | undefined;
   isCurrent?: () => boolean;
   mapPageRows?: (rows: GatewaySessionRow[]) => GatewaySessionRow[];
+  maxListPages?: number;
+  maxSearchRequests?: number;
+  maxSessionKeys?: number;
 }): Promise<VisibleSessionTranscriptSearchResult> {
   const protocolKeyLimit = 200;
-  const sessions = await fetchPagedSessionRows({
-    initialResult: params.result,
-    list: (offset) =>
-      params.listSessions({
-        ...params.listOptions,
-        limit: protocolKeyLimit,
-        offset,
-      }),
-    isCurrent: params.isCurrent,
-    mapPageRows: params.mapPageRows,
-    missingResultError: "Unable to load all sessions for transcript search.",
-    stalledPaginationError: "Session pagination did not advance during transcript search.",
-  });
-  const visibleSessions = sessions ?? [];
+  const maxSessionKeys = params.maxSessionKeys;
+  let rosterTruncated = false;
+  const visibleSessions = maxSessionKeys
+    ? await (async () => {
+        const rowsByKey = new Map<string, GatewaySessionRow>();
+        const maxPages = Math.max(1, params.maxListPages ?? 1);
+        let offset = 0;
+        for (let page = 0; page < maxPages; page += 1) {
+          const result = await params.listSessions({
+            ...params.listOptions,
+            limit: protocolKeyLimit,
+            offset,
+          });
+          if (params.isCurrent && !params.isCurrent()) {
+            return [];
+          }
+          if (!result) {
+            throw new Error("Unable to load sessions for transcript search.");
+          }
+          const rows = params.mapPageRows?.(result.sessions) ?? result.sessions;
+          for (const row of rows) {
+            rowsByKey.set(row.key, row);
+            if (rowsByKey.size >= maxSessionKeys) {
+              rosterTruncated = true;
+              return [...rowsByKey.values()];
+            }
+          }
+          if (!result.hasMore) {
+            return [...rowsByKey.values()];
+          }
+          const nextOffset = result.nextOffset ?? offset + result.sessions.length;
+          if (nextOffset <= offset) {
+            throw new Error("Session pagination did not advance during transcript search.");
+          }
+          offset = nextOffset;
+        }
+        rosterTruncated = true;
+        return [...rowsByKey.values()];
+      })()
+    : ((await fetchPagedSessionRows({
+        initialResult: params.result,
+        list: (offset) =>
+          params.listSessions({
+            ...params.listOptions,
+            limit: protocolKeyLimit,
+            offset,
+          }),
+        isCurrent: params.isCurrent,
+        mapPageRows: params.mapPageRows,
+        missingResultError: "Unable to load all sessions for transcript search.",
+        stalledPaginationError: "Session pagination did not advance during transcript search.",
+      })) ?? []);
   const keysByAgent = new Map<string, string[]>();
   for (const row of visibleSessions) {
     const agentId = params.resolveAgentId(row.key);
@@ -44,8 +85,14 @@ export async function searchVisibleSessionTranscripts(params: {
     keysByAgent.set(agentId, keys);
   }
   const requests: Array<Promise<SessionsSearchResult>> = [];
+  const maxSearchRequests = params.maxSearchRequests ?? Number.POSITIVE_INFINITY;
+  let requestsTruncated = false;
   for (const [agentId, sessionKeys] of keysByAgent) {
     for (let index = 0; index < sessionKeys.length; index += protocolKeyLimit) {
+      if (requests.length >= maxSearchRequests) {
+        requestsTruncated = true;
+        break;
+      }
       requests.push(
         params.client.request<SessionsSearchResult>("sessions.search", {
           agentId,
@@ -54,6 +101,9 @@ export async function searchVisibleSessionTranscripts(params: {
           limit: 25,
         }),
       );
+    }
+    if (requestsTruncated) {
+      break;
     }
   }
   const pages = await Promise.all(requests);
@@ -66,6 +116,8 @@ export async function searchVisibleSessionTranscripts(params: {
     results,
     indexing: pages.some((page) => page.indexing === true),
     truncated:
+      rosterTruncated ||
+      requestsTruncated ||
       pages.some((page) => page.truncated === true) ||
       pages.reduce((total, page) => total + page.results.length, 0) > results.length,
   };

--- a/ui/src/pages/sessions/agent-scope.test.ts
+++ b/ui/src/pages/sessions/agent-scope.test.ts
@@ -118,6 +118,34 @@ describe("searchVisibleSessionTranscripts", () => {
     expect(result.truncated).toBe(true);
   });
 
+  it("does not truncate a terminal roster at the exact key cap", async () => {
+    const request = vi.fn(async (_method: string, _params: unknown) => ({ results: [] }));
+    const sessions = Array.from(
+      { length: 200 },
+      (_, index) => ({ key: `agent:main:session-${index}` }) as GatewaySessionRow,
+    );
+    const listSessions = vi.fn(async () => ({
+      count: sessions.length,
+      totalCount: sessions.length,
+      sessions,
+      hasMore: false,
+    })) as unknown as (options: unknown) => Promise<SessionsListResult>;
+
+    const result = await searchVisibleSessionTranscripts({
+      client: { request } as unknown as GatewayBrowserClient,
+      query: "needle",
+      listSessions,
+      listOptions: {},
+      resolveAgentId: () => "main",
+      maxListPages: 4,
+      maxSearchRequests: 4,
+      maxSessionKeys: 200,
+    });
+
+    expect(result.sessions).toHaveLength(200);
+    expect(result.truncated).toBe(false);
+  });
+
   it("recovers a moving thread when a later page omits the authoritative total", async () => {
     const first = { key: "agent:main:first" } as GatewaySessionRow;
     const moved = { key: "agent:main:moved" } as GatewaySessionRow;

--- a/ui/src/pages/sessions/agent-scope.test.ts
+++ b/ui/src/pages/sessions/agent-scope.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
-import { searchVisibleSessionTranscripts } from "./agent-scope.ts";
+import { searchVisibleSessionTranscripts } from "../../lib/sessions/transcript-search.ts";
 
 describe("searchVisibleSessionTranscripts", () => {
   it("batches every visible session within the protocol key limit", async () => {

--- a/ui/src/pages/sessions/agent-scope.test.ts
+++ b/ui/src/pages/sessions/agent-scope.test.ts
@@ -84,6 +84,40 @@ describe("searchVisibleSessionTranscripts", () => {
     );
   });
 
+  it("bounds palette-style roster enumeration and transcript requests", async () => {
+    const request = vi.fn(async (_method: string, _params: unknown) => ({ results: [] }));
+    const firstPage = Array.from(
+      { length: 200 },
+      (_, index) => ({ key: `agent:main:session-${index}` }) as GatewaySessionRow,
+    );
+    const listSessions = vi.fn(async () => ({
+      count: firstPage.length,
+      totalCount: 10_000,
+      sessions: firstPage,
+      hasMore: true,
+      nextOffset: 200,
+    })) as unknown as (options: unknown) => Promise<SessionsListResult>;
+
+    const result = await searchVisibleSessionTranscripts({
+      client: { request } as unknown as GatewayBrowserClient,
+      query: "needle",
+      listSessions,
+      listOptions: {},
+      resolveAgentId: () => "main",
+      maxListPages: 4,
+      maxSearchRequests: 1,
+      maxSessionKeys: 200,
+    });
+
+    expect(listSessions).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledOnce();
+    expect(request.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ sessionKeys: firstPage.map((row) => row.key) }),
+    );
+    expect(result.sessions).toHaveLength(200);
+    expect(result.truncated).toBe(true);
+  });
+
   it("recovers a moving thread when a later page omits the authoritative total", async () => {
     const first = { key: "agent:main:first" } as GatewaySessionRow;
     const moved = { key: "agent:main:moved" } as GatewaySessionRow;

--- a/ui/src/pages/sessions/agent-scope.ts
+++ b/ui/src/pages/sessions/agent-scope.ts
@@ -1,8 +1,4 @@
-import type { SessionsSearchResult } from "../../../../packages/gateway-protocol/src/index.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentIdentityResult, SessionsListResult } from "../../api/types.ts";
-import type { SessionListOptions } from "../../lib/sessions/index.ts";
-import { fetchPagedSessionRows } from "../../lib/sessions/paged-session-rows.ts";
 import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
 
 export function sessionAgentIds(result: SessionsListResult | null): string[] {
@@ -24,61 +20,4 @@ export function sessionAgentIdentityById(
       .map((agentId) => [agentId, getIdentity(agentId)] as const)
       .filter((entry): entry is readonly [string, AgentIdentityResult] => Boolean(entry[1])),
   );
-}
-
-export async function searchVisibleSessionTranscripts(params: {
-  client: GatewayBrowserClient;
-  query: string;
-  result: SessionsListResult | null;
-  listSessions: (options: SessionListOptions) => Promise<SessionsListResult | null>;
-  listOptions: SessionListOptions;
-  resolveAgentId: (sessionKey: string) => string | undefined;
-}): Promise<SessionsSearchResult> {
-  const protocolKeyLimit = 200;
-  const sessions = await fetchPagedSessionRows({
-    initialResult: params.result,
-    list: (offset) =>
-      params.listSessions({
-        ...params.listOptions,
-        limit: protocolKeyLimit,
-        offset,
-      }),
-    missingResultError: "Unable to load all sessions for transcript search.",
-    stalledPaginationError: "Session pagination did not advance during transcript search.",
-  });
-  const keysByAgent = new Map<string, string[]>();
-  for (const row of sessions ?? []) {
-    const agentId = params.resolveAgentId(row.key);
-    if (!agentId) {
-      continue;
-    }
-    const keys = keysByAgent.get(agentId) ?? [];
-    keys.push(row.key);
-    keysByAgent.set(agentId, keys);
-  }
-  const requests: Array<Promise<SessionsSearchResult>> = [];
-  for (const [agentId, sessionKeys] of keysByAgent) {
-    for (let index = 0; index < sessionKeys.length; index += protocolKeyLimit) {
-      requests.push(
-        params.client.request<SessionsSearchResult>("sessions.search", {
-          agentId,
-          sessionKeys: sessionKeys.slice(index, index + protocolKeyLimit),
-          query: params.query,
-          limit: 25,
-        }),
-      );
-    }
-  }
-  const pages = await Promise.all(requests);
-  const results = pages
-    .flatMap((page) => page.results)
-    .toSorted((left, right) => right.score - left.score || right.timestamp - left.timestamp)
-    .slice(0, 25);
-  return {
-    results,
-    indexing: pages.some((page) => page.indexing === true),
-    truncated:
-      pages.some((page) => page.truncated === true) ||
-      pages.reduce((total, page) => total + page.results.length, 0) > results.length,
-  };
 }

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -63,6 +63,7 @@ import {
   parseAgentSessionKey,
   resolveUiConfiguredMainKey,
 } from "../../lib/sessions/session-key.ts";
+import { searchVisibleSessionTranscripts } from "../../lib/sessions/transcript-search.ts";
 import { formatPreservedWorktreesNotice } from "../../lib/sessions/worktree-preservation.ts";
 import { showToast } from "../../lib/toast.ts";
 import { isActiveWorkboardCard } from "../../lib/workboard/card-state.ts";
@@ -70,11 +71,7 @@ import { captureSessionToWorkboard } from "../../lib/workboard/index.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
-import {
-  searchVisibleSessionTranscripts,
-  sessionAgentIdentityById,
-  sessionAgentIds,
-} from "./agent-scope.ts";
+import { sessionAgentIdentityById, sessionAgentIds } from "./agent-scope.ts";
 import { rememberSessionCustomGroup, sessionCategoryNames } from "./custom-groups.ts";
 import { loadStoredGroupBy, saveStoredGroupBy } from "./page-state.ts";
 import { sessionsPageListQuery, type SessionsRouteData } from "./route.ts";

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5285,6 +5285,12 @@ td.data-table-key-col {
   padding: 6px 0;
 }
 
+.cmd-palette__search-notice {
+  padding: 6px 18px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
 .cmd-palette__group-label {
   padding: 8px 18px 4px;
   color: var(--muted);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5285,12 +5285,6 @@ td.data-table-key-col {
   padding: 6px 0;
 }
 
-.cmd-palette__search-notice {
-  padding: 6px 18px;
-  color: var(--muted);
-  font-size: 12px;
-}
-
 .cmd-palette__group-label {
   padding: 8px 18px 4px;
   color: var(--muted);


### PR DESCRIPTION
## What Problem This Solves

The command palette previously searched session metadata but not words that appeared only inside messages. Its other navigation entries also exposed only broad page labels, so users could not directly find individual automations, skills, plugins, apps, agents, settings sections, or configured models/providers.

## What Changed

- Combine visible-session metadata with the existing SQLite FTS5 transcript index after two characters.
- Coalesce requests for 50 ms, ignore stale responses, rank metadata before BM25 transcript matches, and show one compact excerpt for context-only matches.
- Lazily load bounded catalog summaries when the palette is used, cache them per connection, and match names/descriptions locally.
- Search individual automations, skills, plugins, apps, agents, settings sections, and configured models/providers without adding another field or loading catalogs at Gateway startup.
- Keep transcript work bounded to four roster pages, 200 keys, and four FTS requests.
- Preserve metadata results when FTS fails and visibly surface rejected, indexing, or truncated transcript searches.
- Avoid falsely marking a terminal roster of exactly 200 sessions as truncated.

Hidden reasoning, tool arguments/output, secrets, full skill bodies, automation payloads/history, and plugin configuration remain outside search.

## Validation\n\n- GitHub exact-head CI: **152 checks completed, zero substantive failures**.\n- ClawSweeper exact-head review: **no findings**, Platinum Hermit (4/6), ready for maintainer review.\n
- Exact head: `6207636026c7230b37a486c0ad3cb2d022feb95c`
- Focused unit suite: **3 files, 29 tests passed**.
- Browser E2E: **11 tests passed**, covering unified session and catalog search.
- Full `check:changed`: passed (format, dead-code, i18n, core/UI typechecks, lint).
- Production `pnpm build`: passed, including Control UI JS/CSS performance budgets.
- Autoreview (`gpt-5.6-sol`, high): clean; patch correct at 0.98 confidence.
- Real isolated Gateway proof exercised actual agent sessions, SQLite FTS, automation/catalog RPCs, and the production Control UI. Transcript lookup completed in **13.5 ms**, and all seven catalog categories rendered.
- Live proof viewport: Chromium, 1440×900, dark mode; validated WebM recording: 10.84 seconds.

The visual proof below was captured from the validated catalog-search tree immediately before the final completeness-only review fixes. The exact pushed head was subsequently rebuilt and its changed behavior is covered by the focused regressions above.

![Built Control UI command palette returning metadata and transcript-only session matches](https://github.com/user-attachments/assets/ed6c598d-0fd9-4bee-9910-aeac0cdb1a82)

https://github.com/user-attachments/assets/a475d589-5c4a-4422-aa07-6ce8846b9c41

## Attribution

AI-assisted implementation; I reviewed and understand the resulting code and tests.

