### PR TITLE
fix(embeddings): reject empty vectors from compatible providers

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3625,7 +3625,7 @@ src/plugins/native-module-require.ts	3
 src/plugins/official-external-plugin-catalog-snapshot-store.ts	4
 src/plugins/official-external-plugin-targets.ts	1
 src/plugins/official-external-provider-endpoints.ts	1
-src/plugins/openai-compatible-embedding-provider.ts	3
+src/plugins/openai-compatible-embedding-provider.ts	2
 src/plugins/plugin-cache-primitives.ts	2
 src/plugins/plugin-command-dispatch-contract.ts	1
 src/plugins/plugin-command-execution.ts	3

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -77,7 +77,7 @@ async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknow
 
 async function startEmbeddingServer(params?: {
   token?: string;
-  respond?: (request: CapturedRequest) => FixtureResponse | Record<string, unknown>;
+  respond?: (request: CapturedRequest) => FixtureResponse | Record<string, unknown> | null;
   status?: number;
 }): Promise<{ baseUrl: string; requests: CapturedRequest[] }> {
   const requests: CapturedRequest[] = [];
@@ -102,11 +102,13 @@ async function startEmbeddingServer(params?: {
         res.writeHead(params?.status ?? 200, { "content-type": "application/json" });
         res.end(
           JSON.stringify(
-            params?.respond?.(captured) ?? {
-              object: "list",
-              data: [{ object: "embedding", embedding: [0.1, 0.2, 0.3], index: 0 }],
-              model: body.model,
-            },
+            params?.respond
+              ? params.respond(captured)
+              : {
+                  object: "list",
+                  data: [{ object: "embedding", embedding: [0.1, 0.2, 0.3], index: 0 }],
+                  model: body.model,
+                },
           ),
         );
       } catch (error) {
@@ -909,16 +911,26 @@ describe("openai-compatible generic embedding provider", () => {
     ).rejects.toThrow("missing model");
   });
 
-  it("keeps remote parser failures behind the provider-specific error prefix", async () => {
-    const server = await startEmbeddingServer({ respond: () => ({ data: [] }) });
+  it.each([
+    { name: "missing vectors", input: "hello", response: { data: [] } },
+    { name: "empty direct vector", input: "hello", response: { data: [{ embedding: [] }] } },
+    {
+      name: "empty batch vector",
+      input: ["hello", "world"],
+      response: { data: [{ embedding: [1] }, { embedding: [] }] },
+    },
+    { name: "null response root", input: "hello", response: null },
+  ])("rejects malformed $name with the provider-specific error", async ({ input, response }) => {
+    const server = await startEmbeddingServer({ respond: () => response });
     const { provider } = await createOpenAICompatibleEmbeddingProvider(
       createOptions({
         model: "text-embedding-bge-m3",
         remote: { baseUrl: server.baseUrl },
       }),
     );
+    const request = typeof input === "string" ? provider.embed(input) : provider.embedBatch(input);
 
-    await expect(provider.embed("hello")).rejects.toThrow(
+    await expect(request).rejects.toThrow(
       "openai-compatible embeddings failed: malformed JSON response",
     );
   });

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -3,7 +3,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asOptionalRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
+import { readProviderJsonArrayFieldResponse } from "../agents/provider-http-errors.js";
 import type {
   AcquireConfiguredProviderLocalService,
   ConfiguredProviderLocalServiceTarget,
@@ -41,10 +41,6 @@ type OpenAICompatibleEmbeddingClient = {
   documentInputType?: string;
   localServiceTarget?: ConfiguredProviderLocalServiceTarget;
   acquireLocalService?: AcquireConfiguredProviderLocalService;
-};
-
-type OpenAICompatibleEmbeddingResponse = {
-  data?: unknown;
 };
 
 type ConfiguredEmbeddingProvider = {
@@ -259,7 +255,7 @@ function malformedEmbeddingResponse(): Error {
 }
 
 function readEmbeddingVector(value: unknown): number[] {
-  if (!Array.isArray(value)) {
+  if (!Array.isArray(value) || value.length === 0) {
     throw malformedEmbeddingResponse();
   }
   for (const entry of value) {
@@ -270,24 +266,17 @@ function readEmbeddingVector(value: unknown): number[] {
   return value;
 }
 
-function readEmbeddingVectors(
-  payload: OpenAICompatibleEmbeddingResponse,
-  expectedCount: number,
-): number[][] {
-  if (!Array.isArray(payload.data) || payload.data.length !== expectedCount) {
+function readEmbeddingVectors(data: unknown[], expectedCount: number): number[][] {
+  if (data.length !== expectedCount) {
     throw malformedEmbeddingResponse();
   }
-  return payload.data.map((entry) => {
+  return data.map((entry) => {
     const record = asRecord(entry);
     if (!record) {
       throw malformedEmbeddingResponse();
     }
     return readEmbeddingVector(record.embedding);
   });
-}
-
-async function readJsonResponse(response: Response): Promise<unknown> {
-  return await readProviderJsonResponse(response, "openai-compatible embeddings failed");
 }
 
 async function readEmbeddingErrorBodySnippet(response: Response): Promise<string | undefined> {
@@ -349,7 +338,11 @@ async function postEmbeddingRequest(params: {
         throw await createEmbeddingHttpError(response);
       }
       return readEmbeddingVectors(
-        (await readJsonResponse(response)) as OpenAICompatibleEmbeddingResponse,
+        await readProviderJsonArrayFieldResponse(
+          response,
+          "openai-compatible embeddings failed",
+          "data",
+        ),
         input.length,
       );
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users indexing or querying memory through an OpenAI-compatible embedding provider would silently accept unusable zero-dimensional vectors, including empty members in otherwise valid batches. A provider returning a JSON `null` response also surfaced an unhelpful raw JavaScript exception instead of the existing provider-specific malformed-response error.

## Why This Change Was Made

Validate embedding vectors at their generic producer using the same nonempty-vector invariant already enforced by the memory-host provider. Reuse the existing shared provider JSON array-field reader to validate response roots and data arrays, deleting the duplicate parser, obsolete response type, and unsafe root assertion.

## User Impact

Malformed embedding-provider responses now fail immediately with the actionable existing `openai-compatible embeddings failed: malformed JSON response` message instead of silently entering memory indexing, batch embeddings, or the Gateway `/v1/embeddings` response.

## Evidence

- Real isolated loopback HTTP regression before the fix: an empty direct vector incorrectly resolved as `[]`, a mixed batch incorrectly resolved as `[[1], []]`, and a `null` response root leaked `Cannot read properties of null (reading 'data')`; all three now reject with the existing provider-specific malformed-response error.
- Complete generic-provider, canonical memory-host sibling, shared provider-HTTP parser, and Gateway embeddings suites: **91 tests passed across four files**.
- All existing supported-provider response fixtures and bounded-response/error behavior remain covered by the complete suites.
- Focused formatting, boundary lint, both exact CI ratchets, and `git diff --check` passed; independent structured review reported no actionable findings.
- Production LOC: **+10/-17 (net -7)**. Tests: **+21/-9 (net +12)**.
- Removed one unsafe production type assertion and tightened its exact assertion-safety baseline from **3 to 2**; no unrelated baseline entries changed.
- Provenance: the generic provider's original vector guard dates to #85269; the canonical memory-host sibling already rejects empty direct and batch vectors through #117200.
- Proof uses isolated local HTTP fixtures and the real Gateway route; no external provider, credentials, configuration contracts, or public SDK surfaces were changed.
