### PR TITLE
fix(tui): preserve queued messages when reselecting the current session

### DIFF
--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1436,26 +1436,122 @@ describe("tui session actions", () => {
     }
   });
 
-  it("preserves run ownership when reloading the same session selection", async () => {
+  it.each([
+    { name: "canonical key", selectedKey: "agent:main:main" },
+    { name: "request-key alias", selectedKey: "main" },
+  ])("preserves same-session run ownership while reloading its $name", async ({ selectedKey }) => {
     const sessionKey = "agent:main:main";
+    const history = createDeferred<unknown>();
     const invalidateRunOwnership = vi.fn();
-    const state = createBaseState({ currentSessionKey: sessionKey });
+    const clearLocalRunIds = vi.fn();
+    const btw = createBtwPresenter();
+    const chatLog = new ChatLog();
+    const state = createBaseState({
+      currentSessionKey: sessionKey,
+      currentSessionId: "session-main",
+      activeChatRunId: "active-run",
+      pendingSubmit: acceptedSubmit("queued-run", "queued user message"),
+      activityStatus: "streaming",
+      historyLoaded: true,
+      sessionInfo: { updatedAt: 200, model: "current-model", modelProvider: "current-provider" },
+    });
+    sendPendingUser(state, "queued-run", "queued user message");
+    chatLog.addPendingUser("queued-run", "queued user message");
     const { setSession } = createTestSessionActions({
       client: makeTuiBackend({
         listSessions: vi.fn(),
-        loadHistory: vi.fn().mockResolvedValue({
-          sessionId: "session-main",
-          sessionInfo: { key: sessionKey, sessionId: "session-main" },
-          messages: [],
-        }),
+        loadHistory: vi.fn(() => history.promise),
       }),
+      chatLog,
+      btw,
       state,
       invalidateRunOwnership,
+      clearLocalRunIds,
+      setActivityStatus: (status) => {
+        state.activityStatus = status;
+      },
+    });
+
+    const reloading = setSession(selectedKey);
+
+    expect(invalidateRunOwnership).not.toHaveBeenCalled();
+    expect(clearLocalRunIds).not.toHaveBeenCalled();
+    expect(btw.clear).not.toHaveBeenCalled();
+    expect(state.activeChatRunId).toBe("active-run");
+    expect(getPendingSubmitAcceptedRunId(state)).toBe("queued-run");
+    expect(state.activityStatus).toBe("streaming");
+    expect(state.historyLoaded).toBe(true);
+    expect(state.sessionInfo.updatedAt).toBe(200);
+    expect(chatLog.countPendingUsers()).toBe(1);
+
+    history.resolve({
+      sessionId: "session-main",
+      sessionInfo: {
+        key: sessionKey,
+        sessionId: "session-main",
+        updatedAt: 100,
+        model: "stale-model",
+        modelProvider: "stale-provider",
+      },
+      messages: [],
+      inFlightRun: { runId: "active-run", text: "active response" },
+    });
+    await reloading;
+
+    expect(state.currentSessionKey).toBe(sessionKey);
+    expect(state.activeChatRunId).toBe("active-run");
+    expect(getPendingSubmitAcceptedRunId(state)).toBe("queued-run");
+    expect(getPendingSubmitDraft(state)).toEqual({
+      runId: "queued-run",
+      text: "queued user message",
+    });
+    expect(state.sessionInfo).toMatchObject({
+      updatedAt: 200,
+      model: "current-model",
+      modelProvider: "current-provider",
+    });
+    expect(chatLog.countPendingUsers()).toBe(1);
+    expect(chatLog.render(120).join("\n")).toContain("queued user message");
+    expect(invalidateRunOwnership).not.toHaveBeenCalled();
+    expect(clearLocalRunIds).not.toHaveBeenCalled();
+    expect(btw.clear).toHaveBeenCalledOnce();
+  });
+
+  it("preserves same-session run ownership when its history reload fails", async () => {
+    const sessionKey = "agent:main:main";
+    const chatLog = new ChatLog();
+    const state = createBaseState({
+      currentSessionKey: sessionKey,
+      currentSessionId: "session-main",
+      activeChatRunId: "active-run",
+      pendingSubmit: acceptedSubmit("queued-run", "queued user message"),
+      activityStatus: "streaming",
+      historyLoaded: true,
+      sessionInfo: { updatedAt: 200, model: "current-model" },
+    });
+    sendPendingUser(state, "queued-run", "queued user message");
+    chatLog.addPendingUser("queued-run", "queued user message");
+    const { setSession } = createTestSessionActions({
+      client: makeTuiBackend({
+        listSessions: vi.fn(),
+        loadHistory: vi.fn().mockRejectedValue(new Error("gateway disconnected")),
+      }),
+      chatLog,
+      state,
+      setActivityStatus: (status) => {
+        state.activityStatus = status;
+      },
     });
 
     await setSession(sessionKey);
 
-    expect(invalidateRunOwnership).not.toHaveBeenCalled();
+    expect(state.activeChatRunId).toBe("active-run");
+    expect(getPendingSubmitAcceptedRunId(state)).toBe("queued-run");
+    expect(state.activityStatus).toBe("streaming");
+    expect(state.historyLoaded).toBe(true);
+    expect(state.sessionInfo.updatedAt).toBe(200);
+    expect(chatLog.countPendingUsers()).toBe(1);
+    expect(chatLog.render(120).join("\n")).toContain("gateway disconnected");
   });
 
   it("adopts an in-flight run with no buffered text (Codex) and shows streaming", async () => {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -105,25 +105,23 @@ export function createSessionActions(context: SessionActionContext) {
     }
     state.currentAgentId = nextSelection.agentId;
     state.currentSessionKey = nextSelection.key;
-    state.activeChatRunId = null;
-    submit.clearPendingSubmit(state);
-    setActivityStatus("idle");
     if (selectionChanged) {
+      state.activeChatRunId = null;
+      submit.clearPendingSubmit(state);
+      setActivityStatus("idle");
       state.currentSessionId = null;
       state.sessionInfo.displayName = undefined;
       clearTuiSessionModeOverrides(state.sessionInfo);
-    }
-    // Session keys can move backwards in updatedAt ordering; drop previous session freshness
-    // so refresh data for the newly selected session isn't rejected as stale.
-    state.sessionInfo.updatedAt = null;
-    state.historyLoaded = false;
-    if (selectionChanged) {
+      // Different sessions can move backwards in freshness; same-session
+      // reloads must retain their active runs and newer authoritative state.
+      state.sessionInfo.updatedAt = null;
+      state.historyLoaded = false;
       // Live prompt identities belong to the old selection, not its pending successor.
       chatLog.clearAll();
+      chatLog.clearPendingUsers();
+      clearLocalRunIds?.();
+      btw.clear();
     }
-    chatLog.clearPendingUsers();
-    clearLocalRunIds?.();
-    btw.clear();
     updateHeader();
     updateFooter();
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reselecting their current terminal session with `/session`, its canonical alias, or the session picker would silently lose ownership of an active response and queued message while chat history refreshed. A second message could bypass the one-pending-send gate, a failed history request could permanently erase the queued row, and an older snapshot could roll back the session's displayed model.

## Why This Change Was Made

The TUI already distinguishes changing to another agent/session from refreshing the same conversation, but its lifecycle cleanup incorrectly ran for both. Keep active runs, pending sends, local-run identity, and authoritative metadata intact for the existing owner; retire them only when the agent/session owner actually changes. Same-key reset continues to use its separate generation-fenced lifecycle.

## User Impact

Terminal users can safely reopen their current session without losing a queued prompt, admitting overlapping sends, changing the displayed model to stale data, or dropping an in-flight response after a history failure. Switching to a different session or agent still clears its previous conversation normally.

## Evidence

- Three authentic owner-boundary regressions failed before the production change and pass after it: canonical current-session selection, request-key alias selection, and history-load failure.
- An actual `runTui()` fake-backend PTY reproduced the same user sequence before and after the fix: start a streamed response, queue another prompt, rerun `/session agent:main:main`, and try a third prompt during the delayed history request.
  - Before: `OVERLAPPING_SEND_ADMITTED`, `thirdSendCount=1`.
  - After: `OVERLAPPING_SEND_BLOCKED`, `thirdSendCount=0`.
- Full owner, command, event, session, run-coordinator, and submission suites: **446 passing tests across 6 files**.
- Separate independent review: **257 passing tests across 3 files**, with distinct-agent/global ownership, canonical aliases, pending transcript projection, stale metadata, failed history, and reset generation checked explicitly.
- Fresh independent authenticated whole-branch review: clean; secret scan clean.
- Production delta: **2 lines removed**; no public API, configuration, protocol, persistence, or security changes.

Validation command:

```sh
env OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-tui-owner-cache \
  node scripts/run-vitest.mjs run --configLoader runner \
  src/tui/tui-session-actions.test.ts \
  src/tui/tui-command-handlers.test.ts \
  src/tui/tui-event-handlers.test.ts \
  src/tui/tui-session-events.test.ts \
  src/tui/tui-session-run-coordinator.test.ts \
  src/tui/tui-submit-state.test.ts --maxWorkers=2
```
