### PR TITLE
fix(apps): prevent Unicode numerals from freezing code highlights

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCodeHighlighter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCodeHighlighter.swift
@@ -140,7 +140,7 @@ enum ChatCodeHighlighter {
                 // trailing digits never reach here because the identifier
                 // branch below consumes them first.
                 while end < chars.count,
-                      chars[end].isHexDigit || chars[end] == "." || chars[end] == "_"
+                      chars[end].isNumber || chars[end].isHexDigit || chars[end] == "." || chars[end] == "_"
                       || chars[end] == "x" || chars[end] == "X" || chars[end] == "o"
                       || chars[end] == "b"
                 {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatCodeHighlighterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatCodeHighlighterTests.swift
@@ -86,6 +86,17 @@ struct ChatCodeHighlighterTests {
         #expect(tokens.contains(where: { $0.0 == .number && $0.1 == "3" }))
     }
 
+    @Test func `unicode numerals advance highlighting without changing source`() {
+        for numeral in ["①", "½", "١", "Ⅷ"] {
+            let code = "let value = \(numeral)"
+            let tokens = self.kinds(code, language: "swift")
+
+            #expect(tokens.map(\.1).joined().utf8.elementsEqual(code.utf8))
+            #expect(!tokens.map(\.1).contains(""))
+            #expect(tokens.contains(where: { $0.0 == .number && $0.1 == numeral }))
+        }
+    }
+
     @Test func `unknown language passes through unstyled`() {
         let attributed = ChatCodeHighlighter.attributedCode("SELECT *", languageId: "sql")
         #expect(String(attributed.characters) == "SELECT *")


### PR DESCRIPTION
## What Problem This Solves

Prevents native macOS/iOS chat and workspace previews from freezing when a highlighted source-code block contains Unicode numerals such as `①`, `½`, `١`, or `Ⅷ`.

## Why This Change Was Made

The shared code tokenizer classified every Unicode number as a numeric token but its consuming loop advanced only over hexadecimal digits and ASCII punctuation. Non-hexadecimal Unicode numerals therefore produced an empty token without advancing the cursor, causing an infinite loop and unbounded memory growth on the UI rendering path. Align the consuming predicate with the existing numeric-token admission predicate.

## User Impact

Native chat responses and source-file previews render Unicode numeric examples immediately instead of hanging the application. Existing ASCII numbers, hexadecimal literals, identifiers, comments, strings, and unsupported-language behavior remain unchanged.

## Evidence

- Reproduced the pre-fix hang with a bounded real Swift Package test; the helper remained stuck until explicitly terminated.
- Added one owner-boundary regression covering circled numbers, fractions, Arabic-Indic digits, and Roman numerals while asserting exact UTF-8 preservation and nonempty tokens.
- `swift test --package-path apps/shared/OpenClawKit --filter ChatCodeHighlighterTests` — all 14 native highlighter tests passed.
- Repository SwiftFormat lint and `git diff --check` passed.
- Independent structured Codex review found no actionable issues.
- Production delta: +1/-1 lines; no configuration, protocol, persistence, provider, or dependency changes.

## ClawSweeper Rank-up Moves

- Exact-head native CI completed successfully, including the required `openclaw/ci-gate` check.
- A before/after screenshot is skipped: this change fixes a tokenizer hang without altering rendered appearance, and the bounded failing/passing native Swift regression directly proves the observable freeze and recovery.
