### PR TITLE
feat(ui): link chat and presence identities to their activity feed

### DIFF
--- a/ui/src/components/person-activity-link.ts
+++ b/ui/src/components/person-activity-link.ts
@@ -1,0 +1,99 @@
+import { html } from "lit";
+import { activityPersonLocation } from "../app-route-paths.ts";
+import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
+
+/**
+ * Routing an identity surface needs to open one person's Activity feed. Hosts pass it
+ * explicitly because some surfaces (the portaled session hovercard) render outside the
+ * application context tree and cannot consume it.
+ */
+export type PersonActivityRouting = {
+  basePath: string;
+  navigate: (personId: string) => void;
+};
+
+type PersonActivityLink = { href: string; open: (event: MouseEvent) => void };
+
+/** Structural view of the application context, so identity chrome stays out of app/ imports. */
+type PersonActivityNavigator = {
+  readonly basePath: string;
+  navigate: (routeId: "activity", options: { pathname: string; search: string }) => void;
+};
+
+/** `beforeNavigate` lets transient hosts (hovercards, popovers) dismiss themselves first. */
+export function personActivityRouting(
+  context: PersonActivityNavigator,
+  beforeNavigate?: () => void,
+): PersonActivityRouting {
+  return {
+    basePath: context.basePath,
+    navigate: (personId: string) => {
+      beforeNavigate?.();
+      context.navigate("activity", activityPersonLocation(personId, context.basePath));
+    },
+  };
+}
+
+/** Null when the host supplied no routing, or the actor carries no usable person id. */
+export function personActivityLink(
+  personId: string | null | undefined,
+  routing: PersonActivityRouting | undefined,
+): PersonActivityLink | null {
+  const id = personId?.trim();
+  if (!id || !routing) {
+    return null;
+  }
+  return {
+    href: activityPersonLocation(id, routing.basePath).href,
+    open: (event: MouseEvent) => {
+      if (!shouldHandleNavigationClick(event)) {
+        return;
+      }
+      event.preventDefault();
+      routing.navigate(id);
+    },
+  };
+}
+
+/** The person's name as the accessible link target; plain text when there is nowhere to go. */
+export function renderPersonName(
+  label: string,
+  link: PersonActivityLink | null,
+  className: string,
+) {
+  return link
+    ? html`<a class="${className} person-activity-link" href=${link.href} @click=${link.open}
+        >${label}</a
+      >`
+    : html`<span class=${className}>${label}</span>`;
+}
+
+/**
+ * Wraps an avatar that already sits beside its own labelled name link. The twin is hidden
+ * from assistive tech and the tab order so one identity never yields two targets; see the
+ * focusable filter in session-progress-hovercard.runtime.ts.
+ */
+export function renderPersonAvatarLink(avatar: unknown, link: PersonActivityLink | null) {
+  return link
+    ? html`<a
+        class="person-activity-avatar-link"
+        href=${link.href}
+        tabindex="-1"
+        aria-hidden="true"
+        @click=${link.open}
+        >${avatar}</a
+      >`
+    : avatar;
+}
+
+/**
+ * Wraps an avatar that stands alone (facepiles, the header owner chip). The avatar keeps its
+ * own aria-label, which becomes the link's accessible name, so it stays a real tab stop.
+ */
+export function renderStandalonePersonLink(avatar: unknown, link: PersonActivityLink | null) {
+  return link
+    ? html`<a class="person-activity-avatar-link" href=${link.href} @click=${link.open}
+        >${avatar}</a
+      >`
+    : avatar;
+}

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -352,9 +352,7 @@ describe("renderSessionHovercard", () => {
     const name = container.querySelector<HTMLAnchorElement>(".session-hovercard__identity-name");
     expect(name?.getAttribute("href")).toBe("/ui/activity?person=alice");
     expect(
-      container
-        .querySelector(".session-hovercard__identity-avatar-link")
-        ?.getAttribute("aria-hidden"),
+      container.querySelector(".person-activity-avatar-link")?.getAttribute("aria-hidden"),
     ).toBe("true");
 
     const click = new MouseEvent("click", { bubbles: true, cancelable: true });
@@ -407,7 +405,7 @@ describe("renderSessionHovercard", () => {
     render(renderSessionHovercard({ row: row() }), container);
 
     expect(container.querySelector(".session-hovercard__identity-name")?.tagName).toBe("SPAN");
-    expect(container.querySelector(".session-hovercard__identity-avatar-link")).toBeNull();
+    expect(container.querySelector(".person-activity-avatar-link")).toBeNull();
   });
 
   it("keeps authoritative overflow when the participant projection is truncated", () => {

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -5,11 +5,15 @@ import type {
   ControlUiSessionPullRequest,
   ControlUiSessionPullRequestSnapshot,
 } from "../../../src/gateway/control-ui-contract.js";
-import { activityPersonLocation } from "../app-route-paths.ts";
 import { i18n, t } from "../i18n/index.ts";
-import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { SidebarSessionHovercardRow } from "./app-sidebar-session-types.ts";
 import { icons } from "./icons.ts";
+import {
+  personActivityLink,
+  renderPersonAvatarLink,
+  renderPersonName,
+  type PersonActivityRouting,
+} from "./person-activity-link.ts";
 import { sessionOwnerInitials, type SessionCreatedActor } from "./session-owner-chip.ts";
 import { renderSessionProgressCard } from "./session-progress-card.ts";
 import "./viewer-facepile.ts";
@@ -28,17 +32,11 @@ type SessionHovercardAvatarAuth = {
   authReady: boolean;
 };
 
-/** Opens the Activity feed for one identity; supplied by the hovercard host that owns routing. */
-export type SessionHovercardPersonActivity = {
-  basePath: string;
-  navigate: (personId: string) => void;
-};
-
 type SessionHovercardInput = {
   row?: SidebarSessionHovercardRow;
   selfUserId?: string;
   avatarAuth?: SessionHovercardAvatarAuth;
-  personActivity?: SessionHovercardPersonActivity;
+  personActivity?: PersonActivityRouting;
   pullRequests?: ControlUiSessionPullRequestSnapshot;
   progressCard?: ProgressCard | null;
 };
@@ -179,38 +177,6 @@ function renderHeader(row: SidebarSessionHovercardRow) {
   </header>`;
 }
 
-type PersonActivityLink = { href: string; open: (event: MouseEvent) => void };
-
-function personActivityLink(
-  personId: string,
-  personActivity: SessionHovercardPersonActivity | undefined,
-): PersonActivityLink | null {
-  if (!personActivity) {
-    return null;
-  }
-  return {
-    href: activityPersonLocation(personId, personActivity.basePath).href,
-    open: (event: MouseEvent) => {
-      if (!shouldHandleNavigationClick(event)) {
-        return;
-      }
-      event.preventDefault();
-      personActivity.navigate(personId);
-    },
-  };
-}
-
-function renderPersonName(label: string, link: PersonActivityLink | null, className: string) {
-  return link
-    ? html`<a
-        class="${className} session-hovercard__identity-link"
-        href=${link.href}
-        @click=${link.open}
-        >${label}</a
-      >`
-    : html`<span class=${className}>${label}</span>`;
-}
-
 /**
  * Keeps the locale's own "with {name}" phrasing and list separators while making each
  * name its own link. A translation that lost its placeholder falls back to plain text
@@ -219,7 +185,7 @@ function renderPersonName(label: string, link: PersonActivityLink | null, classN
 function renderParticipantNames(
   participants: readonly SessionCreatedActor[],
   formattedNames: string,
-  personActivity: SessionHovercardPersonActivity | undefined,
+  personActivity: PersonActivityRouting | undefined,
 ) {
   const [prefix, suffix] = t("sessionsView.withParticipant").split("{name}");
   if (suffix === undefined) {
@@ -334,17 +300,7 @@ function renderSessionContext({
           class="session-hovercard__context-row session-hovercard__identity-row"
           aria-label=${[creatorLabel, participantSummary].filter(Boolean).join(", ")}
         >
-          ${creatorActivity
-            ? // Decorative twin of the name link: the name below carries the accessible target.
-              html`<a
-                class="session-hovercard__identity-avatar-link"
-                href=${creatorActivity.href}
-                tabindex="-1"
-                aria-hidden="true"
-                @click=${creatorActivity.open}
-                >${creatorAvatar}</a
-              >`
-            : creatorAvatar}
+          ${renderPersonAvatarLink(creatorAvatar, creatorActivity)}
           <span class="session-hovercard__identity-copy">
             ${creatorLabel
               ? renderPersonName(creatorLabel, creatorActivity, "session-hovercard__identity-name")

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -1,7 +1,6 @@
 import type { ProgressCard } from "@openclaw/gateway-protocol";
 import { ReactiveElement, render } from "lit";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
-import { activityPersonLocation } from "../app-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { resolveControlUiAuthCandidates } from "../app/control-ui-auth.ts";
 import type { ApplicationGateway } from "../app/gateway.ts";
@@ -17,11 +16,9 @@ import {
 } from "../lib/session-pull-requests.ts";
 import { parseAgentSessionKey } from "../lib/sessions/session-key.ts";
 import type { AppSidebarSessionNavigationElement } from "./app-sidebar-session-navigation.ts";
+import { personActivityRouting, type PersonActivityRouting } from "./person-activity-link.ts";
 import { createPortaledHovercard, PortaledHovercardController } from "./portaled-hovercard.ts";
-import {
-  renderSessionHovercard,
-  type SessionHovercardPersonActivity,
-} from "./session-hovercard.ts";
+import { renderSessionHovercard } from "./session-hovercard.ts";
 import { SessionLinkTitler } from "./session-link-titling.ts";
 import {
   SESSION_MENU_OPEN_EVENT,
@@ -554,19 +551,10 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     ];
   }
 
-  private personActivity(): SessionHovercardPersonActivity | undefined {
+  private personActivity(): PersonActivityRouting | undefined {
     const context = this.applicationContext;
-    if (!context) {
-      return undefined;
-    }
-    return {
-      basePath: context.basePath,
-      navigate: (personId) => {
-        // The card outlives its trigger row after navigation, so close it with the same call.
-        this.close();
-        context.navigate("activity", activityPersonLocation(personId, context.basePath));
-      },
-    };
+    // The card outlives its trigger row after navigation, so close it on the way out.
+    return context ? personActivityRouting(context, () => this.close()) : undefined;
   }
 
   private close(animateExit = false): void {

--- a/ui/src/components/viewer-facepile.test.ts
+++ b/ui/src/components/viewer-facepile.test.ts
@@ -326,3 +326,38 @@ it("keeps collaboration UI dormant for a solo identity", () => {
     }),
   ).toBe(true);
 });
+
+it("links faces only when the host opts in, so nested facepiles stay plain", async () => {
+  const users: PresenceViewer[] = [
+    { id: "profile-ada", name: "Ada King", watchedSessions: [] },
+    { id: "profile-mira", name: "Mira", watchedSessions: [] },
+  ];
+  const mount = async (personActivity?: { basePath: string; navigate: (id: string) => void }) => {
+    const facepile = document.createElement("openclaw-viewer-facepile") as HTMLElement & {
+      staticUsers: readonly PresenceViewer[];
+      personActivity?: { basePath: string; navigate: (id: string) => void };
+      updateComplete: Promise<boolean>;
+    };
+    facepile.staticUsers = users;
+    if (personActivity) {
+      facepile.personActivity = personActivity;
+    }
+    document.body.append(facepile);
+    await facepile.updateComplete;
+    return facepile;
+  };
+
+  const navigate = vi.fn();
+  const linked = await mount({ basePath: "", navigate });
+  expect(
+    [...linked.querySelectorAll<HTMLAnchorElement>("a.person-activity-avatar-link")].map((link) =>
+      link.getAttribute("href"),
+    ),
+  ).toEqual(["/activity?person=profile-ada", "/activity?person=profile-mira"]);
+
+  // Sidebar rows and collapsed group headers render facepiles inside an anchor or button;
+  // a nested link there would break the parent's click target.
+  const plain = await mount();
+  expect(plain.querySelector("a")).toBeNull();
+  expect(plain.querySelectorAll("openclaw-viewer-avatar")).toHaveLength(2);
+});

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -13,6 +13,11 @@ import {
   resolveIdentityAvatarView,
   type IdentityAvatarView,
 } from "./identity-avatar-view.ts";
+import {
+  personActivityLink,
+  renderStandalonePersonLink,
+  type PersonActivityRouting,
+} from "./person-activity-link.ts";
 import "./tooltip.ts";
 
 function readPresenceEntries(value: unknown): PresenceEntry[] {
@@ -78,6 +83,12 @@ class ViewerFacepile extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) excludeUserId?: string;
   @property({ attribute: false }) staticUsers?: readonly PresenceViewer[];
   @property({ type: Number, attribute: "max-visible" }) maxVisible = 3;
+  /**
+   * Opt-in: linking each face to its Activity feed. Facepiles rendered inside an existing
+   * anchor or button (sidebar rows, collapsed group headers) must leave this unset — a
+   * nested interactive element would break the parent's click target.
+   */
+  @property({ attribute: false }) personActivity?: PersonActivityRouting;
 
   override render() {
     const projection = projectPresenceEntries(
@@ -110,7 +121,13 @@ class ViewerFacepile extends OpenClawLightDomContentsElement {
       ${visible.map(
         (user) => html`<openclaw-tooltip .content=${presenceViewerLabel(user)}>
           <span class="viewer-facepile__tooltip-anchor">
-            <openclaw-viewer-avatar .user=${user} variant="session"></openclaw-viewer-avatar>
+            ${renderStandalonePersonLink(
+              html`<openclaw-viewer-avatar
+                .user=${user}
+                variant="session"
+              ></openclaw-viewer-avatar>`,
+              personActivityLink(user.id, this.personActivity),
+            )}
           </span>
         </openclaw-tooltip>`,
       )}

--- a/ui/src/e2e/identity-activity-links.e2e.test.ts
+++ b/ui/src/e2e/identity-activity-links.e2e.test.ts
@@ -15,7 +15,7 @@ const proofDir = path.join(
   process.cwd(),
   ".artifacts",
   "control-ui-e2e",
-  "session-hovercard-identity",
+  "identity-activity-links",
 );
 
 async function captureProof(page: Page, fileName: string): Promise<void> {
@@ -141,6 +141,99 @@ suite.define(() => {
           .poll(() => activityPage.locator('[data-activity-identity="profile-mira"]').count())
           .toBe(1);
         await captureProof(page, "hovercard-participant-activity.png");
+      },
+    );
+  });
+
+  it("opens an activity feed from the chat header identities and a peer message author", async () => {
+    const now = Date.now();
+    const sessionKey = "agent:main:shared-thread";
+
+    await suite.withPage(
+      {
+        hasTouch: false,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
+          hasMultipleSessionSharingIdentities: true,
+          presenceUsers: [
+            { self: true, id: "profile-self", name: "You" },
+            { id: "profile-ada", name: "Ada King" },
+            { id: "profile-mira", name: "Mira" },
+          ],
+          historyMessages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "Handing this over." }],
+              timestamp: now - 120_000,
+              __openclaw: { id: "ada-message", senderId: "profile-ada", senderName: "Ada King" },
+            },
+          ],
+          methodResponses: {
+            "progressCard.get": { card: null },
+            "sessions.list": chatSessionListResponse([
+              {
+                createdActor: { type: "human", id: "profile-ada", label: "Ada King" },
+                createdAt: now - 3 * 60 * 60_000,
+                key: sessionKey,
+                kind: "direct",
+                label: "Shared thread",
+                displayName: "Shared thread",
+                owner: { actor: { type: "human", id: "profile-ada", label: "Ada King" } },
+                participants: [{ type: "human", id: "profile-mira", label: "Mira" }],
+                participantCount: 1,
+                updatedAt: now - 60_000,
+              },
+            ]),
+          },
+          sessionKey,
+        });
+
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+
+        const ownerLink = page.locator(
+          ".chat-pane__header a.person-activity-avatar-link:has(openclaw-session-owner-chip)",
+        );
+        await ownerLink.waitFor({ state: "visible" });
+        expect(await ownerLink.getAttribute("href")).toBe("/activity?person=profile-ada");
+        const participantLink = page.locator(
+          ".chat-pane__participants a.person-activity-avatar-link",
+        );
+        expect(await participantLink.getAttribute("href")).toBe("/activity?person=profile-mira");
+
+        const author = page.locator("a.chat-sender-name");
+        await author.waitFor({ state: "visible" });
+        await expect.poll(() => author.textContent()).toBe("Ada King");
+        expect(await author.getAttribute("href")).toBe("/activity?person=profile-ada");
+        await captureProof(page, "chat-identity-links.png");
+
+        await participantLink.click();
+        await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
+        expect(new URL(page.url()).searchParams.get("person")).toBe("profile-mira");
+        await expect
+          .poll(() =>
+            page
+              .locator("openclaw-activity-page")
+              .locator('[data-activity-identity="profile-mira"]')
+              .count(),
+          )
+          .toBe(1);
+        await captureProof(page, "chat-participant-activity.png");
+
+        await page.goBack();
+        const authorAgain = page.locator("a.chat-sender-name");
+        await authorAgain.waitFor({ state: "visible" });
+        // The persistent-identity footer only takes pointer events once its group is hovered,
+        // which is what reaching for the name does anyway.
+        await page.locator(".chat-group--peer").hover();
+        await authorAgain.click();
+        await waitForControlUiRoute(page, { pathname: "/activity", routeId: "activity" });
+        expect(new URL(page.url()).searchParams.get("person")).toBe("profile-ada");
+        await captureProof(page, "chat-author-activity.png");
       },
     );
   });

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -353,6 +353,13 @@
     },
     {
       "count": 1,
+      "kind": "object-property",
+      "name": "title",
+      "path": "ui/src/pages/chat/components/chat-pane-header.test-support.ts",
+      "text": "Session title"
+    },
+    {
+      "count": 1,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/pages/config/mcp.ts",

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -16,6 +16,10 @@ import {
 } from "../../app/update-overlay-helpers.ts";
 import { COMMAND_PALETTE_OPEN_EVENT } from "../../components/command-palette-contract.ts";
 import { icons } from "../../components/icons.ts";
+import {
+  personActivityRouting,
+  type PersonActivityRouting,
+} from "../../components/person-activity-link.ts";
 import { sessionMenuReasons } from "../../components/session-menu-access.ts";
 import { listAssignableSessionOwners } from "../../components/session-owner-chip.ts";
 import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
@@ -57,6 +61,10 @@ import type { SidebarLayout } from "./sidebar-layout.ts";
 
 export abstract class ChatPaneHeader extends ChatPaneDiscussion {
   /** Gateway-served project icon for a session workspace, on the same credentials as agent avatars. */
+  private personActivityRouting(): PersonActivityRouting {
+    return personActivityRouting(this.context);
+  }
+
   private resolveWorkspaceIcon(sessionKey: string | undefined) {
     if (!sessionKey) {
       return null;
@@ -422,6 +430,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
     const instanceId = sharingSnapshot.client?.instanceId;
     const result = this.state?.sessionsResult;
     const showOwnerChip = (result?.owners?.length ?? 0) >= 2 || (row?.participantCount ?? 0) > 0;
+    const personActivity = this.personActivityRouting();
     const renderedOwnerId = showOwnerChip ? row?.owner?.actor.id : undefined;
     const presence = projectPresencePayload(this.presencePayload, selfId, instanceId);
     const ownerViewing = presence.users.some(
@@ -446,6 +455,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       session: row,
       showOwnerChip,
       ownerViewing,
+      personActivity,
       catalog,
       editing: this.headerEditing && this.headerRenameSessionKey === row?.key,
       renameValue: this.headerRenameValue,
@@ -477,6 +487,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               .sessionKey=${key}
               .excludeUserId=${renderedOwnerId}
               .maxVisible=${4}
+              .personActivity=${personActivity}
               variant="session"
             ></openclaw-viewer-facepile>`
           : nothing,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -4,6 +4,7 @@ import { hasOperatorAdminAccess, hasOperatorWriteAccess } from "../../app/operat
 import { cancelQuestionPrompt, submitQuestionPrompt } from "../../app/question-prompt.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "../../app/user-profile.ts";
 import { navigateMarkdownSession } from "../../components/markdown-session-links.ts";
+import { personActivityRouting } from "../../components/person-activity-link.ts";
 import { t } from "../../i18n/index.ts";
 import {
   resolveControlUiFollowUpMode,
@@ -619,6 +620,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       userId: selfUser?.id ?? null,
       userName: selfUser?.name ?? state.userName,
       userAvatar: selfUser?.avatarUrl ?? state.userAvatar,
+      personActivity: personActivityRouting(this.context),
       localMediaPreviewRoots: state.localMediaPreviewRoots,
       embedSandboxMode: state.embedSandboxMode,
       allowExternalEmbedUrls: state.allowExternalEmbedUrls,

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -21,6 +21,7 @@ import { renderExecApprovalCard } from "../../components/exec-approval-card.ts";
 import { icons } from "../../components/icons.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
 import type { SessionLinkTarget } from "../../components/markdown-session-links.ts";
+import type { PersonActivityRouting } from "../../components/person-activity-link.ts";
 import { t } from "../../i18n/index.ts";
 import type { BoardProvider } from "../../lib/board/provider.ts";
 import type {
@@ -185,6 +186,7 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     userId?: string | null;
     userName?: string | null;
     userAvatar?: string | null;
+    personActivity?: PersonActivityRouting;
     localMediaPreviewRoots?: string[];
     assistantAttachmentAuthToken?: string | null;
     resolveArtifactDownload?: ArtifactDownloadResolver;
@@ -340,6 +342,7 @@ export function renderChat(props: ChatProps) {
       userId: props.userId,
       userName: props.userName,
       userAvatar: props.userAvatar,
+      personActivity: props.personActivity,
       basePath: props.basePath,
       resourceBasePath: props.resourceBasePath,
       fullMessageAgentId: props.fullMessageAgentId,

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -2,6 +2,11 @@ import { html, nothing } from "lit";
 import { resolveLocalUserName } from "../../../app/user-identity.ts";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
+import {
+  personActivityLink,
+  renderPersonName,
+  type PersonActivityRouting,
+} from "../../../components/person-activity-link.ts";
 import { t } from "../../../i18n/index.ts";
 import type { BoardProvider } from "../../../lib/board/provider.ts";
 import type { MessageGroup } from "../../../lib/chat/chat-types.ts";
@@ -87,6 +92,8 @@ type RenderMessageGroupOptions = {
   assistantAvatar?: string | null;
   userId?: string | null;
   userName?: string | null;
+  /** Routing for peer sender names; absent leaves them plain text. */
+  personActivity?: PersonActivityRouting;
   userAvatar?: string | null;
   showAvatarGutter?: boolean;
   showAssistantAvatar?: boolean;
@@ -597,7 +604,12 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
               ${normalizedRole === "user" && !showAvatarGutter
                 ? renderChatAuthorAvatar(group.sender)
                 : nothing}
-              <span class="chat-sender-name">${who}</span>
+              ${renderPersonName(
+                who,
+                // Only other people's messages: your own name links nowhere useful.
+                isPeerGroup ? personActivityLink(group.sender?.id, opts.personActivity) : null,
+                "chat-sender-name",
+              )}
               ${renderMessageMeta(group.timestamp, meta)}
             </div>
             ${isPeerGroup

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1945,6 +1945,42 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".chat-author-avatar")).toBeNull();
   });
 
+  it("links a peer sender's name to their activity feed and leaves your own plain", () => {
+    const navigate = vi.fn();
+    const renderSender = (senderId: string) => {
+      const container = document.createElement("div");
+      const message = { role: "user", content: "hello", timestamp: 1000 };
+      render(
+        renderTestMessageGroup(
+          createMessageGroup(message, "user", {
+            key: `sender-link-${senderId}`,
+            senderLabel: "Alice Example",
+            sender: { id: senderId, name: "Alice Example" },
+            messages: [createMessageEntry(`sender-link-${senderId}-message`, message)],
+          }),
+          {
+            userId: "me",
+            userName: "Local User",
+            personActivity: { basePath: "", navigate },
+          },
+        ),
+        container,
+      );
+      return container;
+    };
+
+    const peer = renderSender("profile-alice");
+    const link = peer.querySelector<HTMLAnchorElement>("a.chat-sender-name");
+    expect(link?.textContent).toBe("Alice Example");
+    expect(link?.getAttribute("href")).toBe("/activity?person=profile-alice");
+    link?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(navigate).toHaveBeenCalledWith("profile-alice");
+
+    const own = renderSender("me");
+    expect(own.querySelector("a.chat-sender-name")).toBeNull();
+    expect(own.querySelector(".chat-sender-name")?.textContent).toBe("Local User");
+  });
+
   it("tints attributed user groups with the sender's stable identity hue", () => {
     const renderGroupFor = (sender?: { id: string; name: string }) => {
       const container = document.createElement("div");

--- a/ui/src/pages/chat/components/chat-pane-header-identity.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header-identity.test.ts
@@ -1,0 +1,71 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  chatPaneHeaderSessionRow as row,
+  mountChatPaneHeader,
+  type ChatPaneHeaderProps,
+} from "./chat-pane-header.test-support.ts";
+
+const containers: HTMLElement[] = [];
+
+afterEach(() => {
+  containers.splice(0).forEach((container) => container.remove());
+});
+
+function mountHeader(patch: Partial<ChatPaneHeaderProps> = {}) {
+  return mountChatPaneHeader(containers, patch);
+}
+
+describe("chat pane header identity links", () => {
+  it("links the owner chip and each participant face to their activity feed", async () => {
+    const navigate = vi.fn();
+    const { container } = mountHeader({
+      showOwnerChip: true,
+      personActivity: { basePath: "", navigate },
+      session: row({
+        owner: { actor: { type: "human", id: "ada", label: "Ada King" } },
+        participants: [
+          { type: "human", id: "mira", label: "Mira" },
+          { type: "human", id: "riley", label: "Riley" },
+        ],
+        participantCount: 2,
+      }),
+    });
+
+    const facepile = container.querySelector<HTMLElement & { updateComplete?: Promise<unknown> }>(
+      "openclaw-viewer-facepile.chat-pane__participants",
+    );
+    await facepile?.updateComplete;
+    const ownerLink = container.querySelector<HTMLAnchorElement>(
+      "a.person-activity-avatar-link:has(openclaw-session-owner-chip)",
+    );
+    expect(ownerLink?.getAttribute("href")).toBe("/activity?person=ada");
+    const participantLinks = [
+      ...container.querySelectorAll<HTMLAnchorElement>(
+        ".chat-pane__participants a.person-activity-avatar-link",
+      ),
+    ];
+    expect(participantLinks.map((link) => link.getAttribute("href"))).toEqual([
+      "/activity?person=mira",
+      "/activity?person=riley",
+    ]);
+
+    ownerLink?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(navigate).toHaveBeenCalledWith("ada");
+  });
+
+  it("leaves identities unlinked when the header has no activity routing", () => {
+    const { container } = mountHeader({
+      showOwnerChip: true,
+      session: row({
+        owner: { actor: { type: "human", id: "ada", label: "Ada King" } },
+        participants: [{ type: "human", id: "mira", label: "Mira" }],
+        participantCount: 1,
+      }),
+    });
+
+    expect(container.querySelector("a.person-activity-avatar-link")).toBeNull();
+    expect(container.querySelector("openclaw-session-owner-chip")).not.toBeNull();
+  });
+});

--- a/ui/src/pages/chat/components/chat-pane-header.test-support.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test-support.ts
@@ -1,0 +1,65 @@
+import { html, nothing, render } from "lit";
+import { vi } from "vitest";
+import type { GatewaySessionRow } from "../../../api/types.ts";
+import { renderChatPaneHeader } from "./chat-pane-header.ts";
+
+export type ChatPaneHeaderProps = Parameters<typeof renderChatPaneHeader>[0];
+
+export function chatPaneHeaderSessionRow(
+  patch: Partial<GatewaySessionRow> = {},
+): GatewaySessionRow {
+  return { key: "agent:main:test", kind: "direct", updatedAt: 0, ...patch };
+}
+
+/**
+ * Mounts the header with every required prop filled in. Callers own teardown so each suite
+ * keeps its own afterEach; `containers` collects the mounted nodes for removal.
+ */
+export function mountChatPaneHeader(
+  containers: HTMLElement[],
+  patch: Partial<ChatPaneHeaderProps> = {},
+) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  containers.push(container);
+  const props: ChatPaneHeaderProps = {
+    paneId: "pane-1",
+    narrow: false,
+    mergedChrome: false,
+    title: "Session title",
+    session: chatPaneHeaderSessionRow(),
+    catalog: false,
+    editing: false,
+    renameValue: "Session title",
+    workspaceRoot: "/repo/openclaw",
+    workspaceLabel: "openclaw",
+    workspaceIcon: null,
+    parentSession: null,
+    branch: "feature/header",
+    branches: [],
+    branchSwitchDisabledReason: null,
+    platform: "darwin",
+    canReveal: true,
+    copiedAction: null,
+    renameDisabledReason: undefined,
+    panelActions: nothing,
+    discussionAction: nothing,
+    diffAction: nothing,
+    backgroundTasksAction: nothing,
+    workspaceAction: nothing,
+    sessionRailAction: nothing,
+    sessionMenuAction: nothing,
+    onBeginRename: vi.fn(),
+    onRenameInput: vi.fn(),
+    onCommitRename: vi.fn(),
+    onCancelRename: vi.fn(),
+    onMenuOpenChange: vi.fn(),
+    onMenuAction: vi.fn(),
+    onOpenParentSession: vi.fn(),
+    onBranchSelect: vi.fn(),
+    ...patch,
+  };
+  props.gatewaysSnapshot ??= props.nativeGateways?.snapshot;
+  render(html`${renderChatPaneHeader(props)}`, container);
+  return { container, props };
+}

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { html, nothing, render } from "lit";
+import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { GatewaySessionRow, PresenceEntry, SessionsListResult } from "../../../api/types.ts";
@@ -18,14 +18,17 @@ import { createTestChatPane } from "../chat-pane.test-support.ts";
 import type { ChatPageHost } from "../chat-state-host.ts";
 import { createBackgroundTasksProps } from "./chat-background-tasks.ts";
 import {
+  chatPaneHeaderSessionRow as row,
+  mountChatPaneHeader,
+  type ChatPaneHeaderProps,
+} from "./chat-pane-header.test-support.ts";
+import {
   canRevealSessionWorkspace,
   renderChatPaneHeader,
   resolveChatPaneParentSession,
   resolveChatPaneWorkspace,
 } from "./chat-pane-header.ts";
 import { createSessionWorkspaceProps } from "./chat-session-workspace.ts";
-
-type ChatPaneHeaderProps = Parameters<typeof renderChatPaneHeader>[0];
 
 const containers: HTMLElement[] = [];
 
@@ -68,54 +71,8 @@ const gatewaySnapshot: NativeGatewaysSnapshot = {
   currentId: "primary",
 };
 
-function row(patch: Partial<GatewaySessionRow> = {}): GatewaySessionRow {
-  return { key: "agent:main:test", kind: "direct", updatedAt: 0, ...patch };
-}
-
-function mount(patch: Partial<ChatPaneHeaderProps> = {}) {
-  const container = document.createElement("div");
-  document.body.append(container);
-  containers.push(container);
-  const props: ChatPaneHeaderProps = {
-    paneId: "pane-1",
-    narrow: false,
-    mergedChrome: false,
-    title: "Session title",
-    session: row(),
-    catalog: false,
-    editing: false,
-    renameValue: "Session title",
-    workspaceRoot: "/repo/openclaw",
-    workspaceLabel: "openclaw",
-    workspaceIcon: null,
-    parentSession: null,
-    branch: "feature/header",
-    branches: [],
-    branchSwitchDisabledReason: null,
-    platform: "darwin",
-    canReveal: true,
-    copiedAction: null,
-    renameDisabledReason: undefined,
-    panelActions: nothing,
-    discussionAction: nothing,
-    diffAction: nothing,
-    backgroundTasksAction: nothing,
-    workspaceAction: nothing,
-    sessionRailAction: nothing,
-    sessionMenuAction: nothing,
-    onBeginRename: vi.fn(),
-    onRenameInput: vi.fn(),
-    onCommitRename: vi.fn(),
-    onCancelRename: vi.fn(),
-    onMenuOpenChange: vi.fn(),
-    onMenuAction: vi.fn(),
-    onOpenParentSession: vi.fn(),
-    onBranchSelect: vi.fn(),
-    ...patch,
-  };
-  props.gatewaysSnapshot ??= props.nativeGateways?.snapshot;
-  render(html`${renderChatPaneHeader(props)}`, container);
-  return { container, props };
+function mountHeader(patch: Partial<ChatPaneHeaderProps> = {}) {
+  return mountChatPaneHeader(containers, patch);
 }
 
 function mountIntegratedPresenceHeader(params: {
@@ -162,16 +119,16 @@ function mountIntegratedPresenceHeader(params: {
 describe("chat pane header", () => {
   it("hides the gateway picker without capability and with one gateway", () => {
     Object.assign(window, { __OPENCLAW_NATIVE_WEB_CHROME__: true });
-    expect(mount().container.querySelector(".chat-pane__gateway-menu")).toBeNull();
+    expect(mountHeader().container.querySelector(".chat-pane__gateway-menu")).toBeNull();
     const one = nativeGateways({ gateways: [gatewaySnapshot.gateways[0]!], currentId: "primary" });
     expect(
-      mount({ nativeGateways: one }).container.querySelector(".chat-pane__gateway-menu"),
+      mountHeader({ nativeGateways: one }).container.querySelector(".chat-pane__gateway-menu"),
     ).toBeNull();
   });
 
   it("renders gateway rows, primary tag, and current checkmark", () => {
     Object.assign(window, { __OPENCLAW_NATIVE_WEB_CHROME__: true });
-    const { container } = mount({ nativeGateways: nativeGateways(gatewaySnapshot) });
+    const { container } = mountHeader({ nativeGateways: nativeGateways(gatewaySnapshot) });
     const rows = container.querySelectorAll(".chat-pane__gateway-item");
     expect(rows).toHaveLength(2);
     expect(container.querySelectorAll(".chat-pane__gateway-menu-item")).toHaveLength(4);
@@ -185,12 +142,12 @@ describe("chat pane header", () => {
     const select = vi.fn();
     const openWindow = vi.fn();
     const capability = { ...nativeGateways(gatewaySnapshot), select, openWindow };
-    const first = mount({ nativeGateways: capability }).container.querySelectorAll(
+    const first = mountHeader({ nativeGateways: capability }).container.querySelectorAll(
       ".chat-pane__gateway-item",
     )[1];
     first?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(select).toHaveBeenCalledWith("profile:studio");
-    const second = mount({ nativeGateways: capability }).container.querySelectorAll(
+    const second = mountHeader({ nativeGateways: capability }).container.querySelectorAll(
       ".chat-pane__gateway-item",
     )[1];
     second?.dispatchEvent(new MouseEvent("click", { bubbles: true, altKey: true }));
@@ -202,7 +159,7 @@ describe("chat pane header", () => {
     const select = vi.fn();
     const openWindow = vi.fn();
     const capability = { ...nativeGateways(gatewaySnapshot), select, openWindow };
-    const current = mount({ nativeGateways: capability }).container.querySelector(
+    const current = mountHeader({ nativeGateways: capability }).container.querySelector(
       ".chat-pane__gateway-item",
     );
     current?.dispatchEvent(new MouseEvent("click", { bubbles: true, altKey: true }));
@@ -219,7 +176,7 @@ describe("chat pane header", () => {
         return current;
       },
     };
-    const mounted = mount({ nativeGateways: capability, gatewaysSnapshot: current });
+    const mounted = mountHeader({ nativeGateways: capability, gatewaysSnapshot: current });
     const next = {
       ...gatewaySnapshot,
       gateways: [
@@ -253,7 +210,7 @@ describe("chat pane header", () => {
       ),
       currentId: "profile:studio",
     };
-    const { container } = mount({ nativeGateways: nativeGateways(snapshot) });
+    const { container } = mountHeader({ nativeGateways: nativeGateways(snapshot) });
     const item = Array.from(container.querySelectorAll("wa-dropdown-item")).find((candidate) =>
       candidate.textContent?.includes("Set as primary"),
     );
@@ -268,7 +225,7 @@ describe("chat pane header", () => {
     const onPalette = (event: Event) => paletteEvents.push(event);
     window.addEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, onDrawer);
     window.addEventListener(COMMAND_PALETTE_OPEN_EVENT, onPalette);
-    const { container } = mount({ mergedChrome: true, catalog: true, session: undefined });
+    const { container } = mountHeader({ mergedChrome: true, catalog: true, session: undefined });
     const drawer = container.querySelector<HTMLButtonElement>('[aria-label="Expand sidebar"]');
     const palette = container.querySelector<HTMLButtonElement>(
       '[aria-label="Open command palette"]',
@@ -287,13 +244,13 @@ describe("chat pane header", () => {
   });
 
   it("omits shell chrome actions when the header is not merged", () => {
-    const { container } = mount();
+    const { container } = mountHeader();
     expect(container.querySelector(".chat-pane__nav-toggle")).toBeNull();
     expect(container.querySelector(".chat-pane__palette-open")).toBeNull();
   });
 
   it("places the session menu last in the header action row", () => {
-    const { container } = mount({
+    const { container } = mountHeader({
       mergedChrome: true,
       onClosePane: vi.fn(),
       sessionMenuAction: html`<button data-action="session-menu"></button>`,
@@ -306,7 +263,7 @@ describe("chat pane header", () => {
   });
 
   it("moves narrow session actions into the compact menu", () => {
-    const { container } = mount({
+    const { container } = mountHeader({
       narrow: true,
       mergedChrome: true,
       panelActions: html`<button data-action="persistent-surface"></button>`,
@@ -332,7 +289,7 @@ describe("chat pane header", () => {
   });
 
   it("keeps narrow catalog panel shortcuts visible without a session menu", () => {
-    const { container } = mount({
+    const { container } = mountHeader({
       narrow: true,
       catalog: true,
       session: undefined,
@@ -343,7 +300,7 @@ describe("chat pane header", () => {
   });
 
   it("renders an editable title and workspace chip", () => {
-    const { container, props } = mount();
+    const { container, props } = mountHeader();
     const title = container.querySelector<HTMLButtonElement>(".chat-pane__session-title-button");
     const chip = container.querySelector<HTMLButtonElement>(".chat-pane__workspace-chip");
     expect(title?.textContent?.trim()).toBe("Session title");
@@ -355,7 +312,7 @@ describe("chat pane header", () => {
   it("renders a quiet cloud placement chip with move and stop actions", () => {
     const onPlacementMove = vi.fn();
     const onPlacementReclaim = vi.fn();
-    const { container } = mount({
+    const { container } = mountHeader({
       session: row({
         placement: {
           state: "active",
@@ -412,7 +369,7 @@ describe("chat pane header", () => {
         updatedAtMs: 300_000,
       },
     });
-    const { container } = mount({ session });
+    const { container } = mountHeader({ session });
 
     expect(container.querySelector(".chat-pane__placement-chip")?.textContent?.trim()).toBe(
       "Moving to Gateway…",
@@ -420,7 +377,7 @@ describe("chat pane header", () => {
   });
 
   it.each(["local", "reclaimed"] as const)("hides the placement chip for %s state", (state) => {
-    const { container } = mount({
+    const { container } = mountHeader({
       session: row({
         placement: {
           state,
@@ -435,7 +392,7 @@ describe("chat pane header", () => {
   });
 
   it("places pane presence between the identity trail and face control", () => {
-    const { container } = mount({
+    const { container } = mountHeader({
       presence: html`<span data-slot="presence"></span>`,
       faceControl: html`<span data-slot="face"></span>`,
     });
@@ -445,7 +402,7 @@ describe("chat pane header", () => {
   });
 
   it("leads with the project, then a separator, then the session title", () => {
-    const { container } = mount();
+    const { container } = mountHeader();
     const crumbs = container.querySelector(".chat-pane__crumbs");
     const segments = [...(crumbs?.children ?? [])].map((child) => child.className);
     expect(segments).toEqual([
@@ -461,7 +418,7 @@ describe("chat pane header", () => {
 
   it("places a clickable parent between the project and child session", () => {
     const parentSession = { key: "agent:main:parent", title: "Release prep" };
-    const { container, props } = mount({ parentSession });
+    const { container, props } = mountHeader({ parentSession });
     const crumbs = container.querySelector(".chat-pane__crumbs");
 
     expect([...(crumbs?.children ?? [])].map((child) => child.className)).toEqual([
@@ -478,7 +435,7 @@ describe("chat pane header", () => {
   });
 
   it("drops the separator when the session has no project segment", () => {
-    const { container } = mount({ workspaceLabel: null, workspaceRoot: null });
+    const { container } = mountHeader({ workspaceLabel: null, workspaceRoot: null });
     expect(container.querySelector(".chat-pane__crumb-sep")).toBeNull();
     expect(container.querySelector(".chat-pane__crumbs")?.firstElementChild?.className).toContain(
       "chat-pane__session-title",
@@ -486,7 +443,7 @@ describe("chat pane header", () => {
   });
 
   it("keeps the rename input inside the trail so the project stays visible", () => {
-    const { container } = mount({ editing: true, renameValue: "Renaming" });
+    const { container } = mountHeader({ editing: true, renameValue: "Renaming" });
     const crumbs = container.querySelector(".chat-pane__crumbs");
     expect(crumbs?.querySelector(".chat-pane__workspace-chip")).not.toBeNull();
     expect(crumbs?.querySelector<HTMLInputElement>(".chat-pane__session-title-input")?.value).toBe(
@@ -495,7 +452,7 @@ describe("chat pane header", () => {
   });
 
   it("renders the permanent owner chip only when attribution chrome is enabled", () => {
-    const shown = mount({
+    const shown = mountHeader({
       showOwnerChip: true,
       session: row({
         createdActor: { type: "human", id: "profile-ada", label: "Ada" },
@@ -504,7 +461,7 @@ describe("chat pane header", () => {
     });
     expect(shown.container.querySelector("openclaw-session-owner-chip")).not.toBeNull();
 
-    const dormant = mount({
+    const dormant = mountHeader({
       showOwnerChip: false,
       session: row({ createdActor: { type: "human", id: "profile-ada", label: "Ada" } }),
     });
@@ -512,7 +469,7 @@ describe("chat pane header", () => {
   });
 
   it("renders the bounded static participant facepile beside the owner", async () => {
-    const mounted = mount({
+    const mounted = mountHeader({
       showOwnerChip: true,
       session: row({
         createdActor: { type: "human", id: "profile-ada", label: "Ada" },
@@ -633,7 +590,7 @@ describe("chat pane header", () => {
   });
 
   it("renders the durable session actor avatar with the header attribution semantics", async () => {
-    const mounted = mount({
+    const mounted = mountHeader({
       showOwnerChip: true,
       session: row({
         createdActor: {
@@ -662,12 +619,12 @@ describe("chat pane header", () => {
   });
 
   it("routes Enter and Escape from the rename input", () => {
-    const enter = mount({ editing: true, renameValue: "  Updated  " });
+    const enter = mountHeader({ editing: true, renameValue: "  Updated  " });
     const enterInput = enter.container.querySelector<HTMLInputElement>("input");
     enterInput?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
     expect(enter.props.onCommitRename).toHaveBeenCalledOnce();
 
-    const escape = mount({ editing: true });
+    const escape = mountHeader({ editing: true });
     escape.container
       .querySelector("input")
       ?.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Escape" }));
@@ -676,7 +633,7 @@ describe("chat pane header", () => {
   });
 
   it("keeps catalog sessions static and without a workspace chip", () => {
-    const { container } = mount({
+    const { container } = mountHeader({
       catalog: true,
       session: undefined,
       panelActions: html`<span data-action="terminal"></span>`,
@@ -698,7 +655,9 @@ describe("chat pane header", () => {
   });
 
   it("keeps read-only gateway session titles static", () => {
-    const { container } = mount({ renameDisabledReason: "Operator write access is required." });
+    const { container } = mountHeader({
+      renameDisabledReason: "Operator write access is required.",
+    });
     expect(container.querySelector(".chat-pane__session-title-button")).toBeNull();
     expect(container.querySelector(".chat-pane__session-title")?.textContent).toContain(
       "Session title",
@@ -709,12 +668,12 @@ describe("chat pane header", () => {
   });
 
   it("shows copied feedback on the workspace chip", () => {
-    const { container } = mount({ copiedAction: "copy-path" });
+    const { container } = mountHeader({ copiedAction: "copy-path" });
     expect(container.querySelector(".chat-pane__workspace-chip")?.textContent).toContain("Copied");
   });
 
   it("shows cloud placement and hides reveal when disabled", () => {
-    const { container } = mount({
+    const { container } = mountHeader({
       session: row({
         placement: { state: "active" } as GatewaySessionRow["placement"],
       }),
@@ -726,19 +685,19 @@ describe("chat pane header", () => {
   });
 
   it("shows an incognito indicator for in-memory threads", () => {
-    const { container } = mount({ session: row({ incognito: true }) });
+    const { container } = mountHeader({ session: row({ incognito: true }) });
     expect(container.querySelector(".chat-pane__incognito")?.getAttribute("aria-label")).toBe(
       "Incognito session",
     );
   });
 
   it("hides one branch and lists multiple branches with the active tip marked", () => {
-    const one = mount({
+    const one = mountHeader({
       branches: [{ leafEntryId: "only", headline: "Only path", messageCount: 1, active: true }],
     });
     expect(one.container.querySelector(".chat-pane__branches-trigger")).toBeNull();
 
-    const multiple = mount({
+    const multiple = mountHeader({
       branches: [
         { leafEntryId: "active", headline: "Current work", messageCount: 4, active: true },
         {
@@ -775,7 +734,7 @@ describe("chat pane header", () => {
   });
 
   it("disables branch switching while the agent is working", () => {
-    const { container, props } = mount({
+    const { container, props } = mountHeader({
       branchSwitchDisabledReason: "Branch switch is unavailable while the agent is working.",
       branches: [
         { leafEntryId: "active", headline: "Current work", messageCount: 4, active: true },
@@ -827,7 +786,7 @@ describe("chat pane parent resolution", () => {
 
 describe("chat pane workspace chip icon", () => {
   async function mountChip(workspaceIcon: ChatPaneHeaderProps["workspaceIcon"]) {
-    const { container } = mount({ workspaceIcon });
+    const { container } = mountHeader({ workspaceIcon });
     const element = container.querySelector("openclaw-workspace-icon") as
       | (HTMLElement & { updateComplete?: Promise<unknown> })
       | null;
@@ -925,7 +884,7 @@ describe("chat pane workspace chip icon", () => {
       authTokens: ["token"],
       authReady: true,
     };
-    const mounted = mount({ workspaceIcon });
+    const mounted = mountHeader({ workspaceIcon });
     const element = mounted.container.querySelector("openclaw-workspace-icon") as
       | (HTMLElement & { updateComplete?: Promise<unknown> })
       | null;

--- a/ui/src/pages/chat/components/chat-pane-header.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.ts
@@ -14,6 +14,11 @@ import {
   type ShellNavDrawerToggleDetail,
 } from "../../../components/command-palette-contract.ts";
 import { icons } from "../../../components/icons.ts";
+import {
+  personActivityLink,
+  renderStandalonePersonLink,
+  type PersonActivityRouting,
+} from "../../../components/person-activity-link.ts";
 import { renderSessionOwnerChip } from "../../../components/session-owner-chip.ts";
 import { isCloudWorkerPlacementState } from "../../../components/session-row-badges.ts";
 import { syncDropdownItemRadio } from "../../../components/web-awesome.ts";
@@ -44,6 +49,7 @@ type ChatPaneHeaderProps = {
   session: GatewaySessionRow | undefined;
   showOwnerChip?: boolean;
   ownerViewing?: boolean;
+  personActivity?: PersonActivityRouting;
   catalog: boolean;
   editing: boolean;
   renameValue: string;
@@ -445,11 +451,16 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
           >`
         : nothing}
       ${renderIdentityCrumbs(props, copied, copyPathLabel, copyBranchLabel)}
-      ${renderSessionOwnerChip(
-        props.showOwnerChip ? props.session?.owner?.actor : undefined,
-        "header",
-        props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
-        props.ownerViewing,
+      ${renderStandalonePersonLink(
+        renderSessionOwnerChip(
+          props.showOwnerChip ? props.session?.owner?.actor : undefined,
+          "header",
+          props.session?.owner?.assignedAt !== undefined ? "owned" : "created",
+          props.ownerViewing,
+        ),
+        props.showOwnerChip
+          ? personActivityLink(props.session?.owner?.actor.id, props.personActivity)
+          : null,
       )}
       ${props.showOwnerChip && props.session?.participants?.length
         ? html`<openclaw-viewer-facepile
@@ -461,6 +472,7 @@ export function renderChatPaneHeader(props: ChatPaneHeaderProps) {
               watchedSessions: [],
             }))}
             .maxVisible=${4}
+            .personActivity=${props.personActivity}
             variant="session"
           ></openclaw-viewer-facepile>`
         : nothing}

--- a/ui/src/pages/chat/components/chat-read-only-transcript.test.ts
+++ b/ui/src/pages/chat/components/chat-read-only-transcript.test.ts
@@ -1,0 +1,28 @@
+/* @vitest-environment jsdom */
+
+import { nothing } from "lit";
+import { expect, it, vi } from "vitest";
+import type { ChatThreadProps } from "./chat-thread-interactions.ts";
+import type { ChatTranscriptController } from "./chat-transcript-controller.ts";
+
+const renderChatThread = vi.fn(
+  (_props: ChatThreadProps, _transcript: ChatTranscriptController) => nothing,
+);
+
+vi.mock("./chat-thread.ts", () => ({ renderChatThread }));
+
+const { renderReadOnlyTranscript } = await import("./chat-read-only-transcript.ts");
+
+it("forwards identity routing so task transcripts link peer authors like the live thread", () => {
+  const personActivity = { basePath: "", navigate: vi.fn() };
+  renderReadOnlyTranscript({
+    chat: { personActivity, userId: "me" } as unknown as ChatThreadProps,
+    messages: [],
+    paneId: "pane-1",
+    sessionKey: "agent:main:task",
+    transcript: {} as ChatTranscriptController,
+  });
+
+  expect(renderChatThread).toHaveBeenCalledTimes(1);
+  expect(renderChatThread.mock.calls[0]?.[0].personActivity).toBe(personActivity);
+});

--- a/ui/src/pages/chat/components/chat-read-only-transcript.ts
+++ b/ui/src/pages/chat/components/chat-read-only-transcript.ts
@@ -34,6 +34,8 @@ export function renderReadOnlyTranscript(params: {
       userId: chat.userId,
       userName: chat.userName,
       userAvatar: chat.userAvatar,
+      // Peer authors link to their Activity feed here exactly as in the live transcript.
+      personActivity: chat.personActivity,
       basePath: chat.basePath,
       fullMessageAgentId: chat.fullMessageAgentId,
       loadFullAssistantMessage: chat.loadFullAssistantMessage,

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -8,6 +8,7 @@ import { copyMarkdownLabel } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import type { SessionLinkTarget } from "../../../components/markdown-session-links.ts";
+import type { PersonActivityRouting } from "../../../components/person-activity-link.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import type { BoardProvider } from "../../../lib/board/provider.ts";
@@ -61,6 +62,8 @@ export type ReplyMessageAccess = {
 
 export type ChatThreadProps = {
   paneId: string;
+  /** Routing for peer sender names in a shared session. */
+  personActivity?: PersonActivityRouting;
   sessionKey: string;
   boardProvider?: BoardProvider;
   announceTranscript?: boolean;

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -341,6 +341,7 @@ export function projectChatTranscript(
       userId: props.userId ?? null,
       userName: props.userName ?? null,
       userAvatar: props.userAvatar ?? null,
+      personActivity: props.personActivity,
       showAvatarGutter: !isDirectThread,
       contextWindow: threadContextWindow,
       onReply: props.onSetReply

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -174,22 +174,6 @@
   font-weight: 500;
 }
 
-.session-hovercard__identity-avatar-link {
-  display: block;
-  min-width: 0;
-  line-height: 0;
-}
-
-.session-hovercard__identity-link {
-  color: inherit;
-  text-decoration: none;
-}
-
-.session-hovercard__identity-link:hover,
-.session-hovercard__identity-link:focus-visible {
-  text-decoration: underline;
-}
-
 .session-hovercard__identity-separator {
   flex: none;
   color: var(--muted);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -6276,20 +6276,17 @@ td.data-table-key-col {
   }
 }
 
-/* Identity links: a person's name or avatar anywhere in the UI opens their Activity feed.
-   Neutral until hover so identity chrome keeps its weight in dense surfaces. */
+/* Identity links (a name or avatar opening that person's Activity feed) stay neutral
+   until hover so identity chrome keeps its weight in dense surfaces. */
 .person-activity-link {
   color: inherit;
-  text-decoration: none;
 }
 
-.person-activity-link:hover,
-.person-activity-link:focus-visible {
-  text-decoration: underline;
+.person-activity-link:not(:hover, :focus-visible) {
+  text-decoration: none;
 }
 
 .person-activity-avatar-link {
   display: block;
-  min-width: 0;
   line-height: 0;
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -6275,3 +6275,21 @@ td.data-table-key-col {
     transform: rotate(-10deg);
   }
 }
+
+/* Identity links: a person's name or avatar anywhere in the UI opens their Activity feed.
+   Neutral until hover so identity chrome keeps its weight in dense surfaces. */
+.person-activity-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.person-activity-link:hover,
+.person-activity-link:focus-visible {
+  text-decoration: underline;
+}
+
+.person-activity-avatar-link {
+  display: block;
+  min-width: 0;
+  line-height: 0;
+}

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2198,32 +2198,6 @@ openclaw-settings-save-indicator:empty {
   }
 }
 
-.nav-collapse-toggle {
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
-  border: 1px solid color-mix(in srgb, var(--border-strong) 68%, transparent);
-  border-radius: var(--radius-md);
-  transition:
-    background var(--duration-fast) ease,
-    border-color var(--duration-fast) ease,
-    color var(--duration-fast) ease,
-    transform var(--duration-fast) ease;
-  margin-bottom: 0;
-  color: var(--muted);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
-}
-
-.nav-collapse-toggle:hover {
-  background: color-mix(in srgb, var(--bg-hover) 90%, transparent);
-  border-color: color-mix(in srgb, var(--border-strong) 88%, transparent);
-  color: var(--text);
-  transform: translateY(-1px);
-}
-
 .nav-collapse-toggle__icon {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Follows #128313, which made the session hovercard's identities clickable.

## What Problem This Solves

The hovercard now links the people it shows, but the same faces and names appear
elsewhere with nothing behind them. Inside a session, the header shows the owner and
everyone participating or watching, and a shared thread labels each message with its
author — all inert. The rule "an identity is clickable" only holds if it holds
everywhere, otherwise it reads as a quirk of one card.

## Why This Change Was Made

Identity chrome in chat and presence now links to that person's Activity feed:
the chat pane header owner chip, the participants facepile, the viewing-now presence
facepile, and peer message authors in a shared thread.

The hovercard's link helpers move into `ui/src/components/person-activity-link.ts`,
which now owns the whole pattern: building the href from `activityPersonLocation()`,
intercepting only unmodified primary clicks, rendering a name as a link or plain text,
and the decorative avatar twin. It also owns `personActivityRouting()`, so the two hosts
that supply routing (the portaled hovercard, which closes itself on the way out, and the
chat pane) no longer each hand-roll the navigate closure.

Facepile links are opt-in via a `personActivity` property, and that is the load-bearing
detail: the same `openclaw-viewer-facepile` is rendered inside the sidebar row's `<a>`
and inside the collapsed group-header `<button>`, where a nested anchor would be invalid
HTML and would break the parent's click target. Those call sites simply do not opt in,
and a test pins that behavior.

Non-goals, each for a reason found in the code rather than assumed:
- Sidebar session rows and Activity feed rows keep plain identities — both render the
  actor inside the row's own anchor. The sidebar case is already served by the hovercard.
- Menu items (owner filter, owner assignment, sharing members, identity menu) keep plain
  identities; they are `wa-dropdown-item` elements where a link breaks menu semantics.
- The workboard claim badge is not linked: `metadata.claim.ownerId` is a worker/claim id,
  not a gateway person id, so it would deep-link to a "Person not found" page.
- Your own message author stays plain text; only peer senders link.

## User Impact

Clicking a face or a name in chat — the session owner, someone watching, or whoever wrote
a message — opens their Activity feed. Identity chrome looks exactly as before at rest;
links reveal themselves on hover/focus with an underline.

Ids are not always real, so linking is conditional: `SenderIdentity.id` is optional, the
header maps participants with `id ?? ""`, and blank ids render plain text instead of a
link to nowhere.

## Evidence

Real-browser Playwright run against the built Control UI with a mocked gateway
(`ui/src/e2e/identity-activity-links.e2e.test.ts`, renamed from
`session-hovercard-identity.e2e.test.ts` now that it covers more than the hovercard):
asserts the header owner and participant hrefs, the peer author href, then clicks through
to `/activity?person=<id>` for a participant and for the message author, checking the
router state and the rendered destination identity each time.

That run also surfaced a real interaction detail worth knowing: the persistent-identity
message footer carries `pointer-events: none` until its group is hovered, so the author
link becomes clickable exactly when you reach for it. The test hovers the group first and
says why.

Unit coverage: header owner + participant links and the unrouted fallback
(`chat-pane-header-identity.test.ts`), peer-vs-own sender names (`chat-message.test.ts`),
and the facepile opt-in guard protecting the nesting rule (`viewer-facepile.test.ts`).

Also run: `node scripts/check-changed.mjs` (green), the full `ui/src/components` and
`ui/src/pages/chat` unit suites (4795 passed), and the `chat-attributed-identity` +
`session-progress-hovercard` e2e suites to check the surfaces this change touches.
Codex autoreview on the diff reported no accepted findings.

Two housekeeping notes: `chat-pane-header.test.ts` was already near the 1000-line lint cap,
so its mount harness moved to `chat-pane-header.test-support.ts` and the new identity tests
live in their own file rather than under a `max-lines` suppression. That support file adds
one entry to the raw-copy baseline for its `"Session title"` fixture, refreshed with the
keyless `pnpm ui:i18n:baseline`.

Live multi-identity proof on a real gateway remains infeasible for the same reason as
#128313: these surfaces only appear once a session carries two distinct authenticated
identities.
