### PR TITLE
fix(cli): report container launch failures instead of exit 1

### DIFF
--- a/src/cli/container-target.test.ts
+++ b/src/cli/container-target.test.ts
@@ -22,6 +22,7 @@ type SpawnResult = {
   status: number | null;
   stdout?: string;
   signal?: NodeJS.Signals;
+  error?: Error;
 };
 type SpawnMock = ReturnType<typeof vi.fn> & typeof nodeSpawnSync;
 
@@ -198,12 +199,12 @@ describe("maybeRunCliInContainer", () => {
   });
 
   it.each([
-    { signal: "SIGINT" as const, exitCode: 130 },
-    { signal: "SIGTERM" as const, exitCode: 143 },
-  ])("preserves exit code $exitCode when the container child exits from $signal", (testCase) => {
+    { result: { status: 7 }, exitCode: 7, outcome: "status 7" },
+    { result: { status: null, signal: "SIGINT" as const }, exitCode: 130, outcome: "SIGINT" },
+    { result: { status: null, signal: "SIGTERM" as const }, exitCode: 143, outcome: "SIGTERM" },
+  ])("preserves exit code $exitCode when the container child returns $outcome", (testCase) => {
     const spawnSync = mockSpawn(runningContainer, missingContainer, {
-      status: null,
-      signal: testCase.signal,
+      ...testCase.result,
     });
 
     expect(
@@ -216,6 +217,29 @@ describe("maybeRunCliInContainer", () => {
       exitCode: testCase.exitCode,
     });
   });
+
+  it.each(["ENOENT", "EACCES"])(
+    "throws the original %s launch error from the container exec",
+    (code) => {
+      const launchError = Object.assign(new Error(`spawnSync podman ${code}`), { code });
+      const spawnSync = mockSpawn(runningContainer, missingContainer, {
+        status: null,
+        error: launchError,
+      });
+
+      let thrown: unknown;
+      try {
+        maybeRunCliInContainer(["node", "openclaw", "status"], {
+          env: { OPENCLAW_CONTAINER: "demo" } as NodeJS.ProcessEnv,
+          spawnSync,
+        });
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBe(launchError);
+    },
+  );
 
   it("uses OPENCLAW_CONTAINER when the flag is absent", () => {
     const spawnSync = mockSpawn(runningContainer, missingContainer, successfulExec);

--- a/src/cli/container-target.ts
+++ b/src/cli/container-target.ts
@@ -320,6 +320,9 @@ export function maybeRunCliInContainer(
       env: buildContainerExecEnv(resolvedDeps.env),
     },
   );
+  if (result.error) {
+    throw result.error;
+  }
   return {
     handled: true,
     exitCode: resolveSubprocessExitCode(result.status, result.signal),


### PR DESCRIPTION
Closes #127477.

## What Problem This Solves

Fixes an issue where container-target commands returned only exit code 1 when the selected Docker or Podman executable became unavailable or unlaunchable between inspection and execution.

## Why This Change Was Made

The final runtime launch now surfaces its original synchronous error before the existing status and signal conversion. Runtime probes and normal child exit handling remain unchanged.

AI-assisted: yes.

## User Impact

Operators can now distinguish a runtime launch failure such as ENOENT or EACCES from a command inside the container exiting with status 1.

## Evidence

- The focused container-target suite passes all 37 cases, including preserved status, SIGINT, and SIGTERM handling.
- The exact-head changed-file gate and fresh autoreview pass.

Real behavior proof on exact head `66f8832f764334977038d824def3032b85d058fb` (macOS): a PATH-level Podman fixture returns `true` from `inspect`, removes its own execute permission, and leaves the final real OS launch to fail with EACCES. The pre-fix path exited 1 with no output; the patched built CLI produced:

```console
$ PATH="<proof-shim>:$PATH" node openclaw.mjs --container proof status
[openclaw] Could not start the CLI.
[openclaw] Reason: spawnSync podman EACCES
[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
[openclaw] Try: openclaw doctor
[openclaw] Help: openclaw --help
$ echo $?
1
```
