### PR TITLE
improve(mattermost): speed up inbound direct-message replies

### DIFF
--- a/extensions/mattermost/src/channel.send-loopback.test.ts
+++ b/extensions/mattermost/src/channel.send-loopback.test.ts
@@ -3,6 +3,8 @@ import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime
 import { withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { mattermostPlugin } from "./channel.js";
+import { deliverMattermostReplyPayload } from "./mattermost/reply-delivery.js";
+import { sendMessageMattermost } from "./mattermost/send.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 import { setMattermostRuntime } from "./runtime.js";
 
@@ -17,6 +19,76 @@ vi.mock("./mattermost/runtime-api.js", async () => ({
 }));
 
 describe("Mattermost send action loopback", () => {
+  it("reuses the inbound provider channel when delivering a direct reply", async () => {
+    const requests: Array<{ path: string; body?: unknown }> = [];
+
+    await withServer(
+      (request, response) => {
+        let body = "";
+        request.setEncoding("utf8");
+        request.on("data", (chunk) => {
+          body += chunk;
+        });
+        request.on("end", () => {
+          const path = request.url ?? "";
+          requests.push({ path, ...(body ? { body: JSON.parse(body) as unknown } : {}) });
+          response.writeHead(201, { "content-type": "application/json" });
+          if (path === "/api/v4/users/me") {
+            response.end(JSON.stringify({ id: "cccccccccccccccccccccccccc" }));
+            return;
+          }
+          if (path === "/api/v4/channels/direct") {
+            response.end(JSON.stringify({ id: CHANNEL_ID }));
+            return;
+          }
+          response.end(
+            JSON.stringify({
+              id: "post-loopback",
+              channel_id: CHANNEL_ID,
+              message: "prepared direct reply",
+            }),
+          );
+        });
+      },
+      async (baseUrl) => {
+        const core = createPluginRuntimeMock();
+        setMattermostRuntime(core);
+        const cfg = {
+          channels: {
+            mattermost: {
+              botToken: "prepared-inbound-loopback",
+              baseUrl,
+              network: { dangerouslyAllowPrivateNetwork: true },
+            },
+          },
+        } as OpenClawConfig;
+
+        const result = await deliverMattermostReplyPayload({
+          core,
+          cfg,
+          payload: { text: "prepared direct reply" },
+          channelId: CHANNEL_ID,
+          accountId: "default",
+          textLimit: 4000,
+          tableMode: "off",
+          sendMessage: sendMessageMattermost,
+        });
+
+        expect(result).toMatchObject({
+          outcome: "text",
+          messageIds: ["post-loopback"],
+          visibleReplySent: true,
+        });
+        expect(requests).toEqual([
+          {
+            path: "/api/v4/posts",
+            body: { channel_id: CHANNEL_ID, message: "prepared direct reply" },
+          },
+        ]);
+      },
+    );
+  });
+
   it("sends text with blank attachment placeholders and rejects nonblank payloads", async () => {
     const requests: Array<{ path: string; body: unknown }> = [];
 

--- a/extensions/mattermost/src/delivery-trace.test.ts
+++ b/extensions/mattermost/src/delivery-trace.test.ts
@@ -196,7 +196,7 @@ function setupMattermostTrace(recorder: WireRecorder) {
       core,
       cfg,
       payload: resolvedPayload,
-      to: `channel:${CHANNEL_ID}`,
+      channelId: CHANNEL_ID,
       accountId: ACCOUNT_ID,
       agentId: "agent",
       replyToId: resolveMattermostReplyRootId({

--- a/extensions/mattermost/src/mattermost/client.retry.test.ts
+++ b/extensions/mattermost/src/mattermost/client.retry.test.ts
@@ -1,64 +1,7 @@
 // Mattermost tests cover client.retry plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createMattermostClient,
-  createMattermostDirectChannelWithRetry,
-  resolveMattermostReplyDeliveryBarrierTimeoutMs,
-} from "./client.js";
-
-describe("resolveMattermostReplyDeliveryBarrierTimeoutMs", () => {
-  it("uses the default barrier for non-DM deliveries", () => {
-    expect(
-      resolveMattermostReplyDeliveryBarrierTimeoutMs({
-        isDirect: false,
-        queuedCounts: { tool: 1, block: 1, final: 1 },
-      }),
-    ).toBeUndefined();
-  });
-
-  it("uses the default barrier when no deliveries were queued", () => {
-    expect(
-      resolveMattermostReplyDeliveryBarrierTimeoutMs({
-        isDirect: true,
-        queuedCounts: { tool: 0, block: 0, final: 0 },
-      }),
-    ).toBeUndefined();
-  });
-
-  it("covers the default retry envelope plus scheduling slack", () => {
-    expect(
-      resolveMattermostReplyDeliveryBarrierTimeoutMs({
-        isDirect: true,
-        queuedCounts: { tool: 0, block: 0, final: 1 },
-      }),
-    ).toBe(210_000);
-  });
-
-  it("covers one maximum retry envelope per queued delivery", () => {
-    expect(
-      resolveMattermostReplyDeliveryBarrierTimeoutMs({
-        isDirect: true,
-        dmRetryOptions: {
-          maxRetries: 10,
-          maxDelayMs: 60_000,
-          timeoutMs: 120_000,
-        },
-        queuedCounts: { tool: 1, block: 0, final: 1 },
-      }),
-    ).toBe(3_960_000);
-  });
-
-  it("includes the configured inter-block delay budget", () => {
-    expect(
-      resolveMattermostReplyDeliveryBarrierTimeoutMs({
-        isDirect: true,
-        queuedCounts: { tool: 0, block: 2, final: 0 },
-        humanDelayBudgetMs: 180_000,
-      }),
-    ).toBe(600_000);
-  });
-});
+import { createMattermostClient, createMattermostDirectChannelWithRetry } from "./client.js";
 
 describe("createMattermostDirectChannelWithRetry", () => {
   const mockFetch = vi.fn<typeof fetch>();

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -393,35 +393,6 @@ export type CreateDmChannelRetryOptions = {
   onRetry?: (attempt: number, delayMs: number, error: Error) => void;
 };
 
-const DM_REPLY_DELIVERY_BARRIER_SLACK_MS = 60_000;
-
-/** Covers DM creation retries without extending channel-delivery stalls. */
-export function resolveMattermostReplyDeliveryBarrierTimeoutMs(params: {
-  isDirect: boolean;
-  dmRetryOptions?: CreateDmChannelRetryOptions;
-  queuedCounts: Readonly<Record<"tool" | "block" | "final", number>>;
-  humanDelayBudgetMs?: number;
-}): number | undefined {
-  if (!params.isDirect) {
-    return undefined;
-  }
-  const deliveryCount = Object.values(params.queuedCounts).reduce((sum, count) => sum + count, 0);
-  if (deliveryCount === 0) {
-    return undefined;
-  }
-  const maxRetries = params.dmRetryOptions?.maxRetries ?? 3;
-  const maxDelayMs = params.dmRetryOptions?.maxDelayMs ?? 10_000;
-  const timeoutMs = params.dmRetryOptions?.timeoutMs ?? 30_000;
-  const perDeliveryTimeoutMs =
-    (maxRetries + 1) * timeoutMs + maxRetries * maxDelayMs + DM_REPLY_DELIVERY_BARRIER_SLACK_MS;
-  const totalTimeoutMs =
-    perDeliveryTimeoutMs * deliveryCount + Math.max(0, params.humanDelayBudgetMs ?? 0);
-  return resolveTimerTimeoutMs(
-    Number.isFinite(totalTimeoutMs) ? totalTimeoutMs : Number.MAX_SAFE_INTEGER,
-    perDeliveryTimeoutMs,
-  );
-}
-
 const RETRYABLE_NETWORK_ERROR_CODES = new Set([
   "ECONNRESET",
   "ECONNREFUSED",
@@ -500,8 +471,8 @@ export async function createMattermostDirectChannelWithRetry(
       attempts: maxRetries + 1,
       // Core retry raises maxDelayMs to the minDelayMs floor, but the schema
       // allows initialDelayMs above the (defaulted) maxDelayMs cap. The cap is
-      // the documented contract here and the reply-delivery barrier budgets
-      // with it, so clamp the base instead of letting the floor win.
+      // the documented contract here, so clamp the base instead of letting
+      // the floor win.
       minDelayMs: Math.min(initialDelayMs, maxDelayMs),
       maxDelayMs,
       // Full jitter (uniform [delay, 2*delay) with maxDelayMs applied after

--- a/extensions/mattermost/src/mattermost/monitor-event-plan.ts
+++ b/extensions/mattermost/src/mattermost/monitor-event-plan.ts
@@ -5,7 +5,6 @@ import type { MattermostChannel } from "./client.js";
 import { resolveMattermostTrustedChatKind } from "./monitor-auth.js";
 import { resolveMattermostThreadSessionContext } from "./monitor-context.js";
 import type { MattermostMonitorContext } from "./monitor-types.js";
-import { createMattermostReplyDeliveryBarrier } from "./reply-delivery.js";
 import { logTypingFailure } from "./runtime-api.js";
 
 type MattermostEventPlanParams = {
@@ -101,46 +100,39 @@ export async function buildMattermostEventPlan(
         OriginatingChannel: "mattermost" as const,
         OriginatingTo: to,
       }),
-    createReplyPlan: () => {
-      const deliveryBarrier = createMattermostReplyDeliveryBarrier({
-        isDirect: kind === "direct",
-        dmRetryOptions: monitor.account.config.dmChannelRetry,
-      });
-      return {
-        textLimit: monitor.core.channel.text.resolveTextChunkLimit(
-          monitor.cfg,
-          "mattermost",
-          monitor.account.accountId,
-          { fallbackLimit: monitor.account.textChunkLimit ?? 4000 },
-        ),
-        tableMode: monitor.core.channel.text.resolveMarkdownTableMode({
-          cfg: monitor.cfg,
-          channel: "mattermost",
-          accountId: monitor.account.accountId,
-        }),
-        deliveryBarrier,
-        replyPipeline: {
-          typing: {
-            start: () =>
-              monitor.resources.sendTypingIndicator(params.channelId, thread.effectiveReplyToId),
-            onStartError: (error: unknown) => {
-              logTypingFailure({
-                log: monitor.logDebugMessage,
-                channel: "mattermost",
-                target: params.channelId,
-                error,
-              });
-            },
+    createReplyPlan: () => ({
+      textLimit: monitor.core.channel.text.resolveTextChunkLimit(
+        monitor.cfg,
+        "mattermost",
+        monitor.account.accountId,
+        { fallbackLimit: monitor.account.textChunkLimit ?? 4000 },
+      ),
+      tableMode: monitor.core.channel.text.resolveMarkdownTableMode({
+        cfg: monitor.cfg,
+        channel: "mattermost",
+        accountId: monitor.account.accountId,
+      }),
+      replyPipeline: {
+        typing: {
+          start: () =>
+            monitor.resources.sendTypingIndicator(params.channelId, thread.effectiveReplyToId),
+          onStartError: (error: unknown) => {
+            logTypingFailure({
+              log: monitor.logDebugMessage,
+              channel: "mattermost",
+              target: params.channelId,
+              error,
+            });
           },
         },
-        replyOptions: {
-          disableBlockStreaming:
-            typeof monitor.account.blockStreaming === "boolean"
-              ? !monitor.account.blockStreaming
-              : undefined,
-        },
-      };
-    },
+      },
+      replyOptions: {
+        disableBlockStreaming:
+          typeof monitor.account.blockStreaming === "boolean"
+            ? !monitor.account.blockStreaming
+            : undefined,
+      },
+    }),
   };
 }
 

--- a/extensions/mattermost/src/mattermost/monitor-interactions.ts
+++ b/extensions/mattermost/src/mattermost/monitor-interactions.ts
@@ -95,7 +95,7 @@ export function registerMattermostInteractions(params: {
         if (!eventPlan) {
           return;
         }
-        const { channelDisplay, kind, route, thread, to } = eventPlan;
+        const { channelDisplay, channelId, kind, route, thread, to } = eventPlan;
         const bodyText = `[Button click: user @${button.userName} selected "${button.actionName}"]`;
         const ctxPayload = eventPlan.finalizeContext({
           Body: bodyText,
@@ -109,8 +109,7 @@ export function registerMattermostInteractions(params: {
           WasMentioned: true,
           CommandAuthorized: false,
         });
-        const { deliveryBarrier, replyOptions, replyPipeline, tableMode, textLimit } =
-          eventPlan.createReplyPlan();
+        const { replyOptions, replyPipeline, tableMode, textLimit } = eventPlan.createReplyPlan();
         await core.channel.inbound.dispatch({
           cfg,
           channel: "mattermost",
@@ -128,7 +127,7 @@ export function registerMattermostInteractions(params: {
                 core,
                 cfg,
                 payload,
-                to,
+                channelId,
                 accountId: account.accountId,
                 agentId: route.agentId,
                 replyToId: resolveMattermostInteractionReplyRootId({
@@ -141,7 +140,6 @@ export function registerMattermostInteractions(params: {
                 textLimit,
                 tableMode,
                 sendMessage: sendMessageMattermost,
-                onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
               });
               if (result.visibleReplySent) {
                 runtime.log?.(`delivered button-click reply to ${to}`);
@@ -154,8 +152,6 @@ export function registerMattermostInteractions(params: {
           },
           replyPipeline,
           dispatcherOptions: {
-            resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
-            onDeliverySettled: deliveryBarrier.markDeliverySettled,
             humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
           },
           replyOptions,

--- a/extensions/mattermost/src/mattermost/monitor-interactions.ts
+++ b/extensions/mattermost/src/mattermost/monitor-interactions.ts
@@ -163,7 +163,6 @@ export function registerMattermostInteractions(params: {
     source: "mattermost-interactions",
     accountId: account.accountId,
     log: (message: string) => runtime.log?.(message),
-    replaceExisting: true,
     throwOnFailure: true,
   });
 }

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.test.ts
@@ -7,7 +7,6 @@ const mocks = vi.hoisted(() => ({
   buildModelsProviderData: vi.fn(),
   deliverReply: vi.fn(),
   dispatch: vi.fn(),
-  markDeliverySettled: vi.fn(),
   parseContext: vi.fn(),
   runDetachedWebhookWork: vi.fn(),
 }));
@@ -75,6 +74,7 @@ describe("Mattermost model-picker interaction dispatch", () => {
       content: "model updated",
     });
     mocks.buildEventPlan.mockResolvedValue({
+      channelId: "channel-1",
       channelDisplay: "Lifecycle",
       kind: "channel",
       roomLabel: "#lifecycle",
@@ -83,11 +83,6 @@ describe("Mattermost model-picker interaction dispatch", () => {
       to: "channel:channel-1",
       finalizeContext: (context: Record<string, unknown>) => context,
       createReplyPlan: () => ({
-        deliveryBarrier: {
-          trackDmChannelResolution: vi.fn(),
-          resolveTimeoutPolicy: vi.fn(),
-          markDeliverySettled: mocks.markDeliverySettled,
-        },
         replyOptions: {},
         replyPipeline: {},
         tableMode: "off",
@@ -98,19 +93,15 @@ describe("Mattermost model-picker interaction dispatch", () => {
       const delivery = params.delivery as
         | { deliver?: (payload: { text: string; replyToId?: string }) => Promise<unknown> }
         | undefined;
-      const dispatcherOptions = params.dispatcherOptions as
-        | { onDeliverySettled?: () => void }
-        | undefined;
       await delivery?.deliver?.({
         text: "model updated",
         replyToId: "interaction:picker-post-1:select:openai/gpt-5.4",
       });
-      dispatcherOptions?.onDeliverySettled?.();
       return {};
     });
   });
 
-  it("reserves independent work before ack and observes terminal settlement", async () => {
+  it("reserves independent work before ack", async () => {
     let detachedRun: (() => Promise<void>) | undefined;
     mocks.runDetachedWebhookWork.mockImplementation((run: () => Promise<void>) => {
       detachedRun = run;
@@ -162,14 +153,10 @@ describe("Mattermost model-picker interaction dispatch", () => {
       expect.objectContaining({
         channel: "mattermost",
         delivery: expect.objectContaining({ observeMessageSent: true }),
-        dispatcherOptions: expect.objectContaining({
-          onDeliverySettled: mocks.markDeliverySettled,
-        }),
       }),
     );
-    expect(mocks.markDeliverySettled).toHaveBeenCalledOnce();
     expect(mocks.deliverReply).toHaveBeenCalledWith(
-      expect.objectContaining({ replyToId: "picker-post-1" }),
+      expect.objectContaining({ channelId: "channel-1", replyToId: "picker-post-1" }),
     );
     expect(updateModelPickerPost).toHaveBeenCalledWith(
       expect.objectContaining({ message: "updated picker" }),

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.ts
@@ -49,7 +49,7 @@ export function createMattermostModelPickerInteractionHandler(
   const { resolveChannelInfo, updateModelPickerPost } = resources;
 
   const runModelPickerCommand = async (params: RunModelPickerCommandParams): Promise<void> => {
-    const { channelDisplay, kind, roomLabel, route, thread, to } = params.eventPlan;
+    const { channelDisplay, channelId, kind, roomLabel, route, thread } = params.eventPlan;
     const fromLabel =
       kind === "direct"
         ? `Mattermost DM from ${params.senderName}`
@@ -68,7 +68,7 @@ export function createMattermostModelPickerInteractionHandler(
       CommandAuthorized: params.commandAuthorized,
       CommandSource: "native" as const,
     });
-    const { deliveryBarrier, replyOptions, replyPipeline, tableMode, textLimit } =
+    const { replyOptions, replyPipeline, tableMode, textLimit } =
       params.eventPlan.createReplyPlan();
     await core.channel.inbound.dispatch({
       cfg,
@@ -92,7 +92,7 @@ export function createMattermostModelPickerInteractionHandler(
             core,
             cfg,
             payload: trimmedPayload,
-            to,
+            channelId,
             accountId: account.accountId,
             agentId: route.agentId,
             replyToId: resolveMattermostInteractionReplyRootId({
@@ -106,7 +106,6 @@ export function createMattermostModelPickerInteractionHandler(
             // The picker path already converts and trims text before delivery.
             tableMode: "off",
             sendMessage: sendMessageMattermost,
-            onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
           });
         },
         onError: (err, info) => {
@@ -114,10 +113,6 @@ export function createMattermostModelPickerInteractionHandler(
         },
       },
       replyPipeline,
-      dispatcherOptions: {
-        resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
-        onDeliverySettled: deliveryBarrier.markDeliverySettled,
-      },
       replyOptions,
     });
   };

--- a/extensions/mattermost/src/mattermost/monitor-posts.ts
+++ b/extensions/mattermost/src/mattermost/monitor-posts.ts
@@ -171,7 +171,7 @@ export function createMattermostPostHandler(monitor: MattermostMonitorContext) {
           if (created) {
             try {
               await sendMessageMattermost(
-                `user:${senderId}`,
+                `channel:${channelId}`,
                 core.channel.pairing.buildPairingReply({
                   channel: "mattermost",
                   idLine: `Your Mattermost user id: ${senderId}`,

--- a/extensions/mattermost/src/mattermost/monitor-turn.ts
+++ b/extensions/mattermost/src/mattermost/monitor-turn.ts
@@ -88,7 +88,6 @@ export async function dispatchMattermostInboundTurn(
   const { channelId, kind, route, senderId, thread, to } = eventPlan;
   const { effectiveReplyToId } = thread;
   const {
-    deliveryBarrier,
     replyOptions,
     replyPipeline: baseReplyPipeline,
     tableMode,
@@ -282,8 +281,6 @@ export async function dispatchMattermostInboundTurn(
 
   const dispatcherOptions: NonNullable<ChannelInboundTurnPlan["dispatcherOptions"]> = {
     ...dispatcherPipeline,
-    resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
-    onDeliverySettled: deliveryBarrier.markDeliverySettled,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     typingCallbacks,
   };
@@ -335,7 +332,7 @@ export async function dispatchMattermostInboundTurn(
             core,
             cfg,
             payload: resolvedPayload,
-            to,
+            channelId,
             accountId: account.accountId,
             agentId: route.agentId,
             replyToId: resolveMattermostReplyRootId({
@@ -346,7 +343,6 @@ export async function dispatchMattermostInboundTurn(
             textLimit,
             tableMode,
             sendMessage: sendMessageMattermost,
-            onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
           }).catch((error: unknown) => {
             if (isChannelPartialDeliveryError(error)) {
               markThreadParticipation();

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -780,9 +780,11 @@ describe("mattermost inbound user posts", () => {
         accountId: "default",
         pluginId: "mattermost",
         source: "mattermost-interactions",
-        replaceExisting: true,
         throwOnFailure: true,
       }),
+    );
+    expect(mockState.registerPluginHttpRoute.mock.calls[0]?.[0]).not.toHaveProperty(
+      "replaceExisting",
     );
     expect(mockState.registerMattermostMonitorSlashCommands).not.toHaveBeenCalled();
     expect(webSocketFactory).not.toHaveBeenCalled();

--- a/extensions/mattermost/src/mattermost/reply-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.test.ts
@@ -6,10 +6,7 @@ import type { ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../../runtime-api.js";
-import {
-  createMattermostReplyDeliveryBarrier,
-  deliverMattermostReplyPayload,
-} from "./reply-delivery.js";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import type { MattermostSendResult } from "./send.js";
 
 type DeliverMattermostReplyPayloadParams = Parameters<typeof deliverMattermostReplyPayload>[0];
@@ -59,68 +56,6 @@ function createSendMessageMock() {
   });
 }
 
-describe("createMattermostReplyDeliveryBarrier", () => {
-  it("extends while direct deliveries or DM resolution remain unsettled", async () => {
-    const barrier = createMattermostReplyDeliveryBarrier({ isDirect: true });
-    const policy = barrier.resolveTimeoutPolicy({
-      queuedCounts: { tool: 1, block: 0, final: 1 },
-      humanDelayBudgetMs: 0,
-    });
-    expect(policy?.maxTimeoutMs).toBe(420_000);
-    expect(policy?.shouldExtend()).toBe(true);
-
-    let resolveResolution: () => void = () => {};
-    const resolution = new Promise<void>((resolve) => {
-      resolveResolution = resolve;
-    });
-    barrier.trackDmChannelResolution(resolution);
-    expect(policy?.shouldExtend()).toBe(true);
-
-    resolveResolution();
-    await resolution;
-    await Promise.resolve();
-    expect(policy?.shouldExtend()).toBe(true);
-
-    barrier.markDeliverySettled();
-    expect(policy?.shouldExtend()).toBe(true);
-
-    barrier.markDeliverySettled();
-    expect(policy?.shouldExtend()).toBe(false);
-  });
-
-  it("stays extended between failed retries until queued deliveries settle", async () => {
-    const barrier = createMattermostReplyDeliveryBarrier({ isDirect: true });
-    const policy = barrier.resolveTimeoutPolicy({
-      queuedCounts: { tool: 1, block: 0, final: 1 },
-      humanDelayBudgetMs: 0,
-    });
-    let rejectResolution: (error: Error) => void = () => {};
-    const resolution = new Promise<void>((_resolve, reject) => {
-      rejectResolution = reject;
-    });
-    barrier.trackDmChannelResolution(resolution);
-
-    rejectResolution(new Error("DM creation failed"));
-    await expect(resolution).rejects.toThrow("DM creation failed");
-    await Promise.resolve();
-    barrier.markDeliverySettled();
-    expect(policy?.shouldExtend()).toBe(true);
-
-    barrier.markDeliverySettled();
-    expect(policy?.shouldExtend()).toBe(false);
-  });
-
-  it("does not extend non-DM delivery", () => {
-    const barrier = createMattermostReplyDeliveryBarrier({ isDirect: false });
-    expect(
-      barrier.resolveTimeoutPolicy({
-        queuedCounts: { tool: 1, block: 1, final: 1 },
-        humanDelayBudgetMs: 0,
-      }),
-    ).toBeUndefined();
-  });
-});
-
 describe("deliverMattermostReplyPayload", () => {
   it("suppresses payloads flagged as reasoning", async () => {
     const sendMessage = createSendMessageMock();
@@ -131,7 +66,7 @@ describe("deliverMattermostReplyPayload", () => {
       core,
       cfg,
       payload: { text: "hidden", isReasoning: true },
-      to: "channel:town-square",
+      channelId: "town-square",
       accountId: "default",
       agentId: "agent-1",
       replyToId: "root-post",
@@ -161,7 +96,7 @@ describe("deliverMattermostReplyPayload", () => {
       core,
       cfg,
       payload: { text: "non-trivial input that the converter strips" },
-      to: "channel:town-square",
+      channelId: "town-square",
       accountId: "default",
       agentId: "agent-1",
       replyToId: "root-post",
@@ -187,7 +122,7 @@ describe("deliverMattermostReplyPayload", () => {
       core,
       cfg,
       payload: { text: "  \n Reasoning:\n_hidden_" },
-      to: "channel:town-square",
+      channelId: "town-square",
       accountId: "default",
       agentId: "agent-1",
       replyToId: "root-post",
@@ -208,7 +143,7 @@ describe("deliverMattermostReplyPayload", () => {
       core,
       cfg,
       payload: { text: "> Reasoning:\n> _hidden_" },
-      to: "channel:town-square",
+      channelId: "town-square",
       accountId: "default",
       agentId: "agent-1",
       replyToId: "root-post",
@@ -229,7 +164,7 @@ describe("deliverMattermostReplyPayload", () => {
       core,
       cfg,
       payload: { text: "Intro line\nReasoning: appears in content but is not a prefix" },
-      to: "channel:town-square",
+      channelId: "town-square",
       accountId: "default",
       agentId: "agent-1",
       replyToId: "root-post",
@@ -269,7 +204,7 @@ describe("deliverMattermostReplyPayload", () => {
         core,
         cfg,
         payload: { text: "caption", mediaUrl },
-        to: "channel:town-square",
+        channelId: "town-square",
         accountId: "default",
         agentId,
         replyToId: "root-post",
@@ -311,7 +246,7 @@ describe("deliverMattermostReplyPayload", () => {
       core,
       cfg,
       payload: { text: "hello" },
-      to: "channel:town-square",
+      channelId: "channel-1",
       accountId: "default",
       agentId: "agent-1",
       replyToId: "root-post",
@@ -322,7 +257,7 @@ describe("deliverMattermostReplyPayload", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(sendMessage).toHaveBeenCalledWith(
-      "channel:town-square",
+      "channel:channel-1",
       "hello",
       expect.objectContaining({
         cfg,
@@ -349,7 +284,7 @@ describe("deliverMattermostReplyPayload", () => {
       core,
       cfg,
       payload: { text: "alpha beta" },
-      to: "channel:town-square",
+      channelId: "town-square",
       accountId: "default",
       replyToId: "root-post",
       textLimit: 6,
@@ -386,7 +321,7 @@ describe("deliverMattermostReplyPayload", () => {
       core: createReplyDeliveryCore(),
       cfg: {},
       payload: { text: "requested text" },
-      to: "channel:town-square",
+      channelId: "town-square",
       accountId: "default",
       textLimit: 4000,
       tableMode: "off",
@@ -416,7 +351,7 @@ describe("deliverMattermostReplyPayload", () => {
         core,
         cfg,
         payload: { text: "alpha beta" },
-        to: "channel:town-square",
+        channelId: "town-square",
         accountId: "default",
         replyToId: "root-post",
         textLimit: 6,

--- a/extensions/mattermost/src/mattermost/reply-delivery.ts
+++ b/extensions/mattermost/src/mattermost/reply-delivery.ts
@@ -15,15 +15,7 @@ import {
   isReasoningReplyPayload,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
-import type {
-  ReplyDispatchKind,
-  ReplyFollowupAdmissionBarrierTimeoutPolicy,
-  ReplyPayload,
-} from "openclaw/plugin-sdk/reply-runtime";
-import {
-  resolveMattermostReplyDeliveryBarrierTimeoutMs,
-  type CreateDmChannelRetryOptions,
-} from "./client.js";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { MattermostSendResult } from "./send.js";
 
 type MarkdownTableMode = Parameters<PluginRuntime["channel"]["text"]["convertMarkdownTables"]>[1];
@@ -37,58 +29,8 @@ type SendMattermostMessage = (
     mediaUrl?: string;
     mediaLocalRoots?: readonly string[];
     replyToId?: string;
-    onDmChannelResolution?: (resolution: PromiseLike<unknown>) => void;
   },
 ) => Promise<MattermostSendResult>;
-
-export function createMattermostReplyDeliveryBarrier(params: {
-  isDirect: boolean;
-  dmRetryOptions?: CreateDmChannelRetryOptions;
-}) {
-  let activeDmChannelResolutions = 0;
-  let queuedDeliveryCount = 0;
-  let settledDeliveryCount = 0;
-  const trackDmChannelResolution = (resolution: PromiseLike<unknown>) => {
-    activeDmChannelResolutions += 1;
-    void Promise.resolve(resolution).then(
-      () => {
-        activeDmChannelResolutions -= 1;
-      },
-      () => {
-        activeDmChannelResolutions -= 1;
-      },
-    );
-  };
-  const markDeliverySettled = () => {
-    settledDeliveryCount += 1;
-  };
-  const resolveTimeoutPolicy = (context: {
-    queuedCounts: Readonly<Record<ReplyDispatchKind, number>>;
-    humanDelayBudgetMs: number;
-  }): ReplyFollowupAdmissionBarrierTimeoutPolicy | undefined => {
-    const { queuedCounts } = context;
-    queuedDeliveryCount = Object.values(queuedCounts).reduce((sum, count) => sum + count, 0);
-    const maxTimeoutMs = resolveMattermostReplyDeliveryBarrierTimeoutMs({
-      isDirect: params.isDirect,
-      dmRetryOptions: params.dmRetryOptions,
-      queuedCounts,
-      humanDelayBudgetMs: context.humanDelayBudgetMs,
-    });
-    if (maxTimeoutMs === undefined) {
-      return undefined;
-    }
-    return {
-      maxTimeoutMs,
-      shouldExtend: () =>
-        activeDmChannelResolutions > 0 || settledDeliveryCount < queuedDeliveryCount,
-    };
-  };
-  return {
-    trackDmChannelResolution,
-    markDeliverySettled,
-    resolveTimeoutPolicy,
-  };
-}
 
 /**
  * Result of `deliverMattermostReplyPayload`. Inbound delivery adapters use this
@@ -116,14 +58,13 @@ export async function deliverMattermostReplyPayload(params: {
   core: PluginRuntime;
   cfg: OpenClawConfig;
   payload: ReplyPayload;
-  to: string;
+  channelId: string;
   accountId: string;
   agentId?: string;
   replyToId?: string;
   textLimit: number;
   tableMode: MarkdownTableMode;
   sendMessage: SendMattermostMessage;
-  onDmChannelResolution?: (resolution: PromiseLike<unknown>) => void;
 }): Promise<MattermostReplyDeliveryResult> {
   if (isReasoningReplyPayload(params.payload)) {
     return {
@@ -146,6 +87,7 @@ export async function deliverMattermostReplyPayload(params: {
   );
   const results: MattermostSendResult[] = [];
   const acceptedContents: string[] = [];
+  const deliveryTarget = `channel:${params.channelId}`;
   let outcome: Exclude<MattermostReplyDeliveryOutcome, "reasoning_skipped">;
   try {
     outcome = await deliverTextOrMediaReply({
@@ -154,27 +96,21 @@ export async function deliverMattermostReplyPayload(params: {
       chunkText: (value) =>
         params.core.channel.text.chunkMarkdownTextWithMode(value, params.textLimit, chunkMode),
       sendText: async (chunk) => {
-        const result = await params.sendMessage(params.to, chunk, {
+        const result = await params.sendMessage(deliveryTarget, chunk, {
           cfg: params.cfg,
           accountId: params.accountId,
           replyToId: params.replyToId,
-          ...(params.onDmChannelResolution
-            ? { onDmChannelResolution: params.onDmChannelResolution }
-            : {}),
         });
         results.push(result);
         acceptedContents.push(result.content);
       },
       sendMedia: async ({ mediaUrl, caption }) => {
-        const result = await params.sendMessage(params.to, caption ?? "", {
+        const result = await params.sendMessage(deliveryTarget, caption ?? "", {
           cfg: params.cfg,
           accountId: params.accountId,
           mediaUrl,
           mediaLocalRoots,
           replyToId: params.replyToId,
-          ...(params.onDmChannelResolution
-            ? { onDmChannelResolution: params.onDmChannelResolution }
-            : {}),
         });
         results.push(result);
         acceptedContents.push(result.content);

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -847,25 +847,6 @@ describe("sendMessageMattermost user-first resolution", () => {
     expect(res.channelId).toBe("dm-channel-id");
   });
 
-  it("observes cache-miss DM resolution but not cached sends", async () => {
-    const userId = "iiiiii9999999999iiiiii9999"; // 26 chars
-    const onDmChannelResolution = vi.fn();
-    mockState.resolveMattermostAccount.mockReturnValue(makeAccount("token-dm-observer-t9"));
-
-    await sendMessageMattermost(`user:${userId}`, "first", {
-      cfg: TEST_CFG,
-      onDmChannelResolution,
-    });
-    await sendMessageMattermost(`user:${userId}`, "second", {
-      cfg: TEST_CFG,
-      onDmChannelResolution,
-    });
-
-    expect(onDmChannelResolution).toHaveBeenCalledTimes(1);
-    expect(onDmChannelResolution).toHaveBeenCalledWith(expect.any(Promise));
-    expect(mockState.createMattermostDirectChannelWithRetry).toHaveBeenCalledTimes(1);
-  });
-
   it("does not apply user-first resolution for explicit channel: prefix", async () => {
     // Unique token + id — explicit channel: prefix, no probe, no DM
     const chanId = "eeeeee5555555555eeeeee5555"; // 26 chars

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -61,8 +61,6 @@ type MattermostSendOpts = {
   attachmentText?: string;
   /** Retry options for DM channel creation */
   dmRetryOptions?: CreateDmChannelRetryOptions;
-  /** Observe the bounded cache-miss DM channel resolution lifecycle. */
-  onDmChannelResolution?: (resolution: PromiseLike<unknown>) => void;
   /** Report the provider-finalized send before later fallible bookkeeping. */
   onDeliveryResult?: (result: MattermostSendResult) => Promise<void> | void;
 };
@@ -250,7 +248,6 @@ type ResolveTargetChannelIdParams = {
   token: string;
   allowPrivateNetwork?: boolean;
   dmRetryOptions?: CreateDmChannelRetryOptions;
-  onDmChannelResolution?: (resolution: PromiseLike<unknown>) => void;
   logger?: { debug?: (msg: string) => void; warn?: (msg: string) => void };
 };
 
@@ -311,7 +308,7 @@ async function resolveTargetChannelId(params: ResolveTargetChannelIdParams): Pro
     allowPrivateNetwork: params.allowPrivateNetwork,
   });
 
-  const resolution = createMattermostDirectChannelWithRetry(client, [botUser.id, userId], {
+  const channel = await createMattermostDirectChannelWithRetry(client, [botUser.id, userId], {
     ...params.dmRetryOptions,
     onRetry: (attempt, delayMs, error) => {
       // Call user's onRetry if provided
@@ -324,8 +321,6 @@ async function resolveTargetChannelId(params: ResolveTargetChannelIdParams): Pro
       }
     },
   });
-  params.onDmChannelResolution?.(resolution);
-  const channel = await resolution;
   cacheOutboundEntry(dmChannelCache, dmKey, channel.id, MATTERMOST_TARGET_CACHE_MAX_ENTRIES);
   return channel.id;
 }
@@ -398,7 +393,6 @@ async function resolveMattermostSendContext(
     token,
     allowPrivateNetwork,
     dmRetryOptions,
-    onDmChannelResolution: opts.onDmChannelResolution,
     logger: core.logging.shouldLogVerbose() ? logger : undefined,
   });
 

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -127,11 +127,6 @@ vi.mock("./monitor-auth.js", () => ({
 }));
 
 vi.mock("./reply-delivery.js", () => ({
-  createMattermostReplyDeliveryBarrier: vi.fn(() => ({
-    markDeliverySettled: vi.fn(),
-    resolveTimeoutPolicy: vi.fn(),
-    trackDmChannelResolution: vi.fn(),
-  })),
   deliverMattermostReplyPayload: vi.fn(),
 }));
 

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -34,10 +34,7 @@ import {
   authorizeMattermostCommandInvocation,
   normalizeMattermostAllowList,
 } from "./monitor-auth.js";
-import {
-  createMattermostReplyDeliveryBarrier,
-  deliverMattermostReplyPayload,
-} from "./reply-delivery.js";
+import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import {
   buildModelsProviderData,
   isRequestBodyLimitError,
@@ -788,7 +785,7 @@ async function handleSlashCommandAsync(params: {
   if (pickerEntry) {
     const data = await buildModelsProviderData(cfg, route.agentId);
     if (data.providers.length === 0) {
-      await sendMessageMattermost(to, "No models available.", {
+      await sendMessageMattermost(`channel:${channelId}`, "No models available.", {
         cfg,
         accountId: account.accountId,
       });
@@ -820,7 +817,7 @@ async function handleSlashCommandAsync(params: {
               currentModel,
             });
 
-    await sendMessageMattermost(to, view.text, {
+    await sendMessageMattermost(`channel:${channelId}`, view.text, {
       cfg,
       accountId: account.accountId,
       buttons: view.buttons,
@@ -874,10 +871,6 @@ async function handleSlashCommandAsync(params: {
   });
 
   const humanDelay = resolveHumanDelayConfig(cfg, route.agentId);
-  const deliveryBarrier = createMattermostReplyDeliveryBarrier({
-    isDirect: kind === "direct",
-    dmRetryOptions: account.config.dmChannelRetry,
-  });
 
   await core.channel.inbound.dispatch({
     cfg,
@@ -896,13 +889,12 @@ async function handleSlashCommandAsync(params: {
           core,
           cfg,
           payload,
-          to,
+          channelId,
           accountId: account.accountId,
           agentId: route.agentId,
           textLimit,
           tableMode,
           sendMessage: sendMessageMattermost,
-          onDmChannelResolution: deliveryBarrier.trackDmChannelResolution,
         });
         if (result.visibleReplySent) {
           runtime.log?.(`delivered slash reply to ${to}`);
@@ -929,8 +921,6 @@ async function handleSlashCommandAsync(params: {
       },
     },
     dispatcherOptions: {
-      resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
-      onDeliverySettled: deliveryBarrier.markDeliverySettled,
       humanDelay,
     },
     replyOptions: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where inbound Mattermost direct-message replies would rediscover a channel already identified by the inbound event, adding `GET /users/me` and `POST /channels/direct` before every cold reply.

## Why This Change Was Made

Inbound reply delivery now uses the authoritative provider channel ID carried by Mattermost post, interaction, model-picker, pairing, and slash-command events. Semantic DM routing remains user-based for sessions and last-route storage, while generic proactive `user:` sends retain their existing DM resolution, cache, and retry behavior.

The reply-only DM-resolution observer and extended admission barrier are removed because inbound delivery no longer performs that resolution.

## User Impact

Mattermost DM replies avoid two unnecessary provider requests on a cold route, reducing latency and server work without changing reply text, media, threading, receipts, routing identity, or retry semantics.

## Evidence

- Provider-loopback regression: inbound DM reply makes only `POST /api/v4/posts` with the prepared channel ID and unchanged message payload.
- Focused owner/sibling proof: 7 files / 89 tests passed; final send/client/loopback rerun: 3 files / 69 tests passed.
- Full Mattermost extension: 51 files / 751 tests passed.
- `node scripts/check-changed.mjs`: passed (`extensions`, `extensionTests`), including format, production/test typechecks, type-aware Oxlint (0 warnings/errors), dead exports, plugin boundaries, guards, and import cycles.
- Structured autoreview: TruffleHog clean; Codex `gpt-5.6-sol` / high reported no findings and `patch is correct` (0.98 confidence).
- `git diff --check`: clean.
