### PR TITLE
fix: location.get can return a stale fix when no cached location is fresh enough

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt
@@ -4,8 +4,10 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.location.Location
+import android.location.LocationListener
 import android.location.LocationManager
 import android.os.CancellationSignal
+import android.os.Looper
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -39,9 +41,9 @@ class LocationCaptureManager(
       }
 
       // Prefer a recent cached fix before waking GPS/network providers.
-      val cached = bestLastKnown(manager, desiredProviders, maxAgeMs)
       val location =
-        cached ?: requestCurrent(manager, desiredProviders, timeoutMs)
+        bestLastKnown(manager, desiredProviders, maxAgeMs)
+          ?: requestCurrent(manager, desiredProviders, timeoutMs, maxAgeMs)
 
       val timestamp = DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(location.time))
       val source = location.provider
@@ -81,19 +83,23 @@ class LocationCaptureManager(
     if (!fineOk && !coarseOk) {
       throw IllegalStateException("LOCATION_PERMISSION_REQUIRED: grant Location permission")
     }
-    val now = System.currentTimeMillis()
-    val candidates =
-      providers.mapNotNull { provider -> manager.getLastKnownLocation(provider) }.filter { it.time <= now }
-    val freshest = candidates.maxByOrNull { it.time } ?: return null
-    // maxAgeMs is a caller contract; stale cached fixes force a live provider request.
-    if (maxAgeMs != null && now - freshest.time > maxAgeMs) return null
-    return freshest
+    // maxAgeMs applies to every successful fix, regardless of which Android API supplied it.
+    return providers
+      .mapNotNull { provider -> manager.getLastKnownLocation(provider) }
+      .filter { it.isFresh(maxAgeMs) }
+      .maxByOrNull { it.time }
+  }
+
+  private fun Location.isFresh(maxAgeMs: Long?): Boolean {
+    val ageMs = System.currentTimeMillis() - time
+    return ageMs >= 0 && (maxAgeMs == null || ageMs <= maxAgeMs)
   }
 
   private suspend fun requestCurrent(
     manager: LocationManager,
     providers: List<String>,
     timeoutMs: Long,
+    maxAgeMs: Long?,
   ): Location {
     val fineOk =
       ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ==
@@ -112,9 +118,34 @@ class LocationCaptureManager(
       withTimeout(timeoutMs.coerceAtLeast(1)) {
         suspendCancellableCoroutine<Location?> { cont ->
           val signal = CancellationSignal()
-          cont.invokeOnCancellation { signal.cancel() }
+          var activeListener: LocationListener? = null
+          cont.invokeOnCancellation {
+            signal.cancel()
+            activeListener?.let(manager::removeUpdates)
+          }
           manager.getCurrentLocation(resolved, signal, context.mainExecutor) { location ->
-            cont.resume(location) { _, _, _ -> }
+            if (!cont.isActive) return@getCurrentLocation
+            if (location == null || location.isFresh(maxAgeMs)) {
+              cont.resume(location) { _, _, _ -> }
+              return@getCurrentLocation
+            }
+            val listener =
+              object : LocationListener {
+                override fun onLocationChanged(update: Location) {
+                  if (!cont.isActive) {
+                    manager.removeUpdates(this)
+                    return
+                  }
+                  if (!update.isFresh(maxAgeMs)) return
+                  manager.removeUpdates(this)
+                  cont.resume(update) { _, _, _ -> }
+                }
+              }
+            activeListener = listener
+            // Cancellation can remove before registration; fence both sides to avoid a live leak.
+            if (!cont.isActive) return@getCurrentLocation
+            manager.requestLocationUpdates(resolved, 0L, 0f, listener, Looper.getMainLooper())
+            if (!cont.isActive) manager.removeUpdates(listener)
           }
         }
       }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/LocationCaptureManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/LocationCaptureManagerTest.kt
@@ -5,11 +5,20 @@ import android.content.Context
 import android.location.Location
 import android.location.LocationManager
 import android.os.Looper
+import android.os.SystemClock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
+import java.time.Duration
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
@@ -64,5 +73,192 @@ class LocationCaptureManagerTest : NodeHandlerRobolectricTest() {
     } finally {
       executor.shutdownNow()
     }
+  }
+
+  @Test(timeout = 10_000)
+  fun getLocation_rejectsFutureCurrentAndListenerLocationsUntilFreshFixArrives() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
+    val locationManager = app.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    val shadowManager = shadowOf(locationManager)
+    shadowManager.setProviderEnabled(LocationManager.GPS_PROVIDER, true)
+    shadowManager.simulateLocation(
+      LocationManager.GPS_PROVIDER,
+      location(1.0, ageMs = 0).apply { time += 2_000 },
+    )
+
+    val captureScope = CoroutineScope(Dispatchers.IO)
+    try {
+      val result =
+        captureScope.async {
+          LocationCaptureManager(app).getLocation(
+            desiredProviders = listOf(LocationManager.GPS_PROVIDER),
+            maxAgeMs = 500,
+            timeoutMs = 5_000,
+            isPrecise = true,
+          )
+        }
+
+      idleUntil("future current location callback") {
+        result.isCompleted || shadowManager.getLocationRequests(LocationManager.GPS_PROVIDER).isNotEmpty()
+      }
+      assertFalse("the current-location callback returned a future fix", result.isCompleted)
+
+      shadowManager.simulateLocation(
+        LocationManager.GPS_PROVIDER,
+        location(2.0, ageMs = 0).apply { time += 2_000 },
+      )
+      shadowOf(Looper.getMainLooper()).idle()
+      assertFalse("the location listener returned a future fix", result.isCompleted)
+
+      shadowManager.simulateLocation(LocationManager.GPS_PROVIDER, location(3.0, ageMs = 0))
+      idleUntil("fresh location after future callbacks") { result.isCompleted }
+
+      val payload = runBlocking { result.await() }.payloadJson
+      assertTrue("expected the fresh fix, got $payload", payload.contains("\"lat\":3.0"))
+      assertTrue(shadowManager.getLocationRequests(LocationManager.GPS_PROVIDER).isEmpty())
+    } finally {
+      captureScope.cancel()
+    }
+  }
+
+  @Test(timeout = 10_000)
+  fun getLocation_rejectsStaleCurrentAndListenerLocationsUntilFreshFixArrives() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
+    val locationManager = app.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    val shadowManager = shadowOf(locationManager)
+    shadowManager.setProviderEnabled(LocationManager.GPS_PROVIDER, true)
+    shadowManager.simulateLocation(LocationManager.GPS_PROVIDER, location(1.0, ageMs = 2_000))
+
+    val captureScope = CoroutineScope(Dispatchers.IO)
+    try {
+      val result =
+        captureScope.async {
+          LocationCaptureManager(app).getLocation(
+            desiredProviders = listOf(LocationManager.GPS_PROVIDER),
+            maxAgeMs = 500,
+            timeoutMs = 5_000,
+            isPrecise = true,
+          )
+        }
+
+      idleUntil("current location callback") {
+        result.isCompleted || shadowManager.getLocationRequests(LocationManager.GPS_PROVIDER).isNotEmpty()
+      }
+      assertFalse("the current-location callback returned a stale fix", result.isCompleted)
+
+      shadowManager.simulateLocation(LocationManager.GPS_PROVIDER, location(2.0, ageMs = 1_000))
+      shadowOf(Looper.getMainLooper()).idle()
+      assertFalse("the location listener returned a stale fix", result.isCompleted)
+      assertTrue(
+        "the listener must stay registered after a stale update",
+        shadowManager.getLocationRequests(LocationManager.GPS_PROVIDER).isNotEmpty(),
+      )
+
+      shadowManager.simulateLocation(LocationManager.GPS_PROVIDER, location(3.0, ageMs = 0))
+      idleUntil("fresh location callback") { result.isCompleted }
+
+      val payload = runBlocking { result.await() }.payloadJson
+      assertTrue("expected the fresh fix, got $payload", payload.contains("\"lat\":3.0"))
+      assertTrue(shadowManager.getLocationRequests(LocationManager.GPS_PROVIDER).isEmpty())
+    } finally {
+      captureScope.cancel()
+    }
+  }
+
+  @Test(timeout = 10_000)
+  fun getLocation_timesOutAndRemovesListenerWhenNoFreshFixArrives() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
+    val locationManager = app.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    val shadowManager = shadowOf(locationManager)
+    shadowManager.setProviderEnabled(LocationManager.GPS_PROVIDER, true)
+    shadowManager.simulateLocation(LocationManager.GPS_PROVIDER, location(1.0, ageMs = 2_000))
+
+    val captureScope = CoroutineScope(Dispatchers.IO)
+    try {
+      val result =
+        captureScope.async {
+          LocationCaptureManager(app).getLocation(
+            desiredProviders = listOf(LocationManager.GPS_PROVIDER),
+            maxAgeMs = 500,
+            timeoutMs = 250,
+            isPrecise = true,
+          )
+        }
+
+      idleUntil("location listener registration") {
+        shadowManager.getLocationRequests(LocationManager.GPS_PROVIDER).isNotEmpty()
+      }
+      shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(300))
+      idleUntil("stale location timeout") { result.isCompleted }
+      try {
+        runBlocking { result.await() }
+        fail("a stale location must time out rather than satisfy the request")
+      } catch (_: TimeoutCancellationException) {
+        assertTrue(shadowManager.getLocationRequests(LocationManager.GPS_PROVIDER).isEmpty())
+      }
+    } finally {
+      captureScope.cancel()
+    }
+  }
+
+  @Test(timeout = 10_000)
+  fun getLocation_removesRegisteredListenerWhenCallerCancels() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
+    val locationManager = app.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    val shadowManager = shadowOf(locationManager)
+    shadowManager.setProviderEnabled(LocationManager.GPS_PROVIDER, true)
+    shadowManager.simulateLocation(LocationManager.GPS_PROVIDER, location(1.0, ageMs = 2_000))
+
+    val captureScope = CoroutineScope(Dispatchers.IO)
+    try {
+      val result =
+        captureScope.async {
+          LocationCaptureManager(app).getLocation(
+            desiredProviders = listOf(LocationManager.GPS_PROVIDER),
+            maxAgeMs = 500,
+            timeoutMs = 5_000,
+            isPrecise = true,
+          )
+        }
+
+      idleUntil("cancellable location listener") {
+        shadowManager.getLocationRequests(LocationManager.GPS_PROVIDER).isNotEmpty()
+      }
+      result.cancel()
+      idleUntil("location listener cancellation") {
+        shadowManager.getLocationRequests(LocationManager.GPS_PROVIDER).isEmpty()
+      }
+      assertTrue(result.isCancelled)
+    } finally {
+      captureScope.cancel()
+    }
+  }
+
+  private fun location(
+    latitude: Double,
+    ageMs: Long,
+  ): Location =
+    Location(LocationManager.GPS_PROVIDER).apply {
+      this.latitude = latitude
+      longitude = latitude
+      accuracy = 5f
+      time = System.currentTimeMillis() - ageMs
+      elapsedRealtimeNanos = (SystemClock.elapsedRealtime() - ageMs) * 1_000_000
+    }
+
+  private fun idleUntil(
+    description: String,
+    condition: () -> Boolean,
+  ) {
+    val deadline = System.currentTimeMillis() + 2_000
+    while (!condition() && System.currentTimeMillis() < deadline) {
+      shadowOf(Looper.getMainLooper()).idle()
+      Thread.sleep(10)
+    }
+    assertTrue("timed out waiting for $description", condition())
   }
 }


### PR DESCRIPTION
Closes #128005

## What Problem This Solves

Android `location.get` can return a location older than the caller's `maxAgeMs` even though its cached-location path already rejects stale fixes. Android's `LocationManager.getCurrentLocation` is explicitly permitted to satisfy a current request from a recent cached fix, and `requestLocationUpdates` also does not promise that every callback satisfies the application's stricter wall-clock freshness contract. `LocationCaptureManager` trusted the current-location callback without enforcing that contract.

The architectural owner is `apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt`. Android SDK 36 documents the cached-current behavior in `android/location/LocationManager.java`; the Linux location owner already rejects stale updates and waits for a fresh result in `extensions/linux-node/src/location.ts`.

## Repair

- Apply one shared wall-clock freshness predicate to cached locations, the `getCurrentLocation` callback, and every subsequent `requestLocationUpdates` callback. Preserve current main's recently landed rejection of future-dated cached fixes and extend that same invariant to current and listener callbacks; filter invalid cached candidates before selecting the freshest valid provider.
- When the framework shortcut is stale, keep listening until a genuinely fresh fix arrives or the original caller timeout expires. Preserve existing null-result, permission, provider-selection, unbounded-age, and handler timeout behavior.
- Cancel the platform request and unregister the active listener on caller cancellation or timeout. Fence listener registration before and after registration so cancellation cannot leak location updates.
- Preserve the existing future-dated cached-fix regression and add producer-level coverage for future-dated current and listener callbacks, stale current fix → stale listener callback → fresh fix, stale-only timeout with cleanup, and cancellation with cleanup.

The original contributor patch accepted the first listener update without rechecking its freshness; this rewrite addresses that ClawSweeper rank-up and independently identified cancellation race at the producer.

## Evidence

Pre-fix producer regression failed with the exact stale-current assertion; the final focused suite passed all 15 tests across `LocationCaptureManagerTest` (five owner cases, including the existing future-dated cache case and new future-dated current/listener case) and `LocationHandlerTest` (ten cases).

Also verified on an actual booted Android API 36 emulator against the production `LocationCaptureManager`, real `LocationManager`, real foreground `MainActivity`, granted fine/coarse location permissions, and a shell-owned Android mock provider. The temporary instrumentation directly asserted returned latitude `3.5` and a timestamp age of at most 1,000 ms; it is not part of this PR.

Frozen-main APK, `maxAgeMs = 1000`, real platform location with a current monotonic timestamp but a wall-clock timestamp 45 seconds old:

```text
LOCATION_BEFORE_STALE_WALL_AGE_MS=45000
java.lang.AssertionError: expected:<3.5> but was:<1.25>
Tests run: 1, Failures: 1
```

Reviewed candidate APK, same emulator/provider/signing/permissions, initial stale location `1.25`, another stale listener update `2.0`, then a fresh fix `3.5`:

```text
LOCATION_AFTER_INITIAL_STALE_LAT=1.25
LOCATION_LISTENER_STATE=service: ProviderRequest[@0, WorkSource{10214 ai.openclaw.app.debug}]
LOCATION_AFTER_SECOND_STALE_LAT=2.0
LOCATION_AFTER_FRESH_LAT=3.5
Time: 2.195
OK (1 test)
```

Final platform state confirmed the listener was unregistered (`ProviderRequest[OFF]`), the app's request was foreground, and the temporary mock provider was removed.

Production delta: +42/-11 (net +31); permanent regression coverage: +196 test lines relative to current main. The production growth is the necessary real Android listener lifecycle, coherent future/stale age validation, and cancellation ownership absent from the original shortcut-only implementation. No new configuration, dependency, compatibility fallback, permission policy, or changelog change.

Thanks to @corvid-reads for reporting the device behavior and the original fix.
