### PR TITLE
fix(ui): sidebar menus open in Safari

### DIFF
--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -303,116 +303,114 @@ export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
   const { activeId, activeName, agents } = params;
   const rows = sidebarAgentMenuRows(params);
   return html`
-    <openclaw-menu-surface>
-      <wa-dropdown
-        class="sidebar-customize-menu sidebar-agent-menu"
-        .open=${true}
-        placement="bottom-start"
-        .distance=${0}
-        aria-label=${t("agentChip.menuLabel")}
-        @pointerenter=${params.onPointerEnter}
-        @pointerleave=${params.onPointerLeave}
-        @wa-select=${(event: CustomEvent<{ item: HTMLElement & { value?: string } }>) => {
-          event.preventDefault();
-          const item = event.detail.item;
-          if (item.dataset.nativeNavigation) {
-            delete item.dataset.nativeNavigation;
-            params.onClose(false);
-            return;
-          }
-          const value = item.value;
-          if (!value) {
-            return;
-          }
+    <wa-dropdown
+      class="sidebar-customize-menu sidebar-agent-menu"
+      .open=${true}
+      placement="bottom-start"
+      .distance=${0}
+      aria-label=${t("agentChip.menuLabel")}
+      @pointerenter=${params.onPointerEnter}
+      @pointerleave=${params.onPointerLeave}
+      @wa-select=${(event: CustomEvent<{ item: HTMLElement & { value?: string } }>) => {
+        event.preventDefault();
+        const item = event.detail.item;
+        if (item.dataset.nativeNavigation) {
+          delete item.dataset.nativeNavigation;
           params.onClose(false);
-          if (value.startsWith(AGENT_VALUE_PREFIX)) {
-            params.onSwitchAgent(decodeURIComponent(value.slice(AGENT_VALUE_PREFIX.length)));
-            return;
-          }
-          switch (value) {
-            case `${COMMAND_VALUE_PREFIX}capabilities`:
-              params.onAskCapabilities(activeId);
-              break;
-            case `${COMMAND_VALUE_PREFIX}agent-settings`:
-              params.onNavigate("agents", {
-                pathname: pathForAgentPanel(activeId, null, params.basePath),
-              });
-              break;
-            case `${COMMAND_VALUE_PREFIX}new-agent`:
-              params.onNavigate("custodian", { search: "?intent=new-agent" });
-              break;
-          }
-        }}
-        @wa-after-show=${(event: Event) => {
-          if (!(event.currentTarget instanceof HTMLElement)) {
-            return;
-          }
-          params.onAfterShow();
-          if (params.openMode === "hover") {
-            return;
-          }
-          focusActiveAgentMenuItem(event.currentTarget);
-        }}
-        @keydown=${(event: KeyboardEvent) => {
-          if (moveSidebarMenuFocus(event)) {
-            return;
-          }
-          if (typeaheadSidebarMenuFocus(event)) {
-            return;
-          }
-          const item =
-            event.target instanceof HTMLElement
-              ? event.target.closest<HTMLElement>(
-                  ".sidebar-agent-menu__agent-grid > wa-dropdown-item:not([disabled])",
-                )
-              : null;
-          if ((event.key === "Enter" || event.key === " ") && item) {
-            event.preventDefault();
-            event.stopPropagation();
-            item.click();
-            return;
-          }
-          trackDropdownKeyboardDismissal(event, params.onTabAway);
-        }}
-        @wa-after-hide=${(event: Event) => closeMenuAfterOwnDropdownHide(event, params.onClose)}
+          return;
+        }
+        const value = item.value;
+        if (!value) {
+          return;
+        }
+        params.onClose(false);
+        if (value.startsWith(AGENT_VALUE_PREFIX)) {
+          params.onSwitchAgent(decodeURIComponent(value.slice(AGENT_VALUE_PREFIX.length)));
+          return;
+        }
+        switch (value) {
+          case `${COMMAND_VALUE_PREFIX}capabilities`:
+            params.onAskCapabilities(activeId);
+            break;
+          case `${COMMAND_VALUE_PREFIX}agent-settings`:
+            params.onNavigate("agents", {
+              pathname: pathForAgentPanel(activeId, null, params.basePath),
+            });
+            break;
+          case `${COMMAND_VALUE_PREFIX}new-agent`:
+            params.onNavigate("custodian", { search: "?intent=new-agent" });
+            break;
+        }
+      }}
+      @wa-after-show=${(event: Event) => {
+        if (!(event.currentTarget instanceof HTMLElement)) {
+          return;
+        }
+        params.onAfterShow();
+        if (params.openMode === "hover") {
+          return;
+        }
+        focusActiveAgentMenuItem(event.currentTarget);
+      }}
+      @keydown=${(event: KeyboardEvent) => {
+        if (moveSidebarMenuFocus(event)) {
+          return;
+        }
+        if (typeaheadSidebarMenuFocus(event)) {
+          return;
+        }
+        const item =
+          event.target instanceof HTMLElement
+            ? event.target.closest<HTMLElement>(
+                ".sidebar-agent-menu__agent-grid > wa-dropdown-item:not([disabled])",
+              )
+            : null;
+        if ((event.key === "Enter" || event.key === " ") && item) {
+          event.preventDefault();
+          event.stopPropagation();
+          item.click();
+          return;
+        }
+        trackDropdownKeyboardDismissal(event, params.onTabAway);
+      }}
+      @wa-after-hide=${(event: Event) => closeMenuAfterOwnDropdownHide(event, params.onClose)}
+    >
+      <button
+        slot="trigger"
+        type="button"
+        tabindex="-1"
+        aria-hidden="true"
+        aria-label=${t("agentChip.menuLabel")}
+        style="position: fixed; left: ${position.x}px; top: ${position.top}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
+      ></button>
+      ${agents.length > 1
+        ? html`
+            <div class="sidebar-customize-menu__title">${t("agentChip.agents")}</div>
+            <div class="sidebar-agent-menu__agent-grid">
+              ${rows.map((entry) => renderAgentRow(entry, params))}
+            </div>
+          `
+        : nothing}
+      <div class="sidebar-customize-menu__separator" role="separator"></div>
+      <wa-dropdown-item class="sidebar-customize-menu__item" value="command:new-agent">
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.users}</span>
+        <span class="sidebar-customize-menu__text">${t("custodian.newAgent")}</span>
+      </wa-dropdown-item>
+      <wa-dropdown-item
+        class="sidebar-customize-menu__item"
+        value="command:capabilities"
+        ?disabled=${!params.connected}
       >
-        <button
-          slot="trigger"
-          type="button"
-          tabindex="-1"
-          aria-hidden="true"
-          aria-label=${t("agentChip.menuLabel")}
-          style="position: fixed; left: ${position.x}px; top: ${position.top}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
-        ></button>
-        ${agents.length > 1
-          ? html`
-              <div class="sidebar-customize-menu__title">${t("agentChip.agents")}</div>
-              <div class="sidebar-agent-menu__agent-grid">
-                ${rows.map((entry) => renderAgentRow(entry, params))}
-              </div>
-            `
-          : nothing}
-        <div class="sidebar-customize-menu__separator" role="separator"></div>
-        <wa-dropdown-item class="sidebar-customize-menu__item" value="command:new-agent">
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.users}</span>
-          <span class="sidebar-customize-menu__text">${t("custodian.newAgent")}</span>
-        </wa-dropdown-item>
-        <wa-dropdown-item
-          class="sidebar-customize-menu__item"
-          value="command:capabilities"
-          ?disabled=${!params.connected}
-        >
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.bot}</span>
-          <span class="sidebar-customize-menu__text">
-            ${t("agentChip.whatCanAgentDo", { name: activeName })}
-          </span>
-        </wa-dropdown-item>
-        <wa-dropdown-item class="sidebar-customize-menu__item" value="command:agent-settings">
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.users}</span>
-          <span class="sidebar-customize-menu__text">${t("agentChip.agentSettings")}</span>
-        </wa-dropdown-item>
-      </wa-dropdown>
-    </openclaw-menu-surface>
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.bot}</span>
+        <span class="sidebar-customize-menu__text">
+          ${t("agentChip.whatCanAgentDo", { name: activeName })}
+        </span>
+      </wa-dropdown-item>
+      <wa-dropdown-item class="sidebar-customize-menu__item" value="command:agent-settings">
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.users}</span>
+        <span class="sidebar-customize-menu__text">${t("agentChip.agentSettings")}</span>
+      </wa-dropdown-item>
+    </wa-dropdown>
   `;
 }
 
@@ -427,163 +425,159 @@ export function renderSidebarIdentityMenu(params: SidebarIdentityMenuParams) {
       ? params.profileViewer.email
       : null;
   return html`
-    <openclaw-menu-surface>
-      <wa-dropdown
-        class="sidebar-customize-menu sidebar-identity-menu"
-        style=${`--sidebar-identity-menu-min-width: ${params.triggerWidth}px`}
-        .open=${true}
-        placement="top-start"
-        .distance=${0}
-        aria-label=${t("profilePage.identity.menuLabel")}
-        @wa-select=${(event: CustomEvent<{ item: HTMLElement & { value?: string } }>) => {
-          event.preventDefault();
-          const item = event.detail.item;
-          if (item.dataset.nativeNavigation) {
-            delete item.dataset.nativeNavigation;
-            params.onClose(false);
-            return;
-          }
-          const value = item.value;
-          if (!value) {
-            return;
-          }
+    <wa-dropdown
+      class="sidebar-customize-menu sidebar-identity-menu"
+      style=${`--sidebar-identity-menu-min-width: ${params.triggerWidth}px`}
+      .open=${true}
+      placement="top-start"
+      .distance=${0}
+      aria-label=${t("profilePage.identity.menuLabel")}
+      @wa-select=${(event: CustomEvent<{ item: HTMLElement & { value?: string } }>) => {
+        event.preventDefault();
+        const item = event.detail.item;
+        if (item.dataset.nativeNavigation) {
+          delete item.dataset.nativeNavigation;
           params.onClose(false);
-          if (value.startsWith(LINK_VALUE_PREFIX)) {
-            openExternalUrlSafe(decodeURIComponent(value.slice(LINK_VALUE_PREFIX.length)));
-            return;
-          }
-          switch (value) {
-            case `${COMMAND_VALUE_PREFIX}profile`:
-              params.onNavigate("profile", { hash: "#settings-profile-identity" });
-              break;
-            case `${COMMAND_VALUE_PREFIX}settings`:
-              params.onNavigate("appearance");
-              break;
-            case `${COMMAND_VALUE_PREFIX}usage`:
-              params.onNavigate("usage");
-              break;
-            case `${COMMAND_VALUE_PREFIX}pair-mobile`:
-              params.onPairMobile();
-              break;
-            case `${COMMAND_VALUE_PREFIX}apps`:
-              params.onNavigate("apps");
-              break;
-            case `${COMMAND_VALUE_PREFIX}debug-overlay`:
-              requestDebugOverlayToggle();
-              break;
-            case `${COMMAND_VALUE_PREFIX}retry-connect`:
-              params.onRetryConnect?.();
-              break;
-          }
-        }}
-        @keydown=${(event: KeyboardEvent) => {
-          if (!moveSidebarMenuFocus(event)) {
-            trackDropdownKeyboardDismissal(event, params.onTabAway);
-          }
-        }}
-        @wa-after-hide=${(event: Event) => closeMenuAfterOwnDropdownHide(event, params.onClose)}
+          return;
+        }
+        const value = item.value;
+        if (!value) {
+          return;
+        }
+        params.onClose(false);
+        if (value.startsWith(LINK_VALUE_PREFIX)) {
+          openExternalUrlSafe(decodeURIComponent(value.slice(LINK_VALUE_PREFIX.length)));
+          return;
+        }
+        switch (value) {
+          case `${COMMAND_VALUE_PREFIX}profile`:
+            params.onNavigate("profile", { hash: "#settings-profile-identity" });
+            break;
+          case `${COMMAND_VALUE_PREFIX}settings`:
+            params.onNavigate("appearance");
+            break;
+          case `${COMMAND_VALUE_PREFIX}usage`:
+            params.onNavigate("usage");
+            break;
+          case `${COMMAND_VALUE_PREFIX}pair-mobile`:
+            params.onPairMobile();
+            break;
+          case `${COMMAND_VALUE_PREFIX}apps`:
+            params.onNavigate("apps");
+            break;
+          case `${COMMAND_VALUE_PREFIX}debug-overlay`:
+            requestDebugOverlayToggle();
+            break;
+          case `${COMMAND_VALUE_PREFIX}retry-connect`:
+            params.onRetryConnect?.();
+            break;
+        }
+      }}
+      @keydown=${(event: KeyboardEvent) => {
+        if (!moveSidebarMenuFocus(event)) {
+          trackDropdownKeyboardDismissal(event, params.onTabAway);
+        }
+      }}
+      @wa-after-hide=${(event: Event) => closeMenuAfterOwnDropdownHide(event, params.onClose)}
+    >
+      <button
+        slot="trigger"
+        type="button"
+        tabindex="-1"
+        aria-hidden="true"
+        aria-label=${t("profilePage.identity.menuLabel")}
+        style="position: fixed; left: ${position.x}px; bottom: ${position.bottom}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
+      ></button>
+      ${profileName
+        ? html`<wa-dropdown-item
+              class="sidebar-customize-menu__item sidebar-identity-menu__header"
+              value="command:profile"
+            >
+              <span slot="icon" class="sidebar-identity-menu__avatar" aria-hidden="true">
+                <openclaw-viewer-avatar
+                  .user=${params.profileViewer}
+                  variant="footer"
+                ></openclaw-viewer-avatar>
+              </span>
+              <span class="sidebar-identity-menu__identity">
+                <span class="sidebar-identity-menu__name" title=${profileName}>${profileName}</span>
+                ${profileEmail
+                  ? html`<span class="sidebar-identity-menu__email" title=${profileEmail}
+                      >${profileEmail}</span
+                    >`
+                  : nothing}
+              </span>
+            </wa-dropdown-item>
+            <div class="sidebar-customize-menu__separator" role="separator"></div>`
+        : nothing}
+      <wa-dropdown-item class="sidebar-customize-menu__item" value="command:settings">
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.settings}</span>
+        <span class="sidebar-customize-menu__text">${t("nav.settings")}</span>
+        <kbd slot="details" class="session-menu__shortcut" aria-hidden="true"
+          >${isApplePlatform() ? "⌘⇧," : "Ctrl+Shift+,"}</kbd
+        >
+      </wa-dropdown-item>
+      <wa-dropdown-item class="sidebar-customize-menu__item" value="command:usage">
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.coins}</span>
+        <span class="sidebar-customize-menu__text">${titleForRoute("usage")}</span>
+      </wa-dropdown-item>
+      <div class="sidebar-customize-menu__separator" role="separator"></div>
+      <wa-dropdown-item
+        class="sidebar-customize-menu__item sidebar-pair-mobile"
+        value="command:pair-mobile"
+        ?disabled=${!params.canPairDevice}
+        title=${params.canPairDevice ? nothing : t("devices.pairing.adminRequired")}
       >
-        <button
-          slot="trigger"
-          type="button"
-          tabindex="-1"
-          aria-hidden="true"
-          aria-label=${t("profilePage.identity.menuLabel")}
-          style="position: fixed; left: ${position.x}px; bottom: ${position.bottom}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
-        ></button>
-        ${profileName
-          ? html`<wa-dropdown-item
-                class="sidebar-customize-menu__item sidebar-identity-menu__header"
-                value="command:profile"
-              >
-                <span slot="icon" class="sidebar-identity-menu__avatar" aria-hidden="true">
-                  <openclaw-viewer-avatar
-                    .user=${params.profileViewer}
-                    variant="footer"
-                  ></openclaw-viewer-avatar>
-                </span>
-                <span class="sidebar-identity-menu__identity">
-                  <span class="sidebar-identity-menu__name" title=${profileName}
-                    >${profileName}</span
-                  >
-                  ${profileEmail
-                    ? html`<span class="sidebar-identity-menu__email" title=${profileEmail}
-                        >${profileEmail}</span
-                      >`
-                    : nothing}
-                </span>
-              </wa-dropdown-item>
-              <div class="sidebar-customize-menu__separator" role="separator"></div>`
-          : nothing}
-        <wa-dropdown-item class="sidebar-customize-menu__item" value="command:settings">
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.settings}</span>
-          <span class="sidebar-customize-menu__text">${t("nav.settings")}</span>
-          <kbd slot="details" class="session-menu__shortcut" aria-hidden="true"
-            >${isApplePlatform() ? "⌘⇧," : "Ctrl+Shift+,"}</kbd
-          >
-        </wa-dropdown-item>
-        <wa-dropdown-item class="sidebar-customize-menu__item" value="command:usage">
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.coins}</span>
-          <span class="sidebar-customize-menu__text">${titleForRoute("usage")}</span>
-        </wa-dropdown-item>
-        <div class="sidebar-customize-menu__separator" role="separator"></div>
-        <wa-dropdown-item
-          class="sidebar-customize-menu__item sidebar-pair-mobile"
-          value="command:pair-mobile"
-          ?disabled=${!params.canPairDevice}
-          title=${params.canPairDevice ? nothing : t("devices.pairing.adminRequired")}
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.smartphone}</span>
+        <span class="sidebar-customize-menu__text">${t("devices.pairing.button")}</span>
+      </wa-dropdown-item>
+      <wa-dropdown-item class="sidebar-customize-menu__item" value="command:apps">
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.layoutGrid}</span>
+        <span class="sidebar-customize-menu__text">${t("agentChip.getApps")}</span>
+      </wa-dropdown-item>
+      <wa-dropdown-item class="sidebar-customize-menu__item" value="command:debug-overlay">
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.activity}</span>
+        <span class="sidebar-customize-menu__text">${t("debug.overlay.title")}</span>
+        <span slot="details" class="session-menu__shortcut" aria-hidden="true"
+          >${DEBUG_OVERLAY_SHORTCUT_LABEL}</span
         >
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.smartphone}</span>
-          <span class="sidebar-customize-menu__text">${t("devices.pairing.button")}</span>
-        </wa-dropdown-item>
-        <wa-dropdown-item class="sidebar-customize-menu__item" value="command:apps">
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.layoutGrid}</span>
-          <span class="sidebar-customize-menu__text">${t("agentChip.getApps")}</span>
-        </wa-dropdown-item>
-        <wa-dropdown-item class="sidebar-customize-menu__item" value="command:debug-overlay">
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.activity}</span>
-          <span class="sidebar-customize-menu__text">${t("debug.overlay.title")}</span>
-          <span slot="details" class="session-menu__shortcut" aria-hidden="true"
-            >${DEBUG_OVERLAY_SHORTCUT_LABEL}</span
-          >
-        </wa-dropdown-item>
-        <div class="sidebar-customize-menu__separator" role="separator"></div>
-        <wa-dropdown-item
-          class="sidebar-customize-menu__item sidebar-identity-menu__help"
-          value="command:help"
+      </wa-dropdown-item>
+      <div class="sidebar-customize-menu__separator" role="separator"></div>
+      <wa-dropdown-item
+        class="sidebar-customize-menu__item sidebar-identity-menu__help"
+        value="command:help"
+      >
+        <span slot="icon" class="nav-item__icon" aria-hidden="true"
+          >${icons.circleQuestionMark}</span
         >
-          <span slot="icon" class="nav-item__icon" aria-hidden="true"
-            >${icons.circleQuestionMark}</span
-          >
-          <span class="sidebar-customize-menu__text">${t("agentChip.help")}</span>
-          ${renderIdentityMenuHelpSubmenu()}
-        </wa-dropdown-item>
-        ${params.offline
-          ? html`<div class="sidebar-customize-menu__separator" role="separator"></div>
-              <wa-dropdown-item
-                class="sidebar-customize-menu__item sidebar-identity-menu__retry"
-                value="command:retry-connect"
-              >
-                <span class="sidebar-customize-menu__text">${t("connection.retryNow")}</span>
-              </wa-dropdown-item>`
-          : nothing}
-        <div class="sidebar-customize-menu__separator" role="separator"></div>
-        <div class="sidebar-identity-menu__footer">
-          <openclaw-sidebar-build-chip
-            .variant=${"identity"}
-            .basePath=${params.basePath}
-            .gatewayVersion=${params.gatewayVersion}
-            .updateAttentionDismissed=${params.updateAttentionDismissed}
-            .onNavigate=${(routeId: "about") => {
-              params.onClose();
-              params.onNavigate(routeId);
-            }}
-          ></openclaw-sidebar-build-chip>
-          <span class="sidebar-mode-switch">
-            <openclaw-theme-mode-toggle .mode=${params.themeMode}></openclaw-theme-mode-toggle>
-          </span>
-        </div>
-      </wa-dropdown>
-    </openclaw-menu-surface>
+        <span class="sidebar-customize-menu__text">${t("agentChip.help")}</span>
+        ${renderIdentityMenuHelpSubmenu()}
+      </wa-dropdown-item>
+      ${params.offline
+        ? html`<div class="sidebar-customize-menu__separator" role="separator"></div>
+            <wa-dropdown-item
+              class="sidebar-customize-menu__item sidebar-identity-menu__retry"
+              value="command:retry-connect"
+            >
+              <span class="sidebar-customize-menu__text">${t("connection.retryNow")}</span>
+            </wa-dropdown-item>`
+        : nothing}
+      <div class="sidebar-customize-menu__separator" role="separator"></div>
+      <div class="sidebar-identity-menu__footer">
+        <openclaw-sidebar-build-chip
+          .variant=${"identity"}
+          .basePath=${params.basePath}
+          .gatewayVersion=${params.gatewayVersion}
+          .updateAttentionDismissed=${params.updateAttentionDismissed}
+          .onNavigate=${(routeId: "about") => {
+            params.onClose();
+            params.onNavigate(routeId);
+          }}
+        ></openclaw-sidebar-build-chip>
+        <span class="sidebar-mode-switch">
+          <openclaw-theme-mode-toggle .mode=${params.themeMode}></openclaw-theme-mode-toggle>
+        </span>
+      </div>
+    </wa-dropdown>
   `;
 }

--- a/ui/src/components/app-sidebar-nav-menus.ts
+++ b/ui/src/components/app-sidebar-nav-menus.ts
@@ -172,49 +172,46 @@ export function renderSidebarMoreMenu(params: SidebarMoreMenuParams) {
     params.isRouteEnabled(routeId),
   );
   return html`
-    <openclaw-menu-surface>
-      <wa-dropdown
-        class="sidebar-customize-menu sidebar-more-menu"
-        .open=${true}
-        placement="bottom-start"
-        .distance=${0}
+    <wa-dropdown
+      class="sidebar-customize-menu sidebar-more-menu"
+      .open=${true}
+      placement="bottom-start"
+      .distance=${0}
+      aria-label=${t("nav.more")}
+      @wa-select=${(event: CustomEvent<{ item: HTMLElement & { value?: string } }>) => {
+        event.preventDefault();
+        const item = event.detail.item;
+        if (item.dataset.nativeNavigation) {
+          delete item.dataset.nativeNavigation;
+          return;
+        }
+        const value = item.value;
+        if (value === "customize") {
+          params.onEditPinnedItems();
+          return;
+        }
+        if (value && moreRoutes.includes(value as SidebarNavRoute)) {
+          params.onNavigateRoute(value as SidebarNavRoute);
+        }
+      }}
+      @keydown=${(event: KeyboardEvent) => trackDropdownKeyboardDismissal(event, params.onTabAway)}
+      @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
+    >
+      <button
+        slot="trigger"
+        type="button"
+        tabindex="-1"
+        aria-hidden="true"
         aria-label=${t("nav.more")}
-        @wa-select=${(event: CustomEvent<{ item: HTMLElement & { value?: string } }>) => {
-          event.preventDefault();
-          const item = event.detail.item;
-          if (item.dataset.nativeNavigation) {
-            delete item.dataset.nativeNavigation;
-            return;
-          }
-          const value = item.value;
-          if (value === "customize") {
-            params.onEditPinnedItems();
-            return;
-          }
-          if (value && moreRoutes.includes(value as SidebarNavRoute)) {
-            params.onNavigateRoute(value as SidebarNavRoute);
-          }
-        }}
-        @keydown=${(event: KeyboardEvent) =>
-          trackDropdownKeyboardDismissal(event, params.onTabAway)}
-        @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
-      >
-        <button
-          slot="trigger"
-          type="button"
-          tabindex="-1"
-          aria-hidden="true"
-          aria-label=${t("nav.more")}
-          style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
-        ></button>
-        ${moreRoutes.map((routeId) => renderMoreMenuRoute(params, routeId))}
-        <div class="sidebar-customize-menu__separator" role="separator"></div>
-        <wa-dropdown-item class="sidebar-customize-menu__item" value="customize">
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.penLine}</span>
-          <span class="sidebar-customize-menu__text">${t("nav.customize")}</span>
-        </wa-dropdown-item>
-      </wa-dropdown>
-    </openclaw-menu-surface>
+        style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
+      ></button>
+      ${moreRoutes.map((routeId) => renderMoreMenuRoute(params, routeId))}
+      <div class="sidebar-customize-menu__separator" role="separator"></div>
+      <wa-dropdown-item class="sidebar-customize-menu__item" value="customize">
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.penLine}</span>
+        <span class="sidebar-customize-menu__text">${t("nav.customize")}</span>
+      </wa-dropdown-item>
+    </wa-dropdown>
   `;
 }
 
@@ -238,75 +235,69 @@ export function renderSidebarCustomizeMenu(params: SidebarCustomizeMenuParams) {
     return nothing;
   }
   return html`
-    <openclaw-menu-surface>
-      <wa-dropdown
-        class="sidebar-customize-menu sidebar-pin-editor-menu"
-        .open=${true}
-        placement="bottom-start"
-        .distance=${0}
-        aria-label=${t("nav.customize")}
-        @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-          event.preventDefault();
-          const value = event.detail.item.value;
-          if (value === "reset") {
-            params.onReset();
-          } else if (value?.startsWith("workboard:")) {
-            const boardId = value.slice("workboard:".length);
-            if (params.workboardBoards.some((board) => board.id === boardId)) {
-              params.onToggleWorkboardBoard(boardId);
-            }
-          } else if (value && SIDEBAR_NAV_ROUTES.includes(value as SidebarNavRoute)) {
-            params.onToggleRoute(value as SidebarNavRoute);
+    <wa-dropdown
+      class="sidebar-customize-menu sidebar-pin-editor-menu"
+      .open=${true}
+      placement="bottom-start"
+      .distance=${0}
+      aria-label=${t("nav.customize")}
+      @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+        event.preventDefault();
+        const value = event.detail.item.value;
+        if (value === "reset") {
+          params.onReset();
+        } else if (value?.startsWith("workboard:")) {
+          const boardId = value.slice("workboard:".length);
+          if (params.workboardBoards.some((board) => board.id === boardId)) {
+            params.onToggleWorkboardBoard(boardId);
           }
-        }}
-        @keydown=${(event: KeyboardEvent) =>
-          trackDropdownKeyboardDismissal(event, params.onTabAway)}
-        @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
-      >
-        <button
-          slot="trigger"
-          type="button"
-          tabindex="-1"
-          aria-hidden="true"
-          aria-label=${t("nav.customize")}
-          style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
-        ></button>
-        <div class="sidebar-customize-menu__title">${t("nav.customize")}</div>
-        ${params.preferencesBrowserOnly
-          ? html`<div class="sidebar-customize-menu__provenance" role="note">
-              ${t("quickSettings.personal.browserOnly")}
-            </div>`
-          : nothing}
-        ${SIDEBAR_NAV_ROUTES.filter((routeId) => params.isRouteEnabled(routeId)).map((routeId) => {
-          const visible = params.sidebarEntries.includes(
-            serializeSidebarEntry({ type: "route", route: routeId }),
-          );
-          return html`
-            <wa-dropdown-item
-              class="sidebar-customize-menu__item"
-              type="checkbox"
-              value=${routeId}
-              .checked=${visible}
+        } else if (value && SIDEBAR_NAV_ROUTES.includes(value as SidebarNavRoute)) {
+          params.onToggleRoute(value as SidebarNavRoute);
+        }
+      }}
+      @keydown=${(event: KeyboardEvent) => trackDropdownKeyboardDismissal(event, params.onTabAway)}
+      @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
+    >
+      <button
+        slot="trigger"
+        type="button"
+        tabindex="-1"
+        aria-hidden="true"
+        aria-label=${t("nav.customize")}
+        style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
+      ></button>
+      <div class="sidebar-customize-menu__title">${t("nav.customize")}</div>
+      ${params.preferencesBrowserOnly
+        ? html`<div class="sidebar-customize-menu__provenance" role="note">
+            ${t("quickSettings.personal.browserOnly")}
+          </div>`
+        : nothing}
+      ${SIDEBAR_NAV_ROUTES.filter((routeId) => params.isRouteEnabled(routeId)).map((routeId) => {
+        const visible = params.sidebarEntries.includes(
+          serializeSidebarEntry({ type: "route", route: routeId }),
+        );
+        return html`
+          <wa-dropdown-item
+            class="sidebar-customize-menu__item"
+            type="checkbox"
+            value=${routeId}
+            .checked=${visible}
+          >
+            <span slot="icon" class="nav-item__icon" aria-hidden="true"
+              >${icons[navigationIconForRoute(routeId)]}</span
             >
-              <span slot="icon" class="nav-item__icon" aria-hidden="true"
-                >${icons[navigationIconForRoute(routeId)]}</span
-              >
-              <span class="sidebar-customize-menu__text">${titleForRoute(routeId)}</span>
-            </wa-dropdown-item>
-          `;
-        })}
-        ${params.isRouteEnabled("workboard") && params.workboardBoards.length > 0
-          ? params.workboardRenderers?.renderCustomize(
-              params.workboardBoards,
-              params.sidebarEntries,
-            )
-          : nothing}
-        <div class="sidebar-customize-menu__separator" role="separator"></div>
-        <wa-dropdown-item class="sidebar-customize-menu__item" value="reset">
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.refresh}</span>
-          <span class="sidebar-customize-menu__text">${t("nav.customizeReset")}</span>
-        </wa-dropdown-item>
-      </wa-dropdown>
-    </openclaw-menu-surface>
+            <span class="sidebar-customize-menu__text">${titleForRoute(routeId)}</span>
+          </wa-dropdown-item>
+        `;
+      })}
+      ${params.isRouteEnabled("workboard") && params.workboardBoards.length > 0
+        ? params.workboardRenderers?.renderCustomize(params.workboardBoards, params.sidebarEntries)
+        : nothing}
+      <div class="sidebar-customize-menu__separator" role="separator"></div>
+      <wa-dropdown-item class="sidebar-customize-menu__item" value="reset">
+        <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.refresh}</span>
+        <span class="sidebar-customize-menu__text">${t("nav.customizeReset")}</span>
+      </wa-dropdown-item>
+    </wa-dropdown>
   `;
 }

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -113,79 +113,74 @@ export function renderSidebarSessionGroupMenu(params: {
   return keyed(
     menu,
     html`
-      <openclaw-menu-surface>
-        <wa-dropdown
-          class="session-menu sidebar-session-group-menu"
-          .open=${true}
-          placement="bottom-start"
-          .distance=${0}
-          aria-label=${t("sessionsView.groupMenu", { group: menu.group })}
-          @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-            event.preventDefault();
-            const value = event.detail.item.value;
-            if (
-              (value === "group-defaults" ||
-                value === "rename-group" ||
-                value === "new-group" ||
-                value === "delete-group") &&
-              !params.actionDisabledReasons?.[value]
-            ) {
-              params.onAction(value, menu.group);
-            }
-          }}
-          @keydown=${(event: KeyboardEvent) =>
-            trackDropdownKeyboardDismissal(event, () => params.trigger?.focus())}
-          @wa-after-hide=${(event: Event) =>
-            params.onClose(consumeDropdownKeyboardDismissal(event))}
+      <wa-dropdown
+        class="session-menu sidebar-session-group-menu"
+        .open=${true}
+        placement="bottom-start"
+        .distance=${0}
+        aria-label=${t("sessionsView.groupMenu", { group: menu.group })}
+        @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+          event.preventDefault();
+          const value = event.detail.item.value;
+          if (
+            (value === "group-defaults" ||
+              value === "rename-group" ||
+              value === "new-group" ||
+              value === "delete-group") &&
+            !params.actionDisabledReasons?.[value]
+          ) {
+            params.onAction(value, menu.group);
+          }
+        }}
+        @keydown=${(event: KeyboardEvent) =>
+          trackDropdownKeyboardDismissal(event, () => params.trigger?.focus())}
+        @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
+      >
+        ${renderSidebarMenuTrigger(menu, t("sessionsView.groupMenu", { group: menu.group }))}
+        <wa-dropdown-item
+          class="session-menu__item"
+          value="group-defaults"
+          ?disabled=${!params.connected ||
+          Boolean(params.actionDisabledReasons?.["group-defaults"])}
+          title=${params.actionDisabledReasons?.["group-defaults"] ?? nothing}
         >
-          ${renderSidebarMenuTrigger(menu, t("sessionsView.groupMenu", { group: menu.group }))}
-          <wa-dropdown-item
-            class="session-menu__item"
-            value="group-defaults"
-            ?disabled=${!params.connected ||
-            Boolean(params.actionDisabledReasons?.["group-defaults"])}
-            title=${params.actionDisabledReasons?.["group-defaults"] ?? nothing}
+          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.settings}</span>
+          <span class="session-menu__text"
+            >${params.groupDefaultsUnavailable
+              ? `${t("common.retry")}: ${t("sessionsView.groupDefaultsMenu")}`
+              : t("sessionsView.groupDefaultsMenu")}</span
           >
-            <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.settings}</span>
-            <span class="session-menu__text"
-              >${params.groupDefaultsUnavailable
-                ? `${t("common.retry")}: ${t("sessionsView.groupDefaultsMenu")}`
-                : t("sessionsView.groupDefaultsMenu")}</span
-            >
-          </wa-dropdown-item>
-          <wa-dropdown-item
-            class="session-menu__item"
-            value="rename-group"
-            ?disabled=${!params.connected ||
-            Boolean(params.actionDisabledReasons?.["rename-group"])}
-            title=${params.actionDisabledReasons?.["rename-group"] ?? nothing}
-          >
-            <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.edit}</span>
-            <span class="session-menu__text">${t("sessionsView.renameGroupMenu")}</span>
-          </wa-dropdown-item>
-          <wa-dropdown-item
-            class="session-menu__item"
-            value="new-group"
-            ?disabled=${!params.connected || Boolean(params.actionDisabledReasons?.["new-group"])}
-            title=${params.actionDisabledReasons?.["new-group"] ?? nothing}
-          >
-            <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.folder}</span>
-            <span class="session-menu__text">${t("sessionsView.newGroup")}</span>
-          </wa-dropdown-item>
-          <div class="session-menu__separator" role="separator"></div>
-          <wa-dropdown-item
-            class="session-menu__item session-menu__item--destructive"
-            value="delete-group"
-            variant="danger"
-            ?disabled=${!params.connected ||
-            Boolean(params.actionDisabledReasons?.["delete-group"])}
-            title=${params.actionDisabledReasons?.["delete-group"] ?? nothing}
-          >
-            <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.trash}</span>
-            <span class="session-menu__text">${t("sessionsView.deleteGroupMenu")}</span>
-          </wa-dropdown-item>
-        </wa-dropdown>
-      </openclaw-menu-surface>
+        </wa-dropdown-item>
+        <wa-dropdown-item
+          class="session-menu__item"
+          value="rename-group"
+          ?disabled=${!params.connected || Boolean(params.actionDisabledReasons?.["rename-group"])}
+          title=${params.actionDisabledReasons?.["rename-group"] ?? nothing}
+        >
+          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.edit}</span>
+          <span class="session-menu__text">${t("sessionsView.renameGroupMenu")}</span>
+        </wa-dropdown-item>
+        <wa-dropdown-item
+          class="session-menu__item"
+          value="new-group"
+          ?disabled=${!params.connected || Boolean(params.actionDisabledReasons?.["new-group"])}
+          title=${params.actionDisabledReasons?.["new-group"] ?? nothing}
+        >
+          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.folder}</span>
+          <span class="session-menu__text">${t("sessionsView.newGroup")}</span>
+        </wa-dropdown-item>
+        <div class="session-menu__separator" role="separator"></div>
+        <wa-dropdown-item
+          class="session-menu__item session-menu__item--destructive"
+          value="delete-group"
+          variant="danger"
+          ?disabled=${!params.connected || Boolean(params.actionDisabledReasons?.["delete-group"])}
+          title=${params.actionDisabledReasons?.["delete-group"] ?? nothing}
+        >
+          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.trash}</span>
+          <span class="session-menu__text">${t("sessionsView.deleteGroupMenu")}</span>
+        </wa-dropdown-item>
+      </wa-dropdown>
     `,
   );
 }
@@ -215,52 +210,49 @@ export function renderSidebarCatalogViewMenu(params: {
   return keyed(
     position,
     html`
-      <openclaw-menu-surface>
-        <wa-dropdown
-          class="sidebar-session-sort-menu sidebar-catalog-view-menu"
-          .open=${true}
-          placement="bottom-start"
-          .distance=${0}
-          aria-label=${t("chat.sidebar.catalogViewOptions")}
-          @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-            event.preventDefault();
-            const value = event.detail.item.value;
-            if (value?.startsWith("grouping:")) {
-              params.onGroupingChange(value.slice("grouping:".length) as CatalogProjectGrouping);
-            } else if (value?.startsWith("owner:")) {
-              params.onOwnerFilterChange(value.slice("owner:".length) || null);
-            } else if (value === "involving-me") {
-              params.onOwnerFilterChange(null, true);
-            } else if (value === "hide-catalog") {
-              params.onHide();
-            }
-          }}
-          @keydown=${(event: KeyboardEvent) =>
-            trackDropdownKeyboardDismissal(event, () => params.trigger?.focus())}
-          @wa-after-hide=${(event: Event) =>
-            params.onClose(consumeDropdownKeyboardDismissal(event))}
-        >
-          ${renderSidebarMenuTrigger(position, t("chat.sidebar.catalogViewOptions"))}
-          <div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
-          ${groupingOptions.map((option) =>
-            renderSidebarMenuRadioItem({
-              value: `grouping:${option.grouping}`,
-              checked: params.grouping === option.grouping,
-              label: option.label,
-            }),
-          )}
-          ${renderSidebarOwnerFilter(
-            params.owners,
-            params.ownerFilterId,
-            params.involvingMe,
-            params.selfOwnerId,
-          )}
-          <div class="session-menu__separator" role="separator"></div>
-          <wa-dropdown-item class="sidebar-session-sort-menu__item" value="hide-catalog">
-            <span class="session-menu__text">${t("chat.sidebar.hideFromSidebar")}</span>
-          </wa-dropdown-item>
-        </wa-dropdown>
-      </openclaw-menu-surface>
+      <wa-dropdown
+        class="sidebar-session-sort-menu sidebar-catalog-view-menu"
+        .open=${true}
+        placement="bottom-start"
+        .distance=${0}
+        aria-label=${t("chat.sidebar.catalogViewOptions")}
+        @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+          event.preventDefault();
+          const value = event.detail.item.value;
+          if (value?.startsWith("grouping:")) {
+            params.onGroupingChange(value.slice("grouping:".length) as CatalogProjectGrouping);
+          } else if (value?.startsWith("owner:")) {
+            params.onOwnerFilterChange(value.slice("owner:".length) || null);
+          } else if (value === "involving-me") {
+            params.onOwnerFilterChange(null, true);
+          } else if (value === "hide-catalog") {
+            params.onHide();
+          }
+        }}
+        @keydown=${(event: KeyboardEvent) =>
+          trackDropdownKeyboardDismissal(event, () => params.trigger?.focus())}
+        @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
+      >
+        ${renderSidebarMenuTrigger(position, t("chat.sidebar.catalogViewOptions"))}
+        <div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
+        ${groupingOptions.map((option) =>
+          renderSidebarMenuRadioItem({
+            value: `grouping:${option.grouping}`,
+            checked: params.grouping === option.grouping,
+            label: option.label,
+          }),
+        )}
+        ${renderSidebarOwnerFilter(
+          params.owners,
+          params.ownerFilterId,
+          params.involvingMe,
+          params.selfOwnerId,
+        )}
+        <div class="session-menu__separator" role="separator"></div>
+        <wa-dropdown-item class="sidebar-session-sort-menu__item" value="hide-catalog">
+          <span class="session-menu__text">${t("chat.sidebar.hideFromSidebar")}</span>
+        </wa-dropdown-item>
+      </wa-dropdown>
     `,
   );
 }
@@ -300,119 +292,116 @@ export function renderSidebarSessionSortMenu(params: {
   return keyed(
     position,
     html`
-      <openclaw-menu-surface>
-        <wa-dropdown
-          class="sidebar-session-sort-menu"
-          .open=${true}
-          placement="bottom-start"
-          .distance=${0}
-          aria-label=${t("chat.sidebar.sortSessions")}
-          @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-            event.preventDefault();
-            const value = event.detail.item.value;
-            if (value?.startsWith("grouping:")) {
-              params.onGroupingChange(value.slice("grouping:".length) as SidebarSessionsGrouping);
-            } else if (value?.startsWith("sort:")) {
-              params.onSortModeChange(value.slice("sort:".length) as SidebarSessionSortMode);
-            } else if (value?.startsWith("status:")) {
-              params.onStatusFilterChange(
-                value.slice("status:".length) as SidebarSessionStatusFilter,
-              );
-            } else if (value?.startsWith("owner:")) {
-              params.onOwnerFilterChange(value.slice("owner:".length) || null);
-            } else if (value === "involving-me") {
-              params.onOwnerFilterChange(null, true);
-            } else if (value === "show-preview") {
-              params.onShowPreviewChange(!params.showPreview);
-            } else if (value === "show-cron") {
-              params.onShowCronChange(!params.showCron);
-            } else if (value === "show-system") {
-              params.onShowSystemChange(!params.showSystem);
-            }
-          }}
-          @keydown=${(event: KeyboardEvent) =>
-            trackDropdownKeyboardDismissal(event, () => params.trigger?.focus())}
-          @wa-after-hide=${(event: Event) =>
-            params.onClose(consumeDropdownKeyboardDismissal(event))}
+      <wa-dropdown
+        class="sidebar-session-sort-menu"
+        .open=${true}
+        placement="bottom-start"
+        .distance=${0}
+        aria-label=${t("chat.sidebar.sortSessions")}
+        @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+          event.preventDefault();
+          const value = event.detail.item.value;
+          if (value?.startsWith("grouping:")) {
+            params.onGroupingChange(value.slice("grouping:".length) as SidebarSessionsGrouping);
+          } else if (value?.startsWith("sort:")) {
+            params.onSortModeChange(value.slice("sort:".length) as SidebarSessionSortMode);
+          } else if (value?.startsWith("status:")) {
+            params.onStatusFilterChange(
+              value.slice("status:".length) as SidebarSessionStatusFilter,
+            );
+          } else if (value?.startsWith("owner:")) {
+            params.onOwnerFilterChange(value.slice("owner:".length) || null);
+          } else if (value === "involving-me") {
+            params.onOwnerFilterChange(null, true);
+          } else if (value === "show-preview") {
+            params.onShowPreviewChange(!params.showPreview);
+          } else if (value === "show-cron") {
+            params.onShowCronChange(!params.showCron);
+          } else if (value === "show-system") {
+            params.onShowSystemChange(!params.showSystem);
+          }
+        }}
+        @keydown=${(event: KeyboardEvent) =>
+          trackDropdownKeyboardDismissal(event, () => params.trigger?.focus())}
+        @wa-after-hide=${(event: Event) => params.onClose(consumeDropdownKeyboardDismissal(event))}
+      >
+        ${renderSidebarMenuTrigger(position, t("chat.sidebar.sortSessions"))}
+        <div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
+        ${groupingOptions
+          .filter((option) => option.grouping !== "person" || params.peopleSortAvailable)
+          .map((option) =>
+            renderSidebarMenuRadioItem({
+              value: `grouping:${option.grouping}`,
+              checked: params.grouping === option.grouping,
+              label: option.label,
+            }),
+          )}
+        <div class="session-menu__separator" role="separator"></div>
+        <div class="sidebar-session-sort-menu__title">${t("chat.sidebar.sortBy")}</div>
+        ${SIDEBAR_SESSION_SORT_OPTIONS.filter(
+          (option) => option.mode !== "people" || params.peopleSortAvailable,
+        ).map((option) =>
+          renderSidebarMenuRadioItem({
+            value: `sort:${option.mode}`,
+            checked: params.sortMode === option.mode,
+            label: t(option.labelKey),
+          }),
+        )}
+        <div class="session-menu__separator" role="separator"></div>
+        <div class="sidebar-session-sort-menu__title">${t("sessionsView.status")}</div>
+        ${SIDEBAR_SESSION_STATUS_OPTIONS.map((statusFilter) =>
+          renderSidebarMenuRadioItem({
+            value: `status:${statusFilter}`,
+            checked: params.statusFilter === statusFilter,
+            label:
+              statusFilter === "active"
+                ? t("common.active")
+                : statusFilter === "archived"
+                  ? t("sessionsView.archived")
+                  : t("sessionsView.all"),
+          }),
+        )}
+        ${renderSidebarOwnerFilter(
+          params.owners,
+          params.ownerFilterId,
+          params.involvingMe,
+          params.selfOwnerId,
+        )}
+        <div class="session-menu__separator" role="separator"></div>
+        <wa-dropdown-item
+          class="sidebar-session-sort-menu__item"
+          type="checkbox"
+          value="show-preview"
+          .checked=${params.showPreview}
         >
-          ${renderSidebarMenuTrigger(position, t("chat.sidebar.sortSessions"))}
-          <div class="sidebar-session-sort-menu__title">${t("sessionsView.groupBy")}</div>
-          ${groupingOptions
-            .filter((option) => option.grouping !== "person" || params.peopleSortAvailable)
-            .map((option) =>
-              renderSidebarMenuRadioItem({
-                value: `grouping:${option.grouping}`,
-                checked: params.grouping === option.grouping,
-                label: option.label,
-              }),
-            )}
-          <div class="session-menu__separator" role="separator"></div>
-          <div class="sidebar-session-sort-menu__title">${t("chat.sidebar.sortBy")}</div>
-          ${SIDEBAR_SESSION_SORT_OPTIONS.filter(
-            (option) => option.mode !== "people" || params.peopleSortAvailable,
-          ).map((option) =>
-            renderSidebarMenuRadioItem({
-              value: `sort:${option.mode}`,
-              checked: params.sortMode === option.mode,
-              label: t(option.labelKey),
-            }),
-          )}
-          <div class="session-menu__separator" role="separator"></div>
-          <div class="sidebar-session-sort-menu__title">${t("sessionsView.status")}</div>
-          ${SIDEBAR_SESSION_STATUS_OPTIONS.map((statusFilter) =>
-            renderSidebarMenuRadioItem({
-              value: `status:${statusFilter}`,
-              checked: params.statusFilter === statusFilter,
-              label:
-                statusFilter === "active"
-                  ? t("common.active")
-                  : statusFilter === "archived"
-                    ? t("sessionsView.archived")
-                    : t("sessionsView.all"),
-            }),
-          )}
-          ${renderSidebarOwnerFilter(
-            params.owners,
-            params.ownerFilterId,
-            params.involvingMe,
-            params.selfOwnerId,
-          )}
-          <div class="session-menu__separator" role="separator"></div>
-          <wa-dropdown-item
-            class="sidebar-session-sort-menu__item"
-            type="checkbox"
-            value="show-preview"
-            .checked=${params.showPreview}
+          <span class="session-menu__text">${t("sessionsView.showSessionPreview")}</span>
+          <span slot="details" class="session-menu__check" aria-hidden="true"
+            >${params.showPreview ? icons.check : nothing}</span
           >
-            <span class="session-menu__text">${t("sessionsView.showSessionPreview")}</span>
-            <span slot="details" class="session-menu__check" aria-hidden="true"
-              >${params.showPreview ? icons.check : nothing}</span
-            >
-          </wa-dropdown-item>
-          <wa-dropdown-item
-            class="sidebar-session-sort-menu__item"
-            type="checkbox"
-            value="show-cron"
-            .checked=${params.showCron}
+        </wa-dropdown-item>
+        <wa-dropdown-item
+          class="sidebar-session-sort-menu__item"
+          type="checkbox"
+          value="show-cron"
+          .checked=${params.showCron}
+        >
+          <span class="session-menu__text">${t("sessionsView.showCronSessions")}</span>
+          <span slot="details" class="session-menu__check" aria-hidden="true"
+            >${params.showCron ? icons.check : nothing}</span
           >
-            <span class="session-menu__text">${t("sessionsView.showCronSessions")}</span>
-            <span slot="details" class="session-menu__check" aria-hidden="true"
-              >${params.showCron ? icons.check : nothing}</span
-            >
-          </wa-dropdown-item>
-          <wa-dropdown-item
-            class="sidebar-session-sort-menu__item"
-            type="checkbox"
-            value="show-system"
-            .checked=${params.showSystem}
+        </wa-dropdown-item>
+        <wa-dropdown-item
+          class="sidebar-session-sort-menu__item"
+          type="checkbox"
+          value="show-system"
+          .checked=${params.showSystem}
+        >
+          <span class="session-menu__text">${t("sessionsView.showSystemSessions")}</span>
+          <span slot="details" class="session-menu__check" aria-hidden="true"
+            >${params.showSystem ? icons.check : nothing}</span
           >
-            <span class="session-menu__text">${t("sessionsView.showSystemSessions")}</span>
-            <span slot="details" class="session-menu__check" aria-hidden="true"
-              >${params.showSystem ? icons.check : nothing}</span
-            >
-          </wa-dropdown-item>
-        </wa-dropdown>
-      </openclaw-menu-surface>
+        </wa-dropdown-item>
+      </wa-dropdown>
     `,
   );
 }

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -11,7 +11,6 @@ import { beginNativeWindowDragFromTopInset } from "../app/native-window-drag.ts"
 import { t } from "../i18n/index.ts";
 import { BoardAvailabilityController } from "../lib/board/availability-controller.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
-import "./menu-surface.ts";
 import "./session-menu.ts";
 import "./sidebar-agent-card.ts";
 import "./sidebar-attention.ts";

--- a/ui/src/components/lobster-pet-dismiss-menu.ts
+++ b/ui/src/components/lobster-pet-dismiss-menu.ts
@@ -1,6 +1,5 @@
 import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
-import "./menu-surface.ts";
 import "./web-awesome.ts";
 
 export type LobsterPetDismissMenuPosition = { x: number; y: number };
@@ -18,38 +17,36 @@ export function renderLobsterPetDismissMenu(params: {
   // relocating it, so top-start is forced directly since the footer always
   // has clear room above — leaving it to flip risks a shrunk-in-place menu.
   return html`
-    <openclaw-menu-surface>
-      <wa-dropdown
-        class="session-menu lobster-pet-dismiss-menu"
-        .open=${true}
-        placement="top-start"
-        .distance=${0}
+    <wa-dropdown
+      class="session-menu lobster-pet-dismiss-menu"
+      .open=${true}
+      placement="top-start"
+      .distance=${0}
+      aria-label=${t("quickSettings.appearance.lobsterVisits")}
+      @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
+        event.preventDefault();
+        if (event.detail.item.value === "dismiss") {
+          params.onDismiss(false);
+        } else if (event.detail.item.value === "dismiss-permanently") {
+          params.onDismiss(true);
+        }
+      }}
+      @wa-after-hide=${params.onClose}
+    >
+      <button
+        slot="trigger"
+        type="button"
+        tabindex="-1"
+        aria-hidden="true"
         aria-label=${t("quickSettings.appearance.lobsterVisits")}
-        @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) => {
-          event.preventDefault();
-          if (event.detail.item.value === "dismiss") {
-            params.onDismiss(false);
-          } else if (event.detail.item.value === "dismiss-permanently") {
-            params.onDismiss(true);
-          }
-        }}
-        @wa-after-hide=${params.onClose}
+        style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
+      ></button>
+      <wa-dropdown-item class="session-menu__item" value="dismiss"
+        >${t("common.dismiss")}</wa-dropdown-item
       >
-        <button
-          slot="trigger"
-          type="button"
-          tabindex="-1"
-          aria-hidden="true"
-          aria-label=${t("quickSettings.appearance.lobsterVisits")}
-          style="position: fixed; left: ${position.x}px; top: ${position.y}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
-        ></button>
-        <wa-dropdown-item class="session-menu__item" value="dismiss"
-          >${t("common.dismiss")}</wa-dropdown-item
-        >
-        <wa-dropdown-item class="session-menu__item" value="dismiss-permanently"
-          >${t("common.dismissAndDontShowAgain")}</wa-dropdown-item
-        >
-      </wa-dropdown>
-    </openclaw-menu-surface>
+      <wa-dropdown-item class="session-menu__item" value="dismiss-permanently"
+        >${t("common.dismissAndDontShowAgain")}</wa-dropdown-item
+      >
+    </wa-dropdown>
   `;
 }

--- a/ui/src/components/menu-surface.browser.test.ts
+++ b/ui/src/components/menu-surface.browser.test.ts
@@ -2,12 +2,14 @@ import { afterEach, describe, expect, it } from "vitest";
 import "../test-helpers/load-styles.ts";
 import "./menu-surface.ts";
 import "./resizable-divider.ts";
+import "./web-awesome.ts";
 
 // Real-browser regression for the sidebar menu z-order bug: the nav column is
 // a stacking context (.shell-nav z-index 10) painted below the sidebar
 // resizer (.sidebar-resizer z-index 20), so a fixed-position menu rendered
 // inside the nav is overdrawn by the divider unless it is promoted to the
-// popover top layer via openclaw-menu-surface.
+// popover top layer. Plain overlays use openclaw-menu-surface; Web Awesome
+// dropdowns already own their popup and must not nest inside that surface.
 //
 // The repo-level test shard also collects *.browser.test.ts under jsdom,
 // which has neither the Popover API nor real layout; the paint-order
@@ -77,7 +79,7 @@ describe.skipIf(!hasPopoverApi)("sidebar menu stacking", () => {
     expect(hitTestOnDivider(menu, divider)).toBe(divider);
   });
 
-  it("paints a menu hosted in openclaw-menu-surface above the resizer divider", async () => {
+  it("paints a plain menu hosted in openclaw-menu-surface above the resizer divider", async () => {
     await useDesktopViewport();
     const { nav, divider } = mountShell();
     const surface = document.createElement("openclaw-menu-surface");
@@ -89,5 +91,47 @@ describe.skipIf(!hasPopoverApi)("sidebar menu stacking", () => {
     const hit = hitTestOnDivider(menu, divider);
     expect(hit).not.toBeNull();
     expect(menu.contains(hit)).toBe(true);
+  });
+
+  it("paints a Web Awesome dropdown above the divider through its own popover", async () => {
+    await useDesktopViewport();
+    const { nav, divider } = mountShell();
+    const dividerBounds = divider.getBoundingClientRect();
+    const dropdown = document.createElement("wa-dropdown") as HTMLElement & {
+      open: boolean;
+      updateComplete: Promise<unknown>;
+    };
+    dropdown.className = "sidebar-session-sort-menu";
+    const trigger = document.createElement("button");
+    trigger.slot = "trigger";
+    trigger.style.position = "fixed";
+    trigger.style.left = `${Math.round(dividerBounds.left) - 120}px`;
+    trigger.style.top = "100px";
+    const item = document.createElement("wa-dropdown-item");
+    item.className = "sidebar-session-sort-menu__item";
+    item.textContent = "Created";
+    dropdown.append(trigger, item);
+    nav.append(dropdown);
+    dropdown.open = true;
+    await dropdown.updateComplete;
+
+    const popup = dropdown.shadowRoot?.querySelector<
+      HTMLElement & { updateComplete: Promise<unknown> }
+    >("wa-popup");
+    await popup?.updateComplete;
+    const popupSurface = popup?.shadowRoot?.querySelector<HTMLElement>('[part="popup"]');
+    await expect.poll(() => popupSurface?.matches(":popover-open")).toBe(true);
+    expect(dropdown.closest("openclaw-menu-surface")).toBeNull();
+
+    const menu = dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+    expect(menu).not.toBeNull();
+    const menuBounds = menu!.getBoundingClientRect();
+    expect(menuBounds.right).toBeGreaterThan(dividerBounds.left);
+    const hit = document.elementFromPoint(
+      dividerBounds.left + dividerBounds.width / 2,
+      menuBounds.top + menuBounds.height / 2,
+    );
+    expect(hit).not.toBeNull();
+    expect(dropdown.contains(hit)).toBe(true);
   });
 });

--- a/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
+++ b/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
@@ -70,6 +70,7 @@ suite.define(() => {
         const menuTrigger = activePane.getByRole("button", {
           name: "Actions for Terminal continuation",
         });
+        await expect.poll(() => menuTrigger.getAttribute("aria-expanded")).toBe("false");
         await menuTrigger.press("Enter");
         const dropdown = menuTrigger.locator("xpath=ancestor::wa-dropdown");
         const action = dropdown.getByText("Continue in terminal…", { exact: true });

--- a/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
+++ b/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
@@ -120,8 +120,7 @@ async function measureDismissMenu(currentPage: Page) {
       menuTop: menuRect.top,
       menuBottom: menuRect.bottom,
       popupIsTopLayer: popupBox ? popupBox.matches(":popover-open") : null,
-      menuSurfaceIsTopLayer:
-        document.querySelector("openclaw-menu-surface")?.matches(":popover-open") ?? null,
+      hasOuterMenuSurface: dropdown.closest("openclaw-menu-surface") !== null,
       hostHeight: hostStyle?.height ?? null,
       hostOverflow: hostStyle?.overflow ?? null,
       itemHeights: [...dropdown.querySelectorAll("wa-dropdown-item")].map(
@@ -185,7 +184,11 @@ suite.define(() => {
 
     // Asserting on the whole measurement so a regression prints the anchor
     // position and resolved max-height that explain it.
-    expect(measurement).toMatchObject({ overflowPx: 0 });
+    expect(measurement).toMatchObject({
+      overflowPx: 0,
+      popupIsTopLayer: true,
+      hasOuterMenuSurface: false,
+    });
   });
 
   // Control: the identical menu content, anchored away from the bottom edge.

--- a/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.e2e.test.ts
@@ -12,8 +12,6 @@ import {
   replaceGatewayClient,
   waitForCommittedChatRoute,
 } from "./new-session-page.test-support.ts";
-import { waitForCommittedState } from "./settle.test-support.ts";
-
 const suite = createNewSessionPageE2eSuite();
 const SESSION_PLACEMENT_STARTUP_RUNTIME_REQUEST =
   /\/assets\/session-placement-startup\.runtime-[^/?]+\.js(?:\?.*)?$/;
@@ -200,6 +198,7 @@ suite.define(() => {
       expect(firstSend.params).toMatchObject({
         attachments: [{ fileName: "pixel.png", content: ONE_PIXEL_PNG_B64 }],
       });
+      await waitForCommittedChatRoute(page);
       await gateway.rejectDeferred("sessions.send", {
         code: "UNAVAILABLE",
         message: "send outcome unknown",
@@ -243,51 +242,6 @@ suite.define(() => {
         sessionKey,
       );
       expect(startupError).toContain("send outcome unknown");
-      await waitForCommittedChatRoute(page);
-      await waitForCommittedState(
-        page,
-        ({ messageId: expectedMessageId, recoveryPrefix, sessionKey: expectedSessionKey }) => {
-          if (
-            typeof expectedMessageId !== "string" ||
-            typeof recoveryPrefix !== "string" ||
-            typeof expectedSessionKey !== "string"
-          ) {
-            return false;
-          }
-          for (let index = 0; index < sessionStorage.length; index += 1) {
-            const key = sessionStorage.key(index);
-            if (!key?.startsWith(recoveryPrefix)) {
-              continue;
-            }
-            const raw = sessionStorage.getItem(key);
-            if (!raw) {
-              continue;
-            }
-            try {
-              const value: unknown = JSON.parse(raw);
-              if (typeof value !== "object" || value === null || Array.isArray(value)) {
-                continue;
-              }
-              const recovery = value as Record<string, unknown>;
-              if (
-                recovery.sessionKey === expectedSessionKey &&
-                recovery.messageId === expectedMessageId &&
-                recovery.phase === "sending"
-              ) {
-                return true;
-              }
-            } catch {
-              // Ignore unrelated malformed rows in the current recovery namespace.
-            }
-          }
-          return false;
-        },
-        {
-          messageId,
-          recoveryPrefix: "openclaw.new-session.session-placement-recovery.v1:",
-          sessionKey,
-        },
-      );
       await gateway.setMethodResponse("sessions.send", {
         runId: "run-reload-recovery",
         status: "started",

--- a/ui/src/e2e/sidebar-account-footer.e2e.test.ts
+++ b/ui/src/e2e/sidebar-account-footer.e2e.test.ts
@@ -43,6 +43,9 @@ async function assertSingleAccountTarget(page: Page, sidebar: Locator) {
 
 async function assertIdentityMenuContract(sidebar: Locator, menu: Locator) {
   expect(await menu.locator('wa-dropdown-item[value="command:recent-activity"]').count()).toBe(0);
+  expect(
+    await menu.evaluate((dropdown) => dropdown.closest("openclaw-menu-surface") !== null),
+  ).toBe(false);
 }
 
 async function runAccountFooterProof(page: Page, sidebar: Locator, branch: "feature" | "main") {

--- a/ui/src/test-helpers/app-sidebar-cases/transient-menus.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/transient-menus.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createGateway, createSessions, mountSidebar } from "../app-sidebar.ts";
+import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar transient menus", () => {
-  // Regression: the nav column is a stacking context (z-index 10) painted
-  // below the sidebar resizer (z-index 20), so transient menus must render
-  // through the top-layer surface host instead of plain fixed divs.
-  it("hosts the session sort menu in the top-layer menu surface", async () => {
+  it("lets the session sort dropdown own its popover without another top-layer host", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(
       gateway,
@@ -23,7 +21,26 @@ describe("AppSidebar transient menus", () => {
 
     const menu = sidebar.querySelector(".sidebar-session-sort-menu");
     expect(menu).not.toBeNull();
-    expect(menu?.closest("openclaw-menu-surface")).not.toBeNull();
+    expect(menu?.closest("openclaw-menu-surface")).toBeNull();
+  });
+
+  it("keeps the plain attention panel inside its top-layer menu surface", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    const attention = sidebar.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
+      "openclaw-sidebar-attention",
+    );
+    await attention?.updateComplete;
+    const trigger = attention?.querySelector<HTMLButtonElement>(".sidebar-issues-button");
+    expect(trigger).not.toBeNull();
+
+    trigger?.click();
+
+    await waitForFast(() => {
+      const panel = attention?.querySelector(".sidebar-issues-panel");
+      expect(panel).not.toBeNull();
+      expect(panel?.closest("openclaw-menu-surface")).not.toBeNull();
+    });
   });
 
   it("ignores a stale sort-menu hide after opening its replacement", async () => {
@@ -74,6 +91,7 @@ describe("AppSidebar transient menus", () => {
       'wa-dropdown-item[value="command:agent-settings"]',
     );
     expect(firstMenu).not.toBeNull();
+    expect(firstMenu?.closest("openclaw-menu-surface")).toBeNull();
     expect(settingsItem).not.toBeNull();
     firstMenu?.dispatchEvent(
       new CustomEvent("wa-select", {
@@ -110,6 +128,7 @@ describe("AppSidebar transient menus", () => {
     await sidebar.updateComplete;
     const firstMenu = sidebar.querySelector<HTMLElement>(".sidebar-more-menu");
     expect(firstMenu).not.toBeNull();
+    expect(firstMenu?.closest("openclaw-menu-surface")).toBeNull();
     trigger.click();
     await sidebar.updateComplete;
     trigger.click();
@@ -136,6 +155,7 @@ describe("AppSidebar transient menus", () => {
     await sidebar.updateComplete;
     const firstMenu = sidebar.querySelector<HTMLElement>(".sidebar-customize-menu");
     expect(firstMenu).not.toBeNull();
+    expect(firstMenu?.closest("openclaw-menu-surface")).toBeNull();
     firstMenu?.dispatchEvent(
       new CustomEvent("wa-select", {
         bubbles: true,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Safari users could click sidebar popup controls such as **Filter & sort** or the account/settings menu, but no menu appeared. Chrome continued to work, making the default Safari experience look silently broken.

## Why This Change Was Made

Web Awesome dropdowns already promote their own popup into the browser top layer. The sidebar still wrapped those dropdowns in the older `openclaw-menu-surface` manual popover introduced before the Web Awesome migration, creating nested popover ownership that Safari suppresses.

This removes the redundant wrapper from all Web Awesome sidebar dropdowns while retaining `openclaw-menu-surface` for the plain attention panel that still needs it. There is no browser sniffing or fallback path: each transient surface now has one canonical top-layer owner.

AI-assisted; implementation and behavior were reviewed and verified.

## User Impact

Safari users can open the Sessions filter, account/settings, agent, customization, group, catalog, and lobster-dismiss menus normally again. Chromium behavior, keyboard focus, menu dismissal, overflow sizing, and sidebar-resizer z-order remain intact.

## Evidence

### Before: Safari click focuses the filter control but renders no menu

![Safari sidebar filter before](https://github.com/user-attachments/assets/925f7ed9-06fc-4e8f-b36d-8de0454a5c56)

### After: Safari renders the filter through Web Awesome's single popup owner

![Safari sidebar filter after](https://github.com/user-attachments/assets/5dbe4514-8f00-4f27-9b32-8c1027f3d92f)

### After: the account/settings menu opens in Safari too

![Safari account settings menu after](https://github.com/user-attachments/assets/28ab775b-d1d6-493d-8e9c-58f27d31b227)

Live observations:

- Real Safari 27, real synthesized mouse input: pre-fix filter and identity triggers rendered no overlay; post-fix both menus rendered and exposed their menu items.
- Chromium mocked Control UI: the filter menu rendered with `popupOpen: true`, one dropdown, and zero nested `openclaw-menu-surface` ancestors.
- Chromium was live-tested post-fix; the reported Chrome behavior remains the control case because the fix removes redundant ownership rather than adding a Safari-specific path.

Focused validation:

- `node scripts/run-vitest.mjs ui/src/components/menu-surface.test.ts ui/src/components/app-sidebar.test.ts` — 290 passed.
- `cd ui && node ../scripts/run-vitest.mjs run --config vitest.config.ts --project browser src/components/menu-surface.browser.test.ts` — 3 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-interactions.e2e.test.ts ui/src/e2e/sidebar-account-footer.e2e.test.ts ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts` — 15 passed.
- `node scripts/check-changed.mjs -- <9 changed UI paths>` — passed.
- `pnpm build` — passed; initial cold build exceeded the local 10-minute harness ceiling, and the warmed rerun completed in 1m 34.6s.
- `git diff --check` — passed.
- First exact-head CI exposed a pre-existing frame-polled cloud-startup E2E assertion. The PR now waits for the committed route before rejecting the deferred send and removes the redundant sessionStorage implementation-detail poll; the focused scenario passed 12/12 independent serial repeats, the full file passed, and the sibling recovery file passed.
- Second exact-head CI exposed a pre-existing Web Awesome initialization race in the terminal-continuation E2E. The test now waits for the trigger's observable `aria-expanded="false"` readiness before preserving the Enter-key interaction; the focused test passed 12/12 independent serial repeats and the original UI E2E shard 4/11 passed 24 files / 71 tests.
- Direct dependency-contract inspection: pinned `@awesome.me/webawesome` 3.10.0 installs the dropdown trigger listener during first update, owns the internal popup as `popover="manual"`, and calls `showPopover()`/`hidePopover()` itself. This is why an additional outer manual-popover owner is both redundant and unsafe in Safari.
- Codex autoreview after every change — no accepted/actionable findings.

Production LOC: +598/-628 (net -30). Tests and test support: +82/-57 (net +25).

Provenance: [#105598](https://github.com/openclaw/openclaw/pull/105598) added the top-layer wrapper for the pre-Web-Awesome menus; [#106865](https://github.com/openclaw/openclaw/pull/106865) migrated the menus to Web Awesome, whose popup already owns the top layer, leaving the now-broken nested ownership in place.
