### PR TITLE
fix(agents): settle nested code mode bridge calls

### DIFF
--- a/src/agents/agent-tools.abort.ts
+++ b/src/agents/agent-tools.abort.ts
@@ -24,7 +24,7 @@ function throwAbortError(): never {
  * Tool settlements pass through untouched to preserve tool error semantics,
  * including non-Error rejections.
  */
-function raceWithAbortSignal<T>(
+export function raceWithAbortSignal<T>(
   promise: Promise<T>,
   signal: AbortSignal,
   yieldRunSignal?: AbortSignal,

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -3,6 +3,7 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "@openclaw/normalization-core/number-coercion";
+import { raceWithAbortSignal } from "./agent-tools.abort.js";
 import { runBridgeRequest } from "./code-mode-bridge.js";
 import type { CodeModeCatalogProjection } from "./code-mode-catalog.js";
 import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "./code-mode-control-tools.js";
@@ -56,6 +57,7 @@ type CodeModeRunState = {
 
 const MAX_ACTIVE_CODE_MODE_RUNS = 64;
 const MAX_AGENT_WAIT_SNAPSHOT_TTL_WINDOWS = 4;
+const BRIDGE_CLOSED_MESSAGE = "Code Mode tool canceled, expired, or owner lost; start a new run.";
 
 export const activeRuns = new Map<string, CodeModeRunState>();
 export const resumingRunIds = new Set<string>();
@@ -158,16 +160,8 @@ export function cancelPendingBridgeStatesById(
     return;
   }
   const canceled = new Set(canceledRequestIds);
-  const retained = pending.filter((entry) => {
-    if (!canceled.has(entry.id)) {
-      return true;
-    }
-    if (!entry.settled) {
-      entry.cancel?.();
-    }
-    return false;
-  });
-  pending.splice(0, pending.length, ...retained);
+  cancelPendingBridgeStates(pending.filter((entry) => canceled.has(entry.id)));
+  pending.splice(0, pending.length, ...pending.filter((entry) => !canceled.has(entry.id)));
 }
 
 /** Deliver bridge responses in actual settlement order, not request order. */
@@ -351,9 +345,13 @@ export function createPendingBridgeStates(params: {
     // Bridge calls start immediately while the VM snapshot is stored. Their
     // settled values are later replayed into QuickJS by the wait tool.
     const abortController = new AbortController();
-    const signal = params.signal
-      ? AbortSignal.any([params.signal, abortController.signal])
-      : abortController.signal;
+    const signal = AbortSignal.any(
+      [params.signal, params.ctx.abortSignal, abortController.signal].filter(
+        (candidate): candidate is AbortSignal => candidate !== undefined,
+      ),
+    );
+    const target = params.catalogProjection.byCallableName.get(String(request.args[0]));
+    const yieldRunSignal = target?.name === "sessions_yield" ? params.ctx.abortSignal : undefined;
     const tracksDispatch = request.method !== "sleep";
     if (tracksDispatch) {
       params.bridgeDispatch.started = true;
@@ -362,21 +360,29 @@ export function createPendingBridgeStates(params: {
         params.bridgeDispatch.repairProvenance = "invalid";
       }
     }
+    const bridgeCall = runBridgeRequest({
+      runtime: params.runtime,
+      catalogProjection: params.catalogProjection,
+      namespaceRuntime: params.namespaceRuntime,
+      parentToolCallId: params.parentToolCallId,
+      codeModeRunId: params.codeModeRunId,
+      maxOutputBytes: params.config.maxOutputBytes,
+      remainingMs: Math.max(1, params.deadlineMs - Date.now()),
+      ctx: params.ctx,
+      request,
+      signal,
+      onUpdate: params.onUpdate,
+    });
+    const completion = raceWithAbortSignal(bridgeCall, signal, yieldRunSignal).catch(
+      (): SettledBridgeRequest => ({
+        id: request.id,
+        ok: false,
+        error: signal.reason instanceof Error ? signal.reason.message : BRIDGE_CLOSED_MESSAGE,
+      }),
+    );
     const state: PendingBridgeState = {
       ...request,
-      promise: runBridgeRequest({
-        runtime: params.runtime,
-        catalogProjection: params.catalogProjection,
-        namespaceRuntime: params.namespaceRuntime,
-        parentToolCallId: params.parentToolCallId,
-        codeModeRunId: params.codeModeRunId,
-        maxOutputBytes: params.config.maxOutputBytes,
-        remainingMs: Math.max(1, params.deadlineMs - Date.now()),
-        ctx: params.ctx,
-        request,
-        signal,
-        onUpdate: params.onUpdate,
-      }).then((settled) => {
+      promise: completion.then((settled) => {
         const trustedNoStart = tracksDispatch && consumeTrustedToolNoStartError(settled);
         if (tracksDispatch && params.bridgeDispatch.repairProvenance !== "invalid") {
           params.bridgeDispatch.repairProvenance =
@@ -401,7 +407,7 @@ export function createPendingBridgeStates(params: {
         }
         return settled;
       }),
-      cancel: () => abortController.abort(),
+      cancel: () => abortController.abort(new Error(BRIDGE_CLOSED_MESSAGE)),
     };
     return state;
   });

--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -1,0 +1,282 @@
+/** Real QuickJS bridge coverage for subscribed embedded tool lifecycles. */
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createDiagnosticEmbeddedRunOwner } from "../logging/diagnostic-run-activity.js";
+import { disposeAllCodeModeRuns } from "./code-mode-state.js";
+import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
+import {
+  pluginToolWithExecute,
+  resetCodeModeTestState,
+  resultDetails,
+  testing,
+} from "./code-mode.test-support.js";
+import { prepareEmbeddedAttemptStream } from "./embedded-agent-runner/run/attempt-stream-prepare.js";
+import { clearActiveEmbeddedRun } from "./embedded-agent-runner/runs.js";
+import { createStubSessionHarness } from "./embedded-agent-subscribe.e2e-harness.js";
+import { countActiveToolExecutions } from "./embedded-agent-subscribe.handlers.tools.js";
+import { createToolSearchCatalogRef } from "./tool-search.js";
+import { jsonResult } from "./tools/common.js";
+
+function createSubscribedCodeModeHarness(params: {
+  name: string;
+  onBlockReplyFlush?: () => Promise<void>;
+  timeoutMs?: number;
+}) {
+  const runId = `run-code-mode-${params.name}`;
+  const sessionId = `session-code-mode-${params.name}`;
+  const sessionKey = `agent:main:${params.name}`;
+  const config = {
+    tools: { codeMode: { enabled: true, timeoutMs: params.timeoutMs ?? 1_500 } },
+  } as never;
+  const catalogRef = createToolSearchCatalogRef();
+  const runAbortController = new AbortController();
+  const { session } = createStubSessionHarness();
+  const activeSession = Object.assign(session, {
+    agent: { hasQueuedMessages: () => false },
+    isStreaming: false,
+    messages: [],
+    pendingMessageCount: 0,
+  });
+  const stream = prepareEmbeddedAttemptStream({
+    attempt: { config, runId, sessionId, sessionKey } as never,
+    activeSession: activeSession as never,
+    hookRunner: undefined as never,
+    hookAgentId: "main",
+    diagnosticTrace: {} as never,
+    diagnosticOwner: createDiagnosticEmbeddedRunOwner({ sessionId, sessionKey, runId }),
+    clientToolCallSlots: [],
+    toolSearchTargetTranscriptProjections: [],
+    isReplaySafeTool: () => false,
+    runAbortController,
+    abortRun: () => runAbortController.abort(),
+    markExternalAbort: () => undefined,
+    getRunState: () => ({
+      aborted: runAbortController.signal.aborted,
+      promptError: undefined,
+      timedOut: false,
+      yieldDetected: false,
+    }),
+    hasDeliveredSourceReply: () => false,
+    markSourceReplyDelivered: () => undefined,
+    onBlockReply: undefined,
+    onBlockReplyFlush: params.onBlockReplyFlush,
+    sandboxSessionKey: sessionKey,
+    builtinToolNames: new Set(),
+    replaySafeToolNames: new Set(),
+  });
+  const context = {
+    config,
+    runtimeConfig: config,
+    sessionId,
+    sessionKey,
+    runId,
+    catalogRef,
+    abortSignal: runAbortController.signal,
+    executeTool: stream.toolSearchCatalogExecutor,
+  };
+  return {
+    ...context,
+    tools: createCodeModeTools(context),
+    runAbortController,
+    subscription: stream.subscription,
+    dispose: () => {
+      stream.subscription.unsubscribe();
+      clearActiveEmbeddedRun(sessionId, stream.queueHandle, sessionKey);
+    },
+  };
+}
+
+describe("Code Mode subscribed bridge lifecycle", () => {
+  afterEach(() => resetCodeModeTestState());
+
+  it("starts a subscribed nested tool without re-entering its outer presentation flush", async () => {
+    const blockReplyFlush = createDeferred();
+    const onBlockReplyFlush = vi.fn(() => blockReplyFlush.promise);
+    const harness = createSubscribedCodeModeHarness({ name: "circular-flush", onBlockReplyFlush });
+    const target = pluginToolWithExecute("release_flush", "Release the pending reply", async () => {
+      blockReplyFlush.resolve();
+      return jsonResult({ released: true });
+    });
+    applyCodeModeCatalog({ ...harness, tools: [...harness.tools, target] });
+
+    try {
+      const result = resultDetails(
+        await expectDefined(harness.tools[0], "Code Mode exec test invariant").execute(
+          "code-call-circular-flush",
+          { code: "return await release_flush({});" },
+        ),
+      );
+
+      expect(result.status, JSON.stringify(result)).toBe("completed");
+      expect(result.value).toEqual({ released: true });
+      expect(target.execute).toHaveBeenCalledOnce();
+      expect(onBlockReplyFlush).not.toHaveBeenCalled();
+      expect(harness.subscription.getItemLifecycle()).toMatchObject({
+        startedCount: 1,
+        completedCount: 1,
+        activeCount: 0,
+      });
+      expect(countActiveToolExecutions(harness.runId)).toBe(0);
+      expect(testing.activeRuns.size).toBe(0);
+    } finally {
+      blockReplyFlush.resolve();
+      harness.dispose();
+    }
+  });
+
+  it("settles subscribed nested dispatch exactly once across repeated exec and wait turns", async () => {
+    const blockReplyFlush = createDeferred();
+    const onBlockReplyFlush = vi.fn(() => blockReplyFlush.promise);
+    const harness = createSubscribedCodeModeHarness({
+      name: "repeated-lifecycle",
+      onBlockReplyFlush,
+    });
+    const target = pluginToolWithExecute("finish_stage", "Finish one suspended stage", async () => {
+      blockReplyFlush.resolve();
+      return jsonResult({ finished: true });
+    });
+    applyCodeModeCatalog({ ...harness, tools: [...harness.tools, target] });
+
+    try {
+      for (let stage = 0; stage < 2; stage += 1) {
+        const suspended = resultDetails(
+          await expectDefined(harness.tools[0], "Code Mode exec test invariant").execute(
+            `code-call-stage-${stage}`,
+            { code: 'await yield_control("pause"); return await finish_stage({});' },
+          ),
+        );
+        expect(suspended).toMatchObject({ status: "waiting", reason: "yield" });
+
+        const completed = resultDetails(
+          await expectDefined(harness.tools[1], "Code Mode wait test invariant").execute(
+            `code-wait-stage-${stage}`,
+            { runId: suspended.runId },
+          ),
+        );
+        expect(completed).toMatchObject({ status: "completed", value: { finished: true } });
+        expect(countActiveToolExecutions(harness.runId)).toBe(0);
+      }
+
+      expect(target.execute).toHaveBeenCalledTimes(2);
+      expect(onBlockReplyFlush).not.toHaveBeenCalled();
+      expect(harness.subscription.getItemLifecycle()).toMatchObject({
+        startedCount: 2,
+        completedCount: 2,
+        activeCount: 0,
+      });
+      expect(testing.activeRuns.size).toBe(0);
+    } finally {
+      blockReplyFlush.resolve();
+      harness.dispose();
+    }
+  });
+
+  it("preserves the initiating sessions_yield result across its run-owner handoff", async () => {
+    const harness = createSubscribedCodeModeHarness({ name: "yield-handoff" });
+    const handoffReason = { code: "sessions_yield", turnHandoff: true } as const;
+    const target = pluginToolWithExecute(
+      "sessions_yield",
+      "Hand off the current turn",
+      async () => {
+        harness.runAbortController.abort(handoffReason);
+        return jsonResult({ status: "yielded" });
+      },
+    );
+    applyCodeModeCatalog({ ...harness, tools: [...harness.tools, target] });
+
+    try {
+      const result = resultDetails(
+        await expectDefined(harness.tools[0], "Code Mode exec test invariant").execute(
+          "code-call-yield-handoff",
+          { code: "return await sessions_yield({});" },
+        ),
+      );
+
+      expect(result).toMatchObject({ status: "completed", value: { status: "yielded" } });
+      expect(target.execute).toHaveBeenCalledOnce();
+      expect(countActiveToolExecutions(harness.runId)).toBe(0);
+      expect(testing.activeRuns.size).toBe(0);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it.each([
+    { kind: "explicit cancellation", close: "cancel" },
+    { kind: "run-owner loss", close: "abort" },
+    { kind: "snapshot expiry", close: "expire" },
+    { kind: "gateway shutdown", close: "shutdown" },
+  ] as const)(
+    "settles an abort-ignoring subscribed tool exactly once after $kind",
+    async ({ close }) => {
+      const downstream = createDeferred();
+      const harness = createSubscribedCodeModeHarness({
+        name: `closure-${close}`,
+        timeoutMs: 2_000,
+      });
+      const target = pluginToolWithExecute("stalled_target", "Ignore cancellation", async () => {
+        await downstream.promise;
+        return jsonResult({ late: true });
+      });
+      applyCodeModeCatalog({ ...harness, tools: [...harness.tools, target] });
+
+      try {
+        const suspended = resultDetails(
+          await expectDefined(harness.tools[0], "Code Mode exec test invariant").execute(
+            `code-call-${close}`,
+            {
+              code: `const target = stalled_target({});
+                await yield_control("pause");
+                try { return await target; } catch (error) { return error.message; }`,
+            },
+          ),
+        );
+        expect(suspended.status).toBe("waiting");
+        expect(target.execute).toHaveBeenCalledOnce();
+        expect(countActiveToolExecutions(harness.runId)).toBe(1);
+
+        const parked = testing.activeRuns.get(suspended.runId as string);
+        const pending = parked?.pending.find((entry) => entry.method === "callValue");
+        expect(pending).toBeDefined();
+        if (!parked || !pending) {
+          throw new Error("expected one parked subscribed tool call");
+        }
+        const settlements = vi.fn();
+        void pending.promise.then(settlements);
+        const waiting = expectDefined(harness.tools[1], "Code Mode wait test invariant").execute(
+          `code-wait-${close}`,
+          { runId: suspended.runId },
+        );
+
+        if (close === "cancel") {
+          pending.cancel?.();
+        } else if (close === "abort") {
+          harness.runAbortController.abort(new Error("run owner closed"));
+        } else if (close === "expire") {
+          parked.expiresAt = Date.now() - 1;
+          testing.removeExpiredRuns();
+        } else {
+          disposeAllCodeModeRuns();
+        }
+
+        const settlement = await pending.promise;
+        expect(settlement).toMatchObject({ id: pending.id, ok: false });
+        expect(settlement.ok ? "" : settlement.error).toMatch(/cancel|abort|expir|owner|shut/i);
+        expect(resultDetails(await waiting).status).not.toBe("waiting");
+        await vi.waitFor(() => expect(countActiveToolExecutions(harness.runId)).toBe(0));
+        expect(settlements).toHaveBeenCalledOnce();
+        expect(harness.subscription.getItemLifecycle().activeCount).toBe(0);
+        expect(testing.activeRuns.size).toBe(0);
+
+        downstream.resolve();
+        await Promise.resolve();
+        expect(target.execute).toHaveBeenCalledOnce();
+        expect(settlements).toHaveBeenCalledOnce();
+      } finally {
+        downstream.resolve();
+        harness.dispose();
+      }
+    },
+  );
+});

--- a/src/agents/code-mode.test-support.ts
+++ b/src/agents/code-mode.test-support.ts
@@ -3,7 +3,12 @@ import { setPluginToolMeta } from "../plugins/tools.js";
 import { codeModeReplayIdForToolCall } from "./code-mode-bridge.js";
 import { resolveCodeModeHeadlessConfig } from "./code-mode-runtime.js";
 import type { CodeModeSkill } from "./code-mode-skills.js";
-import { activeRuns, removeExpiredRuns, resumingRunIds } from "./code-mode-state.js";
+import {
+  activeRuns,
+  disposeAllCodeModeRuns,
+  removeExpiredRuns,
+  resumingRunIds,
+} from "./code-mode-state.js";
 import { normalizeCodeModeWorkerResult, runCodeModeWorker } from "./code-mode-worker.js";
 import { createCodeModeTools } from "./code-mode.js";
 import { createToolSearchCatalogRef, type ToolSearchCatalogRef } from "./tool-search.js";
@@ -20,8 +25,7 @@ export const testing = {
 };
 
 export function resetCodeModeTestState(): void {
-  testing.activeRuns.clear();
-  testing.resumingRunIds.clear();
+  disposeAllCodeModeRuns();
 }
 
 export function fakeTool(name: string, description: string): AnyAgentTool {

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -19,6 +19,7 @@ import {
   buildAgentHookContextIdentityFields,
 } from "../../../plugins/hook-agent-context.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+import { raceWithAbortSignal } from "../../agent-tools.abort.js";
 import { recordStructuredReplayTrustForToolCall } from "../../agent-tools.before-tool-call.js";
 import { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
 import { cancelPendingAgentQuestionForSession } from "../../harness/gateway-question.js";
@@ -335,6 +336,9 @@ export function prepareEmbeddedAttemptStream(input: {
   toolMetasForTerminal = subscription.toolMetas;
 
   const toolSearchCatalogExecutor: ToolSearchCatalogToolExecutor = async (toolParams) => {
+    const runSignal = input.runAbortController.signal;
+    const signal = AbortSignal.any([toolParams.signal ?? runSignal, runSignal]);
+    const yieldRunSignal = toolParams.toolName === "sessions_yield" ? runSignal : undefined;
     try {
       if (toolParams.source === "openclaw" && toolParams.sourceName === "core") {
         recordStructuredReplayTrustForToolCall(
@@ -343,7 +347,7 @@ export function prepareEmbeddedAttemptStream(input: {
           attempt.runId,
         );
       }
-      const result = await subscription.runToolLifecycle({
+      const lifecycle = subscription.runToolLifecycle({
         toolName: toolParams.toolName,
         toolCallId: toolParams.toolCallId,
         args: toolParams.input,
@@ -351,38 +355,44 @@ export function prepareEmbeddedAttemptStream(input: {
         hideFromChannelProgress:
           "hideFromChannelProgress" in toolParams.tool &&
           toolParams.tool.hideFromChannelProgress === true,
-        execute: async (onImplementationStart) => {
-          const signal = toolParams.signal ?? input.runAbortController.signal;
-          const preparer = getInternalToolExecutionPreparer(toolParams.tool);
-          if (!preparer) {
-            onImplementationStart();
-            return await toolParams.tool.execute(
-              toolParams.toolCallId,
-              toolParams.input,
-              signal,
-              toolParams.onUpdate,
-              undefined as never,
-            );
-          }
-          const prepared = await preparer({
-            toolCallId: toolParams.toolCallId,
-            args: toolParams.input,
-            signal,
-            onUpdate: toolParams.onUpdate,
-          });
-          try {
-            if (prepared.kind === "immediate") {
-              if (prepared.outcome.kind === "error") {
-                throw prepared.outcome.error;
+        execute: (onImplementationStart) =>
+          raceWithAbortSignal(
+            (async () => {
+              signal.throwIfAborted();
+              const preparer = getInternalToolExecutionPreparer(toolParams.tool);
+              if (!preparer) {
+                onImplementationStart();
+                return await toolParams.tool.execute(
+                  toolParams.toolCallId,
+                  toolParams.input,
+                  signal,
+                  toolParams.onUpdate,
+                  undefined as never,
+                );
               }
-              return prepared.outcome.result;
-            }
-            return await prepared.execute(onImplementationStart);
-          } finally {
-            prepared.dispose();
-          }
-        },
+              const prepared = await preparer({
+                toolCallId: toolParams.toolCallId,
+                args: toolParams.input,
+                signal,
+                onUpdate: toolParams.onUpdate,
+              });
+              try {
+                if (prepared.kind === "immediate") {
+                  if (prepared.outcome.kind === "error") {
+                    throw prepared.outcome.error;
+                  }
+                  return prepared.outcome.result;
+                }
+                return await prepared.execute(onImplementationStart);
+              } finally {
+                prepared.dispose();
+              }
+            })(),
+            signal,
+            yieldRunSignal,
+          ),
       });
+      const result = await raceWithAbortSignal(lifecycle, signal, yieldRunSignal);
       // Settlement persists every queued projection. Validate the final result
       // first so a rejected hidden-tool value never enters session history.
       const acceptedResult = await toolParams.acceptResultBeforeProjection(result);

--- a/src/agents/embedded-agent-subscribe.handlers.tools.start.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.start.ts
@@ -320,6 +320,7 @@ export function handleToolExecutionStart(
     args: unknown;
     replaySafe?: boolean;
     hideFromChannelProgress?: boolean;
+    lifecycleProvenance?: "nested";
   },
 ): void | Promise<void> {
   const startToolName = normalizeToolPolicyName(evt.toolName);
@@ -616,7 +617,10 @@ export function handleToolExecutionStart(
     }
   };
 
-  // Flush pending block replies to preserve message boundaries before tool execution.
+  // Only the outer provider tool owns the block-reply presentation boundary.
+  if (evt.lifecycleProvenance === "nested") {
+    return continueToolExecutionStart();
+  }
   let flushBlockReplyBufferResult: void | Promise<void>;
   try {
     flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer();

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -621,6 +621,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
         args: toolParams.args,
         replaySafe: toolParams.replaySafe,
         hideFromChannelProgress: toolParams.hideFromChannelProgress,
+        lifecycleProvenance: "nested",
       } as never);
       let executionStarted = false;
       const onImplementationStart = () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running QuickJS Code Mode with a nested bridge tool call could see the run remain in `waiting` / `pending_tools` indefinitely without the requested target ever being invoked. The nested synthetic lifecycle recursively awaited the outer block-reply presentation flush, creating a deadlock before the call produced any outcome.

## Why This Change Was Made

Make the nested synthetic lifecycle skip only the duplicate block-reply presentation boundary while preserving normal hooks, telemetry, and approvals. Race bridge calls against call, run, and context closure, and ensure each bridge call settles and wakes the owner exactly once.

Landed #128088 handles outcomes after they exist; this change fixes calls that never produced an outcome.

## User Impact

QuickJS Code Mode nested bridge calls reach their target and finish deterministically, including cancellation and closure paths, instead of silently hanging before invocation. Existing lifecycle hooks, telemetry, and approval behavior remain intact.

## Evidence

- Deterministic pre-fix reproduction observed `waiting` / `pending_tools` with zero target invocations.
- Focused validation: `node scripts/run-vitest.mjs src/agents/code-mode.bridge.lifecycle.test.ts src/agents/code-mode.bridge.test.ts src/agents/code-mode.wait.test.ts src/agents/code-mode.agent-loop.test.ts src/agents/code-mode-worker-lifecycle.test.ts` — five files, 66 tests passed across two Vitest shards.
- Changed gates, formatting, type, lint, import-cycle, and diff checks passed; two clean autoreviews.
- Production LOC: `+81/-60` (net `+21`); tests/test-support: `+289/-3` (net `+286`).
