### PR TITLE
fix(ci): prevent gateway profile live startup stalls

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -3342,7 +3342,9 @@ jobs:
     needs: validate_selected_ref
     if: inputs.include_live_suites && !inputs.live_models_only && (inputs.live_suite_filter == '' || (startsWith(inputs.live_suite_filter, 'native-live-') && !startsWith(inputs.live_suite_filter, 'native-live-extensions-media') && inputs.live_suite_filter != 'native-live-extensions-a-k'))
     continue-on-error: ${{ inputs.advisory || inputs.live_advisory }}
-    runs-on: ${{ inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
+    # Source-transformed gateway profile startup can saturate standard hosted
+    # runners long enough to invalidate its same-event-loop startup probe.
+    runs-on: ${{ startsWith(matrix.suite_id, 'native-live-src-gateway-profiles') && 'blacksmith-8vcpu-ubuntu-2404' || (inputs.use_github_hosted_runners && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404') }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     strategy:
       fail-fast: false

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3549,7 +3549,7 @@ describe("package artifact reuse", () => {
       /validate_special_e2e:[\s\S]*?runs-on: \$\{\{ inputs\.use_github_hosted_runners && 'ubuntu-24\.04' \|\| 'blacksmith-8vcpu-ubuntu-2404' \}\}/u,
     );
     expect(workflow).toMatch(
-      /validate_live_provider_suites:[\s\S]*?runs-on: \$\{\{ inputs\.use_github_hosted_runners && 'ubuntu-24\.04' \|\| 'blacksmith-8vcpu-ubuntu-2404' \}\}/u,
+      /validate_live_provider_suites:[\s\S]*?runs-on: \$\{\{ startsWith\(matrix\.suite_id, 'native-live-src-gateway-profiles'\) && 'blacksmith-8vcpu-ubuntu-2404' \|\| \(inputs\.use_github_hosted_runners && 'ubuntu-24\.04' \|\| 'blacksmith-8vcpu-ubuntu-2404'\) \}\}/u,
     );
     expect(workflow).toContain("suite_id: native-live-src-gateway-core");
     expect(workflow).toContain("suite_id: native-live-src-gateway-backends");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full release validation routed source-transformed gateway profile live suites to standard GitHub-hosted runners, causing gateway startup probes to expire before any provider model coverage ran.

Completed run https://github.com/openclaw/openclaw/actions/runs/32546714131 showed the same startup boundary failing across independent profile lanes on `ubuntu-24.04`:

- OpenAI: 180000 ms gateway-start probe timeout
- OpenAI API default: 180000 ms gateway-start probe timeout
- MiniMax: 90000 ms gateway-start probe timeout
- Google: 90000 ms gateway-start probe timeout

## Why This Change Was Made

The reusable workflow now keeps only `native-live-src-gateway-profiles*` matrix entries on the existing 8-vCPU Blacksmith runner. Other native live suites continue to honor `use_github_hosted_runners`, preserving the broader release-runner policy.

This is a workflow-owner repair: it does not weaken assertions, retry startup, or increase probe timeouts. The existing workflow contract test now locks the narrow routing exception.

## User Impact

Release validation should reach provider live coverage instead of reporting false gateway startup failures caused by insufficient hosted-runner capacity. Runtime and product behavior are unchanged.

## Evidence

- Reconciled onto requested base `7864980d9e8b74ee1d37b101f99925e29ae4ffc8`.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts -- -t 'shards broad native live tests instead of one serial live-all job'` — passed.
- `node scripts/check-changed.mjs -- .github/workflows/openclaw-live-and-e2e-checks-reusable.yml test/scripts/package-acceptance-workflow.test.ts` — passed.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings.
- Full workflow test file: 176/177 passed; the unrelated Telegram-only fixture failure (`raw_telegram_scenarios[@]: unbound variable`) reproduces independently and is untouched by this diff.
- Exact-head focused proof: https://github.com/openclaw/openclaw/actions/runs/32699474969 at `32265cd2919d9dbeb4547305e7e7b77f895b5f2b`, filtered to `native-live-src-gateway-profiles-minimax` with repo E2E, release-path, OpenWebUI, Docker, and other live suites disabled.
- The MiniMax job was admitted on `blacksmith-8vcpu-ubuntu-2404`; auth/model selection reached `wanted=2`, `candidates=2`, `skipped=0`.
- The repair is not proven: gateway startup still exceeded the strict 90000 ms probe timeout and completed only after 167 seconds, before any provider/model coverage. The focused run failed and was not retried, so this PR remains held from merge.

AI-assisted: yes. The change, runner boundary, and evidence were manually inspected.
