### PR TITLE
docs(nodes): clarify Mac node system commands

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -846,7 +846,7 @@ openclaw nodes invoke --node <idOrNameOrIp> --command photos.latest --params '{"
 
 ## System commands (node host / mac node)
 
-The macOS node exposes `system.run`, `system.which`, `system.notify`, and `system.execApprovals.get/set`. The headless node host exposes `system.run.prepare`, `system.run`, `system.which`, and `system.execApprovals.get/set`.
+The macOS node and headless node host both expose `system.run.prepare`, `system.run`, `system.which`, and `system.execApprovals.get/set`; the macOS node also exposes `system.notify`.
 
 Examples:
 


### PR DESCRIPTION
Refs #103873
Refs #105642

## What Problem This Solves

Fixes an issue where the node documentation said only the headless node host exposed `system.run.prepare`, even though the macOS app now embeds the same TypeScript node-host runtime and advertises that shared command surface.

## Why This Change Was Made

Updates the stale system-command sentence to describe the shared macOS/headless commands and the macOS-only `system.notify` addition. The canonical shared-runtime implementation was landed by @steipete in #105642; this PR only corrects the leftover documentation mismatch.

## User Impact

Operators can accurately determine which approval-gated system commands are available from macOS and headless nodes. There are no runtime, configuration, test, changelog, or localization changes.

## Evidence

- Current `main` builds the node-host manifest from `NODE_SYSTEM_RUN_COMMANDS` and `NODE_EXEC_APPROVALS_COMMANDS`; those lists include `system.run.prepare`, `system.run`, `system.which`, and `system.execApprovals.get/set`.
- The macOS coordinator merges the embedded worker manifest with native app capabilities and commands, adding `system.notify`.
- `pnpm docs:list`
- `node scripts/check-docs-mdx.mjs docs/nodes/index.md`
- `./node_modules/.bin/oxfmt --check docs/nodes/index.md`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings (`gpt-5.6-sol`, high reasoning, 0.99 confidence).
- Diff: one documentation file, `+1/-1`.

Punchcard-Session: silver-summit-cedar-9k
