### PR TITLE
[AI-assisted] docs(browser): teach the code-mode global call, not the removed tools.call API

### DIFF
--- a/extensions/browser/skills/browser-automation/SKILL.md
+++ b/extensions/browser/skills/browser-automation/SKILL.md
@@ -48,15 +48,15 @@ Use this skill when you need the `browser` tool for anything beyond a single pag
 
 ## Code Mode Loop
 
-When `tools.codeMode` is enabled, the Browser tool has no normal turn — it is cataloged behind `exec`/`wait`. Call it from exec cells as an async global, using the callable name the exec quick index advertises for the Browser tool (normally `browser`; colliding names get suffixed, and a client tool can win an identical name). If the quick index omits or renames it, discover it with `catalog.search("browser")` and call the returned handle:
+When `tools.codeMode` is enabled, the Browser tool has no normal turn — it is cataloged behind `exec`/`wait`. Call it from exec cells as an async global, using the callable name the exec quick index advertises for the Browser tool (normally `browser`; colliding names get suffixed, and a client tool can win an identical name). An exact `catalog.search("browser")` returns a handle already bound to the effective callable name, so resolve the handle in each cell and call it instead of hard-coding the literal global; an empty result means the Browser tool is not cataloged in this run.
+
+Keep the same labeled tab through the loop, and alternate reads with actions. Each `exec` cell starts a fresh VM — bindings from a completed cell are gone in the next, and only runs left `waiting` keep their state until `wait` resumes them — so carry comparison state across cells by returning it and re-embedding the returned values in the next cell:
 
 ```javascript
-let previous = { url: undefined, newElements: undefined };
-```
-
-Keep the same labeled tab through the loop, and alternate reads with actions:
-
-```javascript
+// previous = the url/newElements returned by the last completed cell (a fresh
+// VM runs this cell, so prior bindings do not exist here).
+const previous = { url: "https://example.com/inbox", newElements: 0 };
+const [browser] = await catalog.search("browser", { limit: 1 });
 const details = await browser({
   action: "snapshot",
   snapshotFormat: "ai",
@@ -68,7 +68,6 @@ const changed =
   details?.url !== previous.url ||
   (details?.newElements ?? 0) > 0 ||
   details?.blockedByDialog === true;
-previous = { url: details?.url, newElements: details?.newElements };
 return {
   targetId: details?.targetId,
   url: details?.url,
@@ -82,6 +81,7 @@ return {
 - To read text inside code mode, run a targeted `act` evaluate (requires the evaluate capability; `browser.evaluateEnabled` can disable it) and keep the returned value bounded, because page-script output is untrusted:
 
 ```javascript
+const [browser] = await catalog.search("browser", { limit: 1 });
 const read = await browser({
   action: "act",
   kind: "evaluate",
@@ -94,10 +94,10 @@ return { url: read?.url, text: read?.result };
 When evaluate is unavailable, keep the loop on structured state only.
 
 - Return only the fields the next step needs; never return the whole details object.
-- Keep `previous` between cells when a url change or new-element count helps explain a change.
+- Completed cells share no state: re-embed the previous cell's returned `url`/`newElements` in the next cell, or keep the comparison inside one cell. Only `waiting` runs persist, resumed by `wait`.
 - Interleave each act with a URL or tabs check before the next dependent act.
 - If a batch returns `aborted`, take a fresh snapshot before continuing.
-- If `newElements` is positive, inspect those elements first, then update the saved state.
+- If `newElements` is positive, inspect those elements first, then update the re-embedded state.
 - Use separate act calls when navigation is expected between steps.
 
 ## Tab Hygiene

--- a/extensions/browser/skills/browser-automation/SKILL.md
+++ b/extensions/browser/skills/browser-automation/SKILL.md
@@ -48,40 +48,42 @@ Use this skill when you need the `browser` tool for anything beyond a single pag
 
 ## Code Mode Loop
 
-When `tools.codeMode` is enabled, call the Browser tool from exec cells:
+When `tools.codeMode` is enabled, call the Browser tool from exec cells as the async global `browser(...)`:
 
 ```javascript
-const browserTool = "openclaw:browser:browser";
-let previousSnapshot = "";
-const callBrowser = async (input) => await tools.call(browserTool, input);
+let previous = { url: undefined, newElements: undefined };
 ```
 
 Keep the same labeled tab through the loop, and alternate reads with actions:
 
 ```javascript
-const snapshotCall = await callBrowser({
+const details = await browser({
   action: "snapshot",
+  snapshotFormat: "ai",
   targetId: "task",
   refs: "aria",
   interactive: true,
 });
-const details = snapshotCall?.result?.details ?? {};
-const snapshot = (snapshotCall?.result?.content ?? []).map((block) => block?.text ?? "").join("\n");
-const relevant = snapshot
-  .split("\n")
-  .filter((line) => /submit|dialog|error|\[new\]/i.test(line))
-  .slice(0, 12);
-const changed = snapshot !== previousSnapshot;
-previousSnapshot = snapshot;
-return { targetId: details.targetId, url: details.url, relevant, changed };
+const changed =
+  details?.url !== previous.url ||
+  (details?.newElements ?? 0) > 0 ||
+  details?.blockedByDialog === true;
+previous = { url: details?.url, newElements: details?.newElements };
+return {
+  targetId: details?.targetId,
+  url: details?.url,
+  newElements: details?.newElements,
+  stats: details?.stats,
+  changed,
+};
 ```
 
-- Request interactive-only snapshots and filter them in code before returning.
-- Return only the handful of relevant elements; never return the full tree.
-- Keep `previousSnapshot` between cells when a local diff helps explain a change.
+- Code-mode calls return the tool's structured `details` directly (`targetId`, `url`, `newElements`, `stats`, `blockedByDialog`); rendered page text is not available to code cells, so take a normal snapshot turn when you must read the page.
+- Return only the fields the next step needs; never return the whole details object.
+- Keep `previous` between cells when a url change or new-element count helps explain a change.
 - Interleave each act with a URL or tabs check before the next dependent act.
 - If a batch returns `aborted`, take a fresh snapshot before continuing.
-- If `[new]` markers appear, inspect those elements first, then update the saved snapshot.
+- If `newElements` is positive, inspect those elements first, then update the saved state.
 - Use separate act calls when navigation is expected between steps.
 
 ## Tab Hygiene

--- a/extensions/browser/skills/browser-automation/SKILL.md
+++ b/extensions/browser/skills/browser-automation/SKILL.md
@@ -48,7 +48,7 @@ Use this skill when you need the `browser` tool for anything beyond a single pag
 
 ## Code Mode Loop
 
-When `tools.codeMode` is enabled, call the Browser tool from exec cells as the async global `browser(...)`:
+When `tools.codeMode` is enabled, the Browser tool has no normal turn — it is cataloged behind `exec`/`wait`. Call it from exec cells as an async global, using the callable name the exec quick index advertises for the Browser tool (normally `browser`; colliding names get suffixed, and a client tool can win an identical name). If the quick index omits or renames it, discover it with `catalog.search("browser")` and call the returned handle:
 
 ```javascript
 let previous = { url: undefined, newElements: undefined };
@@ -78,7 +78,21 @@ return {
 };
 ```
 
-- Code-mode calls return the tool's structured `details` directly (`targetId`, `url`, `newElements`, `stats`, `blockedByDialog`); rendered page text is not available to code cells, so take a normal snapshot turn when you must read the page.
+- Code-mode calls return the tool's structured `details` directly (`targetId`, `url`, `newElements`, `stats`, `blockedByDialog`); rendered page text is not returned to code cells.
+- To read text inside code mode, run a targeted `act` evaluate (requires the evaluate capability; `browser.evaluateEnabled` can disable it) and keep the returned value bounded, because page-script output is untrusted:
+
+```javascript
+const read = await browser({
+  action: "act",
+  kind: "evaluate",
+  fn: "() => document.body.innerText.slice(0, 2000)",
+  targetId: "task",
+});
+return { url: read?.url, text: read?.result };
+```
+
+When evaluate is unavailable, keep the loop on structured state only.
+
 - Return only the fields the next step needs; never return the whole details object.
 - Keep `previous` between cells when a url change or new-element count helps explain a change.
 - Interleave each act with a URL or tabs check before the next dependent act.


### PR DESCRIPTION
## What Problem This Solves

The browser-automation skill's **Code Mode Loop** still taught the guest to call the Browser tool via `tools.call("openclaw:browser:browser", input)` and read the `.result.details` / `.result.content` envelope. That API was removed by #126262 (merged 2026-08-20, "improve(code-mode): call tools as global functions"); an agent following the skill verbatim in code mode fails on the first cell.

The first revision of this fix still had two dead ends, caught in review: it told readers to take a "normal snapshot turn" to read the page (no such turn exists while code mode is active — the Browser tool is cataloged behind `exec`/`wait` and the bridge strips snapshot `content`), and it hard-coded the callable name `browser` (the catalog can suffix colliding globals and lets a client tool win an identical name, so the run's quick index is the only authority).

## Root cause

The skill predates #126262. Code mode now exposes enabled tools as async global functions (`src/agents/code-mode.ts`: "Enabled tools are async global functions listed in the quick index"), and the bridge returns the tool's structured `details` directly — `src/agents/code-mode-bridge.ts` `callValue`:

```ts
value =
  isRecord(called.result) && "details" in called.result
    ? called.result.details
    : called.result;
```

So `result.content` (rendered page text) never reaches a code cell; only `details` does. Callable names are run-scoped: `createCodeModeCatalogProjection` (`src/agents/code-mode-catalog.ts`) suffixes colliding/reserved names (`suffixedCallableName`) and `selectEffectiveEntries` lets a client tool win an exact-name collision, which is why the exec quick index (and `catalog.search` fallback) is the documented way to resolve a callable.

## Fix

Rewrite the loop for the current contract:

- call the Browser tool through the async global the exec quick index advertises (normally `browser`), falling back to `catalog.search("browser")` when the index omits or renames it,
- read the structured `details` (`targetId`, `url`, `newElements`, `stats`, `blockedByDialog` — all present in `safeDetails` from `extensions/browser/src/browser-tool.snapshot.ts`),
- diff `url` / `newElements` between cells instead of filtering snapshot text,
- read page text inside code mode via a targeted `act` evaluate (`{ action: "act", kind: "evaluate", fn, targetId }`; the fn's value comes back in `details.result`, and `browser.evaluateEnabled` can disable it), keeping the returned value bounded — or stay on structured state only when evaluate is unavailable.

Docs only; no code paths touched.

## Evidence

### Real Code Mode + Browser execution transcript (after-fix, head `4ef2e571`)

Ran on this branch with a harness that boots the **real gateway with the real browser plugin (headless Chromium)**, resolves the real gateway-scoped tool surface, applies the real code-mode catalog compaction (`applyCodeModeCatalog`, force-enabled like an engaged code-mode turn), and drives the real `exec` tool with the three cells the revised skill teaches. The page is a loopback-only fixture (`http://127.0.0.1:<port>/`) — nothing to redact: no external URLs, keys, or credentials are involved. Transcript ends with `PROOF-TRANSCRIPT-END`; each cell's `exec` result came back `status: "completed"` with real catalog telemetry (`callCount` 0 → 2 → 3 across cells).

**Cell 1 — callable discovery (quick-index global + `catalog.search` fallback):**

```js
const found = await catalog.search("browser");
const entry = found.find((candidate) => candidate?.toolName === "browser");
return {
  matches: found.map((candidate) => candidate?.toolName ?? candidate?.name),
  callable: typeof entry,
  globalName: typeof browser === "function" ? "browser" : undefined,
};
```

```json
{
  "status": "completed",
  "value": { "matches": ["browser"], "callable": "function", "globalName": "browser" },
  "telemetry": { "catalogSize": 31, "searchCount": 1, "callCount": 0, "visibleTools": ["exec", "wait"] }
}
```

**Cell 2 — `open` + structured snapshot loop (reading `details`, not snapshot text):**

```js
let previous = { url: undefined, newElements: undefined };
const opened = await browser({ action: "open", url: "http://127.0.0.1:<port>/" });
const details = await browser({
  action: "snapshot",
  snapshotFormat: "ai",
  targetId: opened?.suggestedTargetId ?? opened?.targetId ?? "task",
  refs: "aria",
  interactive: true,
});
const changed =
  details?.url !== previous.url ||
  (details?.newElements ?? 0) > 0 ||
  details?.blockedByDialog === true;
previous = { url: details?.url, newElements: details?.newElements };
return {
  targetId: details?.targetId,
  url: details?.url,
  newElements: details?.newElements,
  stats: details?.stats,
  changed,
};
```

```json
{
  "status": "completed",
  "value": {
    "targetId": "8EBD0393F324C2788760085803C7C99E",
    "url": "http://127.0.0.1:<port>/",
    "stats": { "lines": 2, "chars": 82, "refs": 2, "interactive": 2 },
    "changed": true
  },
  "telemetry": { "callCount": 2, "visibleTools": ["exec", "wait"] }
}
```

**Cell 3 — bounded evaluate read (`act`/`kind: "evaluate"`, value in `result`):**

```js
const read = await browser({
  action: "act",
  kind: "evaluate",
  fn: "() => document.body.innerText.slice(0, 2000)",
  targetId: "8EBD0393F324C2788760085803C7C99E",
});
return { url: read?.url, text: read?.result };
```

```json
{
  "status": "completed",
  "value": {
    "url": "http://127.0.0.1:<port>/",
    "text": "Browser skill code-mode proof\n\nPROOF-PAGE-READY\n\nQuery  Submit"
  },
  "telemetry": { "callCount": 3, "visibleTools": ["exec", "wait"] }
}
```

This shows exactly what the fix teaches: the Browser callable resolves as the run-scoped `browser` global (and via `catalog.search("browser")`), the snapshot loop consumes **structured `details`** (`targetId`, `url`, `stats` — rendered page text never reaches the cell), and page text is read through a targeted bounded `evaluate` whose value returns in `details.result`.

After-fix verification on this branch (node 22.23.2, fresh `pnpm install`):

- Real guest runtime, `node --import tsx scripts/test-projects.mts -- src/agents/code-mode.guest.test.ts` — **21/21 passed**, including "exposes catalog tools as bare globals and removes the legacy guest surface", "keeps normalized, reserved, and colliding prompt names aligned with runtime", "uses the client tool as the single winner for a shadowed exact name", and "returns structured values from globals and callable catalog handles" (globals return structured `details` to code cells; callable names come from the runtime projection).
- Real act formatter (`formatBrowserExternalToolResult`, `extensions/browser/src/browser-tool.actions.ts`) with an evaluate act payload `{ ok: true, targetId: "task", url: "https://example.com/after-submit", result: "Submitted\nConfirmation #42" }` returns `details = { ok, targetId, url, result }` — the evaluate value reaches code cells via `details.result` — while `content[0].text` is wrapped as `EXTERNAL_UNTRUSTED_CONTENT` and never returned to code cells.
- On current `main`, `git grep "tools.call" extensions/browser` matches only this skill's stale example — every other reference in docs is a different surface (`mcp.tools.call.v1` node command, the Tool Search `openclaw.tools.call` bridge, cron migration history).
- Each taught field was checked against `main` source: global name resolution (`code-mode-catalog.ts`), details shape (`browser-tool.snapshot.ts` `safeDetails`), act response contract (`{ ok, targetId, url?, result? }` from `client-actions-core.ts` / `routes/agent.act.ts`), evaluate gating (`browser.evaluateEnabled`, `browser-tool.schema.ts`).
- `npx --yes oxfmt@0.60.0 --check extensions/browser/skills/browser-automation/SKILL.md` passes (repo-pinned version).

## Risks

Low — docs-only change to a skill file. The evaluate example assumes the evaluate capability is enabled (default); the doc says to fall back to structured state when it is not.

