### PR TITLE
feat(sessions): create detached sibling sessions

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -11,20 +11,20 @@ OpenClaw gives agents tools to work across sessions, inspect status, and orchest
 
 ## Available tools
 
-| Tool                 | What it does                                                                            |
-| -------------------- | --------------------------------------------------------------------------------------- |
-| `sessions`           | Patch, reset, delete, or assign ownership of visible sessions and manage session groups |
-| `sessions_list`      | List sessions with optional filters (kind, label, agent, archive, preview)              |
-| `sessions_search`    | Search visible session transcripts and return matching excerpts                         |
-| `sessions_history`   | Read the transcript of a specific session                                               |
-| `sessions_send`      | Run another session on the same Gateway and optionally wait                             |
-| `conversations_list` | List stable external conversation addresses                                             |
-| `conversations_send` | Send to one exact external conversation without running a local session                 |
-| `conversations_turn` | Send to one exact external conversation and wait for its correlated reply               |
-| `sessions_spawn`     | Spawn an isolated sub-agent session for background work                                 |
-| `sessions_yield`     | End the current turn and wait for follow-up sub-agent results                           |
-| `subagents`          | List or cancel background work in this session tree                                     |
-| `session_status`     | Show a `/status`-style card and optionally set a per-session model override             |
+| Tool                 | What it does                                                                       |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| `sessions`           | Create detached sessions; patch, reset, delete, or assign ownership; manage groups |
+| `sessions_list`      | List sessions with optional filters (kind, label, agent, archive, preview)         |
+| `sessions_search`    | Search visible session transcripts and return matching excerpts                    |
+| `sessions_history`   | Read the transcript of a specific session                                          |
+| `sessions_send`      | Run another session on the same Gateway and optionally wait                        |
+| `conversations_list` | List stable external conversation addresses                                        |
+| `conversations_send` | Send to one exact external conversation without running a local session            |
+| `conversations_turn` | Send to one exact external conversation and wait for its correlated reply          |
+| `sessions_spawn`     | Spawn an isolated sub-agent session for background work                            |
+| `sessions_yield`     | End the current turn and wait for follow-up sub-agent results                      |
+| `subagents`          | List or cancel background work in this session tree                                |
+| `session_status`     | Show a `/status`-style card and optionally set a per-session model override        |
 
 These tools are still subject to the active tool profile and allow/deny policy. `tools.profile: "coding"` includes the full session orchestration set. `tools.profile: "messaging"` includes session self-service, discovery, recall, cross-session messaging, external-conversation tools, and the complete spawn lifecycle (`sessions_spawn`, `sessions_yield`, and `subagents`). The UI-only task-suggestion tools `suggest_task` and `dismiss_task` remain coding-profile tools.
 
@@ -60,13 +60,14 @@ Use [`sessions_search`](/concepts/session-search) for exact full-text recall acr
 
 The owner-gated `sessions` tool exposes bounded self-service surfaces:
 
+- `action: "create"` creates an idle, detached root session with no parent, spawn lineage, inherited sub-agent policy, or child-count relationship. Pass `label`, `agentId`, and `permissionMode` (`read-only`, `guarded`, `workspace`, or `full`); omission defaults to `guarded`. The result returns its session key and durable session ID. Use `sessions_send` with that key during the same turn to start work; the narrow create-to-send access grant expires when the creating turn ends. This action appears only during a direct admitted operator turn, and `full` additionally requires a direct local administrator turn.
 - `action: "patch"` changes the current session by default, or another visible session selected by `sessionKey`. It can set the label, persistent sidebar `icon`, sidebar `category`, pin/archive state, model, and thinking level. Pass `null` or an empty string to clear `category`; assigning a category adds it to the catalog on first use. The icon must be one emoji grapheme or one of the named icons `braces`, `book`, `monitor`, `bot`, `kanban`, and `coins`; pass an empty string to clear it. The Control UI picker also accepts a custom emoji and shows the macOS (Control-Command-Space) or Windows (Windows-period) system emoji picker shortcut. Archiving or restoring another session requires its `sessions_list` `sessionId` as `expectedSessionId`.
 - `action: "reset"` resets another visible session selected by `sessionKey`.
 - `action: "delete"` first archives and then deletes the exact same generation of another visible session selected by `sessionKey`. By default its transcript is retained as a deleted archive; pass `deleteTranscript: false` to leave the transcript state untouched. Resetting or deleting the session currently running the tool is rejected.
 - `action: "assign_owner"` hands session responsibility to a person or agent. Pass `ownerType` (`"human"` or `"agent"`) and `ownerId`; the target is the current session by default, or another visible session via `sessionKey`. Agent owner ids must name a configured agent. The assignment records who reassigned it and when, and the Control UI reflects the new owner immediately. Ownership is display and responsibility, not access control; see [Multi-user mode](/concepts/multi-user).
 - `group_list`, `group_set`, `group_rename`, and `group_delete` manage the global ordered session-group catalog. `group_set` replaces the ordered name list rather than assigning a session; use `action: "patch"` with `category` for membership.
 
-Use `sessions_spawn` with `visible: true` to create a persistent dashboard session. Pass `category` to place it in a sidebar group atomically; omit `category` or pass an empty string to leave it ungrouped. This keeps session creation on the controlled spawn path, which enforces the parent's tool policy, sandbox, concurrency limits, and run timeout.
+Use `sessions_spawn` with `visible: true` when the new session should run a delegated task as a child. Pass `category` to place it in a sidebar group atomically; omit `category` or pass an empty string to leave it ungrouped. The spawn path enforces the parent's tool policy, sandbox, depth, concurrency limits, and run timeout. Use `sessions action=create` instead when the new session must be an independent sibling with no parent lifecycle relationship.
 
 An agent-selected model patch stays reversible until that selection completes a successful run. If the selected model is definitively unusable because of authentication, billing, or model-not-found failure, OpenClaw restores the previous model and writes a visible system note. Transient rate-limit, overload, timeout, network, and server failures do not undo the selection.
 

--- a/src/agents/cron-creator-authority-context.ts
+++ b/src/agents/cron-creator-authority-context.ts
@@ -4,9 +4,12 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { CronScheduledToolCallerOrigin } from "../cron/scheduled-tool-policy.js";
 import {
   createCronCreatorAuthorityRunScope,
+  mintDetachedSessionCreationAuthority,
   mintCronCreatorAuthorityGrant,
+  registerCronCreatorAuthorityCleanup,
   revokeCronCreatorAuthorityRunScope,
   type CronCreatorAuthorityRunScope,
+  type DetachedSessionCreationAuthority,
 } from "../gateway/cron-creator-authority-grant.js";
 import type {
   CronCreatorToolAuthorityMaterialization,
@@ -178,6 +181,8 @@ export function bindActiveOperatorTurnAuthority(runId: string | undefined):
   | {
       source: "channel-owner" | "local";
       assertActive: () => void;
+      detachedSessionAuthority: DetachedSessionCreationAuthority;
+      onClose: (cleanup: () => void) => void;
     }
   | undefined {
   const authority = activeCronCreatorAuthority.getStore();
@@ -199,5 +204,10 @@ export function bindActiveOperatorTurnAuthority(runId: string | undefined):
         throw new Error("operator turn authority is no longer active");
       }
     },
+    detachedSessionAuthority: mintDetachedSessionCreationAuthority(
+      authority,
+      authority.callerOrigin.kind === "local",
+    ),
+    onClose: (cleanup) => registerCronCreatorAuthorityCleanup(authority, cleanup),
   };
 }

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -359,6 +359,7 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
           createSessionsTool({
             agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
             agentSessionId: options?.sessionId,
+            runId: options?.runId,
             requesterAgentIdOverride: sessionAgentId,
             sandboxed: options?.sandboxed,
             config: resolvedConfig,

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -368,6 +368,7 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       emoji: "🗂️",
       title: "Session Settings",
       actions: {
+        create: { label: "create", detailKeys: ["agentId", "label", "permissionMode"] },
         patch: {
           label: "update",
           detailKeys: ["sessionKey", "label", "pinned", "archived", "model", "thinkingLevel"],

--- a/src/agents/tools/in-process-gateway.ts
+++ b/src/agents/tools/in-process-gateway.ts
@@ -36,6 +36,7 @@ type AgentToolGatewayRequest = Pick<
 > & {
   agentRunTracking?: GatewayAgentRunTaskOwner;
   agentToolCaller?: TrustedAgentToolCaller;
+  sessionCreation?: TrustedSessionCreation;
 };
 
 const agentToolGatewayRuntimeIdentities = new WeakMap<object, AgentRuntimeIdentity>();
@@ -80,10 +81,14 @@ export const callAgentToolGatewayRequest: AgentToolGatewayRequestCaller = async 
     if (runtimeIdentity) {
       throw new Error("trusted agent runtime identity requires in-process Gateway dispatch");
     }
+    if (request.sessionCreation?.detachedAuthority) {
+      throw new Error("detached session authority requires in-process Gateway dispatch");
+    }
     const { callGateway } = await import("../../gateway/call.js");
     const {
       agentRunTracking: _agentRunTracking,
       agentToolCaller: _agentToolCaller,
+      sessionCreation: _sessionCreation,
       ...wireRequest
     } = request;
     return await callGateway<T>(wireRequest);
@@ -98,6 +103,7 @@ export const callAgentToolGatewayRequest: AgentToolGatewayRequestCaller = async 
     forceSyntheticClient: true,
     ...(request.agentRunTracking ? { agentRunTracking: request.agentRunTracking } : {}),
     ...(request.agentToolCaller ? { agentToolCaller: request.agentToolCaller } : {}),
+    ...(request.sessionCreation ? { sessionCreation: request.sessionCreation } : {}),
     syntheticScopes: scopes,
     ...(request.expectFinal !== undefined ? { expectFinal: request.expectFinal } : {}),
     ...(request.onAccepted ? { onAccepted: request.onAccepted } : {}),

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -30,6 +30,7 @@ import {
 
 export {
   createAgentToAgentPolicy,
+  createSessionVisibilityChecker,
   createSessionVisibilityRowChecker,
   resolveEffectiveSessionToolsVisibility,
 } from "../../plugin-sdk/session-visibility.js";

--- a/src/agents/tools/sessions-tool-create.ts
+++ b/src/agents/tools/sessions-tool-create.ts
@@ -1,0 +1,102 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { SessionsCreateResult } from "../../../packages/gateway-protocol/src/index.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveSessionAgentId } from "../agent-scope.js";
+import { bindActiveOperatorTurnAuthority } from "../cron-creator-authority-context.js";
+import {
+  jsonResult,
+  readToolStringParam,
+  ToolAuthorizationError,
+  ToolInputError,
+} from "./common.js";
+import type { AgentToolGatewayRequestCaller } from "./in-process-gateway.js";
+import { createAgentToAgentPolicy, createSessionVisibilityChecker } from "./sessions-access.js";
+import { resolveSessionToolContext } from "./sessions-helpers.js";
+
+export const SESSION_CREATE_PERMISSION_MODES = [
+  "read-only",
+  "guarded",
+  "workspace",
+  "full",
+] as const;
+const PERMISSION_MODE_VALUES: ReadonlySet<string> = new Set(SESSION_CREATE_PERMISSION_MODES);
+
+export function prepareDetachedSessionCreation(options: {
+  agentSessionKey?: string;
+  requesterAgentIdOverride?: string;
+  runId?: string;
+  config?: OpenClawConfig;
+  callGateway: AgentToolGatewayRequestCaller;
+}) {
+  const authority = bindActiveOperatorTurnAuthority(options.runId);
+  if (!authority) {
+    return undefined;
+  }
+  const context = resolveSessionToolContext(options);
+  const requesterAgentId = resolveSessionAgentId({
+    config: context.cfg,
+    sessionKey: context.effectiveRequesterKey,
+    agentId: options.requesterAgentIdOverride,
+  });
+  const createdSessionIds = new Map<string, string>();
+  const unregister = createSessionVisibilityChecker.registerScopedAccessProvider((request) => {
+    if (
+      request.action !== "send" ||
+      request.requesterSessionKey !== context.effectiveRequesterKey
+    ) {
+      return undefined;
+    }
+    authority.assertActive();
+    const expectedSessionId = createdSessionIds.get(request.targetSessionKey);
+    return expectedSessionId ? { expectedSessionId } : undefined;
+  });
+  authority.onClose(unregister);
+  const admin = authority.source === "local";
+
+  return {
+    admin,
+    execute: async (params: Record<string, unknown>) => {
+      authority.assertActive();
+      const permissionMode = readToolStringParam(params, "permissionMode") ?? "guarded";
+      if (!PERMISSION_MODE_VALUES.has(permissionMode)) {
+        throw new ToolInputError("permissionMode must be read-only, guarded, workspace, or full");
+      }
+      if (permissionMode === "full" && !admin) {
+        throw new ToolAuthorizationError(
+          "Ask an administrator to create a full session from a direct local operator turn, or choose guarded, workspace, or read-only.",
+        );
+      }
+      const agentId =
+        normalizeOptionalString(readToolStringParam(params, "agentId")) ?? requesterAgentId;
+      if (
+        agentId !== requesterAgentId &&
+        !createAgentToAgentPolicy(context.cfg).isAllowed(requesterAgentId, agentId)
+      ) {
+        throw new ToolAuthorizationError(
+          "Cross-agent session creation requires tools.agentToAgent.enabled and an allow rule for both agents.",
+        );
+      }
+      const label = normalizeOptionalString(readToolStringParam(params, "label"));
+      const result = await options.callGateway<SessionsCreateResult>({
+        method: "sessions.create",
+        params: { agentId, ...(label ? { label } : {}), permissionMode },
+        sessionCreation: {
+          via: "operator",
+          actor: { type: "agent", id: requesterAgentId },
+          detachedAuthority: authority.detachedSessionAuthority,
+        },
+      });
+      if (!result.sessionId) {
+        throw new ToolInputError("Session creation did not return its durable session identity");
+      }
+      createdSessionIds.set(result.key, result.sessionId);
+      return jsonResult({
+        status: "created",
+        key: result.key,
+        sessionId: result.sessionId,
+        mode: permissionMode,
+        nextStep: "Use sessions_send with this key to start work in the detached session.",
+      });
+    },
+  };
+}

--- a/src/agents/tools/sessions-tool.create.test.ts
+++ b/src/agents/tools/sessions-tool.create.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import { revokeCronCreatorAuthorityRunScope } from "../../gateway/cron-creator-authority-grant.js";
+import { createSessionVisibilityChecker } from "../../plugin-sdk/session-visibility.js";
+import {
+  createCronCreatorAuthorityCapability,
+  runWithCronCreatorAuthorityCapability,
+} from "../cron-creator-authority-context.js";
+import type { AgentToolGatewayRequestCaller } from "./in-process-gateway.js";
+import { createSessionsTool } from "./sessions-tool.js";
+
+type GatewayRequest = Parameters<AgentToolGatewayRequestCaller>[0];
+
+describe("sessions tool detached creation", () => {
+  it("exposes create only during an admitted operator turn", async () => {
+    const unavailable = createSessionsTool({ agentSessionKey: "agent:main:main", runId: "run" });
+    const action = (unavailable.parameters as { properties: { action: { enum: string[] } } })
+      .properties.action;
+    expect(action.enum).not.toContain("create");
+
+    const authority = createCronCreatorAuthorityCapability("run", {
+      kind: "external",
+      channel: "discord",
+    })!;
+    await runWithCronCreatorAuthorityCapability(authority, async () => {
+      const tool = createSessionsTool({ agentSessionKey: "agent:main:main", runId: "run" });
+      expect(tool.parameters).toMatchObject({
+        properties: {
+          action: { enum: expect.arrayContaining(["create"]) },
+          permissionMode: { enum: ["read-only", "guarded", "workspace"] },
+        },
+      });
+      expect(tool.parameters).not.toHaveProperty("properties.parentSessionKey");
+      expect(tool.parameters).not.toHaveProperty("properties.fork");
+    });
+  });
+
+  it("creates a full detached session with live local admin authority", async () => {
+    let request: GatewayRequest | undefined;
+    const callGateway: AgentToolGatewayRequestCaller = async <T>(next: GatewayRequest) => {
+      request = next;
+      next.sessionCreation?.detachedAuthority?.assertActive();
+      return {
+        ok: true,
+        key: "agent:research:dashboard:detached",
+        sessionId: "detached-session",
+      } as T;
+    };
+    const authority = createCronCreatorAuthorityCapability("admin-run", { kind: "local" })!;
+
+    await runWithCronCreatorAuthorityCapability(authority, async () => {
+      const tool = createSessionsTool({
+        agentSessionKey: "agent:main:main",
+        requesterAgentIdOverride: "main",
+        runId: "admin-run",
+        config: { tools: { agentToAgent: { enabled: true } } },
+        callGateway,
+      });
+      const result = await tool.execute("create-detached", {
+        action: "create",
+        agentId: "research",
+        label: "Research",
+        permissionMode: "full",
+      });
+
+      expect(request).toMatchObject({
+        method: "sessions.create",
+        params: { agentId: "research", label: "Research", permissionMode: "full" },
+        sessionCreation: {
+          via: "operator",
+          actor: { type: "agent", id: "main" },
+          detachedAuthority: { admin: true },
+        },
+      });
+      expect(result.details).toEqual({
+        status: "created",
+        key: "agent:research:dashboard:detached",
+        sessionId: "detached-session",
+        mode: "full",
+        nextStep: "Use sessions_send with this key to start work in the detached session.",
+      });
+      expect(
+        createSessionVisibilityChecker.resolveScopedAccess({
+          action: "send",
+          requesterSessionKey: "agent:main:main",
+          targetSessionKey: "agent:research:dashboard:detached",
+        }),
+      ).toEqual({ expectedSessionId: "detached-session" });
+    });
+    expect(
+      createSessionVisibilityChecker.resolveScopedAccess({
+        action: "send",
+        requesterSessionKey: "agent:main:main",
+        targetSessionKey: "agent:research:dashboard:detached",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns the committed receipt when authority closes with the gateway response", async () => {
+    const authority = createCronCreatorAuthorityCapability("run", { kind: "local" })!;
+    const callGateway: AgentToolGatewayRequestCaller = async <T>() => {
+      revokeCronCreatorAuthorityRunScope(authority);
+      return { ok: true, key: "agent:main:dashboard:committed", sessionId: "committed" } as T;
+    };
+
+    await runWithCronCreatorAuthorityCapability(authority, async () => {
+      const tool = createSessionsTool({
+        agentSessionKey: "agent:main:main",
+        runId: "run",
+        callGateway,
+      });
+      await expect(tool.execute("create", { action: "create" })).resolves.toMatchObject({
+        details: { status: "created", sessionId: "committed" },
+      });
+    });
+  });
+
+  it("rejects full creation without real admin authority", async () => {
+    const callGateway = vi.fn();
+    const authority = createCronCreatorAuthorityCapability("run", {
+      kind: "external",
+      channel: "discord",
+    })!;
+    await runWithCronCreatorAuthorityCapability(authority, async () => {
+      const tool = createSessionsTool({
+        agentSessionKey: "agent:main:main",
+        runId: "run",
+        callGateway,
+      });
+      await expect(
+        tool.execute("create-full", { action: "create", permissionMode: "full" }),
+      ).rejects.toThrow("Ask an administrator to create a full session");
+    });
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it("keeps cross-agent creation behind the agent-to-agent policy", async () => {
+    const callGateway = vi.fn();
+    const authority = createCronCreatorAuthorityCapability("run", { kind: "local" })!;
+    await runWithCronCreatorAuthorityCapability(authority, async () => {
+      const tool = createSessionsTool({
+        agentSessionKey: "agent:main:main",
+        requesterAgentIdOverride: "main",
+        runId: "run",
+        callGateway,
+      });
+      await expect(
+        tool.execute("cross-agent", { action: "create", agentId: "research" }),
+      ).rejects.toThrow("Cross-agent session creation requires tools.agentToAgent.enabled");
+    });
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+
+  it("expires a retained create tool when admitted authority closes", async () => {
+    const callGateway = vi.fn();
+    const authority = createCronCreatorAuthorityCapability("run", { kind: "local" })!;
+    let retained: ReturnType<typeof createSessionsTool> | undefined;
+    await runWithCronCreatorAuthorityCapability(authority, async () => {
+      retained = createSessionsTool({
+        agentSessionKey: "agent:main:main",
+        runId: "run",
+        callGateway,
+      });
+    });
+
+    await expect(
+      retained?.execute("stale-create", { action: "create", permissionMode: "guarded" }),
+    ).rejects.toThrow("authority is no longer active");
+    expect(callGateway).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/tools/sessions-tool.test.ts
+++ b/src/agents/tools/sessions-tool.test.ts
@@ -180,23 +180,6 @@ describe("sessions tool", () => {
     expect(tool.parameters).not.toHaveProperty("properties.message");
   });
 
-  it("does not expose direct session creation outside controlled spawning", async () => {
-    const callGateway = vi.fn();
-    const tool = createSessionsTool({
-      agentSessionKey: "agent:main:main",
-      config: {},
-      callGateway,
-    });
-
-    await expect(tool.execute("create-uncontrolled-session", { action: "create" })).rejects.toThrow(
-      "Unknown action: create",
-    );
-    expect(tool.parameters).not.toHaveProperty("properties.parentSessionKey");
-    expect(tool.parameters).not.toHaveProperty("properties.agentId");
-    expect(tool.parameters).not.toHaveProperty("properties.fork");
-    expect(callGateway).not.toHaveBeenCalled();
-  });
-
   it("assigns a visible session owner and returns the projected identity", async () => {
     const callGateway = vi.fn(async (request: { method: string }) => {
       if (request.method !== "sessions.assignOwner") {

--- a/src/agents/tools/sessions-tool.ts
+++ b/src/agents/tools/sessions-tool.ts
@@ -44,6 +44,10 @@ import {
 } from "./sessions-access.js";
 import { resolveSessionToolContext } from "./sessions-helpers.js";
 import { resolveSessionReference, shouldResolveSessionIdInput } from "./sessions-resolution.js";
+import {
+  prepareDetachedSessionCreation,
+  SESSION_CREATE_PERMISSION_MODES,
+} from "./sessions-tool-create.js";
 
 const ACTIONS = [
   "patch",
@@ -162,9 +166,27 @@ const SessionsToolSchema = Type.Object(
   { additionalProperties: false },
 );
 
+function buildSessionsCreateSchema(admin: boolean) {
+  const permissionModes = admin
+    ? SESSION_CREATE_PERMISSION_MODES
+    : SESSION_CREATE_PERMISSION_MODES.slice(0, -1);
+  return Type.Object(
+    {
+      ...SessionsToolSchema.properties,
+      action: stringEnum(["create", ...ACTIONS] as const, { description: "Action" }),
+      agentId: Type.Optional(
+        Type.String({ description: "Configured agent for a newly created detached session" }),
+      ),
+      permissionMode: Type.Optional(stringEnum(permissionModes)),
+    },
+    { additionalProperties: false },
+  );
+}
+
 type SessionsToolOptions = {
   agentSessionKey?: string;
   agentSessionId?: string;
+  runId?: string;
   requesterAgentIdOverride?: string;
   sandboxed?: boolean;
   config?: OpenClawConfig;
@@ -325,6 +347,7 @@ async function resolvePatchTarget(
 
 export function createSessionsTool(opts: SessionsToolOptions = {}): AnyAgentTool {
   const gatewayRequest = opts.callGateway ?? callAgentToolGatewayRequest;
+  const detachedCreate = prepareDetachedSessionCreation({ ...opts, callGateway: gatewayRequest });
   const callGateway = <T = Record<string, unknown>>(
     method: string,
     params: Record<string, unknown>,
@@ -332,12 +355,23 @@ export function createSessionsTool(opts: SessionsToolOptions = {}): AnyAgentTool
   return {
     label: "Sessions",
     name: "sessions",
-    description:
-      "Session settings, ownership, reset, delete, and sidebar categories: patch label/icon/category/status, pin, archive/restore, model/thinking override; category assigns one session while group_set replaces the ordered category catalog; assign_owner hands responsibility to a human or agent; reset/delete visible sessions; group_list/group_set/group_rename/group_delete.",
-    parameters: SessionsToolSchema,
+    description: detachedCreate
+      ? "Create detached sessions; patch visible session settings and ownership; reset/delete sessions; manage sidebar categories."
+      : "Patch visible session settings and ownership; reset/delete sessions; manage sidebar categories.",
+    parameters: detachedCreate
+      ? buildSessionsCreateSchema(detachedCreate.admin)
+      : SessionsToolSchema,
     execute: async (_toolCallId, rawArgs) => {
       const params = rawArgs as Record<string, unknown>;
       const action = readToolStringParam(params, "action", { required: true });
+      if (action === "create") {
+        if (!detachedCreate) {
+          throw new ToolAuthorizationError(
+            "Detached session creation is available only during a direct admitted operator turn.",
+          );
+        }
+        return await detachedCreate.execute(params);
+      }
       if (action === "reset" || action === "delete") {
         const rawKey = readToolStringParam(params, "sessionKey", { required: true });
         const { agentId, isRequesterSession, key } = await resolvePatchTarget(

--- a/src/config/sessions/session-entry-provenance.ts
+++ b/src/config/sessions/session-entry-provenance.ts
@@ -36,7 +36,7 @@ export type SessionOwnerAssignment = {
   assignedAt?: number;
 };
 export type SessionCreatedVia =
-  | "operator" // gateway sessions.create (Control UI / operator clients)
+  | "operator" // gateway sessions.create (Control UI, operator clients, or admitted agent tool)
   | "spawn" // sessions_spawn native or ACP subagent spawn
   | "channel" // inbound channel conversation materialization
   | "cron"

--- a/src/gateway/cron-creator-authority-grant.ts
+++ b/src/gateway/cron-creator-authority-grant.ts
@@ -15,9 +15,15 @@ export type CronCreatorAuthorityRunScope = {
   readonly callerOrigin: CronScheduledToolCallerOrigin;
   readonly signal: AbortSignal;
   readonly grantTokens: Set<string>;
+  readonly onRevoke: Set<() => void>;
   active: boolean;
   abort: () => void;
 };
+
+export type DetachedSessionCreationAuthority = Readonly<{
+  admin: boolean;
+  assertActive: () => void;
+}>;
 
 type CronCreatorAuthorityGrantEntry = {
   scope: CronCreatorAuthorityRunScope;
@@ -27,6 +33,7 @@ type CronCreatorAuthorityGrantEntry = {
 };
 
 const grantsByToken = new Map<string, CronCreatorAuthorityGrantEntry>();
+const detachedSessionAuthorities = new WeakSet<object>();
 
 function expiredAuthorityError(): Error & { status: number } {
   return Object.assign(
@@ -47,6 +54,7 @@ export function createCronCreatorAuthorityRunScope(
     callerOrigin: normalizeCronScheduledToolCallerOrigin(callerOrigin),
     signal: abortController.signal,
     grantTokens: new Set(),
+    onRevoke: new Set(),
     active: true,
     abort: () => abortController.abort(expiredAuthorityError()),
   };
@@ -101,9 +109,48 @@ export function revokeCronCreatorAuthorityRunScope(scope: CronCreatorAuthorityRu
   }
   scope.active = false;
   scope.abort();
+  for (const cleanup of scope.onRevoke) {
+    cleanup();
+  }
+  scope.onRevoke.clear();
   for (const token of scope.grantTokens) {
     revokeCronCreatorAuthorityGrant(token);
   }
+}
+
+export function mintDetachedSessionCreationAuthority(
+  scope: CronCreatorAuthorityRunScope,
+  admin: boolean,
+): DetachedSessionCreationAuthority {
+  const authority = Object.freeze({
+    admin,
+    assertActive: () => {
+      scope.signal.throwIfAborted();
+      if (!scope.active) {
+        scope.signal.throwIfAborted();
+      }
+    },
+  });
+  authority.assertActive();
+  detachedSessionAuthorities.add(authority);
+  return authority;
+}
+
+export function registerCronCreatorAuthorityCleanup(
+  scope: CronCreatorAuthorityRunScope,
+  cleanup: () => void,
+): void {
+  if (!scope.active || scope.signal.aborted) {
+    cleanup();
+    return;
+  }
+  scope.onRevoke.add(cleanup);
+}
+
+export function isDetachedSessionCreationAuthority(
+  value: unknown,
+): value is DetachedSessionCreationAuthority {
+  return typeof value === "object" && value !== null && detachedSessionAuthorities.has(value);
 }
 
 /** Consumes one live exact-run grant synchronously at the cron commit boundary. */

--- a/src/gateway/server-methods/session-creation-provenance.ts
+++ b/src/gateway/server-methods/session-creation-provenance.ts
@@ -3,10 +3,13 @@ import type {
   SessionCreatedVia,
 } from "../../config/sessions/session-entry-provenance.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
+import type { DetachedSessionCreationAuthority } from "../cron-creator-authority-grant.js";
 
 export type TrustedSessionCreation = {
   via: SessionCreatedVia;
   actor?: SessionCreatedActor;
+  /** In-process authority for an agent-authored detached root creation. */
+  detachedAuthority?: DetachedSessionCreationAuthority;
   /** Exact spawning session retained separately from the stable actor identity. */
   requesterSessionKey?: string;
   /** Immutable completion recipient for a spawn-owned visible session. */

--- a/src/gateway/server-methods/session-detached-create-authority.ts
+++ b/src/gateway/server-methods/session-detached-create-authority.ts
@@ -1,0 +1,78 @@
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { isDetachedSessionCreationAuthority } from "../cron-creator-authority-grant.js";
+import type { TrustedSessionCreation } from "./session-creation-provenance.js";
+
+export class DetachedSessionAuthorityExpiredError extends TypeError {}
+
+export function resolveDetachedSessionAuthority(params: {
+  creation: TrustedSessionCreation;
+  hasInitialTurn: boolean;
+  parentSessionKey?: string;
+  spawnDepth?: number;
+  fork?: boolean;
+  forkFrom?: "last-completed";
+  succeedsParent?: boolean;
+  permissionMode?: string;
+}) {
+  const supplied = params.creation.detachedAuthority;
+  if (!supplied) {
+    return { authority: undefined };
+  }
+  if (!isDetachedSessionCreationAuthority(supplied)) {
+    return {
+      error: errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        "Detached session creation authority is invalid.",
+      ),
+    };
+  }
+  const hasLineage =
+    params.parentSessionKey !== undefined ||
+    params.spawnDepth !== undefined ||
+    params.fork === true ||
+    params.forkFrom !== undefined ||
+    params.succeedsParent !== undefined;
+  if (
+    params.creation.via !== "operator" ||
+    params.creation.actor?.type !== "agent" ||
+    hasLineage ||
+    params.hasInitialTurn
+  ) {
+    return {
+      error: errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        "Detached session creation cannot include parent, spawn, fork, successor, or initial-turn state.",
+      ),
+    };
+  }
+  if (params.permissionMode === "full" && !supplied.admin) {
+    return {
+      error: errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        "permissionMode full requires an admitted local administrator turn. Ask an administrator to create the full session.",
+      ),
+    };
+  }
+  try {
+    supplied.assertActive();
+  } catch {
+    return {
+      error: errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        "Detached session creation authority is no longer active. Retry from a new direct operator turn.",
+      ),
+    };
+  }
+  return {
+    authority: supplied,
+    assertActive: () => {
+      try {
+        supplied.assertActive();
+      } catch {
+        throw new DetachedSessionAuthorityExpiredError(
+          "Detached session creation authority is no longer active. Retry from a new direct operator turn.",
+        );
+      }
+    },
+  };
+}

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -49,6 +49,10 @@ import {
 } from "./session-create-initial-turn.js";
 import { prepareSessionCreateFilesystemRoot } from "./session-create-root.js";
 import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
+import {
+  DetachedSessionAuthorityExpiredError,
+  resolveDetachedSessionAuthority,
+} from "./session-detached-create-authority.js";
 import { sessionLog } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -147,6 +151,21 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       hasInitialTurn,
       message: initialMessage,
     } = initialTurn;
+    const sessionCreation = resolveOperatorSessionCreation(client, { allowTrustedHint: true });
+    const detached = resolveDetachedSessionAuthority({
+      creation: sessionCreation,
+      hasInitialTurn,
+      parentSessionKey,
+      spawnDepth: p.spawnDepth,
+      fork: p.fork,
+      forkFrom: p.forkFrom,
+      succeedsParent: p.succeedsParent,
+      permissionMode: p.permissionMode,
+    });
+    if (detached.error) {
+      respond(false, undefined, detached.error);
+      return;
+    }
     let requestedCwd = normalizeOptionalString(p.cwd);
     const requestedExecNode = normalizeOptionalString(p.execNode);
     const requestedProjectId = normalizeOptionalString(p.projectId);
@@ -485,7 +504,6 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
     let runError: unknown;
     let runMeta: Record<string, unknown> | undefined;
     let messageSeq: number | undefined;
-    const sessionCreation = resolveOperatorSessionCreation(client, { allowTrustedHint: true });
     const spawnRequesterSessionKey =
       sessionCreation.via === "spawn"
         ? normalizeOptionalString(sessionCreation.requesterSessionKey)
@@ -502,6 +520,13 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       ADMIN_SCOPE,
       clientScopes,
     ).allowed;
+    const createCommitGuard =
+      commitGuard || detached.assertActive
+        ? () => {
+            commitGuard?.();
+            detached.assertActive?.();
+          }
+        : undefined;
     const modelCatalogAgentId = sessionAgentId;
     if (!authority.ensureActive()) {
       return;
@@ -521,6 +546,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       visibility: p.visibility,
       allowExistingModelSelection,
       parentSessionKey,
+      detachedRoot: detached.authority !== undefined,
       spawnDepth: p.spawnDepth,
       spawnToolPolicy:
         sessionCreation.via === "spawn" && sessionCreation.inheritedToolPolicy
@@ -556,7 +582,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       armSessionDiffBaselineCapture: true,
       loadGatewayModelCatalog: () =>
         context.loadGatewayModelCatalog({ agentId: modelCatalogAgentId }),
-      ...(commitGuard ? { commitGuard } : {}),
+      ...(createCommitGuard ? { commitGuard: createCommitGuard } : {}),
       afterCreate: async ({ key, agentId, entry, storePath }) => {
         if (!authority.hasActive()) {
           return;
@@ -602,7 +628,13 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
           });
         }
       },
-    }).catch((error: unknown) => authority.handleClosedError(error));
+    }).catch((error: unknown) => {
+      if (error instanceof DetachedSessionAuthorityExpiredError) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, error.message));
+        return undefined;
+      }
+      return authority.handleClosedError(error);
+    });
     if (!created) {
       return;
     }

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -43,6 +43,11 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import {
+  createCronCreatorAuthorityRunScope,
+  mintDetachedSessionCreationAuthority,
+  revokeCronCreatorAuthorityRunScope,
+} from "./cron-creator-authority-grant.js";
+import {
   attachGatewayLocalUserIngress,
   prepareGatewayLocalUserIngress,
 } from "./local-user-ingress.js";
@@ -2985,6 +2990,57 @@ test.each([undefined, "main"])(
   },
 );
 
+test("sessions.create commits an admitted agent-tool creation as a detached root", async () => {
+  const { storePath } = await createSessionStoreDir();
+  testState.sessionConfig = { dmScope: "main" };
+  const scope = createCronCreatorAuthorityRunScope("detached-admin", { kind: "local" });
+  const authority = mintDetachedSessionCreationAuthority(scope, true);
+
+  const created = await directSessionReq<{
+    key?: string;
+    entry?: {
+      createdVia?: string;
+      createdActor?: { type?: string; id?: string };
+      parentSessionKey?: string;
+      spawnedBy?: string;
+      spawnDepth?: number;
+      permissionMode?: string;
+    };
+  }>(
+    "sessions.create",
+    { agentId: "main", label: "Detached", permissionMode: "full" },
+    {
+      client: {
+        connect: { scopes: ["operator.admin"] },
+        internal: {
+          syntheticClient: true,
+          sessionCreation: {
+            via: "operator",
+            actor: { type: "agent", id: "main" },
+            detachedAuthority: authority,
+          },
+        },
+      } as never,
+    },
+  );
+
+  expect(created.ok, JSON.stringify(created.error)).toBe(true);
+  expect(created.payload?.entry).toMatchObject({
+    createdVia: "operator",
+    createdActor: { type: "agent", id: "main" },
+    spawnDepth: 0,
+    permissionMode: "full",
+  });
+  expect(created.payload?.entry).not.toHaveProperty("parentSessionKey");
+  expect(created.payload?.entry).not.toHaveProperty("spawnedBy");
+  expect(() => authority.assertActive()).not.toThrow();
+  const key = requireNonEmptyString(created.payload?.key, "detached session key");
+  expect(loadSessionEntry({ agentId: "main", sessionKey: key, storePath })).toMatchObject({
+    spawnDepth: 0,
+    permissionMode: "full",
+  });
+});
+
 test("sessions.create preserves an explicit parent under main dmScope", async () => {
   await createSessionStoreDir();
   testState.sessionConfig = { dmScope: "main" };
@@ -3207,6 +3263,84 @@ test("sessions.create commits no session after delegated authority closes", asyn
 
   expect(created.ok).toBe(false);
   expect(created.error?.message).toContain("agent runtime authority is no longer active");
+  expect(
+    loadCombinedSessionStoreForGatewayCore(getRuntimeConfig()).store[sessionKey],
+  ).toBeUndefined();
+});
+
+test("sessions.create commits no detached root after its turn authority closes", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:dashboard:detached-authority-race";
+  const scope = createCronCreatorAuthorityRunScope("detached-stale", { kind: "local" });
+  const authority = mintDetachedSessionCreationAuthority(scope, false);
+  const writerEntered = createDeferredCore();
+  const releaseWriter = createDeferredCore();
+  const resolvedStore = resolveSqliteStoreScope(storePath, { agentId: "main" });
+  const heldWriter = runExclusiveSqliteSessionWrite(resolvedStore, async () => {
+    writerEntered.resolve();
+    await releaseWriter.promise;
+  });
+  await writerEntered.promise;
+
+  const creating = directSessionReq(
+    "sessions.create",
+    { agentId: "main", key: sessionKey, permissionMode: "guarded" },
+    {
+      client: {
+        connect: { scopes: ["operator.write"] },
+        internal: {
+          syntheticClient: true,
+          sessionCreation: {
+            via: "operator",
+            actor: { type: "agent", id: "main" },
+            detachedAuthority: authority,
+          },
+        },
+      } as never,
+    },
+  );
+  try {
+    await vi.waitFor(() =>
+      expect(isSessionLifecycleMutationActive(storePath, [sessionKey])).toBe(true),
+    );
+    revokeCronCreatorAuthorityRunScope(scope);
+  } finally {
+    releaseWriter.resolve();
+    await heldWriter;
+  }
+  const created = await creating;
+
+  expect(created.ok).toBe(false);
+  expect(created.error?.message).toContain("authority is no longer active");
+  expect(
+    loadCombinedSessionStoreForGatewayCore(getRuntimeConfig()).store[sessionKey],
+  ).toBeUndefined();
+});
+
+test("sessions.create rejects a forged detached authority", async () => {
+  await createSessionStoreDir();
+  const sessionKey = "agent:main:dashboard:forged-detached-authority";
+
+  const created = await directSessionReq(
+    "sessions.create",
+    { agentId: "main", key: sessionKey, permissionMode: "full" },
+    {
+      client: {
+        connect: { scopes: ["operator.admin"] },
+        internal: {
+          syntheticClient: true,
+          sessionCreation: {
+            via: "operator",
+            actor: { type: "agent", id: "main" },
+            detachedAuthority: { admin: true, assertActive: () => {} },
+          },
+        },
+      } as never,
+    },
+  );
+
+  expect(created.ok).toBe(false);
+  expect(created.error?.message).toBe("Detached session creation authority is invalid.");
   expect(
     loadCombinedSessionStoreForGatewayCore(getRuntimeConfig()).store[sessionKey],
   ).toBeUndefined();

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -341,6 +341,8 @@ export async function createGatewaySession(params: {
   requestingOperatorScopes?: readonly string[];
   /** Trusted in-process creation provenance; never populated from public Gateway params. */
   creation?: { via: SessionCreatedVia; actor?: SessionCreatedActor };
+  /** Authorized agent-tool creation that must not join navigation or spawn lineage. */
+  detachedRoot?: boolean;
   /** Exact harness namespace authorized by the scoped plugin runtime. */
   authorizedAgentHarnessId?: string;
   /** Exact plugin namespace authorized by the scoped plugin runtime. */
@@ -658,6 +660,7 @@ export async function createGatewaySession(params: {
   // Incognito roots omit durable lineage so notices cannot cross the storage boundary.
   const dashboardParentSessionKey =
     !parentSessionKey &&
+    params.detachedRoot !== true &&
     !params.authorizedPluginId &&
     !incognito &&
     params.fork !== true &&


### PR DESCRIPTION
Closes #128233

## What Problem This Solves

Agents could only create persistent sessions through `sessions_spawn`, which makes the new session a parent-bound child. That is the wrong lifecycle when the agent needs an independent sibling session with no spawn lineage, depth/child-count relationship, inherited subagent policy, or creator-owned cleanup.

## Why This Change Was Made

Adds a narrow `sessions action=create` contract for idle detached roots and routes it through the existing in-process `sessions.create` Gateway owner. The action is visible only during a direct admitted operator turn. `permissionMode: "full"` additionally requires real local administrator authority; stored full-session mode is never treated as authority. The capability is process-local, nominal, revalidated at the durable commit, and revoked with the turn.

The creator receives a temporary exact-session `sessions_send` visibility grant so the returned next step works under the default tree policy. That grant expires with the creating turn and does not become parentage, spawn lineage, ownership, or lifecycle guardianship. Cross-agent creation still requires the existing `tools.agentToAgent` policy.

This supersedes the broad direct-create prohibition recorded in #114477 only for idle detached roots. It does not add `sessions.patch` lifecycle policy, continuation, worker delegation, TUI behavior, or a protocol-version/storage change.

## User Impact

An admitted session can create a separately managed sibling session, choose its label, agent, and permission mode, then start work through `sessions_send` in the same turn. The result includes the key, durable session ID, effective permission mode, and explicit next step.

## Evidence

- Pre-fix regression: the four original tool boundary cases failed because `action=create` was unknown.
- `node scripts/run-vitest.mjs src/agents/tools/sessions-tool.create.test.ts src/agents/tools/sessions-tool.test.ts` — 35 passed.
- `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts` — 232 passed.
- `node scripts/run-vitest.mjs src/agents/tools/in-process-gateway.test.ts src/agents/cron-creator-authority-context.test.ts src/gateway/cron-creator-authority-grant.test.ts` — 24 passed.
- `node scripts/check-changed.mjs` — passed, including core/test tsgo, lint, database guards, and import-cycle checks.
- `pnpm prompt:snapshots:check` — 7 snapshot files current.
- `pnpm docs:list` — passed.
- `./.agents/skills/autoreview/scripts/autoreview --mode uncommitted --max-priority P1` — clean after addressing create-to-send visibility and post-commit receipt findings.
- `codex --dangerously-bypass-approvals-and-sandbox review --base origin/main` — no actionable correctness findings on the final staged patch. Its extra raw `tsc` attempt exhausted the review sandbox heap; repository-required `tsgo` passed through `check-changed`.
- Codex source inspected directly: `../codex/codex-rs/core/src/tools/handlers/multi_agents.rs:1-6` and `../codex/codex-rs/core/src/agent/control.rs:100-121` confirm subagents inherit one root tree and are not the detached-session model used here.

Production LOC: +325/-7 (net +318). Tests: +304/-17 (net +287). Docs: +16/-15 (net +1). The production growth implements the new model-visible action, closure-bound authority, temporary exact-session access, and Gateway commit validation; persistence remains in the existing `sessions.create` owner.

AI-assisted. No live UI/channel proof: this is a model-tool and Gateway boundary change with no Control UI surface; focused real router/store tests exercise the final persisted behavior.
