### PR TITLE
perf(test): avoid running focused Gateway suites twice

### DIFF
--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -95,6 +95,32 @@ describe("projects vitest config", () => {
     expect(gatewayFallback.exclude).toContain("server.sessions.compaction-read-errors.test.ts");
   });
 
+  it("limits isolated Gateway include files to the project's owned tests", () => {
+    const unrelatedTest = "src/gateway/worker-environments/workspace-sync-scripts.test.ts";
+    const mixedIncludeFile = patternFiles.writePatternFile("mixed-include.json", [
+      ...gatewayServerIsolatedTestFiles,
+      unrelatedTest,
+    ]);
+    const unrelatedIncludeFile = patternFiles.writePatternFile("unrelated-include.json", [
+      unrelatedTest,
+    ]);
+
+    expect(
+      requireTestConfig(
+        createGatewayServerIsolatedVitestConfig({
+          OPENCLAW_VITEST_INCLUDE_FILE: mixedIncludeFile,
+        }),
+      ).include,
+    ).toEqual(gatewayServerIsolatedTestFiles);
+    expect(
+      requireTestConfig(
+        createGatewayServerIsolatedVitestConfig({
+          OPENCLAW_VITEST_INCLUDE_FILE: unrelatedIncludeFile,
+        }),
+      ).include,
+    ).toEqual([]);
+  });
+
   it("covers each normal full-suite test file exactly once after configs cached filtered includes", async () => {
     const contractTestConfigs = [
       contractChannelSurfaceConfig,

--- a/test/vitest/vitest.gateway-server-isolated.config.ts
+++ b/test/vitest/vitest.gateway-server-isolated.config.ts
@@ -2,7 +2,11 @@
 // the shared module cache.
 import { defineConfig } from "vitest/config";
 import { gatewayServerIsolatedTestFiles } from "./vitest.gateway-server-paths.mjs";
-import { loadPatternListFromEnv, narrowIncludePatternsForCli } from "./vitest.pattern-file.ts";
+import {
+  intersectIncludePatterns,
+  loadPatternListFromEnv,
+  narrowIncludePatternsForCli,
+} from "./vitest.pattern-file.ts";
 import { resolveRepoRootPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 
 export function createGatewayServerIsolatedVitestConfig(
@@ -10,7 +14,10 @@ export function createGatewayServerIsolatedVitestConfig(
   options: { argv?: string[] } = {},
 ) {
   const sharedTest = sharedVitestConfig.test ?? {};
-  const includeFromEnv = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
+  const includeFromEnv = intersectIncludePatterns(
+    gatewayServerIsolatedTestFiles,
+    loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env),
+  );
   const cliInclude = narrowIncludePatternsForCli(gatewayServerIsolatedTestFiles, options.argv);
 
   return defineConfig({


### PR DESCRIPTION
Related: #123976
Related: #106307

## What Problem This Solves

Fixes an issue where developers running a focused Gateway test would execute the same suite twice when the shared Vitest include file also reached the isolated Gateway project. A recently added real-process quiescence regression made the duplicate work particularly expensive.

## Why This Change Was Made

Intersect the isolated Gateway project's include file with its existing canonical owned-file list, using the same existing ownership helper already used by its sibling Gateway and contract projects. Keep its real module isolation, its legitimate compaction regression, and every worker-process lifecycle assertion unchanged.

## User Impact

Focused Gateway development and validation become approximately 46% faster for the measured real-process suite. No production behavior, dependencies, snapshots, timeouts, mocks, or security/lifecycle contracts change.

## Evidence

Same Blacksmith Testbox, one Vitest worker, distinct filesystem caches, excluded warmups, and a reversible before/after/before/after sequence:

| Measurement | Before | After |
| --- | --- | --- |
| Retained wall samples | 45.50 s, 45.31 s | 24.50 s, 24.44 s, 24.32 s |
| Mean wall time | 45.41 s | 24.42 s, saving 20.99 s (46.2%) |
| Vitest body time | 41.14-41.24 s | 20.57-20.64 s |
| Meaningful worker lifecycle cases | 11 | 11 |
| Actual executions/projects | 22 across two projects | 11 in the owning Gateway project |

- Focused benchmark: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/worker-environments/workspace-sync-scripts.test.ts --maxWorkers=1 --reporter=verbose`.
- Existing isolated owner: `src/gateway/server.sessions.compaction-read-errors.test.ts`, five cases passed only in `gateway-server-isolated`.
- Configuration ownership regression: `test/vitest-projects-config.test.ts`, 20 cases passed; the new mixed/unrelated include regression fails against the original config and passes with the owner-boundary fix.
- Neighboring scoped-project and watch ownership: `test/vitest-scoped-config.test.ts`, 98 cases passed.
- Complete changed gate: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- test/vitest-projects-config.test.ts test/vitest/vitest.gateway-server-isolated.config.ts`.
- Structured autoreview clean; targeted formatting and `git diff --check` clean.
- Production LOC: `+0/-0`. Test/config LOC: `+35/-2`.
- Maximum RSS was noisy and slightly higher in the after samples; no memory improvement is claimed.
