### PR TITLE
fix(test): provide runtime to Ollama parity registration

### DIFF
--- a/test/plugins/bundled-provider-auth-literal-parity.test-support.ts
+++ b/test/plugins/bundled-provider-auth-literal-parity.test-support.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createPluginRuntimeMock } from "../../src/plugin-sdk/plugin-test-runtime.js";
 import { listBundledPluginMetadata } from "../../src/plugins/bundled-plugin-metadata.js";
 import type { PluginManifest } from "../../src/plugins/manifest.js";
 import type {
@@ -219,6 +220,7 @@ export function defineBundledProviderAuthLiteralParityTests(shardIndex: number):
           name: pluginId,
           source: `bundled:${pluginId}`,
         });
+        captured.api.runtime = createPluginRuntimeMock();
         register(captured.api);
         registrationResultByPluginId.set(pluginId, { status: "fulfilled", value: captured });
       } catch (reason) {


### PR DESCRIPTION
Related regression: https://github.com/openclaw/openclaw/pull/128034

Unblocks: https://github.com/openclaw/openclaw/pull/128375

## What Problem This Solves

Fixes a current-`main` test regression where bundled provider auth parity checks fail while registering Ollama. The Ollama registration added in #128034 now consumes the host plugin runtime, but the parity harness still supplied an empty captured runtime.

## Why This Change Was Made

The shared parity harness now seeds every captured plugin registration with the canonical plugin runtime mock before invoking the plugin entrypoint. This keeps the harness production-shaped without special-casing Ollama or changing Ollama runtime behavior.

## User Impact

No product runtime behavior changes. Maintainers regain a green bundled-provider parity lane, and #128375 can complete its exact-head CI.

## Evidence

- Current-main base `977bbe2667728670a7011f5be23409124c45b723`: bundled provider parity reproduced 45/46 passing. The sole failure was Ollama registration reading missing `api.runtime.llm.acquireLocalService`.
- Exact head `a076c31f0be2c292bde908210f443ef9c80f6234`: bundled provider parity passed 46/46.
- Ollama owner tests passed 278/278 across `extensions/ollama/index.test.ts`, `extensions/ollama/lazy-import.test.ts`, and `extensions/ollama/src/stream-runtime.test.ts`.
- `pnpm format:check test/plugins/bundled-provider-auth-literal-parity.test-support.ts` passed.
- `git diff --check` passed.
- `check-changed` passed conflict, attribution, deprecation, extension export, duplicate coverage, coercion, dependency pin, formatting, patch, and temp-creation gates. Its root test type lane stopped on unrelated sparse-checkout omissions plus the existing shared-install `pako` declaration gap; exact-head clean-install CI is the authority for that lane.
- Autoreview reported no accepted or actionable finding.
- Production LOC: `+0/-0`; tests: `+2/-0`.

AI-assisted: yes. The author inspected the failure path and validated the exact patch.

Punchcard-Session: ember-valley-orchard-5e

Punchcard-Receipt: `pc1.cHVuY2hjYXJkLXNlcnZlci1yZWNlaXB0LXYxAGF0dF8wMU0wUkJZNjBCTUtZN0ROUDFUSFYxNThWNQB0bnRfMDFKMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAAdXNyXzAxSjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAxAGRldl8zODZGRjVCMzQxQTI2NzQzQjJDREEzMEY0RAB3cmtfMDFNMFJCQkJBRUY3SDFDMkE0UFJCU0I0MFoAc2VzXzAxTTBSQkJEN1dCNko5OFFRMzZTUzZCM1ROAGVtYmVyLXZhbGxleS1vcmNoYXJkLTVlAG9wZW5jbGF3L29wZW5jbGF3AAAxMjgzOTYANzBhYmYyMDczMWQwMzNmY2QzNmUyMWIyZGMwNTgyNWE3YmRkNmQ0MWUwYzg1M2E3NWFjZjViMDNjMDZiMTk2NgBzaWduaW5nLXYxAGk4UTFQWGdMMzREc0UxU0o1WjFTZjIzYUxqVEJWQ2ZianpQb1BvSkNIMG4tam1WZkp3Qm1wRkxNZElqNnlvTnBSWU15NkI3S1ZNdWRzRk1PUWZYVkJBADIwMjYtMDgtMjNUMjI6MzA6MjUuMDM1WgA.L9-zjZweOq4pC58kftEDoy7KR_Zf98meYWnmtJqoRuuT3u9mrfDS1zG0u5QIost98ZMhsWJ-lhNkd-L33tF1Ag`
