### PR TITLE
fix(telegram): delete business callback messages through their owning account

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback-actions.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.ts
@@ -85,7 +85,11 @@ export function createTelegramCallbackMessageActions(params: {
   };
 
   const deleteCallbackMessage = async () => {
-    return await bot.api.deleteMessage(callbackMessage.chat.id, callbackMessage.message_id);
+    return callbackBusinessParams
+      ? await bot.api.deleteBusinessMessages(callbackBusinessParams.business_connection_id, [
+          callbackMessage.message_id,
+        ])
+      : await bot.api.deleteMessage(callbackMessage.chat.id, callbackMessage.message_id);
   };
 
   const replyToCallbackChat = async (text: string, replyParams?: TelegramCallbackReplyParams) => {

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -341,6 +341,7 @@ const grammySpies = vi.hoisted(() => ({
   editMessageTextSpy: vi.fn(async () => ({ message_id: 88 })) as AnyAsyncMock,
   editMessageReplyMarkupSpy: vi.fn(async () => ({ message_id: 88 })) as AnyAsyncMock,
   deleteMessageSpy: vi.fn(async () => true) as AnyAsyncMock,
+  deleteBusinessMessagesSpy: vi.fn(async () => true) as AnyAsyncMock,
   setMessageReactionSpy: vi.fn(async () => undefined) as AnyAsyncMock,
   setMyCommandsSpy: vi.fn(async () => undefined) as AnyAsyncMock,
   getMeSpy: vi.fn(async () => ({
@@ -367,6 +368,7 @@ export const sendChatActionSpy: AnyMock = grammySpies.sendChatActionSpy;
 export const editMessageTextSpy: AnyAsyncMock = grammySpies.editMessageTextSpy;
 export const editMessageReplyMarkupSpy: AnyAsyncMock = grammySpies.editMessageReplyMarkupSpy;
 export const deleteMessageSpy: AnyAsyncMock = grammySpies.deleteMessageSpy;
+export const deleteBusinessMessagesSpy: AnyAsyncMock = grammySpies.deleteBusinessMessagesSpy;
 export const setMessageReactionSpy: AnyAsyncMock = grammySpies.setMessageReactionSpy;
 export const setMyCommandsSpy: AnyAsyncMock = grammySpies.setMyCommandsSpy;
 export const getChatSpy: AnyAsyncMock = grammySpies.getChatSpy;
@@ -442,6 +444,7 @@ const telegramBotRuntimeForTest = {
       editMessageText: grammySpies.editMessageTextSpy,
       editMessageReplyMarkup: grammySpies.editMessageReplyMarkupSpy,
       deleteMessage: grammySpies.deleteMessageSpy,
+      deleteBusinessMessages: grammySpies.deleteBusinessMessagesSpy,
       setMessageReaction: grammySpies.setMessageReactionSpy,
       setMyCommands: grammySpies.setMyCommandsSpy,
       getMe: grammySpies.getMeSpy,
@@ -699,6 +702,8 @@ beforeEach(() => {
   editMessageReplyMarkupSpy.mockResolvedValue({ message_id: 88 });
   deleteMessageSpy.mockReset();
   deleteMessageSpy.mockResolvedValue(true);
+  deleteBusinessMessagesSpy.mockReset();
+  deleteBusinessMessagesSpy.mockResolvedValue(true);
   enqueueSystemEventSpy.mockReset();
   wasSentByBot.mockReset();
   wasSentByBot.mockReturnValue(false);

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -94,6 +94,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
 const {
   answerCallbackQuerySpy,
   commandSpy,
+  deleteBusinessMessagesSpy,
   deleteMessageSpy,
   dispatchReplyWithBufferedBlockDispatcher,
   editMessageReplyMarkupSpy,
@@ -5476,6 +5477,31 @@ describe("createTelegramBot", () => {
     );
 
     expect(deleteMessageSpy).toHaveBeenCalledWith(1234, 11);
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
+  it("deletes plugin-owned business callbacks through their business connection", async () => {
+    const callbackHandler = createTelegramPluginCallbackHandler({
+      handler: (async ({ respond }: TelegramInteractiveHandlerContext) => {
+        await respond.deleteMessage();
+        return { handled: true };
+      }) as never,
+    });
+
+    await callbackHandler(
+      createTelegramCallbackContext({
+        id: "business-callback-delete",
+        data: "codexapp:delete:thread-1",
+        message: {
+          business_connection_id: "business-delete-1",
+          message_id: 11,
+          text: "Select a thread",
+        },
+      }),
+    );
+
+    expect(deleteBusinessMessagesSpy).toHaveBeenCalledWith("business-delete-1", [11]);
+    expect(deleteMessageSpy).not.toHaveBeenCalled();
     expect(replySpy).not.toHaveBeenCalled();
   });
 

--- a/extensions/telegram/src/transport-payload.test.ts
+++ b/extensions/telegram/src/transport-payload.test.ts
@@ -315,4 +315,74 @@ describe("Telegram topic transport payloads", () => {
     });
     expect(request && parseJsonBody(request)).not.toHaveProperty("message_thread_id");
   });
+
+  it.each([
+    {
+      name: "ordinary callbacks",
+      businessConnectionId: undefined,
+      expectedMethod: "deleteMessage",
+      expectedPayload: { chat_id: DIRECT_CHAT_ID, message_id: 41 },
+    },
+    {
+      name: "business callbacks",
+      businessConnectionId: "business-delete-1",
+      expectedMethod: "deleteBusinessMessages",
+      expectedPayload: { business_connection_id: "business-delete-1", message_ids: [41] },
+    },
+  ])("deletes $name through their owning Bot API endpoint", async (testCase) => {
+    const callbackMessage = directMessagesMessage(
+      testCase.businessConnectionId
+        ? { business_connection_id: testCase.businessConnectionId }
+        : {},
+    ) as unknown as Message;
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      threadSpec: { id: DIRECT_TOPIC_ID, scope: "direct-messages" },
+    });
+
+    await actions.deleteCallbackMessage();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.method).toBe(testCase.expectedMethod);
+    expect(requests[0] && parseJsonBody(requests[0])).toEqual(testCase.expectedPayload);
+  });
+
+  it("removes business media callbacks before sending their text replacement", async () => {
+    const callbackMessage = directMessagesMessage({
+      business_connection_id: "business-media-1",
+      text: undefined,
+      caption: "Choose an action",
+    }) as unknown as Message;
+    const actions = createTelegramCallbackMessageActions({
+      bot,
+      callbackMessage,
+      threadSpec: { id: DIRECT_TOPIC_ID, scope: "direct-messages" },
+    });
+    const editMessage = vi
+      .spyOn(bot.api, "editMessageText")
+      .mockRejectedValueOnce(
+        new Error("400: Bad Request: there is no text in the message to edit"),
+      );
+
+    try {
+      await actions.editCallbackMessageWithButtons("Replacement", []);
+    } finally {
+      editMessage.mockRestore();
+    }
+
+    expect(requests.map((request) => request.method)).toEqual([
+      "deleteBusinessMessages",
+      "sendMessage",
+    ]);
+    expect(requests[0] && parseJsonBody(requests[0])).toEqual({
+      business_connection_id: "business-media-1",
+      message_ids: [41],
+    });
+    expect(requests[1] && parseJsonBody(requests[1])).toMatchObject({
+      business_connection_id: "business-media-1",
+      direct_messages_topic_id: DIRECT_TOPIC_ID,
+      text: "Replacement",
+    });
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users interacting with Telegram business-account message buttons could not delete the selected business message. When a photo or caption button needed to be replaced with text, the failed deletion was swallowed and the stale original message remained beside its replacement.

## Why This Change Was Made

Telegram owns business-message deletion through a different Bot API endpoint than ordinary message deletion. The existing private callback-action owner already carries the authoritative business connection for edits and replies; this change uses the same owner to select `deleteBusinessMessages(business_connection_id, [message_id])` for business callbacks while preserving `deleteMessage(chat_id, message_id)` for ordinary callbacks. Both plugin-requested deletion and media-to-text callback replacement inherit the repair without changes to authorization, configuration, public APIs, or persistent state.

Production delta: +4 lines. This is required by Telegram's separate business-only endpoint and message-ID-array contract; no generic deletion endpoint accepts the business connection.

## User Impact

Telegram business-account buttons now correctly remove their message, and business photo/caption controls are cleaned up before a text replacement is sent. Ordinary Telegram message deletion remains unchanged.

## Evidence

- Exact reviewed head: `5d1ae433b02973fa009bdc2093a7a630e74a20f5`.
- Authentic pre-fix RED: three checked-in regressions failed at the real plugin callback boundary, actual grammY Bot API request boundary, and media replacement lifecycle; the ordinary deletion regression passed.
- Post-fix owner proof: 323 tests passed across six complete Telegram callback, business-message, question, native-command, interactive-fallback, and transport suites.
- Separate independent review: 300 tests passed across four complete owner and sibling suites; no actionable findings.
- Fresh authenticated full committed-branch code review: clean.
- Real grammY request proof: ordinary deletion emits `deleteMessage` with `{ chat_id, message_id }`; business deletion emits `deleteBusinessMessages` with `{ business_connection_id, message_ids: [message_id] }`; media replacement deletes the business message before sending the replacement.
- Targeted type-aware lint, formatting, max-lines ratchet, assertion ratchet, dependency guards, plugin boundary, dead-export scan, and doctor contract tests passed.
- Existing unrelated shared-dependency type mismatch: broad extension typecheck reports only unchanged `extensions/acpx` diagnostics; current main has byte-identical affected files, and no changed Telegram file has a type error.
