### PR TITLE
improve(googlechat): avoid duplicate DM route reads

### DIFF
--- a/extensions/googlechat/src/targets.outbound-session.test.ts
+++ b/extensions/googlechat/src/targets.outbound-session.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { resolveGoogleChatOutboundSessionRoute } from "./targets.js";
+
+const mocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(
+    async (params: { url: string; init?: RequestInit; timeoutMs?: number }) => ({
+      response: await fetch(params.url, params.init),
+      release: async () => {},
+    }),
+  ),
+  getGoogleChatAccessToken: vi.fn().mockResolvedValue("token"),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
+}));
+
+vi.mock("./auth.js", () => ({
+  getGoogleChatAccessToken: mocks.getGoogleChatAccessToken,
+}));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
+  vi.doUnmock("./auth.js");
+  vi.resetModules();
+});
+
+describe("outbound session routing", () => {
+  it("reuses direct-message metadata for route classification", async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      return new Response(JSON.stringify({ name: "spaces/DM-AAA", spaceType: "DIRECT_MESSAGE" }), {
+        status: 200,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const route = await resolveGoogleChatOutboundSessionRoute({
+      cfg: {},
+      agentId: "main",
+      target: "users/alice",
+    });
+
+    expect(route).toMatchObject({
+      peer: { kind: "direct", id: "spaces/DM-AAA" },
+      chatType: "direct",
+      from: "googlechat:spaces/DM-AAA",
+      to: "spaces/DM-AAA",
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://chat.googleapis.com/v1/spaces:findDirectMessage?name=users%2Falice",
+      {
+        method: "GET",
+        headers: {
+          Authorization: "Bearer token",
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  });
+});

--- a/extensions/googlechat/src/targets.ts
+++ b/extensions/googlechat/src/targets.ts
@@ -68,17 +68,17 @@ function stripMessageSuffix(target: string): string {
   return target.slice(0, index);
 }
 
-export async function resolveGoogleChatOutboundSpace(params: {
+async function resolveGoogleChatOutboundSpaceDetails(params: {
   account: ResolvedGoogleChatAccount;
   target: string;
-}): Promise<string> {
+}): Promise<{ name: string; resource?: GoogleChatSpace }> {
   const normalized = normalizeGoogleChatTarget(params.target);
   if (!normalized) {
     throw new Error("Missing Google Chat target.");
   }
   const base = stripMessageSuffix(normalized);
   if (isGoogleChatSpaceTarget(base)) {
-    return base;
+    return { name: base };
   }
   if (isGoogleChatUserTarget(base)) {
     const dm = await findGoogleChatDirectMessage({
@@ -88,9 +88,16 @@ export async function resolveGoogleChatOutboundSpace(params: {
     if (!dm?.name) {
       throw new Error(`No Google Chat DM found for ${base}`);
     }
-    return dm.name;
+    return { name: dm.name, resource: dm };
   }
-  return base;
+  return { name: base };
+}
+
+export async function resolveGoogleChatOutboundSpace(params: {
+  account: ResolvedGoogleChatAccount;
+  target: string;
+}): Promise<string> {
+  return (await resolveGoogleChatOutboundSpaceDetails(params)).name;
 }
 
 export async function resolveGoogleChatOutboundSessionRoute(params: {
@@ -100,19 +107,26 @@ export async function resolveGoogleChatOutboundSessionRoute(params: {
   target: string;
 }) {
   const account = resolveGoogleChatAccount({ cfg: params.cfg, accountId: params.accountId });
-  const spaceName = await resolveGoogleChatOutboundSpace({ account, target: params.target });
+  const resolvedSpace = await resolveGoogleChatOutboundSpaceDetails({
+    account,
+    target: params.target,
+  });
+  const spaceName = resolvedSpace.name;
   if (!isGoogleChatSpaceTarget(spaceName)) {
     return null;
   }
-  let space: GoogleChatSpace;
-  try {
-    space = await getGoogleChatSpace({ account, spaceName });
-  } catch {
-    // Space classification only enriches session routing. Delivery must remain
-    // available when this auxiliary read is unavailable or lacks permission.
-    return null;
+  let chatType = resolvedSpace.resource
+    ? resolveGoogleChatSpaceChatType(resolvedSpace.resource)
+    : undefined;
+  if (!chatType) {
+    try {
+      chatType = resolveGoogleChatSpaceChatType(await getGoogleChatSpace({ account, spaceName }));
+    } catch {
+      // Space classification only enriches session routing. Delivery must remain
+      // available when this auxiliary read is unavailable or lacks permission.
+      return null;
+    }
   }
-  const chatType = resolveGoogleChatSpaceChatType(space);
   if (!chatType) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ordinary Google Chat direct-message sends performed a redundant space lookup while preparing the outbound session route. Resolving a user target already returns the full direct-message `Space`, but routing discarded that metadata and immediately fetched the same space again only to classify it.

## Why This Change Was Made

The private target resolver now carries the provider-returned `Space` alongside its canonical name so session routing can reuse its type metadata. Explicit space targets and missing or unclassified metadata retain the existing `spaces.get` fallback; the exported string resolver and the separate send-boundary user-to-space resolution are unchanged.

No cache, retry, idempotency, config, protocol, security, storage, or public SDK behavior changes. AI-assisted implementation and verification.

## User Impact

Direct-message session routing uses one provider read instead of two before delivery, reducing route preparation latency and Google Chat API traffic. Message text, cards, thread projection, route identity, and error behavior remain unchanged.

## Evidence

- Exact current-main regression: the focused provider-boundary test failed before the production change with `expected vi.fn() to be called once, but got 2 times`; it passes with one exact `spaces:findDirectMessage` request after the change.
- Controlled route benchmark from the independently frozen defect lane (40 iterations, 5 ms/provider read): 80 → 40 reads and 464.0 → 250.0 ms (50% fewer reads, 46.1% lower route elapsed). Current-main code reproduced the same deterministic 2 → 1 request differential.
- Owner + action/channel siblings: 3 files, 75 tests passed.
- Full Google Chat extension: 30 files, 331 tests passed.
- `node scripts/check-changed.mjs -- extensions/googlechat/src/targets.ts extensions/googlechat/src/targets.outbound-session.test.ts` passed (format, production/test typechecks, type-aware lint with 0 findings, dead exports, boundaries, guards, and import cycles).
- `git diff --check` passed.
- Build was not classified: no package, build output, dynamic import, or published-surface change.
- Fresh autoreview: TruffleHog clean; Codex `gpt-5.6-sol` / high reported no actionable findings and `patch is correct` at 0.99 confidence.
- Live provider mutation was not performed because no Google Chat credentials were available; the defect and regression are fully observable before the send boundary.
