### PR TITLE
feat(browser): standalone extension relay daemon with native-host wake-up

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -77,7 +77,6 @@ extensions/browser/src/browser/extension-install.ts	3
 extensions/browser/src/browser/extension-native-host.ts	1
 extensions/browser/src/browser/extension-native-protocol.ts	1
 extensions/browser/src/browser/extension-relay/auth-v2.ts	10
-extensions/browser/src/browser/extension-relay/relay-auth.ts	1
 extensions/browser/src/browser/extension-relay/relay-bridge.ts	9
 extensions/browser/src/browser/extension-relay/relay-protocol.ts	4
 extensions/browser/src/browser/output-files.ts	1

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -708,6 +708,7 @@ const config = {
       "browser-profiles.ts!",
       // Built by tsdown as the native messaging executable; Chrome launches it by path.
       "native-host-entry.ts!",
+      "relay-daemon-entry.ts!",
       // Chrome manifest/package scripts load these without TypeScript imports.
       "chrome-extension/background.js!",
       "chrome-extension/options.js!",

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -178,8 +178,13 @@ pairings continue to use the relay on the browser-node host, while explicit
 `--gateway-url` pairings remain direct-remote and manual-only.
 
 The advanced manual `extension pair` command without `--gateway-url` retains
-the host-local `/extension` relay URL. It does not wake Browser control, so the
-selected profile relay must already be running before the extension connects.
+the host-local `/extension` relay URL. With the native host installed,
+**Automatic local setup** enabled, and an extension build that supports relay
+wake-up, reconnecting can start a standalone relay on the saved pairing's
+configured port. This does not start Gateway browser control: authenticated CDP
+clients can use the standalone relay without a Gateway, but `openclaw browser`
+actions still require one. For source-checkout testing, load the managed unpacked
+copy from the same OpenClaw installation.
 
 `extension cdp --legacy-bearer` is a temporary migration escape hatch. It
 prints the old Bearer header with a warning only while

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -107,7 +107,7 @@ openclaw config set browser.defaultProfile chrome
 Fresh automatic pairings use **All tabs**. Existing valid pairings are never
 overwritten, and older pairings keep their stored access mode.
 
-For local setup, native bootstrap connects the extension through the local
+For fresh local setup, native bootstrap connects the extension through the local
 Gateway's exact `/browser/extension` route. That first authenticated connection
 wakes the lazy browser-control service and starts the profile's loopback relay;
 OpenClaw and local clients such as mcporter then use that profile relay port.
@@ -118,6 +118,43 @@ Browser-node setup remains different: the extension connects to the relay on
 the browser-node host while the node uses its configured remote Gateway. An
 explicit `--gateway-url` pairing connects directly to that remote Gateway and
 remains a manual-only flow.
+
+### Standalone direct-loopback relay
+
+A pairing on `ws://127.0.0.1:<port>/extension` can run without a local Gateway
+or browser node. On macOS and Linux, the bundled extension can ask the installed
+native host to start a standalone relay when reconnecting to that endpoint.
+Automatic local setup must be enabled. Requests are limited to once per minute;
+the extension still authenticates the relay with connection-bound v2 proofs.
+This requires both the updated native host and an extension build containing
+relay wake-up support. Do not assume the Store v2.2.0 build includes that code;
+the bundled unpacked development copy is the source-build validation path.
+
+Automatic wake-up requires the exact `127.0.0.1` host that the daemon serves.
+Other loopback aliases, including `localhost` and IPv6, do not trigger wake-up;
+use the canonical IPv4 endpoint when pairing for standalone operation.
+
+Wake-up uses the port in the extension's existing canonical pairing. It does
+not switch to the first configured profile. The native host resolves current
+`browser.profiles` and permits only an extension-driver relay port, including
+automatically allocated ports and explicit `cdpPort` pins. A removed profile
+or stale port fails closed; correct the pairing to match the current profile.
+Gateway `/browser/extension` routes and remote pairings never trigger local
+daemon wake-up. Browser-node pairings that use a direct loopback relay can use
+it even when their Gateway hint points to a remote host.
+
+An existing listener keeps ownership of its port. Otherwise, the native host
+spawns `dist/extensions/browser/relay-daemon-entry.js` as a detached process.
+The daemon uses the same per-host relay key and stays alive while an extension
+or CDP client is connected. After both disconnect, it exits following ten
+minutes of inactivity, checked every 30 seconds. Closing Chrome alone does not
+stop it while a CDP client remains connected. A later reconnect can wake it again.
+
+The standalone daemon defaults to **v2-only authentication**, independently of
+the Gateway relay's legacy default. Only an explicit
+`browser.extensionRelay.allowLegacyAuth=true` enables legacy authentication;
+an unset value, `false`, or a config-read failure never enables it. Prefer v2
+clients so the persistent key is not disclosed to a process occupying the port.
 
 ### Choose tab access
 
@@ -165,7 +202,7 @@ Settings shows redacted relay/native bootstrap status and the **Use automatic
 local setup** switch.
 
 - Turning automatic setup off preserves a valid existing pairing but prevents
-  new native bootstrap attempts.
+  new native bootstrap and standalone relay wake-up attempts.
 - **Disconnect and disable automatic setup** revokes the pairing immediately,
   detaches debugger sessions, and persists the opt-out.
 - **Use local OpenClaw** clears the opt-out and retries the native host.
@@ -233,8 +270,10 @@ Manual pairing remains useful on Windows and for recovery. Treat the complete
 pairing string as a password.
 
 Without `--gateway-url`, this command retains the host-local `/extension` relay
-for standalone manual pairing. It does not wake Browser control; the selected
-profile relay must already be running before the extension connects.
+for standalone manual pairing. It does not wake Browser control. With native
+wake-up support installed and automatic local setup enabled, the extension can
+start that relay on reconnect without a local Gateway. Otherwise, the relay
+must already be running, for example through Browser control or a browser node.
 
 For a laptop that has Chrome but does not run OpenClaw or a browser node, pair
 directly to a remote Gateway:
@@ -330,20 +369,28 @@ The extension requests only:
 - `tabs` and `tabGroups`: discover tabs and enforce access mode;
 - `storage`: persist pairing, access mode, session pauses, and bootstrap opt-out;
 - `alarms`: wake the MV3 worker for relay/bootstrap retries;
-- `nativeMessaging`: request one local bootstrap pairing.
+- `nativeMessaging`: request a local bootstrap pairing or wake its configured relay.
 
 It does not request `activeTab`, `contextMenus`, `scripting`, or `sidePanel`.
 
 ## Native bootstrap security
 
-The native host is `ai.openclaw.browser_bootstrap`. Each
-`chrome.runtime.sendNativeMessage` call starts one process, reads one request,
-writes one response, and exits.
+The native host is `ai.openclaw.browser_bootstrap`. The extension opens a
+`chrome.runtime.connectNative` port for one request, validates the response,
+then disconnects. The host writes one response and exits; a spawned standalone
+relay outlives this short-lived native connection.
 
 The request uses a versioned, length-prefixed JSON frame with a fresh 16-byte
 nonce. The host caps input at 4 KiB, requires fatal UTF-8 decoding and exact
 fields, verifies the caller origin against the exact installed manifest, and
-returns only a locally generated pairing or a bounded non-secret failure code.
+returns only a locally generated pairing, a relay status, or a bounded
+non-secret failure code. The bootstrap request remains exactly
+`{v:1, op:"bootstrap", nonce}`. Relay wake-up uses
+`{v:1, op:"ensure_relay", nonce, relayPort}` with a required integer port from
+1 through 65535. Missing, duplicate, malformed, or extra fields are rejected.
+After manifest and caller validation, the host checks the requested port
+against current extension profiles before probing or spawning. No request can
+supply a host, executable path, or credential to the launcher.
 The response is below Chrome's 1 MiB native-message limit. Pairing keys never
 appear in launcher arguments, manifests, status JSON, or diagnostics.
 
@@ -370,7 +417,10 @@ manifest has no `key`; only these development IDs depend on approved
 OpenClaw-owned realpaths.
 
 The relay itself uses connection-bound HMAC proofs. The persistent per-host key
-is not sent in a URL, header, WebSocket subprotocol, or application frame.
+is not sent in a URL, header, WebSocket subprotocol, or application frame during
+v2 authentication. On POSIX hosts, each key read rejects foreign-owned and
+non-regular files and tightens an owned group/other-accessible file to `0600`;
+if tightening fails, the key is refused. Windows uses its existing ACL policy.
 
 ## Troubleshooting
 
@@ -399,10 +449,12 @@ openclaw doctor
   OpenClaw**.
 - **Manual setup required:** use Settings for the advanced pairing flow. This
   is expected on Windows and direct extension-only remote Gateway setups.
-- **Relay unavailable:** confirm `openclaw gateway run` or the managed Gateway
-  service is running for local setup, or confirm the browser node is running
-  for browser-node setup. Then run browser doctor. No separate browser prewarm
-  should be necessary.
+- **Relay unavailable:** for `/browser/extension` pairings, confirm the target
+  Gateway is running. For direct loopback `/extension` pairings, check native
+  host registration, wake-up support in the extension build, automatic setup,
+  and that the paired port still belongs to an extension profile. Allow for the
+  one-minute wake-up throttle, then run browser doctor. No local Gateway is
+  required for the standalone path.
 
 See [Browser](/tools/browser) for the full profile model and the managed
 `openclaw` and Chrome MCP `user` profiles.

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -45,8 +45,11 @@ development IDs. After pre-registration succeeds, add
 
 The extension pairs on its first native call; you do not need to open its
 popup, reload it, or restart Chrome during a normal first-time setup. The
-installer then reads the profile's `Secure Preferences` and verifies the exact
-Store ID independently from any extension path.
+installer then inspects the profile's `Preferences` and `Secure Preferences`
+backing files and verifies the exact Store ID independently from any extension
+path. Chromium selects the backing file by settings-enforcement policy; Linux
+normally uses `Preferences`. Both files receive the same ownership, path, file
+type, permission, and size checks.
 
 For extension development, the command also copies the bundled extension to a
 stable OpenClaw-owned directory. Use that unpacked copy only as a development
@@ -155,6 +158,18 @@ the Gateway relay's legacy default. Only an explicit
 `browser.extensionRelay.allowLegacyAuth=true` enables legacy authentication;
 an unset value, `false`, or a config-read failure never enables it. Prefer v2
 clients so the persistent key is not disclosed to a process occupying the port.
+
+Gateway browser control can join a standalone relay that already owns the
+configured profile and port. It authenticates that exact owner with v2 and uses
+its existing bridge; it does not start a second listener. Stopping Gateway
+releases only Gateway's connections, leaving the daemon, its direct extension
+connection, and other CDP clients running. Gateway-first automatic setup through
+`/browser/extension` remains supported.
+
+Both processes need an OpenClaw build that supports this owner-access protocol. A
+mismatched profile, port, key, or stricter authentication policy produces an
+error; Gateway never takes over the listener or falls back to legacy credentials.
+The daemon's stricter v2-only default is compatible with Gateway's default.
 
 ### Choose tab access
 

--- a/extensions/browser/chrome-extension/background.initial-target.test.ts
+++ b/extensions/browser/chrome-extension/background.initial-target.test.ts
@@ -177,7 +177,7 @@ describe.each(["all", "selected"] as const)("created initial target in %s mode",
       expect(harness.debuggerAttach).toHaveBeenCalledExactlyOnceWith({ tabId: 101 }, "1.3");
       expect(harness.tabsRemove).toHaveBeenCalledExactlyOnceWith(101);
     } finally {
-      client.onClose();
+      await client.onClose();
       bridge.dispose();
     }
   });

--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -17,7 +17,7 @@ import { openAuthenticatedRelaySocket } from "./modules/relay-connection.js";
 import {
   ACCESS_MODE_SELECTED,
   createPairingConfigStore,
-  isDirectLoopbackRelayUrl,
+  directLoopbackRelayPort,
   reconnectDelayMs,
   toRelayTabInfo,
 } from "./modules/relay-core.js";
@@ -394,7 +394,7 @@ async function connectRelay(isConnectionAllowed = () => true) {
     return;
   }
   closeRelaySocket();
-  maybeEnsureRelayDaemon(relayUrl);
+  void maybeEnsureRelayDaemon(relayUrl, connectionIsCurrent).catch(() => {});
   setBadge("connecting");
   let ws;
   const owner = relayDebugger.createOwner(
@@ -506,8 +506,14 @@ function handleRelayOpeningDeadline() {
  * host (rate-limited) to spawn the standalone relay daemon so the extension
  * has something to connect to without a running Gateway.
  */
-function maybeEnsureRelayDaemon(relayUrl) {
-  if (reconnectAttempt === 0 || !isDirectLoopbackRelayUrl(relayUrl)) {
+async function maybeEnsureRelayDaemon(relayUrl, connectionIsCurrent) {
+  const relayPort = directLoopbackRelayPort(relayUrl);
+  if (reconnectAttempt === 0 || relayPort === null) {
+    return;
+  }
+  const { disabled } = await nativeBootstrap.status();
+  // Opt-out or pair revocation can win the storage read above.
+  if (disabled || retiredCopilotCustodyBlocked || !connectionIsCurrent()) {
     return;
   }
   const now = Date.now();
@@ -515,7 +521,7 @@ function maybeEnsureRelayDaemon(relayUrl) {
     return;
   }
   lastRelayEnsureAtMs = now;
-  void requestRelayEnsure(chrome).catch(() => {});
+  await requestRelayEnsure(relayPort, chrome);
 }
 
 function scheduleReconnect() {

--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -2,6 +2,7 @@ import {
   createNativeBootstrapController,
   discardRetiredCopilotState,
   prepareRetiredCopilotState,
+  requestRelayEnsure,
 } from "./modules/native-bootstrap.js";
 import { createPopupMessageHandler } from "./modules/popup-background.js";
 import { createRelayCommandHandler } from "./modules/relay-command-handler.js";
@@ -16,6 +17,7 @@ import { openAuthenticatedRelaySocket } from "./modules/relay-connection.js";
 import {
   ACCESS_MODE_SELECTED,
   createPairingConfigStore,
+  isDirectLoopbackRelayUrl,
   reconnectDelayMs,
   toRelayTabInfo,
 } from "./modules/relay-core.js";
@@ -30,6 +32,7 @@ const BADGE = {
   on: { text: "ON", color: "#0F9D58" },
   error: { text: "!", color: "#B91C1C" },
 };
+const RELAY_ENSURE_MIN_INTERVAL_MS = 60_000;
 const RELAY_WATCHDOG_ALARM = "openclaw-relay-watchdog";
 const RELAY_OPENING_DEADLINE_ALARM = "openclaw-relay-opening-deadline";
 const RELAY_AUTH_TIMEOUT_MS = 10_000;
@@ -44,6 +47,7 @@ let relayOpeningDeadlineTimer = null;
 let relayAuthenticatedSocket = null;
 let relaySocketOwner = null;
 let relayStatusHint = "";
+let lastRelayEnsureAtMs = 0;
 let reconciledPairingInvalidationRevision = 0;
 let relayConnectionGeneration = 0;
 let relayConnectionsSuspended = false;
@@ -390,6 +394,7 @@ async function connectRelay(isConnectionAllowed = () => true) {
     return;
   }
   closeRelaySocket();
+  maybeEnsureRelayDaemon(relayUrl);
   setBadge("connecting");
   let ws;
   const owner = relayDebugger.createOwner(
@@ -494,6 +499,23 @@ function handleRelayOpeningDeadline() {
   setBadge("error");
   relayStatusHint = "Relay authentication v2 timed out. Make sure OpenClaw is up to date.";
   scheduleReconnect();
+}
+
+/**
+ * On a reconnect cycle against a direct loopback relay URL, ask the native
+ * host (rate-limited) to spawn the standalone relay daemon so the extension
+ * has something to connect to without a running Gateway.
+ */
+function maybeEnsureRelayDaemon(relayUrl) {
+  if (reconnectAttempt === 0 || !isDirectLoopbackRelayUrl(relayUrl)) {
+    return;
+  }
+  const now = Date.now();
+  if (now - lastRelayEnsureAtMs < RELAY_ENSURE_MIN_INTERVAL_MS) {
+    return;
+  }
+  lastRelayEnsureAtMs = now;
+  void requestRelayEnsure(chrome).catch(() => {});
 }
 
 function scheduleReconnect() {

--- a/extensions/browser/chrome-extension/background.test.ts
+++ b/extensions/browser/chrome-extension/background.test.ts
@@ -422,3 +422,62 @@ describe("relay pairing and authentication", () => {
     expect(harness.storageValues).not.toHaveProperty("relayUrl");
   });
 });
+
+describe("standalone relay wake-up", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(100_000);
+  });
+
+  afterEach(async () => {
+    await cleanupBackgroundHarnesses();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it.each([18798, 20123])(
+    "wakes the paired port %i on reconnect, at most once per minute",
+    async (relayPort) => {
+      const harness = await loadBackground({
+        storedConfig: { relayUrl: `ws://127.0.0.1:${relayPort}/extension`, token: TEST_RELAY_KEY },
+        nativeMessage: async (request) => ({
+          v: 1,
+          ok: true,
+          nonce: (request as { nonce: string }).nonce,
+          relay: "spawned",
+        }),
+      });
+      expect(harness.sendNativeMessage).not.toHaveBeenCalled();
+      harness.relaySockets.at(-1)?.close();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(harness.sendNativeMessage).toHaveBeenCalledExactlyOnceWith(
+        "ai.openclaw.browser_bootstrap",
+        { v: 1, op: "ensure_relay", nonce: expect.any(String), relayPort },
+      );
+      harness.relaySockets.at(-1)?.close();
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(harness.relaySockets).toHaveLength(3);
+      expect(harness.sendNativeMessage).toHaveBeenCalledOnce();
+      vi.setSystemTime(Date.now() + 60_000);
+      harness.relaySockets.at(-1)?.close();
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(harness.sendNativeMessage).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each([
+    ["local Gateway", "ws://127.0.0.1:18789/browser/extension", false],
+    ["remote Gateway", "wss://gateway.example.com/browser/extension", false],
+    ["secure loopback", "wss://localhost:18798/extension", false],
+    ["automatic setup opt-out", "ws://127.0.0.1:18798/extension", true],
+  ])("does not wake a daemon for %s", async (_label, relayUrl, nativeBootstrapDisabled) => {
+    const harness = await loadBackground({
+      storedConfig: { relayUrl, token: TEST_RELAY_KEY, nativeBootstrapDisabled },
+    });
+    harness.relaySockets.at(-1)?.close();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(harness.relaySockets).toHaveLength(2);
+    expect(harness.sendNativeMessage).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/browser/chrome-extension/background.test.ts
+++ b/extensions/browser/chrome-extension/background.test.ts
@@ -55,6 +55,33 @@ describe("native extension bootstrap", () => {
     expect(harness.storageValues).not.toHaveProperty("relayUrl");
   });
 
+  it("recovers after a repaired manifest only when automatic setup is explicitly enabled again", async () => {
+    let repaired = false;
+    const harness = await loadBackground({
+      storedConfig: {},
+      nativeMessage: async (request) =>
+        repaired ? nativeSuccess(request) : { v: 1, ok: false, code: "manifest_invalid" },
+    });
+    await vi.waitFor(() =>
+      expect(harness.storageValues).toMatchObject({
+        nativeBootstrapState: "manual_required",
+        nativeBootstrapFailureCode: "manifest_invalid",
+      }),
+    );
+    repaired = true;
+    harness.alarmListener({ name: "openclaw-relay-watchdog" });
+    await sendRuntimeMessage(harness, { type: "getStatus" });
+    expect(harness.sendNativeMessage).toHaveBeenCalledOnce();
+    expect(harness.relaySockets).toHaveLength(0);
+    await expect(
+      sendRuntimeMessage(harness, { type: "setNativeBootstrapEnabled", enabled: true }),
+    ).resolves.toMatchObject({ ok: true });
+    await vi.waitFor(() => expect(harness.relaySockets).toHaveLength(1));
+    expect(harness.storageValues.nativeBootstrapState).toBe("ready");
+    expect(harness.storageValues).not.toHaveProperty("nativeBootstrapFailureCode");
+    expect(harness.sendNativeMessage).toHaveBeenCalledTimes(2);
+  });
+
   it("coalesces startup, watchdog, and popup attempts", async () => {
     let resolveNative = (_value: unknown) => {};
     const pending = new Promise((resolve) => {

--- a/extensions/browser/chrome-extension/bootstrap-diagnostics.test-support.ts
+++ b/extensions/browser/chrome-extension/bootstrap-diagnostics.test-support.ts
@@ -181,9 +181,9 @@ export function createBootstrapDiagnostic() {
             observe(client, false, raw);
             callbacks.onMessage(raw);
           },
-          onClose: () => {
+          onClose: async () => {
             try {
-              callbacks.onClose();
+              await callbacks.onClose();
             } finally {
               append({ phase: "client.close", client, count: bridge.cdpClientCount });
             }

--- a/extensions/browser/chrome-extension/bootstrap-diagnostics.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap-diagnostics.test.ts
@@ -17,7 +17,7 @@ function observerFixture() {
       reply = socket.send;
       return {
         onMessage: receive,
-        onClose: () => {
+        onClose: async () => {
           count--;
           socket.close();
         },
@@ -65,7 +65,7 @@ describe("bootstrap diagnostic observation", () => {
     expect(bridge.attachCdpClientSocket).toBe(original);
   });
 
-  it("caps flood output but retains the action outcome and teardown", () => {
+  it("caps flood output but retains the action outcome and teardown", async () => {
     const output = vi.spyOn(process.stderr, "write").mockReturnValue(true);
     const diagnostic = createBootstrapDiagnostic();
     const { bridge, reply } = observerFixture();
@@ -82,7 +82,7 @@ describe("bootstrap diagnostic observation", () => {
     }
     diagnostic.mark("navigate.status", 500);
     diagnostic.flush();
-    callbacks.onClose();
+    await callbacks.onClose();
     diagnostic.mark("relay.closed", true);
     diagnostic.flush();
     diagnostic.flush();

--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -251,7 +251,8 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
             }),
         );
         cleanups.push(async () => {
-          const bridge = getBrowserControlState()?.extensionRelays?.get("e2e")?.bridge;
+          const currentRelay = getBrowserControlState()?.extensionRelays?.get("e2e");
+          const bridge = currentRelay?.ownership === "owned" ? currentRelay.bridge : undefined;
           const sessions = [...chromeMcpSessions.values()].slice(0, 8);
           try {
             await stopBrowserControlService();
@@ -395,8 +396,12 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         try {
           await expect
             .poll(
-              () =>
-                getBrowserControlState()?.extensionRelays?.get("e2e")?.bridge.extensionConnected,
+              () => {
+                const currentRelay = getBrowserControlState()?.extensionRelays?.get("e2e");
+                return (
+                  currentRelay?.ownership === "owned" && currentRelay.bridge.extensionConnected
+                );
+              },
               { timeout: 15_000 },
             )
             .toBe(true);
@@ -409,7 +414,7 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           });
         }
         const relay = getBrowserControlState()?.extensionRelays?.get("e2e");
-        if (!relay || relay.port !== relayPort) {
+        if (!relay || relay.ownership !== "owned" || relay.port !== relayPort) {
           throw new Error("Gateway wakeup did not start the configured extension relay");
         }
         diagnostic.watchRelay(relay.bridge);

--- a/extensions/browser/chrome-extension/modules/native-bootstrap.d.ts
+++ b/extensions/browser/chrome-extension/modules/native-bootstrap.d.ts
@@ -52,6 +52,13 @@ type RetiredCopilotStorage = {
   };
 };
 
+export function requestRelayEnsure(chromeApi?: {
+  runtime: {
+    connectNative(name: string): NativeMessagePort;
+    lastError?: { message?: string };
+  };
+}): Promise<{ status: "spawned" | "running" | "skipped" | "unavailable" }>;
+
 export function prepareRetiredCopilotState(
   chromeApi?: RetiredCopilotStorage,
 ): Promise<{ blocked: boolean }>;

--- a/extensions/browser/chrome-extension/modules/native-bootstrap.d.ts
+++ b/extensions/browser/chrome-extension/modules/native-bootstrap.d.ts
@@ -52,12 +52,15 @@ type RetiredCopilotStorage = {
   };
 };
 
-export function requestRelayEnsure(chromeApi?: {
-  runtime: {
-    connectNative(name: string): NativeMessagePort;
-    lastError?: { message?: string };
-  };
-}): Promise<{ status: "spawned" | "running" | "skipped" | "unavailable" }>;
+export function requestRelayEnsure(
+  relayPort: number,
+  chromeApi?: {
+    runtime: {
+      connectNative(name: string): NativeMessagePort;
+      lastError?: { message?: string };
+    };
+  },
+): Promise<{ status: "spawned" | "running" | "skipped" | "unavailable" }>;
 
 export function prepareRetiredCopilotState(
   chromeApi?: RetiredCopilotStorage,

--- a/extensions/browser/chrome-extension/modules/native-bootstrap.js
+++ b/extensions/browser/chrome-extension/modules/native-bootstrap.js
@@ -90,6 +90,29 @@ function sendNativeBootstrap(chromeApi, request) {
   });
 }
 
+const RELAY_ENSURE_STATUSES = new Set(["spawned", "running", "skipped"]);
+
+/** Ask the native host to start the standalone relay daemon when nothing serves the relay port. */
+export async function requestRelayEnsure(chromeApi = chrome) {
+  const nonce = randomRelayBase64Url(crypto, 16);
+  let response;
+  try {
+    response = await sendNativeBootstrap(chromeApi, { v: 1, op: "ensure_relay", nonce });
+  } catch {
+    return { status: "unavailable" };
+  }
+  if (
+    hasExactKeys(response, ["v", "ok", "nonce", "relay"]) &&
+    response.v === 1 &&
+    response.ok === true &&
+    response.nonce === nonce &&
+    RELAY_ENSURE_STATUSES.has(response.relay)
+  ) {
+    return { status: response.relay };
+  }
+  return { status: "unavailable" };
+}
+
 /** Own coalescing, retry policy, opt-out, and late-response revocation. */
 export function createNativeBootstrapController({ chromeApi = chrome, getPairing, applyPairing }) {
   let inFlight = null;

--- a/extensions/browser/chrome-extension/modules/native-bootstrap.js
+++ b/extensions/browser/chrome-extension/modules/native-bootstrap.js
@@ -93,11 +93,11 @@ function sendNativeBootstrap(chromeApi, request) {
 const RELAY_ENSURE_STATUSES = new Set(["spawned", "running", "skipped"]);
 
 /** Ask the native host to start the standalone relay daemon when nothing serves the relay port. */
-export async function requestRelayEnsure(chromeApi = chrome) {
+export async function requestRelayEnsure(relayPort, chromeApi = chrome) {
   const nonce = randomRelayBase64Url(crypto, 16);
   let response;
   try {
-    response = await sendNativeBootstrap(chromeApi, { v: 1, op: "ensure_relay", nonce });
+    response = await sendNativeBootstrap(chromeApi, { v: 1, op: "ensure_relay", nonce, relayPort });
   } catch {
     return { status: "unavailable" };
   }

--- a/extensions/browser/chrome-extension/modules/native-bootstrap.test.ts
+++ b/extensions/browser/chrome-extension/modules/native-bootstrap.test.ts
@@ -3,6 +3,7 @@ import {
   createNativeBootstrapController,
   discardRetiredCopilotState,
   prepareRetiredCopilotState,
+  requestRelayEnsure,
 } from "./native-bootstrap.js";
 
 const COPILOT_LOCAL_KEYS = [
@@ -382,5 +383,65 @@ describe("native bootstrap timeout", () => {
       failureCode: "native_host_timeout",
     });
     expect(disconnect).toHaveBeenCalledOnce();
+  });
+});
+
+type EnsurePortScript = (request: { nonce: string }) => unknown;
+
+function ensureChromeApi(script: EnsurePortScript | "disconnect") {
+  const connectNative = vi.fn(() => {
+    let messageListener: ((response: unknown) => void) | undefined;
+    let disconnectListener: (() => void) | undefined;
+    return {
+      disconnect: vi.fn(),
+      onMessage: {
+        addListener: (listener: (response: unknown) => void) => {
+          messageListener = listener;
+        },
+      },
+      onDisconnect: {
+        addListener: (listener: () => void) => {
+          disconnectListener = listener;
+        },
+      },
+      postMessage: (request: { nonce: string }) => {
+        queueMicrotask(() => {
+          if (script === "disconnect") {
+            disconnectListener?.();
+            return;
+          }
+          messageListener?.(script(request));
+        });
+      },
+    };
+  });
+  return { runtime: { connectNative, lastError: undefined } };
+}
+
+describe("requestRelayEnsure", () => {
+  it("returns the relay status when the native host answers with the echoed nonce", async () => {
+    const chromeApi = ensureChromeApi((request) => ({
+      v: 1,
+      ok: true,
+      nonce: request.nonce,
+      relay: "spawned",
+    }));
+    await expect(requestRelayEnsure(chromeApi)).resolves.toEqual({ status: "spawned" });
+  });
+
+  it("treats a nonce mismatch as unavailable", async () => {
+    const chromeApi = ensureChromeApi(() => ({
+      v: 1,
+      ok: true,
+      nonce: "AAAAAAAAAAAAAAAAAAAAAA",
+      relay: "spawned",
+    }));
+    await expect(requestRelayEnsure(chromeApi)).resolves.toEqual({ status: "unavailable" });
+  });
+
+  it("treats a missing native host as unavailable", async () => {
+    await expect(requestRelayEnsure(ensureChromeApi("disconnect"))).resolves.toEqual({
+      status: "unavailable",
+    });
   });
 });

--- a/extensions/browser/chrome-extension/modules/native-bootstrap.test.ts
+++ b/extensions/browser/chrome-extension/modules/native-bootstrap.test.ts
@@ -420,13 +420,16 @@ function ensureChromeApi(script: EnsurePortScript | "disconnect") {
 
 describe("requestRelayEnsure", () => {
   it("returns the relay status when the native host answers with the echoed nonce", async () => {
-    const chromeApi = ensureChromeApi((request) => ({
-      v: 1,
-      ok: true,
-      nonce: request.nonce,
-      relay: "spawned",
-    }));
-    await expect(requestRelayEnsure(chromeApi)).resolves.toEqual({ status: "spawned" });
+    const chromeApi = ensureChromeApi((request) => {
+      expect(request).toEqual({
+        v: 1,
+        op: "ensure_relay",
+        nonce: expect.any(String),
+        relayPort: 20123,
+      });
+      return { v: 1, ok: true, nonce: request.nonce, relay: "spawned" };
+    });
+    await expect(requestRelayEnsure(20123, chromeApi)).resolves.toEqual({ status: "spawned" });
   });
 
   it("treats a nonce mismatch as unavailable", async () => {
@@ -436,11 +439,11 @@ describe("requestRelayEnsure", () => {
       nonce: "AAAAAAAAAAAAAAAAAAAAAA",
       relay: "spawned",
     }));
-    await expect(requestRelayEnsure(chromeApi)).resolves.toEqual({ status: "unavailable" });
+    await expect(requestRelayEnsure(20123, chromeApi)).resolves.toEqual({ status: "unavailable" });
   });
 
   it("treats a missing native host as unavailable", async () => {
-    await expect(requestRelayEnsure(ensureChromeApi("disconnect"))).resolves.toEqual({
+    await expect(requestRelayEnsure(20123, ensureChromeApi("disconnect"))).resolves.toEqual({
       status: "unavailable",
     });
   });

--- a/extensions/browser/chrome-extension/modules/relay-core.d.ts
+++ b/extensions/browser/chrome-extension/modules/relay-core.d.ts
@@ -35,6 +35,8 @@ export function createPairingConfigStore(storage: {
 
 export function buildRelayWsProtocols(): string[];
 
+export function isDirectLoopbackRelayUrl(raw: unknown): boolean;
+
 export function reconnectDelayMs(attempt: number): number;
 
 export function nearestGroupColor(hex: unknown): string;

--- a/extensions/browser/chrome-extension/modules/relay-core.d.ts
+++ b/extensions/browser/chrome-extension/modules/relay-core.d.ts
@@ -35,7 +35,7 @@ export function createPairingConfigStore(storage: {
 
 export function buildRelayWsProtocols(): string[];
 
-export function isDirectLoopbackRelayUrl(raw: unknown): boolean;
+export function directLoopbackRelayPort(raw: unknown): number | null;
 
 export function reconnectDelayMs(attempt: number): number;
 

--- a/extensions/browser/chrome-extension/modules/relay-core.js
+++ b/extensions/browser/chrome-extension/modules/relay-core.js
@@ -51,6 +51,17 @@ function isAllowedWebSocketUrl(url) {
   return url.protocol === "wss:" || (url.protocol === "ws:" && isLoopbackHost(url.hostname));
 }
 
+/** True for a loopback ws:// relay URL on the direct /extension path — the URL the standalone relay daemon serves. */
+export function isDirectLoopbackRelayUrl(raw) {
+  let url;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  return url.protocol === "ws:" && isLoopbackHost(url.hostname) && url.pathname === "/extension";
+}
+
 function parseGatewayHint(raw) {
   if (typeof raw !== "string") {
     return null;

--- a/extensions/browser/chrome-extension/modules/relay-core.js
+++ b/extensions/browser/chrome-extension/modules/relay-core.js
@@ -51,15 +51,26 @@ function isAllowedWebSocketUrl(url) {
   return url.protocol === "wss:" || (url.protocol === "ws:" && isLoopbackHost(url.hostname));
 }
 
-/** True for a loopback ws:// relay URL on the direct /extension path — the URL the standalone relay daemon serves. */
-export function isDirectLoopbackRelayUrl(raw) {
+/** Wake-up carries only a port; match the relay server's 127.0.0.1 bind address. */
+export function directLoopbackRelayPort(raw) {
   let url;
   try {
     url = new URL(raw);
   } catch {
-    return false;
+    return null;
   }
-  return url.protocol === "ws:" && isLoopbackHost(url.hostname) && url.pathname === "/extension";
+  const port = Number(url.port || 80);
+  return url.protocol === "ws:" &&
+    url.hostname === "127.0.0.1" &&
+    url.pathname === "/extension" &&
+    port > 0 &&
+    !url.username &&
+    !url.password &&
+    !url.hash &&
+    normalizeRelayQuery(url) &&
+    url.toString() === raw
+    ? port
+    : null;
 }
 
 function parseGatewayHint(raw) {

--- a/extensions/browser/chrome-extension/modules/relay-core.test.ts
+++ b/extensions/browser/chrome-extension/modules/relay-core.test.ts
@@ -7,6 +7,7 @@ import {
   nearestGroupColor,
   parsePairingString,
   reconnectDelayMs,
+  isDirectLoopbackRelayUrl,
 } from "./relay-core.js";
 
 const RELAY_SECRET = "a".repeat(64);
@@ -390,5 +391,22 @@ describe("nearestGroupColor", () => {
   it("falls back to orange for invalid input", () => {
     expect(nearestGroupColor("not-a-color")).toBe("orange");
     expect(nearestGroupColor(undefined)).toBe("orange");
+  });
+});
+
+describe("isDirectLoopbackRelayUrl", () => {
+  it("accepts only loopback ws:// URLs on the direct /extension path", () => {
+    expect(isDirectLoopbackRelayUrl("ws://127.0.0.1:18799/extension")).toBe(true);
+    expect(isDirectLoopbackRelayUrl("ws://localhost:18799/extension")).toBe(true);
+    expect(isDirectLoopbackRelayUrl("ws://[::1]:18799/extension")).toBe(true);
+  });
+
+  it("rejects gateway routes, remote hosts, and malformed values", () => {
+    expect(isDirectLoopbackRelayUrl("ws://127.0.0.1:18789/browser/extension")).toBe(false);
+    expect(isDirectLoopbackRelayUrl("wss://gateway.example.com/browser/extension")).toBe(false);
+    expect(isDirectLoopbackRelayUrl("ws://10.0.0.5:18799/extension")).toBe(false);
+    expect(isDirectLoopbackRelayUrl("http://127.0.0.1:18799/extension")).toBe(false);
+    expect(isDirectLoopbackRelayUrl("not a url")).toBe(false);
+    expect(isDirectLoopbackRelayUrl(undefined)).toBe(false);
   });
 });

--- a/extensions/browser/chrome-extension/modules/relay-core.test.ts
+++ b/extensions/browser/chrome-extension/modules/relay-core.test.ts
@@ -7,7 +7,7 @@ import {
   nearestGroupColor,
   parsePairingString,
   reconnectDelayMs,
-  isDirectLoopbackRelayUrl,
+  directLoopbackRelayPort,
 } from "./relay-core.js";
 
 const RELAY_SECRET = "a".repeat(64);
@@ -394,19 +394,34 @@ describe("nearestGroupColor", () => {
   });
 });
 
-describe("isDirectLoopbackRelayUrl", () => {
-  it("accepts only loopback ws:// URLs on the direct /extension path", () => {
-    expect(isDirectLoopbackRelayUrl("ws://127.0.0.1:18799/extension")).toBe(true);
-    expect(isDirectLoopbackRelayUrl("ws://localhost:18799/extension")).toBe(true);
-    expect(isDirectLoopbackRelayUrl("ws://[::1]:18799/extension")).toBe(true);
+describe("directLoopbackRelayPort", () => {
+  it("accepts the canonical IPv4 listener on the direct /extension path", () => {
+    expect(directLoopbackRelayPort("ws://127.0.0.1:18799/extension")).toBe(18799);
+    expect(directLoopbackRelayPort("ws://127.0.0.1:20123/extension?profile=work")).toBe(20123);
   });
 
   it("rejects gateway routes, remote hosts, and malformed values", () => {
-    expect(isDirectLoopbackRelayUrl("ws://127.0.0.1:18789/browser/extension")).toBe(false);
-    expect(isDirectLoopbackRelayUrl("wss://gateway.example.com/browser/extension")).toBe(false);
-    expect(isDirectLoopbackRelayUrl("ws://10.0.0.5:18799/extension")).toBe(false);
-    expect(isDirectLoopbackRelayUrl("http://127.0.0.1:18799/extension")).toBe(false);
-    expect(isDirectLoopbackRelayUrl("not a url")).toBe(false);
-    expect(isDirectLoopbackRelayUrl(undefined)).toBe(false);
+    expect(directLoopbackRelayPort("ws://127.0.0.1:18789/browser/extension")).toBeNull();
+    expect(directLoopbackRelayPort("wss://gateway.example.com/browser/extension")).toBeNull();
+    expect(directLoopbackRelayPort("ws://10.0.0.5:18799/extension")).toBeNull();
+    expect(directLoopbackRelayPort("http://127.0.0.1:18799/extension")).toBeNull();
+    expect(directLoopbackRelayPort("not a url")).toBeNull();
+    expect(directLoopbackRelayPort(undefined)).toBeNull();
+  });
+
+  it.each([
+    "ws://localhost:18799/extension",
+    "ws://localhost.:18799/extension",
+    "ws://127.25.0.1:18799/extension",
+    "ws://[::1]:18799/extension",
+    "ws://[::ffff:7f00:1]:18799/extension",
+    "ws://user:password@127.0.0.1:18799/extension",
+    "ws://127.0.0.1:18799/extension#secret",
+    "ws://127.0.0.1:18799/extension?host=remote",
+    "ws://127.0.0.1:18799/extension?profile=one&profile=two",
+    "ws://127.0.0.1:0/extension",
+    "wss://127.0.0.1:18799/extension",
+  ])("rejects noncanonical or unsupported wake-up target %s", (url) => {
+    expect(directLoopbackRelayPort(url)).toBeNull();
   });
 });

--- a/extensions/browser/native-host-entry.ts
+++ b/extensions/browser/native-host-entry.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import {
   parseBrowserNativeHostOrigins,
   runBrowserNativeHost,
@@ -29,6 +30,14 @@ async function main(): Promise<void> {
       const { buildBrowserNativeHostPairing } =
         await import("./src/browser/extension-native-host.runtime.js");
       return await buildBrowserNativeHostPairing();
+    },
+    ensureRelay: async () => {
+      const { ensureBrowserNativeRelay } =
+        await import("./src/browser/extension-native-host.runtime.js");
+      // Resolve the sibling entry here, not relative to a shared runtime chunk.
+      return await ensureBrowserNativeRelay(
+        fileURLToPath(new URL("./relay-daemon-entry.js", import.meta.url)),
+      );
     },
   });
   const response = responseFrame;

--- a/extensions/browser/native-host-entry.ts
+++ b/extensions/browser/native-host-entry.ts
@@ -31,11 +31,12 @@ async function main(): Promise<void> {
         await import("./src/browser/extension-native-host.runtime.js");
       return await buildBrowserNativeHostPairing();
     },
-    ensureRelay: async () => {
+    ensureRelay: async (port) => {
       const { ensureBrowserNativeRelay } =
         await import("./src/browser/extension-native-host.runtime.js");
       // Resolve the sibling entry here, not relative to a shared runtime chunk.
       return await ensureBrowserNativeRelay(
+        port,
         fileURLToPath(new URL("./relay-daemon-entry.js", import.meta.url)),
       );
     },

--- a/extensions/browser/relay-daemon-entry.ts
+++ b/extensions/browser/relay-daemon-entry.ts
@@ -1,0 +1,36 @@
+/**
+ * Standalone extension relay daemon. Hosts the loopback relay the OpenClaw
+ * Chrome extension dials, with no Gateway required — CDP clients (mcporter,
+ * Playwright, chrome-devtools-mcp) attach through the same relay port. Spawned
+ * on demand by the native messaging host, or run manually.
+ */
+import { runExtensionRelayDaemon } from "./src/browser/relay-daemon.js";
+
+const DEFAULT_RELAY_PORT = 18_799;
+
+function resolvePortArgument(argv: string[]): number {
+  const index = argv.indexOf("--port");
+  const raw = index >= 0 ? argv[index + 1] : undefined;
+  if (raw === undefined) {
+    return DEFAULT_RELAY_PORT;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 65_535) {
+    throw new Error(`invalid --port value: ${raw}`);
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const run = await runExtensionRelayDaemon({ port: resolvePortArgument(process.argv.slice(2)) });
+  const stop = (): void => run.stop();
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  const reason = await run.done;
+  process.exitCode = reason === "no-credential" ? 1 : 0;
+}
+
+void main().catch((error: unknown) => {
+  process.stderr.write(`openclaw relay daemon failed: ${String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/extensions/browser/relay-daemon-entry.ts
+++ b/extensions/browser/relay-daemon-entry.ts
@@ -4,9 +4,25 @@
  * Playwright, chrome-devtools-mcp) attach through the same relay port. Spawned
  * on demand by the native messaging host, or run manually.
  */
+import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { runExtensionRelayDaemon } from "./src/browser/relay-daemon.js";
 
 const DEFAULT_RELAY_PORT = 18_799;
+
+/**
+ * The standalone daemon is v2-only by default. Honor an explicit
+ * `browser.extensionRelay.allowLegacyAuth=true` opt-in, but never fall back to
+ * legacy on a read/parse failure — fail closed to the stricter mode. Read the
+ * raw config value (not the resolved `?? true` default) so an unset key stays
+ * v2-only rather than inheriting the gateway's permissive default.
+ */
+function resolveAllowLegacyAuth(): boolean {
+  try {
+    return getRuntimeConfig().browser?.extensionRelay?.allowLegacyAuth === true;
+  } catch {
+    return false;
+  }
+}
 
 function resolvePortArgument(argv: string[]): number {
   const index = argv.indexOf("--port");
@@ -22,7 +38,10 @@ function resolvePortArgument(argv: string[]): number {
 }
 
 async function main(): Promise<void> {
-  const run = await runExtensionRelayDaemon({ port: resolvePortArgument(process.argv.slice(2)) });
+  const run = await runExtensionRelayDaemon({
+    port: resolvePortArgument(process.argv.slice(2)),
+    allowLegacyAuth: resolveAllowLegacyAuth(),
+  });
   const stop = (): void => run.stop();
   process.once("SIGINT", stop);
   process.once("SIGTERM", stop);

--- a/extensions/browser/src/browser/extension-install-layout.test.ts
+++ b/extensions/browser/src/browser/extension-install-layout.test.ts
@@ -18,7 +18,7 @@ import {
   FOUNDATION_STORE_ID,
   predictedId,
   useExtensionInstallFixture,
-  writeSecurePreferences,
+  writeChromePreferences,
 } from "./extension-install.test-support.js";
 
 const ID_A = "abcdefghijklmnopabcdefghijklmnop";
@@ -204,7 +204,7 @@ describe("deterministic unpacked extension ID", () => {
   });
 });
 
-describe("Secure Preferences discovery", () => {
+describe.each(["Preferences", "Secure Preferences"] as const)("%s discovery", (filename) => {
   it("discovers multiple exact unpacked IDs and ignores name, location, and path lookalikes", async () => {
     const value = await fixture();
     const installed = await installStableChromeExtension(value.bundledDir, value.deps);
@@ -214,7 +214,8 @@ describe("Secure Preferences discovery", () => {
     }
     const installedId = await predictedId(installed, value.deps.platform);
     const bundledId = await predictedId(value.bundledDir, value.deps.platform);
-    await writeSecurePreferences({
+    await writeChromePreferences({
+      filename,
       userDataDir: chrome.userDataDir,
       profile: "Default",
       entries: {
@@ -227,7 +228,8 @@ describe("Secure Preferences discovery", () => {
         ["p".repeat(32)]: { location: 1, path: installed, manifest: { name: "OpenClaw" } },
       },
     });
-    await writeSecurePreferences({
+    await writeChromePreferences({
+      filename,
       userDataDir: chrome.userDataDir,
       profile: "Profile 1",
       entries: {
@@ -247,6 +249,31 @@ describe("Secure Preferences discovery", () => {
       ["Default", installedId],
       ["Profile 1", bundledId],
     ]);
+    await fs.symlink(
+      path.join(chrome.userDataDir, "Default"),
+      path.join(chrome.userDataDir, "Profile 2"),
+    );
+    const otherFilename = filename === "Preferences" ? "Secure Preferences" : "Preferences";
+    for (const profile of ["Default", "Profile 1"]) {
+      const profileDir = path.join(chrome.userDataDir, profile);
+      await fs.copyFile(path.join(profileDir, filename), path.join(profileDir, otherFilename));
+    }
+    const duplicated = await discoverChromeExtensionIds({
+      approvedDirs: [installed, value.bundledDir],
+      storeExtensionId: FOUNDATION_STORE_ID,
+      deps: value.deps,
+    });
+    expect(duplicated).toEqual({
+      ...result,
+      discovered: result.discovered.map((entry) => ({
+        ...entry,
+        securePreferencesPath: path.join(chrome.userDataDir, entry.profile, "Secure Preferences"),
+      })),
+      storeDiscovered: result.storeDiscovered.map((entry) => ({
+        ...entry,
+        securePreferencesPath: path.join(chrome.userDataDir, entry.profile, "Secure Preferences"),
+      })),
+    });
     for (const entry of result.discovered) {
       expect(entry.extensionId).toBe(
         generateChromeExtensionIdForPath(entry.extensionPath, value.deps.platform),
@@ -269,7 +296,8 @@ describe("Secure Preferences discovery", () => {
       throw new Error("missing Chrome fixture root");
     }
     const expected = await predictedId(installed, value.deps.platform);
-    await writeSecurePreferences({
+    await writeChromePreferences({
+      filename,
       userDataDir: chrome.userDataDir,
       profile: "Default",
       entries: { [ID_A]: { location: 4, path: installed } },
@@ -285,47 +313,78 @@ describe("Secure Preferences discovery", () => {
     expect(result.issues[0]).toContain(`does not match predicted ID ${expected}`);
   });
 
-  it("fails closed on malformed, oversized, locked, and symlinked profile metadata", async () => {
-    const value = await fixture();
-    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
-    if (!chrome) {
-      throw new Error("missing Chrome fixture root");
-    }
-    const malformed = await writeSecurePreferences({
-      userDataDir: chrome.userDataDir,
-      profile: "Default",
-      entries: {},
-    });
-    await fs.writeFile(malformed, "{partial", { mode: 0o600 });
-    const profileLink = path.join(chrome.userDataDir, "Profile 2");
-    await fs.symlink(path.join(chrome.userDataDir, "Default"), profileLink);
-    const oversized = await writeSecurePreferences({
-      userDataDir: chrome.userDataDir,
-      profile: "Profile 3",
-      entries: {},
-    });
-    await fs.truncate(oversized, 32 * 1024 * 1024 + 1);
-    const canLockFile = process.platform !== "win32" && process.getuid?.() !== 0;
-    if (canLockFile) {
-      const locked = await writeSecurePreferences({
+  it.for([
+    { failure: "malformed", issue: "JSON" },
+    { failure: "oversized", issue: "32 MiB inspection limit" },
+    { failure: "locked", issue: "EACCES" },
+    { failure: "symlink", issue: "Unsafe file" },
+    { failure: "directory", issue: "Unsafe file" },
+    { failure: "unsafe-mode", issue: "group/world-writable" },
+    { failure: "foreign-owner", issue: "foreign owner" },
+  ])(
+    "rejects $failure metadata even when the other store contains a valid identity",
+    async ({ failure, issue }, { skip }) => {
+      if (
+        (process.platform === "win32" &&
+          ["locked", "unsafe-mode", "foreign-owner"].includes(failure)) ||
+        (failure === "locked" && process.getuid?.() === 0)
+      ) {
+        skip();
+      }
+      const value = await fixture();
+      const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
+      if (!chrome) {
+        throw new Error("missing Chrome fixture root");
+      }
+      const extensionId = await predictedId(value.bundledDir, value.deps.platform);
+      const entries = { [extensionId]: { location: 4, path: value.bundledDir } };
+      const unsafe = await writeChromePreferences({
+        filename,
         userDataDir: chrome.userDataDir,
-        profile: "Profile 4",
-        entries: {},
+        profile: "Default",
+        entries,
       });
-      await fs.chmod(locked, 0o000);
-    }
-
-    const result = await discoverChromeExtensionIds({
-      approvedDirs: [value.bundledDir],
-      deps: value.deps,
-    });
-    expect(result.discovered).toEqual([]);
-    expect(result.issues.join("\n")).toContain("Default");
-    expect(result.issues.join("\n")).toContain("Profile 3");
-    if (canLockFile) {
-      expect(result.issues.join("\n")).toContain("Profile 4");
-    }
-  });
+      const valid = await writeChromePreferences({
+        filename: filename === "Preferences" ? "Secure Preferences" : "Preferences",
+        userDataDir: chrome.userDataDir,
+        profile: "Default",
+        entries,
+      });
+      if (failure === "malformed") {
+        await fs.writeFile(unsafe, "{partial");
+      } else if (failure === "oversized") {
+        await fs.truncate(unsafe, 32 * 1024 * 1024 + 1);
+      } else if (failure === "locked" || failure === "unsafe-mode") {
+        await fs.chmod(unsafe, failure === "locked" ? 0o000 : 0o662);
+      } else if (failure === "foreign-owner") {
+        const realLstat = fs.lstat.bind(fs);
+        vi.spyOn(fs, "lstat").mockImplementation(async (target) => {
+          const info = await realLstat(target);
+          return String(target) === unsafe
+            ? statsWithUid(info, (process.getuid?.() ?? 0) + 1)
+            : info;
+        });
+      } else {
+        await fs.unlink(unsafe);
+        if (failure === "symlink") {
+          await fs.symlink(valid, unsafe);
+        } else {
+          await fs.mkdir(unsafe);
+        }
+      }
+      const result = await discoverChromeExtensionIds({
+        approvedDirs: [value.bundledDir],
+        deps: value.deps,
+      });
+      expect(result.discovered).toEqual([
+        expect.objectContaining({ extensionId, securePreferencesPath: valid }),
+      ]);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]).toContain("Default");
+      expect(result.issues[0]).toContain(filename);
+      expect(result.issues[0]).toContain(issue);
+    },
+  );
 
   it("does not approve a foreign stable copy in status discovery", async () => {
     const value = await fixture();
@@ -336,7 +395,8 @@ describe("Secure Preferences discovery", () => {
     if (!chrome) {
       throw new Error("missing Chrome fixture root");
     }
-    await writeSecurePreferences({
+    await writeChromePreferences({
+      filename,
       userDataDir: chrome.userDataDir,
       profile: "Default",
       entries: { [await predictedId(target, value.deps.platform)]: { location: 4, path: target } },

--- a/extensions/browser/src/browser/extension-install-layout.ts
+++ b/extensions/browser/src/browser/extension-install-layout.ts
@@ -8,7 +8,7 @@ import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 const EXTENSION_ID_PATTERN = /^[a-p]{32}$/;
 const UNPACKED_MANIFEST_LOCATION = 4;
 const OWNED_COPY_MARKER = ".openclaw-owned.json";
-const SECURE_PREFERENCES_MAX_BYTES = 32 * 1024 * 1024;
+const PREFERENCES_MAX_BYTES = 32 * 1024 * 1024;
 
 export type ChromeProduct = "chrome" | "chrome-for-testing" | "chromium";
 export type ChromeProductRoot = {
@@ -22,6 +22,7 @@ export type DiscoveredChromeExtension = {
   browser: string;
   userDataDir: string;
   profile: string;
+  /** Source backing file, either Preferences or Secure Preferences. */
   securePreferencesPath: string;
   extensionId: string;
   extensionPath: string;
@@ -353,82 +354,85 @@ export async function discoverChromeExtensionIds(params: {
         continue;
       }
       const profileDir = path.join(root.userDataDir, profileEntry.name);
-      const securePreferencesPath = path.join(profileDir, "Secure Preferences");
-      const secureInfo = await pathInfo(securePreferencesPath);
-      if (!secureInfo) {
-        continue;
-      }
-      try {
-        await assertOwnedPath(profileDir, "directory");
-        await assertOwnedPath(securePreferencesPath, "file");
-        if (secureInfo.size > SECURE_PREFERENCES_MAX_BYTES) {
-          throw new Error("Secure Preferences exceeds the 32 MiB inspection limit");
-        }
-        const preferences: unknown = JSON.parse(await fs.readFile(securePreferencesPath, "utf8"));
-        const settings = (preferences as { extensions?: { settings?: unknown } })?.extensions
-          ?.settings;
-        if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
+      // Chromium partitions extension settings by enforcement policy across both stores.
+      for (const filename of ["Preferences", "Secure Preferences"]) {
+        const preferencesPath = path.join(profileDir, filename);
+        const preferencesInfo = await pathInfo(preferencesPath);
+        if (!preferencesInfo) {
           continue;
         }
-        for (const [extensionId, rawEntry] of Object.entries(settings)) {
-          if (
-            !EXTENSION_ID_PATTERN.test(extensionId) ||
-            !rawEntry ||
-            typeof rawEntry !== "object"
-          ) {
+        try {
+          await assertOwnedPath(profileDir, "directory");
+          await assertOwnedPath(preferencesPath, "file");
+          if (preferencesInfo.size > PREFERENCES_MAX_BYTES) {
+            throw new Error(`${filename} exceeds the 32 MiB inspection limit`);
+          }
+          const preferences: unknown = JSON.parse(await fs.readFile(preferencesPath, "utf8"));
+          const settings = (preferences as { extensions?: { settings?: unknown } })?.extensions
+            ?.settings;
+          if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
             continue;
           }
-          const entry = rawEntry as {
-            from_webstore?: unknown;
-            location?: unknown;
-            path?: unknown;
-          };
-          if (
-            extensionId === params.storeExtensionId &&
-            entry.from_webstore === true &&
-            entry.location !== UNPACKED_MANIFEST_LOCATION
-          ) {
-            storeDiscovered.push({
+          for (const [extensionId, rawEntry] of Object.entries(settings)) {
+            if (
+              !EXTENSION_ID_PATTERN.test(extensionId) ||
+              !rawEntry ||
+              typeof rawEntry !== "object"
+            ) {
+              continue;
+            }
+            const entry = rawEntry as {
+              from_webstore?: unknown;
+              location?: unknown;
+              path?: unknown;
+            };
+            if (
+              extensionId === params.storeExtensionId &&
+              entry.from_webstore === true &&
+              entry.location !== UNPACKED_MANIFEST_LOCATION
+            ) {
+              storeDiscovered.push({
+                product: root.product,
+                browser: root.label,
+                userDataDir: root.userDataDir,
+                profile: profileEntry.name,
+                securePreferencesPath: preferencesPath,
+                extensionId,
+              });
+              continue;
+            }
+            if (entry.location !== UNPACKED_MANIFEST_LOCATION || typeof entry.path !== "string") {
+              continue;
+            }
+            const recordedPath = path.isAbsolute(entry.path)
+              ? entry.path
+              : path.join(profileDir, "Extensions", entry.path);
+            const canonicalPath = await fs.realpath(recordedPath).catch(() => null);
+            if (!canonicalPath || !approved.has(comparablePath(canonicalPath, platform))) {
+              continue;
+            }
+            const predictedId = generateChromeExtensionIdForPath(canonicalPath, platform);
+            if (extensionId !== predictedId) {
+              const issue = `${root.label} profile ${profileEntry.name}: unpacked extension ID ${extensionId} does not match predicted ID ${predictedId} for ${canonicalPath}`;
+              issues.push(issue);
+              identityMismatches.push(issue);
+              continue;
+            }
+            discovered.push({
               product: root.product,
               browser: root.label,
               userDataDir: root.userDataDir,
               profile: profileEntry.name,
-              securePreferencesPath,
+              securePreferencesPath: preferencesPath,
               extensionId,
+              extensionPath: canonicalPath,
             });
-            continue;
           }
-          if (entry.location !== UNPACKED_MANIFEST_LOCATION || typeof entry.path !== "string") {
-            continue;
-          }
-          const recordedPath = path.isAbsolute(entry.path)
-            ? entry.path
-            : path.join(profileDir, "Extensions", entry.path);
-          const canonicalPath = await fs.realpath(recordedPath).catch(() => null);
-          if (!canonicalPath || !approved.has(comparablePath(canonicalPath, platform))) {
-            continue;
-          }
-          const predictedId = generateChromeExtensionIdForPath(canonicalPath, platform);
-          if (extensionId !== predictedId) {
-            const issue = `${root.label} profile ${profileEntry.name}: unpacked extension ID ${extensionId} does not match predicted ID ${predictedId} for ${canonicalPath}`;
-            issues.push(issue);
-            identityMismatches.push(issue);
-            continue;
-          }
-          discovered.push({
-            product: root.product,
-            browser: root.label,
-            userDataDir: root.userDataDir,
-            profile: profileEntry.name,
-            securePreferencesPath,
-            extensionId,
-            extensionPath: canonicalPath,
-          });
+        } catch (error) {
+          issues.push(
+            `${root.label} profile ${profileEntry.name} (${filename}): ${error instanceof Error ? error.message : String(error)}`,
+          );
         }
-      } catch (error) {
-        issues.push(
-          `${root.label} profile ${profileEntry.name}: ${error instanceof Error ? error.message : String(error)}`,
-        );
       }
     }
   }

--- a/extensions/browser/src/browser/extension-install.native-host.e2e.test.ts
+++ b/extensions/browser/src/browser/extension-install.native-host.e2e.test.ts
@@ -10,7 +10,7 @@ import {
   predictedId,
   useExtensionInstallFixture,
   useNativeHostLaunchFixture,
-  writeSecurePreferences,
+  writeChromePreferences,
 } from "./extension-install.test-support.js";
 
 const BUILT_NATIVE_HOST_PATH = path.resolve("dist/extensions/browser/native-host-entry.js");
@@ -54,7 +54,7 @@ describe.skipIf(process.platform === "win32")("native host registration", () => 
       throw new Error("missing Chromium fixture root");
     }
     const extensionId = await predictedId(installed, deps.platform);
-    await writeSecurePreferences({
+    await writeChromePreferences({
       userDataDir: chromium.userDataDir,
       profile: "Default",
       entries: { [extensionId]: { location: 4, path: installed } },

--- a/extensions/browser/src/browser/extension-install.test-support.ts
+++ b/extensions/browser/src/browser/extension-install.test-support.ts
@@ -10,14 +10,15 @@ export async function predictedId(candidate: string, platform: NodeJS.Platform =
   return generateChromeExtensionIdForPath(await fs.realpath(candidate), platform);
 }
 
-export async function writeSecurePreferences(params: {
+export async function writeChromePreferences(params: {
   userDataDir: string;
   profile: string;
   entries: Record<string, unknown>;
+  filename?: "Preferences" | "Secure Preferences";
 }) {
   const profileDir = path.join(params.userDataDir, params.profile);
   await fs.mkdir(profileDir, { recursive: true, mode: 0o700 });
-  const file = path.join(profileDir, "Secure Preferences");
+  const file = path.join(profileDir, params.filename ?? "Preferences");
   await fs.writeFile(file, JSON.stringify({ extensions: { settings: params.entries } }), {
     mode: 0o600,
   });

--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -19,7 +19,7 @@ import {
   FOUNDATION_STORE_ID,
   predictedId,
   useExtensionInstallFixture,
-  writeSecurePreferences,
+  writeChromePreferences,
 } from "./extension-install.test-support.js";
 
 const fixture = useExtensionInstallFixture();
@@ -74,78 +74,99 @@ describe("native host registration", () => {
     expect(status.issues[0]).toContain("if Chrome has not been launched yet, launch it first");
   });
 
-  it("pre-registers predicted IDs before waiting, then verifies Chrome's recorded ID", async () => {
-    const value = await fixture();
-    const installed = stableChromeExtensionDir(value.deps);
-    const chromium = chromeProductRoots(value.deps).find((root) => root.product === "chromium");
-    if (!chromium) {
-      throw new Error("missing Chromium fixture root");
-    }
-    await fs.mkdir(chromium.userDataDir, { recursive: true, mode: 0o700 });
-    const installedId = generateChromeExtensionIdForPath(installed, value.deps.platform);
-    const bundledId = await predictedId(value.bundledDir, value.deps.platform);
-    let now = 0;
-    let wroteProfile = false;
-    const status = await installChromeExtensionBootstrap({
-      bundledDir: value.bundledDir,
-      pluginRoot: value.pluginRoot,
-      waitMs: 1_000,
-      deps: {
-        ...value.deps,
-        now: () => now,
-        sleep: async (ms) => {
-          now += ms;
-          if (!wroteProfile) {
-            const manifestPath = path.join(
-              chromium.nativeManifestDir,
-              "ai.openclaw.browser_bootstrap.json",
-            );
-            const preRegistration = JSON.parse(await fs.readFile(manifestPath, "utf8")) as {
-              allowed_origins: string[];
-            };
-            expect(preRegistration.allowed_origins).toEqual(
-              [installedId, bundledId, FOUNDATION_STORE_ID]
-                .toSorted()
-                .map((id) => `chrome-extension://${id}/`),
-            );
-            wroteProfile = true;
-            await writeSecurePreferences({
-              userDataDir: chromium.userDataDir,
-              profile: "Default",
-              entries: {
-                [installedId]: { location: 4, path: installed },
-              },
-            });
-          }
+  it.each(["Preferences", "Secure Preferences"] as const)(
+    "pre-registers predicted IDs before waiting, then verifies Chrome's recorded ID in %s",
+    async (filename) => {
+      const value = await fixture();
+      const installed = stableChromeExtensionDir(value.deps);
+      const chromium = chromeProductRoots(value.deps).find((root) => root.product === "chromium");
+      if (!chromium) {
+        throw new Error("missing Chromium fixture root");
+      }
+      await fs.mkdir(chromium.userDataDir, { recursive: true, mode: 0o700 });
+      const installedId = generateChromeExtensionIdForPath(installed, value.deps.platform);
+      const bundledId = await predictedId(value.bundledDir, value.deps.platform);
+      let now = 0;
+      let wroteProfile = false;
+      await writeChromePreferences({
+        userDataDir: chromium.userDataDir,
+        profile: "Default",
+        filename: filename === "Preferences" ? "Secure Preferences" : "Preferences",
+        entries: {},
+      });
+      const status = await installChromeExtensionBootstrap({
+        bundledDir: value.bundledDir,
+        pluginRoot: value.pluginRoot,
+        waitMs: 1_000,
+        deps: {
+          ...value.deps,
+          now: () => now,
+          sleep: async (ms) => {
+            now += ms;
+            if (!wroteProfile) {
+              const manifestPath = path.join(
+                chromium.nativeManifestDir,
+                "ai.openclaw.browser_bootstrap.json",
+              );
+              const preRegistration = JSON.parse(await fs.readFile(manifestPath, "utf8")) as {
+                allowed_origins: string[];
+              };
+              expect(preRegistration.allowed_origins).toEqual(
+                [installedId, bundledId, FOUNDATION_STORE_ID]
+                  .toSorted()
+                  .map((id) => `chrome-extension://${id}/`),
+              );
+              wroteProfile = true;
+              await writeChromePreferences({
+                filename,
+                userDataDir: chromium.userDataDir,
+                profile: "Default",
+                entries: {
+                  [installedId]: { location: 4, path: installed, disable_reasons: [] },
+                },
+              });
+            }
+          },
         },
-      },
-    });
+      });
 
-    expect(status.manualSetupRequired).toBe(false);
-    const registration = status.registrations.find((entry) => entry.product === "chromium");
-    expect(registration).toMatchObject({
-      state: "owned",
-      extensionIds: [installedId, bundledId, FOUNDATION_STORE_ID].toSorted(),
-    });
-    const manifest = await fs.readFile(registration?.manifestPath ?? "", "utf8");
-    expect(manifest).toContain(`chrome-extension://${installedId}/`);
-    expect(manifest).toContain(`chrome-extension://${FOUNDATION_STORE_ID}/`);
-    expect(manifest).not.toMatch(/[0-9a-f]{64}/u);
-    expect(JSON.stringify(status)).not.toMatch(/pairingString|token|Bearer/u);
-    if (process.platform !== "win32") {
-      expect((await fs.stat(registration?.manifestPath ?? "")).mode & 0o777).toBe(0o600);
-      const launcherPath = (JSON.parse(manifest) as { path: string }).path;
-      expect((await fs.stat(launcherPath)).mode & 0o777).toBe(0o700);
-      const launcher = await fs.readFile(launcherPath, "utf8");
-      const expectedOrigins = [installedId, bundledId, FOUNDATION_STORE_ID]
-        .toSorted()
-        .map((id) => `chrome-extension://${id}/`);
-      expect(launcher.match(/chrome-extension:\/\/[a-p]{32}\//gu)?.toSorted()).toEqual(
-        expectedOrigins,
-      );
-      expect(launcher).not.toMatch(/pairingString|Bearer|#[A-Za-z0-9_-]{20}/u);
-    }
-  });
+      expect(status.issues).toEqual([]);
+      expect(status.discovered).toEqual([
+        expect.objectContaining({
+          extensionId: installedId,
+          extensionPath: installed,
+          securePreferencesPath: path.join(chromium.userDataDir, "Default", filename),
+        }),
+      ]);
+      expect(status.manualSetupRequired).toBe(false);
+      await expect(
+        browserExtensionStatus({ bundledDir: value.bundledDir, deps: value.deps }),
+      ).resolves.toEqual(status);
+      const registration = status.registrations.find((entry) => entry.product === "chromium");
+      expect(registration).toMatchObject({
+        state: "owned",
+        extensionIds: [installedId, bundledId, FOUNDATION_STORE_ID].toSorted(),
+      });
+      const manifest = await fs.readFile(registration?.manifestPath ?? "", "utf8");
+      expect(manifest).toContain(`chrome-extension://${installedId}/`);
+      expect(manifest).toContain(`chrome-extension://${FOUNDATION_STORE_ID}/`);
+      expect(manifest).not.toMatch(/[0-9a-f]{64}/u);
+      expect(JSON.stringify(status)).not.toMatch(/pairingString|token|Bearer/u);
+      if (process.platform !== "win32") {
+        expect((await fs.stat(registration?.manifestPath ?? "")).mode & 0o777).toBe(0o600);
+        const launcherPath = (JSON.parse(manifest) as { path: string }).path;
+        expect((await fs.stat(launcherPath)).mode & 0o777).toBe(0o700);
+        const launcher = await fs.readFile(launcherPath, "utf8");
+        const expectedOrigins = [installedId, bundledId, FOUNDATION_STORE_ID]
+          .toSorted()
+          .map((id) => `chrome-extension://${id}/`);
+        expect(launcher.match(/chrome-extension:\/\/[a-p]{32}\//gu)?.toSorted()).toEqual(
+          expectedOrigins,
+        );
+        expect(launcher).not.toMatch(/pairingString|Bearer|#[A-Za-z0-9_-]{20}/u);
+      }
+    },
+  );
 
   it("treats the exact Store record as installed without approving its recorded path", async () => {
     const value = await fixture();
@@ -154,7 +175,7 @@ describe("native host registration", () => {
       throw new Error("missing Chrome fixture root");
     }
     const arbitraryPath = path.join(value.root, "not-an-owned-extension-path");
-    await writeSecurePreferences({
+    await writeChromePreferences({
       userDataDir: chrome.userDataDir,
       profile: "Default",
       entries: {
@@ -189,7 +210,7 @@ describe("native host registration", () => {
     if (!chrome) {
       throw new Error("missing Chrome fixture root");
     }
-    await writeSecurePreferences({
+    await writeChromePreferences({
       userDataDir: chrome.userDataDir,
       profile: "Default",
       entries: { [extensionId]: { location: 4, path: installed } },
@@ -245,7 +266,7 @@ describe("native host registration", () => {
       JSON.stringify({ name: "foreign", path: "/foreign/host", allowed_origins: [] }),
       { mode: 0o600 },
     );
-    await writeSecurePreferences({
+    await writeChromePreferences({
       userDataDir: chromium.userDataDir,
       profile: "Default",
       entries: { [extensionId]: { location: 4, path: installed } },
@@ -271,7 +292,7 @@ describe("native host registration", () => {
     if (!chrome) {
       throw new Error("missing Chrome fixture root");
     }
-    await writeSecurePreferences({
+    await writeChromePreferences({
       userDataDir: chrome.userDataDir,
       profile: "Default",
       entries: { [installedId]: { location: 4, path: installed } },
@@ -329,7 +350,7 @@ describe("native host registration", () => {
       if (!chrome) {
         throw new Error("missing Chrome fixture root");
       }
-      await writeSecurePreferences({
+      await writeChromePreferences({
         userDataDir: chrome.userDataDir,
         profile: "Default",
         entries: { [installedId]: { location: 4, path: installed } },
@@ -367,7 +388,7 @@ describe("native host registration", () => {
     if (!chrome) {
       throw new Error("missing Chrome fixture root");
     }
-    await writeSecurePreferences({
+    await writeChromePreferences({
       userDataDir: chrome.userDataDir,
       profile: "Default",
       entries: { [extensionId]: { location: 4, path: installed } },
@@ -405,7 +426,7 @@ describe("native host registration", () => {
     if (!chrome) {
       throw new Error("missing Chrome fixture root");
     }
-    await writeSecurePreferences({
+    await writeChromePreferences({
       userDataDir: chrome.userDataDir,
       profile: "Default",
       entries: { [installedId]: { location: 4, path: installed } },
@@ -457,7 +478,7 @@ describe("native host registration", () => {
     if (!chrome) {
       throw new Error("missing Chrome fixture root");
     }
-    await writeSecurePreferences({
+    await writeChromePreferences({
       userDataDir: chrome.userDataDir,
       profile: "Default",
       entries: { [installedId]: { location: 4, path: installed } },
@@ -513,7 +534,7 @@ describe("native host registration", () => {
     if (!chrome) {
       throw new Error("missing Chrome fixture root");
     }
-    await writeSecurePreferences({
+    await writeChromePreferences({
       userDataDir: chrome.userDataDir,
       profile: "Default",
       entries: { [installedId]: { location: 4, path: installed } },
@@ -598,7 +619,7 @@ describe("native host registration", () => {
       if (!chromium) {
         throw new Error("missing Chromium fixture root");
       }
-      await writeSecurePreferences({
+      await writeChromePreferences({
         userDataDir: chromium.userDataDir,
         profile: "Default",
         entries: { [FOUNDATION_STORE_ID]: { location: 1, from_webstore: true } },
@@ -729,7 +750,7 @@ describe("native host registration", () => {
     }
     await fs.mkdir(chrome.userDataDir, { recursive: true, mode: 0o700 });
     const installed = await installStableChromeExtension(value.bundledDir, value.deps);
-    await writeSecurePreferences({
+    await writeChromePreferences({
       userDataDir: chromium.userDataDir,
       profile: "Default",
       entries: {

--- a/extensions/browser/src/browser/extension-native-host.runtime.ts
+++ b/extensions/browser/src/browser/extension-native-host.runtime.ts
@@ -1,9 +1,17 @@
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import { buildBrowserExtensionPairing } from "./extension-pairing.js";
+import { buildBrowserExtensionPairing, firstExtensionRelayPort } from "./extension-pairing.js";
+import { ensureExtensionRelayDaemonProcess } from "./extension-relay-daemon-spawn.js";
 
 export function buildBrowserNativeHostPairing() {
   return buildBrowserExtensionPairing({
     cfg: getRuntimeConfig(),
     localTransport: "gateway",
+  });
+}
+
+export function ensureBrowserNativeRelay(entryPath: string) {
+  return ensureExtensionRelayDaemonProcess({
+    port: firstExtensionRelayPort(getRuntimeConfig()),
+    entryPath,
   });
 }

--- a/extensions/browser/src/browser/extension-native-host.runtime.ts
+++ b/extensions/browser/src/browser/extension-native-host.runtime.ts
@@ -1,5 +1,5 @@
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import { buildBrowserExtensionPairing, firstExtensionRelayPort } from "./extension-pairing.js";
+import { buildBrowserExtensionPairing } from "./extension-pairing.js";
 import { ensureExtensionRelayDaemonProcess } from "./extension-relay-daemon-spawn.js";
 
 export function buildBrowserNativeHostPairing() {
@@ -9,9 +9,6 @@ export function buildBrowserNativeHostPairing() {
   });
 }
 
-export function ensureBrowserNativeRelay(entryPath: string) {
-  return ensureExtensionRelayDaemonProcess({
-    port: firstExtensionRelayPort(getRuntimeConfig()),
-    entryPath,
-  });
+export function ensureBrowserNativeRelay(port: number, entryPath: string) {
+  return ensureExtensionRelayDaemonProcess({ port, cfg: getRuntimeConfig(), entryPath });
 }

--- a/extensions/browser/src/browser/extension-native-host.test.ts
+++ b/extensions/browser/src/browser/extension-native-host.test.ts
@@ -339,3 +339,44 @@ describe("native host origin and topology boundary", () => {
     });
   });
 });
+
+describe("native host ensure_relay", () => {
+  it("reports the injected relay status with the echoed nonce", async () => {
+    const ensureRelay = vi.fn(async () => "spawned" as const);
+    const result = await invokeHost({
+      input: chunks(frame(requestJson({ op: "ensure_relay" }))),
+      ensureRelay,
+    });
+    expect(result.response).toEqual({ v: 1, ok: true, nonce: NONCE, relay: "spawned" });
+    expect(ensureRelay).toHaveBeenCalledTimes(1);
+    expect(result.writes).toHaveLength(1);
+  });
+
+  it("reports skipped when no relay launcher is wired", async () => {
+    const result = await invokeHost({
+      input: chunks(frame(requestJson({ op: "ensure_relay" }))),
+    });
+    expect(result.response).toEqual({ v: 1, ok: true, nonce: NONCE, relay: "skipped" });
+  });
+
+  it("maps a relay launcher failure to relay_unavailable", async () => {
+    const result = await invokeHost({
+      input: chunks(frame(requestJson({ op: "ensure_relay" }))),
+      ensureRelay: async () => {
+        throw new Error("spawn failed");
+      },
+    });
+    expect(result.response).toEqual({ v: 1, ok: false, code: "relay_unavailable" });
+  });
+
+  it("still validates the manifest before ensuring the relay", async () => {
+    const ensureRelay = vi.fn(async () => "spawned" as const);
+    const result = await invokeHost({
+      input: chunks(frame(requestJson({ op: "ensure_relay" }))),
+      callerOrigin: OTHER_ORIGIN,
+      ensureRelay,
+    });
+    expect(result.response).toEqual({ v: 1, ok: false, code: "origin_forbidden" });
+    expect(ensureRelay).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/browser/src/browser/extension-native-host.test.ts
+++ b/extensions/browser/src/browser/extension-native-host.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { relayTestKey } from "../../chrome-extension/relay-key.test-support.js";
 import { parseBrowserNativeHostOrigins, runBrowserNativeHost } from "./extension-native-host.js";
@@ -9,6 +10,9 @@ import {
   encodeBrowserNativeResponse,
   readBrowserNativeFrame,
 } from "./extension-native-protocol.js";
+import { ensureExtensionRelayDaemonProcess } from "./extension-relay-daemon-spawn.js";
+import { runExtensionRelayDaemon } from "./relay-daemon.js";
+import { getFreePort } from "./test-port.js";
 
 const EXTENSION_ID = "abcdefghijklmnopabcdefghijklmnop";
 const ORIGIN = `chrome-extension://${EXTENSION_ID}/`;
@@ -200,6 +204,7 @@ async function invokeHost(overrides: Partial<Parameters<typeof runBrowserNativeH
     input: chunks(frame(requestJson())),
     write: (value) => writes.push(value),
     buildPairing: async () => ({ pairingString: PAIRING, topology: "local" }),
+    ensureRelay: async () => "skipped",
     ...overrides,
   });
   return { response, writes, fixture };
@@ -293,6 +298,7 @@ describe("native host origin and topology boundary", () => {
       input: chunks(frame(requestJson())),
       write: vi.fn(),
       buildPairing,
+      ensureRelay: async () => "skipped",
     });
 
     expect(response).toEqual({ v: 1, ok: false, code: "manifest_invalid" });
@@ -320,6 +326,7 @@ describe("native host origin and topology boundary", () => {
       input: chunks(frame(requestJson())),
       write: (value) => writes.push(value),
       buildPairing: async () => ({ pairingString: PAIRING, topology: "local" }),
+      ensureRelay: async () => "skipped",
     });
     expect(response).toEqual({ v: 1, ok: false, code: "manifest_invalid" });
   });
@@ -341,10 +348,118 @@ describe("native host origin and topology boundary", () => {
 });
 
 describe("native host ensure_relay", () => {
+  it.each([
+    ["missing port", requestJson({ op: "ensure_relay" })],
+    ...[0, -1, 65536, 18799.5, "18799", null, {}, [18799]].map((relayPort) => [
+      `invalid port ${JSON.stringify(relayPort)}`,
+      requestJson({ op: "ensure_relay", relayPort }),
+    ]),
+    [
+      "duplicate port",
+      `{"v":1,"op":"ensure_relay","nonce":"${NONCE}","relayPort":18799,"relayPort":18798}`,
+    ],
+    [
+      "escaped duplicate port",
+      `{"v":1,"op":"ensure_relay","nonce":"${NONCE}","relayPort":18799,"relay\\u0050ort":18798}`,
+    ],
+    ...["host", "entryPath", "token", "profile"].map((key) => [
+      key,
+      requestJson({ op: "ensure_relay", relayPort: 18799, [key]: "untrusted" }),
+    ]),
+    ["bootstrap with target", requestJson({ relayPort: 18799 })],
+  ])("rejects %s without invoking the relay launcher", async (_label, raw) => {
+    const ensureRelay = vi.fn(async () => "spawned" as const);
+    const result = await invokeHost({ input: chunks(frame(raw)), ensureRelay });
+    expect(result.response).toEqual({ v: 1, ok: false, code: "invalid_request" });
+    expect(ensureRelay).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["unconfigured", 20124],
+    ["managed browser", 18800],
+    ["Gateway", 18789],
+    ["remote browser", 29443],
+  ])("rejects the %s port before probing or spawning", async (_label, relayPort) => {
+    const probe = vi.fn(async () => false);
+    const spawnProcess = vi.fn();
+    const result = await invokeHost({
+      input: chunks(frame(requestJson({ op: "ensure_relay", relayPort }))),
+      ensureRelay: async (port) =>
+        await ensureExtensionRelayDaemonProcess({
+          port,
+          cfg: { browser: { profiles: { remote: { cdpUrl: "https://browser.example:29443" } } } },
+          entryPath: "/opt/openclaw/dist/extensions/browser/relay-daemon-entry.js",
+          probe,
+          spawnProcess,
+        }),
+    });
+    expect(result.response).toEqual({ v: 1, ok: false, code: "relay_unavailable" });
+    expect(probe).not.toHaveBeenCalled();
+    expect(spawnProcess).not.toHaveBeenCalled();
+  });
+
+  it.each(["non-first automatic", "explicitly pinned"])(
+    "wakes the %s profile through the native frame and config boundary",
+    async (allocation) => {
+      const fixture = await nativeFixture();
+      const relayPort = await getFreePort();
+      await fs.mkdir(path.join(fixture.stateDir, "credentials"), { mode: 0o700 });
+      await fs.writeFile(
+        path.join(fixture.stateDir, "credentials", "browser-extension-relay.secret"),
+        relayTestKey(1),
+        { mode: 0o600 },
+      );
+      await withEnvAsync(
+        { OPENCLAW_STATE_DIR: fixture.stateDir, OPENCLAW_GATEWAY_PORT: undefined },
+        async () => {
+          let daemon: ReturnType<typeof runExtensionRelayDaemon> | undefined;
+          try {
+            const result = await invokeHost({
+              ...fixture,
+              input: chunks(frame(requestJson({ op: "ensure_relay", relayPort }))),
+              ensureRelay: async (port) =>
+                await ensureExtensionRelayDaemonProcess({
+                  port,
+                  cfg: {
+                    gateway: { port: relayPort - 9 },
+                    browser: {
+                      profiles: {
+                        chrome: { driver: "extension" },
+                        work: {
+                          driver: "extension",
+                          ...(allocation === "explicitly pinned" ? { cdpPort: relayPort } : {}),
+                        },
+                      },
+                    },
+                  },
+                  entryPath: "/opt/openclaw/dist/extensions/browser/relay-daemon-entry.js",
+                  // Keep the real config, port probe, credential read and relay server;
+                  // only replace process creation so the test owns daemon cleanup.
+                  spawnProcess: (_command, args) => {
+                    daemon = runExtensionRelayDaemon({ port: Number(args[2]) });
+                  },
+                }),
+            });
+            expect(result.response).toEqual({ v: 1, ok: true, nonce: NONCE, relay: "spawned" });
+            const run = await daemon;
+            expect(run?.port).toBe(relayPort);
+            const response = await fetch(`http://127.0.0.1:${relayPort}/json/version`);
+            expect(response.status).toBe(401);
+            expect(await response.json()).toEqual({ error: "Unauthorized" });
+          } finally {
+            const run = await daemon;
+            run?.stop();
+            await run?.done;
+          }
+        },
+      );
+    },
+  );
+
   it("reports the injected relay status with the echoed nonce", async () => {
     const ensureRelay = vi.fn(async () => "spawned" as const);
     const result = await invokeHost({
-      input: chunks(frame(requestJson({ op: "ensure_relay" }))),
+      input: chunks(frame(requestJson({ op: "ensure_relay", relayPort: 18799 }))),
       ensureRelay,
     });
     expect(result.response).toEqual({ v: 1, ok: true, nonce: NONCE, relay: "spawned" });
@@ -352,16 +467,9 @@ describe("native host ensure_relay", () => {
     expect(result.writes).toHaveLength(1);
   });
 
-  it("reports skipped when no relay launcher is wired", async () => {
-    const result = await invokeHost({
-      input: chunks(frame(requestJson({ op: "ensure_relay" }))),
-    });
-    expect(result.response).toEqual({ v: 1, ok: true, nonce: NONCE, relay: "skipped" });
-  });
-
   it("maps a relay launcher failure to relay_unavailable", async () => {
     const result = await invokeHost({
-      input: chunks(frame(requestJson({ op: "ensure_relay" }))),
+      input: chunks(frame(requestJson({ op: "ensure_relay", relayPort: 18799 }))),
       ensureRelay: async () => {
         throw new Error("spawn failed");
       },
@@ -372,7 +480,7 @@ describe("native host ensure_relay", () => {
   it("still validates the manifest before ensuring the relay", async () => {
     const ensureRelay = vi.fn(async () => "spawned" as const);
     const result = await invokeHost({
-      input: chunks(frame(requestJson({ op: "ensure_relay" }))),
+      input: chunks(frame(requestJson({ op: "ensure_relay", relayPort: 18799 }))),
       callerOrigin: OTHER_ORIGIN,
       ensureRelay,
     });

--- a/extensions/browser/src/browser/extension-native-host.ts
+++ b/extensions/browser/src/browser/extension-native-host.ts
@@ -5,6 +5,7 @@ import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   type BrowserNativeBootstrapResponse,
+  type BrowserNativeRelayEnsureStatus,
   decodeBrowserNativeFrame,
   encodeBrowserNativeResponse,
   readBrowserNativeFrame,
@@ -136,6 +137,8 @@ export async function runBrowserNativeHost(params: {
   input: AsyncIterable<Buffer>;
   write: (frame: Buffer) => void;
   buildPairing: () => Promise<{ pairingString: string; topology: string }>;
+  /** Ensure the standalone extension relay daemon is running (ensure_relay op). */
+  ensureRelay?: () => Promise<BrowserNativeRelayEnsureStatus>;
   stateDir?: string;
   platform?: NodeJS.Platform;
 }): Promise<BrowserNativeBootstrapResponse> {
@@ -161,26 +164,35 @@ export async function runBrowserNativeHost(params: {
         params.write(encodeBrowserNativeResponse(response));
         return response;
       }
-      try {
-        const pairing = await params.buildPairing();
-        response =
-          pairing.topology === "direct-remote"
-            ? { v: 1, ok: false, code: "manual_required" }
-            : {
-                v: 1,
-                ok: true,
-                nonce: decoded.request.nonce,
-                pairingString: pairing.pairingString,
-              };
-      } catch (error) {
-        response = {
-          v: 1,
-          ok: false,
-          code:
-            error instanceof Error && error.message.includes("--gateway-url")
-              ? "manual_required"
-              : "pairing_unavailable",
-        };
+      if (decoded.request.op === "ensure_relay") {
+        try {
+          const relay = params.ensureRelay ? await params.ensureRelay() : "skipped";
+          response = { v: 1, ok: true, nonce: decoded.request.nonce, relay };
+        } catch {
+          response = { v: 1, ok: false, code: "relay_unavailable" };
+        }
+      } else {
+        try {
+          const pairing = await params.buildPairing();
+          response =
+            pairing.topology === "direct-remote"
+              ? { v: 1, ok: false, code: "manual_required" }
+              : {
+                  v: 1,
+                  ok: true,
+                  nonce: decoded.request.nonce,
+                  pairingString: pairing.pairingString,
+                };
+        } catch (error) {
+          response = {
+            v: 1,
+            ok: false,
+            code:
+              error instanceof Error && error.message.includes("--gateway-url")
+                ? "manual_required"
+                : "pairing_unavailable",
+          };
+        }
       }
     }
   } catch {

--- a/extensions/browser/src/browser/extension-native-host.ts
+++ b/extensions/browser/src/browser/extension-native-host.ts
@@ -138,7 +138,7 @@ export async function runBrowserNativeHost(params: {
   write: (frame: Buffer) => void;
   buildPairing: () => Promise<{ pairingString: string; topology: string }>;
   /** Ensure the standalone extension relay daemon is running (ensure_relay op). */
-  ensureRelay?: () => Promise<BrowserNativeRelayEnsureStatus>;
+  ensureRelay: (port: number) => Promise<BrowserNativeRelayEnsureStatus>;
   stateDir?: string;
   platform?: NodeJS.Platform;
 }): Promise<BrowserNativeBootstrapResponse> {
@@ -166,7 +166,7 @@ export async function runBrowserNativeHost(params: {
       }
       if (decoded.request.op === "ensure_relay") {
         try {
-          const relay = params.ensureRelay ? await params.ensureRelay() : "skipped";
+          const relay = await params.ensureRelay(decoded.request.relayPort);
           response = { v: 1, ok: true, nonce: decoded.request.nonce, relay };
         } catch {
           response = { v: 1, ok: false, code: "relay_unavailable" };

--- a/extensions/browser/src/browser/extension-native-protocol.ts
+++ b/extensions/browser/src/browser/extension-native-protocol.ts
@@ -12,10 +12,13 @@ type BrowserNativeFailureCode =
   | "origin_forbidden"
   | "manifest_invalid"
   | "manual_required"
-  | "pairing_unavailable";
-type BrowserNativeBootstrapRequest = { v: 1; op: "bootstrap"; nonce: string };
+  | "pairing_unavailable"
+  | "relay_unavailable";
+export type BrowserNativeRelayEnsureStatus = "spawned" | "running" | "skipped";
+type BrowserNativeBootstrapRequest = { v: 1; op: "bootstrap" | "ensure_relay"; nonce: string };
 export type BrowserNativeBootstrapResponse =
   | { v: 1; ok: true; nonce: string; pairingString: string }
+  | { v: 1; ok: true; nonce: string; relay: BrowserNativeRelayEnsureStatus }
   | { v: 1; ok: false; code: BrowserNativeFailureCode };
 
 function readNativeUint32(buffer: Buffer, offset = 0): number {
@@ -150,8 +153,10 @@ function parseBrowserNativeRequest(raw: string): BrowserNativeBootstrapRequest |
     return null;
   }
   const record = asNullableRecord(parsed);
-  return record?.v === 1 && record.op === "bootstrap" && isCanonicalNonce(record.nonce)
-    ? { v: 1, op: "bootstrap", nonce: record.nonce }
+  return record?.v === 1 &&
+    (record.op === "bootstrap" || record.op === "ensure_relay") &&
+    isCanonicalNonce(record.nonce)
+    ? { v: 1, op: record.op, nonce: record.nonce }
     : null;
 }
 

--- a/extensions/browser/src/browser/extension-native-protocol.ts
+++ b/extensions/browser/src/browser/extension-native-protocol.ts
@@ -15,7 +15,9 @@ type BrowserNativeFailureCode =
   | "pairing_unavailable"
   | "relay_unavailable";
 export type BrowserNativeRelayEnsureStatus = "spawned" | "running" | "skipped";
-type BrowserNativeBootstrapRequest = { v: 1; op: "bootstrap" | "ensure_relay"; nonce: string };
+type BrowserNativeBootstrapRequest =
+  | { v: 1; op: "bootstrap"; nonce: string }
+  | { v: 1; op: "ensure_relay"; nonce: string; relayPort: number };
 export type BrowserNativeBootstrapResponse =
   | { v: 1; ok: true; nonce: string; pairingString: string }
   | { v: 1; ok: true; nonce: string; relay: BrowserNativeRelayEnsureStatus }
@@ -142,10 +144,6 @@ function parseBrowserNativeRequest(raw: string): BrowserNativeBootstrapRequest |
   if (!keys || new Set(keys).size !== keys.length) {
     return null;
   }
-  const expected = ["v", "op", "nonce"];
-  if (keys.length !== expected.length || !expected.every((key) => keys.includes(key))) {
-    return null;
-  }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -153,10 +151,23 @@ function parseBrowserNativeRequest(raw: string): BrowserNativeBootstrapRequest |
     return null;
   }
   const record = asNullableRecord(parsed);
-  return record?.v === 1 &&
-    (record.op === "bootstrap" || record.op === "ensure_relay") &&
-    isCanonicalNonce(record.nonce)
-    ? { v: 1, op: record.op, nonce: record.nonce }
+  if (record?.v !== 1 || !isCanonicalNonce(record.nonce)) {
+    return null;
+  }
+  const expected =
+    record.op === "ensure_relay" ? ["v", "op", "nonce", "relayPort"] : ["v", "op", "nonce"];
+  if (keys.length !== expected.length || !expected.every((key) => keys.includes(key))) {
+    return null;
+  }
+  if (record.op === "bootstrap") {
+    return { v: 1, op: "bootstrap", nonce: record.nonce };
+  }
+  return record.op === "ensure_relay" &&
+    typeof record.relayPort === "number" &&
+    Number.isInteger(record.relayPort) &&
+    record.relayPort >= 1 &&
+    record.relayPort <= 65_535
+    ? { v: 1, op: "ensure_relay", nonce: record.nonce, relayPort: record.relayPort }
     : null;
 }
 

--- a/extensions/browser/src/browser/extension-pairing.ts
+++ b/extensions/browser/src/browser/extension-pairing.ts
@@ -15,7 +15,7 @@ type BrowserExtensionPairing = {
 
 type PairingConfig = OpenClawConfig & { browser?: BrowserConfig };
 
-export function firstExtensionRelayPort(cfg: PairingConfig): number {
+function firstExtensionRelayPort(cfg: PairingConfig): number {
   const resolved = resolveBrowserConfig(cfg.browser, cfg);
   for (const [name, profile] of Object.entries(resolved.profiles)) {
     if (profile.driver === "extension") {

--- a/extensions/browser/src/browser/extension-pairing.ts
+++ b/extensions/browser/src/browser/extension-pairing.ts
@@ -15,7 +15,7 @@ type BrowserExtensionPairing = {
 
 type PairingConfig = OpenClawConfig & { browser?: BrowserConfig };
 
-function firstExtensionRelayPort(cfg: PairingConfig): number {
+export function firstExtensionRelayPort(cfg: PairingConfig): number {
   const resolved = resolveBrowserConfig(cfg.browser, cfg);
   for (const [name, profile] of Object.entries(resolved.profiles)) {
     if (profile.driver === "extension") {

--- a/extensions/browser/src/browser/extension-relay-daemon-spawn.test.ts
+++ b/extensions/browser/src/browser/extension-relay-daemon-spawn.test.ts
@@ -1,0 +1,69 @@
+import net from "node:net";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ensureExtensionRelayDaemonProcess,
+  isRelayPortServed,
+} from "./extension-relay-daemon-spawn.js";
+
+const ENTRY = "/opt/openclaw/dist/extensions/browser/relay-daemon-entry.js";
+
+describe("ensureExtensionRelayDaemonProcess", () => {
+  it("skips when no relay credential exists", async () => {
+    const spawnProcess = vi.fn();
+    const status = await ensureExtensionRelayDaemonProcess({
+      port: 18_799,
+      entryPath: ENTRY,
+      readToken: () => null,
+      probe: async () => false,
+      spawnProcess,
+    });
+    expect(status).toBe("skipped");
+    expect(spawnProcess).not.toHaveBeenCalled();
+  });
+
+  it("reports running without spawning when the port is already served", async () => {
+    const spawnProcess = vi.fn();
+    const status = await ensureExtensionRelayDaemonProcess({
+      port: 18_799,
+      entryPath: ENTRY,
+      readToken: () => "a".repeat(64),
+      probe: async () => true,
+      spawnProcess,
+    });
+    expect(status).toBe("running");
+    expect(spawnProcess).not.toHaveBeenCalled();
+  });
+
+  it("spawns the daemon entry with the resolved port", async () => {
+    const spawnProcess = vi.fn();
+    const status = await ensureExtensionRelayDaemonProcess({
+      port: 19_123,
+      entryPath: ENTRY,
+      execPath: "/usr/bin/node",
+      readToken: () => "a".repeat(64),
+      probe: async () => false,
+      spawnProcess,
+    });
+    expect(status).toBe("spawned");
+    expect(spawnProcess).toHaveBeenCalledWith("/usr/bin/node", [ENTRY, "--port", "19123"]);
+  });
+});
+
+describe("isRelayPortServed", () => {
+  it("detects a listening loopback server and a closed port", async () => {
+    const server = net.createServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    try {
+      expect(await isRelayPortServed(port)).toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+    expect(await isRelayPortServed(port)).toBe(false);
+  });
+});

--- a/extensions/browser/src/browser/extension-relay-daemon-spawn.test.ts
+++ b/extensions/browser/src/browser/extension-relay-daemon-spawn.test.ts
@@ -1,9 +1,6 @@
 import net from "node:net";
 import { describe, expect, it, vi } from "vitest";
-import {
-  ensureExtensionRelayDaemonProcess,
-  isRelayPortServed,
-} from "./extension-relay-daemon-spawn.js";
+import { ensureExtensionRelayDaemonProcess } from "./extension-relay-daemon-spawn.js";
 
 const ENTRY = "/opt/openclaw/dist/extensions/browser/relay-daemon-entry.js";
 
@@ -11,6 +8,7 @@ describe("ensureExtensionRelayDaemonProcess", () => {
   it("skips when no relay credential exists", async () => {
     const spawnProcess = vi.fn();
     const status = await ensureExtensionRelayDaemonProcess({
+      cfg: {},
       port: 18_799,
       entryPath: ENTRY,
       readToken: () => null,
@@ -21,22 +19,10 @@ describe("ensureExtensionRelayDaemonProcess", () => {
     expect(spawnProcess).not.toHaveBeenCalled();
   });
 
-  it("reports running without spawning when the port is already served", async () => {
-    const spawnProcess = vi.fn();
-    const status = await ensureExtensionRelayDaemonProcess({
-      port: 18_799,
-      entryPath: ENTRY,
-      readToken: () => "a".repeat(64),
-      probe: async () => true,
-      spawnProcess,
-    });
-    expect(status).toBe("running");
-    expect(spawnProcess).not.toHaveBeenCalled();
-  });
-
   it("spawns the daemon entry with the resolved port", async () => {
     const spawnProcess = vi.fn();
     const status = await ensureExtensionRelayDaemonProcess({
+      cfg: { browser: { profiles: { work: { driver: "extension", cdpPort: 19123 } } } },
       port: 19_123,
       entryPath: ENTRY,
       execPath: "/usr/bin/node",
@@ -49,21 +35,31 @@ describe("ensureExtensionRelayDaemonProcess", () => {
   });
 });
 
-describe("isRelayPortServed", () => {
-  it("detects a listening loopback server and a closed port", async () => {
+describe("relay port ownership", () => {
+  it("leaves an existing listener alone and spawns only after it closes", async () => {
     const server = net.createServer();
     await new Promise<void>((resolve) => {
       server.listen(0, "127.0.0.1", () => resolve());
     });
     const address = server.address();
     const port = typeof address === "object" && address ? address.port : 0;
+    const spawnProcess = vi.fn();
+    const params = {
+      cfg: { browser: { profiles: { work: { driver: "extension" as const, cdpPort: port } } } },
+      port,
+      entryPath: ENTRY,
+      readToken: () => "a".repeat(64),
+      spawnProcess,
+    };
     try {
-      expect(await isRelayPortServed(port)).toBe(true);
+      expect(await ensureExtensionRelayDaemonProcess(params)).toBe("running");
+      expect(spawnProcess).not.toHaveBeenCalled();
     } finally {
       await new Promise<void>((resolve) => {
         server.close(() => resolve());
       });
     }
-    expect(await isRelayPortServed(port)).toBe(false);
+    expect(await ensureExtensionRelayDaemonProcess(params)).toBe("spawned");
+    expect(spawnProcess).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/browser/src/browser/extension-relay-daemon-spawn.ts
+++ b/extensions/browser/src/browser/extension-relay-daemon-spawn.ts
@@ -1,0 +1,55 @@
+import { spawn } from "node:child_process";
+import net from "node:net";
+import type { BrowserNativeRelayEnsureStatus } from "./extension-native-protocol.js";
+import { readExtensionRelayToken } from "./extension-relay/relay-auth.js";
+
+const PORT_PROBE_TIMEOUT_MS = 750;
+
+/** True when something already accepts connections on the loopback port. */
+export async function isRelayPortServed(port: number): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const socket = net.connect({ host: "127.0.0.1", port });
+    const finish = (served: boolean): void => {
+      socket.destroy();
+      resolve(served);
+    };
+    socket.setTimeout(PORT_PROBE_TIMEOUT_MS, () => finish(false));
+    socket.once("connect", () => finish(true));
+    socket.once("error", () => finish(false));
+  });
+}
+
+/**
+ * Ensure the standalone relay daemon serves the extension relay port. The
+ * daemon is spawned detached so it outlives this one-shot native host; binding
+ * the port is the single-instance lock, so concurrent spawns are harmless.
+ */
+export async function ensureExtensionRelayDaemonProcess(params: {
+  port: number;
+  entryPath: string;
+  execPath?: string;
+  readToken?: () => string | null;
+  probe?: (port: number) => Promise<boolean>;
+  spawnProcess?: (command: string, args: string[]) => void;
+}): Promise<BrowserNativeRelayEnsureStatus> {
+  const readToken = params.readToken ?? readExtensionRelayToken;
+  if (!readToken()) {
+    return "skipped";
+  }
+  const probe = params.probe ?? isRelayPortServed;
+  if (await probe(params.port)) {
+    return "running";
+  }
+  const spawnProcess =
+    params.spawnProcess ??
+    ((command: string, args: string[]): void => {
+      const child = spawn(command, args, { detached: true, stdio: "ignore" });
+      child.unref();
+    });
+  spawnProcess(params.execPath ?? process.execPath, [
+    params.entryPath,
+    "--port",
+    String(params.port),
+  ]);
+  return "spawned";
+}

--- a/extensions/browser/src/browser/extension-relay-daemon-spawn.ts
+++ b/extensions/browser/src/browser/extension-relay-daemon-spawn.ts
@@ -1,12 +1,14 @@
 import { spawn } from "node:child_process";
 import net from "node:net";
+import type { OpenClawConfig } from "../sdk-config.js";
+import { resolveBrowserConfig, resolveProfile } from "./config.js";
 import type { BrowserNativeRelayEnsureStatus } from "./extension-native-protocol.js";
 import { readExtensionRelayToken } from "./extension-relay/relay-auth.js";
 
 const PORT_PROBE_TIMEOUT_MS = 750;
 
 /** True when something already accepts connections on the loopback port. */
-export async function isRelayPortServed(port: number): Promise<boolean> {
+async function isRelayPortServed(port: number): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
     const socket = net.connect({ host: "127.0.0.1", port });
     const finish = (served: boolean): void => {
@@ -26,12 +28,25 @@ export async function isRelayPortServed(port: number): Promise<boolean> {
  */
 export async function ensureExtensionRelayDaemonProcess(params: {
   port: number;
+  cfg: OpenClawConfig;
   entryPath: string;
   execPath?: string;
   readToken?: () => string | null;
   probe?: (port: number) => Promise<boolean>;
   spawnProcess?: (command: string, args: string[]) => void;
 }): Promise<BrowserNativeRelayEnsureStatus> {
+  // Resolve current config only after native caller validation. A pairing may
+  // outlive its profile; never wake a removed target or substitute another port.
+  const resolved = resolveBrowserConfig(params.cfg.browser, params.cfg);
+  const configured = Object.keys(resolved.profiles).some((name) => {
+    const profile = resolved.profiles[name];
+    return (
+      profile?.driver === "extension" && resolveProfile(resolved, name)?.cdpPort === params.port
+    );
+  });
+  if (!resolved.enabled || !configured) {
+    throw new Error("Relay port is not configured for an extension profile");
+  }
   const readToken = params.readToken ?? readExtensionRelayToken;
   if (!readToken()) {
     return "skipped";

--- a/extensions/browser/src/browser/extension-relay/auth-v2-crypto.ts
+++ b/extensions/browser/src/browser/extension-relay/auth-v2-crypto.ts
@@ -10,7 +10,7 @@ type BrowserRelayProofKind = "server" | "client" | "accept";
 type BrowserRelayRole = "extension" | "cdp";
 type BrowserRelayTransport = "websocket" | "connection";
 type BrowserRelayMethod = "GET" | "SEQUENCE";
-type BrowserRelayFlow = "extension" | "cdp" | "json-list";
+type BrowserRelayFlow = "extension" | "cdp" | "json-list" | "owner";
 
 export type BrowserRelayProofFields = {
   keyId: string;

--- a/extensions/browser/src/browser/extension-relay/auth-v2-websocket.ts
+++ b/extensions/browser/src/browser/extension-relay/auth-v2-websocket.ts
@@ -1,0 +1,143 @@
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import type { RawData, WebSocket } from "ws";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { BrowserRelayProofFields } from "./auth-v2-crypto.js";
+import {
+  BROWSER_RELAY_CHALLENGE_TTL_MS,
+  parseRelayAuthHello,
+  parseRelayAuthResponse,
+  parseStrictJsonObject,
+  type BrowserRelayAuthV2Authority,
+} from "./auth-v2.js";
+import {
+  boundedRawDataByteLength,
+  MAX_WEBSOCKET_AUTH_MESSAGE_BYTES,
+} from "./preauth-websocket-guard.js";
+const log = createSubsystemLogger("browser").child("extension-relay");
+
+export function authenticateExtensionWebSocket(params: {
+  ws: WebSocket;
+  authority: BrowserRelayAuthV2Authority;
+  resource: string;
+  binding?: Pick<BrowserRelayProofFields, "role" | "flow">;
+  prepareAuthenticated: () => Promise<() => void>;
+  removePreAuthGuard?: () => void;
+}): void {
+  const { ws, authority } = params;
+  let stage: "hello" | "response" | "authenticated" | "failed" = "hello";
+  let preAuthGuardActive = true;
+  const removePreAuthGuard = () => {
+    if (!preAuthGuardActive) {
+      return;
+    }
+    preAuthGuardActive = false;
+    params.removePreAuthGuard?.();
+  };
+  const timer = setTimeout(() => {
+    stage = "failed";
+    ws.off("message", onMessage);
+    ws.close(4008, "browser relay auth timeout");
+    ws.terminate();
+  }, BROWSER_RELAY_CHALLENGE_TTL_MS);
+  timer.unref?.();
+  const release = () => {
+    clearTimeout(timer);
+    removePreAuthGuard();
+    authority.releaseConnection(ws);
+  };
+  if (
+    !authority.registerPendingConnection(ws, () => {
+      ws.close(4003, "browser relay key rotated");
+    })
+  ) {
+    clearTimeout(timer);
+    ws.close(4013, "browser relay auth capacity reached");
+    return;
+  }
+  ws.once("close", release);
+  const fail = (code: number, reason: string) => {
+    if (stage === "failed") {
+      return;
+    }
+    stage = "failed";
+    clearTimeout(timer);
+    ws.off("message", onMessage);
+    ws.close(code, reason);
+    const terminateTimer = setTimeout(() => ws.terminate(), 100);
+    terminateTimer.unref?.();
+  };
+  const onMessage = (data: RawData, isBinary: boolean) => {
+    if (isBinary) {
+      fail(4003, "binary browser relay auth frames are not allowed");
+      return;
+    }
+    if (
+      boundedRawDataByteLength(data, MAX_WEBSOCKET_AUTH_MESSAGE_BYTES) >
+      MAX_WEBSOCKET_AUTH_MESSAGE_BYTES
+    ) {
+      fail(4003, "browser relay auth frame is too large");
+      return;
+    }
+    const raw = rawDataToString(data);
+    const parsed = parseStrictJsonObject(raw);
+    if (stage === "hello") {
+      const hello = parseRelayAuthHello(parsed);
+      if (!hello) {
+        fail(4003, "invalid browser relay auth hello");
+        return;
+      }
+      const challenge = authority.issueChallenge(ws, hello, {
+        role: params.binding?.role ?? "extension",
+        transport: "websocket",
+        method: "GET",
+        resource: params.resource,
+        flow: params.binding?.flow ?? "extension",
+      });
+      if (!challenge) {
+        fail(4003, "browser relay auth rejected");
+        return;
+      }
+      stage = "response";
+      ws.send(JSON.stringify(challenge));
+      return;
+    }
+    if (stage === "response") {
+      const response = parseRelayAuthResponse(parsed);
+      if (!response) {
+        fail(4003, "invalid browser relay auth response");
+        return;
+      }
+      const completed = authority.completeChallenge(ws, response);
+      if (!completed) {
+        fail(4003, "browser relay auth proof failed");
+        return;
+      }
+      stage = "authenticated";
+      // The proof deadline owns only challenge completion. Promotion is now
+      // authoritative, so cold Browser/Gateway preparation must not race it.
+      clearTimeout(timer);
+      removePreAuthGuard();
+      void params
+        .prepareAuthenticated()
+        .then((attach) => {
+          if (ws.readyState !== 1) {
+            return;
+          }
+          ws.off("message", onMessage);
+          attach();
+          ws.send(JSON.stringify(completed.ok), (err) => {
+            if (err) {
+              ws.close(1011, "browser relay auth acknowledgement failed");
+            }
+          });
+        })
+        .catch((err: unknown) => {
+          log.warn(`browser relay post-auth preparation failed: ${String(err)}`);
+          fail(1011, "browser relay unavailable after authentication");
+        });
+      return;
+    }
+    fail(4003, "unexpected browser relay auth frame");
+  };
+  ws.on("message", onMessage);
+}

--- a/extensions/browser/src/browser/extension-relay/auth-v2-websocket.ts
+++ b/extensions/browser/src/browser/extension-relay/auth-v2-websocket.ts
@@ -24,6 +24,9 @@ export function authenticateExtensionWebSocket(params: {
   removePreAuthGuard?: () => void;
 }): void {
   const { ws, authority } = params;
+  // ws closes on receiver/sender errors, but still emits an application error.
+  // Own it before proof and through promotion to borrowed ingress or owner streams.
+  ws.on("error", (err) => log.warn(`relay socket error: ${String(err)}`));
   let stage: "hello" | "response" | "authenticated" | "failed" = "hello";
   let preAuthGuardActive = true;
   const removePreAuthGuard = () => {

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-ingress.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-ingress.integration.test.ts
@@ -1,0 +1,127 @@
+import { once } from "node:events";
+import http from "node:http";
+import net from "node:net";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { afterEach, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import {
+  createBrowserControlContext,
+  startBrowserControlServiceFromConfig,
+  stopBrowserControlService,
+} from "../../control-service.js";
+import { handleGatewayExtensionUpgrade } from "./gateway-relay-route.js";
+import type { RelayOwnerClient } from "./owner-client.js";
+import { RELAY_OWNER_LIMIT } from "./owner-protocol.js";
+import { withConnectedDaemon } from "./relay-coexistence.test-support.js";
+import { ensureExtensionRelayForProfile } from "./relay-lifecycle.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearRuntimeConfigSnapshot();
+});
+
+it.each(["peer-close", "preparation-failure", "superseded"] as const)(
+  "releases a paused legacy ingress after %s without retiring the standalone relay",
+  async (outcome) => {
+    await withConnectedDaemon(async ({ token, extension }) => {
+      const state = await startBrowserControlServiceFromConfig();
+      if (!state) {
+        throw new Error("Expected Browser control state");
+      }
+      const profile = createBrowserControlContext().forProfile("chrome").profile;
+      const relay = await ensureExtensionRelayForProfile(state, profile);
+      if (relay.ownership !== "borrowed") {
+        throw new Error("Expected borrowed relay");
+      }
+      const release = createDeferred<void>();
+      const prepared = createDeferred<{ ws: WebSocket; client: RelayOwnerClient }>();
+      const prepareIngress = relay.client.prepareIngress.bind(relay.client);
+      vi.spyOn(relay.client, "prepareIngress").mockImplementation(async (ws) => {
+        // Hold only the final preparation handoff, after the real owner has
+        // authenticated and allocated its ingress stream. No protocol owner is mocked.
+        const attach = await prepareIngress(ws);
+        prepared.resolve({ ws, client: relay.client });
+        await release.promise;
+        if (outcome === "preparation-failure") {
+          throw new Error("ingress preparation interrupted");
+        }
+        return attach;
+      });
+      const server = http.createServer();
+      server.on("upgrade", (req, socket, head) => {
+        void handleGatewayExtensionUpgrade(req, socket, head);
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Expected loopback listener");
+      }
+      const peer = net.createConnection({ host: "127.0.0.1", port: address.port });
+      const candidate = new WebSocket(
+        `ws://127.0.0.1:${address.port}/browser/extension?profile=chrome`,
+        ["openclaw-extension-relay", `openclaw-extension-token.${token}`],
+        {
+          origin: "chrome-extension://legacy-ingress-cleanup",
+          createConnection: () => peer,
+        },
+      );
+      try {
+        await once(candidate, "open");
+        candidate.send(
+          JSON.stringify({
+            type: "hello",
+            userAgent: "legacy-candidate",
+            browserVersion: "Chrome/candidate",
+            extensionVersion: "2",
+            tabs: [],
+          }),
+        );
+        const { ws, client } = await prepared.promise;
+        expect(ws.isPaused).toBe(true);
+        // A hello waiting in the transport must not replace the active extension.
+        await expect(client.status()).resolves.toMatchObject({
+          identity: { browserVersion: "Chrome/test" },
+        });
+        const serverClosed = once(ws, "close");
+        const peerClosed = once(candidate, "close");
+        if (outcome === "peer-close") {
+          peer.resetAndDestroy();
+          await serverClosed;
+        } else if (outcome === "superseded") {
+          await stopBrowserControlService();
+          await serverClosed;
+        }
+        release.resolve();
+        await serverClosed;
+        const [code] = await peerClosed;
+        if (outcome === "preparation-failure") {
+          expect(code).toBe(1011);
+        }
+        if (outcome !== "superseded") {
+          await expect(client.status()).resolves.toMatchObject({
+            ready: true,
+            identity: { browserVersion: "Chrome/test" },
+          });
+          // Capacity is checked by the real owner: the abandoned ingress must
+          // leave the entire stream budget available, not merely close its peer.
+          for (let index = 0; index < RELAY_OWNER_LIMIT; index += 1) {
+            await client.openTransport();
+          }
+        }
+        expect(extension.readyState).toBe(WebSocket.OPEN);
+        await stopBrowserControlService();
+        expect(extension.readyState).toBe(WebSocket.OPEN);
+      } finally {
+        release.resolve();
+        candidate.terminate();
+        await stopBrowserControlService();
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+      }
+    });
+  },
+);

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -9,7 +9,7 @@ import {
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { withEnvAsync, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it } from "vitest";
-import { WebSocket, type RawData } from "ws";
+import { WebSocket, type ClientOptions, type RawData } from "ws";
 import { parsePairingString } from "../../../chrome-extension/modules/relay-core.js";
 import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
 import {
@@ -21,11 +21,96 @@ import {
 import { buildBrowserExtensionPairing } from "../extension-pairing.js";
 import { runExtensionRelayDaemon } from "../relay-daemon.js";
 import { getFreePort } from "../test-port.js";
-import { createRelayProof, randomRelayNonce, relayKeyIdFromHex } from "./auth-v2-crypto.js";
-import { BROWSER_RELAY_EXTENSION_SUBPROTOCOL } from "./auth-v2.js";
+import {
+  createRelayProof,
+  randomRelayNonce,
+  relayKeyIdFromHex,
+  verifyRelayProof,
+  type BrowserRelayAuthChallenge,
+} from "./auth-v2-crypto.js";
+import {
+  BROWSER_RELAY_EXTENSION_SUBPROTOCOL,
+  BROWSER_RELAY_AUTH_CHALLENGE_PATH,
+  BROWSER_RELAY_AUTH_COMPLETE_PATH,
+} from "./auth-v2.js";
 import { handleGatewayExtensionUpgrade } from "./gateway-relay-route.js";
+import { RawHttpConnection } from "./relay-http.test-support.js";
 
 const RELAY_KEY = relayTestKey(8);
+const EXTENSION_HELLO = {
+  type: "hello",
+  userAgent: "gateway-wakeup-test",
+  browserVersion: "Chrome/test",
+  extensionVersion: "2",
+  tabs: [],
+};
+
+async function relayInventory(port: number): Promise<unknown> {
+  const connection = await RawHttpConnection.connect(port);
+  try {
+    const request = async (pathname: string, body?: object) => {
+      const response = await connection.request(
+        body ? "POST" : "GET",
+        pathname,
+        body ? JSON.stringify(body) : "",
+      );
+      expect(response.status).toBe(200);
+      return JSON.parse(response.body);
+    };
+    const challenge = (await request(BROWSER_RELAY_AUTH_CHALLENGE_PATH, {
+      v: 2,
+      keyId: relayKeyIdFromHex(RELAY_KEY),
+      clientNonce: randomRelayNonce(),
+      role: "cdp",
+      transport: "connection",
+      method: "GET",
+      resource: "/json/list",
+      flow: "json-list",
+    })) as BrowserRelayAuthChallenge;
+    expect(verifyRelayProof(RELAY_KEY, "server", challenge, challenge.serverProof)).toBe(true);
+    const clientProof = createRelayProof(RELAY_KEY, "client", challenge);
+    const accepted = await request(BROWSER_RELAY_AUTH_COMPLETE_PATH, {
+      v: 2,
+      sessionId: challenge.sessionId,
+      clientProof,
+    });
+    expect(
+      verifyRelayProof(RELAY_KEY, "accept", challenge, accepted.acceptProof, clientProof),
+    ).toBe(true);
+    return await request("/json/list");
+  } finally {
+    connection.close();
+  }
+}
+
+function upgradeWithFrames(messages: object[]): {
+  bytes: number;
+  finishRequest: NonNullable<ClientOptions["finishRequest"]>;
+} {
+  const frames = messages.map((message) => {
+    const payload = Buffer.from(JSON.stringify(message));
+    const extended = payload.length >= 126;
+    const header = Buffer.alloc(extended ? 8 : 6);
+    header[0] = 0x81;
+    header[1] = 0x80 | (extended ? 126 : payload.length);
+    if (extended) {
+      header.writeUInt16BE(payload.length, 2);
+    }
+    // The fixed zero mask leaves these synthetic payload bytes unchanged.
+    return Buffer.concat([header, payload]);
+  });
+  const finishRequest: NonNullable<ClientOptions["finishRequest"]> = (request) => {
+    request.once("socket", (socket) => {
+      socket.once("connect", () => {
+        socket.cork();
+        request.end();
+        socket.write(Buffer.concat(frames));
+        socket.uncork();
+      });
+    });
+  };
+  return { bytes: frames.reduce((sum, frame) => sum + frame.byteLength, 0), finishRequest };
+}
 
 function rawDataText(data: RawData): string {
   if (Array.isArray(data)) {
@@ -82,12 +167,22 @@ describe.sequential("local Gateway extension relay wakeup", () => {
   });
 
   it.each([
-    { browserRequestAlreadyWaiting: false, standaloneFirst: false },
-    { browserRequestAlreadyWaiting: true, standaloneFirst: false },
-    { browserRequestAlreadyWaiting: true, standaloneFirst: true },
+    { browserRequestAlreadyWaiting: false, standaloneFirst: false, malformedFrame: false },
+    { browserRequestAlreadyWaiting: true, standaloneFirst: false, malformedFrame: false },
+    { browserRequestAlreadyWaiting: true, standaloneFirst: true, malformedFrame: false },
+    { browserRequestAlreadyWaiting: true, standaloneFirst: true, malformedFrame: true },
+    { browserRequestAlreadyWaiting: false, standaloneFirst: false, legacy: "open" },
+    {
+      browserRequestAlreadyWaiting: true,
+      standaloneFirst: true,
+      legacy: "open",
+      malformedFrame: true,
+    },
+    { browserRequestAlreadyWaiting: false, standaloneFirst: false, legacy: "head" },
+    { browserRequestAlreadyWaiting: true, standaloneFirst: true, legacy: "head" },
   ])(
-    "authenticates Gateway ingress: waiting=$browserRequestAlreadyWaiting standalone=$standaloneFirst",
-    async ({ browserRequestAlreadyWaiting, standaloneFirst }) => {
+    "authenticates Gateway ingress: waiting=$browserRequestAlreadyWaiting standalone=$standaloneFirst malformed=$malformedFrame legacy=$legacy",
+    async ({ browserRequestAlreadyWaiting, standaloneFirst, malformedFrame, legacy }) => {
       const stateDir = await fs.realpath(
         await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-relay-wakeup-")),
       );
@@ -111,7 +206,7 @@ describe.sequential("local Gateway extension relay wakeup", () => {
           },
           browser: {
             enabled: true,
-            extensionRelay: { allowLegacyAuth: false },
+            extensionRelay: { allowLegacyAuth: Boolean(legacy) },
             profiles: { chrome: { driver: "extension" as const, cdpPort: relayPort } },
           },
         };
@@ -128,7 +223,9 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               res.writeHead(426);
               res.end();
             });
+            let upgradeHeadBytes = 0;
             gatewayServer.on("upgrade", (req, socket, head) => {
+              upgradeHeadBytes = head.byteLength;
               void handleGatewayExtensionUpgrade(req, socket, head);
             });
             let extension: WebSocket | undefined;
@@ -161,44 +258,59 @@ describe.sequential("local Gateway extension relay wakeup", () => {
                   .ensureBrowserAvailable({ signal: requestController.signal });
               }
 
-              extension = new WebSocket(parsed.relayUrl, BROWSER_RELAY_EXTENSION_SUBPROTOCOL, {
+              const protocols = legacy
+                ? ["openclaw-extension-relay", `openclaw-extension-token.${RELAY_KEY}`]
+                : BROWSER_RELAY_EXTENSION_SUBPROTOCOL;
+              const inventory = {
+                type: "tabs",
+                tabs: [
+                  {
+                    tabId: 7,
+                    url: "https://example.test/initial",
+                    title: "Coalesced inventory",
+                    active: true,
+                  },
+                ],
+              };
+              const coalesced =
+                legacy === "head" ? upgradeWithFrames([EXTENSION_HELLO, inventory]) : undefined;
+              extension = new WebSocket(parsed.relayUrl, protocols, {
                 origin: "chrome-extension://gateway-wakeup-integration",
+                finishRequest: coalesced?.finishRequest,
               });
               await once(extension, "open");
-              const clientNonce = randomRelayNonce();
-              const challengeMessage = once(extension, "message");
-              extension.send(
-                JSON.stringify({
-                  type: "auth.hello",
-                  v: 2,
-                  keyId: relayKeyIdFromHex(RELAY_KEY),
-                  clientNonce,
-                }),
-              );
-              const [challengeData] = (await challengeMessage) as [RawData];
-              const challenge = JSON.parse(rawDataText(challengeData));
-              const okMessage = once(extension, "message", {
-                signal: AbortSignal.timeout(2_000),
-              });
-              extension.send(
-                JSON.stringify({
-                  type: "auth.response",
-                  v: 2,
-                  sessionId: challenge.sessionId,
-                  clientProof: createRelayProof(RELAY_KEY, "client", challenge),
-                }),
-              );
-              const [okData] = (await okMessage) as [RawData];
-              expect(JSON.parse(rawDataText(okData))).toMatchObject({ type: "auth.ok", v: 2 });
-              extension.send(
-                JSON.stringify({
-                  type: "hello",
-                  userAgent: "gateway-wakeup-test",
-                  browserVersion: "Chrome/test",
-                  extensionVersion: "2",
-                  tabs: [],
-                }),
-              );
+              if (!legacy) {
+                const clientNonce = randomRelayNonce();
+                const challengeMessage = once(extension, "message");
+                extension.send(
+                  JSON.stringify({
+                    type: "auth.hello",
+                    v: 2,
+                    keyId: relayKeyIdFromHex(RELAY_KEY),
+                    clientNonce,
+                  }),
+                );
+                const [challengeData] = (await challengeMessage) as [RawData];
+                const challenge = JSON.parse(rawDataText(challengeData));
+                const okMessage = once(extension, "message", {
+                  signal: AbortSignal.timeout(2_000),
+                });
+                extension.send(
+                  JSON.stringify({
+                    type: "auth.response",
+                    v: 2,
+                    sessionId: challenge.sessionId,
+                    clientProof: createRelayProof(RELAY_KEY, "client", challenge),
+                  }),
+                );
+                const [okData] = (await okMessage) as [RawData];
+                expect(JSON.parse(rawDataText(okData))).toMatchObject({ type: "auth.ok", v: 2 });
+              }
+              if (legacy === "head") {
+                expect(upgradeHeadBytes).toBe(coalesced?.bytes);
+              } else {
+                extension.send(JSON.stringify(EXTENSION_HELLO));
+              }
 
               await expect
                 .poll(async () => {
@@ -214,6 +326,9 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               if (!relay) {
                 throw new Error("extension relay did not start");
               }
+              if (coalesced) {
+                await expect(relayInventory(relayPort)).resolves.toMatchObject(inventory.tabs);
+              }
               if (standaloneFirst) {
                 expect(relay.ownership).toBe("borrowed");
                 if (relay.ownership !== "borrowed") {
@@ -225,6 +340,13 @@ describe.sequential("local Gateway extension relay wakeup", () => {
                 });
                 const profile = createBrowserControlContext().forProfile("chrome").profile;
                 expect(new URL(profile.cdpUrl).username).toBe("");
+                if (malformedFrame) {
+                  const closed = once(extension, "close");
+                  extension.send("invalid client frame", { mask: false });
+                  const [code] = await closed;
+                  expect(code).toBe(1002);
+                  await expect.poll(async () => (await relay.client.status()).ready).toBe(false);
+                }
                 await stopBrowserControlService();
                 const contender = await runExtensionRelayDaemon({ port: relayPort });
                 await expect(contender.done).resolves.toBe("port-in-use");

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -19,6 +19,7 @@ import {
   stopBrowserControlService,
 } from "../../control-service.js";
 import { buildBrowserExtensionPairing } from "../extension-pairing.js";
+import { runExtensionRelayDaemon } from "../relay-daemon.js";
 import { getFreePort } from "../test-port.js";
 import { createRelayProof, randomRelayNonce, relayKeyIdFromHex } from "./auth-v2-crypto.js";
 import { BROWSER_RELAY_EXTENSION_SUBPROTOCOL } from "./auth-v2.js";
@@ -80,9 +81,13 @@ describe.sequential("local Gateway extension relay wakeup", () => {
     });
   });
 
-  it.each([false, true])(
-    "authenticates the extension while a browser request is already waiting: %s",
-    async (browserRequestAlreadyWaiting) => {
+  it.each([
+    { browserRequestAlreadyWaiting: false, standaloneFirst: false },
+    { browserRequestAlreadyWaiting: true, standaloneFirst: false },
+    { browserRequestAlreadyWaiting: true, standaloneFirst: true },
+  ])(
+    "authenticates Gateway ingress: waiting=$browserRequestAlreadyWaiting standalone=$standaloneFirst",
+    async ({ browserRequestAlreadyWaiting, standaloneFirst }) => {
       const stateDir = await fs.realpath(
         await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-relay-wakeup-")),
       );
@@ -127,6 +132,7 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               void handleGatewayExtensionUpgrade(req, socket, head);
             });
             let extension: WebSocket | undefined;
+            let daemon: Awaited<ReturnType<typeof runExtensionRelayDaemon>> | undefined;
             const requestController = new AbortController();
             let browserAvailable: Promise<void> | undefined;
             try {
@@ -134,6 +140,9 @@ describe.sequential("local Gateway extension relay wakeup", () => {
                 gatewayServer.listen(gatewayPort, "127.0.0.1", resolve);
               });
               expect(getBrowserControlState()).toBeNull();
+              if (standaloneFirst) {
+                daemon = await runExtensionRelayDaemon({ port: relayPort });
+              }
 
               const pairing = await buildBrowserExtensionPairing({
                 cfg: config,
@@ -192,17 +201,37 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               );
 
               await expect
-                .poll(
-                  () =>
-                    getBrowserControlState()?.extensionRelays?.get("chrome")?.bridge
-                      .extensionConnected,
-                )
+                .poll(async () => {
+                  const currentRelay = getBrowserControlState()?.extensionRelays?.get("chrome");
+                  return currentRelay?.ownership === "borrowed"
+                    ? (await currentRelay.client.status()).ready
+                    : currentRelay?.bridge.extensionConnected;
+                })
                 .toBe(true);
               await expect(browserAvailable ?? Promise.resolve()).resolves.toBeUndefined();
               const relay = getBrowserControlState()?.extensionRelays?.get("chrome");
               expect(relay?.port).toBe(pairing.relayPort);
               if (!relay) {
                 throw new Error("extension relay did not start");
+              }
+              if (standaloneFirst) {
+                expect(relay.ownership).toBe("borrowed");
+                if (relay.ownership !== "borrowed") {
+                  throw new Error("Expected borrowed relay");
+                }
+                await expect(relay.client.status()).resolves.toMatchObject({
+                  ready: true,
+                  identity: { extensionVersion: "2", browserVersion: "Chrome/test" },
+                });
+                const profile = createBrowserControlContext().forProfile("chrome").profile;
+                expect(new URL(profile.cdpUrl).username).toBe("");
+                await stopBrowserControlService();
+                const contender = await runExtensionRelayDaemon({ port: relayPort });
+                await expect(contender.done).resolves.toBe("port-in-use");
+                return;
+              }
+              if (relay.ownership !== "owned") {
+                throw new Error("Expected owned relay");
               }
 
               for (let request = 0; request < 3; request += 1) {
@@ -230,6 +259,8 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               await browserAvailable?.catch(() => {});
               extension?.terminate();
               await stopBrowserControlService();
+              daemon?.stop();
+              await daemon?.done;
               await closeServer(gatewayServer);
             }
           },

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts
@@ -8,13 +8,31 @@ const getBrowserControlStateMock = vi.fn();
 const startBrowserControlServiceFromConfigMock = vi.fn();
 vi.mock("../../control-service.js", () => ({
   getBrowserControlState: () => getBrowserControlStateMock(),
-  startBrowserControlServiceFromConfig: () => startBrowserControlServiceFromConfigMock(),
+  startBrowserControlServiceFromConfig: async () => {
+    const state = await startBrowserControlServiceFromConfigMock();
+    if (state) {
+      getBrowserControlStateMock.mockReturnValue(state);
+    }
+    return state;
+  },
 }));
 
 const ensureExtensionRelayForProfileMock = vi.fn();
 vi.mock("./relay-lifecycle.js", () => ({
-  ensureExtensionRelayForProfile: (...args: unknown[]) =>
-    ensureExtensionRelayForProfileMock(...args),
+  ensureExtensionRelayForProfile: async (
+    state: ReturnType<typeof stateWithExtensionProfile>,
+    profile: { name: string; cdpPort: number },
+  ) => {
+    const result = await ensureExtensionRelayForProfileMock(state, profile);
+    const relay = {
+      ...result,
+      ownership: "owned",
+      port: profile.cdpPort,
+      token: readExtensionRelayTokenMock(),
+    };
+    state.extensionRelays.set(profile.name, relay);
+    return relay;
+  },
 }));
 
 const resolveProfileMock = vi.fn();
@@ -95,6 +113,10 @@ function v2Req(url = "/browser/extension"): IncomingMessage {
 
 function stateWithExtensionProfile() {
   return {
+    profiles: new Map([
+      ["chrome", { profile: { name: "chrome", driver: "extension", cdpPort: 18799 } }],
+    ]),
+    extensionRelays: new Map(),
     resolved: {
       extensionRelayToken: TOKEN,
       profiles: { chrome: { driver: "extension" } },
@@ -130,7 +152,7 @@ function oversizedMaskedTextFrame(): Buffer {
 
 // Default: the requested profile resolves to a valid extension profile.
 function primeProfile() {
-  resolveProfileMock.mockReturnValue({ name: "chrome", driver: "extension" });
+  resolveProfileMock.mockReturnValue({ name: "chrome", driver: "extension", cdpPort: 18799 });
 }
 
 async function mockSuccessfulUpgrade() {
@@ -237,12 +259,11 @@ describe("handleGatewayExtensionUpgrade", () => {
     );
 
     expect(handled).toBe(true);
-    expect(readExtensionRelayTokenMock).toHaveBeenCalledOnce();
+    expect(readExtensionRelayTokenMock).toHaveBeenCalled();
     expect(startBrowserControlServiceFromConfigMock).toHaveBeenCalledOnce();
-    expect(attachExtensionWebSocketMock).toHaveBeenCalledWith(
-      bridge,
-      expect.objectContaining({ readyState: 1 }),
-    );
+    await expect
+      .poll(() => attachExtensionWebSocketMock.mock.calls)
+      .toContainEqual([bridge, expect.objectContaining({ readyState: 1 })]);
   });
 
   it("does not lazy-start or attach v2 before the in-band client proof succeeds", async () => {
@@ -274,10 +295,9 @@ describe("handleGatewayExtensionUpgrade", () => {
     expect(ensureExtensionRelayForProfileMock).toHaveBeenCalledOnce();
     expect(attachExtensionWebSocketMock).not.toHaveBeenCalled();
     attach();
-    expect(attachExtensionWebSocketMock).toHaveBeenCalledWith(
-      bridge,
-      expect.objectContaining({ readyState: 1 }),
-    );
+    await expect
+      .poll(() => attachExtensionWebSocketMock.mock.calls)
+      .toContainEqual([bridge, expect.objectContaining({ readyState: 1 })]);
   });
 
   it("rejects oversized direct-Gateway upgrade-head data before ws auth or lazy startup", async () => {
@@ -358,10 +378,9 @@ describe("handleGatewayExtensionUpgrade", () => {
     );
     expect(handled).toBe(true);
     expect(ensureExtensionRelayForProfileMock).toHaveBeenCalledOnce();
-    expect(attachExtensionWebSocketMock).toHaveBeenCalledWith(
-      bridge,
-      expect.objectContaining({ readyState: 1 }),
-    );
+    await expect
+      .poll(() => attachExtensionWebSocketMock.mock.calls)
+      .toContainEqual([bridge, expect.objectContaining({ readyState: 1 })]);
   });
 
   it("authenticates against the live relay secret when Browser state is stale", async () => {
@@ -390,9 +409,8 @@ describe("handleGatewayExtensionUpgrade", () => {
 
     expect(handled).toBe(true);
     expect(ensureExtensionRelayForProfileMock).toHaveBeenCalledOnce();
-    expect(attachExtensionWebSocketMock).toHaveBeenCalledWith(
-      bridge,
-      expect.objectContaining({ readyState: 1 }),
-    );
+    await expect
+      .poll(() => attachExtensionWebSocketMock.mock.calls)
+      .toContainEqual([bridge, expect.objectContaining({ readyState: 1 })]);
   });
 });

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts
@@ -162,6 +162,8 @@ async function mockSuccessfulUpgrade() {
     close: vi.fn(),
     terminate: vi.fn(),
     send: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
   });
   vi.spyOn(wsMod.WebSocketServer.prototype, "handleUpgrade").mockImplementation(
     (_req, _socket, _head, cb) => {
@@ -249,7 +251,7 @@ describe("handleGatewayExtensionUpgrade", () => {
     primeProfile();
     const bridge = { id: "fresh-bridge" };
     ensureExtensionRelayForProfileMock.mockResolvedValue({ bridge });
-    await mockSuccessfulUpgrade();
+    const ws = await mockSuccessfulUpgrade();
 
     const { socket } = fakeSocket();
     const handled = await handleGatewayExtensionUpgrade(
@@ -260,6 +262,7 @@ describe("handleGatewayExtensionUpgrade", () => {
 
     expect(handled).toBe(true);
     expect(readExtensionRelayTokenMock).toHaveBeenCalled();
+    expect(() => ws.emit("error", new Error("Invalid WebSocket frame"))).not.toThrow();
     expect(startBrowserControlServiceFromConfigMock).toHaveBeenCalledOnce();
     await expect
       .poll(() => attachExtensionWebSocketMock.mock.calls)

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.ts
@@ -212,6 +212,11 @@ export async function handleGatewayExtensionUpgrade(
   }
   const authority = getBrowserRelayAuthV2Authority(token);
   getWss().handleUpgrade(req, socket, head, (ws) => {
+    // Pause before the first read tick, including upgrade-head bytes. Pausing
+    // after receiver events begin cannot hold already-buffered application frames.
+    ws.pause();
+    // Borrowed ingress never passes through the local bridge's socket binding.
+    ws.on("error", (err) => log.warn(`relay socket error: ${String(err)}`));
     if (
       !authority.registerAuthenticatedConnection(ws, () =>
         ws.close(4003, "browser relay key rotated"),
@@ -222,8 +227,14 @@ export async function handleGatewayExtensionUpgrade(
     }
     ws.once("close", () => authority.releaseConnection(ws));
     void prepareGatewayIngress(resolved, ws)
-      .then((attach) => attach())
-      .catch(() => ws.close(1011, "Relay ingress unavailable"));
+      .then((attach) => {
+        if (ws.readyState === 1) {
+          attach();
+        }
+      })
+      .catch(() => ws.close(1011, "Relay ingress unavailable"))
+      // Failure must also drain the closing handshake instead of stranding a paused peer.
+      .finally(() => ws.resume());
     log.warn(`legacy extension authentication accepted for profile "${resolved.profileName}"`);
   });
   return true;

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.ts
@@ -2,7 +2,7 @@
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
-import { WebSocketServer } from "ws";
+import { WebSocketServer, type WebSocket } from "ws";
 import { getRuntimeConfig } from "../../config/config.js";
 import {
   getBrowserControlState,
@@ -10,6 +10,7 @@ import {
 } from "../../control-service.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveProfile } from "../config.js";
+import { getProfileLifecycle } from "../server-context.lifecycle.js";
 import {
   BROWSER_RELAY_EXTENSION_SUBPROTOCOL,
   getBrowserRelayAuthV2Authority,
@@ -61,7 +62,7 @@ function defaultExtensionProfileName(profiles: Record<string, { driver?: string 
   return "chrome";
 }
 
-async function resolveGatewayBridge(resource: string) {
+async function resolveGatewayRelay(resource: string) {
   let state = getBrowserControlState();
   if (!state) {
     state = await startBrowserControlServiceFromConfig();
@@ -77,9 +78,47 @@ async function resolveGatewayBridge(resource: string) {
   if (!resolved || resolved.driver !== "extension") {
     throw new Error(`Extension browser profile "${profileName}" was not found`);
   }
+  const relay = await ensureExtensionRelayForProfile(state, resolved);
+  const runtime = state.profiles.get(profileName);
+  if (!runtime) {
+    throw new Error("Gateway relay profile is unavailable");
+  }
+  const lifecycle = getProfileLifecycle(runtime);
+  const generation = lifecycle.generation;
   return {
-    bridge: (await ensureExtensionRelayForProfile(state, resolved)).bridge,
+    relay,
     profileName,
+    assertCurrent: () => {
+      if (
+        lifecycle.generation !== generation ||
+        lifecycle.transitionReason ||
+        lifecycle.terminal ||
+        getBrowserControlState() !== state ||
+        state.extensionRelays?.get(profileName) !== relay ||
+        state.profiles.get(profileName) !== runtime ||
+        readExtensionRelayToken() !== relay.token ||
+        resolveProfile(state.resolved, profileName)?.cdpPort !== relay.port
+      ) {
+        throw new Error("Gateway relay ingress was superseded");
+      }
+    },
+  };
+}
+
+async function prepareGatewayIngress(
+  access: Awaited<ReturnType<typeof resolveGatewayRelay>>,
+  ws: WebSocket,
+): Promise<() => void> {
+  access.assertCurrent();
+  const relay = access.relay;
+  const attach =
+    relay.ownership === "borrowed"
+      ? await relay.client.prepareIngress(ws)
+      : () => attachExtensionWebSocket(relay.bridge, ws);
+  return () => {
+    access.assertCurrent();
+    attach();
+    log.info(`extension connected over gateway for profile "${access.profileName}"`);
   };
 }
 
@@ -128,10 +167,12 @@ export async function handleGatewayExtensionUpgrade(
               if (readExtensionRelayToken() !== token) {
                 throw new Error("browser relay key rotated during authentication");
               }
-              const { bridge, profileName } = await resolveGatewayBridge(resource);
+              const attach = await prepareGatewayIngress(await resolveGatewayRelay(resource), ws);
               return () => {
-                attachExtensionWebSocket(bridge, ws);
-                log.info(`extension authenticated over gateway for profile "${profileName}"`);
+                if (readExtensionRelayToken() !== token) {
+                  throw new Error("Relay key rotated");
+                }
+                attach();
               };
             },
           });
@@ -163,7 +204,7 @@ export async function handleGatewayExtensionUpgrade(
 
   let resolved;
   try {
-    resolved = await resolveGatewayBridge(resource);
+    resolved = await resolveGatewayRelay(resource);
   } catch (err) {
     log.warn(`failed to start Browser control for legacy extension relay: ${String(err)}`);
     destroy(socket, "503 Service Unavailable");
@@ -180,7 +221,9 @@ export async function handleGatewayExtensionUpgrade(
       return;
     }
     ws.once("close", () => authority.releaseConnection(ws));
-    attachExtensionWebSocket(resolved.bridge, ws);
+    void prepareGatewayIngress(resolved, ws)
+      .then((attach) => attach())
+      .catch(() => ws.close(1011, "Relay ingress unavailable"));
     log.warn(`legacy extension authentication accepted for profile "${resolved.profileName}"`);
   });
   return true;

--- a/extensions/browser/src/browser/extension-relay/owner-auth-client.test.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-auth-client.test.ts
@@ -1,0 +1,81 @@
+import { once } from "node:events";
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import { afterEach, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
+import { randomRelayId } from "./auth-v2-crypto.js";
+import {
+  BrowserRelayAuthV2Authority,
+  parseRelayAuthHello,
+  parseStrictJsonObject,
+} from "./auth-v2.js";
+import { authenticateRelayOwner } from "./owner-auth-client.js";
+import { relayOwnerResource } from "./owner-protocol.js";
+
+const servers: WebSocketServer[] = [];
+afterEach(async () => {
+  for (const server of servers.splice(0)) {
+    for (const socket of server.clients) {
+      socket.terminate();
+    }
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  }
+});
+
+it.each(["port", "profile", "owner", "key"] as const)(
+  "rejects a listener's mismatched %s proof without disclosing the persistent key or sending a client proof",
+  async (mismatch) => {
+    const token = relayTestKey(12);
+    const authority = new BrowserRelayAuthV2Authority(
+      mismatch === "key" ? relayTestKey(13) : token,
+    );
+    const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    servers.push(server);
+    await once(server, "listening");
+    const address = server.address();
+    if (typeof address === "string" || !address) {
+      throw new Error("Expected loopback address");
+    }
+    const observed: string[] = [];
+    server.on("connection", (ws, request) => {
+      observed.push(JSON.stringify({ url: request.url, headers: request.headers }));
+      authority.registerPendingConnection(ws, () => ws.terminate());
+      ws.on("message", (raw) => {
+        observed.push(rawDataToString(raw));
+        const hello = parseRelayAuthHello(parseStrictJsonObject(rawDataToString(raw)));
+        if (!hello) {
+          throw new Error("Expected auth hello only");
+        }
+        const resource = relayOwnerResource(
+          mismatch === "port" ? address.port + 1 : address.port,
+          mismatch === "profile" ? "another-profile" : "chrome",
+        );
+        const challenge = authority.issueChallenge(
+          ws,
+          { ...hello, keyId: authority.keyId },
+          {
+            role: "cdp",
+            transport: "websocket",
+            method: "GET",
+            flow: "owner",
+            resource: `${resource}&owner=${mismatch === "owner" ? "invalid-owner" : randomRelayId()}`,
+          },
+        );
+        ws.send(JSON.stringify(challenge));
+      });
+    });
+    await expect(
+      authenticateRelayOwner({
+        port: address.port,
+        profile: "chrome",
+        token,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow();
+    expect(observed.join("\n")).not.toContain(token);
+    expect(observed.join("\n")).not.toContain("auth.response");
+    authority.dispose();
+  },
+);

--- a/extensions/browser/src/browser/extension-relay/owner-auth-client.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-auth-client.ts
@@ -1,0 +1,131 @@
+import { once } from "node:events";
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import { WebSocket } from "ws";
+import {
+  createRelayProof,
+  isCanonicalBase64UrlBytes,
+  randomRelayNonce,
+  relayKeyIdFromHex,
+  verifyRelayProof,
+  type BrowserRelayProofFields,
+} from "./auth-v2-crypto.js";
+import {
+  BROWSER_RELAY_CHALLENGE_TTL_MS,
+  BROWSER_RELAY_EXTENSION_SUBPROTOCOL,
+  parseStrictJsonObject,
+} from "./auth-v2.js";
+import { relayOwnerResource } from "./owner-protocol.js";
+
+/** Never send a key or client proof until the configured listener proves its resource. */
+export async function authenticateRelayOwner(params: {
+  port: number;
+  profile: string;
+  token: string;
+  signal: AbortSignal;
+}): Promise<{ ws: WebSocket; owner: string }> {
+  const resource = relayOwnerResource(params.port, params.profile);
+  const disconnected = new AbortController();
+  const signal = AbortSignal.any([
+    disconnected.signal,
+    params.signal,
+    AbortSignal.timeout(BROWSER_RELAY_CHALLENGE_TTL_MS),
+  ]);
+  signal.throwIfAborted();
+  const ws = new WebSocket(
+    `ws://127.0.0.1:${params.port}${resource}`,
+    BROWSER_RELAY_EXTENSION_SUBPROTOCOL,
+    { maxPayload: 64 * 1024 * 1024 },
+  );
+  ws.once("close", () =>
+    disconnected.abort(new Error("Relay owner authentication connection closed")),
+  );
+  const abort = () => ws.terminate();
+  signal.addEventListener("abort", abort, { once: true });
+  // Install an error listener even when an abort wins a pending message read.
+  ws.on("error", () => {});
+  const read = async () => {
+    const [raw] = await once(ws, "message", { signal });
+    const message = parseStrictJsonObject(rawDataToString(raw));
+    if (!message) {
+      throw new Error("Invalid relay owner authentication frame");
+    }
+    return message;
+  };
+  try {
+    await once(ws, "open", { signal });
+    const clientNonce = randomRelayNonce();
+    const keyId = relayKeyIdFromHex(params.token);
+    const challengeRead = read();
+    ws.send(JSON.stringify({ type: "auth.hello", v: 2, keyId, clientNonce }));
+    const challenge = await challengeRead;
+    const owner =
+      typeof challenge.resource === "string"
+        ? challenge.resource.slice(`${resource}&owner=`.length)
+        : "";
+    const now = Date.now();
+    if (
+      Object.keys(challenge).length !== 15 ||
+      challenge.type !== "auth.challenge" ||
+      challenge.v !== 2 ||
+      challenge.keyId !== keyId ||
+      challenge.clientNonce !== clientNonce ||
+      challenge.role !== "cdp" ||
+      challenge.transport !== "websocket" ||
+      challenge.method !== "GET" ||
+      challenge.flow !== "owner" ||
+      challenge.resource !== `${resource}&owner=${owner}` ||
+      !isCanonicalBase64UrlBytes(owner, 16) ||
+      !isCanonicalBase64UrlBytes(challenge.instanceId, 16) ||
+      !isCanonicalBase64UrlBytes(challenge.sessionId, 16) ||
+      !isCanonicalBase64UrlBytes(challenge.serverNonce, 32) ||
+      typeof challenge.issuedAtMs !== "number" ||
+      !Number.isSafeInteger(challenge.issuedAtMs) ||
+      typeof challenge.expiresAtMs !== "number" ||
+      !Number.isSafeInteger(challenge.expiresAtMs) ||
+      challenge.expiresAtMs <= now ||
+      challenge.issuedAtMs > now + 30_000 ||
+      challenge.expiresAtMs - challenge.issuedAtMs !== BROWSER_RELAY_CHALLENGE_TTL_MS
+    ) {
+      throw new Error("Relay owner authentication binding mismatch");
+    }
+    const fields: BrowserRelayProofFields = {
+      keyId,
+      clientNonce,
+      instanceId: challenge.instanceId,
+      sessionId: challenge.sessionId,
+      serverNonce: challenge.serverNonce,
+      issuedAtMs: challenge.issuedAtMs,
+      expiresAtMs: challenge.expiresAtMs,
+      role: "cdp",
+      transport: "websocket",
+      method: "GET",
+      flow: "owner",
+      resource: `${resource}&owner=${owner}`,
+    };
+    if (!verifyRelayProof(params.token, "server", fields, challenge.serverProof)) {
+      throw new Error("Relay owner did not prove the configured key");
+    }
+    const clientProof = createRelayProof(params.token, "client", fields);
+    const acceptedRead = read();
+    ws.send(
+      JSON.stringify({ type: "auth.response", v: 2, sessionId: fields.sessionId, clientProof }),
+    );
+    const accepted = await acceptedRead;
+    if (
+      Object.keys(accepted).length !== 4 ||
+      accepted.type !== "auth.ok" ||
+      accepted.v !== 2 ||
+      accepted.sessionId !== fields.sessionId ||
+      !verifyRelayProof(params.token, "accept", fields, accepted.acceptProof, clientProof)
+    ) {
+      throw new Error("Relay owner acceptance proof failed");
+    }
+    signal.throwIfAborted();
+    return { ws, owner };
+  } catch (error) {
+    ws.terminate();
+    throw error;
+  } finally {
+    signal.removeEventListener("abort", abort);
+  }
+}

--- a/extensions/browser/src/browser/extension-relay/owner-client.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-client.ts
@@ -1,0 +1,311 @@
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import type { ConnectOverCDPTransport } from "playwright-core";
+import type { WebSocket } from "ws";
+import { z } from "zod";
+import { parseStrictJsonObject } from "./auth-v2.js";
+import { authenticateRelayOwner } from "./owner-auth-client.js";
+import {
+  RELAY_OWNER_LIMIT,
+  relayOwnerFrame,
+  relayOwnerReply,
+  relayOwnerRetired,
+  relayOwnerStatus,
+  relayOwnerStreamClosed,
+  type RelayOwnerStatus,
+} from "./owner-protocol.js";
+
+type OwnerStream = {
+  send: (raw: string) => void;
+  close: () => Promise<void>;
+  onFrame?: (raw: string) => void;
+  onClose?: () => void;
+};
+
+export type RelayOperationReference = {
+  resolve: () => Promise<string | undefined>;
+  release: () => Promise<void>;
+  openTransport: () => Promise<ConnectOverCDPTransport>;
+};
+
+/** Client resources are leases on one socket and one proved listener lifetime. */
+export class RelayOwnerClient {
+  private readonly pending = new Map<
+    number,
+    {
+      resolve: (value: unknown) => void;
+      reject: (error: Error) => void;
+    }
+  >();
+  private readonly streams = new Map<number, OwnerStream>();
+  private profileAdmission: () => void = () => {};
+  private sequence = 0;
+  private closed = false;
+  private retirementAcknowledged = false;
+  private closing: Promise<void> | undefined;
+
+  private constructor(
+    private readonly ws: WebSocket,
+    readonly owner: string,
+  ) {
+    ws.on("message", (raw) => {
+      const parsed = parseStrictJsonObject(rawDataToString(raw));
+      if (relayOwnerRetired.safeParse(parsed).success) {
+        this.retirementAcknowledged = true;
+        this.closed = true;
+        for (const pending of this.pending.values()) {
+          pending.reject(new Error("Relay owner retired"));
+        }
+        this.pending.clear();
+        for (const stream of this.streams.values()) {
+          stream.onClose?.();
+        }
+        this.streams.clear();
+        return;
+      }
+      const reply = relayOwnerReply.safeParse(parsed);
+      if (reply.success) {
+        const pending = this.pending.get(reply.data.id);
+        this.pending.delete(reply.data.id);
+        if (reply.data.error) {
+          pending?.reject(new Error(reply.data.error));
+        } else {
+          pending?.resolve(reply.data.result);
+        }
+        return;
+      }
+      const frame = relayOwnerFrame.safeParse(parsed);
+      if (frame.success) {
+        this.streams.get(frame.data.stream)?.onFrame?.(frame.data.frame);
+        return;
+      }
+      const closed = relayOwnerStreamClosed.safeParse(parsed);
+      if (closed.success) {
+        this.streams.get(closed.data.stream)?.onClose?.();
+        this.streams.delete(closed.data.stream);
+        return;
+      }
+      ws.close(4003, "invalid relay owner response");
+    });
+    ws.once("close", () => {
+      this.closed = true;
+      for (const pending of this.pending.values()) {
+        pending.reject(new Error("Relay owner connection lost"));
+      }
+      this.pending.clear();
+      for (const stream of this.streams.values()) {
+        stream.onClose?.();
+      }
+      this.streams.clear();
+    });
+  }
+
+  static async connect(params: {
+    port: number;
+    profile: string;
+    token: string;
+    signal: AbortSignal;
+  }) {
+    const { ws, owner } = await authenticateRelayOwner(params);
+    return new RelayOwnerClient(ws, owner);
+  }
+
+  adoptProfileLease(assertCurrent: () => void): void {
+    this.profileAdmission = assertCurrent;
+  }
+
+  get connected(): boolean {
+    return !this.closed && !this.closing && this.ws.readyState === 1;
+  }
+
+  assertCurrent(): void {
+    this.profileAdmission();
+    if (this.closed || this.closing || this.ws.readyState !== 1) {
+      throw new Error("Relay owner lease is no longer current");
+    }
+  }
+
+  private async request(op: string, fields: Record<string, unknown> = {}): Promise<unknown> {
+    if (this.closed || this.ws.readyState !== 1 || this.pending.size >= RELAY_OWNER_LIMIT) {
+      throw new Error("Relay owner connection unavailable");
+    }
+    const id = ++this.sequence;
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await new Promise<unknown>((resolve, reject) => {
+        this.pending.set(id, { resolve, reject });
+        timer = setTimeout(() => {
+          this.pending.delete(id);
+          reject(new Error("Relay owner response timed out"));
+          // A timed-out mutation cannot be reused as if it never happened.
+          this.ws.terminate();
+        }, 15_000);
+        timer.unref?.();
+        this.ws.send(JSON.stringify({ id, op, ...fields }));
+      });
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+
+  async status(timeoutMs = 0): Promise<RelayOwnerStatus> {
+    this.assertCurrent();
+    const status = relayOwnerStatus.parse(await this.request("ready", { timeoutMs }));
+    this.assertCurrent();
+    return status;
+  }
+
+  async capture(
+    targetId: string,
+    assertOperationCurrent: () => void = () => {},
+  ): Promise<RelayOperationReference> {
+    this.assertCurrent();
+    assertOperationCurrent();
+    const ref = z
+      .string()
+      .nullable()
+      .parse(await this.request("capture", { targetId }));
+    try {
+      this.assertCurrent();
+      assertOperationCurrent();
+    } catch (error) {
+      if (ref) {
+        await this.request("release", { ref });
+      }
+      throw error;
+    }
+    let released = false;
+    const assertReference = () => {
+      this.assertCurrent();
+      assertOperationCurrent();
+      if (released || !ref) {
+        throw new Error("Relay operation target is unavailable");
+      }
+    };
+    return {
+      resolve: async () => {
+        assertReference();
+        const target = z
+          .string()
+          .nullable()
+          .parse(await this.request("resolve", { ref }));
+        assertReference();
+        return target ?? undefined;
+      },
+      openTransport: async () => {
+        assertReference();
+        const transport = await this.openTransport(ref ?? undefined);
+        try {
+          assertReference();
+          const send = transport.send.bind(transport);
+          transport.send = (message) => {
+            assertReference();
+            send(message);
+          };
+          return transport;
+        } catch (error) {
+          transport.close();
+          throw error;
+        }
+      },
+      release: async () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        if (ref) {
+          await this.request("release", { ref });
+        }
+      },
+    };
+  }
+
+  private async openStream(op: "cdp.open" | "ingress.open", ref?: string): Promise<OwnerStream> {
+    this.assertCurrent();
+    const id = z
+      .number()
+      .int()
+      .positive()
+      .parse(await this.request(op, ref ? { ref } : {}));
+    this.assertCurrent();
+    let closed = false;
+    let closing: Promise<void> | undefined;
+    const stream: OwnerStream = {
+      send: (frame) => {
+        this.assertCurrent();
+        if (closed) {
+          throw new Error("Relay stream closed");
+        }
+        this.ws.send(JSON.stringify({ stream: id, frame }));
+      },
+      close: () => {
+        closed = true;
+        return (closing ??= this.request("stream.close", { stream: id }).then(() => {
+          this.streams.delete(id);
+          stream.onClose?.();
+        }));
+      },
+    };
+    this.streams.set(id, stream);
+    return stream;
+  }
+
+  async openTransport(ref?: string): Promise<ConnectOverCDPTransport> {
+    const stream = await this.openStream("cdp.open", ref);
+    const transport: ConnectOverCDPTransport = {
+      send: (message) => stream.send(JSON.stringify(message)),
+      close: () => {
+        void stream.close().catch(() => this.ws.terminate());
+      },
+    };
+    stream.onFrame = (raw) => {
+      const frame = parseStrictJsonObject(raw);
+      if (!frame) {
+        this.ws.terminate();
+        return;
+      }
+      transport.onmessage?.(frame);
+    };
+    stream.onClose = () => transport.onclose?.("Relay CDP stream closed");
+    return transport;
+  }
+
+  async prepareIngress(ws: WebSocket): Promise<() => void> {
+    const stream = await this.openStream("ingress.open");
+    const close = () => {
+      void stream.close().catch(() => this.ws.terminate());
+    };
+    ws.once("close", close);
+    if (ws.readyState !== 1) {
+      close();
+      throw new Error("Gateway extension connection lost");
+    }
+    return () => {
+      this.assertCurrent();
+      stream.onFrame = (raw) => {
+        if (ws.readyState === 1) {
+          ws.send(raw);
+        }
+      };
+      stream.onClose = () => ws.close(1011, "Relay ingress lease closed");
+      ws.on("message", (raw) => {
+        try {
+          stream.send(rawDataToString(raw));
+        } catch {
+          ws.close(1011, "Relay ingress lease closed");
+        }
+      });
+    };
+  }
+
+  close(): Promise<void> {
+    if (this.retirementAcknowledged) {
+      return Promise.resolve();
+    }
+    return (this.closing ??= this.request("close").then(() => {
+      this.closed = true;
+      this.ws.close();
+    }));
+  }
+}

--- a/extensions/browser/src/browser/extension-relay/owner-connection.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-connection.integration.test.ts
@@ -1,0 +1,101 @@
+import { once } from "node:events";
+import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import { afterEach, expect, it } from "vitest";
+import type { RawData, WebSocket } from "ws";
+import {
+  createBrowserControlContext,
+  startBrowserControlServiceFromConfig,
+  stopBrowserControlService,
+} from "../../control-service.js";
+import { authenticateRelayOwner } from "./owner-auth-client.js";
+import { withConnectedDaemon } from "./relay-coexistence.test-support.js";
+
+afterEach(clearRuntimeConfigSnapshot);
+
+function ownerRequests(ws: WebSocket) {
+  let sequence = 0;
+  return async (op: string, fields: object = {}) => {
+    const id = ++sequence;
+    const response = new Promise<{ result?: unknown; error?: string }>((resolve) => {
+      const onMessage = (raw: RawData) => {
+        const value = JSON.parse(rawDataToString(raw));
+        if (value.id === id) {
+          ws.off("message", onMessage);
+          resolve(value);
+        }
+      };
+      ws.on("message", onMessage);
+    });
+    ws.send(JSON.stringify({ id, op, ...fields }));
+    return await response;
+  };
+}
+
+it("scopes references to their authenticated connection and releases native claims on peer loss", async () => {
+  await withConnectedDaemon(async ({ port, token, extension, holdDetach }) => {
+    const connect = () =>
+      authenticateRelayOwner({
+        port,
+        token,
+        profile: "chrome",
+        signal: new AbortController().signal,
+      });
+    const first = await connect();
+    const second = await connect();
+    const request = ownerRequests(first.ws);
+    const other = ownerRequests(second.ws);
+    const hold = holdDetach();
+    try {
+      await startBrowserControlServiceFromConfig();
+      await createBrowserControlContext().forProfile("chrome").listTabs();
+      const { result: ref } = await request("capture", { targetId: "fixture-target" });
+      expect(ref).toBeTypeOf("string");
+      await expect(other("resolve", { ref })).resolves.toEqual({ id: 1, result: null });
+      await request("release", { ref });
+      await expect(request("cdp.open", { ref })).resolves.toHaveProperty("error");
+
+      // Give the first owner a real logical claimant before the Gateway drops its own.
+      const { result: stream } = await request("cdp.open");
+      const attached = new Promise<void>((resolve) => {
+        first.ws.on("message", (raw) => {
+          const value = JSON.parse(rawDataToString(raw));
+          if (
+            value.stream === stream &&
+            value.frame &&
+            JSON.parse(value.frame).method === "Target.attachedToTarget"
+          ) {
+            resolve();
+          }
+        });
+      });
+      first.ws.send(
+        JSON.stringify({
+          stream,
+          frame: JSON.stringify({
+            id: 1,
+            method: "Target.setAutoAttach",
+            params: { autoAttach: true, flatten: true },
+          }),
+        }),
+      );
+      await attached;
+      await stopBrowserControlService();
+      first.ws.terminate();
+      await hold.entered;
+      expect(extension.readyState).toBe(1);
+      await expect(other("ready", { timeoutMs: 0 })).resolves.toMatchObject({
+        result: { ready: true, identity: { extensionVersion: "2" } },
+      });
+      hold.release();
+      const closed = once(second.ws, "close");
+      await other("close");
+      second.ws.close();
+      await closed;
+    } finally {
+      hold.release();
+      first.ws.terminate();
+      second.ws.terminate();
+    }
+  });
+});

--- a/extensions/browser/src/browser/extension-relay/owner-connection.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-connection.integration.test.ts
@@ -99,3 +99,30 @@ it("scopes references to their authenticated connection and releases native clai
     }
   });
 });
+
+it("owns malformed-frame errors after owner authentication without stopping the relay", async () => {
+  await withConnectedDaemon(async ({ port, token, extension }) => {
+    const connect = () =>
+      authenticateRelayOwner({
+        port,
+        token,
+        profile: "chrome",
+        signal: new AbortController().signal,
+      });
+    const failed = await connect();
+    const healthy = await connect();
+    try {
+      const closed = once(failed.ws, "close");
+      failed.ws.send("invalid client frame", { mask: false });
+      const [code] = await closed;
+      expect(code).toBe(1002);
+      await expect(ownerRequests(healthy.ws)("ready", { timeoutMs: 0 })).resolves.toMatchObject({
+        result: { ready: true },
+      });
+      expect(extension.readyState).toBe(1);
+    } finally {
+      failed.ws.terminate();
+      healthy.ws.terminate();
+    }
+  });
+});

--- a/extensions/browser/src/browser/extension-relay/owner-playwright.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-playwright.ts
@@ -1,0 +1,66 @@
+import type { Browser } from "playwright-core";
+import { connectOverCdpTransport } from "../pw-session-cdp-transport.js";
+import type { RelayOperationReference } from "./owner-client.js";
+import { getBorrowedRelayCdpAccess, type BorrowedRelayAccess } from "./relay-access.js";
+
+// Navigation recovery gets its own reference-bound connection. DOM references remain
+// on the ordinary cached Page/Frame and are never copied into this operation cache.
+const operationConnections = new WeakMap<RelayOperationReference, Promise<Browser>>();
+
+export async function closeRelayOperationConnection(
+  reference: RelayOperationReference,
+): Promise<void> {
+  const pending = operationConnections.get(reference);
+  if (!pending) {
+    return;
+  }
+  await (await pending).close();
+  if (operationConnections.get(reference) === pending) {
+    operationConnections.delete(reference);
+  }
+}
+
+export async function connectRelayBrowser(
+  relay: BorrowedRelayAccess,
+  cdpUrl: string,
+  reference?: RelayOperationReference,
+): Promise<Browser> {
+  const existing = reference && operationConnections.get(reference);
+  if (existing) {
+    const browser = await existing;
+    relay.client.assertCurrent();
+    if (!(await reference.resolve())) {
+      throw new Error("Captured relay connection was superseded");
+    }
+    return browser;
+  }
+  const pending = (async () => {
+    const transport = await (reference ? reference.openTransport() : relay.client.openTransport());
+    const browser = await connectOverCdpTransport(cdpUrl, {
+      timeout: 5_000,
+      headers: {},
+      preparedTransport: transport,
+    });
+    try {
+      if (
+        getBorrowedRelayCdpAccess(cdpUrl) !== relay ||
+        (reference && !(await reference.resolve()))
+      ) {
+        throw new Error("Captured relay connection was superseded");
+      }
+      return browser;
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
+  })();
+  if (reference) {
+    operationConnections.set(reference, pending);
+    void pending.catch(() => {
+      if (operationConnections.get(reference) === pending) {
+        operationConnections.delete(reference);
+      }
+    });
+  }
+  return await pending;
+}

--- a/extensions/browser/src/browser/extension-relay/owner-protocol.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-protocol.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const RELAY_OWNER_PATH = "/_openclaw/relay/owner";
+export const RELAY_OWNER_LIMIT = 64;
+export const RELAY_OPERATION_TTL_MS = 5 * 60_000;
+
+export function relayOwnerResource(port: number, profile: string): string {
+  return `${RELAY_OWNER_PATH}?port=${port}&profile=${encodeURIComponent(profile)}`;
+}
+
+const id = z.number().int().positive();
+const reference = z.string().min(1).max(64);
+export const relayOwnerRequest = z.discriminatedUnion("op", [
+  z.strictObject({ id, op: z.literal("ready"), timeoutMs: z.number().int().min(0).max(10_000) }),
+  z.strictObject({ id, op: z.literal("capture"), targetId: z.string().min(1).max(1024) }),
+  z.strictObject({ id, op: z.literal("resolve"), ref: reference }),
+  z.strictObject({ id, op: z.literal("release"), ref: reference }),
+  z.strictObject({ id, op: z.literal("cdp.open"), ref: reference.optional() }),
+  z.strictObject({ id, op: z.literal("ingress.open") }),
+  z.strictObject({ id, op: z.literal("stream.close"), stream: id }),
+  z.strictObject({ id, op: z.literal("close") }),
+]);
+export const relayOwnerFrame = z.strictObject({ stream: id, frame: z.string() });
+export const relayOwnerReply = z.strictObject({
+  id,
+  result: z.unknown().optional(),
+  error: z.string().optional(),
+});
+export const relayOwnerStreamClosed = z.strictObject({ stream: id, closed: z.literal(true) });
+export const relayOwnerStatus = z.strictObject({
+  ready: z.boolean(),
+  allowLegacyAuth: z.boolean(),
+  identity: z
+    .strictObject({
+      browserVersion: z.string(),
+      userAgent: z.string(),
+      extensionVersion: z.string(),
+    })
+    .nullable(),
+  generation: z.number().int().nonnegative(),
+});
+export type RelayOwnerStatus = z.infer<typeof relayOwnerStatus>;
+
+export const relayOwnerRetired = z.strictObject({ retired: z.literal(true) });

--- a/extensions/browser/src/browser/extension-relay/owner-server.test.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-server.test.ts
@@ -1,0 +1,93 @@
+import { once } from "node:events";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import { expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { relayOwnerReply, relayOwnerRetired } from "./owner-protocol.js";
+import { attachRelayOwner } from "./owner-server.js";
+import { ExtensionRelayBridge } from "./relay-bridge.js";
+import { EXTENSION_RELAY_MAX_PAYLOAD_BYTES } from "./relay-server.js";
+
+type SendCallback = (error?: Error) => void;
+type SendOptions = Parameters<WebSocket["send"]>[1];
+
+it.each(["EPIPE", "ECONNRESET"])(
+  "keeps completed owner cleanup successful when its retirement notice fails with %s",
+  async (code) => {
+    const bridge = new ExtensionRelayBridge();
+    const server = new WebSocketServer({
+      host: "127.0.0.1",
+      port: 0,
+      maxPayload: EXTENSION_RELAY_MAX_PAYLOAD_BYTES,
+    });
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected a loopback listener");
+    }
+    const accepted = new Promise<WebSocket>((resolve) => {
+      server.once("connection", resolve);
+    });
+    const peer = new WebSocket(`ws://127.0.0.1:${address.port}`);
+    try {
+      await once(peer, "open");
+      const socket = await accepted;
+      const retire = attachRelayOwner({
+        ws: socket,
+        bridge,
+        allowLegacyAuth: false,
+        isCurrent: () => true,
+      });
+      const opened = once(peer, "message");
+      peer.send(JSON.stringify({ id: 1, op: "cdp.open" }));
+      const [raw] = await opened;
+      expect(relayOwnerReply.parse(JSON.parse(rawDataToString(raw)))).toMatchObject({
+        id: 1,
+        result: expect.any(Number),
+      });
+      expect(bridge.cdpClientCount).toBe(1);
+
+      const notice = createDeferred<SendCallback>();
+      const send = socket.send.bind(socket);
+      vi.spyOn(socket, "send").mockImplementation(
+        (data, optionsOrCallback?: SendOptions | SendCallback, callback?: SendCallback) => {
+          const completion = typeof optionsOrCallback === "function" ? optionsOrCallback : callback;
+          if (typeof data === "string" && relayOwnerRetired.safeParse(JSON.parse(data)).success) {
+            expect(bridge.cdpClientCount).toBe(0);
+            if (!completion) {
+              throw new Error("Retirement notice must observe write completion");
+            }
+            notice.resolve(completion);
+            return;
+          }
+          if (typeof optionsOrCallback === "function") {
+            send(data, optionsOrCallback);
+          } else {
+            send(data, optionsOrCallback ?? {}, callback);
+          }
+        },
+      );
+      let retired = false;
+      const retiring = retire().then(() => {
+        retired = true;
+      });
+      const completeWrite = await notice.promise;
+      expect(retired).toBe(false);
+      const completed = expect(retiring).resolves.toBeUndefined();
+      completeWrite(Object.assign(new Error(`write ${code}`), { code }));
+      await completed;
+      expect(retired).toBe(true);
+      expect(bridge.cdpClientCount).toBe(0);
+    } finally {
+      vi.restoreAllMocks();
+      bridge.dispose();
+      peer.terminate();
+      for (const socket of server.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  },
+);

--- a/extensions/browser/src/browser/extension-relay/owner-server.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-server.ts
@@ -230,9 +230,10 @@ export function attachRelayOwner(params: {
   return async () => {
     await close();
     if (ws.readyState === 1) {
-      // The listener sends retirement only after its exact client's cleanup completed.
-      await new Promise<void>((resolve, reject) => {
-        ws.send(JSON.stringify({ retired: true }), (error) => (error ? reject(error) : resolve()));
+      // Cleanup is acknowledged before this notice. A departing peer may reject
+      // its delivery; wait for the write without turning that loss into failed cleanup.
+      await new Promise<void>((resolve) => {
+        ws.send(JSON.stringify({ retired: true }), () => resolve());
       });
     }
   };

--- a/extensions/browser/src/browser/extension-relay/owner-server.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-server.ts
@@ -1,0 +1,239 @@
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import type { WebSocket } from "ws";
+import { randomRelayId } from "./auth-v2-crypto.js";
+import { parseStrictJsonObject } from "./auth-v2.js";
+import {
+  RELAY_OPERATION_TTL_MS,
+  RELAY_OWNER_LIMIT,
+  relayOwnerFrame,
+  relayOwnerRequest,
+} from "./owner-protocol.js";
+import type { ExtensionRelayBridge } from "./relay-bridge.js";
+import { parseExtensionMessage } from "./relay-protocol.js";
+
+/** All references and streams belong to this authenticated connection, never to a token holder. */
+export function attachRelayOwner(params: {
+  ws: WebSocket;
+  bridge: ExtensionRelayBridge;
+  allowLegacyAuth: boolean;
+  isCurrent: () => boolean;
+}): () => Promise<void> {
+  const { ws, bridge } = params;
+  const controller = new AbortController();
+  const captures = new Map<
+    string,
+    {
+      resolve: () => string | undefined;
+      isCurrent: () => boolean;
+      expires: number;
+      timer: NodeJS.Timeout;
+    }
+  >();
+  const streams = new Map<
+    number,
+    {
+      onMessage: (raw: string) => void;
+      close: () => Promise<void>;
+      ref?: string;
+      closing?: Promise<void>;
+    }
+  >();
+  let nextStream = 0;
+  let pending = 0;
+  let closing: Promise<void> | undefined;
+  const assertCurrent = () => {
+    controller.signal.throwIfAborted();
+    if (!params.isCurrent()) {
+      throw new Error("Relay owner retired");
+    }
+  };
+  const send = (value: unknown) => {
+    if (ws.readyState === 1) {
+      ws.send(JSON.stringify(value));
+    }
+  };
+  const captureFor = (ref: string) => {
+    assertCurrent();
+    const capture = captures.get(ref);
+    if (!capture || capture.expires <= Date.now()) {
+      captures.delete(ref);
+      return undefined;
+    }
+    return capture.isCurrent() ? capture : undefined;
+  };
+  const closeStream = async (id: number) => {
+    const stream = streams.get(id);
+    if (!stream) {
+      return;
+    }
+    // Keep cleanup debt until the real logical/native owner acknowledges it.
+    await (stream.closing ??= stream.close());
+    if (streams.get(id) === stream) {
+      streams.delete(id);
+    }
+    send({ stream: id, closed: true });
+  };
+  const close = () => {
+    controller.abort(new Error("Relay owner connection closed"));
+    for (const capture of captures.values()) {
+      clearTimeout(capture.timer);
+    }
+    captures.clear();
+    return (closing ??= Promise.all([...streams.keys()].map(closeStream)).then(() => {}));
+  };
+  ws.once("close", () => {
+    void close().catch(() => {});
+  });
+  ws.on("message", (raw) => {
+    const message = parseStrictJsonObject(rawDataToString(raw));
+    const streamFrame = relayOwnerFrame.safeParse(message);
+    if (streamFrame.success) {
+      const stream = streams.get(streamFrame.data.stream);
+      try {
+        assertCurrent();
+        if (!stream || stream.closing || (stream.ref && !captureFor(stream.ref))) {
+          throw new Error("Relay operation reference is no longer current");
+        }
+        // Command admission runs at the real bridge, immediately before its session fences.
+        stream.onMessage(streamFrame.data.frame);
+      } catch {
+        void closeStream(streamFrame.data.stream).catch(() =>
+          ws.close(1011, "relay cleanup failed"),
+        );
+      }
+      return;
+    }
+    const request = relayOwnerRequest.safeParse(message);
+    if (!request.success || pending >= RELAY_OWNER_LIMIT) {
+      ws.close(4003, "invalid relay owner request");
+      return;
+    }
+    pending += 1;
+    const requestId = request.data.id;
+    void (async (): Promise<unknown> => {
+      const req = request.data;
+      // Revocation stops admission, not acknowledgement of this connection's
+      // existing cleanup debt. These operations cannot acquire a grant or stream.
+      if (req.op !== "close" && req.op !== "stream.close" && req.op !== "release") {
+        assertCurrent();
+      }
+      switch (req.op) {
+        case "ready": {
+          await bridge.waitForExtensionConnection(controller.signal, req.timeoutMs);
+          assertCurrent();
+          return {
+            ready: bridge.extensionConnected,
+            identity: bridge.identity,
+            generation: bridge.extensionGeneration,
+            allowLegacyAuth: params.allowLegacyAuth,
+          };
+        }
+        case "capture": {
+          const captured = bridge.captureOperationTarget(req.targetId);
+          if (!captured) {
+            return null;
+          }
+          if (captures.size >= RELAY_OWNER_LIMIT) {
+            throw new Error("Relay operation capacity reached");
+          }
+          const ref = randomRelayId();
+          const timer = setTimeout(() => {
+            captures.delete(ref);
+            for (const [id, stream] of streams) {
+              if (stream.ref === ref) {
+                void closeStream(id).catch(() => ws.close(1011, "relay cleanup failed"));
+              }
+            }
+          }, RELAY_OPERATION_TTL_MS);
+          timer.unref?.();
+          captures.set(ref, {
+            resolve: captured,
+            isCurrent: captured.isCurrent,
+            expires: Date.now() + RELAY_OPERATION_TTL_MS,
+            timer,
+          });
+          return ref;
+        }
+        case "resolve":
+          return captureFor(req.ref)?.resolve() ?? null;
+        case "release": {
+          const capture = captures.get(req.ref);
+          if (capture) {
+            clearTimeout(capture.timer);
+          }
+          captures.delete(req.ref);
+          await Promise.all(
+            [...streams]
+              .filter(([, stream]) => stream.ref === req.ref)
+              .map(([id]) => closeStream(id)),
+          );
+          return null;
+        }
+        case "cdp.open":
+        case "ingress.open": {
+          if (streams.size >= RELAY_OWNER_LIMIT) {
+            throw new Error("Relay stream capacity reached");
+          }
+          if (req.op === "cdp.open" && req.ref && !captureFor(req.ref)) {
+            throw new Error("Relay operation reference is no longer current");
+          }
+          const id = ++nextStream;
+          const socket = {
+            send: (frame: string) => send({ stream: id, frame }),
+            close: () => {
+              void closeStream(id).catch(() => ws.close(1011, "relay cleanup failed"));
+            },
+          };
+          if (req.op === "cdp.open") {
+            const handlers = bridge.attachCdpClientSocket(socket);
+            streams.set(id, {
+              onMessage: handlers.onMessage,
+              close: handlers.onClose,
+              ref: req.ref,
+            });
+          } else {
+            const handlers = bridge.attachExtensionSocket(socket);
+            const timer = setTimeout(() => socket.close(), 10_000);
+            timer.unref?.();
+            streams.set(id, {
+              onMessage: (frame) => {
+                if (parseExtensionMessage(frame)?.type === "hello") {
+                  clearTimeout(timer);
+                }
+                handlers.onMessage(frame);
+              },
+              close: async () => {
+                clearTimeout(timer);
+                handlers.onClose();
+              },
+            });
+          }
+          return id;
+        }
+        case "stream.close":
+          await closeStream(req.stream);
+          return null;
+        case "close":
+          await close();
+          return null;
+      }
+      throw new Error("Unsupported relay owner operation");
+    })()
+      .then(
+        (result) => send({ id: requestId, result }),
+        () => send({ id: requestId, error: "Relay owner operation failed or was superseded" }),
+      )
+      .finally(() => {
+        pending -= 1;
+      });
+  });
+  return async () => {
+    await close();
+    if (ws.readyState === 1) {
+      // The listener sends retirement only after its exact client's cleanup completed.
+      await new Promise<void>((resolve, reject) => {
+        ws.send(JSON.stringify({ retired: true }), (error) => (error ? reject(error) : resolve()));
+      });
+    }
+  };
+}

--- a/extensions/browser/src/browser/extension-relay/preauth-websocket-guard.test.ts
+++ b/extensions/browser/src/browser/extension-relay/preauth-websocket-guard.test.ts
@@ -1,10 +1,25 @@
 import { IncomingMessage } from "node:http";
 import { Socket } from "node:net";
 import { Duplex } from "node:stream";
+import { setImmediate } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import { WebSocketServer, type WebSocket } from "ws";
 import { handlePreAuthWebSocketUpgrade } from "./preauth-websocket-guard.js";
 import { EXTENSION_RELAY_MAX_PAYLOAD_BYTES } from "./relay-server.js";
+
+function upgradeRequest(): IncomingMessage {
+  const req = new IncomingMessage(new Socket());
+  req.method = "GET";
+  req.url = "/extension";
+  req.headers = {
+    host: "127.0.0.1",
+    connection: "Upgrade",
+    upgrade: "websocket",
+    "sec-websocket-version": "13",
+    "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+  };
+  return req;
+}
 
 describe("pre-auth WebSocket head admission", () => {
   it("rejects oversized upgrade-head auth data before challenge or bridge promotion", async () => {
@@ -16,16 +31,7 @@ describe("pre-auth WebSocket head admission", () => {
         callback();
       },
     });
-    const req = new IncomingMessage(new Socket());
-    req.method = "GET";
-    req.url = "/extension";
-    req.headers = {
-      host: "127.0.0.1",
-      connection: "Upgrade",
-      upgrade: "websocket",
-      "sec-websocket-version": "13",
-      "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
-    };
+    const req = upgradeRequest();
     const wss = new WebSocketServer({
       noServer: true,
       maxPayload: EXTENSION_RELAY_MAX_PAYLOAD_BYTES,
@@ -55,4 +61,69 @@ describe("pre-auth WebSocket head admission", () => {
       });
     }
   });
+
+  it.each([false, true])(
+    "owns a pending raw write error through close (terminated=%s)",
+    async (terminated) => {
+      let pendingWrite: ((error?: Error | null) => void) | undefined;
+      const socket = new Duplex({
+        read() {},
+        write(chunk: Buffer, _encoding, callback) {
+          if (chunk.toString().startsWith("HTTP/1.1")) {
+            callback();
+          } else {
+            pendingWrite = callback;
+          }
+        },
+      });
+      const rawClosed = vi.fn();
+      socket.once("close", rawClosed);
+      const req = upgradeRequest();
+      const wss = new WebSocketServer({ noServer: true });
+      const writeResult = vi.fn();
+      try {
+        let closeWebSocket = () => {};
+        const closed = new Promise<void>((resolve) => {
+          handlePreAuthWebSocketUpgrade({
+            wss,
+            req,
+            socket,
+            head: Buffer.alloc(0),
+            onUpgrade: (ws) => {
+              ws.once("close", () => resolve());
+              closeWebSocket = () => ws.terminate();
+              ws.send("pending reply", writeResult);
+            },
+          });
+        });
+        await setImmediate();
+        expect(pendingWrite).toBeTypeOf("function");
+        const error = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+        // Node can deliver the write callback before the raw socket's queued
+        // error event. Destroying the wrapper must not orphan that event.
+        process.nextTick(() => pendingWrite?.(error));
+        socket.destroy(error);
+        if (terminated) {
+          closeWebSocket();
+        }
+        await closed;
+        await setImmediate();
+        expect(writeResult).toHaveBeenCalledExactlyOnceWith(error);
+        expect(rawClosed).toHaveBeenCalledOnce();
+        expect(socket.listenerCount("data")).toBe(0);
+        expect(socket.listenerCount("end")).toBe(0);
+        expect(socket.listenerCount("error")).toBe(0);
+        expect(wss.clients.size).toBe(0);
+      } finally {
+        for (const client of wss.clients) {
+          client.terminate();
+        }
+        socket.destroy();
+        req.destroy();
+        await new Promise<void>((resolve) => {
+          wss.close(() => resolve());
+        });
+      }
+    },
+  );
 });

--- a/extensions/browser/src/browser/extension-relay/preauth-websocket-guard.test.ts
+++ b/extensions/browser/src/browser/extension-relay/preauth-websocket-guard.test.ts
@@ -79,7 +79,10 @@ describe("pre-auth WebSocket head admission", () => {
       const rawClosed = vi.fn();
       socket.once("close", rawClosed);
       const req = upgradeRequest();
-      const wss = new WebSocketServer({ noServer: true });
+      const wss = new WebSocketServer({
+        noServer: true,
+        maxPayload: EXTENSION_RELAY_MAX_PAYLOAD_BYTES,
+      });
       const writeResult = vi.fn();
       try {
         let closeWebSocket = () => {};

--- a/extensions/browser/src/browser/extension-relay/preauth-websocket-guard.ts
+++ b/extensions/browser/src/browser/extension-relay/preauth-websocket-guard.ts
@@ -60,11 +60,9 @@ class PreAuthWebSocketTransport extends Duplex {
   override _destroy(error: Error | null, callback: (error?: Error | null) => void): void {
     this.rawSocket.off("data", this.onRawData);
     this.rawSocket.off("end", this.onRawEnd);
-    this.rawSocket.off("close", this.onRawClose);
-    this.rawSocket.off("error", this.onRawError);
-    if (!this.rawSocket.destroyed) {
-      this.rawSocket.destroy();
-    }
+    // A failed write can destroy this wrapper before the raw error event runs.
+    // Keep terminal listeners until raw close, even when already destroyed.
+    this.rawSocket.destroy();
     callback(error);
   }
 
@@ -82,7 +80,10 @@ class PreAuthWebSocketTransport extends Duplex {
   };
 
   private readonly onRawEnd = () => this.push(null);
-  private readonly onRawClose = () => this.destroy();
+  private readonly onRawClose = () => {
+    this.rawSocket.off("error", this.onRawError);
+    this.destroy();
+  };
   private readonly onRawError = (error: Error) => this.destroy(error);
 }
 

--- a/extensions/browser/src/browser/extension-relay/relay-access.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-access.ts
@@ -1,0 +1,44 @@
+import type { RelayOwnerClient } from "./owner-client.js";
+import type { ExtensionRelayHandle } from "./relay-server.js";
+
+export type BorrowedRelayAccess = {
+  ownership: "borrowed";
+  port: number;
+  token: string;
+  /** The requesting profile's policy; the listener's policy is never changed. */
+  allowLegacyAuth: boolean;
+  client: RelayOwnerClient;
+  close: () => Promise<void>;
+};
+export type ExtensionRelayResource = ExtensionRelayHandle | BorrowedRelayAccess;
+
+// Prepared by the profile lifecycle only. This registry never discovers keys or listeners.
+const borrowedCdpAccess = new Map<
+  string,
+  { relay: BorrowedRelayAccess; assertCurrent: () => void }
+>();
+
+export function registerBorrowedRelayCdpAccess(
+  cdpUrl: string,
+  relay: BorrowedRelayAccess,
+  assertCurrent: () => void,
+): () => void {
+  const entry = { relay, assertCurrent };
+  borrowedCdpAccess.set(cdpUrl.replace(/\/$/u, ""), entry);
+  return () => {
+    const key = cdpUrl.replace(/\/$/u, "");
+    if (borrowedCdpAccess.get(key) === entry) {
+      borrowedCdpAccess.delete(key);
+    }
+  };
+}
+
+export function getBorrowedRelayCdpAccess(cdpUrl: string): BorrowedRelayAccess | undefined {
+  const entry = borrowedCdpAccess.get(cdpUrl.replace(/\/$/u, ""));
+  if (!entry) {
+    return undefined;
+  }
+  entry.assertCurrent();
+  entry.relay.client.assertCurrent();
+  return entry.relay;
+}

--- a/extensions/browser/src/browser/extension-relay/relay-auth.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-auth.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { ensureExtensionRelayToken, readExtensionRelayToken } from "./relay-auth.js";
+import {
+  classifyRelaySecretPrivacy,
+  ensureExtensionRelayToken,
+  readExtensionRelayToken,
+} from "./relay-auth.js";
 
 let stateDir = "";
 let secretPath = "";
@@ -136,5 +140,50 @@ describe("extension relay host-local secret", () => {
     } finally {
       fs.rmSync(otherDir, { recursive: true, force: true });
     }
+  });
+
+  const secretFilePath = (): string =>
+    path.join(stateDir, "credentials", "browser-extension-relay.secret");
+
+  it.runIf(process.platform !== "win32")(
+    "self-heals a group/other-readable secret to 0600 and still reads it",
+    async () => {
+      const token = await ensureExtensionRelayToken(env);
+      const secretPath = secretFilePath();
+      fs.chmodSync(secretPath, 0o644);
+      // Reading tightens the mode back to private and still returns the token.
+      expect(readExtensionRelayToken(env)).toBe(token);
+      expect(fs.statSync(secretPath).mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it("refuses a symlinked secret", async () => {
+    const token = await ensureExtensionRelayToken(env);
+    const secretPath = secretFilePath();
+    const realTarget = path.join(stateDir, "elsewhere.secret");
+    fs.renameSync(secretPath, realTarget);
+    fs.symlinkSync(realTarget, secretPath);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(readExtensionRelayToken(env)).toBeNull();
+  });
+});
+
+describe("classifyRelaySecretPrivacy", () => {
+  it("accepts a private, self-owned file", () => {
+    expect(classifyRelaySecretPrivacy({ uid: 501, mode: 0o600 }, 501, "linux")).toBe("ok");
+  });
+
+  it("flags a self-owned file with broad mode for healing", () => {
+    expect(classifyRelaySecretPrivacy({ uid: 501, mode: 0o644 }, 501, "linux")).toBe("heal");
+    expect(classifyRelaySecretPrivacy({ uid: 501, mode: 0o660 }, 501, "linux")).toBe("heal");
+  });
+
+  it("refuses a foreign-owned file regardless of mode", () => {
+    expect(classifyRelaySecretPrivacy({ uid: 0, mode: 0o600 }, 501, "linux")).toBe("refuse");
+  });
+
+  it("trusts Windows ACLs and an unknown uid instead of POSIX bits", () => {
+    expect(classifyRelaySecretPrivacy({ uid: 0, mode: 0o777 }, 501, "win32")).toBe("ok");
+    expect(classifyRelaySecretPrivacy({ uid: 0, mode: 0o777 }, undefined, "linux")).toBe("ok");
   });
 });

--- a/extensions/browser/src/browser/extension-relay/relay-auth.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-auth.test.ts
@@ -2,12 +2,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  classifyRelaySecretPrivacy,
-  ensureExtensionRelayToken,
-  readExtensionRelayToken,
-} from "./relay-auth.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureExtensionRelayToken, readExtensionRelayToken } from "./relay-auth.js";
 
 let stateDir = "";
 let secretPath = "";
@@ -19,6 +15,7 @@ beforeEach(() => {
   env = { OPENCLAW_STATE_DIR: stateDir };
 });
 afterEach(() => {
+  vi.restoreAllMocks();
   fs.rmSync(stateDir, { recursive: true, force: true });
 });
 
@@ -142,48 +139,65 @@ describe("extension relay host-local secret", () => {
     }
   });
 
-  const secretFilePath = (): string =>
-    path.join(stateDir, "credentials", "browser-extension-relay.secret");
-
-  it.runIf(process.platform !== "win32")(
-    "self-heals a group/other-readable secret to 0600 and still reads it",
-    async () => {
+  it.runIf(process.platform !== "win32").each([0o644, 0o660])(
+    "self-heals a secret with mode %i to 0600 and still reads it",
+    async (mode) => {
       const token = await ensureExtensionRelayToken(env);
-      const secretPath = secretFilePath();
-      fs.chmodSync(secretPath, 0o644);
-      // Reading tightens the mode back to private and still returns the token.
+      fs.chmodSync(secretPath, mode);
       expect(readExtensionRelayToken(env)).toBe(token);
       expect(fs.statSync(secretPath).mode & 0o777).toBe(0o600);
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "refuses a foreign-owned secret without changing it",
+    async () => {
+      const token = await ensureExtensionRelayToken(env);
+      const owner = fs.statSync(secretPath).uid;
+      vi.spyOn(process, "getuid").mockReturnValue(owner + 1);
+      expect(readExtensionRelayToken(env)).toBeNull();
+      await expect(ensureExtensionRelayToken(env)).rejects.toThrow("unreadable/malformed");
+      expect(fs.readFileSync(secretPath, "utf8").trim()).toBe(token);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "refuses a broad-mode secret when tightening fails",
+    async () => {
+      await ensureExtensionRelayToken(env);
+      fs.chmodSync(secretPath, 0o644);
+      vi.spyOn(fs, "fchmodSync").mockImplementation(() => {
+        throw new Error("permission denied");
+      });
+      expect(readExtensionRelayToken(env)).toBeNull();
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a key path swapped after inspection without changing its replacement",
+    async () => {
+      await ensureExtensionRelayToken(env);
+      fs.chmodSync(secretPath, 0o644);
+      const replacement = path.join(stateDir, "replacement");
+      fs.writeFileSync(replacement, "b2".repeat(32), { mode: 0o644 });
+      const inspected = fs.lstatSync(secretPath);
+      vi.spyOn(fs, "lstatSync").mockImplementationOnce(() => {
+        fs.renameSync(secretPath, path.join(stateDir, "original"));
+        fs.symlinkSync(replacement, secretPath);
+        return inspected;
+      });
+
+      expect.soft(readExtensionRelayToken(env)).toBeNull();
+      expect(fs.statSync(replacement).mode & 0o777).toBe(0o644);
+    },
+  );
+
   it("refuses a symlinked secret", async () => {
     const token = await ensureExtensionRelayToken(env);
-    const secretPath = secretFilePath();
     const realTarget = path.join(stateDir, "elsewhere.secret");
     fs.renameSync(secretPath, realTarget);
     fs.symlinkSync(realTarget, secretPath);
     expect(token).toMatch(/^[0-9a-f]{64}$/);
     expect(readExtensionRelayToken(env)).toBeNull();
-  });
-});
-
-describe("classifyRelaySecretPrivacy", () => {
-  it("accepts a private, self-owned file", () => {
-    expect(classifyRelaySecretPrivacy({ uid: 501, mode: 0o600 }, 501, "linux")).toBe("ok");
-  });
-
-  it("flags a self-owned file with broad mode for healing", () => {
-    expect(classifyRelaySecretPrivacy({ uid: 501, mode: 0o644 }, 501, "linux")).toBe("heal");
-    expect(classifyRelaySecretPrivacy({ uid: 501, mode: 0o660 }, 501, "linux")).toBe("heal");
-  });
-
-  it("refuses a foreign-owned file regardless of mode", () => {
-    expect(classifyRelaySecretPrivacy({ uid: 0, mode: 0o600 }, 501, "linux")).toBe("refuse");
-  });
-
-  it("trusts Windows ACLs and an unknown uid instead of POSIX bits", () => {
-    expect(classifyRelaySecretPrivacy({ uid: 0, mode: 0o777 }, 501, "win32")).toBe("ok");
-    expect(classifyRelaySecretPrivacy({ uid: 0, mode: 0o777 }, undefined, "linux")).toBe("ok");
   });
 });

--- a/extensions/browser/src/browser/extension-relay/relay-auth.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-auth.ts
@@ -8,13 +8,18 @@
  * Chrome, and no gateway credential ever has to travel to a node.
  */
 import crypto from "node:crypto";
+import fs from "node:fs";
 import path from "node:path";
 import { createSecretFileAtomic, tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file";
 import { resolveOAuthDir } from "openclaw/plugin-sdk/state-paths";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("browser").child("extension-relay");
 
 const RELAY_SECRET_FILE = "browser-extension-relay.secret";
 const RELAY_SECRET_REREAD_ATTEMPTS = 50;
 const RELAY_SECRET_REREAD_DELAY_MS = 10;
+const PRIVATE_SECRET_FILE_MODE = 0o600;
 
 // resolveOAuthDir returns `${stateDir}/credentials`, the shared credentials dir.
 function resolveExtensionRelaySecretPath(env: NodeJS.ProcessEnv = process.env): string {
@@ -26,12 +31,79 @@ function normalizeToken(raw: string): string | null {
   return /^[0-9a-f]{64}$/.test(value) ? value : null;
 }
 
+/**
+ * The relay secret is the whole auth model: anyone who can read it drives the
+ * user's real browser, and loopback is not a trust boundary on a multi-user
+ * host. The fs-safe reader rejects symlinks/hardlinks but does not re-check the
+ * file mode or owner on read, so a secret whose permissions drifted
+ * group/other-readable (loosened umask, restore, shared home) would still be
+ * trusted. Classify the file's privacy before use.
+ */
+export type RelaySecretPrivacy = "ok" | "heal" | "refuse";
+
+/**
+ * Pure privacy decision for a secret file's stat. `heal`: we own it but the
+ * mode is too broad — tighten to 0600 and continue. `refuse`: owned by another
+ * user (never trust a foreign-owned credential). Windows uses ACLs, not POSIX
+ * mode bits, and the create path establishes them, so it is always `ok` here.
+ */
+export function classifyRelaySecretPrivacy(
+  stat: { uid: number; mode: number },
+  selfUid: number | undefined,
+  platform: NodeJS.Platform = process.platform,
+): RelaySecretPrivacy {
+  if (platform === "win32" || selfUid === undefined) {
+    return "ok";
+  }
+  if (stat.uid !== selfUid) {
+    return "refuse";
+  }
+  return (stat.mode & 0o077) === 0 ? "ok" : "heal";
+}
+
+/**
+ * Return the secret path only when it is safe to read: absent (caller handles
+ * null), already private, or self-healable by tightening our own file's mode.
+ * Refuses a foreign-owned or unhealable file so a world-readable credential is
+ * never trusted.
+ */
+function resolveUsableRelaySecretPath(env: NodeJS.ProcessEnv): string | null {
+  const secretPath = resolveExtensionRelaySecretPath(env);
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(secretPath);
+  } catch (err) {
+    // Absent is the normal "not paired yet" case; let the reader return null.
+    return (err as NodeJS.ErrnoException).code === "ENOENT" ? secretPath : null;
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    log.warn("ignoring extension relay secret: not a regular file");
+    return null;
+  }
+  const decision = classifyRelaySecretPrivacy(stat, process.getuid?.());
+  if (decision === "refuse") {
+    log.warn("ignoring extension relay secret: owned by another user");
+    return null;
+  }
+  if (decision === "heal") {
+    try {
+      fs.chmodSync(secretPath, PRIVATE_SECRET_FILE_MODE);
+      log.warn("tightened extension relay secret permissions to 0600");
+    } catch {
+      log.warn("ignoring extension relay secret: permissions are too broad and could not be fixed");
+      return null;
+    }
+  }
+  return secretPath;
+}
+
 /** Read the host-local relay token, or null when it has not been created yet. */
 export function readExtensionRelayToken(env: NodeJS.ProcessEnv = process.env): string | null {
-  return normalizeToken(
-    tryReadSecretFileSync(resolveExtensionRelaySecretPath(env), "browser extension relay secret") ??
-      "",
-  );
+  const secretPath = resolveUsableRelaySecretPath(env);
+  if (!secretPath) {
+    return null;
+  }
+  return normalizeToken(tryReadSecretFileSync(secretPath, "browser extension relay secret") ?? "");
 }
 
 /**

--- a/extensions/browser/src/browser/extension-relay/relay-auth.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-auth.ts
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { createSecretFileAtomic, tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file";
 import { resolveOAuthDir } from "openclaw/plugin-sdk/state-paths";
+import { extractErrorCode } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 
 const log = createSubsystemLogger("browser").child("extension-relay");
@@ -20,6 +21,8 @@ const RELAY_SECRET_FILE = "browser-extension-relay.secret";
 const RELAY_SECRET_REREAD_ATTEMPTS = 50;
 const RELAY_SECRET_REREAD_DELAY_MS = 10;
 const PRIVATE_SECRET_FILE_MODE = 0o600;
+// Keep the existing secret-file reader's byte limit when reading our pinned descriptor.
+const MAX_RELAY_SECRET_BYTES = 16 * 1024;
 
 // resolveOAuthDir returns `${stateDir}/credentials`, the shared credentials dir.
 function resolveExtensionRelaySecretPath(env: NodeJS.ProcessEnv = process.env): string {
@@ -31,79 +34,79 @@ function normalizeToken(raw: string): string | null {
   return /^[0-9a-f]{64}$/.test(value) ? value : null;
 }
 
-/**
- * The relay secret is the whole auth model: anyone who can read it drives the
- * user's real browser, and loopback is not a trust boundary on a multi-user
- * host. The fs-safe reader rejects symlinks/hardlinks but does not re-check the
- * file mode or owner on read, so a secret whose permissions drifted
- * group/other-readable (loosened umask, restore, shared home) would still be
- * trusted. Classify the file's privacy before use.
- */
-export type RelaySecretPrivacy = "ok" | "heal" | "refuse";
-
-/**
- * Pure privacy decision for a secret file's stat. `heal`: we own it but the
- * mode is too broad — tighten to 0600 and continue. `refuse`: owned by another
- * user (never trust a foreign-owned credential). Windows uses ACLs, not POSIX
- * mode bits, and the create path establishes them, so it is always `ok` here.
- */
-export function classifyRelaySecretPrivacy(
-  stat: { uid: number; mode: number },
-  selfUid: number | undefined,
-  platform: NodeJS.Platform = process.platform,
-): RelaySecretPrivacy {
-  if (platform === "win32" || selfUid === undefined) {
-    return "ok";
-  }
-  if (stat.uid !== selfUid) {
-    return "refuse";
-  }
-  return (stat.mode & 0o077) === 0 ? "ok" : "heal";
-}
-
-/**
- * Return the secret path only when it is safe to read: absent (caller handles
- * null), already private, or self-healable by tightening our own file's mode.
- * Refuses a foreign-owned or unhealable file so a world-readable credential is
- * never trusted.
- */
-function resolveUsableRelaySecretPath(env: NodeJS.ProcessEnv): string | null {
-  const secretPath = resolveExtensionRelaySecretPath(env);
-  let stat: fs.Stats;
-  try {
-    stat = fs.lstatSync(secretPath);
-  } catch (err) {
-    // Absent is the normal "not paired yet" case; let the reader return null.
-    return (err as NodeJS.ErrnoException).code === "ENOENT" ? secretPath : null;
-  }
-  if (stat.isSymbolicLink() || !stat.isFile()) {
-    log.warn("ignoring extension relay secret: not a regular file");
-    return null;
-  }
-  const decision = classifyRelaySecretPrivacy(stat, process.getuid?.());
-  if (decision === "refuse") {
-    log.warn("ignoring extension relay secret: owned by another user");
-    return null;
-  }
-  if (decision === "heal") {
-    try {
-      fs.chmodSync(secretPath, PRIVATE_SECRET_FILE_MODE);
-      log.warn("tightened extension relay secret permissions to 0600");
-    } catch {
-      log.warn("ignoring extension relay secret: permissions are too broad and could not be fixed");
-      return null;
-    }
-  }
-  return secretPath;
-}
-
 /** Read the host-local relay token, or null when it has not been created yet. */
 export function readExtensionRelayToken(env: NodeJS.ProcessEnv = process.env): string | null {
-  const secretPath = resolveUsableRelaySecretPath(env);
-  if (!secretPath) {
-    return null;
+  const secretPath = resolveExtensionRelaySecretPath(env);
+  if (process.platform === "win32") {
+    return normalizeToken(
+      tryReadSecretFileSync(secretPath, "browser extension relay secret", {
+        rejectSymlink: true,
+      }) ?? "",
+    );
   }
-  return normalizeToken(tryReadSecretFileSync(secretPath, "browser extension relay secret") ?? "");
+  const uid = process.getuid?.();
+  let fd: number | undefined;
+  let raw: string;
+  try {
+    const before = fs.lstatSync(secretPath);
+    if (!before.isFile() || before.uid !== uid || before.nlink !== 1) {
+      return null;
+    }
+    // Permission checks, tightening, and reading must concern the same inode.
+    // NONBLOCK also prevents a file-to-pipe swap from hanging the native host.
+    fd = fs.openSync(
+      secretPath,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK,
+    );
+    const sameFile = (stat: fs.Stats) =>
+      stat.isFile() &&
+      stat.uid === uid &&
+      stat.nlink === 1 &&
+      stat.dev === before.dev &&
+      stat.ino === before.ino;
+    const opened = fs.fstatSync(fd);
+    if (!sameFile(opened) || !sameFile(fs.lstatSync(secretPath))) {
+      return null;
+    }
+    if ((opened.mode & 0o077) !== 0) {
+      fs.fchmodSync(fd, PRIVATE_SECRET_FILE_MODE);
+      log.warn("tightened extension relay secret permissions to 0600");
+    }
+    const buffer = Buffer.alloc(MAX_RELAY_SECRET_BYTES + 1);
+    let length = 0;
+    while (length < buffer.length) {
+      const count = fs.readSync(fd, buffer, length, buffer.length - length, null);
+      if (count === 0) {
+        break;
+      }
+      length += count;
+    }
+    const after = fs.fstatSync(fd);
+    if (
+      length > MAX_RELAY_SECRET_BYTES ||
+      !sameFile(after) ||
+      (after.mode & 0o077) !== 0 ||
+      !sameFile(fs.lstatSync(secretPath))
+    ) {
+      return null;
+    }
+    raw = buffer.subarray(0, length).toString("utf8");
+  } catch (error) {
+    if (extractErrorCode(error) !== "ENOENT") {
+      log.warn("ignoring extension relay secret: file changed or could not be read privately");
+    }
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+    }
+  }
+  // An exclusive first writer can still be filling an empty file. Preserve the
+  // reader's throwing outcome so ensure retries adoption instead of creating.
+  if (!raw.trim()) {
+    throw new Error("extension relay secret is empty");
+  }
+  return normalizeToken(raw);
 }
 
 /**
@@ -145,7 +148,7 @@ export async function ensureExtensionRelayToken(
         });
         return token;
       } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== "secret-exists") {
+        if (extractErrorCode(err) !== "secret-exists") {
           throw err;
         }
         lastError = err;

--- a/extensions/browser/src/browser/extension-relay/relay-bootstrap.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bootstrap.integration.test.ts
@@ -1,0 +1,167 @@
+import vm from "node:vm";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { afterEach, expect, it, vi } from "vitest";
+import { createRelayCommandHandler } from "../../../chrome-extension/modules/relay-command-handler.js";
+import {
+  createBrowserControlContext,
+  startBrowserControlServiceFromConfig,
+  stopBrowserControlService,
+} from "../../control-service.js";
+import { executeActViaPlaywright } from "../pw-tools-core.interactions.execution.js";
+import { withConnectedDaemon } from "./relay-coexistence.test-support.js";
+
+afterEach(async () => {
+  await stopBrowserControlService();
+  clearRuntimeConfigSnapshot();
+  vi.unstubAllGlobals();
+});
+
+it.each(["owned", "borrowed"] as const)(
+  "evaluates after tabs when the %s relay delays the frame-tree post-access reply",
+  async (ownership) => {
+    const frameTreeHeld = createDeferred<void>();
+    const releaseFrameTree = createDeferred<void>();
+    const laterCommand = createDeferred<void>();
+    const methods = new WeakMap<object, { method?: string; checks: number }>();
+    const realm = vm.createContext({});
+    const objects = new Map<string, unknown>();
+    const evaluated: unknown[] = [];
+    let send: (message: Record<string, unknown>) => void;
+    const event = (context: Record<string, unknown>) =>
+      send({
+        type: "cdpEvent",
+        tabId: 1,
+        method: "Runtime.executionContextCreated",
+        params: { context },
+      });
+    const requireTab = async (_tabId: number, epoch: object) => {
+      const admission = methods.get(epoch)!;
+      if (admission.method === "Page.getFrameTree" && ++admission.checks === 2) {
+        frameTreeHeld.resolve();
+        await releaseFrameTree.promise;
+      }
+      return {
+        id: 1,
+        url: "https://example.com/fixture",
+        windowId: 1,
+        groupId: 1,
+        incognito: false,
+      };
+    };
+    vi.stubGlobal("chrome", {
+      debugger: {
+        sendCommand: async (_target: unknown, method: string, params: Record<string, unknown>) => {
+          switch (method) {
+            case "Page.getFrameTree":
+              return {
+                frameTree: {
+                  frame: {
+                    id: "fixture-target",
+                    loaderId: "loader",
+                    url: "https://example.com/fixture",
+                  },
+                },
+              };
+            case "Target.getTargetInfo":
+              return { targetInfo: { targetId: "fixture-target", title: "Fixture" } };
+            case "Runtime.enable":
+              event({ id: 1, name: "", auxData: { frameId: "fixture-target", isDefault: true } });
+              return {};
+            case "Runtime.runIfWaitingForDebugger":
+              laterCommand.resolve();
+              return {};
+            case "Page.createIsolatedWorld":
+              event({
+                id: 2,
+                name: params.worldName,
+                auxData: { frameId: "fixture-target", isDefault: false },
+              });
+              return { executionContextId: 2 };
+            case "Runtime.evaluate": {
+              objects.set("utility", vm.runInContext(String(params.expression), realm));
+              return { result: { type: "object", objectId: "utility" } };
+            }
+            case "Runtime.callFunctionOn": {
+              const args = (params.arguments as Array<{ value?: unknown; objectId?: string }>).map(
+                (arg) => (arg.objectId ? objects.get(arg.objectId) : arg.value),
+              );
+              const fn = vm.runInContext(`(${String(params.functionDeclaration)})`, realm);
+              const value = await fn.apply(objects.get(String(params.objectId)), args);
+              evaluated.push(value);
+              return { result: { type: "object", value } };
+            }
+            default:
+              return {};
+          }
+        },
+      },
+    });
+    const handler = createRelayCommandHandler({
+      send: (message) => send(message),
+      isCurrent: () => true,
+      attachDebugger: async () => ({ targetId: "fixture-target", assertCurrent: () => {} }),
+      detachDebugger: async () => {},
+      createTab: async () => {},
+      focusWindowForTab: async () => {},
+      scheduleTabsSync: () => {},
+      captureDebugger: () => () => {},
+      captureAccess: (_tabId, method) => {
+        const epoch = { revision: 1, tabRevision: 1 };
+        methods.set(epoch, { method, checks: 0 });
+        return epoch;
+      },
+      requireAccessibleTab: requireTab,
+      requireNavigatedTab: requireTab,
+      navigateTab: async () => {},
+    });
+    await withConnectedDaemon(
+      async () => {
+        await startBrowserControlServiceFromConfig();
+        const ctx = createBrowserControlContext();
+        expect(ctx.state().extensionRelays?.get("chrome")?.ownership).toBe(ownership);
+        const profile = ctx.forProfile("chrome");
+        const listing = profile.listTabs();
+        await frameTreeHeld.promise;
+        // Unrelated bootstrap commands must progress while frame-tree publication waits.
+        await laterCommand.promise;
+        releaseFrameTree.resolve();
+        await expect(listing).resolves.toEqual([
+          expect.objectContaining({ targetId: "fixture-target" }),
+        ]);
+        const abort = new AbortController();
+        const evaluation = executeActViaPlaywright({
+          cdpUrl: profile.profile.cdpUrl,
+          targetId: "fixture-target",
+          action: { kind: "evaluate", fn: "() => 42" },
+          evaluateEnabled: true,
+          signal: abort.signal,
+        });
+        void evaluation.catch(() => {});
+        try {
+          await expect.poll(() => evaluated, { timeout: 1_000 }).toEqual([42]);
+          await expect(evaluation).resolves.toMatchObject({ result: 42 });
+        } finally {
+          abort.abort(new Error("test finished"));
+          await evaluation.catch(() => {});
+        }
+      },
+      ownership === "owned"
+        ? async () => {
+            await startBrowserControlServiceFromConfig();
+            const stopped = createDeferred<void>();
+            return {
+              stop: () => {
+                void stopBrowserControlService().then(stopped.resolve, stopped.reject);
+              },
+              done: stopped.promise,
+            };
+          }
+        : undefined,
+      (command, reply) => {
+        send = reply;
+        void handler(command);
+      },
+    );
+  },
+);

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.cleanup.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.cleanup.test.ts
@@ -1,0 +1,50 @@
+import { expect, it, vi } from "vitest";
+import { ExtensionRelayBridge } from "./relay-bridge.js";
+import { defaultTabs, FakeSocket, flush, sendHello } from "./relay-bridge.test-support.js";
+
+it.each(["attach", "createTab"])(
+  "does not acknowledge close before a pending %s and its native detach finish",
+  async (operation) => {
+    const bridge = new ExtensionRelayBridge();
+    const extensionSocket = new FakeSocket();
+    const extension = bridge.attachExtensionSocket(extensionSocket);
+    sendHello(extension, operation === "attach" ? defaultTabs() : []);
+    const clientSocket = new FakeSocket();
+    const client = bridge.attachCdpClientSocket(clientSocket);
+    try {
+      client.onMessage(
+        JSON.stringify({
+          id: 1,
+          method: operation === "attach" ? "Target.setAutoAttach" : "Target.createTarget",
+          params: operation === "attach" ? { autoAttach: true } : { url: "about:blank" },
+        }),
+      );
+      const command = extensionSocket.frames().find((frame) => frame.type === operation);
+      expect(command).toBeDefined();
+      let finished = false;
+      const closing = client.onClose().then(() => {
+        finished = true;
+      });
+      await flush();
+      expect(finished).toBe(false);
+      extension.onMessage(
+        JSON.stringify({
+          type: "result",
+          seq: command?.seq,
+          result: { tabId: 1, targetId: "target-1" },
+        }),
+      );
+      await vi.waitFor(() =>
+        expect(extensionSocket.frames().some((frame) => frame.type === "detach")).toBe(true),
+      );
+      expect(finished).toBe(false);
+      const detach = extensionSocket.frames().find((frame) => frame.type === "detach");
+      extension.onMessage(JSON.stringify({ type: "result", seq: detach?.seq, result: {} }));
+      await closing;
+      expect(finished).toBe(true);
+      expect(clientSocket.frames()).toEqual([]);
+    } finally {
+      bridge.dispose();
+    }
+  },
+);

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.fetch.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.fetch.test.ts
@@ -228,7 +228,7 @@ describe("ExtensionRelayBridge Fetch ownership", () => {
     pausedRequestId(owner, sessionId);
     reply = (message) =>
       message.type === "cdp" && message.method === "Fetch.failRequest" ? null : replyFor(message);
-    owner.close();
+    const closing = owner.close();
     await flush();
 
     const cleanup = fetchCommands().find((frame) => frame.method === "Fetch.failRequest");
@@ -242,6 +242,7 @@ describe("ExtensionRelayBridge Fetch ownership", () => {
         JSON.stringify({ type: "result", seq: cleanup.seq, result: {} }),
       );
     }
+    await closing;
     await flush();
 
     expect
@@ -263,7 +264,7 @@ describe("ExtensionRelayBridge Fetch ownership", () => {
       message.type === "cdp" && message.method === "Fetch.failRequest"
         ? { type: "error", seq: message.seq, message: "cleanup completion unknown" }
         : replyFor(message);
-    owner.close();
+    await expect(owner.close()).rejects.toThrow("Fetch owner cleanup failed");
     await flush();
     await flush();
 
@@ -402,11 +403,12 @@ describe("ExtensionRelayBridge Fetch ownership", () => {
     const enabling = owner.send("Fetch.enable", sessionId);
     await flush();
     expect(heldEnable).toMatchObject({ method: "Fetch.enable", tabId: 1 });
-    owner.close();
+    const closing = owner.close();
     reply = replyFor;
     extension.handlers.onMessage(
       JSON.stringify({ type: "result", seq: heldEnable?.seq, result: {} }),
     );
+    await closing;
     await flush();
 
     expect(owner.response(enabling)).toBeUndefined();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -423,13 +423,17 @@ describe("ExtensionRelayBridge", () => {
           }),
         );
         // Resolve the old promise, then replace its owner before its continuation.
-        if (lifecycle === "closed client") {
-          cdp.onClose();
-        }
+        const closing = lifecycle === "closed client" ? cdp.onClose() : undefined;
         if (lifecycle === "replaced extension") {
           sendHello(wireExtension(bridge).handlers, []);
         }
         await flush();
+        if (closing) {
+          const detach = socket.frames().find((frame) => frame.type === "detach");
+          expect(detach).toBeDefined();
+          extension.onMessage(JSON.stringify({ type: "result", seq: detach?.seq, result: {} }));
+          await closing;
+        }
         expect(socket.frames().filter((frame) => frame.type === "attach")).toEqual([]);
         if (lifecycle === "active") {
           expect(client.frames().map((frame) => frame.method ?? frame.id)).toEqual([

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -856,20 +856,27 @@ export class ExtensionRelayBridge {
     );
   }
 
-  private async handleCdpRequest(client: CdpClientState, request: CdpRequest): Promise<void> {
-    try {
-      if (request.sessionId) {
-        if (this.browserSessions.get(request.sessionId) === client) {
-          await this.handleBrowserScopedRequest(client, request);
-          return;
-        }
-        await this.handleSessionScopedRequest(client, request);
-        return;
-      }
-      await this.handleBrowserScopedRequest(client, request);
-    } catch (err) {
+  private handleCdpRequest(client: CdpClientState, request: CdpRequest): Promise<void> {
+    const session = request.sessionId ? client.sessions.get(request.sessionId) : undefined;
+    const dispatch =
+      request.sessionId && this.browserSessions.get(request.sessionId) !== client
+        ? this.handleSessionScopedRequest(client, request)
+        : this.handleBrowserScopedRequest(client, request);
+    const completed = dispatch.catch((err: unknown) => {
       this.respondError(client, request, err instanceof Error ? err.message : String(err));
+    });
+    if (session && request.method === "Page.getFrameTree") {
+      // Playwright's CRPage installs Runtime listeners after this reply. Worker access
+      // rechecks can delay it past native events; order only this session's Runtime enable.
+      const ready = Promise.all([session.frameTreeRead, completed]).then(() => {});
+      session.frameTreeRead = ready;
+      void ready.then(() => {
+        if (session.frameTreeRead === ready) {
+          session.frameTreeRead = undefined;
+        }
+      });
     }
+    return completed;
   }
 
   private async handleSessionScopedRequest(
@@ -941,9 +948,22 @@ export class ExtensionRelayBridge {
       return;
     }
     if (request.method === "Runtime.disable") {
+      session.runtimeGeneration++;
       runtime.disable(session);
       this.respond(client, request, {});
       return;
+    }
+    if (request.method === "Runtime.enable" && session.frameTreeRead) {
+      // Disable can retire this pending enable while a peer keeps the physical Runtime alive.
+      const generation = session.runtimeGeneration;
+      await session.frameTreeRead;
+      if (
+        !this.clients.has(client) ||
+        client.sessions.get(sessionId) !== session ||
+        session.runtimeGeneration !== generation
+      ) {
+        throw new Error("Runtime session detached or disabled");
+      }
     }
     const send = () =>
       this.sessions.send(

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -65,6 +65,7 @@ type TabState = {
 type CdpClientState = RelaySessionClient & {
   socket: BridgeSocket;
   autoAttach: boolean;
+  creating: Set<Promise<void>>;
 };
 
 /** Browser identity reported by the paired extension. */
@@ -90,6 +91,7 @@ function toErrorPayload(
  */
 export class ExtensionRelayBridge {
   private extension: { socket: BridgeSocket; identity: ExtensionIdentity } | null = null;
+  extensionGeneration = 0;
   private readonly extensionCandidates = new Set<BridgeSocket>();
   private readonly clients = new Set<CdpClientState>();
   private readonly tabs = new Map<number, TabState>();
@@ -158,7 +160,9 @@ export class ExtensionRelayBridge {
   }
 
   /** Capture the exact extension connection and tab instance for one browser operation. */
-  captureOperationTarget(targetId: string): (() => string | undefined) | undefined {
+  captureOperationTarget(
+    targetId: string,
+  ): ((() => string | undefined) & { isCurrent: () => boolean }) | undefined {
     const extension = this.extension;
     const target = this.tabByTargetId(targetId);
     if (!extension || !target) {
@@ -166,12 +170,12 @@ export class ExtensionRelayBridge {
     }
     // Chrome tab ids survive renderer swaps but can be reused by another browser;
     // pin both the authenticated extension owner and the exact granted tab instance.
-    return () =>
-      this.extension === extension && this.tabs.get(target.tabId) === target.tab
-        ? target.tab.target?.sessionId
-          ? target.tab.target.id
-          : undefined
-        : undefined;
+    const isCurrent = () =>
+      this.extension === extension && this.tabs.get(target.tabId) === target.tab;
+    return Object.assign(
+      () => (isCurrent() && target.tab.target?.sessionId ? target.tab.target.id : undefined),
+      { isCurrent },
+    );
   }
 
   /**
@@ -242,6 +246,7 @@ export class ExtensionRelayBridge {
             this.handleExtensionGone();
           }
         }
+        this.extensionGeneration += 1;
         this.extension = {
           socket,
           identity: {
@@ -478,7 +483,7 @@ export class ExtensionRelayBridge {
       return use(attached);
     } finally {
       tab.claimants.delete(claimant);
-      this.detachUnusedAttachments();
+      void this.detachUnusedAttachments();
     }
   }
 
@@ -638,9 +643,14 @@ export class ExtensionRelayBridge {
   /** Wire up a newly accepted CDP client WebSocket. */
   attachCdpClientSocket(socket: BridgeSocket): {
     onMessage: (raw: string) => void;
-    onClose: () => void;
+    onClose: () => Promise<void>;
   } {
-    const client: CdpClientState = { socket, autoAttach: false, sessions: new Map() };
+    const client: CdpClientState = {
+      socket,
+      autoAttach: false,
+      sessions: new Map(),
+      creating: new Set(),
+    };
     this.clients.add(client);
     const onMessage = (raw: string) => {
       if (!this.clients.has(client)) {
@@ -667,24 +677,28 @@ export class ExtensionRelayBridge {
       }
       void this.handleCdpRequest(client, request as CdpRequest);
     };
-    const onClose = () => {
+    const onClose = async () => {
       this.clients.delete(client);
+      const acquisitions: Promise<unknown>[] = [...client.creating];
       for (const tab of this.tabs.values()) {
         for (const claim of tab.claimants) {
           if (claim.client === client) {
             tab.claimants.delete(claim);
+            if (tab.attaching) {
+              acquisitions.push(tab.attaching.then(() => this.detachUnusedAttachments()));
+            }
           }
         }
       }
-      void this.sessions
-        .close(client)
-        .catch((error: unknown) => log.warn(`Client cleanup incomplete: ${String(error)}`));
+      const cleanup = this.sessions.close(client);
       for (const [sessionId, owner] of this.browserSessions) {
         if (owner === client) {
           this.browserSessions.delete(sessionId);
         }
       }
-      this.detachUnusedAttachments();
+      // A socket can close before an earlier acquisition returns its native identity.
+      // Its acknowledgement includes the eventual detach, not only today's sessions.
+      await Promise.all([cleanup, ...acquisitions, this.detachUnusedAttachments()]);
     };
     return { onMessage, onClose };
   }
@@ -692,21 +706,27 @@ export class ExtensionRelayBridge {
   /**
    * Release a tab only after its last pending or delivered logical claimant leaves.
    */
-  private detachUnusedAttachments(): void {
+  private detachUnusedAttachments(): Promise<void> {
     if (!this.extension) {
-      return;
+      return Promise.resolve();
     }
+    const retirements: Promise<void>[] = [];
     for (const tab of this.tabs.values()) {
-      if (
+      if (tab.retiring) {
+        retirements.push(tab.retiring);
+      } else if (
         tab.target?.sessionId &&
         tab.claimants.size === 0 &&
         !this.sessions.hasRootSessions(tab.target.sessionId)
       ) {
-        void this.retireAttachment(tab.target.sessionId).catch((error: unknown) =>
-          log.warn(`Debugger retirement failed: ${String(error)}`),
-        );
+        retirements.push(this.retireAttachment(tab.target.sessionId));
       }
     }
+    const cleanup = Promise.all(retirements).then(() => {});
+    void cleanup.catch((error: unknown) =>
+      log.warn(`Debugger retirement failed: ${String(error)}`),
+    );
+    return cleanup;
   }
 
   private retireAttachment(rootSessionId: string): Promise<void> {
@@ -780,6 +800,60 @@ export class ExtensionRelayBridge {
       }
     }
     return null;
+  }
+
+  private async createTarget(client: CdpClientState, request: CdpRequest): Promise<void> {
+    const extension = this.extension;
+    const url =
+      typeof request.params?.url === "string" && request.params.url
+        ? request.params.url
+        : "about:blank";
+    const createParams = resolveCreateTargetParams(request.params);
+    const command = { type: "createTab", url, ...createParams } as const;
+    const created = (await this.callExtension(command)) as {
+      tabId?: unknown;
+      targetId?: unknown;
+    } | null;
+    if (this.extension !== extension) {
+      return;
+    }
+    if (typeof created?.tabId !== "number") {
+      this.respondError(client, request, "extension did not return a tabId for createTab");
+      return;
+    }
+    const tabId = created.tabId;
+    if (!this.clients.has(client) && !this.tabs.has(tabId)) {
+      // An abandoned creator never publishes an invented inventory entry.
+      // No tab record means no pending/delivered peer can own this handoff.
+      if (typeof created.targetId === "string") {
+        await this.callExtension({ type: "detach", tabId });
+      }
+      return;
+    }
+    if (!this.tabs.has(tabId)) {
+      this.tabs.set(tabId, {
+        info: { tabId, url, title: "", active: false },
+        claimants: new Set(),
+        restoreAttachment: false,
+      });
+    }
+    // Store 2.2.0 returns only tabId and still needs the separate attach.
+    // New workers own create/group/attach/rollback and return the attachment.
+    await this.withAttachedTab(
+      client,
+      tabId,
+      (attached) => {
+        this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
+          onlyAutoAttach: true,
+        });
+        this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
+          onlyAutoAttach: false,
+          onlyClient: client,
+        });
+        this.respond(client, request, { targetId: attached.targetId });
+      },
+      typeof created.targetId === "string" ? created.targetId : undefined,
+    );
   }
 
   private async handleCdpRequest(client: CdpClientState, request: CdpRequest): Promise<void> {
@@ -1043,59 +1117,13 @@ export class ExtensionRelayBridge {
         return;
       }
       case "Target.createTarget": {
-        const extension = this.extension;
-        const url =
-          typeof request.params?.url === "string" && request.params.url
-            ? request.params.url
-            : "about:blank";
-        const createParams = resolveCreateTargetParams(request.params);
-        const command = { type: "createTab", url, ...createParams } as const;
-        const created = (await this.callExtension(command)) as {
-          tabId?: unknown;
-          targetId?: unknown;
-        } | null;
-        if (this.extension !== extension) {
-          return;
+        const creating = this.createTarget(client, request);
+        client.creating.add(creating);
+        try {
+          await creating;
+        } finally {
+          client.creating.delete(creating);
         }
-        if (typeof created?.tabId !== "number") {
-          this.respondError(client, request, "extension did not return a tabId for createTab");
-          return;
-        }
-        const tabId = created.tabId;
-        if (!this.clients.has(client) && !this.tabs.has(tabId)) {
-          // An abandoned creator never publishes an invented inventory entry.
-          // No tab record means no pending/delivered peer can own this handoff.
-          if (typeof created.targetId === "string") {
-            void this.callExtension({ type: "detach", tabId }).catch((error: unknown) =>
-              log.warn(`Abandoned creation cleanup failed: ${String(error)}`),
-            );
-          }
-          return;
-        }
-        if (!this.tabs.has(tabId)) {
-          this.tabs.set(tabId, {
-            info: { tabId, url, title: "", active: false },
-            claimants: new Set(),
-            restoreAttachment: false,
-          });
-        }
-        // Store 2.2.0 returns only tabId and still needs the separate attach.
-        // New workers own create/group/attach/rollback and return the attachment.
-        await this.withAttachedTab(
-          client,
-          tabId,
-          (attached) => {
-            this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
-              onlyAutoAttach: true,
-            });
-            this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
-              onlyAutoAttach: false,
-              onlyClient: client,
-            });
-            this.respond(client, request, { targetId: attached.targetId });
-          },
-          typeof created.targetId === "string" ? created.targetId : undefined,
-        );
         return;
       }
       case "Target.closeTarget": {

--- a/extensions/browser/src/browser/extension-relay/relay-coexistence.e2e.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-coexistence.e2e.test.ts
@@ -1,0 +1,108 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { clearRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { afterEach, expect, it } from "vitest";
+import {
+  createBrowserControlContext,
+  startBrowserControlServiceFromConfig,
+  stopBrowserControlService,
+} from "../../control-service.js";
+import {
+  externalRelayClient,
+  externalVersion,
+  withConnectedDaemon,
+} from "./relay-coexistence.test-support.js";
+
+afterEach(async () => {
+  await stopBrowserControlService();
+  clearRuntimeConfigSnapshot();
+});
+
+it("borrows the compiled daemon in another process and leaves it serving an external v2 client", async () => {
+  let child: ChildProcess | undefined;
+  await withConnectedDaemon(
+    async ({ port, token }) => {
+      const pid = child?.pid;
+      expect(pid).toBeTypeOf("number");
+      const external = await externalRelayClient(port, token);
+      try {
+        await startBrowserControlServiceFromConfig();
+        const profile = createBrowserControlContext().forProfile("chrome");
+        await profile.ensureBrowserAvailable();
+        await expect(profile.listTabs()).resolves.toEqual([
+          expect.objectContaining({
+            targetId: "fixture-target",
+            url: "https://example.com/fixture",
+          }),
+        ]);
+        await stopBrowserControlService();
+        expect(child?.pid).toBe(pid);
+        expect(child?.exitCode).toBeNull();
+        await expect(externalVersion(external)).resolves.toMatchObject({
+          result: { product: "Chrome/test" },
+        });
+      } finally {
+        external.terminate();
+      }
+    },
+    async (port, stateDir, config) => {
+      const configPath = path.join(stateDir, "openclaw.json");
+      await fs.writeFile(configPath, JSON.stringify(config));
+      child = spawn(
+        process.execPath,
+        [path.resolve("dist/extensions/browser/relay-daemon-entry.js"), "--port", String(port)],
+        {
+          env: {
+            HOME: stateDir,
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_CONFIG_PATH: configPath,
+            PATH: process.env.PATH,
+            TMPDIR: process.env.TMPDIR,
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      const owned = child;
+      const done = new Promise<void>((resolve) => {
+        owned.once("exit", () => resolve());
+      });
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(
+            () => reject(new Error("Compiled relay did not become ready")),
+            10_000,
+          );
+          let output = "";
+          const onData = (chunk: Buffer) => {
+            output = (output + chunk.toString()).slice(-4_096);
+            if (output.includes("standalone extension relay listening")) {
+              clearTimeout(timer);
+              resolve();
+            }
+          };
+          owned.stdout?.on("data", onData);
+          owned.stderr?.on("data", onData);
+          owned.once("error", (error) => {
+            clearTimeout(timer);
+            reject(error);
+          });
+          owned.once("exit", () => {
+            clearTimeout(timer);
+            reject(new Error("Compiled relay exited before readiness"));
+          });
+        });
+      } catch (error) {
+        owned.kill("SIGTERM");
+        await done;
+        throw error;
+      }
+      return {
+        stop: () => {
+          owned.kill("SIGTERM");
+        },
+        done,
+      };
+    },
+  );
+});

--- a/extensions/browser/src/browser/extension-relay/relay-coexistence.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-coexistence.integration.test.ts
@@ -1,0 +1,299 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { afterEach, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
+import {
+  createBrowserControlContext,
+  getBrowserControlState,
+  startBrowserControlServiceFromConfig,
+  stopBrowserControlService,
+} from "../../control-service.js";
+import { resolveBrowserConfig, resolveProfile } from "../config.js";
+import { runExtensionRelayDaemon } from "../relay-daemon.js";
+import { captureBrowserOperationTarget } from "../routes/agent.snapshot-target.js";
+import type { BrowserServerState } from "../server-context.types.js";
+import { getFreePort } from "../test-port.js";
+import { RelayOwnerClient } from "./owner-client.js";
+import {
+  externalRelayClient,
+  externalVersion,
+  withConnectedDaemon,
+} from "./relay-coexistence.test-support.js";
+import { ensureExtensionRelayForProfile, stopExtensionRelays } from "./relay-lifecycle.js";
+
+afterEach(async () => {
+  await stopBrowserControlService();
+  clearRuntimeConfigSnapshot();
+});
+
+it("uses a daemon-owned relay without replacing its listener or closing its extension", async () => {
+  await withConnectedDaemon(async ({ port, token, extension }) => {
+    const external = await externalRelayClient(port, token);
+    try {
+      for (const mismatch of [
+        { port, profile: "wrong-profile", token },
+        { port, profile: "chrome", token: relayTestKey(10) },
+      ]) {
+        await expect(
+          RelayOwnerClient.connect({ ...mismatch, signal: new AbortController().signal }),
+        ).rejects.toThrow();
+      }
+      await startBrowserControlServiceFromConfig();
+      await expect(
+        createBrowserControlContext().forProfile("chrome").ensureBrowserAvailable(),
+      ).resolves.toBeUndefined();
+      const tabs = await createBrowserControlContext().forProfile("chrome").listTabs();
+      expect(tabs).toEqual([
+        expect.objectContaining({
+          targetId: "fixture-target",
+          url: "https://example.com/fixture",
+        }),
+      ]);
+      await stopBrowserControlService();
+      await expect(externalVersion(external)).resolves.toMatchObject({
+        result: { product: "Chrome/test" },
+      });
+      expect(extension.readyState).toBe(WebSocket.OPEN);
+      // A second daemon must still see the original listener, not a free port.
+      const contender = await runExtensionRelayDaemon({ port });
+      await expect(contender.done).resolves.toBe("port-in-use");
+    } finally {
+      external.terminate();
+    }
+  });
+});
+
+it("keeps remote captures on the exact grant across renderer attachment, then revokes them", async () => {
+  await withConnectedDaemon(async ({ port, token, extension, setTarget, sendTabs }) => {
+    const client = await RelayOwnerClient.connect({
+      port,
+      profile: "chrome",
+      token,
+      signal: new AbortController().signal,
+    });
+    try {
+      await startBrowserControlServiceFromConfig();
+      await createBrowserControlContext().forProfile("chrome").listTabs();
+      const reference = await client.capture("fixture-target");
+      await expect(reference.resolve()).resolves.toBe("fixture-target");
+      setTarget("replacement-target");
+      extension.send(JSON.stringify({ type: "detached", tabId: 1, reason: "target_closed" }));
+      await expect.poll(() => reference.resolve()).toBeUndefined();
+      const transport = await reference.openTransport();
+      transport.send({
+        id: 1,
+        method: "Target.setAutoAttach",
+        params: { autoAttach: true, flatten: true },
+      });
+      await expect.poll(() => reference.resolve()).toBe("replacement-target");
+      let closed = false;
+      Object.assign(transport, {
+        onclose: () => {
+          closed = true;
+        },
+      });
+      sendTabs(false);
+      await expect.poll(() => reference.resolve()).toBeUndefined();
+      sendTabs(true);
+      // Even an identical native ID is a new TabState after revoke/regrant.
+      await expect(reference.openTransport()).rejects.toThrow();
+      transport.send({ id: 1, method: "Target.getTargets" });
+      await expect.poll(() => closed).toBe(true);
+      await reference.release();
+      await expect(reference.resolve()).rejects.toThrow();
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+it("coalesces real borrowed acquisitions while independently cancelling one caller", async () => {
+  await withConnectedDaemon(async ({ port }) => {
+    const resolved = resolveBrowserConfig({
+      profiles: { chrome: { driver: "extension", cdpPort: port } },
+    });
+    const state: BrowserServerState = { server: null, port: 0, resolved, profiles: new Map() };
+    const profile = resolveProfile(resolved, "chrome");
+    if (!profile) {
+      throw new Error("Missing fixture profile");
+    }
+    const controller = new AbortController();
+    const first = ensureExtensionRelayForProfile(state, profile, controller.signal);
+    const cancelled = expect(first).rejects.toThrow("caller cancelled");
+    const siblings = Array.from({ length: 4 }, () =>
+      ensureExtensionRelayForProfile(state, profile),
+    );
+    controller.abort(new Error("caller cancelled"));
+    try {
+      await cancelled;
+      const handles = await Promise.all(siblings);
+      expect(handles.every((handle) => handle === handles[0])).toBe(true);
+      expect(handles[0]?.ownership).toBe("borrowed");
+      expect(state.extensionRelays?.size).toBe(1);
+    } finally {
+      await stopExtensionRelays(state);
+    }
+  });
+});
+
+it.each(["port", "name"] as const)(
+  "retires borrowed access on configured profile %s drift without stopping the old daemon",
+  async (change) => {
+    await withConnectedDaemon(async ({ port, token }) => {
+      const external = await externalRelayClient(port, token);
+      try {
+        await startBrowserControlServiceFromConfig();
+        const oldProfile = createBrowserControlContext().forProfile("chrome");
+        const oldRelay = getBrowserControlState()?.extensionRelays?.get("chrome");
+        const replacementPort = change === "port" ? await getFreePort() : port;
+        const replacementName = change === "name" ? "other-profile" : "chrome";
+        const config = {
+          browser: {
+            profiles: {
+              [replacementName]: { driver: "extension" as const, cdpPort: replacementPort },
+            },
+          },
+        };
+        setRuntimeConfigSnapshot(config, config);
+        const current = createBrowserControlContext().forProfile(replacementName);
+        expect(current.profile.cdpPort).toBe(replacementPort);
+        await expect(oldProfile.isTransportAvailable()).rejects.toThrow();
+        await expect
+          .poll(() => getBrowserControlState()?.extensionRelays?.get("chrome") !== oldRelay)
+          .toBe(true);
+        await expect(externalVersion(external)).resolves.toMatchObject({
+          result: { product: "Chrome/test" },
+        });
+      } finally {
+        external.terminate();
+      }
+    });
+  },
+);
+
+it("releases its old lease on key drift and refuses to reconfigure the daemon owner", async () => {
+  await withConnectedDaemon(async ({ stateDir }) => {
+    await startBrowserControlServiceFromConfig();
+    const profile = createBrowserControlContext().forProfile("chrome");
+    await fs.writeFile(
+      path.join(stateDir, "credentials", "browser-extension-relay.secret"),
+      relayTestKey(14),
+    );
+    await expect(profile.ensureBrowserAvailable()).rejects.toThrow();
+    expect(getBrowserControlState()?.extensionRelays?.size).toBe(0);
+  });
+});
+
+it("waits for the actual native detach acknowledgement before borrowed cleanup completes", async () => {
+  await withConnectedDaemon(async ({ port, token, holdDetach }) => {
+    const external = await externalRelayClient(port, token);
+    const hold = holdDetach();
+    try {
+      await startBrowserControlServiceFromConfig();
+      await createBrowserControlContext().forProfile("chrome").listTabs();
+      let completed = false;
+      const stopping = stopBrowserControlService();
+      void stopping.then(
+        () => {
+          completed = true;
+        },
+        () => {
+          completed = true;
+        },
+      );
+      await hold.entered;
+      expect(completed).toBe(false);
+      await expect(externalVersion(external)).resolves.toMatchObject({
+        result: { product: "Chrome/test" },
+      });
+      hold.release();
+      await stopping;
+      expect(completed).toBe(true);
+    } finally {
+      hold.release();
+      external.terminate();
+    }
+  });
+});
+
+it("reacquires a retired daemon owner without reusing its captured references", async () => {
+  await withConnectedDaemon(async ({ restartDaemon }) => {
+    const state = await startBrowserControlServiceFromConfig();
+    if (!state) {
+      throw new Error("Expected browser runtime");
+    }
+    const profile = createBrowserControlContext().forProfile("chrome");
+    await profile.listTabs();
+    const original = state.extensionRelays?.get("chrome");
+    if (original?.ownership !== "borrowed") {
+      throw new Error("Expected borrowed relay");
+    }
+    const reference = await original.client.capture("fixture-target");
+    await restartDaemon();
+    const replacement = await ensureExtensionRelayForProfile(state, profile.profile);
+    expect(replacement).not.toBe(original);
+    expect(replacement.ownership).toBe("borrowed");
+    await expect(reference.resolve()).rejects.toThrow();
+  });
+});
+
+it("fences a captured operation when profile stop advances the generation but retains the relay", async () => {
+  await withConnectedDaemon(async () => {
+    await startBrowserControlServiceFromConfig();
+    const ctx = createBrowserControlContext();
+    const profile = ctx.forProfile("chrome");
+    await profile.listTabs();
+    const original = ctx.state().extensionRelays?.get("chrome");
+    const captured = await captureBrowserOperationTarget({
+      ctx,
+      profileName: "chrome",
+      targetId: "fixture-target",
+    });
+    const transport = await captured?.reference?.openTransport();
+    const resolving = Promise.resolve(captured?.()).catch(() => undefined);
+    await profile.stopRunningBrowser();
+    expect(ctx.state().extensionRelays?.get("chrome")).toBe(original);
+    try {
+      await expect(resolving).resolves.toBeUndefined();
+      expect(() => transport?.send({ id: 1, method: "Browser.getVersion" })).toThrow();
+      await expect(captured?.reference?.openTransport()).rejects.toThrow();
+    } finally {
+      await captured?.release();
+    }
+  });
+});
+
+it("reports an explicit stricter policy conflict without reconfiguring the existing owner", async () => {
+  await withConnectedDaemon(
+    async ({ port, token }) => {
+      const resolved = resolveBrowserConfig({
+        extensionRelay: { allowLegacyAuth: false },
+        profiles: { chrome: { driver: "extension", cdpPort: port } },
+      });
+      const state: BrowserServerState = { server: null, port: 0, resolved, profiles: new Map() };
+      const profile = resolveProfile(resolved, "chrome");
+      if (!profile) {
+        throw new Error("Missing fixture profile");
+      }
+      const external = await externalRelayClient(port, token);
+      try {
+        await expect(ensureExtensionRelayForProfile(state, profile)).rejects.toThrow(
+          "Existing relay permits legacy authentication",
+        );
+        expect(state.extensionRelays?.size).toBe(0);
+        await expect(externalVersion(external)).resolves.toMatchObject({
+          result: { product: "Chrome/test" },
+        });
+      } finally {
+        external.terminate();
+        await stopExtensionRelays(state);
+      }
+    },
+    async (port) => await runExtensionRelayDaemon({ port, allowLegacyAuth: true }),
+  );
+});

--- a/extensions/browser/src/browser/extension-relay/relay-coexistence.test-support.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-coexistence.test-support.ts
@@ -100,6 +100,10 @@ export async function withConnectedDaemon(
     stateDir: string,
     config: object,
   ) => Promise<{ stop: () => void; done: Promise<unknown> }>,
+  handleCdpCommand?: (
+    command: Record<string, unknown>,
+    send: (message: Record<string, unknown>) => void,
+  ) => void,
 ) {
   await withTempDir("relay-coexistence-", async (dir) => {
     const stateDir = await fs.realpath(dir);
@@ -162,6 +166,10 @@ export async function withConnectedDaemon(
             };
             if (command.type === "ping") {
               extension.send(JSON.stringify({ type: "pong" }));
+              return;
+            }
+            if (command.type === "cdp" && handleCdpCommand) {
+              handleCdpCommand(command, (message) => extension.send(JSON.stringify(message)));
               return;
             }
             if (command.type === "detach" && detachHeld) {

--- a/extensions/browser/src/browser/extension-relay/relay-coexistence.test-support.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-coexistence.test-support.ts
@@ -1,0 +1,273 @@
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { withEnvAsync, withTempDir } from "openclaw/plugin-sdk/test-env";
+import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import { expect } from "vitest";
+import { WebSocket } from "ws";
+import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
+import { stopBrowserControlService } from "../../control-service.js";
+import { runExtensionRelayDaemon } from "../relay-daemon.js";
+import { getFreePort } from "../test-port.js";
+import {
+  createRelayProof,
+  randomRelayNonce,
+  relayKeyIdFromHex,
+  verifyRelayProof,
+  type BrowserRelayAuthChallenge,
+} from "./auth-v2-crypto.js";
+import {
+  BROWSER_RELAY_EXTENSION_SUBPROTOCOL,
+  BROWSER_RELAY_AUTH_CHALLENGE_PATH,
+  BROWSER_RELAY_AUTH_COMPLETE_PATH,
+} from "./auth-v2.js";
+import { RawHttpConnection } from "./relay-http.test-support.js";
+
+/** An ordinary external v2 client: HTTP authentication/discovery/upgrade on one socket. */
+export async function externalRelayClient(port: number, token: string): Promise<WebSocket> {
+  const connection = await RawHttpConnection.connect(port);
+  const request = async (pathname: string, body?: unknown) => {
+    const response = await connection.request(
+      body === undefined ? "GET" : "POST",
+      pathname,
+      body === undefined ? "" : JSON.stringify(body),
+      { "Content-Type": "application/json" },
+    );
+    expect(response.status).toBe(200);
+    return response.body;
+  };
+  try {
+    const challenge = JSON.parse(
+      await request(BROWSER_RELAY_AUTH_CHALLENGE_PATH, {
+        v: 2,
+        keyId: relayKeyIdFromHex(token),
+        clientNonce: randomRelayNonce(),
+        role: "cdp",
+        transport: "connection",
+        method: "SEQUENCE",
+        resource: "/json/version -> /cdp",
+        flow: "cdp",
+      }),
+    ) as BrowserRelayAuthChallenge;
+    expect(verifyRelayProof(token, "server", challenge, challenge.serverProof)).toBe(true);
+    const clientProof = createRelayProof(token, "client", challenge);
+    const accepted = JSON.parse(
+      await request(BROWSER_RELAY_AUTH_COMPLETE_PATH, {
+        v: 2,
+        sessionId: challenge.sessionId,
+        clientProof,
+      }),
+    ) as { acceptProof: string };
+    expect(verifyRelayProof(token, "accept", challenge, accepted.acceptProof, clientProof)).toBe(
+      true,
+    );
+    await request("/json/version");
+    const authenticated = connection.takeSocket();
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/cdp`, {
+      createConnection: () => authenticated,
+    });
+    await once(ws, "open").catch((error: unknown) => {
+      throw new Error("External relay upgrade failed", { cause: error });
+    });
+    return ws;
+  } catch (error) {
+    connection.close();
+    throw error;
+  }
+}
+
+export async function externalVersion(ws: WebSocket): Promise<unknown> {
+  const response = once(ws, "message");
+  ws.send(JSON.stringify({ id: 1, method: "Browser.getVersion" }));
+  const [raw] = await response;
+  return JSON.parse(rawDataToString(raw));
+}
+
+export async function withConnectedDaemon(
+  run: (fixture: {
+    port: number;
+    token: string;
+    extension: WebSocket;
+    stateDir: string;
+    setTarget: (value: string) => void;
+    sendTabs: (granted: boolean) => void;
+    holdDetach: () => { entered: Promise<void>; release: () => void };
+    restartDaemon: () => Promise<void>;
+  }) => Promise<void>,
+  startDaemon?: (
+    port: number,
+    stateDir: string,
+    config: object,
+  ) => Promise<{ stop: () => void; done: Promise<unknown> }>,
+) {
+  await withTempDir("relay-coexistence-", async (dir) => {
+    const stateDir = await fs.realpath(dir);
+    const credentials = path.join(stateDir, "credentials");
+    const port = await getFreePort();
+    const token = relayTestKey(9);
+    await fs.mkdir(credentials);
+    await fs.writeFile(path.join(credentials, "browser-extension-relay.secret"), token, {
+      mode: 0o600,
+    });
+    const config = {
+      gateway: { auth: { mode: "token" as const, token: "coexistence-test" } },
+      browser: { profiles: { chrome: { driver: "extension" as const, cdpPort: port } } },
+    };
+    setRuntimeConfigSnapshot(config, config);
+    await withEnvAsync(
+      { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_OAUTH_DIR: credentials },
+      async () => {
+        let daemon = startDaemon
+          ? await startDaemon(port, stateDir, config)
+          : await runExtensionRelayDaemon({ port });
+        const extension = new WebSocket(
+          `ws://127.0.0.1:${port}/extension`,
+          BROWSER_RELAY_EXTENSION_SUBPROTOCOL,
+          { origin: "chrome-extension://coexistence-test" },
+        );
+        let nativeTarget = "fixture-target";
+        let detachHeld = false;
+        let detachEntered = () => {};
+        const detachReplies: Array<() => void> = [];
+        try {
+          await once(extension, "open");
+          const challengeMessage = once(extension, "message");
+          extension.send(
+            JSON.stringify({
+              type: "auth.hello",
+              v: 2,
+              keyId: relayKeyIdFromHex(token),
+              clientNonce: randomRelayNonce(),
+            }),
+          );
+          const [raw] = await challengeMessage;
+          const challenge = JSON.parse(rawDataToString(raw));
+          const authenticated = once(extension, "message");
+          extension.send(
+            JSON.stringify({
+              type: "auth.response",
+              v: 2,
+              sessionId: challenge.sessionId,
+              clientProof: createRelayProof(token, "client", challenge),
+            }),
+          );
+          const [ok] = await authenticated;
+          expect(JSON.parse(rawDataToString(ok))).toMatchObject({ type: "auth.ok", v: 2 });
+          extension.on("message", (frame) => {
+            const command = JSON.parse(rawDataToString(frame)) as {
+              seq: number;
+              type: string;
+              method?: string;
+            };
+            if (command.type === "ping") {
+              extension.send(JSON.stringify({ type: "pong" }));
+              return;
+            }
+            if (command.type === "detach" && detachHeld) {
+              detachReplies.push(() =>
+                extension.send(JSON.stringify({ type: "result", seq: command.seq, result: {} })),
+              );
+              detachEntered();
+              return;
+            }
+            const result =
+              command.type === "attach"
+                ? { targetId: nativeTarget }
+                : command.method === "Target.getTargetInfo"
+                  ? {
+                      targetInfo: {
+                        targetId: nativeTarget,
+                        title: "Fixture",
+                        type: "page",
+                        url: "https://example.com/fixture",
+                      },
+                    }
+                  : command.method === "Page.getFrameTree"
+                    ? {
+                        frameTree: {
+                          frame: {
+                            id: nativeTarget,
+                            name: "",
+                            loaderId: "loader",
+                            url: "https://example.com/fixture",
+                            securityOrigin: "https://example.com",
+                            mimeType: "text/html",
+                          },
+                        },
+                      }
+                    : {};
+            extension.send(JSON.stringify({ type: "result", seq: command.seq, result }));
+          });
+          extension.send(
+            JSON.stringify({
+              type: "hello",
+              browserVersion: "Chrome/test",
+              userAgent: "coexistence-test",
+              extensionVersion: "2",
+              tabs: [
+                { tabId: 1, url: "https://example.com/fixture", title: "Fixture", active: true },
+              ],
+            }),
+          );
+
+          await run({
+            port,
+            token,
+            extension,
+            stateDir,
+            restartDaemon: async () => {
+              daemon.stop();
+              await daemon.done;
+              daemon = startDaemon
+                ? await startDaemon(port, stateDir, config)
+                : await runExtensionRelayDaemon({ port });
+            },
+            holdDetach: () => {
+              detachHeld = true;
+              const entered = new Promise<void>((resolve) => {
+                detachEntered = resolve;
+              });
+              return {
+                entered,
+                release: () => {
+                  detachHeld = false;
+                  for (const reply of detachReplies.splice(0)) {
+                    reply();
+                  }
+                },
+              };
+            },
+            setTarget: (value) => {
+              nativeTarget = value;
+            },
+            sendTabs: (granted) =>
+              extension.send(
+                JSON.stringify({
+                  type: "tabs",
+                  tabs: granted
+                    ? [
+                        {
+                          tabId: 1,
+                          url: "https://example.com/fixture",
+                          title: "Fixture",
+                          active: true,
+                        },
+                      ]
+                    : [],
+                }),
+              ),
+          });
+        } finally {
+          try {
+            await stopBrowserControlService();
+          } finally {
+            extension.terminate();
+            daemon.stop();
+            await daemon.done;
+          }
+        }
+      },
+    );
+  });
+}

--- a/extensions/browser/src/browser/extension-relay/relay-http.test-support.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-http.test-support.ts
@@ -1,0 +1,115 @@
+import net from "node:net";
+
+type RawResponse = {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+};
+
+export class RawHttpConnection {
+  private buffer = Buffer.alloc(0);
+  private readonly waiters: Array<() => void> = [];
+
+  private readonly onData = (chunk: Buffer) => {
+    this.buffer = Buffer.concat([this.buffer, Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)]);
+    this.waiters.splice(0).forEach((resolve) => resolve());
+  };
+
+  private constructor(readonly socket: net.Socket) {
+    socket.on("data", this.onData);
+  }
+
+  takeSocket(): net.Socket {
+    if (this.buffer.length) {
+      throw new Error("Unexpected bytes before WebSocket upgrade");
+    }
+    this.socket.off("data", this.onData);
+    return this.socket;
+  }
+
+  static async connect(port: number): Promise<RawHttpConnection> {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    await new Promise<void>((resolve, reject) => {
+      socket.once("connect", resolve);
+      socket.once("error", reject);
+    });
+    return new RawHttpConnection(socket);
+  }
+
+  async request(
+    method: string,
+    requestPath: string,
+    body = "",
+    headers: Record<string, string> = {},
+  ): Promise<RawResponse> {
+    this.socket.write(
+      [
+        `${method} ${requestPath} HTTP/1.1`,
+        "Host: 127.0.0.1",
+        "Connection: keep-alive",
+        `Content-Length: ${Buffer.byteLength(body)}`,
+        ...Object.entries(headers).map(([key, value]) => `${key}: ${value}`),
+        "",
+        body,
+      ].join("\r\n"),
+    );
+    return await this.readResponse();
+  }
+
+  async upgrade(requestPath: string): Promise<RawResponse> {
+    this.socket.write(
+      [
+        `GET ${requestPath} HTTP/1.1`,
+        "Host: 127.0.0.1",
+        "Connection: Upgrade",
+        "Upgrade: websocket",
+        "Sec-WebSocket-Version: 13",
+        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+        "",
+        "",
+      ].join("\r\n"),
+    );
+    return await this.readResponse({ headersOnly: true });
+  }
+
+  private async waitForData(): Promise<void> {
+    if (this.socket.destroyed) {
+      throw new Error("socket closed before response completed");
+    }
+    await new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  private async readResponse(options: { headersOnly?: boolean } = {}): Promise<RawResponse> {
+    let headerEnd = this.buffer.indexOf("\r\n\r\n");
+    while (headerEnd < 0) {
+      await this.waitForData();
+      headerEnd = this.buffer.indexOf("\r\n\r\n");
+    }
+    const headerText = this.buffer.subarray(0, headerEnd).toString("utf8");
+    const [statusLine, ...headerLines] = headerText.split("\r\n");
+    const headers = Object.fromEntries(
+      headerLines.map((line) => {
+        const separator = line.indexOf(":");
+        return [line.slice(0, separator).toLowerCase(), line.slice(separator + 1).trim()];
+      }),
+    );
+    const contentLength = options.headersOnly ? 0 : Number(headers["content-length"] ?? 0);
+    const responseLength = headerEnd + 4 + contentLength;
+    while (this.buffer.length < responseLength) {
+      await this.waitForData();
+    }
+    const body = this.buffer.subarray(headerEnd + 4, responseLength).toString("utf8");
+    this.buffer = this.buffer.subarray(responseLength);
+    return {
+      status: Number(/^HTTP\/1\.1 (\d+)/u.exec(statusLine ?? "")?.[1] ?? 0),
+      headers,
+      body,
+    };
+  }
+
+  close(): void {
+    this.socket.destroy();
+  }
+}

--- a/extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts
@@ -66,6 +66,7 @@ function createState(token: string, existing?: ExtensionRelayHandle) {
 
 function createHandle(token: string, port = RELAY_PORT): ExtensionRelayHandle {
   return {
+    ownership: "owned",
     port,
     token,
     allowLegacyAuth: true,
@@ -88,6 +89,7 @@ describe("extension relay lifecycle", () => {
     vi.clearAllMocks();
     ensureExtensionRelayTokenMock.mockResolvedValue(ROTATED_TOKEN);
     startExtensionRelayServerMock.mockImplementation(async ({ port, token, allowLegacyAuth }) => ({
+      ownership: "owned",
       port,
       token,
       allowLegacyAuth,
@@ -108,6 +110,7 @@ describe("extension relay lifecycle", () => {
     expect(oldRelay.close).toHaveBeenCalledOnce();
     expect(startExtensionRelayServerMock).toHaveBeenCalledWith({
       port: RELAY_PORT,
+      profileName: PROFILE_NAME,
       token: ROTATED_TOKEN,
       allowLegacyAuth: true,
     });

--- a/extensions/browser/src/browser/extension-relay/relay-lifecycle.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-lifecycle.ts
@@ -1,7 +1,8 @@
 /**
- * Extension relay lifecycle: one relay server per extension-driver profile,
- * owned by the browser control runtime state.
+ * Extension relay lifecycle: one owned listener or authenticated borrowed lease
+ * per extension-driver profile in the browser control runtime.
  */
+import { extractErrorCode } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveProfile, type ResolvedBrowserProfile } from "../config.js";
 import {
@@ -12,7 +13,9 @@ import {
   withProfileOperationLease,
 } from "../server-context.lifecycle.js";
 import type { BrowserServerState, ProfileRuntimeState } from "../server-context.types.js";
-import { type ExtensionRelayHandle, startExtensionRelayServer } from "./relay-server.js";
+import { RelayOwnerClient } from "./owner-client.js";
+import { registerBorrowedRelayCdpAccess, type ExtensionRelayResource } from "./relay-access.js";
+import { startExtensionRelayServer } from "./relay-server.js";
 
 const log = createSubsystemLogger("browser").child("extension-relay");
 
@@ -20,7 +23,7 @@ type PendingRelayEnsure = {
   port: number;
   token: string;
   allowLegacyAuth: boolean;
-  promise: Promise<ExtensionRelayHandle>;
+  promise: Promise<ExtensionRelayResource>;
 };
 
 const pendingRelayEnsures = new WeakMap<ProfileRuntimeState, PendingRelayEnsure>();
@@ -29,7 +32,7 @@ const pendingRelayEnsures = new WeakMap<ProfileRuntimeState, PendingRelayEnsure>
 export const EXTENSION_PAIRING_HINT =
   "Run `openclaw browser extension install`, load the printed unpacked directory once, and wait for automatic setup.";
 
-function relays(state: BrowserServerState): Map<string, ExtensionRelayHandle> {
+function relays(state: BrowserServerState): Map<string, ExtensionRelayResource> {
   if (!state.extensionRelays) {
     state.extensionRelays = new Map();
   }
@@ -68,7 +71,7 @@ export async function ensureExtensionRelayForProfile(
   state: BrowserServerState,
   profile: ResolvedBrowserProfile,
   signal?: AbortSignal,
-): Promise<ExtensionRelayHandle> {
+): Promise<ExtensionRelayResource> {
   for (;;) {
     signal?.throwIfAborted();
     if (!isBrowserRuntimeRunning(state)) {
@@ -153,7 +156,7 @@ async function ensureDesiredRelay(params: {
   runtime: ProfileRuntimeState;
   profile: ResolvedBrowserProfile;
   token: string;
-}): Promise<ExtensionRelayHandle> {
+}): Promise<ExtensionRelayResource> {
   const { state, runtime, profile, token } = params;
   return await withProfileOperationLease({
     state,
@@ -165,12 +168,27 @@ async function ensureDesiredRelay(params: {
       const actor = getProfileLifecycle(runtime);
       const existing = map.get(profile.name);
       if (existing) {
-        if (
+        const matches =
           existing.port === profile.cdpPort &&
           existing.token === token &&
-          existing.allowLegacyAuth === state.resolved.extensionRelay.allowLegacyAuth
-        ) {
-          const current = applyInternalRelayToken(state, profile.name, existing.internalToken);
+          existing.allowLegacyAuth === state.resolved.extensionRelay.allowLegacyAuth;
+        if (matches && existing.ownership === "borrowed" && existing.client.connected) {
+          try {
+            // A live socket can still have an unread retirement notice. Reuse requires
+            // a response from this owner; loss without cleanup acknowledgement stays blocked.
+            await existing.client.status();
+          } catch (error) {
+            if (existing.client.connected) {
+              throw error;
+            }
+          }
+        }
+        if (matches && (existing.ownership !== "borrowed" || existing.client.connected)) {
+          const current = applyInternalRelayToken(
+            state,
+            profile.name,
+            existing.ownership === "borrowed" ? null : existing.internalToken,
+          );
           if (current) {
             Object.assign(profile, current);
           }
@@ -185,13 +203,67 @@ async function ensureDesiredRelay(params: {
         }
         applyInternalRelayToken(state, profile.name, null);
       }
-      let handle: ExtensionRelayHandle | undefined;
+      let handle: ExtensionRelayResource | undefined;
       try {
-        handle = await startExtensionRelayServer({
-          port: profile.cdpPort,
-          token,
-          allowLegacyAuth: state.resolved.extensionRelay.allowLegacyAuth,
-        });
+        try {
+          handle = await startExtensionRelayServer({
+            port: profile.cdpPort,
+            profileName: profile.name,
+            token,
+            allowLegacyAuth: state.resolved.extensionRelay.allowLegacyAuth,
+          });
+        } catch (error) {
+          if (extractErrorCode(error) !== "EADDRINUSE") {
+            throw error;
+          }
+        }
+        if (!handle) {
+          const client = await RelayOwnerClient.connect({
+            port: profile.cdpPort,
+            profile: profile.name,
+            token,
+            signal,
+          });
+          let unregister = () => {};
+          handle = {
+            ownership: "borrowed",
+            port: profile.cdpPort,
+            token,
+            allowLegacyAuth: state.resolved.extensionRelay.allowLegacyAuth,
+            client,
+            close: async () => {
+              await client.close();
+              unregister();
+            },
+          };
+          actor.cleanupRelays.add(handle);
+          const status = await client.status();
+          if (!handle.allowLegacyAuth && status.allowLegacyAuth) {
+            throw new Error(
+              "Existing relay permits legacy authentication; its owner must retire it before this stricter profile can use it.",
+            );
+          }
+          const borrowed = handle;
+          const assertCurrent = () => {
+            if (
+              map.get(profile.name) !== borrowed ||
+              state.profiles.get(profile.name) !== runtime ||
+              actor.transitionReason ||
+              actor.terminal ||
+              actor.cleanupRelays.has(borrowed) ||
+              state.resolved.extensionRelayToken !== token ||
+              resolveProfile(state.resolved, profile.name)?.cdpPort !== borrowed.port
+            ) {
+              throw new Error("Borrowed relay profile lease was superseded");
+            }
+          };
+          client.adoptProfileLease(assertCurrent);
+          unregister = registerBorrowedRelayCdpAccess(
+            `http://127.0.0.1:${profile.cdpPort}`,
+            borrowed,
+            assertCurrent,
+          );
+        }
         actor.cleanupRelays.add(handle);
         signal.throwIfAborted();
         const currentProfile = resolveProfile(state.resolved, profile.name);
@@ -207,7 +279,7 @@ async function ensureDesiredRelay(params: {
         const currentWithInternalAuth = applyInternalRelayToken(
           state,
           profile.name,
-          handle.internalToken,
+          handle.ownership === "borrowed" ? null : handle.internalToken,
         );
         if (!currentWithInternalAuth) {
           throw new Error(`Extension relay profile "${profile.name}" disappeared during startup.`);

--- a/extensions/browser/src/browser/extension-relay/relay-runtime.test-support.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-runtime.test-support.ts
@@ -1,0 +1,169 @@
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { expect, onTestFinished } from "vitest";
+import { ExtensionRelayBridge } from "./relay-bridge.js";
+import { FakeSocket, flush, sendHello, wireExtension } from "./relay-bridge.test-support.js";
+
+export function runtimeContext(id: number) {
+  return {
+    id,
+    uniqueId: `context-${id}`,
+    origin: "https://example.com",
+    name: "",
+    auxData: { isDefault: true, frameId: "target-1" },
+  };
+}
+
+export function createRuntimeFixture() {
+  const bridge = new ExtensionRelayBridge();
+  onTestFinished(() => bridge.dispose());
+  const enabled = new Set<string>();
+  const held: number[] = [];
+  let heldMethod: string | undefined;
+  let accessAllowed = true;
+  let contextOffset = -10;
+  const extension = wireExtension(bridge, (msg) => {
+    if (msg.type === "ping") {
+      return null;
+    }
+    if (msg.type === "attach") {
+      enabled.clear();
+      contextOffset += 10;
+      return { type: "result", seq: msg.seq, result: { targetId: `target-${msg.tabId}` } };
+    }
+    if (msg.type === "cdp") {
+      const key = msg.sessionId ?? "root";
+      if (msg.method === "Runtime.enable") {
+        if (!accessAllowed) {
+          return { type: "error", seq: msg.seq, message: "tab access was revoked" };
+        }
+        // V8 reports existing contexts only on the physical disabled -> enabled transition.
+        if (!enabled.has(key)) {
+          enabled.add(key);
+          event(
+            "Runtime.executionContextCreated",
+            { context: runtimeContext(key === "root" ? 1 + contextOffset : 2) },
+            msg.sessionId,
+          );
+        }
+      }
+      if (msg.method === "Runtime.disable") {
+        enabled.delete(key);
+      }
+      if (msg.method === heldMethod) {
+        held.push(msg.seq);
+        return null;
+      }
+    }
+    return { type: "result", seq: msg.seq, result: {} };
+  });
+  function event(method: string, params: unknown, sessionId?: string) {
+    extension.handlers.onMessage(
+      JSON.stringify({ type: "cdpEvent", tabId: 1, sessionId, method, params }),
+    );
+  }
+  sendHello(extension.handlers);
+  function client() {
+    const socket = new FakeSocket();
+    const handlers = bridge.attachCdpClientSocket(socket);
+    let nextId = 1;
+    function send(method: string, sessionId?: string, params?: Record<string, unknown>) {
+      const id = nextId++;
+      handlers.onMessage(JSON.stringify({ id, method, sessionId, params }));
+      return id;
+    }
+    async function request(method: string, sessionId?: string, params?: Record<string, unknown>) {
+      const id = send(method, sessionId, params);
+      await flush();
+      const response = socket.frames().find((frame) => frame.id === id);
+      expect(response, method).toBeDefined();
+      return response!;
+    }
+    async function attach() {
+      const response = await request("Target.setAutoAttach", undefined, { autoAttach: true });
+      expect(response.error).toBeUndefined();
+      const announcement = socket
+        .frames()
+        .findLast((frame) => frame.method === "Target.attachedToTarget");
+      if (!announcement) {
+        throw new Error("Missing Target.attachedToTarget announcement");
+      }
+      const { sessionId } = announcement.params as { sessionId: string };
+      return sessionId;
+    }
+    async function autoAttach(parent: string) {
+      expect(
+        (
+          await request("Target.setAutoAttach", parent, {
+            autoAttach: true,
+            waitForDebuggerOnStart: true,
+            flatten: true,
+          })
+        ).error,
+      ).toBeUndefined();
+    }
+    function child(targetId: string, parent?: string) {
+      const announcement = socket
+        .frames()
+        .findLast(
+          (frame) =>
+            frame.method === "Target.attachedToTarget" &&
+            (parent === undefined || frame.sessionId === parent) &&
+            asOptionalRecord(asOptionalRecord(frame.params)?.targetInfo)?.targetId === targetId,
+        );
+      const id = asOptionalRecord(announcement?.params)?.sessionId;
+      if (typeof id !== "string") {
+        throw new Error("Missing logical child announcement");
+      }
+      return id;
+    }
+    return { socket, handlers, send, request, attach, autoAttach, child };
+  }
+  function commands(method: string) {
+    return extension.socket.frames().filter((frame) => frame.method === method);
+  }
+  return {
+    bridge,
+    extension,
+    event,
+    client,
+    commands,
+    revokeAccess: () => {
+      accessAllowed = false;
+    },
+    hold: (method = "Runtime.enable") => {
+      heldMethod = method;
+    },
+    release: () => {
+      heldMethod = undefined;
+      for (const seq of held.splice(0)) {
+        extension.handlers.onMessage(JSON.stringify({ type: "result", seq, result: {} }));
+      }
+    },
+  };
+}
+
+export function createdRuntimeContexts(socket: FakeSocket, sessionId: string) {
+  return socket
+    .frames()
+    .filter(
+      (frame) =>
+        frame.sessionId === sessionId && frame.method === "Runtime.executionContextCreated",
+    );
+}
+
+export function expectContextBeforeResult(
+  socket: FakeSocket,
+  sessionId: string,
+  id: unknown,
+  contexts = [runtimeContext(1)],
+) {
+  const frames = socket.frames();
+  const resultIndex = frames.findIndex((frame) => frame.id === id);
+  expect(resultIndex).toBeGreaterThanOrEqual(0);
+  expect(createdRuntimeContexts(socket, sessionId).map((frame) => frame.params)).toEqual(
+    contexts.map((value) => ({ context: value })),
+  );
+  for (const frame of createdRuntimeContexts(socket, sessionId)) {
+    expect(frames.indexOf(frame)).toBeLessThan(resultIndex);
+  }
+}

--- a/extensions/browser/src/browser/extension-relay/relay-runtime.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-runtime.test.ts
@@ -8,202 +8,180 @@ import {
   sendHello,
   wireExtension,
 } from "./relay-bridge.test-support.js";
-
-function context(id: number) {
-  return {
-    id,
-    uniqueId: `context-${id}`,
-    origin: "https://example.com",
-    name: "",
-    auxData: { isDefault: true, frameId: "target-1" },
-  };
-}
-
-function fixture() {
-  const bridge = new ExtensionRelayBridge();
-  onTestFinished(() => bridge.dispose());
-  const enabled = new Set<string>();
-  const held: number[] = [];
-  let heldMethod: string | undefined;
-  let accessAllowed = true;
-  let contextOffset = -10;
-  const extension = wireExtension(bridge, (msg) => {
-    if (msg.type === "ping") {
-      return null;
-    }
-    if (msg.type === "attach") {
-      enabled.clear();
-      contextOffset += 10;
-      return { type: "result", seq: msg.seq, result: { targetId: `target-${msg.tabId}` } };
-    }
-    if (msg.type === "cdp") {
-      const key = msg.sessionId ?? "root";
-      if (msg.method === "Runtime.enable") {
-        if (!accessAllowed) {
-          return { type: "error", seq: msg.seq, message: "tab access was revoked" };
-        }
-        // V8 reports existing contexts only on the physical disabled -> enabled transition.
-        if (!enabled.has(key)) {
-          enabled.add(key);
-          event(
-            "Runtime.executionContextCreated",
-            { context: context(key === "root" ? 1 + contextOffset : 2) },
-            msg.sessionId,
-          );
-        }
-      }
-      if (msg.method === "Runtime.disable") {
-        enabled.delete(key);
-      }
-      if (msg.method === heldMethod) {
-        held.push(msg.seq);
-        return null;
-      }
-    }
-    return { type: "result", seq: msg.seq, result: {} };
-  });
-  function event(method: string, params: unknown, sessionId?: string) {
-    extension.handlers.onMessage(
-      JSON.stringify({ type: "cdpEvent", tabId: 1, sessionId, method, params }),
-    );
-  }
-  sendHello(extension.handlers);
-  function client() {
-    const socket = new FakeSocket();
-    const handlers = bridge.attachCdpClientSocket(socket);
-    let nextId = 1;
-    function send(method: string, sessionId?: string, params?: Record<string, unknown>) {
-      const id = nextId++;
-      handlers.onMessage(JSON.stringify({ id, method, sessionId, params }));
-      return id;
-    }
-    async function request(method: string, sessionId?: string, params?: Record<string, unknown>) {
-      const id = send(method, sessionId, params);
-      await flush();
-      const response = socket.frames().find((frame) => frame.id === id);
-      expect(response, method).toBeDefined();
-      return response!;
-    }
-    async function attach() {
-      const response = await request("Target.setAutoAttach", undefined, { autoAttach: true });
-      expect(response.error).toBeUndefined();
-      const announcement = socket
-        .frames()
-        .findLast((frame) => frame.method === "Target.attachedToTarget");
-      if (!announcement) {
-        throw new Error("Missing Target.attachedToTarget announcement");
-      }
-      const { sessionId } = announcement.params as { sessionId: string };
-      return sessionId;
-    }
-    async function autoAttach(parent: string) {
-      expect(
-        (
-          await request("Target.setAutoAttach", parent, {
-            autoAttach: true,
-            waitForDebuggerOnStart: true,
-            flatten: true,
-          })
-        ).error,
-      ).toBeUndefined();
-    }
-    function child(targetId: string, parent?: string) {
-      const announcement = socket
-        .frames()
-        .findLast(
-          (frame) =>
-            frame.method === "Target.attachedToTarget" &&
-            (parent === undefined || frame.sessionId === parent) &&
-            asOptionalRecord(asOptionalRecord(frame.params)?.targetInfo)?.targetId === targetId,
-        );
-      const id = asOptionalRecord(announcement?.params)?.sessionId;
-      if (typeof id !== "string") {
-        throw new Error("Missing logical child announcement");
-      }
-      return id;
-    }
-    return { socket, handlers, send, request, attach, autoAttach, child };
-  }
-  function commands(method: string) {
-    return extension.socket.frames().filter((frame) => frame.method === method);
-  }
-  return {
-    bridge,
-    extension,
-    event,
-    client,
-    commands,
-    revokeAccess: () => {
-      accessAllowed = false;
-    },
-    hold: (method = "Runtime.enable") => {
-      heldMethod = method;
-    },
-    release: () => {
-      heldMethod = undefined;
-      for (const seq of held.splice(0)) {
-        extension.handlers.onMessage(JSON.stringify({ type: "result", seq, result: {} }));
-      }
-    },
-  };
-}
-
-function created(socket: FakeSocket, sessionId: string) {
-  return socket
-    .frames()
-    .filter(
-      (frame) =>
-        frame.sessionId === sessionId && frame.method === "Runtime.executionContextCreated",
-    );
-}
-
-function expectContextBeforeResult(
-  socket: FakeSocket,
-  sessionId: string,
-  id: unknown,
-  contexts = [context(1)],
-) {
-  const frames = socket.frames();
-  const resultIndex = frames.findIndex((frame) => frame.id === id);
-  expect(resultIndex).toBeGreaterThanOrEqual(0);
-  expect(created(socket, sessionId).map((frame) => frame.params)).toEqual(
-    contexts.map((value) => ({ context: value })),
-  );
-  for (const frame of created(socket, sessionId)) {
-    expect(frames.indexOf(frame)).toBeLessThan(resultIndex);
-  }
-}
+import {
+  runtimeContext,
+  createdRuntimeContexts,
+  expectContextBeforeResult,
+  createRuntimeFixture,
+} from "./relay-runtime.test-support.js";
 
 describe("relay logical Runtime subscriptions", () => {
+  it("orders initial Runtime after all earlier frame reads without blocking peers or other commands", async () => {
+    const f = createRuntimeFixture();
+    const first = f.client();
+    const root = await first.attach();
+    await first.request("Runtime.enable", root);
+    const late = f.client();
+    const lateRoot = await late.attach();
+    f.hold("Page.getFrameTree");
+    const reads = [
+      late.send("Page.getFrameTree", lateRoot),
+      late.send("Page.getFrameTree", lateRoot),
+    ];
+    const enable = late.send("Runtime.enable", lateRoot);
+    await flush();
+    expect(f.commands("Runtime.enable")).toHaveLength(1);
+    // A blocked evaluation can need dialog/Fetch commands to finish. There is no
+    // general CDP queue, even for the logical session waiting on its frame snapshot.
+    await late.request("Page.handleJavaScriptDialog", lateRoot, { accept: true });
+    await late.request("Fetch.enable", lateRoot, { patterns: [{ urlPattern: "*" }] });
+    f.event("Fetch.requestPaused", {
+      requestId: "native-request",
+      request: { url: "https://example.com/blocked", method: "GET", headers: {} },
+      frameId: "target-1",
+      resourceType: "Document",
+    });
+    const paused = late.socket.frames().find((frame) => frame.method === "Fetch.requestPaused");
+    const requestId = asOptionalRecord(paused?.params)?.requestId;
+    expect(requestId).toBeTypeOf("string");
+    await late.request("Fetch.continueRequest", lateRoot, { requestId });
+    expect(f.commands("Fetch.continueRequest").at(-1)?.params).toEqual({
+      requestId: "native-request",
+    });
+    await first.request("Runtime.evaluate", root, { expression: "1" });
+    f.event("Runtime.executionContextCreated", { context: runtimeContext(3) });
+    f.event("Runtime.executionContextDestroyed", { executionContextId: 1 });
+    f.event("Runtime.consoleAPICalled", { type: "log", args: [] });
+    expect(createdRuntimeContexts(first.socket, root).map((frame) => frame.params)).toEqual([
+      { context: runtimeContext(1) },
+      { context: runtimeContext(3) },
+    ]);
+    expect(first.socket.frames().at(-1)).toMatchObject({ method: "Runtime.consoleAPICalled" });
+    expect(createdRuntimeContexts(late.socket, lateRoot)).toEqual([]);
+    const secondRead = f.commands("Page.getFrameTree")[1]!;
+    f.extension.handlers.onMessage(
+      JSON.stringify({ type: "result", seq: secondRead.seq, result: {} }),
+    );
+    await flush();
+    expect(late.socket.frames().find((frame) => frame.id === reads[1])).toBeDefined();
+    expect(f.commands("Runtime.enable")).toHaveLength(1);
+    f.release();
+    await flush();
+    expectContextBeforeResult(late.socket, lateRoot, enable, [runtimeContext(3)]);
+    const frames = late.socket.frames();
+    const contextIndex = frames.findIndex(
+      (frame) => frame.method === "Runtime.executionContextCreated",
+    );
+    for (const id of reads) {
+      expect(frames.findIndex((frame) => frame.id === id)).toBeLessThan(contextIndex);
+    }
+    await late.request("Runtime.enable", lateRoot);
+    expect(createdRuntimeContexts(late.socket, lateRoot)).toHaveLength(1);
+    // Once enabled, a later frame snapshot must not suppress live Runtime events.
+    f.hold("Page.getFrameTree");
+    late.send("Page.getFrameTree", lateRoot);
+    await flush();
+    f.event("Runtime.executionContextCreated", { context: runtimeContext(4) });
+    expect(createdRuntimeContexts(late.socket, lateRoot).at(-1)?.params).toEqual({
+      context: runtimeContext(4),
+    });
+    f.release();
+    await flush();
+  });
+
+  it("rechecks worker access before replay after a delayed frame-tree reply", async () => {
+    const f = createRuntimeFixture();
+    const peer = f.client();
+    await peer.request("Runtime.enable", await peer.attach());
+    const late = f.client();
+    const root = await late.attach();
+    f.hold("Page.getFrameTree");
+    late.send("Page.getFrameTree", root);
+    const enable = late.send("Runtime.enable", root);
+    await flush();
+    f.revokeAccess();
+    f.release();
+    await flush();
+    expect(late.socket.frames().find((frame) => frame.id === enable)?.error).toMatchObject({
+      message: "tab access was revoked",
+    });
+    expect(createdRuntimeContexts(late.socket, root)).toEqual([]);
+  });
+
+  it.each(["disable", "detach", "socket close", "revoke", "replacement", "native detach"])(
+    "fences an enable waiting for frame publication after %s",
+    async (ending) => {
+      const f = createRuntimeFixture();
+      const peer = f.client();
+      const peerRoot = await peer.attach();
+      await peer.request("Runtime.enable", peerRoot);
+      const c = f.client();
+      const root = await c.attach();
+      f.hold("Page.getFrameTree");
+      c.send("Page.getFrameTree", root);
+      const enable = c.send("Runtime.enable", root);
+      await flush();
+      expect(f.commands("Runtime.enable")).toHaveLength(1);
+      if (ending === "disable") {
+        await c.request("Runtime.disable", root);
+      } else if (ending === "detach") {
+        await c.request("Target.detachFromTarget", undefined, { sessionId: root });
+      } else if (ending === "socket close") {
+        await c.handlers.onClose();
+      } else if (ending === "revoke") {
+        f.extension.handlers.onMessage(JSON.stringify({ type: "tabs", tabs: [] }));
+      } else if (ending === "replacement") {
+        sendHello(wireExtension(f.bridge).handlers);
+      } else {
+        f.extension.handlers.onMessage(
+          JSON.stringify({ type: "detached", tabId: 1, reason: "target_closed" }),
+        );
+      }
+      f.release();
+      await flush();
+      expect(f.commands("Runtime.enable")).toHaveLength(1);
+      expect(createdRuntimeContexts(c.socket, root)).toEqual([]);
+      if (ending === "socket close") {
+        expect(c.socket.frames().find((frame) => frame.id === enable)).toBeUndefined();
+      } else {
+        expect(c.socket.frames().find((frame) => frame.id === enable)?.error).toBeDefined();
+      }
+      if (ending === "disable") {
+        const current = await c.request("Runtime.enable", root);
+        expectContextBeforeResult(c.socket, root, current.id);
+      }
+    },
+  );
+
   it("delivers the live default context to a late client before enable completes without replaying to established clients", async () => {
-    const f = fixture();
+    const f = createRuntimeFixture();
     const first = f.client();
     const root = await first.attach();
     const firstEnable = await first.request("Runtime.enable", root);
     expectContextBeforeResult(first.socket, root, firstEnable.id);
     const late = f.client();
     const lateRoot = await late.attach();
-    expect(created(late.socket, lateRoot)).toEqual([]);
+    expect(createdRuntimeContexts(late.socket, lateRoot)).toEqual([]);
     const lateEnable = await late.request("Runtime.enable", lateRoot);
     expectContextBeforeResult(late.socket, lateRoot, lateEnable.id);
     await first.request("Runtime.enable", root);
-    expect(created(first.socket, root)).toHaveLength(1);
+    expect(createdRuntimeContexts(first.socket, root)).toHaveLength(1);
     expect(f.commands("Runtime.enable")).toHaveLength(3);
   });
 
   it.each(["Runtime.executionContextDestroyed", "Runtime.executionContextsCleared"])(
     "never replays retired contexts after %s",
     async (method) => {
-      const f = fixture();
+      const f = createRuntimeFixture();
       const first = f.client();
       const root = await first.attach();
       await first.request("Runtime.enable", root);
       f.event(method, { executionContextId: 1, executionContextUniqueId: "context-1" });
-      f.event("Runtime.executionContextCreated", { context: context(3) });
+      f.event("Runtime.executionContextCreated", { context: runtimeContext(3) });
       const late = f.client();
       const lateRoot = await late.attach();
       const response = await late.request("Runtime.enable", lateRoot);
-      expectContextBeforeResult(late.socket, lateRoot, response.id, [context(3)]);
+      expectContextBeforeResult(late.socket, lateRoot, response.id, [runtimeContext(3)]);
       expect(first.socket.frames()).toContainEqual({
         method,
         sessionId: root,
@@ -213,7 +191,7 @@ describe("relay logical Runtime subscriptions", () => {
   );
 
   it("admits each concurrent enable and delivers each context once to new subscribers", async () => {
-    const f = fixture();
+    const f = createRuntimeFixture();
     const first = f.client();
     const second = f.client();
     const root = await first.attach();
@@ -238,7 +216,7 @@ describe("relay logical Runtime subscriptions", () => {
   it.each(["Runtime.disable", "Target.detachFromTarget", "socket close"])(
     "keeps the other client's Runtime alive after %s",
     async (operation) => {
-      const f = fixture();
+      const f = createRuntimeFixture();
       const first = f.client();
       const second = f.client();
       const root = await first.attach();
@@ -253,9 +231,11 @@ describe("relay logical Runtime subscriptions", () => {
         await first.request(operation, undefined, { sessionId: root });
       }
       const before = first.socket.frames().length;
-      f.event("Runtime.executionContextCreated", { context: context(3) });
+      f.event("Runtime.executionContextCreated", { context: runtimeContext(3) });
       expect(first.socket.frames()).toHaveLength(before);
-      expect(created(second.socket, secondRoot).at(-1)?.params).toEqual({ context: context(3) });
+      expect(createdRuntimeContexts(second.socket, secondRoot).at(-1)?.params).toEqual({
+        context: runtimeContext(3),
+      });
       expect(f.commands("Runtime.disable")).toEqual([]);
       expect(f.extension.socket.frames().filter((frame) => frame.type === "detach")).toEqual([]);
       expect(
@@ -272,7 +252,7 @@ describe("relay logical Runtime subscriptions", () => {
   it.each([false, true])(
     "gives explicit page attachments independent subscriptions (browser parent=%s)",
     async (browserParent) => {
-      const f = fixture();
+      const f = createRuntimeFixture();
       const c = f.client();
       const root = await c.attach();
       await c.request("Runtime.enable", root);
@@ -295,7 +275,7 @@ describe("relay logical Runtime subscriptions", () => {
           waitingForDebugger: false,
         },
       });
-      expect(created(c.socket, alias)).toEqual([]);
+      expect(createdRuntimeContexts(c.socket, alias)).toEqual([]);
       const enabled = await c.request("Runtime.enable", alias);
       expectContextBeforeResult(c.socket, alias, enabled.id);
       await c.request("Runtime.disable", alias);
@@ -318,7 +298,7 @@ describe("relay logical Runtime subscriptions", () => {
   );
 
   it("routes real child contexts separately and retires child routing on detach, including pending enables", async () => {
-    const f = fixture();
+    const f = createRuntimeFixture();
     const c = f.client();
     const root = await c.attach();
     await c.request("Runtime.enable", root);
@@ -333,13 +313,15 @@ describe("relay logical Runtime subscriptions", () => {
     const pending = c.send("Runtime.enable", child);
     await flush();
     f.event("Target.detachedFromTarget", { sessionId: "child", targetId: "frame" });
-    f.event("Runtime.executionContextCreated", { context: context(4) }, "child");
+    f.event("Runtime.executionContextCreated", { context: runtimeContext(4) }, "child");
     f.release();
     await flush();
     expect(c.socket.frames().find((frame) => frame.id === pending)?.error).toBeDefined();
-    expect(created(c.socket, root).map((frame) => frame.params)).toEqual([{ context: context(1) }]);
+    expect(createdRuntimeContexts(c.socket, root).map((frame) => frame.params)).toEqual([
+      { context: runtimeContext(1) },
+    ]);
     expect(
-      created(c.socket, child).some(
+      createdRuntimeContexts(c.socket, child).some(
         (frame) => (frame.params as { context: { id: number } }).context.id === 4,
       ),
     ).toBe(false);
@@ -350,7 +332,7 @@ describe("relay logical Runtime subscriptions", () => {
   it.each([false, true])(
     "keeps child Runtime subscriptions independent and routes detach to their parent (alias only=%s)",
     async (aliasOnly) => {
-      const f = fixture();
+      const f = createRuntimeFixture();
       const first = f.client();
       const root = await first.attach();
       const second = f.client();
@@ -385,17 +367,19 @@ describe("relay logical Runtime subscriptions", () => {
       });
       await first.request("Runtime.enable", firstChild);
       const response = await second.request("Runtime.enable", secondChild);
-      expectContextBeforeResult(second.socket, secondChild, response.id, [context(2)]);
-      expect(created(first.socket, firstChild)).toHaveLength(1);
+      expectContextBeforeResult(second.socket, secondChild, response.id, [runtimeContext(2)]);
+      expect(createdRuntimeContexts(first.socket, firstChild)).toHaveLength(1);
       await first.request("Target.detachFromTarget", root, { sessionId: firstChild });
       expect(first.socket.frames()).toContainEqual({
         sessionId: root,
         method: "Target.detachedFromTarget",
         params: { sessionId: firstChild, targetId: "frame" },
       });
-      f.event("Runtime.executionContextCreated", { context: context(4) }, "child");
-      expect(created(first.socket, firstChild)).toHaveLength(1);
-      expect(created(second.socket, secondChild).at(-1)?.params).toEqual({ context: context(4) });
+      f.event("Runtime.executionContextCreated", { context: runtimeContext(4) }, "child");
+      expect(createdRuntimeContexts(first.socket, firstChild)).toHaveLength(1);
+      expect(createdRuntimeContexts(second.socket, secondChild).at(-1)?.params).toEqual({
+        context: runtimeContext(4),
+      });
       f.event("Target.detachedFromTarget", { sessionId: "child", targetId: "frame" });
       expect(second.socket.frames()).toContainEqual({
         sessionId: secondRoot,
@@ -437,7 +421,7 @@ describe("relay logical Runtime subscriptions", () => {
   });
 
   it("rejects unannounced and foreign root, alias, browser and child sessions without forwarding", async () => {
-    const f = fixture();
+    const f = createRuntimeFixture();
     const owner = f.client();
     const root = await owner.attach();
     const browser = (
@@ -469,7 +453,7 @@ describe("relay logical Runtime subscriptions", () => {
   });
 
   it("does not resume a disabled or closed client's pending enable or accept messages after close", async () => {
-    const f = fixture();
+    const f = createRuntimeFixture();
     const closed = f.client();
     const live = f.client();
     const root = await closed.attach();
@@ -488,21 +472,21 @@ describe("relay logical Runtime subscriptions", () => {
     expect(closed.socket.frames()).toHaveLength(before);
     expect(f.commands("Runtime.evaluate")).toEqual([]);
     expect(live.socket.frames().find((frame) => frame.id === pending)?.error).toBeDefined();
-    const eventsBefore = created(live.socket, liveRoot).length;
-    f.event("Runtime.executionContextCreated", { context: context(3) });
-    expect(created(live.socket, liveRoot)).toHaveLength(eventsBefore);
+    const eventsBefore = createdRuntimeContexts(live.socket, liveRoot).length;
+    f.event("Runtime.executionContextCreated", { context: runtimeContext(3) });
+    expect(createdRuntimeContexts(live.socket, liveRoot)).toHaveLength(eventsBefore);
     await live.request("Runtime.enable", liveRoot);
     expect(
-      created(live.socket, liveRoot)
+      createdRuntimeContexts(live.socket, liveRoot)
         .slice(eventsBefore)
         .map((frame) => frame.params),
-    ).toEqual([{ context: context(1) }, { context: context(3) }]);
+    ).toEqual([{ context: runtimeContext(1) }, { context: runtimeContext(3) }]);
   });
 
   it.each(["revoke", "detach", "replacement", "loss", "shutdown"])(
     "retires context inventory and pending work on %s",
     async (kind) => {
-      const f = fixture();
+      const f = createRuntimeFixture();
       const c = f.client();
       const root = await c.attach();
       f.hold();
@@ -526,7 +510,7 @@ describe("relay logical Runtime subscriptions", () => {
         f.bridge.dispose();
       }
       const before = c.socket.frames().length;
-      f.event("Runtime.executionContextCreated", { context: context(9) });
+      f.event("Runtime.executionContextCreated", { context: runtimeContext(9) });
       f.release();
       await flush();
       if (kind === "shutdown") {
@@ -535,7 +519,7 @@ describe("relay logical Runtime subscriptions", () => {
       }
       expect(c.socket.frames().find((frame) => frame.id === pending)?.error).toBeDefined();
       expect(
-        created(c.socket, root).some(
+        createdRuntimeContexts(c.socket, root).some(
           (frame) => (frame.params as { context: { id: number } }).context.id === 9,
         ),
       ).toBe(false);
@@ -548,8 +532,8 @@ describe("relay logical Runtime subscriptions", () => {
       const next = await c.attach();
       expect(next).not.toBe(root);
       await c.request("Runtime.enable", next);
-      expect(created(c.socket, next).map((frame) => frame.params)).toEqual(
-        kind === "revoke" || kind === "detach" ? [{ context: context(11) }] : [],
+      expect(createdRuntimeContexts(c.socket, next).map((frame) => frame.params)).toEqual(
+        kind === "revoke" || kind === "detach" ? [{ context: runtimeContext(11) }] : [],
       );
     },
   );
@@ -561,7 +545,7 @@ describe("relay logical Runtime subscriptions", () => {
     "access loss",
     "bridge disposal",
   ])("retires every logical target identity on %s", async (ending) => {
-    const f = fixture();
+    const f = createRuntimeFixture();
     const c = f.client();
     const root = await c.attach();
     const browser = asOptionalRecord(
@@ -650,7 +634,7 @@ describe("relay logical Runtime subscriptions", () => {
   it.each([undefined, "unrelated-target"])(
     "uses owned child identities when detach carries %s",
     async (targetId) => {
-      const f = fixture();
+      const f = createRuntimeFixture();
       const c = f.client();
       const root = await c.attach();
       await c.request("Runtime.enable", root);
@@ -684,12 +668,12 @@ describe("relay logical Runtime subscriptions", () => {
       ]);
       expect((await c.request("Page.getFrameTree", root)).error).toBeUndefined();
       expect(f.extension.socket.frames().filter((frame) => frame.type === "detach")).toEqual([]);
-      expect(created(c.socket, root)).toHaveLength(1);
+      expect(createdRuntimeContexts(c.socket, root)).toHaveLength(1);
     },
   );
 
   it("requires current worker admission before replaying a cached Runtime to a new logical owner", async () => {
-    const f = fixture();
+    const f = createRuntimeFixture();
     const first = f.client();
     const root = await first.attach();
     await first.request("Runtime.enable", root);
@@ -699,8 +683,8 @@ describe("relay logical Runtime subscriptions", () => {
     f.revokeAccess();
     const denied = await late.request("Runtime.enable", lateRoot);
     expect.soft(denied.error).toMatchObject({ message: "tab access was revoked" });
-    expect.soft(created(late.socket, lateRoot)).toEqual([]);
-    expect(created(first.socket, root)).toHaveLength(1);
+    expect.soft(createdRuntimeContexts(late.socket, lateRoot)).toEqual([]);
+    expect(createdRuntimeContexts(first.socket, root)).toHaveLength(1);
     expect(f.commands("Runtime.enable")).toHaveLength(2);
     expect(first.socket.closed).toBe(false);
     expect(late.socket.closed).toBe(false);
@@ -708,24 +692,24 @@ describe("relay logical Runtime subscriptions", () => {
   });
 
   it("delivers live events during admission and replays only undelivered current contexts after success", async () => {
-    const f = fixture();
+    const f = createRuntimeFixture();
     const first = f.client();
     const root = await first.attach();
     await first.request("Runtime.enable", root);
-    f.event("Runtime.executionContextCreated", { context: context(2) });
+    f.event("Runtime.executionContextCreated", { context: runtimeContext(2) });
     const late = f.client();
     const lateRoot = await late.attach();
     f.hold();
     const pending = late.send("Runtime.enable", lateRoot);
     await flush();
-    expect.soft(created(late.socket, lateRoot)).toEqual([]);
+    expect.soft(createdRuntimeContexts(late.socket, lateRoot)).toEqual([]);
     expect.soft(late.socket.frames().find((frame) => frame.id === pending)).toBeUndefined();
-    f.event("Runtime.executionContextCreated", { context: context(3) });
+    f.event("Runtime.executionContextCreated", { context: runtimeContext(3) });
     f.event("Runtime.consoleAPICalled", { type: "log", args: [] });
     f.event("Runtime.executionContextDestroyed", { executionContextId: 1 });
     expect
-      .soft(created(late.socket, lateRoot).map((frame) => frame.params))
-      .toEqual([{ context: context(3) }]);
+      .soft(createdRuntimeContexts(late.socket, lateRoot).map((frame) => frame.params))
+      .toEqual([{ context: runtimeContext(3) }]);
     expect(late.socket.frames()).toContainEqual({
       sessionId: lateRoot,
       method: "Runtime.consoleAPICalled",
@@ -733,14 +717,17 @@ describe("relay logical Runtime subscriptions", () => {
     });
     f.release();
     await flush();
-    expectContextBeforeResult(late.socket, lateRoot, pending, [context(3), context(2)]);
-    expect(created(first.socket, root)).toHaveLength(3);
+    expectContextBeforeResult(late.socket, lateRoot, pending, [
+      runtimeContext(3),
+      runtimeContext(2),
+    ]);
+    expect(createdRuntimeContexts(first.socket, root)).toHaveLength(3);
   });
 
   it.each([false, true])(
     "preserves native binding callbacks independently of Runtime enable (disabled=%s)",
     async (disabled) => {
-      const f = fixture();
+      const f = createRuntimeFixture();
       const client = f.client();
       const root = await client.attach();
       const peer = f.client();
@@ -773,7 +760,7 @@ describe("relay logical Runtime subscriptions", () => {
   it.each(["Runtime.removeBinding", "Target.detachFromTarget", "socket close"])(
     "preserves a peer's same-name binding after %s and removes the final native registration",
     async (operation) => {
-      const f = fixture();
+      const f = createRuntimeFixture();
       const first = f.client();
       const firstRoot = await first.attach();
       const second = f.client();
@@ -821,7 +808,7 @@ describe("relay logical Runtime subscriptions", () => {
   it.each([false, true])(
     "cleans up a native add admitted after logical close (peer owns same name=%s)",
     async (sameName) => {
-      const f = fixture();
+      const f = createRuntimeFixture();
       const first = f.client();
       const firstRoot = await first.attach();
       const second = f.client();
@@ -853,7 +840,7 @@ describe("relay logical Runtime subscriptions", () => {
   it.each(["Runtime.addBinding", "Runtime.removeBinding"])(
     "preserves acknowledged binding ownership when native %s fails",
     async (method) => {
-      const f = fixture();
+      const f = createRuntimeFixture();
       const client = f.client();
       const root = await client.attach();
       const name = "failedBinding";
@@ -886,7 +873,7 @@ describe("relay logical Runtime subscriptions", () => {
   );
 
   it("keeps a replacement physical session independent of pending retired bindings", async () => {
-    const f = fixture();
+    const f = createRuntimeFixture();
     const client = f.client();
     const root = await client.attach();
     const name = "retiredBinding";
@@ -914,7 +901,7 @@ describe("relay logical Runtime subscriptions", () => {
   });
 
   it("keeps a concurrent admission alive when another enable for the same logical owner fails", async () => {
-    const f = fixture();
+    const f = createRuntimeFixture();
     const c = f.client();
     const root = await c.attach();
     f.hold();
@@ -935,8 +922,8 @@ describe("relay logical Runtime subscriptions", () => {
     await flush();
     expect(c.socket.frames().find((frame) => frame.id === admitted)).toMatchObject({ result: {} });
     expectContextBeforeResult(c.socket, root, admitted);
-    f.event("Runtime.executionContextCreated", { context: context(3) });
-    expect(created(c.socket, root)).toHaveLength(2);
+    f.event("Runtime.executionContextCreated", { context: runtimeContext(3) });
+    expect(createdRuntimeContexts(c.socket, root)).toHaveLength(2);
     expect(f.commands("Runtime.disable")).toEqual([]);
   });
 });

--- a/extensions/browser/src/browser/extension-relay/relay-runtime.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-runtime.test.ts
@@ -246,7 +246,7 @@ describe("relay logical Runtime subscriptions", () => {
       await first.request("Runtime.enable", root);
       await second.request("Runtime.enable", secondRoot);
       if (operation === "socket close") {
-        first.handlers.onClose();
+        await first.handlers.onClose();
       } else if (operation === "Runtime.disable") {
         await first.request(operation, root);
       } else {
@@ -420,7 +420,7 @@ describe("relay logical Runtime subscriptions", () => {
     );
     const attach = extension.frames().find((frame) => frame.type === "attach");
     expect(attach).toBeDefined();
-    client.onClose();
+    const closing = client.onClose();
     ext.onMessage(
       JSON.stringify({ type: "result", seq: attach!.seq, result: { targetId: "target-1" } }),
     );
@@ -431,6 +431,9 @@ describe("relay logical Runtime subscriptions", () => {
     await flush();
     expect(socket.frames()).toEqual([]);
     expect(extension.frames().filter((frame) => frame.type === "detach")).toHaveLength(1);
+    const detach = extension.frames().find((frame) => frame.type === "detach");
+    ext.onMessage(JSON.stringify({ type: "result", seq: detach?.seq, result: {} }));
+    await closing;
   });
 
   it("rejects unannounced and foreign root, alias, browser and child sessions without forwarding", async () => {
@@ -475,11 +478,12 @@ describe("relay logical Runtime subscriptions", () => {
     closed.send("Runtime.enable", root);
     const pending = live.send("Runtime.enable", liveRoot);
     await flush();
-    closed.handlers.onClose();
+    const closing = closed.handlers.onClose();
     await live.request("Runtime.disable", liveRoot);
     const before = closed.socket.frames().length;
     closed.send("Runtime.evaluate", root);
     f.release();
+    await closing;
     await flush();
     expect(closed.socket.frames()).toHaveLength(before);
     expect(f.commands("Runtime.evaluate")).toEqual([]);
@@ -786,7 +790,7 @@ describe("relay logical Runtime subscriptions", () => {
       await observer.request("Runtime.removeBinding", observerRoot, { name });
       expect(f.commands("Runtime.removeBinding")).toHaveLength(0);
       if (operation === "socket close") {
-        first.handlers.onClose();
+        await first.handlers.onClose();
         await flush();
       } else if (operation === "Target.detachFromTarget") {
         await first.request(operation, undefined, { sessionId: firstRoot });
@@ -829,8 +833,9 @@ describe("relay logical Runtime subscriptions", () => {
       f.hold("Runtime.addBinding");
       const pending = first.send("Runtime.addBinding", firstRoot, { name });
       await flush();
-      first.handlers.onClose();
+      const closing = first.handlers.onClose();
       f.release();
+      await closing;
       await flush();
       expect(first.socket.frames().find((frame) => frame.id === pending)).toBeUndefined();
       expect(f.commands("Runtime.removeBinding")).toHaveLength(sameName ? 0 : 1);

--- a/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
@@ -390,6 +390,20 @@ describe.sequential("extension relay HTTP auth v2", () => {
     connection.close();
   });
 
+  it("closes malformed WebSocket framing before authentication without an unowned error", async () => {
+    handle = await startExtensionRelayServer({ port: 0, token: KEY, allowLegacyAuth: false });
+    const issueChallenge = vi.spyOn(getBrowserRelayAuthV2Authority(KEY), "issueChallenge");
+    // Client frames must be masked. This fails inside ws, before the auth parser.
+    const response = await sendRawV2Frames({
+      port: handle.port,
+      subsequentFrames: [Buffer.from([0x81, 0x00])],
+    });
+    expect(response).toContain("101 Switching Protocols");
+    expect(response).not.toContain("auth.challenge");
+    expect(issueChallenge).not.toHaveBeenCalled();
+    expect(handle.bridge.extensionConnected).toBe(false);
+  });
+
   it.each([
     {
       name: "an oversized first auth message",

--- a/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
@@ -22,6 +22,7 @@ import {
   parseRelayAuthHello,
   parseStrictJsonObject,
 } from "./auth-v2.js";
+import { RawHttpConnection } from "./relay-http.test-support.js";
 import {
   authenticateExtensionWebSocket,
   startExtensionRelayServer,
@@ -29,113 +30,6 @@ import {
 } from "./relay-server.js";
 
 const KEY = "0123456789abcdef".repeat(4);
-
-type RawResponse = {
-  status: number;
-  headers: Record<string, string>;
-  body: string;
-};
-
-class RawHttpConnection {
-  private buffer = Buffer.alloc(0);
-  private readonly waiters: Array<() => void> = [];
-
-  private constructor(readonly socket: net.Socket) {
-    socket.on("data", (chunk) => {
-      this.buffer = Buffer.concat([
-        this.buffer,
-        Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
-      ]);
-      this.waiters.splice(0).forEach((resolve) => resolve());
-    });
-  }
-
-  static async connect(port: number): Promise<RawHttpConnection> {
-    const socket = net.createConnection({ host: "127.0.0.1", port });
-    await new Promise<void>((resolve, reject) => {
-      socket.once("connect", resolve);
-      socket.once("error", reject);
-    });
-    return new RawHttpConnection(socket);
-  }
-
-  async request(
-    method: string,
-    requestPath: string,
-    body = "",
-    headers: Record<string, string> = {},
-  ): Promise<RawResponse> {
-    this.socket.write(
-      [
-        `${method} ${requestPath} HTTP/1.1`,
-        "Host: 127.0.0.1",
-        "Connection: keep-alive",
-        `Content-Length: ${Buffer.byteLength(body)}`,
-        ...Object.entries(headers).map(([key, value]) => `${key}: ${value}`),
-        "",
-        body,
-      ].join("\r\n"),
-    );
-    return await this.readResponse();
-  }
-
-  async upgrade(requestPath: string): Promise<RawResponse> {
-    this.socket.write(
-      [
-        `GET ${requestPath} HTTP/1.1`,
-        "Host: 127.0.0.1",
-        "Connection: Upgrade",
-        "Upgrade: websocket",
-        "Sec-WebSocket-Version: 13",
-        "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
-        "",
-        "",
-      ].join("\r\n"),
-    );
-    return await this.readResponse({ headersOnly: true });
-  }
-
-  private async waitForData(): Promise<void> {
-    if (this.socket.destroyed) {
-      throw new Error("socket closed before response completed");
-    }
-    await new Promise<void>((resolve) => {
-      this.waiters.push(resolve);
-    });
-  }
-
-  private async readResponse(options: { headersOnly?: boolean } = {}): Promise<RawResponse> {
-    let headerEnd = this.buffer.indexOf("\r\n\r\n");
-    while (headerEnd < 0) {
-      await this.waitForData();
-      headerEnd = this.buffer.indexOf("\r\n\r\n");
-    }
-    const headerText = this.buffer.subarray(0, headerEnd).toString("utf8");
-    const [statusLine, ...headerLines] = headerText.split("\r\n");
-    const headers = Object.fromEntries(
-      headerLines.map((line) => {
-        const separator = line.indexOf(":");
-        return [line.slice(0, separator).toLowerCase(), line.slice(separator + 1).trim()];
-      }),
-    );
-    const contentLength = options.headersOnly ? 0 : Number(headers["content-length"] ?? 0);
-    const responseLength = headerEnd + 4 + contentLength;
-    while (this.buffer.length < responseLength) {
-      await this.waitForData();
-    }
-    const body = this.buffer.subarray(headerEnd + 4, responseLength).toString("utf8");
-    this.buffer = this.buffer.subarray(responseLength);
-    return {
-      status: Number(/^HTTP\/1\.1 (\d+)/u.exec(statusLine ?? "")?.[1] ?? 0),
-      headers,
-      body,
-    };
-  }
-
-  close(): void {
-    this.socket.destroy();
-  }
-}
 
 async function authenticate(
   connection: RawHttpConnection,

--- a/extensions/browser/src/browser/extension-relay/relay-server.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.ts
@@ -8,9 +8,11 @@ import {
   readRequestBodyWithLimit,
   WEBHOOK_BODY_READ_DEFAULTS,
 } from "openclaw/plugin-sdk/webhook-ingress";
-import { WebSocketServer, type RawData, type WebSocket } from "ws";
+import { WebSocketServer, type WebSocket } from "ws";
 import { isLoopbackHost } from "../../gateway/net.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { randomRelayId } from "./auth-v2-crypto.js";
+import { authenticateExtensionWebSocket } from "./auth-v2-websocket.js";
 import {
   BROWSER_RELAY_AUTH_CHALLENGE_PATH,
   BROWSER_RELAY_AUTH_COMPLETE_PATH,
@@ -19,18 +21,14 @@ import {
   getBrowserRelayAuthV2Authority,
   invalidateBrowserRelayAuthV2Authority,
   parseExtensionRelayResource,
-  parseRelayAuthHello,
-  parseRelayAuthResponse,
   parseRelayHttpChallengeRequest,
   parseRelayHttpCompleteRequest,
   parseStrictJsonObject,
   type BrowserRelayAuthV2Authority,
 } from "./auth-v2.js";
-import {
-  boundedRawDataByteLength,
-  handlePreAuthWebSocketUpgrade,
-  MAX_WEBSOCKET_AUTH_MESSAGE_BYTES,
-} from "./preauth-websocket-guard.js";
+import { RELAY_OWNER_PATH, relayOwnerResource } from "./owner-protocol.js";
+import { attachRelayOwner } from "./owner-server.js";
+import { handlePreAuthWebSocketUpgrade } from "./preauth-websocket-guard.js";
 import { readExtensionRelayToken } from "./relay-auth.js";
 import { ExtensionRelayBridge } from "./relay-bridge.js";
 import { parseExtensionMessage } from "./relay-protocol.js";
@@ -40,6 +38,8 @@ import {
   requestExtensionProtocolToken,
   requestProtocols,
 } from "./relay-request.js";
+
+export { authenticateExtensionWebSocket } from "./auth-v2-websocket.js";
 
 const log = createSubsystemLogger("browser").child("extension-relay");
 const INTERNAL_CDP_USERNAME = "openclaw-internal";
@@ -68,6 +68,7 @@ type HttpAuthState =
     };
 
 export type ExtensionRelayHandle = {
+  ownership: "owned";
   port: number;
   token: string;
   allowLegacyAuth: boolean;
@@ -174,10 +175,14 @@ async function readAuthBody(req: IncomingMessage): Promise<string | null> {
 
 function bindSocket(
   ws: WebSocket,
-  handlers: { onMessage: (raw: string) => void; onClose: () => void },
+  handlers: { onMessage: (raw: string) => void; onClose: () => void | Promise<void> },
 ): void {
   ws.on("message", (data) => handlers.onMessage(rawDataToString(data)));
-  ws.on("close", handlers.onClose);
+  ws.on("close", () => {
+    void Promise.resolve(handlers.onClose()).catch((error: unknown) =>
+      log.warn(`Client cleanup incomplete: ${String(error)}`),
+    );
+  });
   ws.on("error", (err) => log.warn(`relay socket error: ${String(err)}`));
 }
 
@@ -218,140 +223,17 @@ export function attachExtensionWebSocket(bridge: ExtensionRelayBridge, ws: WebSo
   });
 }
 
-export function authenticateExtensionWebSocket(params: {
-  ws: WebSocket;
-  authority: BrowserRelayAuthV2Authority;
-  resource: string;
-  prepareAuthenticated: () => Promise<() => void>;
-  removePreAuthGuard?: () => void;
-}): void {
-  const { ws, authority } = params;
-  let stage: "hello" | "response" | "authenticated" | "failed" = "hello";
-  let preAuthGuardActive = true;
-  const removePreAuthGuard = () => {
-    if (!preAuthGuardActive) {
-      return;
-    }
-    preAuthGuardActive = false;
-    params.removePreAuthGuard?.();
-  };
-  const timer = setTimeout(() => {
-    stage = "failed";
-    ws.off("message", onMessage);
-    ws.close(4008, "browser relay auth timeout");
-    ws.terminate();
-  }, BROWSER_RELAY_CHALLENGE_TTL_MS);
-  timer.unref?.();
-  const release = () => {
-    clearTimeout(timer);
-    removePreAuthGuard();
-    authority.releaseConnection(ws);
-  };
-  if (
-    !authority.registerPendingConnection(ws, () => {
-      ws.close(4003, "browser relay key rotated");
-    })
-  ) {
-    clearTimeout(timer);
-    ws.close(4013, "browser relay auth capacity reached");
-    return;
-  }
-  ws.once("close", release);
-  const fail = (code: number, reason: string) => {
-    if (stage === "failed") {
-      return;
-    }
-    stage = "failed";
-    clearTimeout(timer);
-    ws.off("message", onMessage);
-    ws.close(code, reason);
-    const terminateTimer = setTimeout(() => ws.terminate(), 100);
-    terminateTimer.unref?.();
-  };
-  const onMessage = (data: RawData, isBinary: boolean) => {
-    if (isBinary) {
-      fail(4003, "binary browser relay auth frames are not allowed");
-      return;
-    }
-    if (
-      boundedRawDataByteLength(data, MAX_WEBSOCKET_AUTH_MESSAGE_BYTES) >
-      MAX_WEBSOCKET_AUTH_MESSAGE_BYTES
-    ) {
-      fail(4003, "browser relay auth frame is too large");
-      return;
-    }
-    const raw = rawDataToString(data);
-    const parsed = parseStrictJsonObject(raw);
-    if (stage === "hello") {
-      const hello = parseRelayAuthHello(parsed);
-      if (!hello) {
-        fail(4003, "invalid browser relay auth hello");
-        return;
-      }
-      const challenge = authority.issueChallenge(ws, hello, {
-        role: "extension",
-        transport: "websocket",
-        method: "GET",
-        resource: params.resource,
-        flow: "extension",
-      });
-      if (!challenge) {
-        fail(4003, "browser relay auth rejected");
-        return;
-      }
-      stage = "response";
-      ws.send(JSON.stringify(challenge));
-      return;
-    }
-    if (stage === "response") {
-      const response = parseRelayAuthResponse(parsed);
-      if (!response) {
-        fail(4003, "invalid browser relay auth response");
-        return;
-      }
-      const completed = authority.completeChallenge(ws, response);
-      if (!completed) {
-        fail(4003, "browser relay auth proof failed");
-        return;
-      }
-      stage = "authenticated";
-      // The proof deadline owns only challenge completion. Promotion is now
-      // authoritative, so cold Browser/Gateway preparation must not race it.
-      clearTimeout(timer);
-      removePreAuthGuard();
-      void params
-        .prepareAuthenticated()
-        .then((attach) => {
-          if (ws.readyState !== 1) {
-            return;
-          }
-          ws.off("message", onMessage);
-          attach();
-          ws.send(JSON.stringify(completed.ok), (err) => {
-            if (err) {
-              ws.close(1011, "browser relay auth acknowledgement failed");
-            }
-          });
-        })
-        .catch((err: unknown) => {
-          log.warn(`browser relay post-auth preparation failed: ${String(err)}`);
-          fail(1011, "browser relay unavailable after authentication");
-        });
-      return;
-    }
-    fail(4003, "unexpected browser relay auth frame");
-  };
-  ws.on("message", onMessage);
-}
-
 export async function startExtensionRelayServer(params: {
   port: number;
+  profileName?: string;
   token: string;
   allowLegacyAuth?: boolean;
   onStateChange?: () => void;
 }): Promise<ExtensionRelayHandle> {
   const allowLegacyAuth = params.allowLegacyAuth ?? true;
   const internalToken = crypto.randomBytes(32).toString("base64url");
+  const owner = randomRelayId();
+  let retired = false;
   if (readExtensionRelayToken() === params.token) {
     getBrowserRelayAuthV2Authority(params.token);
   }
@@ -363,6 +245,7 @@ export async function startExtensionRelayServer(params: {
   const httpStates = new WeakMap<Duplex, HttpAuthState>();
   const socketAuthorities = new WeakMap<Duplex, BrowserRelayAuthV2Authority>();
   const authSockets = new Set<Duplex>();
+  const ownerConnections = new Map<WebSocket, () => Promise<void>>();
 
   const currentAuthority = (): BrowserRelayAuthV2Authority | null => {
     const liveToken = readExtensionRelayToken();
@@ -590,8 +473,64 @@ export async function startExtensionRelayServer(params: {
 
   server.on("upgrade", (req, socket, head) => {
     const path = (req.url ?? "/").split("?")[0];
+    if (retired) {
+      destroySocket(socket, "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\n");
+      return;
+    }
     if (!hasLoopbackHostHeader(req)) {
       destroySocket(socket, "HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n");
+      return;
+    }
+    if (path === RELAY_OWNER_PATH) {
+      const resource = params.profileName
+        ? relayOwnerResource(resolvedPort(), params.profileName)
+        : null;
+      const authority = currentAuthority();
+      const protocols = requestProtocols(req);
+      if (
+        !resource ||
+        req.url !== resource ||
+        !authority ||
+        readExtensionRelayToken() !== params.token ||
+        retired ||
+        protocols.length !== 1 ||
+        protocols[0] !== BROWSER_RELAY_EXTENSION_SUBPROTOCOL
+      ) {
+        destroySocket(socket, "HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n");
+        return;
+      }
+      handlePreAuthWebSocketUpgrade({
+        wss,
+        req,
+        socket,
+        head,
+        onUpgrade: (ws, removePreAuthGuard) =>
+          authenticateExtensionWebSocket({
+            ws,
+            authority,
+            resource: `${resource}&owner=${owner}`,
+            binding: { role: "cdp", flow: "owner" },
+            removePreAuthGuard,
+            prepareAuthenticated: async () => () => {
+              if (retired || readExtensionRelayToken() !== params.token) {
+                throw new Error("Relay owner retired");
+              }
+              const closeOwner = attachRelayOwner({
+                ws,
+                bridge,
+                allowLegacyAuth,
+                isCurrent: () => !retired && readExtensionRelayToken() === params.token,
+              });
+              ownerConnections.set(ws, closeOwner);
+              ws.once("close", () => {
+                void closeOwner().then(
+                  () => ownerConnections.delete(ws),
+                  () => {},
+                );
+              });
+            },
+          }),
+      });
       return;
     }
     if (path === "/extension") {
@@ -697,24 +636,32 @@ export async function startExtensionRelayServer(params: {
   };
 
   return {
+    ownership: "owned",
     port: resolvedPort(),
     token: params.token,
     allowLegacyAuth,
     internalToken,
     bridge,
     close: async () => {
-      for (const socket of authSockets) {
-        clearSocketState(socket);
-        socket.destroy();
+      retired = true;
+      try {
+        await Promise.all([...ownerConnections.values()].map((closeOwner) => closeOwner()));
+      } finally {
+        // This process owns physical retirement even when native cleanup fails.
+        // Failed leases get no acknowledgement; the cleanup error still reaches the owner.
+        for (const socket of authSockets) {
+          clearSocketState(socket);
+          socket.destroy();
+        }
+        for (const client of wss.clients) {
+          client.terminate();
+        }
+        bridge.dispose();
+        wss.close();
+        await new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
       }
-      for (const client of wss.clients) {
-        client.terminate();
-      }
-      bridge.dispose();
-      wss.close();
-      await new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      });
     },
   };
 }

--- a/extensions/browser/src/browser/extension-relay/relay-session-owner.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-session-owner.ts
@@ -36,6 +36,8 @@ type LogicalSession = {
   children: Map<PhysicalSession, LogicalSession>;
   flat: boolean;
   detachedChildren: Set<PhysicalSession>;
+  frameTreeRead?: Promise<void>;
+  runtimeGeneration: number;
 };
 export type RelaySessionClient = {
   socket: { send: (data: string) => void };
@@ -161,6 +163,7 @@ export class RelaySessionOwner {
       children: new Map(),
       flat,
       detachedChildren: new Set(),
+      runtimeGeneration: 0,
     };
     client.sessions.set(sessionId, session);
     physical.subscribers.add(session);

--- a/extensions/browser/src/browser/extension-relay/relay-targets.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-targets.test.ts
@@ -146,7 +146,7 @@ describe("pending tab acquisition claims", () => {
       const first = f.client();
       await first.attach();
       const other = f.client();
-      first.close();
+      await first.close();
       await flush();
       const before = f.commands("detach").length;
       if (peer === "delivered peer") {
@@ -162,8 +162,9 @@ describe("pending tab acquisition claims", () => {
         peer === "pending peer"
           ? other.send("Target.attachToTarget", undefined, { targetId: "target-1" })
           : undefined;
-      lost.close();
+      const closing = lost.close();
       f.release();
+      await closing;
       if (waiting !== undefined) {
         expect((await other.response(waiting)).error).toBeUndefined();
       }

--- a/extensions/browser/src/browser/pw-session-cdp-transport.ts
+++ b/extensions/browser/src/browser/pw-session-cdp-transport.ts
@@ -28,15 +28,18 @@ function contextlessTargetSession(message: Record<string, unknown>): string | un
   return readStringField(params, "sessionId");
 }
 
-export async function connectOverCdpTransport(
+type CdpTransportOptions = {
+  timeout: number;
+  headers: Record<string, string>;
+  lookup?: CdpSocketLookup;
+  resolveWebSocketUrl?: () => Promise<string | undefined>;
+  preparedTransport?: ConnectOverCDPTransport;
+};
+
+async function openCdpTransportSocket(
   connectionUrl: string,
-  opts: {
-    timeout: number;
-    headers: Record<string, string>;
-    lookup?: CdpSocketLookup;
-    resolveWebSocketUrl?: () => Promise<string | undefined>;
-  },
-): Promise<Browser> {
+  opts: CdpTransportOptions,
+): Promise<ConnectOverCDPTransport> {
   const resolvedConnectionUrl = isWebSocketUrl(connectionUrl)
     ? connectionUrl
     : await opts.resolveWebSocketUrl?.();
@@ -55,11 +58,51 @@ export async function connectOverCdpTransport(
       ws.once("error", reject);
       ws.once("close", () => reject(new Error("CDP socket closed")));
     });
+  } catch (error) {
+    ws.close();
+    throw error;
+  }
+  const wire: ConnectOverCDPTransport = {
+    send: (message) => ws.send(JSON.stringify(message)),
+    close: () => {
+      ws.close();
+      const timer = setTimeout(() => {
+        if (ws.readyState !== WebSocket.CLOSED) {
+          ws.terminate();
+        }
+      }, 100);
+      timer.unref?.();
+    },
+  };
+  ws.on("message", (raw) => {
+    try {
+      const parsed = asOptionalRecord(JSON.parse(rawDataToString(raw)));
+      if (!parsed) {
+        wire.close();
+        return;
+      }
+      wire.onmessage?.(parsed);
+    } catch {
+      wire.close();
+    }
+  });
+  ws.on("close", () => wire.onclose?.("CDP socket closed"));
+  ws.on("error", (error) => wire.onclose?.(formatErrorMessage(error)));
+  return wire;
+}
+
+export async function connectOverCdpTransport(
+  connectionUrl: string,
+  opts: CdpTransportOptions,
+): Promise<Browser> {
+  const wire = opts.preparedTransport ?? (await openCdpTransportSocket(connectionUrl, opts));
+  try {
     let onMessage: ((message: object) => void) | undefined;
     let onClose: ((reason?: string) => void) | undefined;
     const pendingMessages: object[] = [];
     let pendingCloseReason: string | undefined;
     let transportClosed = false;
+    let closingReason: string | undefined;
     let transportCloseScheduled = false;
     let nextInternalCommandId = FIRST_INTERNAL_COMMAND_ID;
     const pendingContextlessTargetResumes = new Map<number, string>();
@@ -85,14 +128,9 @@ export async function connectOverCdpTransport(
       });
     };
     const closeTransportSocket = (reason = "CDP socket closed") => {
-      notifyTransportClosed(reason);
-      ws.close();
-      const terminateTimer = setTimeout(() => {
-        if (ws.readyState !== WebSocket.CLOSED) {
-          ws.terminate();
-        }
-      }, 100);
-      terminateTimer.unref?.();
+      closingReason = reason;
+      // Borrowed streams close only after the real owner acknowledges native cleanup.
+      wire.close();
     };
     const sendInternalCommand = (
       method: string,
@@ -100,14 +138,7 @@ export async function connectOverCdpTransport(
       sessionId?: string,
     ): number => {
       const id = nextInternalCommandId--;
-      ws.send(
-        JSON.stringify({
-          id,
-          method,
-          ...(params ? { params } : {}),
-          sessionId,
-        }),
-      );
+      wire.send({ id, method, ...(params ? { params } : {}), sessionId });
       return id;
     };
     const releaseContextlessTarget = (sessionId: string) => {
@@ -118,7 +149,7 @@ export async function connectOverCdpTransport(
     };
     const scheduleMessage = (message: object) => {
       setImmediate(() => {
-        if (transportClosed) {
+        if (transportClosed || closingReason) {
           return;
         }
         if (!onMessage) {
@@ -134,7 +165,10 @@ export async function connectOverCdpTransport(
     };
     const transport: ConnectOverCDPTransport = {
       send: (message) => {
-        ws.send(JSON.stringify(message));
+        if (closingReason || transportClosed) {
+          throw new Error("CDP transport closed");
+        }
+        wire.send(message);
       },
       close: () => {
         closeTransportSocket();
@@ -166,41 +200,39 @@ export async function connectOverCdpTransport(
         }
       },
     };
-    ws.on("message", (raw) => {
-      try {
-        const parsed = asOptionalRecord(JSON.parse(rawDataToString(raw)));
-        if (!parsed) {
-          closeTransportSocket();
-          return;
-        }
-        const id = parsed.id;
-        if (typeof id === "number" && id <= FIRST_INTERNAL_COMMAND_ID) {
-          const targetSessionId = pendingContextlessTargetResumes.get(id);
-          if (targetSessionId) {
-            pendingContextlessTargetResumes.delete(id);
-            sendInternalCommand("Target.detachFromTarget", { sessionId: targetSessionId });
+    Object.assign(wire, {
+      onmessage: (message: object) => {
+        try {
+          const parsed = asOptionalRecord(message);
+          if (!parsed) {
+            closeTransportSocket();
+            return;
           }
-          return;
+          const id = parsed.id;
+          if (typeof id === "number" && id <= FIRST_INTERNAL_COMMAND_ID) {
+            const targetSessionId = pendingContextlessTargetResumes.get(id);
+            if (targetSessionId) {
+              pendingContextlessTargetResumes.delete(id);
+              sendInternalCommand("Target.detachFromTarget", { sessionId: targetSessionId });
+            }
+            return;
+          }
+          const contextlessSessionId = contextlessTargetSession(parsed);
+          if (contextlessSessionId) {
+            releaseContextlessTarget(contextlessSessionId);
+            return;
+          }
+          scheduleMessage(parsed);
+        } catch {
+          closeTransportSocket();
         }
-        const contextlessSessionId = contextlessTargetSession(parsed);
-        if (contextlessSessionId) {
-          releaseContextlessTarget(contextlessSessionId);
-          return;
-        }
-        scheduleMessage(parsed);
-      } catch {
-        closeTransportSocket();
-      }
-    });
-    ws.on("close", () => {
-      scheduleTransportClosed("CDP socket closed");
-    });
-    ws.on("error", (error) => {
-      scheduleTransportClosed(formatErrorMessage(error));
+      },
+      onclose: (reason?: string) =>
+        scheduleTransportClosed(closingReason ?? reason ?? "CDP socket closed"),
     });
     return await getPlaywrightCore().chromium.connectOverCDP(transport, { timeout: opts.timeout });
   } catch (error) {
-    ws.close();
+    wire.close();
     throw error;
   }
 }

--- a/extensions/browser/src/browser/pw-session-connection.ts
+++ b/extensions/browser/src/browser/pw-session-connection.ts
@@ -1,10 +1,9 @@
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { Browser, BrowserContext, CDPSession, Page } from "playwright-core";
+import type { Browser, BrowserContext, Page } from "playwright-core";
 import { formatErrorMessage, toErrorObject } from "../infra/errors.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { withManagedProxyForCdpUrl, withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
-import { PLAYWRIGHT_TARGET_INFO_TIMEOUT_MS } from "./cdp-timeouts.js";
 import {
   assertCdpEndpointAllowed,
   getHeadersWithAuth,
@@ -15,6 +14,12 @@ import {
 } from "./cdp.helpers.js";
 import { getChromeWebSocketEndpoint } from "./chrome.js";
 import { BrowserTabNotFoundError } from "./errors.js";
+import type { RelayOperationReference } from "./extension-relay/owner-client.js";
+import {
+  connectRelayBrowser,
+  closeRelayOperationConnection,
+} from "./extension-relay/owner-playwright.js";
+import { getBorrowedRelayCdpAccess } from "./extension-relay/relay-access.js";
 import { connectOverCdpTransport } from "./pw-session-cdp-transport.js";
 import {
   blockedPageRefsByCdpUrl,
@@ -32,12 +37,15 @@ import {
   type PendingBrowserConnection,
   type PlaywrightConnectionRetirement,
 } from "./pw-session-contracts.js";
+import { pageTargetInfo } from "./pw-session-page-target.js";
 import {
   bindRoleRefsTarget,
   ensurePageState,
   normalizeCdpUrl,
   targetKey,
 } from "./pw-session-state.js";
+
+export { pageTargetInfo } from "./pw-session-page-target.js";
 
 type CdpEndpointPin = NonNullable<Awaited<ReturnType<typeof assertCdpEndpointAllowed>>>;
 
@@ -386,8 +394,18 @@ function observeBrowser(browser: Browser) {
 export async function connectBrowser(
   cdpUrl: string,
   ssrfPolicy?: SsrFPolicy,
+  relayReference?: RelayOperationReference,
 ): Promise<ConnectedBrowser> {
   const normalized = normalizeCdpUrl(cdpUrl);
+  const relay = getBorrowedRelayCdpAccess(normalized);
+  if (relayReference) {
+    if (!relay) {
+      throw new Error("Captured relay connection is unavailable");
+    }
+    const browser = await connectRelayBrowser(relay, normalized, relayReference);
+    observeBrowser(browser);
+    return { browser, cdpUrl: normalized };
+  }
   const cached = cachedByCdpUrl.get(normalized);
   if (cached) {
     return cached;
@@ -410,17 +428,17 @@ export async function connectBrowser(
       try {
         const timeout = 5000 + attempt * 2000;
         let endpointDiscoveryError: unknown;
-        const resolvedEndpoint = await getChromeWebSocketEndpoint(
-          normalized,
-          timeout,
-          ssrfPolicy,
-        ).catch((err: unknown) => {
-          endpointDiscoveryError = err;
-          return null;
-        });
+        const resolvedEndpoint = relay
+          ? null
+          : await getChromeWebSocketEndpoint(normalized, timeout, ssrfPolicy).catch(
+              (err: unknown) => {
+                endpointDiscoveryError = err;
+                return null;
+              },
+            );
         const hasUrlCredentials = stripCdpUrlCredentials(normalized) !== normalized;
         const configuredIsWebSocket = isWebSocketUrl(normalized);
-        if (!resolvedEndpoint && !configuredIsWebSocket) {
+        if (!relay && !resolvedEndpoint && !configuredIsWebSocket) {
           if (hasUrlCredentials) {
             // Playwright preserves explicit headers across HTTP discovery redirects.
             // Keep credentialed discovery in OpenClaw's guarded fetch path instead.
@@ -462,7 +480,13 @@ export async function connectBrowser(
         };
         let browser: Browser;
         try {
-          browser = await connectEndpoint(endpointUrl, endpointLookup);
+          browser = relay
+            ? await connectRelayBrowser(relay, normalized)
+            : await connectEndpoint(endpointUrl, endpointLookup);
+          if (relay && getBorrowedRelayCdpAccess(normalized) !== relay) {
+            await browser.close();
+            throw new Error("Relay connection was superseded");
+          }
         } catch (err) {
           if (!configuredIsWebSocket || endpointUrl === normalized) {
             throw err;
@@ -487,7 +511,7 @@ export async function connectBrowser(
         return connected;
       } catch (err) {
         lastErr = err;
-        if (connectionAttempt.cancelled) {
+        if (connectionAttempt.cancelled || relay) {
           break;
         }
         // Don't retry rate-limit errors; retrying worsens the 429.
@@ -556,83 +580,16 @@ async function partitionAccessiblePages(opts: { cdpUrl: string; pages: Page[] })
   return { accessible, blockedCount };
 }
 
-type PageTargetInfo = { targetId: string; title: string };
-
-// A Page owns one bounded target-info read at a time so concurrent enumerations share its
-// temporary CDP session. Settled reads evict themselves so later calls observe fresh metadata.
-const targetInfoReads = new WeakMap<Page, Promise<PageTargetInfo | null>>();
-
-async function readPageTargetInfo(page: Page): Promise<PageTargetInfo | null> {
-  let session: CDPSession | undefined;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let timedOut = false;
-  let detachStarted = false;
-  const detach = () => {
-    if (!session || detachStarted) {
-      return;
-    }
-    detachStarted = true;
-    void session.detach().catch(() => {});
-  };
-  const timeout = new Promise<null>((resolve) => {
-    timer = setTimeout(() => {
-      timedOut = true;
-      detach();
-      resolve(null);
-    }, PLAYWRIGHT_TARGET_INFO_TIMEOUT_MS);
-    timer.unref?.();
-  });
-  const read = (async () => {
-    session = await page.context().newCDPSession(page);
-    if (timedOut) {
-      detach();
-      return null;
-    }
-    try {
-      const { targetInfo } = await session.send("Target.getTargetInfo");
-      const targetId = normalizeOptionalString(targetInfo.targetId) ?? "";
-      if (!targetId) {
-        return null;
-      }
-      return { targetId, title: targetInfo.title };
-    } finally {
-      detach();
-    }
-  })();
-  try {
-    return await Promise.race([read, timeout]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
-}
-
-export function pageTargetInfo(page: Page): Promise<PageTargetInfo | null> {
-  const existing = targetInfoReads.get(page);
-  if (existing) {
-    return existing;
-  }
-  const pending = readPageTargetInfo(page);
-  targetInfoReads.set(page, pending);
-  const evict = () => {
-    if (targetInfoReads.get(page) === pending) {
-      targetInfoReads.delete(page);
-    }
-  };
-  void pending.then(evict, evict);
-  return pending;
-}
-
 async function getPageForTargetIdOnce(opts: {
   cdpUrl: string;
   targetId?: string;
   ssrfPolicy?: SsrFPolicy;
+  relayReference?: RelayOperationReference;
 }): Promise<Page> {
   if (opts.targetId && isBlockedTarget(opts.cdpUrl, opts.targetId)) {
     throw new BlockedBrowserTargetError();
   }
-  const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+  const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy, opts.relayReference);
   const pages = await getAllPages(browser);
   if (!pages.length) {
     throw new Error("No pages available in the connected browser.");
@@ -666,6 +623,7 @@ export async function getPageForTargetId(opts: {
   cdpUrl: string;
   targetId?: string;
   ssrfPolicy?: SsrFPolicy;
+  relayReference?: RelayOperationReference;
 }): Promise<Page> {
   const reusedCachedBrowser = hasCachedPlaywrightBrowserConnection(opts.cdpUrl);
   try {
@@ -674,7 +632,11 @@ export async function getPageForTargetId(opts: {
     if (!isRecoverableStalePageSelectionError(err, reusedCachedBrowser)) {
       throw err;
     }
-    retirePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl });
+    if (opts.relayReference) {
+      await closeRelayOperationConnection(opts.relayReference);
+    } else {
+      retirePlaywrightBrowserConnection({ cdpUrl: opts.cdpUrl });
+    }
     return await getPageForTargetIdOnce(opts);
   }
 }

--- a/extensions/browser/src/browser/pw-session-navigation.ts
+++ b/extensions/browser/src/browser/pw-session-navigation.ts
@@ -414,7 +414,7 @@ export async function gotoPageWithNavigationGuard(
     url: string;
     timeoutMs: number;
     targetId?: string;
-    assertPageCurrent?: () => void;
+    assertPageCurrent?: () => void | Promise<void>;
   } & BrowserNavigationPolicyOptions,
 ): Promise<Response | null> {
   const navigationPolicy = withBrowserNavigationPolicy(opts.ssrfPolicy, {
@@ -462,7 +462,7 @@ export async function gotoPageWithNavigationGuard(
   let navigationFailed = false;
   let navigationError: unknown;
   try {
-    opts.assertPageCurrent?.();
+    await opts.assertPageCurrent?.();
     response = await opts.page.goto(opts.url, { timeout: opts.timeoutMs });
   } catch (err) {
     navigationFailed = true;

--- a/extensions/browser/src/browser/pw-session-page-target.ts
+++ b/extensions/browser/src/browser/pw-session-page-target.ts
@@ -1,0 +1,71 @@
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { CDPSession, Page } from "playwright-core";
+import { PLAYWRIGHT_TARGET_INFO_TIMEOUT_MS } from "./cdp-timeouts.js";
+
+type PageTargetInfo = { targetId: string; title: string };
+
+// A Page owns one bounded target-info read at a time so concurrent enumerations share its
+// temporary CDP session. Settled reads evict themselves so later calls observe fresh metadata.
+const targetInfoReads = new WeakMap<Page, Promise<PageTargetInfo | null>>();
+
+async function readPageTargetInfo(page: Page): Promise<PageTargetInfo | null> {
+  let session: CDPSession | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  let detachStarted = false;
+  const detach = () => {
+    if (!session || detachStarted) {
+      return;
+    }
+    detachStarted = true;
+    void session.detach().catch(() => {});
+  };
+  const timeout = new Promise<null>((resolve) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      detach();
+      resolve(null);
+    }, PLAYWRIGHT_TARGET_INFO_TIMEOUT_MS);
+    timer.unref?.();
+  });
+  const read = (async () => {
+    session = await page.context().newCDPSession(page);
+    if (timedOut) {
+      detach();
+      return null;
+    }
+    try {
+      const { targetInfo } = await session.send("Target.getTargetInfo");
+      const targetId = normalizeOptionalString(targetInfo.targetId) ?? "";
+      if (!targetId) {
+        return null;
+      }
+      return { targetId, title: targetInfo.title };
+    } finally {
+      detach();
+    }
+  })();
+  try {
+    return await Promise.race([read, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export function pageTargetInfo(page: Page): Promise<PageTargetInfo | null> {
+  const existing = targetInfoReads.get(page);
+  if (existing) {
+    return existing;
+  }
+  const pending = readPageTargetInfo(page);
+  targetInfoReads.set(page, pending);
+  const evict = () => {
+    if (targetInfoReads.get(page) === pending) {
+      targetInfoReads.delete(page);
+    }
+  };
+  void pending.then(evict, evict);
+  return pending;
+}

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -827,6 +827,37 @@ describe("pw-session guarded browser navigation route cleanup", () => {
     expect(getRouteHandler()).toBeNull();
   });
 
+  it("awaits remote ownership validation and rejects revocation before goto", async () => {
+    const { page, pageGoto, pageUnroute } = installBrowserMocks();
+    let entered!: () => void;
+    let release!: () => void;
+    const validating = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const validation = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const task = gotoPageWithNavigationGuard({
+      cdpUrl: "http://127.0.0.1:18792",
+      page,
+      url: "https://93.184.216.34/start",
+      timeoutMs: 1000,
+      targetId: "TARGET_1",
+      assertPageCurrent: async () => {
+        entered();
+        await validation;
+        throw new BrowserTabNotFoundError({ input: "TARGET_1" });
+      },
+    });
+    const rejected = expect(task).rejects.toBeInstanceOf(BrowserTabNotFoundError);
+    await validating;
+    expect(pageGoto).not.toHaveBeenCalled();
+    release();
+    await rejected;
+    expect(pageGoto).not.toHaveBeenCalled();
+    expect(pageUnroute).toHaveBeenCalled();
+  });
+
   it("surfaces navigation route cleanup failure while the page remains open", async () => {
     const { page, pageUnroute } = installBrowserMocks();
     Object.assign(page, { isClosed: () => false });

--- a/extensions/browser/src/browser/pw-session.pinned-transport.test.ts
+++ b/extensions/browser/src/browser/pw-session.pinned-transport.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import * as chromeModule from "./chrome.js";
 import { pwAi } from "./pw-ai.js";
+import { connectOverCdpTransport } from "./pw-session-cdp-transport.js";
 
 const { registerManagedProxyBrowserCdpBypassMock } = vi.hoisted(() => ({
   registerManagedProxyBrowserCdpBypassMock: vi.fn<(url: string) => (() => void) | undefined>(
@@ -213,6 +214,55 @@ describe("pw-session Playwright CDP transport", () => {
         server.close(() => resolve());
       });
     }
+  });
+
+  it("keeps contextless-target cleanup and close acknowledgement on a prepared transport", async () => {
+    const commands: object[] = [];
+    const closeWire = vi.fn();
+    const wire: import("playwright-core").ConnectOverCDPTransport = {
+      send: (message) => commands.push(message),
+      close: closeWire,
+    };
+    const browser = makeBrowser("A", "https://example.com");
+    connectOverCdpSpy.mockImplementationOnce((async (value: unknown) => {
+      const transport = value as import("playwright-core").ConnectOverCDPTransport;
+      const delivered: object[] = [];
+      let closed = false;
+      Object.assign(transport, {
+        onmessage: (message: object) => delivered.push(message),
+        onclose: () => {
+          closed = true;
+        },
+      });
+      wire.onmessage?.({
+        method: "Target.attachedToTarget",
+        params: {
+          sessionId: "worker-session",
+          targetInfo: { targetId: "worker", type: "worker" },
+        },
+      });
+      expect(commands).toEqual([
+        expect.objectContaining({ method: "Runtime.runIfWaitingForDebugger" }),
+      ]);
+      const resume = commands[0] as { id: number };
+      wire.onmessage?.({ id: resume.id, result: {} });
+      expect(commands[1]).toMatchObject({
+        method: "Target.detachFromTarget",
+        params: { sessionId: "worker-session" },
+      });
+      expect(delivered).toEqual([]);
+      transport.close();
+      expect(closeWire).toHaveBeenCalledOnce();
+      expect(closed).toBe(false);
+      wire.onclose?.("cleanup acknowledged");
+      await vi.waitFor(() => expect(closed).toBe(true));
+      return browser.browser;
+    }) as never);
+    await connectOverCdpTransport("http://127.0.0.1:18799", {
+      timeout: 1000,
+      headers: {},
+      preparedTransport: wire,
+    });
   });
 
   it("connects guarded Playwright CDP through the pinned WebSocket transport", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -374,7 +374,7 @@ describe("pw-tools-core.snapshot navigate guard", () => {
       };
       const result = await mod.navigateViaPlaywright(navigation);
 
-      expect(reconnect).toHaveBeenCalledWith("http://127.0.0.1:18792", undefined);
+      expect(reconnect).toHaveBeenCalledWith("http://127.0.0.1:18792", undefined, undefined);
       expect(session.getPageForTargetId).toHaveBeenLastCalledWith(
         expect.objectContaining({ targetId: "replacement-target" }),
       );

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -14,6 +14,8 @@ import { ACT_MAX_VIEWPORT_DIMENSION, resolveBrowserNavigationTimeoutMs } from ".
 import { type AriaSnapshotNode, formatAriaSnapshot, type RawAXNode } from "./cdp.js";
 import type { BrowserDownloadResult } from "./download-types.js";
 import { BrowserTabNotFoundError } from "./errors.js";
+import type { RelayOperationReference } from "./extension-relay/owner-client.js";
+import { closeRelayOperationConnection } from "./extension-relay/owner-playwright.js";
 import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationResultAllowed,
@@ -474,7 +476,8 @@ export async function snapshotRoleViaPlaywright(opts: {
 export async function navigateViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
-  resolveOperationTarget?: () => string | undefined;
+  resolveOperationTarget?: () => string | undefined | Promise<string | undefined>;
+  relayReference?: RelayOperationReference;
   url: string;
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
@@ -519,8 +522,8 @@ export async function navigateViaPlaywright(opts: {
       targetId: currentTargetId,
       ...(opts.resolveOperationTarget
         ? {
-            assertPageCurrent: () => {
-              if (opts.resolveOperationTarget?.() !== currentTargetId) {
+            assertPageCurrent: async () => {
+              if ((await opts.resolveOperationTarget?.()) !== currentTargetId) {
                 throw new BrowserTabNotFoundError({ input: currentTargetId });
               }
             },
@@ -581,21 +584,25 @@ export async function navigateViaPlaywright(opts: {
     }
     // Extension relays can briefly drop CDP during renderer swaps/navigation.
     // Force a clean reconnect, then retry once on the refreshed page handle.
-    await forceDisconnectPlaywrightForTarget({
-      cdpUrl: opts.cdpUrl,
-      targetId: opts.targetId,
-      ssrfPolicy: opts.ssrfPolicy,
-      reason: "retry navigate after detached frame",
-    }).catch(() => {});
+    if (opts.relayReference) {
+      await closeRelayOperationConnection(opts.relayReference);
+    } else {
+      await forceDisconnectPlaywrightForTarget({
+        cdpUrl: opts.cdpUrl,
+        targetId: opts.targetId,
+        ssrfPolicy: opts.ssrfPolicy,
+        reason: "retry navigate after detached frame",
+      }).catch(() => {});
+    }
     if (opts.resolveOperationTarget) {
       // Auto-attach completes during reconnect; only then can the same tab owner prove its new ID.
-      await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
-      const replacementTargetId = opts.resolveOperationTarget();
+      await connectBrowser(opts.cdpUrl, opts.ssrfPolicy, opts.relayReference);
+      const replacementTargetId = await opts.resolveOperationTarget();
       if (!replacementTargetId) {
         throw new BrowserTabNotFoundError({ input: currentTargetId });
       }
       page = await getPageForTargetId({ ...opts, targetId: replacementTargetId });
-      if (opts.resolveOperationTarget() !== replacementTargetId) {
+      if ((await opts.resolveOperationTarget()) !== replacementTargetId) {
         throw new BrowserTabNotFoundError({ input: currentTargetId });
       }
       currentTargetId = replacementTargetId;

--- a/extensions/browser/src/browser/relay-daemon.shutdown.test.ts
+++ b/extensions/browser/src/browser/relay-daemon.shutdown.test.ts
@@ -1,0 +1,20 @@
+import { expect, it, vi } from "vitest";
+import { relayTestKey } from "../../chrome-extension/relay-key.test-support.js";
+import { runExtensionRelayDaemon } from "./relay-daemon.js";
+
+vi.mock("./extension-relay/relay-server.js", () => ({
+  startExtensionRelayServer: async () => ({
+    port: 18799,
+    bridge: { extensionConnected: false, cdpClientCount: 0 },
+    close: async () => {
+      throw new Error("native cleanup refused");
+    },
+  }),
+}));
+
+it("reports failed owner cleanup through done instead of acknowledging daemon shutdown", async () => {
+  const run = await runExtensionRelayDaemon({ port: 18799, readToken: () => relayTestKey(1) });
+  const failed = expect(run.done).rejects.toThrow("native cleanup refused");
+  run.stop();
+  await failed;
+});

--- a/extensions/browser/src/browser/relay-daemon.test.ts
+++ b/extensions/browser/src/browser/relay-daemon.test.ts
@@ -1,0 +1,65 @@
+import net from "node:net";
+import { describe, expect, it } from "vitest";
+import { relayTestKey } from "../../chrome-extension/relay-key.test-support.js";
+import { runExtensionRelayDaemon } from "./relay-daemon.js";
+
+const TOKEN = relayTestKey(1);
+
+describe("runExtensionRelayDaemon", () => {
+  it("refuses to start without a relay credential", async () => {
+    const run = await runExtensionRelayDaemon({ port: 0, readToken: () => null });
+    expect(run.port).toBeNull();
+    await expect(run.done).resolves.toBe("no-credential");
+  });
+
+  it("exits quietly when the relay port is already served", async () => {
+    const server = net.createServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    try {
+      const run = await runExtensionRelayDaemon({ port, readToken: () => TOKEN });
+      expect(run.port).toBeNull();
+      await expect(run.done).resolves.toBe("port-in-use");
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("serves the relay until the idle grace elapses with no peers", async () => {
+    const run = await runExtensionRelayDaemon({
+      port: 0,
+      readToken: () => TOKEN,
+      idleExitMs: 60,
+      pollMs: 15,
+    });
+    expect(run.port).toBeGreaterThan(0);
+    // The bound socket answers while the daemon is alive.
+    const served = await new Promise<boolean>((resolve) => {
+      const socket = net.connect({ host: "127.0.0.1", port: run.port ?? 0 });
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.once("error", () => resolve(false));
+    });
+    expect(served).toBe(true);
+    await expect(run.done).resolves.toBe("idle");
+  });
+
+  it("stops on demand", async () => {
+    const run = await runExtensionRelayDaemon({
+      port: 0,
+      readToken: () => TOKEN,
+      idleExitMs: 60_000,
+      pollMs: 60_000,
+    });
+    expect(run.port).toBeGreaterThan(0);
+    run.stop();
+    await expect(run.done).resolves.toBe("stopped");
+  });
+});

--- a/extensions/browser/src/browser/relay-daemon.test.ts
+++ b/extensions/browser/src/browser/relay-daemon.test.ts
@@ -1,9 +1,38 @@
+import fs from "node:fs/promises";
 import net from "node:net";
-import { describe, expect, it } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { relayTestKey } from "../../chrome-extension/relay-key.test-support.js";
 import { runExtensionRelayDaemon } from "./relay-daemon.js";
 
 const TOKEN = relayTestKey(1);
+
+const tempStateDirs: string[] = [];
+const savedStateDirEnv = process.env.OPENCLAW_STATE_DIR;
+
+afterEach(async () => {
+  if (savedStateDirEnv === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = savedStateDirEnv;
+  }
+  await Promise.all(
+    tempStateDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+/** Point readExtensionRelayToken() at an isolated credentials dir holding TOKEN. */
+async function stageRelaySecret(): Promise<void> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-relay-daemon-"));
+  tempStateDirs.push(stateDir);
+  const credentialsDir = path.join(stateDir, "credentials");
+  await fs.mkdir(credentialsDir, { recursive: true, mode: 0o700 });
+  await fs.writeFile(path.join(credentialsDir, "browser-extension-relay.secret"), `${TOKEN}\n`, {
+    mode: 0o600,
+  });
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+}
 
 describe("runExtensionRelayDaemon", () => {
   it("refuses to start without a relay credential", async () => {
@@ -49,6 +78,47 @@ describe("runExtensionRelayDaemon", () => {
     });
     expect(served).toBe(true);
     await expect(run.done).resolves.toBe("idle");
+  });
+
+  it("is v2-only by default: rejects a VALID legacy Bearer credential so a squatter cannot harvest the secret", async () => {
+    await stageRelaySecret();
+    const run = await runExtensionRelayDaemon({
+      port: 0,
+      idleExitMs: 60_000,
+      pollMs: 60_000,
+    });
+    try {
+      // Even the correct secret over legacy one-directional auth is refused
+      // when allowLegacyAuth is not explicitly enabled.
+      const status = await fetch(`http://127.0.0.1:${run.port}/json/version`, {
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      expect(status.status).toBe(401);
+    } finally {
+      run.stop();
+      await run.done;
+    }
+  });
+
+  it("honors an explicit allowLegacyAuth opt-in", async () => {
+    await stageRelaySecret();
+    const run = await runExtensionRelayDaemon({
+      port: 0,
+      allowLegacyAuth: true,
+      idleExitMs: 60_000,
+      pollMs: 60_000,
+    });
+    try {
+      // With legacy auth enabled the credential is accepted; the request then
+      // reaches the "extension not connected" state (503) rather than 401.
+      const status = await fetch(`http://127.0.0.1:${run.port}/json/version`, {
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      expect(status.status).toBe(503);
+    } finally {
+      run.stop();
+      await run.done;
+    }
   });
 
   it("stops on demand", async () => {

--- a/extensions/browser/src/browser/relay-daemon.ts
+++ b/extensions/browser/src/browser/relay-daemon.ts
@@ -30,11 +30,20 @@ export type RelayDaemonRun = {
 export async function runExtensionRelayDaemon(params: {
   port: number;
   readToken?: () => string | null;
+  /**
+   * Accept the legacy one-directional relay auth (Bearer/Basic/token
+   * subprotocol). Defaults to false: the standalone daemon is v2-only, so a
+   * process that squats the relay port cannot harvest the secret from a legacy
+   * client, and an operator's `extensionRelay.allowLegacyAuth=false` is never
+   * silently reverted. The extension and mcporter both speak v2.
+   */
+  allowLegacyAuth?: boolean;
   idleExitMs?: number;
   pollMs?: number;
   now?: () => number;
 }): Promise<RelayDaemonRun> {
   const readToken = params.readToken ?? readExtensionRelayToken;
+  const allowLegacyAuth = params.allowLegacyAuth ?? false;
   const now = params.now ?? Date.now;
   const idleExitMs = params.idleExitMs ?? RELAY_DAEMON_IDLE_EXIT_MS;
   const pollMs = params.pollMs ?? IDLE_POLL_MS;
@@ -52,7 +61,7 @@ export async function runExtensionRelayDaemon(params: {
 
   let handle: ExtensionRelayHandle;
   try {
-    handle = await startExtensionRelayServer({ port: params.port, token });
+    handle = await startExtensionRelayServer({ port: params.port, token, allowLegacyAuth });
   } catch (error) {
     if ((error as NodeJS.ErrnoException | null)?.code === "EADDRINUSE") {
       log.info(`relay port ${params.port} is already served; standalone daemon not needed`);

--- a/extensions/browser/src/browser/relay-daemon.ts
+++ b/extensions/browser/src/browser/relay-daemon.ts
@@ -1,0 +1,93 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { readExtensionRelayToken } from "./extension-relay/relay-auth.js";
+import {
+  type ExtensionRelayHandle,
+  startExtensionRelayServer,
+} from "./extension-relay/relay-server.js";
+
+const log = createSubsystemLogger("browser").child("relay-daemon");
+
+/** Default grace before a daemon with no extension and no CDP clients exits. */
+export const RELAY_DAEMON_IDLE_EXIT_MS = 10 * 60 * 1000;
+const IDLE_POLL_MS = 30 * 1000;
+
+export type RelayDaemonExitReason = "port-in-use" | "no-credential" | "idle" | "stopped";
+
+export type RelayDaemonRun = {
+  /** Resolves when the daemon decides to exit; the caller owns process.exit. */
+  done: Promise<RelayDaemonExitReason>;
+  /** Bound relay port when the server started; null when startup was refused. */
+  port: number | null;
+  stop: () => void;
+};
+
+/**
+ * Run the standalone extension relay daemon: one loopback relay server with no
+ * Gateway. The daemon stays alive while the paired extension holds its relay
+ * connection or a CDP client is attached, and exits once both sides have been
+ * gone for the idle grace so an idle daemon never outlives Chrome.
+ */
+export async function runExtensionRelayDaemon(params: {
+  port: number;
+  readToken?: () => string | null;
+  idleExitMs?: number;
+  pollMs?: number;
+  now?: () => number;
+}): Promise<RelayDaemonRun> {
+  const readToken = params.readToken ?? readExtensionRelayToken;
+  const now = params.now ?? Date.now;
+  const idleExitMs = params.idleExitMs ?? RELAY_DAEMON_IDLE_EXIT_MS;
+  const pollMs = params.pollMs ?? IDLE_POLL_MS;
+  let resolveDone: (reason: RelayDaemonExitReason) => void = () => {};
+  const done = new Promise<RelayDaemonExitReason>((resolve) => {
+    resolveDone = resolve;
+  });
+
+  const token = readToken();
+  if (!token) {
+    log.warn("relay daemon refused to start: no extension relay credential");
+    resolveDone("no-credential");
+    return { done, port: null, stop: () => {} };
+  }
+
+  let handle: ExtensionRelayHandle;
+  try {
+    handle = await startExtensionRelayServer({ port: params.port, token });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | null)?.code === "EADDRINUSE") {
+      log.info(`relay port ${params.port} is already served; standalone daemon not needed`);
+      resolveDone("port-in-use");
+      return { done, port: null, stop: () => {} };
+    }
+    throw error;
+  }
+  log.info(`standalone extension relay listening on 127.0.0.1:${handle.port}`);
+
+  let lastActiveAtMs = now();
+  let stopped = false;
+  const finish = (reason: RelayDaemonExitReason): void => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    clearInterval(idleTimer);
+    void handle.close().finally(() => resolveDone(reason));
+  };
+  const idleTimer = setInterval(() => {
+    if (handle.bridge.extensionConnected || handle.bridge.cdpClientCount > 0) {
+      lastActiveAtMs = now();
+      return;
+    }
+    if (now() - lastActiveAtMs >= idleExitMs) {
+      log.info("relay daemon idle (no extension, no CDP clients); exiting");
+      finish("idle");
+    }
+  }, pollMs);
+  idleTimer.unref?.();
+
+  return {
+    done,
+    port: handle.port,
+    stop: () => finish("stopped"),
+  };
+}

--- a/extensions/browser/src/browser/relay-daemon.ts
+++ b/extensions/browser/src/browser/relay-daemon.ts
@@ -1,3 +1,4 @@
+import { extractErrorCode } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { readExtensionRelayToken } from "./extension-relay/relay-auth.js";
 import {
@@ -8,12 +9,12 @@ import {
 const log = createSubsystemLogger("browser").child("relay-daemon");
 
 /** Default grace before a daemon with no extension and no CDP clients exits. */
-export const RELAY_DAEMON_IDLE_EXIT_MS = 10 * 60 * 1000;
+const RELAY_DAEMON_IDLE_EXIT_MS = 10 * 60 * 1000;
 const IDLE_POLL_MS = 30 * 1000;
 
-export type RelayDaemonExitReason = "port-in-use" | "no-credential" | "idle" | "stopped";
+type RelayDaemonExitReason = "port-in-use" | "no-credential" | "idle" | "stopped";
 
-export type RelayDaemonRun = {
+type RelayDaemonRun = {
   /** Resolves when the daemon decides to exit; the caller owns process.exit. */
   done: Promise<RelayDaemonExitReason>;
   /** Bound relay port when the server started; null when startup was refused. */
@@ -63,7 +64,7 @@ export async function runExtensionRelayDaemon(params: {
   try {
     handle = await startExtensionRelayServer({ port: params.port, token, allowLegacyAuth });
   } catch (error) {
-    if ((error as NodeJS.ErrnoException | null)?.code === "EADDRINUSE") {
+    if (extractErrorCode(error) === "EADDRINUSE") {
       log.info(`relay port ${params.port} is already served; standalone daemon not needed`);
       resolveDone("port-in-use");
       return { done, port: null, stop: () => {} };

--- a/extensions/browser/src/browser/relay-daemon.ts
+++ b/extensions/browser/src/browser/relay-daemon.ts
@@ -1,5 +1,7 @@
+import { getRuntimeConfig } from "../config/config.js";
 import { extractErrorCode } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveBrowserConfig, resolveProfile } from "./config.js";
 import { readExtensionRelayToken } from "./extension-relay/relay-auth.js";
 import {
   type ExtensionRelayHandle,
@@ -49,8 +51,10 @@ export async function runExtensionRelayDaemon(params: {
   const idleExitMs = params.idleExitMs ?? RELAY_DAEMON_IDLE_EXIT_MS;
   const pollMs = params.pollMs ?? IDLE_POLL_MS;
   let resolveDone: (reason: RelayDaemonExitReason) => void = () => {};
-  const done = new Promise<RelayDaemonExitReason>((resolve) => {
+  let rejectDone: (error: unknown) => void = () => {};
+  const done = new Promise<RelayDaemonExitReason>((resolve, reject) => {
     resolveDone = resolve;
+    rejectDone = reject;
   });
 
   const token = readToken();
@@ -62,7 +66,20 @@ export async function runExtensionRelayDaemon(params: {
 
   let handle: ExtensionRelayHandle;
   try {
-    handle = await startExtensionRelayServer({ port: params.port, token, allowLegacyAuth });
+    const config = getRuntimeConfig();
+    const resolved = resolveBrowserConfig(config.browser, config);
+    const profiles = Object.keys(resolved.profiles).filter((name) => {
+      const profile = resolveProfile(resolved, name);
+      return profile?.driver === "extension" && profile.cdpPort === params.port;
+    });
+    // The listener owns this fact. Ambiguous/unconfigured ports never advertise owner access.
+    const profileName = profiles.length === 1 ? profiles[0] : undefined;
+    handle = await startExtensionRelayServer({
+      port: params.port,
+      token,
+      allowLegacyAuth,
+      profileName,
+    });
   } catch (error) {
     if (extractErrorCode(error) === "EADDRINUSE") {
       log.info(`relay port ${params.port} is already served; standalone daemon not needed`);
@@ -81,7 +98,7 @@ export async function runExtensionRelayDaemon(params: {
     }
     stopped = true;
     clearInterval(idleTimer);
-    void handle.close().finally(() => resolveDone(reason));
+    void handle.close().then(() => resolveDone(reason), rejectDone);
   };
   const idleTimer = setInterval(() => {
     if (handle.bridge.extensionConnected || handle.bridge.cdpClientCount > 0) {

--- a/extensions/browser/src/browser/resolved-config-refresh.ts
+++ b/extensions/browser/src/browser/resolved-config-refresh.ts
@@ -103,7 +103,8 @@ function applyResolvedConfig(
       !lifecycle?.transitionReason &&
       !lifecycle?.cleanupRelays.has(relay) &&
       profile?.driver === "extension" &&
-      profile.cdpPort === relay.port
+      profile.cdpPort === relay.port &&
+      relay.ownership !== "borrowed"
     ) {
       extensionRelayInternalTokens[name] = relay.internalToken;
     }

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -475,300 +475,304 @@ export function registerBrowserAgentActRoutes(
         const hasNavigationResultPolicy = Boolean(
           navigationPolicy.ssrfPolicy || navigationPolicy.browserProxyMode,
         );
-        const resolveRelayTarget = captureBrowserOperationTarget({
+        const resolveRelayTarget = await captureBrowserOperationTarget({
           ctx,
           profileName: profileCtx.profile.name,
           targetId: tab.targetId,
         });
-        const jsonOk = async (
-          extra?: Record<string, unknown>,
-          options?: { resolveCurrentTarget?: boolean; operationTargetId?: string },
-        ) => {
-          const shouldResolveCurrentTarget =
-            options?.resolveCurrentTarget && (!isExistingSession || hasNavigationResultPolicy);
-          const responseTargetId = shouldResolveCurrentTarget
-            ? resolveOperationTargetOutcome({
-                actedOnTargetId: tab.targetId,
-                operationTargetId: options?.operationTargetId,
-                resolveRelayTarget,
-              })
-            : tab.targetId;
-          const url =
-            responseTargetId === tab.targetId
-              ? await resolveTabUrl(tab.url)
-              : await resolveSafeRouteTabUrl({
-                  ctx,
-                  profileCtx,
-                  targetId: responseTargetId,
-                  fallbackUrl: tab.url,
-                  ...(isExistingSession ? existingSessionCallOptions : {}),
-                });
-          return res.json({
-            ok: true,
-            targetId: responseTargetId,
-            ...(url ? { url } : {}),
-            ...extra,
-          });
-        };
-        // Nested batch aliases can differ from the request alias, so prefixes
-        // must stay unique across the full tab set before canonicalization.
-        const actionTabs =
-          action.kind === "batch" && !isExistingSession ? await profileCtx.listTabs() : [tab];
-        if (!actionTabs.some((candidate) => candidate.targetId === tab.targetId)) {
-          actionTabs.unshift(tab);
-        }
-        const targetIdError = canonicalizeActTargetIds(action, tab, actionTabs);
-        if (targetIdError) {
-          return jsonActError(res, 403, ACT_ERROR_CODES.targetIdMismatch, targetIdError);
-        }
-        const profileName = profileCtx.profile.name;
-        if (isExistingSession) {
-          const existingSessionTarget: ExistingSessionOperation = {
-            profileName,
-            profile: profileCtx.profile,
-            targetId: tab.targetId,
-            ...existingSessionCallOptions,
-          };
-          const initialTabTargetIds = hasNavigationResultPolicy
-            ? new Set(
-                (await profileCtx.listTabs(existingSessionCallOptions)).map(
-                  (currentTab) => currentTab.targetId,
-                ),
-              )
-            : new Set<string>();
-          const existingSessionNavigationGuard = {
-            ...existingSessionTarget,
-            ...navigationPolicy,
-            listTabs: () => profileCtx.listTabs(existingSessionCallOptions),
-            initialTabTargetIds,
-          };
-          const unsupportedMessage = getExistingSessionUnsupportedMessage(action);
-          if (unsupportedMessage) {
-            return jsonActError(
-              res,
-              501,
-              ACT_ERROR_CODES.unsupportedForExistingSession,
-              unsupportedMessage,
-            );
-          }
-          switch (action.kind) {
-            case "click":
-              await runExistingSessionActionWithNavigationGuard({
-                execute: () =>
-                  clickChromeMcpElement({
-                    ...existingSessionTarget,
-                    uid: action.ref!,
-                    doubleClick: action.doubleClick ?? false,
-                  }),
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
-            case "clickCoords":
-              await runExistingSessionActionWithNavigationGuard({
-                execute: () =>
-                  clickChromeMcpCoords({
-                    ...existingSessionTarget,
-                    x: action.x,
-                    y: action.y,
-                    doubleClick: action.doubleClick ?? false,
-                    button: action.button as "left" | "right" | "middle" | undefined,
-                    delayMs: action.delayMs,
-                  }),
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
-            case "type":
-              await runExistingSessionActionWithNavigationGuard({
-                execute: async () => {
-                  await fillChromeMcpElement({
-                    ...existingSessionTarget,
-                    uid: action.ref!,
-                    value: action.text,
+        try {
+          const jsonOk = async (
+            extra?: Record<string, unknown>,
+            options?: { resolveCurrentTarget?: boolean; operationTargetId?: string },
+          ) => {
+            const shouldResolveCurrentTarget =
+              options?.resolveCurrentTarget && (!isExistingSession || hasNavigationResultPolicy);
+            const responseTargetId = shouldResolveCurrentTarget
+              ? await resolveOperationTargetOutcome({
+                  actedOnTargetId: tab.targetId,
+                  operationTargetId: options?.operationTargetId,
+                  resolveRelayTarget,
+                })
+              : tab.targetId;
+            const url =
+              responseTargetId === tab.targetId
+                ? await resolveTabUrl(tab.url)
+                : await resolveSafeRouteTabUrl({
+                    ctx,
+                    profileCtx,
+                    targetId: responseTargetId,
+                    fallbackUrl: tab.url,
+                    ...(isExistingSession ? existingSessionCallOptions : {}),
                   });
-                  if (action.submit) {
-                    await pressChromeMcpKey({
-                      ...existingSessionTarget,
-                      key: "Enter",
-                    });
-                  }
-                },
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
-            case "press":
-              await runExistingSessionActionWithNavigationGuard({
-                execute: () =>
-                  pressChromeMcpKey({
-                    ...existingSessionTarget,
-                    key: action.key,
-                  }),
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
-            case "hover":
-              await runExistingSessionActionWithNavigationGuard({
-                execute: () =>
-                  hoverChromeMcpElement({
-                    ...existingSessionTarget,
-                    uid: action.ref!,
-                  }),
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
-            case "scrollIntoView":
-              await runExistingSessionActionWithNavigationGuard({
-                execute: () =>
-                  evaluateChromeMcpScript({
-                    ...existingSessionTarget,
-                    fn: `(el) => { el.scrollIntoView({ block: "center", inline: "center" }); return true; }`,
-                    args: [action.ref!],
-                  }),
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
-            case "drag":
-              await runExistingSessionActionWithNavigationGuard({
-                execute: () =>
-                  dragChromeMcpElement({
-                    ...existingSessionTarget,
-                    fromUid: action.startRef!,
-                    toUid: action.endRef!,
-                  }),
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
-            case "select":
-              await runExistingSessionActionWithNavigationGuard({
-                execute: () =>
-                  fillChromeMcpElement({
-                    ...existingSessionTarget,
-                    uid: action.ref!,
-                    value: action.values[0] ?? "",
-                  }),
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
-            case "fill":
-              await runExistingSessionActionWithNavigationGuard({
-                execute: () =>
-                  fillChromeMcpForm({
-                    ...existingSessionTarget,
-                    elements: action.fields.map((field) => ({
-                      uid: field.ref,
-                      value: String(field.value ?? ""),
-                    })),
-                  }),
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk(undefined, { resolveCurrentTarget: true });
-            case "resize":
-              await resizeChromeMcpPage({
-                ...existingSessionTarget,
-                width: action.width,
-                height: action.height,
-              });
-              return await jsonOk();
-            case "wait":
-              await runExistingSessionActionWithNavigationGuard({
-                execute: () =>
-                  waitForExistingSessionCondition({
-                    ...existingSessionTarget,
-                    timeMs: action.timeMs,
-                    text: action.text,
-                    textGone: action.textGone,
-                    selector: action.selector,
-                    url: action.url,
-                    loadState: action.loadState,
-                    fn: action.fn,
-                    ...navigationPolicy,
-                  }),
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk();
-            case "evaluate": {
-              const result = await runExistingSessionActionWithNavigationGuard({
-                execute: () =>
-                  evaluateChromeMcpScript({
-                    ...existingSessionTarget,
-                    fn: normalizeBrowserEvaluateFunctionSource(
-                      action.fn,
-                      action.ref ? { argumentName: "el" } : undefined,
-                    ),
-                    args: action.ref ? [action.ref] : undefined,
-                  }),
-                guard: existingSessionNavigationGuard,
-              });
-              return await jsonOk({ result }, { resolveCurrentTarget: true });
-            }
-            case "close":
-              await profileCtx.closeTab(tab.targetId, {
-                ...existingSessionCallOptions,
-                exactTargetId: true,
-              });
-              clearSnapshotKeysForTab(ctx, profileCtx.profile.name, tab.targetId);
-              return await jsonOk();
-            case "batch":
+            return res.json({
+              ok: true,
+              targetId: responseTargetId,
+              ...(url ? { url } : {}),
+              ...extra,
+            });
+          };
+          // Nested batch aliases can differ from the request alias, so prefixes
+          // must stay unique across the full tab set before canonicalization.
+          const actionTabs =
+            action.kind === "batch" && !isExistingSession ? await profileCtx.listTabs() : [tab];
+          if (!actionTabs.some((candidate) => candidate.targetId === tab.targetId)) {
+            actionTabs.unshift(tab);
+          }
+          const targetIdError = canonicalizeActTargetIds(action, tab, actionTabs);
+          if (targetIdError) {
+            return jsonActError(res, 403, ACT_ERROR_CODES.targetIdMismatch, targetIdError);
+          }
+          const profileName = profileCtx.profile.name;
+          if (isExistingSession) {
+            const existingSessionTarget: ExistingSessionOperation = {
+              profileName,
+              profile: profileCtx.profile,
+              targetId: tab.targetId,
+              ...existingSessionCallOptions,
+            };
+            const initialTabTargetIds = hasNavigationResultPolicy
+              ? new Set(
+                  (await profileCtx.listTabs(existingSessionCallOptions)).map(
+                    (currentTab) => currentTab.targetId,
+                  ),
+                )
+              : new Set<string>();
+            const existingSessionNavigationGuard = {
+              ...existingSessionTarget,
+              ...navigationPolicy,
+              listTabs: () => profileCtx.listTabs(existingSessionCallOptions),
+              initialTabTargetIds,
+            };
+            const unsupportedMessage = getExistingSessionUnsupportedMessage(action);
+            if (unsupportedMessage) {
               return jsonActError(
                 res,
                 501,
                 ACT_ERROR_CODES.unsupportedForExistingSession,
-                EXISTING_SESSION_LIMITS.act.batch,
+                unsupportedMessage,
               );
+            }
+            switch (action.kind) {
+              case "click":
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    clickChromeMcpElement({
+                      ...existingSessionTarget,
+                      uid: action.ref!,
+                      doubleClick: action.doubleClick ?? false,
+                    }),
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
+              case "clickCoords":
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    clickChromeMcpCoords({
+                      ...existingSessionTarget,
+                      x: action.x,
+                      y: action.y,
+                      doubleClick: action.doubleClick ?? false,
+                      button: action.button as "left" | "right" | "middle" | undefined,
+                      delayMs: action.delayMs,
+                    }),
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
+              case "type":
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: async () => {
+                    await fillChromeMcpElement({
+                      ...existingSessionTarget,
+                      uid: action.ref!,
+                      value: action.text,
+                    });
+                    if (action.submit) {
+                      await pressChromeMcpKey({
+                        ...existingSessionTarget,
+                        key: "Enter",
+                      });
+                    }
+                  },
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
+              case "press":
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    pressChromeMcpKey({
+                      ...existingSessionTarget,
+                      key: action.key,
+                    }),
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
+              case "hover":
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    hoverChromeMcpElement({
+                      ...existingSessionTarget,
+                      uid: action.ref!,
+                    }),
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
+              case "scrollIntoView":
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    evaluateChromeMcpScript({
+                      ...existingSessionTarget,
+                      fn: `(el) => { el.scrollIntoView({ block: "center", inline: "center" }); return true; }`,
+                      args: [action.ref!],
+                    }),
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
+              case "drag":
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    dragChromeMcpElement({
+                      ...existingSessionTarget,
+                      fromUid: action.startRef!,
+                      toUid: action.endRef!,
+                    }),
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
+              case "select":
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    fillChromeMcpElement({
+                      ...existingSessionTarget,
+                      uid: action.ref!,
+                      value: action.values[0] ?? "",
+                    }),
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
+              case "fill":
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    fillChromeMcpForm({
+                      ...existingSessionTarget,
+                      elements: action.fields.map((field) => ({
+                        uid: field.ref,
+                        value: String(field.value ?? ""),
+                      })),
+                    }),
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk(undefined, { resolveCurrentTarget: true });
+              case "resize":
+                await resizeChromeMcpPage({
+                  ...existingSessionTarget,
+                  width: action.width,
+                  height: action.height,
+                });
+                return await jsonOk();
+              case "wait":
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    waitForExistingSessionCondition({
+                      ...existingSessionTarget,
+                      timeMs: action.timeMs,
+                      text: action.text,
+                      textGone: action.textGone,
+                      selector: action.selector,
+                      url: action.url,
+                      loadState: action.loadState,
+                      fn: action.fn,
+                      ...navigationPolicy,
+                    }),
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk();
+              case "evaluate": {
+                const result = await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    evaluateChromeMcpScript({
+                      ...existingSessionTarget,
+                      fn: normalizeBrowserEvaluateFunctionSource(
+                        action.fn,
+                        action.ref ? { argumentName: "el" } : undefined,
+                      ),
+                      args: action.ref ? [action.ref] : undefined,
+                    }),
+                  guard: existingSessionNavigationGuard,
+                });
+                return await jsonOk({ result }, { resolveCurrentTarget: true });
+              }
+              case "close":
+                await profileCtx.closeTab(tab.targetId, {
+                  ...existingSessionCallOptions,
+                  exactTargetId: true,
+                });
+                clearSnapshotKeysForTab(ctx, profileCtx.profile.name, tab.targetId);
+                return await jsonOk();
+              case "batch":
+                return jsonActError(
+                  res,
+                  501,
+                  ACT_ERROR_CODES.unsupportedForExistingSession,
+                  EXISTING_SESSION_LIMITS.act.batch,
+                );
+            }
           }
-        }
 
-        const pw = await requirePwAi(res, `act:${kind}`);
-        if (!pw) {
-          return;
-        }
-        const result = await pw.executeActViaPlaywright({
-          cdpUrl,
-          action,
-          targetId: tab.targetId,
-          evaluateEnabled,
-          ...navigationPolicy,
-          signal,
-        });
-        const resultTargetOptions = {
-          resolveCurrentTarget: true,
-          operationTargetId: result.targetId,
-        };
-        if (result.blockedByDialog) {
-          return await jsonOk({
-            blockedByDialog: true,
-            browserState: result.browserState,
+          const pw = await requirePwAi(res, `act:${kind}`);
+          if (!pw) {
+            return;
+          }
+          const result = await pw.executeActViaPlaywright({
+            cdpUrl,
+            action,
+            targetId: tab.targetId,
+            evaluateEnabled,
+            ...navigationPolicy,
+            signal,
           });
-        }
-        const downloads = result.downloads;
-        if (action.kind === "close" || result.aborted?.reason === "closed") {
-          clearSnapshotKeysForTab(ctx, profileCtx.profile.name, tab.targetId);
-        }
-        switch (action.kind) {
-          case "batch":
-            return await jsonOk(
-              {
-                results: result.results ?? [],
-                ...(result.aborted ? { aborted: result.aborted } : {}),
-                ...(downloads ? { downloads } : {}),
-              },
-              {
-                ...resultTargetOptions,
-                resolveCurrentTarget: result.aborted?.reason !== "closed",
-              },
-            );
-          case "evaluate":
-            return await jsonOk(
-              { result: result.result, ...(downloads ? { downloads } : {}) },
-              resultTargetOptions,
-            );
-          case "click":
-          case "clickCoords":
-            return await jsonOk(downloads ? { downloads } : undefined, resultTargetOptions);
-          case "resize":
-          case "close":
-            return await jsonOk(downloads ? { downloads } : undefined);
-          default:
-            return await jsonOk(downloads ? { downloads } : undefined, resultTargetOptions);
+          const resultTargetOptions = {
+            resolveCurrentTarget: true,
+            operationTargetId: result.targetId,
+          };
+          if (result.blockedByDialog) {
+            return await jsonOk({
+              blockedByDialog: true,
+              browserState: result.browserState,
+            });
+          }
+          const downloads = result.downloads;
+          if (action.kind === "close" || result.aborted?.reason === "closed") {
+            clearSnapshotKeysForTab(ctx, profileCtx.profile.name, tab.targetId);
+          }
+          switch (action.kind) {
+            case "batch":
+              return await jsonOk(
+                {
+                  results: result.results ?? [],
+                  ...(result.aborted ? { aborted: result.aborted } : {}),
+                  ...(downloads ? { downloads } : {}),
+                },
+                {
+                  ...resultTargetOptions,
+                  resolveCurrentTarget: result.aborted?.reason !== "closed",
+                },
+              );
+            case "evaluate":
+              return await jsonOk(
+                { result: result.result, ...(downloads ? { downloads } : {}) },
+                resultTargetOptions,
+              );
+            case "click":
+            case "clickCoords":
+              return await jsonOk(downloads ? { downloads } : undefined, resultTargetOptions);
+            case "resize":
+            case "close":
+              return await jsonOk(downloads ? { downloads } : undefined);
+            default:
+              return await jsonOk(downloads ? { downloads } : undefined, resultTargetOptions);
+          }
+        } finally {
+          await resolveRelayTarget?.release();
         }
       },
     });

--- a/extensions/browser/src/browser/routes/agent.snapshot-target.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot-target.ts
@@ -1,29 +1,74 @@
+import type { RelayOperationReference } from "../extension-relay/owner-client.js";
 import type { BrowserRouteContext } from "../server-context.js";
+import { getProfileLifecycle } from "../server-context.lifecycle.js";
 
-/** Bind relay recovery to the exact registered relay, extension connection, and granted tab. */
-export function captureBrowserOperationTarget(opts: {
+export type BrowserOperationTargetResolver = (() =>
+  | string
+  | undefined
+  | Promise<string | undefined>) & {
+  reference?: RelayOperationReference;
+  release: () => Promise<void>;
+};
+
+/** Pin capture at the actual bridge; a failed capture must never enable generic recovery. */
+export async function captureBrowserOperationTarget(opts: {
   ctx: BrowserRouteContext;
   profileName: string;
   targetId: string;
-}): (() => string | undefined) | undefined {
-  const relay = opts.ctx.state().extensionRelays?.get(opts.profileName);
+}): Promise<BrowserOperationTargetResolver | undefined> {
+  const state = opts.ctx.state();
+  const relay = state.extensionRelays?.get(opts.profileName);
   if (!relay) {
     return undefined;
   }
-  const resolveTarget = relay.bridge.captureOperationTarget(opts.targetId);
-  return () =>
-    opts.ctx.state().extensionRelays?.get(opts.profileName) === relay
-      ? resolveTarget?.()
+  const runtime = state.profiles.get(opts.profileName);
+  if (!runtime) {
+    throw new Error("Browser operation profile is unavailable");
+  }
+  const lifecycle = getProfileLifecycle(runtime);
+  const generation = lifecycle.generation;
+  let released = false;
+  const isCurrent = () =>
+    !released &&
+    opts.ctx.state() === state &&
+    state.extensionRelays?.get(opts.profileName) === relay &&
+    state.profiles.get(opts.profileName) === runtime &&
+    lifecycle.generation === generation;
+  const reference =
+    relay.ownership === "borrowed"
+      ? await relay.client.capture(opts.targetId, () => {
+          if (!isCurrent()) {
+            throw new Error("Browser operation generation was superseded");
+          }
+        })
       : undefined;
+  const resolveTarget =
+    relay.ownership === "borrowed"
+      ? reference?.resolve
+      : relay.bridge.captureOperationTarget(opts.targetId);
+  const resolve = async () => {
+    if (!isCurrent()) {
+      return undefined;
+    }
+    const target = await resolveTarget?.();
+    return isCurrent() ? target : undefined;
+  };
+  return Object.assign(resolve, {
+    reference,
+    release: async () => {
+      released = true;
+      await reference?.release();
+    },
+  });
 }
 
-/** Accept only the acted-on Page or its exact relay-owned tab as a replacement target. */
-export function resolveOperationTargetOutcome(opts: {
+/** Report the acted-on target if its exact owner no longer exposes a replacement. */
+export async function resolveOperationTargetOutcome(opts: {
   actedOnTargetId: string;
   operationTargetId?: string;
-  resolveRelayTarget?: () => string | undefined;
-}): string {
+  resolveRelayTarget?: () => string | undefined | Promise<string | undefined>;
+}): Promise<string> {
   return opts.resolveRelayTarget
-    ? (opts.resolveRelayTarget() ?? opts.actedOnTargetId)
+    ? ((await opts.resolveRelayTarget()) ?? opts.actedOnTargetId)
     : (opts.operationTargetId ?? opts.actedOnTargetId);
 }

--- a/extensions/browser/src/browser/routes/agent.snapshot.test.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.test.ts
@@ -7,22 +7,22 @@ import {
 } from "./agent.snapshot-target.js";
 
 describe("resolveOperationTargetOutcome", () => {
-  it("keeps the acted-on target when the backend cannot prove its successor", () => {
-    expect(resolveOperationTargetOutcome({ actedOnTargetId: "old-123" })).toBe("old-123");
+  it("keeps the acted-on target when the backend cannot prove its successor", async () => {
+    expect(await resolveOperationTargetOutcome({ actedOnTargetId: "old-123" })).toBe("old-123");
   });
 
-  it("accepts the replacement reported by the exact acted-on Playwright page", () => {
+  it("accepts the replacement reported by the exact acted-on Playwright page", async () => {
     expect(
-      resolveOperationTargetOutcome({
+      await resolveOperationTargetOutcome({
         actedOnTargetId: "old-123",
         operationTargetId: "replacement-456",
       }),
     ).toBe("replacement-456");
   });
 
-  it("prefers the exact relay-owned tab over a stale detached Playwright page", () => {
+  it("prefers the exact relay-owned tab over a stale detached Playwright page", async () => {
     expect(
-      resolveOperationTargetOutcome({
+      await resolveOperationTargetOutcome({
         actedOnTargetId: "old-123",
         operationTargetId: "old-123",
         resolveRelayTarget: () => "replacement-456",
@@ -30,9 +30,9 @@ describe("resolveOperationTargetOutcome", () => {
     ).toBe("replacement-456");
   });
 
-  it("never adopts a newcomer when the captured relay owner was revoked or replaced", () => {
+  it("never adopts a newcomer when the captured relay owner was revoked or replaced", async () => {
     expect(
-      resolveOperationTargetOutcome({
+      await resolveOperationTargetOutcome({
         actedOnTargetId: "old-123",
         operationTargetId: "unrelated-999",
         resolveRelayTarget: () => undefined,
@@ -42,12 +42,11 @@ describe("resolveOperationTargetOutcome", () => {
 });
 
 describe("captureBrowserOperationTarget", () => {
-  it("fails closed when a registered relay cannot capture the acted-on target", () => {
+  it("fails closed when a registered relay cannot capture the acted-on target", async () => {
     const relays = new Map([["chrome", { bridge: { captureOperationTarget: () => undefined } }]]);
-    const ctx = {
-      state: () => ({ extensionRelays: relays }),
-    } as unknown as BrowserRouteContext;
-    const resolveRelayTarget = captureBrowserOperationTarget({
+    const state = { extensionRelays: relays, profiles: new Map([["chrome", {}]]) };
+    const ctx = { state: () => state } as unknown as BrowserRouteContext;
+    const resolveRelayTarget = await captureBrowserOperationTarget({
       ctx,
       profileName: "chrome",
       targetId: "old-123",
@@ -55,7 +54,7 @@ describe("captureBrowserOperationTarget", () => {
 
     expect(typeof resolveRelayTarget).toBe("function");
     expect(
-      resolveOperationTargetOutcome({
+      await resolveOperationTargetOutcome({
         actedOnTargetId: "old-123",
         operationTargetId: "unrelated-999",
         resolveRelayTarget,
@@ -63,27 +62,26 @@ describe("captureBrowserOperationTarget", () => {
     ).toBe("old-123");
   });
 
-  it("rejects a replacement relay even when it reports the same profile and target", () => {
+  it("rejects a replacement relay even when it reports the same profile and target", async () => {
     const original = {
       bridge: { captureOperationTarget: () => () => "replacement-456" },
     };
     const relays = new Map([["chrome", original]]);
-    const ctx = {
-      state: () => ({ extensionRelays: relays }),
-    } as unknown as BrowserRouteContext;
-    const resolveRelayTarget = captureBrowserOperationTarget({
+    const state = { extensionRelays: relays, profiles: new Map([["chrome", {}]]) };
+    const ctx = { state: () => state } as unknown as BrowserRouteContext;
+    const resolveRelayTarget = await captureBrowserOperationTarget({
       ctx,
       profileName: "chrome",
       targetId: "old-123",
     });
 
-    expect(resolveRelayTarget?.()).toBe("replacement-456");
+    expect(await resolveRelayTarget?.()).toBe("replacement-456");
     relays.set("chrome", {
       bridge: { captureOperationTarget: () => () => "unrelated-999" },
     });
-    expect(resolveRelayTarget?.()).toBeUndefined();
+    expect(await resolveRelayTarget?.()).toBeUndefined();
     expect(
-      resolveOperationTargetOutcome({
+      await resolveOperationTargetOutcome({
         actedOnTargetId: "old-123",
         operationTargetId: "unrelated-999",
         resolveRelayTarget,

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -377,25 +377,34 @@ export function registerBrowserAgentSnapshotRoutes(
         if (!pw) {
           return;
         }
-        const resolveRelayTarget = captureBrowserOperationTarget({
+        const resolveRelayTarget = await captureBrowserOperationTarget({
           ctx,
           profileName: profileCtx.profile.name,
           targetId: tab.targetId,
         });
-        const result = await pw.navigateViaPlaywright({
-          cdpUrl,
-          targetId: tab.targetId,
-          url,
-          timeoutMs,
-          ...(resolveRelayTarget ? { resolveOperationTarget: resolveRelayTarget } : {}),
-          ...browserNavigationPolicyForProfile(ctx, profileCtx),
-        });
-        const currentTargetId = resolveOperationTargetOutcome({
-          actedOnTargetId: tab.targetId,
-          operationTargetId: result.targetId,
-          resolveRelayTarget,
-        });
-        res.json({ ok: true, ...result, targetId: currentTargetId });
+        try {
+          const result = await pw.navigateViaPlaywright({
+            cdpUrl,
+            targetId: tab.targetId,
+            url,
+            timeoutMs,
+            ...(resolveRelayTarget
+              ? {
+                  resolveOperationTarget: resolveRelayTarget,
+                  relayReference: resolveRelayTarget.reference,
+                }
+              : {}),
+            ...browserNavigationPolicyForProfile(ctx, profileCtx),
+          });
+          const currentTargetId = await resolveOperationTargetOutcome({
+            actedOnTargetId: tab.targetId,
+            operationTargetId: result.targetId,
+            resolveRelayTarget,
+          });
+          res.json({ ok: true, ...result, targetId: currentTargetId });
+        } finally {
+          await resolveRelayTarget?.release();
+        }
       },
     });
   });

--- a/extensions/browser/src/browser/routes/basic.ts
+++ b/extensions/browser/src/browser/routes/basic.ts
@@ -397,13 +397,15 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
         signal: req.signal,
         run: async (signal) => {
           const status = await buildBrowserStatus(ctx, profileCtx, signal);
+          const relay = ctx.state().extensionRelays?.get(profileCtx.profile.name);
+          const identity =
+            relay?.ownership === "borrowed"
+              ? (await relay.client.status()).identity
+              : relay?.bridge.identity;
           const doctorReport = buildBrowserDoctorReport({
             status,
             extensionVersion:
-              status.transport === "extension"
-                ? ctx.state().extensionRelays?.get(profileCtx.profile.name)?.bridge.identity
-                    ?.extensionVersion
-                : undefined,
+              status.transport === "extension" ? identity?.extensionVersion : undefined,
           });
           if (toBoolean(req.query.deep) === true || toBoolean(req.query.live) === true) {
             doctorReport.checks.push(await runBrowserLiveProbe(profileCtx, signal));

--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -47,6 +47,7 @@ import {
   registerProfileHandle,
   releaseProfileHandle,
   withProfileOperationLease,
+  waitForProfileOperation,
 } from "./server-context.lifecycle.js";
 import type {
   BrowserServerState,
@@ -180,18 +181,24 @@ export function createProfileAvailability({
   const ensureExtensionRelay = async (signal?: AbortSignal) => {
     signal?.throwIfAborted();
     if (capabilities.mode !== "local-extension") {
-      return;
+      return undefined;
     }
     const { ensureExtensionRelayForProfile } = await getExtensionRelayModule();
     const current = state();
-    await ensureExtensionRelayForProfile(current, profile, signal);
+    const relay = await ensureExtensionRelayForProfile(current, profile, signal);
     signal?.throwIfAborted();
+    return relay;
   };
   const isReachable = async (
     timeoutMs?: number,
     options?: { ephemeral?: boolean; signal?: AbortSignal },
   ) => {
-    await ensureExtensionRelay(options?.signal);
+    const relay = await ensureExtensionRelay(options?.signal);
+    if (relay?.ownership === "borrowed") {
+      const ready = await relay.client.status();
+      options?.signal?.throwIfAborted();
+      return ready.ready && state().extensionRelays?.get(profile.name) === relay;
+    }
     if (capabilities.usesChromeMcp) {
       // countChromeMcpTabs creates the session if needed — no separate availability call required.
       // Status probes opt into ephemeral so they reuse a cached attach session if one exists,
@@ -237,7 +244,12 @@ export function createProfileAvailability({
     if (capabilities.usesChromeMcp) {
       return await isTransportAvailable(timeoutMs, signal);
     }
-    await ensureExtensionRelay(signal);
+    const relay = await ensureExtensionRelay(signal);
+    if (relay?.ownership === "borrowed") {
+      const ready = await relay.client.status();
+      signal?.throwIfAborted();
+      return ready.ready && state().extensionRelays?.get(profile.name) === relay;
+    }
     const { httpTimeoutMs } = resolveTimeouts(timeoutMs);
     return await isChromeReachable(profile.cdpUrl, httpTimeoutMs, getCdpReachabilityPolicy());
   };
@@ -457,10 +469,18 @@ export function createProfileAvailability({
     if (capabilities.mode === "local-extension") {
       const { ensureExtensionRelayForProfile } = await getExtensionRelayModule();
       const relay = await ensureExtensionRelayForProfile(current, profile, signal);
-      const connected = await relay.bridge.waitForExtensionConnection(
-        signal,
-        CHROME_MCP_ATTACH_READY_WINDOW_MS,
-      );
+      const connected =
+        relay.ownership === "borrowed"
+          ? (
+              await waitForProfileOperation(
+                relay.client.status(CHROME_MCP_ATTACH_READY_WINDOW_MS),
+                signal,
+              )
+            ).ready
+          : await relay.bridge.waitForExtensionConnection(
+              signal,
+              CHROME_MCP_ATTACH_READY_WINDOW_MS,
+            );
       signal.throwIfAborted();
       httpReachable =
         connected &&

--- a/extensions/browser/src/browser/server-context.extension-readiness.test.ts
+++ b/extensions/browser/src/browser/server-context.extension-readiness.test.ts
@@ -33,6 +33,7 @@ function createExtensionProfile() {
   });
   const bridge = new ExtensionRelayBridge();
   const relay = {
+    ownership: "owned",
     port: 18799,
     token: "relay-test-key",
     allowLegacyAuth: true,

--- a/extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts
@@ -170,6 +170,7 @@ function createExtensionRelayFixture(name = "chrome") {
     lastTargetId: "shared-tab",
   });
   const relay = {
+    ownership: "owned",
     port: 18799,
     token: "persistent-relay-test-key",
     allowLegacyAuth: true,

--- a/extensions/browser/src/browser/server-context.lifecycle.ts
+++ b/extensions/browser/src/browser/server-context.lifecycle.ts
@@ -11,7 +11,7 @@ import type { RunningChrome } from "./chrome.js";
 import { stopOpenClawChrome } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { BrowserProfileUnavailableError } from "./errors.js";
-import type { ExtensionRelayHandle } from "./extension-relay/relay-server.js";
+import type { ExtensionRelayResource } from "./extension-relay/relay-access.js";
 import { getBrowserProfileCapabilities } from "./profile-capabilities.js";
 import { getLoadedPwAiModule } from "./pw-ai-module.js";
 import type { PlaywrightConnectionRetirement } from "./pw-session.js";
@@ -30,7 +30,7 @@ type ProfileLifecycleActor = {
   handles: Set<RunningChrome>;
   cleanupChromeMcp: Set<string>;
   cleanupPlaywright: Map<string, PlaywrightConnectionRetirement>;
-  cleanupRelays: Set<ExtensionRelayHandle>;
+  cleanupRelays: Set<ExtensionRelayResource>;
   terminal: ProfileLifecycleTerminal | null;
   transitionReason: string | null;
   blockedReason: string | null;

--- a/extensions/browser/src/browser/server-context.ts
+++ b/extensions/browser/src/browser/server-context.ts
@@ -306,11 +306,14 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
                   })
                     ? 200
                     : current.resolved.remoteCdpTimeoutMs;
-                  activeRunning = await isChromeReachable(
-                    activeProfile.cdpUrl,
-                    probeTimeoutMs,
-                    resolveCdpReachabilityPolicy(activeProfile, current.resolved.ssrfPolicy),
-                  );
+                  activeRunning =
+                    capabilities.mode === "local-extension"
+                      ? await profileCtx.isTransportAvailable(probeTimeoutMs, signal)
+                      : await isChromeReachable(
+                          activeProfile.cdpUrl,
+                          probeTimeoutMs,
+                          resolveCdpReachabilityPolicy(activeProfile, current.resolved.ssrfPolicy),
+                        );
                   if (activeRunning) {
                     const tabs = await profileCtx.listTabs({ signal }).catch(() => []);
                     activeTabCount = tabs.filter((tab) => tab.type === "page").length;

--- a/extensions/browser/src/browser/server-context.types.ts
+++ b/extensions/browser/src/browser/server-context.types.ts
@@ -8,7 +8,7 @@ import type { RunningChrome } from "./chrome.js";
 import type { BrowserOpenResult, BrowserTab, BrowserTransport } from "./client.types.js";
 import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js";
 import type { BrowserErrorResponse } from "./errors.js";
-import type { ExtensionRelayHandle } from "./extension-relay/relay-server.js";
+import type { ExtensionRelayResource } from "./extension-relay/relay-access.js";
 
 export type { BrowserTab };
 
@@ -43,7 +43,7 @@ export type BrowserServerState = {
   resolved: ResolvedBrowserConfig;
   profiles: Map<string, ProfileRuntimeState>;
   /** Running extension relay servers keyed by profile name (extension driver). */
-  extensionRelays?: Map<string, ExtensionRelayHandle>;
+  extensionRelays?: Map<string, ExtensionRelayResource>;
   stopTrackedTabCleanup?: () => void;
   stopUnhandledRejectionHandler?: () => void;
 };

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -689,8 +689,10 @@ describe("browser control server", () => {
       ["openclaw", { bridge: { captureOperationTarget: () => () => "replacement-target" } }],
     ]) as unknown as NonNullable<typeof runtime.extensionRelays>;
     requirePwMock("navigateViaPlaywright").mockImplementationOnce(async (options) => {
-      const targetId = (
-        options as { resolveOperationTarget?: () => string | undefined }
+      const targetId = await (
+        options as {
+          resolveOperationTarget?: () => string | undefined | Promise<string | undefined>;
+        }
       ).resolveOperationTarget?.();
       if (!targetId) {
         throw new Error("captured relay target was not forwarded to navigation");

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -627,6 +627,7 @@ function buildUnifiedDistEntries(): Record<string, string> {
       "extensions/memory-core/src/memory/manager-search-knn.child.ts",
     ...listBundledPluginEntrySources(rootBundledPluginBuildEntries),
     "extensions/browser/native-host-entry": "extensions/browser/native-host-entry.ts",
+    "extensions/browser/relay-daemon-entry": "extensions/browser/relay-daemon-entry.ts",
     ...bundledHookEntries,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Chrome extension with a direct-loopback pairing loses browser automation when no local Gateway or browser node is serving its relay. A tunnel to a remote Gateway does not supply that same-host listener.

Installed testing also exposed two broken supported flows: a native-woken daemon prevented later Gateway browser control with `EADDRINUSE`, and Gateway-owned browser evaluation could hang after a successful tab listing because an execution-context event overtook its initialization response. Both are repaired and now pass real installed Chrome proof.

## Why This Change Was Made

The browser plugin owns an on-demand standalone daemon, and Gateway now distinguishes **owning a listener** from **borrowing authenticated access to its real bridge**. Each configured profile/port has one authoritative bridge in either startup order. Ordinary browser work remains CDP/Playwright; a narrow, existing-v2-authenticated owner channel supplies readiness, bounded connection-local operation references, and forwarding of authenticated Gateway extension ingress. Closing Gateway's lease does not stop the daemon or unrelated external clients.

The native host validates the reconnecting extension's saved port against configured extension profiles before waking it. Automatic wake accepts only the canonical `127.0.0.1` address the daemon serves. The new daemon defaults to mutual v2 authentication; the existing explicit `browser.extensionRelay.allowLegacyAuth=true` opt-in remains available. Normal automatic bootstrap retains its Gateway route.

Connected repairs preserve the same ownership boundaries: descriptor-owned POSIX relay-secret reads; guarded discovery of both Chromium `Preferences` and `Secure Preferences`; raw/WebSocket error ownership through close; immediate/coalesced legacy ingress admission; and cleanup acknowledgement distinct from best-effort final notification delivery. Runtime initialization now waits for earlier frame-tree replies on the exact logical session without serializing unrelated clients, Fetch responses, dialog handling, or other CDP commands.

## User Impact

With a supporting extension/native-host build, a configured direct-loopback pairing can recover its local relay on reconnect without a running Gateway. External authenticated CDP clients can use it directly. Core `openclaw browser` actions still use a Gateway, which can now join an already-running daemon safely. Access revocation, opt-out, exact origins, profile/session generations, and real native cleanup remain authoritative.

The daemon and Gateway both need a build supporting owner access. No new configuration/environment option, dependency, SQLite schema, persistent store, SDK API, or protocol-version bump is introduced. The native request union is IPC framing, not a persistent data-model change. No v3 path, direct-DevTools fallback, remote-secret copying, or Gateway service installation is added. Windows retains manual setup. The unpacked source build was tested; Store v2.2.0 must not be assumed to contain this unpublished feature.

See [Chrome extension setup](https://docs.openclaw.ai/tools/chrome-extension) and [browser CLI](https://docs.openclaw.ai/cli/browser).

## Evidence

Published CI head: [4f47b95ffe4218f874da0df1cc576ea80bec6702](https://github.com/openclaw/openclaw/commit/4f47b95ffe4218f874da0df1cc576ea80bec6702). Its parent [c79e3399c8c91add8019fc5ee954135cb56b00fb](https://github.com/openclaw/openclaw/commit/c79e3399c8c91add8019fc5ee954135cb56b00fb) is the built/live-tested commit. Both have exactly source tree `f389993641a5ff1341c68d105db09ed3aa22a762`: the intervening commit is empty and only refreshes CI. No source file changed after review or installed proof. Fresh exact-head [CI run 33340376759](https://github.com/openclaw/openclaw/actions/runs/33340376759) and [OpenGrep run 33340376753](https://github.com/openclaw/openclaw/actions/runs/33340376753) both passed on attempt 1. Required `openclaw/ci-gate` succeeded, with zero failed or pending checks. Actual CI checkout `eb88e616b3f1f2ed72b3f5cf9ae2644260617e18` contains the published head and repaired main. Source, installed proof, and CI are ready for the native landing workflow; no merge is claimed yet.

### Installed real-Chrome proof

All required installed behavior clauses passed on **Blacksmith Testbox**, lease `tbx_01m1abng2m81wkaac18f2kzcn1`, [run 33338491413](https://github.com/openclaw/openclaw/actions/runs/33338491413). The canonical packer built a self-contained tarball, which was installed into a fresh task HOME with `umask 022`. CLI: `OpenClaw 2026.8.1 (c79e339)`. Artifact SHA-256: `70c6172999e3e928a0e93ec01859255482786f329f023d0b16000bd8e6099588` (62,047,957 bytes).

Chrome for Testing **152.0.7977.54** loaded the managed unpacked copy through the visible Extensions UI and native directory chooser, after native-host registration. Installed dependencies were independently checked: Playwright **1.62.1**, ws **8.21.3**. External control used MCPorter **0.13.8** and chrome-devtools-mcp **1.8.0**, explicit `--autoConnect`, `require` relay policy, and the default discovery budget. No storage injection, fabricated Chrome record, manual daemon launch, relay-URL pin, or discovery-timeout override supplied this proof. The setup driver disconnected before relay-driven actions.

| Flow | Observed result |
|---|---|
| Natural installation | Normal install discovers the exact managed ID/path in real `Preferences`, with `manualSetupRequired=false` and no issues. |
| Gateway first | Native Gateway bootstrap connects; the listener belongs to Gateway. Core tabs/evaluate/snapshot/Doctor pass. Core changes the counter 0→1; external v2 control changes it 1→2. The previously stalled evaluation completes in 1.109 s. |
| Standalone first, then Gateway | With Gateway absent, visible direct pairing and native messaging wake the daemon. External control changes 2→3. Gateway subsequently lists, evaluates 3→4, snapshots, and diagnoses the same bridge without replacing its listener. The same external client performs another action. |
| Borrowed navigation | Gateway navigates the exact existing target through a captured owner reference. The reloaded fixture accepts Core 0→1 and external 1→2, with no Chrome restart. Only the fixture's exact `127.0.0.1` hostname is allowlisted. |
| Gateway-forwarded ingress | Visible Gateway pairing forwards the extension into the daemon's same bridge. Core and external actions/snapshots/Doctor pass; direct pairing is then restored through the visible form. |
| Independent Gateway cleanup | Stopping Gateway leaves the same daemon, Chrome, and external MCP child alive. That unchanged external client performs counter 6→7 afterward. |
| Native recovery | The external consumer is explicitly stopped, then the owned daemon is stopped. Native messaging replaces the listener in 2.608 s; a fresh client's actual action proves readiness and changes the same page 7→8. Chrome is unchanged. Creating and closing a new page also pass. |
| Cleanup | Exact task-owned processes stop, all proof ports close, and the lease is independently observed completed. The operator's Chrome/Gateway and protected Copilot pairing/recovery state are untouched. |

Seventeen captures were inspected and verified synthetic-only. The directory chooser needed two observed activations; the first dismissed path completion. The initial 120-second installer waiter ended before UI setup finished and correctly still requested manual setup; after actual visible loading, the normal idempotent install command discovered the plugin. That setup timing is not hidden as a first-attempt success or fixed with a longer timeout.

This proves **cold-client** recovery after daemon replacement, not retained-client crash reconnection. Protected existing-profile recovery, live non-first-profile configuration, background screenshot capture, and the ten-minute idle expiry were not exercised. Non-first/pinned-port selection has focused regression coverage. No package or Store release was performed.

### Regression and local verification

- Canonical-address and descriptor-swap regressions failed before their repairs; general pairing and concurrent first-writer controls remain covered.
- Real installed testing first exposed the Chromium backing-store miss and daemon-first `EADDRINUSE`; current installed proof above demonstrates both repairs.
- The later execution-context race was captured on the installed predecessor: the default Runtime context arrived before the frame-tree reply, and no user evaluation command was dispatched. A deterministic test using the real extension command handler, relay sockets, and Playwright fails before the repair and passes afterward for **both owned and borrowed** relays.
- Socket EPIPE/ECONNRESET, malformed frames, immediate/coalesced legacy hello, cancellation, stale references, and delayed/native-cleanup failures have boundary regressions. A failed final retirement notification cannot retroactively fail completed cleanup; borrowers still require the actual acknowledgement.
- Latest full Node 24 browser replay: **3,601 passed, 24 skipped** (222 files passed, five skipped). Focused ordering/ownership batch: **115 passed**. Proportional formatting/type/lint/guard checks and full build passed. The final test-helper naming cleanup also passed focused tests and changed checks. Earlier test-only type-library and max-lines failures were repaired using the existing deferred helper and a fixture extraction, not suppressions or configuration changes.
- Fresh **whole-candidate autoreview** completed scoped-clean with no accepted/actionable findings at the configured **P0** threshold. This is not a P1/P2 certificate.

Principal commands (Node 24; full exact command/exit/hash receipts retained locally):

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/relay-bootstrap.integration.test.ts
```

```bash
node scripts/check-changed.mjs -- extensions/browser/src/browser/extension-relay/relay-bridge.ts extensions/browser/src/browser/extension-relay/relay-session-owner.ts extensions/browser/src/browser/extension-relay/relay-runtime.test.ts extensions/browser/src/browser/extension-relay/relay-coexistence.test-support.ts extensions/browser/src/browser/extension-relay/relay-bootstrap.integration.test.ts extensions/browser/src/browser/extension-relay/relay-runtime.test-support.ts
```

```bash
CI=true NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_NODE_TEST_CONFIGS_JSON='["test/vitest/vitest.extension-browser.config.ts"]' OPENCLAW_NODE_TEST_VITEST_ARGS_JSON='[]' OPENCLAW_VITEST_SHARD_NAME=changed-extensions-config-6 node --import tsx scripts/ci-run-node-test-shard.mts
```

```bash
node --import ./scripts/tsx.mjs scripts/build-all.mts
```

```bash
node scripts/package-openclaw-for-docker.mjs --allow-unreleased-changelog --output-dir /tmp/openclaw-relay-autonomous-128379/artifacts
```

### CI and review follow-through

The behavioral commit's browser shard and [OpenGrep run 33337441900](https://github.com/openclaw/openclaw/actions/runs/33337441900) passed. [CI run 33337441820](https://github.com/openclaw/openclaw/actions/runs/33337441820) failed only the docs release-navigation assertion. The independently owned [navigation expectation fix](https://github.com/openclaw/openclaw/pull/133581) landed as [7504a3b3c453](https://github.com/openclaw/openclaw/commit/7504a3b3c45393e793e2a3960585a4e781da94cd). A draft/ready refresh still checked out the old merge input, so one CI-only empty commit forces a fresh synchronize event. The source tree remains identical; the old failed/stale checks are not being relabeled green.

The [latest substantive ClawSweeper review](https://github.com/openclaw/openclaw/pull/128379#issuecomment-5388629085) reviewed the earlier `1a8f89cb` head. Its ownership finding, architectural decision, and rank-up request are addressed by the single real-bridge owner model, both startup-order regressions, and the installed daemon-first/Gateway proof above. The v2-only daemon default with existing explicit legacy opt-in is accepted. The stored-data-model classification of native IPC framing is not a SQLite/schema change. A new review has been queued by the ready-for-review event; its arrival is separate from required CI and verified behavior.

Production: **+2,559/-844, net +1,715**; tests/support: **+3,140/-579, net +2,561**; docs: +90/-18; tooling/config: +2/-1. Raw churn includes authentication/target-info/fixture extractions and `finally` indentation, not additional capabilities. Production growth supplies the standalone lifecycle and authenticated cross-process ownership, generation fencing, bounded operation references, and acknowledged cleanup; the final ordering repair itself is **net +23 production lines**. Release-owned `CHANGELOG.md` is unchanged; release-note context is in this PR.
