### PR TITLE
fix(plugin-sdk): preserve text after empty chunking

### DIFF
--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -923,6 +923,24 @@ describe("deliverTextOrMediaReply", () => {
     expect(sendMedia).not.toHaveBeenCalled();
   });
 
+  it("preserves non-empty text when the reply chunker returns no chunks", async () => {
+    const sendMedia = vi.fn(async () => undefined);
+    const sendText = vi.fn(async () => undefined);
+
+    await expect(
+      deliverTextOrMediaReply({
+        payload: { text: "visible reply" },
+        text: "visible reply",
+        chunkText: () => [],
+        sendText,
+        sendMedia,
+      }),
+    ).resolves.toBe("text");
+
+    expect(sendText).toHaveBeenCalledExactlyOnceWith("visible reply");
+    expect(sendMedia).not.toHaveBeenCalled();
+  });
+
   it("returns empty when chunking produces no sendable text", async () => {
     const sendMedia = vi.fn(async () => undefined);
     const sendText = vi.fn(async () => undefined);

--- a/src/plugin-sdk/reply-payload.test.ts
+++ b/src/plugin-sdk/reply-payload.test.ts
@@ -111,6 +111,29 @@ describe("sendPayloadWithChunkedTextAndMedia", () => {
     expect(result).toEqual({ channel: "test", messageId: "gamma" });
   });
 
+  it("sends the full text when the chunker returns no chunks", async () => {
+    const sendText = vi.fn(async (ctx: { text: string }) => ({
+      channel: "test",
+      messageId: ctx.text,
+    }));
+    const onResult = vi.fn();
+
+    const result = await sendPayloadWithChunkedTextAndMedia({
+      ctx: { payload: { text: "visible reply" } },
+      textChunkLimit: 64,
+      chunker: () => [],
+      sendText,
+      sendMedia: async () => ({ channel: "test", messageId: "media" }),
+      emptyResult: { channel: "test", messageId: "" },
+      onResult,
+    });
+
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(sendText).toHaveBeenCalledWith(expect.objectContaining({ text: "visible reply" }));
+    expect(onResult).toHaveBeenCalledWith({ channel: "test", messageId: "visible reply" });
+    expect(result).toEqual({ channel: "test", messageId: "visible reply" });
+  });
+
   it("detects numeric target IDs", () => {
     expect(isNumericTargetId("12345")).toBe(true);
     expect(isNumericTargetId("  987  ")).toBe(true);
@@ -263,6 +286,35 @@ describe("sendTextMediaPayload", () => {
     expect(sendText).toHaveBeenCalledOnce();
     expect(sendText).toHaveBeenCalledWith(expect.objectContaining({ text: "caption" }));
     expect(result).toEqual({ channel: "test", messageId: "caption" });
+  });
+
+  it("sends the full text when the adapter chunker returns no chunks", async () => {
+    const sendText = vi.fn(async ({ text }) => ({ channel: "test", messageId: text }));
+    const onDeliveryResult = vi.fn();
+
+    const result = await sendTextMediaPayload({
+      channel: "test",
+      ctx: {
+        cfg: {},
+        to: "target",
+        text: "",
+        payload: { text: "visible reply" },
+        onDeliveryResult,
+      },
+      adapter: {
+        textChunkLimit: 64,
+        chunker: () => [],
+        sendText,
+      },
+    });
+
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(sendText).toHaveBeenCalledWith(expect.objectContaining({ text: "visible reply" }));
+    expect(onDeliveryResult).toHaveBeenCalledWith({
+      channel: "test",
+      messageId: "visible reply",
+    });
+    expect(result).toEqual({ channel: "test", messageId: "visible reply" });
   });
 
   it("reports each completed text chunk before a later chunk fails", async () => {

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -523,7 +523,10 @@ export async function deliverTextOrMediaReply(params: {
   if (!params.text) {
     return "empty";
   }
-  const chunks = params.chunkText ? params.chunkText(params.text) : [params.text];
+  const chunks = resolveTextChunksWithFallback(
+    params.text.trim() ? params.text : "",
+    params.chunkText ? params.chunkText(params.text) : [params.text],
+  );
   let sentText = false;
   for (const chunk of chunks) {
     if (!chunk) {

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -215,7 +215,8 @@ export async function sendPayloadWithChunkedTextAndMedia<
     return lastResult;
   }
   const limit = params.textChunkLimit;
-  const chunks = limit && params.chunker ? params.chunker(text, limit) : [text];
+  const chunkedText = limit && params.chunker ? params.chunker(text, limit) : [text];
+  const chunks = resolveTextChunksWithFallback(text, chunkedText);
   const [firstChunk, ...remainingChunks] = chunks;
   if (firstChunk === undefined) {
     return params.emptyResult;
@@ -399,10 +400,11 @@ export async function sendTextMediaPayload(params: {
     return { channel: params.channel, messageId: "" };
   }
   const limit = params.adapter.textChunkLimit;
-  const chunks =
+  const chunkedText =
     limit && params.adapter.chunker
       ? params.adapter.chunker(text, limit, { formatting: params.ctx.formatting })
       : [text];
+  const chunks = resolveTextChunksWithFallback(text, chunkedText);
   let lastResult: Awaited<ReturnType<NonNullable<typeof params.adapter.sendText>>>;
   for (const chunk of chunks) {
     let childReported = false;


### PR DESCRIPTION
## What Problem This Solves

Three Plugin SDK delivery helpers trusted a channel chunker's output directly.
When a chunker returned an empty array for non-empty text,
`sendPayloadWithChunkedTextAndMedia` returned an empty result,
`sendTextMediaPayload` returned an uninitialized result without sending, and
`deliverTextOrMediaReply` classified a real reply as empty. Each path silently
dropped the message.

This closes the P1 message-loss follow-up identified during review of #128288.
The affected helpers are used across Telegram, Zalo, Signal, iMessage,
Mattermost, Discord, Feishu, Slack, and other direct text/media adapters.

## Why This Change Was Made

All three delivery callers now reuse the existing
`resolveTextChunksWithFallback` owner. That canonical helper preserves the
original text when a chunker returns no usable chunks. The reply-delivery path
additionally retains its existing intentional suppression of whitespace-only
text. Normal multi-chunk and media delivery remain unchanged.

The change adds no SDK export, public API, configuration, dependency, schema, or
new fallback policy; it applies the already-shipped policy consistently at all
three owning delivery boundaries.

## User Impact

A non-empty reply is delivered once as its original text when a channel chunker
unexpectedly returns no chunks, instead of silently disappearing. Whitespace-only
messages continue to be suppressed.

## Evidence

- Contributor parent-red proof: the first two new caller-level regressions failed
  before the original fix because `sendText` was called zero times.
- Maintainer sibling audit found the third affected owner after the contributor's
  fix. Its new regression failed on the contributor head with
  `AssertionError: expected 'empty' to be 'text'`; after the owner repair, the
  entire payload suite passed:

  ```text
  OPENCLAW_VITEST_MAX_WORKERS=1 \
    node scripts/run-vitest.mjs src/plugin-sdk/reply-payload.test.ts

  Test Files  1 passed (1)
  Tests       75 passed (75)
  ```

- Existing whitespace-only, media-first, normal multi-chunk, delivery-receipt,
  and callback-ordering cases remain green.
- Fresh isolated independent autoreview of the maintainer sibling repair: no
  accepted or actionable findings; correctness confidence 0.99.
- Formatting and `git diff --check` passed.
- Previous contributor head `1edf88456b73528a55402681a238eba4b18f1986` also
  passed a production-boundary ephemeral Gateway proof:

  ```json
  {"verdict":"PASS","gateway":"ephemeral-in-process","adapter":"createDirectTextMediaOutbound","target":"redacted-recipient","emptyChunkerInjected":true,"sends":1,"originalTextPreserved":true,"receipt":"proof-1"}
  ```

- Stronger real Telegram Desktop differential proof is recorded in the existing
  Mantis comment and run
  https://github.com/openclaw/openclaw/actions/runs/32720568010. Baseline sent
  zero messages; the candidate produced exactly one successful Telegram send
  containing the complete original reply, visible in Telegram Desktop. The
  newly added sibling repair does not change either already-proven path.
- Maintainer-improved head:
  `30cc31a6b79e8cf293ebba52fa44f9d3c3541d86`. Exact-head CI is being refreshed
  after the additional owner/sibling repair.

AI-assisted. The original contributor's commits and credit are preserved.
