### PR TITLE
fix(ui): show failed child-session loading and retry

### DIFF
--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -8,6 +8,7 @@ import { openCatalogSessionInTerminal } from "../lib/sessions/catalog-terminal.t
 import type { SidebarSessionSection } from "../lib/sessions/grouping.ts";
 import type { SessionCatalogGroupsRenderer } from "./app-sidebar-session-catalog-render.ts";
 import {
+  renderChildSessionLoadError,
   renderRecentSession,
   renderSessionTree,
   type SessionListHost,
@@ -451,6 +452,7 @@ export function renderSessionList(params: {
   catalogRenderer: SessionCatalogGroupsRenderer | null;
 }) {
   const { host } = params;
+  const hiddenMainSessionKey = host.mainSessionRow()?.key;
   return html`
     <section
       class="sidebar-sessions ${host.sessionOrganizer.sessionListRemovalDrop
@@ -461,6 +463,7 @@ export function renderSessionList(params: {
       @drop=${(event: DragEvent) => host.handleSessionListDrop(event)}
     >
       ${renderSessionListToolbar(host)}
+      ${hiddenMainSessionKey ? renderChildSessionLoadError(host, hiddenMainSessionKey) : nothing}
       ${host.sessionData.sessionMutationError
         ? html`
             <div

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -237,7 +237,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
         session.childSessionKeys.length > 0 &&
         this.isSessionChildrenExpanded(session) &&
         !this.sessionData.loadedChildSessionKeys.has(session.key) &&
-        !this.sessionData.failedChildSessionKeys.has(session.key) &&
+        !this.sessionData.childSessionErrorsByParent.has(session.key) &&
         !this.sessionData.loadingChildSessionKeys.has(session.key)
       ) {
         void this.sessionData.loadChildSessions(session.key);
@@ -248,7 +248,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       mainRow &&
       (mainRow.childSessions?.length ?? 0) > 0 &&
       !this.sessionData.loadedChildSessionKeys.has(mainRow.key) &&
-      !this.sessionData.failedChildSessionKeys.has(mainRow.key) &&
+      !this.sessionData.childSessionErrorsByParent.has(mainRow.key) &&
       !this.sessionData.loadingChildSessionKeys.has(mainRow.key)
     ) {
       void this.sessionData.loadChildSessions(mainRow.key);

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -56,10 +56,12 @@ export interface SessionListHost {
   readonly sessionData: Pick<
     SessionDataController,
     | "approvalBadgeSnapshot"
+    | "childSessionErrorsByParent"
     | "loadMoreSessionCatalog"
     | "presenceInstanceId"
     | "presencePayload"
     | "refreshSessionCatalogs"
+    | "retryChildSessions"
     | "sessionCatalogRefreshStatus"
     | "sessionMutationError"
   >;
@@ -100,6 +102,7 @@ export interface SessionListHost {
     sessionKey: string,
     worktreeId: string,
   ): SessionPullRequestIndicatorState;
+  mainSessionRow(): { key: string } | null;
   isSessionChildrenExpanded(session: SidebarRecentSession): boolean;
   startSessionDrag(session: SidebarRecentSession): void;
   finishSessionDrag(): void;
@@ -459,6 +462,28 @@ export function renderRecentSession(params: {
   return keyed(session.key, row);
 }
 
+export function renderChildSessionLoadError(host: SessionListHost, parentKey: string) {
+  const error = host.sessionData.childSessionErrorsByParent.get(parentKey);
+  if (!error) {
+    return nothing;
+  }
+  return html`<div
+    class="sidebar-session-error callout danger"
+    data-child-session-error=${parentKey}
+    role="alert"
+  >
+    <span>${error}</span>
+    <button
+      class="sidebar-session-tree__show-more"
+      type="button"
+      data-retry-child-sessions=${parentKey}
+      @click=${() => host.sessionData.retryChildSessions(parentKey)}
+    >
+      ${t("common.retry")}
+    </button>
+  </div>`;
+}
+
 export function renderSessionTree(params: {
   host: SessionListHost;
   session: SidebarRecentSession;
@@ -503,6 +528,7 @@ export function renderSessionTree(params: {
                 ${t("sessionsView.showMoreChildren", { count: String(hiddenChildCount) })}
               </button>`
             : nothing}
+          ${renderChildSessionLoadError(host, session.key)}
           ${session.loadingChildren && session.children.length === 0
             ? html`<span class="sidebar-session-tree__loading">${t("common.loading")}</span>`
             : nothing}

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -16,6 +16,7 @@ import "../test-helpers/app-sidebar-cases/catalog-ownership.ts";
 import "../test-helpers/app-sidebar-cases/catalog-terminal-owner.ts";
 import "../test-helpers/app-sidebar-cases/catalog-pages.ts";
 import "../test-helpers/app-sidebar-cases/categorized-child-sessions.ts";
+import "../test-helpers/app-sidebar-cases/child-session-errors.ts";
 import "../test-helpers/app-sidebar-cases/child-sessions-cap.ts";
 import "../test-helpers/app-sidebar-cases/child-sessions.ts";
 import "../test-helpers/app-sidebar-cases/group-mutations.ts";

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -65,7 +65,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   sessionsLoading = false;
   childSessionRowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>> = {};
   loadedChildSessionKeys: ReadonlySet<string> = new Set();
-  failedChildSessionKeys: ReadonlySet<string> = new Set();
+  childSessionErrorsByParent: ReadonlyMap<string, string> = new Map();
   loadingChildSessionKeys: ReadonlySet<string> = new Set();
   activeSessionLineageRoot: GatewaySessionRow | null = null;
   activeSessionLineageSelectedRow: GatewaySessionRow | null = null;
@@ -383,7 +383,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
         )
       : {};
     this.loadedChildSessionKeys = new Set();
-    this.failedChildSessionKeys = new Set();
+    this.childSessionErrorsByParent = new Map();
     this.loadingChildSessionKeys = new Set();
     if (options.preserveActiveLineage !== true) {
       this.activeSessionLineageRoot = null;
@@ -560,7 +560,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     if (
       !parentKey ||
       this.loadedChildSessionKeys.has(parentKey) ||
-      this.failedChildSessionKeys.has(parentKey) ||
+      this.childSessionErrorsByParent.has(parentKey) ||
       this.loadingChildSessionKeys.has(parentKey)
     ) {
       return;
@@ -586,13 +586,8 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       }
       this.childSessionRowsByParent = { ...this.childSessionRowsByParent, [parentKey]: rows };
       this.loadedChildSessionKeys = new Set([...this.loadedChildSessionKeys, parentKey]);
-      if (this.failedChildSessionKeys.has(parentKey)) {
-        const failedKeys = new Set(this.failedChildSessionKeys);
-        failedKeys.delete(parentKey);
-        this.failedChildSessionKeys = failedKeys;
-      }
       this.notify();
-    } catch {
+    } catch (error) {
       if (generation !== this.childSessionGeneration || sessions !== this.context?.sessions) {
         return;
       }
@@ -602,7 +597,10 @@ export class SessionDataController implements ReactiveController, SessionCatalog
         ...this.childSessionRowsByParent,
         [parentKey]: this.childSessionRowsByParent[parentKey] ?? [],
       };
-      this.failedChildSessionKeys = new Set([...this.failedChildSessionKeys, parentKey]);
+      this.childSessionErrorsByParent = new Map(this.childSessionErrorsByParent).set(
+        parentKey,
+        formatUiError(error),
+      );
       this.notify();
     } finally {
       if (generation === this.childSessionGeneration && sessions === this.context?.sessions) {
@@ -718,10 +716,10 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   }
 
   retryChildSessions(sessionKey: string): void {
-    if (this.failedChildSessionKeys.has(sessionKey)) {
-      const failedKeys = new Set(this.failedChildSessionKeys);
-      failedKeys.delete(sessionKey);
-      this.failedChildSessionKeys = failedKeys;
+    if (this.childSessionErrorsByParent.has(sessionKey)) {
+      const errors = new Map(this.childSessionErrorsByParent);
+      errors.delete(sessionKey);
+      this.childSessionErrorsByParent = errors;
       this.notify();
     }
     void this.loadChildSessions(sessionKey);

--- a/ui/src/test-helpers/app-sidebar-cases/child-session-errors.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-session-errors.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
+import { createGateway, createSessionsHarness, mountSidebar } from "../app-sidebar.ts";
+import { waitForFast } from "../wait-for.ts";
+import "../../components/app-sidebar.ts";
+
+function sessionResult(sessions: SessionsListResult["sessions"]): SessionsListResult {
+  return {
+    ts: 2,
+    path: "",
+    count: sessions.length,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions,
+  };
+}
+
+function parentSession(key: string, childKey: string) {
+  return { key, kind: "direct" as const, updatedAt: 1, childSessions: [childKey] };
+}
+
+function recoveredChild(key: string, parentKey: string, label: string) {
+  return { key, spawnedBy: parentKey, kind: "direct" as const, label, updatedAt: 2 };
+}
+
+describe("AppSidebar child-session load errors", () => {
+  it.each([
+    {
+      failure: "temporary list failure",
+      visibleError: "temporary list failure",
+    },
+    {
+      failure: "OPENAI_API_KEY=sk-1234567890abcdef",
+      visibleError: "OPENAI_API_KEY=sk-123...cdef",
+    },
+  ])(
+    "surfaces $visibleError with an accessible retry action",
+    async ({ failure, visibleError }) => {
+      const parentKey = "agent:main:parent";
+      const childKey = "agent:worker:child";
+      const gateway = createGateway({} as GatewayBrowserClient);
+      const harness = createSessionsHarness("main", [parentKey]);
+      harness.list
+        .mockRejectedValueOnce(new Error(failure))
+        .mockResolvedValueOnce(
+          sessionResult([recoveredChild(childKey, parentKey, "Recovered child")]),
+        );
+      const { sidebar } = await mountSidebar(gateway, harness.sessions);
+      harness.publishList({ result: sessionResult([parentSession(parentKey, childKey)]) });
+      await sidebar.updateComplete;
+      sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
+
+      await waitForFast(() => {
+        const alert = sidebar.querySelector(`[data-child-session-error="${parentKey}"]`);
+        expect(alert?.getAttribute("role")).toBe("alert");
+        expect(alert?.textContent).toContain(visibleError);
+      });
+      if (failure !== visibleError) {
+        expect(sidebar.textContent).not.toContain(failure);
+      }
+
+      const retry = sidebar.querySelector<HTMLButtonElement>(
+        `[data-retry-child-sessions="${parentKey}"]`,
+      );
+      expect(retry?.textContent).toContain("Retry");
+      retry?.click();
+
+      await waitForFast(() => expect(sidebar.textContent).toContain("Recovered child"));
+      expect(harness.list).toHaveBeenCalledTimes(2);
+      expect(sidebar.querySelector("[data-child-session-error]")).toBeNull();
+    },
+  );
+
+  it("keeps failures and retry state scoped to their parent", async () => {
+    const firstParent = "agent:main:first-parent";
+    const secondParent = "agent:main:second-parent";
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const harness = createSessionsHarness("main", [firstParent, secondParent]);
+    let firstAttempts = 0;
+    harness.list.mockImplementation(async (options) => {
+      const parentKey = options?.spawnedBy;
+      if (parentKey === secondParent || firstAttempts++ === 0) {
+        throw new Error(`${parentKey} temporarily unavailable`);
+      }
+      return sessionResult([
+        recoveredChild("agent:worker:first-child", firstParent, "Recovered first child"),
+      ]);
+    });
+    const { sidebar } = await mountSidebar(gateway, harness.sessions);
+    harness.publishList({
+      result: sessionResult(
+        [firstParent, secondParent].map((parentKey) =>
+          parentSession(parentKey, `${parentKey}:child`),
+        ),
+      ),
+    });
+    await sidebar.updateComplete;
+    for (const parentKey of [firstParent, secondParent]) {
+      sidebar
+        .querySelector<HTMLButtonElement>(`[data-child-session-toggle="${parentKey}"]`)
+        ?.click();
+    }
+    await waitForFast(() =>
+      expect(sidebar.querySelectorAll("[data-child-session-error]")).toHaveLength(2),
+    );
+
+    sidebar
+      .querySelector<HTMLButtonElement>(`[data-retry-child-sessions="${firstParent}"]`)
+      ?.click();
+
+    await waitForFast(() => expect(sidebar.textContent).toContain("Recovered first child"));
+    expect(sidebar.querySelector(`[data-child-session-error="${firstParent}"]`)).toBeNull();
+    expect(
+      sidebar.querySelector(`[data-child-session-error="${secondParent}"]`)?.textContent,
+    ).toContain(secondParent);
+  });
+
+  it.each(["main", "agent:main:main"])(
+    "surfaces and retries child failures for the hidden %s main session",
+    async (parentKey) => {
+      const childKey = "agent:main:subagent:recovered";
+      const gateway = createGateway({} as GatewayBrowserClient);
+      const harness = createSessionsHarness("main", [parentKey]);
+      harness.list
+        .mockRejectedValueOnce(new Error("main session children temporarily unavailable"))
+        .mockResolvedValueOnce(
+          sessionResult([recoveredChild(childKey, parentKey, "Recovered main-session child")]),
+        );
+      const { sidebar } = await mountSidebar(gateway, harness.sessions);
+      harness.publishList({ result: sessionResult([parentSession(parentKey, childKey)]) });
+
+      await waitForFast(() => expect(harness.list).toHaveBeenCalledOnce());
+      expect(sidebar.querySelector(`[data-session-key="${parentKey}"]`)).toBeNull();
+      await waitForFast(() => {
+        const alert = sidebar.querySelector(`[data-child-session-error="${parentKey}"]`);
+        expect(alert?.getAttribute("role")).toBe("alert");
+        expect(alert?.textContent).toContain("main session children temporarily unavailable");
+      });
+
+      sidebar
+        .querySelector<HTMLButtonElement>(`[data-retry-child-sessions="${parentKey}"]`)
+        ?.click();
+
+      await waitForFast(() =>
+        expect(sidebar.textContent).toContain("Recovered main-session child"),
+      );
+      expect(harness.list).toHaveBeenCalledTimes(2);
+      expect(sidebar.querySelector("[data-child-session-error]")).toBeNull();
+    },
+  );
+});

--- a/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
@@ -350,6 +350,11 @@ describe("AppSidebar agent chip", () => {
 
     await waitForFast(() => expect(harness.list).toHaveBeenCalledTimes(2));
     expect(sidebar.querySelector(".sidebar-recent-session--child")).toBeNull();
+    await waitForFast(() =>
+      expect(
+        sidebar.querySelector('[data-child-session-error="agent:main:parent"]')?.textContent,
+      ).toContain("child session list returned no result"),
+    );
 
     publishParent(11);
     await waitForFast(() => expect(harness.list).toHaveBeenCalledTimes(3));
@@ -427,6 +432,7 @@ describe("AppSidebar agent chip", () => {
     expect(sidebar.querySelector('[data-session-key="agent:worker:child"]')?.textContent).toContain(
       "Replacement child",
     );
+    expect(sidebar.querySelector("[data-child-session-error]")).toBeNull();
   });
 
   it("nests the selected child under its parent and reveals the active path", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users expanding a Control UI sidebar session would see an empty branch with no error and no way to retry when loading child sessions failed. The default main session was affected too: its children load automatically even though its parent row is intentionally hidden behind the agent identity card.

## Why This Change Was Made

The session-data controller previously swallowed child-session request failures and retained only a private failed-key set that the sidebar could not render. Replace that set with one canonical, redacted error per parent, and share the same accessible error-and-retry presentation between visible session rows and the hidden default-main session. Preserve source/generation fencing, parent isolation, existing child rows, revision resets, and the existing direct retry path.

This adds 27 production lines because a visible, accessible failure outcome and retry must exist on both the visible-parent and hidden-main rendering surfaces; the controller removes the obsolete failed-key path rather than maintaining parallel state. No public API, configuration, authentication, security, protocol, or storage behavior changes.

## User Impact

Operators immediately see why child sessions did not load and can retry directly, including on the default main-session path. Error text is sanitized through the existing UI redaction boundary, and a failure under one parent never leaks into another session.

## Evidence

Before: a failed request leaves an expanded thread empty, without an error or recovery action.

![Before: child sessions fail silently under an expanded Control UI thread](https://github.com/user-attachments/assets/c9d4aa0c-a389-40e7-8525-c45084989377)

After: the same sanitized synthetic thread shows the redacted failure and an accessible Retry button.

![After: failed child session loading displays a visible error and Retry button](https://github.com/user-attachments/assets/5d8774d8-f395-4fed-9668-8691f424528e)

- Authentic real Lit/JSDOM regressions failed against the original controller for visible parents and both hidden main-session key aliases, then passed against the repaired owner and renderer.
- Full owner proof: 339 passing tests across the sidebar, session controller refresh/event lifecycle, navigation, child-session lineage, and error redaction.
- Independent review: 338 passing tests across the same six suites, including parent isolation, stale capability fencing, preserved existing children, direct retry, hidden main aliases, and sanitized screenshot inspection.
- Full committed-change authenticated review: no actionable findings. Exact changed-file formatting, typed lint, style lint, UI localization verification, and max-line/assertion ratchets pass.
- Existing primary-checkout dependency gaps prevent a complete local UI type pass (`@panzoom/panzoom` and `@types/pako` are absent from the shared install); no changed-file type diagnostics were observed, and exact-head CI verifies the complete install.
