### PR TITLE
fix(agents): surface provider auth guidance for terminal failures

### DIFF
--- a/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
@@ -142,6 +142,34 @@ function makeIdleTimeoutFailureInput(options?: { replaySafe?: boolean }) {
 }
 
 describe("handleEmbeddedAssistantFailure", () => {
+  it.each(["auth", "auth_permanent"] as const)(
+    "carries %s profile failures into terminal resolution",
+    async (reason) => {
+      const fixture = makeExhaustedCredentialFailureInput();
+      if (!fixture.input.attemptAssistant) {
+        throw new Error("expected assistant fixture");
+      }
+      fixture.input.attemptAssistant.provider = "openai";
+      fixture.input.attemptAssistant.model = "gpt-5.6-luna";
+      fixture.input.attemptAssistant.errorMessage = undefined;
+      Object.assign(fixture.input, {
+        provider: "openai",
+        modelId: "gpt-5.6-luna",
+        model: "gpt-5.6-luna",
+        activeErrorContext: { provider: "openai", model: "gpt-5.6-luna" },
+        fallbackConfigured: false,
+        authProfileId: undefined,
+        resolveAuthProfileFailureReason: vi.fn(() => reason),
+      });
+      const outcome = await handleEmbeddedAssistantFailure(fixture.input);
+
+      expect(outcome).toMatchObject({
+        action: "proceed",
+        assistantProfileFailureReason: reason,
+      });
+    },
+  );
+
   it("uses prepared OpenRouter ownership for custom-provider billing failures", async () => {
     const fixture = makeExhaustedCredentialFailureInput();
     const provider = "custom-openrouter";

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
@@ -3,8 +3,11 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { hasAcceptedSessionSpawn } from "../../accepted-session-spawn.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
+import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import { collectTextContentBlocks } from "../../content-blocks.js";
 import type { MessagingToolSend } from "../../embedded-agent-messaging.types.js";
+import { renderAuthProfileFailoverCopy } from "../../failover/user-copy.js";
+import { buildProviderAuthRecoveryHint } from "../../provider-auth-recovery-hint.js";
 import { hasOnlyAssistantReasoningContent } from "../../replay-turn-classification.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { hasCommittedMessagingToolDeliveryEvidence } from "../delivery-evidence.js";
@@ -36,6 +39,12 @@ type RunLivenessAttempt = Pick<
   "lastAssistant" | "replayMetadata" | "terminal"
 >;
 
+type TerminalAuthFailureContext = {
+  assistantProfileFailureReason?: AuthProfileFailureReason | null;
+  provider: string;
+  runParams: Pick<Parameters<typeof buildProviderAuthRecoveryHint>[0], "config" | "workspaceDir">;
+};
+
 /**
  * Builds the user-visible incomplete-turn warning when a terminal attempt did
  * not produce a safe final assistant response and no committed delivery/progress
@@ -48,6 +57,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   timedOut: boolean;
   hadPotentialSideEffects?: boolean;
   hasIntentionalTerminalCompletion?: boolean;
+  terminalAuthFailure?: TerminalAuthFailureContext;
   attempt: IncompleteTurnAttempt;
 }): string | null {
   // Prefer the current attempt's terminal message. The session fallback can
@@ -117,9 +127,25 @@ export function resolveIncompleteTurnPayloadText(params: {
     return null;
   }
 
-  return params.hadPotentialSideEffects || params.attempt.replayMetadata.hadPotentialSideEffects
-    ? "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying."
-    : "⚠️ Agent couldn't generate a response. Please try again.";
+  if (params.hadPotentialSideEffects || params.attempt.replayMetadata.hadPotentialSideEffects) {
+    return "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying.";
+  }
+  const authFailure = params.terminalAuthFailure;
+  const reason = authFailure?.assistantProfileFailureReason;
+  if (authFailure && (reason === "auth" || reason === "auth_permanent")) {
+    return renderAuthProfileFailoverCopy({
+      reason,
+      provider: authFailure.provider,
+      allInCooldown: false,
+      recoveryHint: buildProviderAuthRecoveryHint({
+        provider: authFailure.provider,
+        config: authFailure.runParams.config,
+        workspaceDir: authFailure.runParams.workspaceDir,
+        env: process.env,
+      }),
+    });
+  }
+  return "⚠️ Agent couldn't generate a response. Please try again.";
 }
 
 /**

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -50,6 +50,7 @@ function makeTerminalInput(overrides: TerminalInputOverrides = {}): TerminalInpu
     sessionKey: "agent:main:terminal-resolution",
     runId: "run:terminal-resolution",
     agentDir: "/tmp/openclaw-terminal-resolution",
+    workspaceDir: "/tmp/openclaw-terminal-resolution",
     ...overrides.runParams,
   } as TerminalInput["runParams"];
   const base = {
@@ -107,7 +108,78 @@ function makeTerminalInput(overrides: TerminalInputOverrides = {}): TerminalInpu
   return { ...base, ...overrides, runParams };
 }
 
+async function resolveTerminalText(overrides: TerminalInputOverrides): Promise<string | undefined> {
+  const resolved = await resolveEmbeddedRunTerminal(makeTerminalInput(overrides));
+  expect(resolved.action).toBe("complete");
+  if (resolved.action !== "complete") {
+    throw new Error("expected terminal resolution to complete");
+  }
+  return resolved.result.payloads?.[0]?.text;
+}
+
 describe("terminal resolution", () => {
+  it.each([
+    {
+      reason: "auth" as const,
+      expected: "Couldn't sign in to openai. Your saved login looks expired or no longer works.",
+    },
+    {
+      reason: "auth_permanent" as const,
+      expected: "openai isn't accepting your saved login.",
+    },
+  ])("surfaces provider recovery guidance for $reason terminal failures", async (testCase) => {
+    const text = await resolveTerminalText({
+      assistantProfileFailureReason: testCase.reason,
+      maxEmptyResponseRetryAttempts: 0,
+    });
+    expect(text).toContain(testCase.expected);
+    expect(text).toContain("openclaw configure");
+  });
+
+  it("keeps non-auth incomplete turns on the generic warning", async () => {
+    await expect(
+      resolveTerminalText({
+        assistantProfileFailureReason: "timeout",
+        maxEmptyResponseRetryAttempts: 0,
+      }),
+    ).resolves.toBe("⚠️ Agent couldn't generate a response. Please try again.");
+  });
+
+  it("does not replace timeout suppression with auth guidance", async () => {
+    const assistant = emptyAssistant({ stopReason: "aborted" });
+    const attempt = makeEmbeddedRunnerAttempt({
+      terminal: { kind: "timeout", phase: "prompt", source: "external" },
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    });
+    await expect(
+      resolveTerminalText({
+        attempt,
+        attemptAssistant: assistant,
+        assistantProfileFailureReason: "auth",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps the side-effect warning ahead of auth guidance", async () => {
+    const assistant = emptyAssistant({ stopReason: "error" });
+    const attempt = makeEmbeddedRunnerAttempt({
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+    });
+    const text = await resolveTerminalText({
+      attempt,
+      attemptAssistant: assistant,
+      assistantProfileFailureReason: "auth",
+      replayState: { hadPotentialSideEffects: true, replayInvalid: true },
+    });
+    expect(text).toContain("some tool actions may have already been executed");
+    expect(text).not.toContain("Couldn't sign in");
+  });
+
   it("carries presentation across retries until a newer tool outcome replaces it", () => {
     const tracker = createTerminalToolPresentationTracker();
     const firstOrdinal = tracker.allocateOrdinal();

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -356,6 +356,7 @@ export async function resolveEmbeddedRunTerminal(input: {
           timedOut: terminalTimedOut,
           hadPotentialSideEffects: input.replayState.hadPotentialSideEffects,
           hasIntentionalTerminalCompletion: intentionalTerminalCompletion,
+          terminalAuthFailure: input,
           attempt,
         });
   const incompleteTurnFallbackSafe = Boolean(


### PR DESCRIPTION
Related: #112978

Credits Peter Lee (@xialonglee) for the original narrow terminal-copy work in #113066. This replacement keeps that intent, rewrites it against current `main`, and preserves Peter as co-author.

## What Problem This Solves

Fixes an issue where an authentication failure that reached incomplete-turn terminal resolution produced only:

```text
⚠️ Agent couldn't generate a response. Please try again.
```

The failure reason was already classified as `auth` or `auth_permanent`, but terminal presentation discarded it, leaving operators without a provider name or recovery command.

## Why This Change Was Made

Terminal resolution passes its already prepared provider, reason, and run context into the incomplete-turn owner. Only after its existing delivery, timeout, replay-safety, and side-effect gates accept a terminal warning does that owner render the existing provider-aware auth copy.

This does not change model fallback, persisted model selection, auth health, session reset, configuration/defaults, Doctor behavior, SDK/protocol surfaces, or CLI dispatch.

## User Impact

Operators now receive actionable provider-specific recovery guidance, for example:

```text
Couldn't sign in to openai. Your saved login looks expired or no longer works. Run `openclaw models auth login --provider openai` or `openclaw configure`.
```

Permanent auth rejection gets distinct copy. Non-auth failures retain the generic warning, timeout suppression remains silent, and potentially side-effecting turns retain the verification warning.

## Evidence

- Untouched-main red proof at `5833f53c188` (then-current `main`): exactly 2 focused failures showed both `auth` and `auth_permanent` receiving the generic incomplete-turn text while the other 45 tests passed.
- Exact-head proof at `2c4ed9da2bc`: 106 behavior tests passed across terminal resolution, assistant failure production, incomplete-turn metadata, auth copy, failover copy, and canonical terminal outcomes.
- The former unrelated Ollama parity blocker was fixed on `main` by #128396 (`ab013fac6c6`), which is ancestral to this head; its 16-test parity suite also passes here.
- Executable terminal transcript:
  - Before: `⚠️ Agent couldn't generate a response. Please try again.`
  - After auth: `Couldn't sign in to openai. Your saved login looks expired or no longer works. Run openclaw models auth login --provider openai or openclaw configure.`
  - After permanent auth: `openai isn't accepting your saved login. Run openclaw models auth login --provider openai or openclaw configure.`
- `git diff --check`, focused formatting, dead-export scans, core and core-test typechecks, targeted lint, native-state schema parity, database-first storage, sidecar/import-cycle, webhook, and auth guards passed.
- Exact-head hosted CI: all checks green, including `openclaw/ci-gate`.
- Exact-head local autoreview: clean, no accepted or actionable findings.
- Exact-head ClawSweeper: no patch or security findings; its current-main integration rank-up move is satisfied by the green hosted CI.

Production LOC: +30/-3 (net +27) | Tests: +100/-0

AI-assisted maintenance rewrite; scope and behavior were independently validated against current source and the closed contributor PR.

Punchcard-Session: calm-brook-willow-ys
