### PR TITLE
fix(ollama): defer local service lookup until stream creation

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -1,7 +1,10 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import type { ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
-import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  capturePluginRegistration,
+  createPluginRuntimeMock,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
 // Ollama tests cover index plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
@@ -146,6 +149,12 @@ function registerOllamaCloudProvider() {
 }
 
 describe("ollama tool-schema compatibility", () => {
+  it("registers local and cloud providers without accessing the inactive LLM runtime", () => {
+    const captured = capturePluginRegistration(plugin);
+
+    expect(captured.providers.map((provider) => provider.id)).toEqual(["ollama-cloud", "ollama"]);
+  });
+
   it("registers llama.cpp GBNF projection for local and cloud providers", () => {
     for (const provider of registerProvidersWithPluginConfig({})) {
       expect(provider).toMatchObject({

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -807,15 +807,14 @@ async function augmentConfiguredOllamaCatalogModels(params: {
 }
 
 // Local and cloud own distinct auth/catalog policy but share native transport and replay rules.
-const createOllamaSharedProviderHooks = (
-  acquireLocalService: OpenClawPluginApi["runtime"]["llm"]["acquireLocalService"],
-) =>
+const createOllamaSharedProviderHooks = (api: OpenClawPluginApi) =>
   ({
     ...buildProviderToolCompatFamilyHooks("llamacpp-gbnf"),
     createStreamFn: ({ config, model, provider }) => {
       if (model.api !== "ollama") {
         return undefined;
       }
+      const { acquireLocalService } = api.runtime.llm;
       const configuredProviderId =
         findNormalizedProviderKey(config?.models?.providers, provider) ?? provider;
       return createLazyConfiguredOllamaStreamFn({
@@ -856,7 +855,7 @@ export default definePluginEntry({
   description: "Bundled Ollama provider plugin",
   register(api: OpenClawPluginApi) {
     const startupPluginConfig = (api.pluginConfig ?? {}) as OllamaPluginConfig;
-    const providerHooks = createOllamaSharedProviderHooks(api.runtime.llm.acquireLocalService);
+    const providerHooks = createOllamaSharedProviderHooks(api);
     if (api.registrationMode === "full") {
       void checkWsl2CrashLoopRiskLazily(api);
     }


### PR DESCRIPTION
## What Problem This Solves

The Ollama local-service change in #128034 made provider registration eagerly read `api.runtime.llm.acquireLocalService`. Registration-only callers intentionally provide an inactive runtime, so current `main` crashes while capturing the bundled Ollama plugin and its required provider-auth parity CI fails with `Cannot read properties of undefined (reading 'acquireLocalService')`.

## Why This Change Was Made

Keep local-service ownership in the private Ollama shared-provider hook, but capture the plugin API itself and resolve its existing service-acquisition function only when a native Ollama stream is actually created. This preserves the exact host function identity, plugin-scoped authority, configured provider aliases, and both local/cloud provider behavior without faking a runtime or changing the public Plugin SDK.

## User Impact

Bundled Ollama provider registration and manifest/auth validation work again before the LLM runtime is active. Existing local-service startup, native streaming, provider routing, and cloud authentication are unchanged.

## Evidence

- Before the fix, the existing hosted-CI parity path failed at `extensions/ollama/index.ts:859`:
  `node scripts/run-vitest.mjs test/plugins/bundled-provider-auth-literal-parity.test.ts test/plugins/bundled-provider-auth-literal-parity.2.test.ts test/plugins/bundled-provider-auth-literal-parity.3.test.ts --testNamePattern ollama`
- The new real captured-registration owner regression independently failed at the same line before the production change.
- After the fix, `node scripts/run-vitest.mjs extensions/ollama/index.test.ts extensions/ollama/lazy-import.test.ts test/plugins/bundled-provider-auth-literal-parity.test.ts` passes **121 tests**, including all 16 affected parity cases, all Ollama owner regressions, and the existing strict local-service function-identity assertion; an independent reviewer reran the complete command successfully.
- The exact committed parity and strict lazy-identity suites were rerun successfully; focused formatting, `node scripts/run-tsgo.mjs -p extensions/ollama/tsconfig.json --noEmit`, and `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/ollama/index.test.ts extensions/ollama/index.ts` pass.
- Fresh authenticated Codex reviews of both the uncommitted patch and complete committed branch reported no actionable findings.
- Production delta: **3 added / 4 removed (net -1)**. Full local extension typecheck is independently blocked by existing unchanged ACPX/shared-install `promptStarted` and `elicitationModes` mismatches; no ACPX files or dependencies are changed.
