### PR TITLE
fix: clarify cloud dispatch and heartbeat timeout diagnostics

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-heartbeat.ts
+++ b/extensions/crabbox/src/crabbox-worker-heartbeat.ts
@@ -62,6 +62,7 @@ export function createCrabboxHeartbeatManager(dependencies: {
     const controller = new AbortController();
     entry.controller = controller;
     let result: SpawnResult;
+    const startedAt = Date.now();
     try {
       result = await dependencies.run(entry, controller.signal);
     } catch (error) {
@@ -93,7 +94,8 @@ export function createCrabboxHeartbeatManager(dependencies: {
     }
     if (!entry.failureWarned) {
       entry.failureWarned = true;
-      warn(entry, crabboxCommandError("heartbeat", result).message);
+      const message = crabboxCommandError("heartbeat", result).message;
+      warn(entry, message.replace("(timeout)", `(timeout after ${Date.now() - startedAt} ms)`));
     }
     schedule(entry);
   };

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -2097,6 +2097,37 @@ describe("Crabbox worker provider", () => {
     }
   });
 
+  it("reports the measured heartbeat duration when the command times out", async () => {
+    vi.useFakeTimers();
+    const warnings: string[] = [];
+    const provider = providerWithRunner(
+      async (argv) => {
+        if (argv[1] === "inspect") {
+          return commandResult({ stdout: inspectJson() });
+        }
+        if (argv[1] === "heartbeat") {
+          await new Promise((resolve) => setTimeout(resolve, 60_012));
+          return commandResult({ code: null, killed: true, termination: "timeout" });
+        }
+        return commandResult();
+      },
+      (message) => warnings.push(message),
+    );
+    const lease = lifecycleLease();
+
+    try {
+      await expect(provider.inspect(lease)).resolves.toStrictEqual({ status: "active" });
+      await vi.advanceTimersByTimeAsync(60_012);
+
+      expect(warnings).toEqual([
+        "Crabbox heartbeat did not exit normally (timeout after 60012 ms); cloud worker machines may be reaped after 60m of coordinator-idle time",
+      ]);
+    } finally {
+      await provider.destroy(lease);
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps heartbeat transport failures out of lifecycle operations and retries", async () => {
     vi.useFakeTimers();
     let heartbeatAttempts = 0;

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -2106,7 +2106,9 @@ describe("Crabbox worker provider", () => {
           return commandResult({ stdout: inspectJson() });
         }
         if (argv[1] === "heartbeat") {
-          await new Promise((resolve) => setTimeout(resolve, 60_012));
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 60_012);
+          });
           return commandResult({ code: null, killed: true, termination: "timeout" });
         }
         return commandResult();

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -171,7 +171,7 @@ async function validateDispatchExecutionMode(params: {
   }
   respondInvalidWorkerSession(
     params.respond,
-    `runtime ${params.sessionRuntime} requires an SSH-backed cloud worker provider; choose a provider that supports remote-exec, or select an agent/model route with agentRuntime.id "openclaw"`,
+    `selected cloud worker provider does not support the remote-exec execution mode required by runtime ${params.sessionRuntime}; use an approved paired device or a provider that advertises remote-exec`,
   );
   return false;
 }

--- a/src/gateway/server-methods/sessions.dispatch.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.test.ts
@@ -437,7 +437,7 @@ describe("sessions.dispatch", () => {
       expect.objectContaining({
         code: ErrorCodes.INVALID_REQUEST,
         message:
-          'runtime codex requires an SSH-backed cloud worker provider; choose a provider that supports remote-exec, or select an agent/model route with agentRuntime.id "openclaw"',
+          "selected cloud worker provider does not support the remote-exec execution mode required by runtime codex; use an approved paired device or a provider that advertises remote-exec",
       }),
     );
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators dispatching a runtime that requires remote execution were told that SSH was mandatory, even though an approved paired device is also supported. Resolves a second operational blind spot where a timed-out Crabbox heartbeat warned that workers might be reaped without reporting how long the heartbeat actually ran.

## Why This Change Was Made

Keep execution-mode guidance at the Gateway dispatch boundary aligned with the paired-device and remote-exec provider capabilities already documented and implemented. Measure heartbeat runtime inside its owning lifecycle manager and include the actual elapsed milliseconds only in timeout warnings, without changing other command-error shapes or provider behavior.

## User Impact

Operators can choose an approved paired device or a provider advertising remote-exec instead of being sent down an SSH-only dead end. A Crabbox heartbeat timeout now identifies its measured duration, for example `(timeout after 60012 ms)`, making coordinator-idle and worker-reaping incidents diagnosable from the existing warning.

## Evidence

- Before the fixes, the existing Gateway boundary test failed for both unsupported and unadvertised provider modes because the response still claimed SSH was required, and the new Crabbox provider-boundary regression failed because its timeout warning omitted the measured 60012 ms.
- `node scripts/run-vitest.mjs src/gateway/server-methods/sessions.dispatch.test.ts src/gateway/server-methods/sessions.dispatch.device.test.ts`: 4 test files passed, 74 tests passed, including the existing successful paired-device dispatch coverage.
- `node scripts/run-vitest.mjs extensions/crabbox`: 3 test files passed, 125 tests passed. The timeout regression advances a fake clock by 60012 ms while the configured heartbeat timeout is 150000 ms, proving the warning uses measured elapsed time rather than its configured budget.
- `env -u OPENCLAW_TESTBOX OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs`: passed all selected core, core-test, plugin, and plugin-test checks; the environment overrides only prevent inherited remote routing and use the supported full-speed local scheduler.
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, with no accepted or actionable findings.
- Diff split: production **+2 net lines**; tests **+33 net lines**. The existing Control UI locale already uses provider-neutral guidance and remains unchanged.
