### PR TITLE
test(nodes): pin trusted session identity against spoofed invoke params

### DIFF
--- a/src/node-host/invoke.test.ts
+++ b/src/node-host/invoke.test.ts
@@ -212,7 +212,9 @@ describe("node host invoke", () => {
       | NonNullable<OpenClawPluginNodeHostCommandContext["acquireManagedWorkspace"]>
       | undefined;
     const handle = vi.fn<OpenClawPluginNodeHostCommand["handle"]>(
-      async (_paramsJSON, _io, context) => {
+      async (paramsJSON, _io, context) => {
+        expect(JSON.parse(paramsJSON ?? "{}")).toEqual({ sessionKey: "agent:main:other" });
+        expect(context?.sessionKey).toBe(workspaceRequest.sessionKey);
         const acquire = context?.acquireManagedWorkspace;
         if (!acquire) {
           throw new Error("managed workspace authority missing");
@@ -245,7 +247,7 @@ describe("node host invoke", () => {
         id: "invoke-workspace",
         nodeId: "node-1",
         command: "workspace.claim",
-        paramsJSON: "{}",
+        paramsJSON: JSON.stringify({ sessionKey: "agent:main:other" }),
         sessionKey: workspaceRequest.sessionKey,
       },
       { request } as unknown as GatewayClient,


### PR DESCRIPTION
## What Problem This Solves

Microsoft's Lobster fork carries patch 0028 ("node-invoke session binding") enforcing that a node invocation initiated by one session cannot be redeemed from another. Assessment against current main shows the invariant is already fully enforced — the patch targets the obsolete `mcp.invoke` surface, while `mcp.tools.call.v1` carries trusted session identity separately from caller-controlled parameters, with fail-closed checks at gateway dispatch, workspace redemption, and result/progress stream redemption.

## Why This Change Was Made

One strengthening closes the remaining evidence gap: the existing regression did not prove that *spoofed nested session metadata inside caller params* cannot override the trusted identity envelope. The test now injects a conflicting `sessionKey` in `paramsJSON` and asserts the trusted context wins, cross-session claims fail, same-session claims succeed, and retained claims fail after closure.

## User Impact

None at runtime — test-only. Gives Microsoft the parity evidence to delete their patch 0028 carry.

## Evidence

456 focused tests green post-rebase; `check:changed` green; autoreview clean. Production LOC 0; tests +4/−2. Enforcement sites: gateway dispatch session binding (nodes.invoke.ts), cross-session workspace redemption fail-closed (node-host/invoke.ts), connection-bound result/progress redemption (node-registry.invoke-stream.ts).

Parity assessment for Microsoft's Lobster patch 0028 via giodl73-repo/lobster-plugins-and-patches (source commit e9f84234ebdf).
