### PR TITLE
fix(release): reuse canonical job log reader

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -527,6 +527,8 @@ jobs:
             --jq .content | base64 --decode > "${tooling_dir}/validate-full-release-validation-evidence.mjs"
           gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/release-ci-summary.mjs?ref=${WORKFLOW_SHA}" \
             --jq .content | base64 --decode > "${tooling_dir}/release-ci-summary.mjs"
+          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/full-release-validation-policy.mjs?ref=${WORKFLOW_SHA}" \
+            --jq .content | base64 --decode > "${tooling_dir}/full-release-validation-policy.mjs"
           gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/lib/plain-gh.mjs?ref=${WORKFLOW_SHA}" \
             --jq .content | base64 --decode > "${tooling_dir}/lib/plain-gh.mjs"
           gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/plugin-sdk-api-release-evidence.mjs?ref=${WORKFLOW_SHA}" \

--- a/scripts/validate-authorized-beta-focused-evidence.d.mts
+++ b/scripts/validate-authorized-beta-focused-evidence.d.mts
@@ -114,6 +114,10 @@ export declare function assertAuthorizedEligibilityPlanDigest(
   plan: unknown,
   expectedDigest: string,
 ): Promise<string>;
+export declare function assertAuthorizedBetaFocusedJobLogTarget(
+  jobId: string,
+  targetSha: string,
+): Promise<void>;
 export declare function assertAuthorizedHistoricalExecutionPlanChildren(
   children: unknown[],
   expectedSelectedRuns: ReadonlyMap<string, string>,

--- a/scripts/validate-authorized-beta-focused-evidence.mts
+++ b/scripts/validate-authorized-beta-focused-evidence.mts
@@ -301,8 +301,12 @@ function requireJob(params: {
   }
 }
 
-function requireJobLogTarget(jobId: string, targetSha: string) {
-  const log = gh(["api", `repos/${REPOSITORY}/actions/jobs/${jobId}/logs`]);
+export async function assertAuthorizedBetaFocusedJobLogTarget(
+  jobId: string,
+  targetSha: string,
+): Promise<void> {
+  const { createReleaseEvidenceClient } = await import("./release-ci-summary.mjs");
+  const log = createReleaseEvidenceClient(REPOSITORY).getJobLog(jobId);
   if (!log.includes(targetSha)) {
     fail(`job ${jobId} log does not bind target ${targetSha}`);
   }
@@ -508,7 +512,7 @@ export function assertAuthorizedBetaFocusedCandidate(
   }
 }
 
-function assertHistoricalAndFocusedEvidence(policy: AuthorizedBetaFocusedPolicy) {
+async function assertHistoricalAndFocusedEvidence(policy: AuthorizedBetaFocusedPolicy) {
   const historical = policy.historicalFrv;
   requireHistoricalExecutionPlan(policy);
   requireRun({
@@ -622,7 +626,7 @@ function assertHistoricalAndFocusedEvidence(policy: AuthorizedBetaFocusedPolicy)
     conclusion: "success",
     headSha: policy.historicalToolingSha,
   });
-  requireJobLogTarget(focused.ciTargetLogJobId, policy.reviewedHeadSha);
+  await assertAuthorizedBetaFocusedJobLogTarget(focused.ciTargetLogJobId, policy.reviewedHeadSha);
   requireRun({
     runId: focused.pluginRunId,
     attempt: 1,
@@ -646,7 +650,10 @@ function assertHistoricalAndFocusedEvidence(policy: AuthorizedBetaFocusedPolicy)
     conclusion: "success",
     headSha: policy.historicalToolingSha,
   });
-  requireJobLogTarget(focused.pluginTargetLogJobId, policy.reviewedHeadSha);
+  await assertAuthorizedBetaFocusedJobLogTarget(
+    focused.pluginTargetLogJobId,
+    policy.reviewedHeadSha,
+  );
 }
 
 function producerIdentity(args: ParsedArgs): AuthorizedBetaFocusedProducerIdentity {
@@ -855,7 +862,7 @@ async function main() {
   const producer = producerIdentity(args);
   assertAuthorizedBetaFocusedCandidate(policy, candidateRoot);
   assertProducer(producer, command === "create");
-  assertHistoricalAndFocusedEvidence(policy);
+  await assertHistoricalAndFocusedEvidence(policy);
 
   if (command === "create") {
     const inventory = await collectInventory(policy, candidateRoot, true);

--- a/test/scripts/authorized-beta-focused-evidence.test.ts
+++ b/test/scripts/authorized-beta-focused-evidence.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
@@ -44,7 +44,10 @@ type ParsedWorkflow = {
 const REPO_ROOT = resolve(".");
 const VALIDATOR_CLOSURE = [
   "scripts/authorized-beta-focused-policy.json",
+  "scripts/full-release-validation-policy.mjs",
   "scripts/lib/record-shared.mjs",
+  "scripts/lib/plain-gh.mjs",
+  "scripts/release-ci-summary.mjs",
   "scripts/validate-authorized-beta-focused-evidence.mts",
 ] as const;
 
@@ -57,6 +60,57 @@ function stageValidatorClosure(root: string, scriptsDirectory: boolean): string 
     copyFileSync(join(REPO_ROOT, sourcePath), targetPath);
   }
   return join(targetRoot, "validate-authorized-beta-focused-evidence.mts");
+}
+
+function writeGhShim(root: string, body: string): { callsPath: string; ghPath: string } {
+  const callsPath = join(root, "gh-calls.jsonl");
+  const ghPath = join(root, "gh");
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+import { appendFileSync } from "node:fs";
+const args = process.argv.slice(2);
+appendFileSync(process.env.GH_CALLS_PATH, JSON.stringify(args) + "\\n");
+${body}
+`,
+  );
+  chmodSync(ghPath, 0o755);
+  return { callsPath, ghPath };
+}
+
+function runStagedJobLogProbe(body: string, targetSha = "a".repeat(40)) {
+  const root = tempDirs.make("authorized-beta-focused-job-log-");
+  const validatorPath = stageValidatorClosure(root, false);
+  const { callsPath } = writeGhShim(root, body);
+  const probePath = join(root, "probe.mjs");
+  writeFileSync(
+    probePath,
+    [
+      `import { assertAuthorizedBetaFocusedJobLogTarget } from ${JSON.stringify(pathToFileURL(validatorPath).href)};`,
+      `try {`,
+      `  await assertAuthorizedBetaFocusedJobLogTarget("123", ${JSON.stringify(targetSha)});`,
+      `  process.stdout.write("verified");`,
+      `} catch (error) {`,
+      `  process.stderr.write(error instanceof Error ? error.message : String(error));`,
+      `  process.exitCode = 17;`,
+      `}`,
+    ].join("\n"),
+  );
+  const result = spawnSync(process.execPath, [probePath], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GH_CALLS_PATH: callsPath,
+      PATH: `${root}:${process.env.PATH ?? ""}`,
+    },
+  });
+  const calls = readFileSync(callsPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as string[]);
+  return { calls, result };
 }
 
 function namedStep(workflow: ParsedWorkflow, jobName: string, stepName: string) {
@@ -196,26 +250,63 @@ describe("authorized beta focused evidence", () => {
   ])("executes the $name module closure", ({ scriptsDirectory }) => {
     const root = tempDirs.make("authorized-beta-focused-stage-");
     const validatorPath = stageValidatorClosure(root, scriptsDirectory);
+    const targetSha = "a".repeat(40);
+    const { callsPath } = writeGhShim(
+      root,
+      `process.stdout.write("\\u001b[36mtarget ${targetSha}\\u001b[0m");`,
+    );
     const probePath = join(root, "probe.mjs");
     writeFileSync(
       probePath,
       [
-        `import { digestAuthorizedBetaFocusedPolicy, readAuthorizedBetaFocusedPolicy, validateAuthorizedBetaFocusedArtifactShape } from ${JSON.stringify(pathToFileURL(validatorPath).href)};`,
+        `import { assertAuthorizedBetaFocusedJobLogTarget, digestAuthorizedBetaFocusedPolicy, readAuthorizedBetaFocusedPolicy, validateAuthorizedBetaFocusedArtifactShape } from ${JSON.stringify(pathToFileURL(validatorPath).href)};`,
         `const policy = readAuthorizedBetaFocusedPolicy();`,
         `const producer = { repository: "openclaw/openclaw", runId: "123", runAttempt: 1, workflowPath: ".github/workflows/authorized-beta-focused-validation.yml", workflowFullRef: "refs/tags/release-publish/aaaaaaaaaaaa-1", workflowRef: "release-publish/aaaaaaaaaaaa-1", workflowSha: "a".repeat(40) };`,
         `const inventory = { eligibilityPlanDigest: policy.eligibilityPlanDigest, ...policy.inventory };`,
         `const evidence = { schema: "openclaw.authorized-beta-focused-evidence.v1", mode: policy.mode, policySha256: digestAuthorizedBetaFocusedPolicy(policy), releaseTag: policy.releaseTag, candidate: { sha: policy.candidateSha, parentSha: policy.baseCandidateSha, treeSha: policy.candidateTreeSha, packageProjectionSha256: policy.packageProjectionSha256, changedPaths: policy.changedPaths }, producer, historical: { frvRunId: policy.historicalFrv.runId, frvRunAttempt: policy.historicalFrv.runAttempt, releaseChecksRunId: policy.historicalFrv.releaseChecksRunId, performanceRunId: policy.historicalFrv.performanceRunId }, focused: { ciRunId: policy.focusedProof.ciRunId, ciJobId: policy.focusedProof.ciSuccessJobId, pluginRunId: policy.focusedProof.pluginRunId, pluginJobId: policy.focusedProof.pluginSuccessJobId, reviewedHeadSha: policy.reviewedHeadSha }, inventory };`,
         `validateAuthorizedBetaFocusedArtifactShape(evidence, policy, producer, inventory);`,
+        `await assertAuthorizedBetaFocusedJobLogTarget("123", ${JSON.stringify(targetSha)});`,
         `process.stdout.write("verified");`,
       ].join("\n"),
     );
     const result = spawnSync(process.execPath, [probePath], {
       cwd: root,
       encoding: "utf8",
+      env: {
+        ...process.env,
+        GH_CALLS_PATH: callsPath,
+        PATH: `${root}:${process.env.PATH ?? ""}`,
+      },
     });
     expect(result.stderr).toBe("");
     expect(result.status).toBe(0);
     expect(result.stdout).toBe("verified");
+    expect(readFileSync(callsPath, "utf8").trim()).toBe(
+      JSON.stringify([
+        "api",
+        "repos/openclaw/openclaw/actions/jobs/123/logs",
+        "--allow-escape-sequences",
+      ]),
+    );
+  });
+
+  it("rejects a focused job log that does not contain the reviewed SHA", () => {
+    const { calls, result } = runStagedJobLogProbe(
+      'process.stdout.write("\\u001b[31mother\\u001b[0m");',
+    );
+    expect(result.status).toBe(17);
+    expect(result.stderr).toContain("job 123 log does not bind target");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("propagates focused job log helper errors without masking them", () => {
+    const { calls, result } = runStagedJobLogProbe(
+      'process.stderr.write("job log unavailable\\n"); process.exit(23);',
+    );
+    expect(result.status).toBe(17);
+    expect(result.stderr).toContain("Command failed");
+    expect(result.stderr).toContain("job log unavailable");
+    expect(calls).toHaveLength(1);
   });
 
   it("accepts the exact artifact shape and rejects inventory drift", () => {
@@ -371,6 +462,9 @@ describe("authorized beta focused evidence", () => {
     expect(validatorSource).toContain("policy.historicalToolingRef");
     expect(validatorSource).toContain("assertAuthorizedEligibilityPlanDigest(");
     expect(validatorSource).toContain('await import("./release-plan-contract.mjs")');
+    expect(validatorSource).toContain('await import("./release-ci-summary.mjs")');
+    expect(validatorSource).toContain("createReleaseEvidenceClient(REPOSITORY).getJobLog(jobId)");
+    expect(validatorSource).not.toContain("`repos/${REPOSITORY}/actions/jobs/${jobId}/logs`");
     const trustBranch = validatorSource.indexOf("if (includeTrust)");
     const pluginImport = validatorSource.indexOf('await import("./lib/plugin-clawhub-release.ts")');
     expect(trustBranch).toBeGreaterThan(-1);

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -6455,6 +6455,12 @@ describe("package artifact reuse", () => {
       "full-release-validation-${{ inputs.full_release_validation_run_id }}-${{ steps.full_run.outputs.attempt }}",
     );
     expect(trustedTooling.env?.WORKFLOW_SHA).toBe("${{ github.sha }}");
+    expectTextToIncludeAll(trustedTooling.run, [
+      "scripts/release-ci-summary.mjs",
+      "scripts/full-release-validation-policy.mjs",
+      "scripts/lib/plain-gh.mjs",
+      "scripts/validate-authorized-beta-focused-evidence.mts",
+    ]);
     expect(validateManifest.env).toMatchObject({
       RUN_JSON_FILE: "${{ runner.temp }}/full-release-validation-run.json",
       TRUSTED_WORKFLOW_FULL_REF: "${{ github.ref }}",


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/actions/runs/32673326077

## What Problem This Solves

Resolves a beta.3 focused-evidence failure where ANSI-bearing GitHub Actions job logs were rejected before the validator could confirm the reviewed candidate SHA.

## Why This Change Was Made

The focused validator now delegates job-log reads to the existing `createReleaseEvidenceClient(...).getJobLog(...)` owner, which already handles current and legacy GitHub CLI escape-sequence behavior. The release publisher downloads that helper's complete thin import closure. No candidate, policy, inventory, FRV, or `release-ci-summary.mjs` behavior changes.

## User Impact

Release operators can produce and verify the authorized beta.3 focused evidence without raw job-log compatibility failures.

## Evidence

- Hosted failure reproduced: run `32673326077`, job `97277390200`
- Focused validator tests: 10/10 green
- Canonical job-log compatibility tests: 3/3 green
- Publisher closure assertion: 1/1 green
- `actionlint .github/workflows/openclaw-release-publish.yml`: green
- Targeted oxlint for all touched script/test files: green
- Scoped changed gate: conflict/format/guards/erasability and both typechecks green; stopped only on the unrelated pre-existing `preserve-caught-error` finding in `scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs:136`
- `git diff --check`: green

## Exact Lineage

- Base: `a13760c685439aac1a119bf87eab6d63509acd60`
- Head: `cc41f1b5ec7f8eae4492c39e033850fc6b350b9f`
- Tree: `2a14642f9bdb01468cd225da2617ff4873b67ce8`

- [x] AI-assisted
