### PR TITLE
fix(ui): remove Safari bars around chat file links

### DIFF
--- a/ui/src/styles/chat-file-link-presentation.browser.test.ts
+++ b/ui/src/styles/chat-file-link-presentation.browser.test.ts
@@ -15,8 +15,8 @@ const describeFileLinkPresentation = canRunPlaywrightChromium(chromiumExecutable
   ? describe
   : describe.skip;
 
-// The declarations the inline-code chip paints. A file link must match its
-// plain-text sibling on every one of them, whichever syntax produced it.
+// The declarations the inline-code chip paints. File-link labels match across
+// authoring syntax except for glyph spacing owned by the outer anchor.
 const CHIP_PROPERTIES = [
   "backgroundColor",
   "borderTopWidth",
@@ -246,13 +246,21 @@ async function probeWrap(
 }
 
 type StyleSnapshot = Record<(typeof CHIP_PROPERTIES)[number], string>;
+type GlyphSnapshot = {
+  readonly fontSize: string;
+  readonly height: string;
+  readonly maskImage: string;
+  readonly paddingInlineStart: string;
+  readonly position: string;
+  readonly width: string;
+};
 type PresentationProbe = {
-  readonly chatGlyph: { readonly maskImage: string };
+  readonly chatGlyph: GlyphSnapshot;
   readonly fromCode: StyleSnapshot;
   readonly fromText: StyleSnapshot;
   readonly panelFromCode: StyleSnapshot;
   readonly panelFromText: StyleSnapshot;
-  readonly panelGlyph: { readonly maskImage: string };
+  readonly panelGlyph: GlyphSnapshot;
   readonly plainCode: StyleSnapshot;
 };
 
@@ -300,15 +308,24 @@ async function probe(themeMode: "dark" | "light"): Promise<PresentationProbe> {
           properties.map((property) => [property, computed[property as never] as string]),
         );
       };
-      const glyphMask = (selector: string) =>
-        getComputedStyle(resolve(selector), "::before").maskImage;
+      const glyph = (selector: string) => {
+        const computed = getComputedStyle(resolve(selector), "::before");
+        return {
+          fontSize: computed.fontSize,
+          height: computed.height,
+          maskImage: computed.maskImage,
+          paddingInlineStart: computed.paddingInlineStart,
+          position: computed.position,
+          width: computed.width,
+        };
+      };
       return {
-        chatGlyph: { maskImage: glyphMask("#from-text") },
+        chatGlyph: glyph("#from-text"),
         fromCode: read("#from-code > code"),
         fromText: read("#from-text"),
         panelFromCode: read("#panel-from-code > code"),
         panelFromText: read("#panel-from-text"),
-        panelGlyph: { maskImage: glyphMask("#panel-from-text") },
+        panelGlyph: glyph("#panel-from-text"),
         plainCode: read("#plain-code"),
       };
     }, CHIP_PROPERTIES);
@@ -323,7 +340,8 @@ describeFileLinkPresentation("chat file link presentation", () => {
     "renders code-authored and text-authored file links identically in %s",
     async (themeMode) => {
       const { fromCode, fromText } = await probe(themeMode);
-      expect(fromCode).toEqual(fromText);
+      // The anchor reserves glyph space; its nested code label must not reserve it again.
+      expect(fromCode).toEqual({ ...fromText, paddingLeft: "0px" });
     },
   );
 
@@ -350,6 +368,19 @@ describeFileLinkPresentation("chat file link presentation", () => {
       expect(probed.panelFromCode).toEqual(probed.fromCode);
       expect(probed.panelGlyph).toEqual(probed.chatGlyph);
       expect(probed.panelGlyph.maskImage).toContain("svg");
+    },
+  );
+
+  it.each(["light", "dark"] as const)(
+    "gives every masked file glyph a concrete font-sized paint box in %s",
+    async (themeMode) => {
+      const { chatGlyph, panelGlyph } = await probe(themeMode);
+      for (const glyph of [chatGlyph, panelGlyph]) {
+        expect(glyph.position).toBe("absolute");
+        expect(glyph.width).toBe(glyph.fontSize);
+        expect(glyph.height).toBe(glyph.fontSize);
+        expect(glyph.paddingInlineStart).toBe("0px");
+      }
     },
   );
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -616,20 +616,16 @@
    purpose: each renderer's own :where(a) and code rules would otherwise win on
    source order, and sidebar-markdown.css is imported after this file. */
 :is(.chat-text, .sidebar-markdown) a.markdown-file-link {
+  position: relative;
   color: var(--link);
   /* File links are href-less anchors (driven by data-file-path), so the UA
      link pointer does not apply; they are content links and keep the hand. */
   cursor: pointer;
   text-decoration: none;
-  /* Atomic: prose cannot break between the glyph and the label, or at a hyphen
-     inside it. max-width keeps a label the parser could not shorten wrapping
-     inside the chip; the chat scroller's overflow-x: hidden would clip it.
-     The wrap policy is declared here rather than inherited: .chat-text sets
-     overflow-wrap: anywhere but .sidebar-markdown sets no wrapping policy, so
-     an unbreakable label would size the capped box past the panel, whose body
-     hides horizontal overflow, and be clipped instead of wrapping. */
+  /* Keep the glyph and label atomic while long labels wrap inside both renderers. */
   display: inline-block;
   max-width: 100%;
+  padding-inline-start: 1.28em;
   overflow-wrap: anywhere;
 }
 
@@ -644,22 +640,20 @@
    stays out of the accessibility tree and out of copied text, and currentColor
    keeps it on the link color in every theme. Sized in em so it tracks
    --chat-text-size and the user's text-scale setting. The default glyph is the
-   generic document; kinds below match components/file-kind.ts, whose icons are
-   the same Lucide set the file preview modal renders as SVG.
-   Stays `inline`: an atomic box carries its own break opportunity and would push
-   a too-wide label whole to the next line, stranding the glyph. Inline boxes
-   ignore width/height, so 1em comes from padding-inline-start and a mask size. */
+   generic document; kinds below match components/file-kind.ts. Its own concrete
+   paint box keeps WebKit from leaking the mask across inline fragment edges. */
 :is(.chat-text, .sidebar-markdown) a.markdown-file-link::before {
   --file-glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z'/%3E%3Cpolyline points='14 2 14 8 20 8'/%3E%3Cline x1='16' x2='8' y1='13' y2='13'/%3E%3Cline x1='16' x2='8' y1='17' y2='17'/%3E%3Cline x1='10' x2='8' y1='9' y2='9'/%3E%3C/svg%3E");
 
   content: "";
-  display: inline;
-  padding-inline-start: 1em;
-  margin-inline-end: 0.28em;
-  vertical-align: -0.14em;
+  position: absolute;
+  inset-inline-start: 0;
+  top: calc((1lh - 1em) / 2);
+  width: 1em;
+  height: 1em;
   background: currentColor;
-  mask: var(--file-glyph) left center / 1em 1em no-repeat;
-  -webkit-mask: var(--file-glyph) left center / 1em 1em no-repeat;
+  mask: var(--file-glyph) center / contain no-repeat;
+  -webkit-mask: var(--file-glyph) center / contain no-repeat;
 }
 
 :is(.chat-text, .sidebar-markdown) a.markdown-file-link[data-file-kind="code"]::before {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Safari users saw thin horizontal bars above and below workspace file-link icons in Control UI chat messages. The artifact appeared on references such as `chat-send.ts:556` even though the same links rendered correctly in Chrome.

Regression context: #123310 changed the glyph to a padding-sized inline mask to keep it attached to its label when wrapping.

## Why This Change Was Made

WebKit paints the background of that empty inline masked pseudo-element beyond the SVG mask at the inline fragment edges. The shared file-link presentation now gives the glyph an explicit font-sized, absolutely positioned paint box while the anchor reserves its space and retains the existing atomic wrapping behavior in both chat messages and the Chat Detail Panel.

## User Impact

File references render as clean icon-and-label links in Safari without the extra bars. Link spacing, wrapping, keyboard/click behavior, copied text, and Chrome rendering remain unchanged.

## Evidence

- Mocked production Control UI rendered in Playwright WebKit: the pre-fix inline mask reproduces the Safari bars; the fixed source renders cleanly. Before/after captures are attached below.
- `node scripts/run-vitest.mjs run --root ui --config vitest.config.ts --configLoader runner src/styles/chat-file-link-presentation.browser.test.ts src/styles/chat-github-link-presentation.browser.test.ts src/components/markdown-links.test.ts` — 119 tests passed.
- `node scripts/check-changed.mjs -- ui/src/styles/chat/text.css ui/src/styles/chat-file-link-presentation.browser.test.ts` — passed.
- `pnpm ui:build` — passed.
- Fresh autoreview — no accepted/actionable findings.
- Production CSS: +12/-18 (net -6). Tests: +40/-9 (net +31).

Native Safari 27 was available on the proof host, but Safari WebDriver automation was disabled in browser settings; the deterministic WebKit run reproduced the exact reported paint artifact without changing that persistent setting.

AI-assisted: yes. The patch and proof were reviewed and understood before submission.

![Before: WebKit renders horizontal bars around each file-link icon](https://github.com/user-attachments/assets/9e7197d9-37d7-46b6-aa9e-b8fd1f426815)

![After: the same Control UI message renders clean file-link icons](https://github.com/user-attachments/assets/f556d37a-85b4-40d7-8271-61295f58c85f)