### PR TITLE
fix(matrix): send fallback media when attachment list is blank

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -7,6 +7,7 @@ import {
 import {
   buildTtsSupplementMediaPayload,
   getReplyPayloadTtsSupplement,
+  resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CoreConfig, MatrixStreamingMode, ReplyToMode } from "../../types.js";
@@ -153,7 +154,7 @@ export function createMatrixReplyDispatcher(config: {
         return replacement;
       };
       if (draftStream && info.kind !== "tool" && !payload.isCompactionNotice) {
-        const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+        const { hasMedia } = resolveSendableOutboundReplyParts(payload);
         const ttsSupplement = getReplyPayloadTtsSupplement(payload);
         const fallbackPayload =
           ttsSupplement &&

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3635,7 +3635,10 @@ describe("matrix monitor handler draft streaming", () => {
     await finish();
   });
 
-  it("keeps partial preview-first finalization on the existing draft when text is unchanged", async () => {
+  it.each([
+    { name: "plain text", payload: { text: "Single block" } },
+    { name: "blank-only media", payload: { text: "Single block", mediaUrls: ["   "] } },
+  ])("finalizes unchanged partial drafts for $name", async ({ payload }) => {
     const { dispatch, redactEventMock } = createStreamingHarness({
       blockStreamingEnabled: true,
       streaming: "partial",
@@ -3654,7 +3657,7 @@ describe("matrix monitor handler draft streaming", () => {
     expect(draftOptions.msgtype).not.toBe("m.notice");
     expect(draftOptions.includeMentions).toBe(false);
 
-    await deliver({ text: "Single block" }, { kind: "final" });
+    await deliver(payload, { kind: "final" });
 
     // MSC4357: even when text is unchanged, a finalize edit is sent to clear
     // the live marker so supporting clients stop the streaming animation.
@@ -4706,7 +4709,10 @@ describe("matrix monitor handler draft streaming", () => {
     expect(redactEventMock).not.toHaveBeenCalled();
   });
 
-  it("keeps shutdown cleanup for empty final payloads that send nothing", async () => {
+  it.each([
+    { name: "no media", payload: {} },
+    { name: "blank-only media", payload: { mediaUrls: ["   "] } },
+  ])("cleans up empty final drafts with $name", async ({ payload }) => {
     const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
     const { deliver, opts, finish } = await dispatch();
 
@@ -4720,7 +4726,7 @@ describe("matrix monitor handler draft streaming", () => {
       visibleReplySent: false,
       suppression: { reason: "no_visible_result" },
     });
-    await deliver({}, { kind: "final" });
+    await deliver(payload, { kind: "final" });
 
     expect(deliverMatrixRepliesMock).toHaveBeenCalledTimes(1);
     expect(redactEventMock).not.toHaveBeenCalled();
@@ -4857,7 +4863,10 @@ describe("matrix monitor handler draft streaming", () => {
     await finish();
   });
 
-  it("finalizes partial drafts before reusing unchanged media captions", async () => {
+  it.each([
+    { name: "a singular attachment", mediaUrls: undefined },
+    { name: "a singular fallback after blank plural entries", mediaUrls: ["   "] },
+  ])("reuses partial-draft captions for $name", async ({ mediaUrls }) => {
     const { dispatch, redactEventMock } = createStreamingHarness({ streaming: "partial" });
     const { deliver, opts, finish } = await dispatch();
 
@@ -4871,6 +4880,7 @@ describe("matrix monitor handler draft streaming", () => {
       {
         text: "screenshot ready",
         mediaUrl: "https://example.com/image.png",
+        mediaUrls,
       },
       { kind: "final" },
     );

--- a/extensions/matrix/src/matrix/monitor/replies.file-boundary.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.file-boundary.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginRuntime, RuntimeEnv } from "../../../runtime-api.js";
+import { setMatrixRuntime } from "../../runtime.js";
+import type { MatrixClient } from "../sdk.js";
+import { deliverMatrixReplies } from "./replies.js";
+
+const runtimeStub = {
+  config: { current: () => ({}) },
+  channel: {
+    text: {
+      resolveMarkdownTableMode: () => "code",
+      resolveTextChunkLimit: () => 4000,
+      resolveChunkMode: () => "length",
+      chunkMarkdownTextWithMode: (text: string) => [text],
+    },
+  },
+  media: {
+    mediaKindFromMime: () => "unknown",
+    getImageMetadata: async () => null,
+    resizeToJpeg: async () => Buffer.alloc(0),
+  },
+  logging: { shouldLogVerbose: () => false },
+} as unknown as PluginRuntime;
+
+const runtimeEnv = {} as RuntimeEnv;
+
+describe("deliverMatrixReplies file boundary", () => {
+  let tempDir = "";
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "matrix-reply-media-"));
+    setMatrixRuntime(runtimeStub);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reads and sends singular media when plural media entries are blank", async () => {
+    const mediaPath = path.join(tempDir, "fallback.txt");
+    fs.writeFileSync(mediaPath, "matrix-file-boundary-proof");
+    const uploadContent = vi.fn(async () => "mxc://example/fallback");
+    const sendMessage = vi.fn(async () => "$event-1");
+    const client = {
+      prepareRoomForMessageSend: vi.fn(async () => "m.room.message"),
+      uploadContent,
+      sendMessage,
+      getUserId: vi.fn(async () => "@bot:example.org"),
+    } as unknown as MatrixClient;
+
+    const result = await deliverMatrixReplies({
+      cfg: { channels: { matrix: {} } },
+      replies: [{ text: "caption", mediaUrl: mediaPath, mediaUrls: ["   "] }],
+      roomId: "!room:example.org",
+      client,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+      mediaLocalRoots: [tempDir],
+    });
+
+    expect(uploadContent).toHaveBeenCalledWith(
+      Buffer.from("matrix-file-boundary-proof"),
+      "text/plain",
+      "fallback.txt",
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      "!room:example.org",
+      expect.objectContaining({
+        body: "caption",
+        filename: "fallback.txt",
+        msgtype: "m.file",
+        url: "mxc://example/fallback",
+      }),
+      undefined,
+      undefined,
+    );
+    expect(result).toMatchObject({ messageIds: ["$event-1"], visibleReplySent: true });
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -379,6 +379,25 @@ describe("deliverMatrixReplies", () => {
     });
   });
 
+  it("reports blank text with blank-only media as missing", async () => {
+    const result = await deliverMatrixReplies({
+      cfg,
+      replies: [{ text: "   ", mediaUrls: ["   "] }],
+      roomId: "room:2",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(runtimeEnv.error).toHaveBeenCalledWith("matrix reply missing text/media");
+    expect(sendMessageMatrixMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    });
+  });
+
   it("keeps replyToId when threadId is set so Matrix can send fallback metadata", async () => {
     chunkMatrixTextMock.mockImplementation((text: string) => ({
       trimmedText: text.trim(),

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -339,6 +339,27 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(2).replyToId).toBe("reply-text");
   });
 
+  it("uses singular media when plural media entries are blank", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [
+        {
+          text: "caption",
+          mediaUrl: "https://example.com/fallback.jpg",
+          mediaUrls: ["   "],
+        },
+      ],
+      roomId: "room:2",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledOnce();
+    expect(sendOptions(0).mediaUrl).toBe("https://example.com/fallback.jpg");
+  });
+
   it("keeps replyToId when threadId is set so Matrix can send fallback metadata", async () => {
     chunkMatrixTextMock.mockImplementation((text: string) => ({
       trimmedText: text.trim(),

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -360,6 +360,25 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(0).mediaUrl).toBe("https://example.com/fallback.jpg");
   });
 
+  it("reports blank-only media as missing instead of silently suppressing it", async () => {
+    const result = await deliverMatrixReplies({
+      cfg,
+      replies: [{ mediaUrls: ["   "] }],
+      roomId: "room:2",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(runtimeEnv.error).toHaveBeenCalledWith("matrix reply missing text/media");
+    expect(sendMessageMatrixMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      visibleReplySent: false,
+      suppression: { reason: "no_visible_result" },
+    });
+  });
+
   it("keeps replyToId when threadId is set so Matrix can send fallback metadata", async () => {
     chunkMatrixTextMock.mockImplementation((text: string) => ({
       trimmedText: text.trim(),

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -141,12 +141,12 @@ export async function deliverMatrixReplies(params: {
   try {
     for (const reply of params.replies) {
       const visibleText = resolveVisibleMatrixReplyText(reply.text);
-      const { hasMedia, mediaUrls } = resolveSendableOutboundReplyParts(reply);
+      const { hasMedia, hasText, mediaUrls } = resolveSendableOutboundReplyParts(reply);
       if (reply.isReasoning === true || (!hasMedia && reply.text && visibleText === undefined)) {
         logVerbose("matrix reply suppressed as reasoning-only");
         continue;
       }
-      if (!reply?.text && !hasMedia) {
+      if (!hasText && !hasMedia) {
         if (reply?.audioAsVoice) {
           logVerbose("matrix reply has audioAsVoice without media/text; skipping");
           continue;

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -141,7 +141,7 @@ export async function deliverMatrixReplies(params: {
   try {
     for (const reply of params.replies) {
       const visibleText = resolveVisibleMatrixReplyText(reply.text);
-      const hasMedia = Boolean(reply?.mediaUrl) || (reply?.mediaUrls?.length ?? 0) > 0;
+      const { hasMedia, mediaUrls } = resolveSendableOutboundReplyParts(reply);
       if (reply.isReasoning === true || (!hasMedia && reply.text && visibleText === undefined)) {
         logVerbose("matrix reply suppressed as reasoning-only");
         continue;
@@ -161,7 +161,6 @@ export async function deliverMatrixReplies(params: {
           ? undefined
           : replyToIdRaw;
       const rawText = visibleText ?? "";
-      const mediaList = resolveSendableOutboundReplyParts(reply).mediaUrls;
 
       const shouldIncludeReply = (id?: string) =>
         Boolean(id) && (params.threadId || params.replyToMode === "all" || !hasRepliedRef.value);
@@ -174,7 +173,7 @@ export async function deliverMatrixReplies(params: {
         }
       };
 
-      if (mediaList.length === 0) {
+      if (mediaUrls.length === 0) {
         const { chunks } = chunkMatrixText(rawText, {
           cfg: params.cfg,
           accountId: params.accountId,
@@ -198,7 +197,7 @@ export async function deliverMatrixReplies(params: {
       }
 
       let first = true;
-      for (const mediaUrl of mediaList) {
+      for (const mediaUrl of mediaUrls) {
         const caption = first ? rawText : "";
         await sendMessageMatrix(params.roomId, caption, {
           client: params.client,

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -8,6 +8,7 @@ import {
   listMessageReceiptPlatformIds,
   type MessageReceipt,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
 import { getMatrixRuntime } from "../../runtime.js";
@@ -160,11 +161,7 @@ export async function deliverMatrixReplies(params: {
           ? undefined
           : replyToIdRaw;
       const rawText = visibleText ?? "";
-      const mediaList = reply.mediaUrls?.length
-        ? reply.mediaUrls
-        : reply.mediaUrl
-          ? [reply.mediaUrl]
-          : [];
+      const mediaList = resolveSendableOutboundReplyParts(reply).mediaUrls;
 
       const shouldIncludeReply = (id?: string) =>
         Boolean(id) && (params.threadId || params.replyToMode === "all" || !hasRepliedRef.value);


### PR DESCRIPTION
AI-assisted: This change was implemented and validated with Codex.

## What Problem This Solves

Matrix automatic replies could discard a valid singular attachment when `mediaUrls` existed but contained only blank entries. The raw text/array checks and the normalized delivery list also disagreed when neither text nor media was sendable, allowing whitespace-only replies to end with neither a visible message nor the expected missing-result diagnostic.

## Why This Change Was Made

The Matrix automatic-reply path now resolves `hasText`, `hasMedia`, and `mediaUrls` once through the Plugin SDK's canonical sendable-reply selector. Validation, missing-result reporting, and delivery therefore consume the same normalized state, while whitespace filtering and singular fallback remain owned by the shared selector.

Sibling PR #128372 established the shared blank-list fallback. This PR connects the omitted Matrix automatic-reply consumer. PR #127653 covers shared fan-out and durable reconciliation, while #128254 changes reasoning-notice delivery in the same Matrix files; neither changes this selector or covers this failure.

## User Impact

Matrix automatic replies now upload and send a valid fallback attachment when plural attachment entries are blank. A reply containing only whitespace text and blank media now records the normal `matrix reply missing text/media` outcome instead of disappearing silently.

## Evidence

- Exact head: `6b04c79e5f03c9ca9a1b5aa0e5b0f4b4c0b31714`. Original parent-red gate: `c337919f6d4ff030bc46180fea89f7935fe46b4f`. Upstream main at this body refresh: `2aa5eee34e51d0655fd6e7dca1c41f1da1e53e04`.
- Original parent-red: `node scripts/run-vitest.mjs extensions/matrix/src/matrix/monitor/replies.test.ts` failed only the new fallback regression: expected `https://example.com/fallback.jpg`, received three spaces.
- First review-finding parent-red on PR head `e9f5e59df82682f012cd0443634ab78597e8a98d`: blank-only media expected `matrix reply missing text/media`, but the error hook had zero calls and the send path emitted nothing.
- Second review-finding parent-red on PR head `a4f70619cdbdbdb69c740988ac3fd6d07a0bb30b`: whitespace text plus blank-only media again expected the diagnostic, but the error hook had zero calls. Exact head uses the selector's normalized `hasText` and `hasMedia` for the gate.
- Exact-head affected suite on Node 24.15.0: `node scripts/run-vitest.mjs extensions/matrix/src/matrix/monitor/replies.test.ts extensions/matrix/src/matrix/monitor/replies.file-boundary.test.ts` passed 2 files / 20 tests. The boundary test reads a real temporary file through `loadOutboundMediaFromUrl` and exercises the production reply/send pipeline.
- `pnpm exec oxfmt --check` passed for all 3 changed files, and `git diff --check` passed.
- Production delta: +5/-9 (net -4). Tests: +142/-0. All 3 commits use `Alix-007 <li.long15@xydigit.com>` as author and committer.

### Real homeserver proof: fallback delivery

PR head `a4f70619cdbdbdb69c740988ac3fd6d07a0bb30b`, the direct parent of the final normalized-text gate, was run against a disposable loopback Tuwunel v1.8.2 homeserver. The official `v1.8.2-release-all-x86_64-v1-linux-gnu-tuwunel.zst` asset reported digest `sha256:823796258f9252e0b1215d12e6190abba70d81a2a39efc86b419e5a6b3a2cd6c`; the downloaded asset matched that SHA-256 before its static binary was started. The proof performed real token registration, created and joined a real room, then ran `deliverMatrixReplies` with `mediaUrls: ["   "]` and a real local-file `mediaUrl`.

```json
{
  "proof": "PASS",
  "source": "PR head a4f70619 deliverMatrixReplies",
  "homeserver": {
    "binary": "Tuwunel v1.8.2 static x86_64-v1",
    "releaseAssetSha256": "823796258f9252e0b1215d12e6190abba70d81a2a39efc86b419e5a6b3a2cd6c",
    "scope": "disposable loopback; base URL redacted"
  },
  "fallback": {
    "plural": "blank-only",
    "singular": "local file selected"
  },
  "upload": {
    "bytes": 30,
    "route": "/_matrix/media/v3/upload",
    "status": 200
  },
  "roomEvent": {
    "body": "fallback caption",
    "filename": "fallback.txt",
    "msgtype": "m.file",
    "route": "/_matrix/client/v3/rooms/{roomId}/send/m.room.message/{transactionId}",
    "status": 200,
    "type": "m.room.message",
    "urlScheme": "mxc"
  },
  "roundTrip": {
    "bytes": 30,
    "route": "/_matrix/client/v1/media/download/{serverName}/{mediaId}",
    "sha256": "0ff5b069e913b3ee5670a1481165227a8c6dfd62033be45f5393601218fde9d0",
    "sourceMatchesDownload": true,
    "status": 200
  },
  "visibleReplySent": true,
  "eventCount": 1,
  "secretsPrinted": false
}
```

### Real homeserver proof: normalized-empty no-event

The exact final head repeated the same checksum-pinned static homeserver setup, registered three fresh accounts, created and joined a fresh room, and ran `deliverMatrixReplies` with whitespace-only text and blank-only media. It then read the real room timeline from the homeserver.

```json
{
  "proof": "PASS",
  "source": "exact head 6b04c79e deliverMatrixReplies",
  "homeserver": {
    "binary": "Tuwunel v1.8.2 static x86_64-v1",
    "releaseAssetSha256": "823796258f9252e0b1215d12e6190abba70d81a2a39efc86b419e5a6b3a2cd6c",
    "scope": "disposable loopback; base URL redacted"
  },
  "input": {
    "text": "blank-only",
    "mediaUrls": "blank-only"
  },
  "outcome": {
    "diagnostic": "matrix reply missing text/media",
    "suppression": "no_visible_result",
    "visibleReplySent": false
  },
  "transport": {
    "uploadRequestCount": 0,
    "sendRequestCount": 0
  },
  "roomReadback": {
    "route": "/_matrix/client/v3/rooms/{roomId}/messages",
    "status": 200,
    "roomMessageEventCount": 0
  },
  "secretsPrinted": false
}
```

Both proofs omitted or normalized account IDs, room/event IDs, access tokens, registration tokens, loopback ports, and media IDs. Each Tuwunel process, binary, config, database, and payload was removed after exit; no external credentials or persistent room were used.

The repository's Compose-based fixture could not start on this host because its Docker 17.03.3 installation lacks the Compose plugin, and the same daemon rejected the modern image layer with `archive/tar: invalid tar header`. The checksum-pinned official static release provided the equivalent real homeserver boundary without weakening TLS or artifact verification. During the first proof shutdown, the minimal non-persistent Matrix runtime logged one IndexedDB snapshot warning before its existing stop fallback completed; all transport assertions had already passed, the process exited 0, and all temporary state was removed. The exact-head no-event proof used the explicit non-persisting stop path and emitted no such warning.

## Limitations

The real homeservers were loopback-only and the rooms were unencrypted. The proofs cover registration, room creation/join, normalized empty-result handling, production attachment selection, real media upload, real room event storage/readback, and real media download; they do not exercise federation or an external operator-owned Matrix room.
