### PR TITLE
docs(hooks): clarify command logger storage

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -229,7 +229,7 @@ Npm specs are registry-only (package name + optional exact version or dist-tag).
 | --------------------- | ---------------------------------------------------- | -------------------------------------------------------------- |
 | session-memory        | `command:new`, `command:reset`, `session:auto-reset` | Saves session context to `<workspace>/memory/`                 |
 | bootstrap-extra-files | `agent:bootstrap`                                    | Injects additional bootstrap files from glob patterns          |
-| command-logger        | `command`                                            | Logs all commands to `~/.openclaw/logs/commands.log`           |
+| command-logger        | `command`                                            | Logs emitted command events to `~/.openclaw/logs/commands.log` |
 | compaction-notifier   | `session:compact:before`, `session:compact:after`    | Sends visible chat notices when session compaction starts/ends |
 | boot-md               | `gateway:startup`                                    | Runs `BOOT.md` when the gateway starts                         |
 
@@ -284,7 +284,7 @@ when you intentionally want both representations.
 
 ### command-logger details
 
-Logs every slash command as a JSON line (timestamp, action, session key, sender ID, source) to `~/.openclaw/logs/commands.log`.
+Logs each emitted command event as a JSON line (timestamp, action, session key, sender ID, source) to `~/.openclaw/logs/commands.log`. Current core command events are `/new`, `/reset`, and `/stop`; plugins may emit additional actions.
 
 <a id="compaction-notifier"></a>
 

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -34,7 +34,7 @@ Hooks (4/5 ready)
 Ready:
   🚀 boot-md ✓ - Run BOOT.md on gateway startup
   📎 bootstrap-extra-files ✓ - Inject additional workspace bootstrap files during agent bootstrap
-  📝 command-logger ✓ - Log all command events to a centralized audit file
+  📝 command-logger ✓ - Log emitted command events to a centralized audit file
   💾 session-memory ✓ - Save session context to memory when /new or /reset command is issued
 ```
 
@@ -108,7 +108,7 @@ Hook packs install through the unified plugins installer/updater; `openclaw hook
 | --------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------- |
 | boot-md               | `gateway:startup`                                 | Runs `BOOT.md` at gateway startup for each configured agent scope                       |
 | bootstrap-extra-files | `agent:bootstrap`                                 | Injects extra bootstrap files (for example monorepo `AGENTS.md`) during agent bootstrap |
-| command-logger        | `command`                                         | Logs command events to `~/.openclaw/logs/commands.log`                                  |
+| command-logger        | `command`                                         | Logs emitted command events to `~/.openclaw/logs/commands.log`                          |
 | compaction-notifier   | `session:compact:before`, `session:compact:after` | Sends visible chat notices when session compaction starts and finishes                  |
 | session-memory        | `command:new`, `command:reset`                    | Saves session context to memory on `/new` or `/reset`                                   |
 

--- a/docs/refactor/database-first.md
+++ b/docs/refactor/database-first.md
@@ -1439,9 +1439,8 @@ create` validates the written archive by default; `--no-verify` is the
 - The bundled session-memory hook now resolves previous-session context from
   SQLite by `{agentId, sessionId}`. It no longer scans, stores, or synthesizes
   transcript paths or `workspace/sessions` directories.
-- The bundled command-logger hook now writes command audit rows to the shared
-  SQLite `command_log_entries` table instead of appending
-  `logs/commands.log`.
+- The bundled command-logger hook remains a named log artifact. It writes only
+  `logs/commands.log`; it does not write command audit rows to SQLite.
 - Channel pairing allowlists now expose only SQLite-backed read/write helpers at
   runtime. The deprecated plugin SDK path resolver remains for migration
   compatibility; file readers live only in doctor state migration code.
@@ -1478,8 +1477,8 @@ create` validates the written archive by default; `--no-verify` is the
   runtime `cache/*.json` stores, generic
   `thread-bindings.json` sidecars, cron state/run-log JSON, config health JSON,
   restart and lock sidecars, Voice Wake settings, plugin binding approvals,
-  installed plugin index JSON, File Transfer audit JSONL, Memory Wiki activity
-  logs and the old bundled `command-logger` text log. It also bans old
+  installed plugin index JSON, File Transfer audit JSONL, and Memory Wiki
+  activity logs. It also bans old
   root-level doctor legacy module names so
   compatibility code stays under `src/commands/doctor/`. Android debug handlers
   also use logcat/in-memory output instead of staging `camera_debug.log` or
@@ -2290,7 +2289,6 @@ Add a repo check that fails new runtime writes to legacy state paths:
 - `gateway.<hash>.lock`
 - `qmd/embed.lock.lock`
 - `agents/<agentId>/qmd-write.lock.lock`
-- `commands.log`
 - `config-health.json`
 - `port-guard.json`
 - `settings/voicewake.json`

--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -34,9 +34,9 @@ openclaw hooks enable bootstrap-extra-files
 
 ### 📝 command-logger
 
-Logs all command events to a centralized audit file.
+Logs emitted command events to a centralized audit file. Current core actions are `/new`, `/reset`, and `/stop`.
 
-**Events**: `command` (all commands)
+**Events**: `command` (all emitted command actions)
 **What it does**: Appends JSONL entries to command log file.
 **Output**: `~/.openclaw/logs/commands.log`
 

--- a/src/hooks/bundled/command-logger/HOOK.md
+++ b/src/hooks/bundled/command-logger/HOOK.md
@@ -1,6 +1,6 @@
 ---
 name: command-logger
-description: "Log all command events to a centralized audit file"
+description: "Log emitted command events to a centralized audit file"
 homepage: https://docs.openclaw.ai/automation/hooks#command-logger
 metadata:
   {
@@ -15,11 +15,11 @@ metadata:
 
 # Command Logger Hook
 
-Logs all command events (`/new`, `/reset`, `/stop`, etc.) to a centralized audit log file for debugging and monitoring purposes.
+Logs emitted command events to a centralized audit log file for debugging and monitoring purposes. Current core actions are `/new`, `/reset`, and `/stop`; plugins may emit additional actions.
 
 ## What It Does
 
-Every time you issue a command to the agent:
+Every time OpenClaw emits a command event:
 
 1. **Captures event details** - Command action, timestamp, session key, sender ID, source
 2. **Appends to log file** - Writes a JSON line to `~/.openclaw/logs/commands.log`

--- a/src/hooks/bundled/command-logger/handler.ts
+++ b/src/hooks/bundled/command-logger/handler.ts
@@ -1,7 +1,7 @@
 /**
- * Example hook handler: Log all commands to a file
+ * Example hook handler: Log command lifecycle events to a file
  *
- * This handler demonstrates how to create a hook that logs all command events
+ * This handler demonstrates how to create a hook that logs emitted command events
  * to a centralized log file for audit/debugging purposes.
  *
  * Enable this bundled hook with `openclaw hooks enable command-logger` or config:
@@ -31,7 +31,7 @@ import type { HookHandler } from "../../hooks.js";
 const log = createSubsystemLogger("command-logger");
 
 /**
- * Log all command events to a file
+ * Log emitted command events to a file
  */
 const logCommand: HookHandler = async (event) => {
   // Only trigger on command events


### PR DESCRIPTION
## What Problem This Solves

Resolves conflicting command-logger documentation. Some pages claimed the bundled hook had migrated to SQLite or logged every slash command, while its runtime writes only `logs/commands.log` and receives the emitted `command` event family.

## Why This Change Was Made

Document the existing behavior exactly: current core command actions are `/new`, `/reset`, and `/stop`; plugins may emit additional command actions; every emitted action is appended to the JSONL log.

The inert `command_log_entries` table remains unchanged. Removing it from schema 9 would break older schema-9 readers, so retirement is deferred to a future natural schema bump. No runtime, config, schema, migration, or Doctor behavior changes.

## User Impact

Operators can enable `command-logger` knowing it writes `logs/commands.log` only—not SQLite—and does not capture unrelated slash commands that emit no command event.

## Evidence

- `pnpm docs:check-mdx`: passed.
- `pnpm format:docs:check`: passed.
- Handler probe wrote and parsed a Telegram-sourced `/new` JSONL entry.
- Real-user Telegram E2E: doctor passed; QA user sent the group mention; SUT replied `OPENCLAW_E2E_OK`; recorded expectation passed; one request reached the mock provider; clean teardown.
