### PR TITLE
improve(matrix): avoid duplicate outbound body projection

### DIFF
--- a/extensions/matrix/src/matrix/send.preparation-perf.test.ts
+++ b/extensions/matrix/src/matrix/send.preparation-perf.test.ts
@@ -1,0 +1,62 @@
+// Matrix tests cover outbound preparation reuse before provider delivery.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginRuntime } from "../../runtime-api.js";
+import { setMatrixRuntime } from "../runtime.js";
+import type { MatrixClient } from "./sdk.js";
+
+const bodyProjection = vi.hoisted(() => ({ count: 0 }));
+
+vi.mock("./format.js", async () => {
+  const actual = await vi.importActual<typeof import("./format.js")>("./format.js");
+  return {
+    ...actual,
+    markdownToMatrixBody: (markdown: string) => {
+      bodyProjection.count += 1;
+      return actual.markdownToMatrixBody(markdown);
+    },
+  };
+});
+
+import { sendMessageMatrix } from "./send.js";
+
+const runtimeStub = {
+  channel: {
+    text: {
+      chunkMarkdownTextWithMode: (text: string) => [text],
+      resolveChunkMode: () => "length",
+      resolveMarkdownTableMode: () => "code",
+      resolveTextChunkLimit: () => 4000,
+    },
+  },
+} as unknown as PluginRuntime;
+
+describe("sendMessageMatrix preparation performance", () => {
+  beforeEach(() => {
+    bodyProjection.count = 0;
+    setMatrixRuntime(runtimeStub);
+  });
+
+  it("projects a single-event body once before provider delivery", async () => {
+    const sentContent: Array<Record<string, unknown>> = [];
+    const client = {
+      getUserId: async () => "@bot:example.org",
+      prepareRoomForMessageSend: async () => "m.room.message",
+      sendMessage: async (_roomId: string, content: Record<string, unknown>) => {
+        sentContent.push(content);
+        return "$event";
+      },
+    } as unknown as MatrixClient;
+
+    await sendMessageMatrix("room:!room:example.org", "ordinary **Matrix** reply", {
+      cfg: {},
+      client,
+    });
+
+    expect(bodyProjection.count).toBe(1);
+    expect(sentContent).toHaveLength(1);
+    expect(sentContent[0]).toMatchObject({
+      body: "ordinary **Matrix** reply",
+      format: "org.matrix.custom.html",
+    });
+  });
+});

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -227,11 +227,13 @@ export async function sendMessageMatrix(
         : null;
       let plannedEvents: MatrixPreparedEvent[] | undefined = storedPlan?.events;
       if (!plannedEvents) {
-        const { chunks, tableMode } = chunkMatrixText(messageText, {
+        const preparedText = chunkMatrixText(messageText, {
           cfg,
           accountId: opts.accountId,
           preserveWhitespace: true,
         });
+        const { chunks, convertedText, preparedBody, fitsInSingleEvent, tableMode } = preparedText;
+        const singleEventBody = fitsInSingleEvent ? preparedBody : undefined;
         const relation = threadId
           ? buildThreadRelation(threadId, opts.replyToId)
           : buildReplyRelation(opts.replyToId);
@@ -301,6 +303,7 @@ export async function sendMessageMatrix(
             client,
             content,
             markdown: captionMarkdown,
+            preparedBody: captionMarkdown === convertedText ? singleEventBody : undefined,
             tableMode,
           });
           prepareContent(content, receiptKind);
@@ -315,6 +318,7 @@ export async function sendMessageMatrix(
               client,
               content: followup,
               markdown: chunk,
+              preparedBody: chunk === convertedText ? singleEventBody : undefined,
               tableMode,
             });
             prepareContent(followup, "text");
@@ -329,6 +333,7 @@ export async function sendMessageMatrix(
               client,
               content,
               markdown: chunk,
+              preparedBody: chunk === convertedText ? singleEventBody : undefined,
               tableMode,
             });
             prepareContent(content, "text");
@@ -522,6 +527,7 @@ export async function sendSingleTextMessageMatrix(
   const {
     trimmedText,
     convertedText,
+    preparedBody,
     singleEventLimit,
     eventTextLength,
     fitsInSingleEvent,
@@ -561,6 +567,7 @@ export async function sendSingleTextMessageMatrix(
         client,
         content,
         markdown: convertedText,
+        preparedBody,
         includeMentions: opts.includeMentions,
         tableMode,
       });
@@ -631,7 +638,7 @@ export async function editMessageMatrix(
     async (client) => {
       const resolvedRoom = await resolveMatrixRoomId(client, roomId);
       const cfg = requireRuntimeConfig(opts.cfg, "Matrix message edit") as CoreConfig;
-      const { convertedText, tableMode } = prepareMatrixSingleText(newText, {
+      const { convertedText, preparedBody, tableMode } = prepareMatrixSingleText(newText, {
         cfg,
         accountId: opts.accountId,
         preserveWhitespace: true,
@@ -646,6 +653,7 @@ export async function editMessageMatrix(
         client,
         content: newContent,
         markdown: convertedText,
+        preparedBody,
         includeMentions: opts.includeMentions,
         tableMode,
       });

--- a/extensions/matrix/src/matrix/send/chunking.ts
+++ b/extensions/matrix/src/matrix/send/chunking.ts
@@ -25,6 +25,7 @@ import {
 type MatrixPreparedSingleText = {
   trimmedText: string;
   convertedText: string;
+  preparedBody: string;
   singleEventLimit: number;
   eventTextLength: number;
   fitsInSingleEvent: boolean;
@@ -194,13 +195,12 @@ export function prepareMatrixSingleText(
       MATRIX_FORMAT_PROFILE.chunk.limit,
     ),
   );
-  const eventTextLength = Math.max(
-    convertedText.length,
-    markdownToMatrixBody(convertedText).length,
-  );
+  const preparedBody = markdownToMatrixBody(convertedText);
+  const eventTextLength = Math.max(convertedText.length, preparedBody.length);
   return {
     trimmedText,
     convertedText,
+    preparedBody,
     singleEventLimit,
     eventTextLength,
     fitsInSingleEvent: eventTextLength <= singleEventLimit,

--- a/extensions/matrix/src/matrix/send/formatting.ts
+++ b/extensions/matrix/src/matrix/send/formatting.ts
@@ -27,11 +27,12 @@ const getCore = () => getMatrixRuntime();
 async function renderMatrixFormattedContent(params: {
   client: MatrixClient;
   markdown?: string | null;
+  preparedBody?: string;
   includeMentions?: boolean;
   tableMode?: MarkdownTableMode;
 }): Promise<{ body: string; html?: string; mentions?: MatrixMentions }> {
   const markdown = params.markdown ?? "";
-  const body = markdownToMatrixBody(markdown);
+  const body = params.preparedBody ?? markdownToMatrixBody(markdown);
   if (params.includeMentions === false) {
     const html = markdownToMatrixHtml(markdown, { tableMode: params.tableMode }).trimEnd();
     return { body, html: html || undefined };
@@ -68,12 +69,14 @@ export async function enrichMatrixFormattedContent(params: {
   client: MatrixClient;
   content: MatrixFormattedContent;
   markdown?: string | null;
+  preparedBody?: string;
   includeMentions?: boolean;
   tableMode?: MarkdownTableMode;
 }): Promise<void> {
   const { body, html, mentions } = await renderMatrixFormattedContent({
     client: params.client,
     markdown: params.markdown,
+    preparedBody: params.preparedBody,
     includeMentions: params.includeMentions,
     tableMode: params.tableMode,
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending an ordinary single-event Matrix message would pay for the same Markdown-to-Matrix body projection twice before provider delivery. Rich Markdown made this duplicate CPU work measurable on the outbound hot path.

## Why This Change Was Made

Matrix text preparation now carries its already-rendered body to formatting when the exact converted text is sent as one event. Multichunk messages retain the existing per-chunk projection path, and provider payload, routing, retry, storage, and public contracts are unchanged.

## User Impact

Single-event Matrix text, captions, voice followups, single-message sends, and edits avoid one redundant body render. A controlled rich-Markdown benchmark measured a 33.2% reduction in preparation time for the affected path.

## Evidence

- Exact pre-fix regression: focused test failed because one outbound event projected the body twice; candidate passes with one projection.
- Focused Matrix owner/sibling set: 9 files, 212 tests passed.
- Full Matrix extension: 32 files, 537 tests passed across 4 shards.
- Provider-boundary semantic differential: 9 representative cases / 13 SDK events byte-identical after normalizing only `sentAt`.
- `node scripts/check-changed.mjs --timed -- ...`: passed (`extensions, extensionTests`), including production/test typechecks, formatting, type-aware Oxlint (0 findings), dead-code, boundary, guard, and cycle checks.
- `git diff --check`: passed.
- Structured autoreview: TruffleHog clean; Codex `gpt-5.6-sol` / high clean, patch correct at 0.99 confidence.
