### PR TITLE
fix(agents): retire native-hook relays at gateway lifecycle rotation

### DIFF
--- a/src/agents/harness/native-hook-relay.lifecycle-rotation-ordering.test.ts
+++ b/src/agents/harness/native-hook-relay.lifecycle-rotation-ordering.test.ts
@@ -1,0 +1,72 @@
+// Covers lifecycle-rotation handler ordering: a relay admitted by an earlier
+// same-rotation handler must survive this module's own rotation sweep.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { rotateAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
+import { registerNativeHookRelay, testing } from "./native-hook-relay.js";
+
+const lifecycleMock = vi.hoisted(() => {
+  let generationSequence = 0;
+  let generation = `test-generation-${generationSequence}`;
+  const handlers = new Map<string, (nextGeneration: string) => void>();
+  return {
+    get: () => generation,
+    isCurrent: (candidate: string) => candidate === generation,
+    register: (key: string, handler: (nextGeneration: string) => void) => {
+      handlers.set(key, handler);
+    },
+    // Re-inserts an already-registered handler at the end so a handler
+    // registered afterward runs first, reproducing "an earlier same-rotation
+    // handler admits a relay" without depending on real cross-module order.
+    runHandlerLast: (key: string) => {
+      const handler = handlers.get(key);
+      if (!handler) {
+        return;
+      }
+      handlers.delete(key);
+      handlers.set(key, handler);
+    },
+    rotate: () => {
+      generationSequence += 1;
+      generation = `test-generation-${generationSequence}`;
+      for (const handler of handlers.values()) {
+        handler(generation);
+      }
+      return generation;
+    },
+  };
+});
+
+vi.mock("../../infra/agent-events.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/agent-events.js")>()),
+  getAgentEventLifecycleGeneration: lifecycleMock.get,
+  isAgentEventLifecycleGenerationCurrent: lifecycleMock.isCurrent,
+  registerAgentEventLifecycleRotationHandler: lifecycleMock.register,
+  rotateAgentEventLifecycleGeneration: lifecycleMock.rotate,
+}));
+
+afterEach(() => {
+  testing.clearNativeHookRelaysForTests();
+});
+
+describe("native hook relay lifecycle rotation ordering", () => {
+  it("preserves a relay admitted by an earlier handler during the same rotation", () => {
+    lifecycleMock.register("earlier-relay-admitter", () => {
+      registerNativeHookRelay({
+        provider: "codex",
+        relayId: "codex-admitted-mid-rotation",
+        sessionId: "session-1",
+        runId: "run-admitted-mid-rotation",
+        allowedEvents: ["pre_tool_use"],
+      });
+    });
+    // Registered after, so without this reorder it would run after (not
+    // before) the relay-admitting handler and never observe the new relay.
+    lifecycleMock.runHandlerLast("native-hook-relays");
+
+    rotateAgentEventLifecycleGeneration();
+
+    expect(
+      testing.getNativeHookRelayRegistrationForTests("codex-admitted-mid-rotation"),
+    ).toBeDefined();
+  });
+});

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -14,6 +14,7 @@ import {
   createAgentRuntimeApprovalAuthorityValidator,
   mintAgentRuntimeIdentityToken,
 } from "../../gateway/agent-runtime-identity-token.js";
+import { rotateAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { validateAgentRunDelegatedAuthority } from "../../infra/agent-run-registry.js";
 import {
   initializeGlobalHookRunner,
@@ -457,6 +458,46 @@ describe("native hook relay registry", () => {
     expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toBeDefined();
     closeAdmittedRunDelegatedAuthority(admittedRunContext);
     relay.unregister();
+  });
+
+  it("retires a retained relay's registration at lifecycle rotation without waiting for a claim release", async () => {
+    const { admittedRunContext, hostCapabilities } = await createAdmittedHostCapabilityTestFixture({
+      runId: "run-retained-rotation-cleanup",
+    });
+    const relay = registerRetainedNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-retained-rotation-cleanup",
+      sessionId: "session-1",
+      runId: "run-retained-rotation-cleanup",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: hostCapabilities.runBeforeToolCall,
+      assertActive: hostCapabilities.assertActive,
+      retention: {
+        readClaim: readTestNativeAgentId,
+        shouldRetainAfterForegroundClose: () => true,
+        allowPreToolUse: (claim) => claim === "child-thread",
+        onDispose: () => {},
+      },
+    });
+    // Foreground closes while the direct child's claim retains the relay, then
+    // lifecycle rotates without that claim ever being released — the sole
+    // production rotation path always releases claims first, so this exercises
+    // the lower-level lifecycle contract the issue reports as unenforced.
+    relay.unregister();
+    expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toBeDefined();
+
+    rotateAgentEventLifecycleGeneration();
+
+    expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toBeUndefined();
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "pre_tool_use",
+        rawPayload: { agent_id: "child-thread", tool_name: "Bash", tool_input: {} },
+      }),
+    ).rejects.toThrow("native hook relay not found");
+    closeAdmittedRunDelegatedAuthority(admittedRunContext);
   });
 
   it("keeps only a claimed flat native child after foreground cleanup", async () => {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -4,7 +4,11 @@ import {
   MAX_TIMER_TIMEOUT_MS,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
-import { registerAgentEventLifecycleRotationHandler } from "../../infra/agent-events.js";
+import {
+  getAgentEventLifecycleGeneration,
+  isAgentEventLifecycleGenerationCurrent,
+  registerAgentEventLifecycleRotationHandler,
+} from "../../infra/agent-events.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { retainBeforeToolCallForNativeHookRelay } from "./host-capability.js";
@@ -86,6 +90,8 @@ const { relays, relayBridges, invocations } = nativeHookRelayState;
 type RelayLifetime = {
   foregroundOpen: boolean;
   foregroundToken: symbol;
+  /** Gateway lifecycle generation current when this relay was registered. */
+  lifecycleGeneration: string;
   retained?: ReturnType<typeof retainBeforeToolCallForNativeHookRelay>;
   retention?: NativeHookRelayRetention;
   removeAbortListener?: () => void;
@@ -224,6 +230,7 @@ function registerNativeHookRelayInternal(
     setRelayLifetime(registration, {
       foregroundOpen: true,
       foregroundToken: Symbol("native-hook-relay-foreground"),
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
       ...(retained ? { retained } : {}),
       ...(retention ? { retention } : {}),
     });
@@ -653,6 +660,12 @@ function retireNativeHookRelaysForLifecycleRotation(): void {
   // Snapshot first: a reentrant `onDispose` may register a current-generation
   // successor mid-loop, and only registrations present at rotation start are stale.
   for (const [relayId, registration] of Array.from(relays)) {
+    // An earlier same-rotation handler may have already admitted this relay
+    // under the new generation; only the outgoing generation is stale here.
+    const lifecycleGeneration = readRelayLifetime(registration)?.lifecycleGeneration;
+    if (lifecycleGeneration && isAgentEventLifecycleGenerationCurrent(lifecycleGeneration)) {
+      continue;
+    }
     try {
       unregisterNativeHookRelay(relayId, registration);
     } catch (error) {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -4,6 +4,7 @@ import {
   MAX_TIMER_TIMEOUT_MS,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { registerAgentEventLifecycleRotationHandler } from "../../infra/agent-events.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { retainBeforeToolCallForNativeHookRelay } from "./host-capability.js";
@@ -645,6 +646,28 @@ function pruneExpiredNativeHookRelays(now = Date.now()): void {
     }
   }
 }
+
+/** Retires every relay of the outgoing generation at the same boundary that revokes its authority. */
+function retireNativeHookRelaysForLifecycleRotation(): void {
+  const errors: unknown[] = [];
+  // Snapshot first: a reentrant `onDispose` may register a current-generation
+  // successor mid-loop, and only registrations present at rotation start are stale.
+  for (const [relayId, registration] of Array.from(relays)) {
+    try {
+      unregisterNativeHookRelay(relayId, registration);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "Failed to retire stale native hook relays");
+  }
+}
+
+registerAgentEventLifecycleRotationHandler(
+  "native-hook-relays",
+  retireNativeHookRelaysForLifecycleRotation,
+);
 
 function normalizeAllowedEvents(
   events: readonly NativeHookRelayEvent[] | undefined,


### PR DESCRIPTION
Fixes #128411

## What Problem This Solves

`rotateAgentEventLifecycleGeneration()` revokes retained native-hook recovery
authority for a Gateway lifecycle rotation, but it never told the native-hook
relay registry to retire its own process-local resources. A relay that a
direct child retained across foreground close keeps its registration map
entry, localhost bridge, SQLite locator row, expiry timer, and retained
recovery lease installed after rotation — they only get cleaned up later,
through last-child release, attempt abort, same-ID replacement, or TTL
expiry. The current single production restart path (Gateway close +
Codex-harness close) always releases the child claim first, so this is not a
live leak today, but the lower-level lifecycle contract permits it, and any
future or exceptional rotation path (e.g. an in-process restart that skips
harness teardown) would accumulate stale relays, bridges, and timers.

## Why This Change Was Made

The generic relay registry now participates in the existing lifecycle-rotation
cleanup contract, the same mechanism `embedded-agent-runner/run-state.ts` and
`auto-reply/reply/reply-run-registry.registry.ts` already use via
`registerAgentEventLifecycleRotationHandler`. At rotation, `native-hook-relay.ts`
snapshots the exact relay registrations present, then compare-unregisters each
one through the existing canonical `unregisterNativeHookRelay`, which already
removes the relay map entry, bridge server/row, retained lease, invocation
state, approvals, permission state, and expiry timer together. Compare-unregister
(matching on the exact registration object, not just the relay id) means a
same-ID successor created reentrantly by an old registration's `onDispose`
survives, exactly as the existing ordinary-relay replacement path already
guarantees.

No new resource-tracking, no weakening of the existing generation assertion,
and no dependence on TTL — this only adds an eager sweep at the point
authority is already invalidated.

## User Impact

No behavior change on the current production restart path (it already
releases claims and closes clients before rotation, so there is nothing left
for the new handler to clean up in that path). It hardens the lower-level
contract so a future rotation path that skips prior cleanup fails closed
immediately — the caller gets the ordinary `"native hook relay not found"`
response instead of reaching stale retained-authority error handling — rather
than leaking a registration, bridge, and timer until a separate cleanup path
happens to run.

## Evidence

Regression test added:
`src/agents/harness/native-hook-relay.test.ts` — "retires a retained relay's
registration at lifecycle rotation without waiting for a claim release".
It registers a retained relay, closes foreground while the direct child's
claim retains it (so the relay stays registered, matching current behavior),
then rotates the lifecycle generation without releasing that claim, and
asserts the registration is gone and a follow-up invocation gets the plain
`"native hook relay not found"` response instead of invoking stale retained
policy.

Confirmed the test fails without the fix (reverted only the source file,
kept the test):

```
$ git checkout HEAD -- src/agents/harness/native-hook-relay.ts
$ node scripts/run-vitest.mjs src/agents/harness/native-hook-relay.test.ts -t "retires a retained relay"
 FAIL  native hook relay registry > retires a retained relay's registration at lifecycle rotation without waiting for a claim release
AssertionError: expected { …(12) } to be undefined
 Tests  1 failed | 118 skipped (119)
```

And passes with the fix restored:

```
$ node scripts/run-vitest.mjs src/agents/harness/native-hook-relay.test.ts
 Test Files  1 passed (1)
      Tests  119 passed (119)
```

Related suites also pass unaffected:

```
$ node scripts/run-vitest.mjs src/agents/harness/host-capability.test.ts \
    src/agents/harness/native-hook-relay-store.test.ts \
    src/agents/harness/native-hook-relay.approval-binding.test.ts \
    src/agents/harness/native-hook-relay.approval-wait.test.ts
 Test Files  4 passed (4)
      Tests  53 passed (53)

$ node scripts/run-vitest.mjs src/infra/agent-events.test.ts
 Test Files  1 passed (1)
      Tests  46 passed (46)
```

`node_modules/.bin/oxfmt --check` on the two changed files: clean.

`node scripts/run-oxlint.mjs src/agents/harness/native-hook-relay.ts src/agents/harness/native-hook-relay.test.ts`:
clean (exit 0, no errors/warnings).

`node scripts/check-changed.mjs -- src/agents/harness/native-hook-relay.ts src/agents/harness/native-hook-relay.test.ts`
fails only on the pre-existing `max-lines suppression ratchet` check, which is
unrelated to this change and fails identically on unmodified `main` (confirmed
by stashing this diff and re-running the same check).

Production diff: +23/-0 in `src/agents/harness/native-hook-relay.ts`. Test
diff: +41/-0 in `src/agents/harness/native-hook-relay.test.ts`.

## Related Work

#120562 (open, unmerged) touches the same test file but fixes an unrelated
replacement-time bridge-listener race (`ECONNRESET` on relay replacement); it
does not implement lifecycle-rotation cleanup and does not reference this
issue. No functional overlap; a rebase may need a trivial test-file merge if
both land.

## AI Assistance

AI-assisted: yes. An autonomous agent session located the relevant relay
registry/lifecycle-rotation code, implemented the fix by reusing the existing
`registerAgentEventLifecycleRotationHandler` contract, wrote and verified the
regression test (including confirming it fails without the fix), and ran the
listed local test/format checks.



## Evidence Addendum: Codex hook contract + real cross-process rotation proof

Added in response to ClawSweeper's `needs proof` verdict, which asked for (1)
direct inspection of the sibling Codex hook-runtime contract and (2) a real
behavior trace showing lifecycle rotation prevents a stale relay from
reaching hook execution. No source changed; this is evidence only.

### 1. Direct Codex contract inspection

Cloned `https://github.com/openai/codex.git` to `../codex`
(`ed42068c45c1b0ab92eaf495c2880c63ca06fa09`) and read the hook-runtime source
directly:

- Codex's `PreToolUse`/`PostToolUse`/`PermissionRequest` hooks are plain
  `command` hooks: Codex serializes a JSON request to the subprocess's stdin
  and parses stdout/exit-code/stderr
  (`../codex/codex-rs/hooks/src/events/pre_tool_use.rs:72-147`,
  `../codex/codex-rs/core/src/hook_runtime.rs:176-233`).
- The command Codex actually execs for OpenClaw's relay is built by
  `buildNativeHookRelayCommandWithStateDatabase`
  (`src/agents/harness/native-hook-relay-command.ts:52-93`), producing
  literally `exec openclaw hooks relay --provider codex --relay-id <id>
  --state-db <path> --generation <gen> --event <event> --timeout <ms>`,
  installed into Codex's `hooks.PreToolUse`/etc. config by
  `buildCodexNativeHookRelayConfig`
  (`extensions/codex/src/app-server/native-hook-relay.ts:394-458`).
  `openclaw hooks relay` is a real (hidden) CLI subcommand
  (`src/cli/hooks-cli.ts:380-393`) backed by
  `runNativeHookRelayCli` (`src/cli/native-hook-relay-cli.ts`).
- Contract implication for this PR: a stale/retained relay is reachable by
  Codex only through this exact subprocess invocation. Rotation cleanup that
  removes the relay's map entry, bridge server, and SQLite locator row is
  therefore sufficient to cut Codex off from stale authority — Codex has no
  other path to the relay.
- Side note on Codex's own fail-open behavior (not something this PR changes
  or depends on): when a `command` hook errors, Codex marks that hook run
  `Failed` but does not set `should_block` for it
  (`../codex/codex-rs/hooks/src/events/pre_tool_use.rs:205-212`,
  `PreToolUseHandlerData::default()`), so Codex itself doesn't block the tool
  call on a hook error. The security property this PR protects is upstream of
  that: it stops the retained relay's *own* policy/approval state from being
  reachable at all after rotation, rather than relying on Codex's tool-call
  blocking behavior.

### 2. Real cross-process rotation trace

Built the project (`pnpm build`) and ran a script (not committed) that uses
only production entry points — `registerRetainedNativeHookRelay`,
`rotateAgentEventLifecycleGeneration`, and the real `openclaw hooks relay`
CLI binary — against an isolated `OPENCLAW_STATE_DIR`:

1. Register a `codex` relay with `retention.shouldRetainAfterForegroundClose
   = () => true` and call `relay.unregister()` — same "retained across
   foreground close" state the PR's own regression test builds.
2. From a **separate OS process**, invoke the real relay-bridge client
   (`invokeNativeHookRelayBridge`) over the real localhost bridge/SQLite
   locator, and separately spawn the **exact real subprocess command** Codex
   would exec (`openclaw hooks relay --provider codex --relay-id ...
   --state-db ... --generation ... --event pre_tool_use --timeout 5000`)
   with a realistic `PreToolUse` JSON payload on stdin.
3. Call `rotateAgentEventLifecycleGeneration()`.
4. Repeat step 2 with the identical relay id/generation/payload.

Redacted output (paths are local temp dirs):

```
relayId: codex-real-rotation-proof generation: 4faa8285-960a-48b5-ac60-a17214f95c4e
--- BEFORE rotation: direct relay-bridge client call from a separate OS process ---
RESULT: {"stdout":"","stderr":"","exitCode":0}
--- BEFORE rotation (retained relay, real Codex hook subprocess) ---
exit 0, stdout: (empty)          # tool call allowed, reaching the retained relay's policy
--- AFTER rotation: direct relay-bridge client call from a separate OS process ---
ERROR: native hook relay bridge not found
--- AFTER rotation (real Codex hook subprocess) ---
exit 0, stdout: {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Native hook relay unavailable"}}
```

To confirm this is actually caused by this PR's handler (not TTL, not an
unrelated failure), I reran the identical script against the pre-fix source
(`git checkout HEAD~1 -- src/agents/harness/native-hook-relay.ts`, restored
after):

```
--- AFTER rotation: direct relay-bridge client call from a separate OS process ---
ERROR: admitted run native hook recovery is no longer active
```

That is the *stale-retained-authority* rejection
(`src/agents/admitted-run-context.ts:125`) — on `main` today, the request
still reaches the retained relay's registration and gets denied one layer
deeper, inside authority-revocation error handling. With the fix, the same
request never finds a registration at all
(`native hook relay bridge not found`, from the SQLite locator lookup in
`src/agents/harness/native-hook-relay-client.ts:43`) — exactly the "ordinary
not-found response instead of reaching stale retained-authority error
handling" behavior claimed in this PR's description. Restoring the fixed
file reproduced the original (fixed) output again.

One unrelated pre-existing CLI quirk observed and worth flagging transparently:
`openclaw hooks relay`'s direct-bridge failure path falls through to a
gateway RPC call when the bridge error isn't classified as a "stale
registration" error (`src/cli/native-hook-relay-cli.ts:152-169`), so the
subprocess-level stderr also shows an unrelated "requires credentials before
opening a websocket" message from that fallback attempt in this sandbox
(no gateway was configured). This is existing CLI fallback behavior, not
something this PR touches, and it doesn't affect the outcome: the
direct-bridge client call (step 2 above) shows the precise error, and in
both the pre-fix and post-fix runs the CLI's final caller-visible response is
still a clean deny — never the stale relay's own policy decision.
