### PR TITLE
fix(codex): preserve large workspace instructions across resumes

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -106,6 +106,11 @@ artifact. Plan-based migrations can use
 `openclaw/plugin-sdk/runtime-doctor-migrations` to preserve existing move, copy, preview,
 and plugin-state import behavior.
 
+State-migration callbacks can use `context.openPluginBlobStore(...)` when a
+repair must move bounded plugin-state values into the plugin's existing blob
+namespace. Migration execution holds exclusive state ownership across blob and
+keyed-store repair; reconcile any cross-store ownership metadata before returning.
+
 The setup-entry `legacyStateMigrations` option and feature flag,
 `setupFeatures.legacyStateMigrations`,
 `BundledChannelLegacyStateMigrationDetector`, and

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -946,6 +946,11 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
       new TextEncoder().encode("binary or text payload"),
       { contentType: "text/plain" },
     );
+    await blobs.mutate("artifact-1", (current) => ({
+      kind: "set",
+      bytes: current?.bytes ?? new Uint8Array(),
+      metadata: { contentType: "application/octet-stream" },
+    }));
     const blob = await blobs.lookup("artifact-1");
     ```
 
@@ -953,7 +958,7 @@ snapshots; OpenClaw owns all persistence and lifecycle coordination.
 
     `openSyncKeyedStore<T>(...)` returns the same store shape with synchronous methods (`register`, `registerIfAbsent`, `deleteIf`, `lookup`, `consume`, `clear` all return values directly instead of promises) for callers that cannot await.
 
-    `openBlobStore<TMetadata>(...)` stores bounded binary payloads in shared SQLite without base64 or file sidecars. It requires per-entry, per-namespace byte, and row limits; copies byte arrays at the API boundary; and lists metadata without loading every BLOB. `register(...)` is an explicit upsert, including for expired keys. `registerIfAbsent(...)` provides collision-safe creation: an expired key remains occupied until its owner claims it with `deleteExpiredKey(key)` or `deleteExpired()`, preserving metadata needed to remove related named artifacts after the SQLite commit. Any row with a TTL is transient and excluded from backup/restore even before it expires; omit TTL for durable, restorable state. Host fuses cap each BLOB at 100 MiB, each plugin at 512 MiB of physically stored BLOBs, and each plugin at 50,000 physically stored rows, including expired rows awaiting owner cleanup. Use `registerIfAbsent(...)` with `overflowPolicy: "reject-new"` when external materializations must not be silently orphaned by replacement or eviction.
+    `openBlobStore<TMetadata>(...)` stores bounded binary payloads in shared SQLite without base64 or file sidecars. It requires per-entry, per-namespace byte, and row limits; copies byte arrays at the API boundary; and lists metadata without loading every BLOB. `register(...)` is an explicit upsert, including for expired keys. `registerIfAbsent(...)` provides collision-safe creation: an expired key remains occupied until its owner claims it with `deleteExpiredKey(key)` or `deleteExpired()`, preserving metadata needed to remove related named artifacts after the SQLite commit. `mutate(...)` runs a synchronous create, replace, or delete decision against the current live blob in one SQLite transaction; expired rows appear absent to its callback, and an explicit set/delete may replace/remove that stored row. A thrown callback rolls the transaction back. Any row with a TTL is transient and excluded from backup/restore even before it expires; omit TTL for durable, restorable state. Host fuses cap each BLOB at 100 MiB, each plugin at 512 MiB of physically stored BLOBs, and each plugin at 50,000 physically stored rows, including expired rows awaiting owner cleanup. Use `registerIfAbsent(...)` with `overflowPolicy: "reject-new"` when external materializations must not be silently orphaned by replacement or eviction.
 
     `openChannelIngressQueue<TPayload>(...)` opens a persisted ingress queue scoped to the calling plugin, for buffering inbound events that need at-least-once processing across restarts. When stale-claim recovery uses `shouldRecover`, also provide `shouldRecoverCorrupt` if corrupt claimed payloads should be quarantined: its payload-independent claim identity lets the plugin preserve live owner and lane policy before the queue tombstones the row.
 

--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -3,10 +3,14 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  createPluginBlobStoreForTests,
   createPluginStateKeyedStoreForTests,
+  openOpenClawStateDatabase,
+  resetPluginBlobStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type {
+  OpenBlobStoreOptions,
   OpenKeyedStoreOptions,
   PluginDoctorStateMigrationContext,
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
@@ -18,10 +22,14 @@ import {
   normalizeCompatibilityConfig,
   stateMigrations,
 } from "./doctor-contract-api.js";
+import { codexInstructionBlobReference } from "./src/app-server/instruction-blob.js";
 import {
   bindingStoreKey,
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   CODEX_APP_SERVER_BINDING_NAMESPACE,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
   createStoredCodexAppServerBinding,
   hashCodexAppServerBindingFingerprint,
   type StoredCodexAppServerBinding,
@@ -33,6 +41,9 @@ function createDoctorContext(
   afterRegister?: () => Promise<void>,
 ): PluginDoctorStateMigrationContext {
   return {
+    openPluginBlobStore<T>(options: OpenBlobStoreOptions) {
+      return createPluginBlobStoreForTests<T>("codex", options, env);
+    },
     openPluginStateKeyedStore<T>(options: OpenKeyedStoreOptions) {
       const store = createPluginStateKeyedStoreForTests<T>("codex", {
         ...options,
@@ -60,12 +71,27 @@ function openBindingStore(env: NodeJS.ProcessEnv) {
   });
 }
 
+function openInstructionBlobStore(env: NodeJS.ProcessEnv) {
+  return createPluginBlobStoreForTests<{ version: 1; refCount: number }>(
+    "codex",
+    {
+      namespace: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
+      maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+      maxBytesPerEntry: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+      maxBytesPerNamespace: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+      overflowPolicy: "reject-new",
+    },
+    env,
+  );
+}
+
 async function removeCodexDoctorFixture(stateDir: string): Promise<void> {
   // Doctor migrations open per-agent databases and leave the shared state database open under
   // the temporary state dir; both must be released before removal or Windows keeps the files
   // locked and the removal fails with EBUSY. Agent close first: it releases leases through
   // shared state, so the reverse order can reopen it.
   closeOpenClawAgentDatabasesForTest();
+  resetPluginBlobStoreForTests();
   resetPluginStateStoreForTests();
   await fs.rm(stateDir, { recursive: true, force: true });
 }
@@ -137,6 +163,7 @@ async function createBindingMigrationFixture(options: {
 }
 
 afterEach(() => {
+  resetPluginBlobStoreForTests();
   resetPluginStateStoreForTests();
 });
 
@@ -288,6 +315,8 @@ describe("codex doctor contract", () => {
   });
 
   it("imports and archives shipped binding sidecars", async () => {
+    const instructions = `# Frozen legacy policy\n${"multibyte-🦀\n".repeat(6_000)}`;
+    expect(Buffer.byteLength(instructions)).toBeGreaterThan(65_536);
     const fixture = await createBindingMigrationFixture({
       name: "session-current",
       sessionIndex: {
@@ -299,6 +328,7 @@ describe("codex doctor contract", () => {
       },
       threadId: "thread-1",
       binding: {
+        agentWorkspaceDeveloperInstructions: instructions,
         pluginAppPolicyContext: {
           fingerprint: "policy-1",
           apps: {
@@ -339,6 +369,7 @@ describe("codex doctor contract", () => {
       sessionId: "session-current",
       binding: {
         threadId: "thread-1",
+        agentWorkspaceDeveloperInstructionsRef: codexInstructionBlobReference(instructions),
         pluginAppPolicyContext: {
           apps: { app: { destructiveApprovalMode: "ask" } },
         },
@@ -351,7 +382,19 @@ describe("codex doctor contract", () => {
           bindingId: legacyCodexConversationBindingId(fixture.transcriptPath),
         }),
       ),
-    ).resolves.toMatchObject({ state: "active", binding: { threadId: "thread-1" } });
+    ).resolves.toMatchObject({
+      state: "active",
+      binding: {
+        threadId: "thread-1",
+        agentWorkspaceDeveloperInstructionsRef: codexInstructionBlobReference(instructions),
+      },
+    });
+    await expect(
+      openInstructionBlobStore(fixture.env).lookup(codexInstructionBlobReference(instructions)),
+    ).resolves.toMatchObject({
+      bytes: new TextEncoder().encode(instructions),
+      metadata: { version: 1, refCount: 2 },
+    });
     await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
     expect(
       getSessionEntry({
@@ -369,6 +412,375 @@ describe("codex doctor contract", () => {
     ).resolves.not.toHaveProperty("agent:main:session-1.agentHarnessId");
 
     await removeCodexDoctorFixture(fixture.stateDir);
+  });
+
+  it("migrates inline binding rows and reconciles crash-leaked blob references", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-inline-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const context = createDoctorContext(env);
+    const store = openBindingStore(env);
+    const blobs = openInstructionBlobStore(env);
+    const migration = stateMigrations[1]!;
+    const instructions = "Legacy frozen instructions shared by two bindings.";
+    const reference = codexInstructionBlobReference(instructions);
+    const orphanReference = `sha256:${"0".repeat(64)}`;
+    try {
+      for (const bindingId of ["inline-one", "inline-two"]) {
+        await store.register(bindingStoreKey({ kind: "conversation", bindingId }), {
+          version: 1,
+          state: "active",
+          binding: {
+            threadId: `thread-${bindingId}`,
+            cwd: "/repo",
+            agentWorkspaceDeveloperInstructions: instructions,
+          },
+        } as unknown as StoredCodexAppServerBinding);
+      }
+      await blobs.register(orphanReference, new TextEncoder().encode("crash leak"), {
+        version: 1,
+        refCount: 7,
+      });
+      const params = {
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context,
+      };
+
+      await expect(migration.detectLegacyState(params)).resolves.toMatchObject({
+        preview: [expect.stringContaining("2 inline instruction snapshot")],
+      });
+      await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+        changes: [expect.stringContaining("Migrated 2")],
+        warnings: [],
+      });
+      for (const bindingId of ["inline-one", "inline-two"]) {
+        await expect(
+          store.lookup(bindingStoreKey({ kind: "conversation", bindingId })),
+        ).resolves.toMatchObject({
+          state: "active",
+          binding: { agentWorkspaceDeveloperInstructionsRef: reference },
+        });
+      }
+      await expect(blobs.lookup(reference)).resolves.toMatchObject({
+        bytes: new TextEncoder().encode(instructions),
+        metadata: { version: 1, refCount: 2 },
+      });
+      await expect(blobs.lookup(orphanReference)).resolves.toBeUndefined();
+    } finally {
+      await removeCodexDoctorFixture(stateDir);
+    }
+  });
+
+  it("compensates a retained instruction blob when inline-row migration loses CAS", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-cas-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const baseContext = createDoctorContext(env);
+    const store = openBindingStore(env);
+    const blobs = openInstructionBlobStore(env);
+    const instructions = "Inline snapshot whose row changes during doctor repair.";
+    const reference = codexInstructionBlobReference(instructions);
+    const uncertainInstructions = "Blob that an unreadable row could still reference.";
+    const uncertainReference = codexInstructionBlobReference(uncertainInstructions);
+    try {
+      await store.register("conversation:cas-conflict", {
+        version: 1,
+        state: "active",
+        binding: {
+          threadId: "thread-cas-conflict",
+          cwd: "/repo",
+          agentWorkspaceDeveloperInstructions: instructions,
+        },
+      } as unknown as StoredCodexAppServerBinding);
+      await blobs.register(uncertainReference, new TextEncoder().encode(uncertainInstructions), {
+        version: 1,
+        refCount: 1,
+      });
+      const context: PluginDoctorStateMigrationContext = {
+        ...baseContext,
+        openPluginStateKeyedStore<T>(options: OpenKeyedStoreOptions) {
+          const opened = baseContext.openPluginStateKeyedStore<T>(options);
+          return { ...opened, update: async () => false };
+        },
+      };
+      const result = await stateMigrations[1]!.migrateLegacyState({
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context,
+      });
+
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("changed during migration"),
+          expect.stringContaining("binding census is incomplete"),
+        ]),
+      );
+      await expect(blobs.lookup(reference)).resolves.toBeUndefined();
+      await expect(blobs.lookup(uncertainReference)).resolves.toBeDefined();
+      await expect(store.lookup("conversation:cas-conflict")).resolves.toHaveProperty(
+        "binding.agentWorkspaceDeveloperInstructions",
+        instructions,
+      );
+    } finally {
+      await removeCodexDoctorFixture(stateDir);
+    }
+  });
+
+  it("repairs referenced instruction blobs with valid bytes and wrong-shape metadata", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-metadata-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const context = createDoctorContext(env);
+    const store = openBindingStore(env);
+    const blobs = openInstructionBlobStore(env);
+    const instructions = "Frozen instructions with repairable metadata.";
+    const reference = codexInstructionBlobReference(instructions);
+    try {
+      await store.register("conversation:metadata-repair", {
+        version: 1,
+        state: "active",
+        binding: {
+          threadId: "thread-metadata-repair",
+          cwd: "/repo",
+          agentWorkspaceDeveloperInstructionsRef: reference,
+        },
+      });
+      await blobs.register(reference, new TextEncoder().encode(instructions), {
+        version: 2,
+        refCount: 99,
+      } as never);
+      const params = {
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context,
+      };
+
+      await expect(stateMigrations[1]!.detectLegacyState(params)).resolves.toBeTruthy();
+      await expect(stateMigrations[1]!.migrateLegacyState(params)).resolves.toEqual({
+        changes: [],
+        warnings: [],
+      });
+      await expect(blobs.lookup(reference)).resolves.toMatchObject({
+        bytes: new TextEncoder().encode(instructions),
+        metadata: { version: 1, refCount: 1 },
+      });
+    } finally {
+      await removeCodexDoctorFixture(stateDir);
+    }
+  });
+
+  it("diagnoses a referenced digest mismatch without deleting orphan blobs", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-digest-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const context = createDoctorContext(env);
+    const store = openBindingStore(env);
+    const blobs = openInstructionBlobStore(env);
+    const reference = codexInstructionBlobReference("Expected frozen instructions.");
+    const orphanInstructions = "Unreferenced content retained under unsafe census.";
+    const orphanReference = codexInstructionBlobReference(orphanInstructions);
+    try {
+      await store.register("conversation:digest-mismatch", {
+        version: 1,
+        state: "active",
+        binding: {
+          threadId: "thread-digest-mismatch",
+          cwd: "/repo",
+          agentWorkspaceDeveloperInstructionsRef: reference,
+        },
+      });
+      await blobs.register(reference, new TextEncoder().encode("Different valid UTF-8 bytes."), {
+        version: 1,
+        refCount: 1,
+      });
+      await blobs.register(orphanReference, new TextEncoder().encode(orphanInstructions), {
+        version: 1,
+        refCount: 1,
+      });
+      const params = {
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context,
+      };
+
+      await expect(stateMigrations[1]!.detectLegacyState(params)).resolves.toBeTruthy();
+      const result = await stateMigrations[1]!.migrateLegacyState(params);
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("digest mismatch"),
+          expect.stringContaining("referenced blob content is unsafe"),
+        ]),
+      );
+      await expect(blobs.lookup(reference)).resolves.toBeDefined();
+      await expect(blobs.lookup(orphanReference)).resolves.toBeDefined();
+    } finally {
+      await removeCodexDoctorFixture(stateDir);
+    }
+  });
+
+  it("diagnoses invalid UTF-8 in a referenced instruction blob without cleanup", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-utf8-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const context = createDoctorContext(env);
+    const store = openBindingStore(env);
+    const blobs = openInstructionBlobStore(env);
+    const reference = codexInstructionBlobReference("Expected UTF-8 instructions.");
+    const orphanInstructions = "Orphan retained while referenced UTF-8 is invalid.";
+    const orphanReference = codexInstructionBlobReference(orphanInstructions);
+    try {
+      await store.register("conversation:invalid-utf8", {
+        version: 1,
+        state: "active",
+        binding: {
+          threadId: "thread-invalid-utf8",
+          cwd: "/repo",
+          agentWorkspaceDeveloperInstructionsRef: reference,
+        },
+      });
+      await blobs.register(reference, Uint8Array.of(0xff), { version: 1, refCount: 1 });
+      await blobs.register(orphanReference, new TextEncoder().encode(orphanInstructions), {
+        version: 1,
+        refCount: 1,
+      });
+      const params = {
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context,
+      };
+
+      await expect(stateMigrations[1]!.detectLegacyState(params)).resolves.toBeTruthy();
+      const result = await stateMigrations[1]!.migrateLegacyState(params);
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("not valid UTF-8"),
+          expect.stringContaining("referenced blob content is unsafe"),
+        ]),
+      );
+      await expect(blobs.lookup(reference)).resolves.toBeDefined();
+      await expect(blobs.lookup(orphanReference)).resolves.toBeDefined();
+    } finally {
+      await removeCodexDoctorFixture(stateDir);
+    }
+  });
+
+  it("diagnoses invalid instruction metadata JSON without destructive cleanup", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-json-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const context = createDoctorContext(env);
+    const store = openBindingStore(env);
+    const blobs = openInstructionBlobStore(env);
+    const instructions = "Frozen instructions with corrupt metadata JSON.";
+    const reference = codexInstructionBlobReference(instructions);
+    const orphanInstructions = "Orphan retained while metadata census is unreadable.";
+    const orphanReference = codexInstructionBlobReference(orphanInstructions);
+    try {
+      await store.register("conversation:invalid-metadata-json", {
+        version: 1,
+        state: "active",
+        binding: {
+          threadId: "thread-invalid-metadata-json",
+          cwd: "/repo",
+          agentWorkspaceDeveloperInstructionsRef: reference,
+        },
+      });
+      await blobs.register(reference, new TextEncoder().encode(instructions), {
+        version: 1,
+        refCount: 1,
+      });
+      await blobs.register(orphanReference, new TextEncoder().encode(orphanInstructions), {
+        version: 1,
+        refCount: 1,
+      });
+      const { db } = openOpenClawStateDatabase({ env });
+      db.prepare(
+        `UPDATE plugin_blob_entries SET metadata_json = ?
+         WHERE plugin_id = ? AND namespace = ? AND entry_key = ?`,
+      ).run("{", "codex", CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE, reference);
+      const params = {
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context,
+      };
+
+      await expect(stateMigrations[1]!.detectLegacyState(params)).resolves.toMatchObject({
+        preview: [expect.stringContaining("unreadable instruction blob metadata")],
+      });
+      const result = await stateMigrations[1]!.migrateLegacyState(params);
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("metadata census is unreadable"),
+          expect.stringContaining("blob census is unsafe"),
+        ]),
+      );
+      expect(
+        db
+          .prepare(
+            `SELECT entry_key FROM plugin_blob_entries
+             WHERE plugin_id = ? AND namespace = ? ORDER BY entry_key`,
+          )
+          .all("codex", CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE),
+      ).toEqual(
+        [{ entry_key: orphanReference }, { entry_key: reference }].toSorted((a, b) =>
+          a.entry_key.localeCompare(b.entry_key),
+        ),
+      );
+    } finally {
+      await removeCodexDoctorFixture(stateDir);
+    }
+  });
+
+  it("diagnoses a missing referenced instruction blob without deleting orphans", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-doctor-missing-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const context = createDoctorContext(env);
+    const store = openBindingStore(env);
+    const blobs = openInstructionBlobStore(env);
+    const missingReference = codexInstructionBlobReference("Missing frozen instructions.");
+    const orphanInstructions = "Orphan retained while a live reference is missing.";
+    const orphanReference = codexInstructionBlobReference(orphanInstructions);
+    try {
+      await store.register("conversation:missing-reference", {
+        version: 1,
+        state: "active",
+        binding: {
+          threadId: "thread-missing-reference",
+          cwd: "/repo",
+          agentWorkspaceDeveloperInstructionsRef: missingReference,
+        },
+      });
+      await blobs.register(orphanReference, new TextEncoder().encode(orphanInstructions), {
+        version: 1,
+        refCount: 1,
+      });
+      const params = {
+        config: {},
+        env,
+        stateDir,
+        oauthDir: path.join(stateDir, "oauth"),
+        context,
+      };
+
+      await expect(stateMigrations[1]!.detectLegacyState(params)).resolves.toBeTruthy();
+      const result = await stateMigrations[1]!.migrateLegacyState(params);
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(`missing for ${missingReference}`),
+          expect.stringContaining("referenced blob content is unsafe"),
+        ]),
+      );
+      await expect(blobs.lookup(orphanReference)).resolves.toBeDefined();
+    } finally {
+      await removeCodexDoctorFixture(stateDir);
+    }
   });
 
   it.each([

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -11,6 +11,7 @@ import {
   sessionBindingIdentity,
 } from "./src/app-server/session-binding.js";
 import {
+  createCodexTestInstructionBlobStore,
   createCodexTestBindingStateStore,
   testCodexAppServerBindingStore,
 } from "./src/app-server/session-binding.test-helpers.js";
@@ -29,9 +30,11 @@ function createCodexTestRuntime(
   current?: () => unknown,
   stateStore = createCodexTestBindingStateStore(),
 ) {
+  const instructionBlobs = createCodexTestInstructionBlobStore();
   return {
     ...(current ? { config: { current } } : {}),
     state: {
+      openBlobStore: () => instructionBlobs.store,
       openSyncKeyedStore: () => stateStore,
     },
   } as never;

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -10,7 +10,10 @@ import {
   resolveLivePluginConfigObject,
 } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type {
+  PluginBlobStore,
+  PluginStateSyncKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
 import { registerCodexCliMetadata } from "./cli-metadata.js";
 import {
   createCodexAppServerAgentHarness,
@@ -28,6 +31,9 @@ import {
 import {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   CODEX_APP_SERVER_BINDING_NAMESPACE,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
   createLazyCodexAppServerBindingStore,
   type StoredCodexAppServerBinding,
 } from "./src/app-server/session-binding-store.js";
@@ -118,6 +124,7 @@ export default definePluginEntry({
       );
     }
     let bindingStateStore: PluginStateSyncKeyedStore<StoredCodexAppServerBinding> | undefined;
+    let instructionBlobStore: PluginBlobStore<{ version: 1; refCount: number }> | undefined;
     let managedThreadStateStore: PluginStateSyncKeyedStore<StoredCodexManagedThread> | undefined;
     const openBindingStateStore = () =>
       (bindingStateStore ??= api.runtime.state.openSyncKeyedStore<StoredCodexAppServerBinding>({
@@ -139,6 +146,21 @@ export default definePluginEntry({
         return store.update?.bind(store);
       },
     };
+    const openInstructionBlobStore = () =>
+      (instructionBlobStore ??= api.runtime.state.openBlobStore({
+        namespace: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
+        maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+        maxBytesPerEntry: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+        maxBytesPerNamespace: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+        overflowPolicy: "reject-new",
+      }));
+    const lazyInstructionBlobStore: {
+      lookup: PluginBlobStore<{ version: 1; refCount: number }>["lookup"];
+      mutate: PluginBlobStore<{ version: 1; refCount: number }>["mutate"];
+    } = {
+      lookup: (key) => openInstructionBlobStore().lookup(key),
+      mutate: (key, update) => openInstructionBlobStore().mutate(key, update),
+    };
     const openManagedThreadStateStore = () =>
       (managedThreadStateStore ??= api.runtime.state.openSyncKeyedStore<StoredCodexManagedThread>({
         namespace: CODEX_MANAGED_THREAD_NAMESPACE,
@@ -156,6 +178,7 @@ export default definePluginEntry({
     };
     const bindingStore = createLazyCodexAppServerBindingStore(
       lazyBindingStateStore,
+      lazyInstructionBlobStore,
       lazyManagedThreadStateStore,
     );
     registerCodexCliMetadata(api);

--- a/extensions/codex/src/app-server/instruction-blob.ts
+++ b/extensions/codex/src/app-server/instruction-blob.ts
@@ -1,0 +1,118 @@
+import { createHash } from "node:crypto";
+import type { PluginBlobStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { z } from "zod";
+
+type CodexInstructionBlobMetadata = { version: 1; refCount: number };
+export type CodexInstructionBlobStore = Pick<
+  PluginBlobStore<CodexInstructionBlobMetadata>,
+  "lookup" | "mutate"
+>;
+export type CodexInstructionBlobReconciliationStore = CodexInstructionBlobStore &
+  Pick<PluginBlobStore<CodexInstructionBlobMetadata>, "entries">;
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder("utf-8", { fatal: true });
+
+export function readCodexInstructionBlobMetadata(value: unknown): CodexInstructionBlobMetadata {
+  const parsed = z
+    .object({ version: z.literal(1), refCount: z.number().int().positive() })
+    .strict()
+    .safeParse(value);
+  if (!parsed.success) {
+    throw new Error("Invalid Codex app-server instruction blob metadata");
+  }
+  return parsed.data;
+}
+
+export function codexInstructionBlobReference(instructions: string): string {
+  return `sha256:${createHash("sha256").update(instructions).digest("hex")}`;
+}
+
+export function verifyCodexInstructionBlob(reference: string, bytes: Uint8Array): string {
+  let instructions: string;
+  try {
+    instructions = textDecoder.decode(bytes);
+  } catch (error) {
+    throw new Error(`Codex app-server instruction blob is not valid UTF-8: ${reference}`, {
+      cause: error,
+    });
+  }
+  if (codexInstructionBlobReference(instructions) !== reference) {
+    throw new Error(`Codex app-server instruction blob digest mismatch: ${reference}`);
+  }
+  return instructions;
+}
+
+/** Atomically creates immutable content or adds one binding owner. */
+export async function retainCodexInstructionBlob(params: {
+  store: CodexInstructionBlobStore;
+  instructions: string;
+}): Promise<string> {
+  const reference = codexInstructionBlobReference(params.instructions);
+  const bytes = textEncoder.encode(params.instructions);
+  await params.store.mutate(reference, (current) => {
+    if (!current) {
+      return { kind: "set", bytes, metadata: { version: 1, refCount: 1 } };
+    }
+    verifyCodexInstructionBlob(reference, current.bytes);
+    const metadata = readCodexInstructionBlobMetadata(current.metadata);
+    return {
+      kind: "set",
+      bytes: current.bytes,
+      metadata: { version: 1, refCount: metadata.refCount + 1 },
+    };
+  });
+  return reference;
+}
+
+/** Atomically adds one owner to content that was already materialized. */
+export async function retainCodexInstructionBlobReference(
+  store: CodexInstructionBlobStore,
+  reference: string,
+): Promise<void> {
+  await store.mutate(reference, (current) => {
+    if (!current) {
+      throw new Error(`Missing Codex app-server instruction blob: ${reference}`);
+    }
+    verifyCodexInstructionBlob(reference, current.bytes);
+    const metadata = readCodexInstructionBlobMetadata(current.metadata);
+    return {
+      kind: "set",
+      bytes: current.bytes,
+      metadata: { version: 1, refCount: metadata.refCount + 1 },
+    };
+  });
+}
+
+/** Atomically removes one owner, deleting content only after the final owner. */
+export async function releaseCodexInstructionBlob(
+  store: CodexInstructionBlobStore,
+  reference: string,
+): Promise<void> {
+  await store.mutate(reference, (current) => {
+    if (!current) {
+      return undefined;
+    }
+    verifyCodexInstructionBlob(reference, current.bytes);
+    const metadata = readCodexInstructionBlobMetadata(current.metadata);
+    return metadata.refCount === 1
+      ? { kind: "delete" }
+      : {
+          kind: "set",
+          bytes: current.bytes,
+          metadata: { version: 1, refCount: metadata.refCount - 1 },
+        };
+  });
+}
+
+export async function resolveCodexInstructionBlob(
+  store: CodexInstructionBlobStore,
+  reference: string,
+): Promise<string> {
+  const entry = await store.lookup(reference);
+  if (!entry) {
+    throw new Error(`Missing Codex app-server instruction blob: ${reference}`);
+  }
+  readCodexInstructionBlobMetadata(entry.metadata);
+  return verifyCodexInstructionBlob(reference, entry.bytes);
+}

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -156,11 +156,11 @@ export async function prepareCodexAttemptContext(
     sandboxed: sandbox?.enabled === true,
   });
   // A thread keeps the bounded agent-workspace snapshot captured at creation.
-  // Workspace edits take effect only in the next session.
-  const agentWorkspaceDeveloperInstructions = workspaceBootstrapContext.threadDeveloperInstructions
-    ? (connection.mutable.startupBinding?.agentWorkspaceDeveloperInstructions ??
-      workspaceBootstrapContext.threadDeveloperInstructions)
-    : undefined;
+  // A resumed binding owns that snapshot even when the live file disappeared;
+  // only a new native thread may inherit the workspace's current instructions.
+  const agentWorkspaceDeveloperInstructions = connection.mutable.startupBinding
+    ? connection.mutable.startupBinding.agentWorkspaceDeveloperInstructions
+    : workspaceBootstrapContext.threadDeveloperInstructions;
   const baseDeveloperInstructions = joinPresentSections(
     buildDeveloperInstructions(runtimeParams, {
       dynamicTools: toolBridge.availableSpecs,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4047,7 +4047,6 @@ describe("runCodexAppServerAttempt", () => {
       injectedChars: agentsGuidance.length,
       truncated: false,
     });
-
     const updatedGuidance = "Updated AGENTS guidance must wait for a new session.";
     await fs.writeFile(path.join(agentWorkspaceDir, "AGENTS.md"), updatedGuidance);
     const resumeHarness = createResumeHarness();
@@ -4068,6 +4067,64 @@ describe("runCodexAppServerAttempt", () => {
       (threadResume.params as { developerInstructions?: string }).developerInstructions ?? "";
     expect(resumedInstructions).toContain(agentsGuidance);
     expect(resumedInstructions).not.toContain(updatedGuidance);
+  });
+
+  it("resumes frozen oversized external-cwd instructions after AGENTS.md disappears", async () => {
+    const { sessionFile, workspaceDir: executionDir } = createRunPaths();
+    const agentWorkspaceDir = path.join(tempDir, "oversized-agent-workspace");
+    const agentsGuidance =
+      `# Frozen oversized agent workspace guidance\n${"policy-🦀\n".repeat(7_000)}`.trimEnd();
+    expect(Buffer.byteLength(agentsGuidance)).toBeGreaterThan(65_536);
+    await fs.mkdir(executionDir, { recursive: true });
+    await fs.mkdir(agentWorkspaceDir, { recursive: true });
+    await fs.writeFile(path.join(agentWorkspaceDir, "AGENTS.md"), agentsGuidance);
+    const config = {
+      agents: {
+        defaults: {
+          bootstrapMaxChars: 200_000,
+          bootstrapTotalMaxChars: 200_000,
+        },
+      },
+    } as EmbeddedRunAttemptParams["config"];
+
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, executionDir);
+    params.config = config;
+    params.bootstrapWorkspaceDir = agentWorkspaceDir;
+    setAgentWorkspaceForTest(params, agentWorkspaceDir);
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+    const threadStart = harness.requests.find((request) => request.method === "thread/start");
+    if (!threadStart) {
+      throw new Error("expected thread/start request");
+    }
+    const frozenInstructions =
+      (threadStart.params as { developerInstructions?: string }).developerInstructions ?? "";
+    expect(frozenInstructions.includes(agentsGuidance)).toBe(true);
+
+    await fs.rm(path.join(agentWorkspaceDir, "AGENTS.md"));
+    const resumeHarness = createResumeHarness();
+    const resumeParams = createParams(sessionFile, executionDir);
+    resumeParams.config = config;
+    resumeParams.bootstrapWorkspaceDir = agentWorkspaceDir;
+    setAgentWorkspaceForTest(resumeParams, agentWorkspaceDir);
+    const resumedRun = runCodexAppServerAttempt(resumeParams);
+    await resumeHarness.waitForMethod("turn/start");
+    await resumeHarness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await resumedRun;
+    const threadResume = resumeHarness.requests.find(
+      (request) => request.method === "thread/resume",
+    );
+    if (!threadResume) {
+      throw new Error("expected thread/resume request after AGENTS.md removal");
+    }
+    const resumedInstructions =
+      (threadResume.params as { developerInstructions?: string }).developerInstructions ?? "";
+    expect(Buffer.byteLength(resumedInstructions)).toBe(Buffer.byteLength(frozenInstructions));
+    expect(Buffer.from(resumedInstructions).equals(Buffer.from(frozenInstructions))).toBe(true);
+    expect(resumedInstructions.includes(agentsGuidance)).toBe(true);
   });
 
   it("injects bounded MEMORY.md when memory tools are unavailable", async () => {

--- a/extensions/codex/src/app-server/session-binding-meta.ts
+++ b/extensions/codex/src/app-server/session-binding-meta.ts
@@ -1,3 +1,8 @@
 /** Process-stable plugin-state metadata for Codex app-server bindings. */
 export const CODEX_APP_SERVER_BINDING_NAMESPACE = "app-server-thread-bindings";
 export const CODEX_APP_SERVER_BINDING_MAX_ENTRIES = 50_000;
+export const CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE = "app-server-instructions";
+// Workspace bootstrap files are accepted up to 2 MiB. Leave bounded room for
+// the rendered path/header wrapper around one maximum-size AGENTS.md snapshot.
+export const CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES = 2 * 1024 * 1024 + 64 * 1024;
+export const CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES = 512 * 1024 * 1024;

--- a/extensions/codex/src/app-server/session-binding-store.ts
+++ b/extensions/codex/src/app-server/session-binding-store.ts
@@ -1,5 +1,8 @@
 /** Lazy store facade that keeps binding schema/auth code off plugin startup. */
-import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type {
+  PluginBlobStore,
+  PluginStateSyncKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createCodexManagedThreadStore,
   type CodexManagedThreadStore,
@@ -8,10 +11,19 @@ import {
 import {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   CODEX_APP_SERVER_BINDING_NAMESPACE,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
 } from "./session-binding-meta.js";
 import type { CodexAppServerBindingStore, StoredCodexAppServerBinding } from "./session-binding.js";
 
-export { CODEX_APP_SERVER_BINDING_MAX_ENTRIES, CODEX_APP_SERVER_BINDING_NAMESPACE };
+export {
+  CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+  CODEX_APP_SERVER_BINDING_NAMESPACE,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
+};
 export type { StoredCodexAppServerBinding } from "./session-binding.js";
 
 /** Defers schema compilation and auth loading until the first binding operation. */
@@ -20,6 +32,10 @@ export function createLazyCodexAppServerBindingStore(
     PluginStateSyncKeyedStore<StoredCodexAppServerBinding>,
     "entries" | "lookup" | "update"
   >,
+  instructionBlobs: {
+    lookup: PluginBlobStore<{ version: 1; refCount: number }>["lookup"];
+    mutate: PluginBlobStore<{ version: 1; refCount: number }>["mutate"];
+  },
   managedThreadState?: Pick<
     PluginStateSyncKeyedStore<StoredCodexManagedThread>,
     "entries" | "registerIfAbsent"
@@ -28,7 +44,7 @@ export function createLazyCodexAppServerBindingStore(
   let resolved: Promise<CodexAppServerBindingStore> | undefined;
   const store = () =>
     (resolved ??= import("./session-binding.js").then(({ createCodexAppServerBindingStore }) =>
-      createCodexAppServerBindingStore(state),
+      createCodexAppServerBindingStore(state, instructionBlobs),
     ));
   const managedThreads: CodexManagedThreadStore | undefined = managedThreadState
     ? createCodexManagedThreadStore(managedThreadState)

--- a/extensions/codex/src/app-server/session-binding.test-helpers.ts
+++ b/extensions/codex/src/app-server/session-binding.test-helpers.ts
@@ -1,6 +1,10 @@
 /** In-memory binding store helpers for Codex app-server tests. */
 export * from "./session-binding.js";
-import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type {
+  PluginBlobEntry,
+  PluginBlobStore,
+  PluginStateSyncKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
 import { resolveCodexSupervisionAppServerRuntimeOptions } from "./config.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import {
@@ -44,8 +48,42 @@ export function createCodexTestBindingStateStore(): PluginStateSyncKeyedStore<St
   };
 }
 
+export function createCodexTestInstructionBlobStore() {
+  type Metadata = { version: 1; refCount: number };
+  const values = new Map<string, PluginBlobEntry<Metadata>>();
+  const store: {
+    lookup: PluginBlobStore<Metadata>["lookup"];
+    mutate: PluginBlobStore<Metadata>["mutate"];
+  } = {
+    async lookup(key) {
+      return values.get(key);
+    },
+    async mutate(key, update) {
+      const next = update(values.get(key));
+      if (!next) {
+        return false;
+      }
+      if (next.kind === "delete") {
+        return values.delete(key);
+      }
+      values.set(key, {
+        key,
+        bytes: Uint8Array.from(next.bytes),
+        metadata: next.metadata,
+        sizeBytes: next.bytes.byteLength,
+        createdAt: Date.now(),
+      });
+      return true;
+    },
+  };
+  return { store, values };
+}
+
 export function createCodexTestBindingStore(): CodexAppServerBindingStore {
-  return createCodexAppServerBindingStore(createCodexTestBindingStateStore());
+  return createCodexAppServerBindingStore(
+    createCodexTestBindingStateStore(),
+    createCodexTestInstructionBlobStore().store,
+  );
 }
 
 export function buildCodexSupervisionTestConnectionFingerprint(
@@ -61,7 +99,11 @@ export function buildCodexSupervisionTestConnectionFingerprint(
 }
 
 const sharedStateStore = createCodexTestBindingStateStore();
-export const testCodexAppServerBindingStore = createCodexAppServerBindingStore(sharedStateStore);
+const sharedInstructionBlobs = createCodexTestInstructionBlobStore();
+export const testCodexAppServerBindingStore = createCodexAppServerBindingStore(
+  sharedStateStore,
+  sharedInstructionBlobs.store,
+);
 const testSessionIdentities = new Map<
   string,
   { agentId: string; sessionId: string; sessionKey?: string }
@@ -69,6 +111,7 @@ const testSessionIdentities = new Map<
 
 export function resetCodexTestBindingStore(): void {
   sharedStateStore.clear();
+  sharedInstructionBlobs.values.clear();
   testSessionIdentities.clear();
 }
 

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -4,7 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
+  createPluginBlobStoreForTests,
   createPluginStateSyncKeyedStoreForTests,
+  resetPluginBlobStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
@@ -12,6 +14,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   bindingStoreKey,
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
   createCodexAppServerBindingStore,
   createStoredCodexAppServerBinding,
   hashCodexAppServerBindingFingerprint,
@@ -56,6 +61,7 @@ function createStateStore() {
 
 afterEach(() => {
   vi.useRealTimers();
+  resetPluginBlobStoreForTests();
   resetPluginStateStoreForTests();
 });
 
@@ -95,6 +101,106 @@ describe("Codex app-server binding store", () => {
       state: "active",
       binding: { threadId: "thread-1" },
     });
+  });
+
+  it("stores oversized frozen instructions once and resumes identical bytes by reference", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-binding-blob-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    try {
+      const state = createPluginStateSyncKeyedStoreForTests<StoredCodexAppServerBinding>("codex", {
+        namespace: "app-server-thread-bindings-large-test",
+        maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+        overflowPolicy: "reject-new",
+        env,
+      });
+      const blobs = createPluginBlobStoreForTests<{ version: 1; refCount: number }>(
+        "codex",
+        {
+          namespace: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
+          maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+          maxBytesPerEntry: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+          maxBytesPerNamespace: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+          overflowPolicy: "reject-new",
+        },
+        env,
+      );
+      const store = createCodexAppServerBindingStore(state, {
+        lookup: (key) => blobs.lookup(key),
+        mutate: (key, update) => blobs.mutate(key, update),
+      });
+      const instructions = `# Frozen policy\n${"multibyte-🦀\n".repeat(25_000)}`;
+      expect(Buffer.byteLength(instructions)).toBeGreaterThan(256 * 1024);
+      const identities = ["one", "two"].map((bindingId) => ({
+        kind: "conversation" as const,
+        bindingId,
+      }));
+
+      expect(() =>
+        state.register("legacy-too-large", {
+          version: 1,
+          state: "active",
+          binding: {
+            threadId: "thread-inline-overflow",
+            cwd: "/repo",
+            agentWorkspaceDeveloperInstructions: instructions,
+          },
+        } as unknown as StoredCodexAppServerBinding),
+      ).toThrow("65536 byte limit");
+
+      await Promise.all(
+        identities.map((identity, index) =>
+          store.mutate(identity, {
+            kind: "set",
+            binding: {
+              threadId: `thread-${index}`,
+              cwd: "/repo",
+              agentWorkspaceDeveloperInstructions: instructions,
+            },
+          }),
+        ),
+      ).then((results) => expect(results).toEqual([true, true]));
+
+      const rows = identities.map((identity) => state.lookup(bindingStoreKey(identity))!);
+      for (const row of rows) {
+        expect(Buffer.byteLength(JSON.stringify(row))).toBeLessThan(65_536);
+        expect(row).not.toHaveProperty("binding.agentWorkspaceDeveloperInstructions");
+      }
+      const references = rows.map((row) =>
+        row.state === "active" ? row.binding.agentWorkspaceDeveloperInstructionsRef : undefined,
+      );
+      expect(new Set(references).size).toBe(1);
+      const reference = references[0]!;
+      await expect(blobs.lookup(reference)).resolves.toMatchObject({
+        metadata: { version: 1, refCount: 2 },
+      });
+      for (const identity of identities) {
+        await expect(store.read(identity)).resolves.toMatchObject({
+          agentWorkspaceDeveloperInstructions: instructions,
+        });
+      }
+
+      const legacy = { kind: "conversation" as const, bindingId: "legacy-inline" };
+      const legacyInstructions = "Legacy frozen instructions.";
+      state.register(bindingStoreKey(legacy), {
+        version: 1,
+        state: "active",
+        binding: {
+          threadId: "thread-legacy",
+          cwd: "/repo",
+          agentWorkspaceDeveloperInstructions: legacyInstructions,
+        },
+      } as unknown as StoredCodexAppServerBinding);
+      await expect(store.read(legacy)).rejects.toThrow("Invalid Codex app-server binding row");
+
+      await store.mutate(identities[0]!, { kind: "clear" });
+      await expect(blobs.lookup(reference)).resolves.toMatchObject({ metadata: { refCount: 1 } });
+      await store.mutate(identities[1]!, { kind: "clear" });
+      await expect(blobs.lookup(reference)).resolves.toBeUndefined();
+    } finally {
+      resetPluginBlobStoreForTests();
+      resetPluginStateStoreForTests();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("replaces only the exact ordinary thread owner", async () => {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -18,6 +18,12 @@ import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-s
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { z } from "zod";
 import { CODEX_PLUGIN_MARKETPLACE_NAME_PATTERN, normalizeCodexServiceTier } from "./config.js";
+import {
+  releaseCodexInstructionBlob,
+  resolveCodexInstructionBlob,
+  retainCodexInstructionBlob,
+  type CodexInstructionBlobStore,
+} from "./instruction-blob.js";
 import type { CodexManagedThreadStore } from "./managed-thread-store.js";
 import type { PluginAppPolicyContext } from "./plugin-thread-config.js";
 import type { CodexServiceTier } from "./protocol.js";
@@ -26,10 +32,14 @@ const CODEX_APP_SERVER_NATIVE_AUTH_PROVIDER = "openai";
 const PUBLIC_OPENAI_MODEL_PROVIDER = "openai";
 const BINDING_LEASE_RETRY_INTERVAL_MS = 1_000;
 const BOUNDED_BINDING_FINGERPRINT_PATTERN = /^sha256:[a-f0-9]{64}$/i;
+const INSTRUCTION_BLOB_REFERENCE_PATTERN = /^sha256:[a-f0-9]{64}$/;
 
 export {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   CODEX_APP_SERVER_BINDING_NAMESPACE,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
 } from "./session-binding-meta.js";
 export const CODEX_APP_SERVER_BINDING_GUARDED_REQUEST_TIMEOUT_MS = 60_000;
 const BINDING_LEASE_STALE_MS = CODEX_APP_SERVER_BINDING_GUARDED_REQUEST_TIMEOUT_MS + 5_000;
@@ -199,151 +209,179 @@ const pluginAppPolicyContextSchema = z
     pluginAppIds: z.record(z.string(), z.array(z.string())).default({}),
   })
   .strict();
-const threadBindingSchema = z
-  .object({
-    threadId: z.string().refine((value) => Boolean(value.trim())),
-    clientId: optionalStringSchema,
-    cwd: z.string(),
-    rolloutPath: optionalNonBlankStringSchema,
-    // Private runtime ownership. Only the supervision catalog creates this
-    // marker; public OpenClaw session metadata must never authorize user-home access.
-    connectionScope: z.literal("supervision").optional(),
-    supervisionSourceThreadId: z.string().trim().min(1).optional(),
-    authProfileId: optionalStringSchema,
-    // Freeze OpenClaw-carried AGENTS.md at thread creation; bootstrap refreshes
-    // must not mutate the inherited policy of a resumed native session.
-    agentWorkspaceDeveloperInstructions: optionalNonBlankStringSchema,
-    model: optionalStringSchema,
-    // Codex App Server owns selection for supervised and adopted threads. Keep
-    // this marker across resumes so OpenClaw never substitutes a default or fallback.
-    preserveNativeModel: z.literal(true).optional().catch(undefined),
-    // Continue creates the OpenClaw Chat before native execution. This closed
-    // snapshot state is materialized only inside the fully configured harness.
-    pendingSupervisionBranch: pendingSupervisionBranchSchema.optional(),
-    modelProvider: z
-      .string()
-      .transform((value) => value.trim())
-      .pipe(z.string().min(1))
-      .optional()
-      .catch(undefined),
-    // Legacy rows may contain the retired two-field permission overlay. Keep
-    // parsing it so the rest of the binding survives; SessionEntry owns live policy.
-    approvalPolicy: z
-      .preprocess(
-        (value) => (value === "on-failure" ? "on-request" : value),
-        z.enum(["never", "on-request", "untrusted"]).optional(),
-      )
-      .catch(undefined),
-    sandbox: z
-      .enum(["read-only", "workspace-write", "danger-full-access"])
-      .optional()
-      .catch(undefined),
-    serviceTier: z
-      .preprocess(
-        normalizeCodexServiceTier,
-        z.custom<CodexServiceTier>((value) => typeof value === "string").optional(),
-      )
-      .optional()
-      .catch(undefined),
-    networkProxyProfileName: optionalStringSchema,
-    networkProxyConfigFingerprint: optionalStringSchema,
-    dynamicToolsFingerprint: optionalStringSchema,
-    dynamicToolsContainDeferred: optionalBooleanSchema,
-    webSearchThreadConfigFingerprint: optionalStringSchema,
-    nativeSkillIsolationFingerprint: optionalStringSchema,
-    userMcpServersFingerprint: optionalStringSchema,
-    mcpServersFingerprint: optionalStringSchema,
-    configuredMcpOwnershipVersion: z.literal(1).optional().catch(undefined),
-    ringZeroConfigFingerprint: optionalStringSchema,
-    ringZeroClientInstanceId: optionalStringSchema,
-    /** Durable fact preventing a later unrestricted turn from widening this thread. */
-    nativeToolPolicyRestricted: z.literal(true).optional().catch(undefined),
-    nativeHookRelayGeneration: optionalNonBlankStringSchema,
-    appServerRuntimeFingerprint: optionalStringSchema,
-    pluginAppsFingerprint: optionalStringSchema,
-    pluginAppsInputFingerprint: optionalStringSchema,
-    pluginAppPolicyContext: pluginAppPolicyContextSchema.optional().catch(undefined),
-    contextEngine: contextEngineSchema.optional().catch(undefined),
-    environmentSelectionFingerprint: optionalStringSchema,
-    conversationStartId: optionalStringSchema,
-    conversationSourceTransferComplete: z.literal(true).optional().catch(undefined),
-    historyCoveredThrough: optionalTimestampSchema,
-    // Observed density of the last completed turn on this thread: prompt chars
-    // actually sent vs provider-reported input tokens. Read by the no-engine
-    // continuity cap so the next projection is sized from this session's real
-    // content density instead of a fixed chars-per-token guess.
-    continuityCalibration: z
-      .object({
-        promptChars: z.number().int().positive(),
-        inputTokens: z.number().int().positive(),
-      })
-      .optional()
-      .catch(undefined),
-  })
-  .superRefine((binding, context) => {
-    if (binding.connectionScope === "supervision") {
-      if (!binding.supervisionSourceThreadId) {
-        context.addIssue({
-          code: "custom",
-          message: "supervision connection ownership requires its native source thread id",
-        });
-      }
-      if (binding.preserveNativeModel !== true) {
-        context.addIssue({
-          code: "custom",
-          message: "supervision connection ownership requires native model ownership",
-        });
-      }
-      if (binding.conversationSourceTransferComplete !== true) {
-        context.addIssue({
-          code: "custom",
-          message: "supervision connection ownership requires a completed source transfer",
-        });
-      }
-      if (!binding.pendingSupervisionBranch && (!binding.model?.trim() || !binding.modelProvider)) {
-        context.addIssue({
-          code: "custom",
-          message: "materialized supervision bindings require a native model and provider",
-        });
-      }
-    }
-    if (binding.supervisionSourceThreadId && binding.connectionScope !== "supervision") {
+const threadBindingShape = {
+  threadId: z.string().refine((value) => Boolean(value.trim())),
+  clientId: optionalStringSchema,
+  cwd: z.string(),
+  rolloutPath: optionalNonBlankStringSchema,
+  // Private runtime ownership. Only the supervision catalog creates this
+  // marker; public OpenClaw session metadata must never authorize user-home access.
+  connectionScope: z.literal("supervision").optional(),
+  supervisionSourceThreadId: z.string().trim().min(1).optional(),
+  authProfileId: optionalStringSchema,
+  model: optionalStringSchema,
+  // Codex App Server owns selection for supervised and adopted threads. Keep
+  // this marker across resumes so OpenClaw never substitutes a default or fallback.
+  preserveNativeModel: z.literal(true).optional().catch(undefined),
+  // Continue creates the OpenClaw Chat before native execution. This closed
+  // snapshot state is materialized only inside the fully configured harness.
+  pendingSupervisionBranch: pendingSupervisionBranchSchema.optional(),
+  modelProvider: z
+    .string()
+    .transform((value) => value.trim())
+    .pipe(z.string().min(1))
+    .optional()
+    .catch(undefined),
+  // Legacy rows may contain the retired two-field permission overlay. Keep
+  // parsing it so the rest of the binding survives; SessionEntry owns live policy.
+  approvalPolicy: z
+    .preprocess(
+      (value) => (value === "on-failure" ? "on-request" : value),
+      z.enum(["never", "on-request", "untrusted"]).optional(),
+    )
+    .catch(undefined),
+  sandbox: z
+    .enum(["read-only", "workspace-write", "danger-full-access"])
+    .optional()
+    .catch(undefined),
+  serviceTier: z
+    .preprocess(
+      normalizeCodexServiceTier,
+      z.custom<CodexServiceTier>((value) => typeof value === "string").optional(),
+    )
+    .optional()
+    .catch(undefined),
+  networkProxyProfileName: optionalStringSchema,
+  networkProxyConfigFingerprint: optionalStringSchema,
+  dynamicToolsFingerprint: optionalStringSchema,
+  dynamicToolsContainDeferred: optionalBooleanSchema,
+  webSearchThreadConfigFingerprint: optionalStringSchema,
+  nativeSkillIsolationFingerprint: optionalStringSchema,
+  userMcpServersFingerprint: optionalStringSchema,
+  mcpServersFingerprint: optionalStringSchema,
+  configuredMcpOwnershipVersion: z.literal(1).optional().catch(undefined),
+  ringZeroConfigFingerprint: optionalStringSchema,
+  ringZeroClientInstanceId: optionalStringSchema,
+  /** Durable fact preventing a later unrestricted turn from widening this thread. */
+  nativeToolPolicyRestricted: z.literal(true).optional().catch(undefined),
+  nativeHookRelayGeneration: optionalNonBlankStringSchema,
+  appServerRuntimeFingerprint: optionalStringSchema,
+  pluginAppsFingerprint: optionalStringSchema,
+  pluginAppsInputFingerprint: optionalStringSchema,
+  pluginAppPolicyContext: pluginAppPolicyContextSchema.optional().catch(undefined),
+  contextEngine: contextEngineSchema.optional().catch(undefined),
+  environmentSelectionFingerprint: optionalStringSchema,
+  conversationStartId: optionalStringSchema,
+  conversationSourceTransferComplete: z.literal(true).optional().catch(undefined),
+  historyCoveredThrough: optionalTimestampSchema,
+  // Observed density of the last completed turn on this thread: prompt chars
+  // actually sent vs provider-reported input tokens. Read by the no-engine
+  // continuity cap so the next projection is sized from this session's real
+  // content density instead of a fixed chars-per-token guess.
+  continuityCalibration: z
+    .object({
+      promptChars: z.number().int().positive(),
+      inputTokens: z.number().int().positive(),
+    })
+    .optional()
+    .catch(undefined),
+} satisfies z.ZodRawShape;
+
+type ThreadBindingValidationValue = z.infer<z.ZodObject<typeof threadBindingShape>>;
+
+function validateThreadBinding(binding: ThreadBindingValidationValue, context: z.RefinementCtx) {
+  if (binding.connectionScope === "supervision") {
+    if (!binding.supervisionSourceThreadId) {
       context.addIssue({
         code: "custom",
-        message: "a supervision source thread id requires supervision connection ownership",
-      });
-    }
-    if (!binding.pendingSupervisionBranch) {
-      return;
-    }
-    if (binding.threadId !== binding.pendingSupervisionBranch.sourceThreadId) {
-      context.addIssue({
-        code: "custom",
-        message: "pending supervision source must match the provisional thread binding",
-      });
-    }
-    if (binding.supervisionSourceThreadId !== binding.pendingSupervisionBranch.sourceThreadId) {
-      context.addIssue({
-        code: "custom",
-        message: "pending supervision source must match its durable source identity",
+        message: "supervision connection ownership requires its native source thread id",
       });
     }
     if (binding.preserveNativeModel !== true) {
       context.addIssue({
         code: "custom",
-        message: "pending supervision bindings must defer model selection to Codex App Server",
+        message: "supervision connection ownership requires native model ownership",
       });
     }
-    if (binding.connectionScope !== "supervision") {
+    if (binding.conversationSourceTransferComplete !== true) {
       context.addIssue({
         code: "custom",
-        message: "pending supervision bindings require supervision connection ownership",
+        message: "supervision connection ownership requires a completed source transfer",
       });
     }
-  });
+    if (!binding.pendingSupervisionBranch && (!binding.model?.trim() || !binding.modelProvider)) {
+      context.addIssue({
+        code: "custom",
+        message: "materialized supervision bindings require a native model and provider",
+      });
+    }
+  }
+  if (binding.supervisionSourceThreadId && binding.connectionScope !== "supervision") {
+    context.addIssue({
+      code: "custom",
+      message: "a supervision source thread id requires supervision connection ownership",
+    });
+  }
+  if (!binding.pendingSupervisionBranch) {
+    return;
+  }
+  if (binding.threadId !== binding.pendingSupervisionBranch.sourceThreadId) {
+    context.addIssue({
+      code: "custom",
+      message: "pending supervision source must match the provisional thread binding",
+    });
+  }
+  if (binding.supervisionSourceThreadId !== binding.pendingSupervisionBranch.sourceThreadId) {
+    context.addIssue({
+      code: "custom",
+      message: "pending supervision source must match its durable source identity",
+    });
+  }
+  if (binding.preserveNativeModel !== true) {
+    context.addIssue({
+      code: "custom",
+      message: "pending supervision bindings must defer model selection to Codex App Server",
+    });
+  }
+  if (binding.connectionScope !== "supervision") {
+    context.addIssue({
+      code: "custom",
+      message: "pending supervision bindings require supervision connection ownership",
+    });
+  }
+}
+
+const domainThreadBindingSchema = z
+  .object({
+    ...threadBindingShape,
+    // Freeze OpenClaw-carried AGENTS.md at thread creation; bootstrap refreshes
+    // must not mutate the inherited policy of a resumed native session.
+    agentWorkspaceDeveloperInstructions: optionalNonBlankStringSchema,
+  })
+  .superRefine(validateThreadBinding);
+const storedThreadBindingSchema = z
+  .object({
+    ...threadBindingShape,
+    agentWorkspaceDeveloperInstructionsRef: z
+      .string()
+      .regex(INSTRUCTION_BLOB_REFERENCE_PATTERN)
+      .optional(),
+  })
+  // Runtime rows must never silently strip a legacy inline snapshot. Reject it
+  // here so the doctor-owned migration can externalize the bytes deliberately.
+  .strict()
+  .superRefine(validateThreadBinding);
+const legacyThreadBindingSchema = z
+  .object({
+    ...threadBindingShape,
+    agentWorkspaceDeveloperInstructions: optionalNonBlankStringSchema,
+  })
+  .strict()
+  .superRefine(validateThreadBinding);
 
 /** Durable Codex thread facts. Storage identity and schema stay outside this domain value. */
-export type CodexAppServerThreadBinding = z.infer<typeof threadBindingSchema>;
+type StoredCodexAppServerThreadBinding = z.infer<typeof storedThreadBindingSchema>;
+export type CodexAppServerThreadBinding = z.infer<typeof domainThreadBindingSchema>;
 /** Persisted source snapshot and orphan-cleanup state for a supervised native branch. */
 export type CodexAppServerPendingSupervisionBranch = z.infer<typeof pendingSupervisionBranchSchema>;
 
@@ -428,26 +466,41 @@ const storedSessionIdSchema = z
   .pipe(z.string().min(1))
   .optional()
   .catch(undefined);
+const clearedStoredBindingSchema = z.object({
+  version: z.literal(1),
+  state: z.literal("cleared"),
+  sessionId: storedSessionIdSchema,
+  lease: bindingLeaseSchema.optional().catch(undefined),
+  retired: z.literal(true).optional().catch(undefined),
+});
 const storedBindingSchema = z.discriminatedUnion("state", [
   z.object({
     version: z.literal(1),
     state: z.literal("active"),
-    binding: threadBindingSchema,
+    binding: storedThreadBindingSchema,
     sessionId: storedSessionIdSchema,
     lease: bindingLeaseSchema.optional().catch(undefined),
   }),
+  clearedStoredBindingSchema,
+]);
+const legacyStoredBindingSchema = z.discriminatedUnion("state", [
   z.object({
     version: z.literal(1),
-    state: z.literal("cleared"),
+    state: z.literal("active"),
+    binding: legacyThreadBindingSchema,
     sessionId: storedSessionIdSchema,
     lease: bindingLeaseSchema.optional().catch(undefined),
-    retired: z.literal(true).optional().catch(undefined),
   }),
+  clearedStoredBindingSchema,
 ]);
 
 // Session-key rows survive transcript/session-id rotation. The stored physical
 // id fences delayed lifecycle cleanup so an old generation cannot clear its successor.
 export type StoredCodexAppServerBinding = z.infer<typeof storedBindingSchema>;
+export type LegacyStoredCodexAppServerBinding = z.infer<typeof legacyStoredBindingSchema>;
+export type DoctorStoredCodexAppServerBinding =
+  | StoredCodexAppServerBinding
+  | LegacyStoredCodexAppServerBinding;
 
 export function hashCodexAppServerBindingFingerprint(canonical: string): string {
   return `sha256:${createHash("sha256").update(canonical).digest("hex")}`;
@@ -490,25 +543,25 @@ function normalizeLegacyBindingFingerprints<
 
 export function normalizeStoredCodexAppServerBindingFingerprints(
   value: unknown,
-): StoredCodexAppServerBinding | undefined {
-  const stored = readStoredCodexAppServerBinding(value);
+): DoctorStoredCodexAppServerBinding | undefined {
+  const stored = readDoctorStoredCodexAppServerBinding(value);
   if (!stored || stored.state !== "active") {
     return stored;
   }
   const binding = normalizeLegacyBindingFingerprints(stored.binding);
   return binding === stored.binding
     ? stored
-    : readStoredCodexAppServerBinding({ ...stored, binding });
+    : readDoctorStoredCodexAppServerBinding({ ...stored, binding });
 }
 
-/** Encodes a migrated sidecar binding as one canonical plugin-state row. */
+/** Parses a shipped sidecar for doctor-owned canonicalization and import. */
 export function createStoredCodexAppServerBinding(
   value: unknown,
   options: {
     now?: string;
     lookup?: Omit<CodexAppServerAuthProfileLookup, "authProfileId">;
   } = {},
-): Extract<StoredCodexAppServerBinding, { state: "active" }> | undefined {
+): Extract<LegacyStoredCodexAppServerBinding, { state: "active" }> | undefined {
   const rawRecord = asOptionalRecord(value);
   if (!rawRecord) {
     return undefined;
@@ -673,9 +726,36 @@ export async function reclaimCurrentCodexSessionGeneration(params: {
   });
 }
 
+async function hydrateInstructionBlob(
+  store: CodexInstructionBlobStore,
+  binding: StoredCodexAppServerThreadBinding,
+): Promise<CodexAppServerThreadBinding> {
+  const { agentWorkspaceDeveloperInstructionsRef: reference, ...domain } = binding;
+  if (!reference) {
+    return domain;
+  }
+  const instructions = await resolveCodexInstructionBlob(store, reference);
+  return { ...domain, agentWorkspaceDeveloperInstructions: instructions };
+}
+
+function externalizeInstructionBinding(
+  binding: CodexAppServerThreadBinding & { agentWorkspaceDeveloperInstructionsRef?: string },
+  retainedReference?: string,
+): StoredCodexAppServerThreadBinding {
+  const { agentWorkspaceDeveloperInstructions: _instructions, ...stored } = binding;
+  return storedThreadBindingSchema.parse(
+    stripUndefinedValue(
+      retainedReference
+        ? { ...stored, agentWorkspaceDeveloperInstructionsRef: retainedReference }
+        : stored,
+    ),
+  );
+}
+
 /** Creates the single binding facade owned by the Codex plugin runtime. */
 export function createCodexAppServerBindingStore(
   state: BindingStateStore,
+  instructionBlobs?: CodexInstructionBlobStore,
 ): CodexAppServerBindingStore {
   const update = state.update?.bind(state);
   if (!update) {
@@ -825,9 +905,15 @@ export function createCodexAppServerBindingStore(
       if (raw !== undefined && !stored) {
         throw new Error(`Invalid Codex app-server binding row: ${key}`);
       }
-      return stored?.state === "active" && ownsStoredSessionGeneration(identity, stored)
-        ? stored.binding
-        : undefined;
+      if (stored?.state !== "active" || !ownsStoredSessionGeneration(identity, stored)) {
+        return undefined;
+      }
+      if (!instructionBlobs && stored.binding.agentWorkspaceDeveloperInstructionsRef) {
+        throw new Error("Codex app-server instruction blob store is unavailable");
+      }
+      return instructionBlobs
+        ? await hydrateInstructionBlob(instructionBlobs, stored.binding)
+        : readCodexAppServerThreadBinding(stored.binding);
     },
 
     async hasOtherThreadOwner(threadId, currentIdentity) {
@@ -877,163 +963,235 @@ export function createCodexAppServerBindingStore(
     async mutate(identity, mutation) {
       return await runBindingMutation(async () => {
         const key = bindingStoreKey(identity);
+        const patchWithInstructions =
+          mutation.kind === "patch" || mutation.kind === "commit-pending-supervision-branch"
+            ? mutation.patch
+            : undefined;
+        const inputBinding =
+          mutation.kind === "set" || mutation.kind === "replace-thread"
+            ? mutation.binding
+            : undefined;
+        const hasInstructionUpdate = inputBinding
+          ? Object.hasOwn(inputBinding, "agentWorkspaceDeveloperInstructions")
+          : patchWithInstructions
+            ? Object.hasOwn(patchWithInstructions, "agentWorkspaceDeveloperInstructions")
+            : false;
+        const instructions =
+          inputBinding?.agentWorkspaceDeveloperInstructions ??
+          patchWithInstructions?.agentWorkspaceDeveloperInstructions;
+        if (instructions && !instructionBlobs) {
+          throw new Error("Codex app-server instruction blob store is unavailable");
+        }
+        const retainedReference =
+          instructions && instructionBlobs
+            ? await retainCodexInstructionBlob({ store: instructionBlobs, instructions })
+            : undefined;
+        let previousReference: string | undefined;
+        let nextReference: string | undefined;
         // A retained legacy sidecar may be revisited by doctor after runtime
         // clear. Keep provenance so migration cannot resurrect its stale thread.
         const retainLegacyClear =
           mutation.kind === "clear" && key.startsWith("conversation:legacy-");
-        return await transactKey(
-          key,
-          (current, leaseToken) => {
-            const ownsGeneration = ownsStoredSessionGeneration(identity, current);
-            const ownedLease =
-              current?.lease && current.lease.token === leaseToken ? { lease: current.lease } : {};
-            if (mutation.kind === "reclaim-generation") {
-              if (identity.kind !== "session" || !identity.sessionKey?.trim()) {
-                return { result: false };
-              }
-              if (!current) {
-                return { result: true };
-              }
-              if (ownsGeneration) {
-                if (
-                  current.state === "cleared" &&
-                  current.retired === true &&
-                  current.sessionId === mutation.expectedPreviousSessionId
-                ) {
-                  // Reset boundaries now retain the OpenClaw session id. The
-                  // authoritative session-store check above proves this fence
-                  // belongs to the previous in-place lifecycle, not live work.
+        let committed: boolean;
+        try {
+          committed = await transactKey(
+            key,
+            (current, leaseToken) => {
+              const ownsGeneration = ownsStoredSessionGeneration(identity, current);
+              previousReference =
+                current?.state === "active"
+                  ? current.binding.agentWorkspaceDeveloperInstructionsRef
+                  : undefined;
+              nextReference = previousReference;
+              const ownedLease =
+                current?.lease && current.lease.token === leaseToken
+                  ? { lease: current.lease }
+                  : {};
+              if (mutation.kind === "reclaim-generation") {
+                if (identity.kind !== "session" || !identity.sessionKey?.trim()) {
+                  return { result: false };
+                }
+                if (!current) {
+                  return { result: true };
+                }
+                if (ownsGeneration) {
+                  if (
+                    current.state === "cleared" &&
+                    current.retired === true &&
+                    current.sessionId === mutation.expectedPreviousSessionId
+                  ) {
+                    // Reset boundaries now retain the OpenClaw session id. The
+                    // authoritative session-store check above proves this fence
+                    // belongs to the previous in-place lifecycle, not live work.
+                    return {
+                      result: true,
+                      next: {
+                        version: 1,
+                        state: "cleared",
+                        sessionId: identity.sessionId,
+                        ...ownedLease,
+                      },
+                    };
+                  }
                   return {
-                    result: true,
-                    next: {
-                      version: 1,
-                      state: "cleared",
-                      sessionId: identity.sessionId,
-                      ...ownedLease,
-                    },
+                    result: current.state !== "cleared" || current.retired !== true,
                   };
                 }
+                if (current.sessionId !== mutation.expectedPreviousSessionId) {
+                  return { result: false };
+                }
+                // A stale physical generation must never turn private user-home ownership into
+                // an ordinary empty binding. Supervision adoption has an explicit generation
+                // transfer path; every other successor fails closed and preserves this owner.
+                if (
+                  current.state === "active" &&
+                  current.binding.connectionScope === "supervision"
+                ) {
+                  return { result: false };
+                }
+                nextReference = undefined;
                 return {
-                  result: current.state !== "cleared" || current.retired !== true,
+                  result: true,
+                  next: {
+                    version: 1,
+                    state: "cleared",
+                    sessionId: identity.sessionId,
+                    ...ownedLease,
+                  },
                 };
               }
-              if (current.sessionId !== mutation.expectedPreviousSessionId) {
+              const storedActive = current?.state === "active" ? current : undefined;
+              const active = ownsGeneration ? storedActive : undefined;
+              const retiredGeneration =
+                current?.state === "cleared" && current.retired === true && ownsGeneration;
+              const preservesSupervisionOwner =
+                mutation.kind === "set" &&
+                active?.binding.connectionScope === "supervision" &&
+                isSameSupervisionOwner(active.binding, mutation.binding);
+              const clearsPendingSupervisionOwner =
+                mutation.kind === "clear" &&
+                active?.binding.connectionScope === "supervision" &&
+                matchesPendingSupervisionClear(
+                  active.binding,
+                  mutation.threadId,
+                  mutation.expectedPendingSupervisionBranch,
+                );
+              const replacesExpectedOrdinaryOwner =
+                mutation.kind === "replace-thread" &&
+                active?.binding.threadId === mutation.expectedThreadId &&
+                active.binding.connectionScope !== "supervision" &&
+                mutation.binding.connectionScope !== "supervision" &&
+                mutation.binding.threadId !== mutation.expectedThreadId;
+              if (
+                (mutation.kind === "set" &&
+                  ((mutation.if?.kind === "absent" && storedActive) ||
+                    (current !== undefined && !ownsGeneration) ||
+                    retiredGeneration ||
+                    (active?.binding.connectionScope === "supervision" &&
+                      !preservesSupervisionOwner))) ||
+                (mutation.kind === "patch" && active?.binding.threadId !== mutation.threadId) ||
+                (mutation.kind === "replace-thread" && !replacesExpectedOrdinaryOwner) ||
+                ((mutation.kind === "patch-pending-supervision-branch" ||
+                  mutation.kind === "commit-pending-supervision-branch") &&
+                  !matchesPendingSupervisionBranch(active?.binding, mutation.expected)) ||
+                (mutation.kind === "clear" &&
+                  ((mutation.threadId !== undefined &&
+                    active?.binding.threadId !== mutation.threadId) ||
+                    !ownsGeneration ||
+                    (active?.binding.connectionScope === "supervision" &&
+                      !clearsPendingSupervisionOwner)))
+              ) {
                 return { result: false };
               }
-              // A stale physical generation must never turn private user-home ownership into
-              // an ordinary empty binding. Supervision adoption has an explicit generation
-              // transfer path; every other successor fails closed and preserves this owner.
-              if (current.state === "active" && current.binding.connectionScope === "supervision") {
-                return { result: false };
+              if (mutation.kind === "clear" && retiredGeneration) {
+                return { result: true };
               }
-              return {
-                result: true,
-                next: {
-                  version: 1,
-                  state: "cleared",
-                  sessionId: identity.sessionId,
-                  ...ownedLease,
+              if (mutation.kind === "clear") {
+                nextReference = undefined;
+                return {
+                  result: true,
+                  next: {
+                    version: 1,
+                    state: "cleared",
+                    ...storedSessionGeneration(identity, current),
+                    ...ownedLease,
+                  },
+                };
+              }
+              let binding: CodexAppServerThreadBinding;
+              if (mutation.kind === "set" || mutation.kind === "replace-thread") {
+                binding = validateBindingForWrite(mutation.binding);
+              } else if (mutation.kind === "patch-pending-supervision-branch") {
+                binding = validateBindingForWrite({
+                  ...active!.binding,
+                  pendingSupervisionBranch: mutation.pending,
+                });
+              } else if (mutation.kind === "commit-pending-supervision-branch") {
+                binding = validateBindingForWrite({
+                  ...active!.binding,
+                  ...mutation.patch,
+                  threadId: mutation.threadId,
+                  pendingSupervisionBranch: undefined,
+                });
+              } else {
+                binding = validateBindingForWrite({
+                  ...active!.binding,
+                  ...mutation.patch,
+                  threadId: mutation.threadId,
+                });
+              }
+              const storedBinding = externalizeInstructionBinding(
+                {
+                  ...binding,
+                  ...(hasInstructionUpdate ||
+                  mutation.kind === "set" ||
+                  mutation.kind === "replace-thread"
+                    ? { agentWorkspaceDeveloperInstructionsRef: undefined }
+                    : active?.binding.agentWorkspaceDeveloperInstructionsRef
+                      ? {
+                          agentWorkspaceDeveloperInstructionsRef:
+                            active.binding.agentWorkspaceDeveloperInstructionsRef,
+                        }
+                      : {}),
                 },
-              };
-            }
-            const storedActive = current?.state === "active" ? current : undefined;
-            const active = ownsGeneration ? storedActive : undefined;
-            const retiredGeneration =
-              current?.state === "cleared" && current.retired === true && ownsGeneration;
-            const preservesSupervisionOwner =
-              mutation.kind === "set" &&
-              active?.binding.connectionScope === "supervision" &&
-              isSameSupervisionOwner(active.binding, mutation.binding);
-            const clearsPendingSupervisionOwner =
-              mutation.kind === "clear" &&
-              active?.binding.connectionScope === "supervision" &&
-              matchesPendingSupervisionClear(
-                active.binding,
-                mutation.threadId,
-                mutation.expectedPendingSupervisionBranch,
+                retainedReference,
               );
-            const replacesExpectedOrdinaryOwner =
-              mutation.kind === "replace-thread" &&
-              active?.binding.threadId === mutation.expectedThreadId &&
-              active.binding.connectionScope !== "supervision" &&
-              mutation.binding.connectionScope !== "supervision" &&
-              mutation.binding.threadId !== mutation.expectedThreadId;
-            if (
-              (mutation.kind === "set" &&
-                ((mutation.if?.kind === "absent" && storedActive) ||
-                  (current !== undefined && !ownsGeneration) ||
-                  retiredGeneration ||
-                  (active?.binding.connectionScope === "supervision" &&
-                    !preservesSupervisionOwner))) ||
-              (mutation.kind === "patch" && active?.binding.threadId !== mutation.threadId) ||
-              (mutation.kind === "replace-thread" && !replacesExpectedOrdinaryOwner) ||
-              ((mutation.kind === "patch-pending-supervision-branch" ||
-                mutation.kind === "commit-pending-supervision-branch") &&
-                !matchesPendingSupervisionBranch(active?.binding, mutation.expected)) ||
-              (mutation.kind === "clear" &&
-                ((mutation.threadId !== undefined &&
-                  active?.binding.threadId !== mutation.threadId) ||
-                  !ownsGeneration ||
-                  (active?.binding.connectionScope === "supervision" &&
-                    !clearsPendingSupervisionOwner)))
-            ) {
-              return { result: false };
-            }
-            if (mutation.kind === "clear" && retiredGeneration) {
-              return { result: true };
-            }
-            if (mutation.kind === "clear") {
+              nextReference = storedBinding.agentWorkspaceDeveloperInstructionsRef;
               return {
                 result: true,
                 next: {
                   version: 1,
-                  state: "cleared",
+                  state: "active",
+                  binding: storedBinding,
                   ...storedSessionGeneration(identity, current),
                   ...ownedLease,
                 },
               };
-            }
-            let binding: CodexAppServerThreadBinding;
-            if (mutation.kind === "set" || mutation.kind === "replace-thread") {
-              binding = validateBindingForWrite(mutation.binding);
-            } else if (mutation.kind === "patch-pending-supervision-branch") {
-              binding = validateBindingForWrite({
-                ...active!.binding,
-                pendingSupervisionBranch: mutation.pending,
-              });
-            } else if (mutation.kind === "commit-pending-supervision-branch") {
-              binding = validateBindingForWrite({
-                ...active!.binding,
-                ...mutation.patch,
-                threadId: mutation.threadId,
-                pendingSupervisionBranch: undefined,
-              });
-            } else {
-              binding = validateBindingForWrite({
-                ...active!.binding,
-                ...mutation.patch,
-                threadId: mutation.threadId,
-              });
-            }
-            return {
-              result: true,
-              next: {
-                version: 1,
-                state: "active",
-                binding,
-                ...storedSessionGeneration(identity, current),
-                ...ownedLease,
-              },
-            };
-          },
-          // Plain clears may expire immediately: a stale generation that re-sets
-          // the key afterwards is fenced by ownsStoredSessionGeneration on read
-          // and displaced via reclaim-generation; durable stable-key fences come
-          // from retireSessionGeneration, not runtime clears.
-          mutation.kind === "clear" && !retainLegacyClear && !leaseContext.getStore()?.has(key)
-            ? 1
-            : undefined,
-        );
+            },
+            // Plain clears may expire immediately: a stale generation that re-sets
+            // the key afterwards is fenced by ownsStoredSessionGeneration on read
+            // and displaced via reclaim-generation; durable stable-key fences come
+            // from retireSessionGeneration, not runtime clears.
+            mutation.kind === "clear" && !retainLegacyClear && !leaseContext.getStore()?.has(key)
+              ? 1
+              : undefined,
+          );
+        } catch (error) {
+          if (retainedReference && instructionBlobs) {
+            await releaseCodexInstructionBlob(instructionBlobs, retainedReference);
+          }
+          throw error;
+        }
+        if (instructionBlobs) {
+          if (!committed && retainedReference) {
+            await releaseCodexInstructionBlob(instructionBlobs, retainedReference);
+          } else if (committed && previousReference === retainedReference && retainedReference) {
+            await releaseCodexInstructionBlob(instructionBlobs, retainedReference);
+          } else if (committed && previousReference && previousReference !== nextReference) {
+            await releaseCodexInstructionBlob(instructionBlobs, previousReference);
+          }
+        }
+        return committed;
       });
     },
 
@@ -1069,7 +1227,8 @@ export function createCodexAppServerBindingStore(
     async resetSessionGeneration(identity) {
       return await runBindingMutation(async () => {
         const key = bindingStoreKey(identity);
-        return await transactKey(
+        let previousReference: string | undefined;
+        const result = await transactKey(
           key,
           (current, leaseToken) => {
             if (!current) {
@@ -1078,6 +1237,10 @@ export function createCodexAppServerBindingStore(
             if (!ownsStoredSessionGeneration(identity, current)) {
               return { result: "conflict" as const };
             }
+            previousReference =
+              current.state === "active"
+                ? current.binding.agentWorkspaceDeveloperInstructionsRef
+                : undefined;
             // A retired same-id row may be a deletion fence. Only the authoritative
             // session-store reclaim path can prove it belongs to an in-place reset.
             if (current.state === "cleared" && current.retired === true) {
@@ -1097,13 +1260,18 @@ export function createCodexAppServerBindingStore(
           },
           leaseContext.getStore()?.has(key) ? undefined : 1,
         );
+        if (result === "applied" && previousReference && instructionBlobs) {
+          await releaseCodexInstructionBlob(instructionBlobs, previousReference);
+        }
+        return result;
       });
     },
 
     async retireSessionGeneration(identity) {
       return await runBindingMutation(async () => {
         const key = bindingStoreKey(identity);
-        return await transactKey(
+        let previousReference: string | undefined;
+        const result = await transactKey(
           key,
           (current, leaseToken) => {
             if (!current) {
@@ -1112,6 +1280,10 @@ export function createCodexAppServerBindingStore(
             if (!ownsStoredSessionGeneration(identity, current)) {
               return { result: "conflict" as const };
             }
+            previousReference =
+              current.state === "active"
+                ? current.binding.agentWorkspaceDeveloperInstructionsRef
+                : undefined;
             if (current.state === "cleared" && current.retired === true) {
               return { result: "applied" as const };
             }
@@ -1130,6 +1302,10 @@ export function createCodexAppServerBindingStore(
           },
           identity.sessionKey?.trim() ? undefined : PHYSICAL_SESSION_RETIRE_TTL_MS,
         );
+        if (result === "applied" && previousReference && instructionBlobs) {
+          await releaseCodexInstructionBlob(instructionBlobs, previousReference);
+        }
+        return result;
       });
     },
 
@@ -1343,6 +1519,24 @@ export function readStoredCodexAppServerBinding(
     : undefined;
 }
 
+/** Doctor-only parser for pre-blob inline rows from existing main/nightly state. */
+export function readLegacyStoredCodexAppServerBinding(
+  value: unknown,
+): LegacyStoredCodexAppServerBinding | undefined {
+  const result = legacyStoredBindingSchema.safeParse(value);
+  if (!result.success) {
+    return undefined;
+  }
+  return legacyStoredBindingSchema.parse(stripUndefinedValue(result.data));
+}
+
+/** Doctor-only parser accepting either side of the inline-to-reference migration. */
+export function readDoctorStoredCodexAppServerBinding(
+  value: unknown,
+): DoctorStoredCodexAppServerBinding | undefined {
+  return readStoredCodexAppServerBinding(value) ?? readLegacyStoredCodexAppServerBinding(value);
+}
+
 function storedSessionGeneration(
   identity: CodexAppServerBindingIdentity,
   current: StoredCodexAppServerBinding | undefined,
@@ -1386,7 +1580,7 @@ function validateBindingForWrite(
 export function readCodexAppServerThreadBinding(
   value: unknown,
 ): CodexAppServerThreadBinding | undefined {
-  const result = threadBindingSchema.safeParse(value);
+  const result = domainThreadBindingSchema.safeParse(value);
   if (!result.success) {
     return undefined;
   }

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -3397,7 +3397,8 @@ describe("Codex app-server supervised branch lifecycle", () => {
     const probeThreadId = "thread-probe";
     const finalThreadId = "thread-final";
     const lastTurnId = "turn-terminal";
-    const agentWorkspaceDeveloperInstructions = "Follow the frozen supervised AGENTS guidance.";
+    const agentWorkspaceDeveloperInstructions = `# Frozen supervised AGENTS guidance\n${"policy-🦀\n".repeat(7_000)}`;
+    expect(Buffer.byteLength(agentWorkspaceDeveloperInstructions)).toBeGreaterThan(65_536);
     const workspaceDir = path.join(tempDir, "workspace");
     const attempt = createThreadLifecycleParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     attempt.modelId = "outer-global-default";

--- a/extensions/codex/src/migration/session-binding-sidecars.ts
+++ b/extensions/codex/src/migration/session-binding-sidecars.ts
@@ -16,13 +16,26 @@ import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import {
   archiveLegacyStateSource,
   legacyStateFileExists,
+  type PluginDoctorStateMigrationContext,
   type PluginDoctorStateMigration,
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { pathExists } from "openclaw/plugin-sdk/security-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  codexInstructionBlobReference,
+  releaseCodexInstructionBlob,
+  readCodexInstructionBlobMetadata,
+  retainCodexInstructionBlob,
+  retainCodexInstructionBlobReference,
+  type CodexInstructionBlobReconciliationStore,
+  verifyCodexInstructionBlob,
+} from "../app-server/instruction-blob.js";
+import {
   CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
   CODEX_APP_SERVER_BINDING_NAMESPACE,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+  CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
 } from "../app-server/session-binding-meta.js";
 
 const LEGACY_BINDING_SUFFIX = ".codex-app-server.json";
@@ -79,6 +92,180 @@ type SourceMigrationResult = {
   notice?: string;
   warning?: string;
 };
+
+function openInstructionBlobStore(
+  context: PluginDoctorStateMigrationContext,
+): CodexInstructionBlobReconciliationStore {
+  if (!context.openPluginBlobStore) {
+    throw new Error("Codex instruction migration requires doctor blob-store support");
+  }
+  return context.openPluginBlobStore({
+    namespace: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_NAMESPACE,
+    maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+    maxBytesPerEntry: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_BYTES,
+    maxBytesPerNamespace: CODEX_APP_SERVER_INSTRUCTIONS_BLOB_MAX_TOTAL_BYTES,
+    overflowPolicy: "reject-new",
+  });
+}
+
+function readInstructionBindingRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function externalizeInlineInstructions(row: MigratedBindingRow): MigratedBindingRow {
+  if (row.state !== "active" || !isRecord(row.binding)) {
+    return row;
+  }
+  const instructions = row.binding.agentWorkspaceDeveloperInstructions;
+  if (typeof instructions !== "string" || !instructions.trim()) {
+    return row;
+  }
+  const reference = codexInstructionBlobReference(instructions);
+  const binding = { ...row.binding };
+  delete binding.agentWorkspaceDeveloperInstructions;
+  binding.agentWorkspaceDeveloperInstructionsRef = reference;
+  return { ...row, binding };
+}
+
+type PreparedInstructionOwner = {
+  row: MigratedBindingRow;
+  retainedReference?: string;
+};
+
+async function retainInlineInstructionOwner(
+  row: MigratedBindingRow,
+  blobs: CodexInstructionBlobReconciliationStore,
+): Promise<PreparedInstructionOwner> {
+  if (row.state !== "active" || !isRecord(row.binding)) {
+    return { row };
+  }
+  const instructions = row.binding.agentWorkspaceDeveloperInstructions;
+  if (typeof instructions !== "string" || !instructions.trim()) {
+    return { row };
+  }
+  const retainedReference = await retainCodexInstructionBlob({ store: blobs, instructions });
+  return { row: externalizeInlineInstructions(row), retainedReference };
+}
+
+async function retainInstructionOwner(
+  row: MigratedBindingRow,
+  blobs: CodexInstructionBlobReconciliationStore,
+): Promise<PreparedInstructionOwner> {
+  const inline = await retainInlineInstructionOwner(row, blobs);
+  if (inline.retainedReference || inline.row.state !== "active" || !isRecord(inline.row.binding)) {
+    return inline;
+  }
+  const reference = inline.row.binding.agentWorkspaceDeveloperInstructionsRef;
+  if (typeof reference !== "string") {
+    return inline;
+  }
+  await retainCodexInstructionBlobReference(blobs, reference);
+  return { row: inline.row, retainedReference: reference };
+}
+
+async function releasePreparedInstructionOwner(
+  prepared: PreparedInstructionOwner,
+  blobs: CodexInstructionBlobReconciliationStore,
+): Promise<void> {
+  if (prepared.retainedReference) {
+    await releaseCodexInstructionBlob(blobs, prepared.retainedReference);
+  }
+}
+
+async function reconcileInstructionBlobReferences(params: {
+  store: PluginStateKeyedStore<MigratedBindingRow>;
+  blobs: CodexInstructionBlobReconciliationStore;
+  readStored: (value: unknown) => MigratedBindingRow | undefined;
+}): Promise<string[]> {
+  const warnings: string[] = [];
+  const counts = new Map<string, number>();
+  let completeCensus = true;
+  for (const { key, value } of await params.store.entries()) {
+    const stored = params.readStored(value);
+    if (!stored) {
+      completeCensus = false;
+      warnings.push(`Codex instruction references could not inspect invalid binding row ${key}`);
+      continue;
+    }
+    if (stored.state !== "active" || !isRecord(stored.binding)) {
+      continue;
+    }
+    if (stored.binding.agentWorkspaceDeveloperInstructions) {
+      completeCensus = false;
+      warnings.push(`Codex inline instruction binding remains unreconciled at ${key}`);
+      continue;
+    }
+    const reference = stored.binding.agentWorkspaceDeveloperInstructionsRef;
+    if (typeof reference === "string") {
+      counts.set(reference, (counts.get(reference) ?? 0) + 1);
+    }
+  }
+
+  if (!completeCensus) {
+    warnings.push(
+      "Skipped Codex instruction blob cleanup because the binding census is incomplete",
+    );
+    return warnings;
+  }
+
+  let entries: Awaited<ReturnType<CodexInstructionBlobReconciliationStore["entries"]>>;
+  try {
+    entries = await params.blobs.entries();
+  } catch (error) {
+    warnings.push(`Codex instruction blob metadata census is unreadable: ${String(error)}`);
+    warnings.push(
+      "Skipped Codex instruction blob repair and cleanup because the blob census is unsafe",
+    );
+    return warnings;
+  }
+  const present = new Set(entries.map((entry) => entry.key));
+  let safeBlobCensus = true;
+  for (const reference of counts.keys()) {
+    if (!present.has(reference)) {
+      warnings.push(`Codex instruction blob is missing for ${reference}`);
+      safeBlobCensus = false;
+      continue;
+    }
+    try {
+      const current = await params.blobs.lookup(reference);
+      if (!current) {
+        warnings.push(`Codex instruction blob is missing for ${reference}`);
+        safeBlobCensus = false;
+        continue;
+      }
+      verifyCodexInstructionBlob(reference, current.bytes);
+    } catch (error) {
+      warnings.push(`Codex instruction blob is invalid for ${reference}: ${String(error)}`);
+      safeBlobCensus = false;
+    }
+  }
+  if (!safeBlobCensus) {
+    warnings.push(
+      "Skipped Codex instruction blob repair and cleanup because referenced blob content is unsafe",
+    );
+    return warnings;
+  }
+
+  for (const [reference, refCount] of counts) {
+    await params.blobs.mutate(reference, (current) => {
+      if (!current) {
+        return undefined;
+      }
+      verifyCodexInstructionBlob(reference, current.bytes);
+      return {
+        kind: "set",
+        bytes: current.bytes,
+        metadata: { version: 1, refCount },
+      };
+    });
+  }
+  for (const entry of entries) {
+    if (!counts.has(entry.key)) {
+      await params.blobs.mutate(entry.key, (current) => (current ? { kind: "delete" } : undefined));
+    }
+  }
+  return warnings;
+}
 
 // Keep the doctor contract graph independent from the full Codex runtime.
 // The runtime parser loaded in migrateSource validates binding payloads before writes.
@@ -475,6 +662,7 @@ async function migrateSource(
   candidates: LegacyBindingOwner[],
   params: MigrationParams,
   store: PluginStateKeyedStore<MigratedBindingRow>,
+  blobs: CodexInstructionBlobReconciliationStore,
 ): Promise<SourceMigrationResult> {
   let importedKeys = 0;
   const retain = (reason: string): SourceMigrationResult => ({
@@ -500,7 +688,7 @@ async function migrateSource(
           bindingStoreKey,
           createStoredCodexAppServerBinding,
           normalizeStoredCodexAppServerBindingFingerprints,
-          readStoredCodexAppServerBinding,
+          readDoctorStoredCodexAppServerBinding,
         },
         { legacyCodexConversationBindingId },
       ] = await Promise.all([
@@ -551,15 +739,16 @@ async function migrateSource(
         key: string,
         current: MigratedBindingRow,
       ): Promise<{ value?: MigratedBindingRow; warning?: string }> => {
-        const parsed = readStoredCodexAppServerBinding(current);
+        const parsed = readDoctorStoredCodexAppServerBinding(current);
         if (!parsed) {
           return { warning: `canonical plugin state is invalid at ${key}` };
         }
-        const normalized = normalizeStoredCodexAppServerBindingFingerprints(parsed);
-        if (!normalized) {
+        const fingerprintNormalized = normalizeStoredCodexAppServerBindingFingerprints(parsed);
+        if (!fingerprintNormalized) {
           return { warning: `canonical plugin state is invalid at ${key}` };
         }
-        if (isDeepStrictEqual(parsed, normalized)) {
+        const canonical = externalizeInlineInstructions(fingerprintNormalized);
+        if (isDeepStrictEqual(parsed, canonical)) {
           return { value: parsed };
         }
         if (parsed.lease && parsed.lease.expiresAt > Date.now()) {
@@ -569,19 +758,26 @@ async function migrateSource(
         if (!update) {
           return { warning: `canonical plugin state could not be normalized at ${key}` };
         }
-        await update(key, (candidate) => {
-          const candidateParsed = readStoredCodexAppServerBinding(candidate);
-          if (!candidateParsed || !isDeepStrictEqual(candidateParsed, parsed)) {
-            return undefined;
-          }
-          return normalized;
-        });
-        const persisted = readStoredCodexAppServerBinding(await store.lookup(key));
-        if (!persisted || !isDeepStrictEqual(persisted, normalized)) {
+        const prepared = await retainInlineInstructionOwner(fingerprintNormalized, blobs);
+        try {
+          await update(key, (candidate) => {
+            const candidateParsed = readDoctorStoredCodexAppServerBinding(candidate);
+            if (!candidateParsed || !isDeepStrictEqual(candidateParsed, parsed)) {
+              return undefined;
+            }
+            return prepared.row;
+          });
+        } catch (error) {
+          await releasePreparedInstructionOwner(prepared, blobs);
+          throw error;
+        }
+        const persisted = readDoctorStoredCodexAppServerBinding(await store.lookup(key));
+        if (!persisted || !isDeepStrictEqual(persisted, prepared.row)) {
+          await releasePreparedInstructionOwner(prepared, blobs);
           return { warning: `canonical plugin state changed at ${key}` };
         }
         importedKeys++;
-        return { value: normalized };
+        return { value: prepared.row };
       };
       let currentConversation: MigratedBindingRow | undefined;
       for (const key of conversationKeys) {
@@ -595,7 +791,8 @@ async function migrateSource(
         }
         currentConversation ??= result.value;
       }
-      const stored = currentConversation ?? baseStored;
+      const storedSource = currentConversation ?? baseStored;
+      const stored = externalizeInlineInstructions(storedSource);
       const sessionKey = owner
         ? bindingStoreKey({
             kind: "session",
@@ -605,13 +802,25 @@ async function migrateSource(
           })
         : undefined;
       const conversationEntries = conversationKeys.map((key) => ({ key, value: stored }));
+      const conversationSourceEntries = conversationKeys.map((key) => ({
+        key,
+        value: storedSource,
+      }));
       const sessionEntry =
         owner && sessionKey
           ? { key: sessionKey, value: copyBindingForSession(stored, owner.sessionId) }
           : undefined;
+      const sessionSourceEntry =
+        owner && sessionKey
+          ? { key: sessionKey, value: copyBindingForSession(storedSource, owner.sessionId) }
+          : undefined;
       const entries = [...conversationEntries, ...(sessionEntry ? [sessionEntry] : [])];
+      const sourceEntries = [
+        ...conversationSourceEntries,
+        ...(sessionSourceEntry ? [sessionSourceEntry] : []),
+      ];
       const hasExpected = (value: MigratedBindingRow | undefined, target: MigratedBindingRow) => {
-        const parsed = readStoredCodexAppServerBinding(value);
+        const parsed = readDoctorStoredCodexAppServerBinding(value);
         if (!parsed) {
           return false;
         }
@@ -636,9 +845,28 @@ async function migrateSource(
           return retain(`canonical plugin state changed at ${entry.key}`);
         }
       }
-      for (const entry of entries) {
-        if (await store.registerIfAbsent(entry.key, entry.value)) {
+      for (const [index, entry] of entries.entries()) {
+        const sourceEntry = sourceEntries[index]!;
+        const current = await store.lookup(entry.key);
+        if (current !== undefined) {
+          continue;
+        }
+        const prepared = await retainInstructionOwner(sourceEntry.value, blobs);
+        if (!isDeepStrictEqual(prepared.row, entry.value)) {
+          await releasePreparedInstructionOwner(prepared, blobs);
+          return retain(`canonical instruction binding changed at ${entry.key}`);
+        }
+        let registered: boolean;
+        try {
+          registered = await store.registerIfAbsent(entry.key, prepared.row);
+        } catch (error) {
+          await releasePreparedInstructionOwner(prepared, blobs);
+          throw error;
+        }
+        if (registered) {
           importedKeys++;
+        } else {
+          await releasePreparedInstructionOwner(prepared, blobs);
         }
         if (!hasExpected(await store.lookup(entry.key), entry.value)) {
           return retain(`canonical plugin state changed at ${entry.key}`);
@@ -653,7 +881,7 @@ async function migrateSource(
               return retain(`${ownershipWarning}; its stale session binding could not be retired`);
             }
             await update(sessionEntry.key, (current) => {
-              const parsed = readStoredCodexAppServerBinding(current);
+              const parsed = readDoctorStoredCodexAppServerBinding(current);
               if (parsed?.lease && parsed.lease.expiresAt > Date.now()) {
                 return undefined;
               }
@@ -858,6 +1086,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
         maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
         overflowPolicy: "reject-new",
       });
+      const blobs = openInstructionBlobStore(params.context);
       let migrated = 0;
       let partialImports = 0;
       for (const source of sources) {
@@ -865,7 +1094,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
           ownerCollection.owners.get(
             await canonicalPathFromExistingAncestor(source.transcriptPath),
           ) ?? [];
-        const result = await migrateSource(source, candidates, params, store);
+        const result = await migrateSource(source, candidates, params, store, blobs);
         if (result.warning) {
           warnings.push(result.warning);
         }
@@ -888,11 +1117,159 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
           `Migrated ${partialImports} safe Codex app-server binding row(s) to plugin state; retained legacy sidecars needing review`,
         );
       }
+      if (warnings.length === 0) {
+        const { readDoctorStoredCodexAppServerBinding } =
+          await import("../app-server/session-binding.js");
+        warnings.push(
+          ...(await reconcileInstructionBlobReferences({
+            store,
+            blobs,
+            readStored: readDoctorStoredCodexAppServerBinding,
+          })),
+        );
+      }
       return {
         changes,
         warnings,
         ...(notices.length > 0 ? { notices } : {}),
       };
+    },
+  },
+  {
+    id: "codex-app-server-inline-instructions-to-blobs",
+    label: "Codex app-server frozen workspace instructions",
+    async detectLegacyState(params) {
+      const store = params.context.openPluginStateKeyedStore<MigratedBindingRow>({
+        namespace: CODEX_APP_SERVER_BINDING_NAMESPACE,
+        maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+        overflowPolicy: "reject-new",
+      });
+      const blobs = openInstructionBlobStore(params.context);
+      const { readDoctorStoredCodexAppServerBinding } =
+        await import("../app-server/session-binding.js");
+      const counts = new Map<string, number>();
+      let inlineCount = 0;
+      let invalidCount = 0;
+      for (const { value } of await store.entries()) {
+        const stored = readDoctorStoredCodexAppServerBinding(value);
+        if (!stored) {
+          invalidCount++;
+          continue;
+        }
+        if (stored.state !== "active") {
+          continue;
+        }
+        const binding = readInstructionBindingRecord(stored.binding);
+        if (!binding) {
+          invalidCount++;
+          continue;
+        }
+        if (typeof binding.agentWorkspaceDeveloperInstructions === "string") {
+          inlineCount++;
+        }
+        const reference = binding.agentWorkspaceDeveloperInstructionsRef;
+        if (typeof reference === "string") {
+          counts.set(reference, (counts.get(reference) ?? 0) + 1);
+        }
+      }
+      let drifted = invalidCount > 0;
+      let blobEntries: Awaited<ReturnType<CodexInstructionBlobReconciliationStore["entries"]>>;
+      try {
+        blobEntries = await blobs.entries();
+      } catch {
+        return {
+          preview: [
+            "- Codex app-server bindings: inspect unreadable instruction blob metadata without cleanup",
+          ],
+        };
+      }
+      const blobKeys = new Set(blobEntries.map((entry) => entry.key));
+      for (const [reference, count] of counts) {
+        const entry = await blobs.lookup(reference);
+        if (!entry) {
+          drifted = true;
+          continue;
+        }
+        try {
+          verifyCodexInstructionBlob(reference, entry.bytes);
+          drifted ||= readCodexInstructionBlobMetadata(entry.metadata).refCount !== count;
+        } catch {
+          drifted = true;
+        }
+      }
+      drifted ||= blobEntries.some((entry) => !counts.has(entry.key));
+      drifted ||= [...counts.keys()].some((reference) => !blobKeys.has(reference));
+      return inlineCount > 0 || drifted
+        ? {
+            preview: [
+              `- Codex app-server bindings: externalize ${inlineCount} inline instruction snapshot(s) and reconcile blob references`,
+            ],
+          }
+        : null;
+    },
+    async migrateLegacyState(params) {
+      const changes: string[] = [];
+      const warnings: string[] = [];
+      const store = params.context.openPluginStateKeyedStore<MigratedBindingRow>({
+        namespace: CODEX_APP_SERVER_BINDING_NAMESPACE,
+        maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
+        overflowPolicy: "reject-new",
+      });
+      const blobs = openInstructionBlobStore(params.context);
+      const { readDoctorStoredCodexAppServerBinding } =
+        await import("../app-server/session-binding.js");
+      const update = store.update;
+      if (!update) {
+        return {
+          changes,
+          warnings: ["Codex inline instruction bindings require atomic plugin-state updates"],
+        };
+      }
+      let migrated = 0;
+      for (const { key, value } of await store.entries()) {
+        const stored = readDoctorStoredCodexAppServerBinding(value);
+        if (!stored || stored.state !== "active") {
+          continue;
+        }
+        const binding = readInstructionBindingRecord(stored.binding);
+        const instructions = binding?.agentWorkspaceDeveloperInstructions;
+        if (typeof instructions !== "string" || !instructions.trim()) {
+          continue;
+        }
+        if (stored.lease && stored.lease.expiresAt > Date.now()) {
+          warnings.push(`Left leased Codex inline instruction binding unchanged at ${key}`);
+          continue;
+        }
+        const prepared = await retainInlineInstructionOwner(stored, blobs);
+        let updated: boolean;
+        try {
+          updated = await update(key, (candidate) =>
+            isDeepStrictEqual(candidate, stored) ? prepared.row : undefined,
+          );
+        } catch (error) {
+          await releasePreparedInstructionOwner(prepared, blobs);
+          throw error;
+        }
+        if (updated) {
+          migrated++;
+        } else {
+          await releasePreparedInstructionOwner(prepared, blobs);
+          warnings.push(`Codex inline instruction binding changed during migration at ${key}`);
+        }
+      }
+      warnings.push(
+        ...(await reconcileInstructionBlobReferences({
+          store,
+          blobs,
+          readStored: readDoctorStoredCodexAppServerBinding,
+        })),
+      );
+      if (migrated > 0) {
+        changes.push(
+          `Migrated ${migrated} Codex frozen workspace instruction snapshot(s) to plugin blobs`,
+        );
+      }
+      return { changes, warnings };
     },
   },
 ];

--- a/extensions/diffs/src/browser.runtime.test.ts
+++ b/extensions/diffs/src/browser.runtime.test.ts
@@ -842,6 +842,22 @@ function createMemoryBlobStore<TMetadata>(): PluginBlobStore<TMetadata> {
       await register(key, bytes, metadata, opts);
       return true;
     },
+    async mutate(key, update) {
+      const next = update(read(key));
+      if (!next) {
+        return false;
+      }
+      if (next.kind === "delete") {
+        return entries.delete(key);
+      }
+      await register(
+        key,
+        next.bytes,
+        next.metadata,
+        next.ttlMs === undefined ? undefined : { ttlMs: next.ttlMs },
+      );
+      return true;
+    },
     async lookup(key) {
       return read(key);
     },

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -21,6 +21,10 @@ import { resolveSessionStoreTargets } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
+  createPluginBlobStoreForDoctor,
+  type OpenBlobStoreOptions,
+} from "../plugin-state/plugin-blob-store.js";
+import {
   createPluginStateKeyedStore,
   getPluginStateCapacity as resolvePluginStateCapacity,
   importPluginStateEntriesForDoctor,
@@ -260,6 +264,9 @@ function createPluginDoctorStateMigrationContext(
   env: NodeJS.ProcessEnv,
 ): PluginDoctorStateMigrationContext {
   return {
+    openPluginBlobStore<TMetadata>(options: OpenBlobStoreOptions) {
+      return createPluginBlobStoreForDoctor<TMetadata>(pluginId, options, env);
+    },
     getPluginStateCapacity() {
       return resolvePluginStateCapacity(pluginId, env);
     },

--- a/src/plugin-sdk/runtime-doctor-migrations.ts
+++ b/src/plugin-sdk/runtime-doctor-migrations.ts
@@ -48,6 +48,10 @@ export type {
   RetiredChannelKeyRemoval,
 } from "../config/channel-compat-normalization.js";
 export type {
+  OpenBlobStoreOptions,
+  PluginBlobStore,
+} from "../plugin-state/plugin-blob-store.types.js";
+export type {
   OpenKeyedStoreOptions,
   PluginStateKeyedStore,
 } from "../plugin-state/plugin-state-store.js";

--- a/src/plugin-state/plugin-blob-store.sqlite.ts
+++ b/src/plugin-state/plugin-blob-store.sqlite.ts
@@ -43,6 +43,7 @@ type BlobDescriptor = {
 };
 
 type BlobWriteParams = {
+  operation: "register" | "mutate";
   pluginId: string;
   namespace: string;
   key: string;
@@ -56,6 +57,11 @@ type BlobWriteParams = {
 };
 
 type ValidateMetadataJson = (metadataJson: string) => void;
+
+type PluginBlobStoredMutation =
+  | { kind: "set"; bytes: Uint8Array; metadataJson: string; ttlMs?: number }
+  | { kind: "delete" }
+  | undefined;
 
 function createError(params: {
   code: PluginBlobStoreErrorCode;
@@ -280,10 +286,14 @@ function totalBytes(rows: readonly { size_bytes: number | bigint }[]): number {
   return rows.reduce((total, row) => total + Number(row.size_bytes), 0);
 }
 
-function limitError(message: string, env?: NodeJS.ProcessEnv): PluginBlobStoreError {
+function limitError(
+  message: string,
+  operation: "register" | "mutate",
+  env?: NodeJS.ProcessEnv,
+): PluginBlobStoreError {
   return createError({
     code: "PLUGIN_BLOB_LIMIT_EXCEEDED",
-    operation: "register",
+    operation,
     message,
     env,
   });
@@ -306,22 +316,38 @@ function assertProjectedLimits(params: {
   const previousBytes = params.existing ? Number(params.existing.size_bytes) : 0;
   const rowDelta = params.existing ? 0 : 1;
   if (namespaceRows.length + rowDelta > params.write.maxEntries) {
-    throw limitError("Plugin blob namespace reached its stored row limit.", params.write.env);
+    throw limitError(
+      "Plugin blob namespace reached its stored row limit.",
+      params.write.operation,
+      params.write.env,
+    );
   }
   if (
     totalBytes(namespaceRows) - previousBytes + params.write.bytes.byteLength >
     params.write.maxBytesPerNamespace
   ) {
-    throw limitError("Plugin blob namespace reached its stored byte limit.", params.write.env);
+    throw limitError(
+      "Plugin blob namespace reached its stored byte limit.",
+      params.write.operation,
+      params.write.env,
+    );
   }
   if (pluginRows.length + rowDelta > MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN) {
-    throw limitError("Plugin blob store reached its per-plugin row limit.", params.write.env);
+    throw limitError(
+      "Plugin blob store reached its per-plugin row limit.",
+      params.write.operation,
+      params.write.env,
+    );
   }
   if (
     totalBytes(pluginRows) - previousBytes + params.write.bytes.byteLength >
     MAX_PLUGIN_BLOB_BYTES_PER_PLUGIN
   ) {
-    throw limitError("Plugin blob store reached its per-plugin byte limit.", params.write.env);
+    throw limitError(
+      "Plugin blob store reached its per-plugin byte limit.",
+      params.write.operation,
+      params.write.env,
+    );
   }
 }
 
@@ -362,6 +388,7 @@ function deleteOldestUntilWithinLimits(params: {
   ) {
     throw limitError(
       "Plugin blob namespace cannot satisfy its configured limits.",
+      params.write.operation,
       params.write.env,
     );
   }
@@ -400,7 +427,11 @@ function deleteOldestUntilWithinLimits(params: {
     pluginCount > MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN ||
     pluginBytes > MAX_PLUGIN_BLOB_BYTES_PER_PLUGIN
   ) {
-    throw limitError("Plugin blob store cannot satisfy its per-plugin limits.", params.write.env);
+    throw limitError(
+      "Plugin blob store cannot satisfy its per-plugin limits.",
+      params.write.operation,
+      params.write.env,
+    );
   }
   deleteKeys(params.db, {
     pluginId: params.write.pluginId,
@@ -418,7 +449,7 @@ function upsertBlob(db: DatabaseSync, params: BlobWriteParams, now: number): voi
     if (resolved === undefined) {
       throw createError({
         code: "PLUGIN_BLOB_INVALID_INPUT",
-        operation: "register",
+        operation: params.operation,
         message: "Plugin blob ttlMs cannot produce a valid expiry timestamp.",
         env: params.env,
       });
@@ -452,7 +483,7 @@ function upsertBlob(db: DatabaseSync, params: BlobWriteParams, now: number): voi
 
 function writeBlob(params: BlobWriteParams, ifAbsent: boolean): boolean {
   try {
-    openDatabase("register", params.env);
+    openDatabase(params.operation, params.env);
     return runOpenClawStateWriteTransaction(
       ({ db }) => {
         const now = Date.now();
@@ -476,7 +507,7 @@ function writeBlob(params: BlobWriteParams, ifAbsent: boolean): boolean {
   } catch (error) {
     throw wrapError(
       error,
-      "register",
+      params.operation,
       "PLUGIN_BLOB_WRITE_FAILED",
       "Failed to register plugin blob entry.",
       params.env,
@@ -490,6 +521,54 @@ export function pluginBlobRegister(params: BlobWriteParams): void {
 
 export function pluginBlobRegisterIfAbsent(params: BlobWriteParams): boolean {
   return writeBlob(params, true);
+}
+
+export function pluginBlobMutate(
+  params: Omit<BlobWriteParams, "bytes" | "metadataJson" | "ttlMs" | "operation"> & {
+    operation: "mutate";
+    mutate: (current: PluginBlobStoredEntry | undefined) => PluginBlobStoredMutation;
+  },
+): boolean {
+  try {
+    openDatabase(params.operation, params.env);
+    return runOpenClawStateWriteTransaction(
+      ({ db }) => {
+        const now = Date.now();
+        const current = selectLiveBlob(db, { ...params, now });
+        const next = params.mutate(current);
+        if (!next) {
+          return false;
+        }
+        if (next.kind === "delete") {
+          return deleteKey(db, params) > 0;
+        }
+        const write: BlobWriteParams = {
+          ...params,
+          bytes: next.bytes,
+          metadataJson: next.metadataJson,
+          ...(next.ttlMs !== undefined ? { ttlMs: next.ttlMs } : {}),
+        };
+        const existing = selectStoredKeyDescriptor(db, params);
+        if (params.overflowPolicy === "reject-new") {
+          assertProjectedLimits({ db, write, existing });
+        }
+        upsertBlob(db, write, now);
+        if (params.overflowPolicy === "evict-oldest") {
+          deleteOldestUntilWithinLimits({ db, write, now });
+        }
+        return true;
+      },
+      params.env ? { env: params.env } : {},
+    );
+  } catch (error) {
+    throw wrapError(
+      error,
+      params.operation,
+      "PLUGIN_BLOB_WRITE_FAILED",
+      "Failed to mutate plugin blob entry.",
+      params.env,
+    );
+  }
 }
 
 export function pluginBlobLookup(params: {

--- a/src/plugin-state/plugin-blob-store.test.ts
+++ b/src/plugin-state/plugin-blob-store.test.ts
@@ -7,6 +7,7 @@ import {
   resetPluginBlobStoreForTests,
   type OpenBlobStoreOptions,
 } from "./plugin-blob-store.js";
+import { MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN } from "./plugin-blob-store.sqlite.js";
 import { PluginBlobStoreError } from "./plugin-blob-store.types.js";
 
 afterEach(() => {
@@ -56,6 +57,130 @@ describe("plugin blob store", () => {
       expect(entries).toHaveLength(1);
       expect(entries[0]).toMatchObject({ key: "viewer", metadata: { kind: "viewer" } });
       expect("bytes" in entries[0]!).toBe(false);
+    });
+  });
+
+  it("atomically mutates one blob and rolls back callback failures", async () => {
+    await withOpenClawTestState({ label: "plugin-blob-mutate" }, async (state) => {
+      const store = createPluginBlobStore<{ owners: number }>("diffs", options(state.env));
+      await Promise.all(
+        Array.from({ length: 20 }, () =>
+          store.mutate("shared", (current) => ({
+            kind: "set",
+            bytes: current?.bytes ?? new Uint8Array([1, 2, 3]),
+            metadata: { owners: (current?.metadata.owners ?? 0) + 1 },
+          })),
+        ),
+      );
+      await expect(store.lookup("shared")).resolves.toMatchObject({
+        metadata: { owners: 20 },
+        bytes: new Uint8Array([1, 2, 3]),
+      });
+
+      await expect(
+        store.mutate("shared", () => {
+          throw new Error("stop mutation");
+        }),
+      ).rejects.toMatchObject({
+        code: "PLUGIN_BLOB_WRITE_FAILED",
+        operation: "mutate",
+        cause: expect.objectContaining({ message: "stop mutation" }),
+      });
+      await expect(store.lookup("shared")).resolves.toMatchObject({ metadata: { owners: 20 } });
+      await expect(
+        store.mutate("shared", () => ({
+          kind: "set",
+          bytes: new Uint8Array(17),
+          metadata: { owners: 21 },
+        })),
+      ).rejects.toMatchObject({
+        code: "PLUGIN_BLOB_LIMIT_EXCEEDED",
+        operation: "mutate",
+      });
+      await expect(store.lookup("shared")).resolves.toMatchObject({ metadata: { owners: 20 } });
+      await expect(store.mutate("shared", () => ({ kind: "delete" }))).resolves.toBe(true);
+      await expect(store.lookup("shared")).resolves.toBeUndefined();
+    });
+  });
+
+  it("labels namespace and plugin quota failures as mutate operations", async () => {
+    await withOpenClawTestState({ label: "plugin-blob-mutate-quota" }, async (state) => {
+      const rowStore = createPluginBlobStore<{ order: number }>(
+        "diffs",
+        options(state.env, {
+          namespace: "mutate-row-limit",
+          maxEntries: 1,
+          maxBytesPerEntry: 4,
+          maxBytesPerNamespace: 4,
+          overflowPolicy: "reject-new",
+        }),
+      );
+      await rowStore.register("one", new Uint8Array([1]), { order: 1 });
+      await expect(
+        rowStore.mutate("two", () => ({
+          kind: "set",
+          bytes: new Uint8Array([2]),
+          metadata: { order: 2 },
+        })),
+      ).rejects.toMatchObject({
+        code: "PLUGIN_BLOB_LIMIT_EXCEEDED",
+        operation: "mutate",
+        message: expect.stringContaining("stored row limit"),
+      });
+
+      const byteStore = createPluginBlobStore<{ order: number }>(
+        "diffs",
+        options(state.env, {
+          namespace: "mutate-byte-limit",
+          maxEntries: 2,
+          maxBytesPerEntry: 4,
+          maxBytesPerNamespace: 4,
+          overflowPolicy: "reject-new",
+        }),
+      );
+      await byteStore.register("one", new Uint8Array([1, 1]), { order: 1 });
+      await expect(
+        byteStore.mutate("two", () => ({
+          kind: "set",
+          bytes: new Uint8Array([2, 2, 2]),
+          metadata: { order: 2 },
+        })),
+      ).rejects.toMatchObject({
+        code: "PLUGIN_BLOB_LIMIT_EXCEEDED",
+        operation: "mutate",
+        message: expect.stringContaining("stored byte limit"),
+      });
+
+      const pluginCapStore = createPluginBlobStore<{ order: number }>(
+        "plugin-cap",
+        options(state.env, {
+          namespace: "mutate-plugin-limit",
+          overflowPolicy: "reject-new",
+        }),
+      );
+      const { db } = openOpenClawStateDatabase({ env: state.env });
+      db.exec(`
+        WITH RECURSIVE counter(value) AS (
+          VALUES (1)
+          UNION ALL
+          SELECT value + 1 FROM counter WHERE value < ${MAX_PLUGIN_BLOB_ENTRIES_PER_PLUGIN}
+        )
+        INSERT INTO plugin_blob_entries
+          (plugin_id, namespace, entry_key, metadata_json, blob, created_at, expires_at)
+        SELECT 'plugin-cap', 'fixture', printf('row-%05d', value), '{}', zeroblob(0), 1, NULL
+        FROM counter
+      `);
+      await expect(
+        pluginCapStore.mutate("overflow", () => ({
+          kind: "set",
+          bytes: new Uint8Array(),
+          metadata: { order: 1 },
+        })),
+      ).rejects.toMatchObject({
+        code: "PLUGIN_BLOB_LIMIT_EXCEEDED",
+        operation: "mutate",
+        message: expect.stringContaining("per-plugin row limit"),
+      });
     });
   });
 
@@ -287,6 +412,33 @@ describe("plugin blob store", () => {
     });
   });
 
+  it("lets explicit mutate replace an expired key while exposing no live current entry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(4_750);
+    await withOpenClawTestState({ label: "plugin-blob-expired-mutate" }, async (state) => {
+      const store = createPluginBlobStore<{ version: string }>("diffs", options(state.env));
+      await store.register("stable", new Uint8Array([1]), { version: "old" }, { ttlMs: 10 });
+
+      vi.setSystemTime(4_761);
+      await expect(
+        store.mutate("stable", (current) => {
+          expect(current).toBeUndefined();
+          return {
+            kind: "set",
+            bytes: new Uint8Array([2]),
+            metadata: { version: "new" },
+          };
+        }),
+      ).resolves.toBe(true);
+
+      await expect(store.lookup("stable")).resolves.toMatchObject({
+        metadata: { version: "new" },
+        bytes: new Uint8Array([2]),
+      });
+      await expect(store.deleteExpiredKey("stable")).resolves.toBeUndefined();
+    });
+  });
+
   it("evicts by namespace bytes without touching sibling namespaces", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(3_000);
@@ -342,6 +494,15 @@ describe("plugin blob store", () => {
       ).run("diffs", "artifacts", "corrupt", "{", Buffer.from([7]), 1, null);
       await expect(store.lookup("corrupt")).rejects.toMatchObject({
         code: "PLUGIN_BLOB_CORRUPT",
+        operation: "lookup",
+      });
+      await expect(
+        store.mutate("corrupt", () => ({
+          kind: "delete",
+        })),
+      ).rejects.toMatchObject({
+        code: "PLUGIN_BLOB_CORRUPT",
+        operation: "mutate",
       });
     });
   });

--- a/src/plugin-state/plugin-blob-store.ts
+++ b/src/plugin-state/plugin-blob-store.ts
@@ -12,6 +12,7 @@ import {
   pluginBlobDeleteExpired,
   pluginBlobEntries,
   pluginBlobLookup,
+  pluginBlobMutate,
   pluginBlobRegister,
   pluginBlobRegisterIfAbsent,
   type PluginBlobStoredEntry,
@@ -68,16 +69,19 @@ function invalidInput(
   });
 }
 
-function limitError(message: string): PluginBlobStoreError {
+function limitError(
+  message: string,
+  operation: PluginBlobStoreOperation = "register",
+): PluginBlobStoreError {
   return new PluginBlobStoreError(message, {
     code: "PLUGIN_BLOB_LIMIT_EXCEEDED",
-    operation: "register",
+    operation,
   });
 }
 
 const validationErrors = (operation: PluginBlobStoreOperation) => ({
   invalid: (message: string) => invalidInput(message, operation),
-  limit: (message: string) => limitError(message),
+  limit: (message: string) => limitError(message, operation),
 });
 
 function validateNamespace(value: string): string {
@@ -163,22 +167,25 @@ function prepareBlob(params: {
   maxBytesPerEntry: number;
   defaultTtlMs?: number;
   opts?: { ttlMs?: number };
+  operation?: "register" | "mutate";
 }): PreparedBlob {
-  const key = validateKey(params.key, "register");
+  const operation = params.operation ?? "register";
+  const key = validateKey(params.key, operation);
   if (!(params.bytes instanceof Uint8Array)) {
-    throw invalidInput("plugin blob bytes must be a Uint8Array");
+    throw invalidInput("plugin blob bytes must be a Uint8Array", operation);
   }
   if (params.bytes.byteLength > params.maxBytesPerEntry) {
     throw limitError(
       `plugin blob entry exceeds the configured ${params.maxBytesPerEntry} byte limit`,
+      operation,
     );
   }
   const metadataJson = serializePluginStoreJson({
     value: params.metadata,
     label: "plugin blob metadata",
-    errors: validationErrors("register"),
+    errors: validationErrors(operation),
   });
-  const ttlMs = validateTtl(params.opts?.ttlMs, "register") ?? params.defaultTtlMs;
+  const ttlMs = validateTtl(params.opts?.ttlMs, operation) ?? params.defaultTtlMs;
   return {
     key,
     bytes: Uint8Array.from(params.bytes),
@@ -221,10 +228,11 @@ function storedInfoToEntryInfo<TMetadata>(
 
 function storedEntryToEntry<TMetadata>(
   row: PluginBlobStoredEntry,
+  operation: "lookup" | "mutate",
   env?: NodeJS.ProcessEnv,
 ): PluginBlobEntry<TMetadata> {
   return {
-    ...storedInfoToEntryInfo<TMetadata>(row, "lookup", env),
+    ...storedInfoToEntryInfo<TMetadata>(row, operation, env),
     bytes: Uint8Array.from(row.blob),
   };
 }
@@ -267,6 +275,7 @@ function createPluginBlobStoreInternal<TMetadata>(
   });
 
   const writeParams = (blob: PreparedBlob) => ({
+    operation: "register" as const,
     pluginId,
     namespace,
     key: blob.key,
@@ -302,6 +311,41 @@ function createPluginBlobStoreInternal<TMetadata>(
       });
       return pluginBlobRegisterIfAbsent(writeParams(blob));
     },
+    async mutate(key, update) {
+      const normalizedKey = validateKey(key, "mutate");
+      return pluginBlobMutate({
+        operation: "mutate",
+        pluginId,
+        namespace,
+        key: normalizedKey,
+        maxEntries,
+        maxBytesPerNamespace,
+        overflowPolicy,
+        mutate: (row) => {
+          const current = row ? storedEntryToEntry<TMetadata>(row, "mutate", env) : undefined;
+          const next = update(current);
+          if (!next || next.kind === "delete") {
+            return next;
+          }
+          const blob = prepareBlob({
+            key: normalizedKey,
+            bytes: next.bytes,
+            metadata: next.metadata,
+            maxBytesPerEntry,
+            defaultTtlMs,
+            opts: next.ttlMs === undefined ? undefined : { ttlMs: next.ttlMs },
+            operation: "mutate",
+          });
+          return {
+            kind: "set",
+            bytes: blob.bytes,
+            metadataJson: blob.metadataJson,
+            ...(blob.ttlMs !== undefined ? { ttlMs: blob.ttlMs } : {}),
+          };
+        },
+        ...(env ? { env } : {}),
+      });
+    },
     async lookup(key) {
       const row = pluginBlobLookup({
         pluginId,
@@ -309,7 +353,7 @@ function createPluginBlobStoreInternal<TMetadata>(
         key: validateKey(key, "lookup"),
         ...(env ? { env } : {}),
       });
-      return row ? storedEntryToEntry<TMetadata>(row, env) : undefined;
+      return row ? storedEntryToEntry<TMetadata>(row, "lookup", env) : undefined;
     },
     async entries() {
       return pluginBlobEntries({ pluginId, namespace, ...(env ? { env } : {}) }).map((row) =>
@@ -358,6 +402,15 @@ export function createPluginBlobStore<TMetadata>(
   options: OpenBlobStoreOptions,
 ): PluginBlobStore<TMetadata> {
   return createPluginBlobStoreInternal<TMetadata>(pluginId, options);
+}
+
+/** Host-only factory used by doctor migrations with an explicit state environment. */
+export function createPluginBlobStoreForDoctor<TMetadata>(
+  pluginId: string,
+  options: OpenBlobStoreOptions,
+  env: NodeJS.ProcessEnv,
+): PluginBlobStore<TMetadata> {
+  return createPluginBlobStoreInternal<TMetadata>(pluginId, options, env);
 }
 
 /** Test-only factory with an isolated state environment. */

--- a/src/plugin-state/plugin-blob-store.types.ts
+++ b/src/plugin-state/plugin-blob-store.types.ts
@@ -24,6 +24,19 @@ export type PluginBlobStore<TMetadata> = {
     metadata: TMetadata,
     opts?: { ttlMs?: number },
   ): Promise<boolean>;
+  /**
+   * Atomically creates, replaces, or deletes one blob. The callback sees only a
+   * live entry; an explicit set/delete may replace/remove an expired stored row.
+   */
+  mutate(
+    key: string,
+    update: (
+      current: PluginBlobEntry<TMetadata> | undefined,
+    ) =>
+      | { kind: "set"; bytes: Uint8Array; metadata: TMetadata; ttlMs?: number }
+      | { kind: "delete" }
+      | undefined,
+  ): Promise<boolean>;
   lookup(key: string): Promise<PluginBlobEntry<TMetadata> | undefined>;
   entries(): Promise<PluginBlobEntryInfo<TMetadata>[]>;
   delete(key: string): Promise<boolean>;
@@ -54,6 +67,7 @@ export type PluginBlobStoreErrorCode =
 export type PluginBlobStoreOperation =
   | "open"
   | "register"
+  | "mutate"
   | "lookup"
   | "delete"
   | "entries"

--- a/src/plugins/doctor-contract-module.ts
+++ b/src/plugins/doctor-contract-module.ts
@@ -1,6 +1,10 @@
 import type { LegacyConfigRule } from "../config/legacy.shared.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type {
+  OpenBlobStoreOptions,
+  PluginBlobStore,
+} from "../plugin-state/plugin-blob-store.types.js";
+import type {
   OpenKeyedStoreOptions,
   PluginStateKeyedStore,
 } from "../plugin-state/plugin-state-store.js";
@@ -13,6 +17,8 @@ export type PluginDoctorStateMigrationDetection = {
 
 export type PluginDoctorStateMigrationContext = {
   openPluginStateKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>;
+  /** Opens the plugin's canonical blob namespace during exclusive doctor repair. */
+  openPluginBlobStore?: <TMetadata>(options: OpenBlobStoreOptions) => PluginBlobStore<TMetadata>;
   /** Doctor-only batch import preserving source age and remaining retention. */
   importPluginStateEntries?: (
     options: OpenKeyedStoreOptions,


### PR DESCRIPTION
Closes #128362

AI-assisted: yes (Codex).

## What Problem This Solves

Codex native-thread bindings froze the agent-workspace developer instructions inline in the keyed-state row. A sufficiently large `AGENTS.md` snapshot could therefore push the serialized binding above the plugin-state 65,536-byte value limit, preventing the binding from being created or resumed.

## Why

The snapshot must remain byte-stable for the lifetime of the native thread, including after the workspace file changes or disappears. Truncating it at persistence time would silently change thread behavior, and raising the generic keyed-state limit would make an unrelated infrastructure bound absorb unbounded prompt data.

This change instead:

- stores frozen instruction snapshots in the existing bounded plugin blob store under SHA-256 content references;
- keeps only the reference in the binding row and hydrates the exact bytes when reading it;
- adds an atomic blob `mutate(...)` primitive for ref-count updates;
- shares identical snapshots across bindings and deletes content after the final owner releases it;
- automatically migrates existing inline bindings before normal runtime access; and
- reconciles ref counts and orphaned blobs through the doctor migration, while avoiding destructive cleanup when the binding/blob census is incomplete or corrupt.

## User Impact

Large agent-workspace instructions no longer make Codex thread bindings exceed the keyed-state value limit. Resumed threads retain the same frozen instructions after `AGENTS.md` is edited or removed, and stale blob data is bounded and recoverable through the existing migration/doctor path.

## Evidence

- Regression coverage proves an old inline row above 65,536 bytes is rejected, while a 256+ KiB multibyte snapshot persists through a small reference-only binding row and resumes byte-for-byte.
- Two bindings sharing one snapshot produce one blob with ref count 2, then cleanly transition 2 → 1 → deleted.
- Migration/doctor tests cover inline-row conversion, corrupt metadata, digest mismatch, missing referenced content, orphan cleanup, incomplete census safety, and binding-CAS compensation.
- End-to-end Codex tests cover oversized external-workspace instructions across both file replacement and file removal.
- All 450 tests in the seven changed test files pass.
- `pnpm tsgo:core` and `pnpm tsgo:extensions` pass; changed test files also pass a targeted test-source typecheck.
- Changed files pass `oxfmt --check`, `git diff --check`, type-aware core/extension oxlint, assertion-safety, max-lines, conflict-marker, database-first, doctor-registry, runtime-sidecar, import-cycle, deprecated-API, and extension wildcard guards.
