### PR TITLE
fix(discord): refresh stale starter messages in active threads

### DIFF
--- a/extensions/discord/src/monitor/threading.cache.ts
+++ b/extensions/discord/src/monitor/threading.cache.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements threading.cache behavior.
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type { DiscordThreadStarter } from "./threading.types.js";
 
 type DiscordThreadStarterCacheEntry = {
@@ -16,12 +17,12 @@ export function getCachedThreadStarter(key: string, now: number): DiscordThreadS
   if (!entry) {
     return undefined;
   }
-  if (now - entry.updatedAt > DISCORD_THREAD_STARTER_CACHE_TTL_MS) {
+  if (now < entry.updatedAt || now - entry.updatedAt >= DISCORD_THREAD_STARTER_CACHE_TTL_MS) {
     DISCORD_THREAD_STARTER_CACHE.delete(key);
     return undefined;
   }
   DISCORD_THREAD_STARTER_CACHE.delete(key);
-  DISCORD_THREAD_STARTER_CACHE.set(key, { ...entry, updatedAt: now });
+  DISCORD_THREAD_STARTER_CACHE.set(key, entry);
   return entry.value;
 }
 
@@ -32,11 +33,5 @@ export function setCachedThreadStarter(
 ): void {
   DISCORD_THREAD_STARTER_CACHE.delete(key);
   DISCORD_THREAD_STARTER_CACHE.set(key, { value, updatedAt: now });
-  while (DISCORD_THREAD_STARTER_CACHE.size > DISCORD_THREAD_STARTER_CACHE_MAX) {
-    const iter = DISCORD_THREAD_STARTER_CACHE.keys().next();
-    if (iter.done) {
-      break;
-    }
-    DISCORD_THREAD_STARTER_CACHE.delete(iter.value);
-  }
+  pruneMapToMaxSize(DISCORD_THREAD_STARTER_CACHE, DISCORD_THREAD_STARTER_CACHE_MAX);
 }

--- a/extensions/discord/src/monitor/threading.starter.test.ts
+++ b/extensions/discord/src/monitor/threading.starter.test.ts
@@ -2,6 +2,7 @@
 import { StickerFormatType } from "discord-api-types/v10";
 import { describe, expect, it, vi } from "vitest";
 import { ChannelType, type Client } from "../internal/discord.js";
+import { getCachedThreadStarter, setCachedThreadStarter } from "./threading.cache.js";
 import { resolveDiscordThreadStarter } from "./threading.js";
 
 type ResolvedThreadStarter = NonNullable<Awaited<ReturnType<typeof resolveDiscordThreadStarter>>>;
@@ -107,6 +108,69 @@ async function resolveStarter(params: {
 }
 
 describe("resolveDiscordThreadStarter", () => {
+  it("refreshes edited starter content in threads that stay active for a full day", async () => {
+    vi.useFakeTimers();
+    try {
+      const startedAt = new Date("2026-08-23T00:00:00.000Z");
+      vi.setSystemTime(startedAt);
+      let content = "Original assignment";
+      const get = vi.fn(async () => createStarterMessage({ content }));
+      const client = { rest: { get } } as unknown as Client;
+      const params = {
+        channel: { id: `active-thread-${++threadIdIndex}` },
+        client,
+        parentId: "parent-1",
+        parentType: ChannelType.GuildText,
+        resolveTimestampMs: () => undefined,
+      };
+
+      expect(requireThreadStarter(await resolveDiscordThreadStarter(params)).text).toBe(
+        "Original assignment",
+      );
+      content = "Updated assignment";
+
+      for (let minute = 4; minute <= 24 * 60; minute += 4) {
+        vi.setSystemTime(startedAt.getTime() + minute * 60_000);
+        await resolveDiscordThreadStarter(params);
+      }
+
+      expect(requireThreadStarter(await resolveDiscordThreadStarter(params)).text).toBe(
+        "Updated assignment",
+      );
+      expect(get.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { name: "the exact five-minute freshness boundary", now: 1_300_000 },
+    { name: "a clock rollback before the starter was fetched", now: 999_999 },
+  ])("invalidates cached thread starters at $name", ({ now }) => {
+    const key = `expired-thread-${++threadIdIndex}`;
+    setCachedThreadStarter(key, { text: "stale", author: "Alice" }, 1_000_000);
+
+    expect(getCachedThreadStarter(key, now)).toBeUndefined();
+  });
+
+  it("retains recently used thread starters when the 500-entry cache reaches capacity", () => {
+    const prefix = `lru-thread-${++threadIdIndex}-`;
+    for (let index = 0; index < 500; index += 1) {
+      setCachedThreadStarter(
+        `${prefix}${index}`,
+        { text: `starter-${index}`, author: "Alice" },
+        1_000_000,
+      );
+    }
+
+    expect(getCachedThreadStarter(`${prefix}0`, 1_000_001)?.text).toBe("starter-0");
+    setCachedThreadStarter(`${prefix}500`, { text: "new starter", author: "Alice" }, 1_000_002);
+
+    expect(getCachedThreadStarter(`${prefix}0`, 1_000_003)?.text).toBe("starter-0");
+    expect(getCachedThreadStarter(`${prefix}1`, 1_000_003)).toBeUndefined();
+    expect(getCachedThreadStarter(`${prefix}500`, 1_000_003)?.text).toBe("new starter");
+  });
+
   it("falls back to joined embed title and description when content is empty", async () => {
     const { result } = await resolveStarter({
       message: createStarterMessage({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users continuing an active Discord thread would keep receiving answers based on obsolete thread-starter instructions indefinitely after the original message was edited. A thread accessed every four minutes retained its original starter for 24 hours despite the advertised five-minute cache lifetime.

## Why This Change Was Made

Discord's thread-starter cache now preserves the original fetch timestamp when promoting an entry for LRU eviction, expires entries at the exact five-minute boundary, and invalidates future-dated entries after a clock rollback. Its existing 500-entry limit now uses the same bounded-map helper already used by Discord's channel-information cache and Slack's thread resolver, removing duplicate eviction policy.

## User Impact

Active Discord threads pick up corrected starter messages within the existing five-minute freshness window, while recently used threads retain their existing LRU protection. No public configuration, plugin API, authentication, authorization, or persistence behavior changes.

## Evidence

- Before the fix, the new owner-boundary regressions produced three genuine failures: an edited starter stayed stale after 24 simulated hours of activity, an entry remained valid at exactly five minutes, and a future-dated entry survived clock rollback.
- After the fix, all 78 tests across five Discord thread-starter, parent-resolution, auto-threading, threading-utility, and room-event suites pass, including the existing 500-entry LRU eviction guarantee.
- An independent reviewer separately passed all 16 focused owner tests; fresh authenticated review of the complete committed branch found no actionable issues.
- Focused typed lint, formatting, and whitespace validation pass. Unrelated pre-existing ACPX shared-dependency type diagnostics were independently confirmed outside the touched Discord files.
- Production delta: 4 lines added, 9 removed; net minus 5 lines.
- Reviewed head: a434b9c5bf52709cc7adc0bdc1292c4753e969cb.
