### PR TITLE
fix(ai): keep SSE cancellation from blocking outcomes

### DIFF
--- a/packages/ai/src/providers/mistral.bounded-stream.test.ts
+++ b/packages/ai/src/providers/mistral.bounded-stream.test.ts
@@ -26,6 +26,20 @@ async function readAllChunks(body: ReadableStream<Uint8Array> | null): Promise<{
   return { total };
 }
 
+async function settleWithin<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} did not settle`)), 250);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 describe("Mistral bounded-stream-read real wire proof (loopback http.createServer)", () => {
   it("caps an oversized body streamed chunked over real wire", async () => {
     const fetcher = createBoundedMistralFetcher(MAX);
@@ -165,6 +179,31 @@ describe("Mistral bounded-stream-read direct (synthetic ReadableStream)", () => 
     // Synthetic stream chunks are exactly 1 MiB aligned, so cap+1 reads
     // give exactly cap + 1 MiB = 16 MiB + 1 MiB = 17 825 792 bytes.
     expect(got).toBe(16777216 + CHUNK);
+  });
+
+  it("finishes wrapped response cancellation after handing cleanup upstream", async () => {
+    let cancelStarted = false;
+    const upstreamBody = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelStarted = true;
+        return new Promise<void>(() => {});
+      },
+    });
+    const fetcher = createBoundedMistralFetcher(
+      MAX,
+      async () => new Response(upstreamBody, { status: 200 }),
+    );
+    const wrapped = await fetcher("http://unused.invalid/");
+    const reader = wrapped.body?.getReader();
+    if (!reader) {
+      throw new Error("bounded Mistral response did not expose a body reader");
+    }
+
+    await expect(
+      settleWithin(reader.cancel("done"), "wrapped response cancel"),
+    ).resolves.toBeUndefined();
+    expect(cancelStarted).toBe(true);
+    reader.releaseLock();
   });
 });
 

--- a/packages/ai/src/providers/openai-chatgpt-responses-protocol.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses-protocol.test.ts
@@ -15,6 +15,20 @@ const multilineDataLines = JSON.stringify(completedEvent, null, 2)
   .split("\n")
   .map((line) => `data: ${line}`);
 
+async function settleWithin<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} did not settle`)), 250);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 describe("ChatGPT Responses SSE frame boundaries", () => {
   it.each([
     { label: "LF", chunks: [`data: ${serializedCompletedEvent}\n\n`] },
@@ -131,5 +145,31 @@ describe("ChatGPT Responses SSE frame boundaries", () => {
     }
 
     expect(canceled).toBe(true);
+  });
+
+  it("releases the response reader when upstream cancellation remains pending", async () => {
+    let cancelStarted = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(`data: ${serializedCompletedEvent}\n\n`));
+      },
+      cancel() {
+        cancelStarted = true;
+        return new Promise<void>(() => {});
+      },
+    });
+    const iterator = parseOpenAIChatGptResponsesSse(new Response(body))[Symbol.asyncIterator]();
+
+    await expect(settleWithin(iterator.next(), "first response event")).resolves.toEqual({
+      done: false,
+      value: completedEvent,
+    });
+    await expect(
+      settleWithin(iterator.return(undefined), "terminal iterator cleanup"),
+    ).resolves.toEqual({ done: true, value: undefined });
+    expect(cancelStarted).toBe(true);
+
+    const replacementReader = body.getReader();
+    replacementReader.releaseLock();
   });
 });

--- a/packages/ai/src/utils/streaming-byte-guard.test.ts
+++ b/packages/ai/src/utils/streaming-byte-guard.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { createSseByteGuard } from "./streaming-byte-guard.js";
+
+async function settleWithin<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} did not settle`)), 250);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+describe("createSseByteGuard cancellation", () => {
+  it("reports overflow without waiting for upstream cancellation", async () => {
+    let cancelStarted = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(2));
+      },
+      cancel() {
+        cancelStarted = true;
+        return new Promise<void>(() => {});
+      },
+    });
+    const guard = createSseByteGuard(body.getReader(), { maxBytes: 1 });
+
+    await expect(settleWithin(guard.read(), "overflow read")).rejects.toThrow(
+      "SSE stream exceeds 1 bytes (received 2)",
+    );
+    expect(cancelStarted).toBe(true);
+    expect(guard.overflowed()).toBe(true);
+  });
+
+  it("finishes explicit cancellation after handing cleanup upstream", async () => {
+    let cancelStarted = false;
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelStarted = true;
+        return new Promise<void>(() => {});
+      },
+    });
+    const guard = createSseByteGuard(body.getReader(), { maxBytes: 1 });
+
+    await expect(settleWithin(guard.cancel("done"), "explicit cancel")).resolves.toBeUndefined();
+    expect(cancelStarted).toBe(true);
+    expect(guard.cancelled()).toBe(true);
+  });
+});

--- a/packages/ai/src/utils/streaming-byte-guard.ts
+++ b/packages/ai/src/utils/streaming-byte-guard.ts
@@ -43,6 +43,10 @@ export function createSseByteGuard(
   let total = 0;
   let overflowedFlag = false;
   let cancelledFlag = false;
+  const cancelReaderBestEffort = (reason?: unknown): void => {
+    // Upstream cancellation may never settle; cleanup cannot gate the primary outcome.
+    void reader.cancel(reason).catch(() => undefined);
+  };
   return {
     read: async () => {
       if (overflowedFlag || cancelledFlag) {
@@ -58,11 +62,7 @@ export function createSseByteGuard(
         overflowedFlag = true;
         cancelledFlag = true;
         const err = onOverflow({ size: next, maxBytes: opts.maxBytes });
-        try {
-          await reader.cancel(err);
-        } catch {
-          // best-effort cancellation; caller observes the overflow error
-        }
+        cancelReaderBestEffort(err);
         throw err;
       }
       total = next;
@@ -74,11 +74,7 @@ export function createSseByteGuard(
         return;
       }
       cancelledFlag = true;
-      try {
-        await reader.cancel(reason);
-      } catch {
-        // best-effort cancellation
-      }
+      cancelReaderBestEffort(reason);
     },
     totalBytes: () => total,
     overflowed: () => overflowedFlag,


### PR DESCRIPTION
## What Problem This Solves

Closes #127550.

The shared SSE byte guard awaited `ReadableStreamDefaultReader.cancel()` before reporting overflow or completing explicit cleanup. An upstream stream whose cancellation promise remains pending could therefore suppress an already-created overflow error and hang terminal reader-lock cleanup.

## Why This Change Was Made

Cancellation is now handed to the upstream reader as best-effort cleanup while rejection handling remains attached asynchronously. The shared guard owns this behavior, so overflow and every current consumer get the same non-blocking lifecycle contract.

The open #117887 changes proxy-local terminal body ownership and does not modify this guard. Its older cancel-before-release assertion predates #127550; this PR follows the newer maintainer-authored shared contract that upstream cancellation completion must not gate primary outcomes or reader-lock release.

## User Impact

Malformed or oversized provider streams still start upstream cancellation, but a stuck cancellation implementation can no longer hide the visible overflow error or leave ChatGPT and Mistral terminal cleanup waiting forever.

## Evidence

Exact head: `a4e6d5d89215e22e34f52440bab066cd022d5eaa`

- Parent red, same focused command: 36 passed and 4 failed. The guard overflow read, explicit guard cancel, ChatGPT iterator return, and Mistral wrapped-body cancel each timed out after upstream cancellation started.
- Exact-head focused tests: `OPENCLAW_TEST_FAST=1 node scripts/run-vitest.mjs packages/ai/src/utils/streaming-byte-guard.test.ts packages/ai/src/providers/openai-chatgpt-responses-protocol.test.ts packages/ai/src/providers/mistral.bounded-stream.test.ts` - 40 passed.
- Exact-head native stream proof on Node v22.22.0: overflow cancellation started and the canonical `SSE stream exceeds 1 bytes (received 2)` error surfaced; explicit cancellation settled; ChatGPT yielded `response.completed`, settled iterator return, and released its reader lock; Mistral wrapped-body cancellation settled. Every upstream cancellation promise intentionally remained pending.
- `./node_modules/.bin/oxfmt --check` on all four changed files - passed.
- Targeted non-type-aware oxlint on all four changed files - passed.
- Production LOC: +6/-10 (net -4); tests: +132/-0.
- Latest checked main: `0978d55b055a13a80a1b2fa000a476fd535303d4`; target files unchanged from this branch's base.

## AI Assistance

AI-assisted: yes (Codex). I reviewed the shared owner and current consumers, the native Web Streams cancellation contract, the installed Mistral SDK cancellation path, repository history and competing work, and the parent-red/head-green behavior, and I understand the resulting change.
