### PR TITLE
fix(hooks): reload mutable handlers after restored-mtime edits

### DIFF
--- a/src/hooks/import-url.test.ts
+++ b/src/hooks/import-url.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { buildImportUrl } from "./import-url.js";
 
 describe("buildImportUrl", () => {
@@ -25,23 +25,24 @@ describe("buildImportUrl", () => {
     expect(url).toMatch(/^file:\/\//);
   });
 
-  it("appends mtime-based cache buster for workspace hooks", () => {
+  it("appends file-metadata cache buster for workspace hooks", () => {
     const url = buildImportUrl(tmpFile, "openclaw-workspace");
-    expect(url).toMatch(/\?t=[\d.]+&s=\d+/);
+    expect(url).toMatch(/\?t=[\d.]+&c=[\d.]+&s=\d+/);
 
-    const { mtimeMs, size } = fs.statSync(tmpFile);
+    const { ctimeMs, mtimeMs, size } = fs.statSync(tmpFile);
     expect(url).toContain(`?t=${mtimeMs}`);
+    expect(url).toContain(`&c=${ctimeMs}`);
     expect(url).toContain(`&s=${size}`);
   });
 
-  it("appends mtime-based cache buster for managed hooks", () => {
+  it("appends file-metadata cache buster for managed hooks", () => {
     const url = buildImportUrl(tmpFile, "openclaw-managed");
-    expect(url).toMatch(/\?t=[\d.]+&s=\d+/);
+    expect(url).toMatch(/\?t=[\d.]+&c=[\d.]+&s=\d+/);
   });
 
-  it("appends mtime-based cache buster for plugin hooks", () => {
+  it("appends file-metadata cache buster for plugin hooks", () => {
     const url = buildImportUrl(tmpFile, "openclaw-plugin");
-    expect(url).toMatch(/\?t=[\d.]+&s=\d+/);
+    expect(url).toMatch(/\?t=[\d.]+&c=[\d.]+&s=\d+/);
   });
 
   it("returns same URL for bundled hooks across calls (cacheable)", () => {
@@ -54,6 +55,36 @@ describe("buildImportUrl", () => {
     const url1 = buildImportUrl(tmpFile, "openclaw-workspace");
     const url2 = buildImportUrl(tmpFile, "openclaw-workspace");
     expect(url1).toBe(url2);
+  });
+
+  it("reloads a workspace hook after a same-size edit with restored mtime", async () => {
+    const initialSource = 'export default () => "before";\n';
+    const editedSource = 'export default () => "after!";\n';
+    expect(Buffer.byteLength(editedSource)).toBe(Buffer.byteLength(initialSource));
+
+    fs.writeFileSync(tmpFile, initialSource);
+    const cleanTime = new Date(Math.floor(Date.now() / 1000) * 1000);
+    fs.utimesSync(tmpFile, cleanTime, cleanTime);
+    const initialStat = fs.statSync(tmpFile);
+    const initialUrl = buildImportUrl(tmpFile, "openclaw-workspace");
+    const initialHandler = (await import(/* @vite-ignore */ initialUrl)).default as () => string;
+    expect(initialHandler()).toBe("before");
+
+    await vi.waitFor(
+      () => {
+        fs.writeFileSync(tmpFile, editedSource);
+        fs.utimesSync(tmpFile, initialStat.atime, initialStat.mtime);
+        expect(fs.statSync(tmpFile).ctimeMs).not.toBe(initialStat.ctimeMs);
+      },
+      { interval: 1, timeout: 1_000 },
+    );
+
+    const editedStat = fs.statSync(tmpFile);
+    expect(editedStat.size).toBe(initialStat.size);
+    expect(editedStat.mtimeMs).toBe(initialStat.mtimeMs);
+    const editedUrl = buildImportUrl(tmpFile, "openclaw-workspace");
+    const editedHandler = (await import(/* @vite-ignore */ editedUrl)).default as () => string;
+    expect(editedHandler()).toBe("after!");
   });
 
   it("falls back to Date.now() when file does not exist", () => {

--- a/src/hooks/import-url.ts
+++ b/src/hooks/import-url.ts
@@ -6,7 +6,7 @@
  * module cache across gateway restarts.
  *
  * Workspace, managed, and plugin hooks may be edited by the user between
- * restarts. For those we append `?t=<mtime>&s=<size>` so the module key
+ * restarts. For those we append `?t=<mtime>&c=<ctime>&s=<size>` so the module key
  * reflects on-disk changes while staying stable for unchanged files.
  */
 
@@ -29,8 +29,8 @@ export function buildImportUrl(handlerPath: string, source: HookSource): string 
 
   // Use file metadata so the cache key only changes when the file changes
   try {
-    const { mtimeMs, size } = fs.statSync(handlerPath);
-    return `${base}?t=${mtimeMs}&s=${size}`;
+    const { ctimeMs, mtimeMs, size } = fs.statSync(handlerPath);
+    return `${base}?t=${mtimeMs}&c=${ctimeMs}&s=${size}`;
   } catch {
     // If stat fails (unlikely), fall back to Date.now() to guarantee freshness
     return `${base}?t=${Date.now()}`;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators updating a mutable workspace, managed, or plugin hook with an equal-byte-length edit whose modification time is preserved could keep executing the previous handler after an in-process Gateway restart or reload.

## Why This Change Was Made

Mutable hook import URLs now include `ctimeMs` alongside `mtimeMs` and size, using the existing filesystem stat result. This changes the ESM cache key whenever file status changes without adding another read; bundled hook URLs remain unchanged and cacheable.

## User Impact

Same-size hook edits made by sync, restore, or editor tooling are picked up on the next hook reload instead of silently continuing to run stale code.

## Evidence

Exact head: `d5fdcb76fb00cb38210699c4915f8e835aa396ca`

- Parent red: a same-size edit with restored mtime changed `ctimeMs` but produced the same import URL; the second real dynamic import returned `"before"` while disk contained the `"after!"` handler.
- Exact-head real handler proof: `sameBytes=true`, `sameMtime=true`, `ctimeChanged=true`, `importUrlChanged=true`; the first handler returned `"before"` and the second returned `"after!"`.
- Inspectable exact-head proof at artifact commit `4a2e34ae9fb9504acd94ce9edb5384ff04f78c6f`: [README](https://github.com/Alix-007/openclaw/blob/4a2e34ae9fb9504acd94ce9edb5384ff04f78c6f/README.md), [harness](https://github.com/Alix-007/openclaw/blob/4a2e34ae9fb9504acd94ce9edb5384ff04f78c6f/hook-import-ctime-proof.ts), [observation JSON](https://github.com/Alix-007/openclaw/blob/4a2e34ae9fb9504acd94ce9edb5384ff04f78c6f/observation.json), [terminal log](https://github.com/Alix-007/openclaw/blob/4a2e34ae9fb9504acd94ce9edb5384ff04f78c6f/proof.log), and [SHA-256 manifest](https://github.com/Alix-007/openclaw/blob/4a2e34ae9fb9504acd94ce9edb5384ff04f78c6f/SHA256SUMS).
- `OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs src/hooks/import-url.test.ts` - 8 passed.
- `./node_modules/.bin/oxfmt --check src/hooks/import-url.ts src/hooks/import-url.test.ts` - passed.
- Targeted non-type-aware oxlint, conflict-marker check, and `git diff --check` - passed.
- Production LOC: +3/-3 (net 0); tests: +39/-8.
- Current base: `c337919f6d4ff030bc46180fea89f7935fe46b4f`.

## AI Assistance

AI-assisted: yes (Codex). I reviewed the current owner and caller path, repository history and competing work, the Node filesystem metadata contract, and the parent-red/head-green behavior, and I understand the resulting change.
