### PR TITLE
test(codex): lock advertised Ultra session intent

### DIFF
--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -787,28 +787,6 @@ describe("listThinkingLevels", () => {
     ).toBe(true);
   });
 
-  it("does not synthesize Ultra from Max for non-OpenClaw runtimes", () => {
-    const catalog = [
-      {
-        provider: "myazure",
-        id: "gpt-5.6-sol",
-        reasoning: true,
-        compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
-      },
-    ];
-
-    expect(listThinkingLevels("myazure", "gpt-5.6-sol", catalog, "codex")).not.toContain("ultra");
-    expect(
-      resolveSupportedThinkingLevel({
-        provider: "myazure",
-        model: "gpt-5.6-sol",
-        level: "ultra",
-        catalog,
-        agentRuntime: "codex",
-      }),
-    ).toBe("max");
-  });
-
   it("does not let catalog xhigh compat override binary thinking providers", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -763,6 +763,52 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("myazure", "gpt-5.6-sol", catalog, "codex")).not.toContain("ultra");
   });
 
+  it("preserves catalog-advertised Ultra for non-OpenClaw runtimes", () => {
+    const catalog = [
+      {
+        provider: "myazure",
+        id: "gpt-5.6-sol",
+        reasoning: true,
+        compat: {
+          supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+        },
+      },
+    ];
+
+    expect(listThinkingLevels("myazure", "gpt-5.6-sol", catalog, "codex")).toContain("ultra");
+    expect(
+      isThinkingLevelSupported({
+        provider: "myazure",
+        model: "gpt-5.6-sol",
+        level: "ultra",
+        catalog,
+        agentRuntime: "codex",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not synthesize Ultra from Max for non-OpenClaw runtimes", () => {
+    const catalog = [
+      {
+        provider: "myazure",
+        id: "gpt-5.6-sol",
+        reasoning: true,
+        compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"] },
+      },
+    ];
+
+    expect(listThinkingLevels("myazure", "gpt-5.6-sol", catalog, "codex")).not.toContain("ultra");
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "myazure",
+        model: "gpt-5.6-sol",
+        level: "ultra",
+        catalog,
+        agentRuntime: "codex",
+      }),
+    ).toBe("max");
+  });
+
   it("does not let catalog xhigh compat override binary thinking providers", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -204,7 +204,7 @@ function appendCatalogAdvancedThinkingLevels(
   }
   const runtime = normalizeOptionalLowercaseString(agentRuntime);
   if (supportsMax && (runtime === "openclaw" || runtime === "auto")) {
-    // Ultra is OpenClaw's orchestration tier; provider requests use Max.
+    // Max-only catalogs synthesize Ultra only for OpenClaw; other runtimes must advertise it.
     appendProfileLevel(profile, "ultra");
   }
 }

--- a/src/gateway/server.sessions.thinking-e2e.test.ts
+++ b/src/gateway/server.sessions.thinking-e2e.test.ts
@@ -228,7 +228,7 @@ test("e2e #76482: session matching default model inherits default thinking level
   expect(resolved).toContain("high");
 });
 
-test("session rows keep the selected Codex Sol model when runtime metadata contains a response family", async () => {
+test("active Codex sessions patch and list catalog-advertised Ultra", async () => {
   const loadSolCatalog = async () => [
     {
       provider: "openai",
@@ -256,10 +256,11 @@ test("session rows keep the selected Codex Sol model when runtime metadata conta
   });
   expect(session?.agentRuntime?.id).toBe("codex");
   expect(session?.thinkingOptions).toContain("max");
+  expect(session?.thinkingOptions).toContain("ultra");
 
   const patchResponse = await directSessionReq(
     "sessions.patch",
-    { key: "main", thinkingLevel: "max" },
+    { key: "main", thinkingLevel: "ultra" },
     { context: { loadGatewayModelCatalog: loadSolCatalog } },
   );
   expect(patchResponse.ok, patchResponse.error?.message).toBe(true);
@@ -269,9 +270,25 @@ test("session rows keep the selected Codex Sol model when runtime metadata conta
     resolved: {
       modelProvider: "openai",
       model: "gpt-5.6-sol",
-      thinkingLevel: "max",
+      thinkingLevel: "ultra",
     },
   });
+
+  const listResponse = await directSessionReq<SessionsListResult>(
+    "sessions.list",
+    {},
+    { context: { loadGatewayModelCatalog: loadSolCatalog } },
+  );
+  expect(listResponse.ok, listResponse.error?.message).toBe(true);
+  const listedSession = listResponse.payload?.sessions?.find(
+    (candidate) => candidate.key === "agent:main:main",
+  );
+  expect(listedSession).toMatchObject({
+    modelProvider: "openai",
+    model: "gpt-5.6-sol",
+    thinkingLevel: "ultra",
+  });
+  expect(listedSession?.thinkingOptions).toContain("ultra");
 });
 
 test("unsupported generic stored levels clamp through the current profile", async () => {


### PR DESCRIPTION
## What Problem This Solves

Codex models that explicitly advertise `ultra` must retain that session intent through patch/list, while Max-only non-OpenClaw runtimes remain clamped to Max.

Current `main` owns the production repair through #132389 and the corrected app-server-versus-provider-wire oracle through #132431. After rebasing, this PR keeps focused regression coverage at the thinking-profile owner and the exact session patch/list boundary; it no longer duplicates the production repair.

## User Impact

No additional runtime behavior beyond current `main`. The tests lock the repaired behavior: explicitly advertised Ultra remains selectable for Codex and survives the session patch/list round trip. Existing adjacent coverage continues to prove that Max-only third-party runtimes do not synthesize Ultra.

## Evidence

- Original Full Release Validation: https://github.com/openclaw/openclaw/actions/runs/33239702882
- Original Sol failure: https://github.com/openclaw/openclaw/actions/runs/33239717262/job/99067787848
- Original Terra failure: https://github.com/openclaw/openclaw/actions/runs/33239717262/job/99067787912
- Current-main production owner: #132389
- Current-main live-oracle repair: #132431
- Mutation audit: removing catalog Ultra support from current main left the pre-existing focused suites green (81/81), while this PR's session patch/list regression failed at the exact missing-Ultra assertion.
- Exact current-head focused proof: `node scripts/run-vitest.mjs src/auto-reply/thinking.test.ts src/gateway/server.sessions.thinking-e2e.test.ts` — 82 tests passed.
- `pnpm exec oxfmt --check src/auto-reply/thinking.test.ts src/gateway/server.sessions.thinking-e2e.test.ts` passed.
- `git diff --check` passed.

Direct Codex contract inspection:

- `../codex/codex-rs/protocol/src/openai_models.rs:49-80` defines and preserves explicit Ultra as an app-server/session reasoning effort.
- `../codex/codex-rs/app-server/src/models.rs:69-78` projects catalog reasoning efforts without rewriting them.
- `../codex/codex-rs/core/src/session/multi_agents.rs:154-170` derives proactive multi-agent mode from session Ultra.
- `../codex/codex-rs/core/src/client.rs:178-183` clamps Ultra to Max only while constructing a provider request.
- `../codex/codex-rs/core/src/client_tests.rs:300-307` locks that wire-only clamp.

Production LOC: `+1/-1` comment clarification only (net 0). Tests: `+44/-3`.
