### PR TITLE
fix(tts): deliver voice-only replies when speech runtime is cold

### DIFF
--- a/src/tts/tts-payload.ts
+++ b/src/tts/tts-payload.ts
@@ -83,12 +83,17 @@ function hasLegacyFinalMediaDirective(text: string): boolean {
   return /(?:^|\n)\s*MEDIA\s*:/i.test(text);
 }
 
-// A voice-only send (structured voiceText, empty visible text) must still end in a visible
-// outcome when speech cannot be attempted at all; otherwise delivery normalizes the empty
-// payload to null and the send silently vanishes. Mirrors the synthesis-failure fallback.
-function applyExplicitSpeechVisibleFallback(payload: ReplyPayload): ReplyPayload {
-  const explicitText = getReplyPayloadMetadata(payload)?.tts?.text?.trim();
-  if (!explicitText || hasReplyPayloadContent(payload, {})) {
+// Channel-owned content checks distinguish visible blocks from transport-only metadata.
+function applyExplicitSpeechVisibleFallback(
+  payload: ReplyPayload,
+  channel?: string,
+  explicitText = getReplyPayloadMetadata(payload)?.tts?.text?.trim(),
+): ReplyPayload {
+  const channelId = explicitText && payload.channelData ? normalizeMessageChannel(channel) : null;
+  const hasChannelData = channelId
+    ? getChannelPlugin(channelId)?.messaging?.hasStructuredReplyPayload?.({ payload })
+    : undefined;
+  if (!explicitText || hasReplyPayloadContent(payload, { hasChannelData })) {
     return payload;
   }
   return { ...payload, text: explicitText };
@@ -108,7 +113,7 @@ export async function maybeApplyTtsToPayloadCore(
   persistTtsAudio: TtsAudioPersistence,
 ): Promise<ReplyPayload> {
   if (!isSpeechRuntimeAvailable()) {
-    return applyExplicitSpeechVisibleFallback(params.payload);
+    return applyExplicitSpeechVisibleFallback(params.payload, params.channel);
   }
   if (params.payload.isCompactionNotice) {
     return params.payload;
@@ -292,13 +297,5 @@ export async function maybeApplyTtsToPayloadCore(
 
   const latency = Date.now() - ttsStart;
   logVerbose(`TTS: conversion failed after ${latency}ms (${result.error ?? "unknown"}).`);
-  const channelId =
-    explicitTtsText && nextPayload.channelData ? normalizeMessageChannel(params.channel) : null;
-  const hasChannelData = channelId
-    ? getChannelPlugin(channelId)?.messaging?.hasStructuredReplyPayload?.({ payload: nextPayload })
-    : undefined;
-  // Channel-owned content checks keep transport-only metadata from silently dropping the answer.
-  return explicitTtsText && !hasReplyPayloadContent(nextPayload, { hasChannelData })
-    ? { ...nextPayload, text: explicitTtsText }
-    : nextPayload;
+  return applyExplicitSpeechVisibleFallback(nextPayload, params.channel, explicitTtsText);
 }

--- a/src/tts/tts-runtime-fallbacks.test.ts
+++ b/src/tts/tts-runtime-fallbacks.test.ts
@@ -791,31 +791,78 @@ describe("TTS runtime provider fallback and delivery behavior", () => {
 });
 
 describe("cold speech runtime visible fallback", () => {
-  it("materializes voice-only structured speech as visible text when the runtime is unavailable", async () => {
-    const { setSpeechRuntimeAvailabilityGuard } = await import("./runtime-availability.js");
-    setSpeechRuntimeAvailabilityGuard(() => {
-      throw new Error("speech runtime configured cold");
-    });
-    try {
-      const payload: ReplyPayload = { text: "" };
-      setReplyPayloadMetadata(payload, {
-        ttsExplicit: true,
-        tts: { tagged: true, text: "Spoken greeting" },
+  it.each([
+    { loaded: true, structured: false },
+    { loaded: true, structured: true },
+    { loaded: false, structured: false },
+    { loaded: false, structured: true },
+  ])(
+    "delivers voice-only speech when its runtime is unavailable (loaded: $loaded, structured: $structured)",
+    async ({ loaded, structured }) => {
+      const { setSpeechRuntimeAvailabilityGuard } = await import("./runtime-availability.js");
+      const restoreRegistry = installStructuredReplyTestChannel(loaded);
+      setSpeechRuntimeAvailabilityGuard(() => {
+        throw new Error("speech runtime configured cold");
       });
-      const result = await maybeApplyTtsToPayloadCore(
-        {
-          payload,
-          cfg: createTtsConfig("openclaw-speech-cold-runtime-fallback-test"),
-          channel: "slack",
-          kind: "final",
-        },
-        async () => "unused",
-      );
-      expect(result.text).toBe("Spoken greeting");
-    } finally {
-      setSpeechRuntimeAvailabilityGuard(undefined);
-    }
-  });
+      routedPayloads.length = 0;
+      synthesizeMock.mockClear();
+      try {
+        const answer = "Spoken greeting";
+        const channelData = structured
+          ? {
+              slack: {
+                blocks: [
+                  { type: "section", text: { type: "mrkdwn", text: "Visible channel card" } },
+                ],
+              },
+            }
+          : { slack: { unfurl: false } };
+        const cfg = createTtsConfig(`openclaw-speech-cold-runtime-${loaded}-${structured}`);
+        const routingResults: Array<Awaited<ReturnType<typeof routeReply>>> = [];
+        const dispatcher = createReplyDispatcher({
+          beforeDeliver: (payload, info) =>
+            maybeApplyTtsToPayloadCore(
+              { payload, cfg, channel: "slack", kind: info.kind },
+              async () => "unused",
+            ),
+          deliver: async (payload, info) => {
+            routingResults.push(
+              await routeReply({
+                payload,
+                channel: "slack",
+                to: "channel:C123",
+                cfg,
+                replyKind: info.kind,
+              }),
+            );
+          },
+        });
+
+        expect(
+          dispatcher.sendFinalReply(
+            setReplyPayloadMetadata(
+              { text: "", channelData },
+              { ttsExplicit: true, tts: { tagged: true, text: answer } },
+            ),
+          ),
+        ).toBe(true);
+        dispatcher.markComplete();
+        await dispatcher.waitForIdle();
+
+        expect(routingResults).toEqual([{ ok: true, delivered: true, messageId: "tts-route-1" }]);
+        expect(routedPayloads).toHaveLength(1);
+        expect(routedPayloads[0]).toMatchObject({
+          text: structured ? "" : answer,
+          channelData,
+        });
+        expect(synthesizeMock).not.toHaveBeenCalled();
+      } finally {
+        setSpeechRuntimeAvailabilityGuard(undefined);
+        restoreRegistry();
+        routedPayloads.length = 0;
+      }
+    },
+  );
 
   it("keeps payloads with visible text unchanged when the runtime is unavailable", async () => {
     const { setSpeechRuntimeAvailabilityGuard } = await import("./runtime-availability.js");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending voice-only replies would receive no answer when speech support was unavailable and the channel payload contained transport metadata. The reply dispatcher incorrectly treated metadata such as Slack unfurl settings as visible content, then the channel router silently reported the reply undelivered.

## Why This Change Was Made

Use one channel-aware visibility decision for both unavailable speech runtimes and failed speech synthesis. The canonical channel owner distinguishes actual visible structured blocks from transport-only metadata, so an otherwise invisible voice-only reply falls back to its original spoken text while legitimate structured content remains unchanged.

Production code decreases by three lines. No public configuration, plugin SDK contract, protocol, persistence, or speech-provider behavior changes.

## User Impact

Voice-only answers are delivered as readable text when speech cannot run, including before a bundled channel plugin has activated. Existing visible messages, media attachments, and genuine channel-native cards keep their established behavior.

## Evidence

- Authentic pre-fix regression: both loaded and bundled-but-inactive Slack channel paths returned `delivered: false` through the real reply dispatcher and channel router when voice-only replies contained transport-only metadata.
- Post-fix real delivery proof covers all four loaded/bundled × transport-only/visible-block combinations; genuine channel-native blocks remain visible without synthesizing or replacing their text.
- `node scripts/run-vitest.mjs src/tts/tts-runtime-fallbacks.test.ts src/auto-reply/reply/route-reply.test.ts` — 81 tests passed across two suites.
- `node scripts/run-vitest.mjs test/plugins/bundled-provider-auth-literal-parity.test.ts` — all 16 cases passed after rebasing onto the independently landed upstream Ollama parity repair.
- Core and core-test TypeScript, focused formatting/lint, max-lines and assertion-safety ratchets.
- Fresh independent source-aware in-session review: no actionable findings; verified canonical owner, warm synthesis siblings, loaded/bundled channel lookup, unchanged public contracts, and `+13/-16` production LOC.
