### PR TITLE
fix(ci): gate source package producers

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -683,6 +683,7 @@ jobs:
             -e CI=1 \
             -v "${RUNNER_TEMP}/candidate.tar.gz:/input/candidate.tar.gz:ro" \
             -v "${package_dir}:/output" \
+            -v "$PWD/.release-harness:/harness:ro" \
             openclaw-install-candidate-packager:local \
             -lc '
               set -euo pipefail
@@ -693,6 +694,11 @@ jobs:
                 --no-same-permissions \
                 -C "$source_dir"
               cd "$source_dir"
+              preflight_args=(--source-dir "$source_dir")
+              if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]]; then
+                preflight_args+=(--allow-unreleased-changelog)
+              fi
+              node /harness/scripts/package-source-preflight.mjs "${preflight_args[@]}"
               mkdir -p /tmp/corepack
               corepack enable --install-directory /tmp/corepack
               export PATH="/tmp/corepack:$PATH"

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1237,7 +1237,7 @@ jobs:
       OPENCLAW_DOCKER_E2E_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.image }}
       OPENCLAW_DOCKER_E2E_BARE_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.bare_image }}
       OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.functional_image }}
-      OPENCLAW_DOCKER_E2E_PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
+      OPENCLAW_DOCKER_E2E_PACKAGE_ARTIFACT_NAME: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_name || 'docker-e2e-package' }}
       OPENCLAW_DOCKER_E2E_REPO_ROOT: ${{ github.workspace }}
       OPENCLAW_DOCKER_E2E_SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
       OPENCLAW_DOCKER_ALL_RELEASE_PROFILE: ${{ inputs.release_test_profile }}
@@ -1624,7 +1624,7 @@ jobs:
       OPENCLAW_DOCKER_E2E_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.image }}
       OPENCLAW_DOCKER_E2E_BARE_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.bare_image }}
       OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.functional_image }}
-      OPENCLAW_DOCKER_E2E_PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
+      OPENCLAW_DOCKER_E2E_PACKAGE_ARTIFACT_NAME: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_name || 'docker-e2e-package' }}
       OPENCLAW_DOCKER_E2E_REPO_ROOT: ${{ github.workspace }}
       OPENCLAW_DOCKER_E2E_SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
       OPENCLAW_CODEX_NPM_PLUGIN_SPEC: ${{ inputs.codex_plugin_spec }}
@@ -1924,7 +1924,7 @@ jobs:
       OPENAI_BASE_URL: ${{ secrets.OPENAI_BASE_URL }}
       OPENCLAW_DOCKER_E2E_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.image }}
       OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE: ${{ needs.prepare_docker_e2e_image.outputs.functional_image }}
-      OPENCLAW_DOCKER_E2E_PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name || 'docker-e2e-package' }}
+      OPENCLAW_DOCKER_E2E_PACKAGE_ARTIFACT_NAME: ${{ needs.prepare_docker_e2e_image.outputs.package_artifact_name || 'docker-e2e-package' }}
       OPENCLAW_DOCKER_E2E_REPO_ROOT: ${{ github.workspace }}
       OPENCLAW_DOCKER_E2E_SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
       OPENCLAW_CURRENT_PACKAGE_TGZ: .artifacts/docker-e2e-package/openclaw-current.tgz
@@ -2135,8 +2135,8 @@ jobs:
       needs_registry_build: ${{ steps.image_exists.outputs.needs_build }}
       package_sha256: ${{ steps.package.outputs.sha256 }}
       package_version: ${{ steps.package.outputs.version }}
-      package_artifact_name: ${{ steps.upload_package.outputs.artifact-id && format('docker-e2e-package-{0}-{1}', github.run_id, github.run_attempt) || inputs.package_artifact_name }}
-      package_artifact_id: ${{ steps.upload_package.outputs.artifact-id || inputs.package_artifact_id }}
+      package_artifact_name: ${{ steps.upload_package.outputs.artifact-id && format('docker-e2e-package-{0}-{1}', github.run_id, github.run_attempt) || (needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_name || '') }}
+      package_artifact_id: ${{ steps.upload_package.outputs.artifact-id || (needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_id || '') }}
       package_artifact_digest: ${{ steps.upload_package.outputs.artifact-digest || steps.input_package_artifact.outputs.artifact_digest }}
       package_artifact_run_id: ${{ steps.upload_package.outputs.artifact-id && github.run_id || steps.input_package_artifact.outputs.run_id }}
       package_artifact_run_attempt: ${{ steps.upload_package.outputs.artifact-id && github.run_attempt || steps.input_package_artifact.outputs.run_attempt }}
@@ -2745,11 +2745,11 @@ jobs:
           IMAGE_ARTIFACT_NAME: ${{ steps.image_artifact.outputs.artifact_name || inputs.shared_image_artifact_name }}
           IMAGE_ARTIFACT_RUN_ATTEMPT: ${{ steps.upload_image_artifact.outputs.artifact-id && github.run_attempt || inputs.shared_image_artifact_run_attempt }}
           IMAGE_ARTIFACT_RUN_ID: ${{ steps.upload_image_artifact.outputs.artifact-id && github.run_id || inputs.shared_image_artifact_run_id }}
-          PACKAGE_ARTIFACT_DIGEST: ${{ steps.upload_package.outputs.artifact-digest || inputs.package_artifact_digest }}
-          PACKAGE_ARTIFACT_ID: ${{ steps.upload_package.outputs.artifact-id || inputs.package_artifact_id }}
-          PACKAGE_ARTIFACT_NAME: ${{ steps.upload_package.outputs.artifact-id && format('docker-e2e-package-{0}-{1}', github.run_id, github.run_attempt) || inputs.package_artifact_name }}
-          PACKAGE_ARTIFACT_RUN_ATTEMPT: ${{ steps.upload_package.outputs.artifact-id && github.run_attempt || inputs.package_artifact_run_attempt }}
-          PACKAGE_ARTIFACT_RUN_ID: ${{ steps.upload_package.outputs.artifact-id && github.run_id || inputs.package_artifact_run_id }}
+          PACKAGE_ARTIFACT_DIGEST: ${{ steps.upload_package.outputs.artifact-digest || (needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_digest || '') }}
+          PACKAGE_ARTIFACT_ID: ${{ steps.upload_package.outputs.artifact-id || (needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_id || '') }}
+          PACKAGE_ARTIFACT_NAME: ${{ steps.upload_package.outputs.artifact-id && format('docker-e2e-package-{0}-{1}', github.run_id, github.run_attempt) || (needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_name || '') }}
+          PACKAGE_ARTIFACT_RUN_ATTEMPT: ${{ steps.upload_package.outputs.artifact-id && github.run_attempt || (needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_run_attempt || '') }}
+          PACKAGE_ARTIFACT_RUN_ID: ${{ steps.upload_package.outputs.artifact-id && github.run_id || (needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_run_id || '') }}
           PACKAGE_FILE_NAME: ${{ steps.package.outputs.file_name }}
           PACKAGE_SHA256: ${{ steps.package.outputs.sha256 }}
           PACKAGE_SOURCE_SHA: ${{ steps.package.outputs.source_sha }}

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -544,6 +544,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     outputs:
+      package_artifact_present: ${{ steps.validate.outputs.package_artifact_present }}
       selected_sha: ${{ steps.validate.outputs.selected_sha }}
       trusted_reason: ${{ steps.validate.outputs.trusted_reason }}
       workflow_repository: ${{ steps.workflow.outputs.workflow_repository }}
@@ -620,6 +621,9 @@ jobs:
         run: |
           set -euo pipefail
           trusted_reason=""
+          has_non_whitespace() {
+            [[ "$1" =~ [^[:space:]] ]]
+          }
 
           # Resolve here instead of in actions/checkout so short SHAs work too.
           if ! selected_sha="$(git rev-parse --verify "${INPUT_REF}^{commit}")"; then
@@ -643,7 +647,7 @@ jobs:
             exit 1
           fi
 
-          package_tuple_present=0
+          package_tuple_present=false
           for value in \
             "$PACKAGE_ARTIFACT_DIGEST" \
             "$PACKAGE_ARTIFACT_ID" \
@@ -654,20 +658,20 @@ jobs:
             "$PACKAGE_SHA256" \
             "$PACKAGE_SOURCE_SHA" \
             "$PACKAGE_VERSION"; do
-            if [[ -n "${value// }" ]]; then
-              package_tuple_present=1
+            if has_non_whitespace "$value"; then
+              package_tuple_present=true
             fi
           done
-          if [[ "$package_tuple_present" == "1" ]]; then
+          if [[ "$package_tuple_present" == "true" ]]; then
             [[ "$PACKAGE_ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ &&
               "$PACKAGE_ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
-              -n "${PACKAGE_ARTIFACT_NAME// }" &&
+              "$PACKAGE_ARTIFACT_NAME" =~ [^[:space:]] &&
               "$PACKAGE_ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ &&
               "$PACKAGE_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ &&
               "$PACKAGE_FILE_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*\.tgz$ &&
               "$PACKAGE_SHA256" =~ ^[0-9a-f]{64}$ &&
               "$PACKAGE_SOURCE_SHA" =~ ^[0-9a-f]{40}$ &&
-              -n "${PACKAGE_VERSION// }" ]] || {
+              "$PACKAGE_VERSION" =~ [^[:space:]] ]] || {
               echo "Package artifact selection requires the complete immutable artifact and package identity tuple." >&2
               exit 1
             }
@@ -676,6 +680,7 @@ jobs:
               exit 1
             }
           fi
+          echo "package_artifact_present=$package_tuple_present" >> "$GITHUB_OUTPUT"
 
           if [[ "$PREPUBLISH_PLUGIN_REGISTRY_ENABLED" == "true" ]]; then
             prepublish_plugin_registry_tuple_present=0
@@ -686,14 +691,14 @@ jobs:
               "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ATTEMPT" \
               "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ID" \
               "$PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256"; do
-              if [[ -n "${value// }" ]]; then
+              if has_non_whitespace "$value"; then
                 prepublish_plugin_registry_tuple_present=1
               fi
             done
             if [[ "$prepublish_plugin_registry_tuple_present" == "1" ]]; then
               [[ "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ &&
                 "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
-                -n "${PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_NAME// }" &&
+                "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_NAME" =~ [^[:space:]] &&
                 "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ &&
                 "$PREPUBLISH_PLUGIN_REGISTRY_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ &&
                 "$PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
@@ -715,14 +720,14 @@ jobs:
             "$SHARED_IMAGE_ARTIFACT_RUN_ATTEMPT" \
             "$SHARED_IMAGE_ARTIFACT_RUN_ID" \
             "$SHARED_IMAGE_ARCHIVE_SHA256"; do
-            if [[ -n "${value// }" ]]; then
+            if has_non_whitespace "$value"; then
               image_tuple_present=1
             fi
           done
           if [[ "$image_tuple_present" == "1" ]]; then
             [[ "$SHARED_IMAGE_ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ &&
               "$SHARED_IMAGE_ARTIFACT_ID" =~ ^[1-9][0-9]*$ &&
-              -n "${SHARED_IMAGE_ARTIFACT_NAME// }" &&
+              "$SHARED_IMAGE_ARTIFACT_NAME" =~ [^[:space:]] &&
               "$SHARED_IMAGE_ARTIFACT_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ &&
               "$SHARED_IMAGE_ARTIFACT_RUN_ID" =~ ^[1-9][0-9]*$ &&
               "$SHARED_IMAGE_ARCHIVE_SHA256" =~ ^[0-9a-f]{64}$ ]] || {
@@ -755,7 +760,7 @@ jobs:
                 echo "shared_image_policy=no-push-artifact builds local image artifacts and rejects provided images." >&2
                 exit 1
               }
-              if [[ "$image_tuple_present" == "1" && "$package_tuple_present" != "1" ]]; then
+              if [[ "$image_tuple_present" == "1" && "$package_tuple_present" != "true" ]]; then
                 echo "Reusing a Docker image artifact requires its immutable package identity tuple." >&2
                 exit 1
               fi
@@ -2173,20 +2178,18 @@ jobs:
       - name: Resolve source package requirement
         id: package_source
         env:
-          PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name }}
-          PACKAGE_ARTIFACT_RUN_ID: ${{ inputs.package_artifact_run_id }}
+          PACKAGE_ARTIFACT_PRESENT: ${{ needs.validate_selected_ref.outputs.package_artifact_present }}
         shell: bash
         run: |
           set -euo pipefail
           source_package_required=false
-          if [[ ! "$PACKAGE_ARTIFACT_NAME" =~ [^[:space:]] &&
-                ! "$PACKAGE_ARTIFACT_RUN_ID" =~ [^[:space:]] ]]; then
+          if [[ "$PACKAGE_ARTIFACT_PRESENT" != "true" ]]; then
             source_package_required=true
           fi
           echo "required=$source_package_required" >> "$GITHUB_OUTPUT"
 
-      - name: Validate Docker E2E package source metadata
-        if: steps.package_source.outputs.required == 'true'
+      - name: Validate prepare-only Docker E2E package source metadata
+        if: inputs.prepare_only && steps.package_source.outputs.required == 'true'
         env:
           ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
         shell: bash
@@ -2242,8 +2245,21 @@ jobs:
           fi
           echo "plan_json=$plan_path" >> "$GITHUB_OUTPUT"
 
+      - name: Validate Docker E2E package source metadata
+        if: (!inputs.prepare_only) && steps.plan.outputs.needs_package == '1' && steps.package_source.outputs.required == 'true'
+        env:
+          ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(--source-dir "$GITHUB_WORKSPACE")
+          if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]]; then
+            args+=(--allow-unreleased-changelog)
+          fi
+          node .release-harness/scripts/package-source-preflight.mjs "${args[@]}"
+
       - name: Setup Node environment
-        if: steps.package_source.outputs.required == 'true' || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')
+        if: (steps.plan.outputs.needs_package == '1' && steps.package_source.outputs.required == 'true') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')
         uses: ./.github/actions/setup-node-env
         with:
           cache-mode: restore
@@ -2252,7 +2268,7 @@ jobs:
 
       - name: Validate OpenClaw package artifact identity
         id: input_package_artifact
-        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != ''
+        if: steps.plan.outputs.needs_package == '1' && needs.validate_selected_ref.outputs.package_artifact_present == 'true'
         env:
           ARTIFACT_DIGEST: ${{ inputs.package_artifact_digest }}
           ARTIFACT_ID: ${{ inputs.package_artifact_id }}
@@ -2310,7 +2326,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Download current-run OpenClaw Docker E2E package
-        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != '' && inputs.package_artifact_run_id == github.run_id
+        if: steps.plan.outputs.needs_package == '1' && needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_run_id == github.run_id
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           artifact-ids: ${{ inputs.package_artifact_id }}
@@ -2319,7 +2335,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Download previous-run OpenClaw Docker E2E package
-        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id != '' && inputs.package_artifact_run_id != github.run_id
+        if: steps.plan.outputs.needs_package == '1' && needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_run_id != github.run_id
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           artifact-ids: ${{ inputs.package_artifact_id }}
@@ -2453,7 +2469,7 @@ jobs:
 
       - name: Upload OpenClaw Docker E2E package
         id: upload_package
-        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_id == ''
+        if: steps.plan.outputs.needs_package == '1' && needs.validate_selected_ref.outputs.package_artifact_present != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docker-e2e-package-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2214,8 +2214,38 @@ jobs:
           fi
           echo "plan_json=$plan_path" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve source package requirement
+        id: package_source
+        env:
+          NEEDS_PACKAGE: ${{ steps.plan.outputs.needs_package }}
+          PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name }}
+          PACKAGE_ARTIFACT_RUN_ID: ${{ inputs.package_artifact_run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_package_required=false
+          if [[ "$NEEDS_PACKAGE" == "1" &&
+                ! "$PACKAGE_ARTIFACT_NAME" =~ [^[:space:]] &&
+                ! "$PACKAGE_ARTIFACT_RUN_ID" =~ [^[:space:]] ]]; then
+            source_package_required=true
+          fi
+          echo "required=$source_package_required" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Docker E2E package source metadata
+        if: steps.package_source.outputs.required == 'true'
+        env:
+          ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(--source-dir "$GITHUB_WORKSPACE")
+          if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]]; then
+            args+=(--allow-unreleased-changelog)
+          fi
+          node .release-harness/scripts/package-source-preflight.mjs "${args[@]}"
+
       - name: Setup Node environment
-        if: (steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')
+        if: steps.package_source.outputs.required == 'true' || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')
         uses: ./.github/actions/setup-node-env
         with:
           cache-mode: restore
@@ -2300,7 +2330,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Pack OpenClaw package for Docker E2E
-        if: steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == ''
+        if: steps.package_source.outputs.required == 'true'
         env:
           ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
         shell: bash

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2170,6 +2170,34 @@ jobs:
           path: .release-harness
           persist-credentials: false
 
+      - name: Resolve source package requirement
+        id: package_source
+        env:
+          PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name }}
+          PACKAGE_ARTIFACT_RUN_ID: ${{ inputs.package_artifact_run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_package_required=false
+          if [[ ! "$PACKAGE_ARTIFACT_NAME" =~ [^[:space:]] &&
+                ! "$PACKAGE_ARTIFACT_RUN_ID" =~ [^[:space:]] ]]; then
+            source_package_required=true
+          fi
+          echo "required=$source_package_required" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Docker E2E package source metadata
+        if: steps.package_source.outputs.required == 'true'
+        env:
+          ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(--source-dir "$GITHUB_WORKSPACE")
+          if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]]; then
+            args+=(--allow-unreleased-changelog)
+          fi
+          node .release-harness/scripts/package-source-preflight.mjs "${args[@]}"
+
       - name: Setup trusted release harness
         uses: ./.release-harness/.github/actions/setup-release-harness
         with:
@@ -2213,36 +2241,6 @@ jobs:
               }
           fi
           echo "plan_json=$plan_path" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve source package requirement
-        id: package_source
-        env:
-          NEEDS_PACKAGE: ${{ steps.plan.outputs.needs_package }}
-          PACKAGE_ARTIFACT_NAME: ${{ inputs.package_artifact_name }}
-          PACKAGE_ARTIFACT_RUN_ID: ${{ inputs.package_artifact_run_id }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          source_package_required=false
-          if [[ "$NEEDS_PACKAGE" == "1" &&
-                ! "$PACKAGE_ARTIFACT_NAME" =~ [^[:space:]] &&
-                ! "$PACKAGE_ARTIFACT_RUN_ID" =~ [^[:space:]] ]]; then
-            source_package_required=true
-          fi
-          echo "required=$source_package_required" >> "$GITHUB_OUTPUT"
-
-      - name: Validate Docker E2E package source metadata
-        if: steps.package_source.outputs.required == 'true'
-        env:
-          ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          args=(--source-dir "$GITHUB_WORKSPACE")
-          if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]]; then
-            args+=(--allow-unreleased-changelog)
-          fi
-          node .release-harness/scripts/package-source-preflight.mjs "${args[@]}"
 
       - name: Setup Node environment
         if: steps.package_source.outputs.required == 'true' || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')
@@ -2330,7 +2328,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Pack OpenClaw package for Docker E2E
-        if: steps.package_source.outputs.required == 'true'
+        if: steps.plan.outputs.needs_package == '1' && steps.package_source.outputs.required == 'true'
         env:
           ALLOW_UNRELEASED_CHANGELOG: ${{ inputs.allow_unreleased_changelog }}
         shell: bash

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2366,10 +2366,10 @@ jobs:
         id: package
         if: steps.plan.outputs.needs_package == '1'
         env:
-          EXPECTED_PACKAGE_FILE_NAME: ${{ inputs.package_file_name }}
-          EXPECTED_PACKAGE_SHA256: ${{ inputs.package_sha256 }}
-          EXPECTED_PACKAGE_SOURCE_SHA: ${{ inputs.package_source_sha }}
-          EXPECTED_PACKAGE_VERSION: ${{ inputs.package_version }}
+          EXPECTED_PACKAGE_FILE_NAME: ${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_file_name || '' }}
+          EXPECTED_PACKAGE_SHA256: ${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_sha256 || '' }}
+          EXPECTED_PACKAGE_SOURCE_SHA: ${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_source_sha || '' }}
+          EXPECTED_PACKAGE_VERSION: ${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_version || '' }}
           SELECTED_SHA: ${{ needs.validate_selected_ref.outputs.selected_sha }}
           SHARED_IMAGE_POLICY: ${{ inputs.shared_image_policy }}
         shell: bash

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -164,6 +164,27 @@ jobs:
             exit 1
           fi
 
+      - name: Checkout trusted package source preflight
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-harness
+          fetch-depth: 1
+          filter: blob:none
+          persist-credentials: false
+          sparse-checkout: scripts
+
+      - name: Validate npm package source metadata
+        env:
+          RELEASE_REF: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          args=(--source-dir "$GITHUB_WORKSPACE")
+          if [[ "$RELEASE_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            args+=(--allow-unreleased-changelog)
+          fi
+          node .release-harness/scripts/package-source-preflight.mjs "${args[@]}"
+
       - name: Setup Node environment
         id: setup-node-env
         uses: ./.github/actions/setup-node-env

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -797,8 +797,22 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
+      - name: Resolve source package requirement
+        id: package_source
+        env:
+          CANDIDATE_ARTIFACT_JSON: ${{ inputs.candidate_artifact_json }}
+          RELEASE_PACKAGE_SPEC: ${{ needs.resolve_target.outputs.release_package_spec }}
+        run: |
+          set -euo pipefail
+          source_package_required=false
+          if [[ ! "$CANDIDATE_ARTIFACT_JSON" =~ [^[:space:]] &&
+                ! "$RELEASE_PACKAGE_SPEC" =~ [^[:space:]] ]]; then
+            source_package_required=true
+          fi
+          echo "required=$source_package_required" >> "$GITHUB_OUTPUT"
+
       - name: Validate release package source metadata
-        if: inputs.candidate_artifact_json == '' && needs.resolve_target.outputs.release_package_spec == ''
+        if: steps.package_source.outputs.required == 'true'
         env:
           ALLOW_UNRELEASED_CHANGELOG: ${{ needs.resolve_target.outputs.allow_unreleased_changelog }}
           PACKAGE_REF: ${{ needs.resolve_target.outputs.revision }}
@@ -812,7 +826,7 @@ jobs:
 
       - name: Set artifact metadata
         id: artifact
-        if: inputs.candidate_artifact_json == ''
+        if: steps.package_source.outputs.required == 'true' || needs.resolve_target.outputs.release_package_spec != ''
         run: |
           {
             echo "file_name=openclaw-current.tgz"
@@ -822,7 +836,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node environment
-        if: inputs.candidate_artifact_json == ''
+        if: steps.package_source.outputs.required == 'true' || needs.resolve_target.outputs.release_package_spec != ''
         uses: ./.github/actions/setup-node-env
         with:
           cache-mode: restore
@@ -832,7 +846,7 @@ jobs:
 
       - name: Resolve release package artifact
         id: package
-        if: inputs.candidate_artifact_json == ''
+        if: steps.package_source.outputs.required == 'true' || needs.resolve_target.outputs.release_package_spec != ''
         shell: bash
         env:
           CROSS_OS_SCHEDULED: ${{ needs.resolve_target.outputs.cross_os_scheduled }}
@@ -841,11 +855,12 @@ jobs:
           PROVIDER: ${{ needs.resolve_target.outputs.provider }}
           RELEASE_PACKAGE_SPEC: ${{ needs.resolve_target.outputs.release_package_spec }}
           RELEASE_PROFILE: ${{ needs.resolve_target.outputs.release_profile }}
+          SOURCE_PACKAGE_REQUIRED: ${{ steps.package_source.outputs.required }}
         run: |
           set -euo pipefail
           source_args=(--source ref --package-ref "$PACKAGE_REF")
           package_label="ref:${PACKAGE_REF}"
-          if [[ -n "${RELEASE_PACKAGE_SPEC// }" ]]; then
+          if [[ "$SOURCE_PACKAGE_REQUIRED" != "true" ]]; then
             source_args=(--source npm --package-spec "$RELEASE_PACKAGE_SPEC" --package-ref "$PACKAGE_REF")
             package_label="$RELEASE_PACKAGE_SPEC"
           fi

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -168,6 +168,8 @@ jobs:
       qa_live_discord_enabled: ${{ steps.inputs.outputs.qa_live_discord_enabled }}
       qa_live_whatsapp_enabled: ${{ steps.inputs.outputs.qa_live_whatsapp_enabled }}
       qa_live_slack_enabled: ${{ steps.inputs.outputs.qa_live_slack_enabled }}
+      package_mode: ${{ steps.inputs.outputs.package_mode }}
+      candidate_artifact_json: ${{ steps.inputs.outputs.candidate_artifact_json }}
       release_package_spec: ${{ steps.inputs.outputs.release_package_spec }}
       package_acceptance_package_spec: ${{ steps.inputs.outputs.package_acceptance_package_spec }}
       codex_plugin_spec: ${{ steps.inputs.outputs.codex_plugin_spec }}
@@ -432,11 +434,26 @@ jobs:
           RELEASE_FILTER_VALIDATOR: workflow/scripts/github/validate-release-suite-filters.sh
         run: |
           set -euo pipefail
-          if [[ -n "${CANDIDATE_ARTIFACT_JSON_INPUT// }" ]] &&
-            { [[ -n "${RELEASE_PACKAGE_SPEC_INPUT// }" ]] ||
-              [[ -n "${RELEASE_PACKAGE_ACCEPTANCE_PACKAGE_SPEC_INPUT// }" ]]; }; then
+          candidate_artifact_json=""
+          release_package_spec=""
+          package_acceptance_package_spec=""
+          [[ "$CANDIDATE_ARTIFACT_JSON_INPUT" =~ [^[:space:]] ]] &&
+            candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON_INPUT"
+          [[ "$RELEASE_PACKAGE_SPEC_INPUT" =~ [^[:space:]] ]] &&
+            release_package_spec="$RELEASE_PACKAGE_SPEC_INPUT"
+          [[ "$RELEASE_PACKAGE_ACCEPTANCE_PACKAGE_SPEC_INPUT" =~ [^[:space:]] ]] &&
+            package_acceptance_package_spec="$RELEASE_PACKAGE_ACCEPTANCE_PACKAGE_SPEC_INPUT"
+          if [[ -n "$candidate_artifact_json" ]] &&
+            { [[ -n "$release_package_spec" ]] ||
+              [[ -n "$package_acceptance_package_spec" ]]; }; then
             echo "candidate_artifact_json cannot be combined with release package specs." >&2
             exit 1
+          fi
+          package_mode=source
+          if [[ -n "$candidate_artifact_json" ]]; then
+            package_mode=artifact
+          elif [[ -n "$release_package_spec" ]]; then
+            package_mode=published
           fi
           qa_live_matrix_enabled=true
           qa_live_buzz_enabled=true
@@ -515,7 +532,7 @@ jobs:
             exit 1
           fi
           codex_plugin_spec="$RELEASE_CODEX_PLUGIN_SPEC_INPUT"
-          if [[ -z "${codex_plugin_spec// }" && "$RELEASE_PACKAGE_SPEC_INPUT" =~ ^openclaw@(.+)$ ]]; then
+          if [[ -z "${codex_plugin_spec// }" && "$release_package_spec" =~ ^openclaw@(.+)$ ]]; then
             codex_plugin_spec="npm:@openclaw/codex@${BASH_REMATCH[1]}"
           fi
           source "$RELEASE_FILTER_VALIDATOR"
@@ -686,8 +703,10 @@ jobs:
             printf 'qa_live_discord_enabled=%s\n' "$qa_live_discord_enabled"
             printf 'qa_live_whatsapp_enabled=%s\n' "$qa_live_whatsapp_enabled"
             printf 'qa_live_slack_enabled=%s\n' "$qa_live_slack_enabled"
-            printf 'release_package_spec=%s\n' "$RELEASE_PACKAGE_SPEC_INPUT"
-            printf 'package_acceptance_package_spec=%s\n' "$RELEASE_PACKAGE_ACCEPTANCE_PACKAGE_SPEC_INPUT"
+            printf 'package_mode=%s\n' "$package_mode"
+            printf 'candidate_artifact_json=%s\n' "$candidate_artifact_json"
+            printf 'release_package_spec=%s\n' "$release_package_spec"
+            printf 'package_acceptance_package_spec=%s\n' "$package_acceptance_package_spec"
             printf 'codex_plugin_spec=%s\n' "$codex_plugin_spec"
             printf 'cross_os_scheduled=%s\n' "$cross_os_scheduled"
             printf 'live_e2e_scheduled=%s\n' "$live_e2e_scheduled"
@@ -715,8 +734,8 @@ jobs:
           RELEASE_RERUN_GROUP: ${{ inputs.rerun_group }}
           RELEASE_LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
           RELEASE_CROSS_OS_SUITE_FILTER: ${{ inputs.cross_os_suite_filter }}
-          RELEASE_PACKAGE_SPEC: ${{ inputs.release_package_spec }}
-          PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ inputs.package_acceptance_package_spec }}
+          RELEASE_PACKAGE_SPEC: ${{ steps.inputs.outputs.release_package_spec }}
+          PACKAGE_ACCEPTANCE_PACKAGE_SPEC: ${{ steps.inputs.outputs.package_acceptance_package_spec }}
           CODEX_PLUGIN_SPEC: ${{ steps.inputs.outputs.codex_plugin_spec }}
         run: |
           {
@@ -745,12 +764,12 @@ jobs:
               echo "- Cross-OS suite filter: \`${RELEASE_CROSS_OS_SUITE_FILTER}\`"
             fi
             echo "- QA-live lane eligibility: Matrix \`${{ steps.inputs.outputs.qa_live_matrix_enabled }}\`, Buzz \`${{ steps.inputs.outputs.qa_live_buzz_enabled }}\`, Telegram \`${{ steps.inputs.outputs.qa_live_telegram_enabled }}\`, Discord \`${{ steps.inputs.outputs.qa_live_discord_enabled }}\`, WhatsApp \`${{ steps.inputs.outputs.qa_live_whatsapp_enabled }}\`, Slack \`${{ steps.inputs.outputs.qa_live_slack_enabled }}\`"
-            if [[ -n "${RELEASE_PACKAGE_SPEC// }" ]]; then
+            if [[ -n "$RELEASE_PACKAGE_SPEC" ]]; then
               echo "- Release package spec: \`${RELEASE_PACKAGE_SPEC}\`"
             fi
-            if [[ -n "${PACKAGE_ACCEPTANCE_PACKAGE_SPEC// }" ]]; then
+            if [[ -n "$PACKAGE_ACCEPTANCE_PACKAGE_SPEC" ]]; then
               echo "- Package Acceptance package spec: \`${PACKAGE_ACCEPTANCE_PACKAGE_SPEC}\`"
-            elif [[ -n "${RELEASE_PACKAGE_SPEC// }" ]]; then
+            elif [[ -n "$RELEASE_PACKAGE_SPEC" ]]; then
               echo "- Package Acceptance package spec: \`${RELEASE_PACKAGE_SPEC}\`"
             else
               echo "- Package Acceptance package spec: prepared release artifact"
@@ -778,16 +797,16 @@ jobs:
       contents: read
       packages: read
     outputs:
-      artifact_digest: ${{ steps.release_package_upload.outputs.artifact-digest || fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactDigest }}
-      artifact_id: ${{ steps.release_package_upload.outputs.artifact-id || fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactId }}
-      artifact_name: ${{ steps.artifact.outputs.name || fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactName }}
-      artifact_run_attempt: ${{ steps.artifact.outputs.run_attempt || fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactRunAttempt }}
-      artifact_run_id: ${{ steps.artifact.outputs.run_id || fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactRunId }}
-      package_file_name: ${{ steps.artifact.outputs.file_name || fromJSON(inputs.candidate_artifact_json || '{}').packageFileName }}
-      package_sha256: ${{ steps.package.outputs.sha256 || fromJSON(inputs.candidate_artifact_json || '{}').packageSha256 }}
-      package_version: ${{ steps.package.outputs.package_version || fromJSON(inputs.candidate_artifact_json || '{}').packageVersion }}
+      artifact_digest: ${{ steps.release_package_upload.outputs.artifact-digest || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageArtifactDigest }}
+      artifact_id: ${{ steps.release_package_upload.outputs.artifact-id || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageArtifactId }}
+      artifact_name: ${{ steps.artifact.outputs.name || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageArtifactName }}
+      artifact_run_attempt: ${{ steps.artifact.outputs.run_attempt || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageArtifactRunAttempt }}
+      artifact_run_id: ${{ steps.artifact.outputs.run_id || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageArtifactRunId }}
+      package_file_name: ${{ steps.artifact.outputs.file_name || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageFileName }}
+      package_sha256: ${{ steps.package.outputs.sha256 || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageSha256 }}
+      package_version: ${{ steps.package.outputs.package_version || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageVersion }}
       prepublish_plugin_registry_json: ${{ steps.registry_identity.outputs.json }}
-      source_sha: ${{ steps.package.outputs.source_sha || fromJSON(inputs.candidate_artifact_json || '{}').packageSourceSha }}
+      source_sha: ${{ steps.package.outputs.source_sha || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageSourceSha }}
     steps:
       - name: Checkout trusted workflow ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -797,22 +816,8 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
-      - name: Resolve source package requirement
-        id: package_source
-        env:
-          CANDIDATE_ARTIFACT_JSON: ${{ inputs.candidate_artifact_json }}
-          RELEASE_PACKAGE_SPEC: ${{ needs.resolve_target.outputs.release_package_spec }}
-        run: |
-          set -euo pipefail
-          source_package_required=false
-          if [[ ! "$CANDIDATE_ARTIFACT_JSON" =~ [^[:space:]] &&
-                ! "$RELEASE_PACKAGE_SPEC" =~ [^[:space:]] ]]; then
-            source_package_required=true
-          fi
-          echo "required=$source_package_required" >> "$GITHUB_OUTPUT"
-
       - name: Validate release package source metadata
-        if: steps.package_source.outputs.required == 'true'
+        if: needs.resolve_target.outputs.package_mode == 'source'
         env:
           ALLOW_UNRELEASED_CHANGELOG: ${{ needs.resolve_target.outputs.allow_unreleased_changelog }}
           PACKAGE_REF: ${{ needs.resolve_target.outputs.revision }}
@@ -826,7 +831,7 @@ jobs:
 
       - name: Set artifact metadata
         id: artifact
-        if: steps.package_source.outputs.required == 'true' || needs.resolve_target.outputs.release_package_spec != ''
+        if: needs.resolve_target.outputs.package_mode != 'artifact'
         run: |
           {
             echo "file_name=openclaw-current.tgz"
@@ -836,7 +841,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node environment
-        if: steps.package_source.outputs.required == 'true' || needs.resolve_target.outputs.release_package_spec != ''
+        if: needs.resolve_target.outputs.package_mode != 'artifact'
         uses: ./.github/actions/setup-node-env
         with:
           cache-mode: restore
@@ -846,21 +851,21 @@ jobs:
 
       - name: Resolve release package artifact
         id: package
-        if: steps.package_source.outputs.required == 'true' || needs.resolve_target.outputs.release_package_spec != ''
+        if: needs.resolve_target.outputs.package_mode != 'artifact'
         shell: bash
         env:
           CROSS_OS_SCHEDULED: ${{ needs.resolve_target.outputs.cross_os_scheduled }}
           DOCKER_REQUIRED: ${{ needs.resolve_target.outputs.docker_required }}
           PACKAGE_REF: ${{ needs.resolve_target.outputs.revision }}
           PROVIDER: ${{ needs.resolve_target.outputs.provider }}
+          PACKAGE_MODE: ${{ needs.resolve_target.outputs.package_mode }}
           RELEASE_PACKAGE_SPEC: ${{ needs.resolve_target.outputs.release_package_spec }}
           RELEASE_PROFILE: ${{ needs.resolve_target.outputs.release_profile }}
-          SOURCE_PACKAGE_REQUIRED: ${{ steps.package_source.outputs.required }}
         run: |
           set -euo pipefail
           source_args=(--source ref --package-ref "$PACKAGE_REF")
           package_label="ref:${PACKAGE_REF}"
-          if [[ "$SOURCE_PACKAGE_REQUIRED" != "true" ]]; then
+          if [[ "$PACKAGE_MODE" == "published" ]]; then
             source_args=(--source npm --package-spec "$RELEASE_PACKAGE_SPEC" --package-ref "$PACKAGE_REF")
             package_label="$RELEASE_PACKAGE_SPEC"
           fi
@@ -874,7 +879,7 @@ jobs:
             )"
           fi
           docker_packages='[]'
-          if [[ "$DOCKER_REQUIRED" == "true" && -z "${RELEASE_PACKAGE_SPEC// }" ]]; then
+          if [[ "$DOCKER_REQUIRED" == "true" && "$PACKAGE_MODE" == "source" ]]; then
             export OPENCLAW_DOCKER_ALL_PROFILE=release-path
             export OPENCLAW_DOCKER_ALL_PLAN_RELEASE_ALL=1
             export OPENCLAW_DOCKER_ALL_INCLUDE_OPENWEBUI="${{ needs.resolve_target.outputs.release_profile != 'beta' }}"
@@ -926,7 +931,7 @@ jobs:
 
       - name: Upload release package artifact
         id: release_package_upload
-        if: inputs.candidate_artifact_json == ''
+        if: needs.resolve_target.outputs.package_mode != 'artifact'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ steps.artifact.outputs.name }}
@@ -938,7 +943,7 @@ jobs:
 
       - name: Upload shared prerelease plugin registry artifact
         id: prepublish_plugin_registry_upload
-        if: inputs.candidate_artifact_json == '' && steps.package.outputs.plugin_registry_manifest_sha256 != ''
+        if: needs.resolve_target.outputs.package_mode != 'artifact' && steps.package.outputs.plugin_registry_manifest_sha256 != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docker-e2e-prepublish-plugin-registry-${{ github.run_id }}-${{ github.run_attempt }}
@@ -947,7 +952,7 @@ jobs:
           if-no-files-found: error
 
       - name: Validate release package artifact binding
-        if: inputs.candidate_artifact_json == ''
+        if: needs.resolve_target.outputs.package_mode != 'artifact'
         env:
           ARTIFACT_DIGEST: ${{ steps.release_package_upload.outputs.artifact-digest }}
           ARTIFACT_ID: ${{ steps.release_package_upload.outputs.artifact-id }}
@@ -977,7 +982,7 @@ jobs:
             "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Validate shared prerelease plugin registry binding
-        if: inputs.candidate_artifact_json == '' && steps.package.outputs.plugin_registry_manifest_sha256 != ''
+        if: needs.resolve_target.outputs.package_mode != 'artifact' && steps.package.outputs.plugin_registry_manifest_sha256 != ''
         env:
           ARTIFACT_DIGEST: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-digest }}
           ARTIFACT_ID: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id }}
@@ -998,9 +1003,9 @@ jobs:
             "$ARTIFACT_RUN_ID" "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Validate shared release candidate identity
-        if: inputs.candidate_artifact_json != ''
+        if: needs.resolve_target.outputs.package_mode == 'artifact'
         env:
-          CANDIDATE_ARTIFACT_JSON: ${{ inputs.candidate_artifact_json }}
+          CANDIDATE_ARTIFACT_JSON: ${{ needs.resolve_target.outputs.candidate_artifact_json }}
           GH_TOKEN: ${{ github.token }}
           SELECTED_SHA: ${{ needs.resolve_target.outputs.revision }}
         run: |
@@ -1070,7 +1075,7 @@ jobs:
       - name: Prepare prerelease plugin registry identity
         id: registry_identity
         env:
-          CANDIDATE_ARTIFACT_JSON: ${{ inputs.candidate_artifact_json }}
+          CANDIDATE_ARTIFACT_JSON: ${{ needs.resolve_target.outputs.candidate_artifact_json }}
           GENERATED_ARTIFACT_DIGEST: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-digest }}
           GENERATED_ARTIFACT_ID: ${{ steps.prepublish_plugin_registry_upload.outputs.artifact-id }}
           GENERATED_MANIFEST_SHA256: ${{ steps.package.outputs.plugin_registry_manifest_sha256 }}
@@ -1259,7 +1264,7 @@ jobs:
       package_sha256: ${{ needs.prepare_release_package.outputs.package_sha256 }}
       package_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
       package_version: ${{ needs.prepare_release_package.outputs.package_version }}
-      enable_prepublish_plugin_registry: ${{ needs.resolve_target.outputs.release_package_spec == '' }}
+      enable_prepublish_plugin_registry: ${{ needs.resolve_target.outputs.package_mode != 'published' }}
       prepublish_plugin_registry_artifact_name: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactName || '' }}
       prepublish_plugin_registry_artifact_id: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactId || '' }}
       prepublish_plugin_registry_artifact_digest: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryArtifactDigest || '' }}
@@ -1268,12 +1273,12 @@ jobs:
       prepublish_plugin_registry_manifest_sha256: ${{ fromJSON(needs.prepare_release_package.outputs.prepublish_plugin_registry_json || '{}').prepublishPluginRegistryManifestSha256 || '' }}
       codex_plugin_spec: ${{ needs.resolve_target.outputs.codex_plugin_spec }}
       shared_image_artifact_namespace: release-docker
-      shared_image_artifact_name: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactName || '' }}
-      shared_image_artifact_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactId || '' }}
-      shared_image_artifact_digest: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactDigest || '' }}
-      shared_image_artifact_run_id: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactRunId || '' }}
-      shared_image_artifact_run_attempt: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArtifactRunAttempt || '' }}
-      shared_image_archive_sha256: ${{ fromJSON(inputs.candidate_artifact_json || '{}').imageArchiveSha256 || '' }}
+      shared_image_artifact_name: ${{ fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').imageArtifactName || '' }}
+      shared_image_artifact_id: ${{ fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').imageArtifactId || '' }}
+      shared_image_artifact_digest: ${{ fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').imageArtifactDigest || '' }}
+      shared_image_artifact_run_id: ${{ fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').imageArtifactRunId || '' }}
+      shared_image_artifact_run_attempt: ${{ fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').imageArtifactRunAttempt || '' }}
+      shared_image_archive_sha256: ${{ fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').imageArchiveSha256 || '' }}
       shared_image_policy: no-push-artifact
     secrets: *live_e2e_release_secrets
 
@@ -1291,7 +1296,7 @@ jobs:
       advisory: false
       allow_frozen_target_scenario_omissions: ${{ inputs.allow_frozen_target_scenario_omissions }}
       workflow_ref: ${{ github.sha }}
-      source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.release_package_spec != '') && 'npm' || 'artifact' }}
+      source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.package_mode == 'published') && 'npm' || 'artifact' }}
       package_spec: ${{ needs.resolve_target.outputs.package_acceptance_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}
       artifact_digest: ${{ needs.prepare_release_package.outputs.artifact_digest }}
       artifact_id: ${{ needs.prepare_release_package.outputs.artifact_id }}
@@ -1299,7 +1304,7 @@ jobs:
       artifact_run_attempt: ${{ needs.prepare_release_package.outputs.artifact_run_attempt }}
       artifact_run_id: ${{ needs.prepare_release_package.outputs.artifact_run_id }}
       package_file_name: ${{ needs.prepare_release_package.outputs.package_file_name }}
-      package_sha256: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.release_package_spec == '') && needs.prepare_release_package.outputs.package_sha256 || '' }}
+      package_sha256: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.package_mode != 'published') && needs.prepare_release_package.outputs.package_sha256 || '' }}
       package_source_sha: ${{ needs.prepare_release_package.outputs.source_sha }}
       package_version: ${{ needs.prepare_release_package.outputs.package_version }}
       suite_profile: custom
@@ -1309,7 +1314,7 @@ jobs:
       telegram_mode: ${{ needs.resolve_target.outputs.skip_package_telegram_e2e == 'true' && 'none' || 'mock-openai' }}
       telegram_advisory: ${{ needs.resolve_target.outputs.release_profile == 'beta' }}
       shared_image_artifact_namespace: release-package
-      candidate_artifact_json: ${{ inputs.candidate_artifact_json }}
+      candidate_artifact_json: ${{ needs.resolve_target.outputs.candidate_artifact_json }}
       shared_image_policy: no-push-artifact
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -797,6 +797,19 @@ jobs:
           fetch-depth: 0
           filter: blob:none
 
+      - name: Validate release package source metadata
+        if: inputs.candidate_artifact_json == '' && needs.resolve_target.outputs.release_package_spec == ''
+        env:
+          ALLOW_UNRELEASED_CHANGELOG: ${{ needs.resolve_target.outputs.allow_unreleased_changelog }}
+          PACKAGE_REF: ${{ needs.resolve_target.outputs.revision }}
+        run: |
+          set -euo pipefail
+          args=(--ref "$PACKAGE_REF")
+          if [[ "$ALLOW_UNRELEASED_CHANGELOG" == "true" ]]; then
+            args+=(--allow-unreleased-changelog)
+          fi
+          node scripts/package-source-preflight.mjs "${args[@]}"
+
       - name: Set artifact metadata
         id: artifact
         if: inputs.candidate_artifact_json == ''

--- a/scripts/lib/cross-os-release-checks/install.ts
+++ b/scripts/lib/cross-os-release-checks/install.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import { dirname, join, relative, resolve, win32 as pathWin32 } from "node:path";
 import { pathToFileURL } from "node:url";
+import { validatePackageSourceDir } from "../../package-source-preflight.mjs";
 import { isLocalBuildMetadataDistPath } from "../local-build-metadata-paths.mts";
 import type { CandidateBuild, LaneCommandParams, LaneState, PackageJson } from "./config.ts";
 import {
@@ -35,6 +36,7 @@ export async function prepareCandidate(params: {
   logsDir: string;
 }): Promise<CandidateBuild> {
   logPhase("prepare", "resolve-source-sha");
+  validatePackageSourceDir(params.sourceDir, { allowUnreleasedChangelog: true });
   const packageJson = readPackageJson(params.sourceDir);
   const hasUiBuildScript = packageJsonHasScript(packageJson, "ui:build");
   const sourceSha = (

--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -15,6 +15,7 @@ import { assertRealOutputRoot } from "./lib/output-root-guard.mjs";
 import { isRecord } from "./lib/record-shared.mjs";
 import { resolveNpmRunner } from "./npm-runner.mts";
 import { preparePackageChangelog, restorePackageChangelog } from "./package-changelog.mjs";
+import { validateBundledPackageDependencyAlignment } from "./package-source-dependencies.mjs";
 import { resolvePnpmRunner } from "./pnpm-runner.mts";
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -787,19 +788,12 @@ export async function prepareBundledAiRuntimePackage(
     if (typeof stagedPackageJson.version !== "string" || !stagedPackageJson.version) {
       throw new Error("packed @openclaw/ai package must declare a version");
     }
-    for (const [name, version] of Object.entries(stagedPackageJson.dependencies ?? {})) {
-      if (typeof version !== "string") {
-        throw new Error(`packed @openclaw/ai dependency ${name} must declare a string version`);
-      }
-      if (version === "0.0.0-private") {
-        continue;
-      }
-      const rootVersion = packageJson.dependencies?.[name];
-      if (rootVersion !== version && rootVersion !== `workspace:${version}`) {
-        throw new Error(
-          `root package.json must declare ${name}@${version} to bundle @openclaw/ai without duplicate dependencies`,
-        );
-      }
+    const alignedDependencies = validateBundledPackageDependencyAlignment({
+      bundledDependencies: stagedPackageJson.dependencies,
+      bundledPackageLabel: "packed @openclaw/ai",
+      rootDependencies: packageJson.dependencies,
+    });
+    for (const [name, version] of alignedDependencies) {
       packageJson.dependencies![name] = version;
     }
     // Root owns these exact dependencies. Removing them from the staged copy keeps npm from

--- a/scripts/package-source-dependencies.d.mts
+++ b/scripts/package-source-dependencies.d.mts
@@ -1,0 +1,6 @@
+export function validateBundledPackageDependencyAlignment(params: {
+  bundledDependencies?: unknown;
+  bundledPackageLabel: string;
+  rootDependencies?: unknown;
+  rootPackageLabel?: string;
+}): Array<[string, string]>;

--- a/scripts/package-source-dependencies.mjs
+++ b/scripts/package-source-dependencies.mjs
@@ -1,14 +1,10 @@
 const PRIVATE_WORKSPACE_VERSION = "0.0.0-private";
 
-function isRecord(value) {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function dependenciesRecord(value, label) {
   if (value === undefined) {
     return {};
   }
-  if (!isRecord(value)) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`${label} dependencies must be an object when present`);
   }
   return value;

--- a/scripts/package-source-dependencies.mjs
+++ b/scripts/package-source-dependencies.mjs
@@ -1,0 +1,45 @@
+const PRIVATE_WORKSPACE_VERSION = "0.0.0-private";
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function dependenciesRecord(value, label) {
+  if (value === undefined) {
+    return {};
+  }
+  if (!isRecord(value)) {
+    throw new Error(`${label} dependencies must be an object when present`);
+  }
+  return value;
+}
+
+export function validateBundledPackageDependencyAlignment({
+  bundledDependencies,
+  bundledPackageLabel,
+  rootDependencies,
+  rootPackageLabel = "root package.json",
+}) {
+  const bundled = dependenciesRecord(bundledDependencies, bundledPackageLabel);
+  const root = dependenciesRecord(rootDependencies, rootPackageLabel);
+  const aligned = [];
+  for (const [name, version] of Object.entries(bundled)) {
+    if (typeof version !== "string") {
+      throw new Error(`${bundledPackageLabel} dependency ${name} must declare a string version`);
+    }
+    if (version === PRIVATE_WORKSPACE_VERSION) {
+      continue;
+    }
+    const rootVersion = root[name];
+    if (rootVersion !== undefined && typeof rootVersion !== "string") {
+      throw new Error(`${rootPackageLabel} dependency ${name} must declare a string version`);
+    }
+    if (rootVersion !== version && rootVersion !== `workspace:${version}`) {
+      throw new Error(
+        `${rootPackageLabel} must declare ${name}@${version} to bundle @openclaw/ai without duplicate dependencies`,
+      );
+    }
+    aligned.push([name, version]);
+  }
+  return aligned;
+}

--- a/scripts/package-source-preflight.d.mts
+++ b/scripts/package-source-preflight.d.mts
@@ -1,0 +1,14 @@
+type PackageSourcePreflightOptions = {
+  allowUnreleasedChangelog?: boolean;
+};
+
+export function validatePackageSource(params: {
+  aiManifestContent: string | null;
+  allowUnreleasedChangelog?: boolean;
+  changelogContent: string;
+  rootManifestContent: string;
+}): string;
+export function validatePackageSourceRef(
+  ref: string,
+  options?: PackageSourcePreflightOptions,
+): string;

--- a/scripts/package-source-preflight.d.mts
+++ b/scripts/package-source-preflight.d.mts
@@ -12,3 +12,7 @@ export function validatePackageSourceRef(
   ref: string,
   options?: PackageSourcePreflightOptions,
 ): string;
+export function validatePackageSourceDir(
+  sourceDir: string,
+  options?: PackageSourcePreflightOptions,
+): string;

--- a/scripts/package-source-preflight.mjs
+++ b/scripts/package-source-preflight.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { extractCurrentPackageChangelog } from "./package-changelog.mjs";
+import { validateBundledPackageDependencyAlignment } from "./package-source-dependencies.mjs";
 
 const FULL_GIT_COMMIT_RE = /^[0-9a-f]{40}$/u;
 const ROOT_MANIFEST_PATH = "package.json";
@@ -14,6 +16,7 @@ function parseArgs(argv) {
   const options = {
     allowUnreleasedChangelog: false,
     ref: "",
+    sourceDir: "",
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -26,10 +29,21 @@ function parseArgs(argv) {
       index += 1;
       continue;
     }
+    if (arg === "--source-dir") {
+      options.sourceDir = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
     throw new Error(`Unknown package source preflight option: ${arg}`);
   }
-  if (!FULL_GIT_COMMIT_RE.test(options.ref)) {
-    throw new Error(`--ref must be a full lowercase commit SHA; got ${options.ref || "<missing>"}`);
+  if (options.ref && options.sourceDir) {
+    throw new Error("Use exactly one of --ref or --source-dir.");
+  }
+  if (options.ref && !FULL_GIT_COMMIT_RE.test(options.ref)) {
+    throw new Error(`--ref must be a full lowercase commit SHA; got ${options.ref}`);
+  }
+  if (!options.ref && !options.sourceDir) {
+    throw new Error("Use exactly one of --ref or --source-dir.");
   }
   return options;
 }
@@ -77,13 +91,12 @@ export function validatePackageSource({
     );
   }
 
-  for (const [name, version] of Object.entries(aiManifest.dependencies ?? {})) {
-    if (rootDependencies[name] !== version) {
-      throw new Error(
-        `${ROOT_MANIFEST_PATH} must match ${AI_MANIFEST_PATH} dependency ${name}@${version}; found ${JSON.stringify(rootDependencies[name])}.`,
-      );
-    }
-  }
+  validateBundledPackageDependencyAlignment({
+    bundledDependencies: aiManifest.dependencies,
+    bundledPackageLabel: AI_MANIFEST_PATH,
+    rootDependencies,
+    rootPackageLabel: ROOT_MANIFEST_PATH,
+  });
   return rootManifest.version;
 }
 
@@ -111,9 +124,32 @@ export function validatePackageSourceRef(ref, options = {}) {
   });
 }
 
+function readSourceFile(sourceDir, file, { optional = false } = {}) {
+  try {
+    return readFileSync(path.join(sourceDir, file), "utf8");
+  } catch (error) {
+    if (optional && error?.code === "ENOENT") {
+      return null;
+    }
+    throw new Error(`Unable to read ${file} from ${sourceDir}.`, { cause: error });
+  }
+}
+
+export function validatePackageSourceDir(sourceDir, options = {}) {
+  const resolvedSourceDir = path.resolve(sourceDir);
+  return validatePackageSource({
+    aiManifestContent: readSourceFile(resolvedSourceDir, AI_MANIFEST_PATH, { optional: true }),
+    allowUnreleasedChangelog: options.allowUnreleasedChangelog,
+    changelogContent: readSourceFile(resolvedSourceDir, CHANGELOG_PATH),
+    rootManifestContent: readSourceFile(resolvedSourceDir, ROOT_MANIFEST_PATH),
+  });
+}
+
 function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
-  const version = validatePackageSourceRef(options.ref, options);
+  const version = options.ref
+    ? validatePackageSourceRef(options.ref, options)
+    : validatePackageSourceDir(options.sourceDir, options);
   console.log(`package-source-preflight: source manifests and changelog are valid (${version}).`);
 }
 

--- a/scripts/package-source-preflight.mjs
+++ b/scripts/package-source-preflight.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { extractCurrentPackageChangelog } from "./package-changelog.mjs";
+
+const FULL_GIT_COMMIT_RE = /^[0-9a-f]{40}$/u;
+const ROOT_MANIFEST_PATH = "package.json";
+const AI_MANIFEST_PATH = "packages/ai/package.json";
+const CHANGELOG_PATH = "CHANGELOG.md";
+
+function parseArgs(argv) {
+  const options = {
+    allowUnreleasedChangelog: false,
+    ref: "",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--allow-unreleased-changelog") {
+      options.allowUnreleasedChangelog = true;
+      continue;
+    }
+    if (arg === "--ref") {
+      options.ref = argv[index + 1] ?? "";
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown package source preflight option: ${arg}`);
+  }
+  if (!FULL_GIT_COMMIT_RE.test(options.ref)) {
+    throw new Error(`--ref must be a full lowercase commit SHA; got ${options.ref || "<missing>"}`);
+  }
+  return options;
+}
+
+function parseManifest(content, manifestPath) {
+  try {
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error(`Failed to parse ${manifestPath}.`, { cause: error });
+  }
+}
+
+export function validatePackageSource({
+  aiManifestContent,
+  allowUnreleasedChangelog = false,
+  changelogContent,
+  rootManifestContent,
+}) {
+  const rootManifest = parseManifest(rootManifestContent, ROOT_MANIFEST_PATH);
+  if (typeof rootManifest.version !== "string") {
+    throw new Error(`${ROOT_MANIFEST_PATH} version must be a string.`);
+  }
+  extractCurrentPackageChangelog(changelogContent, rootManifest.version, {
+    allowUnreleased: allowUnreleasedChangelog,
+  });
+
+  const rootDependencies = rootManifest.dependencies ?? {};
+  const aiDependency = rootDependencies["@openclaw/ai"];
+  if (aiManifestContent === null) {
+    if (aiDependency === undefined) {
+      return rootManifest.version;
+    }
+    throw new Error(`${ROOT_MANIFEST_PATH} declares @openclaw/ai without ${AI_MANIFEST_PATH}.`);
+  }
+
+  const aiManifest = parseManifest(aiManifestContent, AI_MANIFEST_PATH);
+  if (aiDependency !== "workspace:*") {
+    throw new Error(
+      `${ROOT_MANIFEST_PATH} must depend on @openclaw/ai via workspace:*; found ${JSON.stringify(aiDependency)}.`,
+    );
+  }
+  if (aiManifest.version !== rootManifest.version) {
+    throw new Error(
+      `${AI_MANIFEST_PATH} version must match ${ROOT_MANIFEST_PATH}: expected ${rootManifest.version}, found ${String(aiManifest.version ?? "<missing>")}.`,
+    );
+  }
+
+  for (const [name, version] of Object.entries(aiManifest.dependencies ?? {})) {
+    if (rootDependencies[name] !== version) {
+      throw new Error(
+        `${ROOT_MANIFEST_PATH} must match ${AI_MANIFEST_PATH} dependency ${name}@${version}; found ${JSON.stringify(rootDependencies[name])}.`,
+      );
+    }
+  }
+  return rootManifest.version;
+}
+
+function readGitFile(ref, file, { optional = false } = {}) {
+  try {
+    return execFileSync("git", ["show", `${ref}:${file}`], {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      timeout: 30_000,
+    });
+  } catch (error) {
+    if (optional && error?.status === 128) {
+      return null;
+    }
+    throw new Error(`Unable to read ${file} from ${ref}.`, { cause: error });
+  }
+}
+
+export function validatePackageSourceRef(ref, options = {}) {
+  return validatePackageSource({
+    aiManifestContent: readGitFile(ref, AI_MANIFEST_PATH, { optional: true }),
+    allowUnreleasedChangelog: options.allowUnreleasedChangelog,
+    changelogContent: readGitFile(ref, CHANGELOG_PATH),
+    rootManifestContent: readGitFile(ref, ROOT_MANIFEST_PATH),
+  });
+}
+
+function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const version = validatePackageSourceRef(options.ref, options);
+  console.log(`package-source-preflight: source manifests and changelog are valid (${version}).`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/resolve-openclaw-package-candidate.mts
+++ b/scripts/resolve-openclaw-package-candidate.mts
@@ -24,6 +24,7 @@ import { terminateManagedChild } from "./lib/managed-child-process.mts";
 import { resolveNpmJsonEntries } from "./lib/npm-json-output.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import { resolveNpmRunner } from "./npm-runner.mts";
+import { validatePackageSourceDir } from "./package-source-preflight.mjs";
 import { createPrepublishPluginRegistryArtifact } from "./prepublish-plugin-registry-artifact.mjs";
 
 const ROOT_DIR = resolveRepoRoot(import.meta.url);
@@ -1676,6 +1677,7 @@ async function resolveCandidate(options: PackageCandidateOptions) {
       }
       packageSourceSha = packageSource.selectedSha;
       packageTrustedReason = packageSource.trustedReason;
+      validatePackageSourceDir(packageSource.sourceDir, { allowUnreleasedChangelog: true });
       await installPackageSourceDeps(packageSource.sourceDir);
       await run("node", [
         "scripts/package-openclaw-for-docker.mjs",

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -241,6 +241,7 @@ describe("package-openclaw-for-docker", () => {
       "scripts/package-openclaw-for-docker.mts",
       "scripts/package-changelog.mjs",
       "scripts/package-docs-map.mjs",
+      "scripts/package-source-dependencies.mjs",
       "scripts/docs-list.js",
       "scripts/npm-runner.mts",
       "scripts/pnpm-runner.mts",

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -71,6 +71,7 @@ import {
   parseArgs,
   parseManagedGatewayServiceInstalled,
   packageHasScript,
+  prepareCandidate,
   readInstalledVersion,
   readBoundedCrossOsResponseText,
   readRunnerOverrideEnv,
@@ -1330,6 +1331,49 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     expect(installSource).toMatch(
       /function assertNoLegacyPluginDependencyStagingDebris\(packageRoot: string\)/u,
     );
+  });
+
+  it("preflights standalone source candidates before cross-OS dependency installation", async () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-cross-os-source-preflight-"));
+    const sourceDir = join(root, "source");
+    const logsDir = join(root, "logs");
+    const outputDir = join(root, "output");
+    mkdirSync(join(sourceDir, "packages", "ai"), { recursive: true });
+    mkdirSync(logsDir, { recursive: true });
+    writeFileSync(
+      join(sourceDir, "package.json"),
+      JSON.stringify({
+        name: "openclaw",
+        version: "2026.8.1",
+        dependencies: {
+          "@openclaw/ai": "workspace:*",
+          "partial-json": "0.1.8",
+        },
+      }),
+    );
+    writeFileSync(
+      join(sourceDir, "packages", "ai", "package.json"),
+      JSON.stringify({
+        name: "@openclaw/ai",
+        version: "2026.8.1",
+        dependencies: {
+          "partial-json": "0.1.7",
+        },
+      }),
+    );
+    writeFileSync(
+      join(sourceDir, "CHANGELOG.md"),
+      "# Changelog\n\n## Unreleased\n\n- Validate source metadata before installing dependencies.\n",
+    );
+
+    try {
+      await expect(prepareCandidate({ logsDir, outputDir, sourceDir })).rejects.toThrow(
+        "package.json must declare partial-json@0.1.7",
+      );
+      expect(existsSync(join(logsDir, "pnpm-install.log"))).toBe(false);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
   });
 
   it("filters the cross-OS runner matrix to a focused OS suite", () => {

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -110,24 +110,24 @@ describe("cross-OS release checks workflow", () => {
     const producer = job(release, "prepare_release_package");
     expect(producer.outputs).toMatchObject({
       artifact_digest:
-        "${{ steps.release_package_upload.outputs.artifact-digest || fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactDigest }}",
+        "${{ steps.release_package_upload.outputs.artifact-digest || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageArtifactDigest }}",
       artifact_id:
-        "${{ steps.release_package_upload.outputs.artifact-id || fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactId }}",
+        "${{ steps.release_package_upload.outputs.artifact-id || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageArtifactId }}",
       artifact_name:
-        "${{ steps.artifact.outputs.name || fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactName }}",
+        "${{ steps.artifact.outputs.name || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageArtifactName }}",
       artifact_run_attempt:
-        "${{ steps.artifact.outputs.run_attempt || fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactRunAttempt }}",
+        "${{ steps.artifact.outputs.run_attempt || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageArtifactRunAttempt }}",
       artifact_run_id:
-        "${{ steps.artifact.outputs.run_id || fromJSON(inputs.candidate_artifact_json || '{}').packageArtifactRunId }}",
+        "${{ steps.artifact.outputs.run_id || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageArtifactRunId }}",
       package_file_name:
-        "${{ steps.artifact.outputs.file_name || fromJSON(inputs.candidate_artifact_json || '{}').packageFileName }}",
+        "${{ steps.artifact.outputs.file_name || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageFileName }}",
       package_sha256:
-        "${{ steps.package.outputs.sha256 || fromJSON(inputs.candidate_artifact_json || '{}').packageSha256 }}",
+        "${{ steps.package.outputs.sha256 || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageSha256 }}",
       package_version:
-        "${{ steps.package.outputs.package_version || fromJSON(inputs.candidate_artifact_json || '{}').packageVersion }}",
+        "${{ steps.package.outputs.package_version || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageVersion }}",
       prepublish_plugin_registry_json: "${{ steps.registry_identity.outputs.json }}",
       source_sha:
-        "${{ steps.package.outputs.source_sha || fromJSON(inputs.candidate_artifact_json || '{}').packageSourceSha }}",
+        "${{ steps.package.outputs.source_sha || fromJSON(needs.resolve_target.outputs.candidate_artifact_json || '{}').packageSourceSha }}",
     });
     expect(step(producer, "Checkout trusted workflow ref").with).toMatchObject({
       ref: "${{ github.sha }}",
@@ -245,7 +245,7 @@ describe("cross-OS release checks workflow", () => {
     const resolvePackage = step(producer, "Resolve release package artifact");
     expect(resolvePackage.run).toContain('if [[ "$CROSS_OS_SCHEDULED" == "true" ]]');
     expect(resolvePackage.run).toContain(
-      'if [[ "$DOCKER_REQUIRED" == "true" && -z "${RELEASE_PACKAGE_SPEC// }" ]]',
+      'if [[ "$DOCKER_REQUIRED" == "true" && "$PACKAGE_MODE" == "source" ]]',
     );
     expect(resolvePackage.run).toContain("registry_args=()");
     expect(resolvePackage.run).toContain("if [[ \"$required_packages\" != '[]' ]]");

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2831,7 +2831,7 @@ describe("package acceptance workflow", () => {
     );
     expect(releaseChecksWorkflow).toContain("refs/heads/release-ci/[0-9a-f]{12}-[0-9]+");
     expect(releaseChecksWorkflow).toContain(
-      "source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.release_package_spec != '') && 'npm' || 'artifact' }}",
+      "source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.package_mode == 'published') && 'npm' || 'artifact' }}",
     );
     expect(releaseChecksWorkflow).toContain(
       "package_spec: ${{ needs.resolve_target.outputs.package_acceptance_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
@@ -3316,7 +3316,7 @@ describe("package artifact reuse", () => {
       prepareDockerImageStepNames.indexOf(planStepName),
     );
     expect(workflowStep(prepareDockerImage, setupCandidateStepName)).toMatchObject({
-      if: "(steps.plan.outputs.needs_package == '1' && inputs.package_artifact_name == '' && inputs.package_artifact_run_id == '') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')",
+      if: "steps.package_source.outputs.required == 'true' || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')",
       uses: "./.github/actions/setup-node-env",
     });
     expect(workflowStep(prepareDockerImage, planStepName).env).toEqual({
@@ -4442,7 +4442,7 @@ describe("package artifact reuse", () => {
       artifact_run_id: "${{ needs.prepare_release_package.outputs.artifact_run_id }}",
       package_file_name: "${{ needs.prepare_release_package.outputs.package_file_name }}",
       package_sha256:
-        "${{ (needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.release_package_spec == '') && needs.prepare_release_package.outputs.package_sha256 || '' }}",
+        "${{ (needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.package_mode != 'published') && needs.prepare_release_package.outputs.package_sha256 || '' }}",
       package_source_sha: "${{ needs.prepare_release_package.outputs.source_sha }}",
       package_version: "${{ needs.prepare_release_package.outputs.package_version }}",
       suite_profile: "custom",
@@ -4475,7 +4475,7 @@ describe("package artifact reuse", () => {
     );
     expect(workflow).toContain("uses: ./.github/workflows/package-acceptance.yml");
     expect(workflow).toContain(
-      "source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.release_package_spec != '') && 'npm' || 'artifact' }}",
+      "source: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.package_mode == 'published') && 'npm' || 'artifact' }}",
     );
     expect(workflow).toContain(
       "package_spec: ${{ needs.resolve_target.outputs.package_acceptance_package_spec || needs.resolve_target.outputs.release_package_spec || 'openclaw@beta' }}",
@@ -4485,7 +4485,7 @@ describe("package artifact reuse", () => {
       "artifact_name: ${{ needs.prepare_release_package.outputs.artifact_name }}",
     );
     expect(workflow).toContain(
-      "package_sha256: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.release_package_spec == '') && needs.prepare_release_package.outputs.package_sha256 || '' }}",
+      "package_sha256: ${{ (needs.resolve_target.outputs.package_acceptance_package_spec == '' && needs.resolve_target.outputs.package_mode != 'published') && needs.prepare_release_package.outputs.package_sha256 || '' }}",
     );
     expect(workflow).toContain("suite_profile: custom");
     expect(String(packageAcceptanceJob.with?.docker_lanes ?? "").split(/\s+/u)).toEqual([

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3198,7 +3198,9 @@ describe("package artifact reuse", () => {
     );
     expect(workflow).toContain("Download current-run OpenClaw Docker E2E package");
     expect(workflow).toContain("Download previous-run OpenClaw Docker E2E package");
-    expect(workflow).toContain("inputs.package_artifact_id != ''");
+    expect(workflow).toContain(
+      "needs.validate_selected_ref.outputs.package_artifact_present == 'true'",
+    );
     expect(workflow).toContain(
       'bare_image="${PROVIDED_BARE_IMAGE:-ghcr.io/${repository}-docker-e2e-bare:${image_tag}}"',
     );
@@ -3316,7 +3318,7 @@ describe("package artifact reuse", () => {
       prepareDockerImageStepNames.indexOf(planStepName),
     );
     expect(workflowStep(prepareDockerImage, setupCandidateStepName)).toMatchObject({
-      if: "steps.package_source.outputs.required == 'true' || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')",
+      if: "(steps.plan.outputs.needs_package == '1' && steps.package_source.outputs.required == 'true') || (inputs.enable_prepublish_plugin_registry && steps.plan.outputs.needs_prepublish_plugin_registry == '1' && inputs.prepublish_plugin_registry_artifact_id == '')",
       uses: "./.github/actions/setup-node-env",
     });
     expect(workflowStep(prepareDockerImage, planStepName).env).toEqual({

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -146,6 +146,126 @@ exit 64
   }
 }
 
+function runLiveSourcePackageBuildAndValidation(packageEnv: Record<string, string>) {
+  const workflow = readWorkflow(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml");
+  const pack = workflowStep(
+    workflow,
+    "prepare_docker_e2e_image",
+    "Pack OpenClaw package for Docker E2E",
+  );
+  const validate = workflowStep(
+    workflow,
+    "prepare_docker_e2e_image",
+    "Validate OpenClaw Docker E2E package",
+  );
+  const artifactTuple = runLiveArtifactTupleValidation(packageEnv);
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-live-source-package-"));
+  const fakeBin = path.join(tempDir, "bin");
+  const callsPath = path.join(tempDir, "calls");
+  const outputPath = path.join(tempDir, "output");
+  const summaryPath = path.join(tempDir, "summary");
+  const selectedSha = "a".repeat(40);
+  mkdirSync(fakeBin);
+  writeFileSync(
+    path.join(fakeBin, "node"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$CALLS_PATH"
+if [[ "$1" == "scripts/package-openclaw-for-docker.mjs" ]]; then
+  shift
+  output_dir=""
+  output_name=""
+  while (( "$#" )); do
+    case "$1" in
+      --output-dir) output_dir="$2"; shift 2 ;;
+      --output-name) output_name="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  fixture="$(mktemp -d)"
+  mkdir -p "$fixture/package/dist" "$output_dir"
+  printf '%s\\n' '{"name":"openclaw","version":"2026.8.1"}' > "$fixture/package/package.json"
+  printf '{"commit":"%s"}\\n' "$SELECTED_SHA" > "$fixture/package/dist/build-info.json"
+  tar -czf "$output_dir/$output_name" -C "$fixture" package
+  rm -rf "$fixture"
+  exit 0
+fi
+if [[ "$1" == "scripts/check-openclaw-package-tarball.mjs" ]]; then
+  exit 0
+fi
+exit 64
+`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    path.join(fakeBin, "timeout"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+shift 2
+exec "$@"
+`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    path.join(fakeBin, "sha256sum"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%064d  %s\\n' 0 "$1"
+`,
+    { mode: 0o755 },
+  );
+  const commonEnv = {
+    ...process.env,
+    ALLOW_UNRELEASED_CHANGELOG: "false",
+    CALLS_PATH: callsPath,
+    GITHUB_OUTPUT: outputPath,
+    GITHUB_STEP_SUMMARY: summaryPath,
+    GITHUB_WORKSPACE: tempDir,
+    PATH: `${fakeBin}:${process.env.PATH}`,
+    SELECTED_SHA: selectedSha,
+    SHARED_IMAGE_POLICY: "existing-only",
+  };
+  try {
+    const buildResult = spawnSync("bash", ["--noprofile", "--norc", "-c", pack.run ?? ""], {
+      cwd: tempDir,
+      encoding: "utf8",
+      env: commonEnv,
+    });
+    const artifactPresent = artifactTuple.output.package_artifact_present === "true";
+    const validationResult = spawnSync(
+      "bash",
+      ["--noprofile", "--norc", "-c", validate.run ?? ""],
+      {
+        cwd: tempDir,
+        encoding: "utf8",
+        env: {
+          ...commonEnv,
+          EXPECTED_PACKAGE_FILE_NAME: artifactPresent ? packageEnv.PACKAGE_FILE_NAME : "",
+          EXPECTED_PACKAGE_SHA256: artifactPresent ? packageEnv.PACKAGE_SHA256 : "",
+          EXPECTED_PACKAGE_SOURCE_SHA: artifactPresent ? packageEnv.PACKAGE_SOURCE_SHA : "",
+          EXPECTED_PACKAGE_VERSION: artifactPresent ? packageEnv.PACKAGE_VERSION : "",
+        },
+      },
+    );
+    const output =
+      validationResult.status === 0
+        ? Object.fromEntries(
+            readFileSync(outputPath, "utf8")
+              .trim()
+              .split("\n")
+              .map((line) => {
+                const separator = line.indexOf("=");
+                return [line.slice(0, separator), line.slice(separator + 1)];
+              }),
+          )
+        : {};
+    const calls = readFileSync(callsPath, "utf8").trim().split("\n");
+    return { artifactTuple, buildResult, calls, output, validationResult, validate };
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
 function runReleaseInputCapture(params: {
   candidateArtifactJson?: string;
   releasePackageSpec?: string;
@@ -475,6 +595,45 @@ describe("package source preflight", () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(output.package_artifact_present).toBe("false");
+  });
+
+  it("builds and validates a source package for a whitespace-only artifact tuple", () => {
+    const whitespace = " \t\n ";
+    const result = runLiveSourcePackageBuildAndValidation({
+      PACKAGE_ARTIFACT_DIGEST: whitespace,
+      PACKAGE_ARTIFACT_ID: whitespace,
+      PACKAGE_ARTIFACT_NAME: whitespace,
+      PACKAGE_ARTIFACT_RUN_ATTEMPT: whitespace,
+      PACKAGE_ARTIFACT_RUN_ID: whitespace,
+      PACKAGE_FILE_NAME: whitespace,
+      PACKAGE_SHA256: whitespace,
+      PACKAGE_SOURCE_SHA: whitespace,
+      PACKAGE_VERSION: whitespace,
+    });
+
+    expect(result.artifactTuple.result.status, result.artifactTuple.result.stderr).toBe(0);
+    expect(result.artifactTuple.output.package_artifact_present).toBe("false");
+    expect(result.validate.env).toMatchObject({
+      EXPECTED_PACKAGE_FILE_NAME:
+        "${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_file_name || '' }}",
+      EXPECTED_PACKAGE_SHA256:
+        "${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_sha256 || '' }}",
+      EXPECTED_PACKAGE_SOURCE_SHA:
+        "${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_source_sha || '' }}",
+      EXPECTED_PACKAGE_VERSION:
+        "${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_version || '' }}",
+    });
+    expect(result.buildResult.status, result.buildResult.stderr).toBe(0);
+    expect(result.validationResult.status, result.validationResult.stderr).toBe(0);
+    expect(result.calls).toEqual([
+      expect.stringContaining("scripts/package-openclaw-for-docker.mjs"),
+      expect.stringContaining("scripts/check-openclaw-package-tarball.mjs"),
+    ]);
+    expect(result.output).toMatchObject({
+      file_name: "openclaw-current.tgz",
+      source_sha: "a".repeat(40),
+      version: "2026.8.1",
+    });
   });
 
   it("guards install-smoke candidate packaging before its dependency install", () => {

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -1,0 +1,140 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import {
+  validatePackageSource,
+  validatePackageSourceRef,
+} from "../../scripts/package-source-preflight.mjs";
+
+const changelog = `# Changelog
+
+## Unreleased
+
+- Package source preflight notes with enough detail.
+`;
+
+function rootManifest(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    name: "openclaw",
+    version: "2026.8.1",
+    dependencies: {
+      "@openclaw/ai": "workspace:*",
+      openai: "6.49.0",
+    },
+    ...overrides,
+  });
+}
+
+function aiManifest(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    name: "@openclaw/ai",
+    version: "2026.8.1",
+    dependencies: {
+      openai: "6.49.0",
+    },
+    ...overrides,
+  });
+}
+
+describe("package source preflight", () => {
+  it("accepts aligned source manifests and the explicitly allowed Unreleased section", () => {
+    expect(
+      validatePackageSource({
+        aiManifestContent: aiManifest(),
+        allowUnreleasedChangelog: true,
+        changelogContent: changelog,
+        rootManifestContent: rootManifest(),
+      }),
+    ).toBe("2026.8.1");
+  });
+
+  it("uses canonical package changelog validation", () => {
+    expect(() =>
+      validatePackageSource({
+        aiManifestContent: aiManifest(),
+        changelogContent: changelog,
+        rootManifestContent: rootManifest(),
+      }),
+    ).toThrow("CHANGELOG.md does not contain a release section for 2026.8.1.");
+  });
+
+  it("rejects source package version drift", () => {
+    expect(() =>
+      validatePackageSource({
+        aiManifestContent: aiManifest({ version: "2026.8.2" }),
+        allowUnreleasedChangelog: true,
+        changelogContent: changelog,
+        rootManifestContent: rootManifest(),
+      }),
+    ).toThrow("packages/ai/package.json version must match package.json");
+  });
+
+  it("rejects @openclaw/ai dependency drift before packing", () => {
+    expect(() =>
+      validatePackageSource({
+        aiManifestContent: aiManifest({
+          dependencies: {
+            openai: "6.50.0",
+          },
+        }),
+        allowUnreleasedChangelog: true,
+        changelogContent: changelog,
+        rootManifestContent: rootManifest(),
+      }),
+    ).toThrow(
+      'package.json must match packages/ai/package.json dependency openai@6.50.0; found "6.49.0".',
+    );
+  });
+
+  it("preserves historical sources from before the @openclaw/ai workspace split", () => {
+    expect(
+      validatePackageSource({
+        aiManifestContent: null,
+        allowUnreleasedChangelog: true,
+        changelogContent: changelog,
+        rootManifestContent: rootManifest({ dependencies: {} }),
+      }),
+    ).toBe("2026.8.1");
+  });
+
+  it("validates the current source ref without modifying the checkout", () => {
+    expect(
+      validatePackageSourceRef("HEAD", {
+        allowUnreleasedChangelog: true,
+      }),
+    ).toBe("2026.8.1");
+  });
+
+  it("runs before dependency setup only for source-built release packages", () => {
+    const workflow = parse(
+      readFileSync(".github/workflows/openclaw-release-checks.yml", "utf8"),
+    ) as {
+      jobs: {
+        prepare_release_package: {
+          steps: Array<{ env?: Record<string, string>; if?: string; name?: string; run?: string }>;
+        };
+      };
+    };
+    const steps = workflow.jobs.prepare_release_package.steps;
+    const preflightIndex = steps.findIndex(
+      (step) => step.name === "Validate release package source metadata",
+    );
+    const setupIndex = steps.findIndex((step) => step.name === "Setup Node environment");
+    const packageIndex = steps.findIndex(
+      (step) => step.name === "Resolve release package artifact",
+    );
+    const preflight = steps[preflightIndex];
+
+    expect(preflightIndex).toBeGreaterThan(-1);
+    expect(preflightIndex).toBeLessThan(setupIndex);
+    expect(preflightIndex).toBeLessThan(packageIndex);
+    expect(preflight).toBeDefined();
+    if (!preflight) {
+      throw new Error("missing package source preflight step");
+    }
+    expect(preflight.if).toContain("inputs.candidate_artifact_json == ''");
+    expect(preflight.if).toContain("needs.resolve_target.outputs.release_package_spec == ''");
+    expect(preflight.env?.PACKAGE_REF).toBe("${{ needs.resolve_target.outputs.revision }}");
+    expect(preflight.run).toContain("node scripts/package-source-preflight.mjs");
+  });
+});

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -1,8 +1,13 @@
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import { validateBundledPackageDependencyAlignment } from "../../scripts/package-source-dependencies.mjs";
 import {
   validatePackageSource,
+  validatePackageSourceDir,
   validatePackageSourceRef,
 } from "../../scripts/package-source-preflight.mjs";
 
@@ -34,6 +39,49 @@ function aiManifest(overrides: Record<string, unknown> = {}) {
     },
     ...overrides,
   });
+}
+
+type WorkflowStep = {
+  env?: Record<string, string>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type Workflow = {
+  jobs: Record<string, { steps: WorkflowStep[] }>;
+};
+
+function readWorkflow(file: string): Workflow {
+  return parse(readFileSync(file, "utf8")) as Workflow;
+}
+
+function workflowStep(workflow: Workflow, job: string, name: string): WorkflowStep {
+  const found = workflow.jobs[job]?.steps.find((step) => step.name === name);
+  expect(found, `${job}: ${name}`).toBeDefined();
+  return found!;
+}
+
+function runSourceRequirement(step: WorkflowStep, env: Record<string, string>) {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-package-source-workflow-"));
+  const outputPath = path.join(tempDir, "output");
+  try {
+    const result = spawnSync("bash", ["--noprofile", "--norc", "-c", step.run ?? ""], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...env,
+        GITHUB_OUTPUT: outputPath,
+      },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    return readFileSync(outputPath, "utf8").trim();
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
 }
 
 describe("package source preflight", () => {
@@ -82,7 +130,59 @@ describe("package source preflight", () => {
         rootManifestContent: rootManifest(),
       }),
     ).toThrow(
-      'package.json must match packages/ai/package.json dependency openai@6.50.0; found "6.49.0".',
+      "package.json must declare openai@6.50.0 to bundle @openclaw/ai without duplicate dependencies",
+    );
+  });
+
+  it("shares exact, workspace, private, and value-type dependency semantics with packaging", () => {
+    expect(
+      validateBundledPackageDependencyAlignment({
+        bundledDependencies: {
+          exact: "1.2.3",
+          private: "0.0.0-private",
+          workspace: "4.5.6",
+        },
+        bundledPackageLabel: "packed @openclaw/ai",
+        rootDependencies: {
+          exact: "1.2.3",
+          workspace: "workspace:4.5.6",
+        },
+      }),
+    ).toEqual([
+      ["exact", "1.2.3"],
+      ["workspace", "4.5.6"],
+    ]);
+
+    expect(() =>
+      validateBundledPackageDependencyAlignment({
+        bundledDependencies: { invalid: 123 },
+        bundledPackageLabel: "packed @openclaw/ai",
+        rootDependencies: { invalid: "123" },
+      }),
+    ).toThrow("packed @openclaw/ai dependency invalid must declare a string version");
+    expect(() =>
+      validateBundledPackageDependencyAlignment({
+        bundledDependencies: { invalid: "1.2.3" },
+        bundledPackageLabel: "packed @openclaw/ai",
+        rootDependencies: { invalid: 123 },
+      }),
+    ).toThrow("root package.json dependency invalid must declare a string version");
+  });
+
+  it("rejects real partial-json source manifest drift", () => {
+    const root = JSON.parse(readFileSync("package.json", "utf8")) as {
+      dependencies: Record<string, string>;
+    };
+    root.dependencies["partial-json"] = "0.1.8";
+    expect(() =>
+      validatePackageSource({
+        aiManifestContent: readFileSync("packages/ai/package.json", "utf8"),
+        allowUnreleasedChangelog: true,
+        changelogContent: readFileSync("CHANGELOG.md", "utf8"),
+        rootManifestContent: JSON.stringify(root),
+      }),
+    ).toThrow(
+      "package.json must declare partial-json@0.1.7 to bundle @openclaw/ai without duplicate dependencies",
     );
   });
 
@@ -103,19 +203,21 @@ describe("package source preflight", () => {
         allowUnreleasedChangelog: true,
       }),
     ).toBe("2026.8.1");
+    expect(
+      validatePackageSourceDir(process.cwd(), {
+        allowUnreleasedChangelog: true,
+      }),
+    ).toBe("2026.8.1");
   });
 
-  it("runs before dependency setup only for source-built release packages", () => {
-    const workflow = parse(
-      readFileSync(".github/workflows/openclaw-release-checks.yml", "utf8"),
-    ) as {
-      jobs: {
-        prepare_release_package: {
-          steps: Array<{ env?: Record<string, string>; if?: string; name?: string; run?: string }>;
-        };
-      };
-    };
-    const steps = workflow.jobs.prepare_release_package.steps;
+  it("normalizes release-check source selection and guards the source resolver", () => {
+    const workflow = readWorkflow(".github/workflows/openclaw-release-checks.yml");
+    const steps = workflow.jobs.prepare_release_package!.steps;
+    const sourceRequirement = workflowStep(
+      workflow,
+      "prepare_release_package",
+      "Resolve source package requirement",
+    );
     const preflightIndex = steps.findIndex(
       (step) => step.name === "Validate release package source metadata",
     );
@@ -123,18 +225,118 @@ describe("package source preflight", () => {
     const packageIndex = steps.findIndex(
       (step) => step.name === "Resolve release package artifact",
     );
-    const preflight = steps[preflightIndex];
+    const preflight = steps[preflightIndex]!;
+    const packageStep = steps[packageIndex]!;
+    const setup = workflowStep(workflow, "prepare_release_package", "Setup Node environment");
 
     expect(preflightIndex).toBeGreaterThan(-1);
     expect(preflightIndex).toBeLessThan(setupIndex);
     expect(preflightIndex).toBeLessThan(packageIndex);
-    expect(preflight).toBeDefined();
-    if (!preflight) {
-      throw new Error("missing package source preflight step");
-    }
-    expect(preflight.if).toContain("inputs.candidate_artifact_json == ''");
-    expect(preflight.if).toContain("needs.resolve_target.outputs.release_package_spec == ''");
+    expect(
+      runSourceRequirement(sourceRequirement, {
+        CANDIDATE_ARTIFACT_JSON: "",
+        RELEASE_PACKAGE_SPEC: " \t ",
+      }),
+    ).toBe("required=true");
+    expect(
+      runSourceRequirement(sourceRequirement, {
+        CANDIDATE_ARTIFACT_JSON: "",
+        RELEASE_PACKAGE_SPEC: "openclaw@beta",
+      }),
+    ).toBe("required=false");
+    expect(preflight.if).toBe("steps.package_source.outputs.required == 'true'");
     expect(preflight.env?.PACKAGE_REF).toBe("${{ needs.resolve_target.outputs.revision }}");
     expect(preflight.run).toContain("node scripts/package-source-preflight.mjs");
+    expect(packageStep.env?.SOURCE_PACKAGE_REQUIRED).toBe(
+      "${{ steps.package_source.outputs.required }}",
+    );
+    expect(setup.if).toContain("steps.package_source.outputs.required == 'true'");
+    expect(packageStep.if).toContain("steps.package_source.outputs.required == 'true'");
+    expect(packageStep.run).toContain('if [[ "$SOURCE_PACKAGE_REQUIRED" != "true" ]]');
+  });
+
+  it("guards the default live/E2E candidate producer before setup and packing", () => {
+    const workflow = readWorkflow(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml");
+    const steps = workflow.jobs.prepare_docker_e2e_image!.steps;
+    const sourceRequirement = workflowStep(
+      workflow,
+      "prepare_docker_e2e_image",
+      "Resolve source package requirement",
+    );
+    const preflight = workflowStep(
+      workflow,
+      "prepare_docker_e2e_image",
+      "Validate Docker E2E package source metadata",
+    );
+    const setup = workflowStep(workflow, "prepare_docker_e2e_image", "Setup Node environment");
+    const pack = workflowStep(
+      workflow,
+      "prepare_docker_e2e_image",
+      "Pack OpenClaw package for Docker E2E",
+    );
+
+    expect(
+      runSourceRequirement(sourceRequirement, {
+        NEEDS_PACKAGE: "1",
+        PACKAGE_ARTIFACT_NAME: " ",
+        PACKAGE_ARTIFACT_RUN_ID: "\t",
+      }),
+    ).toBe("required=true");
+    expect(
+      runSourceRequirement(sourceRequirement, {
+        NEEDS_PACKAGE: "1",
+        PACKAGE_ARTIFACT_NAME: "release-package-1",
+        PACKAGE_ARTIFACT_RUN_ID: "123",
+      }),
+    ).toBe("required=false");
+    expect(steps.indexOf(preflight)).toBeLessThan(steps.indexOf(setup));
+    expect(steps.indexOf(preflight)).toBeLessThan(steps.indexOf(pack));
+    expect(preflight.run).toContain("node .release-harness/scripts/package-source-preflight.mjs");
+    expect(preflight.if).toBe("steps.package_source.outputs.required == 'true'");
+    expect(setup.if).toContain("steps.package_source.outputs.required == 'true'");
+    expect(pack.if).toBe("steps.package_source.outputs.required == 'true'");
+  });
+
+  it("guards install-smoke candidate packaging before its dependency install", () => {
+    const workflow = readWorkflow(".github/workflows/install-smoke-reusable.yml");
+    const packageCandidate = workflowStep(
+      workflow,
+      "installer_smoke_candidate_payload",
+      "Package candidate only inside pinned harness",
+    );
+    expect(packageCandidate.run).toContain('-v "$PWD/.release-harness:/harness:ro"');
+    expect(packageCandidate.run).toContain(
+      'node /harness/scripts/package-source-preflight.mjs "${preflight_args[@]}"',
+    );
+    expect(packageCandidate.run!.indexOf("package-source-preflight.mjs")).toBeLessThan(
+      packageCandidate.run!.indexOf("pnpm install --frozen-lockfile"),
+    );
+  });
+
+  it("guards npm source producers with trusted tooling before Node setup", () => {
+    const workflow = readWorkflow(".github/workflows/openclaw-npm-release.yml");
+    const steps = workflow.jobs.preflight_openclaw_npm!.steps;
+    const checkout = workflowStep(
+      workflow,
+      "preflight_openclaw_npm",
+      "Checkout trusted package source preflight",
+    );
+    const preflight = workflowStep(
+      workflow,
+      "preflight_openclaw_npm",
+      "Validate npm package source metadata",
+    );
+    const setup = workflowStep(workflow, "preflight_openclaw_npm", "Setup Node environment");
+    const build = workflowStep(workflow, "preflight_openclaw_npm", "Build");
+
+    expect(checkout.with).toMatchObject({
+      ref: "${{ github.workflow_sha }}",
+      path: ".release-harness",
+    });
+    expect(preflight.run).toContain("node .release-harness/scripts/package-source-preflight.mjs");
+    expect(preflight.run).toContain('if [[ "$RELEASE_REF" =~ ^[0-9a-fA-F]{40}$ ]]');
+    expect(steps.indexOf(checkout)).toBeLessThan(steps.indexOf(preflight));
+    expect(steps.indexOf(preflight)).toBeLessThan(steps.indexOf(setup));
+    expect(steps.indexOf(preflight)).toBeLessThan(steps.indexOf(build));
   });
 });

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -52,7 +52,10 @@ type WorkflowStep = {
 };
 
 type Workflow = {
-  jobs: Record<string, { steps: WorkflowStep[]; with?: Record<string, unknown> }>;
+  jobs: Record<
+    string,
+    { outputs?: Record<string, unknown>; steps: WorkflowStep[]; with?: Record<string, unknown> }
+  >;
 };
 
 function readWorkflow(file: string): Workflow {
@@ -79,6 +82,65 @@ function runSourceRequirement(step: WorkflowStep, env: Record<string, string>) {
     });
     expect(result.status, result.stderr).toBe(0);
     return readFileSync(outputPath, "utf8").trim();
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+function runLiveArtifactTupleValidation(packageEnv: Record<string, string>) {
+  const workflow = readWorkflow(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml");
+  const step = workflowStep(workflow, "validate_selected_ref", "Validate selected ref");
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-live-artifact-tuple-"));
+  const fakeBin = path.join(tempDir, "bin");
+  const outputPath = path.join(tempDir, "output");
+  const summaryPath = path.join(tempDir, "summary");
+  const selectedSha = "a".repeat(40);
+  mkdirSync(fakeBin);
+  writeFileSync(
+    path.join(fakeBin, "git"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "rev-parse" && "$2" == "--verify" ]]; then
+  printf '%s\\n' "$SELECTED_SHA"
+  exit 0
+fi
+if [[ "$1" == "merge-base" && "$2" == "--is-ancestor" ]]; then
+  exit 0
+fi
+exit 64
+`,
+    { mode: 0o755 },
+  );
+  const stepEnv = Object.fromEntries(Object.keys(step.env ?? {}).map((name) => [name, ""]));
+  try {
+    const result = spawnSync("bash", ["--noprofile", "--norc", "-c", step.run ?? ""], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...stepEnv,
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_STEP_SUMMARY: summaryPath,
+        INPUT_REF: "main",
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        PROVIDED_BARE_IMAGE: "ghcr.io/openclaw/openclaw:test",
+        SELECTED_SHA: selectedSha,
+        SHARED_IMAGE_POLICY: "existing-only",
+        ...packageEnv,
+      },
+    });
+    const output =
+      result.status === 0
+        ? Object.fromEntries(
+            readFileSync(outputPath, "utf8")
+              .trim()
+              .split("\n")
+              .map((line) => {
+                const separator = line.indexOf("=");
+                return [line.slice(0, separator), line.slice(separator + 1)];
+              }),
+          )
+        : {};
+    return { output, result };
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }
@@ -333,7 +395,7 @@ describe("package source preflight", () => {
     expect(workflowSource.match(/\$\{\{ inputs\.release_package_spec \}\}/gu)).toHaveLength(1);
   });
 
-  it("guards the default live/E2E candidate producer before setup and packing", () => {
+  it("guards prepare-only source before harness setup and skips no-package lane setup", () => {
     const workflow = readWorkflow(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml");
     const steps = workflow.jobs.prepare_docker_e2e_image!.steps;
     const sourceRequirement = workflowStep(
@@ -341,7 +403,12 @@ describe("package source preflight", () => {
       "prepare_docker_e2e_image",
       "Resolve source package requirement",
     );
-    const preflight = workflowStep(
+    const prepareOnlyPreflight = workflowStep(
+      workflow,
+      "prepare_docker_e2e_image",
+      "Validate prepare-only Docker E2E package source metadata",
+    );
+    const plannedPreflight = workflowStep(
       workflow,
       "prepare_docker_e2e_image",
       "Validate Docker E2E package source metadata",
@@ -360,26 +427,54 @@ describe("package source preflight", () => {
 
     expect(
       runSourceRequirement(sourceRequirement, {
-        PACKAGE_ARTIFACT_NAME: " ",
-        PACKAGE_ARTIFACT_RUN_ID: "\t",
+        PACKAGE_ARTIFACT_PRESENT: "false",
       }),
     ).toBe("required=true");
     expect(
       runSourceRequirement(sourceRequirement, {
-        PACKAGE_ARTIFACT_NAME: "release-package-1",
-        PACKAGE_ARTIFACT_RUN_ID: "123",
+        PACKAGE_ARTIFACT_PRESENT: "true",
       }),
     ).toBe("required=false");
-    expect(steps.indexOf(preflight)).toBeLessThan(steps.indexOf(harnessSetup));
+    expect(steps.indexOf(prepareOnlyPreflight)).toBeLessThan(steps.indexOf(harnessSetup));
     expect(harnessSetup.uses).toBe("./.release-harness/.github/actions/setup-release-harness");
-    expect(steps.indexOf(preflight)).toBeLessThan(steps.indexOf(setup));
-    expect(steps.indexOf(preflight)).toBeLessThan(steps.indexOf(pack));
-    expect(preflight.run).toContain("node .release-harness/scripts/package-source-preflight.mjs");
-    expect(preflight.if).toBe("steps.package_source.outputs.required == 'true'");
-    expect(setup.if).toContain("steps.package_source.outputs.required == 'true'");
+    expect(steps.indexOf(plannedPreflight)).toBeGreaterThan(
+      steps.findIndex((step) => step.name === "Plan Docker E2E images"),
+    );
+    expect(steps.indexOf(plannedPreflight)).toBeLessThan(steps.indexOf(setup));
+    expect(steps.indexOf(plannedPreflight)).toBeLessThan(steps.indexOf(pack));
+    expect(prepareOnlyPreflight.run).toContain(
+      "node .release-harness/scripts/package-source-preflight.mjs",
+    );
+    expect(prepareOnlyPreflight.if).toBe(
+      "inputs.prepare_only && steps.package_source.outputs.required == 'true'",
+    );
+    expect(plannedPreflight.if).toBe(
+      "(!inputs.prepare_only) && steps.plan.outputs.needs_package == '1' && steps.package_source.outputs.required == 'true'",
+    );
+    expect(setup.if).toContain(
+      "steps.plan.outputs.needs_package == '1' && steps.package_source.outputs.required == 'true'",
+    );
     expect(pack.if).toBe(
       "steps.plan.outputs.needs_package == '1' && steps.package_source.outputs.required == 'true'",
     );
+  });
+
+  it("treats tab and newline-only package artifact tuples as absent", () => {
+    const whitespace = " \t\n ";
+    const { output, result } = runLiveArtifactTupleValidation({
+      PACKAGE_ARTIFACT_DIGEST: whitespace,
+      PACKAGE_ARTIFACT_ID: whitespace,
+      PACKAGE_ARTIFACT_NAME: whitespace,
+      PACKAGE_ARTIFACT_RUN_ATTEMPT: whitespace,
+      PACKAGE_ARTIFACT_RUN_ID: whitespace,
+      PACKAGE_FILE_NAME: whitespace,
+      PACKAGE_SHA256: whitespace,
+      PACKAGE_SOURCE_SHA: whitespace,
+      PACKAGE_VERSION: whitespace,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(output.package_artifact_present).toBe("false");
   });
 
   it("guards install-smoke candidate packaging before its dependency install", () => {

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -52,7 +52,7 @@ type WorkflowStep = {
 };
 
 type Workflow = {
-  jobs: Record<string, { steps: WorkflowStep[] }>;
+  jobs: Record<string, { steps: WorkflowStep[]; with?: Record<string, unknown> }>;
 };
 
 function readWorkflow(file: string): Workflow {
@@ -79,6 +79,57 @@ function runSourceRequirement(step: WorkflowStep, env: Record<string, string>) {
     });
     expect(result.status, result.stderr).toBe(0);
     return readFileSync(outputPath, "utf8").trim();
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+function runReleaseInputCapture(params: {
+  candidateArtifactJson?: string;
+  releasePackageSpec?: string;
+}) {
+  const workflow = readWorkflow(".github/workflows/openclaw-release-checks.yml");
+  const step = workflowStep(workflow, "resolve_target", "Capture selected inputs");
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-release-inputs-"));
+  const outputPath = path.join(tempDir, "output");
+  const stepEnv = Object.fromEntries(Object.keys(step.env ?? {}).map((name) => [name, ""]));
+  try {
+    const result = spawnSync("bash", ["--noprofile", "--norc", "-c", step.run ?? ""], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ...stepEnv,
+        CANDIDATE_ARTIFACT_JSON_INPUT: params.candidateArtifactJson ?? "",
+        GITHUB_OUTPUT: outputPath,
+        RELEASE_ALLOW_UNRELEASED_CHANGELOG_INPUT: "false",
+        RELEASE_CROSS_OS_SUITE_FILTER_INPUT: "",
+        RELEASE_FAIL_FAST_INPUT: "false",
+        RELEASE_FILTER_VALIDATOR: path.resolve("scripts/github/validate-release-suite-filters.sh"),
+        RELEASE_LIVE_SUITE_FILTER_INPUT: "",
+        RELEASE_MODE_INPUT: "both",
+        RELEASE_PACKAGE_SPEC_INPUT: params.releasePackageSpec ?? "",
+        RELEASE_PROFILE_INPUT: "beta",
+        RELEASE_PROVIDER_INPUT: "openai",
+        RELEASE_QA_DISCORD_LIVE_CI_ENABLED: "false",
+        RELEASE_QA_SLACK_LIVE_CI_ENABLED: "false",
+        RELEASE_QA_WHATSAPP_LIVE_CI_ENABLED: "false",
+        RELEASE_REF_INPUT: "main",
+        RELEASE_RERUN_GROUP_INPUT: "package",
+        RELEASE_RUN_MATURITY_SCORECARD_INPUT: "false",
+        RELEASE_RUN_RELEASE_SOAK_INPUT: "false",
+        RELEASE_SKIP_PACKAGE_TELEGRAM_E2E_INPUT: "false",
+      },
+    });
+    expect(result.status, result.stderr).toBe(0);
+    return Object.fromEntries(
+      readFileSync(outputPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => {
+          const separator = line.indexOf("=");
+          return [line.slice(0, separator), line.slice(separator + 1)];
+        }),
+    );
   } finally {
     rmSync(tempDir, { force: true, recursive: true });
   }
@@ -210,14 +261,9 @@ describe("package source preflight", () => {
     ).toBe("2026.8.1");
   });
 
-  it("normalizes release-check source selection and guards the source resolver", () => {
+  it("normalizes release-check package mode and guards the source resolver", () => {
     const workflow = readWorkflow(".github/workflows/openclaw-release-checks.yml");
     const steps = workflow.jobs.prepare_release_package!.steps;
-    const sourceRequirement = workflowStep(
-      workflow,
-      "prepare_release_package",
-      "Resolve source package requirement",
-    );
     const preflightIndex = steps.findIndex(
       (step) => step.name === "Validate release package source metadata",
     );
@@ -228,31 +274,63 @@ describe("package source preflight", () => {
     const preflight = steps[preflightIndex]!;
     const packageStep = steps[packageIndex]!;
     const setup = workflowStep(workflow, "prepare_release_package", "Setup Node environment");
+    const upload = workflowStep(
+      workflow,
+      "prepare_release_package",
+      "Upload release package artifact",
+    );
+    const artifactIdentity = workflowStep(
+      workflow,
+      "prepare_release_package",
+      "Validate shared release candidate identity",
+    );
 
     expect(preflightIndex).toBeGreaterThan(-1);
     expect(preflightIndex).toBeLessThan(setupIndex);
     expect(preflightIndex).toBeLessThan(packageIndex);
+    expect(runReleaseInputCapture({ releasePackageSpec: " \t " })).toMatchObject({
+      candidate_artifact_json: "",
+      package_mode: "source",
+      release_package_spec: "",
+    });
+    expect(runReleaseInputCapture({ releasePackageSpec: "openclaw@beta" })).toMatchObject({
+      candidate_artifact_json: "",
+      package_mode: "published",
+      release_package_spec: "openclaw@beta",
+    });
+    expect(runReleaseInputCapture({ candidateArtifactJson: " \t " })).toMatchObject({
+      candidate_artifact_json: "",
+      package_mode: "source",
+      release_package_spec: "",
+    });
     expect(
-      runSourceRequirement(sourceRequirement, {
-        CANDIDATE_ARTIFACT_JSON: "",
-        RELEASE_PACKAGE_SPEC: " \t ",
-      }),
-    ).toBe("required=true");
-    expect(
-      runSourceRequirement(sourceRequirement, {
-        CANDIDATE_ARTIFACT_JSON: "",
-        RELEASE_PACKAGE_SPEC: "openclaw@beta",
-      }),
-    ).toBe("required=false");
-    expect(preflight.if).toBe("steps.package_source.outputs.required == 'true'");
+      runReleaseInputCapture({ candidateArtifactJson: '{"packageArtifactId":"1"}' }),
+    ).toMatchObject({
+      candidate_artifact_json: '{"packageArtifactId":"1"}',
+      package_mode: "artifact",
+      release_package_spec: "",
+    });
+    expect(preflight.if).toBe("needs.resolve_target.outputs.package_mode == 'source'");
     expect(preflight.env?.PACKAGE_REF).toBe("${{ needs.resolve_target.outputs.revision }}");
     expect(preflight.run).toContain("node scripts/package-source-preflight.mjs");
-    expect(packageStep.env?.SOURCE_PACKAGE_REQUIRED).toBe(
-      "${{ steps.package_source.outputs.required }}",
-    );
-    expect(setup.if).toContain("steps.package_source.outputs.required == 'true'");
-    expect(packageStep.if).toContain("steps.package_source.outputs.required == 'true'");
-    expect(packageStep.run).toContain('if [[ "$SOURCE_PACKAGE_REQUIRED" != "true" ]]');
+    expect(packageStep.env?.PACKAGE_MODE).toBe("${{ needs.resolve_target.outputs.package_mode }}");
+    expect(setup.if).toBe("needs.resolve_target.outputs.package_mode != 'artifact'");
+    expect(packageStep.if).toBe("needs.resolve_target.outputs.package_mode != 'artifact'");
+    expect(packageStep.run).toContain('if [[ "$PACKAGE_MODE" == "published" ]]');
+    expect(upload.if).toBe("needs.resolve_target.outputs.package_mode != 'artifact'");
+    expect(artifactIdentity.if).toBe("needs.resolve_target.outputs.package_mode == 'artifact'");
+    expect(workflow.jobs.docker_e2e_release_checks?.with).toMatchObject({
+      enable_prepublish_plugin_registry:
+        "${{ needs.resolve_target.outputs.package_mode != 'published' }}",
+    });
+    expect(workflow.jobs.package_acceptance_release_checks?.with).toMatchObject({
+      candidate_artifact_json: "${{ needs.resolve_target.outputs.candidate_artifact_json }}",
+      source:
+        "${{ (needs.resolve_target.outputs.package_acceptance_package_spec != '' || needs.resolve_target.outputs.package_mode == 'published') && 'npm' || 'artifact' }}",
+    });
+    const workflowSource = readFileSync(".github/workflows/openclaw-release-checks.yml", "utf8");
+    expect(workflowSource.match(/\$\{\{ inputs\.candidate_artifact_json \}\}/gu)).toHaveLength(1);
+    expect(workflowSource.match(/\$\{\{ inputs\.release_package_spec \}\}/gu)).toHaveLength(1);
   });
 
   it("guards the default live/E2E candidate producer before setup and packing", () => {
@@ -268,6 +346,11 @@ describe("package source preflight", () => {
       "prepare_docker_e2e_image",
       "Validate Docker E2E package source metadata",
     );
+    const harnessSetup = workflowStep(
+      workflow,
+      "prepare_docker_e2e_image",
+      "Setup trusted release harness",
+    );
     const setup = workflowStep(workflow, "prepare_docker_e2e_image", "Setup Node environment");
     const pack = workflowStep(
       workflow,
@@ -277,24 +360,26 @@ describe("package source preflight", () => {
 
     expect(
       runSourceRequirement(sourceRequirement, {
-        NEEDS_PACKAGE: "1",
         PACKAGE_ARTIFACT_NAME: " ",
         PACKAGE_ARTIFACT_RUN_ID: "\t",
       }),
     ).toBe("required=true");
     expect(
       runSourceRequirement(sourceRequirement, {
-        NEEDS_PACKAGE: "1",
         PACKAGE_ARTIFACT_NAME: "release-package-1",
         PACKAGE_ARTIFACT_RUN_ID: "123",
       }),
     ).toBe("required=false");
+    expect(steps.indexOf(preflight)).toBeLessThan(steps.indexOf(harnessSetup));
+    expect(harnessSetup.uses).toBe("./.release-harness/.github/actions/setup-release-harness");
     expect(steps.indexOf(preflight)).toBeLessThan(steps.indexOf(setup));
     expect(steps.indexOf(preflight)).toBeLessThan(steps.indexOf(pack));
     expect(preflight.run).toContain("node .release-harness/scripts/package-source-preflight.mjs");
     expect(preflight.if).toBe("steps.package_source.outputs.required == 'true'");
     expect(setup.if).toContain("steps.package_source.outputs.required == 'true'");
-    expect(pack.if).toBe("steps.package_source.outputs.required == 'true'");
+    expect(pack.if).toBe(
+      "steps.plan.outputs.needs_package == '1' && steps.package_source.outputs.required == 'true'",
+    );
   });
 
   it("guards install-smoke candidate packaging before its dependency install", () => {

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -10,6 +10,7 @@ import {
   validatePackageSourceDir,
   validatePackageSourceRef,
 } from "../../scripts/package-source-preflight.mjs";
+import { writeRunSummary } from "../../scripts/test-docker-all.mts";
 
 const changelog = `# Changelog
 
@@ -54,7 +55,12 @@ type WorkflowStep = {
 type Workflow = {
   jobs: Record<
     string,
-    { outputs?: Record<string, unknown>; steps: WorkflowStep[]; with?: Record<string, unknown> }
+    {
+      env?: Record<string, string>;
+      outputs?: Record<string, unknown>;
+      steps: WorkflowStep[];
+      with?: Record<string, unknown>;
+    }
   >;
 };
 
@@ -597,7 +603,7 @@ describe("package source preflight", () => {
     expect(output.package_artifact_present).toBe("false");
   });
 
-  it("builds and validates a source package for a whitespace-only artifact tuple", () => {
+  it("keeps a whitespace-only artifact tuple in source mode through Docker reports", async () => {
     const whitespace = " \t\n ";
     const result = runLiveSourcePackageBuildAndValidation({
       PACKAGE_ARTIFACT_DIGEST: whitespace,
@@ -634,6 +640,68 @@ describe("package source preflight", () => {
       source_sha: "a".repeat(40),
       version: "2026.8.1",
     });
+
+    const workflow = readWorkflow(".github/workflows/openclaw-live-and-e2e-checks-reusable.yml");
+    const prepared = workflow.jobs.prepare_docker_e2e_image!;
+    expect(prepared.outputs).toMatchObject({
+      package_artifact_id:
+        "${{ steps.upload_package.outputs.artifact-id || (needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_id || '') }}",
+      package_artifact_name:
+        "${{ steps.upload_package.outputs.artifact-id && format('docker-e2e-package-{0}-{1}', github.run_id, github.run_attempt) || (needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_artifact_name || '') }}",
+    });
+    const reportArtifactName =
+      "${{ needs.prepare_docker_e2e_image.outputs.package_artifact_name || 'docker-e2e-package' }}";
+    for (const jobId of [
+      "validate_docker_e2e",
+      "validate_docker_lanes",
+      "validate_docker_openwebui",
+    ]) {
+      expect(workflow.jobs[jobId]!.env?.OPENCLAW_DOCKER_E2E_PACKAGE_ARTIFACT_NAME).toBe(
+        reportArtifactName,
+      );
+    }
+    const candidateManifest = workflowStep(
+      workflow,
+      "prepare_docker_e2e_image",
+      "Emit immutable release candidate tuple",
+    );
+    for (const name of [
+      "PACKAGE_ARTIFACT_DIGEST",
+      "PACKAGE_ARTIFACT_ID",
+      "PACKAGE_ARTIFACT_NAME",
+      "PACKAGE_ARTIFACT_RUN_ATTEMPT",
+      "PACKAGE_ARTIFACT_RUN_ID",
+    ]) {
+      expect(candidateManifest.env?.[name]).toContain(
+        "needs.validate_selected_ref.outputs.package_artifact_present == 'true'",
+      );
+    }
+
+    const noPackageArtifactName =
+      result.artifactTuple.output.package_artifact_present === "true" ? whitespace : "";
+    expect(noPackageArtifactName).toBe("");
+    const reportDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-live-source-report-"));
+    try {
+      await writeRunSummary(
+        reportDir,
+        {
+          failures: [{ name: "live-models", status: 1 }],
+          lanes: [],
+          status: "failed",
+        },
+        {
+          OPENCLAW_DOCKER_E2E_PACKAGE_ARTIFACT_NAME: noPackageArtifactName || "docker-e2e-package",
+          OPENCLAW_DOCKER_E2E_SELECTED_SHA: "a".repeat(40),
+        },
+      );
+      const summary = JSON.parse(readFileSync(path.join(reportDir, "summary.json"), "utf8"));
+      const failures = JSON.parse(readFileSync(path.join(reportDir, "failures.json"), "utf8"));
+      expect(summary.packageArtifactName).toBe("docker-e2e-package");
+      expect(failures.packageArtifactName).toBe("docker-e2e-package");
+      expect(JSON.stringify({ failures, summary })).not.toContain(whitespace);
+    } finally {
+      rmSync(reportDir, { force: true, recursive: true });
+    }
   });
 
   it("guards install-smoke candidate packaging before its dependency install", () => {

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -1139,10 +1139,14 @@ describe("release validation no-push transport", () => {
     });
     expect(step(dockerProducer, "Setup trusted release harness").if).toBeUndefined();
     expect(validatePackage.env).toMatchObject({
-      EXPECTED_PACKAGE_FILE_NAME: "${{ inputs.package_file_name }}",
-      EXPECTED_PACKAGE_SHA256: "${{ inputs.package_sha256 }}",
-      EXPECTED_PACKAGE_SOURCE_SHA: "${{ inputs.package_source_sha }}",
-      EXPECTED_PACKAGE_VERSION: "${{ inputs.package_version }}",
+      EXPECTED_PACKAGE_FILE_NAME:
+        "${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_file_name || '' }}",
+      EXPECTED_PACKAGE_SHA256:
+        "${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_sha256 || '' }}",
+      EXPECTED_PACKAGE_SOURCE_SHA:
+        "${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_source_sha || '' }}",
+      EXPECTED_PACKAGE_VERSION:
+        "${{ needs.validate_selected_ref.outputs.package_artifact_present == 'true' && inputs.package_version || '' }}",
     });
     expect(validatePackage.run).toContain('"$SHARED_IMAGE_POLICY" == "no-push-artifact"');
     expect(validatePackage.run).toContain(

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -104,13 +104,20 @@ afterEach(async () => {
 });
 
 describe("resolve-openclaw-package-candidate", () => {
-  it("allows Unreleased notes when packaging an exact ref candidate", () => {
+  it("preflights package-acceptance ref candidates before dependency installation", () => {
     const script = readFileSync("scripts/resolve-openclaw-package-candidate.mts", "utf8");
     const refPackageBuild = script.slice(
       script.indexOf('if (options.source === "ref")'),
       script.indexOf('} else if (options.source === "npm")'),
     );
+    const workflow = readFileSync(".github/workflows/package-acceptance.yml", "utf8");
 
+    expect(workflow).toContain('--source "$SOURCE"');
+    expect(workflow).toContain("PACKAGE_REF: ${{ inputs.package_ref }}");
+    expect(refPackageBuild).toContain("validatePackageSourceDir(packageSource.sourceDir");
+    expect(refPackageBuild.indexOf("validatePackageSourceDir")).toBeLessThan(
+      refPackageBuild.indexOf("installPackageSourceDeps"),
+    );
     expect(refPackageBuild).toContain('"scripts/package-openclaw-for-docker.mjs"');
     expect(refPackageBuild).toContain('"--allow-unreleased-changelog"');
   });


### PR DESCRIPTION
## What Problem This Solves

Release package producers could install candidate dependencies or start builds
before discovering invalid package versions, missing changelog sections, or
dependency drift between the root package and `@openclaw/ai`.

Whitespace-only release package inputs could also select source mode initially
but diverge into artifact or published-package behavior later in the reusable
release check.

## Why This Change Was Made

This adds one dependency-free, read-only package-source preflight that reuses
the canonical package changelog parser. A shared manifest dependency validator
also owns the Docker packer's accepted exact or `workspace:${version}`
alignment, private `0.0.0-private` exclusion, and dependency value-type checks.

Trusted source validation now runs before candidate dependency installation at
the canonical `resolveCandidate(source=ref)` and cross-OS `prepareCandidate`
producer boundaries. Direct release checks, install-smoke packaging, npm
preflight, and live/E2E source packaging are guarded before their source-build
setup.

The reusable release check emits one normalized package mode:
`source`, `published`, or `artifact`. Package setup, resolution, upload,
artifact identity, live registry, Docker image identity, and Package Acceptance
conditions consume that mode and normalized inputs. Whitespace-only
`candidate_artifact_json` and `release_package_spec` therefore remain source
mode end to end.

For live/E2E, prepare-only source validation remains before
`setup-release-harness`, whose composite action installs dependencies.
Non-default Docker lanes plan first, then preflight and set up source only when
the plan reports `needs_package=1`; no-package lanes such as live models and
plugin binding command escape skip both operations. Artifact tuple presence is
normalized with all shell whitespace, including tabs and newlines. Package
validation, prepared outputs, candidate manifests, and Docker summary/failure
reports consume only the canonical tuple state.

This does not duplicate dist inventory checks, modify
`.github/workflows/full-release-validation.yml`, dispatch validation, or alter
beta, publication, or release state.

## User Impact

Invalid release source now fails at its producer boundary with a specific
diagnostic, before candidate dependency installation or packaging. Product
runtime behavior is unchanged.

## Evidence

- Exact-ref and source-directory preflight against the current package source:
  passed.
- Package-source, Package Acceptance, and Docker scheduler tests: 238 passed.
- Cross-OS producer, candidate resolver, and release workflow tests: 189
  passed.
- Docker package helper E2E: 36 passed, 3 platform skips.
- Real `partial-json` manifest drift regression: passed before candidate
  dependency installation.
- Whitespace-only candidate artifact and release package spec mode regressions:
  passed.
- Tab/newline-only live/E2E artifact tuple regression: passed.
- End-to-end whitespace source package pack and validation regression: passed;
  raw tuple fields do not select artifact paths or metadata comparisons.
- Whitespace source mode emits blank no-package outputs and stable,
  non-whitespace package names in Docker summary and failure JSON.
- Live/E2E no-package lane regression verifies source preflight and setup remain
  gated by `needs_package`.
- Package Acceptance ref-mode and standalone cross-OS source-mode producer
  regressions: passed.
- Actionlint for the five affected reusable/source workflows: passed.
- Focused oxlint, oxfmt check, YAML parse, direct preflight, privacy scan, and
  `git diff --check`: passed.
- `pnpm tsgo:scripts` reaches only the unrelated existing
  `ui/vite.config.ts` missing declaration for `pako`.
- No Full Release Validation workflow was dispatched and no beta, publication,
  or release state was changed.

Production/workflow LOC: `+420/-86` (net `+334`) | Tests: `+820/-17`.
The production growth establishes the shared dependency/preflight owner and
normalizes release package mode across existing producer and consumer paths.

AI-assisted: yes. The implementation follows independently reviewed audit and
correction scopes.
