### PR TITLE
fix(sessions): delete progress cards with session artifacts

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-node-artifacts.ts
+++ b/src/config/sessions/session-accessor.sqlite-node-artifacts.ts
@@ -326,17 +326,15 @@ export function deleteSessionNodeArtifacts(
       db.deleteFrom("board_tabs").where("session_key", "=", sessionKey),
     );
   }
-  if (presentTables.has("heartbeat_outcomes")) {
-    executeSqliteQuerySync(
-      database.db,
-      db.deleteFrom("heartbeat_outcomes").where("session_key", "=", sessionKey),
-    );
-  }
-  if (presentTables.has("session_participants")) {
-    executeSqliteQuerySync(
-      database.db,
-      db.deleteFrom("session_participants").where("session_key", "=", sessionKey),
-    );
+  for (const table of [
+    "heartbeat_outcomes",
+    "session_participants",
+    "session_progress_cards",
+  ] as const) {
+    if (!presentTables.has(table)) {
+      continue;
+    }
+    executeSqliteQuerySync(database.db, db.deleteFrom(table).where("session_key", "=", sessionKey));
   }
   clearSessionCollaborationForKey(database, sessionKey);
 }

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -7,6 +7,10 @@ import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.j
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import {
+  readSessionProgressCard,
+  writeSessionProgressCard,
+} from "../../session-cards/progress-card-store.js";
+import {
   onInternalSessionTranscriptUpdate,
   onSessionTranscriptUpdate,
 } from "../../sessions/transcript-events.js";
@@ -2852,6 +2856,33 @@ describe("session accessor seam", () => {
       });
     },
   );
+
+  it("clears progress cards when lifecycle deletion retains transcript windows", async () => {
+    const sessionKey = "agent:main:progress-delete";
+    const scope = { agentId: "main", sessionId: "progress-delete", sessionKey, storePath };
+    await replaceSessionEntry(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+    const databasePath = expectDefined(
+      resolveSqliteTargetFromSessionStorePath(storePath, { agentId: scope.agentId }).path,
+      "progress delete database path",
+    );
+    const database = openOpenClawAgentDatabase({ agentId: scope.agentId, path: databasePath });
+    writeSessionProgressCard(database.db, sessionKey, { markdown: "Working" });
+
+    const result = await deleteSessionEntryLifecycle({
+      archiveTranscript: false,
+      storePath,
+      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+    });
+
+    expect(result.deleted).toBe(true);
+    expect(loadSessionEntry(scope)).toBeUndefined();
+    expect(
+      database.db
+        .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+        .get(sessionKey),
+    ).toEqual({ entry_valid: -1 });
+    expect(readSessionProgressCard(database.db, sessionKey)).toBeNull();
+  });
 
   it("trims a manual compact transcript and clears stale token metadata", async () => {
     const sessionId = "11111111-1111-4111-8111-111111111111";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where deleting a session while retaining transcript history left its progress card behind, so stale progress could remain visible after the session entry was gone.

## Why This Change Was Made

Retained-history deletion tombstones the session row, which intentionally prevents the SQLite foreign-key cascade. The existing node-artifact deletion owner now explicitly removes progress cards alongside heartbeat and participant artifacts before collaboration cleanup.

AI-assisted maintainer fix. I reviewed the final code, proof, and exact landing diff.

## User Impact

Deleting a session now removes its progress UI state even when transcript retention keeps the tombstoned session row. Other retained history and collaboration cleanup behavior are unchanged.

## Evidence

- Production LOC: `+9/-11` (net `-2`); tests: `+31/-0`; exactly two files.
- Current-main base: `3d302c58c6e9b069d84357074a71e0f65b001cfa`; exact head: `f3d7d32e7331dc7b23b7a800216f7c035a204d27`.
- Exact diff SHA-256: `2506c7189204bed79a9d9f32dff3a13f45dff7f490ca044b410880544d66dae1`.
- Genuine regression proof: 109/110 before the repair, with the card remaining while the session entry was absent and `entry_valid = -1`.
- Final current-main owner proof: 110/110 passed; independent owner proof also passed 110/110.
- Formatting, typed lint, production typing, scope, and diff checks passed.
- No DDL, schema-version, migration, config, API, or security contract change.
- Mandatory exact-source autoreview: secret scan clean; isolated Codex review reported no accepted or actionable findings.
