### PR TITLE
docs(telemetry): lead with what is on by default and thank opt-in users

### DIFF
--- a/docs/gateway/telemetry.md
+++ b/docs/gateway/telemetry.md
@@ -1,16 +1,33 @@
 ---
-summary: "Understand daily update checks, optional anonymous feature statistics, and every privacy control"
+summary: "What OpenClaw sends: a daily update check by default, optional anonymous feature statistics, and every privacy control"
 title: "Usage telemetry and update checks"
 read_when:
-  - Checking what information OpenClaw sends during its daily update check
+  - Checking what information OpenClaw sends and what it never collects
+  - Deciding whether to share anonymous feature statistics
   - Enabling or disabling anonymous feature statistics
   - Disabling all automatic update-check requests
 ---
 
-OpenClaw checks for a newer version at most once every 24 hours. By default,
-this request includes only basic software and platform information. Anonymous
-feature statistics are sent only when you explicitly opt in, and they reuse the
-same request rather than creating a second one.
+**The only thing OpenClaw sends on its own is a daily update check.** It asks
+whether a newer version exists, and the request carries nothing but the version,
+operating system, and CPU architecture already visible to any package registry.
+Everything else on this page is opt-in.
+
+Anonymous feature statistics — which channels and providers you have configured
+— are **off by default** and never turn themselves on. When you do enable them,
+they ride along with that same daily update check instead of adding a second
+request.
+
+If you turn them on: thank you. Feature statistics are the only way we learn
+which channels, providers, and plugins people actually use, and they decide what
+gets improved, what gets fixed first, and what can safely be retired. A handful
+of Discord anecdotes is otherwise the entire evidence base. We publish what we
+learn back to everyone at
+[telemetry.openclaw.ai](https://telemetry.openclaw.ai), so the data you
+contribute stays visible to you.
+
+Declining is a completely normal choice and changes nothing about how OpenClaw
+works for you.
 
 ## Inspect what is sent
 
@@ -98,6 +115,12 @@ When you explicitly enable feature statistics, the same daily request becomes a
 The sender and `openclaw telemetry show` use the same payload builder, so the
 JSON displayed by the CLI is the same payload the sender would use at that
 moment.
+
+Reports carry no identifier of any kind, which means they cannot be linked to
+each other. We can see that some install runs Telegram with Anthropic models; we
+cannot see that it is the same install as yesterday, and we cannot build a
+history of any single machine. That costs us retention analysis, and we consider
+it worth paying.
 
 ### What is never collected
 


### PR DESCRIPTION
## What Problem This Solves

The telemetry page landed in #128476 described the mechanics accurately but buried the two things a reader most wants answered in the first five seconds: what runs without asking, and whether sharing is optional. It also never said why sharing helps or thanked anyone for doing it, which reads as extraction rather than a request.

## Why This Change Was Made

The page now opens by stating plainly that the daily update check is the only thing OpenClaw sends on its own, and that it carries nothing a package registry does not already see. Feature statistics are named as off by default and opt-in immediately after.

A short paragraph then explains what opting in actually buys the project — evidence for what gets improved, fixed first, or retired instead of Discord anecdotes — thanks people who enable it, links the public aggregates so contributors see their data come back, and states that declining is a normal choice that changes nothing.

One paragraph is added under the payload table making the unlinkability tradeoff concrete: we can see that some install runs Telegram with Anthropic models, but not that it is the same install as yesterday, and we accept losing retention analysis for that.

## User Impact

Docs only. No behavior, config, or code changes.

## Evidence

`pnpm docs:list` lists the page with its updated summary; `pnpm docs:check-config-examples` passes; `git diff --check` is clean. No config fences changed.