### PR TITLE
fix(codex): gate native runs before agent start

### DIFF
--- a/extensions/codex/src/app-server/attempt-results.ts
+++ b/extensions/codex/src/app-server/attempt-results.ts
@@ -7,7 +7,11 @@ import type {
   EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { CodexSystemPromptReport } from "./attempt-context.js";
-import { attemptTerminal, type EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import {
+  attemptTerminal,
+  type AttemptFailureSource,
+  type EmbeddedRunAttemptResult,
+} from "./attempt-terminal.js";
 import type { CodexAttemptTurnWatchTimeoutKind } from "./attempt-turn-watches.js";
 
 const CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_USER_MESSAGE =
@@ -105,13 +109,15 @@ export function buildCodexTurnStartFailureResult(params: {
   params: EmbeddedRunAttemptParams;
   message: string;
   promptError?: unknown;
+  /** Attributes pre-turn failures owned by a gate rather than the prompt path. */
+  promptErrorSource?: AttemptFailureSource;
   messagesSnapshot: AgentMessage[];
   systemPromptReport: CodexSystemPromptReport;
 }): EmbeddedRunAttemptResult {
   return {
     terminal: attemptTerminal.normalize({
       promptError: params.promptError ?? params.message,
-      promptErrorSource: "prompt",
+      promptErrorSource: params.promptErrorSource ?? "prompt",
     }),
     sessionIdUsed: params.params.sessionId,
     messagesSnapshot: params.messagesSnapshot,

--- a/extensions/codex/src/app-server/run-attempt-before-agent-run.ts
+++ b/extensions/codex/src/app-server/run-attempt-before-agent-run.ts
@@ -1,0 +1,161 @@
+/**
+ * Fail-closed before_agent_run gate for Codex native app-server attempts.
+ *
+ * Runs once per admitted turn after the final turn prompt, developer
+ * instructions, and history projection are settled, and before any
+ * `thread/start`, `turn/start`, or `llm_input` emission, so a block starts no
+ * Codex work at all. The core gate records its decision in the run-scoped
+ * admission memo, so outer attempt re-dispatch replays it instead of charging
+ * the gate again.
+ */
+import {
+  embeddedAgentLog,
+  formatErrorMessage,
+  runAgentHarnessBeforeAgentRunHook,
+  type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { buildCodexTurnStartFailureResult } from "./attempt-results.js";
+import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import { emitCodexAppServerEvent, runCodexAgentEndHook } from "./run-attempt-lifecycle.js";
+import type { CodexAttemptResources } from "./run-attempt-resources.js";
+
+type CodexBeforeAgentRunBlock = { blockedBy: string; message: string };
+
+type CodexUserTurnRecorder = NonNullable<EmbeddedRunAttemptParams["userTurnTranscriptRecorder"]>;
+type CodexBlockedUserTurnMessage = Parameters<CodexUserTurnRecorder["persistBlocked"]>[0] & {
+  idempotencyKey: string;
+};
+
+/**
+ * Returns a blocked attempt result when a plugin gate rejects this turn, or
+ * `undefined` when the attempt may proceed to Codex startup.
+ */
+export async function runCodexAttemptBeforeAgentRunGate(
+  resources: CodexAttemptResources,
+): Promise<{ result: EmbeddedRunAttemptResult } | undefined> {
+  const { prompt, trajectoryRecorder, markTrajectoryEndRecorded, runCleanupStep } = resources;
+  const { context, turnState, systemPromptReport, buildRenderedCodexDeveloperInstructions } =
+    prompt;
+  const { runtime, attemptTools, historyState, hookContext, hookRunner } = context;
+  const { connection } = runtime;
+  const { params, attemptStartedAt, abortFromUpstream } = connection;
+  const outcome = await runAgentHarnessBeforeAgentRunHook({
+    event: {
+      prompt: turnState.codexTurnPromptText,
+      systemPrompt: buildRenderedCodexDeveloperInstructions(),
+      messages: historyState.messages,
+      channelId: hookContext.channelId,
+      // Trusted attempt identity is hook-only evidence; it never becomes model
+      // or tool input and grants no additional privilege to the turn.
+      accountId: params.agentAccountId ?? undefined,
+      senderId: params.senderId ?? undefined,
+      senderIsOwner: params.senderIsOwner ?? undefined,
+    },
+    ctx: hookContext,
+    hookRunner,
+    // Run-scoped memo owned by the outer run loop: outer re-dispatch of this
+    // same admitted run replays its decision instead of recharging the gate.
+    ...(params.beforeAgentRunAdmission ? { admission: params.beforeAgentRunAdmission } : {}),
+  });
+  if (outcome.action !== "blocked") {
+    return undefined;
+  }
+
+  const blockedUserMessage = buildCodexBlockedUserTurnMessage(params, outcome);
+  await persistCodexBlockedUserTurn(params, blockedUserMessage);
+  void emitCodexAppServerEvent(params, {
+    stream: "codex_app_server.lifecycle",
+    data: { phase: "before_agent_run_blocked", blockedBy: outcome.blockedBy },
+  });
+  trajectoryRecorder?.recordEvent("session.ended", {
+    status: "error",
+    promptError: outcome.message,
+  });
+  markTrajectoryEndRecorded();
+  // agent_end carries the redacted blocked turn as evidence; the plugin-local
+  // block reason stays inside the gate decision and never reaches consumers.
+  const blockedMessagesSnapshot = [...historyState.messages, blockedUserMessage];
+  await runCodexAgentEndHook(params, {
+    event: {
+      messages: blockedMessagesSnapshot,
+      success: false,
+      error: outcome.message,
+      durationMs: Date.now() - attemptStartedAt,
+    },
+    ctx: hookContext,
+    hookRunner,
+  });
+  // Startup never ran, so no client lease, thread, route, relay, or sandbox
+  // environment exists; only the surfaces materialized during tool preparation
+  // and the upstream abort listener need releasing here.
+  await runCleanupStep("codex-before-agent-run-scoped-mcp-dispose", () =>
+    attemptTools.scopedMcpTools?.dispose(),
+  );
+  await runCleanupStep("codex-before-agent-run-scheduled-mcp-dispose", () =>
+    attemptTools.scheduledConfiguredMcp?.dispose(),
+  );
+  await runCleanupStep("codex-before-agent-run-trajectory-flush", () =>
+    trajectoryRecorder?.flush(),
+  );
+  await runCleanupStep("codex-before-agent-run-abort-listener", () => {
+    params.abortSignal?.removeEventListener("abort", abortFromUpstream);
+  });
+  return {
+    result: buildCodexTurnStartFailureResult({
+      params,
+      message: outcome.message,
+      promptError: new Error(outcome.message),
+      promptErrorSource: "hook:before_agent_run",
+      messagesSnapshot: blockedMessagesSnapshot,
+      systemPromptReport,
+    }),
+  };
+}
+
+/**
+ * Builds the redacted blocked user turn. Only the rendered block text is
+ * retained; the idempotency key gives the canonical recorder a stable identity
+ * for the blocked turn while its self-persistence guard owns re-dispatch dedupe.
+ */
+function buildCodexBlockedUserTurnMessage(
+  params: EmbeddedRunAttemptParams,
+  block: CodexBeforeAgentRunBlock,
+): CodexBlockedUserTurnMessage {
+  const nowMs = Date.now();
+  return {
+    role: "user",
+    content: [{ type: "text", text: block.message }],
+    timestamp: nowMs,
+    idempotencyKey: `hook-block:before_agent_run:user:${params.runId}`,
+    __openclaw: {
+      beforeAgentRunBlocked: { blockedBy: block.blockedBy, blockedAt: nowMs },
+    },
+  };
+}
+
+/**
+ * Commits the blocked turn through the canonical user-turn recorder so blocked
+ * bookkeeping and the persistence notification stay owned by that boundary.
+ */
+async function persistCodexBlockedUserTurn(
+  params: EmbeddedRunAttemptParams,
+  blockedUserMessage: CodexBlockedUserTurnMessage,
+): Promise<void> {
+  const recorder = params.userTurnTranscriptRecorder;
+  if (!recorder) {
+    return;
+  }
+  try {
+    const persisted = await recorder.persistBlocked(blockedUserMessage);
+    if (!persisted) {
+      return;
+    }
+    params.onUserMessagePersisted?.(persisted.message);
+  } catch (error) {
+    embeddedAgentLog.warn(
+      `before_agent_run block: failed to persist redacted Codex user message: ${formatErrorMessage(
+        error,
+      )}`,
+    );
+  }
+}

--- a/extensions/codex/src/app-server/run-attempt.before-agent-run.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.before-agent-run.test.ts
@@ -1,0 +1,382 @@
+// Codex tests cover the fail-closed before_agent_run gate on native app-server attempts.
+import path from "node:path";
+import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
+import { CodexAppServerRpcError } from "./client.js";
+import {
+  createAppServerHarness,
+  createParams,
+  createStartedThreadHarness,
+  fastWait,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+  threadStartResult,
+  turnStartResult,
+} from "./run-attempt-test-harness.js";
+import { writeCodexAppServerBinding } from "./session-binding.test-helpers.js";
+
+setupRunAttemptTestHooks();
+
+const OPENCLAW_META_KEY = "__openclaw";
+const DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
+  "features.standalone_web_search": false,
+  web_search: "disabled",
+});
+
+type GateFixture = {
+  abortController: AbortController;
+  onUserMessagePersisted: ReturnType<typeof vi.fn>;
+  params: EmbeddedRunAttemptParams;
+  persistBlocked: ReturnType<typeof vi.fn>;
+  removeAbortListener: ReturnType<typeof vi.spyOn>;
+  runId: string;
+};
+
+// Each test owns a distinct runId: the gate memoizes its decision per run, so
+// sharing one id across tests would replay an earlier test's admission.
+function createGateParams(label: string): GateFixture {
+  const runId = `run-${label}`;
+  const params = createParams(
+    path.join(tempDir, `${label}.jsonl`),
+    path.join(tempDir, `workspace-${label}`),
+    { runId },
+  );
+  params.agentAccountId = "account-7";
+  params.senderId = "sender-7";
+  params.senderIsOwner = true;
+  params.messageChannel = "telegram";
+  params.currentChannelId = "telegram:chat-42";
+  const abortController = new AbortController();
+  params.abortSignal = abortController.signal;
+  // One logical run owns one opaque gate memo; production allocates it in the
+  // outer run loop and copies the reference into every dispatched attempt.
+  params.beforeAgentRunAdmission = {};
+  const removeAbortListener = vi.spyOn(abortController.signal, "removeEventListener");
+  const onUserMessagePersisted = vi.fn();
+  params.onUserMessagePersisted = onUserMessagePersisted;
+  const persistBlocked = vi.fn(async (message: unknown) => ({ message }));
+  params.userTurnTranscriptRecorder = {
+    message: undefined,
+    resolveMessage: async () => undefined,
+    markRuntimePersisted() {},
+    getAdmissionReceipt: () => undefined,
+    persistBlocked,
+  } as unknown as EmbeddedRunAttemptParams["userTurnTranscriptRecorder"];
+  return {
+    abortController,
+    onUserMessagePersisted,
+    params,
+    persistBlocked,
+    removeAbortListener,
+    runId,
+  };
+}
+
+describe("runCodexAppServerAttempt before_agent_run gate", () => {
+  it("runs the gate once with the final prompt and trusted identity, then starts the turn", async () => {
+    const beforeAgentRun = vi.fn(() => ({ outcome: "pass" }) as const);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_agent_run", handler: beforeAgentRun }]),
+    );
+    const harness = createStartedThreadHarness();
+    const { params, runId } = createGateParams("gate-pass");
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    expect(beforeAgentRun).toHaveBeenCalledTimes(1);
+    const [event, ctx] = beforeAgentRun.mock.calls[0] as unknown as [
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ];
+    expect(event.prompt).toBe("hello");
+    expect(event.systemPrompt).toContain("You are a personal agent running inside OpenClaw.");
+    expect(event.messages).toEqual([]);
+    expect(event.accountId).toBe("account-7");
+    expect(event.senderId).toBe("sender-7");
+    expect(event.senderIsOwner).toBe(true);
+    // Channel identity comes from the host-proven attempt fields, not the prompt.
+    expect(event.channelId).toBe("chat-42");
+    expect(ctx.runId).toBe(runId);
+    expect(ctx.sessionId).toBe("session-1");
+    // The gate never turns trusted identity into model input.
+    const turnStart = harness.requests.find((entry) => entry.method === "turn/start");
+    expect(JSON.stringify(turnStart?.params)).not.toContain("sender-7");
+  });
+
+  it("starts no Codex work and fails closed when a plugin blocks the run", async () => {
+    const agentEnd = vi.fn();
+    const llmInput = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          pluginId: "guardrail",
+          hookName: "before_agent_run",
+          handler: () => ({ outcome: "block", reason: "secret-policy", message: "not allowed" }),
+        },
+        { hookName: "agent_end", handler: agentEnd },
+        { hookName: "llm_input", handler: llmInput },
+      ]),
+    );
+    const harness = createStartedThreadHarness();
+    const { onUserMessagePersisted, params, persistBlocked, removeAbortListener, runId } =
+      createGateParams("gate-block");
+    const onAgentEvent = vi.fn();
+    params.onAgentEvent = onAgentEvent;
+
+    const result = await runCodexAppServerAttempt(params);
+
+    expect(harness.requests.map((entry) => entry.method)).not.toContain("thread/start");
+    expect(harness.requests.map((entry) => entry.method)).not.toContain("turn/start");
+    expect(llmInput).not.toHaveBeenCalled();
+    const terminal = readAttemptTerminal(result);
+    expect(terminal.promptErrorSource).toBe("hook:before_agent_run");
+    expect((terminal.promptError as Error).message).toBe(
+      "Your message could not be sent: not allowed (blocked by guardrail)",
+    );
+    expect(result.assistantTexts).toEqual([]);
+    // Plugin-local reason detail never reaches the operator-visible surface.
+    expect(String(terminal.promptError)).not.toContain("secret-policy");
+
+    expect(persistBlocked).toHaveBeenCalledTimes(1);
+    const persisted = persistBlocked.mock.calls[0]?.[0] as {
+      content: { text: string }[];
+      idempotencyKey: string;
+    } & Record<string, { beforeAgentRunBlocked?: { blockedBy?: string } }>;
+    expect(persisted.content[0]?.text).toBe(
+      "Your message could not be sent: not allowed (blocked by guardrail)",
+    );
+    expect(persisted.idempotencyKey).toBe(`hook-block:before_agent_run:user:${runId}`);
+    expect(persisted[OPENCLAW_META_KEY]?.beforeAgentRunBlocked?.blockedBy).toBe("guardrail");
+    expect(JSON.stringify(persisted)).not.toContain("secret-policy");
+
+    // Canonical user-turn bookkeeping still notifies the persistence listener.
+    expect(onUserMessagePersisted).toHaveBeenCalledTimes(1);
+    // The upstream abort listener is released even though startup never ran.
+    expect(removeAbortListener).toHaveBeenCalledWith("abort", expect.any(Function));
+
+    await vi.waitFor(() => expect(agentEnd).toHaveBeenCalledTimes(1));
+    const [agentEndEvent] = agentEnd.mock.calls[0] as unknown as [
+      { error?: string; messages?: { content?: { text?: string }[] }[]; success?: boolean },
+    ];
+    expect(agentEndEvent.success).toBe(false);
+    expect(agentEndEvent.error).toBe(
+      "Your message could not be sent: not allowed (blocked by guardrail)",
+    );
+    // agent_end carries the redacted blocked turn, never the plugin-local reason.
+    expect(agentEndEvent.messages?.at(-1)?.content?.[0]?.text).toBe(
+      "Your message could not be sent: not allowed (blocked by guardrail)",
+    );
+    expect(JSON.stringify(agentEndEvent)).not.toContain("secret-policy");
+    expect(
+      onAgentEvent.mock.calls
+        .map(([event]) => event as { data?: { phase?: string } })
+        .some((event) => event.data?.phase === "before_agent_run_blocked"),
+    ).toBe(true);
+  });
+
+  it("fails closed without starting Codex when the gate hook throws", async () => {
+    const llmInput = vi.fn();
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_agent_run",
+          handler: () => {
+            throw new Error("gate exploded");
+          },
+        },
+        { hookName: "llm_input", handler: llmInput },
+      ]),
+    );
+    const harness = createStartedThreadHarness();
+    const { params, persistBlocked } = createGateParams("gate-throw");
+
+    const result = await runCodexAppServerAttempt(params);
+
+    expect(harness.requests.map((entry) => entry.method)).not.toContain("thread/start");
+    expect(harness.requests.map((entry) => entry.method)).not.toContain("turn/start");
+    expect(llmInput).not.toHaveBeenCalled();
+    const terminal = readAttemptTerminal(result);
+    expect(terminal.promptErrorSource).toBe("hook:before_agent_run");
+    expect((terminal.promptError as Error).message).toBe(
+      "Your message could not be sent: blocked by before_agent_run",
+    );
+    expect(persistBlocked).toHaveBeenCalledTimes(1);
+    expect(String(persistBlocked.mock.calls[0]?.[0])).not.toContain("gate exploded");
+  });
+
+  it("runs the gate exactly once across an internal turn/start retry", async () => {
+    const beforeAgentRun = vi.fn(() => ({ outcome: "pass" }) as const);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_agent_run", handler: beforeAgentRun }]),
+    );
+    const { params } = createGateParams("gate-retry");
+    await writeCodexAppServerBinding(params.sessionFile as string, {
+      threadId: "thread-existing",
+      cwd: params.workspaceDir as string,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      historyCoveredThrough: new Date().toISOString(),
+      webSearchThreadConfigFingerprint: DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT,
+      dynamicToolsFingerprint: "[]",
+    });
+    let turnStartCalls = 0;
+    const harnessRef: { current?: ReturnType<typeof createAppServerHarness> } = {};
+    const harness = createAppServerHarness(async (method) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-existing");
+      }
+      if (method === "turn/start") {
+        turnStartCalls += 1;
+        if (turnStartCalls === 1) {
+          queueMicrotask(() => {
+            void harnessRef.current?.notify({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-existing",
+                turnId: "compact-turn",
+                turn: { id: "compact-turn", status: "completed" },
+              },
+            });
+          });
+          throw new CodexAppServerRpcError(
+            {
+              message: "cannot steer a compact turn",
+              data: {
+                message: "cannot steer a compact turn",
+                codexErrorInfo: { activeTurnNotSteerable: { turnKind: "compact" } },
+                additionalDetails: null,
+              },
+            },
+            "turn/start",
+          );
+        }
+        return turnStartResult("turn-1");
+      }
+      return {};
+    });
+    harnessRef.current = harness;
+
+    const run = runCodexAppServerAttempt(params);
+    await vi.waitFor(
+      () =>
+        expect(harness.requests.filter((entry) => entry.method === "turn/start")).toHaveLength(2),
+      fastWait,
+    );
+    await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await run;
+
+    // Two native turn/start attempts, still one admitted OpenClaw turn.
+    expect(beforeAgentRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("still blocks when no user-turn recorder is attached", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          pluginId: "guardrail",
+          hookName: "before_agent_run",
+          handler: () => ({ outcome: "block", reason: "secret-policy", message: "not allowed" }),
+        },
+      ]),
+    );
+    const harness = createStartedThreadHarness();
+    const { params } = createGateParams("gate-no-recorder");
+    params.userTurnTranscriptRecorder = undefined;
+
+    const result = await runCodexAppServerAttempt(params);
+
+    expect(harness.requests.map((entry) => entry.method)).not.toContain("turn/start");
+    const terminal = readAttemptTerminal(result);
+    expect(terminal.promptErrorSource).toBe("hook:before_agent_run");
+    expect((terminal.promptError as Error).message).toBe(
+      "Your message could not be sent: not allowed (blocked by guardrail)",
+    );
+  });
+
+  it("runs the gate once across outer attempt re-dispatch for the same run", async () => {
+    const beforeAgentRun = vi.fn(() => ({ outcome: "pass" }) as const);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_agent_run", handler: beforeAgentRun }]),
+    );
+    let turnStartCalls = 0;
+    const harness = createAppServerHarness(async (method) => {
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      // The re-dispatched attempt resumes the thread the failed attempt bound.
+      if (method === "thread/resume") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        turnStartCalls += 1;
+        if (turnStartCalls === 1) {
+          throw new Error("codex app-server transport failed");
+        }
+        return turnStartResult();
+      }
+      return {};
+    });
+    const { params } = createGateParams("gate-redispatch");
+
+    // First dispatch fails after the gate admitted the turn.
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow(
+      "codex app-server transport failed",
+    );
+    expect(beforeAgentRun).toHaveBeenCalledTimes(1);
+
+    // Outer recovery re-dispatches the same admitted run.
+    const retryRun = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await retryRun;
+
+    expect(turnStartCalls).toBe(2);
+    expect(beforeAgentRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("gates each logical run separately when a runId is reused", async () => {
+    const beforeAgentRun = vi.fn(() => ({ outcome: "pass" }) as const);
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_agent_run", handler: beforeAgentRun }]),
+    );
+    const harness = createStartedThreadHarness();
+    const { params } = createGateParams("gate-run-reuse");
+
+    for (let logicalRun = 0; logicalRun < 2; logicalRun += 1) {
+      // A later logical run reusing this runId gets its own admission memo and
+      // must be gated again; only the shared reference short-circuits.
+      params.beforeAgentRunAdmission = {};
+      const run = runCodexAppServerAttempt(params);
+      await vi.waitFor(
+        () =>
+          expect(harness.requests.filter((entry) => entry.method === "turn/start")).toHaveLength(
+            logicalRun + 1,
+          ),
+        fastWait,
+      );
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await run;
+    }
+
+    expect(beforeAgentRun).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the no-hook path untouched", async () => {
+    initializeGlobalHookRunner(createMockPluginRegistry([]));
+    const harness = createStartedThreadHarness();
+    const { params, persistBlocked } = createGateParams("gate-absent");
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    const result = await run;
+
+    expect(readAttemptTerminal(result).promptErrorSource).toBeNull();
+    expect(persistBlocked).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2,6 +2,7 @@
 import type { EmbeddedRunAttemptParamsV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import { activateCodexAttemptTurn } from "./run-attempt-active-turn.js";
+import { runCodexAttemptBeforeAgentRunGate } from "./run-attempt-before-agent-run.js";
 import { cleanupCodexAttempt } from "./run-attempt-cleanup.js";
 import { prepareCodexAttemptConnection } from "./run-attempt-connection.js";
 import { prepareCodexAttemptContext } from "./run-attempt-context.js";
@@ -32,6 +33,13 @@ export async function runCodexAppServerAttempt(
   const resources = prepareCodexAttemptResources(attemptPrompt);
   attemptTools.runtimeYieldCompletionClaim.current = () =>
     resources.state.nativeHookRelay?.hasClaimedDirectChild() ?? false;
+  // Single gate call site for the attempt: compact retry, context-overflow
+  // thread restart, thread rotation, and turn/start retry all live below it,
+  // so the hook can never rerun for the same admitted turn.
+  const beforeAgentRunBlock = await runCodexAttemptBeforeAgentRunGate(resources);
+  if (beforeAgentRunBlock) {
+    return beforeAgentRunBlock.result;
+  }
   await startCodexAttemptRuntime(resources);
 
   const turnRuntime = createCodexAttemptTurnState(resources);

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -312,7 +312,9 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: conversation-binding inspection result and runtime inspector.
       // +2: restore shipped channel setup helpers until stable packages migrate.
       // +1: canonical untrusted audio-transcript formatter for channel plugins.
-      4340,
+      // +1: fail-closed before_agent_run gate for the Codex native app-server
+      //     harness, so it reuses core block-message/exactly-once policy.
+      4341,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -404,7 +406,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: read-only authoritative conversation-binding inspector.
       // +2: restore shipped channel setup helpers until stable packages migrate.
       // +1: canonical untrusted audio-transcript formatter for channel plugins.
-      2581,
+      // +1: fail-closed before_agent_run gate for the Codex native app-server harness.
+      2582,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -111,11 +111,10 @@ export async function runPreparedEmbeddedLoop(
     { config: params.config },
   );
   params = { ...params, admittedRunContext: preparedRuntime.admittedRunContext };
-  // Admission is resolved once before the retry loop. Carry that exact object through every
-  // attempt/recovery owner so downstream dispatch cannot lose the admitted context.
+  params.beforeAgentRunAdmission ??= {};
+  // Carry the admitted context and gate memo through every attempt/recovery owner.
   const admittedRunInput: PreparedEmbeddedRunInput = { ...input, runParams: params };
-  provider = preparedRuntime.provider;
-  modelId = preparedRuntime.modelId;
+  ({ provider, modelId } = preparedRuntime);
   const {
     requestedModelId,
     model,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -46,6 +46,7 @@ import type {
   ToolResultFormat,
 } from "../../embedded-agent-subscribe.shared-types.js";
 import type { FastModeAutoProgressState } from "../../fast-mode.js";
+import type { AgentHarnessBeforeAgentRunAdmission } from "../../harness/before-agent-run-admission.js";
 import type { ContextEngineLogicalTurnLease } from "../../harness/context-engine-logical-turn.js";
 import type { ContextEngineTurnAttemptFacts } from "../../harness/context-engine-turn-attempt.js";
 import type { ExpectedAgentHarnessRuntimeArtifact } from "../../harness/runtime-artifact.types.js";
@@ -87,6 +88,11 @@ export type CurrentInboundPromptContext = {
 export type RunEmbeddedAgentParams = {
   /** Already-admitted internal execution; mutually exclusive with preparedRunAdmission. */
   admittedRunContext?: AdmittedRunContext;
+  /**
+   * Run-scoped before_agent_run gate memo, allocated once outside the attempt
+   * retry loop so re-dispatch replays the decision instead of recharging it.
+   */
+  beforeAgentRunAdmission?: AgentHarnessBeforeAgentRunAdmission;
   /** Host-only post-prepare continuation, removed before plugin invocation. */
   preparedRunAdmission?: PreparedAgentRunAdmission;
   /** Caller-owned in-memory transcript for ephemeral helper runs. */

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -270,6 +270,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
   });
   const attemptParams: EmbeddedRunAttemptParams = {
     admittedRunContext: params.admittedRunContext,
+    beforeAgentRunAdmission: params.beforeAgentRunAdmission,
     contextEngineAgentId: runtime.contextEngineAgentId,
     ...(control.pluginHarnessOwnsTransport ? { sandbox: pluginSandbox } : {}),
     operation: "attempt",

--- a/src/agents/harness/before-agent-run-admission.ts
+++ b/src/agents/harness/before-agent-run-admission.ts
@@ -1,0 +1,13 @@
+/**
+ * Run-scoped memo for the fail-closed before_agent_run gate.
+ *
+ * The memo is the logical run's own object: allocated once outside the attempt
+ * retry loop and copied by reference into each dispatched attempt, so a
+ * decision cannot outlive its run or be reached by a later run that reuses the
+ * same runId. Harnesses pass it back to the gate helper and never inspect it.
+ */
+
+/** One run's recorded gate decision. Opaque to harnesses. */
+export type AgentHarnessBeforeAgentRunAdmission = {
+  decision?: { action: "proceed" } | { action: "blocked"; blockedBy: string; message: string };
+};

--- a/src/agents/harness/lifecycle-hook-helpers.test.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   awaitAgentHarnessAgentEndHook,
   runAgentHarnessAgentEndHook,
   runAgentHarnessBeforeAgentFinalizeHook,
+  runAgentHarnessBeforeAgentRunHook,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,
 } from "./lifecycle-hook-helpers.js";
@@ -314,5 +315,204 @@ describe("agent harness lifecycle hook helpers", () => {
       action: "revise",
       reason: secondInstruction,
     });
+  });
+});
+
+describe("before_agent_run gate", () => {
+  const GATE_EVENT = { prompt: "hello", systemPrompt: "system", messages: [] };
+
+  it("proceeds when no runner advertises the gate", async () => {
+    const hookRunner = { hasHooks: vi.fn(() => false), runBeforeAgentRun: vi.fn() };
+    await expect(
+      runAgentHarnessBeforeAgentRunHook({ event: GATE_EVENT, ctx: {}, hookRunner } as never),
+    ).resolves.toEqual({ action: "proceed" });
+    expect(hookRunner.runBeforeAgentRun).not.toHaveBeenCalled();
+  });
+
+  it("charges the gate once across re-dispatch sharing one run admission", async () => {
+    const runBeforeAgentRun = vi.fn(async () => undefined);
+    const hookRunner = { hasHooks: vi.fn(() => true), runBeforeAgentRun };
+    const admission = {};
+    const dispatch = async () =>
+      await runAgentHarnessBeforeAgentRunHook({
+        event: GATE_EVENT,
+        ctx: { runId: "run-1" },
+        hookRunner,
+        admission,
+      } as never);
+    await expect(dispatch()).resolves.toEqual({ action: "proceed" });
+    await expect(dispatch()).resolves.toEqual({ action: "proceed" });
+    expect(runBeforeAgentRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays the blocked decision across re-dispatch of one run", async () => {
+    const runBeforeAgentRun = vi.fn(async () => ({
+      decision: { outcome: "block", reason: "internal-detail", message: "nope" },
+      pluginId: "guardrail",
+    }));
+    const hookRunner = { hasHooks: vi.fn(() => true), runBeforeAgentRun };
+    const admission = {};
+    const dispatch = async () =>
+      await runAgentHarnessBeforeAgentRunHook({
+        event: GATE_EVENT,
+        ctx: { runId: "run-1" },
+        hookRunner,
+        admission,
+      } as never);
+    const first = await dispatch();
+    const second = await dispatch();
+    expect(second).toEqual(first);
+    expect(second).toMatchObject({ action: "blocked", blockedBy: "guardrail" });
+    expect(runBeforeAgentRun).toHaveBeenCalledTimes(1);
+  });
+
+  it("never carries a decision between logical runs that reuse one runId", async () => {
+    const runBeforeAgentRun = vi.fn(async () => undefined);
+    const hookRunner = { hasHooks: vi.fn(() => true), runBeforeAgentRun };
+    // Two logical runs, same runId, one admission each: the memo is the run's
+    // own object, so the second run must still be gated.
+    for (const admission of [{}, {}]) {
+      await runAgentHarnessBeforeAgentRunHook({
+        event: GATE_EVENT,
+        ctx: { runId: "run-1" },
+        hookRunner,
+        admission,
+      } as never);
+    }
+    expect(runBeforeAgentRun).toHaveBeenCalledTimes(2);
+  });
+
+  it("gates every call when no run admission is supplied", async () => {
+    const runBeforeAgentRun = vi.fn(async () => undefined);
+    const hookRunner = { hasHooks: vi.fn(() => true), runBeforeAgentRun };
+    for (let index = 0; index < 2; index += 1) {
+      await runAgentHarnessBeforeAgentRunHook({
+        event: GATE_EVENT,
+        ctx: { runId: "run-1" },
+        hookRunner,
+      } as never);
+    }
+    expect(runBeforeAgentRun).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed when the gate is advertised but has no runner method", async () => {
+    const hookRunner = { hasHooks: vi.fn(() => true) };
+    await expect(
+      runAgentHarnessBeforeAgentRunHook({ event: GATE_EVENT, ctx: {}, hookRunner } as never),
+    ).resolves.toEqual({
+      action: "blocked",
+      blockedBy: "before_agent_run",
+      message: "Your message could not be sent: blocked by before_agent_run",
+    });
+    expect(hookRunner.hasHooks).toHaveBeenCalledWith("before_agent_run");
+  });
+
+  it.each([
+    { label: "pass", result: { decision: { outcome: "pass" }, pluginId: "gate" } },
+    { label: "void", result: undefined },
+  ])("proceeds on a $label decision", async ({ result }) => {
+    const hookRunner = {
+      hasHooks: vi.fn(() => true),
+      runBeforeAgentRun: vi.fn(async () => result),
+    };
+    await expect(
+      runAgentHarnessBeforeAgentRunHook({ event: GATE_EVENT, ctx: {}, hookRunner } as never),
+    ).resolves.toEqual({ action: "proceed" });
+  });
+
+  it("blocks with the plugin attribution and never leaks the plugin-local reason", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn(() => true),
+      runBeforeAgentRun: vi.fn(async () => ({
+        decision: {
+          outcome: "block",
+          reason: "internal-policy-detail",
+          message: "quota exhausted",
+        },
+        pluginId: "billing",
+      })),
+    };
+    const outcome = await runAgentHarnessBeforeAgentRunHook({
+      event: GATE_EVENT,
+      ctx: {},
+      hookRunner,
+    } as never);
+    expect(outcome).toEqual({
+      action: "blocked",
+      blockedBy: "billing",
+      message: "Your message could not be sent: quota exhausted (blocked by billing)",
+    });
+    expect(JSON.stringify(outcome)).not.toContain("internal-policy-detail");
+  });
+
+  it("fails closed when the gate hook throws", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn(() => true),
+      runBeforeAgentRun: vi.fn(async () => {
+        throw new Error("gate exploded");
+      }),
+    };
+    const outcome = await runAgentHarnessBeforeAgentRunHook({
+      event: GATE_EVENT,
+      ctx: {},
+      hookRunner,
+    } as never);
+    expect(outcome).toEqual({
+      action: "blocked",
+      blockedBy: "before_agent_run",
+      message: "Your message could not be sent: blocked by before_agent_run",
+    });
+  });
+
+  it("hands hooks a bounded, isolated history snapshot", async () => {
+    let observed: unknown[] = [];
+    const hookRunner = {
+      hasHooks: vi.fn(() => true),
+      runBeforeAgentRun: vi.fn(async (event: { messages: unknown[] }) => {
+        observed = event.messages;
+        (observed[0] as { content: string }).content = "mutated";
+        return undefined;
+      }),
+    };
+    const messages = Array.from({ length: 105 }, (_index, index) => ({
+      role: "user",
+      content: `message-${index}`,
+    }));
+    await runAgentHarnessBeforeAgentRunHook({
+      event: { ...GATE_EVENT, messages },
+      ctx: {},
+      hookRunner,
+    } as never);
+    expect(observed).toHaveLength(100);
+    expect((observed[0] as { content: string }).content).toBe("mutated");
+    // Source history stays untouched: hooks never mutate the in-session copy.
+    expect(messages[5]?.content).toBe("message-5");
+    expect(messages.at(-1)?.content).toBe("message-104");
+  });
+
+  it("forwards trusted identity fields as hook-only evidence", async () => {
+    const runBeforeAgentRun = vi.fn(
+      async (_event: Record<string, unknown>, _ctx: Record<string, unknown>) => undefined,
+    );
+    await runAgentHarnessBeforeAgentRunHook({
+      event: {
+        ...GATE_EVENT,
+        channelId: "telegram:1",
+        accountId: "acct-1",
+        senderId: "sender-1",
+        senderIsOwner: true,
+      },
+      ctx: { runId: "run-1", agentId: "main" },
+      hookRunner: { hasHooks: vi.fn(() => true), runBeforeAgentRun },
+    } as never);
+    expect(runBeforeAgentRun.mock.calls[0]?.[0]).toMatchObject({
+      prompt: "hello",
+      systemPrompt: "system",
+      channelId: "telegram:1",
+      accountId: "acct-1",
+      senderId: "sender-1",
+      senderIsOwner: true,
+    });
+    expect(runBeforeAgentRun.mock.calls[0]?.[1]).toMatchObject({ runId: "run-1", agentId: "main" });
   });
 });

--- a/src/agents/harness/lifecycle-hook-helpers.ts
+++ b/src/agents/harness/lifecycle-hook-helpers.ts
@@ -8,17 +8,21 @@ import { createHash } from "node:crypto";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as normalizeTrimmedString } from "@openclaw/normalization-core/string-coerce";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveBlockMessage } from "../../plugins/hook-decision-types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type {
   PluginHookAgentEndEvent,
   PluginHookBeforeAgentFinalizeEvent,
   PluginHookBeforeAgentFinalizeResult,
+  PluginHookBeforeAgentRunEvent,
   PluginHookLlmInputEvent,
   PluginHookLlmOutputEvent,
 } from "../../plugins/hook-types.js";
 import type { VoidHookRunOptions } from "../../plugins/hooks.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import type { AgentHarnessBeforeAgentRunAdmission } from "./before-agent-run-admission.js";
 import { buildAgentHookContext, type AgentHarnessHookContext } from "./hook-context.js";
+import { limitAgentHookHistoryMessages } from "./hook-history.js";
 
 const log = createSubsystemLogger("agents/harness");
 const FINALIZE_RETRY_BUDGET_KEY = Symbol.for("openclaw.pluginFinalizeRetryBudget");
@@ -97,6 +101,99 @@ export function runAgentHarnessLlmOutputHook(params: {
     .catch((error: unknown) => {
       log.warn(`llm_output hook failed: ${String(error)}`);
     });
+}
+
+/** Closed outcome of the fail-closed before_agent_run gate. */
+type AgentHarnessBeforeAgentRunOutcome =
+  | { action: "proceed" }
+  | { action: "blocked"; blockedBy: string; message: string };
+
+/** Attribution used when the gate itself fails rather than a plugin deciding to block. */
+const BEFORE_AGENT_RUN_FAILURE_ATTRIBUTION = "before_agent_run";
+
+/** Fail-closed outcome for a gate that could not produce a plugin decision. */
+function buildBeforeAgentRunGateFailure(reason: string): AgentHarnessBeforeAgentRunOutcome {
+  return {
+    action: "blocked",
+    blockedBy: BEFORE_AGENT_RUN_FAILURE_ATTRIBUTION,
+    message: resolveBlockMessage(
+      { outcome: "block", reason },
+      { blockedBy: BEFORE_AGENT_RUN_FAILURE_ATTRIBUTION },
+    ),
+  };
+}
+
+/**
+ * Runs the fail-closed before_agent_run gate for a harness attempt.
+ *
+ * Block-message rendering stays here so plugin-local `reason` text can never
+ * reach a user-facing surface, and history is bounded/cloned here so every
+ * runtime gets the same isolated snapshot without copying the policy.
+ */
+export async function runAgentHarnessBeforeAgentRunHook(params: {
+  event: Omit<PluginHookBeforeAgentRunEvent, "messages"> & { messages?: readonly unknown[] };
+  ctx: AgentHarnessHookContext;
+  hookRunner?: AgentHarnessHookRunner;
+  /** Run-scoped memo; outer attempt re-dispatch replays its recorded decision. */
+  admission?: AgentHarnessBeforeAgentRunAdmission;
+}): Promise<AgentHarnessBeforeAgentRunOutcome> {
+  const admission = params.admission;
+  if (admission?.decision) {
+    return admission.decision;
+  }
+  const hookRunner = params.hookRunner ?? getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("before_agent_run")) {
+    return { action: "proceed" };
+  }
+  if (typeof hookRunner.runBeforeAgentRun !== "function") {
+    // Enforcement is configured but cannot execute; an unrunnable gate must
+    // never silently admit the turn.
+    log.warn("before_agent_run gate is registered but not runnable; blocking request");
+    return recordBeforeAgentRunOutcome(
+      admission,
+      buildBeforeAgentRunGateFailure("before_agent_run gate is not runnable"),
+    );
+  }
+  let result: Awaited<ReturnType<NonNullable<typeof hookRunner>["runBeforeAgentRun"]>> | undefined;
+  try {
+    result = await hookRunner.runBeforeAgentRun(
+      {
+        ...params.event,
+        /** Gives hooks a bounded snapshot they cannot mutate in-session. */
+        messages: limitAgentHookHistoryMessages(params.event.messages ?? []).map((message) =>
+          structuredClone(message),
+        ),
+      },
+      buildAgentHookContext(params.ctx),
+    );
+  } catch (error) {
+    log.warn(`before_agent_run hook failed; blocking request: ${String(error)}`);
+    return recordBeforeAgentRunOutcome(
+      admission,
+      buildBeforeAgentRunGateFailure("before_agent_run hook failed"),
+    );
+  }
+  const decision = result?.decision;
+  if (decision?.outcome !== "block") {
+    return recordBeforeAgentRunOutcome(admission, { action: "proceed" });
+  }
+  const blockedBy = result?.pluginId ?? "unknown";
+  log.warn(`before_agent_run hook blocked by ${blockedBy}`);
+  return recordBeforeAgentRunOutcome(admission, {
+    action: "blocked",
+    blockedBy,
+    message: resolveBlockMessage(decision, { blockedBy }),
+  });
+}
+
+function recordBeforeAgentRunOutcome(
+  admission: AgentHarnessBeforeAgentRunAdmission | undefined,
+  outcome: AgentHarnessBeforeAgentRunOutcome,
+): AgentHarnessBeforeAgentRunOutcome {
+  if (admission) {
+    admission.decision = outcome;
+  }
+  return outcome;
 }
 
 async function executeAgentHarnessAgentEndHook(params: {

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -542,6 +542,7 @@ export {
   awaitAgentHarnessAgentEndHook,
   getAgentHarnessHookRunner,
   runAgentHarnessBeforeAgentFinalizeHook,
+  runAgentHarnessBeforeAgentRunHook,
   runAgentHarnessAgentEndHook,
   runAgentHarnessLlmInputHook,
   runAgentHarnessLlmOutputHook,


### PR DESCRIPTION
## Summary

- run `before_agent_run` admission for native Codex app-server attempts before lifecycle start and model-input events
- memoize the admission decision across retries of the same logical run
- persist blocked outcomes with redaction and clean up run-scoped state
- add regression coverage for ordering, retries, fail-closed behavior, redaction, and cleanup

## Verification

- 334 regression tests passed
- 31 final gate tests passed
- full changed-file checks passed, including typecheck, type-aware lint, SDK surface, dead-export, and import-cycle guards
- fresh exact-commit review passed

## Security

- reviewed lifecycle ordering, hook identity, retry/replay behavior, persisted blocked results, and cleanup
- no remaining confirmed security findings