### PR TITLE
fix(acpx): resolve MCP environment SecretRefs

### DIFF
--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -73,7 +73,73 @@
             },
             "env": {
               "type": "object",
-              "additionalProperties": { "type": "string" },
+              "additionalProperties": {
+                "anyOf": [
+                  { "type": "string" },
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "source": { "type": "string", "const": "env" },
+                          "provider": {
+                            "type": "string",
+                            "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                          },
+                          "id": {
+                            "type": "string",
+                            "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                          }
+                        },
+                        "required": ["source", "provider", "id"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "source": { "type": "string", "const": "store" },
+                          "provider": {
+                            "type": "string",
+                            "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                          },
+                          "id": {
+                            "type": "string",
+                            "pattern": "^[A-Z][A-Z0-9_]{0,127}$"
+                          }
+                        },
+                        "required": ["source", "provider", "id"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "source": { "type": "string", "const": "file" },
+                          "provider": {
+                            "type": "string",
+                            "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                          },
+                          "id": { "type": "string" }
+                        },
+                        "required": ["source", "provider", "id"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "source": { "type": "string", "const": "exec" },
+                          "provider": {
+                            "type": "string",
+                            "pattern": "^[a-z][a-z0-9_-]{0,63}$"
+                          },
+                          "id": { "type": "string" }
+                        },
+                        "required": ["source", "provider", "id"],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                ]
+              },
               "description": "Environment variables for the MCP server"
             }
           },
@@ -160,7 +226,7 @@
       }
     ],
     "secretInputs": {
-      "bundledDefaultEnabled": false,
+      "bundledDefaultEnabled": true,
       "paths": [
         {
           "path": "mcpServers.*.env.*",

--- a/extensions/acpx/src/config-schema.ts
+++ b/extensions/acpx/src/config-schema.ts
@@ -2,6 +2,7 @@
  * ACPX plugin configuration schema and public config types. Runtime setup uses
  * this file as the single source of truth for validation and defaulting.
  */
+import { buildSecretInputSchema, type SecretInput } from "openclaw/plugin-sdk/secret-input";
 import { z } from "zod";
 
 const ACPX_PERMISSION_MODES = ["approve-all", "approve-reads", "deny-all"] as const;
@@ -19,7 +20,7 @@ export const DEFAULT_ACPX_TIMEOUT_SECONDS = 120;
 export type McpServerConfig = {
   command: string;
   args?: string[];
-  env?: Record<string, string>;
+  env?: Record<string, SecretInput>;
 };
 
 /** Normalized MCP server config emitted to the ACPX runtime process. */
@@ -73,8 +74,8 @@ const McpServerConfigSchema = z.object({
     .optional()
     .describe("Arguments to pass to the command"),
   env: z
-    .record(z.string(), z.string({ error: "env values must be strings" }), {
-      error: "env must be an object of strings",
+    .record(z.string(), buildSecretInputSchema(), {
+      error: "env must be an object of secret inputs",
     })
     .optional()
     .describe("Environment variables for the MCP server"),

--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -2,13 +2,29 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { validateJsonSchemaValue } from "openclaw/plugin-sdk/json-schema-runtime";
 import { buildPluginConfigSchema } from "openclaw/plugin-sdk/plugin-entry";
 import { describe, expect, it } from "vitest";
 import { AcpxPluginConfigSchema } from "./config-schema.js";
-import { resolveAcpxPluginConfig, resolveAcpxPluginRoot } from "./config.js";
+import { resolveAcpxPluginConfig, resolveAcpxPluginRoot, toAcpMcpServers } from "./config.js";
 
 const requireFromTest = createRequire(import.meta.url);
 const TSX_IMPORT = requireFromTest.resolve("tsx");
+const pluginManifest = JSON.parse(
+  fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+) as { configSchema: Record<string, unknown> };
+
+function validateMcpServerEnvValue(value: unknown) {
+  const config = { mcpServers: { proof: { command: "node", env: { TOKEN: value } } } };
+  return {
+    runtime: AcpxPluginConfigSchema.safeParse(config).success,
+    manifest: validateJsonSchemaValue({
+      schema: pluginManifest.configSchema,
+      cacheKey: "acpx.manifest.config-schema",
+      value: config,
+    }).ok,
+  };
+}
 
 function expectedMcpServerArgs(params: { sourceEntry: string; distEntry: string }): string[] {
   const distEntry = path.resolve(params.distEntry);
@@ -19,6 +35,75 @@ function expectedMcpServerArgs(params: { sourceEntry: string; distEntry: string 
 }
 
 describe("embedded acpx plugin config", () => {
+  it.each([
+    ["literal", "literal-token"],
+    ["env", { source: "env", provider: "default", id: "MCP_TOKEN" }],
+    ["file", { source: "file", provider: "vault", id: "/mcp/token" }],
+    ["exec", { source: "exec", provider: "vault", id: "mcp/token" }],
+    ["store", { source: "store", provider: "default", id: "MCP_TOKEN" }],
+  ])("accepts %s MCP server env SecretInput in both production validators", (_source, value) => {
+    expect(validateMcpServerEnvValue(value)).toEqual({ runtime: true, manifest: true });
+  });
+
+  it.each([
+    ["missing provider", { source: "env", id: "MCP_TOKEN" }],
+    ["missing id", { source: "env", provider: "default" }],
+    ["unknown source", { source: "unknown", provider: "default", id: "MCP_TOKEN" }],
+    ["unexpected field", { source: "env", provider: "default", id: "MCP_TOKEN", extra: true }],
+    ["invalid provider", { source: "env", provider: "INVALID", id: "MCP_TOKEN" }],
+    ["invalid env id", { source: "env", provider: "default", id: "lowercase" }],
+  ])("rejects malformed MCP server env SecretInput with %s", (_reason, value) => {
+    expect(validateMcpServerEnvValue(value)).toEqual({ runtime: false, manifest: false });
+  });
+
+  it("passes materialized MCP environment strings to ACP without changing them", () => {
+    expect(
+      toAcpMcpServers({
+        proof: {
+          command: "node",
+          env: {
+            LITERAL: "literal-token",
+            RESOLVED: "materialized-secret-value",
+            BARE_SHAPED: "$MCP_TOKEN",
+            BRACED_SHAPED: "${MCP_TOKEN}",
+            PADDED: "  token  ",
+            EMPTY: "",
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        name: "proof",
+        command: "node",
+        args: [],
+        env: [
+          { name: "LITERAL", value: "literal-token" },
+          { name: "RESOLVED", value: "materialized-secret-value" },
+          { name: "BARE_SHAPED", value: "$MCP_TOKEN" },
+          { name: "BRACED_SHAPED", value: "${MCP_TOKEN}" },
+          { name: "PADDED", value: "  token  " },
+          { name: "EMPTY", value: "" },
+        ],
+      },
+    ]);
+  });
+
+  it("rejects unresolved structured MCP environment references at the ACP boundary", () => {
+    expect(() =>
+      toAcpMcpServers({
+        proof: {
+          command: "node",
+          env: { TOKEN: { source: "env", provider: "default", id: "MCP_TOKEN" } },
+        },
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        name: "UnresolvedSecretInputError",
+        path: "plugins.entries.acpx.config.mcpServers.proof.env.TOKEN",
+      }),
+    );
+  });
+
   it("resolves workspace stateDir and cwd by default", () => {
     const workspaceDir = path.resolve("/tmp/openclaw-acpx");
     const resolved = resolveAcpxPluginConfig({
@@ -185,13 +270,8 @@ describe("embedded acpx plugin config", () => {
   });
 
   it("keeps the runtime json schema in sync with the manifest config schema", () => {
-    const pluginRoot = resolveAcpxPluginRoot();
-    const manifest = JSON.parse(
-      fs.readFileSync(path.join(pluginRoot, "openclaw.plugin.json"), "utf8"),
-    ) as { configSchema?: unknown };
-
     expect(buildPluginConfigSchema(AcpxPluginConfigSchema).jsonSchema).toEqual(
-      manifest.configSchema,
+      pluginManifest.configSchema,
     );
   });
 });

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -7,6 +7,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { formatPluginConfigIssue } from "openclaw/plugin-sdk/extension-shared";
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { AcpxPluginConfigSchema, DEFAULT_ACPX_TIMEOUT_SECONDS } from "./config-schema.js";
 import type {
@@ -219,10 +220,18 @@ export function toAcpMcpServers(mcpServers: Record<string, McpServerConfig>): Ac
     name,
     command: server.command,
     args: [...(server.args ?? [])],
-    env: Object.entries(server.env ?? {}).map(([envName, value]) => ({
-      name: envName,
-      value,
-    })),
+    env: Object.entries(server.env ?? {}).map(([envName, input]) => {
+      const configPath = `plugins.entries.acpx.config.mcpServers.${name}.env.${envName}`;
+      // Snapshot preparation owns inline refs; materialized strings can resemble refs.
+      const value =
+        typeof input === "string"
+          ? input
+          : normalizeResolvedSecretInputString({ value: input, path: configPath });
+      if (value === undefined) {
+        throw new Error(`${configPath} must be a string or resolved SecretRef.`);
+      }
+      return { name: envName, value };
+    }),
   }));
 }
 

--- a/src/secrets/runtime-config-collectors-plugins.bundled.test.ts
+++ b/src/secrets/runtime-config-collectors-plugins.bundled.test.ts
@@ -18,6 +18,79 @@ const explicitMainRoster: NonNullable<OpenClawConfig["agents"]> = {
 };
 
 describe("collectPluginConfigAssignments bundled plugin manifests", () => {
+  it("resolves default-enabled ACPX MCP SecretRefs without reinterpreting materialized strings", async () => {
+    const acpx = findBundledPluginMetadataById("acpx", {
+      includeChannelConfigs: false,
+      includeSyntheticChannelConfigs: false,
+    });
+    expect(acpx?.manifest.enabledByDefault).toBe(true);
+    expect(acpx?.manifest.configContracts?.secretInputs?.bundledDefaultEnabled).toBe(true);
+
+    const config = {
+      agents: explicitMainRoster,
+      plugins: {
+        entries: {
+          acpx: {
+            config: {
+              mcpServers: {
+                proof: {
+                  command: "node",
+                  env: {
+                    TOKEN: envRef("MCP_TOKEN"),
+                    BARE: "$BARE_TOKEN",
+                    BRACED: "${BRACED_TOKEN}",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const env = {
+      MCP_TOKEN: "resolved-token",
+      BARE_TOKEN: "$OTHER",
+      BRACED_TOKEN: "${OTHER}",
+    };
+    const context = createResolverContext({ sourceConfig: config, env });
+
+    collectPluginConfigAssignments({
+      config,
+      defaults: undefined,
+      context,
+      loadablePluginOrigins: new Map([["acpx", "bundled"]]),
+    });
+
+    expect(context.assignments.map((assignment) => assignment.path)).toEqual([
+      "plugins.entries.acpx.config.mcpServers.proof.env.TOKEN",
+      "plugins.entries.acpx.config.mcpServers.proof.env.BARE",
+      "plugins.entries.acpx.config.mcpServers.proof.env.BRACED",
+    ]);
+    expect(context.warnings).toEqual([]);
+
+    const inlineRefs = context.assignments.slice(1).map((assignment) => assignment.ref);
+    await expect(
+      resolveSecretRefValues(inlineRefs, {
+        config,
+        env: {},
+        cache: createResolverContext({ sourceConfig: config, env: {} }).cache,
+      }),
+    ).rejects.toThrow('Environment variable "BARE_TOKEN" is missing or empty.');
+
+    const resolved = await resolveSecretRefValues(
+      context.assignments.map((assignment) => assignment.ref),
+      { config, env, cache: context.cache },
+    );
+    applyResolvedAssignments({ assignments: context.assignments, resolved });
+    expect(config.plugins?.entries?.acpx?.config).toMatchObject({
+      mcpServers: {
+        proof: {
+          env: { TOKEN: "resolved-token", BARE: "$OTHER", BRACED: "${OTHER}" },
+        },
+      },
+    });
+  });
+
   it("assigns each webhooks route SecretRef to its exact runtime owner", () => {
     expect(
       findBundledPluginMetadataById("webhooks", {

--- a/src/secrets/runtime-config-collectors-plugins.test.ts
+++ b/src/secrets/runtime-config-collectors-plugins.test.ts
@@ -127,7 +127,7 @@ describe("collectPluginConfigAssignments", () => {
           legacyPluginIds: [],
           configContracts: {
             secretInputs: {
-              bundledDefaultEnabled: false,
+              bundledDefaultEnabled: true,
               paths: [{ path: "mcpServers.*.env.*", expected: "string" }],
             },
           },
@@ -382,8 +382,15 @@ describe("collectPluginConfigAssignments", () => {
     expectInactiveAcpxConfig(createAcpxMcpSecretConfig({ entry: { enabled: false } }));
   });
 
-  it("treats bundled acpx SecretRef surfaces as inactive until enabled", () => {
-    expectInactiveAcpxConfig(createAcpxMcpSecretConfig({ plugins: { enabled: true } }));
+  it("collects bundled acpx SecretRefs when the plugin is enabled by default", () => {
+    const context = collectAcpxConfigAssignments(
+      createAcpxMcpSecretConfig({ plugins: { enabled: true } }),
+    );
+
+    expect(context.assignments.map((assignment) => assignment.path)).toEqual([
+      "plugins.entries.acpx.config.mcpServers.s1.env.K",
+    ]);
+    expect(context.warnings).toEqual([]);
   });
 
   it("skips assignments when plugin is in denylist", () => {
@@ -413,6 +420,13 @@ describe("collectPluginConfigAssignments", () => {
     expect(context.assignments).toHaveLength(1);
   });
 
+  it("keeps installed ACPX SecretRefs active without explicit plugin enablement", () => {
+    const context = collectAssignments(createAcpxMcpSecretConfig({}), [["acpx", "config"]]);
+
+    expect(context.assignments).toHaveLength(1);
+    expect(context.warnings).toEqual([]);
+  });
+
   it("ignores plain string env values", () => {
     const config = createPluginConfig("acpx", {
       mcpServers: {
@@ -434,7 +448,7 @@ describe("collectPluginConfigAssignments", () => {
           command: "node",
           env: {
             INLINE: "${INLINE_KEY}",
-            SECOND: "${SECOND_KEY}",
+            SECOND: "$SECOND_KEY",
             LITERAL: "hello",
           },
         },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ACPX advertised MCP server environment values as plain strings while the public SecretRef inventory and schema allowed credential-like configuration elsewhere. Structured SecretRefs were rejected by ACPX's production schema, and the default-enabled plugin's configured MCP secrets could be skipped during snapshot collection.

## Why This Change Was Made

ACPX MCP environment values now accept the canonical SecretInput contract in both Zod and manifest schemas. The Gateway resolves them during snapshot preparation, and the ACP conversion boundary passes only strings to the published ACPX/ACP SDK contract. Remaining structured references fail strictly; materialized strings whose bytes resemble `$NAME` remain literal and are never reparsed.

The secret collector now follows ACPX's actual default activation. Runtime ownership remains intentionally unknown and strict because ACPX MCP environment credentials do not yet have a proven independently gated runtime owner.

## User Impact

Operators can use environment-, file-, exec-, or store-backed SecretRefs for MCP server environment variables. The resolved values reach delegated ACP agents as strings; missing references fail startup safely without exposing identifiers.

AI-assisted implementation; I reviewed the dependency contracts, code, tests, security boundary, and live delegated ACP flow.

## Evidence

- Pre-fix production validation rejected the documented object and default-enabled collection produced no assignment.
- Runtime and manifest validators accept all four SecretRef sources and reject malformed objects.
- Boundary tests preserve literal/materialized template-looking strings and reject remaining structured refs.
- 701 focused tests passed after rebasing onto current `main`; dependency and API contract checks passed.
- Autoreview was clean before and after rebase. Dedicated security review found no qualifying vulnerability.
- Direct dependency inspection covered ACP SDK 1.3.0, ACPX 0.13.1, Codex ACP 1.1.7, and sibling Codex MCP environment source.
- Isolated real dev Gateway with unique state/port invoked `sessions_spawn` using `runtime: "acp"`; the bundled ACPX runtime created a real ACP session and delivered the materialized MCP environment string to a temporary adapter. Missing-reference startup remained strict and sanitized.

Production LOC: +84/-9. Tests: +159/-11.
