### PR TITLE
fix(codex): reclaim binding capacity after session deletion

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -996,6 +996,22 @@ disable <name>` update its persisted policy. Mutations require an owner or
 - `/codex computer-use [status|install]` manages Codex Computer Use.
 - `/codex help` lists the full command tree.
 
+When `/codex resume` attaches a thread without an existing verified harness
+binding, its next turn checks the native thread's stored tool catalog and
+applies the current harness configuration before continuing. This first
+attachment requires the local stdio app-server and its per-agent Codex home.
+It also needs exclusive use of that app-server while applying configuration;
+if another turn or native child is active, wait for it to finish and retry.
+Use [Codex supervision](/plugins/codex-supervision) or native Codex to continue
+threads in a shared user home or on another app-server.
+
+Codex cannot replace a thread's dynamic tool catalog during resume. If that
+catalog differs from the current harness tools, its metadata cannot be read,
+or Codex cannot confirm that it applied the configuration, OpenClaw reports
+the problem and keeps the selected native thread intact. It does not silently
+start another thread. Use `/new` to start with the current harness tools, or
+continue the preserved thread in native Codex.
+
 ### Shared Fast mode and Codex fast mode
 
 `/fast` controls the shared OpenClaw policy. A directive-only `/fast off`

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -1585,6 +1585,14 @@ allocation. An OS hard limit can terminate Codex rather than backpressure it.
 `plugins.entries.codex.config.discovery.timeoutMs` or disable discovery.
 See [Codex harness reference](/plugins/codex-harness-reference#model-discovery).
 
+**Codex plugin state has reached its row limit:** run `openclaw doctor` to
+check for bindings left behind by deleted or expired OpenClaw sessions. Stop
+the Gateway, then run `openclaw doctor --fix` to remove proven orphaned session
+bindings after session repair. Doctor preserves supervised bindings, active
+leases, ambiguous ownership, and bindings whose session store cannot be read.
+This cleanup does not delete native Codex thread history or managed-thread
+advisory records.
+
 **WebSocket transport fails immediately:** check `appServer.url`,
 `authToken`, headers, and that the remote app-server speaks the same Codex
 app-server protocol version. Codex WebSocket transport remains experimental

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -118,6 +118,14 @@ Harnesses may use the plan for decisions that need to match OpenClaw behavior,
 but treat it as host-owned attempt state: do not mutate it or use it to switch
 providers/models inside a turn.
 
+For auxiliary session control calls, `resolveSessionModelRef` from
+`openclaw/plugin-sdk/model-session-runtime` resolves the current model selection.
+`prepareAgentRuntimeAuth` from `openclaw/plugin-sdk/agent-harness-runtime` selects
+its auth route and ordered credential attempts from the caller's loaded auth
+snapshot. Preserve the selected attempt's profile, API, and fallback restrictions
+when materializing credentials; this keeps control calls on the same billing
+route as agent turns.
+
 ### Request-transport contract
 
 `supports(ctx)` receives the resolved model transport in `ctx.modelProvider`.

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -599,8 +599,22 @@ The OpenClaw transcript remains the compatibility layer for:
 - switching back to the built-in OpenClaw harness on a later turn
 - generic `/new`, `/reset`, and session deletion behavior
 
-If your harness stores a sidecar binding, implement `reset(...)` so OpenClaw
-can clear it when the owning OpenClaw session is reset.
+Store native bindings in plugin state. Implement `reset(...)` for an in-place
+session reset and `withSessionDeletion(params, run)` for removal of a session
+key, including expiry and maintenance. A physical session ID changing at the
+same key is a transfer, not deletion; preserve any compaction adoption path.
+
+`withSessionDeletion` acquires the native owner's lease before calling
+`run({ commit, rollback })`. Core invokes the synchronous `commit()` at the
+session row deletion boundary and `rollback()` if the transaction fails.
+Rollback must also tolerate a failed or unapplied commit. Keep asynchronous
+subscription cleanup after `run` so it does not hold the SQLite writer queue;
+do not restore bindings for errors after the session transaction committed.
+
+Recheck `params.assertCurrent()` after awaited work and immediately before
+mutating native state. The callback belongs to one registered harness lifetime;
+retaining it after the operation closes does not retain authority. Post-delete
+hooks are notifications, not the owner of durable binding removal.
 
 ## Tool and media results
 

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -97,7 +97,7 @@ including empty results without range metadata. Only an explicit
 missing files; registered-input normalization remains available through the
 next Plugin SDK major.
 
-### Channel state migration declarations
+### Plugin state migration declarations
 
 Channel plugins should declare `doctorContract.stateMigrations: true` in
 `openclaw.plugin.json` and export `stateMigrations` from their doctor-contract
@@ -105,6 +105,15 @@ artifact. Plan-based migrations can use
 `definePluginDoctorMigrationFromPlans(...)` from
 `openclaw/plugin-sdk/runtime-doctor-migrations` to preserve existing move, copy, preview,
 and plugin-state import behavior.
+
+Use `phase: "after-session-repair"` when a migration needs canonical session
+ownership evidence. Ordinary Doctor detects these migrations; `--fix` applies
+them after session repair under SQLite maintenance ownership. The context
+provides bounded `readPluginStateEntriesInKeyRange` and
+`readSessionIdentityEvidenceBatch` reads, plus
+`deletePluginStateEntriesIfUnchanged` only during a fenced repair. Preserve
+unknown or ambiguous ownership. Delete only the observed raw rows; callbacks
+retained after maintenance ends cannot authorize later writes.
 
 The setup-entry `legacyStateMigrations` option and feature flag,
 `setupFeatures.legacyStateMigrations`,

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -99,7 +99,7 @@ next Plugin SDK major.
 
 ### Plugin state migration declarations
 
-Channel plugins should declare `doctorContract.stateMigrations: true` in
+Plugins should declare `doctorContract.stateMigrations: true` in
 `openclaw.plugin.json` and export `stateMigrations` from their doctor-contract
 artifact. Plan-based migrations can use
 `definePluginDoctorMigrationFromPlans(...)` from

--- a/extensions/codex/doctor-contract-api.ts
+++ b/extensions/codex/doctor-contract-api.ts
@@ -2,7 +2,10 @@
  * Doctor contract hooks for Codex plugin config and state migrations.
  */
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { codexOrphanedSessionBindingMigration } from "./src/migration/session-binding-orphans.js";
+import { stateMigrations as legacyStateMigrations } from "./src/migration/session-binding-sidecars.js";
 
 type LegacyConfigRule = {
   path: string[];
@@ -134,4 +137,7 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
   };
 }
 
-export { stateMigrations } from "./src/migration/session-binding-sidecars.js";
+export const stateMigrations: PluginDoctorStateMigration[] = [
+  ...legacyStateMigrations,
+  codexOrphanedSessionBindingMigration,
+];

--- a/extensions/codex/harness.test.ts
+++ b/extensions/codex/harness.test.ts
@@ -23,6 +23,9 @@ import { createCodexAppServerAgentHarness } from "./harness.js";
 import { buildCodexRuntimeModelParams } from "./src/app-server/model-runtime.js";
 import {
   createCodexTestBindingStore,
+  createCodexTestBindingStateStore,
+  createCodexAppServerBindingStore,
+  bindingStoreKey,
   sessionBindingIdentity,
   testCodexAppServerBindingStore,
 } from "./src/app-server/session-binding.test-helpers.js";
@@ -579,8 +582,9 @@ describe("Codex agent harness reset()", () => {
     }
   });
 
-  it("keeps deleted session generations retired", async () => {
-    const bindingStore = createCodexTestBindingStore();
+  it("removes deleted session bindings before the post-delete reset event", async () => {
+    const state = createCodexTestBindingStateStore();
+    const bindingStore = createCodexAppServerBindingStore(state);
     const identity = sessionBindingIdentity({
       agentId: "worker",
       sessionId: "session-1",
@@ -592,6 +596,19 @@ describe("Codex agent harness reset()", () => {
     });
     const harness = createCodexAppServerAgentHarness({ bindingStore });
 
+    await harness.withSessionDeletion?.(
+      {
+        agentId: "worker",
+        sessionId: "session-1",
+        sessionKey: "agent:worker:main",
+        assertCurrent() {},
+      },
+      async (mutation) => {
+        mutation.commit();
+        expect(state.lookup(bindingStoreKey(identity))).toBeUndefined();
+      },
+    );
+
     await harness.reset?.({
       agentId: "worker",
       sessionId: "session-1",
@@ -599,12 +616,46 @@ describe("Codex agent harness reset()", () => {
       reason: "deleted",
     });
 
+    expect(state.lookup(bindingStoreKey(identity))).toBeUndefined();
+  });
+
+  it("rejects supervised deletion before invoking the session transaction", async () => {
+    const bindingStore = createCodexTestBindingStore();
+    const identity = sessionBindingIdentity({
+      agentId: "worker",
+      sessionId: "supervised",
+      sessionKey: "agent:worker:main",
+    });
+    await bindingStore.mutate(identity, {
+      kind: "set",
+      binding: {
+        threadId: "thread-supervised",
+        cwd: "/repo",
+        connectionScope: "supervision",
+        supervisionSourceThreadId: "thread-source",
+        model: "gpt-5.5",
+        modelProvider: "openai",
+        preserveNativeModel: true,
+        conversationSourceTransferComplete: true,
+      },
+    });
+    const harness = createCodexAppServerAgentHarness({ bindingStore });
+    const run = vi.fn();
     await expect(
-      bindingStore.mutate(identity, {
-        kind: "set",
-        binding: { threadId: "thread-stale", cwd: "/repo" },
-      }),
-    ).resolves.toBe(false);
+      harness.withSessionDeletion?.(
+        {
+          agentId: "worker",
+          sessionId: "supervised",
+          sessionKey: "agent:worker:main",
+          assertCurrent() {},
+        },
+        run,
+      ),
+    ).rejects.toThrow("owned by supervision");
+    expect(run).not.toHaveBeenCalled();
+    await expect(bindingStore.read(identity)).resolves.toMatchObject({
+      threadId: "thread-supervised",
+    });
   });
 });
 

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -318,8 +318,14 @@ export function createCodexAppServerAgentHarness(
         pluginConfig: options?.resolvePluginConfig?.() ?? options?.pluginConfig,
       });
     },
+    withSessionDeletion: async (params, run) => {
+      const { withCodexAppServerSessionDeletion } =
+        await import("./src/app-server/session-retirement.js");
+      params.assertCurrent();
+      return withCodexAppServerSessionDeletion(options.bindingStore, params, run);
+    },
     reset: async (params) => {
-      if (params.sessionId) {
+      if (params.sessionId && params.reason !== "deleted") {
         const [
           { reclaimCurrentCodexSessionGeneration, sessionBindingIdentity },
           { retireCodexAppServerSessionGeneration },
@@ -336,7 +342,7 @@ export function createCodexAppServerAgentHarness(
           retireCodexAppServerSessionGeneration({
             bindingStore: options.bindingStore,
             identity,
-            mode: params.reason === "deleted" ? "retire" : "reset",
+            mode: "reset",
           });
         let reset = await resetGeneration();
         if (reset === "conflict") {

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -62,13 +62,7 @@ import {
 } from "./src/supervision-tools.js";
 import { createCodexWebSearchProvider } from "./src/web-search-provider.js";
 
-const ENDED_SESSION_REASONS: ReadonlySet<string> = new Set([
-  "new",
-  "reset",
-  "idle",
-  "daily",
-  "deleted",
-]);
+const ENDED_SESSION_REASONS: ReadonlySet<string> = new Set(["new", "reset", "idle", "daily"]);
 
 export default definePluginEntry({
   id: "codex",
@@ -136,11 +130,13 @@ export default definePluginEntry({
     // store only when a proxied runtime performs the first binding operation.
     const lazyBindingStateStore: Pick<
       PluginStateSyncKeyedStore<StoredCodexAppServerBinding>,
-      "delete" | "entries" | "lookup" | "update"
+      "deleteIf" | "entries" | "lookup" | "registerIfAbsent" | "update"
     > = {
-      delete: (key) => openBindingStateStore().delete(key),
+      deleteIf: (key, predicate) => openBindingStateStore().deleteIf!(key, predicate),
       entries: () => openBindingStateStore().entries(),
       lookup: (key) => openBindingStateStore().lookup(key),
+      registerIfAbsent: (key, value, options) =>
+        openBindingStateStore().registerIfAbsent(key, value, options),
       get update() {
         const store = openBindingStateStore();
         return store.update?.bind(store);
@@ -389,7 +385,7 @@ export default definePluginEntry({
       // under a different session key. The only cross-key emitter (gateway child
       // creation) keeps the parent row live; same-key rollovers omit or repeat
       // the key and still retire, as do unknown-current-key ends (no provable
-      // handoff) and later idle/daily/deleted ends. See #106778.
+      // handoff) and later idle/daily ends. See #106778.
       const endedSessionKey = sessionKey?.trim();
       const nextSessionKey = event.nextSessionKey?.trim();
       if (endedSessionKey && nextSessionKey && nextSessionKey !== endedSessionKey) {

--- a/extensions/codex/src/app-server/attempt-client-cleanup.ts
+++ b/extensions/codex/src/app-server/attempt-client-cleanup.ts
@@ -144,12 +144,19 @@ export async function unsubscribeCodexThreadBestEffort(
   params: {
     threadId: string;
     timeoutMs: number;
+    assertCurrent?: () => void;
   },
 ): Promise<boolean> {
   try {
-    await unsubscribeCodexAppServerLiveThread(client, params.threadId, params.timeoutMs);
+    await unsubscribeCodexAppServerLiveThread(
+      client,
+      params.threadId,
+      params.timeoutMs,
+      params.assertCurrent,
+    );
     return true;
   } catch (error) {
+    params.assertCurrent?.();
     embeddedAgentLog.debug("codex app-server thread unsubscribe cleanup failed", {
       threadId: params.threadId,
       error,

--- a/extensions/codex/src/app-server/client-runtime.test.ts
+++ b/extensions/codex/src/app-server/client-runtime.test.ts
@@ -489,6 +489,26 @@ describe("Codex app-server client runtime", () => {
     );
   });
 
+  it("rechecks deletion authority before sending the physical unsubscribe", async () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    ensureCodexAppServerClientRuntime(harness.client, { agentDir: "/tmp/agent" });
+    await retainCodexAppServerLiveThread(harness.client, "thread-deleted");
+    const request = vi.spyOn(harness.client, "request");
+    let current = true;
+    const release = releaseCodexAppServerLiveThread(harness.client, "thread-deleted", () => {
+      if (!current) {
+        throw new Error("deletion owner closed");
+      }
+    });
+    current = false;
+    await expect(release).rejects.toThrow("deletion owner closed");
+    expect(request).not.toHaveBeenCalled();
+    await expect(
+      consumeCodexAppServerLiveThread(harness.client, "thread-deleted"),
+    ).resolves.toEqual(expect.objectContaining({ release: expect.any(Function) }));
+  });
+
   it("transfers ownership only for the exact immutable thread fingerprint", async () => {
     const harness = createClientHarness();
     clients.push(harness.client);

--- a/extensions/codex/src/app-server/client-runtime.ts
+++ b/extensions/codex/src/app-server/client-runtime.ts
@@ -26,7 +26,7 @@ type RetainedLiveThread = {
   configFingerprint?: string;
   serviceTier?: CodexServiceTier | null;
   expiresAt: number;
-  release: (threadId: string) => Promise<void>;
+  release: (threadId: string, assertCurrent?: () => void) => Promise<void>;
 };
 
 type ThreadReleaseTransition = {
@@ -38,7 +38,7 @@ type ThreadReleaseTransition = {
 export type CodexAppServerLiveThreadOwnership = {
   configFingerprint?: string;
   serviceTier?: CodexServiceTier | null;
-  release: (threadId: string) => Promise<void>;
+  release: (threadId: string, assertCurrent?: () => void) => Promise<void>;
 };
 
 /** Match Codex's native grace window without retaining inactive conversations indefinitely. */
@@ -195,10 +195,12 @@ async function releaseRetainedThread(
   client: CodexAppServerClient,
   runtime: ClientRuntime,
   threadId: string,
+  assertCurrent?: () => void,
 ): Promise<boolean> {
   const pendingRelease = runtime.releasingThreads.get(threadId);
   if (pendingRelease) {
     await pendingRelease.completion;
+    assertCurrent?.();
     return false;
   }
   const retained = runtime.retainedThreads.get(threadId);
@@ -217,7 +219,10 @@ async function releaseRetainedThread(
   // Keep release ownership addressable until unsubscribe settles. Unrelated
   // conversations must stay reusable while only this thread transitions.
   const transition: ThreadReleaseTransition = {
-    completion: Promise.resolve().then(() => retained.release(threadId)),
+    completion: Promise.resolve().then(() => {
+      assertCurrent?.();
+      return assertCurrent ? retained.release(threadId, assertCurrent) : retained.release(threadId);
+    }),
   };
   runtime.releasingThreads.set(threadId, transition);
   try {
@@ -286,7 +291,7 @@ async function evictExcessIdleThreads(
 export async function retainCodexAppServerLiveThread(
   client: CodexAppServerClient,
   threadId: string,
-  releaseThread?: (threadId: string) => Promise<void>,
+  releaseThread?: (threadId: string, assertCurrent?: () => void) => Promise<void>,
   configFingerprint?: string,
   serviceTier?: CodexServiceTier | null,
 ): Promise<boolean> {
@@ -322,8 +327,8 @@ export async function retainCodexAppServerLiveThread(
     expiresAt: Date.now() + CODEX_APP_SERVER_LIVE_THREAD_IDLE_TIMEOUT_MS,
     release:
       (releaseThread ? (physicalThreadReleases.get(releaseThread) ?? releaseThread) : undefined) ??
-      (async (releasedThreadId) => {
-        await unsubscribeCodexAppServerLiveThread(client, releasedThreadId, 5_000);
+      (async (releasedThreadId, assertCurrent) => {
+        await unsubscribeCodexAppServerLiveThread(client, releasedThreadId, 5_000, assertCurrent);
       }),
   };
   runtime.retainedThreads.set(threadId, retained);
@@ -400,8 +405,8 @@ export async function claimCodexAppServerLiveThread(
   }
   const retained = runtime.retainedThreads.get(threadId) ?? {
     expiresAt: Date.now() + CODEX_APP_SERVER_LIVE_THREAD_IDLE_TIMEOUT_MS,
-    release: async (releasedThreadId: string) => {
-      await unsubscribeCodexAppServerLiveThread(client, releasedThreadId, 5_000);
+    release: async (releasedThreadId: string, assertCurrent?: () => void) => {
+      await unsubscribeCodexAppServerLiveThread(client, releasedThreadId, 5_000, assertCurrent);
     },
   };
   return claimCodexAppServerThreadOwnership(client, runtime, threadId, retained);
@@ -417,7 +422,7 @@ function claimCodexAppServerThreadOwnership(
   const claimed = Symbol(threadId);
   runtime.claimedThreads.set(threadId, claimed);
   scheduleRetainedThreadEviction(client, runtime);
-  const release = async (releasedThreadId: string): Promise<void> => {
+  const release = async (releasedThreadId: string, assertCurrent?: () => void): Promise<void> => {
     // Codex subscriptions have no generation identifier. An obsolete owner
     // must be rejected before it can unsubscribe a replacement's live turn.
     if (releasedThreadId !== threadId || runtime.claimedThreads.get(threadId) !== claimed) {
@@ -435,7 +440,10 @@ function claimCodexAppServerThreadOwnership(
         if (runtime.closed || runtime.claimedThreads.get(threadId) !== claimed) {
           return;
         }
-        await retained.release(releasedThreadId);
+        assertCurrent?.();
+        await (assertCurrent
+          ? retained.release(releasedThreadId, assertCurrent)
+          : retained.release(releasedThreadId));
       }),
     };
     runtime.releasingThreads.set(threadId, transition);
@@ -462,6 +470,20 @@ function claimCodexAppServerThreadOwnership(
 }
 
 /** Distinguish active claimed ownership from an already-evicted idle subscription. */
+export function hasCodexAppServerLiveThread(
+  client: CodexAppServerClient,
+  threadId: string,
+): boolean {
+  const runtime = configuredClients.get(client);
+  return (
+    runtime !== undefined &&
+    !runtime.closed &&
+    (runtime.retainedThreads.has(threadId) ||
+      runtime.releasingThreads.has(threadId) ||
+      runtime.claimedThreads.has(threadId))
+  );
+}
+
 export function isCodexAppServerLiveThreadClaimed(
   client: CodexAppServerClient,
   threadId: string,
@@ -475,18 +497,21 @@ export async function unsubscribeCodexAppServerLiveThread(
   client: CodexAppServerClient,
   threadId: string,
   timeoutMs: number,
+  assertCurrent?: () => void,
 ): Promise<void> {
   const runtime = configuredClients.get(client);
   const claimed = runtime?.claimedThreads.get(threadId);
   let transition = runtime?.releasingThreads.get(threadId);
   if (transition?.physicalRelease) {
     await transition.physicalRelease;
+    assertCurrent?.();
     return;
   }
   const physicalRelease = Promise.resolve().then(async () => {
     if (claimed !== undefined && runtime?.claimedThreads.get(threadId) !== claimed) {
       return;
     }
+    assertCurrent?.();
     await client.request("thread/unsubscribe", { threadId }, { timeoutMs });
   });
   const ownsTransition = runtime !== undefined && transition === undefined;
@@ -516,9 +541,10 @@ export async function unsubscribeCodexAppServerLiveThread(
 export async function releaseCodexAppServerLiveThread(
   client: CodexAppServerClient,
   threadId: string,
+  assertCurrent?: () => void,
 ): Promise<boolean> {
   const runtime = configuredClients.get(client);
-  return runtime ? await releaseRetainedThread(client, runtime, threadId) : false;
+  return runtime ? await releaseRetainedThread(client, runtime, threadId, assertCurrent) : false;
 }
 
 /** Native child work pins its parent's subscription even after the foreground parent turn ends. */

--- a/extensions/codex/src/app-server/request.ts
+++ b/extensions/codex/src/app-server/request.ts
@@ -18,6 +18,7 @@ import {
   isCodexAppServerStartSelectionChangedError,
   releaseLeasedSharedCodexAppServerClient,
   retireSharedCodexAppServerClientIfCurrent,
+  type CodexAppServerClientOptions,
 } from "./shared-client.js";
 import { withTimeout } from "./timeout.js";
 
@@ -53,46 +54,37 @@ export async function requestCodexAppServerClientJson<T = JsonValue | undefined>
   );
 }
 
+type CodexAppServerJsonClientOptions = Pick<
+  CodexAppServerClientOptions,
+  | "timeoutMs"
+  | "pluginConfig"
+  | "startOptions"
+  | "authProfileId"
+  | "authProfileStore"
+  | "authBindingFingerprint"
+  | "preparedAuth"
+  | "authRequirement"
+  | "agentDir"
+  | "config"
+> & {
+  sessionKey?: string;
+  sessionId?: string;
+  isolated?: boolean;
+};
+
 /** Sends a typed Codex app-server request and returns the method-specific response shape. */
-export async function requestCodexAppServerJson<M extends CodexAppServerRequestMethod>(params: {
-  method: M;
-  requestParams: CodexAppServerRequestParams<M>;
-  timeoutMs?: number;
-  pluginConfig?: unknown;
-  startOptions?: CodexAppServerStartOptions;
-  authProfileId?: string | null;
-  agentDir?: string;
-  config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
-  sessionKey?: string;
-  sessionId?: string;
-  isolated?: boolean;
-}): Promise<CodexAppServerRequestResult<M>>;
-export async function requestCodexAppServerJson<T = JsonValue | undefined>(params: {
-  method: string;
-  requestParams?: unknown;
-  timeoutMs?: number;
-  pluginConfig?: unknown;
-  startOptions?: CodexAppServerStartOptions;
-  authProfileId?: string | null;
-  agentDir?: string;
-  config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
-  sessionKey?: string;
-  sessionId?: string;
-  isolated?: boolean;
-}): Promise<T>;
-export async function requestCodexAppServerJson<T = JsonValue | undefined>(params: {
-  method: string;
-  requestParams?: unknown;
-  timeoutMs?: number;
-  pluginConfig?: unknown;
-  startOptions?: CodexAppServerStartOptions;
-  authProfileId?: string | null;
-  agentDir?: string;
-  config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
-  sessionKey?: string;
-  sessionId?: string;
-  isolated?: boolean;
-}): Promise<T> {
+export async function requestCodexAppServerJson<M extends CodexAppServerRequestMethod>(
+  params: CodexAppServerJsonClientOptions & {
+    method: M;
+    requestParams: CodexAppServerRequestParams<M>;
+  },
+): Promise<CodexAppServerRequestResult<M>>;
+export async function requestCodexAppServerJson<T = JsonValue | undefined>(
+  params: CodexAppServerJsonClientOptions & { method: string; requestParams?: unknown },
+): Promise<T>;
+export async function requestCodexAppServerJson<T = JsonValue | undefined>(
+  params: CodexAppServerJsonClientOptions & { method: string; requestParams?: unknown },
+): Promise<T> {
   // Fail closed before spawning or leasing a client for a guard-blocked method.
   const sandboxBlock = resolveCodexAppServerDirectSandboxBypassBlock({
     method: params.method,
@@ -201,17 +193,8 @@ async function readCodexAccountEmailBestEffort(
  * callback re-runs once when the client's start selection changed underneath it.
  */
 export async function withCodexAppServerJsonClient<T>(
-  params: {
-    timeoutMs?: number;
+  params: CodexAppServerJsonClientOptions & {
     timeoutMessage?: string;
-    pluginConfig?: unknown;
-    startOptions?: CodexAppServerStartOptions;
-    authProfileId?: string | null;
-    agentDir?: string;
-    config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
-    sessionKey?: string;
-    sessionId?: string;
-    isolated?: boolean;
     // Bounds the isolated-client shutdown. Callers on a tight result deadline
     // pass a small budget so cleanup cannot breach the outer timeout; defaults
     // to the conservative graceful/force-kill window used elsewhere.
@@ -247,6 +230,10 @@ export async function withCodexAppServerJsonClient<T>(
             pluginConfig: params.pluginConfig,
             timeoutMs: remainingTimeoutMs(),
             authProfileId: params.authProfileId,
+            authProfileStore: params.authProfileStore,
+            authBindingFingerprint: params.authBindingFingerprint,
+            preparedAuth: params.preparedAuth,
+            authRequirement: params.authRequirement,
             agentDir: params.agentDir,
             config: params.config,
             abandonSignal: timeoutController.signal,

--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -101,12 +101,14 @@ export async function cleanupCodexAttempt(
               resourceState.client,
               resourceState.thread.threadId,
               resourceState.thread.liveThreadOwnership?.release ??
-                (async (threadId) => {
+                (async (threadId, assertCurrent) => {
                   const released = await unsubscribeCodexThreadBestEffort(resourceState.client, {
                     threadId,
                     timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+                    assertCurrent,
                   });
                   if (!released) {
+                    assertCurrent?.();
                     await closeCodexStartupClientBestEffort(resourceState.client);
                     throw new CodexAppServerUnsafeSubscriptionError(
                       `Codex retained thread subscription could not be released: ${threadId}`,

--- a/extensions/codex/src/app-server/session-binding-store.ts
+++ b/extensions/codex/src/app-server/session-binding-store.ts
@@ -38,7 +38,8 @@ export function createLazyCodexAppServerBindingStore(
     read: async (identity) => (await store()).read(identity),
     hasOtherThreadOwner: async (threadId, currentIdentity) =>
       (await store()).hasOtherThreadOwner(threadId, currentIdentity),
-    mutate: async (identity, mutation) => (await store()).mutate(identity, mutation),
+    mutate: async (identity, mutation, assertCurrent) =>
+      (await store()).mutate(identity, mutation, assertCurrent),
     prepareSessionGenerationReclaim: async (identity) =>
       (await store()).prepareSessionGenerationReclaim(identity),
     adoptSessionGeneration: async (identity, previousSessionId) =>

--- a/extensions/codex/src/app-server/session-binding-store.ts
+++ b/extensions/codex/src/app-server/session-binding-store.ts
@@ -18,7 +18,7 @@ export type { StoredCodexAppServerBinding } from "./session-binding.js";
 export function createLazyCodexAppServerBindingStore(
   state: Pick<
     PluginStateSyncKeyedStore<StoredCodexAppServerBinding>,
-    "entries" | "lookup" | "update"
+    "deleteIf" | "entries" | "lookup" | "registerIfAbsent" | "update"
   >,
   managedThreadState?: Pick<
     PluginStateSyncKeyedStore<StoredCodexManagedThread>,
@@ -45,6 +45,8 @@ export function createLazyCodexAppServerBindingStore(
       (await store()).adoptSessionGeneration(identity, previousSessionId),
     resetSessionGeneration: async (identity) => (await store()).resetSessionGeneration(identity),
     retireSessionGeneration: async (identity) => (await store()).retireSessionGeneration(identity),
+    withSessionDeletion: async (identity, assertCurrent, run) =>
+      (await store()).withSessionDeletion(identity, assertCurrent, run),
     withThreadArchiveFence: async (run) => (await store()).withThreadArchiveFence(run),
     withLease: async (identity, run) => (await store()).withLease(identity, run),
   };

--- a/extensions/codex/src/app-server/session-binding.test-helpers.ts
+++ b/extensions/codex/src/app-server/session-binding.test-helpers.ts
@@ -39,6 +39,10 @@ export function createCodexTestBindingStateStore(): PluginStateSyncKeyedStore<St
       return value;
     },
     delete: (key) => values.delete(key),
+    deleteIf: (key, predicate) => {
+      const value = values.get(key);
+      return value !== undefined && predicate(value) && values.delete(key);
+    },
     entries: () => [...values].map(([key, value]) => ({ key, value, createdAt: 0 })),
     clear: () => values.clear(),
   };

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -48,6 +48,10 @@ function createStateStore() {
       return value;
     },
     delete: (key) => values.delete(key),
+    deleteIf: (key, predicate) => {
+      const value = values.get(key);
+      return value !== undefined && predicate(value) && values.delete(key);
+    },
     entries: () => [...values].map(([key, value]) => ({ key, value, createdAt: 0 })),
     clear: () => values.clear(),
   };
@@ -60,6 +64,147 @@ afterEach(() => {
 });
 
 describe("Codex app-server binding store", () => {
+  it("deletes only the requested stable owner and restores it on transaction rollback", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-binding-delete-"));
+    try {
+      const state = createPluginStateSyncKeyedStoreForTests<StoredCodexAppServerBinding>("codex", {
+        namespace: "deletion-test",
+        maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+        overflowPolicy: "reject-new",
+        env: { ...process.env, OPENCLAW_STATE_DIR: root },
+      });
+      const store = createCodexAppServerBindingStore(state);
+      const base = {
+        kind: "session" as const,
+        agentId: "main",
+        sessionId: "shared-id",
+        sessionKey: "agent:main:cron:job",
+      };
+      const run = { ...base, sessionKey: `${base.sessionKey}:run:one` };
+      for (const identity of [base, run]) {
+        await store.mutate(identity, {
+          kind: "set",
+          binding: {
+            threadId: identity.sessionKey,
+            cwd: "/repo",
+          },
+        });
+      }
+      const original = state.lookup(bindingStoreKey(run));
+      await store.withSessionDeletion(
+        run,
+        () => {},
+        async (_binding, mutation) => {
+          mutation.commit();
+          expect(state.lookup(bindingStoreKey(run))).toBeUndefined();
+          expect(state.lookup(bindingStoreKey(base))).toMatchObject({ state: "active" });
+          mutation.rollback();
+        },
+      );
+      expect(state.lookup(bindingStoreKey(run))).toEqual(original);
+      let retainedCommit: (() => void) | undefined;
+      await store.withSessionDeletion(
+        run,
+        () => {},
+        async (_binding, mutation) => {
+          retainedCommit = mutation.commit;
+          mutation.commit();
+        },
+      );
+      expect(state.entries().map(({ key }) => key)).toEqual([bindingStoreKey(base)]);
+      expect(retainedCommit).toThrow("lease");
+    } finally {
+      resetPluginStateStoreForTests();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("removes retired fences without creating rows for absent bindings", async () => {
+    const { state, values } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const identity = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "old",
+      sessionKey: "agent:main:cron:expired",
+    };
+    await store.mutate(identity, { kind: "set", binding: { threadId: "old", cwd: "/repo" } });
+    await store.retireSessionGeneration(identity);
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await store.withSessionDeletion(
+        identity,
+        () => {},
+        async (binding, mutation) => {
+          expect(binding).toBeUndefined();
+          mutation.commit();
+        },
+      );
+      expect(values.size).toBe(0);
+    }
+  });
+
+  it("rejects revoked deletion authority and never restores over a successor", async () => {
+    const { state, values } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const identity = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "old",
+      sessionKey: "agent:main:cron:expired",
+    };
+    await store.mutate(identity, { kind: "set", binding: { threadId: "old", cwd: "/repo" } });
+    let active = true;
+    await expect(
+      store.withSessionDeletion(
+        identity,
+        () => {
+          if (!active) {
+            throw new Error("owner revoked");
+          }
+        },
+        async (_binding, mutation) => {
+          active = false;
+          expect(mutation.commit).toThrow("owner revoked");
+        },
+      ),
+    ).rejects.toThrow("owner revoked");
+    expect(values.get(bindingStoreKey(identity))).toMatchObject({
+      state: "active",
+      sessionId: "old",
+    });
+    // Revocation intentionally leaves the lease for expiry. The next owner is
+    // independent persisted state, not a continuation of that closed callback.
+    const successor = {
+      version: 1 as const,
+      state: "active" as const,
+      sessionId: "new",
+      binding: { threadId: "new", cwd: "/repo" },
+    };
+    state.register(bindingStoreKey(identity), successor);
+    await expect(
+      store.withSessionDeletion(
+        identity,
+        () => {},
+        async (_binding, mutation) => {
+          mutation.commit();
+        },
+      ),
+    ).rejects.toThrow("generation changed");
+    expect(values.get(bindingStoreKey(identity))).toEqual(successor);
+
+    const current = { ...identity, sessionId: "new" };
+    await store.withSessionDeletion(
+      current,
+      () => {},
+      async (_binding, mutation) => {
+        mutation.commit();
+        state.register(bindingStoreKey(identity), successor);
+        expect(mutation.rollback).toThrow("changed before session deletion rollback");
+      },
+    );
+    expect(values.get(bindingStoreKey(identity))).toEqual(successor);
+  });
+
   it("normalizes the retired approval policy in persisted bindings", () => {
     expect(
       readCodexAppServerThreadBinding({

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLazyCodexAppServerBindingStore } from "./session-binding-store.js";
 import {
   bindingStoreKey,
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
@@ -64,6 +65,35 @@ afterEach(() => {
 });
 
 describe("Codex app-server binding store", () => {
+  it("rechecks resume authority after the lazy store resolves and before writing", async () => {
+    const { state } = createStateStore();
+    const store = createLazyCodexAppServerBindingStore(state);
+    const identity = { kind: "conversation" as const, bindingId: "pending-resume" };
+    const binding = {
+      threadId: "thread-pending",
+      cwd: "/repo",
+      pendingResumeConfiguration: true as const,
+    };
+    await store.mutate(identity, { kind: "set", binding });
+    let current = true;
+    const writing = store.mutate(
+      identity,
+      {
+        kind: "patch",
+        threadId: binding.threadId,
+        patch: { pendingResumeConfiguration: undefined },
+      },
+      () => {
+        if (!current) {
+          throw new Error("resume authority changed");
+        }
+      },
+    );
+    current = false;
+    await expect(writing).rejects.toThrow("resume authority changed");
+    expect(await store.read(identity)).toEqual(binding);
+  });
+
   it("deletes only the requested stable owner and restores it on transaction rollback", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-binding-delete-"));
     try {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -1,9 +1,11 @@
 /** SQLite-backed Codex app-server thread bindings. */
 import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash, randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import {
   AgentHarnessSessionSupersededError,
   embeddedAgentLog,
+  type AgentHarnessSessionDeletionMutation,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   ensureAuthProfileStore,
@@ -550,12 +552,14 @@ export function createStoredCodexAppServerBinding(
 
 type BindingStateStore = Pick<
   PluginStateSyncKeyedStore<StoredCodexAppServerBinding>,
-  "entries" | "lookup" | "update"
+  "deleteIf" | "entries" | "lookup" | "registerIfAbsent" | "update"
 >;
 
 type BindingLeaseOwner = {
   token: string;
+  phase: "held" | "deleted" | "closed";
   failure?: Error;
+  assertCurrent?: () => void;
 };
 
 function bindingLeaseLostError(key: string, cause?: unknown): Error {
@@ -587,6 +591,14 @@ export type CodexAppServerBindingStore = {
   retireSessionGeneration(
     identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
   ): Promise<CodexSessionGenerationRetirementResult>;
+  withSessionDeletion<T>(
+    identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
+    assertCurrent: () => void,
+    run: (
+      binding: CodexAppServerThreadBinding | undefined,
+      mutation: AgentHarnessSessionDeletionMutation,
+    ) => Promise<T>,
+  ): Promise<T>;
   withThreadArchiveFence<T>(run: () => Promise<T>): Promise<T>;
   withLease<T>(identity: CodexAppServerBindingIdentity, run: () => Promise<T>): Promise<T>;
 };
@@ -627,6 +639,8 @@ export function scopeCodexRunBindingStore(params: {
       params.bindingStore.resetSessionGeneration(mapSessionIdentity(identity)),
     retireSessionGeneration: (identity) =>
       params.bindingStore.retireSessionGeneration(mapSessionIdentity(identity)),
+    withSessionDeletion: (identity, assertCurrent, run) =>
+      params.bindingStore.withSessionDeletion(mapSessionIdentity(identity), assertCurrent, run),
     withThreadArchiveFence: (run) => params.bindingStore.withThreadArchiveFence(run),
     withLease: (identity, run) => params.bindingStore.withLease(mapIdentity(identity), run),
   };
@@ -724,11 +738,12 @@ export function createCodexAppServerBindingStore(
   };
 
   const renewLease = (key: string, owner: BindingLeaseOwner): void => {
-    if (owner.failure) {
+    if (owner.failure || owner.phase !== "held") {
       return;
     }
     try {
       let renewed = false;
+      owner.assertCurrent?.();
       const stored = update(key, (raw) => {
         const current = readStoredCodexAppServerBinding(raw);
         if (raw !== undefined && !current) {
@@ -763,6 +778,7 @@ export function createCodexAppServerBindingStore(
       result: T;
     },
     ttlMs?: number,
+    assertCurrent?: () => void,
   ): Promise<T> => {
     const deadline = Date.now() + BINDING_LEASE_WAIT_MS;
     while (true) {
@@ -770,10 +786,15 @@ export function createCodexAppServerBindingStore(
       let leaseLost = false;
       let result!: T;
       const ownedLease = leaseContext.getStore()?.get(key);
+      if (ownedLease && ownedLease.phase !== "held") {
+        throw bindingLeaseLostError(key);
+      }
       if (ownedLease?.failure) {
         throw ownedLease.failure;
       }
       const ownedToken = ownedLease?.token;
+      assertCurrent?.();
+      ownedLease?.assertCurrent?.();
       update(
         key,
         (raw) => {
@@ -814,6 +835,119 @@ export function createCodexAppServerBindingStore(
         throw new Error(`Timed out waiting for Codex binding lease: ${key}`);
       }
       await sleep(BINDING_LEASE_RETRY_INTERVAL_MS);
+    }
+  };
+
+  const withBindingLease = async <T>(
+    identity: CodexAppServerBindingIdentity,
+    run: () => Promise<T>,
+    options: { allowRetired?: boolean; assertCurrent?: () => void } = {},
+  ): Promise<T> => {
+    options.assertCurrent?.();
+    const key = bindingStoreKey(identity);
+    const owned = leaseContext.getStore();
+    const existingOwner = owned?.get(key);
+    if (existingOwner) {
+      if (existingOwner.phase !== "held") {
+        throw bindingLeaseLostError(key);
+      }
+      const failureBeforeRun = existingOwner.failure;
+      if (failureBeforeRun) {
+        throw failureBeforeRun;
+      }
+      const result = await run();
+      options.assertCurrent?.();
+      const failureAfterRun = existingOwner.failure;
+      if (failureAfterRun) {
+        throw failureAfterRun;
+      }
+      return result;
+    }
+    const token = randomUUID();
+    const acquired = await transactKey(
+      key,
+      (current) => {
+        if (
+          current?.state === "cleared" &&
+          current.retired === true &&
+          ownsStoredSessionGeneration(identity, current) &&
+          !options.allowRetired
+        ) {
+          return { result: false };
+        }
+        const lease = { token, expiresAt: Date.now() + BINDING_LEASE_STALE_MS };
+        if (current?.state === "active") {
+          return {
+            result: true,
+            next: { ...current, ...preservedSessionGeneration(identity, current), lease },
+          };
+        }
+        if (current?.state === "cleared" && current.retired === true) {
+          return { result: true, next: { ...current, lease } };
+        }
+        return {
+          result: true,
+          next: {
+            version: 1,
+            state: "cleared",
+            ...preservedSessionGeneration(identity, current),
+            lease,
+          },
+        };
+      },
+      undefined,
+      options.assertCurrent,
+    );
+    options.assertCurrent?.();
+    if (!acquired) {
+      throw new Error(`Codex binding generation was retired: ${key}`);
+    }
+    const owner: BindingLeaseOwner = { token, phase: "held", assertCurrent: options.assertCurrent };
+    const nested = new Map(owned);
+    nested.set(key, owner);
+    // Long app-server RPCs can outlive the stale-owner window. Renew with an
+    // exact-token CAS so live work stays serialized while a replaced owner remains fenced.
+    const heartbeat = setInterval(() => renewLease(key, owner), BINDING_LEASE_RENEW_INTERVAL_MS);
+    heartbeat.unref();
+    try {
+      const result = await leaseContext.run(nested, run);
+      options.assertCurrent?.();
+      if (owner.failure) {
+        throw owner.failure;
+      }
+      return result;
+    } finally {
+      clearInterval(heartbeat);
+      owner.phase = "closed";
+      options.assertCurrent?.();
+      try {
+        const current = readStoredCodexAppServerBinding(state.lookup(key));
+        if (current?.lease?.token === token) {
+          const ttlMs =
+            current.state === "active" || (current.retired === true && !key.startsWith("session:"))
+              ? undefined
+              : current.retired === true
+                ? PHYSICAL_SESSION_RETIRE_TTL_MS
+                : 1;
+          options.assertCurrent?.();
+          update(
+            key,
+            (raw) => {
+              const stored = readStoredCodexAppServerBinding(raw);
+              if (stored?.lease?.token !== token) {
+                return undefined;
+              }
+              const { lease: _lease, ...released } = stored;
+              return released;
+            },
+            ttlMs === undefined ? undefined : { ttlMs },
+          );
+        }
+      } catch (error) {
+        options.assertCurrent?.();
+        // A crashed owner leaves only its bounded lease for recovery.
+        embeddedAgentLog.warn("failed to release codex app-server binding lease", { key, error });
+      }
     }
   };
 
@@ -1150,111 +1284,101 @@ export function createCodexAppServerBindingStore(
       }
     },
 
-    async withLease(identity, run) {
+    async withSessionDeletion(identity, assertCurrent, run) {
       const key = bindingStoreKey(identity);
-      const owned = leaseContext.getStore();
-      const existingOwner = owned?.get(key);
-      if (existingOwner) {
-        const failureBeforeRun = existingOwner.failure;
-        if (failureBeforeRun) {
-          throw failureBeforeRun;
-        }
-        const result = await run();
-        const failureAfterRun = existingOwner.failure;
-        if (failureAfterRun) {
-          throw failureAfterRun;
-        }
-        return result;
+      const deleteIf = state.deleteIf?.bind(state);
+      if (!deleteIf) {
+        throw new Error("Codex session deletion requires conditional plugin-state deletion");
       }
-      const token = randomUUID();
-      const acquired = await transactKey(key, (current) => {
-        if (
-          current?.state === "cleared" &&
-          current.retired === true &&
-          ownsStoredSessionGeneration(identity, current)
-        ) {
-          return { result: false };
-        }
-        const lease = { token, expiresAt: Date.now() + BINDING_LEASE_STALE_MS };
-        if (current?.state === "active") {
-          return {
-            result: true,
-            next: { ...current, ...preservedSessionGeneration(identity, current), lease },
-          };
-        }
-        if (current?.state === "cleared" && current.retired === true) {
-          return { result: true, next: { ...current, lease } };
-        }
-        return {
-          result: true,
-          next: {
-            version: 1,
-            state: "cleared",
-            ...preservedSessionGeneration(identity, current),
-            lease,
-          },
-        };
-      });
-      if (!acquired) {
-        throw new Error(`Codex binding generation was retired: ${key}`);
-      }
-      const owner: BindingLeaseOwner = { token };
-      const nested = new Map(owned);
-      nested.set(key, owner);
-      // Long app-server RPCs can outlive the stale-owner window. Renew with an
-      // exact-token CAS so live work stays serialized while a replaced owner remains fenced.
-      const heartbeat = setInterval(() => renewLease(key, owner), BINDING_LEASE_RENEW_INTERVAL_MS);
-      heartbeat.unref();
-      try {
-        const result = await leaseContext.run(nested, run);
-        if (owner.failure) {
-          throw owner.failure;
-        }
-        return result;
-      } finally {
-        clearInterval(heartbeat);
-        try {
-          const removeOwnedLease = (
-            raw: unknown,
-            matches: (current: StoredCodexAppServerBinding) => boolean,
-          ) => {
-            const current = readStoredCodexAppServerBinding(raw);
-            if (!current || !matches(current) || current.lease?.token !== token) {
-              return undefined;
-            }
-            const { lease: _lease, ...released } = current;
-            return released;
-          };
-          const releasedActive = update(key, (raw) =>
-            removeOwnedLease(raw, (current) => current.state === "active"),
-          );
-          if (!releasedActive) {
-            const releasedRetired = update(
-              key,
-              (raw) =>
-                removeOwnedLease(
-                  raw,
-                  (current) => current.state === "cleared" && current.retired === true,
-                ),
-              key.startsWith("session:") ? { ttlMs: PHYSICAL_SESSION_RETIRE_TTL_MS } : undefined,
-            );
-            if (!releasedRetired) {
-              update(
-                key,
-                (raw) => removeOwnedLease(raw, (current) => current.state === "cleared"),
-                { ttlMs: 1 },
-              );
-            }
+      return await runBindingMutation(async () => {
+        assertCurrent();
+        if (state.lookup(key) === undefined) {
+          let active = true;
+          try {
+            return await run(undefined, {
+              commit() {
+                assertCurrent();
+                if (!active || state.lookup(key) !== undefined) {
+                  throw new Error("Codex binding changed before session deletion");
+                }
+              },
+              rollback() {},
+            });
+          } finally {
+            active = false;
           }
-        } catch (error) {
-          // The bounded lease expires after a crashed or disconnected owner.
-          embeddedAgentLog.warn("failed to release codex app-server binding lease", {
-            key,
-            error,
-          });
         }
-      }
+        return await withBindingLease(
+          identity,
+          async () => {
+            const owner = leaseContext.getStore()!.get(key)!;
+            const expected = state.lookup(key);
+            const stored = readStoredCodexAppServerBinding(expected);
+            if (!stored || !ownsStoredSessionGeneration(identity, stored)) {
+              throw new Error("Codex binding generation changed before session deletion");
+            }
+            const { lease: _lease, ...expectedValue } = stored;
+            let deleted: StoredCodexAppServerBinding | undefined;
+            let active = true;
+            const assertActive = () => {
+              assertCurrent();
+              if (!active || owner.phase === "closed" || owner.failure) {
+                throw owner.failure ?? bindingLeaseLostError(key);
+              }
+            };
+            try {
+              return await run(stored.state === "active" ? stored.binding : undefined, {
+                commit() {
+                  assertActive();
+                  if (deleted) {
+                    return;
+                  }
+                  const current = state.lookup(key);
+                  const parsed = readStoredCodexAppServerBinding(current);
+                  const { lease, ...value } = parsed ?? {};
+                  if (
+                    !current ||
+                    lease?.token !== owner.token ||
+                    lease.expiresAt <= Date.now() ||
+                    !isDeepStrictEqual(value, expectedValue) ||
+                    !deleteIf(key, (raw) => isDeepStrictEqual(raw, current))
+                  ) {
+                    throw new Error("Codex binding changed before session deletion");
+                  }
+                  deleted = current;
+                  // The agent transaction commits synchronously after this removal. No
+                  // heartbeat may recreate the deleted row while artifacts are published.
+                  owner.phase = "deleted";
+                },
+                rollback() {
+                  assertActive();
+                  if (!deleted) {
+                    return;
+                  }
+                  const restored = {
+                    ...deleted,
+                    lease: {
+                      token: owner.token,
+                      expiresAt: Date.now() + BINDING_LEASE_STALE_MS,
+                    },
+                  };
+                  if (!state.registerIfAbsent(key, restored)) {
+                    throw new Error("Codex binding changed before session deletion rollback");
+                  }
+                  deleted = undefined;
+                  owner.phase = "held";
+                },
+              });
+            } finally {
+              active = false;
+            }
+          },
+          { allowRetired: true, assertCurrent },
+        );
+      });
     },
+
+    withLease: withBindingLease,
   };
 }
 

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -222,6 +222,9 @@ const threadBindingSchema = z
     // Continue creates the OpenClaw Chat before native execution. This closed
     // snapshot state is materialized only inside the fully configured harness.
     pendingSupervisionBranch: pendingSupervisionBranchSchema.optional(),
+    // Manual attachment records intent; only the harness can attest its native
+    // tool catalog and observe a configured reload before admitting a turn.
+    pendingResumeConfiguration: z.literal(true).optional(),
     modelProvider: z
       .string()
       .transform((value) => value.trim())
@@ -577,6 +580,7 @@ export type CodexAppServerBindingStore = {
   mutate(
     identity: CodexAppServerBindingIdentity,
     mutation: CodexAppServerBindingMutation,
+    assertCurrent?: () => void,
   ): Promise<boolean>;
   prepareSessionGenerationReclaim(
     identity: Extract<CodexAppServerBindingIdentity, { kind: "session" }>,
@@ -627,7 +631,8 @@ export function scopeCodexRunBindingStore(params: {
         threadId,
         identity ? mapIdentity(identity) : undefined,
       ),
-    mutate: (identity, mutation) => params.bindingStore.mutate(mapIdentity(identity), mutation),
+    mutate: (identity, mutation, assertCurrent) =>
+      params.bindingStore.mutate(mapIdentity(identity), mutation, assertCurrent),
     prepareSessionGenerationReclaim: (identity) =>
       params.bindingStore.prepareSessionGenerationReclaim(mapSessionIdentity(identity)),
     adoptSessionGeneration: (identity, expectedPreviousSessionId) =>
@@ -1008,7 +1013,7 @@ export function createCodexAppServerBindingStore(
       return { kind: "verify", expectedPreviousSessionId: currentSessionId };
     },
 
-    async mutate(identity, mutation) {
+    async mutate(identity, mutation, assertCurrent) {
       return await runBindingMutation(async () => {
         const key = bindingStoreKey(identity);
         // A retained legacy sidecar may be revisited by doctor after runtime
@@ -1167,6 +1172,7 @@ export function createCodexAppServerBindingStore(
           mutation.kind === "clear" && !retainLegacyClear && !leaseContext.getStore()?.has(key)
             ? 1
             : undefined,
+          assertCurrent,
         );
       });
     },

--- a/extensions/codex/src/app-server/session-retirement.test.ts
+++ b/extensions/codex/src/app-server/session-retirement.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createDeferred, withTestTimeout } from "../../../../test/helpers/promise.js";
 import { legacyCodexConversationBindingId } from "../conversation-binding-data.js";
 import {
   claimCodexAppServerLiveThread,
@@ -18,6 +18,7 @@ import {
   withCodexAppServerThreadMutation,
   withExclusiveCodexAppServerThread,
 } from "./thread-ownership.js";
+import { withTimeout } from "./timeout.js";
 
 const session = {
   kind: "session" as const,
@@ -124,29 +125,25 @@ describe("Codex session deletion subscriptions", () => {
     await fixture.seed();
     await retainCodexAppServerBindingSubscription(fixture.client, fixture.binding.threadId);
     const successor = { ...session, sessionId: "session-after-deletion" };
-    const resumeEntered = createDeferred();
-    const allowResume = createDeferred();
-    const committed = createDeferred();
+    const resumeEntered = createDeferred<void>();
+    const allowResume = createDeferred<void>();
+    const committed = createDeferred<void>();
     const resuming = withCodexAppServerThreadMutation(fixture.binding.threadId, async () => {
       resumeEntered.resolve();
       await allowResume.promise;
       await fixture.resume(successor);
     });
-    await withTestTimeout(resumeEntered.promise, 5_000, "resume did not enter the native queue");
+    await withTimeout(resumeEntered.promise, 5_000, "resume did not enter the native queue");
     const deletion = fixture.remove(session, async (mutation) => {
       mutation.commit();
       committed.resolve();
     });
     const completion = Promise.allSettled([resuming, deletion]);
     try {
-      await withTestTimeout(
-        committed.promise,
-        5_000,
-        "native resume queue blocked session deletion",
-      );
+      await withTimeout(committed.promise, 5_000, "native resume queue blocked session deletion");
       allowResume.resolve();
       expect(
-        await withTestTimeout(completion, 5_000, "native deletion cleanup did not settle"),
+        await withTimeout(completion, 5_000, "native deletion cleanup did not settle"),
       ).toEqual([
         { status: "fulfilled", value: undefined },
         { status: "fulfilled", value: undefined },
@@ -158,7 +155,7 @@ describe("Codex session deletion subscriptions", () => {
       expect(fixture.request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
     } finally {
       allowResume.resolve();
-      await withTestTimeout(completion, 5_000, "resume and deletion cleanup did not settle");
+      await withTimeout(completion, 5_000, "resume and deletion cleanup did not settle");
     }
   });
 
@@ -166,8 +163,8 @@ describe("Codex session deletion subscriptions", () => {
     const fixture = createFixture();
     await fixture.seed();
     await retainCodexAppServerBindingSubscription(fixture.client, fixture.binding.threadId);
-    const unsubscribeStarted = createDeferred();
-    const unsubscribeAcknowledged = createDeferred();
+    const unsubscribeStarted = createDeferred<void>();
+    const unsubscribeAcknowledged = createDeferred<void>();
     fixture.request.mockImplementation(async (method) => {
       if (method === "thread/unsubscribe") {
         unsubscribeStarted.resolve();
@@ -179,7 +176,7 @@ describe("Codex session deletion subscriptions", () => {
     const deletionCompletion = Promise.allSettled([deletion]);
     let resuming: Promise<void> | undefined;
     try {
-      await withTestTimeout(unsubscribeStarted.promise, 5_000, "deletion did not unsubscribe");
+      await withTimeout(unsubscribeStarted.promise, 5_000, "deletion did not unsubscribe");
       const successor = { ...session, sessionId: "session-after-deletion" };
       let resumeEntered = false;
       resuming = withExclusiveCodexAppServerThread({
@@ -197,7 +194,7 @@ describe("Codex session deletion subscriptions", () => {
       expect(await fixture.bindingStore.read(session)).toBeUndefined();
       unsubscribeAcknowledged.resolve();
       expect(
-        await withTestTimeout(completion, 5_000, "resume did not follow deletion cleanup"),
+        await withTimeout(completion, 5_000, "resume did not follow deletion cleanup"),
       ).toEqual([
         { status: "fulfilled", value: undefined },
         { status: "fulfilled", value: undefined },
@@ -210,7 +207,7 @@ describe("Codex session deletion subscriptions", () => {
       expect(hasCodexAppServerLiveThread(fixture.client, fixture.binding.threadId)).toBe(true);
     } finally {
       unsubscribeAcknowledged.resolve();
-      await withTestTimeout(
+      await withTimeout(
         Promise.allSettled([deletionCompletion, resuming]),
         5_000,
         "unsubscribe and resume cleanup did not settle",
@@ -225,7 +222,7 @@ describe("Codex session deletion subscriptions", () => {
     await fixture.seed(sibling);
     await retainCodexAppServerBindingSubscription(fixture.client, fixture.binding.threadId);
 
-    await withTestTimeout(
+    await withTimeout(
       fixture.remove(session, async (first) => {
         await fixture.remove(sibling, async (second) => {
           first.commit();

--- a/extensions/codex/src/app-server/session-retirement.test.ts
+++ b/extensions/codex/src/app-server/session-retirement.test.ts
@@ -1,0 +1,259 @@
+import { randomUUID } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../../test/helpers/promise.js";
+import { legacyCodexConversationBindingId } from "../conversation-binding-data.js";
+import {
+  claimCodexAppServerLiveThread,
+  consumeCodexAppServerLiveThread,
+  ensureCodexAppServerClientRuntime,
+  hasCodexAppServerLiveThread,
+  isCodexAppServerLiveThreadClaimed,
+} from "./client-runtime.js";
+import { createCodexTestBindingStore } from "./session-binding.test-helpers.js";
+import { withCodexAppServerSessionDeletion } from "./session-retirement.js";
+import * as sharedClients from "./shared-client.js";
+import { createClientHarness } from "./test-support.js";
+import {
+  retainCodexAppServerBindingSubscription,
+  withCodexAppServerThreadMutation,
+  withExclusiveCodexAppServerThread,
+} from "./thread-ownership.js";
+
+const session = {
+  kind: "session" as const,
+  agentId: "main",
+  sessionKey: "agent:main:dashboard:retirement",
+  sessionId: "session-before-deletion",
+};
+
+describe("Codex session deletion subscriptions", () => {
+  const clients: ReturnType<typeof createClientHarness>[] = [];
+
+  afterEach(() => {
+    for (const harness of clients) {
+      harness.client.close();
+      harness.emitExit();
+    }
+    clients.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  function createFixture() {
+    const harness = createClientHarness();
+    clients.push(harness);
+    const { client } = harness;
+    const bindingStore = createCodexTestBindingStore();
+    const binding = {
+      threadId: `thread-${randomUUID()}`,
+      clientId: client.getInstanceId(),
+      cwd: "/repo",
+    };
+    const request = vi.spyOn(client, "request").mockResolvedValue({ status: "unsubscribed" });
+    const releaseClientLease = vi.fn();
+    vi.spyOn(sharedClients, "retainSharedCodexAppServerClientByInstanceId").mockImplementation(
+      (clientId) =>
+        clientId === binding.clientId ? { client, release: releaseClientLease } : undefined,
+    );
+    ensureCodexAppServerClientRuntime(client, {
+      agentDir: "/tmp/codex-retirement-agent",
+      authMode: "prepared-api-key",
+    });
+
+    const seed = async (identity = session) => {
+      await bindingStore.mutate(identity, { kind: "set", binding });
+    };
+    const remove = (
+      identity = session,
+      run: Parameters<typeof withCodexAppServerSessionDeletion<void>>[2] = async (mutation) => {
+        mutation.commit();
+      },
+    ) =>
+      withCodexAppServerSessionDeletion(
+        bindingStore,
+        { ...identity, assertCurrent: () => {} },
+        run,
+      );
+    const resume = async (identity: typeof session) => {
+      await bindingStore.withLease(identity, async () => {
+        await client.request("thread/resume", { threadId: binding.threadId });
+        await retainCodexAppServerBindingSubscription(client, binding.threadId);
+        if (!(await bindingStore.mutate(identity, { kind: "set", binding }))) {
+          throw new Error("resumed binding did not commit");
+        }
+      });
+    };
+    return { bindingStore, binding, client, remove, request, resume, seed };
+  }
+
+  it("rejects a claimed native thread before invoking the session transaction", async () => {
+    const fixture = createFixture();
+    await fixture.seed();
+    await claimCodexAppServerLiveThread(fixture.client, fixture.binding.threadId);
+    const transaction = vi.fn(async () => {});
+
+    await expect(fixture.remove(session, transaction)).rejects.toThrow("claimed by active work");
+
+    expect(transaction).not.toHaveBeenCalled();
+    expect(await fixture.bindingStore.read(session)).toEqual(fixture.binding);
+    expect(isCodexAppServerLiveThreadClaimed(fixture.client, fixture.binding.threadId)).toBe(true);
+    expect(fixture.request).not.toHaveBeenCalled();
+  });
+
+  it("removes a migrated session binding without unsubscribing its surviving legacy conversation", async () => {
+    const fixture = createFixture();
+    const conversation = {
+      kind: "conversation" as const,
+      bindingId: legacyCodexConversationBindingId("/repo/legacy-session.jsonl"),
+    };
+    await fixture.seed();
+    await fixture.bindingStore.mutate(conversation, { kind: "set", binding: fixture.binding });
+    await retainCodexAppServerBindingSubscription(fixture.client, fixture.binding.threadId);
+
+    await fixture.remove();
+
+    expect(await fixture.bindingStore.read(session)).toBeUndefined();
+    expect(await fixture.bindingStore.read(conversation)).toEqual(fixture.binding);
+    expect(
+      await consumeCodexAppServerLiveThread(fixture.client, fixture.binding.threadId),
+    ).toBeDefined();
+    expect(fixture.request).not.toHaveBeenCalled();
+  });
+
+  it("preserves a same-key successor when resume owns the native queue before deletion cleanup", async () => {
+    const fixture = createFixture();
+    await fixture.seed();
+    await retainCodexAppServerBindingSubscription(fixture.client, fixture.binding.threadId);
+    const successor = { ...session, sessionId: "session-after-deletion" };
+    const resumeEntered = createDeferred();
+    const allowResume = createDeferred();
+    const committed = createDeferred();
+    const resuming = withCodexAppServerThreadMutation(fixture.binding.threadId, async () => {
+      resumeEntered.resolve();
+      await allowResume.promise;
+      await fixture.resume(successor);
+    });
+    await withTestTimeout(resumeEntered.promise, 5_000, "resume did not enter the native queue");
+    const deletion = fixture.remove(session, async (mutation) => {
+      mutation.commit();
+      committed.resolve();
+    });
+    const completion = Promise.allSettled([resuming, deletion]);
+    try {
+      await withTestTimeout(
+        committed.promise,
+        5_000,
+        "native resume queue blocked session deletion",
+      );
+      allowResume.resolve();
+      expect(
+        await withTestTimeout(completion, 5_000, "native deletion cleanup did not settle"),
+      ).toEqual([
+        { status: "fulfilled", value: undefined },
+        { status: "fulfilled", value: undefined },
+      ]);
+      expect(await fixture.bindingStore.read(successor)).toEqual(fixture.binding);
+      expect(
+        await consumeCodexAppServerLiveThread(fixture.client, fixture.binding.threadId),
+      ).toBeDefined();
+      expect(fixture.request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+    } finally {
+      allowResume.resolve();
+      await withTestTimeout(completion, 5_000, "resume and deletion cleanup did not settle");
+    }
+  });
+
+  it("holds the native queue through unsubscribe acknowledgement before a successor resumes", async () => {
+    const fixture = createFixture();
+    await fixture.seed();
+    await retainCodexAppServerBindingSubscription(fixture.client, fixture.binding.threadId);
+    const unsubscribeStarted = createDeferred();
+    const unsubscribeAcknowledged = createDeferred();
+    fixture.request.mockImplementation(async (method) => {
+      if (method === "thread/unsubscribe") {
+        unsubscribeStarted.resolve();
+        await unsubscribeAcknowledged.promise;
+      }
+      return {};
+    });
+    const deletion = fixture.remove();
+    const deletionCompletion = Promise.allSettled([deletion]);
+    let resuming: Promise<void> | undefined;
+    try {
+      await withTestTimeout(unsubscribeStarted.promise, 5_000, "deletion did not unsubscribe");
+      const successor = { ...session, sessionId: "session-after-deletion" };
+      let resumeEntered = false;
+      resuming = withExclusiveCodexAppServerThread({
+        bindingStore: fixture.bindingStore,
+        identity: successor,
+        threadId: fixture.binding.threadId,
+        run: async () => {
+          resumeEntered = true;
+          await fixture.resume(successor);
+        },
+      });
+      const completion = Promise.allSettled([deletion, resuming]);
+      await withCodexAppServerThreadMutation(`other-${fixture.binding.threadId}`, async () => {});
+      expect(resumeEntered).toBe(false);
+      expect(await fixture.bindingStore.read(session)).toBeUndefined();
+      unsubscribeAcknowledged.resolve();
+      expect(
+        await withTestTimeout(completion, 5_000, "resume did not follow deletion cleanup"),
+      ).toEqual([
+        { status: "fulfilled", value: undefined },
+        { status: "fulfilled", value: undefined },
+      ]);
+      expect(fixture.request.mock.calls.map(([method]) => method)).toEqual([
+        "thread/unsubscribe",
+        "thread/resume",
+      ]);
+      expect(await fixture.bindingStore.read(successor)).toEqual(fixture.binding);
+      expect(hasCodexAppServerLiveThread(fixture.client, fixture.binding.threadId)).toBe(true);
+    } finally {
+      unsubscribeAcknowledged.resolve();
+      await withTestTimeout(
+        Promise.allSettled([deletionCompletion, resuming]),
+        5_000,
+        "unsubscribe and resume cleanup did not settle",
+      );
+    }
+  });
+
+  it("deletes nested same-thread owners without deadlock and releases their subscription once", async () => {
+    const fixture = createFixture();
+    const sibling = { ...session, sessionKey: "agent:main:cron:retirement:run:child" };
+    await fixture.seed();
+    await fixture.seed(sibling);
+    await retainCodexAppServerBindingSubscription(fixture.client, fixture.binding.threadId);
+
+    await withTestTimeout(
+      fixture.remove(session, async (first) => {
+        await fixture.remove(sibling, async (second) => {
+          first.commit();
+          second.commit();
+        });
+      }),
+      5_000,
+      "nested deletion deadlocked on a shared native thread",
+    );
+
+    expect(await fixture.bindingStore.read(session)).toBeUndefined();
+    expect(await fixture.bindingStore.read(sibling)).toBeUndefined();
+    expect(fixture.request.mock.calls.map(([method]) => method)).toEqual(["thread/unsubscribe"]);
+    expect(hasCodexAppServerLiveThread(fixture.client, fixture.binding.threadId)).toBe(false);
+  });
+
+  it("unsubscribes an incognito thread without an idle registry entry", async () => {
+    const fixture = createFixture();
+    const incognito = { ...session, sessionKey: "agent:main:dashboard:incognito-retirement" };
+    await fixture.seed(incognito);
+
+    await fixture.remove(incognito);
+
+    expect(await fixture.bindingStore.read(incognito)).toBeUndefined();
+    expect(fixture.request).toHaveBeenCalledExactlyOnceWith(
+      "thread/unsubscribe",
+      { threadId: fixture.binding.threadId },
+      { timeoutMs: 5_000 },
+    );
+  });
+});

--- a/extensions/codex/src/app-server/session-retirement.ts
+++ b/extensions/codex/src/app-server/session-retirement.ts
@@ -1,3 +1,7 @@
+import type {
+  AgentHarnessSessionDeletionMutation,
+  AgentHarnessSessionDeletionParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
 import { isIncognitoSessionKey } from "../incognito-session.js";
 import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
@@ -5,14 +9,134 @@ import {
   CodexAppServerUnsafeSubscriptionError,
   unsubscribeCodexThreadBestEffort,
 } from "./attempt-client-cleanup.js";
-import { releaseCodexAppServerLiveThread } from "./client-runtime.js";
+import {
+  hasCodexAppServerLiveThread,
+  isCodexAppServerLiveThreadClaimed,
+  releaseCodexAppServerLiveThread,
+} from "./client-runtime.js";
 import { codexNativeSubagentMonitorRuntime } from "./native-subagent-monitor.js";
 import type {
   CodexAppServerBindingIdentity,
   CodexAppServerBindingStore,
+  CodexAppServerThreadBinding,
   CodexSessionGenerationRetirementResult,
 } from "./session-binding.js";
 import { retainSharedCodexAppServerClientByInstanceId } from "./shared-client.js";
+import { withCodexAppServerThreadMutation } from "./thread-ownership.js";
+
+async function releaseSessionSubscription(
+  client: NonNullable<ReturnType<typeof retainSharedCodexAppServerClientByInstanceId>>["client"],
+  binding: CodexAppServerThreadBinding,
+  sessionKey: string | undefined,
+  assertCurrent?: () => void,
+): Promise<void> {
+  assertCurrent?.();
+  // End child ownership before the parent subscription, so late completions
+  // cannot deliver into a replacement OpenClaw session generation.
+  codexNativeSubagentMonitorRuntime.retireParent(client, binding.threadId);
+  const released = await releaseCodexAppServerLiveThread(client, binding.threadId, assertCurrent);
+  assertCurrent?.();
+  if (!released && isIncognitoSessionKey(sessionKey)) {
+    const unsubscribed = await unsubscribeCodexThreadBestEffort(client, {
+      threadId: binding.threadId,
+      timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+      assertCurrent,
+    });
+    assertCurrent?.();
+    if (!unsubscribed) {
+      await closeCodexStartupClientBestEffort(client);
+      throw new CodexAppServerUnsafeSubscriptionError(
+        `Codex retired session subscription could not be released: ${binding.threadId}`,
+      );
+    }
+  }
+}
+
+/** Prepare exact binding deletion before the session owner commits either database. */
+export async function withCodexAppServerSessionDeletion<T>(
+  bindingStore: CodexAppServerBindingStore,
+  params: AgentHarnessSessionDeletionParams,
+  run: (mutation: AgentHarnessSessionDeletionMutation) => Promise<T>,
+): Promise<T> {
+  const { assertCurrent } = params;
+  const identity = {
+    kind: "session" as const,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+  };
+  return await bindingStore.withSessionDeletion(
+    identity,
+    assertCurrent,
+    async (binding, mutation) => {
+      assertCurrent();
+      if (binding?.connectionScope === "supervision") {
+        throw new Error("Cannot delete a session while its Codex binding is owned by supervision");
+      }
+      const clientLease = binding?.clientId
+        ? retainSharedCodexAppServerClientByInstanceId(binding.clientId)
+        : undefined;
+      const assertUnclaimed = () => {
+        assertCurrent();
+        if (
+          clientLease &&
+          binding &&
+          isCodexAppServerLiveThreadClaimed(clientLease.client, binding.threadId)
+        ) {
+          throw new Error(
+            "Cannot delete a session while its Codex thread is claimed by active work",
+          );
+        }
+      };
+      let committed = false;
+      try {
+        assertUnclaimed();
+        return await run({
+          commit() {
+            assertUnclaimed();
+            mutation.commit();
+            committed = true;
+          },
+          rollback() {
+            mutation.rollback();
+            committed = false;
+          },
+        });
+      } finally {
+        try {
+          // An artifact publication failure after COMMIT still ends this subscription;
+          // only the session owner's transaction rollback may restore the binding.
+          if (committed && binding && clientLease) {
+            await withCodexAppServerThreadMutation(binding.threadId, async () => {
+              assertCurrent();
+              // Most expired bindings no longer have a live subscription. Only
+              // live threads need the persisted-owner check (idle retention is bounded).
+              if (
+                !hasCodexAppServerLiveThread(clientLease.client, binding.threadId) &&
+                !isIncognitoSessionKey(params.sessionKey)
+              ) {
+                return;
+              }
+              // The deleted row is absent now. Any surviving owner, including a
+              // successor at the same key, keeps its connection-scoped subscription.
+              if (await bindingStore.hasOtherThreadOwner(binding.threadId)) {
+                return;
+              }
+              await releaseSessionSubscription(
+                clientLease.client,
+                binding,
+                params.sessionKey,
+                assertUnclaimed,
+              );
+            });
+          }
+        } finally {
+          clientLease?.release();
+        }
+      }
+    },
+  );
+}
 
 /** Retire binding and native subscription under the same generation/physical-client ownership fence. */
 export async function retireCodexAppServerSessionGeneration(params: {
@@ -47,24 +171,7 @@ export async function retireCodexAppServerSessionGeneration(params: {
       return result;
     }
     try {
-      // Reset retires native-child ownership before unsubscribing its parent;
-      // late child completions must never reach a replacement session generation.
-      codexNativeSubagentMonitorRuntime.retireParent(clientLease.client, binding.threadId);
-      const released = await releaseCodexAppServerLiveThread(clientLease.client, binding.threadId);
-      if (!released && isIncognitoSessionKey(params.identity.sessionKey)) {
-        // Ephemeral threads have no rollout to resume, so they intentionally
-        // bypass idle eviction but still end with their owning OpenClaw session.
-        const unsubscribed = await unsubscribeCodexThreadBestEffort(clientLease.client, {
-          threadId: binding.threadId,
-          timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-        });
-        if (!unsubscribed) {
-          await closeCodexStartupClientBestEffort(clientLease.client);
-          throw new CodexAppServerUnsafeSubscriptionError(
-            `Codex retired session subscription could not be released: ${binding.threadId}`,
-          );
-        }
-      }
+      await releaseSessionSubscription(clientLease.client, binding, params.identity.sessionKey);
     } finally {
       clientLease.release();
     }

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -5,10 +5,12 @@ import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { WebSocketServer, type RawData } from "ws";
+import type { CodexAppServerPreparedAuth } from "./auth-bridge.js";
 import { CodexAppServerClient } from "./client.js";
 import type { CodexAppServerStartOptions } from "./config.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import { codexNativeSubagentMonitorRuntime } from "./native-subagent-monitor.js";
+import { withCodexAppServerJsonClient } from "./request.js";
 import { createClientHarness } from "./test-support.js";
 import { CODEX_APP_SERVER_VERSION, MIN_SUPPORTED_CODEX_APP_SERVER_VERSION } from "./version.js";
 
@@ -1422,6 +1424,62 @@ describe("shared Codex app-server client", () => {
     });
     expect(mocks.resolveCodexAppServerPreparedApiKeyCacheKey).toHaveBeenCalledWith("platform-key");
   });
+
+  it.each(["api-key", "subscription"] as const)(
+    "reuses a turn's %s physical client for a control resume",
+    async (authRequirement) => {
+      const harness = createClientHarness();
+      const start = vi
+        .spyOn(CodexAppServerClient, "start")
+        .mockReturnValueOnce(harness.client)
+        .mockImplementation(() => {
+          throw new Error("control resume opened a second physical client");
+        });
+      const preparedAuth: CodexAppServerPreparedAuth =
+        authRequirement === "api-key"
+          ? { kind: "api-key", apiKey: "platform-key" }
+          : {
+              kind: "profile",
+              profileId: "openai:scoped",
+              store: {
+                version: 1,
+                profiles: {
+                  "openai:scoped": { type: "token", provider: "openai", token: "prepared-token" },
+                },
+              },
+            };
+      const options = {
+        timeoutMs: 1000,
+        agentDir: "/tmp/openclaw-agent",
+        preparedAuth,
+        authRequirement,
+        authBindingFingerprint:
+          authRequirement === "subscription" ? "profile-credential-fingerprint" : undefined,
+      };
+      const producer = getSharedCodexAppServerClient(options);
+      await sendInitializeResult(harness, "openclaw/0.149.0 (macOS; test)");
+      await expect(producer).resolves.toBe(harness.client);
+      const response = { thread: { id: "thread-resume" } };
+      const request = vi.spyOn(harness.client, "request").mockResolvedValue(response as never);
+
+      await expect(
+        withCodexAppServerJsonClient(options, async (send, client) => {
+          expect(client).toBe(harness.client);
+          return await send({
+            method: "thread/resume",
+            requestParams: { threadId: "thread-resume" },
+          });
+        }),
+      ).resolves.toEqual(response);
+
+      expect(start).toHaveBeenCalledOnce();
+      expect(request).toHaveBeenCalledExactlyOnceWith(
+        "thread/resume",
+        { threadId: "thread-resume" },
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    },
+  );
 
   it("rejects ambiguous prepared and legacy auth before starting a client", async () => {
     const startSpy = vi.spyOn(CodexAppServerClient, "start");

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -12,6 +12,7 @@ import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import { codexNativeSubagentMonitorRuntime } from "./native-subagent-monitor.js";
 import { withCodexAppServerJsonClient } from "./request.js";
 import { createClientHarness } from "./test-support.js";
+import { CodexAdoptedThreadActiveError } from "./thread-lifecycle-errors.js";
 import { CODEX_APP_SERVER_VERSION, MIN_SUPPORTED_CODEX_APP_SERVER_VERSION } from "./version.js";
 
 const mocks = vi.hoisted(() => ({
@@ -117,6 +118,7 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
 
 import {
   assertCodexAppServerClientStartSelectionCurrent,
+  captureExclusiveSharedCodexAppServerClient,
   getSharedCodexAppServerClient,
   readCodexAppServerClientDesktopGeneration,
   readCodexAppServerClientProcessIdentity,
@@ -478,6 +480,104 @@ describe("shared Codex app-server client", () => {
     expect(retained?.client).toBe(client);
     retained?.release();
     expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
+  });
+
+  it("captures configuration ownership only for a sole registered lease", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+    expect(() => captureExclusiveSharedCodexAppServerClient(harness.client)).toThrow(
+      CodexAdoptedThreadActiveError,
+    );
+    const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
+    await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
+    const client = await acquire;
+    expect(captureExclusiveSharedCodexAppServerClient(client)).not.toThrow();
+
+    const retained = retainSharedCodexAppServerClientByInstanceId(client.getInstanceId());
+    expect(() => captureExclusiveSharedCodexAppServerClient(client)).toThrow(
+      CodexAdoptedThreadActiveError,
+    );
+    retained?.release();
+    expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
+    expect(() => captureExclusiveSharedCodexAppServerClient(client)).toThrow(
+      CodexAdoptedThreadActiveError,
+    );
+  });
+
+  it.each(["acquire", "retain"] as const)(
+    "revokes captured configuration ownership after a completed sibling %s",
+    async (operation) => {
+      const harness = createClientHarness();
+      vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+      const options = {
+        timeoutMs: 1_000,
+        config: {},
+        startOptions: {
+          transport: "stdio",
+          homeScope: "agent",
+          command: "codex",
+          args: ["app-server"],
+          headers: {},
+        } satisfies CodexAppServerStartOptions,
+      };
+      const acquire = getLeasedSharedCodexAppServerClient(options);
+      await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
+      const client = await acquire;
+      const assertExclusive = captureExclusiveSharedCodexAppServerClient(client);
+      if (operation === "acquire") {
+        expect(await getLeasedSharedCodexAppServerClient(options)).toBe(client);
+        expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
+      } else {
+        retainSharedCodexAppServerClientIfCurrent(client)?.();
+      }
+
+      expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
+      expect(captureExclusiveSharedCodexAppServerClient(client)).not.toThrow();
+      expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
+    },
+  );
+
+  it("revokes configuration ownership when an unleased acquire is pending", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+    const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
+    await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
+    const client = await acquire;
+    const assertExclusive = captureExclusiveSharedCodexAppServerClient(client);
+    let observedPendingAcquire = false;
+    await getSharedCodexAppServerClient({
+      timeoutMs: 1_000,
+      onStartedClient: () => {
+        observedPendingAcquire = true;
+        expect(() => captureExclusiveSharedCodexAppServerClient(client)).toThrow(
+          CodexAdoptedThreadActiveError,
+        );
+        expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
+      },
+    });
+
+    expect(observedPendingAcquire).toBe(true);
+    expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
+    expect(captureExclusiveSharedCodexAppServerClient(client)).not.toThrow();
+    expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
+  });
+
+  it("revokes configuration ownership when its physical client is retired", async () => {
+    const harness = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+    const acquire = getLeasedSharedCodexAppServerClient({ timeoutMs: 1_000 });
+    await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
+    const client = await acquire;
+    const assertExclusive = captureExclusiveSharedCodexAppServerClient(client);
+    retireSharedCodexAppServerClientIfCurrent(client);
+
+    expect(assertExclusive).toThrow(CodexAdoptedThreadActiveError);
+    expect(() => captureExclusiveSharedCodexAppServerClient(client)).toThrow(
+      CodexAdoptedThreadActiveError,
+    );
+    expect(harness.stdinDestroyed).toBe(false);
+    expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
+    expect(harness.stdinDestroyed).toBe(true);
   });
 
   it("does not consume a co-lease when selection replacement acquisition fails", async () => {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -46,6 +46,7 @@ import {
   resolveManagedCodexNativeCommand,
 } from "./managed-binary.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
+import { CodexAdoptedThreadActiveError } from "./thread-lifecycle-errors.js";
 import { withTimeout } from "./timeout.js";
 
 export type { CodexAppServerPreparedAuth } from "./auth-bridge.js";
@@ -57,6 +58,7 @@ type SharedCodexAppServerClientEntry = {
   startup?: SharedCodexAppServerClientStartup;
   activeLeases: number;
   pendingAcquires: number;
+  leaseGeneration: number;
   closeWhenIdle: boolean;
   closeError?: Error;
   startupAbort?: AbortController;
@@ -726,6 +728,7 @@ async function acquireSharedCodexAppServerClient(
     }
   }
   if (warmClient) {
+    warmClient.entry.leaseGeneration += 1;
     options?.onStartedClient?.(warmClient.client);
     const release = leaseOptions?.leased ? retainSharedClientEntry(warmClient.entry) : undefined;
     return release ? { client: warmClient.client, release } : { client: warmClient.client };
@@ -1430,6 +1433,37 @@ export function retainSharedCodexAppServerClientByInstanceId(
   return undefined;
 }
 
+/** Captures sole physical-client ownership across awaited configuration adoption. */
+export function captureExclusiveSharedCodexAppServerClient(
+  client: CodexAppServerClient,
+): () => void {
+  const state = getSharedCodexAppServerClientState();
+  for (const [key, entry] of state.clients) {
+    if (entry.client !== client) {
+      continue;
+    }
+    const generation = entry.leaseGeneration;
+    const assertExclusive = () => {
+      // A sibling can resume native children without OpenClaw's thread queue.
+      // Even a completed intervening lease invalidates this configuration proof.
+      if (
+        state.clients.get(key) !== entry ||
+        entry.client !== client ||
+        entry.closeWhenIdle ||
+        entry.closeError ||
+        entry.activeLeases !== 1 ||
+        entry.pendingAcquires !== 0 ||
+        entry.leaseGeneration !== generation
+      ) {
+        throw new CodexAdoptedThreadActiveError();
+      }
+    };
+    assertExclusive();
+    return assertExclusive;
+  }
+  throw new CodexAdoptedThreadActiveError();
+}
+
 /**
  * Retires a matching shared client. Default is graceful: detach from the map
  * (future acquisitions get a fresh client) and close once leases drain.
@@ -1624,6 +1658,7 @@ function getOrCreateSharedClientEntry(
     entry = {
       activeLeases: 0,
       pendingAcquires: 0,
+      leaseGeneration: 0,
       closeWhenIdle: false,
       onStartedClientCallbacks: new Set(),
     };
@@ -1663,6 +1698,7 @@ export function clearSharedCodexAppServerClientIfCurrentAndUnclaimed(
 
 function retainPendingSharedClientAcquire(entry: SharedCodexAppServerClientEntry): () => void {
   let released = false;
+  entry.leaseGeneration += 1;
   entry.pendingAcquires += 1;
   return () => {
     if (released) {
@@ -1677,6 +1713,7 @@ function retainPendingSharedClientAcquire(entry: SharedCodexAppServerClientEntry
 
 function retainSharedClientEntry(entry: SharedCodexAppServerClientEntry): () => void {
   let released = false;
+  entry.leaseGeneration += 1;
   entry.activeLeases += 1;
   return () => {
     if (released) {

--- a/extensions/codex/src/app-server/thread-fingerprints.ts
+++ b/extensions/codex/src/app-server/thread-fingerprints.ts
@@ -9,7 +9,7 @@ import {
 import { hashCodexAppServerBindingFingerprint } from "./session-binding.js";
 import { resolveCodexGpt56MultiAgentVersion } from "./thread-binding-policy.js";
 
-export function codexDynamicToolsFingerprint(dynamicTools: CodexDynamicToolSpec[]): string {
+export function codexDynamicToolsFingerprint(dynamicTools: readonly JsonValue[]): string {
   return fingerprintDynamicTools(dynamicTools);
 }
 
@@ -25,11 +25,11 @@ export function areCodexDynamicToolFingerprintsCompatible(params: {
   return areDynamicToolFingerprintsCompatible(params.previous, params.next, params.nextLegacy);
 }
 
-function fingerprintDynamicTools(dynamicTools: CodexDynamicToolSpec[]): string {
+function fingerprintDynamicTools(dynamicTools: readonly JsonValue[]): string {
   return hashCodexAppServerBindingFingerprint(legacyFingerprintDynamicTools(dynamicTools));
 }
 
-function legacyFingerprintDynamicTools(dynamicTools: CodexDynamicToolSpec[]): string {
+function legacyFingerprintDynamicTools(dynamicTools: readonly JsonValue[]): string {
   return JSON.stringify(
     dynamicTools.map(fingerprintDynamicToolSpec).toSorted(compareJsonFingerprint),
   );

--- a/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
@@ -1,0 +1,231 @@
+import path from "node:path";
+import { isIncognitoSessionKey } from "../incognito-session.js";
+import { readCodexSessionMeta } from "../session-catalog-provenance.js";
+import {
+  resolveCodexAppServerHomeDir,
+  resolveCodexAppServerLocalHomeDir,
+} from "./auth-start-options.js";
+import { isCodexAppServerLiveThreadClaimed } from "./client-runtime.js";
+import { resolveCodexAppServerClientInstanceId } from "./client.js";
+import { isJsonObject } from "./protocol.js";
+import {
+  sessionBindingIdentity,
+  type CodexAppServerBindingIdentity,
+  type CodexAppServerThreadBinding,
+} from "./session-binding.js";
+import { captureExclusiveSharedCodexAppServerClient } from "./shared-client.js";
+import { shouldRotateCodexGpt56MultiAgentBinding } from "./thread-binding-policy.js";
+import { isContextEngineBindingCompatible } from "./thread-context-engine.js";
+import { codexDynamicToolsFingerprint } from "./thread-fingerprints.js";
+import { CodexThreadBindingConflictError } from "./thread-lifecycle-errors.js";
+import { resolveCodexThreadAgentDir, resumeExistingCodexThread } from "./thread-lifecycle-io.js";
+import type {
+  CodexAppServerThreadLifecycleBinding,
+  CodexStartOrResumeThreadParams,
+  CodexThreadRequestContext,
+} from "./thread-lifecycle-types.js";
+import { releaseCodexConsumedLiveThread } from "./thread-lifecycle-warm.js";
+import { withExclusiveCodexAppServerThread } from "./thread-ownership.js";
+
+/** Preserve attach's native-queue-before-binding-lease order when consuming pending intent. */
+export async function withCodexThreadLifecycleBinding(
+  params: CodexStartOrResumeThreadParams,
+  run: (
+    identity: CodexAppServerBindingIdentity,
+    binding: CodexAppServerThreadBinding | undefined,
+  ) => Promise<CodexAppServerThreadLifecycleBinding>,
+): Promise<CodexAppServerThreadLifecycleBinding> {
+  const identity = sessionBindingIdentity({
+    sessionId: params.params.sessionId,
+    sessionKey: params.params.sessionKey,
+    agentId: params.agentId ?? params.params.agentId,
+    config: params.params.config,
+  });
+  const snapshot = await params.bindingStore.read(identity);
+  const pendingThreadId = snapshot?.pendingResumeConfiguration ? snapshot.threadId : undefined;
+  const runWithLease = () =>
+    params.bindingStore.withLease(identity, async () => {
+      const binding = await params.bindingStore.read(identity);
+      if (
+        pendingThreadId &&
+        (binding?.threadId !== pendingThreadId || !binding.pendingResumeConfiguration)
+      ) {
+        throw new CodexThreadBindingConflictError(
+          pendingThreadId,
+          "acquiring a pending resume configuration",
+        );
+      }
+      if (!pendingThreadId && binding?.pendingResumeConfiguration) {
+        throw new CodexThreadBindingConflictError(
+          binding.threadId,
+          "acquiring a pending resume configuration",
+        );
+      }
+      return await run(identity, binding);
+    });
+  return pendingThreadId
+    ? await withExclusiveCodexAppServerThread({
+        bindingStore: params.bindingStore,
+        identity,
+        threadId: pendingThreadId,
+        run: runWithLease,
+      })
+    : await runWithLease();
+}
+
+type PendingResumeContext = CodexThreadRequestContext & {
+  binding: CodexAppServerThreadBinding;
+  clearCurrentBinding: (operation: string) => Promise<void>;
+  releaseRetainedThread: (threadId: string, assertCurrent: () => void) => Promise<boolean>;
+  transientRestriction: boolean;
+};
+
+/** Completes manual attachment only under the native queue and exact binding lease. */
+export async function resumePendingCodexThread(
+  params: CodexStartOrResumeThreadParams,
+  context: PendingResumeContext,
+): Promise<CodexAppServerThreadLifecycleBinding> {
+  const { binding, contextEngineBinding, lifecycleTiming, restrictedToolSurface } = context;
+  if (
+    isIncognitoSessionKey(params.params.sessionKey) ||
+    context.transientRestriction ||
+    (!restrictedToolSurface && binding.nativeToolPolicyRestricted === true) ||
+    (contextEngineBinding
+      ? !isContextEngineBindingCompatible(binding.contextEngine, contextEngineBinding)
+      : binding.contextEngine !== undefined) ||
+    shouldRotateCodexGpt56MultiAgentBinding({
+      bindingModel: binding.model,
+      requestedModel: params.params.modelId,
+    })
+  ) {
+    throw new Error(
+      `Cannot configure resumed Codex thread ${binding.threadId} under a transient or incompatible session policy. ` +
+        "The thread is preserved; retry from its normal session or use /new for the current policy.",
+    );
+  }
+  const prebuiltPluginThreadConfig = params.pluginThreadConfig?.enabled
+    ? await lifecycleTiming.measure("plugin-config-build", () => params.pluginThreadConfig?.build())
+    : undefined;
+  const clientId = resolveCodexAppServerClientInstanceId(params.client);
+  const configuration = await preparePendingCodexThreadResume(
+    params,
+    binding,
+    context.dynamicToolsFingerprint,
+    async (assertCurrent) => {
+      const released = await context.releaseRetainedThread(binding.threadId, assertCurrent);
+      assertCurrent();
+      if (!released || (binding.clientId && binding.clientId !== clientId)) {
+        await releaseCodexConsumedLiveThread({
+          client: params.client,
+          abandonClient: params.abandonClient,
+          lifecycleTiming,
+          threadId: binding.threadId,
+          assertCurrent,
+        });
+      }
+    },
+  );
+  try {
+    const resumed = await resumeExistingCodexThread(params, {
+      ...context,
+      prebuiltPluginThreadConfig,
+      assertResumeConfiguration: configuration.assertConfigured,
+      assertResumeOwnership: configuration.assertCurrent,
+    });
+    if (!resumed) {
+      throw new Error(`Codex did not configure resumed thread ${binding.threadId}.`);
+    }
+    return resumed;
+  } finally {
+    configuration.dispose();
+  }
+}
+
+/** Manual attachment is intent, never evidence that loaded native overrides took effect. */
+async function preparePendingCodexThreadResume(
+  params: CodexStartOrResumeThreadParams,
+  binding: CodexAppServerThreadBinding,
+  dynamicToolsFingerprint: string,
+  releaseSubscription: (assertCurrent: () => void) => Promise<void>,
+): Promise<{ assertConfigured: () => void; assertCurrent: () => void; dispose: () => void }> {
+  const fail = (reason: string) =>
+    new Error(
+      `Cannot configure resumed Codex thread ${binding.threadId}: ${reason}. ` +
+        "The thread is preserved; continue it in native Codex or use /new for the current OpenClaw tools.",
+    );
+  const agentDir = resolveCodexThreadAgentDir(params);
+  const localHome = resolveCodexAppServerLocalHomeDir(params.appServer.start, agentDir);
+  if (
+    params.appServer.start.transport !== "stdio" ||
+    params.appServer.start.homeScope === "user" ||
+    path.resolve(localHome) !== resolveCodexAppServerHomeDir(agentDir) ||
+    binding.connectionScope === "supervision" ||
+    binding.preserveNativeModel === true
+  ) {
+    throw fail("configuration adoption requires an OpenClaw-owned local Codex home");
+  }
+  if (isCodexAppServerLiveThreadClaimed(params.client, binding.threadId)) {
+    throw fail("the thread is claimed by active work; stop that run before resuming");
+  }
+  // Codex can reuse a concurrently resumed child while ignoring overrides.
+  // Only an uninterrupted sole client lease makes the unload receipt conclusive.
+  const assertCurrent = captureExclusiveSharedCodexAppServerClient(params.client);
+  const { thread } = await params.client.request(
+    "thread/read",
+    { threadId: binding.threadId, includeTurns: false },
+    { signal: params.signal },
+  );
+  assertCurrent();
+  const statusType = thread.status?.type;
+  if (thread.id !== binding.threadId || (statusType !== "idle" && statusType !== "notLoaded")) {
+    throw fail("the native thread is not idle; wait for its current run to finish");
+  }
+  let unloaded = statusType === "notLoaded";
+  const dispose = params.client.addNotificationHandler((notification) => {
+    if (
+      notification.method === "thread/status/changed" &&
+      isJsonObject(notification.params) &&
+      notification.params.threadId === binding.threadId &&
+      isJsonObject(notification.params.status) &&
+      notification.params.status.type === "notLoaded"
+    ) {
+      unloaded = true;
+    }
+  });
+  try {
+    const rolloutPath = thread.path ?? binding.rolloutPath;
+    const metadata = rolloutPath
+      ? await readCodexSessionMeta(path.join(localHome, "sessions"), rolloutPath, binding.threadId)
+      : undefined;
+    if (!metadata) {
+      throw fail("its native tool catalog could not be read from the selected Codex home");
+    }
+    // Codex restores absent/null dynamic_tools as [], and thread/resume cannot
+    // replace that immutable catalog. Equality also rejects malformed tool shapes.
+    const recordedTools = metadata.dynamic_tools ?? [];
+    if (
+      !Array.isArray(recordedTools) ||
+      codexDynamicToolsFingerprint(recordedTools) !== dynamicToolsFingerprint
+    ) {
+      throw fail("its immutable native tool catalog does not match the current OpenClaw tools");
+    }
+    assertCurrent();
+    await releaseSubscription(assertCurrent);
+    assertCurrent();
+    return {
+      assertConfigured: () => {
+        assertCurrent();
+        // Codex 0.149.1 broadcasts notLoaded only after successful shutdown;
+        // a timeout can instead acknowledge resume while ignoring every override.
+        if (!unloaded) {
+          throw fail("Codex did not confirm unloading its previous configuration");
+        }
+      },
+      assertCurrent,
+      dispose,
+    };
+  } catch (error) {
+    dispose();
+    throw error;
+  }
+}

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -17,10 +17,7 @@ import {
 } from "./client.js";
 import { isMessageOnlyCodexSourceReply } from "./dynamic-tool-profile.js";
 import { markStartedCodexManagedThread } from "./managed-thread-store.js";
-import {
-  applyCodexNativeSkillIsolation,
-  type CodexNativeSkillIsolation,
-} from "./native-skill-isolation.js";
+import { applyCodexNativeSkillIsolation } from "./native-skill-isolation.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import {
   attestCodexPluginThreadApps,
@@ -33,11 +30,7 @@ import {
 } from "./plugin-thread-config.js";
 import { assertCodexThreadStartResponse } from "./protocol-validators.js";
 import type { CodexThread, JsonObject } from "./protocol.js";
-import type {
-  CodexAppServerBindingIdentity,
-  CodexAppServerContextEngineBinding,
-  CodexAppServerThreadBinding,
-} from "./session-binding.js";
+import type { CodexAppServerThreadBinding } from "./session-binding.js";
 import { isCodexAppServerStartSelectionChangedError } from "./shared-client.js";
 import {
   fingerprintCodexThreadConfig,
@@ -50,15 +43,12 @@ import {
   CodexThreadStartRequestError,
 } from "./thread-lifecycle-errors.js";
 import { buildStartedCodexThreadBinding } from "./thread-lifecycle-result.js";
-import type { CodexThreadLifecycleTimingTracker } from "./thread-lifecycle-timing.js";
 import type {
   CodexAppServerThreadLifecycleBinding,
   CodexStartOrResumeThreadParams,
+  CodexThreadRequestContext,
 } from "./thread-lifecycle-types.js";
-import {
-  resolveCodexAppServerModelProvider,
-  resolveCodexAppServerThreadModelSelection,
-} from "./thread-model-selection.js";
+import { resolveCodexAppServerModelProvider } from "./thread-model-selection.js";
 import {
   attestCodexRestrictedToolSurfaceMcpServersDisabled,
   buildThreadResumeParams,
@@ -66,35 +56,7 @@ import {
 } from "./thread-requests.js";
 import { resumeCodexAppServerThread } from "./thread-resume.js";
 
-type ThreadRequestContext = {
-  bindingIdentity: CodexAppServerBindingIdentity;
-  startModelSelection: ReturnType<typeof resolveCodexAppServerThreadModelSelection>;
-  startModelProvider?: string;
-  userMcpServersConfigPatch?: JsonObject;
-  dynamicToolsFingerprint: string;
-  dynamicToolsContainDeferred: boolean;
-  webSearchThreadConfigFingerprint?: string;
-  nativeSkillIsolationFingerprint?: string;
-  userMcpServersFingerprint?: string;
-  ringZeroConfigFingerprint?: string;
-  ringZeroClientInstanceId?: string;
-  networkProxyConfigFingerprint?: string;
-  contextEngineBinding?: CodexAppServerContextEngineBinding;
-  environmentSelectionFingerprint?: string;
-  hostSystemAgentActive: boolean;
-  ringZeroActive: boolean;
-  restrictedToolSurface: boolean;
-  restrictedToolSurfaceInheritedMcpServerNames: string[];
-  nativeSkillIsolation?: CodexNativeSkillIsolation;
-  lifecycleTiming: CodexThreadLifecycleTimingTracker;
-  normalizeBindingModelProvider: (
-    authProfileId: string | undefined,
-    modelProvider: string | undefined,
-  ) => string | undefined;
-  throwIfAborted: () => void;
-};
-
-type ResumeThreadContext = ThreadRequestContext & {
+type ResumeThreadContext = CodexThreadRequestContext & {
   binding: CodexAppServerThreadBinding;
   clearCurrentBinding: (operation: string) => Promise<void>;
   prebuiltPluginThreadConfig?: CodexPluginThreadConfig;
@@ -102,26 +64,28 @@ type ResumeThreadContext = ThreadRequestContext & {
     configPatch?: JsonObject;
     nativeHookRelayGeneration?: string;
   };
+  assertResumeConfiguration?: () => void;
+  assertResumeOwnership?: () => void;
 };
 
-type StartThreadContext = ThreadRequestContext & {
+type StartThreadContext = CodexThreadRequestContext & {
   prebuiltPluginThreadConfig?: CodexPluginThreadConfig;
   preserveExistingBinding: boolean;
   rotatedContextEngineBinding: boolean;
   replacementPredecessor?: CodexAppServerThreadBinding;
 };
 
-function resolveManagedThreadSourceHomeId(params: CodexStartOrResumeThreadParams): string {
+export function resolveCodexThreadAgentDir(params: CodexStartOrResumeThreadParams): string {
   const agentId = resolveSessionAgentIds({
     config: params.params.config,
     sessionKey: params.params.sessionKey,
     agentId: params.agentId ?? params.params.agentId,
   }).sessionAgentId;
-  const agentDir =
+  return (
     params.agentDir ??
     params.params.agentDir ??
-    resolveAgentDir(params.params.config ?? {}, agentId);
-  return codexCatalogHomeId(resolveCodexAppServerLocalHomeDir(params.appServer.start, agentDir));
+    resolveAgentDir(params.params.config ?? {}, agentId)
+  );
 }
 
 function resolveCodexThreadRolloutPath(thread: CodexThread): string | undefined {
@@ -245,12 +209,25 @@ export async function resumeExistingCodexThread(
         client: params.client,
         // Retiring the exact client keeps an indeterminate resume
         // subscription from ever re-entering the shared pool.
-        abandonClient:
-          params.abandonClient ?? (() => closeCodexStartupClientBestEffort(params.client)),
+        abandonClient: async () => {
+          context.assertResumeOwnership?.();
+          await (
+            params.abandonClient ?? (() => closeCodexStartupClientBestEffort(params.client))
+          )();
+        },
         request: resumeParams,
         signal: params.signal,
       }),
     );
+    context.assertResumeConfiguration?.();
+    if (resumeBinding.pendingResumeConfiguration) {
+      await attestCodexPluginThreadApps({
+        client: params.client,
+        threadId: response.thread.id,
+        appIds: context.prebuiltPluginThreadConfig?.provisionalAppIds ?? [],
+        signal: params.signal,
+      });
+    }
     if (
       ringZeroActive ||
       isMessageOnlyCodexSourceReply(params.params) ||
@@ -266,6 +243,7 @@ export async function resumeExistingCodexThread(
           ),
         );
       } catch (error) {
+        context.assertResumeOwnership?.();
         await (params.abandonClient ?? (() => closeCodexStartupClientBestEffort(params.client)))();
         throw new CodexRestrictedToolSurfaceAttestationError(error);
       }
@@ -280,6 +258,7 @@ export async function resumeExistingCodexThread(
       // Resume moves native subscription ownership to this physical client.
       // Keeping its previous client id disables warm reuse after every restart.
       clientId: resolveCodexAppServerClientInstanceId(params.client),
+      pendingResumeConfiguration: undefined,
       cwd: params.cwd,
       rolloutPath: resolveCodexThreadRolloutPath(response.thread) ?? resumeBinding.rolloutPath,
       authProfileId: boundAuthProfileId,
@@ -318,11 +297,11 @@ export async function resumeExistingCodexThread(
       environmentSelectionFingerprint,
     } satisfies Partial<Omit<CodexAppServerThreadBinding, "threadId">>;
     const committed = await lifecycleTiming.measure("thread-resume-write-binding", () =>
-      params.bindingStore.mutate(bindingIdentity, {
-        kind: "patch",
-        threadId: resumeBinding.threadId,
-        patch: resumePatch,
-      }),
+      params.bindingStore.mutate(
+        bindingIdentity,
+        { kind: "patch", threadId: resumeBinding.threadId, patch: resumePatch },
+        context.assertResumeConfiguration,
+      ),
     );
     if (!committed) {
       throw new CodexThreadBindingConflictError(
@@ -384,7 +363,9 @@ export async function resumeExistingCodexThread(
       throw error;
     }
     if (error instanceof CodexRestrictedToolSurfaceAttestationError) {
-      await clearCurrentBinding("retiring a failed restricted-tool-surface attestation");
+      if (!resumeBinding.pendingResumeConfiguration) {
+        await clearCurrentBinding("retiring a failed restricted-tool-surface attestation");
+      }
       throw error;
     }
     if (error instanceof CodexAdoptedThreadActiveError) {
@@ -401,9 +382,11 @@ export async function resumeExistingCodexThread(
     // resume, so the best-effort unsubscribe below is cosmetic for that
     // case. Only post-acceptance failures must prove the release.
     const resumeRejected = error instanceof CodexAppServerRpcError;
+    context.assertResumeOwnership?.();
     const subscriptionReleased = await unsubscribeCodexThreadBestEffort(params.client, {
       threadId: resumeBinding.threadId,
       timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+      assertCurrent: context.assertResumeOwnership,
     });
     if (
       !subscriptionReleased &&
@@ -416,7 +399,11 @@ export async function resumeExistingCodexThread(
         { cause: error },
       );
     }
-    if (isCodexAppServerConnectionClosedError(error) || params.signal?.aborted) {
+    if (
+      resumeBinding.pendingResumeConfiguration ||
+      isCodexAppServerConnectionClosedError(error) ||
+      params.signal?.aborted
+    ) {
       throw error;
     }
     embeddedAgentLog.warn("codex app-server thread resume failed; starting a new thread", {
@@ -642,7 +629,9 @@ export async function startFreshCodexThread(
         );
       }
     };
-    const managedSourceHomeId = resolveManagedThreadSourceHomeId(params);
+    const managedSourceHomeId = codexCatalogHomeId(
+      resolveCodexAppServerLocalHomeDir(params.appServer.start, resolveCodexThreadAgentDir(params)),
+    );
     await lifecycleTiming.measure("thread-start-mark-managed", () =>
       markStartedCodexManagedThread(params.bindingStore.managedThreads, {
         sourceHomeId: managedSourceHomeId,

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -1,6 +1,7 @@
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { isIncognitoSessionKey } from "../incognito-session.js";
 import { closeCodexStartupClientBestEffort } from "./attempt-client-cleanup.js";
+import { isCodexAppServerLiveThreadClaimed } from "./client-runtime.js";
 import { resolveCodexAppServerClientInstanceId } from "./client.js";
 import { applyCodexNativeSkillIsolation } from "./native-skill-isolation.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
@@ -14,12 +15,13 @@ import {
   createCodexSessionGenerationSupersededError,
   normalizeCodexAppServerBindingModelProvider,
   reclaimCurrentCodexSessionGeneration,
-  sessionBindingIdentity,
-  type CodexAppServerBindingIdentity,
   type CodexAppServerPendingSupervisionBranch,
   type CodexAppServerThreadBinding,
 } from "./session-binding.js";
-import { retainSharedCodexAppServerClientByInstanceId } from "./shared-client.js";
+import {
+  captureExclusiveSharedCodexAppServerClient,
+  retainSharedCodexAppServerClientByInstanceId,
+} from "./shared-client.js";
 import {
   isTransientWebSearchRestriction,
   shouldRecheckRecoverablePluginBinding,
@@ -32,6 +34,10 @@ import {
   areUserMcpServersFingerprintsCompatible,
   shouldStartTransientNoToolThread,
 } from "./thread-fingerprints.js";
+import {
+  resumePendingCodexThread,
+  withCodexThreadLifecycleBinding,
+} from "./thread-lifecycle-adoption.js";
 import { CodexThreadBindingConflictError } from "./thread-lifecycle-errors.js";
 import { resumeExistingCodexThread, startFreshCodexThread } from "./thread-lifecycle-io.js";
 import { prepareCodexThreadLifecyclePreflight } from "./thread-lifecycle-preflight.js";
@@ -53,13 +59,9 @@ export async function startOrResumeThread(
 ): Promise<CodexAppServerThreadLifecycleBinding> {
   const incognito = isIncognitoSessionKey(params.params.sessionKey);
   const clientId = resolveCodexAppServerClientInstanceId(params.client);
-  const bindingIdentity: CodexAppServerBindingIdentity = sessionBindingIdentity({
-    sessionId: params.params.sessionId,
-    sessionKey: params.params.sessionKey,
-    agentId: params.agentId ?? params.params.agentId,
-    config: params.params.config,
-  });
-  return await params.bindingStore.withLease(bindingIdentity, async () => {
+  return await withCodexThreadLifecycleBinding(params, async (bindingIdentity, currentBinding) => {
+    let binding = currentBinding;
+    const preflight = await prepareCodexThreadLifecyclePreflight(params);
     const {
       contextEngineBinding,
       dynamicToolsContainDeferred,
@@ -80,10 +82,7 @@ export async function startOrResumeThread(
       userMcpServersConfigPatch,
       userMcpServersFingerprint,
       webSearchThreadConfigFingerprint,
-    } = await prepareCodexThreadLifecyclePreflight(params);
-    let binding = await lifecycleTiming.measure("read-binding", () =>
-      params.bindingStore.read(bindingIdentity),
-    );
+    } = preflight;
     let replacementPredecessor: CodexAppServerThreadBinding | undefined;
     const initialBoundThreadId = binding?.threadId;
     const initialBoundClientId = binding?.clientId;
@@ -102,30 +101,46 @@ export async function startOrResumeThread(
     const releaseRetainedThread = async (
       threadId: string,
       ownerClientId = initialBoundClientId,
+      assertCurrent?: () => void,
     ) => {
       if (ownerClientId && ownerClientId !== clientId) {
         // Auth/runtime rotation selects a new physical client, but its map
         // cannot release a subscription owned by the previous app-server.
         const previousClient = retainSharedCodexAppServerClientByInstanceId(ownerClientId);
         if (!previousClient) {
-          return;
+          return false;
         }
         try {
-          await releaseCodexRetainedLiveThread({
+          const assertPrevious = assertCurrent
+            ? captureExclusiveSharedCodexAppServerClient(previousClient.client)
+            : undefined;
+          if (isCodexAppServerLiveThreadClaimed(previousClient.client, threadId)) {
+            throw new Error(`Codex thread ${threadId} is claimed by active work; stop it first.`);
+          }
+          return await releaseCodexRetainedLiveThread({
             client: previousClient.client,
             lifecycleTiming,
             threadId,
+            assertCurrent: assertCurrent
+              ? () => {
+                  assertCurrent();
+                  assertPrevious?.();
+                }
+              : undefined,
           });
         } finally {
           previousClient.release();
         }
-        return;
       }
-      await releaseCodexRetainedLiveThread({
+      if (isCodexAppServerLiveThreadClaimed(params.client, threadId)) {
+        throw new Error(`Codex thread ${threadId} is claimed by active work; stop it first.`);
+      }
+      return await releaseCodexRetainedLiveThread({
         client: params.client,
         abandonClient: params.abandonClient,
         lifecycleTiming,
         threadId,
+        assertCurrent,
       });
     };
     if (!binding && bindingIdentity.kind === "session" && bindingIdentity.sessionKey) {
@@ -244,6 +259,45 @@ export async function startOrResumeThread(
       }
       binding = undefined;
     };
+    const resolveRequestContext = () => {
+      const startModelSelection = resolveCodexAppServerThreadModelSelection({
+        provider: params.params.provider,
+        model: params.runtimeModelId ?? params.params.modelId,
+        binding,
+        authProfileId: params.params.authProfileId,
+        authProfileStore: params.params.authProfileStore,
+        agentDir: params.params.agentDir,
+        config: params.params.config,
+      });
+      return {
+        ...preflight,
+        bindingIdentity,
+        startModelSelection,
+        startModelProvider: startModelSelection.modelProvider,
+        normalizeBindingModelProvider,
+        throwIfAborted,
+      };
+    };
+    const transientDelegationRestriction = params.params.delegationCapability === "report_only";
+    const persistentWebSearchRestriction =
+      params.webSearchAllowed === false && params.persistentWebSearchAllowed === false;
+    const transientNativeToolRestriction =
+      params.nativeCodeModeEnabled === false && !persistentWebSearchRestriction;
+    const transientWebSearchRestriction = isTransientWebSearchRestriction(params);
+    if (binding?.pendingResumeConfiguration) {
+      return await resumePendingCodexThread(params, {
+        ...resolveRequestContext(),
+        binding,
+        clearCurrentBinding,
+        releaseRetainedThread: (threadId, assertCurrent) =>
+          releaseRetainedThread(threadId, initialBoundClientId, assertCurrent),
+        transientRestriction:
+          transientDelegationRestriction ||
+          transientNativeToolRestriction ||
+          transientWebSearchRestriction,
+      });
+    }
+
     if (
       binding?.threadId &&
       !restrictedToolSurface &&
@@ -312,19 +366,10 @@ export async function startOrResumeThread(
       await clearCurrentBinding("rotating a GPT-5.6 multi-agent thread binding");
       binding = undefined;
     }
-    const startModelSelection = resolveCodexAppServerThreadModelSelection({
-      provider: params.params.provider,
-      model: params.runtimeModelId ?? params.params.modelId,
-      binding,
-      authProfileId: params.params.authProfileId,
-      authProfileStore: params.params.authProfileStore,
-      agentDir: params.params.agentDir,
-      config: params.params.config,
-    });
-    const startModelProvider = startModelSelection.modelProvider;
+    const requestContext = resolveRequestContext();
+    const { startModelSelection, startModelProvider } = requestContext;
     // Capability read failures use managed search for this turn but must not
     // create a binding that later looks like a confirmed provider-policy change.
-    const transientDelegationRestriction = params.params.delegationCapability === "report_only";
     let preserveExistingBinding =
       transientDelegationRestriction ||
       (!ringZeroActive &&
@@ -335,11 +380,6 @@ export async function startOrResumeThread(
     const webSearchBindingChanged =
       binding?.threadId &&
       binding.webSearchThreadConfigFingerprint !== webSearchThreadConfigFingerprint;
-    const persistentWebSearchRestriction =
-      params.webSearchAllowed === false && params.persistentWebSearchAllowed === false;
-    const transientNativeToolRestriction =
-      params.nativeCodeModeEnabled === false && !persistentWebSearchRestriction;
-    const transientWebSearchRestriction = isTransientWebSearchRestriction(params);
     const explicitTransientWebSearchRestriction =
       params.webSearchAllowed === false &&
       params.persistentWebSearchAllowed !== false &&
@@ -645,29 +685,8 @@ export async function startOrResumeThread(
         // leaves; resume_running_thread shuts down the old cached session.
         await releaseRetainedThread(binding.threadId);
         const resumed = await resumeExistingCodexThread(params, {
+          ...requestContext,
           binding,
-          bindingIdentity,
-          startModelSelection,
-          startModelProvider,
-          userMcpServersConfigPatch,
-          dynamicToolsFingerprint,
-          dynamicToolsContainDeferred,
-          webSearchThreadConfigFingerprint,
-          nativeSkillIsolationFingerprint,
-          userMcpServersFingerprint,
-          ringZeroConfigFingerprint,
-          ringZeroClientInstanceId,
-          networkProxyConfigFingerprint,
-          contextEngineBinding,
-          environmentSelectionFingerprint,
-          hostSystemAgentActive,
-          ringZeroActive,
-          restrictedToolSurface,
-          restrictedToolSurfaceInheritedMcpServerNames,
-          nativeSkillIsolation,
-          lifecycleTiming,
-          normalizeBindingModelProvider,
-          throwIfAborted,
           clearCurrentBinding,
           prebuiltFinalConfigPatch: warmReuse.prebuiltFinalConfigPatch,
           prebuiltPluginThreadConfig,
@@ -682,28 +701,7 @@ export async function startOrResumeThread(
       await releaseRetainedThread(initialBoundThreadId);
     }
     const started = await startFreshCodexThread(params, {
-      bindingIdentity,
-      startModelSelection,
-      startModelProvider,
-      userMcpServersConfigPatch,
-      dynamicToolsFingerprint,
-      dynamicToolsContainDeferred,
-      webSearchThreadConfigFingerprint,
-      nativeSkillIsolationFingerprint,
-      userMcpServersFingerprint,
-      ringZeroConfigFingerprint,
-      ringZeroClientInstanceId,
-      networkProxyConfigFingerprint,
-      contextEngineBinding,
-      environmentSelectionFingerprint,
-      hostSystemAgentActive,
-      ringZeroActive,
-      restrictedToolSurface,
-      restrictedToolSurfaceInheritedMcpServerNames,
-      nativeSkillIsolation,
-      lifecycleTiming,
-      normalizeBindingModelProvider,
-      throwIfAborted,
+      ...requestContext,
       prebuiltPluginThreadConfig,
       preserveExistingBinding,
       rotatedContextEngineBinding,

--- a/extensions/codex/src/app-server/thread-lifecycle-types.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-types.ts
@@ -2,11 +2,21 @@ import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "ope
 import type { CodexAppServerLiveThreadOwnership } from "./client-runtime.js";
 import type { CodexAppServerClient } from "./client.js";
 import type { CodexAppServerRuntimeOptions } from "./config.js";
+import type { CodexNativeSkillIsolation } from "./native-skill-isolation.js";
 import type { CodexPluginThreadConfig } from "./plugin-thread-config.js";
 import type { CodexDynamicToolSpec, CodexTurnEnvironmentParams, JsonObject } from "./protocol.js";
-import type { CodexAppServerBindingStore, CodexAppServerThreadBinding } from "./session-binding.js";
+import type {
+  CodexAppServerBindingIdentity,
+  CodexAppServerBindingStore,
+  CodexAppServerContextEngineBinding,
+  CodexAppServerThreadBinding,
+} from "./session-binding.js";
 import type { CodexContextEngineThreadBootstrapProjection } from "./thread-context-engine.js";
-import type { CodexThreadLifecycleTimingOptions } from "./thread-lifecycle-timing.js";
+import type {
+  CodexThreadLifecycleTimingTracker,
+  CodexThreadLifecycleTimingOptions,
+} from "./thread-lifecycle-timing.js";
+import type { resolveCodexAppServerThreadModelSelection } from "./thread-model-selection.js";
 import type { CodexNativeWebSearchSupport } from "./web-search.js";
 
 type CodexAppServerThreadLifecycle = {
@@ -85,4 +95,32 @@ export type CodexStartOrResumeThreadParams = {
   signal?: AbortSignal;
   timing?: CodexThreadLifecycleTimingOptions;
   hostSystemAgentActive?: boolean;
+};
+
+export type CodexThreadRequestContext = {
+  bindingIdentity: CodexAppServerBindingIdentity;
+  startModelSelection: ReturnType<typeof resolveCodexAppServerThreadModelSelection>;
+  startModelProvider?: string;
+  userMcpServersConfigPatch?: JsonObject;
+  dynamicToolsFingerprint: string;
+  dynamicToolsContainDeferred: boolean;
+  webSearchThreadConfigFingerprint?: string;
+  nativeSkillIsolationFingerprint?: string;
+  userMcpServersFingerprint?: string;
+  ringZeroConfigFingerprint?: string;
+  ringZeroClientInstanceId?: string;
+  networkProxyConfigFingerprint?: string;
+  contextEngineBinding?: CodexAppServerContextEngineBinding;
+  environmentSelectionFingerprint?: string;
+  hostSystemAgentActive: boolean;
+  ringZeroActive: boolean;
+  restrictedToolSurface: boolean;
+  restrictedToolSurfaceInheritedMcpServerNames: string[];
+  nativeSkillIsolation?: CodexNativeSkillIsolation;
+  lifecycleTiming: CodexThreadLifecycleTimingTracker;
+  normalizeBindingModelProvider: (
+    authProfileId: string | undefined,
+    modelProvider: string | undefined,
+  ) => string | undefined;
+  throwIfAborted: () => void;
 };

--- a/extensions/codex/src/app-server/thread-lifecycle-warm.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-warm.ts
@@ -2,9 +2,13 @@ import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
   closeCodexStartupClientBestEffort,
   CodexAppServerUnsafeSubscriptionError,
+  isCodexAppServerUnsafeSubscriptionError,
   unsubscribeCodexThreadBestEffort,
 } from "./attempt-client-cleanup.js";
-import { consumeCodexAppServerLiveThread } from "./client-runtime.js";
+import {
+  consumeCodexAppServerLiveThread,
+  releaseCodexAppServerLiveThread,
+} from "./client-runtime.js";
 import type { CodexAppServerClient } from "./client.js";
 import { applyCodexNativeSkillIsolation } from "./native-skill-isolation.js";
 import {
@@ -61,6 +65,7 @@ type CodexLiveThreadReleaseParams = {
   lifecycleTiming: CodexThreadLifecycleTimingTracker;
   threadId: string;
   cause?: unknown;
+  assertCurrent?: () => void;
 };
 
 /** Preserves the caller's abort reason across thread ownership transitions. */
@@ -89,25 +94,41 @@ export async function releaseCodexConsumedLiveThread(
     unsubscribeCodexThreadBestEffort(options.client, {
       threadId: options.threadId,
       timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+      assertCurrent: options.assertCurrent,
     }),
   );
   if (released) {
     return;
   }
+  return await abandonCodexLiveThreadRelease(options, options.cause);
+}
+
+async function abandonCodexLiveThreadRelease(
+  options: CodexLiveThreadReleaseParams,
+  cause?: unknown,
+): Promise<never> {
+  options.assertCurrent?.();
   await (options.abandonClient ?? (() => closeCodexStartupClientBestEffort(options.client)))();
   throw new CodexAppServerUnsafeSubscriptionError(
     `Codex retained thread subscription could not be released: ${options.threadId}`,
-    options.cause !== undefined ? { cause: options.cause } : undefined,
+    cause !== undefined ? { cause } : undefined,
   );
 }
 
-/** Transfers retained-slot ownership before unconditionally releasing it. */
+/** Releases through the retained owner, preserving its guarded callback and rollback. */
 export async function releaseCodexRetainedLiveThread(
   options: CodexLiveThreadReleaseParams,
-): Promise<void> {
-  if (await consumeCodexAppServerLiveThread(options.client, options.threadId)) {
-    // An abort must not leave a consumed subscription orphaned on the client.
-    await releaseCodexConsumedLiveThread(options);
+): Promise<boolean> {
+  try {
+    return await options.lifecycleTiming.measure("retained-thread-unsubscribe", () =>
+      releaseCodexAppServerLiveThread(options.client, options.threadId, options.assertCurrent),
+    );
+  } catch (error) {
+    // An owner callback may already have retired the client; do not close it twice.
+    if (isCodexAppServerUnsafeSubscriptionError(error)) {
+      throw error;
+    }
+    return await abandonCodexLiveThreadRelease(options, error);
   }
 }
 

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -1,14 +1,18 @@
 // Codex tests cover thread lifecycle.binding plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
+import { resumeThread } from "../command-handler-bindings.js";
+import { resolveCodexCommandDeps } from "../command-handler-deps.js";
 import {
+  claimCodexAppServerLiveThread,
   ensureCodexAppServerClientRuntime,
   retainCodexAppServerLiveThread,
 } from "./client-runtime.js";
-import { CodexAppServerRpcError } from "./client.js";
+import { CodexAppServerClient, CodexAppServerRpcError } from "./client.js";
 import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
-import type { CodexDynamicToolFunctionSpec } from "./protocol.js";
+import type { CodexDynamicToolFunctionSpec, JsonValue } from "./protocol.js";
 import {
   createParams as createRunAttemptParams,
   setupRunAttemptTestHooks,
@@ -21,11 +25,17 @@ import {
   testCodexAppServerBindingStore,
   writeCodexAppServerBinding as writeRawCodexAppServerBinding,
 } from "./session-binding.test-helpers.js";
+import {
+  getLeasedSharedCodexAppServerClient,
+  releaseLeasedSharedCodexAppServerClient,
+  retainSharedCodexAppServerClientIfCurrent,
+} from "./shared-client.js";
 import { fingerprintEnvironmentSelection } from "./thread-fingerprints.js";
 import {
   buildThreadResumeParams,
   startOrResumeThread as startOrResumeThreadImpl,
 } from "./thread-lifecycle.js";
+import { withCodexAppServerThreadMutation } from "./thread-ownership.js";
 
 function startOrResumeThread(
   params: Omit<Parameters<typeof startOrResumeThreadImpl>[0], "bindingStore">,
@@ -286,6 +296,163 @@ function createTwoCalendarAppPolicyContext() {
     pluginAppIds: {
       "google-calendar": ["google-calendar-app", "google-calendar-secondary-app"],
     },
+  };
+}
+
+async function createManualResumeFixture(
+  options: {
+    active?: boolean;
+    cold?: boolean;
+    receipt?: "none" | "stale" | "unrelated" | "malformed";
+    dynamicTools?: CodexDynamicToolFunctionSpec[];
+    recordedTools?: JsonValue;
+    missingMetadata?: boolean;
+    omitCatalog?: boolean;
+    competingLease?: "read" | "release" | "resume";
+  } = {},
+) {
+  const dynamicTools = options.dynamicTools ?? [];
+  vi.stubEnv("HOME", tempDir);
+  vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tempDir, "isolated-state"));
+  const sessionFile = path.join(tempDir, "manual-resume-session.jsonl");
+  const workspaceDir = path.join(tempDir, "manual-resume-workspace");
+  const agentDir = path.join(tempDir, "agent");
+  const threadId = "thread-manual-resume";
+  const rolloutPath = path.join(agentDir, "codex-home", "sessions", `rollout-${threadId}.jsonl`);
+  await fs.mkdir(path.dirname(rolloutPath), { recursive: true });
+  await fs.writeFile(
+    rolloutPath,
+    `${JSON.stringify({ type: "session_meta", payload: { id: threadId, ...(options.omitCatalog ? {} : { dynamic_tools: options.recordedTools ?? dynamicTools }) } })}\n`,
+  );
+  if (options.missingMetadata) {
+    await fs.rm(rolloutPath);
+  }
+  const response = threadStartResult(threadId, { cwd: workspaceDir });
+  const thread = { ...response.thread, path: rolloutPath };
+  let resumes = 0;
+  const compete = () => {
+    // A sibling can start and finish between reads; sole ownership at the
+    // final snapshot must not erase that intervening native runtime activity.
+    const release = retainSharedCodexAppServerClientIfCurrent(harness.client);
+    expect(release).toBeTypeOf("function");
+    release?.();
+  };
+  const harness = createFakeCodexAppServerClient(async (method: string) => {
+    if (method === "skills/list") {
+      return { data: [{ cwd: workspaceDir, errors: [], skills: [] }] };
+    }
+    if (method === "thread/read") {
+      if (options.competingLease === "read") {
+        compete();
+      }
+      if (options.receipt === "stale") {
+        await harness.notify({
+          method: "thread/status/changed",
+          params: { threadId, status: { type: "notLoaded" } },
+        });
+      }
+      return {
+        thread: {
+          ...thread,
+          status: options.active
+            ? { type: "active", activeFlags: [] }
+            : { type: options.cold ? "notLoaded" : "idle" },
+        },
+      };
+    }
+    if (method === "thread/unsubscribe") {
+      if (options.competingLease === "release") {
+        compete();
+      }
+      return { status: "unsubscribed" };
+    }
+    if (method === "thread/resume") {
+      if (resumes > 0 && options.competingLease === "resume") {
+        compete();
+      }
+      if (resumes++ > 0 && options.receipt !== "none" && options.receipt !== "stale") {
+        await harness.notify({
+          method: "thread/status/changed",
+          params: {
+            threadId: options.receipt === "unrelated" ? "other-thread" : threadId,
+            status: options.receipt === "malformed" ? null : { type: "notLoaded" },
+          },
+        });
+      }
+      return { ...response, thread };
+    }
+    throw new Error(`unexpected method: ${method}`);
+  });
+  const { client } = harness;
+  Object.assign(client, {
+    initialize: async () => undefined,
+    addTransportExitHandler: () => () => undefined,
+    setThreadSessionRequestGuard: () => undefined,
+    close: () => harness.close(),
+  });
+  const start = vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(client);
+  try {
+    await getLeasedSharedCodexAppServerClient({
+      startOptions: { ...createThreadLifecycleAppServerOptions().start, command: process.execPath },
+      authProfileId: null,
+      agentDir,
+      config: {},
+    });
+  } finally {
+    start.mockRestore();
+  }
+  const params = { ...createParams(sessionFile, workspaceDir), agentDir };
+  registerCodexTestSessionIdentity(sessionFile, params.sessionId, params.sessionKey);
+  await resumeThread(
+    resolveCodexCommandDeps({
+      bindingStore: testCodexAppServerBindingStore,
+      codexControlRequest: async (_pluginConfig, method, requestParams, requestOptions) => {
+        const result = await client.request<JsonValue>(method, requestParams);
+        await requestOptions?.onResponse?.(result, client, { authProfileId: undefined });
+        return result;
+      },
+    }),
+    {
+      channel: "test",
+      isAuthorizedSender: true,
+      senderIsOwner: true,
+      commandBody: `/codex resume ${threadId}`,
+      config: {},
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      sessionFile,
+      requestConversationBinding: async () => ({ status: "error", message: "unused" }),
+      detachConversationBinding: async () => ({ removed: false }),
+      getCurrentConversationBinding: async () => null,
+    },
+    undefined,
+    [threadId],
+  );
+  const common = {
+    client,
+    params,
+    cwd: workspaceDir,
+    dynamicTools,
+    appServer: createThreadLifecycleAppServerOptions(),
+    userMcpServersEnabled: false,
+  };
+  return {
+    ...harness,
+    close: () => {
+      releaseLeasedSharedCodexAppServerClient(client);
+      harness.close();
+    },
+    common,
+    sessionFile,
+    threadId,
+    identity: {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    },
+    start: (overrides: Partial<Parameters<typeof startOrResumeThread>[0]> = {}) =>
+      startOrResumeThread({ ...common, ...overrides }),
   };
 }
 
@@ -671,51 +838,194 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
   });
 
-  it("releases an unverified manual-resume owner before applying canonical harness overrides", async () => {
-    const sessionFile = path.join(tempDir, "manual-resume-session.jsonl");
-    const workspaceDir = path.join(tempDir, "manual-resume-workspace");
-    await writeCodexAppServerBinding(sessionFile, {
-      threadId: "thread-manual-resume",
-      clientId: "client-manual-resume",
-      cwd: workspaceDir,
-    });
-    const request = vi.fn(async (method: string) => {
-      if (method === "thread/unsubscribe") {
-        return {};
+  it.each([
+    {
+      label: "loaded native thread",
+      options: { dynamicTools: [createNamedDynamicTool("example")] },
+    },
+    {
+      label: "cold native thread with no stored tools",
+      options: { cold: true, omitCatalog: true, receipt: "none" as const },
+    },
+  ])(
+    "configures the actual manual-resume binding without replacing its native thread: $label",
+    async ({ options }) => {
+      const fixture = await createManualResumeFixture(options);
+      try {
+        const resumed = await fixture.start();
+        expect(resumed).toMatchObject({
+          threadId: fixture.threadId,
+          clientId: fixture.client.getInstanceId(),
+          lifecycle: { action: "resumed" },
+        });
+        expect(
+          (await readCodexAppServerBinding(fixture.sessionFile))?.pendingResumeConfiguration,
+        ).toBeUndefined();
+        expect(
+          fixture.request.mock.calls
+            .map(([method]) => method)
+            .filter((method) => method !== "skills/list"),
+        ).toEqual(["thread/resume", "thread/read", "thread/unsubscribe", "thread/resume"]);
+      } finally {
+        fixture.close();
       }
-      if (method === "thread/resume") {
-        return threadStartResult("thread-manual-resume");
+    },
+  );
+
+  it.each([
+    { options: { receipt: "none" as const }, error: "did not confirm unloading" },
+    { options: { receipt: "unrelated" as const }, error: "did not confirm unloading" },
+    { options: { receipt: "stale" as const }, error: "did not confirm unloading" },
+    { options: { receipt: "malformed" as const }, error: "did not confirm unloading" },
+    { options: { missingMetadata: true }, error: "tool catalog could not be read" },
+    { options: { recordedTools: { invalid: true } }, error: "immutable native tool catalog" },
+    {
+      options: { recordedTools: [createNamedDynamicTool("old-tool")] },
+      error: "immutable native tool catalog",
+    },
+    { options: { active: true }, error: "native thread is not idle" },
+  ])(
+    "preserves pending manual resume when native configuration cannot be attested: $options",
+    async ({ options, error }) => {
+      const fixture = await createManualResumeFixture(options);
+      const before = await readCodexAppServerBinding(fixture.sessionFile);
+      const handlers = fixture.notifications.length;
+      try {
+        await expect(fixture.start()).rejects.toThrow(error);
+        expect(await readCodexAppServerBinding(fixture.sessionFile)).toEqual(before);
+        expect(fixture.request.mock.calls.some(([method]) => method === "thread/start")).toBe(
+          false,
+        );
+        expect(fixture.notifications).toHaveLength(handlers);
+      } finally {
+        fixture.close();
       }
-      throw new Error(`unexpected method: ${method}`);
-    });
-    const client = {
-      getInstanceId: () => "client-manual-resume",
-      request,
-      addNotificationHandler: () => () => undefined,
-      addRequestHandler: () => () => undefined,
-      addCloseHandler: () => () => undefined,
-    } as never;
-    ensureCodexAppServerClientRuntime(client, { agentDir: workspaceDir });
-    await retainCodexAppServerLiveThread(client, "thread-manual-resume");
+    },
+  );
 
-    const resumed = await startOrResumeThread({
-      client,
-      params: createParams(sessionFile, workspaceDir),
-      cwd: workspaceDir,
-      dynamicTools: [],
-      appServer: createThreadLifecycleAppServerOptions(),
-      userMcpServersEnabled: false,
-    });
+  it.each(["claimed", "sibling"] as const)(
+    "does not unsubscribe a pending manual-resume thread owned by %s work",
+    async (owner) => {
+      const fixture = await createManualResumeFixture();
+      try {
+        if (owner === "claimed") {
+          await claimCodexAppServerLiveThread(fixture.client, fixture.threadId);
+        } else {
+          await testCodexAppServerBindingStore.mutate(
+            { kind: "conversation", bindingId: "surviving-conversation" },
+            {
+              kind: "set",
+              binding: {
+                threadId: fixture.threadId,
+                clientId: fixture.client.getInstanceId(),
+                cwd: fixture.common.cwd,
+              },
+            },
+          );
+        }
+        const before = await readCodexAppServerBinding(fixture.sessionFile);
+        await expect(fixture.start()).rejects.toThrow(
+          owner === "claimed" ? "claimed by active work" : "owned by another",
+        );
+        expect(await readCodexAppServerBinding(fixture.sessionFile)).toEqual(before);
+        expect(
+          fixture.request.mock.calls
+            .map(([method]) => method)
+            .filter((method) => method !== "skills/list"),
+        ).toEqual(["thread/resume"]);
+      } finally {
+        fixture.close();
+      }
+    },
+  );
 
-    expect(resumed).toMatchObject({
-      threadId: "thread-manual-resume",
-      clientId: "client-manual-resume",
-      lifecycle: { action: "resumed" },
+  it.each(["remote", "user-home", "transient", "unknown-search"] as const)(
+    "preserves pending manual resume outside its supported configuration scope: %s",
+    async (scope) => {
+      const fixture = await createManualResumeFixture();
+      try {
+        const overrides: Partial<Parameters<typeof startOrResumeThread>[0]> =
+          scope === "transient"
+            ? { nativeCodeModeEnabled: false }
+            : scope === "unknown-search"
+              ? { nativeProviderWebSearchSupport: "unknown" }
+              : {
+                  appServer: {
+                    ...fixture.common.appServer,
+                    start: {
+                      ...fixture.common.appServer.start,
+                      ...(scope === "remote" ? { transport: "websocket" } : { homeScope: "user" }),
+                    },
+                  },
+                };
+        const before = await readCodexAppServerBinding(fixture.sessionFile);
+        await expect(fixture.start(overrides)).rejects.toThrow(
+          "Cannot configure resumed Codex thread",
+        );
+        expect(await readCodexAppServerBinding(fixture.sessionFile)).toEqual(before);
+        expect(
+          fixture.request.mock.calls.some(
+            ([method]) => method === "thread/start" || method === "thread/unsubscribe",
+          ),
+        ).toBe(false);
+      } finally {
+        fixture.close();
+      }
+    },
+  );
+
+  it.each(["read", "release", "resume"] as const)(
+    "does not certify resume configuration after a competing client lease during %s",
+    async (competingLease) => {
+      const fixture = await createManualResumeFixture({ cold: true, competingLease });
+      const before = await readCodexAppServerBinding(fixture.sessionFile);
+      try {
+        await expect(fixture.start()).rejects.toThrow("another runner");
+        expect(await readCodexAppServerBinding(fixture.sessionFile)).toEqual(before);
+        expect(fixture.request.mock.calls.some(([method]) => method === "thread/start")).toBe(
+          false,
+        );
+        expect(
+          fixture.request.mock.calls.filter(([method]) => method === "thread/unsubscribe"),
+        ).toHaveLength(competingLease === "read" ? 0 : 1);
+      } finally {
+        fixture.close();
+      }
+    },
+  );
+
+  it("rejects a pending binding deleted while waiting for the native owner queue", async () => {
+    const fixture = await createManualResumeFixture();
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const blocker = withCodexAppServerThreadMutation(fixture.threadId, async () => {
+      entered.resolve();
+      await release.promise;
     });
-    expect(request.mock.calls.map(([method]) => method)).toEqual([
-      "thread/unsubscribe",
-      "thread/resume",
-    ]);
+    await entered.promise;
+    const read = vi.spyOn(testCodexAppServerBindingStore, "read");
+    const pendingRead = createDeferred<void>();
+    read.mockImplementationOnce(async () => {
+      const binding = await readCodexAppServerBinding(fixture.sessionFile);
+      pendingRead.resolve();
+      return binding;
+    });
+    const starting = fixture.start();
+    try {
+      await pendingRead.promise;
+      await testCodexAppServerBindingStore.mutate(fixture.identity, {
+        kind: "clear",
+        threadId: fixture.threadId,
+      });
+      release.resolve();
+      await expect(starting).rejects.toThrow("acquiring a pending resume configuration");
+      expect(fixture.request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+    } finally {
+      release.resolve();
+      await blocker;
+      read.mockRestore();
+      fixture.close();
+    }
   });
 
   it("reuses an isolated retained thread without dropping native skill isolation", async () => {

--- a/extensions/codex/src/app-server/thread-ownership.ts
+++ b/extensions/codex/src/app-server/thread-ownership.ts
@@ -21,6 +21,14 @@ import { retainSharedCodexAppServerClientByInstanceId } from "./shared-client.js
 
 const nativeThreadOwners = new KeyedAsyncQueue();
 
+/** Serialize connection-scoped unsubscribe with attach/resume of the same native thread. */
+export async function withCodexAppServerThreadMutation<T>(
+  threadId: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  return await nativeThreadOwners.enqueue(`thread:${threadId}`, run);
+}
+
 /** Codex subscriptions belong to a physical connection, not the native thread ID alone. */
 export function isSameCodexAppServerThreadOwner(
   current: Pick<CodexAppServerThreadBinding, "threadId" | "clientId"> | undefined,
@@ -41,7 +49,7 @@ export async function withExclusiveCodexAppServerThread<T>(params: {
   threadId: string;
   run: () => Promise<T>;
 }): Promise<T> {
-  return await nativeThreadOwners.enqueue(`thread:${params.threadId}`, async () => {
+  return await withCodexAppServerThreadMutation(params.threadId, async () => {
     if (await params.bindingStore.hasOtherThreadOwner(params.threadId, params.identity)) {
       throw new Error(
         `Codex thread ${params.threadId} is owned by another OpenClaw session or conversation.`,
@@ -69,12 +77,14 @@ export async function retainCodexAppServerBindingSubscription(
     client,
     threadId,
     ownership?.release ??
-      (async (releasedThreadId) => {
+      (async (releasedThreadId, assertCurrent) => {
         const unsubscribed = await unsubscribeCodexThreadBestEffort(client, {
           threadId: releasedThreadId,
           timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+          assertCurrent,
         });
         if (!unsubscribed) {
+          assertCurrent?.();
           await closeCodexStartupClientBestEffort(client);
           throw new CodexAppServerUnsafeSubscriptionError(
             `Codex thread subscription could not be released: ${releasedThreadId}`,

--- a/extensions/codex/src/command-handler-bindings.ts
+++ b/extensions/codex/src/command-handler-bindings.ts
@@ -344,6 +344,7 @@ export async function resumeThread(
         }
         const currentBinding = await deps.bindingStore.read(identity);
         assertCodexBindingMayBeReplaced(currentBinding, "attaching a different resumed thread");
+        let pendingResumeConfiguration = false;
         const commitResumedThread = async (
           value: unknown,
           client: CodexAppServerClient,
@@ -376,6 +377,13 @@ export async function resumeThread(
             threadId: effectiveThreadId,
             clientId,
           });
+          const sameThreadBinding =
+            bindingBeforeCommit?.threadId === effectiveThreadId ? bindingBeforeCommit : undefined;
+          pendingResumeConfiguration =
+            sameThreadBinding?.preserveNativeModel !== true &&
+            (!sameThreadBinding?.dynamicToolsFingerprint ||
+              !sameThreadBinding.webSearchThreadConfigFingerprint ||
+              sameThreadBinding.pendingResumeConfiguration === true);
           let retained = false;
           try {
             const knownOwnership = sameOwner
@@ -397,10 +405,12 @@ export async function resumeThread(
             const committed = await deps.bindingStore.mutate(identity, {
               kind: "set",
               binding: {
-                ...(bindingBeforeCommit?.threadId === effectiveThreadId ? bindingBeforeCommit : {}),
+                ...sameThreadBinding,
                 threadId: effectiveThreadId,
                 clientId,
                 cwd: resumedCwd,
+                rolloutPath: response.thread.path ?? sameThreadBinding?.rolloutPath,
+                pendingResumeConfiguration: pendingResumeConfiguration ? true : undefined,
                 authProfileId,
                 model: response.model,
                 modelProvider,
@@ -436,7 +446,7 @@ export async function resumeThread(
         );
         return `Attached this OpenClaw session to Codex thread ${formatCodexDisplayText(
           normalizedThreadId,
-        )}.`;
+        )}.${pendingResumeConfiguration ? " The next turn will validate its tools and apply this session's configuration before continuing." : ""}`;
       }),
   });
 }

--- a/extensions/codex/src/command-handler-bindings.ts
+++ b/extensions/codex/src/command-handler-bindings.ts
@@ -5,7 +5,6 @@ import {
 } from "openclaw/plugin-sdk/model-session-runtime";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
-import { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-bridge.js";
 import { consumeCodexAppServerLiveThread } from "./app-server/client-runtime.js";
 import type { CodexAppServerClient } from "./app-server/client.js";
 import { isCodexFastServiceTier } from "./app-server/config.js";
@@ -345,13 +344,11 @@ export async function resumeThread(
         }
         const currentBinding = await deps.bindingStore.read(identity);
         assertCodexBindingMayBeReplaced(currentBinding, "attaching a different resumed thread");
-        const authProfileId = resolveCodexAppServerAuthProfileIdForAgent({
-          authProfileId: currentBinding?.authProfileId,
-          agentDir: scope.agentDir,
-          config: ctx.config,
-        });
-        let committedResponse = false;
-        const commitResumedThread = async (value: unknown, client?: CodexAppServerClient) => {
+        const commitResumedThread = async (
+          value: unknown,
+          client: CodexAppServerClient,
+          { authProfileId }: { authProfileId?: string },
+        ) => {
           const response = assertCodexThreadResumeResponse(value);
           const effectiveThreadId = response.thread.id;
           if (effectiveThreadId !== normalizedThreadId) {
@@ -374,27 +371,23 @@ export async function resumeThread(
             bindingBeforeCommit,
             "committing a different resumed thread",
           );
-          const clientId = client?.getInstanceId();
-          const sameOwner = client
-            ? isSameCodexAppServerThreadOwner(bindingBeforeCommit, {
-                threadId: effectiveThreadId,
-                clientId,
-              })
-            : bindingBeforeCommit?.threadId === effectiveThreadId;
+          const clientId = client.getInstanceId();
+          const sameOwner = isSameCodexAppServerThreadOwner(bindingBeforeCommit, {
+            threadId: effectiveThreadId,
+            clientId,
+          });
           let retained = false;
           try {
-            if (client) {
-              const knownOwnership = sameOwner
-                ? await consumeCodexAppServerLiveThread(client, effectiveThreadId)
-                : undefined;
-              retained = await retainCodexAppServerBindingSubscription(
-                client,
-                effectiveThreadId,
-                knownOwnership,
-              );
-              if (!retained) {
-                throw new Error("Codex resumed thread lost its native subscription owner.");
-              }
+            const knownOwnership = sameOwner
+              ? await consumeCodexAppServerLiveThread(client, effectiveThreadId)
+              : undefined;
+            retained = await retainCodexAppServerBindingSubscription(
+              client,
+              effectiveThreadId,
+              knownOwnership,
+            );
+            if (!retained) {
+              throw new Error("Codex resumed thread lost its native subscription owner.");
             }
             if (bindingBeforeCommit && !sameOwner) {
               // The old row must remain authoritative until its subscription
@@ -406,7 +399,7 @@ export async function resumeThread(
               binding: {
                 ...(bindingBeforeCommit?.threadId === effectiveThreadId ? bindingBeforeCommit : {}),
                 threadId: effectiveThreadId,
-                ...(clientId ? { clientId } : {}),
+                clientId,
                 cwd: resumedCwd,
                 authProfileId,
                 model: response.model,
@@ -418,14 +411,13 @@ export async function resumeThread(
               throw new Error("Codex thread binding changed while attaching the resumed thread.");
             }
           } catch (error) {
-            if (client && !sameOwner) {
+            if (!sameOwner) {
               await rollbackCodexAppServerBindingSubscription(client, effectiveThreadId, retained);
             }
             throw error;
           }
-          committedResponse = true;
         };
-        const response = await deps.codexControlRequest(
+        await deps.codexControlRequest(
           pluginConfig,
           CODEX_CONTROL_METHODS.resumeThread,
           {
@@ -434,16 +426,14 @@ export async function resumeThread(
           },
           {
             config: ctx.config,
+            agentId: scope.agentId,
             agentDir: scope.agentDir,
-            authProfileId,
+            authProfileId: currentBinding?.authProfileId,
             sessionKey: ctx.sessionKey,
             sessionId: ctx.sessionId,
             onResponse: commitResumedThread,
           },
         );
-        if (!committedResponse) {
-          await commitResumedThread(response);
-        }
         return `Attached this OpenClaw session to Codex thread ${formatCodexDisplayText(
           normalizedThreadId,
         )}.`;

--- a/extensions/codex/src/command-rpc.test.ts
+++ b/extensions/codex/src/command-rpc.test.ts
@@ -6,7 +6,7 @@ import {
   replaceRuntimeAuthProfileStoreSnapshots,
   type AuthProfileStore,
 } from "openclaw/plugin-sdk/agent-runtime";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   clearSessionStoreCacheForTest,
   upsertSessionEntry,

--- a/extensions/codex/src/command-rpc.test.ts
+++ b/extensions/codex/src/command-rpc.test.ts
@@ -1,17 +1,246 @@
-// Codex tests cover command rpc plugin behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { codexControlRequest } from "./command-rpc.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  replaceRuntimeAuthProfileStoreSnapshots,
+  type AuthProfileStore,
+} from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  clearSessionStoreCacheForTest,
+  upsertSessionEntry,
+} from "openclaw/plugin-sdk/session-store-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { withCodexAppServerJsonClient } from "./app-server/request.js";
+import { createClientHarness } from "./app-server/test-support.js";
+import { codexControlRequest, type CodexControlRequestOptions } from "./command-rpc.js";
 
 const requestCodexAppServerJsonMock = vi.hoisted(() => vi.fn());
+const withCodexAppServerJsonClientMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./app-server/request.js", () => ({
   requestCodexAppServerJson: requestCodexAppServerJsonMock,
+  withCodexAppServerJsonClient: withCodexAppServerJsonClientMock,
 }));
 
 describe("Codex command RPC helpers", () => {
-  beforeEach(() => {
+  let tempDir: string;
+  let agentDir: string;
+  let config: OpenClawConfig;
+  let harness: ReturnType<typeof createClientHarness>;
+  const sessionKey = "agent:main:control";
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-control-auth-"));
+    agentDir = path.join(tempDir, "agents", "main", "agent");
+    vi.stubEnv("OPENCLAW_STATE_DIR", tempDir);
+    vi.stubEnv("OPENAI_API_KEY", undefined);
+    vi.stubEnv("CODEX_API_KEY", undefined);
+    config = { agents: { defaults: { model: { primary: "openai/gpt-5.5" } } } };
+    setAuthStore({ version: 1, profiles: {} });
+    harness = createClientHarness();
     requestCodexAppServerJsonMock.mockReset();
+    requestCodexAppServerJsonMock.mockResolvedValue({ thread: { id: "thread-1" } });
+    withCodexAppServerJsonClientMock.mockReset();
+    withCodexAppServerJsonClientMock.mockImplementation(
+      async (
+        _options: Parameters<typeof withCodexAppServerJsonClient>[0],
+        run: Parameters<typeof withCodexAppServerJsonClient>[1],
+      ) => await run(requestCodexAppServerJsonMock, harness.client),
+    );
   });
+
+  afterEach(async () => {
+    harness.client.close();
+    clearRuntimeAuthProfileStoreSnapshots();
+    clearSessionStoreCacheForTest();
+    vi.unstubAllEnvs();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  function setAuthStore(store: AuthProfileStore) {
+    replaceRuntimeAuthProfileStoreSnapshots([{ agentDir, store }]);
+  }
+
+  function resume(options: Partial<CodexControlRequestOptions> = {}) {
+    return codexControlRequest(
+      {},
+      "thread/resume",
+      { threadId: "thread-1" },
+      {
+        config,
+        agentDir,
+        sessionKey,
+        sessionId: "session-1",
+        onResponse: vi.fn(),
+        ...options,
+      },
+    );
+  }
+
+  function acquiredOptions() {
+    return withCodexAppServerJsonClientMock.mock.calls[0]?.[0] as Parameters<
+      typeof withCodexAppServerJsonClient
+    >[0];
+  }
+
+  it("resumes with the prepared environment API key and publishes no legacy profile", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "control-platform-key");
+    const onResponse = vi.fn();
+
+    await resume({ onResponse });
+
+    expect(acquiredOptions()).toMatchObject({
+      preparedAuth: { kind: "api-key", apiKey: "control-platform-key" },
+      authRequirement: "api-key",
+      agentDir,
+    });
+    expect(acquiredOptions().authProfileId).toBeUndefined();
+    expect(onResponse).toHaveBeenCalledWith({ thread: { id: "thread-1" } }, harness.client, {
+      authProfileId: undefined,
+    });
+  });
+
+  it.each(["oauth", "token"] as const)(
+    "keeps %s subscription routing and rotates an automatic profile past cooldown",
+    async (type) => {
+      vi.stubEnv("OPENAI_API_KEY", "unrelated-platform-key");
+      const token = `e30.${Buffer.from(
+        JSON.stringify({
+          "https://api.openai.com/auth": { chatgpt_account_id: "control-account" },
+        }),
+      ).toString("base64url")}.test-signature`;
+      const credential =
+        type === "oauth"
+          ? {
+              type,
+              provider: "openai",
+              access: token,
+              refresh: "control-refresh",
+              expires: Date.now() + 3_600_000,
+              accountId: "control-account",
+            }
+          : { type, provider: "openai", token };
+      setAuthStore({
+        version: 1,
+        profiles: { "openai:old": credential, "openai:ready": credential },
+        order: { openai: ["openai:old", "openai:ready"] },
+        usageStats: { "openai:old": { cooldownUntil: Date.now() + 60_000 } },
+      });
+      await upsertSessionEntry({
+        agentId: "main",
+        sessionKey,
+        entry: {
+          sessionId: "session-1",
+          updatedAt: Date.now(),
+          authProfileOverride: "openai:old",
+          authProfileOverrideSource: "auto",
+        },
+      });
+      const onResponse = vi.fn();
+
+      await resume({ authProfileId: "openai:old", onResponse });
+
+      expect(acquiredOptions()).toMatchObject({
+        authRequirement: "subscription",
+        preparedAuth: {
+          kind: "profile",
+          profileId: "openai:ready",
+          snapshot: { loginParams: { type: "chatgptAuthTokens", accessToken: token } },
+        },
+      });
+      expect(acquiredOptions().authProfileId).toBeUndefined();
+      expect(acquiredOptions().authBindingFingerprint).toEqual(
+        type === "token" ? expect.stringMatching(/^[a-f0-9]{64}$/) : undefined,
+      );
+      expect(onResponse).toHaveBeenCalledWith(expect.anything(), harness.client, {
+        authProfileId: "openai:ready",
+      });
+    },
+  );
+
+  it("honors a user-pinned API profile over automatic order and ambient credentials", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "unrelated-platform-key");
+    setAuthStore({
+      version: 1,
+      profiles: {
+        "openai:first": { type: "api_key", provider: "openai", key: "automatic-key" },
+        "openai:pinned": { type: "api_key", provider: "openai", key: "pinned-key" },
+      },
+      order: { openai: ["openai:first", "openai:pinned"] },
+    });
+    await upsertSessionEntry({
+      agentId: "main",
+      sessionKey,
+      entry: {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        authProfileOverride: "openai:pinned",
+        authProfileOverrideSource: "user",
+      },
+    });
+
+    await resume({ authProfileId: "openai:first" });
+
+    expect(acquiredOptions()).toMatchObject({
+      authRequirement: "api-key",
+      preparedAuth: { kind: "api-key", apiKey: "pinned-key" },
+    });
+  });
+
+  it("does not replace a cooled configured profile with an ambient API key", async () => {
+    vi.stubEnv("OPENAI_API_KEY", "unrelated-platform-key");
+    config.models = {
+      providers: {
+        openai: { baseUrl: "https://api.openai.com/v1", apiKey: "openai:owned", models: [] },
+      },
+    };
+    setAuthStore({
+      version: 1,
+      profiles: { "openai:owned": { type: "api_key", provider: "openai", key: "owned-key" } },
+      usageStats: { "openai:owned": { cooldownUntil: Date.now() + 60_000 } },
+    });
+
+    await expect(resume()).rejects.toThrow("temporarily unavailable");
+
+    expect(withCodexAppServerJsonClientMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves diagnostic requests independent of the current non-Codex model", async () => {
+    config.agents!.defaults!.model = { primary: "anthropic/claude-sonnet-4-6" };
+
+    await codexControlRequest({}, "thread/list", {}, { config, sessionKey, agentDir });
+
+    expect(requestCodexAppServerJsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "thread/list", config, sessionKey }),
+    );
+    expect(withCodexAppServerJsonClientMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["native-auth", "user-home"] as const)(
+    "keeps %s control subscriptions outside prepared login",
+    async (scope) => {
+      vi.stubEnv("OPENAI_API_KEY", "unrelated-platform-key");
+
+      await resume(
+        scope === "native-auth"
+          ? { authProfileId: null }
+          : {
+              startOptions: {
+                transport: "stdio",
+                homeScope: "user",
+                command: "codex",
+                args: ["app-server", "--listen", "stdio://"],
+                headers: {},
+              },
+            },
+      );
+
+      expect(acquiredOptions().preparedAuth).toBeUndefined();
+      expect(acquiredOptions().authRequirement).toBeUndefined();
+    },
+  );
 
   it("uses an explicit control connection instead of ordinary harness start options", async () => {
     requestCodexAppServerJsonMock.mockResolvedValue({ thread: { id: "thread-1" } });

--- a/extensions/codex/src/command-rpc.test.ts
+++ b/extensions/codex/src/command-rpc.test.ts
@@ -8,6 +8,12 @@ import {
 } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
+  createEmptyPluginRegistry,
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
   clearSessionStoreCacheForTest,
   upsertSessionEntry,
 } from "openclaw/plugin-sdk/session-store-runtime";
@@ -29,9 +35,19 @@ describe("Codex command RPC helpers", () => {
   let agentDir: string;
   let config: OpenClawConfig;
   let harness: ReturnType<typeof createClientHarness>;
+  let previousPluginRegistry: ReturnType<typeof getActivePluginRegistry>;
   const sessionKey = "agent:main:control";
 
   beforeEach(async () => {
+    previousPluginRegistry = getActivePluginRegistry();
+    const registry = createEmptyPluginRegistry();
+    // Provide the provider hook contract; source discovery is outside this control-auth fixture.
+    registry.providers.push({
+      pluginId: "openai",
+      provider: { id: "openai", label: "OpenAI", auth: [] },
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-control-auth-"));
     agentDir = path.join(tempDir, "agents", "main", "agent");
     vi.stubEnv("OPENCLAW_STATE_DIR", tempDir);
@@ -52,6 +68,11 @@ describe("Codex command RPC helpers", () => {
   });
 
   afterEach(async () => {
+    if (previousPluginRegistry) {
+      setActivePluginRegistry(previousPluginRegistry);
+    } else {
+      resetPluginRuntimeStateForTest();
+    }
     harness.client.close();
     clearRuntimeAuthProfileStoreSnapshots();
     clearSessionStoreCacheForTest();

--- a/extensions/codex/src/command-rpc.ts
+++ b/extensions/codex/src/command-rpc.ts
@@ -1,5 +1,19 @@
-// Codex plugin module implements command rpc behavior.
-import type { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-bridge.js";
+import { prepareAgentRuntimeAuth } from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveSessionAgentIds,
+} from "openclaw/plugin-sdk/agent-runtime";
+import { resolveSessionModelRef } from "openclaw/plugin-sdk/model-session-runtime";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { prepareCodexAppServerAuthBinding } from "./app-server/auth-binding.js";
+import {
+  resolveCodexAppServerAuthProfileId,
+  resolveCodexAppServerAuthProfileStore,
+  resolveCodexAppServerPreparedAuthHandoff,
+  type resolveCodexAppServerAuthProfileIdForAgent,
+} from "./app-server/auth-bridge.js";
 import {
   CODEX_CONTROL_METHODS,
   describeControlFailure,
@@ -29,14 +43,123 @@ type AuthProfileOrderConfig = Parameters<
 export type CodexControlRequestOptions = {
   config?: AuthProfileOrderConfig;
   authProfileId?: string | null;
+  agentId?: string;
   agentDir?: string;
   sessionKey?: string;
   sessionId?: string;
   isolated?: boolean;
   startOptions?: CodexAppServerStartOptions;
   timeoutMs?: number;
-  onResponse?: (response: unknown, client: CodexAppServerClient) => Promise<void>;
+  onResponse?: (
+    response: unknown,
+    client: CodexAppServerClient,
+    auth: { authProfileId?: string },
+  ) => Promise<void>;
 };
+
+async function prepareControlAuth(
+  options: CodexControlRequestOptions,
+  startOptions: CodexAppServerStartOptions,
+) {
+  if (
+    !options.onResponse ||
+    !options.config ||
+    !options.sessionKey ||
+    options.authProfileId === null ||
+    startOptions.homeScope === "user"
+  ) {
+    return {
+      authProfileId: options.authProfileId ?? undefined,
+      clientOptions: { authProfileId: options.authProfileId },
+    };
+  }
+  const config = options.config;
+  const { sessionAgentId } = resolveSessionAgentIds({
+    config,
+    sessionKey: options.sessionKey,
+    agentId: options.agentId,
+  });
+  const agentDir = options.agentDir ?? resolveAgentDir(config, sessionAgentId);
+  const workspaceDir = resolveAgentWorkspaceDir(config, sessionAgentId);
+  const entry = getSessionEntry({
+    agentId: sessionAgentId,
+    storePath: resolveStorePath(config.session?.store, { agentId: sessionAgentId }),
+    sessionKey: options.sessionKey,
+    hydrateSkillPromptRefs: false,
+    readConsistency: "latest",
+  });
+  const model = resolveSessionModelRef(config, entry, sessionAgentId);
+  const store = resolveCodexAppServerAuthProfileStore({ agentDir, config });
+  const { plan, attempts } = prepareAgentRuntimeAuth({
+    provider: model.provider,
+    modelId: model.model,
+    config,
+    agentDir,
+    workspaceDir,
+    authProfileStore: store,
+    sessionAuthProfileId: entry?.authProfileOverride ?? options.authProfileId,
+    sessionAuthProfileSource: entry?.authProfileOverrideSource,
+    harnessId: "codex",
+    harnessAuthBootstrap: "harness",
+  });
+  const route = plan.modelRoute;
+  // A control subscription must use the same prepared auth partition as a turn.
+  // Unsubscribe leaves Codex's native writer loaded for 30 minutes; another
+  // process cannot resume that thread, even after its OpenClaw binding is gone.
+  const resolvedAuth = route
+    ? await resolveApiKeyForProvider({
+        provider: route.provider,
+        modelId: route.modelId,
+        modelApi: route.api,
+        cfg: config,
+        agentDir,
+        workspaceDir,
+        store,
+        profileId: attempts[0]?.profileId,
+        lockedProfile: plan.forwardedAuthProfileSource === "user",
+        allowAuthProfileFallback: attempts[0]?.allowAuthProfileFallback,
+        skipSetupProviderFallback: true,
+      })
+    : undefined;
+  const handoff = await resolveCodexAppServerPreparedAuthHandoff({
+    authRequirement: route?.authRequirement,
+    resolvedApiKey: resolvedAuth?.apiKey,
+    authProfileId: route
+      ? plan.forwardedAuthProfileId
+      : resolveCodexAppServerAuthProfileId({
+          authProfileId: plan.forwardedAuthProfileId,
+          store,
+          config,
+        }),
+    authProfileStore: store,
+    agentDir,
+    homeScope: startOptions.homeScope ?? "agent",
+    config,
+    subscriptionProfileRequiredError:
+      "Prepared Codex subscription route requires a forwarded OpenAI OAuth or token profile.",
+    subscriptionProfileUnusableError: "Prepared Codex subscription auth profile is unusable.",
+  });
+  const binding = handoff.authProfileId
+    ? await prepareCodexAppServerAuthBinding({
+        authProfileId: handoff.authProfileId,
+        authProfileStore: store,
+        agentDir,
+        config,
+      })
+    : undefined;
+  return {
+    authProfileId: handoff.authProfileId,
+    clientOptions: {
+      ...(handoff.preparedAuth
+        ? { preparedAuth: handoff.preparedAuth }
+        : { authProfileId: handoff.authProfileId }),
+      authRequirement: route?.authRequirement,
+      authProfileStore: binding?.authProfileStore ?? store,
+      authBindingFingerprint: binding?.fingerprint,
+      agentDir,
+    },
+  };
+}
 
 export function requestOptions(
   pluginConfig: unknown,
@@ -78,22 +201,24 @@ export async function codexControlRequest(
   const runtime = options.startOptions
     ? resolveCodexSupervisionAppServerRuntimeOptions({ pluginConfig })
     : resolveCodexAppServerRuntimeOptions({ pluginConfig });
+  const startOptions = options.startOptions ?? runtime.start;
+  const auth = await prepareControlAuth(options, startOptions);
   const controlRequestOptions = {
     timeoutMs: options.timeoutMs ?? runtime.requestTimeoutMs,
-    startOptions: options.startOptions ?? runtime.start,
+    startOptions,
     config: options.config,
     sessionKey: options.sessionKey,
     sessionId: options.sessionId,
-    authProfileId: options.authProfileId,
     agentDir: options.agentDir,
     isolated: options.isolated,
+    ...auth.clientOptions,
   };
   if (options.onResponse) {
     return await withCodexAppServerJsonClient(controlRequestOptions, async (request, client) => {
       const response = await request({ method, requestParams });
       // Subscription-producing control requests must publish their exact
       // physical-client ownership before this shared lease can be released.
-      await options.onResponse!(response, client);
+      await options.onResponse!(response, client, { authProfileId: auth.authProfileId });
       return response;
     });
   }

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -684,7 +684,7 @@ describe("codex command", () => {
     await expect(
       handleCodexCommand(createContext("resume thread-123", sessionFile), { deps }),
     ).resolves.toEqual({
-      text: "Attached this OpenClaw session to Codex thread thread-123.",
+      text: "Attached this OpenClaw session to Codex thread thread-123. The next turn will validate its tools and apply this session's configuration before continuing.",
     });
 
     expect(codexControlRequest).toHaveBeenCalledExactlyOnceWith(
@@ -907,6 +907,7 @@ describe("codex command", () => {
       cwd: "/repo",
       authProfileId: "openai:previous",
       dynamicToolsFingerprint: "known-dynamic-tools",
+      webSearchThreadConfigFingerprint: "known-web-search",
       pluginAppsFingerprint: "known-plugin-apps",
     });
     const release = vi.fn(async () => undefined);
@@ -1101,7 +1102,7 @@ describe("codex command", () => {
 
     resolveResume(createThreadResumeResponse({ threadId: "thread-123" }));
     await expect(command).resolves.toEqual({
-      text: "Attached this OpenClaw session to Codex thread thread-123.",
+      text: "Attached this OpenClaw session to Codex thread thread-123. The next turn will validate its tools and apply this session's configuration before continuing.",
     });
     await competingOwner;
     expect(order).toEqual(["resume-start", "resume-done", "competing-owner"]);
@@ -1157,7 +1158,9 @@ describe("codex command", () => {
       { deps: createDeps({ codexControlRequest }) },
     );
 
-    expect(result.text).toBe("Attached this OpenClaw session to Codex thread thread-new.");
+    expect(result.text).toBe(
+      "Attached this OpenClaw session to Codex thread thread-new. The next turn will validate its tools and apply this session's configuration before continuing.",
+    );
     expect(codexControlRequest).toHaveBeenCalledTimes(1);
     await expect(
       testCodexAppServerBindingStore.read({
@@ -1248,6 +1251,7 @@ describe("codex command", () => {
       authProfileId: "openai:work",
       model: "gpt-5.4",
       historyCoveredThrough: expect.any(String),
+      pendingResumeConfiguration: true,
     });
   });
 

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -47,11 +47,13 @@ import type {
   CodexPluginsConfigBlock,
   CodexPluginsManagementIO,
 } from "./command-plugins-management.js";
+import type { CodexControlRequestOptions } from "./command-rpc.js";
 import { codexConversationBindingRuntime } from "./conversation-binding.js";
 
 type CodexPluginConfigEntry = NonNullable<CodexPluginsConfigBlock["plugins"]>[string];
 
 let tempDir: string;
+const resumeClients: CodexAppServerClient[] = [];
 
 function createContext(
   args: string,
@@ -183,6 +185,30 @@ async function writeTestBinding(
   binding: CodexAppServerThreadBinding,
 ): Promise<void> {
   await testCodexAppServerBindingStore.mutate(identity, { kind: "set", binding });
+}
+
+function createResumeControlRequest(
+  response:
+    | ReturnType<typeof createThreadResumeResponse>
+    | (() => Promise<ReturnType<typeof createThreadResumeResponse>>),
+  auth: { authProfileId?: string } = {},
+) {
+  const harness = createClientHarness();
+  resumeClients.push(harness.client);
+  ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
+  vi.spyOn(harness.client, "request").mockResolvedValue({} as never);
+  return vi.fn(
+    async (
+      _pluginConfig: unknown,
+      _method: string,
+      _params: unknown,
+      options?: CodexControlRequestOptions,
+    ) => {
+      const value = typeof response === "function" ? await response() : response;
+      await options?.onResponse?.(value, harness.client, auth);
+      return value;
+    },
+  );
 }
 
 function supervisedTestBinding(threadId = "thread-supervised"): CodexAppServerThreadBinding {
@@ -386,6 +412,9 @@ describe("codex command", () => {
   });
 
   afterEach(async () => {
+    for (const client of resumeClients.splice(0)) {
+      client.close();
+    }
     codexDiagnosticsFeedbackState.clear();
     resetSharedCodexAppServerClientForTests();
     clearRuntimeAuthProfileStoreSnapshots();
@@ -647,20 +676,10 @@ describe("codex command", () => {
 
   it("attaches the current session to an existing Codex thread", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
-    const requests: Array<{ method: string; params: unknown; options: unknown }> = [];
-    const deps = createDeps({
-      codexControlRequest: vi.fn(
-        async (
-          _pluginConfig: unknown,
-          method: string,
-          requestParamsValue: unknown,
-          options: unknown,
-        ) => {
-          requests.push({ method, params: requestParamsValue, options });
-          return createThreadResumeResponse({ threadId: "thread-123" });
-        },
-      ),
-    });
+    const codexControlRequest = createResumeControlRequest(
+      createThreadResumeResponse({ threadId: "thread-123" }),
+    );
+    const deps = createDeps({ codexControlRequest });
 
     await expect(
       handleCodexCommand(createContext("resume thread-123", sessionFile), { deps }),
@@ -668,16 +687,15 @@ describe("codex command", () => {
       text: "Attached this OpenClaw session to Codex thread thread-123.",
     });
 
-    expect(requests).toEqual([
-      {
-        method: "thread/resume",
-        params: { threadId: "thread-123", excludeTurns: true },
-        options: expect.objectContaining({
-          agentDir: path.join(tempDir, "agents", "main", "agent"),
-          sessionId: "session-1",
-        }),
-      },
-    ]);
+    expect(codexControlRequest).toHaveBeenCalledExactlyOnceWith(
+      undefined,
+      "thread/resume",
+      { threadId: "thread-123", excludeTurns: true },
+      expect.objectContaining({
+        agentDir: path.join(tempDir, "agents", "main", "agent"),
+        sessionId: "session-1",
+      }),
+    );
     await expect(
       testCodexAppServerBindingStore.read({
         kind: "session",
@@ -699,11 +717,9 @@ describe("codex command", () => {
         _pluginConfig: unknown,
         _method: string,
         _params: unknown,
-        options?: {
-          onResponse?: (value: unknown, client: CodexAppServerClient) => Promise<void>;
-        },
+        options?: CodexControlRequestOptions,
       ) => {
-        await options?.onResponse?.(response, harness.client);
+        await options?.onResponse?.(response, harness.client, {});
         return response;
       },
     );
@@ -758,11 +774,9 @@ describe("codex command", () => {
         _pluginConfig: unknown,
         _method: string,
         _params: unknown,
-        options?: {
-          onResponse?: (value: unknown, client: CodexAppServerClient) => Promise<void>;
-        },
+        options?: CodexControlRequestOptions,
       ) => {
-        await options?.onResponse?.(response, harness.client);
+        await options?.onResponse?.(response, harness.client, {});
         return response;
       },
     );
@@ -836,11 +850,9 @@ describe("codex command", () => {
           _pluginConfig: unknown,
           _method: string,
           _params: unknown,
-          options?: {
-            onResponse?: (value: unknown, client: CodexAppServerClient) => Promise<void>;
-          },
+          options?: CodexControlRequestOptions,
         ) => {
-          await options?.onResponse?.(response, replacement.client);
+          await options?.onResponse?.(response, replacement.client, {});
           return response;
         },
       );
@@ -893,6 +905,7 @@ describe("codex command", () => {
       threadId: "thread-known-resume",
       clientId: harness.client.getInstanceId(),
       cwd: "/repo",
+      authProfileId: "openai:previous",
       dynamicToolsFingerprint: "known-dynamic-tools",
       pluginAppsFingerprint: "known-plugin-apps",
     });
@@ -910,11 +923,9 @@ describe("codex command", () => {
         _pluginConfig: unknown,
         _method: string,
         _params: unknown,
-        options?: {
-          onResponse?: (value: unknown, client: CodexAppServerClient) => Promise<void>;
-        },
+        options?: CodexControlRequestOptions,
       ) => {
-        await options?.onResponse?.(response, harness.client);
+        await options?.onResponse?.(response, harness.client, {});
         return response;
       },
     );
@@ -929,6 +940,7 @@ describe("codex command", () => {
         dynamicToolsFingerprint: "known-dynamic-tools",
         pluginAppsFingerprint: "known-plugin-apps",
       });
+      expect((await testCodexAppServerBindingStore.read(identity))?.authProfileId).toBeUndefined();
       await expect(
         consumeCodexAppServerLiveThread(
           harness.client,
@@ -1010,15 +1022,13 @@ describe("codex command", () => {
           _pluginConfig: unknown,
           _method: string,
           _params: unknown,
-          options?: {
-            onResponse?: (value: unknown, client: CodexAppServerClient) => Promise<void>;
-          },
+          options?: CodexControlRequestOptions,
         ) => {
           const resumed = await harness.client.request("thread/resume", {
             threadId: "thread-active-resume",
             excludeTurns: true,
           });
-          await options?.onResponse?.(resumed, harness.client);
+          await options?.onResponse?.(resumed, harness.client, {});
           return response;
         },
       );
@@ -1071,7 +1081,7 @@ describe("codex command", () => {
     const resumeResponse = new Promise<ReturnType<typeof createThreadResumeResponse>>((resolve) => {
       resolveResume = resolve;
     });
-    const codexControlRequest = vi.fn(async () => {
+    const codexControlRequest = createResumeControlRequest(async () => {
       order.push("resume-start");
       const response = await resumeResponse;
       order.push("resume-done");
@@ -1134,7 +1144,7 @@ describe("codex command", () => {
       sessionKey,
       entry: { sessionId: "session-new", updatedAt: Date.now() },
     });
-    const codexControlRequest = vi.fn(async () =>
+    const codexControlRequest = createResumeControlRequest(
       createThreadResumeResponse({ threadId: "thread-new" }),
     );
 
@@ -1161,7 +1171,7 @@ describe("codex command", () => {
 
   it("does not report a resumed thread as attached after a generation conflict", async () => {
     const mutate = vi.fn(async () => false);
-    const codexControlRequest = vi.fn(async () =>
+    const codexControlRequest = createResumeControlRequest(
       createThreadResumeResponse({ threadId: "thread-123", model: "gpt-5.5" }),
     );
 
@@ -1198,8 +1208,9 @@ describe("codex command", () => {
         },
       },
     ]);
-    const codexControlRequest = vi.fn(async () =>
+    const codexControlRequest = createResumeControlRequest(
       createThreadResumeResponse({ threadId: "thread-123" }),
+      { authProfileId: "openai:work" },
     );
     const storePath = path.join(tempDir, "worker-sessions.json");
     await upsertSessionEntry({
@@ -1221,7 +1232,7 @@ describe("codex command", () => {
       undefined,
       CODEX_CONTROL_METHODS.resumeThread,
       expect.any(Object),
-      expect.objectContaining({ agentDir, authProfileId: "openai:work" }),
+      expect.objectContaining({ agentDir, authProfileId: undefined }),
     );
     await expect(
       testCodexAppServerBindingStore.read({
@@ -1232,6 +1243,7 @@ describe("codex command", () => {
       }),
     ).resolves.toEqual({
       threadId: "thread-123",
+      clientId: expect.any(String),
       cwd: "/repo",
       authProfileId: "openai:work",
       model: "gpt-5.4",
@@ -1240,7 +1252,7 @@ describe("codex command", () => {
   });
 
   it("uses the host agent for global session keys", async () => {
-    const codexControlRequest = vi.fn(async () =>
+    const codexControlRequest = createResumeControlRequest(
       createThreadResumeResponse({ threadId: "thread-work", model: "gpt-5.5" }),
     );
 
@@ -1675,7 +1687,9 @@ describe("codex command", () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const unsafe = "thread-123 <@U123> [trusted](https://evil)";
     const deps = createDeps({
-      codexControlRequest: vi.fn(async () => createThreadResumeResponse({ threadId: unsafe })),
+      codexControlRequest: createResumeControlRequest(
+        createThreadResumeResponse({ threadId: unsafe }),
+      ),
     });
 
     const result = await handleCodexCommand(createContext(`resume "${unsafe}"`, sessionFile), {

--- a/extensions/codex/src/migration/session-binding-orphans.ts
+++ b/extensions/codex/src/migration/session-binding-orphans.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+import { setImmediate } from "node:timers/promises";
+import type {
+  PluginDoctorStateMigration,
+  PluginDoctorStateMigrationContext,
+} from "openclaw/plugin-sdk/runtime-doctor-migrations";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { CODEX_APP_SERVER_BINDING_NAMESPACE } from "../app-server/session-binding-meta.js";
+
+const PAGE_SIZE = 512;
+const KEY_PREFIXES = ["session-key:", "session:"] as const;
+
+type MigrationParams = Parameters<PluginDoctorStateMigration["migrateLegacyState"]>[0];
+type BindingRow = ReturnType<
+  NonNullable<PluginDoctorStateMigrationContext["readPluginStateEntriesInKeyRange"]>
+>[number];
+
+// Destructive repair recognizes only ordinary session ownership. Runtime parsing tolerates
+// optional-field damage; that must not erase supervision or lease uncertainty during repair.
+function readBindingCandidate(row: BindingRow, prefix: (typeof KEY_PREFIXES)[number]) {
+  const identity = /^([a-z0-9][a-z0-9_-]{0,63}):(.+)$/u.exec(row.key.slice(prefix.length));
+  if (!identity) {
+    return undefined;
+  }
+  const agentId = identity[1]!;
+  const keyIdentity = identity[2]!;
+  const stored = asOptionalRecord(row.value);
+  const sessionId = typeof stored?.sessionId === "string" ? stored.sessionId.trim() : "";
+  const stable = prefix === "session-key:";
+  if (
+    !stored ||
+    stored.version !== 1 ||
+    !sessionId ||
+    (stable ? !/^[A-Za-z0-9_-]{43}$/u.test(keyIdentity) : sessionId !== keyIdentity)
+  ) {
+    return undefined;
+  }
+  if (stored.state === "cleared") {
+    if (stored.binding !== undefined || (stored.retired !== undefined && stored.retired !== true)) {
+      return undefined;
+    }
+  } else if (stored.state === "active") {
+    const binding = asOptionalRecord(stored.binding);
+    if (
+      !binding ||
+      typeof binding.threadId !== "string" ||
+      !binding.threadId.trim() ||
+      typeof binding.cwd !== "string" ||
+      binding.connectionScope !== undefined ||
+      binding.supervisionSourceThreadId !== undefined ||
+      binding.pendingSupervisionBranch !== undefined ||
+      stored.retired !== undefined
+    ) {
+      return undefined;
+    }
+  } else {
+    return undefined;
+  }
+  if (stored.lease !== undefined) {
+    const lease = asOptionalRecord(stored.lease);
+    if (
+      !lease ||
+      typeof lease.token !== "string" ||
+      !lease.token.trim() ||
+      typeof lease.expiresAt !== "number" ||
+      !Number.isFinite(lease.expiresAt) ||
+      lease.expiresAt > Date.now()
+    ) {
+      return undefined;
+    }
+  }
+  return { row, agentId, sessionId, stable };
+}
+
+async function scanBindings(
+  { context }: MigrationParams,
+  remove?: NonNullable<PluginDoctorStateMigrationContext["deletePluginStateEntriesIfUnchanged"]>,
+) {
+  const readPage = context.readPluginStateEntriesInKeyRange;
+  const readEvidence = context.readSessionIdentityEvidenceBatch;
+  let deleted = 0;
+  let changed = 0;
+  if (!readPage || !readEvidence) {
+    return { found: false, deleted, changed };
+  }
+  for (const prefix of KEY_PREFIXES) {
+    let after: string | undefined;
+    while (true) {
+      const rows = readPage(CODEX_APP_SERVER_BINDING_NAMESPACE, {
+        prefix,
+        ...(after ? { after } : {}),
+        limit: PAGE_SIZE,
+      });
+      if (rows.length === 0) {
+        break;
+      }
+      after = rows.at(-1)?.key;
+      const candidates = rows.flatMap((row) => {
+        const candidate = readBindingCandidate(row, prefix);
+        return candidate ? [candidate] : [];
+      });
+      if (candidates.length > 0) {
+        const identities = new Map(
+          candidates.map(({ agentId, sessionId }) => [
+            `${agentId}\0${sessionId}`,
+            { agentId, sessionId },
+          ]),
+        );
+        const evidence = new Map(
+          (await readEvidence([...identities.values()])).map((owner) => [
+            `${owner.agentId}\0${owner.sessionId}`,
+            owner,
+          ]),
+        );
+        const stale = candidates
+          .filter(({ row, agentId, sessionId, stable }) => {
+            const owner = evidence.get(`${agentId}\0${sessionId}`);
+            if (!owner || owner.state === "unknown") {
+              return false;
+            }
+            if (owner.state !== "current") {
+              return true;
+            }
+            if (!stable) {
+              return false;
+            }
+            const digest = createHash("sha256").update(owner.sessionKey).digest("base64url");
+            return row.key !== `session-key:${agentId}:${digest}`;
+          })
+          .map(({ row }) => row);
+        if (stale.length > 0) {
+          if (!remove) {
+            return { found: true, deleted, changed };
+          }
+          const result = remove(CODEX_APP_SERVER_BINDING_NAMESPACE, stale);
+          deleted += result.deleted;
+          changed += result.changed;
+        }
+      }
+      if (rows.length < PAGE_SIZE) {
+        break;
+      }
+      // SQLite work is synchronous; yield so the host's maintenance leases can renew between pages.
+      await setImmediate();
+    }
+  }
+  return { found: false, deleted, changed };
+}
+
+export const codexOrphanedSessionBindingMigration: PluginDoctorStateMigration = {
+  id: "codex-app-server-orphaned-session-bindings",
+  label: "Codex app-server orphaned session bindings",
+  doctorOnly: true,
+  phase: "after-session-repair",
+  async detectLegacyState(params) {
+    return (await scanBindings(params)).found
+      ? { preview: ["- Codex app-server bindings: remove orphaned session ownership"] }
+      : null;
+  },
+  async migrateLegacyState(params) {
+    const remove = params.context.deletePluginStateEntriesIfUnchanged;
+    if (!remove) {
+      return {
+        changes: [],
+        warnings: ["Codex session binding repair requires locked SQLite maintenance ownership"],
+      };
+    }
+    const { deleted, changed } = await scanBindings(params, remove);
+    return {
+      changes:
+        deleted > 0 ? [`Removed ${deleted} orphaned Codex app-server session binding(s)`] : [],
+      warnings:
+        changed > 0
+          ? [`Preserved ${changed} Codex app-server session binding(s) changed during repair`]
+          : [],
+    };
+  },
+};

--- a/extensions/codex/src/session-catalog-provenance.ts
+++ b/extensions/codex/src/session-catalog-provenance.ts
@@ -1,8 +1,12 @@
 import path from "node:path";
 import { createZstdDecompress } from "node:zlib";
 import { root as openSafeFilesystemRoot } from "openclaw/plugin-sdk/file-access-runtime";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { CodexThread } from "./app-server/protocol.js";
+import {
+  isJsonObject,
+  type CodexThread,
+  type JsonObject,
+  type JsonValue,
+} from "./app-server/protocol.js";
 
 const MAX_SESSION_META_BYTES = 1024 * 1024;
 const SESSION_META_READ_CHUNK_BYTES = 64 * 1024;
@@ -23,11 +27,11 @@ function cacheProvenance(key: string, value: boolean): void {
 }
 
 /** Undefined means the metadata line is not durable enough to cache yet. */
-async function readOpenClawOriginator(
+export async function readCodexSessionMeta(
   sessionsRoot: string,
   rolloutPath: string,
   threadId: string,
-): Promise<boolean | undefined> {
+): Promise<JsonObject | null | undefined> {
   let safeRoot: Awaited<ReturnType<typeof openSafeFilesystemRoot>>;
   try {
     safeRoot = await openSafeFilesystemRoot(sessionsRoot, {
@@ -75,18 +79,22 @@ async function readOpenClawOriginator(
       if (!line) {
         continue;
       }
-      let parsed: unknown;
+      let parsed: JsonValue;
       try {
-        parsed = JSON.parse(line) as unknown;
+        // SAFETY: JSON.parse without a reviver returns JSON shapes; envelope/id checks follow.
+        parsed = JSON.parse(line) as JsonValue;
       } catch {
         continue;
       }
-      if (!isRecord(parsed) || parsed.type !== "session_meta" || !isRecord(parsed.payload)) {
-        return false;
+      if (
+        !isJsonObject(parsed) ||
+        parsed.type !== "session_meta" ||
+        !isJsonObject(parsed.payload)
+      ) {
+        return null;
       }
       const payload = parsed.payload;
-      const recordedId = payload.id ?? payload.session_id;
-      return recordedId === threadId && payload.originator === "openclaw";
+      return payload.id === threadId ? payload : null;
     } catch {
       continue;
     } finally {
@@ -115,7 +123,8 @@ export async function isOpenClawManagedCodexThread(
   if (cached !== undefined) {
     return cached;
   }
-  const managed = await readOpenClawOriginator(localSessionsRoot, rolloutPath, thread.id);
+  const metadata = await readCodexSessionMeta(localSessionsRoot, rolloutPath, thread.id);
+  const managed = metadata === undefined ? undefined : metadata?.originator === "openclaw";
   // A missing or still-being-written rollout must not become a permanent false
   // negative. Newly created sessions are additionally covered by the durable
   // ownership store, while a completed metadata line can be cached safely.

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -415,7 +415,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // -4: approval display sanitizers moved to a non-public leaf module
       //     (exec-approval-text-sanitize) to break the exec-approvals cycle.
       // +2: bounded ask_user owner-order map builder and option resolver.
-      2580,
+      // +2: canonical session-model selection and auxiliary runtime-auth preparation.
+      2582,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -317,7 +317,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // -5: approval display sanitizers moved to a non-public leaf module
       //     (exec-approval-text-sanitize) to break the exec-approvals cycle.
       // +3: typed ask_user option-index contract and two bounded owner-order resolvers.
-      4341,
+      // +2: exact-session deletion parameters and synchronous companion mutation contract.
+      4343,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -318,7 +318,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       //     (exec-approval-text-sanitize) to break the exec-approvals cycle.
       // +3: typed ask_user option-index contract and two bounded owner-order resolvers.
       // +2: exact-session deletion parameters and synchronous companion mutation contract.
-      4343,
+      // +2: canonical session-model selection and auxiliary runtime-auth preparation.
+      4345,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/harness/session-deletion.ts
+++ b/src/agents/harness/session-deletion.ts
@@ -1,0 +1,106 @@
+import { capturePluginLifecycleAuthority } from "../../plugins/registry-lifecycle.js";
+import { getPluginRegistryState } from "../../plugins/runtime-state.js";
+import { getPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { getPluginRuntimeGenerationRegistry } from "../../plugins/runtime/generation-scope.js";
+import type {
+  AgentHarnessSessionDeletionMutation,
+  AgentHarnessSessionDeletionParams,
+} from "./types.js";
+
+export type AgentHarnessSessionDeletionTarget = Omit<
+  AgentHarnessSessionDeletionParams,
+  "assertCurrent"
+> & { agentHarnessId?: string };
+export type PreparedAgentHarnessSessionDeletion = AgentHarnessSessionDeletionMutation & {
+  assertCurrent: () => void;
+};
+
+/** Reuse the registered harness owner; deletion is not a second plugin registration surface. */
+export function captureAgentHarnessSessionDeletions() {
+  const scopedRegistry = () =>
+    getPluginRuntimeGenerationRegistry() ?? getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+  const scoped = scopedRegistry();
+  const registry = scoped ?? getPluginRegistryState()?.activeRegistry;
+  const owners =
+    registry?.agentHarnesses.flatMap((registration) => {
+      const prepare = registration.harness.withSessionDeletion;
+      if (!prepare) {
+        return [];
+      }
+      const record = registry.plugins.find((plugin) => plugin.id === registration.pluginId);
+      const current =
+        record || registration.pluginId === "core"
+          ? capturePluginLifecycleAuthority(registry, record, {
+              scopedRuntime: scoped === registry,
+            })
+          : undefined;
+      return [{ registration, prepare, current }];
+    }) ?? [];
+  return owners.length === 0
+    ? undefined
+    : async <T>(
+        targets: readonly AgentHarnessSessionDeletionTarget[],
+        run: (
+          prepared: ReadonlyMap<string, readonly PreparedAgentHarnessSessionDeletion[]>,
+        ) => Promise<T>,
+      ): Promise<T> => {
+        const pending = targets.flatMap((target) =>
+          owners
+            .filter(
+              ({ registration }) =>
+                !target.agentHarnessId || target.agentHarnessId === registration.harness.id,
+            )
+            .map((owner) => ({ owner, target })),
+        );
+        const prepared = new Map<string, PreparedAgentHarnessSessionDeletion[]>();
+        const prepareNext = async (index: number): Promise<T> => {
+          const candidate = pending[index];
+          if (!candidate) {
+            return await run(prepared);
+          }
+          const { owner, target } = candidate;
+          let active = true;
+          const assertCurrent = () => {
+            if (
+              !active ||
+              !owner.current?.() ||
+              (scoped && scopedRegistry() !== scoped) ||
+              !registry?.agentHarnesses.includes(owner.registration) ||
+              owner.registration.harness.withSessionDeletion !== owner.prepare
+            ) {
+              throw new Error(
+                `Session deletion harness owner changed: ${owner.registration.harness.id}`,
+              );
+            }
+          };
+          try {
+            assertCurrent();
+            const result = await owner.prepare<T>(
+              { ...target, assertCurrent },
+              async (mutation) => {
+                assertCurrent();
+                const mutations = prepared.get(target.sessionKey) ?? [];
+                mutations.push({
+                  assertCurrent,
+                  commit: () => {
+                    assertCurrent();
+                    mutation.commit();
+                  },
+                  rollback: () => {
+                    assertCurrent();
+                    mutation.rollback();
+                  },
+                });
+                prepared.set(target.sessionKey, mutations);
+                return await prepareNext(index + 1);
+              },
+            );
+            assertCurrent();
+            return result;
+          } finally {
+            active = false;
+          }
+        };
+        return await prepareNext(0);
+      };
+}

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -424,8 +424,30 @@ type AgentHarnessCompactionCapability = {
   compact?(params: AgentHarnessCompactParams): Promise<AgentHarnessCompactResult | undefined>;
 };
 
+export type AgentHarnessSessionDeletionParams = {
+  agentId: string;
+  sessionKey: string;
+  sessionId: string;
+  lifecycleRevision?: string;
+  /** Revalidate the captured registry, harness, and operation before each side effect. */
+  assertCurrent: () => void;
+};
+
+export type AgentHarnessSessionDeletionMutation = {
+  /** Synchronously remove only the prepared owner's state at the session commit edge. */
+  commit: () => void;
+  /** Restore only that removal when the authoritative session transaction rolls back. */
+  rollback: () => void;
+};
+
 type AgentHarnessSessionLifecycleCapability = {
   reset?(params: AgentHarnessResetParams): Promise<void> | void;
+  /** Prepare outside the session writer; release native resources after its commit completes. */
+  withSessionDeletion?<T>(
+    this: void,
+    params: AgentHarnessSessionDeletionParams,
+    run: (mutation: AgentHarnessSessionDeletionMutation) => Promise<T>,
+  ): Promise<T>;
   dispose?(): Promise<void> | void;
 };
 

--- a/src/commands/doctor-session-transcripts.incident.test.ts
+++ b/src/commands/doctor-session-transcripts.incident.test.ts
@@ -1,0 +1,263 @@
+// Doctor repairs incident-scale Codex plugin state only after durable session convergence.
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  loadExactSessionEntryReadOnly,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  createPluginStateKeyedStore,
+  getPluginStateCapacity,
+  pluginStateDoctorEntriesInKeyRange,
+  resetPluginStateStoreForTests,
+} from "../plugin-state/plugin-state-store.js";
+import { seedPluginStateEntriesForTests } from "../plugin-state/plugin-state-store.test-helpers.js";
+import type { PluginDoctorStateMigration } from "../plugins/doctor-contract-registry.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+
+const note = vi.hoisted(() => vi.fn());
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note }));
+
+vi.mock("../plugins/doctor-contract-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/doctor-contract-registry.js")>();
+  const { loadBundledPluginPublicSurface } =
+    await import("../plugin-sdk/test-helpers/public-surface-loader.js");
+  const { stateMigrations } = await loadBundledPluginPublicSurface<{
+    stateMigrations: PluginDoctorStateMigration[];
+  }>({ pluginId: "codex", artifactBasename: "doctor-contract-api.js" });
+  return {
+    ...actual,
+    listPluginDoctorStateMigrationEntries: () =>
+      stateMigrations.map((migration) => ({ pluginId: "codex", migration })),
+  };
+});
+
+import { noteSessionTranscriptHealth } from "./doctor-session-transcripts.js";
+
+const BINDING_NAMESPACE = "app-server-thread-bindings";
+const MANAGED_THREAD_NAMESPACE = "app-server-managed-threads";
+const SESSION_BINDING_COUNT = 47_794;
+const ADVISORY_MANAGED_THREAD_COUNT = 2_206;
+const PLUGIN_STATE_CAPACITY = 50_000;
+
+let incidentStateDir: string | undefined;
+
+const stableKey = (sessionKey: string, agentId = "main") =>
+  `session-key:${agentId}:${createHash("sha256").update(sessionKey).digest("base64url")}`;
+
+afterEach(async () => {
+  closeOpenClawAgentDatabasesForTest();
+  resetPluginStateStoreForTests();
+  vi.unstubAllEnvs();
+  note.mockClear();
+  if (incidentStateDir) {
+    await fs.rm(incidentStateDir, { recursive: true, force: true });
+    incidentStateDir = undefined;
+  }
+});
+
+describe("doctor incident-scale Codex binding repair", () => {
+  it("repairs a full store of mixed stable bindings without losing current or uncertain ownership", async () => {
+    incidentStateDir = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-incident-")),
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", incidentStateDir);
+    const env = process.env;
+    const config: OpenClawConfig = {
+      agents: { entries: { main: { default: true } } },
+      plugins: { entries: { codex: { enabled: true } } },
+    };
+
+    const rows: Parameters<typeof seedPluginStateEntriesForTests>[0] = [];
+    const retain = (key: string, sessionId: string, extra: Record<string, unknown> = {}) => {
+      rows.push({
+        pluginId: "codex",
+        namespace: BINDING_NAMESPACE,
+        key,
+        value: {
+          version: 1,
+          state: "active",
+          sessionId,
+          binding: { threadId: `thread-${sessionId}`, cwd: "/workspace" },
+          ...extra,
+        },
+      });
+    };
+    const currentOwners = (
+      [
+        ["main", "shared-live"],
+        ["other", "shared-live"],
+        ["current-a", "live-a"],
+        ["current-b", "live-b"],
+      ] as const
+    ).map(([name, sessionId]) => ({ sessionKey: `agent:main:${name}`, sessionId }));
+    const readCurrentOwners = () =>
+      currentOwners.map(({ sessionKey }) => ({
+        sessionKey,
+        sessionId: loadExactSessionEntryReadOnly({ agentId: "main", env, sessionKey })?.entry
+          .sessionId,
+      }));
+    // Old timestamps are pruned during seeding; these owners must still exist when Doctor runs.
+    const updatedAt = Date.now();
+    for (const { sessionKey, sessionId } of currentOwners) {
+      await replaceSessionEntry({ agentId: "main", env, sessionKey }, { sessionId, updatedAt });
+      retain(stableKey(sessionKey), sessionId);
+    }
+    expect(readCurrentOwners()).toEqual(currentOwners);
+    // ID-only evidence cannot distinguish an orphan hash from either valid shared-ID owner.
+    retain(stableKey("agent:main:ambiguous-old-key"), "shared-live");
+    retain("session:main:live-a", "live-a");
+    retain(stableKey("agent:missing:unknown", "missing"), "missing-owner");
+    retain("session:main:leased", "leased", {
+      lease: { token: "live-lease", expiresAt: Date.now() + 600_000 },
+    });
+    retain("session:main:supervised", "supervised", {
+      binding: {
+        threadId: "native-source",
+        cwd: "/workspace",
+        connectionScope: "supervision",
+        supervisionSourceThreadId: "native-source",
+      },
+    });
+    retain("session:main:pending", "pending", {
+      binding: {
+        threadId: "pending-source",
+        cwd: "/workspace",
+        pendingSupervisionBranch: { sourceThreadId: "pending-source" },
+      },
+    });
+    retain("conversation:external-owner", "external-owner");
+    retain("session:main:malformed", "malformed", { state: "unknown" });
+    const retainedBindings = rows.slice();
+    const orphanCount = SESSION_BINDING_COUNT - retainedBindings.length;
+    for (let index = 0; index < orphanCount; index += 1) {
+      const sessionId = index === 0 ? "live-b" : `incident-session-${index}`;
+      rows.push({
+        pluginId: "codex",
+        namespace: BINDING_NAMESPACE,
+        key:
+          index > 0 && index < 73
+            ? `session:main:${sessionId}`
+            : stableKey(`agent:main:run:${index}`),
+        value:
+          index % 2 === 0
+            ? {
+                version: 1,
+                state: "active",
+                sessionId,
+                binding: { threadId: `incident-thread-${index}`, cwd: "/workspace" },
+              }
+            : { version: 1, state: "cleared", sessionId, retired: true },
+      });
+    }
+    for (let index = 0; index < ADVISORY_MANAGED_THREAD_COUNT; index += 1) {
+      rows.push({
+        pluginId: "codex",
+        namespace: MANAGED_THREAD_NAMESPACE,
+        key: `sha256:${index.toString(16).padStart(64, "0")}`,
+        value: {
+          version: 1,
+          kind: "managed-thread",
+          sourceHomeId: "incident-source-home",
+          threadId: `managed-thread-${index}`,
+        },
+      });
+    }
+    seedPluginStateEntriesForTests(rows);
+
+    expect(getPluginStateCapacity("codex", env)).toEqual({
+      liveEntries: PLUGIN_STATE_CAPACITY,
+      maxEntries: PLUGIN_STATE_CAPACITY,
+    });
+
+    const runActualDoctorRepair = () =>
+      noteSessionTranscriptHealth({
+        cfg: config,
+        env,
+        sessionDirs: [],
+        sessionSqlite: true,
+        shouldRepair: true,
+      });
+
+    await noteSessionTranscriptHealth({
+      cfg: config,
+      env,
+      sessionDirs: [],
+      sessionSqlite: true,
+      shouldRepair: false,
+    });
+    expect(note.mock.calls.flat().join("\n")).toContain("orphaned session ownership");
+    expect(getPluginStateCapacity("codex", env).liveEntries).toBe(PLUGIN_STATE_CAPACITY);
+    note.mockClear();
+
+    await runActualDoctorRepair();
+
+    expect(readCurrentOwners()).toEqual(currentOwners);
+    const bindingRows = ["session-key:", "session:", "conversation:"].flatMap((prefix) =>
+      pluginStateDoctorEntriesInKeyRange({
+        pluginId: "codex",
+        namespace: BINDING_NAMESPACE,
+        prefix,
+        limit: 512,
+        env,
+      }),
+    );
+    expect(
+      bindingRows
+        .map((row) => ({ key: row.key, value: row.value }))
+        .toSorted((a, b) => a.key.localeCompare(b.key)),
+    ).toEqual(
+      retainedBindings
+        .map((row) => ({ key: row.key, value: row.value }))
+        .toSorted((a, b) => a.key.localeCompare(b.key)),
+    );
+    expect(getPluginStateCapacity("codex", env)).toEqual({
+      liveEntries: ADVISORY_MANAGED_THREAD_COUNT + retainedBindings.length,
+      maxEntries: PLUGIN_STATE_CAPACITY,
+    });
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining(`Removed ${orphanCount} orphaned Codex`),
+      expect.any(String),
+    );
+
+    const managedThreads = createPluginStateKeyedStore<{ threadId: string }>("codex", {
+      namespace: MANAGED_THREAD_NAMESPACE,
+      maxEntries: 20_000,
+      overflowPolicy: "evict-oldest",
+      env,
+    });
+    const preservedRows = await managedThreads.entries();
+    expect(preservedRows).toHaveLength(ADVISORY_MANAGED_THREAD_COUNT);
+    expect(new Set(preservedRows.map((entry) => entry.value.threadId)).size).toBe(
+      ADVISORY_MANAGED_THREAD_COUNT,
+    );
+
+    // Exercise the real cap instead of inferring recovered capacity from the row count.
+    const bindings = createPluginStateKeyedStore<{ recovered: boolean }>("codex", {
+      namespace: BINDING_NAMESPACE,
+      maxEntries: PLUGIN_STATE_CAPACITY,
+      overflowPolicy: "reject-new",
+      env,
+    });
+    await bindings.register("conversation:recovered-headroom", { recovered: true });
+    expect(await bindings.lookup("conversation:recovered-headroom")).toEqual({
+      recovered: true,
+    });
+    await bindings.delete("conversation:recovered-headroom");
+
+    note.mockClear();
+    await runActualDoctorRepair();
+
+    expect(getPluginStateCapacity("codex", env)).toEqual({
+      liveEntries: ADVISORY_MANAGED_THREAD_COUNT + retainedBindings.length,
+      maxEntries: PLUGIN_STATE_CAPACITY,
+    });
+    expect(await managedThreads.entries()).toHaveLength(ADVISORY_MANAGED_THREAD_COUNT);
+    expect(note.mock.calls.flat().join("\n")).not.toContain("orphaned Codex");
+  }, 120_000);
+});

--- a/src/commands/doctor-session-transcripts.test.ts
+++ b/src/commands/doctor-session-transcripts.test.ts
@@ -14,6 +14,7 @@ const repairCanonicalSessionKeys = vi.hoisted(() => vi.fn());
 const migrateLegacyMainSessionKeys = vi.hoisted(() => vi.fn());
 const runDoctorSessionSqlite = vi.hoisted(() => vi.fn());
 const withDoctorSqliteMaintenanceLock = vi.hoisted(() => vi.fn());
+const runPostSessionPluginDoctorStateRepairs = vi.hoisted(() => vi.fn());
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note,
@@ -21,6 +22,10 @@ vi.mock("../../packages/terminal-core/src/note.js", () => ({
 
 vi.mock("./doctor-session-sqlite.js", () => ({
   runDoctorSessionSqlite,
+}));
+
+vi.mock("../infra/state-migrations.doctor.js", () => ({
+  runPostSessionPluginDoctorStateRepairs,
 }));
 
 vi.mock("./doctor-session-incognito-key-repair.js", () => ({
@@ -142,9 +147,15 @@ describe("doctor session transcript repair", () => {
       warnings: [],
     });
     runDoctorSessionSqlite.mockReset();
+    runPostSessionPluginDoctorStateRepairs
+      .mockReset()
+      .mockResolvedValue({ changes: [], warnings: [] });
     withDoctorSqliteMaintenanceLock
       .mockReset()
-      .mockImplementation(async (params: { run: () => unknown }) => await params.run());
+      .mockImplementation(
+        async (params: { run: (authority: { assertCurrent(): void }) => unknown }) =>
+          await params.run({ assertCurrent() {} }),
+      );
     root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-transcripts-"));
   });
 
@@ -374,6 +385,22 @@ describe("doctor session transcript repair", () => {
         "reserved key repair call order",
       ),
     );
+    expect(
+      expectDefined(
+        repairCanonicalSessionDeliveryStates.mock.invocationCallOrder[0],
+        "delivery state repair call order",
+      ),
+    ).toBeLessThan(
+      expectDefined(
+        runPostSessionPluginDoctorStateRepairs.mock.invocationCallOrder[0],
+        "post-session plugin repair call order",
+      ),
+    );
+    expect(runPostSessionPluginDoctorStateRepairs).toHaveBeenCalledWith({
+      config: cfg,
+      env,
+      maintenanceAuthority: { assertCurrent: expect.any(Function) },
+    });
     expect(withDoctorSqliteMaintenanceLock).toHaveBeenCalledWith({
       env,
       operation: "session SQLite import",
@@ -464,6 +491,49 @@ describe("doctor session transcript repair", () => {
     });
     expect(migrateLegacyMainSessionKeys).toHaveBeenCalledWith({ cfg, env, mode: "detect" });
     expect(withDoctorSqliteMaintenanceLock).not.toHaveBeenCalled();
+    expect(runPostSessionPluginDoctorStateRepairs).toHaveBeenCalledWith({
+      config: cfg,
+      env,
+      maintenanceAuthority: undefined,
+    });
+  });
+
+  it("reports post-session plugin changes and actionable ownership warnings", async () => {
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    runDoctorSessionSqlite.mockResolvedValueOnce({
+      totals: {
+        archivedTranscriptFiles: 0,
+        archivedUnreferencedJsonlFiles: 0,
+        importedTranscriptEvents: 0,
+        issues: 0,
+        legacyEntries: 0,
+        sqliteEntries: 0,
+        unreferencedJsonlFiles: 0,
+        validatedTranscriptEvents: 0,
+      },
+    });
+    runPostSessionPluginDoctorStateRepairs.mockResolvedValueOnce({
+      changes: ["Removed 2 orphaned plugin session bindings"],
+      warnings: ["Plugin lifecycle ownership unavailable; rerun openclaw doctor --fix"],
+    });
+
+    await noteSessionTranscriptHealth({
+      cfg: {},
+      env: { ...process.env, OPENCLAW_STATE_DIR: root },
+      sessionDirs: [sessionsDir],
+      sessionSqlite: true,
+      shouldRepair: true,
+    });
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Removed 2 orphaned plugin session bindings"),
+      "Plugin session repair",
+    );
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("rerun openclaw doctor --fix"),
+      "Plugin session repair",
+    );
   });
 
   it("skips session SQLite import when the Gateway owns the state lock", async () => {

--- a/src/commands/doctor-session-transcripts.ts
+++ b/src/commands/doctor-session-transcripts.ts
@@ -19,6 +19,7 @@ import {
 } from "../config/sessions/transcript-tree.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
+import { runPostSessionPluginDoctorStateRepairs } from "../infra/state-migrations.doctor.js";
 import { shortenHomePath } from "../utils.js";
 import {
   repairCanonicalSessionKeys,
@@ -36,6 +37,7 @@ import {
 import {
   DoctorSqliteMaintenanceLockUnavailableError,
   withDoctorSqliteMaintenanceLock,
+  type DoctorSqliteMaintenanceAuthority,
 } from "./doctor-sqlite-maintenance-lock.js";
 import { isLegacyCodexProviderId } from "./doctor/shared/codex-route-model-ref.js";
 
@@ -544,7 +546,7 @@ async function noteSessionSqliteMigrationHealth(params: {
         >
       >
     | undefined;
-  const runSessionSqlite = async () => {
+  const runSessionSqlite = async (maintenanceAuthority?: DoctorSqliteMaintenanceAuthority) => {
     const report = await runDoctorSessionSqlite({
       allAgents: true,
       ...(params.cfg ? { cfg: params.cfg } : {}),
@@ -580,6 +582,15 @@ async function noteSessionSqliteMigrationHealth(params: {
       cfg: params.cfg ?? {},
       env: params.env,
     });
+    const pluginRepair = await runPostSessionPluginDoctorStateRepairs({
+      config: params.cfg ?? {},
+      env: params.env,
+      maintenanceAuthority,
+    });
+    const pluginMessages = [...pluginRepair.changes, ...pluginRepair.warnings];
+    if (pluginMessages.length > 0) {
+      note(pluginMessages.join("\n"), "Plugin session repair");
+    }
     return report;
   };
   let report: Awaited<ReturnType<typeof runSessionSqlite>>;

--- a/src/commands/doctor-sqlite-maintenance-lock.test.ts
+++ b/src/commands/doctor-sqlite-maintenance-lock.test.ts
@@ -171,6 +171,26 @@ describe("doctor SQLite maintenance lock", () => {
     await gatewayLock.release();
   });
 
+  it("revokes retained maintenance authority before releasing the state lock", async () => {
+    const fixture = await createLockFixture();
+    let retained: { assertCurrent(): void } | undefined;
+
+    await withDoctorSqliteMaintenanceLock(
+      {
+        env: fixture.env,
+        operation: "session SQLite import",
+        run(authority) {
+          retained = authority;
+          expect(() => authority.assertCurrent()).not.toThrow();
+        },
+      },
+      { lockOptions: fixture.lockOptions },
+    );
+
+    expect(retained).toBeDefined();
+    expect(() => retained?.assertCurrent()).toThrow(/maintenance authority has expired/);
+  });
+
   it("blocks maintenance when the Gateway used the multi-Gateway override", async () => {
     const fixture = await createLockFixture();
     const run = vi.fn();

--- a/src/commands/doctor-sqlite-maintenance-lock.ts
+++ b/src/commands/doctor-sqlite-maintenance-lock.ts
@@ -32,6 +32,10 @@ type DoctorSqliteMaintenanceLockDeps = {
   lockOptions?: MaintenanceLockOptions;
 };
 
+export type DoctorSqliteMaintenanceAuthority = {
+  assertCurrent(): void;
+};
+
 export class DoctorSqliteMaintenanceLockUnavailableError extends Error {
   constructor(
     operation: string,
@@ -147,7 +151,7 @@ export async function withDoctorSqliteMaintenanceLock<T>(
     env?: NodeJS.ProcessEnv;
     operation: string;
     protectedPaths?: readonly string[];
-    run: () => Promise<T> | T;
+    run: (authority: DoctorSqliteMaintenanceAuthority) => Promise<T> | T;
   },
   deps: DoctorSqliteMaintenanceLockDeps = {},
 ): Promise<T> {
@@ -174,10 +178,18 @@ export async function withDoctorSqliteMaintenanceLock<T>(
     throw new Error(`Cannot run ${params.operation} without exclusive OpenClaw state ownership.`);
   }
 
+  let active = true;
   try {
     assertMaintenancePathsOwnedByStateDir(env, params.operation, params.protectedPaths ?? []);
-    return await params.run();
+    return await params.run({
+      assertCurrent() {
+        if (!active) {
+          throw new Error("Doctor SQLite maintenance authority has expired.");
+        }
+      },
+    });
   } finally {
+    active = false;
     await lock.release();
   }
 }

--- a/src/commands/doctor.test.ts
+++ b/src/commands/doctor.test.ts
@@ -43,7 +43,8 @@ describe("doctorCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.withDoctorSqliteMaintenanceLock.mockImplementation(
-      async (params: { run: () => unknown }) => await params.run(),
+      async (params: { run: (authority: { assertCurrent(): void }) => unknown }) =>
+        await params.run({ assertCurrent() {} }),
     );
   });
 

--- a/src/config/sessions/legacy-main-session-migration-operations.ts
+++ b/src/config/sessions/legacy-main-session-migration-operations.ts
@@ -4,10 +4,7 @@ import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import { isSameOpenClawAgentDatabasePath } from "../../state/openclaw-agent-db-registry.js";
-import {
-  runOpenClawAgentWriteTransaction,
-  type OpenClawAgentDatabase,
-} from "../../state/openclaw-agent-db.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type {
   LegacyMainSessionMigrationMode,
   LegacyMainSessionMigrationOutcome,
@@ -17,6 +14,10 @@ import type {
 } from "./legacy-main-session-migration.contract.js";
 import { readExactSessionEntryRowForCanonicalRepair } from "./session-accessor.sqlite-canonical-repair.js";
 import {
+  runSqliteSessionDeletionTransaction,
+  withSqliteSessionDeletions,
+} from "./session-accessor.sqlite-deletion.js";
+import {
   deleteLegacySessionEntryRows,
   readExactSessionEntryRow,
   writeSessionEntry,
@@ -24,7 +25,10 @@ import {
 import { importSqliteSessionRows } from "./session-accessor.sqlite-import.js";
 import { deleteSessionEntryLifecycle } from "./session-accessor.sqlite-lifecycle.js";
 import { replaceSessionOwnerInTransaction } from "./session-accessor.sqlite-owner.js";
-import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
+import {
+  getSessionKysely,
+  runExclusiveSqliteSessionWrite,
+} from "./session-accessor.sqlite-scope.js";
 import type { SessionEntry } from "./types.js";
 
 function projectEntryIdentity(entry: SessionEntry): SessionEntry {
@@ -121,6 +125,33 @@ function writeMigratedSessionClaim(
   replaceSessionOwnerInTransaction(database, sessionKey, entry.owner);
 }
 
+function mutateLegacySessionClaims<T>(
+  params: {
+    store: PhysicalStore;
+    env: NodeJS.ProcessEnv;
+    claims: readonly SessionClaim[];
+    operationLabel: string;
+  },
+  commit: (database: OpenClawAgentDatabase) => T,
+): Promise<T> {
+  const scope = {
+    agentId: params.store.databaseAgentId,
+    env: params.env,
+    path: params.store.path,
+    ownerStorePath: params.store.ownerStorePath,
+  };
+  return withSqliteSessionDeletions(
+    scope,
+    params.claims.map(({ key: sessionKey, entry }) => ({ sessionKey, entry })),
+    async () =>
+      runExclusiveSqliteSessionWrite(scope, async () =>
+        runSqliteSessionDeletionTransaction(commit, scope, {
+          operationLabel: params.operationLabel,
+        }),
+      ),
+  );
+}
+
 function migrateClaimsInPlace(params: {
   aliases: readonly SessionClaim[];
   canonical?: SessionClaim;
@@ -128,24 +159,33 @@ function migrateClaimsInPlace(params: {
   env: NodeJS.ProcessEnv;
   store: PhysicalStore;
   winner: SessionClaim;
-}): boolean {
-  let committed = false;
-  runOpenClawAgentWriteTransaction(
+}): Promise<boolean> {
+  return mutateLegacySessionClaims(
+    {
+      ...params,
+      claims: params.aliases.filter((claim) => claim.key !== params.canonicalKey),
+      operationLabel: "session-migration.legacy-main-in-place",
+    },
     (database) => {
       const currentAliases = params.aliases.map((claim) =>
         readClaim(database, params.store, claim.key, params.canonicalKey),
       );
-      const currentCanonical = params.canonical
-        ? readClaim(database, params.store, params.canonicalKey, params.canonicalKey)
-        : undefined;
+      // Absence is part of the snapshot: owner preparation may let a new canonical row appear.
+      const currentCanonical = readClaim(
+        database,
+        params.store,
+        params.canonicalKey,
+        params.canonicalKey,
+      );
       if (
         currentAliases.some(
           (claim, index) => !claim || !claimsMatch(claim, params.aliases[index]!),
         ) ||
-        (params.canonical &&
-          (!currentCanonical || !claimsMatch(currentCanonical, params.canonical)))
+        (params.canonical
+          ? !currentCanonical || !claimsMatch(currentCanonical, params.canonical)
+          : currentCanonical !== undefined)
       ) {
-        return;
+        return false;
       }
       if (!currentCanonical) {
         writeMigratedSessionClaim(database, params.canonicalKey, params.winner.entry);
@@ -154,14 +194,14 @@ function migrateClaimsInPlace(params: {
         database,
         params.aliases.map((claim) => claim.key),
         params.canonicalKey,
-        { rehomeMembers: true },
+        {
+          rehomeMembers: true,
+          validatedEntries: new Map(currentAliases.map((claim) => [claim!.key, claim!.entry])),
+        },
       );
-      committed = true;
+      return true;
     },
-    { agentId: params.store.databaseAgentId, env: params.env, path: params.store.path },
-    { operationLabel: "session-migration.legacy-main-in-place" },
   );
-  return committed;
 }
 
 async function copyClaimCrossStore(params: {
@@ -173,7 +213,7 @@ async function copyClaimCrossStore(params: {
   await importSqliteSessionRows({
     agentId: params.destination.databaseAgentId,
     env: params.env,
-    storePath: params.destination.path,
+    storePath: params.destination.ownerStorePath,
     sessionKey: params.canonicalKey,
     entry: params.source.entry,
     skipIfExists: true,
@@ -205,7 +245,7 @@ async function deleteExpectedClaim(claim: SessionClaim): Promise<boolean> {
       eventJson: claim.eventRows.map((row) => row.eventJson),
     },
     requireWriteSuccess: true,
-    storePath: claim.store.path,
+    storePath: claim.store.ownerStorePath,
     target: { canonicalKey: claim.key, storeKeys: [claim.key] },
   });
   return result.deleted;
@@ -215,9 +255,14 @@ function quarantineClaim(params: {
   claim: SessionClaim;
   env: NodeJS.ProcessEnv;
   ownerAgentId: string;
-}): string | undefined {
-  let quarantineKey: string | undefined;
-  runOpenClawAgentWriteTransaction(
+}): Promise<string | undefined> {
+  return mutateLegacySessionClaims(
+    {
+      store: params.claim.store,
+      env: params.env,
+      claims: [params.claim],
+      operationLabel: "session-migration.legacy-main-quarantine",
+    },
     (database) => {
       const fresh = readClaim(
         database,
@@ -226,8 +271,9 @@ function quarantineClaim(params: {
         params.claim.canonicalKey,
       );
       if (!fresh || !claimsMatch(fresh, params.claim)) {
-        return;
+        return undefined;
       }
+      let quarantineKey: string;
       for (let index = 1; ; index += 1) {
         const candidate = `agent:${params.ownerAgentId}:legacy-main-conflict-${index}`;
         if (!readExactSessionEntryRow(database, candidate)) {
@@ -238,16 +284,11 @@ function quarantineClaim(params: {
       writeMigratedSessionClaim(database, quarantineKey, params.claim.entry);
       deleteLegacySessionEntryRows(database, [params.claim.key], quarantineKey, {
         rehomeMembers: true,
+        validatedEntries: new Map([[fresh.key, fresh.entry]]),
       });
+      return quarantineKey;
     },
-    {
-      agentId: params.claim.store.databaseAgentId,
-      env: params.env,
-      path: params.claim.store.path,
-    },
-    { operationLabel: "session-migration.legacy-main-quarantine" },
   );
-  return quarantineKey;
 }
 
 export async function processIdenticalClaims(params: {
@@ -282,13 +323,13 @@ export async function processIdenticalClaims(params: {
   if (!canonical && destinationAliases.length > 0) {
     const inPlaceWinner = freshestClaim(destinationAliases);
     if (
-      !migrateClaimsInPlace({
+      !(await migrateClaimsInPlace({
         aliases: destinationAliases,
         canonicalKey: params.canonicalKey,
         env: params.env,
         store: params.destination,
         winner: inPlaceWinner,
-      })
+      }))
     ) {
       return {
         kind: "divergent-aliases",
@@ -362,14 +403,14 @@ export async function processIdenticalClaims(params: {
   }
   if (params.canonical && destinationAliases.length > 0) {
     if (
-      !migrateClaimsInPlace({
+      !(await migrateClaimsInPlace({
         aliases: destinationAliases,
         canonical: params.canonical,
         canonicalKey: params.canonicalKey,
         env: params.env,
         store: params.destination,
         winner: params.canonical,
-      })
+      }))
     ) {
       return {
         kind: "divergent-canonical",
@@ -431,7 +472,7 @@ export async function repairDivergentClaims(params: {
     }
     if (claimsMatch(claim, canonical)) {
       const cleaned = samePhysicalStore(claim.store, params.destination)
-        ? migrateClaimsInPlace({
+        ? await migrateClaimsInPlace({
             aliases: [claim],
             canonical,
             canonicalKey: params.canonicalKey,
@@ -445,7 +486,7 @@ export async function repairDivergentClaims(params: {
       }
       continue;
     }
-    const quarantineKey = quarantineClaim({
+    const quarantineKey = await quarantineClaim({
       claim,
       env: params.env,
       ownerAgentId: params.ownerAgentId,

--- a/src/config/sessions/legacy-main-session-migration.contract.ts
+++ b/src/config/sessions/legacy-main-session-migration.contract.ts
@@ -40,6 +40,7 @@ export type TranscriptDigest = { eventCount: number; rollingHash: string };
 
 export type PhysicalStore = {
   databaseAgentId: string;
+  ownerStorePath: string;
   path: string;
 };
 

--- a/src/config/sessions/legacy-main-session-migration.test.ts
+++ b/src/config/sessions/legacy-main-session-migration.test.ts
@@ -2,6 +2,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  markPluginRegistryActive,
+  markPluginRegistryRetired,
+} from "../../plugins/registry-lifecycle.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
 import {
   readSessionProgressCard,
   writeSessionProgressCard,
@@ -124,6 +130,44 @@ function readClaim(params: { databaseAgentId: string; databasePath: string; key:
 
 function outcomeKinds(result: Awaited<ReturnType<typeof migrateLegacyMainSessionKeys>>) {
   return result.outcomes.map((outcome) => outcome.kind);
+}
+
+async function recordHarnessDeletions<T>(
+  run: () => Promise<T>,
+  beforePrepare?: () => void | Promise<void>,
+) {
+  const registry = createEmptyPluginRegistry();
+  const committed: string[] = [];
+  registry.agentHarnesses.push({
+    pluginId: "core",
+    source: "test",
+    harness: {
+      id: "migration-fixture",
+      label: "Migration fixture",
+      supports: () => ({ supported: true }),
+      async runAttempt() {
+        throw new Error("unused");
+      },
+      async withSessionDeletion(params, next) {
+        await beforePrepare?.();
+        return next({
+          commit() {
+            params.assertCurrent();
+            committed.push(params.sessionKey);
+          },
+          rollback() {
+            committed.splice(committed.lastIndexOf(params.sessionKey), 1);
+          },
+        });
+      },
+    },
+  });
+  markPluginRegistryActive(registry);
+  try {
+    return { result: await withPluginRuntimeRegistryScope(registry, run), committed };
+  } finally {
+    markPluginRegistryRetired(registry);
+  }
 }
 
 function setLedgerStatus(env: NodeJS.ProcessEnv, status: string): void {
@@ -421,13 +465,16 @@ describe("legacy main session migration", () => {
       { agentId: "main", path: storePath },
     );
 
-    const result = await migrateLegacyMainSessionKeys({
-      cfg: fixture.cfg,
-      env: fixture.env,
-      mode: "automatic",
-    });
+    const { result, committed } = await recordHarnessDeletions(() =>
+      migrateLegacyMainSessionKeys({
+        cfg: fixture.cfg,
+        env: fixture.env,
+        mode: "automatic",
+      }),
+    );
 
     expect(outcomeKinds(result)).toContain("migrated-in-place");
+    expect(committed).toEqual(["agent:main:chat"]);
     expect(
       readClaim({ databaseAgentId: "main", databasePath: storePath, key: "agent:main:chat" }),
     ).toBeUndefined();
@@ -451,6 +498,40 @@ describe("legacy main session migration", () => {
         sessionKey: "agent:ops:chat",
       },
     });
+  });
+
+  it("preserves a canonical owner created while alias deletion is preparing", async () => {
+    const storePath = path.join(tempDirs.make("in-place-owner-race-"), "sessions.sqlite");
+    const fixture = createFixture({
+      agents: { entries: { ops: {} } },
+      session: { store: storePath },
+    });
+    const sourceTarget = {
+      databaseAgentId: "main",
+      databasePath: storePath,
+      key: "agent:main:chat",
+    };
+    const canonicalTarget = { ...sourceTarget, key: "agent:ops:chat" };
+    seedClaim(sourceTarget);
+    const sourceBefore = readClaim(sourceTarget);
+    let canonicalBefore: ReturnType<typeof readClaim>;
+
+    const { result, committed } = await recordHarnessDeletions(
+      () => migrateLegacyMainSessionKeys({ cfg: fixture.cfg, env: fixture.env, mode: "automatic" }),
+      () => {
+        seedClaim({
+          ...canonicalTarget,
+          entry: { sessionId: "concurrent-owner", updatedAt: 200 },
+          events: [{ type: "message", id: "concurrent-event" }],
+        });
+        canonicalBefore = readClaim(canonicalTarget);
+      },
+    );
+
+    expect(readClaim(canonicalTarget)).toEqual(canonicalBefore);
+    expect(readClaim(sourceTarget)).toEqual(sourceBefore);
+    expect(committed).toEqual([]);
+    expect(result.complete).toBe(false);
   });
 
   it.each([
@@ -567,12 +648,15 @@ describe("legacy main session migration", () => {
         key: "agent:ops:chat",
       });
 
-      const result = await migrateLegacyMainSessionKeys({
-        cfg: fixture.cfg,
-        env: fixture.env,
-        mode: "doctor-fix",
-      });
+      const { result, committed } = await recordHarnessDeletions(() =>
+        migrateLegacyMainSessionKeys({
+          cfg: fixture.cfg,
+          env: fixture.env,
+          mode: "doctor-fix",
+        }),
+      );
 
+      expect(committed).toEqual(["agent:main:chat"]);
       const outcome = result.outcomes.find((entry) => entry.kind === "divergent-canonical");
       expect(outcome?.quarantinedKeys).toEqual(["agent:ops:legacy-main-conflict-2"]);
       expect(

--- a/src/config/sessions/legacy-main-session-migration.ts
+++ b/src/config/sessions/legacy-main-session-migration.ts
@@ -187,6 +187,7 @@ function resolvePhysicalStores(params: {
       });
       const physical: PhysicalStore = {
         databaseAgentId: normalizeAgentId(resolved.agentId ?? target.agentId),
+        ownerStorePath: target.storePath,
         path: resolved.path,
       };
       resolvePhysicalPathIdentity(physical.path);
@@ -514,6 +515,7 @@ async function migrateLegacyMainSessionKeysInternal(params: {
     isSameOpenClawAgentDatabasePath(store.path, destinationResolved.path),
   ) ?? {
     databaseAgentId: normalizeAgentId(destinationResolved.agentId ?? ownerAgentId),
+    ownerStorePath: destinationLogical,
     path: destinationResolved.path,
   };
 

--- a/src/config/sessions/session-accessor.readonly.test.ts
+++ b/src/config/sessions/session-accessor.readonly.test.ts
@@ -254,6 +254,32 @@ describe("session accessor readonly listing", () => {
     ]);
   });
 
+  it("does not prefer a main key when only a shared physical session identity is known", async () => {
+    const stateDir = autoTempDirs.make("openclaw-session-readonly-shared-identity-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const agentId = "worker-1";
+    const sessionId = "shared-generation";
+    const mainKey = "agent:worker-1:main";
+    const otherKey = "agent:worker-1:other";
+    for (const sessionKey of [mainKey, otherKey]) {
+      await upsertSessionEntryCore({ agentId, env, sessionKey }, { sessionId, updatedAt: 1 });
+    }
+    const storePath = resolveOpenClawAgentSqlitePath({ agentId, env });
+    const probe = { agentId, env, sessionId, storePath };
+
+    expect(
+      readSessionIdentityEvidenceBatch([
+        probe,
+        { ...probe, sessionKey: mainKey },
+        { ...probe, sessionKey: otherKey },
+      ]),
+    ).toEqual([
+      { status: "unknown", reason: "ambiguous" },
+      { status: "current", sessionKey: mainKey },
+      { status: "current", sessionKey: otherKey },
+    ]);
+  });
+
   it("rejects stale valid projections for unreadable session identity evidence", async () => {
     const stateDir = autoTempDirs.make("openclaw-session-readonly-stale-valid-evidence-");
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/config/sessions/session-accessor.sqlite-deletion.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-deletion.test.ts
@@ -1,0 +1,459 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type {
+  AgentHarness,
+  AgentHarnessSessionDeletionParams,
+} from "../../agents/harness/types.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  markPluginRegistryActive,
+  markPluginRegistryRetired,
+  revokePluginRecordLifecycleEpoch,
+} from "../../plugins/registry-lifecycle.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { createPluginRecord } from "../../plugins/status.test-helpers.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  deferOpenClawAgentPostCommitPublication,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  applySessionEntryLifecycleMutation,
+  applySessionEntryReplacements,
+  deleteSessionEntryLifecycle,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  patchSessionEntryCore,
+  replaceSessionEntry,
+  replaceTranscriptEventsSync,
+} from "./session-accessor.js";
+import * as sessionArchive from "./session-accessor.sqlite-archive.js";
+import { applySessionStoreProjection } from "./session-accessor.sqlite-projection.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("session deletion and native owner state", () => {
+  let storePath: string;
+  const sessionKey = "agent:main:cron:cleanup:run:session";
+  const baseKey = "agent:main:cron:cleanup";
+  const sessionId = "cleanup-session";
+  let bindings: Map<string, string>;
+
+  beforeEach(() => {
+    const tempDir = tempDirs.make("openclaw-session-deletion-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", tempDir);
+    storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");
+    bindings = new Map();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    vi.unstubAllEnvs();
+  });
+
+  function nativeOwner(
+    options: {
+      activate?: boolean;
+      prepare?: (params: AgentHarnessSessionDeletionParams) => Promise<void>;
+      finalize?: () => Promise<void>;
+      afterCommit?: (key: string) => void;
+      afterRollback?: (key: string) => void;
+    } = {},
+  ) {
+    const registry = createEmptyPluginRegistry();
+    const harness: AgentHarness = {
+      id: "native-test",
+      label: "Native test owner",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => {
+        throw new Error("not used");
+      },
+      withSessionDeletion: async (params, run) => {
+        await options.prepare?.(params);
+        params.assertCurrent();
+        const before = bindings.get(params.sessionKey);
+        let committed = false;
+        const result = await run({
+          commit: () => {
+            params.assertCurrent();
+            if (bindings.get(params.sessionKey) !== before) {
+              throw new Error("native binding owner changed");
+            }
+            bindings.delete(params.sessionKey);
+            committed = true;
+            options.afterCommit?.(params.sessionKey);
+          },
+          rollback: () => {
+            params.assertCurrent();
+            if (before !== undefined && !bindings.has(params.sessionKey)) {
+              bindings.set(params.sessionKey, before);
+            }
+            committed = false;
+            options.afterRollback?.(params.sessionKey);
+          },
+        });
+        if (committed) {
+          await options.finalize?.();
+          params.assertCurrent();
+        }
+        return result;
+      },
+    };
+    const record = createPluginRecord({ id: "native-owner" });
+    registry.plugins.push(record);
+    registry.agentHarnesses.push({ harness, pluginId: record.id, source: "runtime" });
+    if (options.activate !== false) {
+      markPluginRegistryActive(registry);
+    }
+    return {
+      record,
+      registry,
+      run: <T>(operation: () => Promise<T>) => withPluginRuntimeRegistryScope(registry, operation),
+    };
+  }
+
+  async function seed(key = sessionKey, harnessId: string | null = "native-test") {
+    await replaceSessionEntry(
+      { sessionKey: key, storePath },
+      {
+        sessionId,
+        lifecycleRevision: "generation-1",
+        updatedAt: Date.now(),
+        ...(harnessId ? { agentHarnessId: harnessId } : {}),
+      },
+    );
+    bindings.set(key, `thread:${key}`);
+  }
+
+  const remove = (key = sessionKey) =>
+    deleteSessionEntryLifecycle({
+      agentId: "main",
+      storePath,
+      target: { canonicalKey: key, storeKeys: [key] },
+      archiveTranscript: false,
+      deleteTranscriptWithoutArchive: true,
+    });
+  const read = (key = sessionKey) =>
+    loadSessionEntry({ sessionKey: key, storePath, readConsistency: "latest" });
+
+  it.each(["recorded", "missing"] as const)(
+    "deletes exact-key ownership with %s harness metadata",
+    async (metadata) => {
+      await seed(sessionKey, metadata === "recorded" ? "native-test" : null);
+      await seed(baseKey);
+      const owner = nativeOwner();
+
+      await owner.run(() => remove());
+
+      expect(read()).toBeUndefined();
+      expect(bindings.has(sessionKey)).toBe(false);
+      expect(read(baseKey)?.sessionId).toBe(sessionId);
+      expect(bindings.has(baseKey)).toBe(true);
+      await owner.run(() => remove(baseKey));
+      expect(bindings.size).toBe(0);
+    },
+  );
+
+  it("rejects an unavailable native owner before deleting session or transcript state", async () => {
+    await seed();
+    replaceTranscriptEventsSync({ sessionKey, sessionId, storePath }, [
+      { type: "session", id: sessionId },
+    ]);
+    const owner = nativeOwner({
+      prepare: async () => {
+        throw new Error("native session is supervised");
+      },
+    });
+
+    await expect(owner.run(() => remove())).rejects.toThrow("native session is supervised");
+
+    expect(read()?.sessionId).toBe(sessionId);
+    expect(await loadTranscriptEvents({ sessionKey, sessionId, storePath })).toHaveLength(1);
+    expect(bindings.has(sessionKey)).toBe(true);
+  });
+
+  it("restores companion state when the session transaction fails after its binding removal", async () => {
+    await seed();
+    const target = resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" });
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: target.path });
+    database.db.exec(
+      "CREATE TEMP TRIGGER reject_session_delete BEFORE DELETE ON session_nodes BEGIN SELECT RAISE(ABORT, 'injected session delete failure'); END",
+    );
+    const owner = nativeOwner();
+
+    await expect(owner.run(() => remove())).rejects.toThrow("injected session delete failure");
+
+    expect(read()?.sessionId).toBe(sessionId);
+    expect(bindings.get(sessionKey)).toBe(`thread:${sessionKey}`);
+  });
+
+  it("does not restore a binding after the session committed but publication failed", async () => {
+    await seed();
+    const owner = nativeOwner();
+
+    await expect(
+      owner.run(() =>
+        applySessionEntryLifecycleMutation({
+          storePath,
+          removals: [{ sessionKey }],
+          skipMaintenance: true,
+          beforeCommitInTransaction: () => {
+            const target = resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" });
+            const database = openOpenClawAgentDatabase({ agentId: "main", path: target.path });
+            deferOpenClawAgentPostCommitPublication(database, () => {
+              throw new Error("injected publication failure");
+            });
+          },
+        }),
+      ),
+    ).rejects.toThrow("injected publication failure");
+
+    expect(read()).toBeUndefined();
+    expect(bindings.has(sessionKey)).toBe(false);
+  });
+
+  it.each([false, true])(
+    "compensates partial commits even when another rollback fails (%s)",
+    async (rollbackFails) => {
+      await seed();
+      await seed(baseKey);
+      const commitError = new Error("companion commit failed after mutation");
+      const rollbackError = new Error("companion rollback reported failure");
+      let commits = 0;
+      let rollbacks = 0;
+      const owner = nativeOwner({
+        afterCommit: () => {
+          if (++commits === 2) {
+            throw commitError;
+          }
+        },
+        afterRollback: () => {
+          if (++rollbacks === 1 && rollbackFails) {
+            throw rollbackError;
+          }
+        },
+      });
+      const deletion = owner.run(() =>
+        applySessionStoreProjection({
+          storePath,
+          skipMaintenance: true,
+          update: (store) => {
+            delete store[baseKey];
+            delete store[sessionKey];
+            return { persist: true, result: undefined };
+          },
+        }),
+      );
+      if (rollbackFails) {
+        await expect(deletion).rejects.toMatchObject({
+          cause: commitError,
+          errors: [commitError, rollbackError],
+        });
+      } else {
+        await expect(deletion).rejects.toBe(commitError);
+      }
+      expect(read()?.sessionId).toBe(sessionId);
+      expect(read(baseKey)?.sessionId).toBe(sessionId);
+      expect(bindings.get(sessionKey)).toBe(`thread:${sessionKey}`);
+      expect(bindings.get(baseKey)).toBe(`thread:${baseKey}`);
+    },
+  );
+
+  it.each(["prepare", "finalize"] as const)(
+    "lets unrelated session writers progress during native %s",
+    async (phase) => {
+      await seed();
+      await seed(baseKey);
+      const entered = createDeferred();
+      const release = createDeferred();
+      const wait = async () => {
+        entered.resolve();
+        await release.promise;
+      };
+      const owner = nativeOwner(phase === "prepare" ? { prepare: wait } : { finalize: wait });
+      const deletion = owner.run(() => remove());
+      try {
+        await withTestTimeout(entered.promise, 5_000, "native deletion did not start");
+        await withTestTimeout(
+          owner.run(() =>
+            patchSessionEntryCore({ sessionKey: baseKey, storePath }, () => ({
+              label: "writer progressed",
+            })),
+          ),
+          5_000,
+          "native cleanup blocked another session writer",
+        );
+        expect(read(baseKey)?.label).toBe("writer progressed");
+      } finally {
+        release.resolve();
+        await deletion;
+      }
+    },
+  );
+
+  it("uses an explicitly scoped prepared registry without globally activating it", async () => {
+    await seed();
+    let retainedGuard: (() => void) | undefined;
+    const owner = nativeOwner({
+      activate: false,
+      prepare: async ({ assertCurrent }) => {
+        retainedGuard = assertCurrent;
+      },
+    });
+    await owner.run(() => remove());
+    expect(read()).toBeUndefined();
+    expect(bindings.has(sessionKey)).toBe(false);
+    expect(() => retainedGuard?.()).toThrow("harness owner changed");
+  });
+
+  it.each(["retired", "reactivated", "record revoked", "registration replaced"] as const)(
+    "rejects a prepared owner after its registry is %s",
+    async (change) => {
+      await seed();
+      const entered = createDeferred();
+      const release = createDeferred();
+      const owner = nativeOwner({
+        activate: false,
+        prepare: async () => {
+          entered.resolve();
+          await release.promise;
+        },
+      });
+      const deletion = owner.run(() => remove());
+      const rejected = expect(deletion).rejects.toThrow("harness owner changed");
+      await entered.promise;
+      if (change === "retired") {
+        markPluginRegistryRetired(owner.registry);
+      } else if (change === "reactivated") {
+        markPluginRegistryActive(owner.registry);
+      } else if (change === "record revoked") {
+        revokePluginRecordLifecycleEpoch(owner.registry, owner.record);
+      } else {
+        owner.registry.agentHarnesses = owner.registry.agentHarnesses.map((registration) =>
+          Object.assign({}, registration),
+        );
+      }
+      release.resolve();
+      await rejected;
+      expect(read()?.sessionId).toBe(sessionId);
+      expect(bindings.has(sessionKey)).toBe(true);
+    },
+  );
+
+  it("rejects a captured prepared owner invoked under a different registry scope", async () => {
+    await seed();
+    const other = createEmptyPluginRegistry();
+    const owner = nativeOwner({
+      activate: false,
+      prepare: async ({ assertCurrent }) => {
+        withPluginRuntimeRegistryScope(other, assertCurrent);
+      },
+    });
+    await expect(owner.run(() => remove())).rejects.toThrow("harness owner changed");
+    expect(read()?.sessionId).toBe(sessionId);
+    expect(bindings.has(sessionKey)).toBe(true);
+  });
+
+  it("preserves history when its native owner retires during archive materialization", async () => {
+    const historicalId = "historical-cleanup-session";
+    const historicalEvent = { type: "session", id: historicalId, content: "retained history" };
+    await replaceSessionEntry(
+      { sessionKey, storePath },
+      { sessionId: historicalId, updatedAt: Date.now() },
+    );
+    expect(
+      replaceTranscriptEventsSync({ sessionKey, sessionId: historicalId, storePath }, [
+        historicalEvent,
+      ]),
+    ).toBe(true);
+    await seed();
+    const entered = createDeferred();
+    const release = createDeferred();
+    const materialize = sessionArchive.materializeSessionStateDeletePlans;
+    vi.spyOn(sessionArchive, "materializeSessionStateDeletePlans").mockImplementationOnce(
+      async (...args) => {
+        const result = await materialize(...args);
+        entered.resolve();
+        await release.promise;
+        return result;
+      },
+    );
+    const owner = nativeOwner();
+    const deletion = owner.run(() =>
+      deleteSessionEntryLifecycle({
+        agentId: "main",
+        storePath,
+        target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+        archiveTranscript: true,
+      }),
+    );
+    const rejected = expect(deletion).rejects.toThrow("harness owner changed");
+    try {
+      await withTestTimeout(entered.promise, 30_000, "history archive did not materialize");
+      markPluginRegistryRetired(owner.registry);
+    } finally {
+      release.resolve();
+    }
+    await rejected;
+    expect(read()?.sessionId).toBe(sessionId);
+    expect(bindings.has(sessionKey)).toBe(true);
+    expect(await loadTranscriptEvents({ sessionKey, sessionId: historicalId, storePath })).toEqual([
+      historicalEvent,
+    ]);
+  });
+
+  it.each(["entry replacement", "whole-store projection", "maintenance"] as const)(
+    "preserves successor bindings and removes deleted keys through %s",
+    async (surface) => {
+      await seed();
+      const owner = nativeOwner();
+      await owner.run(async () => {
+        if (surface === "entry replacement") {
+          await applySessionEntryReplacements({
+            storePath,
+            sessionKeys: [sessionKey],
+            skipMaintenance: true,
+            update: (entries) => ({
+              result: undefined,
+              replacements: entries.map(({ entry, sessionKey: key }) => ({
+                sessionKey: key,
+                entry: { ...entry, sessionId: "replacement-session" },
+              })),
+            }),
+          });
+          return;
+        }
+        if (surface === "whole-store projection") {
+          await applySessionStoreProjection({
+            storePath,
+            skipMaintenance: true,
+            update: (store) => {
+              delete store[sessionKey];
+              return { persist: true, result: undefined };
+            },
+          });
+          return;
+        }
+        await applySessionEntryLifecycleMutation({
+          storePath,
+          maintenanceOverride: {
+            mode: "enforce",
+            maxEntries: 0,
+            pruneAfterMs: Number.MAX_SAFE_INTEGER,
+            preserveRecentMs: 0,
+          },
+        });
+      });
+      expect(bindings.has(sessionKey)).toBe(surface === "entry replacement");
+      expect(read()?.sessionId).toBe(
+        surface === "entry replacement" ? "replacement-session" : undefined,
+      );
+    },
+  );
+});

--- a/src/config/sessions/session-accessor.sqlite-deletion.ts
+++ b/src/config/sessions/session-accessor.sqlite-deletion.ts
@@ -1,0 +1,202 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  captureAgentHarnessSessionDeletions,
+  type AgentHarnessSessionDeletionTarget,
+  type PreparedAgentHarnessSessionDeletion,
+} from "../../agents/harness/session-deletion.js";
+import type { AgentHarnessSessionDeletionMutation } from "../../agents/harness/types.js";
+import { createSqliteLifecycleAggregateError } from "../../infra/sqlite-coordinator.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
+import {
+  isCompetingSessionWorkAdmissionActive,
+  runExclusiveSessionLifecycleMutation,
+} from "../../sessions/session-lifecycle-admission.js";
+import {
+  deferOpenClawAgentPostCommitPublication,
+  runOpenClawAgentWriteTransaction,
+  type OpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { resolveSessionStorePathCore } from "./paths.js";
+import {
+  runExclusiveSqliteSessionWrite,
+  type ResolvedSqliteReadScope,
+} from "./session-accessor.sqlite-scope.js";
+import type { SessionEntry } from "./types.js";
+
+type DeletionEntry = { sessionKey: string; entry: SessionEntry };
+type PreparedDeletion = {
+  target: AgentHarnessSessionDeletionTarget;
+  mutations: readonly PreparedAgentHarnessSessionDeletion[];
+  assertIdle: () => void;
+};
+const deletions = new AsyncLocalStorage<ReadonlyMap<string, PreparedDeletion>>();
+const transactionMutations = new AsyncLocalStorage<AgentHarnessSessionDeletionMutation[]>();
+
+type PreparedSessionWrite<T> = {
+  deletedEntries: readonly DeletionEntry[];
+  beforeCommit?: () => Promise<void>;
+  commit: () => T | Promise<T>;
+};
+
+/** Keep ordinary updates serialized; release the writer only for native or artifact preparation. */
+export async function runPreparedSqliteSessionWrite<T>(
+  scope: ResolvedSqliteReadScope,
+  prepare: () => Promise<PreparedSessionWrite<T>>,
+): Promise<T> {
+  const prepared = await runExclusiveSqliteSessionWrite(scope, async () => {
+    const write = await prepare();
+    return write.deletedEntries.length || write.beforeCommit
+      ? { write }
+      : { result: await write.commit() };
+  });
+  if (!prepared.write) {
+    return prepared.result;
+  }
+  const write = prepared.write;
+  return await withSqliteSessionDeletions(scope, write.deletedEntries, async (assertCurrent) => {
+    await write.beforeCommit?.();
+    return await runExclusiveSqliteSessionWrite(scope, async () => {
+      assertCurrent();
+      return await write.commit();
+    });
+  });
+}
+
+/** Prepare owner leases before entering a physical writer or changing any transcript state. */
+export async function withSqliteSessionDeletions<T>(
+  scope: Pick<ResolvedSqliteReadScope, "agentId" | "env" | "ownerStorePath" | "path">,
+  entries: readonly DeletionEntry[],
+  run: (assertCurrent: () => void) => Promise<T>,
+): Promise<T> {
+  const targets = [
+    ...new Map(
+      entries
+        .filter(({ entry }) => entry.sessionId)
+        .map(({ sessionKey, entry }) => [
+          sessionKey,
+          {
+            agentId: parseAgentSessionKey(sessionKey)?.agentId ?? scope.agentId,
+            sessionKey,
+            sessionId: entry.sessionId,
+            ...(entry.lifecycleRevision ? { lifecycleRevision: entry.lifecycleRevision } : {}),
+            ...(entry.agentHarnessId ? { agentHarnessId: entry.agentHarnessId } : {}),
+          },
+        ]),
+    ).values(),
+  ].toSorted((a, b) => a.sessionKey.localeCompare(b.sessionKey));
+  const ownerStorePath =
+    scope.ownerStorePath ??
+    resolveSessionStorePathCore(undefined, { agentId: scope.agentId, env: scope.env });
+  const assertTargetIdle = (target: AgentHarnessSessionDeletionTarget) => {
+    if (
+      isCompetingSessionWorkAdmissionActive(ownerStorePath, [target.sessionKey, target.sessionId])
+    ) {
+      throw new Error(
+        `Cannot delete session while competing work is in flight for ${target.sessionKey}; retry after the run completes`,
+      );
+    }
+  };
+  targets.forEach(assertTargetIdle);
+  const prepare = captureAgentHarnessSessionDeletions();
+  const invoke = async (
+    prepared: ReadonlyMap<string, readonly PreparedAgentHarnessSessionDeletion[]>,
+  ) => {
+    const assertCurrent = () => {
+      targets.forEach(assertTargetIdle);
+      for (const mutations of prepared.values()) {
+        mutations.forEach((mutation) => mutation.assertCurrent());
+      }
+    };
+    assertCurrent();
+    return await deletions.run(
+      new Map(
+        targets.map((target) => [
+          target.sessionKey,
+          {
+            target,
+            mutations: prepared.get(target.sessionKey) ?? [],
+            assertIdle: () => assertTargetIdle(target),
+          },
+        ]),
+      ),
+      () => run(assertCurrent),
+    );
+  };
+  return await runExclusiveSessionLifecycleMutation({
+    scope: ownerStorePath,
+    identities: targets.flatMap((target) => [target.sessionKey, target.sessionId]),
+    run: async () => (prepare ? await prepare(targets, invoke) : await invoke(new Map())),
+  });
+}
+
+/** Called only at the synchronous SQL edge, after the operation revalidates its row snapshot. */
+export function commitSqliteSessionDeletion(sessionKey: string, entry: SessionEntry): void {
+  const prepared = deletions.getStore()?.get(sessionKey);
+  if (!prepared) {
+    if (captureAgentHarnessSessionDeletions()) {
+      throw new Error(`Session deletion requires prepared harness ownership: ${sessionKey}`);
+    }
+    return;
+  }
+  if (
+    prepared.target.sessionId !== entry.sessionId ||
+    prepared.target.lifecycleRevision !== entry.lifecycleRevision
+  ) {
+    throw new Error(`Session changed before deletion: ${sessionKey}`);
+  }
+  prepared.assertIdle();
+  const rollback = transactionMutations.getStore();
+  if (!rollback) {
+    throw new Error(`Session deletion requires its synchronous transaction: ${sessionKey}`);
+  }
+  for (const mutation of prepared.mutations) {
+    rollback.push(mutation);
+    mutation.commit();
+  }
+}
+
+/** Roll back companion state only if SQLite failed before COMMIT, never after publication. */
+export function runSqliteSessionDeletionTransaction<T>(
+  operation: (database: OpenClawAgentDatabase) => T,
+  options: Parameters<typeof runOpenClawAgentWriteTransaction>[1],
+  transactionOptions?: Parameters<typeof runOpenClawAgentWriteTransaction>[2],
+): T {
+  if (!deletions.getStore() || transactionMutations.getStore()) {
+    return runOpenClawAgentWriteTransaction(operation, options, transactionOptions);
+  }
+  const rollback: AgentHarnessSessionDeletionMutation[] = [];
+  let committed = false;
+  try {
+    return transactionMutations.run(rollback, () =>
+      runOpenClawAgentWriteTransaction(
+        (database) => {
+          deferOpenClawAgentPostCommitPublication(database, () => {
+            committed = true;
+          });
+          return operation(database);
+        },
+        options,
+        transactionOptions,
+      ),
+    );
+  } catch (error) {
+    const failures = [error];
+    if (!committed) {
+      for (const mutation of rollback.toReversed()) {
+        try {
+          mutation.rollback();
+        } catch (rollbackError) {
+          failures.push(rollbackError);
+        }
+      }
+    }
+    if (failures.length > 1) {
+      throw createSqliteLifecycleAggregateError(
+        failures,
+        "Session deletion rollback failed",
+        error,
+      );
+    }
+    throw error;
+  }
+}

--- a/src/config/sessions/session-accessor.sqlite-entry-availability.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-availability.ts
@@ -94,8 +94,10 @@ export function loadExactSessionEntryReadOnlyResult(
 
 type SessionIdentityEvidenceProbe = {
   agentId: string;
+  env?: NodeJS.ProcessEnv;
   sessionId: string;
-  sessionKey: string;
+  /** Omit for identity-only repair: no exact key may override ambiguous physical ownership. */
+  sessionKey?: string;
   storePath: string;
 };
 
@@ -104,7 +106,7 @@ const SESSION_IDENTITY_EVIDENCE_QUERY_CHUNK_SIZE = 400;
 type SessionIdentityEvidenceItem = {
   index: number;
   sessionId: string;
-  sessionKey: string;
+  sessionKey?: string;
 };
 
 type SessionIdentityEvidenceRow = {
@@ -141,7 +143,10 @@ function readSessionIdentityEvidenceRows(
       }
     }
   };
-  readChunks([...new Set(items.map((item) => item.sessionKey))], "session_key");
+  readChunks(
+    [...new Set(items.flatMap((item) => (item.sessionKey ? [item.sessionKey] : [])))],
+    "session_key",
+  );
   readChunks([...new Set(items.map((item) => item.sessionId))], "current_session_id");
 
   const rowsBySessionId = new Map<string, SessionIdentityEvidenceRow[]>();
@@ -161,7 +166,7 @@ function readSessionIdentityEvidenceRows(
     }
   }
   return items.map((item): SessionIdentityEvidenceResult => {
-    const exactRow = rowsByKey.get(item.sessionKey);
+    const exactRow = item.sessionKey ? rowsByKey.get(item.sessionKey) : undefined;
     if (exactRow && exactRow.entry_valid !== -1 && !readableKeys.has(exactRow.session_key)) {
       return { status: "unknown", reason: "row-invalid" };
     }
@@ -170,7 +175,7 @@ function readSessionIdentityEvidenceRows(
       readableKeys.has(exactRow.session_key) &&
       exactRow.current_session_id === item.sessionId
     ) {
-      return { status: "current", sessionKey: item.sessionKey };
+      return { status: "current", sessionKey: exactRow.session_key };
     }
     const fallbackRows = rowsBySessionId.get(item.sessionId) ?? [];
     if (fallbackRows.length !== 1) {
@@ -213,7 +218,7 @@ export function readSessionIdentityEvidenceBatch(
       group.items.push({
         index,
         sessionId: probe.sessionId,
-        sessionKey: resolved.sessionKey ?? "",
+        sessionKey: resolved.sessionKey,
       });
       groups.set(databasePath, group);
     } catch {

--- a/src/config/sessions/session-accessor.sqlite-entry-equality.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-equality.ts
@@ -1,9 +1,21 @@
 import type { SessionEntry } from "./types.js";
 
-type SqliteLifecycleTargetSnapshot = {
+export type SqliteLifecycleTargetSnapshot = {
   primary: { entry: SessionEntry; key: string } | undefined;
   rows: Array<{ entry: SessionEntry; sessionKey: string }>;
 };
+
+type SqliteSessionEntrySelectionSnapshot = {
+  selected: { entry: SessionEntry; row: { session_key: string } } | undefined;
+  selectedRows: Array<{ entry: SessionEntry; sessionKey: string }>;
+};
+
+class SqliteSessionMutationConflictError extends Error {
+  constructor(operationLabel: string) {
+    super(`SQLite session state changed while preparing ${operationLabel}`);
+    this.name = "SqliteSessionMutationConflictError";
+  }
+}
 
 export function sqliteSessionEntriesEqual(
   left: SessionEntry | undefined,
@@ -27,7 +39,7 @@ export function sqliteSessionEntriesEqual(
   return JSON.stringify(leftEntry) === JSON.stringify(rightEntry);
 }
 
-export function sqliteSessionSnapshotRowsEqual(
+function sqliteSessionSnapshotRowsEqual(
   left: Array<{ entry: SessionEntry; sessionKey: string }>,
   right: Array<{ entry: SessionEntry; sessionKey: string }>,
 ): boolean {
@@ -50,4 +62,30 @@ export function sqliteLifecycleTargetSnapshotsEqual(
     sqliteSessionEntriesEqual(expected.primary?.entry, current.primary?.entry) &&
     sqliteSessionSnapshotRowsEqual(expected.rows, current.rows)
   );
+}
+
+export function assertSessionEntrySelectionUnchanged(
+  expected: SqliteSessionEntrySelectionSnapshot,
+  current: SqliteSessionEntrySelectionSnapshot,
+  operationLabel: string,
+): void {
+  const selectedMatches =
+    expected.selected?.row.session_key === current.selected?.row.session_key &&
+    sqliteSessionEntriesEqual(expected.selected?.entry, current.selected?.entry);
+  if (
+    !selectedMatches ||
+    !sqliteSessionSnapshotRowsEqual(expected.selectedRows, current.selectedRows)
+  ) {
+    throw new SqliteSessionMutationConflictError(operationLabel);
+  }
+}
+
+export function assertLifecycleTargetSnapshotUnchanged(
+  expected: SqliteLifecycleTargetSnapshot,
+  current: SqliteLifecycleTargetSnapshot,
+  operationLabel: string,
+): void {
+  if (!sqliteLifecycleTargetSnapshotsEqual(expected, current)) {
+    throw new SqliteSessionMutationConflictError(operationLabel);
+  }
 }

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -12,14 +12,14 @@ import {
   prepareSessionConversationForWrite,
   upsertConversationIdentity,
 } from "./session-accessor.sqlite-conversation.js";
+import { commitSqliteSessionDeletion } from "./session-accessor.sqlite-deletion.js";
 import {
   publishSessionEntryCacheInvalidation,
   trackSessionEntryCacheWrite,
 } from "./session-accessor.sqlite-entry-cache.js";
 import {
-  sqliteLifecycleTargetSnapshotsEqual,
   sqliteSessionEntriesEqual,
-  sqliteSessionSnapshotRowsEqual,
+  type SqliteLifecycleTargetSnapshot,
 } from "./session-accessor.sqlite-entry-equality.js";
 import {
   clearSessionCollaborationForKey,
@@ -76,10 +76,6 @@ type SqliteSessionEntrySelectionSnapshot = {
   selected: ResolvedSessionEntryRow | undefined;
   selectedRows: Array<{ entry: SessionEntry; sessionKey: string }>;
 };
-type SqliteLifecycleTargetSnapshot = {
-  primary: { entry: SessionEntry; key: string } | undefined;
-  rows: Array<{ entry: SessionEntry; sessionKey: string }>;
-};
 
 export function parseReadableSqliteSessionEntryRow(
   database: Pick<OpenClawAgentDatabase, "db">,
@@ -117,13 +113,6 @@ export function parseReadableSqliteSessionEntryRow(
   throw canonicalSessionKeyMigrationRequiredError(
     `invalid persisted session row requires repair for ${row.session_key}`,
   );
-}
-
-class SqliteSessionMutationConflictError extends Error {
-  constructor(operationLabel: string) {
-    super(`SQLite session state changed while preparing ${operationLabel}`);
-    this.name = "SqliteSessionMutationConflictError";
-  }
 }
 
 export function readSessionIdentitySnapshot(
@@ -200,22 +189,6 @@ export function readSessionEntrySelectionSnapshot(
       return row ? [{ entry: cloneSessionEntry(row.entry), sessionKey: candidateKey }] : [];
     }),
   };
-}
-
-export function assertSessionEntrySelectionUnchanged(
-  expected: SqliteSessionEntrySelectionSnapshot,
-  current: SqliteSessionEntrySelectionSnapshot,
-  operationLabel: string,
-): void {
-  const selectedMatches =
-    expected.selected?.row.session_key === current.selected?.row.session_key &&
-    sqliteSessionEntriesEqual(expected.selected?.entry, current.selected?.entry);
-  if (
-    !selectedMatches ||
-    !sqliteSessionSnapshotRowsEqual(expected.selectedRows, current.selectedRows)
-  ) {
-    throw new SqliteSessionMutationConflictError(operationLabel);
-  }
 }
 
 export function readExactSessionEntryRow(
@@ -337,16 +310,6 @@ export function readLifecycleTargetSnapshot(
   };
 }
 
-export function assertLifecycleTargetSnapshotUnchanged(
-  expected: SqliteLifecycleTargetSnapshot,
-  current: SqliteLifecycleTargetSnapshot,
-  operationLabel: string,
-): void {
-  if (!sqliteLifecycleTargetSnapshotsEqual(expected, current)) {
-    throw new SqliteSessionMutationConflictError(operationLabel);
-  }
-}
-
 export function normalizeLifecycleTarget(target: { canonicalKey: string; storeKeys: string[] }): {
   canonicalKey: string;
   storeKeys: string[];
@@ -361,8 +324,18 @@ export function normalizeLifecycleTarget(target: { canonicalKey: string; storeKe
 export function deleteSessionEntryRows(
   database: OpenClawAgentDatabase,
   sessionKey: string,
-  options: { deleteOwnedWindows?: boolean; deliveryCleanupKeys?: readonly string[] } = {},
+  options: {
+    deleteOwnedWindows?: boolean;
+    deliveryCleanupKeys?: readonly string[];
+    validatedEntry?: SessionEntry;
+  } = {},
 ): void {
+  // Doctor supplies the exact row it validated; the runtime parser deliberately rejects that shape.
+  const previousEntry =
+    options.validatedEntry ?? readExactSessionEntryRow(database, sessionKey)?.entry;
+  if (previousEntry) {
+    commitSqliteSessionDeletion(sessionKey, previousEntry);
+  }
   const db = getSessionKysely(database.db);
   const windows = executeSqliteQuerySync(
     database.db,
@@ -528,7 +501,7 @@ export function deleteLegacySessionEntryRows(
   database: OpenClawAgentDatabase,
   legacyKeys: string[],
   sessionKey: string,
-  options: { rehomeMembers?: boolean } = {},
+  options: { rehomeMembers?: boolean; validatedEntries?: ReadonlyMap<string, SessionEntry> } = {},
 ): void {
   if (legacyKeys.length === 0) {
     return;
@@ -537,6 +510,12 @@ export function deleteLegacySessionEntryRows(
   for (const legacyKey of legacyKeys) {
     if (legacyKey === sessionKey) {
       continue;
+    }
+    const previousEntry =
+      options.validatedEntries?.get(legacyKey) ??
+      readExactSessionEntryRow(database, legacyKey)?.entry;
+    if (previousEntry) {
+      commitSqliteSessionDeletion(legacyKey, previousEntry);
     }
     rehomeSessionWindows(database, sessionKey, [legacyKey]);
     copySessionNodeArtifactsForRepair(database, database, [legacyKey], sessionKey, {

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -9,7 +9,6 @@ import {
   isIncognitoOpenClawAgentSqlitePath,
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
-  runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
@@ -28,12 +27,18 @@ import type {
   SessionTranscriptWriteScope,
 } from "./session-accessor.sqlite-contract.js";
 import {
+  runPreparedSqliteSessionWrite,
+  runSqliteSessionDeletionTransaction as runOpenClawAgentWriteTransaction,
+} from "./session-accessor.sqlite-deletion.js";
+import {
   readSessionEntryCache,
   type SessionEntryCacheSnapshot,
 } from "./session-accessor.sqlite-entry-cache.js";
 import {
   assertLifecycleTargetSnapshotUnchanged,
   assertSessionEntrySelectionUnchanged,
+} from "./session-accessor.sqlite-entry-equality.js";
+import {
   collectSessionEntryLookupKeys,
   createSessionIdentitySnapshot,
   deleteLegacySessionEntryRows,
@@ -64,7 +69,6 @@ import {
   resolveSqliteStoreScope,
   resolveSqliteTranscriptArchiveDirectory,
   resolveSqliteTranscriptReadScope,
-  runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
   type ResolvedSqliteScope,
 } from "./session-accessor.sqlite-scope.js";
@@ -567,73 +571,85 @@ async function patchSqliteSessionEntrySnapshot<TSnapshot>(
   params: SqliteSessionEntrySnapshotPatchParams<TSnapshot>,
 ): Promise<SessionEntry | null> {
   const { options, resolved, sessionKey } = params;
-  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
+  const committed = await runPreparedSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const prepared = params.readSnapshot(database);
     const existing = params.existingEntry(prepared);
     const writeBase = existing ?? options.fallbackEntry;
     if (!writeBase) {
-      return { maintenancePlans: [], result: null };
+      return { deletedEntries: [], commit: () => ({ maintenancePlans: [], result: null }) };
     }
     const patch = await params.update(cloneSessionEntry(writeBase), {
       existingEntry: existing ? cloneSessionEntry(existing) : undefined,
     });
-    const maintenancePlans: SessionEntryMaintenancePlan[] = [];
-    let result: SessionEntry | null = null;
-    let previousIdentity = new Map<string, SessionEntry>();
-    let currentIdentity = new Map<string, SessionEntry>();
-    runOpenClawAgentWriteTransaction((writeDatabase) => {
-      const fresh = params.readSnapshot(writeDatabase);
-      params.assertSnapshotUnchanged(prepared, fresh);
-      options.assertCommitAllowed?.();
-      if (!patch) {
-        result = cloneSessionEntry(writeBase);
-        return;
-      }
-      const snapshotRows = params.snapshotRows(fresh);
-      const legacyKeys = params.legacyKeys(fresh);
-      const identityKeys = [
-        sessionKey,
-        ...legacyKeys,
-        ...snapshotRows.map((row) => row.sessionKey),
-      ];
-      previousIdentity = createSessionIdentitySnapshot(snapshotRows);
-      const merged = options.replaceEntry
+    const merged = !patch
+      ? undefined
+      : options.replaceEntry
         ? cloneSessionEntry(patch as SessionEntry)
         : options.preserveActivity
           ? mergeSessionEntryPreserveActivity(writeBase, patch)
           : mergeSessionEntry(writeBase, patch);
-      const next = options.replaceEntry
+    const next = !merged
+      ? undefined
+      : options.replaceEntry
         ? merged
         : preserveSqliteSameKeySessionRolloverLineage({
             next: merged,
             previous: writeBase,
             sessionKey,
           });
-      const selectedPreviousEntry = params.existingEntry(fresh) ?? writeBase;
-      writeSessionEntry(writeDatabase, sessionKey, next, {
-        previousEntry: selectedPreviousEntry,
-      });
-      if (params.rehomeWindows) {
-        rehomeSessionWindows(writeDatabase, sessionKey, legacyKeys);
-      }
-      deleteLegacySessionEntryRows(writeDatabase, legacyKeys, sessionKey, {
-        rehomeMembers: selectedPreviousEntry.sessionId === next.sessionId,
-      });
-      maintenancePlans.push(
-        applySessionEntryMaintenance(writeDatabase, {
-          activeSessionKey: sessionKey,
-          archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-          maintenanceConfig: options.maintenanceConfig,
-          skipMaintenance: options.skipMaintenance,
-          storePath: params.storePath,
-        }),
-      );
-      currentIdentity = readSessionIdentitySnapshot(writeDatabase, identityKeys);
-      result = cloneSessionEntry(next);
-    }, toDatabaseOptions(resolved));
-    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
-    return { maintenancePlans, result };
+    const deletedOwners = next
+      ? params.snapshotRows(prepared).filter((row) => row.sessionKey !== sessionKey)
+      : [];
+    return {
+      deletedEntries: deletedOwners,
+      commit: () => {
+        const maintenancePlans: SessionEntryMaintenancePlan[] = [];
+        let result: SessionEntry | null = null;
+        let previousIdentity = new Map<string, SessionEntry>();
+        let currentIdentity = new Map<string, SessionEntry>();
+        runOpenClawAgentWriteTransaction((writeDatabase) => {
+          const fresh = params.readSnapshot(writeDatabase);
+          params.assertSnapshotUnchanged(prepared, fresh);
+          options.assertCommitAllowed?.();
+          if (!next) {
+            result = cloneSessionEntry(writeBase);
+            return;
+          }
+          const snapshotRows = params.snapshotRows(fresh);
+          const legacyKeys = params.legacyKeys(fresh);
+          const identityKeys = [
+            sessionKey,
+            ...legacyKeys,
+            ...snapshotRows.map((row) => row.sessionKey),
+          ];
+          previousIdentity = createSessionIdentitySnapshot(snapshotRows);
+          const selectedPreviousEntry = params.existingEntry(fresh) ?? writeBase;
+          writeSessionEntry(writeDatabase, sessionKey, next, {
+            previousEntry: selectedPreviousEntry,
+          });
+          if (params.rehomeWindows) {
+            rehomeSessionWindows(writeDatabase, sessionKey, legacyKeys);
+          }
+          deleteLegacySessionEntryRows(writeDatabase, legacyKeys, sessionKey, {
+            rehomeMembers: selectedPreviousEntry.sessionId === next.sessionId,
+          });
+          maintenancePlans.push(
+            applySessionEntryMaintenance(writeDatabase, {
+              activeSessionKey: sessionKey,
+              archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+              maintenanceConfig: options.maintenanceConfig,
+              skipMaintenance: options.skipMaintenance,
+              storePath: params.storePath,
+            }),
+          );
+          currentIdentity = readSessionIdentitySnapshot(writeDatabase, identityKeys);
+          result = cloneSessionEntry(next);
+        }, toDatabaseOptions(resolved));
+        emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
+        return { maintenancePlans, result };
+      },
+    };
   });
   // Worker materialization runs after the initial write releases the lane;
   // final deletion reacquires it and revalidates every planned row.

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -12,7 +12,6 @@ import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   openOpenClawAgentDatabase,
-  runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import type { ResetSessionEntryLifecycleMutation } from "./session-accessor.lifecycle-types.js";
@@ -27,6 +26,11 @@ import type {
   SessionLifecycleArtifactCleanupParams,
   SessionLifecycleArtifactCleanupResult,
 } from "./session-accessor.sqlite-contract.js";
+import {
+  runPreparedSqliteSessionWrite,
+  runSqliteSessionDeletionTransaction as runOpenClawAgentWriteTransaction,
+  withSqliteSessionDeletions,
+} from "./session-accessor.sqlite-deletion.js";
 import {
   sqliteLifecycleTargetSnapshotsEqual,
   sqliteSessionEntriesEqual,
@@ -142,26 +146,38 @@ export async function cleanupSessionLifecycleArtifactsCore(
       nowMs: params.nowMs ?? Date.now(),
     });
   });
-  const materializedPlans = await materializeSessionStateDeletePlans(cleanupPlan.deletePlans);
-  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
-    let removedEntries = 0;
-    let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
-    runOpenClawAgentWriteTransaction((transactionDb) => {
-      assertPlannedLifecycleArtifactEntriesUnchanged(transactionDb, cleanupPlan.entries);
-      archivedTranscripts = deleteMaterializedSessionStatePlans(
-        transactionDb,
-        materializedPlans,
-        undefined,
-        new Set(cleanupPlan.entries.map((entry) => entry.sessionKey)),
-      );
-      removedEntries = deletePlannedLifecycleArtifactEntries(transactionDb, cleanupPlan.entries);
-    }, databaseOptions);
-    emitCommittedSessionEntryRemovals(cleanupPlan.entries);
-    return {
-      removedEntries,
-      archivedTranscripts,
-    };
-  });
+  const committed = await withSqliteSessionDeletions(
+    resolved,
+    cleanupPlan.entries.flatMap(({ expectedEntry: entry, sessionKey }) =>
+      entry ? [{ entry, sessionKey }] : [],
+    ),
+    async (assertCurrent) => {
+      const materializedPlans = await materializeSessionStateDeletePlans(cleanupPlan.deletePlans);
+      return await runExclusiveSqliteSessionWrite(resolved, async () => {
+        let removedEntries = 0;
+        let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
+        runOpenClawAgentWriteTransaction((transactionDb) => {
+          assertCurrent();
+          assertPlannedLifecycleArtifactEntriesUnchanged(transactionDb, cleanupPlan.entries);
+          archivedTranscripts = deleteMaterializedSessionStatePlans(
+            transactionDb,
+            materializedPlans,
+            undefined,
+            new Set(cleanupPlan.entries.map((entry) => entry.sessionKey)),
+          );
+          removedEntries = deletePlannedLifecycleArtifactEntries(
+            transactionDb,
+            cleanupPlan.entries,
+          );
+        }, databaseOptions);
+        emitCommittedSessionEntryRemovals(cleanupPlan.entries);
+        return {
+          removedEntries,
+          archivedTranscripts,
+        };
+      });
+    },
+  );
   const archivedTranscripts = await publishSessionStateArchives(
     resolved,
     committed.archivedTranscripts,
@@ -181,7 +197,7 @@ export async function resetSessionEntryLifecycle(
   // Retained reset history is the store's growth event; give the throttled
   // budget pass a chance to extract-and-evict once we finish.
   try {
-    return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    return await runPreparedSqliteSessionWrite(resolved, async () => {
       const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
       const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
       const current = targetSnapshot.primary;
@@ -189,74 +205,90 @@ export async function resetSessionEntryLifecycle(
         currentEntry: current ? cloneSessionEntry(current.entry) : undefined,
         primaryKey: params.target.canonicalKey,
       });
-      const shouldAppendResetBoundary =
-        params.resetBoundaryReason &&
-        current?.entry.sessionId &&
-        !sqliteSessionEntriesEqual(current.entry, nextEntry);
-      const mutation: ResetSessionEntryLifecycleMutation = {
-        nextEntry: cloneSessionEntry(nextEntry),
-        ...(current ? { previousEntry: cloneSessionEntry(current.entry) } : {}),
-        ...(current?.entry.sessionId ? { previousSessionId: current.entry.sessionId } : {}),
-      };
-      runOpenClawAgentWriteTransaction((transactionDb) => {
-        assertLifecycleTargetUnchanged(transactionDb, params.target, current?.entry, "reset");
-        if (shouldAppendResetBoundary && current?.entry.sessionId && params.resetBoundaryReason) {
-          const event = buildSessionResetBoundaryEvent({
-            events: loadTranscriptEventsFromDatabase(transactionDb, current.entry.sessionId),
-            reason: params.resetBoundaryReason,
-          });
-          const appended = appendTranscriptEventsInTransaction(
-            transactionDb,
-            {
-              ...resolved,
-              sessionId: current.entry.sessionId,
-              sessionKey: current.key,
-            },
-            [event],
-          );
-          if (appended !== 1) {
-            throw new Error(`Failed to append reset boundary for ${current.key}`);
-          }
-        }
-        writeSessionEntry(transactionDb, params.target.canonicalKey, nextEntry, {
-          previousEntry: current?.entry ?? null,
-        });
-        rehomeSessionWindows(transactionDb, params.target.canonicalKey, params.target.storeKeys);
-        deleteLegacySessionEntryRows(
-          transactionDb,
-          params.target.storeKeys,
-          params.target.canonicalKey,
-          { rehomeMembers: current?.entry.sessionId === nextEntry.sessionId },
-        );
-        // Reset only advances the live entry and route. Historical rows stay searchable;
-        // disk-budget cleanup owns durable extraction before reclaiming them.
-      }, toDatabaseOptions(resolved));
-      if (current) {
-        emitSessionIdentityMutation({
-          kind: "reset",
-          previous: {
-            ...(current.entry.sessionId ? { sessionId: current.entry.sessionId } : {}),
-            sessionKeys: targetSnapshot.rows.map((row) => row.sessionKey),
-          },
-          current: {
-            ...(nextEntry.sessionId ? { sessionId: nextEntry.sessionId } : {}),
-            sessionKeys: [params.target.canonicalKey],
-          },
-        });
-      } else {
-        emitSessionIdentityMutation({
-          kind: "create",
-          previous: { sessionKeys: [] },
-          current: {
-            ...(nextEntry.sessionId ? { sessionId: nextEntry.sessionId } : {}),
-            sessionKeys: [params.target.canonicalKey],
-          },
-        });
-      }
-      await params.afterEntryMutation?.(mutation);
+      const deletedOwners = targetSnapshot.rows.filter(
+        ({ sessionKey }) => sessionKey !== params.target.canonicalKey,
+      );
       return {
-        ...mutation,
-        archivedTranscripts: [],
+        deletedEntries: deletedOwners,
+        commit: async () => {
+          const shouldAppendResetBoundary =
+            params.resetBoundaryReason &&
+            current?.entry.sessionId &&
+            !sqliteSessionEntriesEqual(current.entry, nextEntry);
+          const mutation: ResetSessionEntryLifecycleMutation = {
+            nextEntry: cloneSessionEntry(nextEntry),
+            ...(current ? { previousEntry: cloneSessionEntry(current.entry) } : {}),
+            ...(current?.entry.sessionId ? { previousSessionId: current.entry.sessionId } : {}),
+          };
+          runOpenClawAgentWriteTransaction((transactionDb) => {
+            assertLifecycleTargetUnchanged(transactionDb, params.target, current?.entry, "reset");
+            if (
+              shouldAppendResetBoundary &&
+              current?.entry.sessionId &&
+              params.resetBoundaryReason
+            ) {
+              const event = buildSessionResetBoundaryEvent({
+                events: loadTranscriptEventsFromDatabase(transactionDb, current.entry.sessionId),
+                reason: params.resetBoundaryReason,
+              });
+              const appended = appendTranscriptEventsInTransaction(
+                transactionDb,
+                {
+                  ...resolved,
+                  sessionId: current.entry.sessionId,
+                  sessionKey: current.key,
+                },
+                [event],
+              );
+              if (appended !== 1) {
+                throw new Error(`Failed to append reset boundary for ${current.key}`);
+              }
+            }
+            writeSessionEntry(transactionDb, params.target.canonicalKey, nextEntry, {
+              previousEntry: current?.entry ?? null,
+            });
+            rehomeSessionWindows(
+              transactionDb,
+              params.target.canonicalKey,
+              params.target.storeKeys,
+            );
+            deleteLegacySessionEntryRows(
+              transactionDb,
+              params.target.storeKeys,
+              params.target.canonicalKey,
+              { rehomeMembers: current?.entry.sessionId === nextEntry.sessionId },
+            );
+            // Reset only advances the live entry and route. Historical rows stay searchable;
+            // disk-budget cleanup owns durable extraction before reclaiming them.
+          }, toDatabaseOptions(resolved));
+          if (current) {
+            emitSessionIdentityMutation({
+              kind: "reset",
+              previous: {
+                ...(current.entry.sessionId ? { sessionId: current.entry.sessionId } : {}),
+                sessionKeys: targetSnapshot.rows.map((row) => row.sessionKey),
+              },
+              current: {
+                ...(nextEntry.sessionId ? { sessionId: nextEntry.sessionId } : {}),
+                sessionKeys: [params.target.canonicalKey],
+              },
+            });
+          } else {
+            emitSessionIdentityMutation({
+              kind: "create",
+              previous: { sessionKeys: [] },
+              current: {
+                ...(nextEntry.sessionId ? { sessionId: nextEntry.sessionId } : {}),
+                sessionKeys: [params.target.canonicalKey],
+              },
+            });
+          }
+          await params.afterEntryMutation?.(mutation);
+          return {
+            ...mutation,
+            archivedTranscripts: [],
+          };
+        },
       };
     });
   } finally {
@@ -391,150 +423,162 @@ async function deleteSqliteSessionEntryLifecycleLocked(
     return expectedEntryMismatchResult([]);
   }
 
-  const historicalArchivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
-  for (const sessionId of prepared.historicalGenerationIds) {
-    const plan = await runExclusiveSqliteSessionWrite(resolved, async () => {
-      const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-      const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
-      if (
-        !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
-        !shouldDeleteSqliteSessionEntryLifecycle(database, targetSnapshot.primary?.entry, params)
-      ) {
-        return DELETE_EXPECTED_ENTRY_MISMATCH;
-      }
-      const referencedAfterDelete = readReferencedSessionIdsAfterTargetMutation(
-        database,
-        params.target,
-      );
-      if (referencedAfterDelete.has(sessionId)) {
-        return null;
-      }
-      const admissionProtected = collectAdmissionProtectedSessionIds({
-        database,
-        storePath: params.storePath,
-      });
-      if (admissionProtected.has(sessionId)) {
-        throw new Error(
-          `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
-        );
-      }
-      return planSessionStateDeleteIfUnreferenced({
-        archiveDirectory: prepared.archiveDirectory,
-        archiveTranscript: params.archiveTranscript,
-        database,
-        reason: "deleted",
-        referencedSessionIds: referencedAfterDelete,
-        sessionId,
-      });
-    });
-    if (plan === DELETE_EXPECTED_ENTRY_MISMATCH) {
-      return expectedEntryMismatchResult(historicalArchivedTranscripts);
-    }
-    if (!plan) {
-      continue;
-    }
-    const materializedGeneration = await materializeSessionStateDeletePlans([plan]);
-    const archivedGeneration = await runExclusiveSqliteSessionWrite(resolved, async () =>
-      runOpenClawAgentWriteTransaction((transactionDb) => {
-        const targetSnapshot = readLifecycleTargetSnapshot(transactionDb, params.target);
-        if (
-          !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
-          !shouldDeleteSqliteSessionEntryLifecycle(
-            transactionDb,
-            targetSnapshot.primary?.entry,
-            params,
-          )
-        ) {
-          return DELETE_EXPECTED_ENTRY_MISMATCH;
-        }
-        const fenceAtDelete = collectAdmissionProtectedSessionIds({
-          database: transactionDb,
-          storePath: params.storePath,
-        });
-        if (fenceAtDelete.has(sessionId)) {
-          throw new Error(
-            `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
-          );
-        }
-        return deleteMaterializedSessionStatePlans(transactionDb, materializedGeneration);
-      }, toDatabaseOptions(resolved)),
-    );
-    if (archivedGeneration === DELETE_EXPECTED_ENTRY_MISMATCH) {
-      return expectedEntryMismatchResult(historicalArchivedTranscripts);
-    }
-    // Publish each committed generation immediately: a later archive or
-    // transaction failure aborts the deletion, and observers must still see
-    // the removals that already happened (retry completes the remainder).
-    const publishedGeneration = await publishSessionStateArchives(resolved, archivedGeneration);
-    emitArchivedTranscriptUpdates(publishedGeneration);
-    historicalArchivedTranscripts.push(...publishedGeneration);
-  }
-
-  // Archive materialization is the expensive phase. It must run between short
-  // writer-lane sections so unrelated writes to this store can keep progressing.
-  const materializedPlans = await materializeSessionStateDeletePlans(prepared.entryPlans);
-  const result = await runExclusiveSqliteSessionWrite(resolved, async () =>
-    runOpenClawAgentWriteTransaction<DeleteSessionEntryLifecycleResult>((transactionDb) => {
-      const transactionSnapshot = readLifecycleTargetSnapshot(transactionDb, params.target);
-      const transactionEntry = transactionSnapshot.primary?.entry;
-      if (
-        !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, transactionSnapshot) ||
-        !shouldDeleteSqliteSessionEntryLifecycle(transactionDb, transactionEntry, params)
-      ) {
-        return expectedEntryMismatchResult([]);
-      }
-      const archivedTranscripts = deleteMaterializedSessionStatePlans(
-        transactionDb,
-        materializedPlans,
-        undefined,
-        new Set([
-          params.target.canonicalKey,
-          ...params.target.storeKeys,
-          ...transactionSnapshot.rows.map((row) => row.sessionKey),
-        ]),
-      );
-      deleteLifecycleTargetRows(transactionDb, params.target);
-      if (params.deleteDeliveryArtifacts === true) {
-        deleteSessionDeliveryArtifacts(transactionDb, params.target.canonicalKey, [
-          ...params.target.storeKeys,
-          ...transactionSnapshot.rows.map((row) => row.sessionKey),
-        ]);
-      }
-      deleteSessionBoardRows(transactionDb, [
-        params.target.canonicalKey,
-        ...params.target.storeKeys,
-        ...transactionSnapshot.rows.map((row) => row.sessionKey),
-      ]);
-      return {
-        archivedTranscripts,
-        deleted: true,
-        deletedEntry: cloneSessionEntry(prepared.current.entry),
-        ...(prepared.current.entry.sessionId
-          ? { deletedSessionId: prepared.current.entry.sessionId }
-          : {}),
-      };
-    }, toDatabaseOptions(resolved)),
-  );
-  if (result.deleted) {
-    emitSessionIdentityMutation({
-      kind: "delete",
-      previous: {
-        ...(prepared.current.entry.sessionId
-          ? { sessionId: prepared.current.entry.sessionId }
-          : {}),
-        sessionKeys: prepared.targetSnapshot.rows.map((row) => row.sessionKey),
-      },
-    });
-  }
-  result.archivedTranscripts = await publishSessionStateArchives(
+  return await withSqliteSessionDeletions(
     resolved,
-    result.archivedTranscripts,
+    prepared.targetSnapshot.rows,
+    async (assertCurrent) => {
+      const historicalArchivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
+      for (const sessionId of prepared.historicalGenerationIds) {
+        const plan = await runExclusiveSqliteSessionWrite(resolved, async () => {
+          const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+          const targetSnapshot = readLifecycleTargetSnapshot(database, params.target);
+          if (
+            !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
+            !shouldDeleteSqliteSessionEntryLifecycle(
+              database,
+              targetSnapshot.primary?.entry,
+              params,
+            )
+          ) {
+            return DELETE_EXPECTED_ENTRY_MISMATCH;
+          }
+          const referencedAfterDelete = readReferencedSessionIdsAfterTargetMutation(
+            database,
+            params.target,
+          );
+          if (referencedAfterDelete.has(sessionId)) {
+            return null;
+          }
+          const admissionProtected = collectAdmissionProtectedSessionIds({
+            database,
+            storePath: params.storePath,
+          });
+          if (admissionProtected.has(sessionId)) {
+            throw new Error(
+              `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
+            );
+          }
+          return planSessionStateDeleteIfUnreferenced({
+            archiveDirectory: prepared.archiveDirectory,
+            archiveTranscript: params.archiveTranscript,
+            database,
+            reason: "deleted",
+            referencedSessionIds: referencedAfterDelete,
+            sessionId,
+          });
+        });
+        if (plan === DELETE_EXPECTED_ENTRY_MISMATCH) {
+          return expectedEntryMismatchResult(historicalArchivedTranscripts);
+        }
+        if (!plan) {
+          continue;
+        }
+        const materializedGeneration = await materializeSessionStateDeletePlans([plan]);
+        const archivedGeneration = await runExclusiveSqliteSessionWrite(resolved, async () =>
+          runOpenClawAgentWriteTransaction((transactionDb) => {
+            assertCurrent();
+            const targetSnapshot = readLifecycleTargetSnapshot(transactionDb, params.target);
+            if (
+              !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, targetSnapshot) ||
+              !shouldDeleteSqliteSessionEntryLifecycle(
+                transactionDb,
+                targetSnapshot.primary?.entry,
+                params,
+              )
+            ) {
+              return DELETE_EXPECTED_ENTRY_MISMATCH;
+            }
+            const fenceAtDelete = collectAdmissionProtectedSessionIds({
+              database: transactionDb,
+              storePath: params.storePath,
+            });
+            if (fenceAtDelete.has(sessionId)) {
+              throw new Error(
+                `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
+              );
+            }
+            return deleteMaterializedSessionStatePlans(transactionDb, materializedGeneration);
+          }, toDatabaseOptions(resolved)),
+        );
+        if (archivedGeneration === DELETE_EXPECTED_ENTRY_MISMATCH) {
+          return expectedEntryMismatchResult(historicalArchivedTranscripts);
+        }
+        // Publish each committed generation immediately: a later archive or
+        // transaction failure aborts the deletion, and observers must still see
+        // the removals that already happened (retry completes the remainder).
+        const publishedGeneration = await publishSessionStateArchives(resolved, archivedGeneration);
+        emitArchivedTranscriptUpdates(publishedGeneration);
+        historicalArchivedTranscripts.push(...publishedGeneration);
+      }
+
+      // Archive materialization is the expensive phase. It must run between short
+      // writer-lane sections so unrelated writes to this store can keep progressing.
+      const materializedPlans = await materializeSessionStateDeletePlans(prepared.entryPlans);
+      const result = await runExclusiveSqliteSessionWrite(resolved, async () =>
+        runOpenClawAgentWriteTransaction<DeleteSessionEntryLifecycleResult>((transactionDb) => {
+          assertCurrent();
+          const transactionSnapshot = readLifecycleTargetSnapshot(transactionDb, params.target);
+          const transactionEntry = transactionSnapshot.primary?.entry;
+          if (
+            !sqliteLifecycleTargetSnapshotsEqual(prepared.targetSnapshot, transactionSnapshot) ||
+            !shouldDeleteSqliteSessionEntryLifecycle(transactionDb, transactionEntry, params)
+          ) {
+            return expectedEntryMismatchResult([]);
+          }
+          const archivedTranscripts = deleteMaterializedSessionStatePlans(
+            transactionDb,
+            materializedPlans,
+            undefined,
+            new Set([
+              params.target.canonicalKey,
+              ...params.target.storeKeys,
+              ...transactionSnapshot.rows.map((row) => row.sessionKey),
+            ]),
+          );
+          deleteLifecycleTargetRows(transactionDb, params.target);
+          if (params.deleteDeliveryArtifacts === true) {
+            deleteSessionDeliveryArtifacts(transactionDb, params.target.canonicalKey, [
+              ...params.target.storeKeys,
+              ...transactionSnapshot.rows.map((row) => row.sessionKey),
+            ]);
+          }
+          deleteSessionBoardRows(transactionDb, [
+            params.target.canonicalKey,
+            ...params.target.storeKeys,
+            ...transactionSnapshot.rows.map((row) => row.sessionKey),
+          ]);
+          return {
+            archivedTranscripts,
+            deleted: true,
+            deletedEntry: cloneSessionEntry(prepared.current.entry),
+            ...(prepared.current.entry.sessionId
+              ? { deletedSessionId: prepared.current.entry.sessionId }
+              : {}),
+          };
+        }, toDatabaseOptions(resolved)),
+      );
+      if (result.deleted) {
+        emitSessionIdentityMutation({
+          kind: "delete",
+          previous: {
+            ...(prepared.current.entry.sessionId
+              ? { sessionId: prepared.current.entry.sessionId }
+              : {}),
+            sessionKeys: prepared.targetSnapshot.rows.map((row) => row.sessionKey),
+          },
+        });
+      }
+      result.archivedTranscripts = await publishSessionStateArchives(
+        resolved,
+        result.archivedTranscripts,
+      );
+      emitArchivedTranscriptUpdates(result.archivedTranscripts);
+      // Historical generations were emitted per commit above; merge them into
+      // the result after the final emit so callers still see every archive.
+      result.archivedTranscripts.push(...historicalArchivedTranscripts);
+      return result;
+    },
   );
-  emitArchivedTranscriptUpdates(result.archivedTranscripts);
-  // Historical generations were emitted per commit above; merge them into
-  // the result after the final emit so callers still see every archive.
-  result.archivedTranscripts.push(...historicalArchivedTranscripts);
-  return result;
 }
 
 function expectedEntryMismatchResult(

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -3,16 +3,17 @@ import { sql } from "kysely";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import { getChildLogger } from "../../logging/logger.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
-import {
-  runOpenClawAgentWriteTransaction,
-  type OpenClawAgentDatabase,
-} from "../../state/openclaw-agent-db.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { publishSessionStateArchives } from "./session-accessor.sqlite-archive-store.js";
 import {
   materializeSessionStateDeletePlans,
   type SessionStateDeletePlan,
 } from "./session-accessor.sqlite-archive.js";
 import type { SessionLifecycleArchivedTranscript } from "./session-accessor.sqlite-contract.js";
+import {
+  runSqliteSessionDeletionTransaction as runOpenClawAgentWriteTransaction,
+  withSqliteSessionDeletions,
+} from "./session-accessor.sqlite-deletion.js";
 import {
   readSessionEntryCount,
   readSessionEntryStore,
@@ -571,20 +572,27 @@ async function finalizeSqliteSessionEntryMaintenancePlansWithCommit(
     let archivedTranscripts: SessionLifecycleArchivedTranscript[];
     try {
       const materializedPlans = await materializeSessionStateDeletePlans(batch.stateDeletePlans);
-      archivedTranscripts = await commit(() => {
-        let committed: SessionLifecycleArchivedTranscript[] = [];
-        runOpenClawAgentWriteTransaction((database) => {
-          assertPlannedLifecycleArtifactEntriesUnchanged(database, batch.entryRemovals);
-          committed = deleteMaterializedSessionStatePlans(
-            database,
-            materializedPlans,
-            undefined,
-            new Set(batch.entryRemovals.map((removal) => removal.sessionKey)),
-          );
-          deletePlannedLifecycleArtifactEntries(database, batch.entryRemovals);
-        }, toDatabaseOptions(scope));
-        return committed;
-      });
+      archivedTranscripts = await withSqliteSessionDeletions(
+        scope,
+        batch.entryRemovals.flatMap(({ expectedEntry: entry, sessionKey }) =>
+          entry ? [{ entry, sessionKey }] : [],
+        ),
+        async () =>
+          await commit(() => {
+            let committed: SessionLifecycleArchivedTranscript[] = [];
+            runOpenClawAgentWriteTransaction((database) => {
+              assertPlannedLifecycleArtifactEntriesUnchanged(database, batch.entryRemovals);
+              committed = deleteMaterializedSessionStatePlans(
+                database,
+                materializedPlans,
+                undefined,
+                new Set(batch.entryRemovals.map((removal) => removal.sessionKey)),
+              );
+              deletePlannedLifecycleArtifactEntries(database, batch.entryRemovals);
+            }, toDatabaseOptions(scope));
+            return committed;
+          }),
+      );
     } catch (error) {
       warn("SQLite session maintenance cleanup failed", error, batch.stateDeletePlans);
       break;

--- a/src/config/sessions/session-accessor.sqlite-parent-session.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-session.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
   openOpenClawAgentDatabase,
-  runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import type {
@@ -11,6 +10,10 @@ import type {
   ForkSessionFromParentTranscriptResult,
   SessionParentForkDecision,
 } from "./session-accessor.sqlite-contract.js";
+import {
+  runPreparedSqliteSessionWrite,
+  runSqliteSessionDeletionTransaction as runOpenClawAgentWriteTransaction,
+} from "./session-accessor.sqlite-deletion.js";
 import {
   deleteLegacySessionEntryRows,
   normalizeLifecycleTarget,
@@ -134,146 +137,175 @@ export async function forkSessionEntryFromParentTarget(
   const resolved = resolveSqliteStoreScope(params.storePath, { agentId: params.agentId });
   const parentTarget = normalizeLifecycleTarget(params.parentTarget);
   const sessionTarget = normalizeLifecycleTarget(params.sessionTarget);
-  return await runExclusiveSqliteSessionWrite(resolved, async () => {
-    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    const parent = resolveLifecyclePrimaryEntry(database, parentTarget);
-    if (!parent?.entry.sessionId) {
-      return { status: "missing-parent" };
-    }
+  return await runPreparedSqliteSessionWrite<ForkSessionEntryFromParentTargetResult>(
+    resolved,
+    async () => {
+      const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+      const parent = resolveLifecyclePrimaryEntry(database, parentTarget);
+      if (!parent?.entry.sessionId) {
+        return { deletedEntries: [], commit: () => ({ status: "missing-parent" }) };
+      }
 
-    const existing = resolveLifecyclePrimaryEntry(database, sessionTarget);
-    const base = existing?.entry ?? params.fallbackEntry;
-    if (!base) {
-      return { status: "missing-entry" };
-    }
+      const existing = resolveLifecyclePrimaryEntry(database, sessionTarget);
+      const base = existing?.entry ?? params.fallbackEntry;
+      if (!base) {
+        return { deletedEntries: [], commit: () => ({ status: "missing-entry" }) };
+      }
+      const deletedEntries = [
+        ...readSessionIdentitySnapshot(database, sessionTarget.storeKeys),
+      ].flatMap(([sessionKey, entry]) =>
+        sessionKey !== sessionTarget.canonicalKey ? [{ sessionKey, entry }] : [],
+      );
 
-    if (params.skipForkWhen?.(cloneSessionEntry(base))) {
-      const sessionEntry = await persistSqliteParentForkSkipPatch({
-        entry: base,
-        params,
-        sessionTarget,
-        patch: params.skipPatch?.(cloneSessionEntry(base)),
-        resolved,
-      });
+      if (params.skipForkWhen?.(cloneSessionEntry(base))) {
+        return {
+          deletedEntries,
+          commit: async () => {
+            const sessionEntry = await persistSqliteParentForkSkipPatch({
+              entry: base,
+              params,
+              sessionTarget,
+              patch: params.skipPatch?.(cloneSessionEntry(base)),
+              resolved,
+            });
+            return {
+              status: "skipped",
+              reason: "existing-entry",
+              parentEntry: cloneSessionEntry(parent.entry),
+              sessionEntry,
+            };
+          },
+        };
+      }
+
+      const needsTranscriptTokenEstimate =
+        typeof resolveFreshSessionTotalTokens(parent.entry) !== "number" &&
+        typeof parent.entry.sessionId === "string" &&
+        parent.entry.sessionId.length > 0;
+      const transcriptParentTokens = needsTranscriptTokenEstimate
+        ? estimateTranscriptPromptTokens(
+            loadTranscriptEventsFromDatabase(database, parent.entry.sessionId),
+          )
+        : undefined;
+      const decision = planParentForkDecision(parent.entry, transcriptParentTokens);
+      if (decision.status === "skip") {
+        return {
+          deletedEntries,
+          commit: async () => {
+            const patch = params.decisionSkipPatch?.({
+              decision,
+              entry: cloneSessionEntry(base),
+              parentEntry: cloneSessionEntry(parent.entry),
+            });
+            const sessionEntry = await persistSqliteParentForkSkipPatch({
+              entry: base,
+              params,
+              sessionTarget,
+              patch,
+              resolved,
+            });
+            return {
+              status: "skipped",
+              reason: "decision-skip",
+              parentEntry: cloneSessionEntry(parent.entry),
+              sessionEntry,
+              decision,
+            };
+          },
+        };
+      }
+
+      let result: ForkSessionEntryFromParentTargetResult = { status: "failed" };
+      const maintenancePlans: SessionEntryMaintenancePlan[] = [];
+      let previousIdentity = new Map<string, SessionEntry>();
+      let currentIdentity = new Map<string, SessionEntry>();
       return {
-        status: "skipped",
-        reason: "existing-entry",
-        parentEntry: cloneSessionEntry(parent.entry),
-        sessionEntry,
-      };
-    }
-
-    const needsTranscriptTokenEstimate =
-      typeof resolveFreshSessionTotalTokens(parent.entry) !== "number" &&
-      typeof parent.entry.sessionId === "string" &&
-      parent.entry.sessionId.length > 0;
-    const transcriptParentTokens = needsTranscriptTokenEstimate
-      ? estimateTranscriptPromptTokens(
-          loadTranscriptEventsFromDatabase(database, parent.entry.sessionId),
-        )
-      : undefined;
-    const decision = planParentForkDecision(parent.entry, transcriptParentTokens);
-    if (decision.status === "skip") {
-      const patch = params.decisionSkipPatch?.({
-        decision,
-        entry: cloneSessionEntry(base),
-        parentEntry: cloneSessionEntry(parent.entry),
-      });
-      const sessionEntry = await persistSqliteParentForkSkipPatch({
-        entry: base,
-        params,
-        sessionTarget,
-        patch,
-        resolved,
-      });
-      return {
-        status: "skipped",
-        reason: "decision-skip",
-        parentEntry: cloneSessionEntry(parent.entry),
-        sessionEntry,
-        decision,
-      };
-    }
-
-    let result: ForkSessionEntryFromParentTargetResult = { status: "failed" };
-    const maintenancePlans: SessionEntryMaintenancePlan[] = [];
-    let previousIdentity = new Map<string, SessionEntry>();
-    let currentIdentity = new Map<string, SessionEntry>();
-    runOpenClawAgentWriteTransaction((writeDatabase) => {
-      const freshParent = resolveLifecyclePrimaryEntry(writeDatabase, parentTarget)?.entry;
-      if (!freshParent?.sessionId) {
-        result = { status: "missing-parent" };
-        return;
-      }
-      const freshExisting = resolveLifecyclePrimaryEntry(writeDatabase, sessionTarget);
-      const freshBase = freshExisting?.entry ?? params.fallbackEntry;
-      if (!freshBase) {
-        result = { status: "missing-entry" };
-        return;
-      }
-      const fork = forkSqliteParentTranscriptInTransaction(writeDatabase, resolved, {
-        parentEntry: freshParent,
-        parentSessionKey: parentTarget.canonicalKey,
-        targetSessionKey: sessionTarget.canonicalKey,
-      });
-      if (fork.status !== "created") {
-        result =
-          fork.status === "missing-parent" ? { status: "missing-parent" } : { status: "failed" };
-        return;
-      }
-      const patch = params.patch?.({
-        decision,
-        entry: cloneSessionEntry(freshBase),
-        fork: fork.transcript,
-        parentEntry: cloneSessionEntry(freshParent),
-      });
-      const forkIdentityPatch: Partial<InternalSessionEntry> = {
-        ...patch,
-        forkSource: {
-          sessionKey: parentTarget.canonicalKey,
-          sessionId: freshParent.sessionId,
+        deletedEntries,
+        commit: async () => {
+          runOpenClawAgentWriteTransaction((writeDatabase) => {
+            const freshParent = resolveLifecyclePrimaryEntry(writeDatabase, parentTarget)?.entry;
+            if (!freshParent?.sessionId) {
+              result = { status: "missing-parent" };
+              return;
+            }
+            const freshExisting = resolveLifecyclePrimaryEntry(writeDatabase, sessionTarget);
+            const freshBase = freshExisting?.entry ?? params.fallbackEntry;
+            if (!freshBase) {
+              result = { status: "missing-entry" };
+              return;
+            }
+            const fork = forkSqliteParentTranscriptInTransaction(writeDatabase, resolved, {
+              parentEntry: freshParent,
+              parentSessionKey: parentTarget.canonicalKey,
+              targetSessionKey: sessionTarget.canonicalKey,
+            });
+            if (fork.status !== "created") {
+              result =
+                fork.status === "missing-parent"
+                  ? { status: "missing-parent" }
+                  : { status: "failed" };
+              return;
+            }
+            const patch = params.patch?.({
+              decision,
+              entry: cloneSessionEntry(freshBase),
+              fork: fork.transcript,
+              parentEntry: cloneSessionEntry(freshParent),
+            });
+            const forkIdentityPatch: Partial<InternalSessionEntry> = {
+              ...patch,
+              forkSource: {
+                sessionKey: parentTarget.canonicalKey,
+                sessionId: freshParent.sessionId,
+              },
+              forkedFromParent: true,
+              lifecycleRunId: undefined,
+              lastRunId: undefined,
+              sessionId: fork.transcript.sessionId,
+              totalTokens: undefined,
+              totalTokensFresh: false,
+              totalTokensVersion: undefined,
+            };
+            const next = mergeSessionEntry(freshBase, forkIdentityPatch);
+            previousIdentity = readSessionIdentitySnapshot(writeDatabase, sessionTarget.storeKeys);
+            writeSessionEntry(writeDatabase, sessionTarget.canonicalKey, next, {
+              previousEntry: freshBase,
+            });
+            rehomeSessionWindows(
+              writeDatabase,
+              sessionTarget.canonicalKey,
+              sessionTarget.storeKeys,
+            );
+            deleteLegacySessionEntryRows(
+              writeDatabase,
+              sessionTarget.storeKeys,
+              sessionTarget.canonicalKey,
+              { rehomeMembers: freshBase.sessionId === next.sessionId },
+            );
+            maintenancePlans.push(
+              applySessionEntryMaintenance(writeDatabase, {
+                activeSessionKey: sessionTarget.canonicalKey,
+                archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+                skipMaintenance: true,
+                storePath: params.storePath,
+              }),
+            );
+            currentIdentity = readSessionIdentitySnapshot(writeDatabase, sessionTarget.storeKeys);
+            result = {
+              status: "forked",
+              decision,
+              fork: fork.transcript,
+              parentEntry: cloneSessionEntry(freshParent),
+              sessionEntry: cloneSessionEntry(next),
+            };
+          }, toDatabaseOptions(resolved));
+          emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
+          await finalizeSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
+          return result;
         },
-        forkedFromParent: true,
-        lifecycleRunId: undefined,
-        lastRunId: undefined,
-        sessionId: fork.transcript.sessionId,
-        totalTokens: undefined,
-        totalTokensFresh: false,
-        totalTokensVersion: undefined,
       };
-      const next = mergeSessionEntry(freshBase, forkIdentityPatch);
-      previousIdentity = readSessionIdentitySnapshot(writeDatabase, sessionTarget.storeKeys);
-      writeSessionEntry(writeDatabase, sessionTarget.canonicalKey, next, {
-        previousEntry: freshBase,
-      });
-      rehomeSessionWindows(writeDatabase, sessionTarget.canonicalKey, sessionTarget.storeKeys);
-      deleteLegacySessionEntryRows(
-        writeDatabase,
-        sessionTarget.storeKeys,
-        sessionTarget.canonicalKey,
-        { rehomeMembers: freshBase.sessionId === next.sessionId },
-      );
-      maintenancePlans.push(
-        applySessionEntryMaintenance(writeDatabase, {
-          activeSessionKey: sessionTarget.canonicalKey,
-          archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-          skipMaintenance: true,
-          storePath: params.storePath,
-        }),
-      );
-      currentIdentity = readSessionIdentitySnapshot(writeDatabase, sessionTarget.storeKeys);
-      result = {
-        status: "forked",
-        decision,
-        fork: fork.transcript,
-        parentEntry: cloneSessionEntry(freshParent),
-        sessionEntry: cloneSessionEntry(next),
-      };
-    }, toDatabaseOptions(resolved));
-    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
-    await finalizeSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
-    return result;
-  });
+    },
+  );
 }
 
 async function persistSqliteParentForkSkipPatch(params: {

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -7,7 +7,6 @@ import {
 } from "../../sessions/agent-harness-session-key.js";
 import {
   openOpenClawAgentDatabase,
-  runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import {
@@ -33,6 +32,11 @@ import type {
   SessionEntryReplacementUpdate,
   SessionEntryStatus,
 } from "./session-accessor.sqlite-contract.js";
+import {
+  runPreparedSqliteSessionWrite,
+  runSqliteSessionDeletionTransaction as runOpenClawAgentWriteTransaction,
+  withSqliteSessionDeletions,
+} from "./session-accessor.sqlite-deletion.js";
 import { sqliteSessionEntriesEqual } from "./session-accessor.sqlite-entry-equality.js";
 import {
   deleteLegacySessionEntryRows,
@@ -128,13 +132,16 @@ export async function applySessionStoreProjection<T>(params: {
     sessionKey: params.activeSessionKey ?? "",
     storePath: params.storePath,
   });
-  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
+  const committed = await runPreparedSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const before = readSessionEntryStore(database);
     const projected = structuredClone(before);
     const operation = await params.update(projected);
     if (!operation.persist) {
-      return { maintenancePlans: [], result: operation.result };
+      return {
+        deletedEntries: [],
+        commit: () => ({ maintenancePlans: [], result: operation.result }),
+      };
     }
     const lockedEntriesBefore = new Map(
       Object.entries(before).filter(([, entry]) => entry.modelSelectionLocked === true),
@@ -152,43 +159,55 @@ export async function applySessionStoreProjection<T>(params: {
       (sessionKey) => !sqliteSessionEntriesEqual(before[sessionKey], projected[sessionKey]),
     );
     if (changedKeys.length === 0) {
-      return { maintenancePlans: [], result: operation.result };
+      return {
+        deletedEntries: [],
+        commit: () => ({ maintenancePlans: [], result: operation.result }),
+      };
     }
 
     const maintenancePlans: SessionEntryMaintenancePlan[] = [];
-    runOpenClawAgentWriteTransaction(
-      (transactionDb) => {
-        for (const sessionKey of changedKeys) {
-          const current = readExactSessionEntryRow(transactionDb, sessionKey)?.entry;
-          if (!sqliteSessionEntriesEqual(current, before[sessionKey])) {
-            throw new Error(
-              `SQLite session entry changed before store projection for ${sessionKey}`,
+    const deletedOwners = changedKeys.flatMap((sessionKey) => {
+      const entry = before[sessionKey];
+      return entry && !projected[sessionKey] ? [{ entry, sessionKey }] : [];
+    });
+    return {
+      deletedEntries: deletedOwners,
+      commit: () => {
+        runOpenClawAgentWriteTransaction(
+          (transactionDb) => {
+            for (const sessionKey of changedKeys) {
+              const current = readExactSessionEntryRow(transactionDb, sessionKey)?.entry;
+              if (!sqliteSessionEntriesEqual(current, before[sessionKey])) {
+                throw new Error(
+                  `SQLite session entry changed before store projection for ${sessionKey}`,
+                );
+              }
+            }
+            for (const sessionKey of changedKeys) {
+              const entry = projected[sessionKey];
+              if (entry) {
+                writeSessionEntry(transactionDb, sessionKey, cloneSessionEntry(entry), {
+                  previousEntry: before[sessionKey] ?? null,
+                });
+              } else {
+                deleteSessionEntryRows(transactionDb, sessionKey);
+              }
+            }
+            maintenancePlans.push(
+              applySessionEntryMaintenance(transactionDb, {
+                activeSessionKey: params.activeSessionKey ?? "",
+                archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+                skipMaintenance: params.skipMaintenance,
+                storePath: params.storePath,
+              }),
             );
-          }
-        }
-        for (const sessionKey of changedKeys) {
-          const entry = projected[sessionKey];
-          if (entry) {
-            writeSessionEntry(transactionDb, sessionKey, cloneSessionEntry(entry), {
-              previousEntry: before[sessionKey] ?? null,
-            });
-          } else {
-            deleteSessionEntryRows(transactionDb, sessionKey);
-          }
-        }
-        maintenancePlans.push(
-          applySessionEntryMaintenance(transactionDb, {
-            activeSessionKey: params.activeSessionKey ?? "",
-            archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-            skipMaintenance: params.skipMaintenance,
-            storePath: params.storePath,
-          }),
+          },
+          toDatabaseOptions(resolved),
+          { operationLabel: "session.store-projection" },
         );
+        return { maintenancePlans, result: operation.result };
       },
-      toDatabaseOptions(resolved),
-      { operationLabel: "session.store-projection" },
-    );
-    return { maintenancePlans, result: operation.result };
+    };
   });
   await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
     resolved,
@@ -256,8 +275,10 @@ export async function applySessionEntryLifecycleMutation(params: {
     }
     throw error;
   };
-  let projected!: ProjectedLifecycleMutation;
-  let committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
+  let projected: ProjectedLifecycleMutation;
+  let materializedRemovalPlans: MaterializedSessionStateDeletePlan[] = [];
+  let removalArchiveMaterializationFailed = false;
+  const committed = await runPreparedSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     projected = await projectSessionEntryLifecycleMutation(database, {
       ...(params.allowCanonicalRepair ? { allowCanonicalRepair: true } : {}),
@@ -265,26 +286,34 @@ export async function applySessionEntryLifecycleMutation(params: {
       removals,
       upserts,
     });
-    return projected.deletePlans.length === 0
-      ? commitProjectedLifecycleMutation([], false)
-      : undefined;
+    const deletedOwners = projected.removals.flatMap(({ sessionKey, expectedEntry: entry }) => {
+      return entry && !projected.upsertedEntries.some((upsert) => upsert.sessionKey === sessionKey)
+        ? [{ entry, sessionKey }]
+        : [];
+    });
+    return {
+      deletedEntries: deletedOwners,
+      ...(projected.deletePlans.length > 0
+        ? {
+            beforeCommit: async () => {
+              try {
+                materializedRemovalPlans = await materializeSessionStateDeletePlans(
+                  projected.deletePlans,
+                );
+              } catch (error) {
+                removalArchiveMaterializationFailed = true;
+                captureArtifactCleanupError(error);
+              }
+            },
+          }
+        : {}),
+      commit: () =>
+        commitProjectedLifecycleMutation(
+          materializedRemovalPlans,
+          removalArchiveMaterializationFailed,
+        ),
+    };
   });
-  if (!committed) {
-    let materializedRemovalPlans: MaterializedSessionStateDeletePlan[] = [];
-    let removalArchiveMaterializationFailed = false;
-    try {
-      materializedRemovalPlans = await materializeSessionStateDeletePlans(projected.deletePlans);
-    } catch (error) {
-      removalArchiveMaterializationFailed = true;
-      captureArtifactCleanupError(error);
-    }
-    committed = await runExclusiveSqliteSessionWrite(resolved, async () =>
-      commitProjectedLifecycleMutation(
-        materializedRemovalPlans,
-        removalArchiveMaterializationFailed,
-      ),
-    );
-  }
 
   function commitProjectedLifecycleMutation(
     removalPlans: MaterializedSessionStateDeletePlan[],
@@ -428,12 +457,16 @@ export async function applySessionEntryLifecycleMutation(params: {
             transactionDb,
             [removal.sessionKey],
             replacement.canonicalKey,
-            { rehomeMembers: replacement.rehomeMembers },
+            {
+              rehomeMembers: replacement.rehomeMembers,
+              validatedEntries: new Map([[removal.sessionKey, entry]]),
+            },
           );
         } else {
           deleteSessionEntryRows(transactionDb, removal.sessionKey, {
             deleteOwnedWindows: removal.removal.deleteOwnedWindows === true,
             deliveryCleanupKeys: removal.removal.deliveryCleanupKeys,
+            validatedEntry: entry,
           });
         }
         removedSessionKeys.push(removal.sessionKey);
@@ -548,45 +581,52 @@ export async function purgeDeletedAgentSessionEntries(
     return { deletePlans, entryRemovals };
   });
   const materializedPlans = await materializeSessionStateDeletePlans(prepared.deletePlans);
-  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
-    let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
-    const maintenancePlans: SessionEntryMaintenancePlan[] = [];
-    runOpenClawAgentWriteTransaction((transactionDb) => {
-      const currentOwnedSessionKeys = Object.keys(readSessionEntryStore(transactionDb))
-        .filter(
-          (sessionKey) =>
-            resolveStoredSessionOwnerAgentId({
-              cfg: params.cfg,
-              agentId: params.storeAgentId,
-              sessionKey,
-            }) === params.agentId,
-        )
-        .toSorted();
-      const plannedSessionKeys = prepared.entryRemovals
-        .map((removal) => removal.sessionKey)
-        .toSorted();
-      if (JSON.stringify(currentOwnedSessionKeys) !== JSON.stringify(plannedSessionKeys)) {
-        throw new Error("SQLite deleted-agent session entries changed before purge");
-      }
-      assertPlannedLifecycleArtifactEntriesUnchanged(transactionDb, prepared.entryRemovals);
-      archivedTranscripts = deleteMaterializedSessionStatePlans(
-        transactionDb,
-        materializedPlans,
-        undefined,
-        new Set(prepared.entryRemovals.map((removal) => removal.sessionKey)),
-      );
-      deletePlannedLifecycleArtifactEntries(transactionDb, prepared.entryRemovals);
-      maintenancePlans.push(
-        applySessionEntryMaintenance(transactionDb, {
-          activeSessionKey: "",
-          archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-          storePath: params.storePath,
-        }),
-      );
-    }, toDatabaseOptions(resolved));
-    emitCommittedSessionEntryRemovals(prepared.entryRemovals);
-    return { archivedTranscripts, maintenancePlans };
-  });
+  const committed = await withSqliteSessionDeletions(
+    resolved,
+    prepared.entryRemovals.flatMap(({ expectedEntry: entry, sessionKey }) =>
+      entry ? [{ entry, sessionKey }] : [],
+    ),
+    async () =>
+      await runExclusiveSqliteSessionWrite(resolved, async () => {
+        let archivedTranscripts: SessionLifecycleArchivedTranscript[] = [];
+        const maintenancePlans: SessionEntryMaintenancePlan[] = [];
+        runOpenClawAgentWriteTransaction((transactionDb) => {
+          const currentOwnedSessionKeys = Object.keys(readSessionEntryStore(transactionDb))
+            .filter(
+              (sessionKey) =>
+                resolveStoredSessionOwnerAgentId({
+                  cfg: params.cfg,
+                  agentId: params.storeAgentId,
+                  sessionKey,
+                }) === params.agentId,
+            )
+            .toSorted();
+          const plannedSessionKeys = prepared.entryRemovals
+            .map((removal) => removal.sessionKey)
+            .toSorted();
+          if (JSON.stringify(currentOwnedSessionKeys) !== JSON.stringify(plannedSessionKeys)) {
+            throw new Error("SQLite deleted-agent session entries changed before purge");
+          }
+          assertPlannedLifecycleArtifactEntriesUnchanged(transactionDb, prepared.entryRemovals);
+          archivedTranscripts = deleteMaterializedSessionStatePlans(
+            transactionDb,
+            materializedPlans,
+            undefined,
+            new Set(prepared.entryRemovals.map((removal) => removal.sessionKey)),
+          );
+          deletePlannedLifecycleArtifactEntries(transactionDb, prepared.entryRemovals);
+          maintenancePlans.push(
+            applySessionEntryMaintenance(transactionDb, {
+              activeSessionKey: "",
+              archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+              storePath: params.storePath,
+            }),
+          );
+        }, toDatabaseOptions(resolved));
+        emitCommittedSessionEntryRemovals(prepared.entryRemovals);
+        return { archivedTranscripts, maintenancePlans };
+      }),
+  );
   const { archivedTranscripts: maintenanceArchivedTranscripts } =
     await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
       resolved,

--- a/src/config/sessions/session-accessor.sqlite-recovery.ts
+++ b/src/config/sessions/session-accessor.sqlite-recovery.ts
@@ -1,5 +1,9 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { runOpenClawAgentWriteTransaction } from "../../state/openclaw-agent-db.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import {
+  runSqliteSessionDeletionTransaction as runOpenClawAgentWriteTransaction,
+  withSqliteSessionDeletions,
+} from "./session-accessor.sqlite-deletion.js";
 import {
   deleteLegacySessionEntryRows,
   normalizeLifecycleTarget,
@@ -83,153 +87,174 @@ export async function recoverSessionEntryFromRestartTombstone(params: {
     reason: "source-changed",
   };
 
-  await runExclusiveSqliteSessionWrite(resolved, async () => {
-    runOpenClawAgentWriteTransaction((database) => {
-      const source = resolveLifecyclePrimaryEntry(database, sourceTarget)?.entry as
-        | InternalSessionEntry
-        | undefined;
-      const recovery = source?.mainRestartRecovery;
-      const tombstone = recovery?.tombstone;
-      if (!source?.sessionId || !recovery || !tombstone) {
-        result = { status: "conflict", reason: "not-tombstoned" };
-        return;
-      }
+  const aliasKeys = [
+    ...sourceTarget.storeKeys.filter((key) => key !== sourceTarget.canonicalKey),
+    ...successorTarget.storeKeys.filter((key) => key !== successorTarget.canonicalKey),
+  ];
+  const aliasEntries = readSessionIdentitySnapshot(
+    openOpenClawAgentDatabase(toDatabaseOptions(resolved)),
+    aliasKeys,
+  );
+  await withSqliteSessionDeletions(
+    resolved,
+    [...aliasEntries].map(([sessionKey, entry]) => ({ sessionKey, entry })),
+    async () =>
+      await runExclusiveSqliteSessionWrite(resolved, async () => {
+        runOpenClawAgentWriteTransaction((database) => {
+          const source = resolveLifecyclePrimaryEntry(database, sourceTarget)?.entry as
+            | InternalSessionEntry
+            | undefined;
+          const recovery = source?.mainRestartRecovery;
+          const tombstone = recovery?.tombstone;
+          if (!source?.sessionId || !recovery || !tombstone) {
+            result = { status: "conflict", reason: "not-tombstoned" };
+            return;
+          }
 
-      const recoveredSessionKey = tombstone.recoveredSessionKey;
-      const recoveredSessionId = tombstone.recoveredSessionId;
-      if (recoveredSessionKey || recoveredSessionId) {
-        if (!recoveredSessionKey || !recoveredSessionId) {
-          result = { status: "conflict", reason: "successor-missing" };
-          return;
-        }
-        const linked = resolveLifecyclePrimaryEntry(
-          database,
-          normalizeLifecycleTarget({
-            canonicalKey: recoveredSessionKey,
-            storeKeys: [recoveredSessionKey],
-          }),
-        )?.entry;
-        if (!linked || linked.sessionId !== recoveredSessionId) {
-          result = { status: "conflict", reason: "successor-missing" };
-          return;
-        }
-        result = {
-          status: "existing",
-          sourceEntry: cloneSessionEntry(source),
-          successorEntry: cloneSessionEntry(linked),
-          successorKey: recoveredSessionKey,
-        };
-        return;
-      }
+          const recoveredSessionKey = tombstone.recoveredSessionKey;
+          const recoveredSessionId = tombstone.recoveredSessionId;
+          if (recoveredSessionKey || recoveredSessionId) {
+            if (!recoveredSessionKey || !recoveredSessionId) {
+              result = { status: "conflict", reason: "successor-missing" };
+              return;
+            }
+            const linked = resolveLifecyclePrimaryEntry(
+              database,
+              normalizeLifecycleTarget({
+                canonicalKey: recoveredSessionKey,
+                storeKeys: [recoveredSessionKey],
+              }),
+            )?.entry;
+            if (!linked || linked.sessionId !== recoveredSessionId) {
+              result = { status: "conflict", reason: "successor-missing" };
+              return;
+            }
+            result = {
+              status: "existing",
+              sourceEntry: cloneSessionEntry(source),
+              successorEntry: cloneSessionEntry(linked),
+              successorKey: recoveredSessionKey,
+            };
+            return;
+          }
 
-      if (
-        source.sessionId !== params.expected.sessionId ||
-        source.lifecycleRevision !== params.expected.lifecycleRevision ||
-        recovery.cycleId !== params.expected.cycleId ||
-        recovery.revision !== params.expected.revision ||
-        source.pluginOwnerId !== params.expected.pluginOwnerId
-      ) {
-        result = { status: "conflict", reason: "source-changed" };
-        return;
-      }
-      if (resolveLifecyclePrimaryEntry(database, successorTarget)?.entry) {
-        result = { status: "conflict", reason: "target-exists" };
-        return;
-      }
+          if (
+            source.sessionId !== params.expected.sessionId ||
+            source.lifecycleRevision !== params.expected.lifecycleRevision ||
+            recovery.cycleId !== params.expected.cycleId ||
+            recovery.revision !== params.expected.revision ||
+            source.pluginOwnerId !== params.expected.pluginOwnerId
+          ) {
+            result = { status: "conflict", reason: "source-changed" };
+            return;
+          }
+          if (resolveLifecyclePrimaryEntry(database, successorTarget)?.entry) {
+            result = { status: "conflict", reason: "target-exists" };
+            return;
+          }
 
-      const sourceEvents = loadTranscriptEventsFromDatabase(database, source.sessionId);
-      const header = sourceEvents.find(
-        (event): event is Record<string, unknown> => isRecord(event) && event.type === "session",
-      );
-      if (!header) {
-        result = { status: "conflict", reason: "transcript-missing" };
-        return;
-      }
+          const sourceEvents = loadTranscriptEventsFromDatabase(database, source.sessionId);
+          const header = sourceEvents.find(
+            (event): event is Record<string, unknown> =>
+              isRecord(event) && event.type === "session",
+          );
+          if (!header) {
+            result = { status: "conflict", reason: "transcript-missing" };
+            return;
+          }
 
-      const successorSessionId = params.successorEntry.sessionId;
-      const parentSession = formatLegacySqliteSessionMarkerForScope({
-        ...resolved,
-        sessionId: source.sessionId,
-        sessionKey: normalizeSqliteSessionKey(sourceTarget.canonicalKey),
-      });
-      appendTranscriptEventsInTransaction(
-        database,
-        {
-          ...resolved,
-          sessionId: successorSessionId,
-          sessionKey: normalizeSqliteSessionKey(successorTarget.canonicalKey),
-        },
-        [
-          {
-            ...createSessionTranscriptHeader({
-              cwd: typeof header.cwd === "string" ? header.cwd : undefined,
+          const successorSessionId = params.successorEntry.sessionId;
+          const parentSession = formatLegacySqliteSessionMarkerForScope({
+            ...resolved,
+            sessionId: source.sessionId,
+            sessionKey: normalizeSqliteSessionKey(sourceTarget.canonicalKey),
+          });
+          appendTranscriptEventsInTransaction(
+            database,
+            {
+              ...resolved,
               sessionId: successorSessionId,
+              sessionKey: normalizeSqliteSessionKey(successorTarget.canonicalKey),
+            },
+            [
+              {
+                ...createSessionTranscriptHeader({
+                  cwd: typeof header.cwd === "string" ? header.cwd : undefined,
+                  sessionId: successorSessionId,
+                }),
+                parentSession,
+              },
+              ...sourceEvents.filter((event) => !(isRecord(event) && event.type === "session")),
+            ],
+          );
+
+          const now = Date.now();
+          const nextSource: InternalSessionEntry = {
+            ...source,
+            mainRestartRecovery: {
+              ...recovery,
+              revision: recovery.revision + 1,
+              tombstone: {
+                ...tombstone,
+                recoveredSessionId: successorSessionId,
+                recoveredSessionKey: successorTarget.canonicalKey,
+              },
+            },
+            archivedAt: source.archivedAt ?? now,
+            ...(source.archivedBy === undefined && params.archivedBy
+              ? { archivedBy: params.archivedBy }
+              : {}),
+            updatedAt: Math.max(now, (source.updatedAt ?? 0) + 1),
+          };
+          delete nextSource.pinnedAt;
+
+          params.commitGuard?.();
+
+          const identityKeys = [
+            ...sourceTarget.storeKeys,
+            ...successorTarget.storeKeys,
+            sourceTarget.canonicalKey,
+            successorTarget.canonicalKey,
+          ];
+          previousIdentity = readSessionIdentitySnapshot(database, identityKeys);
+          writeSessionEntry(database, successorTarget.canonicalKey, params.successorEntry);
+          writeSessionEntry(database, sourceTarget.canonicalKey, nextSource, {
+            previousEntry: source,
+          });
+          rehomeSessionWindows(database, sourceTarget.canonicalKey, sourceTarget.storeKeys);
+          rehomeSessionWindows(database, successorTarget.canonicalKey, successorTarget.storeKeys);
+          deleteLegacySessionEntryRows(
+            database,
+            sourceTarget.storeKeys,
+            sourceTarget.canonicalKey,
+            {
+              rehomeMembers: true,
+            },
+          );
+          deleteLegacySessionEntryRows(
+            database,
+            successorTarget.storeKeys,
+            successorTarget.canonicalKey,
+            { rehomeMembers: false },
+          );
+          maintenancePlans.push(
+            applySessionEntryMaintenance(database, {
+              activeSessionKey: successorTarget.canonicalKey,
+              archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+              skipMaintenance: true,
+              storePath: params.storePath,
             }),
-            parentSession,
-          },
-          ...sourceEvents.filter((event) => !(isRecord(event) && event.type === "session")),
-        ],
-      );
-
-      const now = Date.now();
-      const nextSource: InternalSessionEntry = {
-        ...source,
-        mainRestartRecovery: {
-          ...recovery,
-          revision: recovery.revision + 1,
-          tombstone: {
-            ...tombstone,
-            recoveredSessionId: successorSessionId,
-            recoveredSessionKey: successorTarget.canonicalKey,
-          },
-        },
-        archivedAt: source.archivedAt ?? now,
-        ...(source.archivedBy === undefined && params.archivedBy
-          ? { archivedBy: params.archivedBy }
-          : {}),
-        updatedAt: Math.max(now, (source.updatedAt ?? 0) + 1),
-      };
-      delete nextSource.pinnedAt;
-
-      params.commitGuard?.();
-
-      const identityKeys = [
-        ...sourceTarget.storeKeys,
-        ...successorTarget.storeKeys,
-        sourceTarget.canonicalKey,
-        successorTarget.canonicalKey,
-      ];
-      previousIdentity = readSessionIdentitySnapshot(database, identityKeys);
-      writeSessionEntry(database, successorTarget.canonicalKey, params.successorEntry);
-      writeSessionEntry(database, sourceTarget.canonicalKey, nextSource, { previousEntry: source });
-      rehomeSessionWindows(database, sourceTarget.canonicalKey, sourceTarget.storeKeys);
-      rehomeSessionWindows(database, successorTarget.canonicalKey, successorTarget.storeKeys);
-      deleteLegacySessionEntryRows(database, sourceTarget.storeKeys, sourceTarget.canonicalKey, {
-        rehomeMembers: true,
-      });
-      deleteLegacySessionEntryRows(
-        database,
-        successorTarget.storeKeys,
-        successorTarget.canonicalKey,
-        { rehomeMembers: false },
-      );
-      maintenancePlans.push(
-        applySessionEntryMaintenance(database, {
-          activeSessionKey: successorTarget.canonicalKey,
-          archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-          skipMaintenance: true,
-          storePath: params.storePath,
-        }),
-      );
-      currentIdentity = readSessionIdentitySnapshot(database, identityKeys);
-      result = {
-        status: "created",
-        sourceEntry: cloneSessionEntry(nextSource),
-        successorEntry: cloneSessionEntry(params.successorEntry),
-        successorKey: successorTarget.canonicalKey,
-      };
-    }, toDatabaseOptions(resolved));
-  });
+          );
+          currentIdentity = readSessionIdentitySnapshot(database, identityKeys);
+          result = {
+            status: "created",
+            sourceEntry: cloneSessionEntry(nextSource),
+            successorEntry: cloneSessionEntry(params.successorEntry),
+            successorKey: successorTarget.canonicalKey,
+          };
+        }, toDatabaseOptions(resolved));
+      }),
+  );
 
   emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
   await finalizeSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);

--- a/src/config/sessions/session-accessor.sqlite-replacement-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-replacement-projection.ts
@@ -1,14 +1,15 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import {
-  openOpenClawAgentDatabase,
-  runOpenClawAgentWriteTransaction,
-} from "../../state/openclaw-agent-db.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { isInternalSessionEffectsKey } from "./internal-session-key.js";
 import type {
   SessionEntryReplacementSnapshot,
   SessionEntryReplacementUpdate,
   SessionEntryStatus,
 } from "./session-accessor.sqlite-contract.js";
+import {
+  runPreparedSqliteSessionWrite,
+  runSqliteSessionDeletionTransaction as runOpenClawAgentWriteTransaction,
+} from "./session-accessor.sqlite-deletion.js";
 import { sqliteSessionEntriesEqual } from "./session-accessor.sqlite-entry-equality.js";
 import {
   deleteLegacySessionEntryRows,
@@ -27,7 +28,6 @@ import {
   cloneSessionEntry,
   resolveSqliteScope,
   resolveSqliteTranscriptArchiveDirectory,
-  runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
 import { readSessionEntriesByStatus } from "./session-accessor.sqlite-status.js";
@@ -69,7 +69,7 @@ async function applySqliteSessionEntryReplacementProjection<T, TReplacement>(
     sessionKey: params.activeSessionKey ?? params.sessionKeys?.[0] ?? "",
     storePath: params.storePath,
   });
-  const committed = await runExclusiveSqliteSessionWrite(resolved, async () => {
+  const committed = await runPreparedSqliteSessionWrite(resolved, async () => {
     const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
     const selectedKeys = params.sessionKeys ? new Set(params.sessionKeys) : undefined;
     const selectedStatuses = params.statuses ? new Set(params.statuses) : undefined;
@@ -145,7 +145,10 @@ async function applySqliteSessionEntryReplacementProjection<T, TReplacement>(
       throw new Error("session entry replacements did not persist any rows");
     }
     if (applicable.length === 0) {
-      return { maintenancePlans: [], result: operation.result };
+      return {
+        deletedEntries: [],
+        commit: () => ({ maintenancePlans: [], result: operation.result }),
+      };
     }
     const validationKeys = new Set(
       applicable.flatMap((replacement) => [
@@ -157,64 +160,77 @@ async function applySqliteSessionEntryReplacementProjection<T, TReplacement>(
     const maintenancePlans: SessionEntryMaintenancePlan[] = [];
     const previous = new Map<string, SessionEntry>();
     const current = new Map<string, SessionEntry>();
-    runOpenClawAgentWriteTransaction(
-      (transactionDb) => {
-        const transactionEntries = new Map<string, SessionEntry>();
-        for (const sessionKey of validationKeys) {
-          const transactionRow = readExactSessionEntryRow(transactionDb, sessionKey);
-          const expectedRow = expectedRows.get(sessionKey);
-          if (
-            transactionRow?.row.entry_json !== expectedRow?.row.entry_json ||
-            !sqliteSessionEntriesEqual(transactionRow?.entry, expectedRow?.entry)
-          ) {
-            throw new Error(`SQLite session entry changed before replacement for ${sessionKey}`);
-          }
-          if (transactionRow) {
-            transactionEntries.set(sessionKey, transactionRow.entry);
-          }
-        }
-        for (const replacement of applicable) {
-          const sourceEntries = [
-            replacement.sessionKey,
-            ...(replacement.previousSessionKeys ?? []),
-          ].flatMap((sessionKey) => {
-            const entry = transactionEntries.get(sessionKey);
-            return entry ? [{ entry, sessionKey }] : [];
-          });
-          const selectedBefore = sourceEntries.toSorted(
-            (left, right) => (right.entry.updatedAt ?? 0) - (left.entry.updatedAt ?? 0),
-          )[0]?.entry;
-          for (const { entry, sessionKey } of sourceEntries) {
-            previous.set(sessionKey, entry);
-          }
-          writeSessionEntry(
-            transactionDb,
-            replacement.sessionKey,
-            cloneSessionEntry(replacement.entry),
-            { previousEntry: selectedBefore ?? null },
-          );
-          deleteLegacySessionEntryRows(
-            transactionDb,
-            [...(replacement.previousSessionKeys ?? [])],
-            replacement.sessionKey,
-            { rehomeMembers: selectedBefore?.sessionId === replacement.entry.sessionId },
-          );
-          current.set(replacement.sessionKey, replacement.entry);
-        }
-        maintenancePlans.push(
-          applySessionEntryMaintenance(transactionDb, {
-            activeSessionKey: params.activeSessionKey ?? "",
-            archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
-            skipMaintenance: params.skipMaintenance ?? true,
-            storePath: params.storePath,
-          }),
+    const deletedOwners = [...validationKeys].flatMap((sessionKey) => {
+      const entry = expectedRows.get(sessionKey)?.entry;
+      return entry && !applicable.some((replacement) => replacement.sessionKey === sessionKey)
+        ? [{ entry, sessionKey }]
+        : [];
+    });
+    return {
+      deletedEntries: deletedOwners,
+      commit: () => {
+        runOpenClawAgentWriteTransaction(
+          (transactionDb) => {
+            const transactionEntries = new Map<string, SessionEntry>();
+            for (const sessionKey of validationKeys) {
+              const transactionRow = readExactSessionEntryRow(transactionDb, sessionKey);
+              const expectedRow = expectedRows.get(sessionKey);
+              if (
+                transactionRow?.row.entry_json !== expectedRow?.row.entry_json ||
+                !sqliteSessionEntriesEqual(transactionRow?.entry, expectedRow?.entry)
+              ) {
+                throw new Error(
+                  `SQLite session entry changed before replacement for ${sessionKey}`,
+                );
+              }
+              if (transactionRow) {
+                transactionEntries.set(sessionKey, transactionRow.entry);
+              }
+            }
+            for (const replacement of applicable) {
+              const sourceEntries = [
+                replacement.sessionKey,
+                ...(replacement.previousSessionKeys ?? []),
+              ].flatMap((sessionKey) => {
+                const entry = transactionEntries.get(sessionKey);
+                return entry ? [{ entry, sessionKey }] : [];
+              });
+              const selectedBefore = sourceEntries.toSorted(
+                (left, right) => (right.entry.updatedAt ?? 0) - (left.entry.updatedAt ?? 0),
+              )[0]?.entry;
+              for (const { entry, sessionKey } of sourceEntries) {
+                previous.set(sessionKey, entry);
+              }
+              writeSessionEntry(
+                transactionDb,
+                replacement.sessionKey,
+                cloneSessionEntry(replacement.entry),
+                { previousEntry: selectedBefore ?? null },
+              );
+              deleteLegacySessionEntryRows(
+                transactionDb,
+                [...(replacement.previousSessionKeys ?? [])],
+                replacement.sessionKey,
+                { rehomeMembers: selectedBefore?.sessionId === replacement.entry.sessionId },
+              );
+              current.set(replacement.sessionKey, replacement.entry);
+            }
+            maintenancePlans.push(
+              applySessionEntryMaintenance(transactionDb, {
+                activeSessionKey: params.activeSessionKey ?? "",
+                archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+                skipMaintenance: params.skipMaintenance ?? true,
+                storePath: params.storePath,
+              }),
+            );
+          },
+          toDatabaseOptions(resolved),
+          { operationLabel: "session.entry-replacements" },
         );
+        emitCommittedSessionIdentityDiff(previous, current);
+        return { maintenancePlans, result: operation.result };
       },
-      toDatabaseOptions(resolved),
-      { operationLabel: "session.entry-replacements" },
-    );
-    emitCommittedSessionIdentityDiff(previous, current);
-    return { maintenancePlans, result: operation.result };
+    };
   });
   await finalizeSessionEntryMaintenancePlansAfterWriterReleaseBestEffort(
     resolved,

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -60,6 +60,7 @@ export type ResolvedSqliteScope = {
   agentId: string;
   databaseAgentId?: string;
   env?: NodeJS.ProcessEnv;
+  ownerStorePath?: string;
   path?: string;
   sessionKey: string;
 };
@@ -68,6 +69,7 @@ export type ResolvedSqliteReadScope = {
   agentId: string;
   databaseAgentId?: string;
   env?: NodeJS.ProcessEnv;
+  ownerStorePath?: string;
   path?: string;
   sessionKey?: string;
 };
@@ -169,6 +171,7 @@ export function resolveSqliteScope(
     agentId,
     ...(storeTarget?.shared && storeTarget.agentId ? { databaseAgentId: storeTarget.agentId } : {}),
     ...(scope.env ? { env: scope.env } : {}),
+    ...(effectiveStorePath ? { ownerStorePath: effectiveStorePath } : {}),
     ...(storeTarget ? { path: storeTarget.path } : {}),
     sessionKey,
   };
@@ -215,6 +218,7 @@ export function resolveSqliteReadScope(
     agentId,
     ...(storeTarget?.shared && storeTarget.agentId ? { databaseAgentId: storeTarget.agentId } : {}),
     ...(scope.env ? { env: scope.env } : {}),
+    ...(effectiveStorePath ? { ownerStorePath: effectiveStorePath } : {}),
     ...(storeTarget ? { path: storeTarget.path } : {}),
     ...(sessionKey ? { sessionKey } : {}),
   };

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -2,7 +2,6 @@ import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import {
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
-  runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { clearAllCliSessions } from "./cli-session-binding.js";
@@ -17,9 +16,13 @@ import type {
   TranscriptMessageAppendOptions,
   TranscriptMessageAppendResult,
 } from "./session-accessor.sqlite-contract.js";
+import {
+  runPreparedSqliteSessionWrite,
+  runSqliteSessionDeletionTransaction as runOpenClawAgentWriteTransaction,
+} from "./session-accessor.sqlite-deletion.js";
+import { assertSessionEntrySelectionUnchanged } from "./session-accessor.sqlite-entry-equality.js";
 import type { ResolvedSessionEntryRow } from "./session-accessor.sqlite-entry-store.js";
 import {
-  assertSessionEntrySelectionUnchanged,
   collectSessionEntryLookupKeys,
   deleteLegacySessionEntryRows,
   readSessionEntryRow,
@@ -372,91 +375,111 @@ export async function appendExpectedSessionTranscriptTurn(
     ...scope,
     sessionId: options.expectedSessionId,
   });
-  return await runExclusiveSqliteSessionWrite(resolved, async () => {
-    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    const preparedEntry = readSessionEntryRow(database, resolved.sessionKey);
-    if (!sessionMatchesExpectedTranscriptTurn(preparedEntry, options)) {
-      return sqliteSessionTranscriptTurnRebound(preparedEntry, options.sessionFile);
-    }
-    const messages = await selectAppendableSqliteTranscriptTurnMessages(
-      {
-        agentId: resolved.agentId,
-        sessionId: options.expectedSessionId,
-        sessionKey: resolved.sessionKey,
-        ...(scope.storePath ? { storePath: scope.storePath } : {}),
-      },
-      options.messages,
-    );
-    let result: SqliteExpectedSessionTranscriptTurnResult = sqliteSessionTranscriptTurnRebound(
-      preparedEntry,
-      options.sessionFile,
-    );
-    let previousIdentity = new Map<string, SessionEntry>();
-    let currentIdentity = new Map<string, SessionEntry>();
-    runOpenClawAgentWriteTransaction((transactionDb) => {
-      const fresh = readSessionEntryRow(transactionDb, resolved.sessionKey);
-      if (!sessionMatchesExpectedTranscriptTurn(fresh, options)) {
-        result = sqliteSessionTranscriptTurnRebound(fresh, options.sessionFile);
-        return;
+  return await runPreparedSqliteSessionWrite<SqliteExpectedSessionTranscriptTurnResult>(
+    resolved,
+    async () => {
+      const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+      const preparedEntry = readSessionEntryRow(database, resolved.sessionKey);
+      if (!sessionMatchesExpectedTranscriptTurn(preparedEntry, options)) {
+        return {
+          deletedEntries: [],
+          commit: () => sqliteSessionTranscriptTurnRebound(preparedEntry, options.sessionFile),
+        };
       }
-      const appendedMessages: TranscriptMessageAppendResult<unknown>[] = [];
-      for (const append of messages) {
-        const { shouldAppend: _shouldAppend, ...appendOptions } = append;
-        const appended = appendTranscriptMessageInTransaction(transactionDb, resolved, {
-          ...appendOptions,
-          messageAlreadyRedacted: options.atomicGroup === true,
-          ...((append.cwd ?? options.cwd) ? { cwd: append.cwd ?? options.cwd } : {}),
-          ...((append.config ?? options.config) ? { config: append.config ?? options.config } : {}),
-        });
-        if (appended) {
-          appendedMessages.push(appended);
-        }
-      }
-      if (
-        options.atomicGroup &&
-        (appendedMessages.length !== messages.length ||
-          appendedMessages.some((message) => message.appended) !==
-            appendedMessages.every((message) => message.appended))
-      ) {
-        throw new Error("SQLite transcript batch was not wholly inserted or replayed");
-      }
-
-      // Later explicit parents can abandon earlier rows. Capture every cursor
-      // from the final active projection before this atomic transaction commits.
-      rememberCommittedTranscriptMessageSequencesInTransaction(
-        transactionDb,
-        resolved.sessionId,
-        appendedMessages,
+      const messages = await selectAppendableSqliteTranscriptTurnMessages(
+        {
+          agentId: resolved.agentId,
+          sessionId: options.expectedSessionId,
+          sessionKey: resolved.sessionKey,
+          ...(scope.storePath ? { storePath: scope.storePath } : {}),
+        },
+        options.messages,
       );
+      let result: SqliteExpectedSessionTranscriptTurnResult = sqliteSessionTranscriptTurnRebound(
+        preparedEntry,
+        options.sessionFile,
+      );
+      let previousIdentity = new Map<string, SessionEntry>();
+      let currentIdentity = new Map<string, SessionEntry>();
+      const aliases = readSessionIdentitySnapshot(
+        database,
+        preparedEntry.legacyKeys.filter((key) => key !== resolved.sessionKey),
+      );
+      return {
+        deletedEntries: [...aliases].map(([sessionKey, entry]) => ({ sessionKey, entry })),
+        commit: () => {
+          runOpenClawAgentWriteTransaction((transactionDb) => {
+            const fresh = readSessionEntryRow(transactionDb, resolved.sessionKey);
+            if (!sessionMatchesExpectedTranscriptTurn(fresh, options)) {
+              result = sqliteSessionTranscriptTurnRebound(fresh, options.sessionFile);
+              return;
+            }
+            const appendedMessages: TranscriptMessageAppendResult<unknown>[] = [];
+            for (const append of messages) {
+              const { shouldAppend: _shouldAppend, ...appendOptions } = append;
+              const appended = appendTranscriptMessageInTransaction(transactionDb, resolved, {
+                ...appendOptions,
+                messageAlreadyRedacted: options.atomicGroup === true,
+                ...((append.cwd ?? options.cwd) ? { cwd: append.cwd ?? options.cwd } : {}),
+                ...((append.config ?? options.config)
+                  ? { config: append.config ?? options.config }
+                  : {}),
+              });
+              if (appended) {
+                appendedMessages.push(appended);
+              }
+            }
+            if (
+              options.atomicGroup &&
+              (appendedMessages.length !== messages.length ||
+                appendedMessages.some((message) => message.appended) !==
+                  appendedMessages.every((message) => message.appended))
+            ) {
+              throw new Error("SQLite transcript batch was not wholly inserted or replayed");
+            }
 
-      const sessionPatch = buildExpectedTranscriptTurnSessionPatch({
-        appendedMessages,
-        currentEntry: fresh.entry,
-        expectedSessionState: options.expectedSessionState,
-        sessionFile: options.sessionFile,
-        sessionLifecyclePatch: options.sessionLifecyclePatch,
-        touchSessionEntry: options.touchSessionEntry,
-      });
-      const next =
-        Object.keys(sessionPatch).length > 0
-          ? mergeSessionEntry(fresh.entry, sessionPatch)
-          : fresh.entry;
-      if (next !== fresh.entry) {
-        const identityKeys = collectSessionEntryLookupKeys(transactionDb, resolved.sessionKey);
-        previousIdentity = readSessionIdentitySnapshot(transactionDb, identityKeys);
-        writeSessionEntry(transactionDb, resolved.sessionKey, next);
-        deleteLegacySessionEntryRows(transactionDb, fresh.legacyKeys, resolved.sessionKey);
-        currentIdentity = readSessionIdentitySnapshot(transactionDb, identityKeys);
-      }
-      result = {
-        appendedMessages,
-        sessionEntry: cloneSessionEntry(next),
-        sessionFile: options.sessionFile,
+            // Later explicit parents can abandon earlier rows. Capture every cursor
+            // from the final active projection before this atomic transaction commits.
+            rememberCommittedTranscriptMessageSequencesInTransaction(
+              transactionDb,
+              resolved.sessionId,
+              appendedMessages,
+            );
+
+            const sessionPatch = buildExpectedTranscriptTurnSessionPatch({
+              appendedMessages,
+              currentEntry: fresh.entry,
+              expectedSessionState: options.expectedSessionState,
+              sessionFile: options.sessionFile,
+              sessionLifecyclePatch: options.sessionLifecyclePatch,
+              touchSessionEntry: options.touchSessionEntry,
+            });
+            const next =
+              Object.keys(sessionPatch).length > 0
+                ? mergeSessionEntry(fresh.entry, sessionPatch)
+                : fresh.entry;
+            if (next !== fresh.entry) {
+              const identityKeys = collectSessionEntryLookupKeys(
+                transactionDb,
+                resolved.sessionKey,
+              );
+              previousIdentity = readSessionIdentitySnapshot(transactionDb, identityKeys);
+              writeSessionEntry(transactionDb, resolved.sessionKey, next);
+              deleteLegacySessionEntryRows(transactionDb, fresh.legacyKeys, resolved.sessionKey);
+              currentIdentity = readSessionIdentitySnapshot(transactionDb, identityKeys);
+            }
+            result = {
+              appendedMessages,
+              sessionEntry: cloneSessionEntry(next),
+              sessionFile: options.sessionFile,
+            };
+          }, toDatabaseOptions(resolved));
+          emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
+          return result;
+        },
       };
-    }, toDatabaseOptions(resolved));
-    emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
-    return result;
-  });
+    },
+  );
 }
 
 function sqliteSessionTranscriptTurnRebound(

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -73,6 +73,7 @@ import {
   type CronLiveSelection,
   type MutableCronSession,
   type PersistCronSessionEntry,
+  setCronSessionAgentHarnessId,
   setCronSessionRuntimeModel,
   syncCronSessionLiveSelection,
 } from "./run-session-state.js";
@@ -281,6 +282,7 @@ function createCronPromptExecutor(params: {
   modelFallbacksOverride?: string[];
   liveSelection: CronLiveSelection;
   cronSession: MutableCronSession;
+  persistSessionEntry: PersistCronSessionEntry;
   persistRunContinuationSession?: () => Promise<void>;
   setRunContinuationCliExecutionProvider?: (provider?: string) => Promise<void>;
   abortSignal?: AbortSignal;
@@ -589,6 +591,13 @@ function createCronPromptExecutor(params: {
           provider: providerOverride,
           model: modelOverride,
         });
+        setCronSessionAgentHarnessId({
+          entry: params.cronSession.sessionEntry,
+          agentHarnessId: candidateRuntime,
+        });
+        // Native bindings can exist before turn/start fails; deletion must retain
+        // the selected owner even when no result metadata is ever returned.
+        await params.persistSessionEntry();
         await params.persistRunContinuationSession?.();
         await params.setRunContinuationCliExecutionProvider?.(
           cliExecution ? executionProvider : undefined,
@@ -954,6 +963,7 @@ export async function executeCronRun(params: {
     modelFallbacksOverride: params.modelFallbacksOverride,
     liveSelection: params.liveSelection,
     cronSession: params.cronSession,
+    persistSessionEntry: params.persistSessionEntry,
     persistRunContinuationSession: params.persistRunContinuationSession,
     setRunContinuationCliExecutionProvider: params.setRunContinuationCliExecutionProvider,
     abortSignal: params.abortSignal,

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -17,11 +17,14 @@ import {
   logWarnMock,
   makeCronSession,
   makeCronSessionEntry,
+  patchSessionEntryMock,
   resolveAgentConfigMock,
   resolveAgentSkillsFilterMock,
   resolveAllowedModelRefMock,
   resolveCronSessionMock,
+  resolveEffectiveAgentRuntimeMock,
   runCliAgentMock,
+  runEmbeddedAgentMock,
   runWithModelFallbackMock,
 } from "./run.test-harness.js";
 
@@ -163,6 +166,44 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     await runSkillFilterCase();
     expect(resolveCronSessionMock).toHaveBeenCalledOnce();
     expect(getFirstMockArg(resolveCronSessionMock, "cron session").forceNew).toBe(true);
+  });
+
+  it("persists the selected harness on base and run rows before turn startup fails", async () => {
+    const persistedAtStartup = new Map<string, Record<string, unknown>>();
+    resolveEffectiveAgentRuntimeMock.mockReturnValue("codex");
+    runWithModelFallbackMock.mockImplementationOnce(
+      async (params: TestModelFallbackRunnerParams) => ({
+        result: await runInitialModelFallbackAttempt(params),
+        provider: params.provider,
+        model: params.model,
+      }),
+    );
+    runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      for (const [index, result] of patchSessionEntryMock.mock.results.entries()) {
+        const scope = requireRecord(
+          getMockCallArg(patchSessionEntryMock, index, 0, "session patch"),
+          "patch scope",
+        );
+        const entry = requireRecord(await result.value, "persisted session entry");
+        persistedAtStartup.set(String(scope.sessionKey), entry);
+      }
+      throw new Error("turn/start rejected before result metadata");
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({ agentId: "main" }),
+    );
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("turn/start rejected before result metadata");
+    expect(persistedAtStartup.get("agent:main:cron:test")).toMatchObject({
+      sessionId: "test-session-id",
+      agentHarnessId: "codex",
+    });
+    expect(persistedAtStartup.get("agent:main:cron:test:run:test-session-id")).toMatchObject({
+      sessionId: "test-session-id",
+      agentHarnessId: "codex",
+    });
   });
 
   it("reuses cached snapshot when version and normalized skillFilter are unchanged", async () => {

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -2090,6 +2090,17 @@ async function verifyCodexSessionDeletion(params: {
   );
   expect(siblingBinding).toBeDefined();
 
+  // A competing attachment must reject before displacing either native owner.
+  await requestCodexCommandText({
+    client,
+    events,
+    sessionKey,
+    command: `/codex resume ${siblingThreadId}`,
+    expectedText: "owned by another OpenClaw session or conversation",
+  });
+  expect(readBindings().find((row) => row.key === before?.key)).toEqual(before);
+  expect(readBindings().find((row) => row.key === siblingBinding?.key)).toEqual(siblingBinding);
+
   const deletion = await client.request<{ deleted: boolean }>("sessions.delete", {
     key: sessionKey,
   });
@@ -2124,6 +2135,7 @@ async function verifyCodexSessionDeletion(params: {
   });
   expect(observedCodexThreadIds.get(sessionKey)).toBe(threadId);
   logCodexLiveStep("session-deletion", {
+    competingResumeRejected: true,
     removedBinding: true,
     siblingContinued: true,
     nativeHistoryResumed: true,

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -5,6 +5,7 @@ import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { describe, expect, it } from "vitest";
 import { GATEWAY_CLIENT_CAPS } from "../../packages/gateway-protocol/src/client-info.js";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
@@ -21,6 +22,7 @@ import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { ContextEngine } from "../context-engine/types.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { pluginStateEntriesInKeyRange } from "../plugin-state/plugin-state-store.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
 import { setTestEnvValue } from "../test-utils/env.js";
 import type { CallGatewayOptions } from "./call.js";
@@ -2045,6 +2047,89 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
   }
 }
 
+async function verifyCodexSessionDeletion(params: {
+  client: GatewayClient;
+  events: EventFrame[];
+  modelKey: string;
+  sessionKey: string;
+}): Promise<void> {
+  const { client, events, modelKey, sessionKey } = params;
+  const threadId = observedCodexThreadIds.get(sessionKey);
+  expect(threadId).toBeTypeOf("string");
+  const sessionId = await readCodexHarnessSessionId({ client, sessionKey });
+  const readBindings = () =>
+    pluginStateEntriesInKeyRange({
+      pluginId: "codex",
+      namespace: "app-server-thread-bindings",
+      keyStartInclusive: "session-key:dev:",
+      keyEndExclusive: "session-key:dev;",
+      limit: 100,
+    });
+  const before = readBindings().find((row) => asOptionalRecord(row.value)?.sessionId === sessionId);
+  expect(before).toBeDefined();
+  const siblingKey = `${sessionKey}:deletion-sibling`;
+  const selectModel = async (key: string) =>
+    requestCodexCommandText({
+      client,
+      events,
+      sessionKey: key,
+      command: `/model ${modelKey} --runtime codex`,
+      expectedText: "Runtime set to codex",
+    });
+  await selectModel(siblingKey);
+  await requestAgentText({
+    client,
+    sessionKey: siblingKey,
+    expectedReply: "SIBLING-READY",
+    message: "Reply with exactly SIBLING-READY and nothing else.",
+  });
+  const siblingThreadId = observedCodexThreadIds.get(siblingKey);
+  const siblingSessionId = await readCodexHarnessSessionId({ client, sessionKey: siblingKey });
+  const siblingBinding = readBindings().find(
+    (row) => asOptionalRecord(row.value)?.sessionId === siblingSessionId,
+  );
+  expect(siblingBinding).toBeDefined();
+
+  const deletion = await client.request<{ deleted: boolean }>("sessions.delete", {
+    key: sessionKey,
+  });
+  expect(deletion.deleted).toBe(true);
+  expect(readBindings().some((row) => row.key === before?.key)).toBe(false);
+  expect(readBindings().find((row) => row.key === siblingBinding?.key)).toEqual(siblingBinding);
+  await requestAgentText({
+    client,
+    sessionKey: siblingKey,
+    expectedReply: "SIBLING-ALIVE",
+    message: "Reply with exactly SIBLING-ALIVE and nothing else.",
+  });
+  expect(observedCodexThreadIds.get(siblingKey)).toBe(siblingThreadId);
+
+  // Session deletion releases OpenClaw ownership, not the native Codex history.
+  // Attach that existing thread to a new session and complete a real turn.
+  await selectModel(sessionKey);
+  const attached = await requestCodexCommandText({
+    client,
+    events,
+    sessionKey,
+    command: `/codex resume ${threadId}`,
+    expectedText: "Attached this OpenClaw session",
+  });
+  expect(attached).toContain(threadId);
+  expect(await readCodexHarnessSessionId({ client, sessionKey })).not.toBe(sessionId);
+  await requestAgentText({
+    client,
+    sessionKey,
+    expectedReply: "DELETED-THREAD-RESUMED",
+    message: "Reply with exactly DELETED-THREAD-RESUMED and nothing else.",
+  });
+  expect(observedCodexThreadIds.get(sessionKey)).toBe(threadId);
+  logCodexLiveStep("session-deletion", {
+    removedBinding: true,
+    siblingContinued: true,
+    nativeHistoryResumed: true,
+  });
+}
+
 describeLive("gateway live (Codex harness)", () => {
   it(
     "runs gateway agent turns through the plugin-owned Codex app-server harness",
@@ -2564,6 +2649,12 @@ describeLive("gateway live (Codex harness)", () => {
             );
           }
         }
+        await verifyCodexSessionDeletion({
+          client,
+          events: gatewayEvents,
+          modelKey,
+          sessionKey: "agent:dev:live-codex-harness",
+        });
       } finally {
         try {
           clearRuntimeConfigSnapshot();

--- a/src/gateway/server.agent.subagent-delivery-context.test.ts
+++ b/src/gateway/server.agent.subagent-delivery-context.test.ts
@@ -1,5 +1,6 @@
 // Subagent delivery-context tests protect route metadata inheritance for child
 // agent sessions and outbound delivery through channel plugins.
+import { randomUUID } from "node:crypto";
 import { describe, expect, test } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
@@ -12,7 +13,13 @@ import { projectSessionDeliveryFields } from "../utils/delivery-context.shared.j
 import { setRegistry } from "./server.agent.gateway-server-agent.mocks.js";
 import { createRegistry } from "./server.e2e-registry-helpers.js";
 import { installConnectedSessionStoreGatewaySuite } from "./test-helpers.connected-session-store.js";
-import { installGatewayTestHooks, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
+import {
+  installGatewayTestHooks,
+  onceMessage,
+  prepareGatewayReplyRuntimeForTest,
+  testState,
+  writeSessionStore,
+} from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
@@ -74,11 +81,20 @@ async function readStoredSessionEntry(key: string): Promise<StoredEntry> {
 }
 
 async function sendAgentRequest(params: Record<string, unknown>): Promise<void> {
-  const res = await rpcReq(gatewaySuite.ws, "agent", {
-    deliver: false,
-    ...params,
-  });
+  await prepareGatewayReplyRuntimeForTest();
+  const id = randomUUID();
+  // Acceptance precedes execution; the next fixture must not delete a session with an active run.
+  const finalResponse = onceMessage(
+    gatewaySuite.ws,
+    (message) =>
+      message.type === "res" && message.id === id && message.payload?.status !== "accepted",
+  );
+  gatewaySuite.ws.send(
+    JSON.stringify({ type: "req", id, method: "agent", params: { deliver: false, ...params } }),
+  );
+  const res = await finalResponse;
   expect(res.ok).toBe(true);
+  expect(res.payload?.status).toBe("ok");
 }
 
 function expectDeliveryContextFields(entry: StoredEntry, expected: Record<string, unknown>): void {

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -21,26 +21,22 @@ import { resolveSessionStoreTargets } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
-  createPluginStateKeyedStore,
-  getPluginStateCapacity as resolvePluginStateCapacity,
-  importPluginStateEntriesForDoctor,
-  type OpenKeyedStoreOptions,
-} from "../plugin-state/plugin-state-store.js";
-import {
   collectRelevantDoctorPluginIds,
   listPluginDoctorSessionStoreAgentIds,
   listPluginDoctorStateMigrationEntries,
-  type PluginDoctorStateMigrationContext,
+  type PluginDoctorStateMigration,
   type PluginDoctorStateMigrationDetection,
 } from "../plugins/doctor-contract-registry.js";
 import { resolveLegacyInstalledPluginIndexStorePath } from "../plugins/installed-plugin-index-store.js";
 import type { PreparedLegacySessionSurfaces } from "../plugins/legacy-session-surfaces.types.js";
+import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import {
   DEFAULT_ACCOUNT_ID,
   DEFAULT_MAIN_KEY,
   LEGACY_IMPLICIT_AGENT_ID,
   normalizeAgentId,
 } from "../routing/session-key.js";
+import { withAgentDatabaseMaintenanceLease } from "../state/openclaw-agent-db.js";
 import {
   detectOpenClawStateDatabaseSchemaMigrations,
   repairOpenClawStateDatabaseSchema,
@@ -100,6 +96,10 @@ import {
   detectLegacyNodeHostConfig,
   migrateLegacyNodeHostConfig,
 } from "./state-migrations.node-host.js";
+import {
+  createPluginDoctorStateMigrationContext,
+  type PluginDoctorRepairAuthority,
+} from "./state-migrations.plugin-doctor-context.js";
 import {
   migrateLegacyInstalledPluginIndex,
   migrateLegacyPluginStateSidecar,
@@ -226,6 +226,8 @@ async function collectPluginDoctorStateMigrationPlans(params: {
   stateDir: string;
   oauthDir: string;
   includeDoctorOnly?: boolean;
+  phase?: PluginDoctorStateMigration["phase"];
+  repairAuthority?: PluginDoctorRepairAuthority;
   warnings?: string[];
 }): Promise<DetectedPluginDoctorStateMigrationPlan[]> {
   const plans: DetectedPluginDoctorStateMigrationPlan[] = [];
@@ -234,7 +236,10 @@ async function collectPluginDoctorStateMigrationPlans(params: {
     config,
     env: params.env,
   })) {
-    if (entry.migration.doctorOnly === true && params.includeDoctorOnly !== true) {
+    if (
+      entry.migration.phase !== params.phase ||
+      (entry.migration.doctorOnly === true && params.includeDoctorOnly !== true)
+    ) {
       continue;
     }
     let detected: PluginDoctorStateMigrationDetection | null;
@@ -244,7 +249,12 @@ async function collectPluginDoctorStateMigrationPlans(params: {
         env: params.env,
         stateDir: params.stateDir,
         oauthDir: params.oauthDir,
-        context: createPluginDoctorStateMigrationContext(entry.pluginId, params.env),
+        context: createPluginDoctorStateMigrationContext({
+          pluginId: entry.pluginId,
+          env: params.env,
+          config,
+          repairAuthority: params.repairAuthority,
+        }),
       });
     } catch (err) {
       params.warnings?.push(`Failed detecting ${entry.migration.label}: ${String(err)}`);
@@ -259,29 +269,6 @@ async function collectPluginDoctorStateMigrationPlans(params: {
     }
   }
   return plans;
-}
-
-function createPluginDoctorStateMigrationContext(
-  pluginId: string,
-  env: NodeJS.ProcessEnv,
-): PluginDoctorStateMigrationContext {
-  return {
-    getPluginStateCapacity() {
-      return resolvePluginStateCapacity(pluginId, env);
-    },
-    importPluginStateEntries(
-      options: OpenKeyedStoreOptions,
-      entries: readonly { key: string; value: unknown; createdAt: number; ttlMs?: number }[],
-    ) {
-      importPluginStateEntriesForDoctor(pluginId, { ...options, env: options.env ?? env }, entries);
-    },
-    openPluginStateKeyedStore<T>(options: OpenKeyedStoreOptions) {
-      return createPluginStateKeyedStore<T>(pluginId, {
-        ...options,
-        env: options.env ?? env,
-      });
-    },
-  };
 }
 
 function tryResolveDoctorStateMigrationAgentId(cfg: OpenClawConfig): string | undefined {
@@ -935,12 +922,44 @@ async function migratePluginDoctorStatePlans(params: {
   env: NodeJS.ProcessEnv;
   stateDir: string;
   oauthDir: string;
+  repairAuthority?: PluginDoctorRepairAuthority;
 }): Promise<MigrationMessages> {
   const changes: string[] = [];
   const warnings: string[] = [];
   const notices: string[] = [];
   if (params.plans.length === 0) {
     return { changes, warnings };
+  }
+
+  const migrate = async () => {
+    for (const plan of params.plans) {
+      try {
+        params.repairAuthority?.assertCurrent();
+        const result = await plan.migration.migrateLegacyState({
+          config: params.config,
+          env: params.env,
+          stateDir: params.stateDir,
+          oauthDir: params.oauthDir,
+          context: createPluginDoctorStateMigrationContext({
+            pluginId: plan.pluginId,
+            env: params.env,
+            config: params.config,
+            repairAuthority: params.repairAuthority,
+          }),
+        });
+        params.repairAuthority?.assertCurrent();
+        changes.push(...result.changes);
+        warnings.push(...result.warnings);
+        notices.push(...(result.notices ?? []));
+      } catch (err) {
+        warnings.push(`Failed migrating ${plan.migration.label}: ${String(err)}`);
+      }
+    }
+    return notices.length > 0 ? { changes, warnings, notices } : { changes, warnings };
+  };
+  // Session repair already holds the Gateway lock and cross-process database fences.
+  if (params.repairAuthority) {
+    return migrate();
   }
 
   let lock: Awaited<ReturnType<typeof acquireGatewayLock>>;
@@ -972,26 +991,93 @@ async function migratePluginDoctorStatePlans(params: {
   try {
     // Plugin migrations may claim retired files after verified import. Keep the
     // predecessor Gateway excluded for the full read, import, and archive window.
-    for (const plan of params.plans) {
-      try {
-        const result = await plan.migration.migrateLegacyState({
-          config: params.config,
-          env: params.env,
-          stateDir: params.stateDir,
-          oauthDir: params.oauthDir,
-          context: createPluginDoctorStateMigrationContext(plan.pluginId, params.env),
-        });
-        changes.push(...result.changes);
-        warnings.push(...result.warnings);
-        notices.push(...(result.notices ?? []));
-      } catch (err) {
-        warnings.push(`Failed migrating ${plan.migration.label}: ${String(err)}`);
-      }
-    }
+    return await migrate();
   } finally {
     await lock.release();
   }
-  return notices.length > 0 ? { changes, warnings, notices } : { changes, warnings };
+}
+
+/** Detect after canonical inspection; destructive repair also requires offline maintenance ownership. */
+export async function runPostSessionPluginDoctorStateRepairs(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  maintenanceAuthority?: { assertCurrent(): void };
+}): Promise<MigrationMessages> {
+  const stateDir = resolveStateDir(params.env);
+  const options = {
+    config: params.config,
+    env: params.env,
+    stateDir,
+    oauthDir: resolveOAuthDir(params.env, stateDir),
+  };
+  const run = async (repairAuthority?: PluginDoctorRepairAuthority): Promise<MigrationMessages> => {
+    const warnings: string[] = [];
+    repairAuthority?.assertCurrent();
+    const plans = await collectPluginDoctorStateMigrationPlans({
+      ...options,
+      cfg: params.config,
+      includeDoctorOnly: true,
+      phase: "after-session-repair",
+      repairAuthority,
+      warnings,
+    });
+    if (!repairAuthority) {
+      return {
+        changes: [],
+        warnings: [
+          ...warnings,
+          ...plans.flatMap((plan) => plan.preview),
+          ...(plans.length
+            ? ['Run "openclaw doctor --fix" to repair plugin session ownership.']
+            : []),
+        ],
+      };
+    }
+    const result = await migratePluginDoctorStatePlans({ ...options, plans, repairAuthority });
+    return { ...result, warnings: [...warnings, ...result.warnings] };
+  };
+  const maintenance = params.maintenanceAuthority;
+  if (!maintenance) {
+    return run();
+  }
+  maintenance.assertCurrent();
+  try {
+    return await withAgentDatabaseMaintenanceLease({ env: params.env }, async (agentLease) =>
+      withPluginLifecycleLease({ env: params.env, waitMs: 5_000 }, async (pluginLease) => {
+        let active = true;
+        const assertCurrent = () => {
+          if (!active) {
+            throw new Error("Plugin Doctor repair authority has expired.");
+          }
+          maintenance.assertCurrent();
+        };
+        const authority: PluginDoctorRepairAuthority = {
+          assertCurrent() {
+            assertCurrent();
+            agentLease.assertOwned();
+            pluginLease.assertOwned();
+          },
+          assertOwnedInTransaction(database) {
+            assertCurrent();
+            agentLease.assertOwnedInTransaction(database);
+            pluginLease.assertOwnedInTransaction(database);
+          },
+        };
+        try {
+          return await run(authority);
+        } finally {
+          active = false;
+        }
+      }),
+    );
+  } catch (error) {
+    return {
+      changes: [],
+      warnings: [
+        `Skipped plugin session repair: ${String(error)}. Stop active agents and run openclaw doctor --fix again.`,
+      ],
+    };
+  }
 }
 
 export async function autoMigrateLegacyPluginDoctorState(params: {

--- a/src/infra/state-migrations.plugin-doctor-context.test.ts
+++ b/src/infra/state-migrations.plugin-doctor-context.test.ts
@@ -1,0 +1,222 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createPluginDoctorStateMigrationContext } from "./state-migrations.plugin-doctor-context.js";
+
+describe("plugin doctor session identity evidence", () => {
+  it("preserves two current keys sharing an identity instead of inventing a main owner", async () => {
+    await withOpenClawTestState(
+      { label: "plugin-doctor-shared-id", applyEnv: false },
+      async ({ env }) => {
+        for (const sessionKey of ["agent:main:main", "agent:main:other"]) {
+          await replaceSessionEntry(
+            { agentId: "main", env, sessionKey },
+            { sessionId: "shared-id", updatedAt: 1 },
+          );
+        }
+        const context = createPluginDoctorStateMigrationContext({
+          pluginId: "codex",
+          env,
+          config: {},
+        });
+
+        await expect(
+          context.readSessionIdentityEvidenceBatch?.([{ agentId: "main", sessionId: "shared-id" }]),
+        ).resolves.toEqual([{ agentId: "main", sessionId: "shared-id", state: "unknown" }]);
+      },
+    );
+  });
+
+  it.each(["per-agent", "fixed"] as const)(
+    "proves absence from an initialized empty %s session store",
+    async (kind) => {
+      await withOpenClawTestState(
+        { label: `plugin-doctor-empty-${kind}`, applyEnv: false },
+        async ({ env, root }) => {
+          const fixedStorePath = path.join(root, "fixed.sqlite");
+          const config: OpenClawConfig =
+            kind === "fixed" ? { session: { store: fixedStorePath } } : {};
+          openOpenClawAgentDatabase({
+            agentId: "main",
+            env,
+            ...(kind === "fixed" ? { path: fixedStorePath } : {}),
+          });
+          const context = createPluginDoctorStateMigrationContext({
+            pluginId: "codex",
+            env,
+            config,
+          });
+
+          await expect(
+            context.readSessionIdentityEvidenceBatch?.([{ agentId: "main", sessionId: "gone" }]),
+          ).resolves.toEqual([{ agentId: "main", sessionId: "gone", state: "absent" }]);
+          expect(context.deletePluginStateEntriesIfUnchanged).toBeUndefined();
+        },
+      );
+    },
+  );
+
+  it.each(["missing", "broken"] as const)(
+    "keeps a %s session store unknown rather than proving absence",
+    async (kind) => {
+      await withOpenClawTestState(
+        { label: `plugin-doctor-${kind}`, applyEnv: false },
+        async ({ env }) => {
+          if (kind === "broken") {
+            openOpenClawAgentDatabase({ agentId: "main", env }).db.exec(
+              "PRAGMA user_version = 999",
+            );
+          }
+          const context = createPluginDoctorStateMigrationContext({
+            pluginId: "codex",
+            env,
+            config: {},
+          });
+
+          await expect(
+            context.readSessionIdentityEvidenceBatch?.([{ agentId: "main", sessionId: "gone" }]),
+          ).resolves.toEqual([{ agentId: "main", sessionId: "gone", state: "unknown" }]);
+        },
+      );
+    },
+  );
+
+  it.each(["malformed", "mismatched-identity"] as const)(
+    "keeps %s fixed-store rows unknown instead of treating them as empty",
+    async (corruption) => {
+      await withOpenClawTestState(
+        { label: `plugin-doctor-fixed-${corruption}`, applyEnv: false },
+        async ({ env, root }) => {
+          const storePath = path.join(root, "fixed.sqlite");
+          const sessionKey = "agent:main:broken";
+          await replaceSessionEntry(
+            { agentId: "main", env, sessionKey, storePath },
+            { sessionId: "broken-session", updatedAt: 1 },
+          );
+          const database = openOpenClawAgentDatabase({ agentId: "main", env, path: storePath }).db;
+          if (corruption === "malformed") {
+            database
+              .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+              .run("{broken", sessionKey);
+          } else {
+            database
+              .prepare("UPDATE session_nodes SET current_session_id = ? WHERE session_key = ?")
+              .run("wrong-session", sessionKey);
+          }
+          const context = createPluginDoctorStateMigrationContext({
+            pluginId: "codex",
+            env,
+            config: { session: { store: storePath } },
+          });
+
+          const sessionId = corruption === "malformed" ? "broken-session" : "wrong-session";
+          await expect(
+            context.readSessionIdentityEvidenceBatch?.([{ agentId: "main", sessionId }]),
+          ).resolves.toEqual([{ agentId: "main", sessionId, state: "unknown" }]);
+        },
+      );
+    },
+  );
+
+  it("resolves the authoritative canonical session key using the Doctor-owned environment", async () => {
+    await withOpenClawTestState(
+      { label: "plugin-doctor-current", applyEnv: false },
+      async ({ env, root }) => {
+        const storePath = path.join(root, "fixed.sqlite");
+        const sessionKey = "agent:main:renamed";
+        await replaceSessionEntry(
+          { agentId: "main", env, sessionKey, storePath },
+          { sessionId: "live", updatedAt: 1 },
+        );
+        const context = createPluginDoctorStateMigrationContext({
+          pluginId: "codex",
+          env,
+          config: { session: { store: storePath } },
+        });
+
+        await expect(
+          context.readSessionIdentityEvidenceBatch?.([{ agentId: "main", sessionId: "live" }]),
+        ).resolves.toEqual([{ agentId: "main", sessionId: "live", state: "current", sessionKey }]);
+      },
+    );
+  });
+
+  it("deduplicates configured SQLite and discovered JSON aliases by physical owner", async () => {
+    await withOpenClawTestState(
+      { label: "plugin-doctor-physical-alias", applyEnv: false },
+      async ({ env, stateDir }) => {
+        const agentRoot = path.join(stateDir, "agents", "main");
+        const storePath = path.join(agentRoot, "agent", "openclaw-agent.sqlite");
+        fs.mkdirSync(path.join(agentRoot, "sessions"), { recursive: true });
+        const sessionKey = "agent:main:renamed";
+        await replaceSessionEntry(
+          { agentId: "main", env, sessionKey, storePath },
+          { sessionId: "live", updatedAt: 1 },
+        );
+        const context = createPluginDoctorStateMigrationContext({
+          pluginId: "codex",
+          env,
+          config: {
+            session: {
+              store: path.join(stateDir, "agents", "{agentId}", "agent", "openclaw-agent.sqlite"),
+            },
+          },
+        });
+
+        await expect(
+          context.readSessionIdentityEvidenceBatch?.([{ agentId: "main", sessionId: "live" }]),
+        ).resolves.toEqual([{ agentId: "main", sessionId: "live", state: "current", sessionKey }]);
+      },
+    );
+  });
+
+  it("rejects retained destructive repair callbacks after their owner expires", async () => {
+    await withOpenClawTestState(
+      { label: "plugin-doctor-expired-repair", applyEnv: false },
+      async ({ env }) => {
+        let active = true;
+        const context = createPluginDoctorStateMigrationContext({
+          pluginId: "codex",
+          env,
+          config: {},
+          repairAuthority: {
+            assertCurrent() {
+              if (!active) {
+                throw new Error("repair owner expired");
+              }
+            },
+            assertOwnedInTransaction() {},
+          },
+        });
+        const options = { namespace: "doctor-repair", maxEntries: 10 };
+        const store = context.openPluginStateKeyedStore<{ sessionId: string }>(options);
+        await store.register("binding:retained", { sessionId: "gone" });
+        const observed = context.readPluginStateEntriesInKeyRange?.(options.namespace, {
+          prefix: "binding:",
+          limit: 10,
+        });
+        expect(observed).toHaveLength(1);
+
+        active = false;
+
+        expect(() =>
+          context.deletePluginStateEntriesIfUnchanged?.(options.namespace, observed ?? []),
+        ).toThrow("repair owner expired");
+        expect(() =>
+          context.readPluginStateEntriesInKeyRange?.(options.namespace, {
+            prefix: "binding:",
+            limit: 10,
+          }),
+        ).toThrow("repair owner expired");
+        await expect(
+          context.readSessionIdentityEvidenceBatch?.([{ agentId: "main", sessionId: "gone" }]),
+        ).rejects.toThrow("repair owner expired");
+        await expect(store.lookup("binding:retained")).resolves.toEqual({ sessionId: "gone" });
+      },
+    );
+  });
+});

--- a/src/infra/state-migrations.plugin-doctor-context.ts
+++ b/src/infra/state-migrations.plugin-doctor-context.ts
@@ -1,0 +1,171 @@
+import type { DatabaseSync } from "node:sqlite";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import { readSessionIdentityEvidenceBatch } from "../config/sessions/session-accessor.js";
+import {
+  resolveExistingAgentSessionStoreTargetsReadOnlyResult,
+  type SessionStoreTargetsReadCache,
+} from "../config/sessions/targets-read-availability.js";
+import { dedupeSessionStoreTargetsBySqliteTarget } from "../config/sessions/targets.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES,
+  createPluginStateKeyedStore,
+  getPluginStateCapacity,
+  importPluginStateEntriesForDoctor,
+  pluginStateDeleteEntriesIfUnchanged,
+  pluginStateDoctorEntriesInKeyRange,
+  type OpenKeyedStoreOptions,
+} from "../plugin-state/plugin-state-store.js";
+import type { PluginDoctorStateMigrationContext } from "../plugins/doctor-contract-module.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+
+type SessionEvidenceResult = Awaited<
+  ReturnType<NonNullable<PluginDoctorStateMigrationContext["readSessionIdentityEvidenceBatch"]>>
+>[number];
+type DoctorSessionStoreTarget = { agentId: string; storePath: string };
+
+export type PluginDoctorRepairAuthority = {
+  assertCurrent(): void;
+  assertOwnedInTransaction(database: DatabaseSync): void;
+};
+
+function resolveDoctorSessionIdentityEvidence(params: {
+  cache: SessionStoreTargetsReadCache;
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  requests: readonly { agentId: string; sessionId: string }[];
+  targetsByAgent: Map<string, readonly DoctorSessionStoreTarget[] | null>;
+}): SessionEvidenceResult[] {
+  if (params.requests.length > MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES) {
+    throw new Error("Plugin doctor session evidence batch exceeds the maximum size.");
+  }
+  const probes: Array<DoctorSessionStoreTarget & { index: number; sessionId: string }> = [];
+  for (const [index, request] of params.requests.entries()) {
+    const agentId = normalizeAgentId(request.agentId);
+    let targets = params.targetsByAgent.get(agentId);
+    if (targets === undefined) {
+      try {
+        const resolved = resolveExistingAgentSessionStoreTargetsReadOnlyResult(
+          params.config,
+          agentId,
+          {
+            cache: params.cache,
+            env: params.env,
+          },
+        );
+        if (!resolved.available) {
+          targets = null;
+        } else {
+          const candidates = resolved.targets.length
+            ? resolved.targets
+            : [
+                {
+                  agentId,
+                  storePath: resolveSessionStorePathCore(params.config.session?.store, {
+                    agentId,
+                    env: params.env,
+                  }),
+                },
+              ];
+          targets = dedupeSessionStoreTargetsBySqliteTarget(candidates, {
+            defaultAgentId: agentId,
+            env: params.env,
+          });
+        }
+      } catch {
+        targets = null;
+      }
+      params.targetsByAgent.set(agentId, targets);
+    }
+    for (const target of targets ?? []) {
+      probes.push({ ...target, index, sessionId: request.sessionId });
+    }
+  }
+  const evidence = readSessionIdentityEvidenceBatch(
+    probes.map(({ agentId, sessionId, storePath }) => ({
+      agentId,
+      env: params.env,
+      sessionId,
+      storePath,
+    })),
+  );
+  const observedByRequest = new Map<number, typeof evidence>();
+  for (const [position, observed] of evidence.entries()) {
+    const index = probes[position]!.index;
+    const previous = observedByRequest.get(index);
+    if (previous) {
+      previous.push(observed);
+    } else {
+      observedByRequest.set(index, [observed]);
+    }
+  }
+  return params.requests.map((request, index): SessionEvidenceResult => {
+    const observed = observedByRequest.get(index);
+    const current = observed?.filter((entry) => entry.status === "current") ?? [];
+    if (
+      !observed?.length ||
+      observed.some((entry) => entry.status === "unknown") ||
+      current.length > 1
+    ) {
+      return { ...request, state: "unknown" };
+    }
+    return current[0]
+      ? { ...request, state: "current", sessionKey: current[0].sessionKey }
+      : { ...request, state: "absent" };
+  });
+}
+
+export function createPluginDoctorStateMigrationContext(params: {
+  pluginId: string;
+  env: NodeJS.ProcessEnv;
+  config: OpenClawConfig;
+  repairAuthority?: PluginDoctorRepairAuthority;
+}): PluginDoctorStateMigrationContext {
+  const { pluginId, env } = params;
+  const cache: SessionStoreTargetsReadCache = new Map();
+  const targetsByAgent = new Map<string, readonly DoctorSessionStoreTarget[] | null>();
+  const context: PluginDoctorStateMigrationContext = {
+    getPluginStateCapacity: () => getPluginStateCapacity(pluginId, env),
+    importPluginStateEntries(options, entries) {
+      importPluginStateEntriesForDoctor(pluginId, { ...options, env: options.env ?? env }, entries);
+    },
+    openPluginStateKeyedStore<T>(options: OpenKeyedStoreOptions) {
+      return createPluginStateKeyedStore<T>(pluginId, { ...options, env: options.env ?? env });
+    },
+    readPluginStateEntriesInKeyRange(namespace, range) {
+      params.repairAuthority?.assertCurrent();
+      return pluginStateDoctorEntriesInKeyRange({
+        pluginId,
+        namespace,
+        ...range,
+        env,
+      });
+    },
+    async readSessionIdentityEvidenceBatch(requests) {
+      params.repairAuthority?.assertCurrent();
+      const evidence = resolveDoctorSessionIdentityEvidence({
+        cache,
+        config: params.config,
+        env,
+        requests,
+        targetsByAgent,
+      });
+      params.repairAuthority?.assertCurrent();
+      return evidence;
+    },
+  };
+  if (params.repairAuthority) {
+    const authority = params.repairAuthority;
+    context.deletePluginStateEntriesIfUnchanged = (namespace, entries) => {
+      authority.assertCurrent();
+      return pluginStateDeleteEntriesIfUnchanged({
+        pluginId,
+        namespace,
+        entries,
+        env,
+        assertOwnedInTransaction: (database) => authority.assertOwnedInTransaction(database),
+      });
+    };
+  }
+  return context;
+}

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -17,7 +17,7 @@ import { definePluginDoctorMigrationFromPlans } from "../plugin-sdk/runtime-doct
 import type {
   PluginDoctorStateMigration,
   PluginDoctorStateMigrationContext,
-} from "../plugins/doctor-contract-registry.js";
+} from "../plugins/doctor-contract-module.js";
 import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { readConfigMachineState, writeConfigMachineState } from "../state/config-machine-state.js";
@@ -111,6 +111,7 @@ const pluginDoctorStateMigrationEntries = vi.hoisted(
           id: string;
           label: string;
           doctorOnly?: boolean;
+          phase?: "after-session-repair";
           detectLegacyState: (params: {
             config: OpenClawConfig;
             env: NodeJS.ProcessEnv;
@@ -1290,6 +1291,78 @@ describe("state migrations", () => {
     expect(repaired.changes).toContain("doctor-only plugin state migrated");
     expect(detectLegacyState).toHaveBeenCalledTimes(2);
     expect(migrateLegacyState).toHaveBeenCalledOnce();
+  });
+
+  it("excludes post-session plugin repair from legacy migration detection and execution", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: { main: {} },
+      },
+    };
+    const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
+    await fs.mkdir(path.dirname(legacyStorePath), { recursive: true });
+    await fs.writeFile(
+      legacyStorePath,
+      JSON.stringify({ legacy: { sessionId: "imported-session", updatedAt: 1 } }),
+      "utf8",
+    );
+    const detect = vi.fn(({ context }: { context: unknown }) => {
+      expect(
+        (context as PluginDoctorStateMigrationContext).deletePluginStateEntriesIfUnchanged,
+      ).toBeUndefined();
+      return { preview: ["fixture plugin migration"] };
+    });
+    const postSessionDetect = vi.fn(() => ({ preview: ["post-session repair"] }));
+    const postSessionMigrate = vi.fn(() => ({ changes: ["post-session phase"], warnings: [] }));
+    pluginDoctorStateMigrationEntries.entries = [
+      {
+        pluginId: "fixture",
+        migration: {
+          id: "fixture-legacy",
+          label: "Fixture legacy plugin migration",
+          doctorOnly: true,
+          detectLegacyState: detect,
+          migrateLegacyState({ context }) {
+            expect(fsSync.existsSync(legacyStorePath)).toBe(true);
+            expect(
+              (context as PluginDoctorStateMigrationContext).deletePluginStateEntriesIfUnchanged,
+            ).toBeUndefined();
+            return { changes: ["legacy phase"], warnings: [] };
+          },
+        },
+      },
+      {
+        pluginId: "fixture",
+        migration: {
+          id: "fixture-after-session-repair",
+          label: "Fixture post-session plugin migration",
+          doctorOnly: true,
+          phase: "after-session-repair",
+          detectLegacyState: postSessionDetect,
+          migrateLegacyState: postSessionMigrate,
+        },
+      },
+    ];
+
+    const detected = await detectLegacyStateMigrations({
+      cfg,
+      env,
+      homedir: () => root,
+      doctorOnlyStateMigrations: true,
+    });
+    const result = await runLegacyStateMigrations({ detected, config: cfg, env });
+
+    expect(result.warnings).toEqual([]);
+    expect(detect).toHaveBeenCalledTimes(2);
+    expect(postSessionDetect).not.toHaveBeenCalled();
+    expect(postSessionMigrate).not.toHaveBeenCalled();
+    expect(result.changes).toContain("legacy phase");
+    expect(result.changes).not.toContain("post-session phase");
   });
 
   it("restores retained Memory Core host events only for explicit plugin-only Doctor repair", async () => {

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -208,6 +208,7 @@ export { resolveAgentRunAbortLifecycleFields } from "../agents/run-termination.j
 export { isHostScopedAgentToolActive } from "../agents/agent-tools.ring-zero-context.js";
 export { log as embeddedAgentLog } from "../agents/embedded-agent-runner/logger.js";
 export { buildAgentRuntimePlan } from "../agents/runtime-plan/build.js";
+export { prepareAgentRuntimeAuth } from "../agents/runtime-plan/prepare-auth.js";
 export { classifyEmbeddedAgentRunResultForModelFallback } from "../agents/embedded-agent-runner/result-fallback-classifier.js";
 export { resolveUserPath } from "../utils.js";
 export { callGatewayTool } from "../agents/tools/gateway.js";

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -99,6 +99,8 @@ export type {
   AgentHarnessSideQuestionResult,
   AgentHarnessSettledTurnFinalizationResult,
   AgentHarnessResetParams,
+  AgentHarnessSessionDeletionParams,
+  AgentHarnessSessionDeletionMutation,
   AgentHarnessSessionForkFailureCode,
   AgentHarnessSessionForkParams,
   AgentHarnessSessionForkResult,

--- a/src/plugin-sdk/model-session-runtime.ts
+++ b/src/plugin-sdk/model-session-runtime.ts
@@ -4,6 +4,7 @@
 export { resolveChannelModelOverride } from "../channels/model-overrides.js";
 export { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 export { resolvePersistedSessionRuntimeId } from "../agents/session-runtime-compat.js";
+export { resolveSessionModelRef } from "../agents/session-model-ref.js";
 export { applySessionModelSelection } from "../model-picker/apply-session-model-selection.js";
 export type {
   ApplySessionModelSelectionParams,

--- a/src/plugin-state/plugin-state-store.doctor-repair.test.ts
+++ b/src/plugin-state/plugin-state-store.doctor-repair.test.ts
@@ -1,0 +1,193 @@
+import { rmSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
+  createPluginStateSyncKeyedStore,
+  MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES,
+  pluginStateDeleteEntriesIfUnchanged,
+  pluginStateDoctorEntriesInKeyRange,
+  pluginStateEntriesInKeyRange,
+  resetPluginStateStoreForTests,
+} from "./plugin-state-store.js";
+import {
+  clearPluginStateStoreForTests,
+  seedPluginStateEntriesForTests,
+} from "./plugin-state-store.test-helpers.js";
+
+let testState: OpenClawTestState | undefined;
+
+beforeAll(async () => {
+  testState = await createOpenClawTestState({ label: "plugin-state-doctor-repair" });
+  rmSync(path.dirname(resolveOpenClawStateSqlitePath()), { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  testState?.applyEnv();
+  clearPluginStateStoreForTests();
+});
+
+afterEach(() => {
+  resetPluginStateStoreForTests({ closeDatabase: false });
+});
+
+afterAll(async () => {
+  resetPluginStateStoreForTests();
+  await testState?.cleanup();
+});
+
+describe("plugin state Doctor repair", () => {
+  it("bulk-deletes only unchanged scoped rows in one bounded transaction", () => {
+    const namespace = "bulk-bindings";
+    seedPluginStateEntriesForTests([
+      ...Array.from({ length: MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES }, (_, index) => ({
+        pluginId: "codex",
+        namespace,
+        key: `binding:${String(index).padStart(4, "0")}`,
+        value: { generation: 1 },
+      })),
+      { pluginId: "codex", namespace: "other", key: "binding:0000", value: { keep: true } },
+      { pluginId: "other", namespace, key: "binding:0000", value: { keep: true } },
+    ]);
+    const observed = pluginStateDoctorEntriesInKeyRange({
+      pluginId: "codex",
+      namespace,
+      prefix: "binding:",
+      limit: MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES,
+    });
+    const store = createPluginStateSyncKeyedStore<{ generation: number }>("codex", {
+      namespace,
+      maxEntries: MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES,
+    });
+    store.register("binding:0000", { generation: 2 });
+    const exec = vi.spyOn(DatabaseSync.prototype, "exec");
+    const ownerAssertions: boolean[] = [];
+    const assertOwnedInTransaction = (database: DatabaseSync) => {
+      ownerAssertions.push(database.isTransaction);
+    };
+    try {
+      expect(
+        pluginStateDeleteEntriesIfUnchanged({
+          pluginId: "codex",
+          namespace,
+          entries: observed,
+          assertOwnedInTransaction,
+        }),
+      ).toEqual({ deleted: MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES - 1, changed: 1 });
+      expect(ownerAssertions).toEqual([true]);
+      expect(exec.mock.calls.filter(([sql]) => sql.trim() === "BEGIN IMMEDIATE")).toHaveLength(1);
+      expect(store.lookup("binding:0000")).toEqual({ generation: 2 });
+      expect(
+        createPluginStateSyncKeyedStore("codex", { namespace: "other", maxEntries: 1 }).lookup(
+          "binding:0000",
+        ),
+      ).toEqual({ keep: true });
+      expect(
+        createPluginStateSyncKeyedStore("other", { namespace, maxEntries: 1 }).lookup(
+          "binding:0000",
+        ),
+      ).toEqual({ keep: true });
+      expect(() =>
+        pluginStateDeleteEntriesIfUnchanged({
+          pluginId: "codex",
+          namespace,
+          entries: [...observed, observed[0]!],
+          assertOwnedInTransaction,
+        }),
+      ).toThrow(/cannot exceed 512 entries/);
+    } finally {
+      exec.mockRestore();
+    }
+  });
+
+  it("pages past malformed rows and compares siblings' original JSON bytes", () => {
+    const namespace = "raw-doctor-bindings";
+    seedPluginStateEntriesForTests([
+      { pluginId: "codex", namespace, key: "binding:a", value: { corrupt: true } },
+      { pluginId: "codex", namespace, key: "binding:b", value: { generation: 1 } },
+      { pluginId: "codex", namespace, key: "binding:c", value: { generation: 1 } },
+      { pluginId: "codex", namespace, key: "binding:d", value: { generation: 1 }, createdAt: -1 },
+    ]);
+    const database = openOpenClawStateDatabase().db;
+    const replaceJson = database.prepare(
+      "UPDATE plugin_state_entries SET value_json = ? WHERE plugin_id = ? AND namespace = ? AND entry_key = ?",
+    );
+    replaceJson.run("{malformed", "codex", namespace, "binding:a");
+    replaceJson.run('{ "generation" : 1 }', "codex", namespace, "binding:b");
+    replaceJson.run('{ "generation" : 1 }', "codex", namespace, "binding:c");
+
+    const first = pluginStateDoctorEntriesInKeyRange({
+      pluginId: "codex",
+      namespace,
+      prefix: "binding:",
+      limit: 1,
+    });
+    expect(first).toEqual([
+      expect.objectContaining({ key: "binding:a", valueJson: "{malformed", expiresAt: null }),
+    ]);
+    expect(first[0]).not.toHaveProperty("value");
+    expect(() =>
+      pluginStateEntriesInKeyRange({
+        pluginId: "codex",
+        namespace,
+        keyStartInclusive: "binding:",
+        keyEndExclusive: "binding;",
+        limit: 1,
+      }),
+    ).toThrow(/corrupt JSON/);
+
+    const siblings = pluginStateDoctorEntriesInKeyRange({
+      pluginId: "codex",
+      namespace,
+      prefix: "binding:",
+      after: first[0]!.key,
+      limit: 2,
+    });
+    expect(siblings).toEqual([
+      expect.objectContaining({
+        key: "binding:b",
+        value: { generation: 1 },
+        valueJson: '{ "generation" : 1 }',
+      }),
+      expect.objectContaining({
+        key: "binding:c",
+        value: { generation: 1 },
+        valueJson: '{ "generation" : 1 }',
+      }),
+    ]);
+    replaceJson.run('{"generation":1}', "codex", namespace, "binding:c");
+
+    expect(() =>
+      pluginStateDeleteEntriesIfUnchanged({
+        pluginId: "codex",
+        namespace,
+        entries: siblings,
+        assertOwnedInTransaction: () => {
+          throw new Error("maintenance ownership expired");
+        },
+      }),
+    ).toThrow(/maintenance ownership expired/);
+    expect(
+      pluginStateDeleteEntriesIfUnchanged({
+        pluginId: "codex",
+        namespace,
+        entries: siblings,
+        assertOwnedInTransaction: () => {},
+      }),
+    ).toEqual({ deleted: 1, changed: 1 });
+    const preserved = pluginStateDoctorEntriesInKeyRange({
+      pluginId: "codex",
+      namespace,
+      prefix: "binding:",
+      limit: 4,
+    });
+    expect(preserved.map((entry) => entry.key)).toEqual(["binding:a", "binding:c", "binding:d"]);
+    expect(preserved[2]).not.toHaveProperty("value");
+  });
+});

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -32,6 +32,7 @@ import {
 // Plugin-wide fuse only; namespace maxEntries still owns normal cache eviction.
 export const MAX_PLUGIN_STATE_VALUE_BYTES = 1_048_576;
 export const MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN = 50_000;
+export const MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES = 512;
 const PLUGIN_STATE_EXPIRY_BATCH_ROWS = 1_024;
 let maxPluginStateEntriesPerPluginForTests: number | undefined;
 
@@ -39,6 +40,12 @@ type PluginStateEntriesTable = OpenClawStateKyselyDatabase["plugin_state_entries
 type PluginStateStoreDatabase = Pick<OpenClawStateKyselyDatabase, "plugin_state_entries">;
 
 type PluginStateRow = Selectable<PluginStateEntriesTable>;
+
+export type PluginDoctorRawStateEntry = Omit<PluginStateEntry<unknown>, "value" | "expiresAt"> & {
+  valueJson: string;
+  value?: unknown;
+  expiresAt: number | null;
+};
 
 type CountRow = {
   count: number | bigint;
@@ -1090,6 +1097,101 @@ export function pluginStateDeleteIf(params: {
   }
 }
 
+/** Deletes one bounded set of exact observed rows in a single synchronous transaction. */
+export function pluginStateDeleteEntriesIfUnchanged(params: {
+  pluginId: string;
+  namespace: string;
+  entries: readonly PluginDoctorRawStateEntry[];
+  assertOwnedInTransaction: (database: DatabaseSync) => void;
+  env?: NodeJS.ProcessEnv;
+}): { deleted: number; changed: number } {
+  if (params.entries.length > MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES) {
+    throw new RangeError(
+      `Plugin state bulk deletion cannot exceed ${MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES} entries.`,
+    );
+  }
+  if (params.entries.length === 0) {
+    return { deleted: 0, changed: 0 };
+  }
+  // Copy plugin-visible envelopes before BEGIN; no plugin-owned accessors run in the transaction.
+  const observed = params.entries.map(({ value: _value, ...entry }) => entry);
+  return runWriteTransaction(
+    "delete",
+    ({ db }) => {
+      params.assertOwnedInTransaction(db);
+      let deleted = 0;
+      for (const entry of observed) {
+        let query = getPluginStateKysely(db)
+          .deleteFrom("plugin_state_entries")
+          .where("plugin_id", "=", params.pluginId)
+          .where("namespace", "=", params.namespace)
+          .where("entry_key", "=", entry.key)
+          .where("value_json", "=", entry.valueJson)
+          .where("created_at", "=", entry.createdAt);
+        query =
+          entry.expiresAt === null
+            ? query.where("expires_at", "is", null)
+            : query.where("expires_at", "=", entry.expiresAt);
+        deleted += Number(executeSqliteQuerySync(db, query).numAffectedRows ?? 0);
+      }
+      return { deleted, changed: observed.length - deleted };
+    },
+    envOptions(params.env),
+  );
+}
+
+/** Doctor-only bounded raw read keeps malformed rows visible and preserves exact CAS bytes. */
+export function pluginStateDoctorEntriesInKeyRange(params: {
+  pluginId: string;
+  namespace: string;
+  prefix: string;
+  after?: string;
+  limit: number;
+  env?: NodeJS.ProcessEnv;
+}): PluginDoctorRawStateEntry[] {
+  if (
+    !params.prefix ||
+    !Number.isSafeInteger(params.limit) ||
+    params.limit < 1 ||
+    params.limit > MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES ||
+    (params.after !== undefined && !params.after.startsWith(params.prefix))
+  ) {
+    throw new RangeError(
+      `Plugin doctor state reads require a valid prefix and a limit of 1-${MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES}.`,
+    );
+  }
+  return readPluginStateRowsInKeyRange(
+    {
+      ...params,
+      keyStartInclusive: params.after === undefined ? params.prefix : `${params.after}\0`,
+      keyEndExclusive: `${params.prefix}\uffff`,
+    },
+    (row): PluginDoctorRawStateEntry => {
+      const createdAt = normalizeSqliteNumber(row.created_at);
+      const expiresAt = normalizeSqliteNumber(row.expires_at);
+      const entry: PluginDoctorRawStateEntry = {
+        key: row.entry_key,
+        valueJson: row.value_json,
+        createdAt: createdAt ?? 0,
+        expiresAt: expiresAt ?? null,
+      };
+      if (
+        !Number.isSafeInteger(createdAt) ||
+        (createdAt ?? -1) < 0 ||
+        (row.expires_at !== null && !Number.isSafeInteger(expiresAt))
+      ) {
+        return entry;
+      }
+      try {
+        entry.value = JSON.parse(row.value_json) as unknown;
+      } catch {
+        // Keep corrupt rows in the page so Doctor can advance past them safely.
+      }
+      return entry;
+    },
+  );
+}
+
 export function pluginStateEntries(params: {
   pluginId: string;
   namespace: string;
@@ -1123,7 +1225,7 @@ export function pluginStateEntries(params: {
 }
 
 /** Internal bounded key-range read for core owners with sortable plugin-state keys. */
-export function pluginStateEntriesInKeyRange(params: {
+type PluginStateKeyRangeParams = {
   pluginId: string;
   namespace: string;
   keyStartInclusive: string;
@@ -1131,7 +1233,18 @@ export function pluginStateEntriesInKeyRange(params: {
   limit: number;
   order?: "asc" | "desc";
   env?: NodeJS.ProcessEnv;
-}): PluginStateEntry<unknown>[] {
+};
+
+export function pluginStateEntriesInKeyRange(
+  params: PluginStateKeyRangeParams,
+): PluginStateEntry<unknown>[] {
+  return readPluginStateRowsInKeyRange(params, (row) => rowToEntry(row, "entries"));
+}
+
+function readPluginStateRowsInKeyRange<T>(
+  params: PluginStateKeyRangeParams,
+  mapRow: (row: PluginStateRow) => T,
+): T[] {
   if (!Number.isSafeInteger(params.limit) || params.limit < 1) {
     throw createPluginStateError({
       code: "PLUGIN_STATE_INVALID_INPUT",
@@ -1160,7 +1273,7 @@ export function pluginStateEntriesInKeyRange(params: {
             limit: params.limit,
             order: params.order ?? "asc",
             now: Date.now(),
-          }).map((row) => rowToEntry(row, "entries")),
+          }).map(mapRow),
         envOptions(params.env),
       ) ?? []
     );

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -42,11 +42,16 @@ export type {
   PluginStateSyncKeyedStore,
 } from "./plugin-state-store.types.js";
 
+export type { PluginDoctorRawStateEntry } from "./plugin-state-store.sqlite.js";
+
 export {
   closePluginStateDatabase,
   countPluginStateLiveEntries,
   getPluginStateCapacity,
   MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN,
+  MAX_PLUGIN_STATE_BULK_DELETE_ENTRIES,
+  pluginStateDeleteEntriesIfUnchanged,
+  pluginStateDoctorEntriesInKeyRange,
   pluginStateEntriesInKeyRange,
   resolveMaxPluginStateEntriesPerPlugin,
   sweepExpiredPluginStateEntries,

--- a/src/plugins/doctor-contract-module.ts
+++ b/src/plugins/doctor-contract-module.ts
@@ -2,6 +2,7 @@ import type { LegacyConfigRule } from "../config/legacy.shared.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type {
   OpenKeyedStoreOptions,
+  PluginDoctorRawStateEntry,
   PluginStateKeyedStore,
 } from "../plugin-state/plugin-state-store.js";
 import { coerceDoctorSessionRouteStateOwners } from "./doctor-session-route-state-owner-types.js";
@@ -20,6 +21,23 @@ export type PluginDoctorStateMigrationContext = {
   ) => void;
   /** Plugin-wide live-row capacity for import preflight. Older test hosts may omit it. */
   getPluginStateCapacity?: () => { liveEntries: number; maxEntries: number };
+  readPluginStateEntriesInKeyRange?: (
+    namespace: string,
+    range: { prefix: string; after?: string; limit: number },
+  ) => PluginDoctorRawStateEntry[];
+  readSessionIdentityEvidenceBatch?: (
+    requests: readonly { agentId: string; sessionId: string }[],
+  ) => Promise<
+    (
+      | { agentId: string; sessionId: string; state: "current"; sessionKey: string }
+      | { agentId: string; sessionId: string; state: "absent" | "unknown" }
+    )[]
+  >;
+  /** Present only while the host owns the offline SQLite maintenance lock. */
+  deletePluginStateEntriesIfUnchanged?: (
+    namespace: string,
+    entries: readonly PluginDoctorRawStateEntry[],
+  ) => { deleted: number; changed: number };
 };
 
 export type PluginDoctorStateMigration = {
@@ -27,6 +45,7 @@ export type PluginDoctorStateMigration = {
   label: string;
   /** Import retired file state only during explicit `doctor --fix` repair. */
   doctorOnly?: boolean;
+  phase?: "after-session-repair";
   detectLegacyState: (params: {
     config: OpenClawConfig;
     env: NodeJS.ProcessEnv;
@@ -124,6 +143,7 @@ function coercePluginDoctorStateMigrations(value: unknown): PluginDoctorStateMig
     id: migration.id.trim(),
     label: migration.label.trim(),
     doctorOnly: migration.doctorOnly === true ? true : undefined,
+    phase: migration.phase === "after-session-repair" ? migration.phase : undefined,
     detectLegacyState: migration.detectLegacyState,
     migrateLegacyState: migration.migrateLegacyState,
   }));

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -35,7 +35,6 @@ type PluginDoctorContractSurface = keyof PluginManifestDoctorContract;
 
 export type {
   PluginDoctorStateMigration,
-  PluginDoctorStateMigrationContext,
   PluginDoctorStateMigrationDetection,
 } from "./doctor-contract-module.js";
 

--- a/src/plugins/registry-lifecycle.ts
+++ b/src/plugins/registry-lifecycle.ts
@@ -5,6 +5,7 @@ const retiredRegistries = new WeakSet<PluginRegistry>();
 const activatedRegistries = new WeakSet<PluginRegistry>();
 const registryEpochs = new WeakMap<PluginRegistry, object>();
 const recordEpochs = new WeakMap<PluginRegistry, WeakMap<PluginRecord, object>>();
+const revokedRecordEpoch = Object.freeze({});
 
 export type PluginRegistryLifecycleEpoch = object;
 type PluginRecordLifecycleEpoch = object;
@@ -82,7 +83,9 @@ export function revokePluginRecordLifecycleEpoch(
   registry: PluginRegistry,
   record: PluginRecord,
 ): void {
-  recordEpochs.get(registry)?.delete(record);
+  const epochs = recordEpochs.get(registry) ?? new WeakMap<PluginRecord, object>();
+  epochs.set(record, revokedRecordEpoch);
+  recordEpochs.set(registry, epochs);
 }
 
 /** True when a registry has been activated for runtime use. */
@@ -93,4 +96,29 @@ export function isPluginRegistryActivated(registry: PluginRegistry): boolean {
 /** True when a registry has been retired by a newer active registry. */
 export function isPluginRegistryRetired(registry: PluginRegistry): boolean {
   return retiredRegistries.has(registry);
+}
+
+/** Capture an activation; reactivating the same objects must not revive an old operation. */
+export function capturePluginLifecycleAuthority(
+  registry: PluginRegistry,
+  record?: PluginRecord,
+  options?: { scopedRuntime?: boolean },
+): (() => boolean) | undefined {
+  const epoch = registryEpochs.get(registry);
+  const recordEpoch = record && recordEpochs.get(registry)?.get(record);
+  if (
+    (!epoch && !options?.scopedRuntime) ||
+    retiredRegistries.has(registry) ||
+    recordEpoch === revokedRecordEpoch
+  ) {
+    return undefined;
+  }
+  return () =>
+    registryEpochs.get(registry) === epoch &&
+    !retiredRegistries.has(registry) &&
+    (!record ||
+      (registry.plugins.includes(record) &&
+        record.enabled &&
+        record.status === "loaded" &&
+        recordEpochs.get(registry)?.get(record) === recordEpoch));
 }

--- a/src/state/openclaw-agent-db-lease.ts
+++ b/src/state/openclaw-agent-db-lease.ts
@@ -15,11 +15,17 @@ import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db-contract.
 import { ensureAgentDatabaseLeaseSchema } from "./openclaw-state-db-schema-additive.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
+import type { OpenClawStateLeaseContext } from "./openclaw-state-lease.js";
 
 type AgentDatabaseLeaseDatabase = Pick<
   OpenClawStateKyselyDatabase,
-  "agent_database_leases" | "agent_deletion_journal"
+  "agent_database_leases" | "agent_deletion_journal" | "state_leases"
 >;
+
+export const AGENT_DATABASE_MAINTENANCE_LEASE = {
+  scope: "core:agent-database-maintenance",
+  key: "global",
+} as const;
 
 export function claimOpenClawAgentDatabaseLease(params: {
   agentId: string;
@@ -37,6 +43,20 @@ export function claimOpenClawAgentDatabaseLease(params: {
     (database) => {
       ensureAgentDatabaseLeaseSchema(database.db);
       const db = getNodeSqliteKysely<AgentDatabaseLeaseDatabase>(database.db);
+      const maintenance = executeSqliteQueryTakeFirstSync(
+        database.db,
+        db
+          .selectFrom("state_leases")
+          .select("owner")
+          .where("scope", "=", AGENT_DATABASE_MAINTENANCE_LEASE.scope)
+          .where("lease_key", "=", AGENT_DATABASE_MAINTENANCE_LEASE.key)
+          .where("expires_at", ">", Date.now()),
+      );
+      if (maintenance) {
+        throw new Error(
+          "Agent database maintenance is in progress; retry after openclaw doctor --fix completes.",
+        );
+      }
       const deletion = executeSqliteQueryTakeFirstSync(
         database.db,
         db.selectFrom("agent_deletion_journal").select("agent_id").where("agent_id", "=", agentId),
@@ -75,21 +95,16 @@ export function releaseOpenClawAgentDatabaseLease(
 }
 
 export function assertNoOpenClawAgentDatabaseLeases(
-  agentIdRaw: string,
+  agentIdRaw: string | OpenClawStateLeaseContext,
   options: OpenClawStateDatabaseOptions = {},
 ): void {
-  const agentId = normalizeAgentId(agentIdRaw);
-  let rows: Array<{
-    agent_id: string;
-    lease_id: string;
-    owner_pid: number;
-    owner_start_time: number | null;
-    path: string;
-  }> = [];
-  runOpenClawStateWriteTransaction((database) => {
+  const maintenance = typeof agentIdRaw === "string" ? undefined : agentIdRaw;
+  const agentId = typeof agentIdRaw === "string" ? normalizeAgentId(agentIdRaw) : undefined;
+  const rows = runOpenClawStateWriteTransaction((database) => {
+    maintenance?.assertOwnedInTransaction(database.db);
     ensureAgentDatabaseLeaseSchema(database.db);
     const db = getNodeSqliteKysely<AgentDatabaseLeaseDatabase>(database.db);
-    rows = executeSqliteQuerySync(
+    return executeSqliteQuerySync(
       database.db,
       db
         .selectFrom("agent_database_leases")
@@ -112,6 +127,7 @@ export function assertNoOpenClawAgentDatabaseLeases(
     .map((row) => row.lease_id);
   if (staleLeaseIds.length > 0) {
     runOpenClawStateWriteTransaction((database) => {
+      maintenance?.assertOwnedInTransaction(database.db);
       ensureAgentDatabaseLeaseSchema(database.db);
       const db = getNodeSqliteKysely<AgentDatabaseLeaseDatabase>(database.db);
       executeSqliteQuerySync(
@@ -125,12 +141,15 @@ export function assertNoOpenClawAgentDatabaseLeases(
     if (staleLeaseIdSet.has(row.lease_id)) {
       continue;
     }
-    const deletionFence = prepareAgentDeletionPathFence(
-      { agentId: row.agent_id, path: row.path, fenceAgentId: agentId },
-      options,
-    );
+    const deletionFence = agentId
+      ? prepareAgentDeletionPathFence(
+          { agentId: row.agent_id, path: row.path, fenceAgentId: agentId },
+          options,
+        )
+      : undefined;
     let leaseStillExists = false;
     runOpenClawStateWriteTransaction((database) => {
+      maintenance?.assertOwnedInTransaction(database.db);
       ensureAgentDatabaseLeaseSchema(database.db);
       const db = getNodeSqliteKysely<AgentDatabaseLeaseDatabase>(database.db);
       leaseStillExists =
@@ -141,12 +160,15 @@ export function assertNoOpenClawAgentDatabaseLeases(
             .select("lease_id")
             .where("lease_id", "=", row.lease_id),
         ) !== undefined;
-      if (leaseStillExists && row.agent_id !== agentId) {
+      if (leaseStillExists && row.agent_id !== agentId && deletionFence) {
         assertAgentDeletionPathFence(database.db, deletionFence);
       }
     }, options);
-    if (leaseStillExists && row.agent_id === agentId) {
-      throw new Error(`Agent ${agentId} database is still open in another process.`);
+    if (leaseStillExists && (!agentId || row.agent_id === agentId)) {
+      const remediation = agentId ? "." : "; stop that process and rerun openclaw doctor --fix.";
+      throw new Error(
+        `Agent ${row.agent_id} database is still open in another process${remediation}`,
+      );
     }
   }
 }

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -50,6 +50,7 @@ import {
   readOpenClawAgentDatabaseRegistryToken,
   resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
+  withAgentDatabaseMaintenanceLease,
 } from "./openclaw-agent-db.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
 import {
@@ -3089,6 +3090,88 @@ describe("openclaw agent database", () => {
       releaseOpenClawAgentDatabaseLease(leaseId, { env });
       deletion.rollback();
     }
+  });
+
+  it("closes cached agent databases and fences new writers during maintenance", async () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const database = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    let assertRetainedOwnership: (() => void) | undefined;
+
+    await withAgentDatabaseMaintenanceLease({ env }, async (maintenance) => {
+      assertRetainedOwnership = () => maintenance.assertOwned();
+      expect(database.db.isOpen).toBe(false);
+      expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow(
+        "Agent database maintenance is in progress",
+      );
+      expect(() =>
+        claimOpenClawAgentDatabaseLease({
+          agentId: "worker-2",
+          path: path.join(stateDir, "worker-2.sqlite"),
+          env,
+        }),
+      ).toThrow("Agent database maintenance is in progress");
+      expect(() =>
+        runOpenClawStateWriteTransaction(({ db }) => maintenance.assertOwnedInTransaction(db), {
+          env,
+        }),
+      ).not.toThrow();
+    });
+
+    expect(assertRetainedOwnership).toBeDefined();
+    expect(() => assertRetainedOwnership?.()).toThrow("was lost");
+    expect(openOpenClawAgentDatabase({ agentId: "worker-1", env }).db.isOpen).toBe(true);
+  });
+
+  it("refuses maintenance while another owner still holds an agent database lease", async () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const leaseId = claimOpenClawAgentDatabaseLease({
+      agentId: "worker-1",
+      path: path.join(stateDir, "worker-1.sqlite"),
+      env,
+    });
+    const repair = vi.fn(async () => undefined);
+
+    try {
+      await expect(withAgentDatabaseMaintenanceLease({ env }, repair)).rejects.toThrow(
+        "stop that process and rerun openclaw doctor --fix",
+      );
+      expect(repair).not.toHaveBeenCalled();
+      expect(() => assertNoOpenClawAgentDatabaseLeases("worker-1", { env })).toThrow(
+        "database is still open",
+      );
+    } finally {
+      releaseOpenClawAgentDatabaseLease(leaseId, { env });
+    }
+
+    await expect(withAgentDatabaseMaintenanceLease({ env }, repair)).resolves.toBeUndefined();
+    expect(repair).toHaveBeenCalledOnce();
+  });
+
+  it("removes dead agent database owners before beginning fenced maintenance", async () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const leaseId = claimOpenClawAgentDatabaseLease({
+      agentId: "worker-1",
+      path: path.join(stateDir, "worker-1.sqlite"),
+      env,
+    });
+    runOpenClawStateWriteTransaction(
+      ({ db }) =>
+        db
+          .prepare("UPDATE agent_database_leases SET owner_pid = -1 WHERE lease_id = ?")
+          .run(leaseId),
+      { env },
+    );
+
+    await withAgentDatabaseMaintenanceLease({ env }, async () => {
+      expect(
+        openOpenClawStateDatabase({ env })
+          .db.prepare("SELECT lease_id FROM agent_database_leases WHERE lease_id = ?")
+          .get(leaseId),
+      ).toBeUndefined();
+    });
   });
 
   it("serializes concurrent ownership claims for one unowned database", async () => {

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -31,6 +31,8 @@ import type {
   OpenClawAgentDatabaseOwnerInspection,
 } from "./openclaw-agent-db-contract.js";
 import {
+  AGENT_DATABASE_MAINTENANCE_LEASE,
+  assertNoOpenClawAgentDatabaseLeases,
   claimOpenClawAgentDatabaseLease,
   releaseOpenClawAgentDatabaseLease,
 } from "./openclaw-agent-db-lease.js";
@@ -63,6 +65,7 @@ import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
+import { withOpenClawStateLease, type OpenClawStateLeaseContext } from "./openclaw-state-lease.js";
 
 export {
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -681,6 +684,30 @@ export function closeOpenClawAgentDatabases(): void {
   if (removedIncognito) {
     incognitoDatabaseGeneration += 1;
   }
+}
+
+/** Fence cross-process agent writers while Doctor reconciles shared plugin state. */
+export function withAgentDatabaseMaintenanceLease<T>(
+  options: Pick<OpenClawStateDatabaseOptions, "env">,
+  run: (maintenance: OpenClawStateLeaseContext) => Promise<T>,
+): Promise<T> {
+  return withOpenClawStateLease(
+    {
+      ...AGENT_DATABASE_MAINTENANCE_LEASE,
+      database: { scope: "shared", options },
+      leaseMs: 60_000,
+      waitMs: 5_000,
+      leaseLabel: "agent database maintenance lease",
+      operationLabel: "agent.database.maintenance.lease",
+    },
+    (maintenance) => {
+      // Claiming first closes the cross-process gap: every later writer claim
+      // observes this same lease inside its authoritative state transaction.
+      closeOpenClawAgentDatabases();
+      assertNoOpenClawAgentDatabaseLeases(maintenance, options);
+      return run(maintenance);
+    },
+  );
 }
 
 /** Close cached agent handles and clear terminal failure latches for test isolation. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where deleting or expiring Codex-backed sessions leaves durable binding rows behind, eventually exhausting the shared plugin-state limit and preventing new work. Failed native startup can leave a binding before the session records its harness, and cron base/run aliases can share a physical session ID without sharing their logical ownership.

## Why This Change Was Made

This rewrites the original patch around the session deletion owner. Core prepares the existing registered harness outside the SQLite writer, then invokes an exact-generation, synchronous companion compare-delete at the row removal edge. Transaction failures compensate that deletion; errors after commit do not resurrect it. Registry replacement, competing work, supervision, and active native claims are checked before the destructive step. Ordinary physical-ID rollover remains a transfer, preserving compaction adoption.

Codex releases the original connection's subscription after commit, serialized with native resume. Any surviving owner, including a same-key successor or legacy conversation binding, preserves the subscription. Upstream native history is never deleted or archived. Cron now persists the selected harness on both base and run rows before native startup.

Doctor uses its existing migration planner, after canonical session repair. It scans bounded pages, uses physical-ID evidence without inventing a main-session key, and compare-deletes only unchanged, proven orphan rows under maintenance ownership. Current, leased, supervised, malformed, ambiguous, and advisory state survives. No schema/version bump, config option, or capacity increase is introduced. The optional harness lifecycle gains two named SDK types so extracted plugin implementations share one public contract. Session-scoped resume now uses the same canonical model/auth planner and credential fingerprint as agent turns, preventing a second native writer while retaining the existing API-key/subscription billing boundary. Two existing generic helpers are exported through their owning SDK runtime entrypoints; no new auth policy or client registry is introduced. Manual attachment now records pending intent, verifies the immutable native tool catalog, and applies configuration only under uninterrupted sole physical-client ownership. The lease-generation guard reaches unsubscribe and the synchronous binding write; failed or competing adoption preserves the selected thread instead of silently starting another.

## User Impact

Session deletion and expiry free binding capacity. Operators with accumulated orphan rows can stop the Gateway and run `openclaw doctor --fix`; ordinary Doctor detects the repair. Other sessions continue working, and deleted OpenClaw sessions can explicitly resume their preserved native Codex history.

The two existing databases still have a process-crash window between their commits; this change provides synchronous compensation, not a distributed transaction. Doctor repairs proven leftover ownership conservatively and does not invent missing native bindings.

## Evidence

- Original-main exact-key deletion regressions fail and pass with the rewrite, including missing harness metadata. Doctor reproductions cover synthetic-main misidentification and canonical-row races.
- A 50,000-row incident fixture removes 47,782 proven orphan bindings, retains 2,218 live/protected/advisory rows including all four logical owners, restores capacity, and is idempotent.
- Current validated coverage: 344 core/Doctor/cron tests with four existing skips, and 833 Codex cases across runs. The broader Codex run caught one unsafe-cleanup error-contract regression; after correcting it, all 170 lifecycle/client/retirement tests passed. Three actual-command/shared-client competing-lease regressions fail before the fence and pass afterward.
- Current plugin/plugin-test types, scoped lint, formatting, assertion/max-lines ratchets, dead-export scans and import-cycle checks pass. Earlier unchanged core/core-test/scripts and remaining schema/database/auth boundary checks also pass. Fresh Codex review reports no findings at its default P0 threshold; independent owner review completed.
- Fresh full Linux arm64 build and authenticated Gateway proof passed at `8f8b29c72f0cb42e0d9483b1e00bdbecae526720`, using Codex 0.149.1 and `openai/gpt-5.6-luna` in a local container. The live test passed in 503.26 seconds (one case passed, one optional case skipped). It rejected a competing resume, verified both original bindings unchanged, deleted the selected session and binding, completed a sibling turn on the same native thread, and resumed the deleted session’s original native thread for a real model reply. Prior authenticated failures drove both the canonical-auth and pending-configuration repairs.
- [CI 33030480464](https://github.com/openclaw/openclaw/actions/runs/33030480464) failed in two test fixtures: the Gateway delivery-context helper returns at acceptance and races the next fixture’s deletion; the OAuth command test timed out. Both fixture repairs now pass: five Gateway cases in original order and all 12 auth cases with cold source caches and the original timeout (OAuth: 1.621s, no plugin discovery). No production changes, timeout increases, auth-policy mocks, or weaker assertions. Pre-rebase test-only head `d18ac70d162f3c011863b051024838d618428080` passed [CI 33033571018](https://github.com/openclaw/openclaw/actions/runs/33033571018). Superseded CI 33024648388 attempt2 received runner shutdown exit143 with no lint diagnostic, then was cancelled for the production repair.
- The pre-rebase head differs from the authenticated live/build head only in `command-rpc.test.ts` and `server.agent.subagent-delivery-context.test.ts`; production and live-test content are identical. Fresh core/plugin test types, lint, format and SDK test-boundary checks pass; fresh Codex review found no actionable issues at the default P0 threshold.
- Production/tooling LOC: +3,397/-1,376 (net +2,021); tests/support: +3,022/-126; docs: +59/-4. Material growth supplies previously missing deletion/compensation, bounded repair and native configuration ownership contracts. It reuses existing registries, leases, SQL helpers and migration/auth planners, removes the old post-delete path, and adds no capacity/config/schema-version surface.

Review follow-through: Doctor migration docs now apply to all plugins. Canonical SDK export sync is idempotent; surface check passes at 4,345 public exports and 2,582 callable exports. The budget values are maintained policy constants, not generated files; the tool has report/check modes only. The generic lifecycle remains optional and closure-bound. The fresh live test passed an actual competing-owner resume denial, followed by allowed deletion, sibling continuation and same-native-thread history resume. The denial comes from the exclusive owner check before the control request; the live test observes the rejection, unchanged bindings and continued sibling work. This is not an instrumented native-I/O trace or an injected stale callback. Separate deterministic owner tests assert no native request for stale/revoked callbacks and competing lease generations. Injecting a retired internal callback through the public Gateway is not a supported operator flow, so that specific rank-up variant remains deterministic proof rather than a live claim.

Redacted observed live result:

```text
Live source head: 8f8b29c72f0cb42e0d9483b1e00bdbecae526720
[gateway-codex-live] session-deletion {"competingResumeRejected":true,"removedBinding":true,"siblingContinued":true,"nativeHistoryResumed":true}
Test Files 1 passed; Tests 1 passed | 1 skipped; exit=0
```

Direct upstream inspection uses Codex `rust-v0.149.1` (`ff29a44391deccde0aba0f8390337d7f3c319ea4`). `thread_processor.rs:944-990` and `thread_state.rs:488-579` show connection/thread membership without reference counting or generation tokens; `thread_lifecycle.rs:7,49-64` and `thread-store/src/local/writer_lock.rs:25-85` explain the retained writer. `thread_processor.rs:4006-4054` plus `thread_status.rs:223-251,336-347` establish successful reload notifications, but `thread_manager.rs:1804-1820` can reuse a concurrently resumed native child. Therefore status notifications alone are insufficient: adoption requires the exact shared-client lease generation through commit. `core/src/session/mod.rs:663-668` establishes the immutable stored dynamic tool catalog. Goal operations remain unchanged because their pinned implementation supports stored threads without loading a writer.

Named follow-ups: the advisory catalog-provenance cache should include the expected thread ID in its key; adoption bypasses that cache and validates the header ID. Separately, Crabbox pristine-workspace GitHub hydration can leak runner registration when fingerprint invalidation fails before sync; owned leaked resources were cleaned up. Current proof is local-container, not remote AWS/Blacksmith proof.

Release-note context: fixes Codex session-deletion/expiry capacity leaks and conservatively repairs accumulated orphan bindings while preserving native history. Original PR and rewrite authored by @steipete.

## Latest Review Follow-through

The reported new fork-skip write race is not reachable with supported canonical targets. `runPreparedSqliteSessionWrite` keeps the original writer when there are no deletion targets and no `beforeCommit`; parent fork selects only noncanonical rows for deletion, but its earlier resolver rejects duplicate rows and a sole noncanonical alias. A final-head executable probe passed both skip branches with an independently queued concurrent update preserved. Duplicate and sole-alias inputs were rejected before deletion preparation, with both rows unchanged. All four cases observed zero deletion preparations. This addresses the review premise without adding unreachable-path guards or changing production behavior.

A separate follow-up is recorded for **cross-process parent-fork skip patches**: the old owner already merged a pre-transaction child snapshot, and its process-local queue does not serialize another process. That pre-existing surface needs a dedicated multi-process reproduction and a coherent fork-owner repair; it is not the new same-process writer-release regression alleged here. Both the pre-rebase and final rebased CI runs are green, including the two previously failing lanes.

The PR was mechanically rebased to `5a22aff71faa2b1e3d9dd295d95c59d62183cc00` after another SDK export change landed on main. Combined surface counts validate at 4,345 public and 2,582 callable exports; canonical export sync is clean. Range-diff confirms the reviewed runtime patch is unchanged. All 29 focused session-deletion/parent-fork tests and the four-case fork probe pass after rebasing. Final [CI 33035491600](https://github.com/openclaw/openclaw/actions/runs/33035491600) passed on that exact head: 156 passing checks, 43 skips, no pending or failed checks. The earlier live/build proof remains at the stated source head, not the full rebased tree.


Maintainer implementation decision after the latest review (03:21 UTC): retain the optional generic `withSessionDeletion` lifecycle for this rewrite. Core owns logical session deletion and harness plugins own their companion bindings; a Codex-specific core hook would put policy in the wrong owner. Existing harness implementations gain no required callback or parameter. Retain the existing two stores with compensation and conservative Doctor repair, explicitly without a cross-database crash-atomicity claim. No table or schema-version change is introduced; existing-database repair, protected rows and idempotence are covered by the incident/migration fixtures. The acting maintainer agent directly inspected the exact sibling Codex source cited above; its absence from the automated review checkout is not a dependency-proof gap in this review. Exact-head CI is now complete and green. All latest rank-up items are addressed without requesting another redundant review cycle.
