### PR TITLE
fix(macos): escape all login LaunchAgent plist paths

### DIFF
--- a/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
@@ -76,10 +76,10 @@ enum LaunchAgentManager {
           <string>ai.openclaw.mac</string>
           <key>ProgramArguments</key>
           <array>
-            <string>\(bundlePath)/Contents/MacOS/OpenClaw</string>
+            <string>\(self.escapePlistText(bundlePath))/Contents/MacOS/OpenClaw</string>
           </array>
           <key>WorkingDirectory</key>
-          <string>\(FileManager().homeDirectoryForCurrentUser.path)</string>
+          <string>\(self.escapePlistText(FileManager().homeDirectoryForCurrentUser.path))</string>
           <key>RunAtLoad</key>
           <true/>
           <key>EnvironmentVariables</key>
@@ -88,9 +88,9 @@ enum LaunchAgentManager {
             <string>\(path)</string>\(profileEnvironment)
           </dict>
           <key>StandardOutPath</key>
-          <string>\(LogLocator.launchdLogPath)</string>
+          <string>\(self.escapePlistText(LogLocator.launchdLogPath))</string>
           <key>StandardErrorPath</key>
-          <string>\(LogLocator.launchdLogPath)</string>
+          <string>\(self.escapePlistText(LogLocator.launchdLogPath))</string>
         </dict>
         </plist>
         """

--- a/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
@@ -50,18 +50,24 @@ struct LaunchAgentManagerTests {
 
     @MainActor
     @Test func `launch at login plist preserves normalized profile environment once`() async throws {
+        let bundlePath = "/Applications/R&D <Team>/OpenClaw.app"
+        let logDirectory = "/tmp/openclaw-login-&<logs>"
         try await TestIsolation.withEnvValues([
             "OPENCLAW_CONFIG_PATH": "  /tmp/custom&<openclaw>\"'.json  ",
+            "OPENCLAW_LOG_DIR": logDirectory,
             "OPENCLAW_STATE_DIR": "/tmp/openclaw-state",
         ]) {
             let plist = LaunchAgentManager.plistContents(
-                bundlePath: "/Applications/OpenClaw.app",
+                bundlePath: bundlePath,
                 preferredPaths: ["/tmp/custom&<bin>", "/usr/bin"])
             let data = try #require(plist.data(using: .utf8))
             let object = try #require(
                 PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
 
             let environment = try #require(object["EnvironmentVariables"] as? [String: String])
+            #expect(object["ProgramArguments"] as? [String] == ["\(bundlePath)/Contents/MacOS/OpenClaw"])
+            #expect(object["StandardOutPath"] as? String == "\(logDirectory)/openclaw-stdout.log")
+            #expect(object["StandardErrorPath"] as? String == "\(logDirectory)/openclaw-stdout.log")
             #expect(environment["OPENCLAW_CONFIG_PATH"] == "/tmp/custom&<openclaw>\"'.json")
             #expect(environment["OPENCLAW_STATE_DIR"] == "/tmp/openclaw-state")
             #expect(environment["PATH"]?.contains("/tmp/custom&<bin>") == true)


### PR DESCRIPTION
## What Problem This Solves

Prevents the macOS app's Launch at Login setting from silently breaking when the app bundle, home directory, or launch log directory contains ordinary XML-sensitive filesystem characters such as `&` or `<`.

## Why This Change Was Made

The macOS login LaunchAgent producer already escaped environment values, but directly interpolated the executable path, working directory, and both log paths into its XML plist. Apple's property-list parser rejects that generated document, so launchd cannot bootstrap the app at login. Escape every dynamic filesystem text node through the existing canonical helper, matching the sibling Gateway LaunchAgent plist generator.

## User Impact

Launch at Login remains functional for valid application and log-directory paths containing ampersands or angle brackets. Existing environment normalization, RunAtLoad behavior, and manual-quit semantics remain unchanged.

## Evidence

- Authentic pre-fix reproduction: Apple's `PropertyListSerialization` rejected the existing generated login plist with `Encountered unknown ampersand-escape sequence at line 9`.
- Extended the existing owner-boundary regression with an application path, log directory, PATH entry, and configuration path containing XML-sensitive characters, then parsed the complete real plist and verified the semantic executable, stdout, stderr, and environment values.
- `swift test --package-path apps/macos --filter LaunchAgentManagerTests` passed all 20 native tests across both login and Gateway LaunchAgent suites.
- Repository SwiftFormat lint and `git diff --check` passed.
- Independent read-only local review inspected the complete owner, app caller, log-path producer, sibling TypeScript plist generator, and regression suite; no actionable findings.
- Production delta: +4/-4 lines, net zero; tests +7/-1. No configuration, protocol, persistence, provider, or dependency changes.
