### PR TITLE
improve(markdown): skip impossible table parses

### DIFF
--- a/packages/markdown-core/src/tables.test.ts
+++ b/packages/markdown-core/src/tables.test.ts
@@ -1,11 +1,30 @@
 // Markdown Core tests cover tables behavior.
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { convertMarkdownTables } from "./tables.js";
 
+const markdownToIRWithMetaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./ir.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./ir.js")>();
+  markdownToIRWithMetaMock.mockImplementation(actual.markdownToIRWithMeta);
+  return { ...actual, markdownToIRWithMeta: markdownToIRWithMetaMock };
+});
+
 describe("convertMarkdownTables", () => {
+  beforeEach(() => {
+    markdownToIRWithMetaMock.mockClear();
+  });
+
   it("falls back to code rendering for block mode", () => {
     const rendered = convertMarkdownTables("| A | B |\n|---|---|\n| 1 | 2 |", "block");
 
     expect(rendered).toBe("```\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```");
+  });
+
+  it("does not parse ordinary text that cannot contain a table", () => {
+    const text = "Ordinary iMessage reply with **bold** and _emphasis_.";
+
+    expect(convertMarkdownTables(text, "code")).toBe(text);
+    expect(markdownToIRWithMetaMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/markdown-core/src/tables.ts
+++ b/packages/markdown-core/src/tables.ts
@@ -13,7 +13,7 @@ const MARKDOWN_STYLE_MARKERS = {
 
 /** Converts markdown tables into the configured plaintext/code rendering mode. */
 export function convertMarkdownTables(markdown: string, mode: MarkdownTableMode): string {
-  if (!markdown || mode === "off") {
+  if (!markdown || mode === "off" || !markdown.includes("|")) {
     return markdown;
   }
   const effectiveMode = mode === "block" ? "code" : mode;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ordinary outbound text with no table syntax still paid for the full Markdown IR/table parser whenever table conversion was enabled. This made routine iMessage replies perform expensive work that could not affect their output.

## Why This Change Was Made

The canonical table converter now rejects text with no `|` before parsing. Markdown-it 14.3.0's installed table rule requires a pipe in the header before accepting a table, so every possible table retains the unchanged parser/render path. No cache, channel-specific special case, or public/config/protocol/security/storage behavior is added.

## User Impact

Ordinary outbound messages without pipes avoid one full Markdown parse while table candidates behave exactly as before. A frozen controlled 4,000-byte benchmark measured a reduction from 1,105.853 to 0.158 microseconds per call (99.9857%); the current candidate measured 0.072 microseconds per call.

## Evidence

- Exact current-main regression: the focused owner test failed because ordinary no-pipe text entered `markdownToIRWithMeta` once; candidate passes with zero parser entries.
- Dependency contract: installed `markdown-it` 14.3.0 table rule returns false when its header line contains no `|`.
- Semantic differential: 9 representative inputs × 4 modes (36 outputs) are byte-identical; baseline and candidate SHA-256 are both `afcc6c9af24435dd6815bc31618d25504661b4bb705129662f59325e3d234514`.
- Full Markdown Core: 23 files, 235 tests passed.
- Full iMessage plugin: 51 files, 1,134 tests passed.
- `core, coreTests` changed gate passed in an isolated normal checkout with an offline frozen install, including production/test typechecks, formatting, type-aware Oxlint (0 findings), dead-code, boundaries, guards, and import cycles. The initial linked-worktree attempt exposed the canonical checkout's stale Pako v1 through its shared `node_modules`; no changed-source failure was implicated.
- Current changed-file classification does not require a build lane; the frozen candidate's classified full build also passed.
- `git diff --check`: passed.
- Structured autoreview: TruffleHog clean; Codex `gpt-5.6-sol` / high clean, patch correct at 0.99 confidence.
