### PR TITLE
fix(apps): prevent stale Now Playing after ownership changes

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMediaPlaybackCoordinator.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMediaPlaybackCoordinator.swift
@@ -154,7 +154,7 @@ final class ChatMediaPlaybackCoordinator {
                   self.activeOwner === owner
             else { return }
             owner.handleRemoteCommand(command)
-            self.nowPlayingCenter.publish(owner.nowPlayingMetadata)
+            self.updateNowPlaying(owner)
         }
         self.nowPlayingCenter.publish(owner.nowPlayingMetadata)
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMediaPlaybackCoordinatorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMediaPlaybackCoordinatorTests.swift
@@ -43,6 +43,7 @@ private final class RecordingNowPlayingOwner: ChatMediaNowPlayingOwner {
         duration: 42,
         elapsed: 3,
         playbackRate: 1)
+    var onCommand: (@MainActor (ChatMediaRemoteCommand) -> Void)?
     private(set) var commands: [ChatMediaRemoteCommand] = []
 
     func stopForMediaPlaybackInterruption() {}
@@ -54,6 +55,7 @@ private final class RecordingNowPlayingOwner: ChatMediaNowPlayingOwner {
             duration: 42,
             elapsed: 4,
             playbackRate: command == .pause ? 0 : 1)
+        self.onCommand?(command)
     }
 }
 
@@ -120,5 +122,33 @@ struct ChatMediaPlaybackCoordinatorTests {
 
         #expect(center.published.count == 1)
         #expect(center.clearCount == 1)
+    }
+
+    @Test(arguments: [false, true])
+    func `remote commands never republish a released or replaced owner`(replaceOwner: Bool) {
+        let center = RecordingNowPlayingCenter()
+        let coordinator = ChatMediaPlaybackCoordinator(nowPlayingCenter: center)
+        let owner = RecordingNowPlayingOwner()
+        let replacement = RecordingNowPlayingOwner()
+        replacement.nowPlayingMetadata = ChatMediaNowPlayingMetadata(
+            title: "next.mov",
+            duration: 12,
+            elapsed: 0,
+            playbackRate: 1)
+        owner.onCommand = { [weak owner] _ in
+            guard let owner else { return }
+            if replaceOwner {
+                coordinator.activate(replacement)
+            } else {
+                coordinator.release(owner)
+            }
+        }
+
+        coordinator.activate(owner)
+        center.send(.play)
+
+        #expect(center.published.count == (replaceOwner ? 2 : 1))
+        #expect(center.published.last?.title == (replaceOwner ? "next.mov" : "clip.mov"))
+        #expect(center.clearCount == (replaceOwner ? 0 : 1))
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Prevents native macOS/iOS Now Playing from displaying stale attachment information after a remote playback command releases the current player or activates a replacement.

## Why This Change Was Made

The shared media coordinator checked playback ownership before dispatching a remote command, but published the original owner's metadata unconditionally after the callback returned. Audio playback failures can synchronously release that owner, and callback-driven replacement can activate another player first. Both paths therefore restored stale system media information. Route post-command publication through the existing canonical `updateNowPlaying` owner check.

## User Impact

Failed native audio playback leaves Now Playing cleared, and replacing an attachment preserves the replacement track's metadata. Normal play, pause, toggle, speech ownership, and stale-release behavior remain unchanged.

## Evidence

- Authentic pre-fix native regression failed independently for both lifecycle cases: released owners were republished after clear, and replaced owners overwrote the replacement track.
- Added one table-driven owner-boundary regression covering synchronous release and replacement, using the existing real coordinator and recording publisher.
- `swift test --package-path apps/shared/OpenClawKit --filter ChatMediaPlaybackCoordinatorTests` passed all five native tests, including both new parameterized cases.
- Repository SwiftFormat lint and `git diff --check` passed.
- Independent read-only local review inspected the complete coordinator, audio/video production owners, callback lifecycle, and sibling speech/release paths.
- Production delta: +1/-1 lines, net zero; tests +30/-0. No configuration, protocol, persistence, provider, or dependency changes.
