### PR TITLE
feat(control-ui): show client IP and time zone on the activity identity card

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1515,6 +1515,7 @@ public struct PresenceEntry: Codable, Sendable {
     public let platform: String?
     public let devicefamily: String?
     public let modelidentifier: String?
+    public let timezone: String?
     public let mode: String?
     public let lastinputseconds: Int?
     public let reason: String?
@@ -1535,6 +1536,7 @@ public struct PresenceEntry: Codable, Sendable {
         platform: String? = nil,
         devicefamily: String? = nil,
         modelidentifier: String? = nil,
+        timezone: String? = nil,
         mode: String? = nil,
         lastinputseconds: Int? = nil,
         reason: String? = nil,
@@ -1554,6 +1556,7 @@ public struct PresenceEntry: Codable, Sendable {
         self.platform = platform
         self.devicefamily = devicefamily
         self.modelidentifier = modelidentifier
+        self.timezone = timezone
         self.mode = mode
         self.lastinputseconds = lastinputseconds
         self.reason = reason
@@ -1575,6 +1578,7 @@ public struct PresenceEntry: Codable, Sendable {
         case platform
         case devicefamily = "deviceFamily"
         case modelidentifier = "modelIdentifier"
+        case timezone = "timeZone"
         case mode
         case lastinputseconds = "lastInputSeconds"
         case reason

--- a/docs/concepts/presence.md
+++ b/docs/concepts/presence.md
@@ -28,6 +28,7 @@ Presence entries are structured objects with fields like:
 - `ip`: best-effort IP address
 - `version`: client version string
 - `deviceFamily` / `modelIdentifier`: hardware hints
+- `timeZone`: self-reported IANA zone (for example `Europe/Vienna`); browsers report it during connect, and it stays useful when the connecting IP is loopback, tunneled, or CGNAT
 - `mode`: `ui`, `webchat`, `cli`, `backend`, `node`, `probe`, `test`
 - `lastInputSeconds`: seconds since last user input, if known
 - `reason`: free-form client-supplied string; the Gateway itself only emits `self`, `connect`, and `disconnect`

--- a/packages/gateway-protocol/src/client-info.ts
+++ b/packages/gateway-protocol/src/client-info.ts
@@ -71,6 +71,8 @@ export type GatewayClientInfo = {
   deviceFamily?: string;
   /** Native hardware/model identifier when available. */
   modelIdentifier?: string;
+  /** Self-reported IANA time zone, such as `Europe/Vienna`, for presence display. */
+  timeZone?: string;
   /** Coarse category from `GATEWAY_CLIENT_MODES` for policy and diagnostics. */
   mode: GatewayClientMode;
   /** Per-installation or per-process id used to distinguish same-product clients. */

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -47,6 +47,8 @@ export const ConnectParamsSchema = closedObject({
     platform: NonEmptyString,
     deviceFamily: Type.Optional(NonEmptyString),
     modelIdentifier: Type.Optional(NonEmptyString),
+    /** Self-reported IANA zone. Bounded because the longest real name is well under this cap. */
+    timeZone: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
     mode: GatewayClientModeSchema,
     instanceId: Type.Optional(NonEmptyString),
   }),

--- a/packages/gateway-protocol/src/schema/snapshot.ts
+++ b/packages/gateway-protocol/src/schema/snapshot.ts
@@ -20,6 +20,7 @@ export const PresenceEntrySchema = closedObject({
   platform: Type.Optional(NonEmptyString),
   deviceFamily: Type.Optional(NonEmptyString),
   modelIdentifier: Type.Optional(NonEmptyString),
+  timeZone: Type.Optional(NonEmptyString),
   mode: Type.Optional(NonEmptyString),
   lastInputSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
   reason: Type.Optional(NonEmptyString),

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -563,6 +563,7 @@ export async function attachAuthenticatedGatewayConnect(
       platform: connectParams.client.platform,
       deviceFamily: connectParams.client.deviceFamily,
       modelIdentifier: connectParams.client.modelIdentifier,
+      timeZone: connectParams.client.timeZone,
       mode: connectParams.client.mode,
       deviceId: device?.id,
       roles: [role],

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -473,7 +473,7 @@ describe("WebSocket request trace context", () => {
   });
 });
 
-function connectTrustedProxyUser(connId: string) {
+function connectTrustedProxyUser(connId: string, clientOverrides: Record<string, unknown> = {}) {
   loadConfigMock.mockImplementationOnce(() => ({
     gateway: {
       auth: {
@@ -522,6 +522,7 @@ function connectTrustedProxyUser(connId: string) {
       version: "dev",
       platform: "test",
       mode: "ui",
+      ...clientOverrides,
     },
     role: "operator",
     caps: [],
@@ -1180,6 +1181,17 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
             "cf-access-jwt-assertion": assertion,
           }),
         }),
+      );
+    });
+  });
+
+  it("carries the client-reported time zone into the presence entry", async () => {
+    connectTrustedProxyUser("conn-time-zone", { timeZone: "Europe/Vienna" });
+
+    await waitForFast(() => {
+      expect(upsertPresenceMock).toHaveBeenCalledWith(
+        "conn-time-zone",
+        expect.objectContaining({ timeZone: "Europe/Vienna" }),
       );
     });
   });

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -19,6 +19,7 @@ export type SystemPresence = {
   platform?: string;
   deviceFamily?: string;
   modelIdentifier?: string;
+  timeZone?: string;
   lastInputSeconds?: number;
   mode?: string;
   reason?: string;

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -438,6 +438,9 @@ export class GatewayBrowserClient {
     const role = CONTROL_UI_OPERATOR_ROLE;
     // Gateway Coupling makes the connect handshake the only version-skew gate.
     // A configured build identity must never be omitted or downgraded.
+    // Browsers know their own zone, so presence gets a location hint that survives
+    // proxies, tunnels, and CGNAT ranges where the connecting IP tells us nothing.
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || undefined;
     const client: ConnectParams["client"] = {
       id: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.CONTROL_UI,
       version: this.opts.clientVersion ?? "control-ui",
@@ -445,6 +448,7 @@ export class GatewayBrowserClient {
       platform: this.opts.platform ?? navigator.platform ?? "web",
       mode: this.opts.mode ?? GATEWAY_CLIENT_MODES.WEBCHAT,
       instanceId: this.opts.instanceId,
+      ...(timeZone ? { timeZone } : {}),
     };
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const explicitPassword = this.opts.password?.trim() || undefined;

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -108,6 +108,39 @@ describe("session activity people filter", () => {
     expect(unresolved?.querySelector('[data-activity-person="explicit-id"]')).toBeNull();
   });
 
+  it("shows the client IP and self-reported time zone on the device row", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    render(
+      renderSessionActivityView(
+        props({
+          filters: { personId: "online", query: "", time: "7d" },
+          retainedIdentity: {
+            id: "online",
+            name: "Online person",
+            watchedSessions: [],
+            entries: [
+              {
+                host: "openclaw-control-ui",
+                platform: "Win32",
+                deviceFamily: "Mac16,6",
+                ip: "203.0.113.7",
+                timeZone: "Europe/Vienna",
+                ts: Date.now(),
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+
+    const device = container.querySelector(".activity-feed__device")?.textContent;
+    expect(device).toContain("203.0.113.7");
+    expect(device).toContain("Europe/Vienna");
+  });
+
   it("selecting Everyone clears the person while preserving the other filters", () => {
     const onFiltersChange = vi.fn();
     const container = document.createElement("div");

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -378,7 +378,9 @@ function renderIdentityHeader(
       ${devices.length > 0
         ? html`<div class="activity-feed__devices">
             ${devices.map((entry) => {
-              const device = [entry.deviceFamily, entry.platform].filter(Boolean).join(" · ");
+              const device = [entry.deviceFamily, entry.platform, entry.ip, entry.timeZone]
+                .filter(Boolean)
+                .join(" · ");
               return html`<div class="activity-feed__device">
                 <span class="activity-feed__device-name"
                   >${entry.host ?? t("activityFeed.unknownDevice")}</span


### PR DESCRIPTION
## What Problem This Solves

The Activity identity card showed only host and platform (`openclaw-control-ui  Win32`), so an operator looking at a teammate could not tell where that person was connecting from. Presence already carried a best-effort `ip` field — it was simply never rendered.

## Why This Change Was Made

Rendering `ip` alone is not enough, because the connecting address is frequently unusable as a location signal:

- connect handling deliberately omits `ip` for loopback clients, so tunneled clients show nothing;
- Tailscale and other CGNAT clients land in `100.64/10`, which `isPrivateOrLoopbackAddress` classifies as private.

A browser knows its own IANA zone regardless of how it reached the Gateway, so the client now self-reports it during the connect handshake. It is a client-reported hint sitting alongside the existing self-reported `platform` and `deviceFamily`, not a derived or inferred fact.

Both protocol additions are optional fields on existing shapes, so no protocol version bump is required.

## User Impact

The device row on the Activity identity card now reads `openclaw-control-ui  MacIntel · 203.0.113.7 · Europe/Vienna` instead of `openclaw-control-ui  MacIntel`. Fields that are absent are omitted, so local-only gateways see no change.

## Evidence

**Live proof.** Isolated gateway (own `OPENCLAW_STATE_DIR`, port 19110, never the operator's 18789) behind a header-injecting reverse proxy standing in for Cloudflare Access, driven by a real browser.

Before / after, captured from the running Control UI:

**Before**

![before](https://github.com/user-attachments/assets/09a3a097-6df4-4bca-adf3-051d57469e7d)

**After**

![after](https://github.com/user-attachments/assets/d561ff05-39ff-49e3-983d-ecc05561dd98)

The captured zone is `Europe/Vienna` while the host Mac is on `America/Los_Angeles` — the browser context was deliberately emulated to a different zone, proving the value is the client's own report rather than anything the server inferred. The IP is the forwarded client address resolved through the trusted-proxy attribution path.

**Automated.**

- `ui/src/pages/activity/session-activity-view.test.ts` — asserts the device row carries both IP and time zone.
- `src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts` — asserts the handshake value reaches the presence entry through a real connect.
- Both verified to fail against pre-change code by stashing each production edit and rerunning.
- `node scripts/check-changed.mjs` green; `packages/gateway-protocol` suite green (552 tests).
- Autoreview (codex / gpt-5.6-sol, high): clean, no accepted findings.

**Production LOC:** +8 production lines, +45 test/doc.
