### PR TITLE
improve(discord): avoid repeated account resolution on sends

### DIFF
--- a/extensions/discord/src/client.test.ts
+++ b/extensions/discord/src/client.test.ts
@@ -33,6 +33,34 @@ describe("createDiscordClient", () => {
     await expect(request(operation, "send")).resolves.toBe("sent");
     expect(operation).toHaveBeenCalledTimes(3);
   });
+
+  it("keeps explicit-token retries bound to the REST account", async () => {
+    registerGateway("default", { isConnected: false } as GatewayPlugin);
+    registerGateway("ops", { isConnected: true } as GatewayPlugin);
+    const client = createDiscordClient({
+      cfg: {
+        channels: {
+          discord: {
+            defaultAccount: "ops",
+            accounts: { ops: { token: "configured-token" } },
+          },
+        },
+      },
+      token: "explicit-token",
+      rest: {} as RequestClient,
+      retry: { attempts: 3, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    });
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValue("sent");
+
+    expect(client.account.accountId).toBe("ops");
+    await expect(client.request(operation, "send")).resolves.toBe("sent");
+    expect(operation).toHaveBeenCalledTimes(4);
+  });
 });
 
 describe("createDiscordRestClient", () => {

--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -14,7 +14,7 @@ import { RequestClient } from "./internal/discord.js";
 import { getGateway } from "./monitor/gateway-registry.js";
 import { resolveDiscordProxyFetchForAccount } from "./proxy-fetch.js";
 import { createDiscordRequestClient } from "./proxy-request-client.js";
-import { createDiscordRetryRunner, type DiscordRetryRunner } from "./retry.js";
+import { createDiscordRetryRunner } from "./retry.js";
 import type { DiscordRuntimeAccountContext } from "./send.types.js";
 import { normalizeDiscordToken } from "./token.js";
 
@@ -139,21 +139,22 @@ export function createDiscordRestClient(opts: DiscordClientOpts) {
   return { token, rest, account };
 }
 
-export function createDiscordClient(opts: DiscordClientOpts): {
-  token: string;
-  rest: RequestClient;
-  request: DiscordRetryRunner;
-} {
-  const { token, rest, account } = createDiscordRestClient(opts);
+export function createDiscordClient(opts: DiscordClientOpts) {
+  const { token, rest, account: restAccount } = createDiscordRestClient(opts);
+  const account = normalizeDiscordToken(opts.token, "channels.discord.token")
+    ? resolveDiscordAccount({ cfg: opts.cfg, accountId: opts.accountId })
+    : restAccount;
+  // Explicit-token REST clients retain their normalized gateway identity; outbound
+  // projection consumers use the canonical configured account returned below.
   const request = createDiscordRetryRunner({
     retry: opts.retry,
     verbose: opts.verbose,
     isGatewayDisconnected: () => {
-      const gateway = getGateway(account.accountId);
+      const gateway = getGateway(restAccount.accountId);
       return gateway !== undefined && !gateway.isConnected;
     },
   });
-  return { token, rest, request };
+  return { token, rest, request, account };
 }
 
 export function resolveDiscordRest(opts: DiscordClientOpts) {

--- a/extensions/discord/src/recipient-resolution.ts
+++ b/extensions/discord/src/recipient-resolution.ts
@@ -42,9 +42,13 @@ export async function parseAndResolveRecipient(
 export async function parseAndResolveChannelRecipient(
   raw: string,
   cfg: OpenClawConfig,
-  accountId?: string,
+  accountId: string,
 ): Promise<DiscordRecipient> {
-  return await parseAndResolveRecipient(raw, cfg, accountId, {
-    defaultKind: "channel",
-  });
+  const resolvedCfg = requireRuntimeConfig(cfg, "Discord recipient resolution");
+  const resolved = await parseAndResolveDiscordTarget(
+    raw,
+    { cfg: resolvedCfg, accountId },
+    { defaultKind: "channel" },
+  );
+  return { kind: resolved.kind, id: resolved.id };
 }

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -7,7 +7,6 @@ import type { OutboundMediaAccess } from "openclaw/plugin-sdk/media-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type { ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveDiscordAccount } from "./accounts.js";
 import { registerDiscordComponentEntries } from "./components-registry.js";
 import {
   buildDiscordComponentMessage,
@@ -300,9 +299,8 @@ export async function sendDiscordComponentMessage(
   }
 
   const cfg = requireRuntimeConfig(opts.cfg, "Discord component send");
-  const accountInfo = resolveDiscordAccount({ cfg, accountId: opts.accountId });
-  const { token, rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
+  const { token, rest, request, account: accountInfo } = createDiscordClient({ ...opts, cfg });
+  const recipient = await parseAndResolveChannelRecipient(to, cfg, accountInfo.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
 
   const channel = await resolveDiscordChannel(rest, channelId);
@@ -374,9 +372,8 @@ export async function editDiscordComponentMessage(
   opts: DiscordComponentSendOpts,
 ): Promise<DiscordSendResult> {
   const cfg = requireRuntimeConfig(opts.cfg, "Discord component edit");
-  const accountInfo = resolveDiscordAccount({ cfg, accountId: opts.accountId });
-  const { token, rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
+  const { token, rest, request, account: accountInfo } = createDiscordClient({ ...opts, cfg });
+  const recipient = await parseAndResolveChannelRecipient(to, cfg, accountInfo.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
   const { body, buildResult } = await buildDiscordComponentPayload({
     spec,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -10,7 +10,6 @@ import { resolveChunkMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chun
 import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { resolveDiscordAccount } from "./accounts.js";
 import { createChannelMessage, createThread, type RequestClient } from "./internal/discord.js";
 import { renderDiscordMarkdown } from "./markdown.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
@@ -159,12 +158,17 @@ function toDiscordSendResult(
 async function resolveDiscordSendTarget(
   to: string,
   opts: DiscordSendOpts,
-): Promise<{ rest: RequestClient; request: DiscordClientRequest; channelId: string }> {
+): Promise<{
+  rest: RequestClient;
+  request: DiscordClientRequest;
+  channelId: string;
+  account: ReturnType<typeof createDiscordClient>["account"];
+}> {
   const cfg = requireRuntimeConfig(opts.cfg, "Discord send target resolution");
-  const { rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
+  const { rest, request, account } = createDiscordClient({ ...opts, cfg });
+  const recipient = await parseAndResolveChannelRecipient(to, cfg, account.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
-  return { rest, request, channelId };
+  return { rest, request, channelId, account };
 }
 
 export async function sendMessageDiscord(
@@ -173,10 +177,7 @@ export async function sendMessageDiscord(
   opts: DiscordSendOpts,
 ): Promise<DiscordSendResult> {
   const cfg = requireRuntimeConfig(opts.cfg, "Discord send");
-  const accountInfo = resolveDiscordAccount({
-    cfg,
-    accountId: opts.accountId,
-  });
+  const { token, rest, request, account: accountInfo } = createDiscordClient({ ...opts, cfg });
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "discord",
@@ -202,8 +203,7 @@ export async function sendMessageDiscord(
     accountId: accountInfo.accountId,
     mentionAliases: accountInfo.config.mentionAliases,
   });
-  const { token, rest, request } = createDiscordClient({ ...opts, cfg });
-  const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
+  const recipient = await parseAndResolveChannelRecipient(to, cfg, accountInfo.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
 
   // Forum/Media channels reject POST /messages; auto-create a thread post instead.
@@ -490,12 +490,13 @@ async function resolveDiscordStructuredSendContext(
   rewrittenContent?: string;
   suppressEmbeds: boolean;
 }> {
-  const cfg = requireRuntimeConfig(opts.cfg, "Discord structured send");
-  const accountInfo = resolveDiscordAccount({
-    cfg,
-    accountId: opts.accountId,
-  });
-  const { rest, request, channelId } = await resolveDiscordSendTarget(to, opts);
+  requireRuntimeConfig(opts.cfg, "Discord structured send");
+  const {
+    rest,
+    request,
+    channelId,
+    account: accountInfo,
+  } = await resolveDiscordSendTarget(to, opts);
   const content = opts.content?.trim();
   const rewrittenContent = content
     ? rewriteDiscordKnownMentions(content, {

--- a/extensions/discord/src/send.voice.ts
+++ b/extensions/discord/src/send.voice.ts
@@ -11,7 +11,6 @@ import {
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { withTempWorkspace, resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
-import { resolveDiscordAccount } from "./accounts.js";
 import type { RequestClient } from "./internal/discord.js";
 import { parseAndResolveChannelRecipient } from "./recipient-resolution.js";
 import type { DiscordReplyReference } from "./reply-reference.js";
@@ -106,15 +105,12 @@ export async function sendVoiceMessageDiscord(
     let channelId: string | undefined;
 
     try {
-      const accountInfo = resolveDiscordAccount({
-        cfg,
-        accountId: opts.accountId,
-      });
       const client = createDiscordClient({ ...opts, cfg });
       token = client.token;
       rest = client.rest;
       const request = client.request;
-      const recipient = await parseAndResolveChannelRecipient(to, cfg, opts.accountId);
+      const accountInfo = client.account;
+      const recipient = await parseAndResolveChannelRecipient(to, cfg, accountInfo.accountId);
       channelId = (await resolveChannelId(rest, recipient, request)).channelId;
 
       const ogg = await ensureOggOpus(localInputPath);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ordinary Discord sends using a configured token repeatedly resolved the same account before provider dispatch. Projection, full-client creation, and channel target resolution each performed equivalent account preparation, adding avoidable CPU work to structured, component, edit, voice, and ordinary message paths.

## Why This Change Was Made

The full Discord client now exposes its canonical prepared account so downstream outbound projection and channel resolution can reuse that fact. Generic REST-only client behavior remains unchanged, and explicit-token retry lookup deliberately stays bound to the synthetic REST account identity while outbound projection uses the configured account.

No cache, configuration, protocol, security, storage, media-staging, provider-payload, or retry-policy contract changes.

## User Impact

Configured-token Discord outbound work performs one account resolution instead of three before dispatch. Provider requests and payloads remain unchanged.

## Evidence

- Current-base red/green diagnostic: ordinary configured-token sends resolved the account 3 times before the repair and 1 time after it.
- Provider-boundary semantic differential: configured-token channel, explicit-token configured-default-account, DM, and forum-thread captures are byte-identical; aggregate SHA-256 `c18759dab3fef2e858a1694a980c2dac253a5b27be9ea3af0e2d48007ec0210a` for both variants.
- Owner projection benchmark with a representative eight-account config, 9 samples × 50,000 sends: baseline-equivalent 3 resolutions median 465.957 ms; candidate-equivalent 1 resolution median 152.786 ms; 67.21% lower account-projection cost (3.05×). This is isolated owner-cost evidence, not an end-to-end latency claim.
- Current mock end-to-end timing was noise-limited: 1,118.716 ms baseline vs 1,120.949 ms candidate per 2,000 sends (−0.2%); no whole-path speedup is claimed.
- Explicit-token retry regression test verifies projection returns the configured `ops` account while gateway-disconnect retry extension remains bound to the `default` REST account.
- Focused owner/sibling tests: 9 files, 202 tests passed.
- Full Discord extension: 227 files, 2,881 tests passed.
- `node scripts/check-changed.mjs`: passed all classified extension and extension-test gates (format, production/test typechecks, type-aware Oxlint 0/0, dead exports, boundaries, guards, import cycles 0). The classifier selected no build lane.
- `git diff --check`: clean.
- Deslop audit: clean.
- TruffleHog preflight: clean. Codex `gpt-5.6-sol` / high autoreview: no actionable findings; `patch is correct` at 0.94 confidence.
- No credentialed or live Discord mutation was performed; proof uses mocked provider boundaries and exact payload captures.
