### PR TITLE
feat(provider): add FreeToken self-hosted provider [AI-assisted]

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1814,5 +1814,21 @@
   {
     "source": "macOS widget panel",
     "target": "macOS 小组件面板"
+  },
+  {
+    "source": "FreeToken",
+    "target": "FreeToken"
+  },
+  {
+    "source": "FreeToken plugin",
+    "target": "FreeToken 插件"
+  },
+  {
+    "source": "freetoken",
+    "target": "freetoken"
+  },
+  {
+    "source": "FreeToken (local MoE models)",
+    "target": "FreeToken（本地 MoE 模型）"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1539,6 +1539,7 @@
                   "providers/fal",
                   "providers/featherless",
                   "providers/fireworks",
+                  "providers/freetoken",
                   "providers/github-copilot",
                   "providers/gmi",
                   "providers/google",

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -52,7 +52,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-57 plugins
+58 plugins
 
 - **[active-memory](/plugins/reference/active-memory)** (`openclaw`) - included in OpenClaw. Runs bounded pre-reply memory retrieval and implements per-agent Remember across conversations for eligible private conversations.
 
@@ -91,6 +91,8 @@ Each entry lists the package, distribution route, and description.
 - **[fal](/plugins/reference/fal)** (`@openclaw/fal-provider`) - included in OpenClaw. Adds fal model provider support to OpenClaw.
 
 - **[file-transfer](/plugins/reference/file-transfer)** (`@openclaw/file-transfer`) - included in OpenClaw. Fetch, list, and write files on paired nodes via dedicated node commands. Bypasses bash stdout truncation by using base64 over node.invoke for binaries up to 16 MB.
+
+- **[freetoken](/plugins/reference/freetoken)** (`@openclaw/freetoken-provider`) - included in OpenClaw. Adds FreeToken model provider support to OpenClaw.
 
 - **[github-copilot](/plugins/reference/github-copilot)** (`@openclaw/github-copilot-provider`) - included in OpenClaw. Adds GitHub Copilot model provider support to OpenClaw.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -16,5 +16,5 @@ Regenerate it with:
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 148
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 149
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/freetoken.md
+++ b/docs/plugins/reference/freetoken.md
@@ -1,0 +1,23 @@
+---
+summary: "Adds FreeToken model provider support to OpenClaw."
+read_when:
+  - You are installing, configuring, or auditing the freetoken plugin
+title: "FreeToken plugin"
+---
+
+# FreeToken plugin
+
+Adds FreeToken model provider support to OpenClaw.
+
+## Distribution
+
+- Package: `@openclaw/freetoken-provider`
+- Install route: included in OpenClaw
+
+## Surface
+
+providers: `freetoken`
+
+## Related docs
+
+- [freetoken](/providers/freetoken)

--- a/docs/providers/freetoken.md
+++ b/docs/providers/freetoken.md
@@ -1,0 +1,101 @@
+---
+summary: "Run OpenClaw with FreeToken (OpenAI-compatible local MoE server)"
+read_when:
+  - You want to run OpenClaw against a local FreeToken server
+  - You want an OpenAI-compatible edge-native MoE runtime
+title: "FreeToken"
+---
+
+FreeToken serves open-weight MoE models through an OpenAI-compatible HTTP API.
+OpenClaw connects through the bundled `freetoken` provider and discovers models
+from the server's `/v1/models` endpoint.
+
+| Property                  | Value                                                           |
+| ------------------------- | --------------------------------------------------------------- |
+| Provider id               | `freetoken`                                                     |
+| Plugin                    | bundled, `enabledByDefault: true`                               |
+| Auth env var              | `FREETOKEN_API_KEY` (any non-empty value if no auth is enabled) |
+| Onboarding flag           | `--auth-choice freetoken`                                       |
+| API                       | OpenAI-compatible (`openai-completions`)                        |
+| Default base URL          | `http://127.0.0.1:1919/v1`                                      |
+| Default model placeholder | `freetoken/Qwen/Qwen3.6-35B-A3B`                                |
+| Pricing                   | Marked external-free (`modelPricing.external: false`)           |
+
+## Getting started
+
+1. Start FreeToken with a supported model:
+
+   ```bash
+   ft serve --model Qwen/Qwen3.6-35B-A3B
+   ```
+
+2. Opt in to provider discovery. Any non-empty value works when the local server
+   is not configured with authentication:
+
+   ```bash
+   export FREETOKEN_API_KEY="freetoken-local"
+   ```
+
+3. Run onboarding or configure a model directly:
+
+   ```bash
+   openclaw onboard --auth-choice freetoken
+   ```
+
+   ```json5
+   {
+     agents: {
+       defaults: {
+         model: { primary: "freetoken/Qwen/Qwen3.6-35B-A3B" },
+       },
+     },
+   }
+   ```
+
+## Model discovery
+
+When `FREETOKEN_API_KEY` is set (or an auth profile exists) and
+`models.providers.freetoken` is not defined, OpenClaw queries
+`http://127.0.0.1:1919/v1/models` and converts the returned ids into model
+entries.
+
+Define `models.providers.freetoken` explicitly when the server uses a different
+host or port, requires a real API key, or needs fixed context/output limits:
+
+```json5
+{
+  models: {
+    providers: {
+      freetoken: {
+        baseUrl: "http://127.0.0.1:1919/v1",
+        apiKey: "${FREETOKEN_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "Qwen/Qwen3.6-35B-A3B",
+            name: "Local FreeToken Qwen3.6",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 32768,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+## Operational notes
+
+- Keep an unauthenticated server bound to loopback. Add authentication and
+  network controls before exposing it beyond the host.
+- OpenAI API compatibility proves request compatibility, not that a model fits
+  the machine. Host RAM, memory bandwidth, PCIe bandwidth, VRAM, context length,
+  and concurrency all affect local MoE performance.
+- Validate a local model in a shadow route before making it the primary model,
+  and keep a known-good fallback provider configured.
+
+See the [FreeToken repository](https://github.com/FlashML-org/FreeToken) for
+runtime installation, supported models, and hardware requirements.

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -44,6 +44,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [fal](/providers/fal)
 - [Featherless AI](/providers/featherless)
 - [Fireworks](/providers/fireworks)
+- [FreeToken (local MoE models)](/providers/freetoken)
 - [GitHub Copilot](/providers/github-copilot)
 - [GMI Cloud](/providers/gmi)
 - [Google (Gemini)](/providers/google)

--- a/extensions/freetoken/README.md
+++ b/extensions/freetoken/README.md
@@ -1,0 +1,3 @@
+# FreeToken Provider
+
+Bundled provider plugin for FreeToken discovery and setup.

--- a/extensions/freetoken/api.ts
+++ b/extensions/freetoken/api.ts
@@ -1,0 +1,7 @@
+// FreeToken API module exposes the plugin public contract.
+export {
+  FREETOKEN_DEFAULT_API_KEY_ENV_VAR,
+  FREETOKEN_DEFAULT_BASE_URL,
+  FREETOKEN_MODEL_PLACEHOLDER,
+  FREETOKEN_PROVIDER_LABEL,
+} from "./defaults.js";

--- a/extensions/freetoken/defaults.ts
+++ b/extensions/freetoken/defaults.ts
@@ -1,0 +1,5 @@
+// FreeToken plugin module implements defaults behavior.
+export const FREETOKEN_DEFAULT_BASE_URL = "http://127.0.0.1:1919/v1";
+export const FREETOKEN_PROVIDER_LABEL = "FreeToken";
+export const FREETOKEN_DEFAULT_API_KEY_ENV_VAR = "FREETOKEN_API_KEY";
+export const FREETOKEN_MODEL_PLACEHOLDER = "Qwen/Qwen3.6-35B-A3B";

--- a/extensions/freetoken/index.test.ts
+++ b/extensions/freetoken/index.test.ts
@@ -1,0 +1,19 @@
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  FREETOKEN_DEFAULT_API_KEY_ENV_VAR,
+  FREETOKEN_DEFAULT_BASE_URL,
+  FREETOKEN_MODEL_PLACEHOLDER,
+} from "./api.js";
+import plugin from "./index.js";
+
+describe("FreeToken provider plugin", () => {
+  it("registers the provider with stable local defaults", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(provider.id).toBe("freetoken");
+    expect(FREETOKEN_DEFAULT_BASE_URL).toBe("http://127.0.0.1:1919/v1");
+    expect(FREETOKEN_DEFAULT_API_KEY_ENV_VAR).toBe("FREETOKEN_API_KEY");
+    expect(FREETOKEN_MODEL_PLACEHOLDER).toBe("Qwen/Qwen3.6-35B-A3B");
+  });
+});

--- a/extensions/freetoken/index.ts
+++ b/extensions/freetoken/index.ts
@@ -1,0 +1,23 @@
+import { defineSelfHostedOpenAICompatibleProvider } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  FREETOKEN_DEFAULT_API_KEY_ENV_VAR,
+  FREETOKEN_DEFAULT_BASE_URL,
+  FREETOKEN_MODEL_PLACEHOLDER,
+  FREETOKEN_PROVIDER_LABEL,
+} from "./api.js";
+
+export default defineSelfHostedOpenAICompatibleProvider({
+  id: "freetoken",
+  label: FREETOKEN_PROVIDER_LABEL,
+  hint: "Edge-native OpenAI-compatible MoE server",
+  groupHint: "Local/self-hosted MoE inference",
+  defaultBaseUrl: FREETOKEN_DEFAULT_BASE_URL,
+  apiKeyEnvVar: FREETOKEN_DEFAULT_API_KEY_ENV_VAR,
+  modelPlaceholder: FREETOKEN_MODEL_PLACEHOLDER,
+  overrides: {
+    buildUnknownModelHint: () =>
+      "FreeToken requires authentication to be registered as a provider. " +
+      "Set FREETOKEN_API_KEY (any value works when the server has no auth) or run " +
+      '"openclaw configure". See: https://docs.openclaw.ai/providers/freetoken',
+  },
+});

--- a/extensions/freetoken/openclaw.plugin.json
+++ b/extensions/freetoken/openclaw.plugin.json
@@ -1,0 +1,52 @@
+{
+  "id": "freetoken",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["freetoken"],
+  "modelCatalog": {
+    "discovery": {
+      "freetoken": "refreshable"
+    }
+  },
+  "providerRequest": {
+    "providers": {
+      "freetoken": {
+        "family": "freetoken"
+      }
+    }
+  },
+  "modelPricing": {
+    "providers": {
+      "freetoken": {
+        "external": false
+      }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "freetoken",
+        "envVars": ["FREETOKEN_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "freetoken",
+      "method": "custom",
+      "choiceId": "freetoken",
+      "choiceLabel": "FreeToken",
+      "choiceHint": "Edge-native OpenAI-compatible MoE server",
+      "groupId": "freetoken",
+      "groupLabel": "FreeToken",
+      "groupHint": "Local/self-hosted MoE inference"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/freetoken/package.json
+++ b/extensions/freetoken/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/freetoken-provider",
+  "version": "2026.8.1",
+  "private": true,
+  "description": "OpenClaw FreeToken provider plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/freetoken/tsconfig.json
+++ b/extensions/freetoken/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,6 +958,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/freetoken:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/github-copilot:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/scripts/generate-plugin-inventory-doc.mts
+++ b/scripts/generate-plugin-inventory-doc.mts
@@ -170,6 +170,7 @@ function humanizeId(value: string) {
     ["exa", "Exa"],
     ["fal", "fal"],
     ["feishu", "Feishu"],
+    ["freetoken", "FreeToken"],
     ["github", "GitHub"],
     ["googlechat", "Google Chat"],
     ["gpt", "GPT"],


### PR DESCRIPTION
AI-assisted: yes.

## What Problem This Solves

FreeToken exposes an OpenAI-compatible local inference API, but OpenClaw has no named provider, onboarding choice, or discovery defaults for it. Users must currently configure a generic endpoint manually.

## Why This Change Was Made

This adds the smallest OpenClaw-owned integration surface: a bundled self-hosted provider plugin using the existing provider helper. CPU/GPU scheduling, model installation, and resource admission remain outside OpenClaw.

Related: #128387

## Shipped Solution

- Adds the `freetoken` bundled provider and `FREETOKEN_API_KEY` opt-in.
- Defaults to `http://127.0.0.1:1919/v1` with refreshable `/v1/models` discovery.
- Adds onboarding metadata, provider docs, generated plugin reference/inventory, and zh-CN glossary entries.
- Adds a focused registration/defaults test.

## User Impact

Users can select and discover a local FreeToken server through the same provider workflow used by other self-hosted runtimes. No production default or agent-loop behavior changes.

## Evidence

- `pnpm test:extension freetoken`: 1 test file, 1 test PASS.
- `pnpm test:contracts:plugins`: 42 files, 1043 tests PASS.
- `pnpm build`: PASS.
- `pnpm check:docs`: PASS; 0 broken links.
- Targeted type-aware oxlint for the new extension and inventory generator: PASS.
- Changed-file formatting and `git diff --check`: PASS.
- Full `pnpm check`: preflight and all typecheck phases PASS; full-repo core lint could not complete because the `tsgolint` subprocess was SIGKILLed by the 16 GB WSL test environment. No changed-file lint errors were reported.

## Checklist

- [x] Focused provider tests
- [x] Shared plugin contracts
- [x] Build
- [x] Docs checks
- [x] No `CHANGELOG.md` edit
- [x] Maintainer-editable fork branch
- [x] Sanitized; no credentials, private paths, or internal identifiers