### PR TITLE
improve(irc): reuse transient connection for chunked sends

### DIFF
--- a/extensions/irc/src/channel.test.ts
+++ b/extensions/irc/src/channel.test.ts
@@ -9,6 +9,7 @@ describe("irc outbound chunking", () => {
     expect(ircOutboundBaseAdapter.deliveryMode).toBe("direct");
     expect(ircOutboundBaseAdapter.chunkerMode).toBe("markdown");
     expect(ircOutboundBaseAdapter.textChunkLimit).toBe(350);
+    expect(ircPlugin.outbound?.sendFormattedText).toBeTypeOf("function");
   });
 });
 

--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -35,7 +35,7 @@ import {
 import { IrcChannelConfigSchema } from "./config-schema.js";
 import { collectIrcMutableAllowlistWarnings } from "./doctor.js";
 import { startIrcGatewayAccount } from "./gateway.js";
-import { ircMessageAdapter } from "./message-adapter.js";
+import { ircMessageAdapter, sendFormattedIrcText } from "./message-adapter.js";
 import {
   isChannelTarget,
   looksLikeIrcTargetId,
@@ -343,7 +343,10 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = createChat
     collectWarnings: collectIrcSecurityWarnings,
   },
   outbound: {
-    base: ircOutboundBaseAdapter,
+    base: {
+      ...ircOutboundBaseAdapter,
+      sendFormattedText: sendFormattedIrcText,
+    },
     attachedResults: {
       channel: "irc",
       sendText: ({ onDeliveryResult: _onDeliveryResult, ...ctx }) =>

--- a/extensions/irc/src/message-adapter.ts
+++ b/extensions/irc/src/message-adapter.ts
@@ -1,15 +1,74 @@
 // Irc plugin module implements message adapter behavior.
-import { defineChannelMessageAdapter } from "openclaw/plugin-sdk/channel-outbound";
-import { sendMessageIrc } from "./send.js";
+import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-contract";
+import {
+  createReplyToFanout,
+  defineChannelMessageAdapter,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
+import { ircOutboundBaseAdapter } from "./outbound-base.js";
+import { sendIrcMessages, sendMessageIrc, type SendIrcResult } from "./send.js";
 import type { CoreConfig } from "./types.js";
 
-async function sendIrcMessage(...args: Parameters<typeof sendMessageIrc>) {
-  const { target, ...result } = await sendMessageIrc(...args);
+function toIrcMessageResult({ target, ...result }: SendIrcResult) {
   return {
     ...result,
     target: { kind: "conversation" as const, id: target },
   };
 }
+
+async function sendIrcMessage(...args: Parameters<typeof sendMessageIrc>) {
+  return toIrcMessageResult(await sendMessageIrc(...args));
+}
+
+export const sendFormattedIrcText: NonNullable<
+  ChannelOutboundAdapter["sendFormattedText"]
+> = async (ctx) => {
+  const { chunkMarkdownTextWithMode, resolveChunkMode, resolveTextChunkLimit } =
+    await import("openclaw/plugin-sdk/reply-chunking");
+  const accountId = ctx.accountId ?? undefined;
+  const textLimit =
+    ctx.formatting?.textLimit ??
+    resolveTextChunkLimit(ctx.cfg, "irc", accountId, {
+      fallbackLimit: ircOutboundBaseAdapter.textChunkLimit,
+    });
+  const chunkMode = ctx.formatting?.chunkMode ?? resolveChunkMode(ctx.cfg, "irc", accountId);
+  const chunkText = (text: string) =>
+    ctx.formatting
+      ? ircOutboundBaseAdapter.chunker(text, textLimit, { formatting: ctx.formatting })
+      : ircOutboundBaseAdapter.chunker(text, textLimit);
+  let chunks: string[];
+  if (chunkMode === "newline") {
+    const blocks = chunkMarkdownTextWithMode(ctx.text, textLimit, chunkMode);
+    if (blocks.length === 0 && ctx.text) {
+      blocks.push(ctx.text);
+    }
+    chunks = blocks.flatMap((block) => {
+      const blockChunks = chunkText(block);
+      return blockChunks.length === 0 && block ? [block] : blockChunks;
+    });
+  } else {
+    chunks = chunkText(ctx.text);
+  }
+
+  const nextReplyToId = createReplyToFanout(ctx);
+  const results = await sendIrcMessages(
+    ctx.to,
+    chunks.map((text) => {
+      const replyTo = nextReplyToId();
+      return replyTo ? { text, replyTo } : { text };
+    }),
+    {
+      cfg: ctx.cfg,
+      accountId,
+      abortSignal: ctx.abortSignal,
+      onPlatformSendDispatch: ctx.onPlatformSendDispatch,
+    },
+    async (result) => {
+      await ctx.onDeliveryResult?.(attachChannelToResult("irc", toIrcMessageResult(result)));
+    },
+  );
+  return results.map((result) => attachChannelToResult("irc", toIrcMessageResult(result)));
+};
 
 export const ircMessageAdapter = defineChannelMessageAdapter({
   id: "irc",

--- a/extensions/irc/src/send.test.ts
+++ b/extensions/irc/src/send.test.ts
@@ -425,6 +425,49 @@ describe("sendMessageIrc cfg threading", () => {
     expect(client.quit).toHaveBeenCalledOnce();
   });
 
+  it("stops before recording another chunk after the connection closes", async () => {
+    const providedCfg = {
+      channels: {
+        irc: {
+          host: "irc.example.com",
+          nick: "openclaw",
+        },
+      },
+    } as unknown as CoreConfig;
+    let ready = true;
+    const client = {
+      isReady: vi.fn(() => ready),
+      join: vi.fn(),
+      sendPrivmsg: vi.fn(),
+      quit: vi.fn(),
+    } as unknown as IrcClient & {
+      join: ReturnType<typeof vi.fn>;
+      sendPrivmsg: ReturnType<typeof vi.fn>;
+      quit: ReturnType<typeof vi.fn>;
+    };
+    hoisted.connectIrcClient.mockResolvedValue(client);
+    const onDeliveryResult = vi.fn(() => {
+      ready = false;
+    });
+    const onPlatformSendDispatch = vi.fn();
+    const text = Array.from({ length: 80 }, (_, index) => `word-${index}`).join(" ");
+
+    await expect(
+      sendFormattedIrcText({
+        cfg: providedCfg,
+        to: "#room",
+        text,
+        onDeliveryResult,
+        onPlatformSendDispatch,
+      }),
+    ).rejects.toThrow("IRC connection closed before send");
+
+    expect(client.sendPrivmsg).toHaveBeenCalledOnce();
+    expect(onPlatformSendDispatch).toHaveBeenCalledOnce();
+    expect(onDeliveryResult).toHaveBeenCalledOnce();
+    expect(client.quit).toHaveBeenCalledOnce();
+  });
+
   it("declares message adapter durable text, media, and reply with receipt proofs", async () => {
     const providedCfg = {
       channels: {

--- a/extensions/irc/src/send.test.ts
+++ b/extensions/irc/src/send.test.ts
@@ -75,7 +75,8 @@ vi.mock("openclaw/plugin-sdk/text-chunking", async () => {
   };
 });
 
-import { ircMessageAdapter } from "./message-adapter.js";
+import { ircMessageAdapter, sendFormattedIrcText } from "./message-adapter.js";
+import { ircOutboundBaseAdapter } from "./outbound-base.js";
 import { sendMessageIrc } from "./send.js";
 
 function resetHoistedMocks() {
@@ -325,6 +326,53 @@ describe("sendMessageIrc cfg threading", () => {
 
     expect(client.sendPrivmsg).not.toHaveBeenCalled();
     expect(hoisted.record).not.toHaveBeenCalled();
+  });
+
+  it("uses one transient connection for a chunked outbound message", async () => {
+    const providedCfg = {
+      channels: {
+        irc: {
+          host: "irc.example.com",
+          nick: "openclaw",
+        },
+      },
+    } as unknown as CoreConfig;
+    const client = {
+      isReady: vi.fn(() => true),
+      join: vi.fn(),
+      sendPrivmsg: vi.fn(),
+      quit: vi.fn(),
+    } as unknown as IrcClient & {
+      join: ReturnType<typeof vi.fn>;
+      sendPrivmsg: ReturnType<typeof vi.fn>;
+      quit: ReturnType<typeof vi.fn>;
+    };
+    hoisted.connectIrcClient.mockResolvedValue(client);
+    const onDeliveryResult = vi.fn();
+    const onPlatformSendDispatch = vi.fn();
+    const text = Array.from({ length: 80 }, (_, index) => `word-${index}`).join(" ");
+    const chunks = ircOutboundBaseAdapter.chunker(text, 350);
+
+    const results = await sendFormattedIrcText({
+      cfg: providedCfg,
+      to: "#room",
+      text,
+      replyToId: "parent-1",
+      replyToIdSource: "explicit",
+      replyToMode: "all",
+      onDeliveryResult,
+      onPlatformSendDispatch,
+    });
+
+    expect(hoisted.connectIrcClient).toHaveBeenCalledOnce();
+    expect(client.join).toHaveBeenCalledOnce();
+    expect(client.sendPrivmsg.mock.calls).toEqual(
+      chunks.map((chunk) => ["#room", `${chunk}\n\n[reply:parent-1]`]),
+    );
+    expect(client.quit).toHaveBeenCalledOnce();
+    expect(onPlatformSendDispatch).toHaveBeenCalledTimes(chunks.length);
+    expect(onDeliveryResult).toHaveBeenCalledTimes(chunks.length);
+    expect(results).toHaveLength(chunks.length);
   });
 
   it("declares message adapter durable text, media, and reply with receipt proofs", async () => {

--- a/extensions/irc/src/send.test.ts
+++ b/extensions/irc/src/send.test.ts
@@ -12,6 +12,9 @@ const hoisted = vi.hoisted(() => {
   const convertMarkdownTables = vi.fn((text: string) => text);
   const stripMarkdown = vi.fn((text: string) => text);
   const record = vi.fn();
+  const buildIrcConnectOptions = vi.fn(
+    (_account: unknown, overrides: Record<string, unknown> = {}) => overrides,
+  );
   return {
     loadConfig,
     resolveMarkdownTableMode,
@@ -20,7 +23,7 @@ const hoisted = vi.hoisted(() => {
     record,
     normalizeIrcMessagingTarget: vi.fn((value: string) => value.trim()),
     connectIrcClient: vi.fn(),
-    buildIrcConnectOptions: vi.fn(() => ({})),
+    buildIrcConnectOptions,
   };
 });
 
@@ -373,6 +376,53 @@ describe("sendMessageIrc cfg threading", () => {
     expect(onPlatformSendDispatch).toHaveBeenCalledTimes(chunks.length);
     expect(onDeliveryResult).toHaveBeenCalledTimes(chunks.length);
     expect(results).toHaveLength(chunks.length);
+  });
+
+  it("does not join after cancellation during transient connection setup", async () => {
+    const providedCfg = {
+      channels: {
+        irc: {
+          host: "irc.example.com",
+          nick: "openclaw",
+        },
+      },
+    } as unknown as CoreConfig;
+    const client = {
+      isReady: vi.fn(() => true),
+      join: vi.fn(),
+      sendPrivmsg: vi.fn(),
+      quit: vi.fn(),
+    } as unknown as IrcClient & {
+      join: ReturnType<typeof vi.fn>;
+      sendPrivmsg: ReturnType<typeof vi.fn>;
+      quit: ReturnType<typeof vi.fn>;
+    };
+    let resolveConnect!: (client: IrcClient) => void;
+    const connect = new Promise<IrcClient>((resolve) => {
+      resolveConnect = resolve;
+    });
+    hoisted.buildIrcConnectOptions.mockImplementation((_account, overrides = {}) => overrides);
+    hoisted.connectIrcClient.mockReturnValue(connect);
+    const abortController = new AbortController();
+
+    const send = sendFormattedIrcText({
+      cfg: providedCfg,
+      to: "#room",
+      text: "hello",
+      abortSignal: abortController.signal,
+    });
+    await vi.waitFor(() => expect(hoisted.connectIrcClient).toHaveBeenCalledOnce());
+    abortController.abort();
+    resolveConnect(client);
+
+    await expect(send).rejects.toMatchObject({ name: "AbortError" });
+    expect(hoisted.buildIrcConnectOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ abortSignal: abortController.signal }),
+    );
+    expect(client.join).not.toHaveBeenCalled();
+    expect(client.sendPrivmsg).not.toHaveBeenCalled();
+    expect(client.quit).toHaveBeenCalledOnce();
   });
 
   it("declares message adapter durable text, media, and reply with receipt proofs", async () => {

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -21,9 +21,16 @@ type SendIrcOptions = {
   replyTo?: string;
   target?: string;
   client?: IrcClient;
+  abortSignal?: AbortSignal;
+  onPlatformSendDispatch?: () => Promise<void>;
 };
 
-type SendIrcResult = {
+type SendIrcMessage = {
+  text: string;
+  replyTo?: string;
+};
+
+export type SendIrcResult = {
   messageId: string;
   target: string;
   receipt: MessageReceipt;
@@ -55,11 +62,12 @@ function resolveTarget(to: string, opts?: SendIrcOptions): string {
   throw new Error(`Invalid IRC target: ${to}`);
 }
 
-export async function sendMessageIrc(
+export async function sendIrcMessages(
   to: string,
-  text: string,
+  messages: readonly SendIrcMessage[],
   opts: SendIrcOptions,
-): Promise<SendIrcResult> {
+  onDeliveryResult?: (result: SendIrcResult) => Promise<void> | void,
+): Promise<SendIrcResult[]> {
   const cfg = requireRuntimeConfig(opts.cfg, "IRC send") as CoreConfig;
   const account = resolveIrcAccount({
     cfg,
@@ -78,44 +86,78 @@ export async function sendMessageIrc(
     channel: "irc",
     accountId: account.accountId,
   });
-  const prepared = stripMarkdown(convertMarkdownTables(text.trim(), tableMode));
-  if (!prepared.trim()) {
+  const preparedMessages = messages.map((message) => {
+    const prepared = stripMarkdown(convertMarkdownTables(message.text.trim(), tableMode));
+    if (!prepared.trim()) {
+      throw new Error("Message must be non-empty for IRC sends");
+    }
+    return {
+      payload: message.replyTo ? `${prepared}\n\n[reply:${message.replyTo}]` : prepared,
+      replyTo: message.replyTo,
+    };
+  });
+  if (preparedMessages.length === 0) {
+    return [];
+  }
+  opts.abortSignal?.throwIfAborted();
+
+  let transient: IrcClient | undefined;
+  const client = opts.client?.isReady()
+    ? opts.client
+    : (transient = await connectIrcClient(
+        buildIrcConnectOptions(account, {
+          connectTimeoutMs: 12000,
+        }),
+      ));
+  if (transient) {
+    if (target.startsWith("#") || target.startsWith("&")) {
+      client.join(target);
+    }
+  }
+
+  const results: SendIrcResult[] = [];
+  try {
+    for (const message of preparedMessages) {
+      opts.abortSignal?.throwIfAborted();
+      await opts.onPlatformSendDispatch?.();
+      client.sendPrivmsg(target, message.payload);
+      recordIrcOutboundActivity(account.accountId);
+
+      const messageId = makeIrcMessageId();
+      const result = {
+        messageId,
+        target,
+        receipt: createMessageReceiptFromOutboundResults({
+          results: [
+            {
+              channel: "irc",
+              messageId,
+              conversationId: target,
+            },
+          ],
+          kind: "text",
+          ...(message.replyTo ? { replyToId: message.replyTo } : {}),
+        }),
+      };
+      results.push(result);
+      await onDeliveryResult?.(result);
+    }
+    return results;
+  } finally {
+    transient?.quit("sent");
+  }
+}
+
+export async function sendMessageIrc(
+  to: string,
+  text: string,
+  opts: SendIrcOptions,
+): Promise<SendIrcResult> {
+  const result = (
+    await sendIrcMessages(to, [{ text, ...(opts.replyTo ? { replyTo: opts.replyTo } : {}) }], opts)
+  )[0];
+  if (!result) {
     throw new Error("Message must be non-empty for IRC sends");
   }
-  const payload = opts.replyTo ? `${prepared}\n\n[reply:${opts.replyTo}]` : prepared;
-
-  const client = opts.client;
-  if (client?.isReady()) {
-    client.sendPrivmsg(target, payload);
-  } else {
-    const transient = await connectIrcClient(
-      buildIrcConnectOptions(account, {
-        connectTimeoutMs: 12000,
-      }),
-    );
-    if (target.startsWith("#") || target.startsWith("&")) {
-      transient.join(target);
-    }
-    transient.sendPrivmsg(target, payload);
-    transient.quit("sent");
-  }
-
-  recordIrcOutboundActivity(account.accountId);
-
-  const messageId = makeIrcMessageId();
-  return {
-    messageId,
-    target,
-    receipt: createMessageReceiptFromOutboundResults({
-      results: [
-        {
-          channel: "irc",
-          messageId,
-          conversationId: target,
-        },
-      ],
-      kind: "text",
-      ...(opts.replyTo ? { replyToId: opts.replyTo } : {}),
-    }),
-  };
+  return result;
 }

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -107,16 +107,16 @@ export async function sendIrcMessages(
     : (transient = await connectIrcClient(
         buildIrcConnectOptions(account, {
           connectTimeoutMs: 12000,
+          abortSignal: opts.abortSignal,
         }),
       ));
-  if (transient) {
-    if (target.startsWith("#") || target.startsWith("&")) {
-      client.join(target);
-    }
-  }
 
   const results: SendIrcResult[] = [];
   try {
+    opts.abortSignal?.throwIfAborted();
+    if (transient && (target.startsWith("#") || target.startsWith("&"))) {
+      client.join(target);
+    }
     for (const message of preparedMessages) {
       opts.abortSignal?.throwIfAborted();
       await opts.onPlatformSendDispatch?.();

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -119,7 +119,14 @@ export async function sendIrcMessages(
     }
     for (const message of preparedMessages) {
       opts.abortSignal?.throwIfAborted();
+      if (!client.isReady()) {
+        throw new Error("IRC connection closed before send");
+      }
       await opts.onPlatformSendDispatch?.();
+      opts.abortSignal?.throwIfAborted();
+      if (!client.isReady()) {
+        throw new Error("IRC connection closed before send");
+      }
       client.sendPrivmsg(target, message.payload);
       recordIrcOutboundActivity(account.accountId);
 


### PR DESCRIPTION
## Summary

- route ordinary IRC formatted text through the channel-owned formatted-send seam
- project all configured chunks/reply fanout first, then send them through one transient IRC connection
- preserve single-send/media entry points and per-chunk abort, dispatch, activity, receipt, and delivery-result behavior

## Root cause

Core chunks a long ordinary IRC message before transport. The prior IRC adapter called `sendText` once per chunk, and every call independently connected, authenticated, joined, sent, and quit. A three-chunk message therefore paid three complete connection handshakes even though the chunks belonged to one prepared outbound operation.

The fix keeps canonical IRC chunk mode, text limit, reply fanout, Markdown/table projection, and the raw client's independent 512-byte line enforcement, while batching only the already-related text chunks through one transient client.

No cache, public SDK, config, protocol, security, storage, media, or retry/idempotency behavior changes.

## Why this boundary

- A cross-send connection cache would add lifecycle, invalidation, and concurrency state.
- Changing the raw client's 512-byte chunking would alter provider protocol behavior.
- Channel-owned `sendFormattedText` already represents one prepared outbound operation and is the narrow owner that can reuse one transient connection without crossing message boundaries.

## Verification

- Current-main relevant preimage blobs exactly match the frozen proven baseline; the full-index patch applied without adaptation.
- Exact-base regression: one intended failure before the formatted-send owner existed; candidate green.
- Full current IRC extension: 19 files / 159 tests passed.
- `check:changed` passed formatting, production/test types, type-aware Oxlint (0 findings), dead exports, boundaries, guards, and import cycles.
- `git diff --check` passed.
- TruffleHog clean; Codex `gpt-5.6-sol` high autoreview found no issue (0.98 correct).
- Stable patch ID: `922d58803db12ae191b3c0b4ccd8b18ee1e99d95`.

Frozen loopback proof used a 15 ms welcome delay and 12 ordinary three-chunk sends with explicit reply fanout:

- connections: 36 → 12 (-66.67%)
- total elapsed: 656.22 ms → 249.84 ms (-61.93%, 2.627x faster)
- median: 52.76 ms → 19.06 ms (-63.87%)
- recipient wire payload SHA-256 remained identical: `e21d1a7b929d819735632b349721f76d1a49513bddd94bc64a4448a18c192190`

No live credentialed IRC provider mutation was performed; the retained loopback server exercised the real socket/client boundary.
