### PR TITLE
fix(ui): terminal messages no longer reload the session roster

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4107,7 +4107,7 @@ ui/src/lib/plugin-activation.ts	3
 ui/src/lib/session-pull-requests.ts	2
 ui/src/lib/sessions/custom-groups.ts	5
 ui/src/lib/sessions/grouping.ts	4
-ui/src/lib/sessions/index.ts	2
+ui/src/lib/sessions/index.ts	1
 ui/src/lib/sessions/navigation.ts	1
 ui/src/lib/sessions/reconcile.ts	10
 ui/src/lib/sessions/session-key.ts	4

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   chatSessionListResponse,
   createChatFlowE2eSuite,
   expectDefined,
+  expectRequestCountStable,
   installMockGateway,
   pauseVirtualClock,
   requireRecord,
@@ -205,13 +206,12 @@ suite.define(() => {
         },
         messageId: "terminal-sidebar-reply",
         messageSeq: 2,
+        session: expectDefined(completed.sessions[0], "completed sidebar session fixture"),
         sessionKey: key,
         status: "done",
       });
-      await expect
-        .poll(async () => (await gateway.getRequests("sessions.list")).length)
-        .toBeGreaterThan(listCount);
       await row.getByText("Repair landed cleanly").waitFor();
+      await expectRequestCountStable(gateway, "sessions.list", listCount);
       expect(await row.textContent()).not.toContain("[[");
       if (captureUiProofEnabled) {
         await page.screenshot({

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -284,6 +284,122 @@ describe("event-driven session list refresh", () => {
     }
   });
 
+  it("refreshes the configured-only roster for a terminal snapshot outside its last list", async () => {
+    vi.useFakeTimers();
+    const mainRow = { key: "agent:main:main", kind: "direct" as const, updatedAt: 1 };
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult(1, [mainRow]);
+    });
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      await sessions.refresh({ force: true });
+      expect(request).toHaveBeenCalledWith(
+        "sessions.list",
+        expect.objectContaining({ configuredAgentsOnly: true }),
+      );
+      request.mockClear();
+
+      emitEvent({
+        type: "event",
+        event: "session.message",
+        payload: {
+          agentId: "local",
+          sessionKey: "agent:local:main",
+          hasActiveRun: false,
+          status: "done",
+          session: {
+            key: "agent:local:main",
+            kind: "direct",
+            updatedAt: 2,
+            archived: false,
+            hasActiveRun: false,
+            status: "done",
+          },
+        },
+      });
+
+      expect(sessions.state.result?.sessions).toEqual([mainRow]);
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+
+      expect(request).toHaveBeenCalledExactlyOnceWith(
+        "sessions.list",
+        expect.objectContaining({ configuredAgentsOnly: true }),
+      );
+      expect(sessions.state.result?.sessions).toEqual([mainRow]);
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps an archived terminal session until the Gateway replaces the active roster", async () => {
+    vi.useFakeTimers();
+    const mainRow = { key: "agent:main:main", kind: "direct" as const, updatedAt: 1 };
+    const fallbackRow = { key: "agent:main:fallback", kind: "direct" as const, updatedAt: 2 };
+    let listCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      listCalls += 1;
+      return sessionsResult(listCalls, listCalls === 1 ? [mainRow] : [fallbackRow]);
+    });
+    const { sessions, emitEvent } = createHarness(
+      request as unknown as GatewayBrowserClient["request"],
+    );
+
+    try {
+      await sessions.refresh({ force: true });
+      request.mockClear();
+      const visibleRosters: SessionsListResult["sessions"][] = [];
+      let previousRoster = sessions.state.result?.sessions;
+      const unsubscribe = sessions.subscribe((next) => {
+        if (next.result?.sessions !== previousRoster) {
+          previousRoster = next.result?.sessions;
+          visibleRosters.push(next.result?.sessions ?? []);
+        }
+      });
+
+      emitEvent({
+        type: "event",
+        event: "session.message",
+        payload: {
+          sessionKey: mainRow.key,
+          hasActiveRun: false,
+          status: "done",
+          session: {
+            ...mainRow,
+            updatedAt: 3,
+            archived: true,
+            hasActiveRun: false,
+            status: "done",
+          },
+        },
+      });
+
+      expect(sessions.state.result?.sessions).toEqual([mainRow]);
+      expect(visibleRosters).toEqual([]);
+      await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+
+      expect(request).toHaveBeenCalledExactlyOnceWith(
+        "sessions.list",
+        expect.objectContaining({ configuredAgentsOnly: true }),
+      );
+      expect(visibleRosters).toEqual([[fallbackRow]]);
+      expect(sessions.state.result?.sessions).toEqual([fallbackRow]);
+      unsubscribe();
+    } finally {
+      sessions.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it.each([
     {
       filter: "ownerId",

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -285,11 +285,27 @@ describe("event-driven session list refresh", () => {
   });
 
   it.each([
-    { filter: "ownerId", query: { ownerId: "profile-ada" } },
-    { filter: "involvingMe", query: { involvingMe: true } },
+    {
+      filter: "ownerId",
+      query: { ownerId: "profile-ada" },
+      applyFilter: (sessions: ReturnType<typeof createSessionCapability>) =>
+        sessions.setOwnerFilter("profile-ada"),
+    },
+    {
+      filter: "involvingMe",
+      query: { involvingMe: true },
+      applyFilter: (sessions: ReturnType<typeof createSessionCapability>) =>
+        sessions.setInvolvingMeFilter(true),
+    },
+    {
+      filter: "search",
+      query: { search: "Ada" },
+      applyFilter: (sessions: ReturnType<typeof createSessionCapability>) =>
+        sessions.refresh({ agentId: "main", search: "Ada", force: true }),
+    },
   ])(
     "refreshes the $filter-filtered primary roster after a terminal session message",
-    async ({ filter, query }) => {
+    async ({ applyFilter, query }) => {
       vi.useFakeTimers();
       const key = "agent:main:main";
       let matchesFilteredRoster = true;
@@ -299,14 +315,18 @@ describe("event-driven session list refresh", () => {
         updatedAt: 1,
         hasActiveRun: true,
         status: "running" as const,
+        label: "Ada",
         owner: { actor: { type: "human" as const, id: "profile-ada", label: "Ada" } },
       };
       const request = vi.fn(
-        async (method: string, params?: { ownerId?: string; involvingMe?: boolean }) => {
+        async (
+          method: string,
+          params?: { ownerId?: string; involvingMe?: boolean; search?: string },
+        ) => {
           if (method !== "sessions.list") {
             throw new Error(`Unexpected request: ${method}`);
           }
-          const filtered = Boolean(params?.ownerId || params?.involvingMe);
+          const filtered = Boolean(params?.ownerId || params?.involvingMe || params?.search);
           return sessionsResult(
             matchesFilteredRoster ? 1 : 2,
             filtered && !matchesFilteredRoster ? [] : [row],
@@ -319,9 +339,7 @@ describe("event-driven session list refresh", () => {
 
       try {
         await sessions.refresh({ agentId: "main", force: true });
-        await (filter === "ownerId"
-          ? sessions.setOwnerFilter("profile-ada")
-          : sessions.setInvolvingMeFilter(true));
+        await applyFilter(sessions);
         expect(sessions.state.result?.sessions.map((session) => session.key)).toEqual([key]);
         request.mockClear();
         matchesFilteredRoster = false;
@@ -338,6 +356,7 @@ describe("event-driven session list refresh", () => {
               updatedAt: 2,
               hasActiveRun: false,
               status: "done",
+              label: "Bob",
               owner: { actor: { type: "human", id: "profile-bob", label: "Bob" } },
             },
           },

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -245,12 +245,27 @@ describe("event-driven session list refresh", () => {
       emitEvent({
         type: "event",
         event: "session.message",
-        payload: { sessionKey: key, updatedAt: 1, status: "done" },
+        payload: {
+          sessionKey: key,
+          hasActiveRun: false,
+          status: "done",
+          session: {
+            key,
+            kind: "direct",
+            updatedAt: 2,
+            hasActiveRun: false,
+            status: "done",
+          },
+        },
       });
       await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
 
-      expect(request).toHaveBeenCalledTimes(2);
-      expect(calls).toEqual({ canonical: 2, main: 2, research: 1 });
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledWith(
+        "sessions.list",
+        expect.objectContaining({ agentId: "main", includeUnknown: false }),
+      );
+      expect(calls).toEqual({ canonical: 1, main: 2, research: 1 });
       expect(sessions.state.result?.sessions[0]).toMatchObject({
         key,
         hasActiveRun: false,

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -284,6 +284,77 @@ describe("event-driven session list refresh", () => {
     }
   });
 
+  it.each([
+    { filter: "ownerId", query: { ownerId: "profile-ada" } },
+    { filter: "involvingMe", query: { involvingMe: true } },
+  ])(
+    "refreshes the $filter-filtered primary roster after a terminal session message",
+    async ({ filter, query }) => {
+      vi.useFakeTimers();
+      const key = "agent:main:main";
+      let matchesFilteredRoster = true;
+      const row = {
+        key,
+        kind: "direct" as const,
+        updatedAt: 1,
+        hasActiveRun: true,
+        status: "running" as const,
+        owner: { actor: { type: "human" as const, id: "profile-ada", label: "Ada" } },
+      };
+      const request = vi.fn(
+        async (method: string, params?: { ownerId?: string; involvingMe?: boolean }) => {
+          if (method !== "sessions.list") {
+            throw new Error(`Unexpected request: ${method}`);
+          }
+          const filtered = Boolean(params?.ownerId || params?.involvingMe);
+          return sessionsResult(
+            matchesFilteredRoster ? 1 : 2,
+            filtered && !matchesFilteredRoster ? [] : [row],
+          );
+        },
+      );
+      const { sessions, emitEvent } = createHarness(
+        request as unknown as GatewayBrowserClient["request"],
+      );
+
+      try {
+        await sessions.refresh({ agentId: "main", force: true });
+        await (filter === "ownerId"
+          ? sessions.setOwnerFilter("profile-ada")
+          : sessions.setInvolvingMeFilter(true));
+        expect(sessions.state.result?.sessions.map((session) => session.key)).toEqual([key]);
+        request.mockClear();
+        matchesFilteredRoster = false;
+
+        emitEvent({
+          type: "event",
+          event: "session.message",
+          payload: {
+            sessionKey: key,
+            hasActiveRun: false,
+            status: "done",
+            session: {
+              ...row,
+              updatedAt: 2,
+              hasActiveRun: false,
+              status: "done",
+              owner: { actor: { type: "human", id: "profile-bob", label: "Bob" } },
+            },
+          },
+        });
+        expect(sessions.state.result?.sessions.map((session) => session.key)).toEqual([key]);
+        await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
+
+        expect(request).toHaveBeenCalledTimes(1);
+        expect(request).toHaveBeenCalledWith("sessions.list", expect.objectContaining(query));
+        expect(sessions.state.result?.sessions).toEqual([]);
+      } finally {
+        sessions.dispose();
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("retains every loaded page when a session event replaces the canonical list", async () => {
     vi.useFakeTimers();
     const rows = Array.from({ length: 120 }, (_, index) => ({

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -342,7 +342,7 @@ describe("event-driven session list refresh", () => {
             },
           },
         });
-        expect(sessions.state.result?.sessions.map((session) => session.key)).toEqual([key]);
+        expect(sessions.state.result?.sessions).toEqual([row]);
         await vi.advanceTimersByTimeAsync(SESSION_EVENT_REFRESH_DEBOUNCE_MS);
 
         expect(request).toHaveBeenCalledTimes(1);

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -424,13 +424,14 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     const status = reconciled.status ?? eventInfo?.status;
     const runEnded =
       hasActiveRun === false || (status !== null && status !== undefined && status !== "running");
-    const reconciledTerminalSession =
+    const primarySnapshotApplied =
       event.event === "session.message" &&
       runEnded &&
       reconciled.applied &&
       typeof payload?.session === "object" &&
-      payload.session !== null;
-    if (eventInfo?.archived !== null || reconciledTerminalSession) {
+      payload.session !== null &&
+      roster.canApplyPrimarySnapshot();
+    if (eventInfo?.archived !== null || primarySnapshotApplied) {
       const result = decorateRows(reconciled.result);
       if (result !== state.result) {
         publishReconciledState({ ...state, result });
@@ -479,7 +480,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         eventInfo?.agentId ??
         parseAgentSessionKey(eventInfo?.key)?.agentId ??
         (typeof payloadAgentId === "string" ? payloadAgentId : undefined),
-      primarySnapshotApplied: reconciledTerminalSession,
+      primarySnapshotApplied,
     });
   });
 

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -474,13 +474,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         publish({ ...state, deletedSessions: remainingDeletedSessions });
       }
     }
-    // Terminal snapshots own the primary row; filtered rosters still need server-side evaluation.
     roster.scheduleEvent({
       agentId:
         eventInfo?.agentId ??
         parseAgentSessionKey(eventInfo?.key)?.agentId ??
         (typeof payloadAgentId === "string" ? payloadAgentId : undefined),
-      refreshPrimary: !reconciledTerminalSession,
+      primarySnapshotApplied: reconciledTerminalSession,
     });
   });
 

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -415,22 +415,33 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       resultAgentId: state.agentId,
       archivedFilter: roster.lastOptions().archivedFilter,
     });
-    if (eventInfo?.archived !== null) {
+    const payload = event.payload as {
+      agentId?: unknown;
+      reason?: unknown;
+      session?: unknown;
+    } | null;
+    const hasActiveRun = reconciled.hasActiveRun ?? eventInfo?.hasActiveRun;
+    const status = reconciled.status ?? eventInfo?.status;
+    const runEnded =
+      hasActiveRun === false || (status !== null && status !== undefined && status !== "running");
+    const reconciledTerminalSession =
+      event.event === "session.message" &&
+      runEnded &&
+      reconciled.applied &&
+      typeof payload?.session === "object" &&
+      payload.session !== null;
+    if (eventInfo?.archived !== null || reconciledTerminalSession) {
       const result = decorateRows(reconciled.result);
       if (result !== state.result) {
         publishReconciledState({ ...state, result });
       }
     }
-    const eventReason = (event.payload as { reason?: unknown } | null)?.reason;
-    const payloadAgentId = (event.payload as { agentId?: unknown } | null)?.agentId;
+    const eventReason = payload?.reason;
+    const payloadAgentId = payload?.agentId;
     if (eventReason === "groups") {
       groups.invalidate();
       void groups.load();
     }
-    const hasActiveRun = reconciled.hasActiveRun ?? eventInfo?.hasActiveRun;
-    const status = reconciled.status ?? eventInfo?.status;
-    const runEnded =
-      hasActiveRun === false || (status !== null && status !== undefined && status !== "running");
     if (event.event === "session.message" && !runEnded) {
       return;
     }
@@ -463,12 +474,13 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         publish({ ...state, deletedSessions: remainingDeletedSessions });
       }
     }
-    // Gateway lists own filtering/order; authoritative events invalidate every matching roster.
+    // Terminal snapshots own the primary row; filtered rosters still need server-side evaluation.
     roster.scheduleEvent({
       agentId:
         eventInfo?.agentId ??
         parseAgentSessionKey(eventInfo?.key)?.agentId ??
         (typeof payloadAgentId === "string" ? payloadAgentId : undefined),
+      refreshPrimary: !reconciledTerminalSession,
     });
   });
 

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -424,14 +424,24 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     const status = reconciled.status ?? eventInfo?.status;
     const runEnded =
       hasActiveRun === false || (status !== null && status !== undefined && status !== "running");
+    const isTerminalMessage = event.event === "session.message" && runEnded;
+    // Only an existing Gateway roster member that remains active can be replaced directly.
     const primarySnapshotApplied =
-      event.event === "session.message" &&
-      runEnded &&
+      isTerminalMessage &&
       reconciled.applied &&
+      eventInfo !== null &&
+      eventInfo.archived !== true &&
       typeof payload?.session === "object" &&
       payload.session !== null &&
-      roster.canApplyPrimarySnapshot();
-    if (eventInfo?.archived !== null || primarySnapshotApplied) {
+      roster.canApplyPrimarySnapshot() &&
+      state.result?.sessions.some((row) =>
+        uiSessionEventMatches(
+          { ...gateway.snapshot, sessionKey: row.key },
+          eventInfo.key,
+          eventInfo.agentId,
+        ),
+      ) === true;
+    if ((eventInfo?.archived !== null && !isTerminalMessage) || primarySnapshotApplied) {
       const result = decorateRows(reconciled.result);
       if (result !== state.result) {
         publishReconciledState({ ...state, result });

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -552,8 +552,10 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       return refresh({ ...options, force: true });
     },
     lastOptions: () => lastListOptions,
-    scheduleEvent(options: { agentId?: string | null } = {}) {
-      eventRefreshCoordinator.schedule();
+    scheduleEvent(options: { agentId?: string | null; refreshPrimary?: boolean } = {}) {
+      if (options.refreshPrimary !== false) {
+        eventRefreshCoordinator.schedule();
+      }
       const agentId = options.agentId ? normalizeAgentId(options.agentId) : null;
       for (const entry of managedLists.values()) {
         const queryAgentId = managedSessionListAgentId(entry);

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -552,8 +552,11 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       return refresh({ ...options, force: true });
     },
     lastOptions: () => lastListOptions,
-    scheduleEvent(options: { agentId?: string | null; refreshPrimary?: boolean } = {}) {
-      if (options.refreshPrimary !== false) {
+    scheduleEvent(options: { agentId?: string | null; primarySnapshotApplied?: boolean } = {}) {
+      // Ownership and participation membership can only be reevaluated by the Gateway.
+      const gatewayFilteredPrimary =
+        Boolean(lastListOptions.ownerId?.trim()) || lastListOptions.involvingMe === true;
+      if (!options.primarySnapshotApplied || gatewayFilteredPrimary) {
         eventRefreshCoordinator.schedule();
       }
       const agentId = options.agentId ? normalizeAgentId(options.agentId) : null;

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -552,9 +552,8 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       return refresh({ ...options, force: true });
     },
     lastOptions: () => lastListOptions,
-    // Ownership and participation membership can only be reevaluated by the Gateway.
-    canApplyPrimarySnapshot: () =>
-      !lastListOptions.ownerId?.trim() && lastListOptions.involvingMe !== true,
+    // Gateway-owned membership filters require an authoritative list refresh.
+    canApplyPrimarySnapshot: () => isPrimarySessionListQuery(lastListOptions),
     scheduleEvent(options: { agentId?: string | null; primarySnapshotApplied?: boolean } = {}) {
       if (!options.primarySnapshotApplied) {
         eventRefreshCoordinator.schedule();

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -552,11 +552,11 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       return refresh({ ...options, force: true });
     },
     lastOptions: () => lastListOptions,
+    // Ownership and participation membership can only be reevaluated by the Gateway.
+    canApplyPrimarySnapshot: () =>
+      !lastListOptions.ownerId?.trim() && lastListOptions.involvingMe !== true,
     scheduleEvent(options: { agentId?: string | null; primarySnapshotApplied?: boolean } = {}) {
-      // Ownership and participation membership can only be reevaluated by the Gateway.
-      const gatewayFilteredPrimary =
-        Boolean(lastListOptions.ownerId?.trim()) || lastListOptions.involvingMe === true;
-      if (!options.primarySnapshotApplied || gatewayFilteredPrimary) {
+      if (!options.primarySnapshotApplied) {
         eventRefreshCoordinator.schedule();
       }
       const agentId = options.agentId ? normalizeAgentId(options.agentId) : null;


### PR DESCRIPTION
Related: #76166

## What Problem This Solves

Fixes an issue where active Control UI tabs performed a full session roster reload after every terminal session message, even though eligible terminal events already carried the authoritative final session row. On large, long-lived session stores, that fan-out repeatedly exercised `sessions.list`, increasing database reads, Gateway CPU, and tail latency.

## Why This Change Was Made

Terminal message snapshots update an eligible primary roster directly and suppress only its redundant follow-up request. The roster owner uses the canonical `isPrimarySessionListQuery` classifier, so queries containing `ownerId`, `involvingMe`, `search`, or any other noncanonical Gateway membership constraint retain their previous matching rows until the Gateway returns an authoritative filtered roster.

Canonical-query classification alone does not establish membership: an incoming terminal event must also match a row in the last authoritative Gateway roster, and its replacement must remain active (`archived !== true`). Configured-only events for agents absent from that roster therefore wait for `sessions.list` instead of inserting an unauthorized row. Archived terminal events likewise preserve the existing visible roster until the Gateway supplies its replacement window, avoiding transient empty or stale membership. The same applied-snapshot decision owns refresh suppression, so every rejected snapshot still receives the authoritative refresh. Managed lists and incomplete terminal events keep their existing Gateway refresh behavior.

This is AI-assisted. I reviewed the implementation, live evidence, tests, and final diff.

## User Impact

Control UI users see the same final run state and sidebar metadata with less Gateway work when eligible runs complete. Ownership-, participation-, search-, and configured-agent-filtered rosters keep their previous authoritative membership until the Gateway confirms any change. Archived terminal sessions are replaced atomically by the refreshed active roster instead of disappearing temporarily. The change is behavioral/performance-only; it does not alter visual design, protocol, configuration, or storage schema.

## Evidence

A live long-lived Gateway showed 442 `sessions.list` responses in 30 minutes across 36 Control UI connections. Median latency was 162 ms, p95 was 1.025 s, p99 was 2.768 s, and the slowest response was 6.131 s. Request bursts repeatedly reread hundreds of megabytes from a multi-gigabyte agent database while eligible terminal events already contained the final row snapshot.

Regression proof before the fix:

- `ui/src/lib/sessions/index.event-refresh.test.ts`: terminal snapshots triggered two list requests instead of the expected managed-list-only request; filtered, absent-agent, and archived terminal snapshots could also bypass the Gateway-owned roster membership boundary.
- `ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts`: the final sidebar update issued a second `sessions.list` request instead of using an eligible event snapshot.

Passing proof after the fix:

- `node scripts/run-vitest.mjs ui/src/lib/sessions/index.test.ts ui/src/lib/sessions/index.event-refresh.test.ts` — 51 unit tests passed, including canonical-query classification and immediate-state regressions for `ownerId`, `involvingMe`, `search`, configured-only absent-agent events, and archived terminal roster refill.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts` — 5 browser tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts` — 3 additional browser tests passed when diagnosing an unrelated transient cloud-startup timeout; the isolated failed CI shard then passed on retry.
- `node scripts/check-changed.mjs -- ui/src/lib/sessions/index.ts ui/src/lib/sessions/session-roster-refresh.ts ui/src/lib/sessions/index.event-refresh.test.ts ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts config/assertion-safety-baseline.txt` — passed the `coreTests`, `ui`, and `tooling` lanes.
- P0–P2 Codex-backed autoreview: clean, no accepted/actionable findings.
- Exact-head CI for `2e288f4c70d054a2d686b291fdd8f2f0105667f3`: [green](https://github.com/openclaw/openclaw/actions/runs/32691821390), with zero pending relevant checks after one isolated flaky-browser-shard retry.

Production LOC: +36/-10 (net +26), making canonical-query eligibility, authoritative prior-row membership, active-row replacement, and primary-versus-managed refresh ownership explicit. Tests: +227/-6 (net +221). Tooling baseline: +1/-1 (net 0), shrinking the assertion-safety count by one.
