### PR TITLE
fix(reply): preserve streaming media caption limits

### DIFF
--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -105,8 +105,8 @@ export function createBlockReplyCoalescer(params: {
     await onFlush(payloadWithMetadata);
   };
 
-  const canMergeBufferedTextWithMedia = (payload: ReplyPayload) =>
-    Boolean(bufferText) &&
+  const canMergeBufferedTextWithMedia = (payload: ReplyPayload, text: string) =>
+    Boolean(bufferText && (!text || bufferText.length + joiner.length + text.length <= maxChars)) &&
     !flushOnEnqueue &&
     !bufferAudioAsVoice &&
     !payload.audioAsVoice &&
@@ -147,7 +147,7 @@ export function createBlockReplyCoalescer(params: {
     const text = reply.text;
     const hasText = reply.hasText;
     if (hasMedia) {
-      if (canMergeBufferedTextWithMedia(payload)) {
+      if (canMergeBufferedTextWithMedia(payload, text)) {
         void onFlush(mergeBufferedTextWithMedia(payload, text));
         return;
       }

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -217,30 +217,47 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(sent).toEqual([{ presentation }]);
   });
 
-  it("merges coalesced text into a following media payload", async () => {
-    const sent: Array<{ text?: string; mediaUrls?: string[] }> = [];
-    const pipeline = createBlockReplyPipeline({
-      onBlockReply: async (payload) => {
-        sent.push({ text: payload.text, mediaUrls: payload.mediaUrls });
-      },
-      timeoutMs: 5000,
-      coalescing: {
-        minChars: 1,
-        maxChars: 200,
-        idleMs: 0,
-        joiner: " ",
-      },
-    });
+  it.each([
+    {
+      maxChars: 200,
+      mediaText: undefined,
+      expected: [{ text: "Preview below", mediaUrls: ["file:///photo.png"] }],
+    },
+    {
+      maxChars: 16,
+      mediaText: "caption",
+      expected: [
+        { text: "Preview below", mediaUrls: undefined },
+        { text: "caption", mediaUrls: ["file:///photo.png"] },
+      ],
+    },
+  ])(
+    "respects the caption limit when coalescing following media %#",
+    async ({ maxChars, mediaText, expected }) => {
+      const sent: Array<{ text?: string; mediaUrls?: string[] }> = [];
+      const pipeline = createBlockReplyPipeline({
+        onBlockReply: async (payload) => {
+          sent.push({ text: payload.text, mediaUrls: payload.mediaUrls });
+        },
+        timeoutMs: 5000,
+        coalescing: {
+          minChars: 1,
+          maxChars,
+          idleMs: 0,
+          joiner: " ",
+        },
+      });
 
-    pipeline.enqueue({ text: "Preview" });
-    pipeline.enqueue({ text: "below" });
-    pipeline.enqueue({ mediaUrls: ["file:///photo.png"] });
-    await pipeline.flush({ force: true });
+      pipeline.enqueue({ text: "Preview" });
+      pipeline.enqueue({ text: "below" });
+      pipeline.enqueue({ text: mediaText, mediaUrls: ["file:///photo.png"] });
+      await pipeline.flush({ force: true });
 
-    expect(sent).toEqual([{ text: "Preview below", mediaUrls: ["file:///photo.png"] }]);
-    expect(pipeline.getSentMediaUrls()).toEqual(["file:///photo.png"]);
-    expect(pipeline.hasSentPayload({ text: "Preview below" })).toBe(true);
-  });
+      expect(sent).toEqual(expected);
+      expect(pipeline.getSentMediaUrls()).toEqual(["file:///photo.png"]);
+      expect(pipeline.hasSentPayload({ text: "Preview below" })).toBe(true);
+    },
+  );
 
   it("keeps media separate across assistant message boundaries", async () => {
     const sent: Array<{ text?: string; mediaUrls?: string[] }> = [];


### PR DESCRIPTION
## What Problem This Solves

Prevents streamed replies followed by a media caption from exceeding the configured channel text limit and failing delivery.

## Root Cause and Repair

The shared block-reply coalescer enforced `maxChars` while combining text-only fragments, but its separate text-plus-media merge path skipped the same size invariant. Buffered text, the joiner, and a media caption could therefore become an oversized outbound payload. Enforce the canonical limit at the existing media merge decision; overflow flushes buffered text first and delivers the original media caption separately.

## Evidence

- Authentic pre-fix regression emitted the oversized `Preview below caption` as one media payload instead of preserving two valid deliveries.
- Expanded the existing real reply-pipeline test into a table covering both the unchanged captionless merge and the oversized-caption split.
- `node scripts/run-vitest.mjs src/auto-reply/reply/block-reply-pipeline.test.ts`: all 23 streaming reply tests passed.
- Independent read-only local review verified channel/chunk limit ownership, exact-limit merging, empty captions, reply metadata, media accounting, text deduplication, send ordering, and sibling visibility paths.
- Focused formatter and `git diff --check` passed. Production +3/-3, net zero; tests +41/-24.
- No configuration, protocol, persistence, provider, or dependency changes.
