### PR TITLE
improve(zalo): avoid duplicate media preparation

### DIFF
--- a/extensions/zalo/src/send.test.ts
+++ b/extensions/zalo/src/send.test.ts
@@ -232,6 +232,7 @@ describe("zalo send", () => {
       },
       undefined,
     );
+    expect(resolveZaloProxyFetchMock).toHaveBeenCalledOnce();
     const successful = requireSuccessfulSend(result, "z-photo-2");
     expect(successful.receipt.platformMessageIds).toEqual(["z-photo-2"]);
   });

--- a/extensions/zalo/src/send.ts
+++ b/extensions/zalo/src/send.ts
@@ -161,11 +161,29 @@ export async function sendMessageZalo(
   const { context } = resolved;
 
   if (options.mediaUrl && (options.mediaUrl.trim() || !text)) {
-    return sendPhotoZalo(context.chatId, options.mediaUrl, {
-      ...options,
-      token: context.token,
-      caption: text || options.caption,
-    });
+    const photoUrl = options.mediaUrl.trim();
+    if (!photoUrl) {
+      return {
+        ok: false,
+        error: "No photo URL provided",
+        receipt: createZaloSendReceipt({ chatId: context.chatId, kind: "media" }),
+      };
+    }
+    const caption = text || options.caption;
+    return await runZaloSend(
+      "Failed to send photo",
+      { chatId: context.chatId, kind: "media" },
+      () =>
+        sendPhoto(
+          context.token,
+          {
+            chat_id: context.chatId,
+            photo: photoUrl,
+            caption: caption !== undefined ? truncateUtf16Safe(caption, 2000) : undefined,
+          },
+          context.fetcher,
+        ),
+    );
   }
 
   return await runZaloSend("Failed to send message", { chatId: context.chatId, kind: "text" }, () =>
@@ -177,39 +195,5 @@ export async function sendMessageZalo(
       },
       context.fetcher,
     ),
-  );
-}
-
-async function sendPhotoZalo(
-  chatId: string,
-  photoUrl: string,
-  options: ZaloSendOptions = {},
-): Promise<ZaloSendResult> {
-  const resolved = resolveSendContextOrFailure(chatId, options);
-  if ("failure" in resolved) {
-    return resolved.failure;
-  }
-  const { context } = resolved;
-
-  if (!photoUrl?.trim()) {
-    return {
-      ok: false,
-      error: "No photo URL provided",
-      receipt: createZaloSendReceipt({ chatId: context.chatId, kind: "media" }),
-    };
-  }
-
-  return await runZaloSend("Failed to send photo", { chatId: context.chatId, kind: "media" }, () =>
-    (async () =>
-      sendPhoto(
-        context.token,
-        {
-          chat_id: context.chatId,
-          photo: photoUrl.trim(),
-          caption:
-            options.caption !== undefined ? truncateUtf16Safe(options.caption, 2000) : undefined,
-        },
-        context.fetcher,
-      ))(),
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Zalo users sending media through a configured account paid for account, token, and proxy preparation twice before a single provider request. This added avoidable work to every ordinary media send.

## Why This Change Was Made

The Zalo sender now carries its already validated send context directly into the photo API call and removes the one-use wrapper that independently prepared the same context again. Text sends, blank-media handling, target normalization, caption truncation, receipts, and provider request semantics remain unchanged; no cache, configuration, protocol, storage, security, or retry contract changes.

## User Impact

Zalo media sends perform one account/proxy preparation instead of two, reducing local outbound preparation latency without changing delivered content or error behavior.

## Evidence

- Current-main red → green: the existing cfg-backed media owner test observed two proxy preparations before the change and one after it.
- Focused Zalo send/API/action/media/target suites: 54/54 passed.
- Full Zalo plugin suite: 26 files, 175/175 passed.
- ZaloUser send/payload sibling suites: 2 files, 31/31 passed.
- `node scripts/check-changed.mjs --timed -- extensions/zalo/src/send.ts extensions/zalo/src/send.test.ts`: passed all extension production/test formatting, typecheck, Oxlint, dead-export, boundary, guard, and import-cycle checks.
- `git diff --check`: passed.
- Structured Codex `gpt-5.6-sol` / high autoreview: clean after TruffleHog preflight; `patch is correct` (0.99).
- Representative controlled benchmark from the unchanged pre-fix owner path: 20,000 media sends per sample changed median preparation time from 107.706 ms to 60.375 ms (−43.9%), with text control remaining at one preparation.
- Live Zalo mutation was not run; the defect and repair are deterministic local preparation behavior before the provider boundary, covered by red/green owner tests and unchanged mocked provider arguments.
