### PR TITLE
fix(qa): keep restart validation on the active pending wait

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -112,7 +112,9 @@ describe("qa scenario catalog causality", () => {
     expect(liveMultiRestartContract).toContain("dmScope: env.cfg.session?.dmScope");
     expect(liveMultiRestartContract).toContain('"saveAs":"inbound"');
     expect(liveMultiRestartContract).toContain("probeText: config.finalMarker");
-    expect(liveMultiRestartContract).toContain("completedToolCallCounts.wait ?? 0) < checkpoint");
+    expect(liveMultiRestartContract).toContain(
+      "assistantToolCallCounts.wait ?? 0) > (summary.completedToolCallCounts.wait ?? 0)",
+    );
     expect(checkpointTranscriptIndex).toBeGreaterThanOrEqual(0);
     expect(checkpointStoreIndex).toBeGreaterThan(checkpointTranscriptIndex);
     expect(checkpointPersistenceAssertIndex).toBeGreaterThan(checkpointStoreIndex);
@@ -199,7 +201,12 @@ describe("qa scenario catalog causality", () => {
     expect(contract.match(/"sendInbound"/gu)).toHaveLength(1);
     expect(contract).not.toContain("startAgentRun");
     expect(contract).not.toContain("chat.send");
-    expect(contract).toContain("completedToolCallCounts.wait ?? 0) < checkpoint");
+    expect(contract).toContain(
+      "assistantToolCallCounts.wait ?? 0) > (summary.completedToolCallCounts.wait ?? 0)",
+    );
+    expect(contract).toContain(
+      "checkpointTranscript.assistantToolCallCounts.wait ?? 0) > (checkpointTranscript.completedToolCallCounts.wait ?? 0)",
+    );
     expect(contract).toContain("probeText: config.promptMarker");
     expect(pendingWaitIndex).toBeGreaterThanOrEqual(0);
     expect(checkpointStoreIndex).toBeGreaterThan(pendingWaitIndex);

--- a/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
+++ b/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
@@ -123,11 +123,11 @@ flow:
                 args:
                   - lambda:
                       async: true
-                      expr: "readSessionTranscriptSummary(env, sessionKey, { probeText: config.promptMarker }).then((summary) => (summary.assistantToolCallCounts.exec ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) >= checkpoint ? summary : undefined).catch(() => undefined)"
+                      expr: "readSessionTranscriptSummary(env, sessionKey, { probeText: config.promptMarker }).then((summary) => (summary.assistantToolCallCounts.exec ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) > (summary.completedToolCallCounts.wait ?? 0) ? summary : undefined).catch(() => undefined)"
                   - expr: liveTurnTimeoutMs(env, 120000)
                   - 25
               - assert:
-                  expr: "(checkpointTranscript.completedToolCallCounts.wait ?? 0) < checkpoint"
+                  expr: "(checkpointTranscript.assistantToolCallCounts.wait ?? 0) > (checkpointTranscript.completedToolCallCounts.wait ?? 0)"
                   message:
                     expr: "`checkpoint ${checkpoint} wait was not pending before restart: ${JSON.stringify(checkpointTranscript)}`"
               - set: checkpointRequests

--- a/qa/scenarios/runtime/gateway-restart-multi-live.yaml
+++ b/qa/scenarios/runtime/gateway-restart-multi-live.yaml
@@ -175,7 +175,7 @@ flow:
                 args:
                   - lambda:
                       async: true
-                      expr: "readSessionTranscriptSummary(env, sessionKey, { probeText: config.finalMarker }).then((summary) => (summary.assistantToolCallCounts.exec ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) >= checkpoint && (summary.completedToolCallCounts.wait ?? 0) < checkpoint ? summary : undefined).catch(() => undefined)"
+                      expr: "readSessionTranscriptSummary(env, sessionKey, { probeText: config.finalMarker }).then((summary) => (summary.assistantToolCallCounts.exec ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) >= checkpoint && (summary.assistantToolCallCounts.wait ?? 0) > (summary.completedToolCallCounts.wait ?? 0) ? summary : undefined).catch(() => undefined)"
                   - expr: liveTurnTimeoutMs(env, 180000)
                   - 50
               - call: readRawQaSessionStore


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where restart qualification could treat an earlier completed `wait` call as proof that the current checkpoint was still pending when one session crossed multiple Gateway replacements.

## Why This Change Was Made

The restart scenarios now compare issued `wait` calls with call-ID-correlated completed results. This preserves the existing three-checkpoint flow while removing the incorrect dependency on checkpoint ordinal.

## User Impact

There is no production runtime change. Main and release qualification now restart only while the active checkpoint wait is genuinely pending, reducing false failures and false-positive restart timing.

## Evidence

- Regression contract failed on the pre-fix scenarios: 2 failed, 9 passed.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog-causality.test.ts extensions/qa-lab/src/scenario-catalog.runtime-pair.test.ts`
  - 2 files passed, 15 tests passed.
- Focused mock OpenAI scenario:
  - `pnpm openclaw qa suite --provider-mode mock-openai --concurrency 1 --model openai/gpt-5.6-luna --alt-model openai/gpt-5.6-luna-alt --scenario gateway-restart-inflight-run --output-dir .artifacts/qa-e2e/qa-wait-correlation`
  - 1 scenario passed through three Gateway replacements.
  - 3 recovery dispatches, 1 final delivery, 0 resend notices.
- `node_modules/.bin/oxfmt --check --threads=1 extensions/qa-lab/src/scenario-catalog-causality.test.ts qa/scenarios/runtime/gateway-restart-inflight-run.yaml qa/scenarios/runtime/gateway-restart-multi-live.yaml`
- `git diff origin/main...HEAD --check`
- Production LOC delta: 0. The change is limited to QA scenarios and their contract test.
