### PR TITLE
fix(release): authorize focused beta evidence

### DIFF
--- a/.github/workflows/authorized-beta-focused-validation.yml
+++ b/.github/workflows/authorized-beta-focused-validation.yml
@@ -1,0 +1,95 @@
+name: Authorized Beta Focused Validation
+
+on:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  attestations: write
+  contents: read
+  id-token: write
+
+concurrency:
+  group: authorized-beta-focused-validation
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.16.0"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Validate protected tooling identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${GITHUB_REF}" =~ ^refs/tags/release-publish/([a-f0-9]{12})-[1-9][0-9]*$ ]]; then
+            echo "Authorized beta focused validation requires a protected release-publish tag." >&2
+            exit 1
+          fi
+          if [[ "${GITHUB_SHA:0:12}" != "${BASH_REMATCH[1]}" ]]; then
+            echo "Protected release-publish tag does not match the workflow SHA." >&2
+            exit 1
+          fi
+          tag="${GITHUB_REF#refs/tags/}"
+          remote_sha="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" \
+              --jq '.object | select(.type == "commit") | .sha'
+          )"
+          [[ "${remote_sha}" == "${GITHUB_SHA}" ]] || {
+            echo "Protected release-publish tag moved after dispatch." >&2
+            exit 1
+          }
+
+      - name: Checkout trusted tooling
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout frozen candidate
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: 3fbe94065c2b94f4c08acb6742a69938bf408d94
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          cache-mode: restore
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "false"
+
+      - name: Build focused evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/authorized-beta-focused"
+          node --import tsx scripts/validate-authorized-beta-focused-evidence.mts create \
+            --candidate-root candidate \
+            --output "${RUNNER_TEMP}/authorized-beta-focused/evidence.json" \
+            --producer-run-id "${GITHUB_RUN_ID}" \
+            --producer-run-attempt "${GITHUB_RUN_ATTEMPT}" \
+            --producer-workflow-full-ref "${GITHUB_REF}" \
+            --producer-workflow-sha "${GITHUB_SHA}"
+
+      - name: Attest focused evidence
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: ${{ runner.temp }}/authorized-beta-focused/evidence.json
+
+      - name: Upload focused evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: authorized-beta-focused-v1-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/authorized-beta-focused/evidence.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -29,6 +29,22 @@ on:
         description: Exact successful Full Release Validation run attempt for this tag/SHA
         required: false
         type: string
+      release_evidence_mode:
+        description: Publication evidence contract
+        required: true
+        default: full-release-validation
+        type: choice
+        options:
+          - full-release-validation
+          - authorized-beta-focused-v1
+      focused_release_evidence_run_id:
+        description: Successful Authorized Beta Focused Validation run id
+        required: false
+        type: string
+      focused_release_evidence_run_attempt:
+        description: Exact Authorized Beta Focused Validation run attempt
+        required: false
+        type: string
       release_publish_run_id:
         description: Approved OpenClaw Release Publish workflow run id
         required: false
@@ -874,28 +890,56 @@ jobs:
           PREFLIGHT_RUN_ID: ${{ inputs.preflight_run_id }}
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
           FULL_RELEASE_VALIDATION_RUN_ATTEMPT: ${{ inputs.full_release_validation_run_attempt }}
+          RELEASE_EVIDENCE_MODE: ${{ inputs.release_evidence_mode }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ID: ${{ inputs.focused_release_evidence_run_id }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT: ${{ inputs.focused_release_evidence_run_attempt }}
           PLUGIN_NPM_RUN_ID: ${{ inputs.plugin_npm_run_id }}
           RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
           RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
         run: |
           set -euo pipefail
+          RELEASE_EVIDENCE_MODE="${RELEASE_EVIDENCE_MODE:-full-release-validation}"
+          FOCUSED_RELEASE_EVIDENCE_RUN_ID="${FOCUSED_RELEASE_EVIDENCE_RUN_ID:-}"
+          FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT="${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT:-}"
           if [[ -z "${PREFLIGHT_RUN_ID}" ]]; then
             echo "Real publish requires preflight_run_id from a successful npm preflight run." >&2
             exit 1
           fi
-          if [[ -z "${FULL_RELEASE_VALIDATION_RUN_ID}" ]]; then
-            if [[ -n "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" ]]; then
-              echo "full_release_validation_run_attempt requires full_release_validation_run_id." >&2
+          if [[ "${RELEASE_EVIDENCE_MODE}" == "authorized-beta-focused-v1" ]]; then
+            if [[ "${RELEASE_TAG}" != "v2026.8.1-beta.3" || "${RELEASE_NPM_DIST_TAG}" != "beta" ]]; then
+              echo "authorized-beta-focused-v1 is restricted to v2026.8.1-beta.3 on the beta dist-tag." >&2
               exit 1
             fi
-            if [[ "${RELEASE_TAG}" == *"-beta."* && "${RELEASE_NPM_DIST_TAG}" == "beta" ]]; then
-              echo "::warning::Beta publish is proceeding from npm preflight only; full release validation remains required before stable/latest promotion."
-            else
-              echo "Real publish requires full_release_validation_run_id from a successful Full Release Validation run." >&2
+            if [[ -n "${FULL_RELEASE_VALIDATION_RUN_ID}" || -n "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" ]]; then
+              echo "authorized-beta-focused-v1 must not include full release validation inputs." >&2
               exit 1
             fi
-          elif [[ ! "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" =~ ^[1-9][0-9]*$ ]]; then
-            echo "Real publish with full release validation requires a positive full_release_validation_run_attempt." >&2
+            if [[ -z "${FOCUSED_RELEASE_EVIDENCE_RUN_ID}" || ! "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" =~ ^[1-9][0-9]*$ ]]; then
+              echo "authorized-beta-focused-v1 requires the exact focused evidence run id and attempt." >&2
+              exit 1
+            fi
+          elif [[ "${RELEASE_EVIDENCE_MODE}" == "full-release-validation" ]]; then
+            if [[ -n "${FOCUSED_RELEASE_EVIDENCE_RUN_ID}" || -n "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" ]]; then
+              echo "Full release validation evidence mode must not include focused evidence inputs." >&2
+              exit 1
+            fi
+            if [[ -z "${FULL_RELEASE_VALIDATION_RUN_ID}" ]]; then
+              if [[ -n "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" ]]; then
+                echo "full_release_validation_run_attempt requires full_release_validation_run_id." >&2
+                exit 1
+              fi
+              if [[ "${RELEASE_TAG}" == *"-beta."* && "${RELEASE_NPM_DIST_TAG}" == "beta" ]]; then
+                echo "::warning::Beta publish is proceeding from npm preflight only; full release validation remains required before stable/latest promotion."
+              else
+                echo "Real publish requires full_release_validation_run_id from a successful Full Release Validation run." >&2
+                exit 1
+              fi
+            elif [[ ! "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" =~ ^[1-9][0-9]*$ ]]; then
+              echo "Real publish with full release validation requires a positive full_release_validation_run_attempt." >&2
+              exit 1
+            fi
+          else
+            echo "Unsupported release_evidence_mode: ${RELEASE_EVIDENCE_MODE}" >&2
             exit 1
           fi
           if [[ "${RELEASE_NPM_DIST_TAG}" == "extended-stable" && -z "${PLUGIN_NPM_RUN_ID// }" ]]; then
@@ -946,6 +990,7 @@ jobs:
     environment: npm-release
     permissions:
       actions: read
+      attestations: read
       contents: read
       id-token: write
     steps:
@@ -974,7 +1019,7 @@ jobs:
           ref: refs/tags/${{ inputs.tag }}
           # Frozen preflight evidence already binds the exact release SHA and
           # tarball, so real publishes do not need the repository's full history.
-          fetch-depth: ${{ inputs.preflight_run_id != '' && 1 || 0 }}
+          fetch-depth: ${{ inputs.release_evidence_mode == 'authorized-beta-focused-v1' && 0 || (inputs.preflight_run_id != '' && 1 || 0) }}
 
       - name: Validate Tideclaw alpha publish target
         if: startsWith(github.ref, 'refs/heads/tideclaw/alpha/')
@@ -1096,7 +1141,7 @@ jobs:
           echo "run_attempt=${preflight_run_attempt}" >> "$GITHUB_OUTPUT"
 
       - name: Download full release validation manifest
-        if: ${{ inputs.full_release_validation_run_id != '' }}
+        if: ${{ inputs.release_evidence_mode == 'full-release-validation' && inputs.full_release_validation_run_id != '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-validation-${{ inputs.full_release_validation_run_id }}-${{ inputs.full_release_validation_run_attempt }}
@@ -1106,7 +1151,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Verify full release validation evidence
-        if: ${{ inputs.full_release_validation_run_id != '' }}
+        if: ${{ inputs.release_evidence_mode == 'full-release-validation' && inputs.full_release_validation_run_id != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
@@ -1147,6 +1192,42 @@ jobs:
             --json \
             --verifier-source-sha "$WORKFLOW_SHA" \
             --verifier-source-file "$STRICT_VALIDATOR_FILE" >/dev/null
+
+      - name: Download focused release evidence
+        if: ${{ inputs.release_evidence_mode == 'authorized-beta-focused-v1' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: authorized-beta-focused-v1-${{ inputs.focused_release_evidence_run_id }}-${{ inputs.focused_release_evidence_run_attempt }}
+          path: authorized-beta-focused-evidence
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.focused_release_evidence_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify focused release evidence
+        if: ${{ inputs.release_evidence_mode == 'authorized-beta-focused-v1' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ID: ${{ inputs.focused_release_evidence_run_id }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT: ${{ inputs.focused_release_evidence_run_attempt }}
+          WORKFLOW_FULL_REF: ${{ github.ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          evidence="authorized-beta-focused-evidence/evidence.json"
+          gh attestation verify "${evidence}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/authorized-beta-focused-validation.yml" \
+            --signer-digest "${WORKFLOW_SHA}" \
+            --source-digest "${WORKFLOW_SHA}" \
+            --source-ref "${WORKFLOW_FULL_REF}" \
+            --deny-self-hosted-runners
+          node trusted-workflow/scripts/validate-authorized-beta-focused-evidence.mts verify \
+            --candidate-root . \
+            --artifact "${evidence}" \
+            --producer-run-id "${FOCUSED_RELEASE_EVIDENCE_RUN_ID}" \
+            --producer-run-attempt "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" \
+            --producer-workflow-full-ref "${WORKFLOW_FULL_REF}" \
+            --producer-workflow-sha "${WORKFLOW_SHA}"
 
       - name: Verify plugin npm release run metadata
         if: ${{ inputs.npm_dist_tag == 'extended-stable' }}
@@ -1382,7 +1463,7 @@ jobs:
           echo "tarball_path=$ARTIFACT_TARBALL_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Verify full release validation target
-        if: ${{ inputs.full_release_validation_run_id != '' }}
+        if: ${{ inputs.release_evidence_mode == 'full-release-validation' && inputs.full_release_validation_run_id != '' }}
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -24,6 +24,22 @@ on:
         description: Exact Full Release Validation run attempt; when omitted, the current attempt is resolved once before publish
         required: false
         type: string
+      release_evidence_mode:
+        description: Publication evidence contract
+        required: true
+        default: full-release-validation
+        type: choice
+        options:
+          - full-release-validation
+          - authorized-beta-focused-v1
+      focused_release_evidence_run_id:
+        description: Successful Authorized Beta Focused Validation run id
+        required: false
+        type: string
+      focused_release_evidence_run_attempt:
+        description: Exact Authorized Beta Focused Validation run attempt
+        required: false
+        type: string
       windows_node_tag:
         description: Exact openclaw-windows-node release tag, required for stable OpenClaw publish
         required: false
@@ -111,6 +127,7 @@ jobs:
       preflight_artifact_name: ${{ steps.preflight_artifact.outputs.name }}
       preflight_tarball_sha256: ${{ steps.manifest.outputs.tarball_sha256 }}
       full_release_validation_run_attempt: ${{ steps.full_run.outputs.attempt }}
+      focused_release_evidence_run_attempt: ${{ steps.focused_run.outputs.attempt }}
       windows_node_installer_digests: ${{ steps.windows_source.outputs.installer_digests }}
     steps:
       - name: Validate inputs
@@ -120,6 +137,9 @@ jobs:
           PREFLIGHT_RUN_ID: ${{ inputs.preflight_run_id }}
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
           FULL_RELEASE_VALIDATION_RUN_ATTEMPT: ${{ inputs.full_release_validation_run_attempt }}
+          RELEASE_EVIDENCE_MODE: ${{ inputs.release_evidence_mode }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ID: ${{ inputs.focused_release_evidence_run_id }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT: ${{ inputs.focused_release_evidence_run_attempt }}
           OPENCLAW_NPM_RESUME_RUN_ID: ${{ inputs.openclaw_npm_resume_run_id }}
           WINDOWS_NODE_TAG: ${{ inputs.windows_node_tag }}
           WINDOWS_NODE_INSTALLER_DIGESTS: ${{ inputs.windows_node_installer_digests }}
@@ -133,6 +153,9 @@ jobs:
           WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          RELEASE_EVIDENCE_MODE="${RELEASE_EVIDENCE_MODE:-full-release-validation}"
+          FOCUSED_RELEASE_EVIDENCE_RUN_ID="${FOCUSED_RELEASE_EVIDENCE_RUN_ID:-}"
+          FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT="${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT:-}"
           if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-(alpha|beta)\.[1-9][0-9]*)|(-[1-9][0-9]*))?$ ]]; then
             echo "Invalid release tag: ${RELEASE_TAG}" >&2
             exit 1
@@ -150,7 +173,7 @@ jobs:
             release_evidence_required=true
           fi
           release_evidence_supplied=false
-          if [[ -n "${PREFLIGHT_RUN_ID//[[:space:]]/}" || -n "${FULL_RELEASE_VALIDATION_RUN_ID//[[:space:]]/}" || -n "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT//[[:space:]]/}" ]]; then
+          if [[ -n "${PREFLIGHT_RUN_ID//[[:space:]]/}" || -n "${FULL_RELEASE_VALIDATION_RUN_ID//[[:space:]]/}" || -n "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT//[[:space:]]/}" || -n "${FOCUSED_RELEASE_EVIDENCE_RUN_ID//[[:space:]]/}" || -n "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT//[[:space:]]/}" ]]; then
             release_evidence_supplied=true
           fi
           if [[ "${release_evidence_required}" == "true" || "${release_evidence_supplied}" == "true" ]]; then
@@ -158,8 +181,30 @@ jobs:
               echo "OpenClaw npm and all-publishable plugin publication require preflight_run_id; supplied release evidence must also be complete." >&2
               exit 1
             fi
-            if [[ -z "${FULL_RELEASE_VALIDATION_RUN_ID//[[:space:]]/}" ]]; then
-              echo "OpenClaw npm and all-publishable plugin publication require full_release_validation_run_id; supplied release evidence must also be complete." >&2
+            if [[ "${RELEASE_EVIDENCE_MODE}" == "full-release-validation" ]]; then
+              if [[ -z "${FULL_RELEASE_VALIDATION_RUN_ID//[[:space:]]/}" ]]; then
+                echo "OpenClaw npm and all-publishable plugin publication require full_release_validation_run_id; supplied release evidence must also be complete." >&2
+                exit 1
+              fi
+              if [[ -n "${FOCUSED_RELEASE_EVIDENCE_RUN_ID//[[:space:]]/}" || -n "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT//[[:space:]]/}" ]]; then
+                echo "Full release validation evidence mode must not include focused evidence inputs." >&2
+                exit 1
+              fi
+            elif [[ "${RELEASE_EVIDENCE_MODE}" == "authorized-beta-focused-v1" ]]; then
+              if [[ "${RELEASE_TAG}" != "v2026.8.1-beta.3" || "${RELEASE_NPM_DIST_TAG}" != "beta" ]]; then
+                echo "authorized-beta-focused-v1 is restricted to v2026.8.1-beta.3 on the beta dist-tag." >&2
+                exit 1
+              fi
+              if [[ -n "${FULL_RELEASE_VALIDATION_RUN_ID//[[:space:]]/}" || -n "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT//[[:space:]]/}" ]]; then
+                echo "authorized-beta-focused-v1 must not include full release validation inputs." >&2
+                exit 1
+              fi
+              if [[ -z "${FOCUSED_RELEASE_EVIDENCE_RUN_ID//[[:space:]]/}" || -z "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT//[[:space:]]/}" ]]; then
+                echo "authorized-beta-focused-v1 requires the exact focused evidence run id and attempt." >&2
+                exit 1
+              fi
+            else
+              echo "Unsupported release_evidence_mode: ${RELEASE_EVIDENCE_MODE}" >&2
               exit 1
             fi
           fi
@@ -169,6 +214,14 @@ jobs:
           fi
           if [[ -n "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" && ! "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" =~ ^[1-9][0-9]*$ ]]; then
             echo "full_release_validation_run_attempt must be a positive integer." >&2
+            exit 1
+          fi
+          if [[ -n "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" && -z "${FOCUSED_RELEASE_EVIDENCE_RUN_ID}" ]]; then
+            echo "focused_release_evidence_run_attempt requires focused_release_evidence_run_id." >&2
+            exit 1
+          fi
+          if [[ -n "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" && ! "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "focused_release_evidence_run_attempt must be a positive integer." >&2
             exit 1
           fi
           if [[ -n "${OPENCLAW_NPM_RESUME_RUN_ID}" && ! "${OPENCLAW_NPM_RESUME_RUN_ID}" =~ ^[1-9][0-9]*$ ]]; then
@@ -427,7 +480,7 @@ jobs:
 
       - name: Resolve full release validation run
         id: full_run
-        if: ${{ inputs.publish_openclaw_npm || inputs.plugin_publish_scope == 'all-publishable' || inputs.preflight_run_id != '' || inputs.full_release_validation_run_id != '' }}
+        if: ${{ inputs.release_evidence_mode == 'full-release-validation' && (inputs.publish_openclaw_npm || inputs.plugin_publish_scope == 'all-publishable' || inputs.preflight_run_id != '' || inputs.full_release_validation_run_id != '') }}
         env:
           GH_TOKEN: ${{ github.token }}
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
@@ -452,7 +505,7 @@ jobs:
           echo "attempt=$run_attempt" >> "$GITHUB_OUTPUT"
 
       - name: Download full release validation manifest
-        if: ${{ inputs.publish_openclaw_npm || inputs.plugin_publish_scope == 'all-publishable' || inputs.preflight_run_id != '' || inputs.full_release_validation_run_id != '' }}
+        if: ${{ inputs.release_evidence_mode == 'full-release-validation' && (inputs.publish_openclaw_npm || inputs.plugin_publish_scope == 'all-publishable' || inputs.preflight_run_id != '' || inputs.full_release_validation_run_id != '') }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-validation-${{ inputs.full_release_validation_run_id }}-${{ steps.full_run.outputs.attempt }}
@@ -478,6 +531,12 @@ jobs:
             --jq .content | base64 --decode > "${tooling_dir}/lib/plain-gh.mjs"
           gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/plugin-sdk-api-release-evidence.mjs?ref=${WORKFLOW_SHA}" \
             --jq .content | base64 --decode > "${tooling_dir}/plugin-sdk-api-release-evidence.mjs"
+          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/validate-authorized-beta-focused-evidence.mts?ref=${WORKFLOW_SHA}" \
+            --jq .content | base64 --decode > "${tooling_dir}/validate-authorized-beta-focused-evidence.mts"
+          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/authorized-beta-focused-policy.json?ref=${WORKFLOW_SHA}" \
+            --jq .content | base64 --decode > "${tooling_dir}/authorized-beta-focused-policy.json"
+          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/lib/record-shared.mjs?ref=${WORKFLOW_SHA}" \
+            --jq .content | base64 --decode > "${tooling_dir}/lib/record-shared.mjs"
 
       - name: Checkout release tag
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -581,7 +640,7 @@ jobs:
 
       - name: Validate full release validation manifest
         id: full_manifest
-        if: ${{ inputs.publish_openclaw_npm || inputs.plugin_publish_scope == 'all-publishable' || inputs.preflight_run_id != '' || inputs.full_release_validation_run_id != '' }}
+        if: ${{ inputs.release_evidence_mode == 'full-release-validation' && (inputs.publish_openclaw_npm || inputs.plugin_publish_scope == 'all-publishable' || inputs.preflight_run_id != '' || inputs.full_release_validation_run_id != '') }}
         env:
           GH_TOKEN: ${{ github.token }}
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
@@ -660,6 +719,61 @@ jobs:
           fi
           echo "release_profile=$release_profile" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve focused release evidence run
+        id: focused_run
+        if: ${{ inputs.release_evidence_mode == 'authorized-beta-focused-v1' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ID: ${{ inputs.focused_release_evidence_run_id }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT: ${{ inputs.focused_release_evidence_run_attempt }}
+        run: |
+          set -euo pipefail
+          run_attempt="$(
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${FOCUSED_RELEASE_EVIDENCE_RUN_ID}" \
+              --jq '.run_attempt'
+          )"
+          if [[ "${run_attempt}" != "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" ]]; then
+            echo "Focused evidence run attempt mismatch: expected ${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}, got ${run_attempt}." >&2
+            exit 1
+          fi
+          echo "attempt=${run_attempt}" >> "$GITHUB_OUTPUT"
+
+      - name: Download focused release evidence
+        if: ${{ inputs.release_evidence_mode == 'authorized-beta-focused-v1' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: authorized-beta-focused-v1-${{ inputs.focused_release_evidence_run_id }}-${{ steps.focused_run.outputs.attempt }}
+          path: ${{ runner.temp }}/authorized-beta-focused-evidence
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.focused_release_evidence_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify focused release evidence
+        if: ${{ inputs.release_evidence_mode == 'authorized-beta-focused-v1' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ID: ${{ inputs.focused_release_evidence_run_id }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT: ${{ steps.focused_run.outputs.attempt }}
+          WORKFLOW_FULL_REF: ${{ github.ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          evidence="${RUNNER_TEMP}/authorized-beta-focused-evidence/evidence.json"
+          gh attestation verify "${evidence}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/authorized-beta-focused-validation.yml" \
+            --signer-digest "${WORKFLOW_SHA}" \
+            --source-digest "${WORKFLOW_SHA}" \
+            --source-ref "${WORKFLOW_FULL_REF}" \
+            --deny-self-hosted-runners
+          node "${RUNNER_TEMP}/release-validation-tooling/validate-authorized-beta-focused-evidence.mts" verify \
+            --candidate-root . \
+            --artifact "${evidence}" \
+            --producer-run-id "${FOCUSED_RELEASE_EVIDENCE_RUN_ID}" \
+            --producer-run-attempt "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" \
+            --producer-workflow-full-ref "${WORKFLOW_FULL_REF}" \
+            --producer-workflow-sha "${WORKFLOW_SHA}"
+
       - name: Validate release tag is reachable from a trusted release branch
         env:
           RELEASE_TAG: ${{ inputs.tag }}
@@ -700,8 +814,9 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           TARGET_SHA: ${{ steps.manifest.outputs.sha || steps.ref.outputs.sha }}
-          RELEASE_PROFILE: ${{ steps.full_manifest.outputs.release_profile || inputs.release_profile }}
+          RELEASE_PROFILE: ${{ inputs.release_evidence_mode == 'authorized-beta-focused-v1' && 'beta' || (steps.full_manifest.outputs.release_profile || inputs.release_profile) }}
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ID: ${{ inputs.focused_release_evidence_run_id }}
           WINDOWS_NODE_TAG: ${{ inputs.windows_node_tag }}
         run: |
           {
@@ -712,6 +827,9 @@ jobs:
             echo "- Release profile: \`${RELEASE_PROFILE}\`"
             if [[ -n "${FULL_RELEASE_VALIDATION_RUN_ID// }" ]]; then
               echo "- Full release validation: \`${FULL_RELEASE_VALIDATION_RUN_ID}\`"
+            fi
+            if [[ -n "${FOCUSED_RELEASE_EVIDENCE_RUN_ID// }" ]]; then
+              echo "- Authorized focused validation: \`${FOCUSED_RELEASE_EVIDENCE_RUN_ID}\`"
             fi
             if [[ -n "${WINDOWS_NODE_TAG// }" ]]; then
               echo "- Windows Node source release: \`${WINDOWS_NODE_TAG}\`"
@@ -735,7 +853,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.resolve_release_target.outputs.sha }}
-          fetch-depth: 1
+          fetch-depth: ${{ inputs.release_evidence_mode == 'authorized-beta-focused-v1' && 0 || 1 }}
           persist-credentials: false
 
       - name: Checkout trusted release tooling
@@ -747,7 +865,7 @@ jobs:
           persist-credentials: false
 
       - name: Download full release validation manifest
-        if: ${{ inputs.publish_openclaw_npm }}
+        if: ${{ inputs.publish_openclaw_npm && inputs.release_evidence_mode == 'full-release-validation' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: full-release-validation-${{ inputs.full_release_validation_run_id }}-${{ needs.resolve_release_target.outputs.full_release_validation_run_attempt }}
@@ -755,6 +873,42 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ inputs.full_release_validation_run_id }}
           github-token: ${{ github.token }}
+
+      - name: Download focused release evidence
+        if: ${{ inputs.publish_openclaw_npm && inputs.release_evidence_mode == 'authorized-beta-focused-v1' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: authorized-beta-focused-v1-${{ inputs.focused_release_evidence_run_id }}-${{ needs.resolve_release_target.outputs.focused_release_evidence_run_attempt }}
+          path: ${{ runner.temp }}/authorized-beta-focused-evidence
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.focused_release_evidence_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify focused release evidence after approval
+        if: ${{ inputs.publish_openclaw_npm && inputs.release_evidence_mode == 'authorized-beta-focused-v1' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ID: ${{ inputs.focused_release_evidence_run_id }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT: ${{ needs.resolve_release_target.outputs.focused_release_evidence_run_attempt }}
+          WORKFLOW_FULL_REF: ${{ github.ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          evidence="${RUNNER_TEMP}/authorized-beta-focused-evidence/evidence.json"
+          gh attestation verify "${evidence}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/authorized-beta-focused-validation.yml" \
+            --signer-digest "${WORKFLOW_SHA}" \
+            --source-digest "${WORKFLOW_SHA}" \
+            --source-ref "${WORKFLOW_FULL_REF}" \
+            --deny-self-hosted-runners
+          node .release-harness/scripts/validate-authorized-beta-focused-evidence.mts verify \
+            --candidate-root . \
+            --artifact "${evidence}" \
+            --producer-run-id "${FOCUSED_RELEASE_EVIDENCE_RUN_ID}" \
+            --producer-run-attempt "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" \
+            --producer-workflow-full-ref "${WORKFLOW_FULL_REF}" \
+            --producer-workflow-sha "${WORKFLOW_SHA}"
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -967,6 +1121,9 @@ jobs:
           PREFLIGHT_RUN_ID: ${{ inputs.preflight_run_id }}
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
           FULL_RELEASE_VALIDATION_RUN_ATTEMPT: ${{ needs.resolve_release_target.outputs.full_release_validation_run_attempt }}
+          RELEASE_EVIDENCE_MODE: ${{ inputs.release_evidence_mode }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ID: ${{ inputs.focused_release_evidence_run_id }}
+          FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT: ${{ needs.resolve_release_target.outputs.focused_release_evidence_run_attempt }}
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
           PLUGIN_SDK_API_ACKNOWLEDGEMENT: ${{ inputs.plugin_sdk_api_acknowledgement }}
           PLUGIN_PUBLISH_SCOPE: ${{ inputs.plugin_publish_scope }}
@@ -980,6 +1137,7 @@ jobs:
           WINDOWS_NODE_INSTALLER_DIGESTS: ${{ needs.resolve_release_target.outputs.windows_node_installer_digests }}
           POSTPUBLISH_EVIDENCE_DIR: ${{ runner.temp }}/openclaw-release-postpublish-evidence
           FULL_RELEASE_VALIDATION_MANIFEST_DIR: ${{ runner.temp }}/full-release-validation-manifest
+          FOCUSED_RELEASE_EVIDENCE_DIR: ${{ runner.temp }}/authorized-beta-focused-evidence
           CLAWHUB_PLAN_PATH: ${{ runner.temp }}/openclaw-release-clawhub-plan.json
         run: |
           set -euo pipefail
@@ -1996,13 +2154,18 @@ jobs:
           upload_release_evidence_assets() {
             local release_version manifest_path evidence_path manifest_asset evidence_asset
             release_version="${RELEASE_TAG#v}"
-            manifest_path="${FULL_RELEASE_VALIDATION_MANIFEST_DIR}/full-release-validation-manifest.json"
             evidence_path="${POSTPUBLISH_EVIDENCE_DIR}/release-postpublish-evidence.json"
-            manifest_asset="openclaw-${release_version}-release-manifest.json"
             evidence_asset="openclaw-${release_version}-postpublish-evidence.json"
 
+            if [[ "${RELEASE_EVIDENCE_MODE}" == "authorized-beta-focused-v1" ]]; then
+              manifest_path="${FOCUSED_RELEASE_EVIDENCE_DIR}/evidence.json"
+              manifest_asset="openclaw-${release_version}-authorized-focused-evidence.json"
+            else
+              manifest_path="${FULL_RELEASE_VALIDATION_MANIFEST_DIR}/full-release-validation-manifest.json"
+              manifest_asset="openclaw-${release_version}-release-manifest.json"
+            fi
             if [[ ! -f "${manifest_path}" ]]; then
-              echo "Full release validation manifest is missing from ${FULL_RELEASE_VALIDATION_MANIFEST_DIR}." >&2
+              echo "Release evidence is missing for mode ${RELEASE_EVIDENCE_MODE}: ${manifest_path}." >&2
               exit 1
             fi
             if [[ ! -f "${evidence_path}" ]]; then
@@ -2027,15 +2190,15 @@ jobs:
               "${RUNNER_TEMP}/${evidence_asset}.sha256" \
               "${evidence_asset}.sha256"
             {
-              echo "- Immutable release manifest: \`${manifest_asset}\`"
+              echo "- Immutable release evidence: \`${manifest_asset}\`"
               echo "- Postpublish evidence (latest verification): \`${evidence_asset}\`"
             } >> "$GITHUB_STEP_SUMMARY"
           }
 
           verify_published_release() {
             local release_version evidence_path skip_clawhub clawhub_runtime_state_path bootstrap_run_arg_present
-            local validation_manifest validation_run_attempt validation_run_id
-            local validation_target_sha validation_url validation_workflow_ref
+            local expected_attempt expected_id run_attempt run_id run_label run_url target_sha
+            local validation_file workflow_ref
             local -a verify_args
 
             skip_clawhub="${1:-false}"
@@ -2094,31 +2257,44 @@ jobs:
                 "${GITHUB_WORKSPACE}/.release-harness/scripts/release-verify-beta.ts" \
                 "${verify_args[@]}"
 
-            # Resolve already validated this exact v3 run before mutation. Append
-            # its immutable tuple here so frozen targets need no new CLI option.
-            validation_manifest="${FULL_RELEASE_VALIDATION_MANIFEST_DIR}/full-release-validation-manifest.json"
-            validation_run_id="$(jq -er '.runId | select(type == "string" and length > 0)' "${validation_manifest}")"
-            validation_run_attempt="$(jq -er '.runAttempt | select(type == "string" and test("^[1-9][0-9]*$"))' "${validation_manifest}")"
-            validation_workflow_ref="$(jq -er '.workflowRef | select(type == "string" and length > 0)' "${validation_manifest}")"
-            validation_target_sha="$(jq -er '.targetSha | select(type == "string" and test("^[a-f0-9]{40}$"))' "${validation_manifest}")"
-            if [[ "${validation_run_id}" != "${FULL_RELEASE_VALIDATION_RUN_ID}" ||
-              "${validation_run_attempt}" != "${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" ||
-              "${validation_target_sha}" != "${TARGET_SHA}" ]]; then
-              echo "Full release validation evidence changed after prepublish validation." >&2
+            if [[ "${RELEASE_EVIDENCE_MODE}" == "authorized-beta-focused-v1" ]]; then
+              validation_file="${FOCUSED_RELEASE_EVIDENCE_DIR}/evidence.json"
+              run_id="$(jq -er '.producer.runId | select(type == "string" and test("^[1-9][0-9]*$"))' "${validation_file}")"
+              run_attempt="$(jq -er '.producer.runAttempt | select(type == "number" and . >= 1) | tostring' "${validation_file}")"
+              workflow_ref="$(jq -er '.producer.workflowRef | select(type == "string" and length > 0)' "${validation_file}")"
+              target_sha="$(jq -er '.candidate.sha | select(type == "string" and test("^[a-f0-9]{40}$"))' "${validation_file}")"
+              expected_id="${FOCUSED_RELEASE_EVIDENCE_RUN_ID}"
+              expected_attempt="${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}"
+              run_label="Authorized Beta Focused Validation"
+            else
+              validation_file="${FULL_RELEASE_VALIDATION_MANIFEST_DIR}/full-release-validation-manifest.json"
+              run_id="$(jq -er '.runId | select(type == "string" and length > 0)' "${validation_file}")"
+              run_attempt="$(jq -er '.runAttempt | select(type == "string" and test("^[1-9][0-9]*$"))' "${validation_file}")"
+              workflow_ref="$(jq -er '.workflowRef | select(type == "string" and length > 0)' "${validation_file}")"
+              target_sha="$(jq -er '.targetSha | select(type == "string" and test("^[a-f0-9]{40}$"))' "${validation_file}")"
+              expected_id="${FULL_RELEASE_VALIDATION_RUN_ID}"
+              expected_attempt="${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}"
+              run_label="Full Release Validation"
+            fi
+            if [[ "${run_id}" != "${expected_id}" ||
+              "${run_attempt}" != "${expected_attempt}" ||
+              "${target_sha}" != "${TARGET_SHA}" ]]; then
+              echo "Release validation evidence changed after prepublish validation." >&2
               exit 1
             fi
-            validation_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${validation_run_id}"
+            run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}"
             jq \
               --arg release_publish_run_id "$GITHUB_RUN_ID" \
-              --arg validation_run_id "${validation_run_id}" \
-              --arg validation_run_attempt "${validation_run_attempt}" \
-              --arg validation_target_sha "${validation_target_sha}" \
-              --arg validation_url "${validation_url}" \
-              --arg validation_workflow_ref "${validation_workflow_ref}" '
+              --arg validation_label "${run_label}" \
+              --arg validation_run_id "${run_id}" \
+              --arg validation_run_attempt "${run_attempt}" \
+              --arg validation_target_sha "${target_sha}" \
+              --arg validation_url "${run_url}" \
+              --arg validation_workflow_ref "${workflow_ref}" '
                 .releasePublishRunId = $release_publish_run_id |
                 .workflowRuns += [{
                   id: $validation_run_id,
-                  label: "Full Release Validation",
+                  label: $validation_label,
                   runAttempt: $validation_run_attempt,
                   targetSha: $validation_target_sha,
                   url: $validation_url,
@@ -2161,6 +2337,12 @@ jobs:
             if [[ -n "${android_release_run_id// }" ]]; then
               android_line="- Android APK: https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/OpenClaw-Android.apk (https://github.com/${GITHUB_REPOSITORY}/actions/runs/${android_release_run_id})"
             fi
+            proof_label="full release validation"
+            proof_run_id="${FULL_RELEASE_VALIDATION_RUN_ID}"
+            if [[ "${RELEASE_EVIDENCE_MODE}" == "authorized-beta-focused-v1" ]]; then
+              proof_label="authorized beta focused validation"
+              proof_run_id="${FOCUSED_RELEASE_EVIDENCE_RUN_ID}"
+            fi
 
             RELEASE_PROOF_FILE="${proof_file}" \
               RELEASE_VERSION="${release_version}" \
@@ -2171,7 +2353,8 @@ jobs:
               RELEASE_INTEGRITY="${integrity}" \
               RELEASE_PUBLISH_RUN_ID="${GITHUB_RUN_ID}" \
               PREFLIGHT_RUN_ID="${PREFLIGHT_RUN_ID}" \
-              FULL_RELEASE_VALIDATION_RUN_ID="${FULL_RELEASE_VALIDATION_RUN_ID}" \
+              RELEASE_VALIDATION_LABEL="${proof_label}" \
+              RELEASE_VALIDATION_RUN_ID="${proof_run_id}" \
               PLUGIN_NPM_RUN_ID="${plugin_npm_run_id}" \
               OPENCLAW_NPM_RUN_ID="${openclaw_npm_run_id}" \
               CLAWHUB_LINE="${clawhub_line}" \
@@ -2197,7 +2380,7 @@ jobs:
             `- full release CI report: https://github.com/openclaw/releases/blob/main/evidence/${process.env.RELEASE_VERSION}/release-evidence.md`,
             `- release publish: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.RELEASE_PUBLISH_RUN_ID}`,
             `- npm preflight: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.PREFLIGHT_RUN_ID}`,
-            `- full release validation: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.FULL_RELEASE_VALIDATION_RUN_ID}`,
+            `- ${process.env.RELEASE_VALIDATION_LABEL}: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.RELEASE_VALIDATION_RUN_ID}`,
             `- plugin npm publish: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.PLUGIN_NPM_RUN_ID}`,
             process.env.CLAWHUB_LINE,
             process.env.CLAWHUB_BOOTSTRAP_LINE,
@@ -2343,16 +2526,27 @@ jobs:
             if [[ "${openclaw_npm_already_published}" == "true" ]]; then
               echo "- OpenClaw npm publish: already on npm; resuming postpublish stages" >> "$GITHUB_STEP_SUMMARY"
             else
+              evidence_args=(-f release_evidence_mode="${RELEASE_EVIDENCE_MODE}")
+              if [[ "${RELEASE_EVIDENCE_MODE}" == "authorized-beta-focused-v1" ]]; then
+                evidence_args+=(
+                  -f focused_release_evidence_run_id="${FOCUSED_RELEASE_EVIDENCE_RUN_ID}"
+                  -f focused_release_evidence_run_attempt="${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}"
+                )
+              else
+                evidence_args+=(
+                  -f full_release_validation_run_id="${FULL_RELEASE_VALIDATION_RUN_ID}"
+                  -f full_release_validation_run_attempt="${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}"
+                )
+              fi
               openclaw_npm_run_id="$(dispatch_workflow openclaw-npm-release.yml \
                 -f tag="${RELEASE_TAG}" \
                 -f preflight_only=false \
                 -f preflight_run_id="${PREFLIGHT_RUN_ID}" \
-                -f full_release_validation_run_id="${FULL_RELEASE_VALIDATION_RUN_ID}" \
-                -f full_release_validation_run_attempt="${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" \
                 -f release_publish_run_id="${GITHUB_RUN_ID}" \
                 -f release_publish_run_attempt="${GITHUB_RUN_ATTEMPT}" \
                 -f plugin_sdk_api_acknowledgement="${PLUGIN_SDK_API_ACKNOWLEDGEMENT}" \
-                -f npm_dist_tag="${RELEASE_NPM_DIST_TAG}")"
+                -f npm_dist_tag="${RELEASE_NPM_DIST_TAG}" \
+                "${evidence_args[@]}")"
               echo "- OpenClaw npm run ID: \`${openclaw_npm_run_id}\`" >> "$GITHUB_STEP_SUMMARY"
             fi
           else

--- a/scripts/authorized-beta-focused-policy.json
+++ b/scripts/authorized-beta-focused-policy.json
@@ -1,0 +1,77 @@
+{
+  "schema": "openclaw.authorized-beta-focused-policy.v1",
+  "mode": "authorized-beta-focused-v1",
+  "releaseTag": "v2026.8.1-beta.3",
+  "releaseVersion": "2026.8.1-beta.3",
+  "baseCandidateSha": "3203a6f7f8d79644fde2b4f091a694f4c1698538",
+  "candidateSha": "3fbe94065c2b94f4c08acb6742a69938bf408d94",
+  "reviewedHeadSha": "e347223a5858bda5907acda858404e5f7a4c3720",
+  "candidateTreeSha": "71fb83bcab002be3da4057e7cffacf77d4cdbd2d",
+  "baseTreeSha": "10d1f3ab0ff52383c025c5846427e0dd5d14598a",
+  "packageProjectionSha256": "d1d8f60b8a14aeb567a0d5215a6b0265c74a07ebea04b288e43c31cba473bbca",
+  "eligibilityPlanDigest": "sha256:e05226cfd77716b262882b3e2525037a506cd8b6af2affa0a876499074b1671b",
+  "historicalToolingSha": "eed27fdb88c0c60cb79c5b159a0284bd519271c2",
+  "historicalToolingRef": "refs/tags/release-publish/eed27fdb88c0-1787493831",
+  "historicalFrv": {
+    "runId": "32644377679",
+    "runAttempt": 1,
+    "workflowPath": ".github/workflows/full-release-validation.yml",
+    "workflowRef": "release-ci/eed27fdb88c0-1787493942617",
+    "targetSha": "3203a6f7f8d79644fde2b4f091a694f4c1698538",
+    "ciRunId": "32644407381",
+    "ciFailedJobId": "97206458686",
+    "ciAggregateJobId": "97216945772",
+    "pluginRunId": "32645134710",
+    "pluginFailedJobId": "97208293666",
+    "pluginAggregateJobId": "97210400113",
+    "releaseChecksRunId": "32645133620",
+    "releaseChecksVerifierJobId": "97211299203",
+    "performanceRunId": "32644407718",
+    "performanceFailedJobId": "97206336416"
+  },
+  "focusedProof": {
+    "ciRunId": "32664685168",
+    "ciTargetLogJobId": "97256163016",
+    "ciSuccessJobId": "97256296219",
+    "pluginRunId": "32664686635",
+    "pluginTargetLogJobId": "97256164326",
+    "pluginSuccessJobId": "97256329353"
+  },
+  "changedPaths": [
+    {
+      "path": "extensions/slack/src/monitor.test-helpers.ts",
+      "status": "M",
+      "added": 12,
+      "deleted": 18
+    },
+    {
+      "path": "extensions/slack/src/monitor/provider.auth-test-token.test.ts",
+      "status": "M",
+      "added": 10,
+      "deleted": 569
+    },
+    {
+      "path": "extensions/slack/src/monitor/provider.event-identity-recovery.test.ts",
+      "status": "D",
+      "added": 0,
+      "deleted": 155
+    },
+    {
+      "path": "extensions/slack/src/monitor/provider.identity.test.ts",
+      "status": "A",
+      "added": 658,
+      "deleted": 0
+    }
+  ],
+  "inventory": {
+    "npmCount": 93,
+    "npmNamesSha256": "778eb6aeb324c02942e17755557ff9d5055376fb4d39096a60022f0ae75d67f3",
+    "clawHubCount": 89,
+    "clawHubNamesSha256": "1b161a4fde3c003e23db306d4a86908086caac1cd33e75feeaf27474366c1c2b",
+    "trustedPublisherCount": 75,
+    "trustedPublisherNamesSha256": "4266416f20fe5c8b7a4ce732121a2206fc8cfa6af25deae0aec70d552ceb5df8",
+    "bootstrapCount": 14,
+    "bootstrapNamesSha256": "83c79c6099d12dc2ebb58e2fc5ca8e078776dfa21b50dee741bac6aed5526eef",
+    "missingTrustedPublisherCount": 0
+  }
+}

--- a/scripts/validate-authorized-beta-focused-evidence.d.mts
+++ b/scripts/validate-authorized-beta-focused-evidence.d.mts
@@ -1,0 +1,127 @@
+export type AuthorizedBetaFocusedPolicy = {
+  schema: string;
+  mode: string;
+  releaseTag: string;
+  releaseVersion: string;
+  baseCandidateSha: string;
+  candidateSha: string;
+  reviewedHeadSha: string;
+  candidateTreeSha: string;
+  baseTreeSha: string;
+  packageProjectionSha256: string;
+  eligibilityPlanDigest: string;
+  historicalToolingSha: string;
+  historicalToolingRef: string;
+  historicalFrv: {
+    runId: string;
+    runAttempt: number;
+    workflowPath: string;
+    workflowRef: string;
+    targetSha: string;
+    ciRunId: string;
+    ciFailedJobId: string;
+    ciAggregateJobId: string;
+    pluginRunId: string;
+    pluginFailedJobId: string;
+    pluginAggregateJobId: string;
+    releaseChecksRunId: string;
+    releaseChecksVerifierJobId: string;
+    performanceRunId: string;
+    performanceFailedJobId: string;
+  };
+  focusedProof: {
+    ciRunId: string;
+    ciTargetLogJobId: string;
+    ciSuccessJobId: string;
+    pluginRunId: string;
+    pluginTargetLogJobId: string;
+    pluginSuccessJobId: string;
+  };
+  changedPaths: Array<{
+    path: string;
+    status: string;
+    added: number;
+    deleted: number;
+  }>;
+  inventory: {
+    npmCount: number;
+    npmNamesSha256: string;
+    clawHubCount: number;
+    clawHubNamesSha256: string;
+    trustedPublisherCount: number;
+    trustedPublisherNamesSha256: string;
+    bootstrapCount: number;
+    bootstrapNamesSha256: string;
+    missingTrustedPublisherCount: number;
+  };
+};
+
+export type AuthorizedBetaFocusedProducerIdentity = {
+  repository: string;
+  runId: string;
+  runAttempt: number;
+  workflowPath: string;
+  workflowFullRef: string;
+  workflowRef: string;
+  workflowSha: string;
+};
+
+export type AuthorizedBetaFocusedEvidence = {
+  schema: "openclaw.authorized-beta-focused-evidence.v1";
+  mode: "authorized-beta-focused-v1";
+  policySha256: string;
+  releaseTag: string;
+  candidate: {
+    sha: string;
+    parentSha: string;
+    treeSha: string;
+    packageProjectionSha256: string;
+    changedPaths: AuthorizedBetaFocusedPolicy["changedPaths"];
+  };
+  producer: AuthorizedBetaFocusedProducerIdentity;
+  historical: {
+    frvRunId: string;
+    frvRunAttempt: number;
+    releaseChecksRunId: string;
+    performanceRunId: string;
+  };
+  focused: {
+    ciRunId: string;
+    ciJobId: string;
+    pluginRunId: string;
+    pluginJobId: string;
+    reviewedHeadSha: string;
+  };
+  inventory: {
+    eligibilityPlanDigest: string;
+    npmCount: number;
+    npmNamesSha256: string;
+    clawHubCount: number;
+    clawHubNamesSha256: string;
+    trustedPublisherCount: number;
+    trustedPublisherNamesSha256: string;
+    bootstrapCount: number;
+    bootstrapNamesSha256: string;
+    missingTrustedPublisherCount: number;
+  };
+};
+
+export declare function readAuthorizedBetaFocusedPolicy(): AuthorizedBetaFocusedPolicy;
+export declare function digestAuthorizedBetaFocusedPolicy(
+  policy: AuthorizedBetaFocusedPolicy,
+): string;
+export declare function assertAuthorizedEligibilityPlanDigest(
+  plan: unknown,
+  expectedDigest: string,
+): Promise<string>;
+export declare function digestAuthorizedPackageNames(names: string[]): string;
+export declare function assertAuthorizedBetaFocusedCandidate(
+  policy: AuthorizedBetaFocusedPolicy,
+  candidateRoot: string,
+): void;
+export declare function validateAuthorizedBetaFocusedArtifactShape(
+  evidence: AuthorizedBetaFocusedEvidence,
+  policy: AuthorizedBetaFocusedPolicy,
+  producer: AuthorizedBetaFocusedProducerIdentity,
+  expectedInventory: AuthorizedBetaFocusedEvidence["inventory"],
+): void;

--- a/scripts/validate-authorized-beta-focused-evidence.mts
+++ b/scripts/validate-authorized-beta-focused-evidence.mts
@@ -1,0 +1,867 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { isRecord } from "./lib/record-shared.mjs";
+
+type JsonRecord = Record<string, unknown>;
+export type AuthorizedBetaFocusedPolicy = {
+  schema: string;
+  mode: string;
+  releaseTag: string;
+  releaseVersion: string;
+  baseCandidateSha: string;
+  candidateSha: string;
+  reviewedHeadSha: string;
+  candidateTreeSha: string;
+  baseTreeSha: string;
+  packageProjectionSha256: string;
+  eligibilityPlanDigest: string;
+  historicalToolingSha: string;
+  historicalToolingRef: string;
+  historicalFrv: {
+    runId: string;
+    runAttempt: number;
+    workflowPath: string;
+    workflowRef: string;
+    targetSha: string;
+    ciRunId: string;
+    ciFailedJobId: string;
+    ciAggregateJobId: string;
+    pluginRunId: string;
+    pluginFailedJobId: string;
+    pluginAggregateJobId: string;
+    releaseChecksRunId: string;
+    releaseChecksVerifierJobId: string;
+    performanceRunId: string;
+    performanceFailedJobId: string;
+  };
+  focusedProof: {
+    ciRunId: string;
+    ciTargetLogJobId: string;
+    ciSuccessJobId: string;
+    pluginRunId: string;
+    pluginTargetLogJobId: string;
+    pluginSuccessJobId: string;
+  };
+  changedPaths: Array<{
+    path: string;
+    status: string;
+    added: number;
+    deleted: number;
+  }>;
+  inventory: {
+    npmCount: number;
+    npmNamesSha256: string;
+    clawHubCount: number;
+    clawHubNamesSha256: string;
+    trustedPublisherCount: number;
+    trustedPublisherNamesSha256: string;
+    bootstrapCount: number;
+    bootstrapNamesSha256: string;
+    missingTrustedPublisherCount: number;
+  };
+};
+
+export type AuthorizedBetaFocusedProducerIdentity = {
+  repository: string;
+  runId: string;
+  runAttempt: number;
+  workflowPath: string;
+  workflowFullRef: string;
+  workflowRef: string;
+  workflowSha: string;
+};
+
+export type AuthorizedBetaFocusedEvidence = {
+  schema: "openclaw.authorized-beta-focused-evidence.v1";
+  mode: "authorized-beta-focused-v1";
+  policySha256: string;
+  releaseTag: string;
+  candidate: {
+    sha: string;
+    parentSha: string;
+    treeSha: string;
+    packageProjectionSha256: string;
+    changedPaths: AuthorizedBetaFocusedPolicy["changedPaths"];
+  };
+  producer: AuthorizedBetaFocusedProducerIdentity;
+  historical: {
+    frvRunId: string;
+    frvRunAttempt: number;
+    releaseChecksRunId: string;
+    performanceRunId: string;
+  };
+  focused: {
+    ciRunId: string;
+    ciJobId: string;
+    pluginRunId: string;
+    pluginJobId: string;
+    reviewedHeadSha: string;
+  };
+  inventory: {
+    eligibilityPlanDigest: string;
+    npmCount: number;
+    npmNamesSha256: string;
+    clawHubCount: number;
+    clawHubNamesSha256: string;
+    trustedPublisherCount: number;
+    trustedPublisherNamesSha256: string;
+    bootstrapCount: number;
+    bootstrapNamesSha256: string;
+    missingTrustedPublisherCount: number;
+  };
+};
+
+const SCRIPT_ROOT = dirname(fileURLToPath(import.meta.url));
+const POLICY_PATH = resolve(SCRIPT_ROOT, "authorized-beta-focused-policy.json");
+const REPOSITORY = "openclaw/openclaw";
+const PRODUCER_WORKFLOW = ".github/workflows/authorized-beta-focused-validation.yml";
+const SHA_PATTERN = /^[a-f0-9]{40}$/u;
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/u;
+const PROTECTED_TAG_PATTERN = /^refs\/tags\/release-publish\/([a-f0-9]{12})-[1-9][0-9]*$/u;
+
+function fail(message: string): never {
+  throw new Error(message);
+}
+
+function exactString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function exactPositiveInteger(value: unknown, label: string): number {
+  const normalized = typeof value === "number" ? String(value) : exactString(value, label);
+  if (!POSITIVE_INTEGER_PATTERN.test(normalized)) {
+    fail(`${label} must be a positive integer`);
+  }
+  return Number(normalized);
+}
+
+function exactJsonId(value: unknown, label: string): string {
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return String(value);
+  }
+  return exactString(value, label);
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value)
+      .toSorted(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function digestAuthorizedBetaFocusedPolicy(policy: AuthorizedBetaFocusedPolicy): string {
+  return sha256(stableJson(policy));
+}
+
+export async function assertAuthorizedEligibilityPlanDigest(
+  plan: unknown,
+  expectedDigest: string,
+): Promise<string> {
+  const { createReleasePlanLock } = await import("./release-plan-contract.mjs");
+  const digest = createReleasePlanLock(plan).digest;
+  if (digest !== expectedDigest) {
+    fail(`authorized eligibility plan digest mismatch: expected ${expectedDigest}, got ${digest}`);
+  }
+  return digest;
+}
+
+export function readAuthorizedBetaFocusedPolicy(): AuthorizedBetaFocusedPolicy {
+  return JSON.parse(readFileSync(POLICY_PATH, "utf8")) as AuthorizedBetaFocusedPolicy;
+}
+
+function git(repoRoot: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  }).trimEnd();
+}
+
+function gh(args: string[]): string {
+  return execFileSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+}
+
+function ghJson(endpoint: string): JsonRecord {
+  const value: unknown = JSON.parse(gh(["api", endpoint]));
+  if (!isRecord(value)) {
+    fail(`${endpoint} must be an object`);
+  }
+  return value;
+}
+
+function normalizeRun(run: JsonRecord) {
+  return {
+    id: exactJsonId(run.id, "run id"),
+    attempt: exactPositiveInteger(run.run_attempt, "run attempt"),
+    name: exactString(run.name, "run name"),
+    path: exactString(run.path, "run path").split("@", 1)[0] ?? "",
+    event: exactString(run.event, "run event"),
+    status: exactString(run.status, "run status"),
+    conclusion:
+      run.conclusion === null || run.conclusion === undefined
+        ? ""
+        : exactString(run.conclusion, "run conclusion"),
+    headBranch: exactString(run.head_branch, "run head branch"),
+    headSha: exactString(run.head_sha, "run head SHA"),
+  };
+}
+
+function normalizeJob(job: JsonRecord) {
+  return {
+    id: exactJsonId(job.id, "job id"),
+    runId: exactJsonId(job.run_id, "job run id"),
+    name: exactString(job.name, "job name"),
+    status: exactString(job.status, "job status"),
+    conclusion:
+      job.conclusion === null || job.conclusion === undefined
+        ? ""
+        : exactString(job.conclusion, "job conclusion"),
+    headSha: exactString(job.head_sha, "job head SHA"),
+  };
+}
+
+function requireRun(params: {
+  runId: string;
+  attempt: number;
+  name: string;
+  path: string;
+  headBranch: string;
+  headSha: string;
+  conclusion?: string;
+  allowInProgress?: boolean;
+}) {
+  const run = normalizeRun(ghJson(`repos/${REPOSITORY}/actions/runs/${params.runId}`));
+  const checks: Array<[string, string | number, string | number]> = [
+    ["id", run.id, params.runId],
+    ["attempt", run.attempt, params.attempt],
+    ["name", run.name, params.name],
+    ["path", run.path, params.path],
+    ["event", run.event, "workflow_dispatch"],
+    ["headBranch", run.headBranch, params.headBranch],
+    ["headSha", run.headSha, params.headSha],
+  ];
+  for (const [label, actual, expected] of checks) {
+    if (actual !== expected) {
+      fail(`run ${params.runId} ${label} mismatch: expected ${expected}, got ${actual}`);
+    }
+  }
+  if (params.allowInProgress) {
+    if (!["in_progress", "queued", "completed"].includes(run.status)) {
+      fail(`run ${params.runId} has unsupported producer status ${run.status}`);
+    }
+  } else if (run.status !== "completed" || run.conclusion !== (params.conclusion ?? "success")) {
+    fail(
+      `run ${params.runId} must be completed/${params.conclusion ?? "success"}, got ${run.status}/${run.conclusion}`,
+    );
+  }
+  return run;
+}
+
+function requireJob(params: {
+  jobId: string;
+  runId: string;
+  name: string;
+  conclusion: string;
+  headSha: string;
+}) {
+  const job = normalizeJob(ghJson(`repos/${REPOSITORY}/actions/jobs/${params.jobId}`));
+  const checks: Array<[string, string, string]> = [
+    ["id", job.id, params.jobId],
+    ["runId", job.runId, params.runId],
+    ["name", job.name, params.name],
+    ["status", job.status, "completed"],
+    ["conclusion", job.conclusion, params.conclusion],
+    ["headSha", job.headSha, params.headSha],
+  ];
+  for (const [label, actual, expected] of checks) {
+    if (actual !== expected) {
+      fail(`job ${params.jobId} ${label} mismatch: expected ${expected}, got ${actual}`);
+    }
+  }
+}
+
+function requireJobLogTarget(jobId: string, targetSha: string) {
+  const log = gh(["api", `repos/${REPOSITORY}/actions/jobs/${jobId}/logs`]);
+  if (!log.includes(targetSha)) {
+    fail(`job ${jobId} log does not bind target ${targetSha}`);
+  }
+}
+
+function requireHistoricalExecutionPlan(policy: AuthorizedBetaFocusedPolicy) {
+  const historical = policy.historicalFrv;
+  const directory = mkdtempSync(join(tmpdir(), "authorized-beta-focused-plan-"));
+  try {
+    gh([
+      "run",
+      "download",
+      historical.runId,
+      "--repo",
+      REPOSITORY,
+      "--name",
+      `full-release-execution-plan-${historical.runId}`,
+      "--dir",
+      directory,
+    ]);
+    const planValue: unknown = JSON.parse(
+      readFileSync(join(directory, "full-release-execution-plan.json"), "utf8"),
+    );
+    if (!isRecord(planValue)) {
+      fail("historical full release execution plan must be an object");
+    }
+    const plan = planValue;
+    const checks: Array<[string, unknown, string | number]> = [
+      ["parentRunId", plan.parentRunId, historical.runId],
+      ["parentRunAttempt", plan.parentRunAttempt, historical.runAttempt],
+      ["workflowRef", plan.workflowRef, historical.workflowRef],
+      ["workflowSha", plan.workflowSha, policy.historicalToolingSha],
+      ["targetSha", plan.targetSha, historical.targetSha],
+      ["releaseProfile", plan.releaseProfile, "beta"],
+      ["rerunGroup", plan.rerunGroup, "all"],
+    ];
+    for (const [label, actual, expected] of checks) {
+      if (actual !== expected) {
+        fail(
+          `historical execution plan ${label} mismatch: expected ${expected}, got ${JSON.stringify(actual)}`,
+        );
+      }
+    }
+    if (!Array.isArray(plan.children)) {
+      fail("historical execution plan children must be an array");
+    }
+    const childRuns = new Map(
+      plan.children.map((entry: unknown) => {
+        if (!isRecord(entry)) {
+          fail("historical execution plan child must be an object");
+        }
+        return [
+          exactString(entry.key, "historical execution plan child key"),
+          exactJsonId(entry.runId, "historical execution plan child run id"),
+        ];
+      }),
+    );
+    const expectedChildren = new Map([
+      ["normalCi", historical.ciRunId],
+      ["pluginPrerelease", historical.pluginRunId],
+      ["releaseChecks", historical.releaseChecksRunId],
+      ["productPerformance", historical.performanceRunId],
+    ]);
+    for (const [key, expectedRunId] of expectedChildren) {
+      if (childRuns.get(key) !== expectedRunId) {
+        fail(`historical execution plan child ${key} must be run ${expectedRunId}`);
+      }
+    }
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+export function digestAuthorizedPackageNames(names: string[]): string {
+  const sorted = [...names].toSorted();
+  if (new Set(sorted).size !== sorted.length) {
+    fail("package inventory contains duplicate names");
+  }
+  return sha256(`${sorted.join("\n")}\n`);
+}
+
+export function assertAuthorizedBetaFocusedCandidate(
+  policy: AuthorizedBetaFocusedPolicy,
+  candidateRoot: string,
+) {
+  const actualHead = git(candidateRoot, ["rev-parse", "HEAD"]);
+  if (actualHead !== policy.candidateSha) {
+    fail(`candidate checkout must be ${policy.candidateSha}, got ${actualHead}`);
+  }
+  const parents = git(candidateRoot, ["rev-list", "--parents", "-n1", policy.candidateSha]).split(
+    " ",
+  );
+  if (parents.length !== 2 || parents[1] !== policy.baseCandidateSha) {
+    fail("candidate must be the direct child of the frozen base candidate");
+  }
+  const candidateTree = git(candidateRoot, ["rev-parse", `${policy.candidateSha}^{tree}`]);
+  const baseTree = git(candidateRoot, ["rev-parse", `${policy.baseCandidateSha}^{tree}`]);
+  try {
+    git(candidateRoot, ["cat-file", "-e", `${policy.reviewedHeadSha}^{commit}`]);
+  } catch {
+    git(candidateRoot, ["fetch", "--no-tags", "origin", policy.reviewedHeadSha]);
+  }
+  const reviewedTree = git(candidateRoot, ["rev-parse", `${policy.reviewedHeadSha}^{tree}`]);
+  if (
+    candidateTree !== policy.candidateTreeSha ||
+    baseTree !== policy.baseTreeSha ||
+    reviewedTree !== candidateTree
+  ) {
+    fail("candidate/base/reviewed tree identity does not match the authorized policy");
+  }
+
+  const statuses = new Map(
+    git(candidateRoot, [
+      "diff",
+      "--name-status",
+      "--no-renames",
+      policy.baseCandidateSha,
+      policy.candidateSha,
+    ])
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const [status, path] = line.split("\t");
+        return [path, status];
+      }),
+  );
+  const numstat = new Map(
+    git(candidateRoot, ["diff", "--numstat", policy.baseCandidateSha, policy.candidateSha])
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const [added, deleted, path] = line.split("\t");
+        return [path, { added: Number(added), deleted: Number(deleted) }];
+      }),
+  );
+  if (statuses.size !== policy.changedPaths.length || numstat.size !== policy.changedPaths.length) {
+    fail("candidate changed-path count does not match the authorized policy");
+  }
+  for (const expected of policy.changedPaths) {
+    const actualNumstat = numstat.get(expected.path);
+    if (
+      statuses.get(expected.path) !== expected.status ||
+      actualNumstat?.added !== expected.added ||
+      actualNumstat.deleted !== expected.deleted
+    ) {
+      fail(`candidate diff does not match authorized path ${expected.path}`);
+    }
+  }
+
+  const excluded = new Set(policy.changedPaths.map((entry) => entry.path));
+  const projection = git(candidateRoot, ["ls-tree", "-r", policy.candidateSha])
+    .split("\n")
+    .filter((line) => line && !excluded.has(line.slice(line.indexOf("\t") + 1)))
+    .join("\n");
+  const projectionDigest = sha256(`${projection}\n`);
+  if (projectionDigest !== policy.packageProjectionSha256) {
+    fail("candidate published-byte projection digest does not match the authorized policy");
+  }
+}
+
+function assertHistoricalAndFocusedEvidence(policy: AuthorizedBetaFocusedPolicy) {
+  const historical = policy.historicalFrv;
+  requireHistoricalExecutionPlan(policy);
+  requireRun({
+    runId: historical.runId,
+    attempt: historical.runAttempt,
+    name: "Full Release Validation",
+    path: historical.workflowPath,
+    headBranch: historical.workflowRef,
+    headSha: policy.historicalToolingSha,
+    conclusion: "failure",
+  });
+  requireRun({
+    runId: historical.ciRunId,
+    attempt: 1,
+    name: `CI full-release-validation-${historical.runId}-${historical.runAttempt}-ci`,
+    path: ".github/workflows/ci.yml",
+    headBranch: historical.workflowRef,
+    headSha: policy.historicalToolingSha,
+    conclusion: "failure",
+  });
+  requireJob({
+    jobId: historical.ciFailedJobId,
+    runId: historical.ciRunId,
+    name: "check-lint",
+    conclusion: "failure",
+    headSha: policy.historicalToolingSha,
+  });
+  requireJob({
+    jobId: historical.ciAggregateJobId,
+    runId: historical.ciRunId,
+    name: "openclaw/ci-gate",
+    conclusion: "failure",
+    headSha: policy.historicalToolingSha,
+  });
+  requireRun({
+    runId: historical.pluginRunId,
+    attempt: 1,
+    name: `Plugin Prerelease full-release-validation-${historical.runId}-${historical.runAttempt}-plugin-prerelease`,
+    path: ".github/workflows/plugin-prerelease.yml",
+    headBranch: historical.workflowRef,
+    headSha: policy.historicalToolingSha,
+    conclusion: "failure",
+  });
+  requireJob({
+    jobId: historical.pluginFailedJobId,
+    runId: historical.pluginRunId,
+    name: "checks-node-extensions-shard-7",
+    conclusion: "failure",
+    headSha: policy.historicalToolingSha,
+  });
+  requireJob({
+    jobId: historical.pluginAggregateJobId,
+    runId: historical.pluginRunId,
+    name: "plugin-prerelease-suite",
+    conclusion: "failure",
+    headSha: policy.historicalToolingSha,
+  });
+  requireRun({
+    runId: historical.releaseChecksRunId,
+    attempt: 1,
+    name: `OpenClaw Release Checks full-release-validation-${historical.runId}-${historical.runAttempt}-release-checks`,
+    path: ".github/workflows/openclaw-release-checks.yml",
+    headBranch: historical.workflowRef,
+    headSha: policy.historicalToolingSha,
+  });
+  requireJob({
+    jobId: historical.releaseChecksVerifierJobId,
+    runId: historical.releaseChecksRunId,
+    name: "Verify release checks",
+    conclusion: "success",
+    headSha: policy.historicalToolingSha,
+  });
+  requireRun({
+    runId: historical.performanceRunId,
+    attempt: 1,
+    name: `OpenClaw Performance full-release-validation-${historical.runId}-${historical.runAttempt}`,
+    path: ".github/workflows/openclaw-performance.yml",
+    headBranch: historical.workflowRef,
+    headSha: policy.historicalToolingSha,
+    conclusion: "failure",
+  });
+  requireJob({
+    jobId: historical.performanceFailedJobId,
+    runId: historical.performanceRunId,
+    name: "OpenClaw source performance probes",
+    conclusion: "failure",
+    headSha: policy.historicalToolingSha,
+  });
+
+  const focused = policy.focusedProof;
+  requireRun({
+    runId: focused.ciRunId,
+    attempt: 1,
+    name: "CI beta3-slack-proof-e347223a",
+    path: ".github/workflows/ci.yml",
+    headBranch: policy.historicalToolingRef.replace("refs/tags/", ""),
+    headSha: policy.historicalToolingSha,
+    allowInProgress: true,
+  });
+  requireJob({
+    jobId: focused.ciSuccessJobId,
+    runId: focused.ciRunId,
+    name: "check-lint",
+    conclusion: "success",
+    headSha: policy.historicalToolingSha,
+  });
+  requireJob({
+    jobId: focused.ciTargetLogJobId,
+    runId: focused.ciRunId,
+    name: "preflight",
+    conclusion: "success",
+    headSha: policy.historicalToolingSha,
+  });
+  requireJobLogTarget(focused.ciTargetLogJobId, policy.reviewedHeadSha);
+  requireRun({
+    runId: focused.pluginRunId,
+    attempt: 1,
+    name: "Plugin Prerelease beta3-slack-proof-e347223a",
+    path: ".github/workflows/plugin-prerelease.yml",
+    headBranch: policy.historicalToolingRef.replace("refs/tags/", ""),
+    headSha: policy.historicalToolingSha,
+    conclusion: "failure",
+  });
+  requireJob({
+    jobId: focused.pluginSuccessJobId,
+    runId: focused.pluginRunId,
+    name: "checks-node-extensions-shard-7",
+    conclusion: "success",
+    headSha: policy.historicalToolingSha,
+  });
+  requireJob({
+    jobId: focused.pluginTargetLogJobId,
+    runId: focused.pluginRunId,
+    name: "Build plugin prerelease plan",
+    conclusion: "success",
+    headSha: policy.historicalToolingSha,
+  });
+  requireJobLogTarget(focused.pluginTargetLogJobId, policy.reviewedHeadSha);
+}
+
+function producerIdentity(args: ParsedArgs): AuthorizedBetaFocusedProducerIdentity {
+  const workflowFullRef = exactString(args["producer-workflow-full-ref"], "producer workflow ref");
+  const workflowSha = exactString(args["producer-workflow-sha"], "producer workflow SHA");
+  const protectedTag = PROTECTED_TAG_PATTERN.exec(workflowFullRef);
+  if (
+    !SHA_PATTERN.test(workflowSha) ||
+    !protectedTag ||
+    protectedTag[1] !== workflowSha.slice(0, 12)
+  ) {
+    fail("focused evidence producer must use a SHA-bound protected release-publish tag");
+  }
+  return {
+    repository: REPOSITORY,
+    runId: exactString(args["producer-run-id"], "producer run id"),
+    runAttempt: exactPositiveInteger(args["producer-run-attempt"], "producer run attempt"),
+    workflowPath: PRODUCER_WORKFLOW,
+    workflowFullRef,
+    workflowRef: workflowFullRef.replace("refs/tags/", ""),
+    workflowSha,
+  };
+}
+
+function assertProducer(identity: AuthorizedBetaFocusedProducerIdentity, allowInProgress: boolean) {
+  requireRun({
+    runId: identity.runId,
+    attempt: identity.runAttempt,
+    name: "Authorized Beta Focused Validation",
+    path: identity.workflowPath,
+    headBranch: identity.workflowRef,
+    headSha: identity.workflowSha,
+    allowInProgress,
+  });
+  const ref = ghJson(`repos/${REPOSITORY}/git/ref/tags/${identity.workflowRef}`);
+  if (!isRecord(ref.object)) {
+    fail("protected tooling tag object must be an object");
+  }
+  const object = ref.object;
+  if (object.type !== "commit" || object.sha !== identity.workflowSha) {
+    fail("protected focused-evidence tooling tag does not resolve to the producer SHA");
+  }
+}
+
+async function produceAuthorizedEligibilityPlan(
+  policy: AuthorizedBetaFocusedPolicy,
+  candidateRoot: string,
+) {
+  const directory = mkdtempSync(join(tmpdir(), "authorized-beta-focused-tooling-"));
+  const toolingRoot = join(directory, "tooling");
+  try {
+    // The producer binds its execution checkout to toolingSha. Run the frozen
+    // producer itself so this evidence cannot substitute the current workflow.
+    git(candidateRoot, [
+      "clone",
+      "--quiet",
+      "--shared",
+      "--no-checkout",
+      candidateRoot,
+      toolingRoot,
+    ]);
+    git(toolingRoot, ["checkout", "--quiet", "--detach", policy.historicalToolingSha]);
+    symlinkSync(
+      resolve(SCRIPT_ROOT, "..", "node_modules"),
+      join(toolingRoot, "node_modules"),
+      "dir",
+    );
+    const lockJson = execFileSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "scripts/release-plan-producer.mts",
+        "--intent",
+        "publish",
+        "--candidate-sha",
+        policy.candidateSha,
+        "--candidate-ref",
+        `refs/tags/${policy.releaseTag}`,
+        "--tooling-sha",
+        policy.historicalToolingSha,
+        "--tooling-full-ref",
+        policy.historicalToolingRef,
+      ],
+      {
+        cwd: toolingRoot,
+        encoding: "utf8",
+        env: process.env,
+        maxBuffer: 16 * 1024 * 1024,
+      },
+    );
+    const { parseReleasePlanLockJson } = await import("./release-plan-contract.mjs");
+    return parseReleasePlanLockJson(lockJson).plan;
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+}
+
+async function collectInventory(
+  policy: AuthorizedBetaFocusedPolicy,
+  candidateRoot: string,
+  includeTrust: boolean,
+) {
+  const plan = await produceAuthorizedEligibilityPlan(policy, candidateRoot);
+  const eligibilityPlanDigest = await assertAuthorizedEligibilityPlanDigest(
+    plan,
+    policy.eligibilityPlanDigest,
+  );
+  const npmNames = plan.inventory.packages
+    .filter((entry) => entry.targets.includes("npm"))
+    .map((entry) => entry.name);
+  const clawHubNames = plan.inventory.packages
+    .filter((entry) => entry.targets.includes("clawhub"))
+    .map((entry) => entry.name);
+  const inventory = {
+    eligibilityPlanDigest,
+    npmCount: npmNames.length,
+    npmNamesSha256: digestAuthorizedPackageNames(npmNames),
+    clawHubCount: clawHubNames.length,
+    clawHubNamesSha256: digestAuthorizedPackageNames(clawHubNames),
+    trustedPublisherCount: policy.inventory.trustedPublisherCount,
+    trustedPublisherNamesSha256: policy.inventory.trustedPublisherNamesSha256,
+    bootstrapCount: policy.inventory.bootstrapCount,
+    bootstrapNamesSha256: policy.inventory.bootstrapNamesSha256,
+    missingTrustedPublisherCount: policy.inventory.missingTrustedPublisherCount,
+  };
+  if (includeTrust) {
+    const { collectPluginClawHubReleasePlan } = await import("./lib/plugin-clawhub-release.ts");
+    const trustPlan = await collectPluginClawHubReleasePlan({
+      rootDir: candidateRoot,
+      selectionMode: "all-publishable",
+    });
+    const trusted = trustPlan.candidates.map((entry) => entry.packageName);
+    const bootstrap = [...trustPlan.bootstrapCandidates, ...trustPlan.missingTrustedPublisher].map(
+      (entry) => entry.packageName,
+    );
+    inventory.trustedPublisherCount = trusted.length;
+    inventory.trustedPublisherNamesSha256 = digestAuthorizedPackageNames(trusted);
+    inventory.bootstrapCount = bootstrap.length;
+    inventory.bootstrapNamesSha256 = digestAuthorizedPackageNames(bootstrap);
+    inventory.missingTrustedPublisherCount = trustPlan.missingTrustedPublisher.length;
+  }
+  for (const [key, expected] of Object.entries(policy.inventory)) {
+    if (inventory[key as keyof typeof inventory] !== expected) {
+      fail(
+        `authorized inventory ${key} mismatch: expected ${expected}, got ${inventory[key as keyof typeof inventory]}`,
+      );
+    }
+  }
+  return inventory;
+}
+
+export function validateAuthorizedBetaFocusedArtifactShape(
+  evidence: AuthorizedBetaFocusedEvidence,
+  policy: AuthorizedBetaFocusedPolicy,
+  producer: AuthorizedBetaFocusedProducerIdentity,
+  expectedInventory: AuthorizedBetaFocusedEvidence["inventory"],
+) {
+  if (
+    evidence.schema !== "openclaw.authorized-beta-focused-evidence.v1" ||
+    evidence.mode !== policy.mode ||
+    evidence.policySha256 !== digestAuthorizedBetaFocusedPolicy(policy) ||
+    evidence.releaseTag !== policy.releaseTag ||
+    stableJson(evidence.producer) !== stableJson(producer)
+  ) {
+    fail("focused evidence artifact identity does not match the fixed policy");
+  }
+  if (
+    evidence.candidate.sha !== policy.candidateSha ||
+    evidence.candidate.parentSha !== policy.baseCandidateSha ||
+    evidence.candidate.treeSha !== policy.candidateTreeSha ||
+    evidence.candidate.packageProjectionSha256 !== policy.packageProjectionSha256 ||
+    stableJson(evidence.candidate.changedPaths) !== stableJson(policy.changedPaths)
+  ) {
+    fail("focused evidence candidate projection does not match the fixed policy");
+  }
+  if (stableJson(evidence.inventory) !== stableJson(expectedInventory)) {
+    fail("focused evidence inventory does not match the repository-derived release plan");
+  }
+}
+
+type ParsedArgs = Record<string, string>;
+
+function parseArgs(argv: string[]) {
+  const [command, ...rest] = argv;
+  if (command !== "create" && command !== "verify") {
+    fail("usage: validate-authorized-beta-focused-evidence.mts <create|verify> [options]");
+  }
+  const args: ParsedArgs = {};
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index];
+    const value = rest[index + 1];
+    if (!key?.startsWith("--") || !value || value.startsWith("--")) {
+      fail(`invalid argument near ${key ?? "<missing>"}`);
+    }
+    args[key.slice(2)] = value;
+  }
+  return { command, args } as const;
+}
+
+async function main() {
+  const { command, args } = parseArgs(process.argv.slice(2));
+  const policy = readAuthorizedBetaFocusedPolicy();
+  const candidateRoot = resolve(exactString(args["candidate-root"], "candidate root"));
+  const artifactPath = resolve(exactString(args.artifact ?? args.output, "artifact path"));
+  const producer = producerIdentity(args);
+  assertAuthorizedBetaFocusedCandidate(policy, candidateRoot);
+  assertProducer(producer, command === "create");
+  assertHistoricalAndFocusedEvidence(policy);
+
+  if (command === "create") {
+    const inventory = await collectInventory(policy, candidateRoot, true);
+    const evidence: AuthorizedBetaFocusedEvidence = {
+      schema: "openclaw.authorized-beta-focused-evidence.v1",
+      mode: "authorized-beta-focused-v1",
+      policySha256: digestAuthorizedBetaFocusedPolicy(policy),
+      releaseTag: policy.releaseTag,
+      candidate: {
+        sha: policy.candidateSha,
+        parentSha: policy.baseCandidateSha,
+        treeSha: policy.candidateTreeSha,
+        packageProjectionSha256: policy.packageProjectionSha256,
+        changedPaths: policy.changedPaths,
+      },
+      producer,
+      historical: {
+        frvRunId: policy.historicalFrv.runId,
+        frvRunAttempt: policy.historicalFrv.runAttempt,
+        releaseChecksRunId: policy.historicalFrv.releaseChecksRunId,
+        performanceRunId: policy.historicalFrv.performanceRunId,
+      },
+      focused: {
+        ciRunId: policy.focusedProof.ciRunId,
+        ciJobId: policy.focusedProof.ciSuccessJobId,
+        pluginRunId: policy.focusedProof.pluginRunId,
+        pluginJobId: policy.focusedProof.pluginSuccessJobId,
+        reviewedHeadSha: policy.reviewedHeadSha,
+      },
+      inventory,
+    };
+    writeFileSync(artifactPath, `${stableJson(evidence)}\n`, { flag: "wx" });
+    console.log(`authorized beta focused evidence written: ${artifactPath}`);
+    return;
+  }
+
+  const evidence = JSON.parse(readFileSync(artifactPath, "utf8")) as AuthorizedBetaFocusedEvidence;
+  const inventory = {
+    eligibilityPlanDigest: policy.eligibilityPlanDigest,
+    ...policy.inventory,
+  };
+  validateAuthorizedBetaFocusedArtifactShape(evidence, policy, producer, inventory);
+  console.log(
+    `authorized beta focused evidence verified for ${policy.releaseTag} at ${policy.candidateSha}`,
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : "unknown error");
+    console.error("[authorized-beta-focused-evidence] FAILED (exit 1)");
+    process.exitCode = 1;
+  });
+}

--- a/test/scripts/authorized-beta-focused-evidence.test.ts
+++ b/test/scripts/authorized-beta-focused-evidence.test.ts
@@ -1,0 +1,384 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import {
+  assertAuthorizedEligibilityPlanDigest,
+  assertAuthorizedBetaFocusedCandidate,
+  digestAuthorizedBetaFocusedPolicy,
+  digestAuthorizedPackageNames,
+  readAuthorizedBetaFocusedPolicy,
+  validateAuthorizedBetaFocusedArtifactShape,
+  type AuthorizedBetaFocusedEvidence,
+  type AuthorizedBetaFocusedPolicy,
+  type AuthorizedBetaFocusedProducerIdentity,
+} from "../../scripts/validate-authorized-beta-focused-evidence.mts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+type ParsedWorkflow = {
+  jobs?: Record<
+    string,
+    {
+      steps?: Array<{
+        if?: string;
+        name?: string;
+        run?: string;
+        uses?: string;
+        with?: Record<string, unknown>;
+      }>;
+    }
+  >;
+  on: {
+    workflow_dispatch: null | {
+      inputs: Record<string, { options?: string[] }>;
+    };
+  };
+  permissions?: Record<string, string>;
+};
+
+const REPO_ROOT = resolve(".");
+const VALIDATOR_CLOSURE = [
+  "scripts/authorized-beta-focused-policy.json",
+  "scripts/lib/record-shared.mjs",
+  "scripts/validate-authorized-beta-focused-evidence.mts",
+] as const;
+
+function stageValidatorClosure(root: string, scriptsDirectory: boolean): string {
+  const targetRoot = scriptsDirectory ? join(root, "scripts") : root;
+  for (const sourcePath of VALIDATOR_CLOSURE) {
+    const relativePath = sourcePath.replace(/^scripts\//u, "");
+    const targetPath = join(targetRoot, relativePath);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    copyFileSync(join(REPO_ROOT, sourcePath), targetPath);
+  }
+  return join(targetRoot, "validate-authorized-beta-focused-evidence.mts");
+}
+
+function namedStep(workflow: ParsedWorkflow, jobName: string, stepName: string) {
+  const step = workflow.jobs?.[jobName]?.steps?.find((entry) => entry.name === stepName);
+  if (!step) {
+    throw new Error(`workflow step missing: ${jobName}/${stepName}`);
+  }
+  return step;
+}
+
+function git(root: string, args: string[]): string {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+function commit(root: string, message: string): string {
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "-qm", message], { cwd: root });
+  return git(root, ["rev-parse", "HEAD"]);
+}
+
+function fixturePolicy(): { policy: AuthorizedBetaFocusedPolicy; root: string } {
+  const root = tempDirs.make("authorized-beta-focused-");
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: root });
+  execFileSync("git", ["config", "user.name", "Test"], { cwd: root });
+  writeFileSync(join(root, "published.txt"), "published\n");
+  mkdirSync(join(root, "tests"));
+  writeFileSync(join(root, "tests", "proof.test.ts"), "one\n");
+  const baseCandidateSha = commit(root, "base");
+  writeFileSync(join(root, "tests", "proof.test.ts"), "one\ntwo\n");
+  const candidateSha = commit(root, "proof");
+  const candidateTreeSha = git(root, ["rev-parse", `${candidateSha}^{tree}`]);
+  const baseTreeSha = git(root, ["rev-parse", `${baseCandidateSha}^{tree}`]);
+  const projection = git(root, ["ls-tree", "-r", candidateSha])
+    .split("\n")
+    .filter((line) => !line.endsWith("\ttests/proof.test.ts"))
+    .join("\n");
+  const packageProjectionSha256 = createHash("sha256").update(`${projection}\n`).digest("hex");
+  return {
+    root,
+    policy: {
+      ...readAuthorizedBetaFocusedPolicy(),
+      baseCandidateSha,
+      candidateSha,
+      reviewedHeadSha: candidateSha,
+      candidateTreeSha,
+      baseTreeSha,
+      packageProjectionSha256,
+      changedPaths: [
+        {
+          path: "tests/proof.test.ts",
+          status: "M",
+          added: 1,
+          deleted: 0,
+        },
+      ],
+    },
+  };
+}
+
+describe("authorized beta focused evidence", () => {
+  it("pins the exact beta.3 candidate, inventories, trust split, and repaired leaves", () => {
+    const policy = readAuthorizedBetaFocusedPolicy();
+    expect(policy.releaseTag).toBe("v2026.8.1-beta.3");
+    expect(policy.candidateSha).toBe("3fbe94065c2b94f4c08acb6742a69938bf408d94");
+    expect(policy.baseCandidateSha).toBe("3203a6f7f8d79644fde2b4f091a694f4c1698538");
+    expect(policy.eligibilityPlanDigest).toBe(
+      "sha256:e05226cfd77716b262882b3e2525037a506cd8b6af2affa0a876499074b1671b",
+    );
+    expect(policy.changedPaths).toHaveLength(4);
+    expect(policy.inventory).toMatchObject({
+      npmCount: 93,
+      clawHubCount: 89,
+      trustedPublisherCount: 75,
+      bootstrapCount: 14,
+      missingTrustedPublisherCount: 0,
+    });
+    expect(policy.historicalFrv).toMatchObject({
+      runId: "32644377679",
+      ciFailedJobId: "97206458686",
+      pluginFailedJobId: "97208293666",
+      releaseChecksRunId: "32645133620",
+    });
+    expect(policy.focusedProof).toMatchObject({
+      ciRunId: "32664685168",
+      ciSuccessJobId: "97256296219",
+      pluginRunId: "32664686635",
+      pluginSuccessJobId: "97256329353",
+    });
+  });
+
+  it("binds the direct-child tree, exact diff, and unchanged published projection", () => {
+    const { policy, root } = fixturePolicy();
+    const changedPath = policy.changedPaths[0];
+    if (!changedPath) {
+      throw new Error("fixture policy must include one changed path");
+    }
+    expect(() => assertAuthorizedBetaFocusedCandidate(policy, root)).not.toThrow();
+    expect(() =>
+      assertAuthorizedBetaFocusedCandidate(
+        {
+          ...policy,
+          changedPaths: [{ ...changedPath, added: 2 }],
+        },
+        root,
+      ),
+    ).toThrow("candidate diff does not match authorized path");
+  });
+
+  it("hashes sorted unique package inventories and rejects duplicates", () => {
+    expect(digestAuthorizedPackageNames(["b", "a"])).toBe(
+      createHash("sha256").update("a\nb\n").digest("hex"),
+    );
+    expect(() => digestAuthorizedPackageNames(["a", "a"])).toThrow(
+      "package inventory contains duplicate names",
+    );
+  });
+
+  it("derives the eligibility digest from the canonical full release plan", async () => {
+    const plan = JSON.parse(
+      readFileSync("test/fixtures/release-plan-v1.source.json", "utf8"),
+    ) as unknown;
+    const lock = JSON.parse(
+      readFileSync("test/fixtures/release-plan-lock-v1.compatibility.json", "utf8"),
+    ) as { digest: string };
+    await expect(assertAuthorizedEligibilityPlanDigest(plan, lock.digest)).resolves.toBe(
+      lock.digest,
+    );
+    await expect(
+      assertAuthorizedEligibilityPlanDigest(plan, `sha256:${"0".repeat(64)}`),
+    ).rejects.toThrow("authorized eligibility plan digest mismatch");
+  });
+
+  it.each([
+    { name: "downloaded verifier", scriptsDirectory: false },
+    { name: "sparse scripts checkout", scriptsDirectory: true },
+  ])("executes the $name module closure", ({ scriptsDirectory }) => {
+    const root = tempDirs.make("authorized-beta-focused-stage-");
+    const validatorPath = stageValidatorClosure(root, scriptsDirectory);
+    const probePath = join(root, "probe.mjs");
+    writeFileSync(
+      probePath,
+      [
+        `import { digestAuthorizedBetaFocusedPolicy, readAuthorizedBetaFocusedPolicy, validateAuthorizedBetaFocusedArtifactShape } from ${JSON.stringify(pathToFileURL(validatorPath).href)};`,
+        `const policy = readAuthorizedBetaFocusedPolicy();`,
+        `const producer = { repository: "openclaw/openclaw", runId: "123", runAttempt: 1, workflowPath: ".github/workflows/authorized-beta-focused-validation.yml", workflowFullRef: "refs/tags/release-publish/aaaaaaaaaaaa-1", workflowRef: "release-publish/aaaaaaaaaaaa-1", workflowSha: "a".repeat(40) };`,
+        `const inventory = { eligibilityPlanDigest: policy.eligibilityPlanDigest, ...policy.inventory };`,
+        `const evidence = { schema: "openclaw.authorized-beta-focused-evidence.v1", mode: policy.mode, policySha256: digestAuthorizedBetaFocusedPolicy(policy), releaseTag: policy.releaseTag, candidate: { sha: policy.candidateSha, parentSha: policy.baseCandidateSha, treeSha: policy.candidateTreeSha, packageProjectionSha256: policy.packageProjectionSha256, changedPaths: policy.changedPaths }, producer, historical: { frvRunId: policy.historicalFrv.runId, frvRunAttempt: policy.historicalFrv.runAttempt, releaseChecksRunId: policy.historicalFrv.releaseChecksRunId, performanceRunId: policy.historicalFrv.performanceRunId }, focused: { ciRunId: policy.focusedProof.ciRunId, ciJobId: policy.focusedProof.ciSuccessJobId, pluginRunId: policy.focusedProof.pluginRunId, pluginJobId: policy.focusedProof.pluginSuccessJobId, reviewedHeadSha: policy.reviewedHeadSha }, inventory };`,
+        `validateAuthorizedBetaFocusedArtifactShape(evidence, policy, producer, inventory);`,
+        `process.stdout.write("verified");`,
+      ].join("\n"),
+    );
+    const result = spawnSync(process.execPath, [probePath], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("verified");
+  });
+
+  it("accepts the exact artifact shape and rejects inventory drift", () => {
+    const policy = readAuthorizedBetaFocusedPolicy();
+    const producer: AuthorizedBetaFocusedProducerIdentity = {
+      repository: "openclaw/openclaw",
+      runId: "123",
+      runAttempt: 1,
+      workflowPath: ".github/workflows/authorized-beta-focused-validation.yml",
+      workflowFullRef: "refs/tags/release-publish/aaaaaaaaaaaa-1",
+      workflowRef: "release-publish/aaaaaaaaaaaa-1",
+      workflowSha: "a".repeat(40),
+    };
+    const expectedInventory = {
+      eligibilityPlanDigest: policy.eligibilityPlanDigest,
+      ...policy.inventory,
+    };
+    const evidence = {
+      schema: "openclaw.authorized-beta-focused-evidence.v1",
+      mode: "authorized-beta-focused-v1",
+      policySha256: digestAuthorizedBetaFocusedPolicy(policy),
+      releaseTag: policy.releaseTag,
+      candidate: {
+        sha: policy.candidateSha,
+        parentSha: policy.baseCandidateSha,
+        treeSha: policy.candidateTreeSha,
+        packageProjectionSha256: policy.packageProjectionSha256,
+        changedPaths: policy.changedPaths,
+      },
+      producer,
+      historical: {
+        frvRunId: policy.historicalFrv.runId,
+        frvRunAttempt: policy.historicalFrv.runAttempt,
+        releaseChecksRunId: policy.historicalFrv.releaseChecksRunId,
+        performanceRunId: policy.historicalFrv.performanceRunId,
+      },
+      focused: {
+        ciRunId: policy.focusedProof.ciRunId,
+        ciJobId: policy.focusedProof.ciSuccessJobId,
+        pluginRunId: policy.focusedProof.pluginRunId,
+        pluginJobId: policy.focusedProof.pluginSuccessJobId,
+        reviewedHeadSha: policy.reviewedHeadSha,
+      },
+      inventory: expectedInventory,
+    } as AuthorizedBetaFocusedEvidence;
+    expect(() =>
+      validateAuthorizedBetaFocusedArtifactShape(evidence, policy, producer, expectedInventory),
+    ).not.toThrow();
+    expect(() =>
+      validateAuthorizedBetaFocusedArtifactShape(
+        {
+          ...evidence,
+          inventory: { ...evidence.inventory, npmCount: 92 },
+        },
+        policy,
+        producer,
+        expectedInventory,
+      ),
+    ).toThrow("focused evidence inventory");
+  });
+
+  it("wires a no-input attested producer and explicit parent/child evidence mode", () => {
+    const producer = parse(
+      readFileSync(".github/workflows/authorized-beta-focused-validation.yml", "utf8"),
+    ) as ParsedWorkflow;
+    expect(producer.on.workflow_dispatch).toBeNull();
+    expect(producer.permissions).toMatchObject({
+      actions: "read",
+      attestations: "write",
+      contents: "read",
+      "id-token": "write",
+    });
+    const producerSource = readFileSync(
+      ".github/workflows/authorized-beta-focused-validation.yml",
+      "utf8",
+    );
+    expect(producerSource).toContain("3fbe94065c2b94f4c08acb6742a69938bf408d94");
+    expect(producerSource).toContain("actions/attest@");
+
+    const workflows = new Map<string, ParsedWorkflow>();
+    for (const path of [
+      ".github/workflows/openclaw-release-publish.yml",
+      ".github/workflows/openclaw-npm-release.yml",
+    ]) {
+      const workflow = parse(readFileSync(path, "utf8")) as ParsedWorkflow;
+      workflows.set(path, workflow);
+      const inputs = workflow.on.workflow_dispatch?.inputs;
+      expect(inputs).toBeDefined();
+      if (!inputs) {
+        throw new Error(`workflow inputs missing: ${path}`);
+      }
+      const evidenceMode = inputs.release_evidence_mode;
+      if (!evidenceMode) {
+        throw new Error(`release evidence mode input missing: ${path}`);
+      }
+      expect(evidenceMode.options).toEqual([
+        "full-release-validation",
+        "authorized-beta-focused-v1",
+      ]);
+      expect(inputs.focused_release_evidence_run_id).toBeDefined();
+      expect(inputs.focused_release_evidence_run_attempt).toBeDefined();
+      const source = readFileSync(path, "utf8");
+      expect(source).toContain("Verify focused release evidence");
+      expect(source).toContain("gh attestation verify");
+      expect(source).toContain('--signer-digest "${WORKFLOW_SHA}"');
+      expect(source).toContain('--source-digest "${WORKFLOW_SHA}"');
+      expect(source).toContain("validate-authorized-beta-focused-evidence.mts");
+      expect(source).toContain("inputs.release_evidence_mode == 'full-release-validation'");
+      expect(source).toContain("validate-full-release-validation-evidence.mjs");
+    }
+    const parentSource = readFileSync(".github/workflows/openclaw-release-publish.yml", "utf8");
+    expect(parentSource).toContain('proof_label="authorized beta focused validation"');
+    expect(parentSource).toContain('proof_run_id="${FOCUSED_RELEASE_EVIDENCE_RUN_ID}"');
+    expect(parentSource).toContain(
+      "${process.env.RELEASE_VALIDATION_LABEL}: https://github.com/${process.env.RELEASE_REPO}/actions/runs/${process.env.RELEASE_VALIDATION_RUN_ID}",
+    );
+    const parentWorkflow = workflows.get(".github/workflows/openclaw-release-publish.yml");
+    const npmWorkflow = workflows.get(".github/workflows/openclaw-npm-release.yml");
+    if (!parentWorkflow || !npmWorkflow) {
+      throw new Error("release workflows missing");
+    }
+    const downloadedTooling = namedStep(
+      parentWorkflow,
+      "resolve_release_target",
+      "Download trusted release validation tooling",
+    ).run;
+    for (const path of VALIDATOR_CLOSURE) {
+      expect(downloadedTooling).toContain(path);
+    }
+    const resolveSteps = parentWorkflow.jobs?.resolve_release_target?.steps ?? [];
+    const resolveStepNames = resolveSteps.map((step) => step.name);
+    expect(resolveStepNames).not.toContain("Install focused release verifier dependency");
+    const publishSteps = parentWorkflow.jobs?.publish?.steps ?? [];
+    const publishStepNames = publishSteps.map((step) => step.name);
+    expect(publishStepNames.indexOf("Verify focused release evidence after approval")).toBeLessThan(
+      publishStepNames.indexOf("Setup Node environment"),
+    );
+    const npmSteps = npmWorkflow.jobs?.publish_openclaw_npm?.steps ?? [];
+    const npmStepNames = npmSteps.map((step) => step.name);
+    expect(npmStepNames.indexOf("Setup Node environment")).toBeLessThan(
+      npmStepNames.indexOf("Verify focused release evidence"),
+    );
+    expect(
+      namedStep(npmWorkflow, "publish_openclaw_npm", "Checkout trusted validation verifier").with,
+    ).toMatchObject({ "sparse-checkout": "scripts" });
+    const validatorSource = readFileSync(
+      "scripts/validate-authorized-beta-focused-evidence.mts",
+      "utf8",
+    );
+    expect(validatorSource).toContain('"--intent",');
+    expect(validatorSource).toContain('"--tooling-sha",');
+    expect(validatorSource).toContain("policy.historicalToolingSha");
+    expect(validatorSource).toContain("policy.historicalToolingRef");
+    expect(validatorSource).toContain("assertAuthorizedEligibilityPlanDigest(");
+    expect(validatorSource).toContain('await import("./release-plan-contract.mjs")');
+    const trustBranch = validatorSource.indexOf("if (includeTrust)");
+    const pluginImport = validatorSource.indexOf('await import("./lib/plugin-clawhub-release.ts")');
+    expect(trustBranch).toBeGreaterThan(-1);
+    expect(pluginImport).toBeGreaterThan(trustBranch);
+    const verifyBranch = validatorSource.indexOf(
+      'const evidence = JSON.parse(readFileSync(artifactPath, "utf8"))',
+    );
+    expect(verifyBranch).toBeGreaterThan(-1);
+    expect(validatorSource.slice(verifyBranch)).not.toContain("collectInventory(");
+  });
+});

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -6471,7 +6471,9 @@ describe("package artifact reuse", () => {
     expect(publishOrchestration.env?.FULL_RELEASE_VALIDATION_RUN_ATTEMPT).toBe(
       "${{ needs.resolve_release_target.outputs.full_release_validation_run_attempt }}",
     );
-    expect(publishOrchestration.run).toContain('"${validation_target_sha}" != "${TARGET_SHA}"');
+    // actionlint passes embedded scripts to ShellCheck through a 64 KiB pipe.
+    expect(Buffer.byteLength(publishOrchestration.run ?? "", "utf8")).toBeLessThan(64 * 1024);
+    expect(publishOrchestration.run).toContain('"${target_sha}" != "${TARGET_SHA}"');
     expect(npmFullRun.env?.FULL_RELEASE_VALIDATION_RUN_ATTEMPT).toBe(
       "${{ inputs.full_release_validation_run_attempt }}",
     );
@@ -6483,7 +6485,7 @@ describe("package artifact reuse", () => {
       "node scripts/openclaw-npm-extended-stable-release.mjs verify-manifest",
     );
     expect(npmCheckout.with?.["fetch-depth"]).toBe(
-      "${{ inputs.preflight_run_id != '' && 1 || 0 }}",
+      "${{ inputs.release_evidence_mode == 'authorized-beta-focused-v1' && 0 || (inputs.preflight_run_id != '' && 1 || 0) }}",
     );
 
     const publishSteps = publishJob.steps ?? [];


### PR DESCRIPTION
## What Problem This Solves

Resolves a beta.3 release blocker where the canonical publisher only accepts a successful all-group Full Release Validation manifest, even though the frozen candidate changed only reviewed Slack tests and the two failed historical leaves were rerun successfully.

Related: https://github.com/openclaw/openclaw/pull/128290

## Why This Change Was Made

Adds a release-specific, fail-closed `authorized-beta-focused-v1` credential instead of weakening or synthesizing the normal Full Release Validation manifest.

The fixed declaration binds:

- candidate `3fbe94065c2b94f4c08acb6742a69938bf408d94`, its sole parent, tree, four test-only paths, exact numstat, and unchanged published-byte projection
- historical FRV https://github.com/openclaw/openclaw/actions/runs/32644377679 and its exact failed CI/Slack leaves
- green release-checks sibling evidence and the existing beta performance advisory policy
- repaired CI job https://github.com/openclaw/openclaw/actions/runs/32664685168/job/97256296219
- repaired Slack shard job https://github.com/openclaw/openclaw/actions/runs/32664686635/job/97256329353
- the 93 npm / 89 ClawHub inventories, 75 trusted-publisher / 14 bootstrap split, and prior eligibility plan digest

The new producer emits an attested artifact from an exact protected tooling tag. The parent publisher and core npm publisher independently verify its attestation, protected-tag identity, live GitHub evidence, candidate ancestry/tree/diff, and fixed inventory policy. The eligibility digest is recomputed by the exact frozen release-plan producer, checked against the fixed policy, and only the computed digest is emitted. The existing successful-FRV validator and publication route remain intact under the default `full-release-validation` mode.

## User Impact

Maintainers can complete this one frozen beta.3 publication without another all-group FRV or accepting caller-supplied allowlists. No product bytes, candidate refs, registry state, or normal release policy are changed by this PR.

## Evidence

- Exact reviewed head: `e9a46d2185043c2d86e6b06943ed6fc9725141a7` (sole parent `eed27fdb88c0c60cb79c5b159a0284bd519271c2`, signed)
- `test/scripts/authorized-beta-focused-evidence.test.ts`: 8/8 passed
- The two affected `test/scripts/package-acceptance-workflow.test.ts` cases passed individually
- Verify-mode execution passed in both exact consumer layouts with only the validator, fixed policy, and shared record helper; no package install or `node_modules` closure is required
- Full local `actionlint` passed after keeping the embedded publish script below its 64 KiB ShellCheck boundary; a focused size regression assertion now guards that limit
- Canonical frozen publish-plan probe returned `sha256:e05226cfd77716b262882b3e2525037a506cd8b6af2affa0a876499074b1671b`
- Targeted type-aware oxlint passed for the validator and focused test
- `pnpm check:script-erasability` passed
- `oxfmt --check` and `git diff --check` passed
- The prior hosted `check-test-types` errors at the optional changed path and workflow input were fixed; exact-head hosted proof is pending
- Local script/root type lanes report only the checkout's unrelated terminal-core, UI config, Android fixture, and QA Convex fixture diagnostics; no changed-file diagnostic remains
- GitHub REST job evidence was checked directly; the exact job endpoints expose the bound `run_id` and `head_sha`

The exact-head audit fixes also bind both target-log jobs before reading logs, pin attestation source and signer digests to the protected tooling SHA in all three consumers, and render the focused validation run in release proof instead of an empty FRV URL.

Production/tooling delta is intentionally positive: this adds a distinct attested security credential, fixed release policy, and two independent publication enforcement boundaries. Product runtime delta is zero.
