### PR TITLE
fix(cron): reset trigger state when once changes

### DIFF
--- a/src/cron/service.declarative-jobs.test.ts
+++ b/src/cron/service.declarative-jobs.test.ts
@@ -62,6 +62,7 @@ function ownedDeclaration(params: {
   declarationKey: string;
   owner: TriggerStateOwner;
   script?: string;
+  once?: boolean;
   state?: CronJobCreate["state"];
   sameOwnerEdit?: boolean;
 }): CronJobCreate {
@@ -71,14 +72,14 @@ function ownedDeclaration(params: {
     delivery: { mode: "none" },
     trigger:
       params.owner === "condition"
-        ? { script, ...(params.sameOwnerEdit ? { once: true } : {}) }
+        ? { script, ...(params.once !== undefined ? { once: params.once } : {}) }
         : undefined,
     payload:
       params.owner === "script"
         ? { kind: "script", script, ...(params.sameOwnerEdit ? { timeoutSeconds: 45 } : {}) }
         : { kind: "agentTurn", message: "report" },
     ...(params.state ? { state: params.state } : {}),
-    ...(params.sameOwnerEdit && params.owner === "none" ? { displayName: "Updated report" } : {}),
+    ...(params.sameOwnerEdit ? { displayName: "Updated report" } : {}),
   });
 }
 
@@ -252,6 +253,8 @@ describe("CronService declarative jobs", () => {
         previous: TriggerStateOwner;
         next: TriggerStateOwner;
         replaceScript?: boolean;
+        previousOnce?: boolean;
+        nextOnce?: boolean;
         sameOwnerEdit?: boolean;
         replacementState?: CronJobCreate["state"];
       }> = [
@@ -277,6 +280,64 @@ describe("CronService declarative jobs", () => {
         { name: "same script owner", previous: "script", next: "script", sameOwnerEdit: true },
         { name: "same absent owner", previous: "none", next: "none", sameOwnerEdit: true },
         {
+          name: "same explicit-false condition owner",
+          previous: "condition",
+          next: "condition",
+          previousOnce: false,
+          nextOnce: false,
+          sameOwnerEdit: true,
+        },
+        {
+          name: "condition once enabled from default",
+          previous: "condition",
+          next: "condition",
+          nextOnce: true,
+        },
+        {
+          name: "condition once disabled to default",
+          previous: "condition",
+          next: "condition",
+          previousOnce: true,
+        },
+        {
+          name: "condition once enabled from explicit false",
+          previous: "condition",
+          next: "condition",
+          previousOnce: false,
+          nextOnce: true,
+        },
+        {
+          name: "condition once disabled to explicit false",
+          previous: "condition",
+          next: "condition",
+          previousOnce: true,
+          nextOnce: false,
+        },
+        {
+          name: "condition once made explicit false",
+          previous: "condition",
+          next: "condition",
+          nextOnce: false,
+        },
+        {
+          name: "condition explicit false omitted",
+          previous: "condition",
+          next: "condition",
+          previousOnce: false,
+        },
+        {
+          name: "condition once explicit replacement",
+          previous: "condition",
+          next: "condition",
+          nextOnce: true,
+          replacementState: {
+            triggerState: { owner: "replacement" },
+            triggerEvalCount: 0,
+            lastTriggerEvalAtMs: 444,
+            lastTriggerFireAtMs: 555,
+          },
+        },
+        {
           name: "explicit replacement state and count",
           previous: "condition",
           next: "condition",
@@ -299,6 +360,7 @@ describe("CronService declarative jobs", () => {
           const input = ownedDeclaration({
             declarationKey,
             owner: testCase.previous,
+            once: testCase.previousOnce,
             state: retiredTriggerState,
           });
           if (mutationPath === "ordinary update") {
@@ -314,6 +376,7 @@ describe("CronService declarative jobs", () => {
             declarationKey,
             owner: testCase.next,
             script: testCase.replaceScript ? 'return "replacement"' : undefined,
+            once: testCase.nextOnce,
             state: testCase.replacementState,
             sameOwnerEdit: testCase.sameOwnerEdit,
           });

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -140,9 +140,9 @@ function finalizeUpdatedJob(params: {
 
   const previousScript = job.payload.kind === "script" ? job.payload.script : undefined;
   const nextScript = nextJob.payload.kind === "script" ? nextJob.payload.script : undefined;
-  if (job.trigger?.script !== nextJob.trigger?.script || previousScript !== nextScript) {
-    // Trigger and payload scripts share one durable state slot; only its exact
-    // executable owner may inherit it, while explicit replacement values win.
+  if (!isDeepStrictEqual(job.trigger, nextJob.trigger) || previousScript !== nextScript) {
+    // Trigger and payload scripts share one durable state slot. Exact persisted
+    // definitions own it, matching in-flight ownership; explicit replacements win.
     for (const field of [
       "triggerState",
       "triggerEvalCount",


### PR DESCRIPTION
## What Problem This Solves

Changing a conditional cron trigger's `once` flag kept the previous trigger evaluation state because update finalization compared only the trigger script. A job could therefore inherit a stale cursor, evaluation count, or last-fire timestamp after its persisted trigger definition changed.

This closes the P1 follow-up left by #126940: `timer-outcomes` treats `script + once` as the trigger owner, but mutation finalization did not.

## Why This Change Was Made

`finalizeUpdatedJob` now compares the complete persisted trigger definition with `isDeepStrictEqual`, while retaining the existing separate comparison for script payload owners. When ownership changes, the same four trigger-owned state fields are cleared; explicit replacement state still wins.

The regression matrix covers omitted, explicit `false`, and `true` transitions through both ordinary updates and declarative convergence, including SQLite persistence and restart readback.

## User Impact

Cron jobs no longer silently reuse trigger evaluation state after `once` changes. Unchanged trigger definitions keep their state, and callers that explicitly supply replacement state retain it. No config or API surface changes.

## Evidence

- Before the fix, a real temporary SQLite update from `once: false` to `once: true` read back stale `triggerState: { cursor: 9 }`.
- After the fix, the four trigger-owned fields are absent after readback while unrelated `lastRunAtMs: 333` remains.
- `node scripts/run-vitest.mjs src/cron/service.declarative-jobs.test.ts` - 9 tests passed on Node 24.15.0 at exact head.
- `git diff --check` - passed.
- Fresh autoreview - clean, no P0/P1 findings; correctness confidence 0.96.

Testbox changed-gate proof is unavailable in this environment because the Crabbox and Blacksmith binaries are not installed; exact-head GitHub CI remains the broad gate.
