### PR TITLE
improve(gateway): overlap macOS system-CA warmup with startup

### DIFF
--- a/src/gateway/server-start.ts
+++ b/src/gateway/server-start.ts
@@ -10,6 +10,7 @@ import type { GatewayServer, GatewayServerOptions } from "./server-public.js";
 import { createGatewayHttpTransport } from "./server-runtime-state.js";
 import { runGatewayShutdownSteps } from "./server-shutdown.js";
 import { finishGatewayStartup } from "./server-startup-finish.js";
+import { beginMacOSSystemCaWarmupOnce } from "./system-ca-warmup.js";
 
 const loadGatewayStartupPostAttachModule = createLazyRuntimeModule(
   () => import("./server-startup-post-attach.js"),
@@ -40,6 +41,11 @@ export async function startGatewayServerCore(
     releasePostReadyWork = resolve;
   });
   const gatewayKernel = await createGatewayKernel(port, opts);
+  if (!gatewayKernel.minimalTestGateway) {
+    // Start the Keychain read early so it overlaps bootstrap; post-attach awaits the
+    // shared promise before plugins can use TLS.
+    void beginMacOSSystemCaWarmupOnce({ log });
+  }
   let startupSettled: Promise<void>;
   const {
     beginClosePrelude,

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -52,7 +52,10 @@ import {
   type GatewayStartupOutcomeRecorder,
 } from "./server-startup-outcomes.js";
 import { measureStartup, type GatewayStartupTrace } from "./server-startup-trace.js";
-import { warmMacOSSystemCaOffMainThread } from "./system-ca-warmup.js";
+import {
+  beginMacOSSystemCaWarmupOnce,
+  type warmMacOSSystemCaOffMainThread,
+} from "./system-ca-warmup.js";
 const ACP_BACKEND_READY_TIMEOUT_MS = 5_000;
 const ACP_BACKEND_READY_POLL_MS = 50;
 const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 5_000;
@@ -1003,7 +1006,7 @@ const defaultGatewayPostAttachRuntimeDeps: GatewayPostAttachRuntimeDeps = {
   scheduleGatewayUpdateCheck: async (...args) =>
     (await import("../infra/update-startup.js")).scheduleGatewayUpdateCheck(...args),
   startGatewaySidecars,
-  warmSystemCa: warmMacOSSystemCaOffMainThread,
+  warmSystemCa: beginMacOSSystemCaWarmupOnce,
   loadSubagentRegistryActivation: async () =>
     (await import("../agents/subagents/registry/subagent-registry.js")).activateSubagentRegistry,
 };

--- a/src/gateway/system-ca-warmup.test.ts
+++ b/src/gateway/system-ca-warmup.test.ts
@@ -127,3 +127,35 @@ describe("warmMacOSSystemCaOffMainThread", () => {
     );
   });
 });
+
+describe("beginMacOSSystemCaWarmupOnce", () => {
+  it("shares one worker across concurrent and settled calls", async () => {
+    vi.resetModules();
+    const { beginMacOSSystemCaWarmupOnce } = await import("./system-ca-warmup.js");
+    const worker = new FakeWorker();
+    const createWorker = vi.fn(() => worker);
+    const options = { platform: "darwin" as const, env: {}, createWorker };
+
+    const first = beginMacOSSystemCaWarmupOnce(options);
+    const concurrent = beginMacOSSystemCaWarmupOnce(options);
+
+    expect(concurrent).toBe(first);
+    expect(createWorker).toHaveBeenCalledOnce();
+
+    worker.emit("message", { ok: true, certificateCount: 42 });
+    await first;
+
+    expect(beginMacOSSystemCaWarmupOnce(options)).toBe(first);
+    expect(createWorker).toHaveBeenCalledOnce();
+  });
+
+  it("settles without creating a worker outside macOS", async () => {
+    vi.resetModules();
+    const { beginMacOSSystemCaWarmupOnce } = await import("./system-ca-warmup.js");
+    const createWorker = vi.fn(() => new FakeWorker());
+
+    await beginMacOSSystemCaWarmupOnce({ platform: "linux", env: {}, createWorker });
+
+    expect(createWorker).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/system-ca-warmup.ts
+++ b/src/gateway/system-ca-warmup.ts
@@ -36,6 +36,8 @@ type SystemCaWarmupOptions = {
 
 type SystemCaWarmupMessage = { ok: true; certificateCount: number } | { ok: false; error: string };
 
+let macOSSystemCaWarmupPromise: Promise<void> | undefined;
+
 function isSystemCaWarmupMessage(value: unknown): value is SystemCaWarmupMessage {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return false;
@@ -143,4 +145,12 @@ export async function warmMacOSSystemCaOffMainThread(
     // A wedged trustd lookup must not keep an otherwise stopped gateway process alive.
     worker.unref();
   });
+}
+
+/**
+ * One warmup worker runs per process, and every caller awaits its shared completion.
+ * The settled promise is retained after success or failure because warmup is only an optimization.
+ */
+export function beginMacOSSystemCaWarmupOnce(options: SystemCaWarmupOptions = {}): Promise<void> {
+  return (macOSSystemCaWarmupPromise ??= warmMacOSSystemCaOffMainThread(options));
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a macOS Gateway could spend up to 4972ms of a first boot after the OS trust cache went cold waiting for the default system CA set on the readiness critical path. The same lookup measured 3529ms in a fresh standalone Node process, while subsequent Gateway boots measured 16-160ms.

## Why This Change Was Made

The Gateway now starts one process-wide system-CA warmup immediately after kernel creation, allowing the Keychain read to overlap the remaining bootstrap and attach work. The existing post-attach barrier awaits that same retained promise before plugins or worker providers can use TLS; warmup failures remain fail-open and are not retried because this is only an optimization. Minimal test gateways remain unchanged. No config or changelog surface is added.

## User Impact

Cold macOS Gateway starts can overlap the expensive trust-cache read with other startup work instead of paying the full delay serially before readiness. Warm starts and non-macOS platforms retain their existing behavior.

## Evidence

- Pre-fix regression: the new owner-boundary tests failed in both Gateway Vitest configurations because the single-flight entry point was absent.
- `node scripts/run-vitest.mjs src/gateway/system-ca-warmup.test.ts` — 16 tests passed across 2 configurations.
- `node scripts/run-vitest.mjs src/gateway/server-import-boundary.test.ts` — 16 tests passed across 2 configurations.
- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts` — 168 tests passed across 2 configurations; the injected barrier still completes before worker reconciliation and sidecars.
- `node scripts/check-changed.mjs` — Blacksmith Testbox sync timed out before the checks ran (exit 124); the authorized local fallback completed all selected core and core-test gates successfully.
- `pnpm build` — passed.
- Built isolated Gateway using the sanitized copied state on port 19791 reached `/readyz`; residual barrier trace: `startup trace: post-attach.system-ca 0.5ms total=1456.6ms eventLoopMax=0.0ms`.
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- Production LOC: +21/-2 (net +19); tests: +32/-0. The production growth is the lifecycle-owned single-flight entry point, its early kickoff, and the existing dependency barrier retarget; no parallel warmup path or compatibility layer was added.
