### PR TITLE
docs(slack): use canonical postAs key

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1959,7 +1959,7 @@ Primary reference: [Configuration reference - Slack](/gateway/config-channels#sl
 
 <Accordion title="High-signal Slack fields">
 
-- mode/auth: `identity`, `mode`, `botToken`, `appToken`, `userToken`, `signingSecret`, `webhookPath`, `accounts.*`
+- mode/auth: `postAs`, `mode`, `botToken`, `appToken`, `userToken`, `signingSecret`, `webhookPath`, `accounts.*`
 - DM access: `dm.enabled`, `dmPolicy`, `allowFrom` (legacy: `dm.policy`, `dm.allowFrom`), `dm.groupEnabled`, `dm.groupChannels`
 - compatibility toggle: `dangerouslyAllowNameMatching` (break-glass; keep off unless needed)
 - channel access: `groupPolicy`, `channels.*`, `channels.*.users`, `channels.*.requireMention`, `implicitMentions.*`

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -466,7 +466,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 
 - **Socket mode** requires both `botToken` and `appToken` (`SLACK_BOT_TOKEN` + `SLACK_APP_TOKEN` for default account env fallback).
 - **HTTP mode** requires `botToken` plus `signingSecret` (at root or per-account).
-- **User identity** (`identity: "user"`) posts and reads as the authorizing human. It requires `userToken` plus `appToken` in Socket Mode, or `userToken` plus `signingSecret` in HTTP mode. No bot token or bot user is required. See [User identity](/channels/slack#user-identity-post-as-a-real-person) for user scopes and event subscriptions.
+- **User identity** (`postAs: "user"`) posts and reads as the authorizing human. It requires `userToken` plus `appToken` in Socket Mode, or `userToken` plus `signingSecret` in HTTP mode. No bot token or bot user is required. See [User identity](/channels/slack#user-identity-post-as-a-real-person) for user scopes and event subscriptions.
 - Slack detects Enterprise Grid org-wide installations automatically from the
   bot token with `auth.test`; no installation-mode setting is required.
   Enterprise DMs support `disabled`, `open`, `allowlist`, and workspace-scoped


### PR DESCRIPTION
Related: #109837
Related: #121373

@steipete, this follows the canonical Slack user-identity config shipped by those changes.

## What Problem This Solves

Slack documentation still names the retired `identity` configuration key in two reference locations, even though strict config parsing accepts `postAs` and rejects `identity`.

## Why This Change Was Made

Use the canonical `postAs` key consistently in the Slack configuration reference and high-signal field list. This is documentation-only; runtime and tests are unchanged.

## User Impact

Operators following the Slack docs now receive a configuration key that the current strict schema accepts.

## Evidence

- Red/green docs assertion: two stale `identity` references before the change, zero after.
- Strict schema probe: `postAs: "user"` accepted; `identity: "user"` rejected as an unrecognized key.
- `pnpm docs:list`
- `pnpm docs:check-config-examples`
- `git diff --check`
- `node scripts/check-changed.mjs -- docs/gateway/config-channels.md docs/channels/slack.md`
- Scope: docs `+2/-2`; production `0`; tests `0`.
