### PR TITLE
fix(state): avoid startup refusal when retired identity reappears

### DIFF
--- a/src/infra/state-migrations.device-identity.test.ts
+++ b/src/infra/state-migrations.device-identity.test.ts
@@ -708,6 +708,69 @@ describe("legacy device identity Doctor migration", () => {
     expect(receipt(env)).toMatchObject({ removed_source: 1 });
   });
 
+  it("preserves receipt-covered retired bytes as a notice after canonical identity rotation", async () => {
+    const { env, stateDir } = useStateDir();
+    const sourcePath = await writeLegacy({ stateDir });
+    const sourceBytes = await fsp.readFile(sourcePath, "utf8");
+    await migrate(stateDir, env);
+    const replacement = anotherIdentity();
+    const db = database(env);
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<MigrationDatabase>(db)
+        .updateTable("device_identities")
+        .set({
+          device_id: replacement.deviceId,
+          public_key_pem: replacement.publicKeyPem,
+          private_key_pem: replacement.privateKeyPem,
+          created_at_ms: replacement.createdAtMs,
+          updated_at_ms: replacement.createdAtMs,
+        })
+        .where("identity_key", "=", "primary"),
+    );
+    await fsp.writeFile(sourcePath, sourceBytes, "utf8");
+
+    closeOpenClawStateDatabaseForTest();
+    const retry = await migrate(stateDir, env);
+
+    expect(retry.warnings).toEqual([]);
+    expect(retry.notices?.join("\n")).toContain("canonical SQLite identity has since changed");
+    await expect(fsp.readFile(sourcePath, "utf8")).resolves.toBe(sourceBytes);
+    expect(identityRow(env)?.device_id).toBe(replacement.deviceId);
+    expect(receipt(env)).toMatchObject({ removed_source: 1 });
+  });
+
+  it.each(["missing", "invalid"] as const)(
+    "keeps receipt-covered retired bytes fatal when the canonical identity is %s",
+    async (canonicalState) => {
+      const { env, stateDir } = useStateDir();
+      const sourcePath = await writeLegacy({ stateDir });
+      const sourceBytes = await fsp.readFile(sourcePath);
+      await migrate(stateDir, env);
+      await fsp.writeFile(sourcePath, sourceBytes);
+      const db = database(env);
+      const query = getNodeSqliteKysely<MigrationDatabase>(db)
+        .updateTable("device_identities")
+        .set({ public_key_pem: "invalid-public-key", private_key_pem: "invalid-private-key" })
+        .where("identity_key", "=", "primary");
+      executeSqliteQuerySync(
+        db,
+        canonicalState === "missing"
+          ? getNodeSqliteKysely<MigrationDatabase>(db)
+              .deleteFrom("device_identities")
+              .where("identity_key", "=", "primary")
+          : query,
+      );
+
+      closeOpenClawStateDatabaseForTest();
+      const retry = await migrate(stateDir, env);
+
+      expect(retry.warnings.join("\n")).toContain("canonical SQLite device identity");
+      expect(retry.notices ?? []).toEqual([]);
+      expect(fs.existsSync(sourcePath)).toBe(true);
+    },
+  );
+
   it("preserves a divergent recreated identity as a boot-safe notice while the canonical row is valid", async () => {
     const { env, stateDir } = useStateDir();
     const sourcePath = await writeLegacy({ stateDir });

--- a/src/infra/state-migrations.device-identity.ts
+++ b/src/infra/state-migrations.device-identity.ts
@@ -166,6 +166,24 @@ function verifyCanonicalIdentity(
   }
 }
 
+function readCanonicalIdentityRelation(
+  identity: NormalizedLegacyDeviceIdentity,
+  env: NodeJS.ProcessEnv,
+): "same" | "different" | "unavailable" {
+  try {
+    const canonical = readStoredDeviceIdentityReadOnly({ env, identityKey: IDENTITY_KEY });
+    if (!canonical) {
+      return "unavailable";
+    }
+    return canonical.deviceId === identity.deviceId &&
+      deviceIdentityKeyMaterialMatches(canonical, identity)
+      ? "same"
+      : "different";
+  } catch {
+    return "unavailable";
+  }
+}
+
 function importAndRecordReceipt(params: {
   env: NodeJS.ProcessEnv;
   sourcePath: string;
@@ -337,15 +355,11 @@ async function cleanupReceiptSources(params: {
     if (snapshot.sha256 !== params.receipt.sourceSha256) {
       // SQLite owns runtime identity; warning about inert retired bytes would
       // make startup refuse an otherwise healthy gateway.
-      try {
-        if (readStoredDeviceIdentityReadOnly({ env: params.env, identityKey: IDENTITY_KEY })) {
-          notices.push(
-            `Preserved retired device identity ${candidate}: bytes differ from the migration receipt; the canonical SQLite identity remains authoritative. Archive or delete the file to clear this notice.`,
-          );
-          continue;
-        }
-      } catch {
-        // Invalid canonical identity must retain its readiness-blocking warning.
+      if (readCanonicalIdentityRelation(snapshot.identity, params.env) !== "unavailable") {
+        notices.push(
+          `Preserved retired device identity ${candidate}: bytes differ from the migration receipt; the canonical SQLite identity remains authoritative. Archive or delete the file to clear this notice.`,
+        );
+        continue;
       }
       warnings.push(
         `Retired device identity cleanup preserved ${candidate}: bytes differ from the migration receipt.`,
@@ -354,6 +368,17 @@ async function cleanupReceiptSources(params: {
     }
     try {
       verifyCanonicalIdentity(snapshot.identity, params.env);
+    } catch (error) {
+      if (readCanonicalIdentityRelation(snapshot.identity, params.env) === "different") {
+        notices.push(
+          `Preserved retired device identity ${candidate}: bytes match the migration receipt, but the canonical SQLite identity has since changed and remains authoritative. Archive or delete the file to clear this notice.`,
+        );
+        continue;
+      }
+      warnings.push(`Retired device identity cleanup failed for ${candidate}: ${String(error)}`);
+      continue;
+    }
+    try {
       await removePath({ ...params, sourcePath: candidate });
       removed += 1;
     } catch (error) {


### PR DESCRIPTION
## Summary

### High Level TLDR

When a previously retired `device.json` reappears after the canonical SQLite device identity has legitimately rotated, OpenClaw currently refuses startup even though SQLite contains a valid authoritative identity. This change preserves the retired file and emits an informational notice instead. Missing, unreadable, or invalid canonical SQLite identity remains fatal.

## What Problem This Solves

Fixes an issue where users restoring an exact receipt-covered legacy `device.json` after canonical device identity rotation would enter a startup refusal loop despite having a valid authoritative SQLite identity.

## Root Cause

The migration receipt records the retired source hash and successful source removal. If those exact old bytes later reappear, receipt cleanup verifies them against the current canonical SQLite row before removing them. A legitimate SQLite identity rotation makes that comparison fail, and the cleanup failure becomes a warning. Gateway startup treats migration warnings as readiness failures, even though runtime identity loading already trusts the valid SQLite row.

On untouched `origin/main` at `323a0efdd078d6599cf5c95aace1dacddcacd3ba`, the focused regression fails with:

```text
Retired device identity cleanup failed for .../identity/device.json: Error: canonical SQLite device identity no longer matches the legacy source
```

## Why This Change Was Made

Cleanup now distinguishes a matching canonical identity, a valid but different canonical identity, and unavailable or invalid canonical state. Only a validated different SQLite identity converts this receipt-covered mismatch into a notice. The retired file remains byte-for-byte intact, and OpenClaw does not automatically move, delete, or quarantine cryptographic material in this case.

## User Impact

OpenClaw can start with the valid rotated SQLite identity while clearly reporting the restored legacy file for operator cleanup. Unsafe fallback states remain readiness-blocking.

## Real behavior proof

The regression performs the full ownership path in a temporary state directory:

1. Migrate legacy identity A into SQLite and remove the source.
2. Rotate the canonical SQLite row to valid identity B.
3. Restore the exact receipt-covered bytes for identity A at `identity/device.json`.
4. Run startup migration cleanup again.

Before the patch, the focused test fails because cleanup emits a warning. On this exact head, it passes and proves that warnings are empty, the notice is present, the restored file is unchanged, SQLite still contains identity B, and the successful-removal receipt remains intact.

```text
Test Files  1 passed (1)
Tests       1 passed | 30 skipped (31)
```

Additional table coverage proves missing and invalid canonical SQLite state still emits a warning and preserves the file.

## Evidence

- Final caller-focused run: 3 Vitest shards passed, 69 tests total.
- Repository changed-files gate passed, including formatting, type checks, lint, database-first guards, and import-cycle checks.
- Independent final review found no actionable defects in validity handling, receipt semantics, cleanup failures, caller gating, or coordinator coverage.
- No live Gateway, config, identity file, SQLite database, service, or deployment was touched.

## Verification

```bash
pnpm test src/infra/state-migrations.device-identity.test.ts src/node-host/startup-state-migrations.test.ts src/commands/doctor-config-preflight.state-migration.test.ts
node scripts/check-changed.mjs -- src/infra/state-migrations.device-identity.ts src/infra/state-migrations.device-identity.test.ts
node scripts/run-vitest.mjs src/infra/state-migrations.device-identity.test.ts -t 'preserves receipt-covered retired bytes'
```

Performance proof used Linux 7.0.0-30-generic x86_64 and Node v25.9.0, one warmup plus five identical focused-test samples per tree:

- Current-main baseline median: 4.20 s
- Patched median: 4.25 s
- Difference: 0.05 s (1.2%), within run-to-run test harness noise

## What was not tested

No live Gateway startup, production state, real operator identity file, deployment, restart, or platform-specific native writer was exercised. The real startup refusal boundary is covered through the startup migration and Doctor preflight callers using temporary state and SQLite stores.

AI assistance was used to implement and validate this change.
