### PR TITLE
fix(ui): stop offering Open in editor for remote checkouts

### DIFF
--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -43,6 +43,7 @@ import {
   CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES,
 } from "../../../src/shared/device-bootstrap-profile.js";
 import { formatUiError } from "../lib/format-error.ts";
+import { isLoopbackHostname } from "../lib/gateway-locality.ts";
 import {
   clearDeviceAuthToken,
   loadDeviceAuthToken,
@@ -77,26 +78,13 @@ function browserSecureContext(): boolean {
   return win?.isSecureContext === true;
 }
 
-function isLoopbackIPv4Host(host: string): boolean {
-  const octets = host.split(".");
-  return (
-    octets.length === 4 &&
-    octets[0] === "127" &&
-    octets.every((octet) => /^\d+$/.test(octet) && Number(octet) <= 255)
-  );
-}
-
 function isTrustedRetryEndpoint(url: string): boolean {
   try {
     const gatewayUrl = new URL(url, window.location.href);
-    const host = gatewayUrl.hostname.trim().toLowerCase();
-    const isLoopbackHost = host === "localhost" || host === "::1" || host === "[::1]";
-    const isLoopbackIPv4 = isLoopbackIPv4Host(host);
-    if (isLoopbackHost || isLoopbackIPv4) {
-      return true;
-    }
-    const pageUrl = new URL(window.location.href);
-    return gatewayUrl.host === pageUrl.host;
+    return (
+      isLoopbackHostname(gatewayUrl.hostname) ||
+      gatewayUrl.host === new URL(window.location.href).host
+    );
   } catch {
     return false;
   }

--- a/ui/src/app/native-editor-locality.runtime.ts
+++ b/ui/src/app/native-editor-locality.runtime.ts
@@ -1,0 +1,31 @@
+import type { ReactiveControllerHost } from "lit";
+import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
+import { nativeGatewaysCapability } from "./native-gateways.runtime.ts";
+
+export function isNativeLocalGateway(): boolean {
+  const snapshot = nativeGatewaysCapability()?.snapshot;
+  // SSH tunnels give remote gateways loopback URLs; only the native-declared kind proves locality.
+  return snapshot?.gateways.find((gateway) => gateway.id === snapshot.currentId)?.kind === "local";
+}
+
+type EditorFile = { path: string; root?: string | null };
+
+export function localEditorFilePath(content: EditorFile, execNode?: string | null): string | null {
+  if (execNode || !isNativeLocalGateway()) {
+    return null;
+  }
+  if (/^(?:\/|[a-z]:[\\/]|\\\\)/i.test(content.path)) {
+    return content.path;
+  }
+  return content.root
+    ? `${content.root.replace(/[\\/]+$/, "")}/${content.path.replace(/^[\\/]+/, "")}`
+    : null;
+}
+
+export function observeNativeGateway(host: ReactiveControllerHost, onChange?: () => void): void {
+  void new SubscriptionsController(host).watch(
+    nativeGatewaysCapability,
+    (gateways, notify) => gateways.subscribe(notify),
+    onChange,
+  );
+}

--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -156,11 +156,13 @@ describe("sidebar session sort modes", () => {
 });
 
 describe("sidebar session live-run projection", () => {
-  it("projects the durable last-message preview", () => {
+  it("projects durable message and execution-owner facts", () => {
     expect(
-      projectSidebarSession({ lastMessagePreview: "The final reply is durable." })
-        .lastMessagePreview,
-    ).toBe("The final reply is durable.");
+      projectSidebarSession({
+        lastMessagePreview: "The final reply is durable.",
+        execNode: "build-mac",
+      }),
+    ).toMatchObject({ lastMessagePreview: "The final reply is durable.", execNode: "build-mac" });
   });
 
   it.each([

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -247,6 +247,7 @@ export function buildSidebarSessionNavigationState(input: {
         context?.sessions.isPreparedWorkSession(row.key) === true,
       acpSession: isAcpSessionKey(row.key),
       worktreeId: row.worktree?.id,
+      execNode: row.execNode,
       placementState: row.placement?.state,
       diskSpaceStatus:
         row.placement?.state === "active" ? row.placement.diskSpace?.status : undefined,

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -100,6 +100,7 @@ export type SidebarRecentSession = {
   /** ACP-backed harness session; lands in the Coding zone with work sessions. */
   acpSession?: boolean;
   worktreeId?: string;
+  execNode?: string;
   placementState?: SessionPlacementState;
   diskSpaceStatus?: SessionPlacementDiskSpace["status"];
   workspaceConflictCount?: number;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -138,7 +138,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   private sessionNavigationState: SidebarSessionNavigationState | undefined;
   private projectedSessionRows: SidebarRecentSession[] | undefined;
   private readonly narrationSubscriptions = this.createNarrationSubscriptions();
-  private readonly nativeGatewaysChanged = () => this.requestUpdate();
+  private readonly nativeGatewaysChanged = () => this.sidebarMenus.closeSessionMenu();
   private readonly refreshAppearanceSettings = () => this.context?.theme.refresh();
   private readonly hiddenSessionCatalogsChanged = () => {
     this.hiddenSessionCatalogIds = loadStoredHiddenSessionCatalogIds();

--- a/ui/src/components/board/board-widget-frame.test.ts
+++ b/ui/src/components/board/board-widget-frame.test.ts
@@ -91,6 +91,7 @@ describe("board widget frame terminal failure message", () => {
     for (const origin of [
       "http://localhost:18790",
       "http://127.0.0.1:18790",
+      "http://127.0.0.5:18790",
       "http://[::1]:18790",
     ]) {
       const message = terminalFailureError({ widget: {}, resolvedSandboxOrigin: origin });

--- a/ui/src/components/board/board-widget-frame.ts
+++ b/ui/src/components/board/board-widget-frame.ts
@@ -6,6 +6,7 @@ import type { BoardWidgetFrameUrl } from "../../lib/board/view-types.ts";
 import { BoardWidgetSandboxHost } from "../../lib/board/widget-sandbox-host.ts";
 import { remainingBoardWidgetTicketTtlMs } from "../../lib/board/widget-ticket-lifetime.ts";
 import { formatUiError } from "../../lib/format-error.ts";
+import { isLoopbackHostname } from "../../lib/gateway-locality.ts";
 import { installWidgetThemeObserver, postWidgetTheme } from "../../lib/widget-theme.ts";
 import { resolveGatewayHttpOrigin, resolveSandboxHostUrl } from "../sandbox-host.ts";
 
@@ -20,10 +21,6 @@ const TICKET_REFRESH_MAX_RETRY_MS = 30_000;
 
 function documentHidden(): boolean {
   return typeof document !== "undefined" && document.visibilityState === "hidden";
-}
-
-function isLoopbackHostname(hostname: string): boolean {
-  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 }
 
 // Without mcp.apps.sandboxOrigin the sandbox URL is the gateway origin with the

--- a/ui/src/components/session-menu-work.test.ts
+++ b/ui/src/components/session-menu-work.test.ts
@@ -18,8 +18,12 @@ function pullRequest(overrides: Partial<ControlUiSessionPullRequest>): ControlUi
   };
 }
 
-function sessionMenuClient(request: (method: string, params: unknown) => Promise<unknown>) {
+function sessionMenuClient(
+  request: (method: string, params: unknown) => Promise<unknown>,
+  gatewayUrl = "ws://localhost:18789",
+) {
   return {
+    gatewayUrl,
     request: request as never,
   };
 }
@@ -50,6 +54,51 @@ describe("session pull request indicators", () => {
 });
 
 describe("fetchSessionMenuWork", () => {
+  it.each([
+    { name: "localhost", gatewayUrl: "ws://localhost:18789", expectedPath: "/work/trees/demo" },
+    { name: "same-origin relative URL", gatewayUrl: "/gateway", expectedPath: "/work/trees/demo" },
+    {
+      name: "IPv4 loopback block",
+      gatewayUrl: "ws://127.0.0.5:18789",
+      expectedPath: "/work/trees/demo",
+    },
+    { name: "IPv6 loopback", gatewayUrl: "ws://[::1]:18789", expectedPath: "/work/trees/demo" },
+    { name: "remote gateway", gatewayUrl: "wss://gateway.example.test", expectedPath: null },
+    { name: "gateway LAN address", gatewayUrl: "ws://192.168.1.5:18789", expectedPath: null },
+    {
+      name: "deceptive loopback hostname",
+      gatewayUrl: "wss://127.0.0.1.evil.com",
+      expectedPath: null,
+    },
+    {
+      name: "remote execution node",
+      gatewayUrl: "ws://localhost:18789",
+      execNode: "build-mac",
+      expectedPath: null,
+    },
+  ])("exposes editor paths only for viewer-local files: $name", async (testCase) => {
+    const request = vi.fn(async () => ({
+      worktrees: [{ id: "wt-1", path: "/work/trees/demo" }],
+    }));
+
+    await expect(
+      fetchSessionMenuWork({
+        client: sessionMenuClient(request, testCase.gatewayUrl),
+        loadPullRequests: async () => ({
+          pullRequests: [pullRequest({ url: "https://example.test/pr" })],
+          rateLimited: false,
+          status: "ready",
+        }),
+        worktreeId: "wt-1",
+        execNode: testCase.execNode,
+      }),
+    ).resolves.toEqual({
+      pullRequestUrl: "https://example.test/pr",
+      worktreePath: testCase.expectedPath,
+    });
+    expect(request).toHaveBeenCalledTimes(testCase.expectedPath ? 1 : 0);
+  });
+
   it("resolves the PR URL and worktree path in one pass", async () => {
     const request = vi.fn((_method: string) => {
       return Promise.resolve({
@@ -71,9 +120,6 @@ describe("fetchSessionMenuWork", () => {
     await expect(
       fetchSessionMenuWork({
         client: sessionMenuClient(request),
-        pullRequestsAvailable: true,
-        sessionKey: "agent:main:demo",
-        agentId: "main",
         loadPullRequests: async () => ({
           pullRequests: [pullRequest({ url: "https://example.test/pr" })],
           rateLimited: false,
@@ -93,8 +139,6 @@ describe("fetchSessionMenuWork", () => {
     await expect(
       fetchSessionMenuWork({
         client: sessionMenuClient(failing),
-        pullRequestsAvailable: true,
-        sessionKey: "agent:main:demo",
         loadPullRequests: async () => {
           throw new Error("offline");
         },
@@ -108,8 +152,6 @@ describe("fetchSessionMenuWork", () => {
     await expect(
       fetchSessionMenuWork({
         client: sessionMenuClient(request),
-        pullRequestsAvailable: false,
-        sessionKey: "agent:main:demo",
         worktreeId: "wt-1",
       }),
     ).resolves.toEqual({ pullRequestUrl: null, worktreePath: null });

--- a/ui/src/components/session-menu-work.test.ts
+++ b/ui/src/components/session-menu-work.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ControlUiSessionPullRequest } from "../../../src/gateway/control-ui-contract.js";
+import { isLoopbackHostname } from "../lib/gateway-locality.ts";
+import {
+  clearNativeGatewayTestState,
+  setNativeGatewayTestState,
+} from "../test-helpers/native-gateways.ts";
 import {
   fetchSessionMenuWork,
   resolveSessionPullRequestIndicatorState,
@@ -18,15 +23,28 @@ function pullRequest(overrides: Partial<ControlUiSessionPullRequest>): ControlUi
   };
 }
 
-function sessionMenuClient(
-  request: (method: string, params: unknown) => Promise<unknown>,
-  gatewayUrl = "ws://localhost:18789",
-) {
-  return {
-    gatewayUrl,
-    request: request as never,
-  };
+function sessionMenuClient(request: (method: string, params: unknown) => Promise<unknown>) {
+  return { request: request as never };
 }
+
+beforeEach(() => {
+  setNativeGatewayTestState("local");
+});
+
+afterEach(() => {
+  clearNativeGatewayTestState();
+  vi.restoreAllMocks();
+});
+
+describe("isLoopbackHostname", () => {
+  it.each([
+    ["127.0.0.5", true],
+    ["[::1]", true],
+    ["127.0.0.1.evil.com", false],
+  ])("classifies %s as loopback: %s", (hostname, expected) => {
+    expect(isLoopbackHostname(hostname)).toBe(expected);
+  });
+});
 
 describe("session pull request indicators", () => {
   it.each([
@@ -55,42 +73,31 @@ describe("session pull request indicators", () => {
 
 describe("fetchSessionMenuWork", () => {
   it.each([
-    { name: "localhost", gatewayUrl: "ws://localhost:18789", expectedPath: "/work/trees/demo" },
-    { name: "same-origin relative URL", gatewayUrl: "/gateway", expectedPath: "/work/trees/demo" },
-    {
-      name: "IPv4 loopback block",
-      gatewayUrl: "ws://127.0.0.5:18789",
-      expectedPath: "/work/trees/demo",
-    },
-    { name: "IPv6 loopback", gatewayUrl: "ws://[::1]:18789", expectedPath: "/work/trees/demo" },
-    { name: "remote gateway", gatewayUrl: "wss://gateway.example.test", expectedPath: null },
-    { name: "gateway LAN address", gatewayUrl: "ws://192.168.1.5:18789", expectedPath: null },
-    {
-      name: "deceptive loopback hostname",
-      gatewayUrl: "wss://127.0.0.1.evil.com",
-      expectedPath: null,
-    },
+    { name: "plain browser", nativeGateway: null, expectedPath: null },
+    { name: "native local gateway", nativeGateway: "local", expectedPath: "/work/trees/demo" },
+    { name: "native remote gateway", nativeGateway: "remote", expectedPath: null },
     {
       name: "remote execution node",
-      gatewayUrl: "ws://localhost:18789",
+      nativeGateway: "local",
       execNode: "build-mac",
       expectedPath: null,
     },
-  ])("exposes editor paths only for viewer-local files: $name", async (testCase) => {
+  ] as const)("exposes editor paths only for native-local files: $name", async (testCase) => {
+    setNativeGatewayTestState(testCase.nativeGateway);
     const request = vi.fn(async () => ({
       worktrees: [{ id: "wt-1", path: "/work/trees/demo" }],
     }));
 
     await expect(
       fetchSessionMenuWork({
-        client: sessionMenuClient(request, testCase.gatewayUrl),
+        client: sessionMenuClient(request),
         loadPullRequests: async () => ({
           pullRequests: [pullRequest({ url: "https://example.test/pr" })],
           rateLimited: false,
           status: "ready",
         }),
         worktreeId: "wt-1",
-        execNode: testCase.execNode,
+        execNode: "execNode" in testCase ? testCase.execNode : undefined,
       }),
     ).resolves.toEqual({
       pullRequestUrl: "https://example.test/pr",

--- a/ui/src/components/session-menu-work.ts
+++ b/ui/src/components/session-menu-work.ts
@@ -4,13 +4,13 @@ import type {
   ControlUiSessionPullRequestSnapshot,
 } from "../../../src/gateway/control-ui-contract.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
-import { isLoopbackGatewayUrl } from "../lib/gateway-locality.ts";
+import { isNativeLocalGateway } from "../app/native-editor-locality.runtime.ts";
 
 // Shared by the app sidebar and the Sessions page: both hosts resolve the
 // same worktree-session extras (PR link, checkout path) when opening the
 // session context menu, after the menu is already visible.
 type SessionMenuWorkParams = {
-  client: Pick<GatewayBrowserClient, "request" | "gatewayUrl">;
+  client: Pick<GatewayBrowserClient, "request">;
   /** Omitted when the Gateway does not advertise pushed PR snapshots. */
   loadPullRequests?: () => Promise<ControlUiSessionPullRequestSnapshot | undefined>;
   worktreeId?: string;
@@ -61,10 +61,10 @@ async function loadPullRequestUrl(params: SessionMenuWorkParams): Promise<string
 
 async function loadWorktreePath(params: SessionMenuWorkParams): Promise<string | null> {
   const worktreeId = params.worktreeId;
-  // The checkout path only means anything to an editor running on the same
-  // machine as the browser, so withhold it for a remote gateway or a session
-  // pinned to an exec node. Callers render the editor entry off this value.
-  if (!worktreeId || params.execNode || !isLoopbackGatewayUrl(params.client.gatewayUrl)) {
+  if (!worktreeId || params.execNode) {
+    return null;
+  }
+  if (!isNativeLocalGateway()) {
     return null;
   }
   try {

--- a/ui/src/components/session-menu-work.ts
+++ b/ui/src/components/session-menu-work.ts
@@ -4,20 +4,17 @@ import type {
   ControlUiSessionPullRequestSnapshot,
 } from "../../../src/gateway/control-ui-contract.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { isLoopbackGatewayUrl } from "../lib/gateway-locality.ts";
 
 // Shared by the app sidebar and the Sessions page: both hosts resolve the
 // same worktree-session extras (PR link, checkout path) when opening the
 // session context menu, after the menu is already visible.
-type SessionMenuWorkClient = Pick<GatewayBrowserClient, "request">;
-
 type SessionMenuWorkParams = {
-  client: SessionMenuWorkClient;
-  /** Pushed session PR snapshots are optional; skip when the Gateway lacks them. */
-  pullRequestsAvailable: boolean;
-  sessionKey: string;
-  agentId?: string;
+  client: Pick<GatewayBrowserClient, "request" | "gatewayUrl">;
+  /** Omitted when the Gateway does not advertise pushed PR snapshots. */
   loadPullRequests?: () => Promise<ControlUiSessionPullRequestSnapshot | undefined>;
   worktreeId?: string;
+  execNode?: string;
 };
 
 type SessionMenuWorkResult = {
@@ -29,12 +26,7 @@ export type SessionPullRequestIndicatorState = "none" | "open" | "merged";
 
 // Menu offers a single Open PR action; prefer the PR a maintainer most
 // likely wants: active first, merged history next, closed last.
-const PR_STATE_ORDER: ReadonlyArray<ControlUiSessionPullRequest["state"]> = [
-  "open",
-  "draft",
-  "merged",
-  "closed",
-];
+const PR_STATE_ORDER = ["open", "draft", "merged", "closed"] as const;
 
 function pickSessionMenuPullRequestUrl(
   pullRequests: readonly ControlUiSessionPullRequest[],
@@ -51,23 +43,16 @@ function pickSessionMenuPullRequestUrl(
 export function resolveSessionPullRequestIndicatorState(
   pullRequests: readonly ControlUiSessionPullRequest[],
 ): SessionPullRequestIndicatorState {
-  if (
-    pullRequests.some(
-      (pullRequest) => pullRequest.state === "open" || pullRequest.state === "draft",
-    )
-  ) {
+  if (pullRequests.some(({ state }) => state === "open" || state === "draft")) {
     return "open";
   }
-  return pullRequests.some((pullRequest) => pullRequest.state === "merged") ? "merged" : "none";
+  return pullRequests.some(({ state }) => state === "merged") ? "merged" : "none";
 }
 
 async function loadPullRequestUrl(params: SessionMenuWorkParams): Promise<string | null> {
-  if (!params.pullRequestsAvailable || !params.loadPullRequests) {
-    return null;
-  }
   try {
-    const result = await params.loadPullRequests();
-    return result ? pickSessionMenuPullRequestUrl(result.pullRequests) : null;
+    const snapshot = await params.loadPullRequests?.();
+    return pickSessionMenuPullRequestUrl(snapshot?.pullRequests ?? []);
   } catch {
     // Optional affordance: a GitHub or gateway hiccup just leaves Open PR disabled.
     return null;
@@ -76,7 +61,10 @@ async function loadPullRequestUrl(params: SessionMenuWorkParams): Promise<string
 
 async function loadWorktreePath(params: SessionMenuWorkParams): Promise<string | null> {
   const worktreeId = params.worktreeId;
-  if (!worktreeId) {
+  // The checkout path only means anything to an editor running on the same
+  // machine as the browser, so withhold it for a remote gateway or a session
+  // pinned to an exec node. Callers render the editor entry off this value.
+  if (!worktreeId || params.execNode || !isLoopbackGatewayUrl(params.client.gatewayUrl)) {
     return null;
   }
   try {

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -726,7 +726,7 @@ describe("session menu", () => {
     expect(openPr.disabled).toBe(false);
     expect(openPr.hasAttribute("data-new-tab-action")).toBe(true);
     expect(openPr.querySelector(".session-menu__shortcut")?.textContent).toBe("G");
-    expect(menuItem(menu, "Open in").disabled).toBe(true);
+    expect(menuItemLabels(menu)).not.toContain("Open in");
 
     document.dispatchEvent(
       new KeyboardEvent("keydown", { key: "g", bubbles: true, cancelable: true }),

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -40,6 +40,8 @@ type SessionMenuData = {
  * Worktree-session extras resolved lazily by the menu host after open; null
  * hides the block entirely (plain chat sessions), loading keeps the items
  * rendered-but-disabled so the menu layout never shifts under the pointer.
+ * A resolved null `worktreePath` drops the editor row for good — see
+ * `gateway-locality.ts` for why a remote checkout never gets one.
  */
 export type SessionMenuWork = {
   loading: boolean;
@@ -223,6 +225,10 @@ class SessionMenu extends OpenClawLightDomElement {
     }
     const pullRequestUrl = work.pullRequestUrl;
     const worktreePath = work.worktreePath;
+    // Hold the row while the path resolves so the menu does not shift under the
+    // pointer, then drop it once we know the checkout is unreachable from this
+    // browser: a disabled row would only advertise a handoff that cannot run.
+    const showEditorEntry = work.loading || Boolean(worktreePath);
     return html`
       <wa-dropdown-item
         class="session-menu__item"
@@ -238,25 +244,28 @@ class SessionMenu extends OpenClawLightDomElement {
         <span class="session-menu__text">${t("sessionsView.openPullRequest")}</span>
         ${menuShortcutHint("g")}
       </wa-dropdown-item>
-      ${this.compact
-        ? renderCompactSessionMenuNavigationItem({
-            view: "open-in",
-            label: t("sessionsView.openInEditorMenu"),
-            icon: icons.externalLink,
-            disabled: this.disabled || !worktreePath,
-          })
-        : html`<wa-dropdown-item
-            class="session-menu__item"
-            ?disabled=${this.disabled || !worktreePath}
-          >
-            <span slot="icon" class="session-menu__icon" aria-hidden="true"
-              >${icons.externalLink}</span
-            >
-            <span class="session-menu__text">${t("sessionsView.openInEditorMenu")}</span>
-            ${worktreePath ? this.renderEditorSubmenu() : nothing}
-          </wa-dropdown-item>`}
+      ${showEditorEntry ? this.renderEditorEntry(worktreePath) : nothing}
       <div class="session-menu__separator" role="separator"></div>
     `;
+  }
+
+  private renderEditorEntry(worktreePath: string | null) {
+    if (this.compact) {
+      return renderCompactSessionMenuNavigationItem({
+        view: "open-in",
+        label: t("sessionsView.openInEditorMenu"),
+        icon: icons.externalLink,
+        disabled: this.disabled || !worktreePath,
+      });
+    }
+    return html`<wa-dropdown-item
+      class="session-menu__item"
+      ?disabled=${this.disabled || !worktreePath}
+    >
+      <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.externalLink}</span>
+      <span class="session-menu__text">${t("sessionsView.openInEditorMenu")}</span>
+      ${worktreePath ? this.renderEditorSubmenu() : nothing}
+    </wa-dropdown-item>`;
   }
 
   private renderEditorSubmenu(inline = false) {

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -41,7 +41,7 @@ type SessionMenuData = {
  * hides the block entirely (plain chat sessions), loading keeps the items
  * rendered-but-disabled so the menu layout never shifts under the pointer.
  * A resolved null `worktreePath` drops the editor row for good — see
- * `gateway-locality.ts` for why a remote checkout never gets one.
+ * `native-editor-locality.runtime.ts` for which checkouts ever get one.
  */
 export type SessionMenuWork = {
   loading: boolean;

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -399,15 +399,15 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
     );
     void fetchSessionMenuWork({
       client,
-      pullRequestsAvailable:
+      loadPullRequests:
         isGatewayMethodAdvertised(
           context.gateway.snapshot,
           SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
-        ) === true,
-      sessionKey: session.key,
-      agentId: parseAgentSessionKey(session.key)?.agentId ?? selectedAgentId,
-      loadPullRequests: () => store.load(this, pullRequestKey),
+        ) === true
+          ? () => store.load(this, pullRequestKey)
+          : undefined,
       worktreeId: session.worktreeId,
+      execNode: session.execNode,
     }).then((work) => {
       if (version === this.sessionMenuWorkVersion) {
         this.updateState("sessionMenuWork", { loading: false, ...work });

--- a/ui/src/lib/gateway-locality.ts
+++ b/ui/src/lib/gateway-locality.ts
@@ -1,0 +1,20 @@
+export function isLoopbackHostname(hostname: string): boolean {
+  const host = hostname.trim().toLowerCase();
+  return (
+    host === "localhost" ||
+    host === "::1" ||
+    host === "[::1]" ||
+    (/^127(?:\.\d{1,3}){3}$/.test(host) && host.split(".").every((octet) => Number(octet) <= 255))
+  );
+}
+
+export function isLoopbackGatewayUrl(gatewayUrl: string | null | undefined): boolean {
+  try {
+    // The UI origin can differ; rejecting LAN aliases avoids a false-local editor handoff.
+    return Boolean(
+      gatewayUrl && isLoopbackHostname(new URL(gatewayUrl, window.location.href).hostname),
+    );
+  } catch {
+    return false;
+  }
+}

--- a/ui/src/lib/gateway-locality.ts
+++ b/ui/src/lib/gateway-locality.ts
@@ -1,43 +1,7 @@
 export function isLoopbackHostname(hostname: string): boolean {
   const host = hostname.trim().toLowerCase();
   return (
-    host === "localhost" ||
-    host === "::1" ||
-    host === "[::1]" ||
+    ["localhost", "::1", "[::1]"].includes(host) ||
     (/^127(?:\.\d{1,3}){3}$/.test(host) && host.split(".").every((octet) => Number(octet) <= 255))
   );
-}
-
-export function isLoopbackGatewayUrl(gatewayUrl: string | null | undefined): boolean {
-  try {
-    // The UI origin can differ; rejecting LAN aliases avoids a false-local editor handoff.
-    return Boolean(
-      gatewayUrl && isLoopbackHostname(new URL(gatewayUrl, window.location.href).hostname),
-    );
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Absolute path only when an editor on this machine could actually open it.
- * Null for a remote gateway or exec node even though the path itself is known,
- * so callers must not reuse this for display or copy affordances. Lives here
- * rather than beside either caller: the file view and the diff panel both need
- * it, and importing across those two modules closes a dependency cycle.
- */
-export function localEditorFilePath(
-  content: { path: string; root?: string | null },
-  gatewayUrl: string | null | undefined,
-  execNode: string | null | undefined,
-): string | null {
-  if (execNode || !isLoopbackGatewayUrl(gatewayUrl)) {
-    return null;
-  }
-  if (/^(?:\/|[a-z]:[\\/]|\\\\)/i.test(content.path)) {
-    return content.path;
-  }
-  return content.root
-    ? `${content.root.replace(/[\\/]+$/, "")}/${content.path.replace(/^[\\/]+/, "")}`
-    : null;
 }

--- a/ui/src/lib/gateway-locality.ts
+++ b/ui/src/lib/gateway-locality.ts
@@ -18,3 +18,26 @@ export function isLoopbackGatewayUrl(gatewayUrl: string | null | undefined): boo
     return false;
   }
 }
+
+/**
+ * Absolute path only when an editor on this machine could actually open it.
+ * Null for a remote gateway or exec node even though the path itself is known,
+ * so callers must not reuse this for display or copy affordances. Lives here
+ * rather than beside either caller: the file view and the diff panel both need
+ * it, and importing across those two modules closes a dependency cycle.
+ */
+export function localEditorFilePath(
+  content: { path: string; root?: string | null },
+  gatewayUrl: string | null | undefined,
+  execNode: string | null | undefined,
+): string | null {
+  if (execNode || !isLoopbackGatewayUrl(gatewayUrl)) {
+    return null;
+  }
+  if (/^(?:\/|[a-z]:[\\/]|\\\\)/i.test(content.path)) {
+    return content.path;
+  }
+  return content.root
+    ? `${content.root.replace(/[\\/]+$/, "")}/${content.path.replace(/^[\\/]+/, "")}`
+    : null;
+}

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../../../src/gateway/control-ui-contract.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { applicationContext } from "../../app/context.ts";
+import { observeNativeGateway } from "../../app/native-editor-locality.runtime.ts";
 import type {
   NativeGatewaysCapability,
   NativeGatewaysSnapshot,
@@ -450,6 +451,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
 
   constructor() {
     super();
+    observeNativeGateway(this);
     void new SubscriptionsController(this)
       .watch(
         () => this.context?.overlays,

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -20,6 +20,7 @@ import { sessionMenuReasons } from "../../components/session-menu-access.ts";
 import { listAssignableSessionOwners } from "../../components/session-owner-chip.ts";
 import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
 import { t } from "../../i18n/index.ts";
+import { isLoopbackGatewayUrl } from "../../lib/gateway-locality.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { hasSessionPresenceViewers, projectPresencePayload } from "../../lib/presence-users.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
@@ -545,7 +546,10 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               .sessionLabel=${normalizeOptionalString(row.label) ??
               normalizeOptionalString(this.paneTitle) ??
               row.key}
-              .worktreePath=${row.execNode ? null : workspace.root}
+              .worktreePath=${row.execNode ||
+              !isLoopbackGatewayUrl(sharingSnapshot.client?.gatewayUrl)
+                ? null
+                : workspace.root}
               .archived=${row.archived === true}
               .onboarding=${this.onboarding}
               .preferencesBrowserOnly=${this.context.runtimeConfig?.state.connected &&

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -9,6 +9,7 @@ import {
   renderScopeUpgradeTrigger,
   scopeUpgradeStatusUsesSessionHeader,
 } from "../../app/device-scope-upgrade.ts";
+import { isNativeLocalGateway } from "../../app/native-editor-locality.runtime.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import {
   formatUpdateCampaignLabel,
@@ -20,7 +21,6 @@ import { sessionMenuReasons } from "../../components/session-menu-access.ts";
 import { listAssignableSessionOwners } from "../../components/session-owner-chip.ts";
 import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
 import { t } from "../../i18n/index.ts";
-import { isLoopbackGatewayUrl } from "../../lib/gateway-locality.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { hasSessionPresenceViewers, projectPresencePayload } from "../../lib/presence-users.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
@@ -546,10 +546,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
               .sessionLabel=${normalizeOptionalString(row.label) ??
               normalizeOptionalString(this.paneTitle) ??
               row.key}
-              .worktreePath=${row.execNode ||
-              !isLoopbackGatewayUrl(sharingSnapshot.client?.gatewayUrl)
-                ? null
-                : workspace.root}
+              .worktreePath=${row.execNode || !isNativeLocalGateway() ? null : workspace.root}
               .archived=${row.archived === true}
               .onboarding=${this.onboarding}
               .preferencesBrowserOnly=${this.context.runtimeConfig?.state.connected &&

--- a/ui/src/pages/chat/components/chat-detail-panel.ts
+++ b/ui/src/pages/chat/components/chat-detail-panel.ts
@@ -15,7 +15,7 @@ import {
   renderSidebarPanel,
 } from "./chat-sidebar-content.ts";
 import {
-  absoluteFilePath,
+  localEditorFilePath,
   computeFileMatches,
   emptyCopyFeedback,
   readFileDraft,
@@ -29,6 +29,8 @@ type ChatDetailPanelContent = Exclude<SidebarContent, { kind: "task" }>;
 
 class ChatDetailPanel extends OpenClawLightDomElement {
   @property({ attribute: false }) content: ChatDetailPanelContent | null = null;
+  @property({ attribute: false }) gatewayUrl: string | null = null;
+  @property({ attribute: false }) execNode: string | null = null;
   @property() basePath = "";
   @property() canvasPluginSurfaceUrl: string | null = null;
   @property() embedSandboxMode: EmbedSandboxMode = "scripts";
@@ -318,7 +320,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     if (content?.kind !== "file") {
       return;
     }
-    const absPath = absoluteFilePath(content);
+    const absPath = localEditorFilePath(content, this.gatewayUrl, this.execNode);
     if (!absPath) {
       return;
     }
@@ -593,8 +595,10 @@ class ChatDetailPanel extends OpenClawLightDomElement {
         copyFeedback: this.fileCopyFeedback,
         currentMatchIndex,
         dirty: this.fileDirty,
+        execNode: this.execNode,
         editorMenuOpen: this.fileEditorMenuOpen,
         editing: this.fileEditing,
+        gatewayUrl: this.gatewayUrl,
         loadingEditor: this.fileEditorLoading,
         mountKey: this.fileOperationVersion,
         matches,

--- a/ui/src/pages/chat/components/chat-detail-panel.ts
+++ b/ui/src/pages/chat/components/chat-detail-panel.ts
@@ -6,6 +6,7 @@ import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { type EditorId, openEditor } from "../../../lib/editor-links.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
+import { localEditorFilePath } from "../../../lib/gateway-locality.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import type { SidebarContent } from "./chat-sidebar-content-types.ts";
 import {
@@ -15,7 +16,6 @@ import {
   renderSidebarPanel,
 } from "./chat-sidebar-content.ts";
 import {
-  localEditorFilePath,
   computeFileMatches,
   emptyCopyFeedback,
   readFileDraft,

--- a/ui/src/pages/chat/components/chat-detail-panel.ts
+++ b/ui/src/pages/chat/components/chat-detail-panel.ts
@@ -1,4 +1,8 @@
 import { property, state } from "lit/decorators.js";
+import {
+  localEditorFilePath,
+  observeNativeGateway,
+} from "../../../app/native-editor-locality.runtime.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import type { SessionLinkTarget } from "../../../components/markdown-session-links.ts";
 import { t } from "../../../i18n/index.ts";
@@ -6,7 +10,6 @@ import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { type EditorId, openEditor } from "../../../lib/editor-links.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
-import { localEditorFilePath } from "../../../lib/gateway-locality.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import type { SidebarContent } from "./chat-sidebar-content-types.ts";
 import {
@@ -29,7 +32,6 @@ type ChatDetailPanelContent = Exclude<SidebarContent, { kind: "task" }>;
 
 class ChatDetailPanel extends OpenClawLightDomElement {
   @property({ attribute: false }) content: ChatDetailPanelContent | null = null;
-  @property({ attribute: false }) gatewayUrl: string | null = null;
   @property({ attribute: false }) execNode: string | null = null;
   @property() basePath = "";
   @property() canvasPluginSurfaceUrl: string | null = null;
@@ -73,6 +75,11 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     FileCopyAction,
     ReturnType<typeof globalThis.setTimeout>
   >();
+
+  constructor() {
+    super();
+    observeNativeGateway(this);
+  }
 
   override connectedCallback() {
     super.connectedCallback();
@@ -320,7 +327,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     if (content?.kind !== "file") {
       return;
     }
-    const absPath = localEditorFilePath(content, this.gatewayUrl, this.execNode);
+    const absPath = localEditorFilePath(content, this.execNode);
     if (!absPath) {
       return;
     }
@@ -598,7 +605,6 @@ class ChatDetailPanel extends OpenClawLightDomElement {
         execNode: this.execNode,
         editorMenuOpen: this.fileEditorMenuOpen,
         editing: this.fileEditing,
-        gatewayUrl: this.gatewayUrl,
         loadingEditor: this.fileEditorLoading,
         mountKey: this.fileOperationVersion,
         matches,

--- a/ui/src/pages/chat/components/chat-detail-slot.ts
+++ b/ui/src/pages/chat/components/chat-detail-slot.ts
@@ -1,5 +1,6 @@
 import { html, type TemplateResult } from "lit";
 import type { ChatPageHost } from "../chat-state-host.ts";
+import { selectedChatSessionRow } from "../chat-state-route.ts";
 import type { ChatProps } from "../chat-view.ts";
 import { openSlot, type SidebarLayout } from "../sidebar-layout.ts";
 import type { BackgroundTasksProps } from "./chat-background-tasks.types.ts";
@@ -55,6 +56,8 @@ export function renderChatDetailSlot(params: {
     html`<openclaw-chat-detail-panel
       class="chat-sidebar"
       .content=${content}
+      .gatewayUrl=${host.client?.gatewayUrl ?? null}
+      .execNode=${selectedChatSessionRow(host)?.execNode ?? null}
       .basePath=${params.chat.basePath ?? ""}
       .canvasPluginSurfaceUrl=${host.canvasPluginSurfaceUrl}
       .embedSandboxMode=${host.embedSandboxMode}

--- a/ui/src/pages/chat/components/chat-detail-slot.ts
+++ b/ui/src/pages/chat/components/chat-detail-slot.ts
@@ -56,7 +56,6 @@ export function renderChatDetailSlot(params: {
     html`<openclaw-chat-detail-panel
       class="chat-sidebar"
       .content=${content}
-      .gatewayUrl=${host.client?.gatewayUrl ?? null}
       .execNode=${selectedChatSessionRow(host)?.execNode ?? null}
       .basePath=${params.chat.basePath ?? ""}
       .canvasPluginSurfaceUrl=${host.canvasPluginSurfaceUrl}

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -7,6 +7,10 @@ import type { UiSettings } from "../../../app/settings.ts";
 import { icons } from "../../../components/icons.ts";
 import type { SessionOwnerOption } from "../../../components/session-owner-chip.ts";
 import type { SessionCapability } from "../../../lib/sessions/index.ts";
+import {
+  clearNativeGatewayTestState,
+  setNativeGatewayTestState,
+} from "../../../test-helpers/native-gateways.ts";
 import { createTestChatPane } from "../chat-pane.test-support.ts";
 import type { ChatPageHost } from "../chat-state-host.ts";
 import { createBackgroundTasksProps } from "./chat-background-tasks.ts";
@@ -28,6 +32,8 @@ afterEach(() => {
   for (const container of containers.splice(0)) {
     container.remove();
   }
+  clearNativeGatewayTestState();
+  vi.restoreAllMocks();
 });
 
 function settings(): UiSettings {
@@ -137,40 +143,60 @@ function select(menu: ParentNode, value: string) {
 
 describe("chat header session menu", () => {
   it.each([
-    { gatewayUrl: "ws://localhost:18789", offered: true },
-    { gatewayUrl: "wss://gateway.example.test", offered: false },
-    { gatewayUrl: "ws://localhost:18789", execNode: "build-mac", offered: false },
-  ])("offers session editors only for viewer-local workspaces: $gatewayUrl", async (testCase) => {
-    const client = { gatewayUrl: testCase.gatewayUrl } as GatewayBrowserClient;
-    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    const session = {
-      key: state.sessionKey,
-      kind: "direct" as const,
-      updatedAt: 0,
-      spawnedWorkspaceDir: "/workspace",
-      ...(testCase.execNode ? { execNode: testCase.execNode, execCwd: "/remote/workspace" } : {}),
-    };
-    state.settings = {} as ChatPageHost["settings"];
-    const container = document.createElement("div");
-    document.body.append(container);
-    containers.push(container);
-    render(
-      pane.renderPaneHeader(
-        createSessionWorkspaceProps(state),
-        createBackgroundTasksProps(state),
-        session,
-        false,
-        undefined,
-        false,
-      ),
-      container,
-    );
-    const menu = container.querySelector<HeaderMenuElement>("openclaw-chat-header-session-menu");
-    await menu?.updateComplete;
+    { name: "plain browser", nativeGateway: null, offered: false },
+    { name: "native local gateway", nativeGateway: "local", offered: true },
+    { name: "native remote gateway", nativeGateway: "remote", offered: false },
+    {
+      name: "SSH-tunneled remote native gateway",
+      nativeGateway: "remote",
+      gatewayUrl: "ws://127.0.0.1:18789",
+      offered: false,
+    },
+    {
+      name: "remote execution node",
+      nativeGateway: "local",
+      execNode: "build-mac",
+      offered: false,
+    },
+  ] as const)(
+    "offers session editors only for native-local workspaces: $name",
+    async (testCase) => {
+      setNativeGatewayTestState(testCase.nativeGateway);
+      const client = {
+        gatewayUrl: "gatewayUrl" in testCase ? testCase.gatewayUrl : "ws://localhost:18789",
+      } as GatewayBrowserClient;
+      const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+      const session = {
+        key: state.sessionKey,
+        kind: "direct" as const,
+        updatedAt: 0,
+        spawnedWorkspaceDir: "/workspace",
+        ...("execNode" in testCase
+          ? { execNode: testCase.execNode, execCwd: "/remote/workspace" }
+          : {}),
+      };
+      state.settings = {} as ChatPageHost["settings"];
+      const container = document.createElement("div");
+      document.body.append(container);
+      containers.push(container);
+      render(
+        pane.renderPaneHeader(
+          createSessionWorkspaceProps(state),
+          createBackgroundTasksProps(state),
+          session,
+          false,
+          undefined,
+          false,
+        ),
+        container,
+      );
+      const menu = container.querySelector<HeaderMenuElement>("openclaw-chat-header-session-menu");
+      await menu?.updateComplete;
 
-    expect(menu?.textContent?.includes("Open in")).toBe(testCase.offered);
-    expect(menu?.textContent?.includes("Cursor")).toBe(testCase.offered);
-  });
+      expect(menu?.textContent?.includes("Open in")).toBe(testCase.offered);
+      expect(menu?.textContent?.includes("Cursor")).toBe(testCase.offered);
+    },
+  );
 
   it("renders the curated session actions in order", async () => {
     const menu = await mountMenu();

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -2,9 +2,14 @@
 
 import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { UiSettings } from "../../../app/settings.ts";
 import { icons } from "../../../components/icons.ts";
 import type { SessionOwnerOption } from "../../../components/session-owner-chip.ts";
+import type { SessionCapability } from "../../../lib/sessions/index.ts";
+import { createTestChatPane } from "../chat-pane.test-support.ts";
+import type { ChatPageHost } from "../chat-state-host.ts";
+import { createBackgroundTasksProps } from "./chat-background-tasks.ts";
 import "./chat-header-session-menu.ts";
 import type {
   HeaderMenuAction,
@@ -12,6 +17,7 @@ import type {
   HeaderMenuQuickAction,
   HeaderMenuStatusAction,
 } from "./chat-header-session-menu.ts";
+import { createSessionWorkspaceProps } from "./chat-session-workspace.ts";
 
 type HeaderMenuElement = HTMLElement & { updateComplete: Promise<boolean> };
 type MenuItemElement = HTMLElement & { checked: boolean; disabled: boolean; submenuOpen?: boolean };
@@ -130,6 +136,42 @@ function select(menu: ParentNode, value: string) {
 }
 
 describe("chat header session menu", () => {
+  it.each([
+    { gatewayUrl: "ws://localhost:18789", offered: true },
+    { gatewayUrl: "wss://gateway.example.test", offered: false },
+    { gatewayUrl: "ws://localhost:18789", execNode: "build-mac", offered: false },
+  ])("offers session editors only for viewer-local workspaces: $gatewayUrl", async (testCase) => {
+    const client = { gatewayUrl: testCase.gatewayUrl } as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const session = {
+      key: state.sessionKey,
+      kind: "direct" as const,
+      updatedAt: 0,
+      spawnedWorkspaceDir: "/workspace",
+      ...(testCase.execNode ? { execNode: testCase.execNode, execCwd: "/remote/workspace" } : {}),
+    };
+    state.settings = {} as ChatPageHost["settings"];
+    const container = document.createElement("div");
+    document.body.append(container);
+    containers.push(container);
+    render(
+      pane.renderPaneHeader(
+        createSessionWorkspaceProps(state),
+        createBackgroundTasksProps(state),
+        session,
+        false,
+        undefined,
+        false,
+      ),
+      container,
+    );
+    const menu = container.querySelector<HeaderMenuElement>("openclaw-chat-header-session-menu");
+    await menu?.updateComplete;
+
+    expect(menu?.textContent?.includes("Open in")).toBe(testCase.offered);
+    expect(menu?.textContent?.includes("Cursor")).toBe(testCase.offered);
+  });
+
   it("renders the curated session actions in order", async () => {
     const menu = await mountMenu();
     const labels = Array.from(

--- a/ui/src/pages/chat/components/chat-sidebar-content.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content.ts
@@ -177,7 +177,6 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
                 ? html`<openclaw-session-diff
                     .loader=${content.load}
                     .loadFileText=${content.loadFileText ?? null}
-                    .gatewayUrl=${props.fileView?.gatewayUrl ?? null}
                     .execNode=${props.fileView?.execNode ?? null}
                     .openFile=${content.openFile ?? null}
                     .revealFile=${content.revealFile ?? null}

--- a/ui/src/pages/chat/components/chat-sidebar-content.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content.ts
@@ -177,6 +177,8 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
                 ? html`<openclaw-session-diff
                     .loader=${content.load}
                     .loadFileText=${content.loadFileText ?? null}
+                    .gatewayUrl=${props.fileView?.gatewayUrl ?? null}
+                    .execNode=${props.fileView?.execNode ?? null}
                     .openFile=${content.openFile ?? null}
                     .revealFile=${content.revealFile ?? null}
                   ></openclaw-session-diff>`

--- a/ui/src/pages/chat/components/chat-sidebar-editor-menu.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-editor-menu.ts
@@ -10,7 +10,13 @@ export function renderChatSidebarEditorMenu(params: {
   onOpenChange: (open: boolean) => void;
   onOpenEditor: (editor: EditorId) => void;
 }) {
-  const label = params.absolutePath ? "Open in editor" : "Workspace root unknown";
+  // A null path means the file is not reachable from this browser (remote
+  // gateway or exec node), so the handoff would silently no-op. Drop the
+  // control rather than leaving a disabled one that cannot explain itself.
+  if (!params.absolutePath) {
+    return nothing;
+  }
+  const label = "Open in editor";
   return html`
     <div class="sidebar-file-view__editor">
       <openclaw-tooltip .content=${label}>
@@ -32,19 +38,16 @@ export function renderChatSidebarEditorMenu(params: {
             class="btn btn--sm sidebar-file-view__action"
             type="button"
             aria-label=${label}
-            ?disabled=${!params.absolutePath}
           >
             ${icons.externalLink}
           </button>
-          ${params.absolutePath
-            ? EDITOR_IDS.map(
-                (editor) => html`
-                  <wa-dropdown-item class="sidebar-file-view__editor-item" value=${editor}>
-                    ${EDITOR_LABELS[editor]}
-                  </wa-dropdown-item>
-                `,
-              )
-            : nothing}
+          ${EDITOR_IDS.map(
+            (editor) => html`
+              <wa-dropdown-item class="sidebar-file-view__editor-item" value=${editor}>
+                ${EDITOR_LABELS[editor]}
+              </wa-dropdown-item>
+            `,
+          )}
         </wa-dropdown>
       </openclaw-tooltip>
     </div>

--- a/ui/src/pages/chat/components/chat-sidebar-editor-menu.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-editor-menu.ts
@@ -10,9 +10,6 @@ export function renderChatSidebarEditorMenu(params: {
   onOpenChange: (open: boolean) => void;
   onOpenEditor: (editor: EditorId) => void;
 }) {
-  // A null path means the file is not reachable from this browser (remote
-  // gateway or exec node), so the handoff would silently no-op. Drop the
-  // control rather than leaving a disabled one that cannot explain itself.
   if (!params.absolutePath) {
     return nothing;
   }

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.ts
@@ -1,10 +1,10 @@
 import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
+import { localEditorFilePath } from "../../../app/native-editor-locality.runtime.ts";
 import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import type { EditorId } from "../../../lib/editor-links.ts";
-import { localEditorFilePath } from "../../../lib/gateway-locality.ts";
 import type { SidebarContent } from "./chat-sidebar-content-types.ts";
 import { renderChatSidebarEditorMenu } from "./chat-sidebar-editor-menu.ts";
 
@@ -64,7 +64,6 @@ export type FileViewControls = {
   execNode: string | null;
   editorMenuOpen: boolean;
   editing: boolean;
-  gatewayUrl: string | null;
   loadingEditor: boolean;
   mountKey: number;
   matches: number[];
@@ -118,7 +117,7 @@ export function renderSidebarFile(
   onViewRawText: () => void,
   controls?: FileViewControls,
 ) {
-  const absolutePath = localEditorFilePath(content, controls?.gatewayUrl, controls?.execNode);
+  const absolutePath = localEditorFilePath(content, controls?.execNode);
   const matchNumber = controls?.matches.length ? controls.currentMatchIndex + 1 : 0;
   return html`
     <section class="sidebar-file-view">

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.ts
@@ -4,7 +4,7 @@ import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import type { EditorId } from "../../../lib/editor-links.ts";
-import { isLoopbackGatewayUrl } from "../../../lib/gateway-locality.ts";
+import { localEditorFilePath } from "../../../lib/gateway-locality.ts";
 import type { SidebarContent } from "./chat-sidebar-content-types.ts";
 import { renderChatSidebarEditorMenu } from "./chat-sidebar-editor-menu.ts";
 
@@ -51,27 +51,6 @@ export function computeFileMatches(content: string, query: string): number[] {
     .flatMap((line, index) =>
       line.toLocaleLowerCase().includes(normalizedQuery) ? [index + 1] : [],
     );
-}
-
-/**
- * Absolute path only when an editor on this machine could actually open it.
- * Null for a remote gateway or exec node even though the path itself is known,
- * so callers must not reuse this for display or copy affordances.
- */
-export function localEditorFilePath(
-  content: Pick<FileSidebarContent, "path" | "root">,
-  gatewayUrl: string | null | undefined,
-  execNode: string | null | undefined,
-): string | null {
-  if (execNode || !isLoopbackGatewayUrl(gatewayUrl)) {
-    return null;
-  }
-  if (/^(?:\/|[a-z]:[\\/]|\\\\)/i.test(content.path)) {
-    return content.path;
-  }
-  return content.root
-    ? `${content.root.replace(/[\\/]+$/, "")}/${content.path.replace(/^[\\/]+/, "")}`
-    : null;
 }
 
 export type FileCopyAction = "path" | "contents";

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.ts
@@ -4,6 +4,7 @@ import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import type { EditorId } from "../../../lib/editor-links.ts";
+import { isLoopbackGatewayUrl } from "../../../lib/gateway-locality.ts";
 import type { SidebarContent } from "./chat-sidebar-content-types.ts";
 import { renderChatSidebarEditorMenu } from "./chat-sidebar-editor-menu.ts";
 
@@ -52,18 +53,25 @@ export function computeFileMatches(content: string, query: string): number[] {
     );
 }
 
-export function absoluteFilePath(content: FileSidebarContent): string | null {
-  if (
-    content.path.startsWith("/") ||
-    /^[a-z]:[\\/]/i.test(content.path) ||
-    content.path.startsWith("\\\\")
-  ) {
-    return content.path;
-  }
-  if (!content.root) {
+/**
+ * Absolute path only when an editor on this machine could actually open it.
+ * Null for a remote gateway or exec node even though the path itself is known,
+ * so callers must not reuse this for display or copy affordances.
+ */
+export function localEditorFilePath(
+  content: Pick<FileSidebarContent, "path" | "root">,
+  gatewayUrl: string | null | undefined,
+  execNode: string | null | undefined,
+): string | null {
+  if (execNode || !isLoopbackGatewayUrl(gatewayUrl)) {
     return null;
   }
-  return `${content.root.replace(/[\\/]+$/, "")}/${content.path.replace(/^[\\/]+/, "")}`;
+  if (/^(?:\/|[a-z]:[\\/]|\\\\)/i.test(content.path)) {
+    return content.path;
+  }
+  return content.root
+    ? `${content.root.replace(/[\\/]+$/, "")}/${content.path.replace(/^[\\/]+/, "")}`
+    : null;
 }
 
 export type FileCopyAction = "path" | "contents";
@@ -74,8 +82,10 @@ export type FileViewControls = {
   copyFeedback: FileCopyFeedback;
   currentMatchIndex: number;
   dirty: boolean;
+  execNode: string | null;
   editorMenuOpen: boolean;
   editing: boolean;
+  gatewayUrl: string | null;
   loadingEditor: boolean;
   mountKey: number;
   matches: number[];
@@ -129,7 +139,7 @@ export function renderSidebarFile(
   onViewRawText: () => void,
   controls?: FileViewControls,
 ) {
-  const absolutePath = absoluteFilePath(content);
+  const absolutePath = localEditorFilePath(content, controls?.gatewayUrl, controls?.execNode);
   const matchNumber = controls?.matches.length ? controls.currentMatchIndex + 1 : 0;
   return html`
     <section class="sidebar-file-view">

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -2,6 +2,10 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { openEditor } from "../../../lib/editor-links.ts";
+import {
+  clearNativeGatewayTestState,
+  setNativeGatewayTestState,
+} from "../../../test-helpers/native-gateways.ts";
 import { hasUniformLineEndings } from "./chat-sidebar.ts";
 
 describe("hasUniformLineEndings", () => {
@@ -62,22 +66,30 @@ describe("file sidebar editor locality", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     document.body.replaceChildren();
+    clearNativeGatewayTestState();
   });
 
   it.each([
-    { gatewayUrl: "ws://localhost:18789", offered: true },
-    { gatewayUrl: "wss://gateway.example.test", offered: false },
-    { gatewayUrl: "ws://localhost:18789", execNode: "build-mac", offered: false },
-  ])("offers editors only when the file belongs to this viewer: $gatewayUrl", async (testCase) => {
+    { name: "plain browser", nativeGateway: null, offered: false },
+    { name: "native local gateway", nativeGateway: "local", offered: true },
+    // Covers the documented `ssh -N -L 18789:127.0.0.1:18789` tunnel: the URL
+    // is loopback, the workspace is not. Only the native kind catches this.
+    { name: "native remote gateway", nativeGateway: "remote", offered: false },
+    {
+      name: "remote execution node",
+      nativeGateway: "local",
+      execNode: "build-mac",
+      offered: false,
+    },
+  ] as const)("offers editors only for native-local files: $name", async (testCase) => {
+    setNativeGatewayTestState(testCase.nativeGateway);
     const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
       content: unknown;
-      gatewayUrl: string;
       execNode: string | null;
       ensureFileEditor: () => Promise<void>;
       updateComplete: Promise<unknown>;
     };
-    panel.gatewayUrl = testCase.gatewayUrl;
-    panel.execNode = testCase.execNode ?? null;
+    panel.execNode = "execNode" in testCase ? (testCase.execNode ?? null) : null;
     panel.content = {
       kind: "file",
       path: "src/example.ts",
@@ -95,6 +107,32 @@ describe("file sidebar editor locality", () => {
     );
     // Absent, not merely disabled: a dead control cannot explain why it is dead.
     expect(panel.querySelector(".sidebar-file-view__editor") !== null).toBe(testCase.offered);
+  });
+
+  it("removes editor controls when the native gateway switches to remote", async () => {
+    setNativeGatewayTestState("local");
+    const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+      content: unknown;
+      ensureFileEditor: () => Promise<void>;
+      updateComplete: Promise<unknown>;
+    };
+    panel.content = {
+      kind: "file",
+      path: "src/example.ts",
+      name: "example.ts",
+      root: "/workspace",
+      content: "const answer = 42;",
+    };
+    vi.spyOn(panel, "ensureFileEditor").mockResolvedValue();
+    document.body.append(panel);
+    await panel.updateComplete;
+    expect(panel.querySelector('[aria-label="Open in editor"]')).not.toBeNull();
+
+    setNativeGatewayTestState("remote");
+    await panel.updateComplete;
+
+    expect(panel.querySelector('[aria-label="Open in editor"]')).toBeNull();
+    expect(panel.querySelector(".sidebar-file-view__editor")).toBeNull();
   });
 });
 

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -58,6 +58,46 @@ describe("openEditor", () => {
   });
 });
 
+describe("file sidebar editor locality", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.replaceChildren();
+  });
+
+  it.each([
+    { gatewayUrl: "ws://localhost:18789", offered: true },
+    { gatewayUrl: "wss://gateway.example.test", offered: false },
+    { gatewayUrl: "ws://localhost:18789", execNode: "build-mac", offered: false },
+  ])("offers editors only when the file belongs to this viewer: $gatewayUrl", async (testCase) => {
+    const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+      content: unknown;
+      gatewayUrl: string;
+      execNode: string | null;
+      ensureFileEditor: () => Promise<void>;
+      updateComplete: Promise<unknown>;
+    };
+    panel.gatewayUrl = testCase.gatewayUrl;
+    panel.execNode = testCase.execNode ?? null;
+    panel.content = {
+      kind: "file",
+      path: "src/example.ts",
+      name: "example.ts",
+      root: "/workspace",
+      content: "const answer = 42;",
+    };
+    vi.spyOn(panel, "ensureFileEditor").mockResolvedValue();
+    document.body.append(panel);
+    await panel.updateComplete;
+
+    expect(panel.querySelector('[aria-label="Open in editor"]') !== null).toBe(testCase.offered);
+    expect(panel.querySelectorAll(".sidebar-file-view__editor-item")).toHaveLength(
+      testCase.offered ? 4 : 0,
+    );
+    // Absent, not merely disabled: a dead control cannot explain why it is dead.
+    expect(panel.querySelector(".sidebar-file-view__editor") !== null).toBe(testCase.offered);
+  });
+});
+
 describe("markdown sidebar", () => {
   it("opens workspace files from markdown preview clicks", async () => {
     const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {

--- a/ui/src/pages/chat/components/session-diff-panel.test.ts
+++ b/ui/src/pages/chat/components/session-diff-panel.test.ts
@@ -2,11 +2,14 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionsDiffResult } from "../../../../../packages/gateway-protocol/src/index.js";
+import {
+  clearNativeGatewayTestState,
+  setNativeGatewayTestState,
+} from "../../../test-helpers/native-gateways.ts";
 import type { SessionDiffFileTextLoader, SessionDiffLoader } from "./session-diff-panel.ts";
 import "./session-diff-panel.ts";
 
 type SessionDiffElement = HTMLElement & {
-  gatewayUrl: string | null;
   execNode: string | null;
   loadFileText: SessionDiffFileTextLoader | null;
   loader: SessionDiffLoader | null;
@@ -71,17 +74,25 @@ function fileResult(patch: string): SessionsDiffResult {
 
 afterEach(() => {
   document.body.replaceChildren();
+  clearNativeGatewayTestState();
+  vi.restoreAllMocks();
 });
 
 describe("SessionDiffPanel", () => {
   it.each([
-    { gatewayUrl: "ws://localhost:18789", offered: true },
-    { gatewayUrl: "wss://gateway.example.test", offered: false },
-    { gatewayUrl: "ws://localhost:18789", execNode: "build-mac", offered: false },
-  ])("offers file editors only for viewer-local checkouts: $gatewayUrl", async (testCase) => {
+    { name: "plain browser", nativeGateway: null, offered: false },
+    { name: "native local gateway", nativeGateway: "local", offered: true },
+    { name: "native remote gateway", nativeGateway: "remote", offered: false },
+    {
+      name: "remote execution node",
+      nativeGateway: "local",
+      execNode: "build-mac",
+      offered: false,
+    },
+  ] as const)("offers file editors only for native-local checkouts: $name", async (testCase) => {
+    setNativeGatewayTestState(testCase.nativeGateway);
     const panel = document.createElement("openclaw-session-diff") as SessionDiffElement;
-    panel.gatewayUrl = testCase.gatewayUrl;
-    panel.execNode = testCase.execNode ?? null;
+    panel.execNode = "execNode" in testCase ? (testCase.execNode ?? null) : null;
     panel.loader = vi.fn(async () => ({ ...fileResult(SNAPSHOT_PATCH), root: "/workspace" }));
     document.body.append(panel);
 
@@ -92,6 +103,25 @@ describe("SessionDiffPanel", () => {
     const menu = panel.querySelector("openclaw-session-diff-menu");
     expect(menu?.textContent?.includes("Open in Editor")).toBe(testCase.offered);
     expect(menu?.textContent?.includes("Cursor")).toBe(testCase.offered);
+  });
+
+  it("closes an open editor menu when the native gateway switches to remote", async () => {
+    setNativeGatewayTestState("local");
+    const panel = document.createElement("openclaw-session-diff") as SessionDiffElement;
+    panel.loader = vi.fn(async () => ({ ...fileResult(SNAPSHOT_PATCH), root: "/workspace" }));
+    document.body.append(panel);
+
+    await vi.waitFor(() => expect(panel.querySelector(".session-diff__file-menu")).not.toBeNull());
+    panel.querySelector<HTMLButtonElement>(".session-diff__file-menu")?.click();
+    await panel.updateComplete;
+    expect(panel.querySelector("openclaw-session-diff-menu")?.textContent).toContain(
+      "Open in Editor",
+    );
+
+    setNativeGatewayTestState("remote");
+    await panel.updateComplete;
+
+    expect(panel.querySelector("openclaw-session-diff-menu")).toBeNull();
   });
 
   it("commits only the latest loader result after a rapid loader change", async () => {

--- a/ui/src/pages/chat/components/session-diff-panel.test.ts
+++ b/ui/src/pages/chat/components/session-diff-panel.test.ts
@@ -6,6 +6,8 @@ import type { SessionDiffFileTextLoader, SessionDiffLoader } from "./session-dif
 import "./session-diff-panel.ts";
 
 type SessionDiffElement = HTMLElement & {
+  gatewayUrl: string | null;
+  execNode: string | null;
   loadFileText: SessionDiffFileTextLoader | null;
   loader: SessionDiffLoader | null;
   readonly updateComplete: Promise<boolean>;
@@ -72,6 +74,26 @@ afterEach(() => {
 });
 
 describe("SessionDiffPanel", () => {
+  it.each([
+    { gatewayUrl: "ws://localhost:18789", offered: true },
+    { gatewayUrl: "wss://gateway.example.test", offered: false },
+    { gatewayUrl: "ws://localhost:18789", execNode: "build-mac", offered: false },
+  ])("offers file editors only for viewer-local checkouts: $gatewayUrl", async (testCase) => {
+    const panel = document.createElement("openclaw-session-diff") as SessionDiffElement;
+    panel.gatewayUrl = testCase.gatewayUrl;
+    panel.execNode = testCase.execNode ?? null;
+    panel.loader = vi.fn(async () => ({ ...fileResult(SNAPSHOT_PATCH), root: "/workspace" }));
+    document.body.append(panel);
+
+    await vi.waitFor(() => expect(panel.querySelector(".session-diff__file-menu")).not.toBeNull());
+    panel.querySelector<HTMLButtonElement>(".session-diff__file-menu")?.click();
+    await panel.updateComplete;
+
+    const menu = panel.querySelector("openclaw-session-diff-menu");
+    expect(menu?.textContent?.includes("Open in Editor")).toBe(testCase.offered);
+    expect(menu?.textContent?.includes("Cursor")).toBe(testCase.offered);
+  });
+
   it("commits only the latest loader result after a rapid loader change", async () => {
     const first = deferred<SessionsDiffResult>();
     const second = deferred<SessionsDiffResult>();

--- a/ui/src/pages/chat/components/session-diff-panel.ts
+++ b/ui/src/pages/chat/components/session-diff-panel.ts
@@ -27,6 +27,7 @@ import { formatUiError } from "../../../lib/format-error.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { getSafeLocalStorage } from "../../../local-storage.ts";
 import { renderDiffBlock, renderDiffStatChips } from "./chat-diff-render.ts";
+import { localEditorFilePath } from "./chat-sidebar-file-view.ts";
 import type {
   SessionDiffMenuAction,
   SessionDiffMenuData,
@@ -125,10 +126,6 @@ function splitPath(filePath: string): { directory: string; name: string } {
     : { directory: normalized.slice(0, separator), name: normalized.slice(separator + 1) };
 }
 
-function absolutePath(root: string, filePath: string): string {
-  return `${root.replace(/[\\/]+$/, "")}/${filePath.replace(/^[\\/]+/, "")}`;
-}
-
 function shellArgument(value: string): string {
   return /^[A-Za-z0-9_./:@+-]+$/.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
 }
@@ -154,6 +151,8 @@ function taskResult(result: SessionsDiffResult): SessionDiffTaskResult {
 }
 
 class SessionDiffPanel extends OpenClawLightDomElement {
+  @property({ attribute: false }) gatewayUrl: string | null = null;
+  @property({ attribute: false }) execNode: string | null = null;
   @property({ attribute: false }) loader: SessionDiffLoader | null = null;
   @property({ attribute: false }) loadFileText: SessionDiffFileTextLoader | null = null;
   @property({ attribute: false }) openFile: ((path: string) => void) | null = null;
@@ -477,7 +476,13 @@ class SessionDiffPanel extends OpenClawLightDomElement {
     const { file } = view;
     const collapsed = this.collapsedPaths.has(file.path);
     const { directory, name } = splitPath(file.path);
-    const absPath = result.root ? absolutePath(result.root, file.path) : undefined;
+    const absPath = result.root
+      ? (localEditorFilePath(
+          { root: result.root, path: file.path },
+          this.gatewayUrl,
+          this.execNode,
+        ) ?? undefined)
+      : undefined;
     const pathTitle = file.oldPath ? `${file.oldPath} → ${file.path}` : file.path;
     return html`
       <section class="session-diff__file" data-status=${file.status}>

--- a/ui/src/pages/chat/components/session-diff-panel.ts
+++ b/ui/src/pages/chat/components/session-diff-panel.ts
@@ -7,6 +7,10 @@ import type {
   SessionDiffFile,
   SessionsDiffResult,
 } from "../../../../../packages/gateway-protocol/src/index.js";
+import {
+  localEditorFilePath,
+  observeNativeGateway,
+} from "../../../app/native-editor-locality.runtime.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import "../../../components/tooltip.ts";
@@ -24,7 +28,6 @@ import type { DiffLine } from "../../../lib/chat/tool-call-diff.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { openEditor } from "../../../lib/editor-links.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
-import { localEditorFilePath } from "../../../lib/gateway-locality.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { getSafeLocalStorage } from "../../../local-storage.ts";
 import { renderDiffBlock, renderDiffStatChips } from "./chat-diff-render.ts";
@@ -151,7 +154,6 @@ function taskResult(result: SessionsDiffResult): SessionDiffTaskResult {
 }
 
 class SessionDiffPanel extends OpenClawLightDomElement {
-  @property({ attribute: false }) gatewayUrl: string | null = null;
   @property({ attribute: false }) execNode: string | null = null;
   @property({ attribute: false }) loader: SessionDiffLoader | null = null;
   @property({ attribute: false }) loadFileText: SessionDiffFileTextLoader | null = null;
@@ -168,6 +170,13 @@ class SessionDiffPanel extends OpenClawLightDomElement {
   private readonly fileTextCache = new WeakMap<FileView, Promise<string[] | null>>();
   private readonly unavailableFileText = new WeakSet<FileView>();
   private prefetchedDiffResult: SessionsDiffResult | null = null;
+
+  constructor() {
+    super();
+    observeNativeGateway(this, () => {
+      this.menu = null;
+    });
+  }
 
   private readonly diffTask = new Task(this, {
     args: () =>
@@ -477,11 +486,7 @@ class SessionDiffPanel extends OpenClawLightDomElement {
     const collapsed = this.collapsedPaths.has(file.path);
     const { directory, name } = splitPath(file.path);
     const absPath = result.root
-      ? (localEditorFilePath(
-          { root: result.root, path: file.path },
-          this.gatewayUrl,
-          this.execNode,
-        ) ?? undefined)
+      ? (localEditorFilePath({ root: result.root, path: file.path }, this.execNode) ?? undefined)
       : undefined;
     const pathTitle = file.oldPath ? `${file.oldPath} → ${file.path}` : file.path;
     return html`

--- a/ui/src/pages/chat/components/session-diff-panel.ts
+++ b/ui/src/pages/chat/components/session-diff-panel.ts
@@ -24,10 +24,10 @@ import type { DiffLine } from "../../../lib/chat/tool-call-diff.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { openEditor } from "../../../lib/editor-links.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
+import { localEditorFilePath } from "../../../lib/gateway-locality.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { getSafeLocalStorage } from "../../../local-storage.ts";
 import { renderDiffBlock, renderDiffStatChips } from "./chat-diff-render.ts";
-import { localEditorFilePath } from "./chat-sidebar-file-view.ts";
 import type {
   SessionDiffMenuAction,
   SessionDiffMenuData,

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -1369,15 +1369,15 @@ class SessionsPage extends OpenClawLightDomElement {
     );
     void fetchSessionMenuWork({
       client: scope.client,
-      pullRequestsAvailable:
+      loadPullRequests:
         isGatewayMethodAdvertised(
           scope.context.gateway.snapshot,
           SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
-        ) === true,
-      sessionKey: row.key,
-      agentId: this.sessionAgentId(row.key, scope.context),
-      loadPullRequests: () => store.load(this, pullRequestKey),
+        ) === true
+          ? () => store.load(this, pullRequestKey)
+          : undefined,
       worktreeId: row.worktree.id,
+      execNode: row.execNode,
     }).then((work) => {
       if (version === this.sessionMenuWorkVersion) {
         this.sessionMenuWork = { loading: false, ...work };

--- a/ui/src/test-helpers/native-gateways.ts
+++ b/ui/src/test-helpers/native-gateways.ts
@@ -1,0 +1,43 @@
+import { vi } from "vitest";
+import * as nativeGateways from "../app/native-gateways.runtime.ts";
+import type { NativeGateway, NativeGatewaysSnapshot } from "../app/native-gateways.runtime.ts";
+
+export function setNativeGatewayTestState(kind: NativeGateway["kind"] | null): void {
+  if (!kind) {
+    Reflect.deleteProperty(window, "__OPENCLAW_NATIVE_GATEWAYS__");
+    Reflect.deleteProperty(window, "webkit");
+    vi.spyOn(nativeGateways, "nativeGatewaysCapability").mockReturnValue(null);
+    return;
+  }
+  const snapshot: NativeGatewaysSnapshot = {
+    gateways: [
+      {
+        id: "local",
+        name: "Local Gateway",
+        kind: "local",
+        isPrimary: true,
+        canPromote: false,
+        health: "ok",
+      },
+      {
+        id: "remote",
+        name: "Remote Gateway",
+        kind: "remote",
+        isPrimary: false,
+        canPromote: true,
+        health: "ok",
+      },
+    ],
+    currentId: kind,
+  };
+  Object.assign(window, {
+    __OPENCLAW_NATIVE_GATEWAYS__: snapshot,
+    webkit: { messageHandlers: { openclawGateways: { postMessage: vi.fn() } } },
+  });
+  window.dispatchEvent(new CustomEvent("openclaw:native-gateways-changed", { detail: snapshot }));
+}
+
+export function clearNativeGatewayTestState(): void {
+  Reflect.deleteProperty(window, "__OPENCLAW_NATIVE_GATEWAYS__");
+  Reflect.deleteProperty(window, "webkit");
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators were offered **Open in > Cursor / VS Code / Windsurf / Zed** on sessions whose files were not on their computer. Clicking it did nothing at all: no editor, no error, no toast, no recorded reason.

It appears on four surfaces, all affected: the sidebar/Sessions session context menu, the chat header session menu, the session file view toolbar, and the session diff file menu.

## Why This Change Was Made

`openEditor` builds a `cursor://file/<path>` custom-scheme URL. That URL is resolved by the OS behind the **browser**, while the path comes from the **Gateway's** filesystem. The handoff only works when the browser runs on the Gateway host, and nothing checked that.

**A loopback gateway URL does not prove locality.** The documented way to reach a remote Gateway is an SSH tunnel:

```
ssh -N -L 18789:127.0.0.1:18789 user@host
```

The browser then dials `127.0.0.1` while the workspace lives on the VPS. That command is the documented default in `docs/install/hetzner.md`, `docs/install/digitalocean.md`, `docs/install/oracle.md`, `docs/install/raspberry-pi.md`, `docs/platforms/linux.md`, `docs/nodes/index.md` and `docs/gateway/remote.md`; `docs/platforms/mac/remote.md` states it outright — "The gateway sees the node's IP as `127.0.0.1` because the tunnel is loopback." Server-side peer IP is fooled identically, so a sandboxed browser has no way to distinguish the two cases.

The native macOS app *does* know. `AppState.ConnectionMode` is `local`/`remote`, and `DashboardGatewayCatalog` serialises it as `kind` on each entry of `window.__OPENCLAW_NATIVE_GATEWAYS__`, so a tunneled gateway is `"remote"` despite its loopback URL. The gate now reads that fact through the existing `nativeGatewaysCapability` seam, keeps the pre-existing remote-exec-node condition, and drops the `gatewayUrl` plumbing entirely.

No remote alternative is offered. Remote-SSH URIs (`vscode://vscode-remote/ssh-remote+host/path`) were considered and rejected: they need SSH plus a matching editor extension configured on the viewer's machine, and the Gateway cannot know a target reachable from there.

## User Impact

- **Native macOS app on a local gateway: no change.** Full editor submenu, as today.
- **Native macOS app on a remote gateway (including an SSH tunnel with a `127.0.0.1` URL): entry absent.**
- **Plain browser: entry absent — including at genuine `localhost`.** This is the deliberate cost of refusing to guess: there is no authoritative locality signal in a browser, and on Linux and Windows there is no native app to supply one, so those users lose an affordance that appears to work today. A menu item that silently does nothing was judged worse than no menu item.
- Absent, not disabled — a greyed-out row still advertises a handoff that cannot run. While the checkout path is still resolving the row is held in place so the menu does not shift under the pointer; it is dropped once resolution confirms ineligibility.
- Switching gateways inside the app re-evaluates live: open menus close and diff menus drop their editor entry.

## Evidence

Captured on the mocked Control UI dev server, same build and session, opening the same menu. The native shell is simulated by injecting the exact snapshot `DashboardWindowController` writes at document start (`__OPENCLAW_NATIVE_GATEWAYS__` plus the `webkit.messageHandlers.openclawGateways` handler the capability requires) — this is a UI-level proof of the gate, not a run of the packaged Mac app.

| Context | Editor entries in menu |
| --- | --- |
| Native shell, gateway `kind: "local"` | `["Open in","Cursor","VS Code","Windsurf","Zed"]` |
| Native shell, gateway `kind: "remote"` (the tunnel case) | `[]` |
| Plain browser, no native shell | `[]` |

Screenshots below. Earlier screenshots on this PR were taken against the loopback design and no longer describe shipped behavior.

Automated:

- `pnpm build` — clean, and **zero `[INEFFECTIVE_DYNAMIC_IMPORT]`** (the new module is statically imported everywhere).
- `node --import tsx scripts/check-import-cycles.ts` and `check-madge-import-cycles.ts` — 0 cycles each. An earlier revision of this branch failed CI on a madge cycle; the helper now lives in a leaf module.
- `node scripts/run-vitest.mjs ui/src/components ui/src/pages/chat/components ui/src/api/gateway.node.test.ts` — 9,996 passed.
- `node scripts/check-changed.mjs` — passed.
- Regression guards verified to actually catch the bug: forcing the predicate back to "always local" fails three tests (plain browser, native remote gateway, and the live gateway-switch case).

Production LOC: net **−1** versus `main` (the new 31-line locality module is offset by deleting the loopback helper and the `gatewayUrl` plumbing).

Known gap: the mocked dev server's `worktrees.list` fixture does not match its `sidebar zones` session row's worktree id, so the sidebar/Sessions variant of the menu is not reachable there; proof uses the chat header menu, one of the same four producers. Worth a follow-up to make the mock self-consistent.
