### PR TITLE
fix(agents): close stuck reasoning previews when provider streams end

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.ts
@@ -19,6 +19,7 @@ import { hasAssistantVisibleReply } from "./embedded-agent-subscribe.handlers.me
 import {
   buildAssistantStreamData,
   emitAssistantMessageStart,
+  emitReasoningEnd,
   extractStandaloneMessageToolText,
   hasMessageToolOnlySourceDelivery,
   isOpenAiCompletionsAssistantMessage,
@@ -152,6 +153,10 @@ export function handleMessageEnd(
   const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(assistantMessage);
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
   const suppressMessageToolOnlySourceReplyOutput = hasMessageToolOnlySourceDelivery(ctx);
+  // Provider completion can omit thinking_end; close the visible lane before final output.
+  if (!suppressMessageToolOnlySourceReplyOutput) {
+    emitReasoningEnd(ctx);
+  }
   ctx.noteLastAssistant(assistantMessage);
   ctx.noteCompletedAssistant(assistantMessage);
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts
@@ -363,6 +363,36 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(onReasoningEnd).not.toHaveBeenCalled();
   });
 
+  it("does not expose a reasoning boundary after message-tool-only delivery", async () => {
+    const onReasoningStream = vi.fn();
+    const onReasoningEnd = vi.fn();
+    const { emit } = createBlockReplyHarness("message_end", {
+      sourceReplyDeliveryMode: "message_tool_only",
+      reasoningMode: "stream",
+      onReasoningEnd,
+      onReasoningStream,
+    });
+
+    emit({
+      type: "message_update",
+      message: { role: "assistant", content: [{ type: "thinking", thinking: "private" }] },
+      assistantMessageEvent: { type: "thinking_delta", delta: "private" },
+    });
+    expect(onReasoningStream).toHaveBeenCalledTimes(1);
+
+    await emitMessageToolLifecycle({
+      emit,
+      toolCallId: "tool-message-after-reasoning",
+      message: "Starting the requested work.",
+      to: null,
+      result: { details: { deliveryStatus: "sent" } },
+    });
+    emitAssistantMessageEnd(emit, "Private final output.");
+    await Promise.resolve();
+
+    expect(onReasoningEnd).not.toHaveBeenCalled();
+  });
+
   it("suppresses later tagged reasoning streams after message-tool-only delivery", async () => {
     const onReasoningStream = vi.fn();
     const onReasoningEnd = vi.fn();

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -1006,6 +1006,74 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(onReasoningEnd).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    { label: "successful", stopReason: "stop", phase: undefined },
+    { label: "failed", stopReason: "error", phase: undefined },
+    { label: "aborted", stopReason: "aborted", phase: undefined },
+    { label: "commentary", stopReason: "stop", phase: "commentary" },
+  ] as const)(
+    "closes a reasoning preview before the $label message ends without thinking_end",
+    ({ stopReason, phase }) => {
+      const visibleEvents: string[] = [];
+      const onReasoningEnd = vi.fn(async () => {
+        visibleEvents.push("reasoning-end");
+      });
+      const { emit } = createSubscribedHarness({
+        runId: "run-reasoning-terminal",
+        reasoningMode: "stream",
+        onReasoningStream: vi.fn(),
+        onReasoningEnd,
+        onAgentEvent: (event) => {
+          if (event.stream === "assistant") {
+            visibleEvents.push("assistant");
+          }
+        },
+      });
+      const thinkingMessage = {
+        role: "assistant" as const,
+        content: [{ type: "thinking" as const, thinking: "Checking files" }],
+      };
+
+      emit({ type: "message_start", message: thinkingMessage });
+      emit({
+        type: "message_update",
+        message: thinkingMessage,
+        assistantMessageEvent: { type: "thinking_delta", delta: "Checking files" },
+      });
+      emit({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          stopReason,
+          ...(phase ? { phase } : {}),
+          content: [
+            { type: "thinking", thinking: "Checking files" },
+            { type: "text", text: "Final answer" },
+          ],
+        },
+      });
+
+      expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+      expect(visibleEvents[0]).toBe("reasoning-end");
+    },
+  );
+
+  it("does not close a reasoning preview that was never opened", () => {
+    const onReasoningEnd = vi.fn();
+    const { emit } = createSubscribedHarness({
+      runId: "run-without-reasoning",
+      reasoningMode: "stream",
+      onReasoningEnd,
+    });
+
+    emit({
+      type: "message_end",
+      message: { role: "assistant", content: [{ type: "text", text: "Final answer" }] },
+    });
+
+    expect(onReasoningEnd).not.toHaveBeenCalled();
+  });
+
   type ReasoningWindowGateCase = {
     label: string;
     reasoningMode: "off" | "stream";


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users watching streamed reasoning previews in Discord, Slack, Telegram, or Mattermost would see a stale thinking preview or an incorrect boundary before the final answer when a provider completed, failed, or was cancelled without first sending an explicit thinking-end event. Commentary-only terminal messages had the same missing completion signal.

## Why This Change Was Made

The generic provider event contract permits successful, failed, and aborted terminal messages without an intermediate thinking-end event. Close an already-open reasoning lane at its canonical assistant-message completion boundary before emitting final output, using the existing idempotent completion helper; continue suppressing the completion callback once message-tool-only source delivery makes the lane private.

The five production lines are necessary for the existing-helper import, documented lifecycle ordering, and the privacy-preserving guard; no new runtime, configuration, protocol, persistence, or provider-specific path is introduced.

## User Impact

Reasoning previews now finish exactly once before the answer or commentary replaces them, including interrupted provider streams. Existing explicitly completed previews remain idempotent, unopened previews remain silent, and message-tool-only source delivery never leaks a private reasoning boundary.

## Evidence

- Authentic production-subscriber regressions failed on the unchanged baseline in all four cases: successful, failed, aborted, and commentary assistant messages each produced zero completion callbacks when the provider omitted thinking-end.
- The fixed owner and privacy boundary pass 133 focused checks:

  ```text
  node scripts/run-vitest.mjs \
    src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts \
    src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.source-reply-suppression.test.ts \
    src/agents/embedded-agent-subscribe.handlers.messages.lifecycle.test.ts \
    src/agents/embedded-agent-subscribe.callback-fatal.test.ts
  ```

- An independent reviewer passed 419 tests across 12 suites, including the actual Discord, Slack, Telegram, and Mattermost reasoning-preview consumers.
- Core production and agent-test typechecks, typed lint, formatting, independent owner review, and authenticated committed-diff review all passed.
- Provider behavior was replayed through the real production subscription and its actual channel callbacks; no external provider credentials or operator Gateway were accessed.
