### PR TITLE
fix(claws): keep deletion fence through cleanup

### DIFF
--- a/src/claws/lifecycle-config-removal.ts
+++ b/src/claws/lifecycle-config-removal.ts
@@ -10,7 +10,14 @@ import {
 } from "../gateway/server-methods/agents-config-mutations.js";
 import { withAgentExecApprovalsRemoved } from "../infra/exec-approvals.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
+import {
+  completeAgentDeletionJournalInDatabase,
+  readAgentDeletionJournal,
+} from "../state/agent-deletion-journal.js";
+import type {
+  OpenClawStateDatabase,
+  OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db-contract.js";
 import { digestClawAgentConfig } from "./agent-config-digest.js";
 import {
   deletionEffects,
@@ -28,6 +35,7 @@ type ClawAgentConfigRemovalParams = {
   fallbackWorkspace: string;
   config?: OpenClawConfig;
   commitConfig?: ConfigCommit;
+  stateDatabase?: OpenClawStateDatabaseOptions;
   trashPath?: ClawTrashPath;
   onModified: () => Error;
 };
@@ -157,22 +165,40 @@ export async function claimClawAgentConfigRemoval(params: ClawAgentConfigRemoval
   const effects = deletionEffects(config, params.agentId, params.fallbackWorkspace);
   // beginAgentDeletion takes over an existing journal row instead of refusing it, so rolling back
   // a row this call did not open would erase another deletion's record.
-  const existingJournal = readAgentDeletionJournal(params.agentId);
-  const deletion = beginAgentDeletion({
-    agentId: params.agentId,
-    workspaceDir: effects.workspace,
-    agentDir: effects.agentDir,
-    sessionsDir: effects.sessionsDir,
-    // Claw removal owns selective cleanup and may retain modified or untracked workspace entries,
-    // so the journal must not claim authority to trash them.
-    deleteFiles: existingJournal?.deleteFiles ?? false,
-  });
+  const existingJournal = readAgentDeletionJournal(params.agentId, params.stateDatabase);
+  const deletion = beginAgentDeletion(
+    {
+      agentId: params.agentId,
+      workspaceDir: effects.workspace,
+      agentDir: effects.agentDir,
+      sessionsDir: effects.sessionsDir,
+      // Claw removal owns selective cleanup and may retain modified or untracked workspace entries,
+      // so the journal must not claim authority to trash them.
+      deleteFiles: existingJournal?.deleteFiles ?? false,
+    },
+    params.stateDatabase,
+  );
   try {
-    const result = await withAgentExecApprovalsRemoved(params.agentId, async () =>
-      commitClawAgentConfigRemoval({ ...params, config }),
+    const result = await withAgentExecApprovalsRemoved(
+      params.agentId,
+      async () => commitClawAgentConfigRemoval({ ...params, config }),
+      params.stateDatabase,
     );
     deletion.commit();
-    return { ...result, completeDeletion: deletion.finish };
+    return {
+      ...result,
+      completeDeletion: (database: OpenClawStateDatabase) => {
+        if (
+          !completeAgentDeletionJournalInDatabase(
+            database,
+            params.agentId,
+            deletion.entry.operationId,
+          )
+        ) {
+          throw new Error(`Failed to complete deletion journal for agent ${params.agentId}.`);
+        }
+      },
+    };
   } catch (error) {
     if (!existingJournal) {
       deletion.rollback();

--- a/src/claws/lifecycle-config-removal.ts
+++ b/src/claws/lifecycle-config-removal.ts
@@ -172,10 +172,7 @@ export async function claimClawAgentConfigRemoval(params: ClawAgentConfigRemoval
       commitClawAgentConfigRemoval({ ...params, config }),
     );
     deletion.commit();
-    // The journal fences only the roster and approvals commit here; Claw's own filesystem cleanup
-    // runs afterwards and may legitimately end partial, so completion is recorded now.
-    deletion.finish();
-    return result;
+    return { ...result, completeDeletion: deletion.finish };
   } catch (error) {
     if (!existingJournal) {
       deletion.rollback();

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -26,6 +26,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { root as fsSafeRoot, FsSafeError } from "../infra/fs-safe.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { unregisterOpenClawAgentDatabases } from "../state/openclaw-agent-db-registry.js";
+import type { OpenClawStateDatabase } from "../state/openclaw-state-db-contract.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -460,13 +461,15 @@ export function releaseClawRemoveRows(
   agentId: string,
   files: RemovedWorkspaceFile[],
   complete: boolean,
+  completeDeletion: (database: OpenClawStateDatabase) => void,
   options: OpenClawStateDatabaseOptions,
 ): void {
   if (complete) {
     // Keep the install record as the retry owner until database discovery is released.
     unregisterOpenClawAgentDatabases({ agentId, env: options.env });
   }
-  runOpenClawStateWriteTransaction(({ db }) => {
+  runOpenClawStateWriteTransaction((database) => {
+    const { db } = database;
     if (clawStateTableExists(db, "claw_workspace_files")) {
       for (const file of files.filter((candidate) => candidate.action !== "error")) {
         db /* sqlite-allow-raw: remove one owned Claw workspace-file row. */
@@ -474,6 +477,7 @@ export function releaseClawRemoveRows(
           .run(agentId, file.path);
       }
     }
+    // Partial removals keep both the journal fence and install retry owner intact.
     if (!complete) {
       return;
     }
@@ -487,6 +491,8 @@ export function releaseClawRemoveRows(
         .prepare("DELETE FROM claw_installs WHERE agent_id = ?")
         .run(agentId);
     }
+    // Complete removals release the fence and retry owner in the same transaction.
+    completeDeletion(database);
   }, options);
   if (complete) {
     deleteCachedClawInstallSchemaVersion(agentId, options);

--- a/src/claws/lifecycle-remove-approvals.test.ts
+++ b/src/claws/lifecycle-remove-approvals.test.ts
@@ -55,9 +55,10 @@ async function buildApprovalFixture() {
 
 describe("Claw exec approvals removal", () => {
   it.each([
-    { label: "config-file commit", useCommitConfig: false },
-    { label: "commitConfig seam", useCommitConfig: true },
-  ])("removes only the claw agent policy through the $label", async ({ useCommitConfig }) => {
+    { label: "config-file commit", commit: false, complete: true },
+    { label: "commitConfig seam", commit: true, complete: true },
+    { label: "partial cleanup", commit: false, complete: false },
+  ])("removes only the claw agent policy through the $label", async ({ commit, complete }) => {
     const addPlan = await buildApprovalFixture();
 
     await withTempHomeConfig({}, async ({ home }) => {
@@ -86,15 +87,15 @@ describe("Claw exec approvals removal", () => {
           },
         },
       });
-      const plan = useCommitConfig
+      const plan = commit
         ? await buildClawRemovePlan("worker", { env, config })
         : await buildClawRemovePlan("worker");
       const common = {
         consentPlanIntegrity: plan.planIntegrity,
-        trashPath: async () => true,
+        trashPath: async () => complete,
       };
 
-      const result = useCommitConfig
+      const result = commit
         ? await applyClawRemovePlan(plan, {
             ...common,
             env,
@@ -105,7 +106,10 @@ describe("Claw exec approvals removal", () => {
           })
         : await applyClawRemovePlan(plan, common);
 
-      expect(result).toMatchObject({ status: "complete", agentRemoved: true });
+      expect(result).toMatchObject({
+        status: complete ? "complete" : "partial",
+        agentRemoved: true,
+      });
       expect(loadExecApprovals().agents).toEqual({
         "*": { security: "deny" },
         kept: {
@@ -114,7 +118,7 @@ describe("Claw exec approvals removal", () => {
         },
       });
       expect(readAgentDeletionJournal("worker")).toMatchObject({
-        cleanupCompleted: true,
+        cleanupCompleted: complete,
         deleteFiles: false,
       });
     });

--- a/src/claws/lifecycle-remove-approvals.test.ts
+++ b/src/claws/lifecycle-remove-approvals.test.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createAgent } from "../agents/agent-create.js";
 import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
 import { withTempHomeConfig, writeOpenClawConfig } from "../config/test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -116,6 +117,44 @@ describe("Claw exec approvals removal", () => {
         cleanupCompleted: true,
         deleteFiles: false,
       });
+    });
+  });
+
+  it("blocks recreating the agent until destructive cleanup finishes", async () => {
+    const addPlan = await buildApprovalFixture();
+
+    await withTempHomeConfig({}, async ({ home }) => {
+      const env = { OPENCLAW_STATE_DIR: join(home, ".openclaw") };
+      setTestEnvValue("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR);
+      let config: OpenClawConfig = {};
+      await applyClawAddPlan(addPlan, {
+        consentPlanIntegrity: addPlan.planIntegrity,
+        env,
+        commitConfig: async (transform) => {
+          config = transform(config);
+        },
+      });
+      await writeOpenClawConfig(home, config);
+      const plan = await buildClawRemovePlan("worker");
+      let creationDuringCleanup: Awaited<ReturnType<typeof createAgent>> | undefined;
+
+      const result = await applyClawRemovePlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        trashPath: async () => {
+          creationDuringCleanup ??= await createAgent({
+            name: "worker",
+            workspace: join(home, "replacement-worker"),
+          });
+          return true;
+        },
+      });
+
+      expect(creationDuringCleanup).toMatchObject({
+        status: "error",
+        reason: "deletion-pending",
+      });
+      expect(result).toMatchObject({ status: "complete", agentRemoved: true });
+      expect(readAgentDeletionJournal("worker")).toMatchObject({ cleanupCompleted: true });
     });
   });
 

--- a/src/claws/lifecycle-remove-approvals.test.ts
+++ b/src/claws/lifecycle-remove-approvals.test.ts
@@ -7,14 +7,17 @@ import { withTempHomeConfig, writeOpenClawConfig } from "../config/test-helpers.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadExecApprovals, saveExecApprovals } from "../infra/exec-approvals.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { applyClawAddPlan } from "./add.js";
 import {
   claimClawAgentConfigRemoval,
   digestClawAgentRemovalSurface,
 } from "./lifecycle-config-removal.js";
-import { applyClawRemovePlan, buildClawRemovePlan } from "./lifecycle-state.js";
+import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawSourceIdentity } from "./types.js";
@@ -159,6 +162,55 @@ describe("Claw exec approvals removal", () => {
       });
       expect(result).toMatchObject({ status: "complete", agentRemoved: true });
       expect(readAgentDeletionJournal("worker")).toMatchObject({ cleanupCompleted: true });
+    });
+  });
+
+  it("keeps the Claw retry owner when deletion journal completion is interrupted", async () => {
+    const addPlan = await buildApprovalFixture();
+
+    await withTempHomeConfig({}, async ({ home }) => {
+      const env = { OPENCLAW_STATE_DIR: join(home, ".openclaw") };
+      setTestEnvValue("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR);
+      let config: OpenClawConfig = {};
+      await applyClawAddPlan(addPlan, {
+        consentPlanIntegrity: addPlan.planIntegrity,
+        env,
+        commitConfig: async (transform) => {
+          config = transform(config);
+        },
+      });
+      await writeOpenClawConfig(home, config);
+      const plan = await buildClawRemovePlan("worker", { env, config });
+      const state = openOpenClawStateDatabase({ env });
+      state.db.exec(`
+        CREATE TRIGGER fail_claw_deletion_completion
+        BEFORE UPDATE OF cleanup_completed ON agent_deletion_journal
+        WHEN NEW.cleanup_completed = 1
+        BEGIN
+          SELECT RAISE(ABORT, 'injected deletion journal completion failure');
+        END;
+      `);
+
+      await expect(
+        applyClawRemovePlan(plan, {
+          consentPlanIntegrity: plan.planIntegrity,
+          env,
+          config,
+          commitConfig: async (transform) => {
+            config = transform(config);
+          },
+          trashPath: async () => true,
+        }),
+      ).rejects.toThrow("injected deletion journal completion failure");
+
+      expect(readAgentDeletionJournal("worker", { env })).toMatchObject({
+        cleanupCompleted: false,
+      });
+      await expect(readClawStatus("worker", { env, config })).resolves.toMatchObject({
+        records: [
+          expect.objectContaining({ install: expect.objectContaining({ agentId: "worker" }) }),
+        ],
+      });
     });
   });
 

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
 import { upsertCronJobRow } from "../cron/store/row-codec.js";
 import type { CronStoredJob } from "../cron/types.js";
+import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import {
   listOpenClawRegisteredAgentDatabases,
   registerOpenClawAgentDatabase,
@@ -901,6 +902,9 @@ describe("Claw status and remove", () => {
       status: "partial",
       agentRemoved: true,
       error: { code: "workspace_cleanup_failed" },
+    });
+    expect(readAgentDeletionJournal("worker")).toMatchObject({
+      cleanupCompleted: false,
     });
     await expect(
       readClawStatus("worker", { env: current.env, config: nextConfig }),

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -6,7 +6,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeCronJobCreate } from "../cron/normalize.js";
 import { upsertCronJobRow } from "../cron/store/row-codec.js";
 import type { CronStoredJob } from "../cron/types.js";
-import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import {
   listOpenClawRegisteredAgentDatabases,
   registerOpenClawAgentDatabase,
@@ -902,9 +901,6 @@ describe("Claw status and remove", () => {
       status: "partial",
       agentRemoved: true,
       error: { code: "workspace_cleanup_failed" },
-    });
-    expect(readAgentDeletionJournal("worker")).toMatchObject({
-      cleanupCompleted: false,
     });
     await expect(
       readClawStatus("worker", { env: current.env, config: nextConfig }),

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -600,13 +600,8 @@ export async function applyClawRemovePlan(
     trashPath: options.trashPath,
     onModified: () => new ClawRemoveError("agent_modified", "Agent config changed during remove."),
   });
-  const {
-    agentRemoved,
-    cleanupTargets,
-    completeDeletion,
-    configBeforeDelete,
-    nextConfig: committedNextConfig,
-  } = configRemoval;
+  const { agentRemoved, cleanupTargets, configBeforeDelete } = configRemoval;
+  const committedNextConfig = configRemoval.nextConfig;
   if (!options.commitConfig || options.purgeSessions) {
     const purgeSessions =
       options.purgeSessions ??
@@ -681,9 +676,9 @@ export async function applyClawRemovePlan(
     updateClawInstallRecordStatus(agentId, "partial", options);
   }
   releaseClawRemoveRows(plan.agentId, workspaceFiles, complete, options);
+  // Keep replacement agents fenced until every Claw-owned destructive cleanup step is terminal.
   if (complete) {
-    // Keep replacement agents fenced until every Claw-owned destructive cleanup step is terminal.
-    completeDeletion();
+    configRemoval.completeDeletion();
   }
   return {
     schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -597,11 +597,13 @@ export async function applyClawRemovePlan(
     fallbackWorkspace: record.install.workspace,
     config: options.config,
     commitConfig: options.commitConfig,
+    stateDatabase: options,
     trashPath: options.trashPath,
     onModified: () => new ClawRemoveError("agent_modified", "Agent config changed during remove."),
   });
   const { agentRemoved, cleanupTargets, configBeforeDelete } = configRemoval;
   const committedNextConfig = configRemoval.nextConfig;
+  const completeDeletion = configRemoval.completeDeletion;
   if (!options.commitConfig || options.purgeSessions) {
     const purgeSessions =
       options.purgeSessions ??
@@ -675,11 +677,7 @@ export async function applyClawRemovePlan(
   if (!complete) {
     updateClawInstallRecordStatus(agentId, "partial", options);
   }
-  releaseClawRemoveRows(plan.agentId, workspaceFiles, complete, options);
-  // Keep replacement agents fenced until every Claw-owned destructive cleanup step is terminal.
-  if (complete) {
-    configRemoval.completeDeletion();
-  }
+  releaseClawRemoveRows(plan.agentId, workspaceFiles, complete, completeDeletion, options);
   return {
     schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
     stability: CLAW_OUTPUT_STABILITY,

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -603,6 +603,7 @@ export async function applyClawRemovePlan(
   const {
     agentRemoved,
     cleanupTargets,
+    completeDeletion,
     configBeforeDelete,
     nextConfig: committedNextConfig,
   } = configRemoval;
@@ -680,6 +681,10 @@ export async function applyClawRemovePlan(
     updateClawInstallRecordStatus(agentId, "partial", options);
   }
   releaseClawRemoveRows(plan.agentId, workspaceFiles, complete, options);
+  if (complete) {
+    // Keep replacement agents fenced until every Claw-owned destructive cleanup step is terminal.
+    completeDeletion();
+  }
   return {
     schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
     stability: CLAW_OUTPUT_STABILITY,

--- a/src/infra/exec-approvals-store.ts
+++ b/src/infra/exec-approvals-store.ts
@@ -6,6 +6,7 @@ import {
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId, normalizeAgentIdStrict } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
 import {
   openOpenClawStateDatabase,
@@ -72,9 +73,11 @@ function snapshotFromExecApprovalsDatabase(
   });
 }
 
-function readExecApprovalsSnapshotFromDatabase(): ExecApprovalsSnapshot {
+function readExecApprovalsSnapshotFromDatabase(
+  options: OpenClawStateDatabaseOptions = {},
+): ExecApprovalsSnapshot {
   assertNoPendingLegacyExecApprovals();
-  return snapshotFromExecApprovalsDatabase(openOpenClawStateDatabase().db);
+  return snapshotFromExecApprovalsDatabase(openOpenClawStateDatabase(options).db);
 }
 
 function readExecApprovalsSnapshotFromDatabaseReadOnly(): ExecApprovalsSnapshot {
@@ -88,15 +91,22 @@ function readExecApprovalsSnapshotFromDatabaseReadOnly(): ExecApprovalsSnapshot 
   );
 }
 
-export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
+function readExecApprovalsSnapshotWithOptions(
+  options: OpenClawStateDatabaseOptions = {},
+): ExecApprovalsSnapshot {
   try {
-    return readExecApprovalsSnapshotFromDatabase();
+    return readExecApprovalsSnapshotFromDatabase(options);
   } catch (error) {
     if (error instanceof ExecApprovalsMigrationRequiredError) {
       throw error;
     }
+    // A caller-selected state owner must fail closed instead of reading another database.
     throw new ExecApprovalsStoreUnavailableError(error);
   }
+}
+
+export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
+  return readExecApprovalsSnapshotWithOptions();
 }
 
 export function loadExecApprovals(): ExecApprovalsFile {
@@ -161,6 +171,7 @@ type InternalExecApprovalsUpdate = ExecApprovalsUpdate & {
 
 function updateExecApprovalsInTransaction(
   params: InternalExecApprovalsUpdate,
+  options: OpenClawStateDatabaseOptions = {},
 ): ExecApprovalsSnapshot | null {
   assertNoPendingLegacyExecApprovals();
   return runOpenClawStateWriteTransaction(
@@ -194,7 +205,7 @@ function updateExecApprovalsInTransaction(
         row: { raw_json: raw },
       });
     },
-    {},
+    options,
     { operationLabel: "exec-approvals.update" },
   );
 }
@@ -217,10 +228,11 @@ export async function updateExecApprovals(
 export async function withAgentExecApprovalsRemoved<T>(
   agentId: string,
   commit: () => Promise<T>,
+  options: OpenClawStateDatabaseOptions = {},
 ): Promise<T> {
   const key = normalizeAgentId(agentId);
-  const snapshot = readExecApprovalsSnapshot();
-  const operationId = readAgentDeletionJournal(key)?.operationId;
+  const snapshot = readExecApprovalsSnapshotWithOptions(options);
+  const operationId = readAgentDeletionJournal(key, options)?.operationId;
   if (!operationId) {
     throw new ExecApprovalsMutationFencedError();
   }
@@ -229,17 +241,20 @@ export async function withAgentExecApprovalsRemoved<T>(
     return normalizedPolicyKey.ok && normalizedPolicyKey.value === key;
   });
   if (removedPolicyEntries.length > 0) {
-    const updated = updateExecApprovalsInTransaction({
-      baseHash: snapshot.hash,
-      authority: { action: "remove", agentId: key, operationId },
-      update: (file) => {
-        const agents = { ...file.agents };
-        for (const [policyKey] of removedPolicyEntries) {
-          delete agents[policyKey];
-        }
-        return { ...file, agents };
+    const updated = updateExecApprovalsInTransaction(
+      {
+        baseHash: snapshot.hash,
+        authority: { action: "remove", agentId: key, operationId },
+        update: (file) => {
+          const agents = { ...file.agents };
+          for (const [policyKey] of removedPolicyEntries) {
+            delete agents[policyKey];
+          }
+          return { ...file, agents };
+        },
       },
-    });
+      options,
+    );
     if (!updated) {
       throw new Error("Exec approvals changed while deleting agent; retry deletion.");
     }
@@ -250,7 +265,7 @@ export async function withAgentExecApprovalsRemoved<T>(
         agentId: key,
         operationId,
       });
-    });
+    }, options);
   }
   try {
     return await commit();
@@ -260,13 +275,16 @@ export async function withAgentExecApprovalsRemoved<T>(
     }
     if (removedPolicyEntries.length > 0) {
       try {
-        updateExecApprovalsInTransaction({
-          authority: { action: "restore", agentId: key, operationId },
-          update: (file) => ({
-            ...file,
-            agents: { ...file.agents, ...Object.fromEntries(removedPolicyEntries) },
-          }),
-        });
+        updateExecApprovalsInTransaction(
+          {
+            authority: { action: "restore", agentId: key, operationId },
+            update: (file) => ({
+              ...file,
+              agents: { ...file.agents, ...Object.fromEntries(removedPolicyEntries) },
+            }),
+          },
+          options,
+        );
       } catch (rollbackError) {
         throw new AgentDeletionAuthorityRollbackError(
           [error, rollbackError],

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -505,22 +505,30 @@ export function completeAgentDeletionJournal(
   operationId: string,
   options: OpenClawStateDatabaseOptions = {},
 ): boolean {
+  return runOpenClawStateWriteTransaction(
+    (database) => completeAgentDeletionJournalInDatabase(database, agentId, operationId),
+    options,
+  );
+}
+
+/** Complete a deletion journal inside a caller-owned shared-state transaction. */
+export function completeAgentDeletionJournalInDatabase(
+  database: OpenClawStateDatabase,
+  agentId: string,
+  operationId: string,
+): boolean {
   const id = normalizeAgentId(agentId);
-  let completed = false;
-  runOpenClawStateWriteTransaction((database) => {
-    ensureAgentDeletionJournalSchema(database.db);
-    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
-    const result = executeSqliteQuerySync(
-      database.db,
-      db
-        .updateTable("agent_deletion_journal")
-        .set({ cleanup_completed: 1 })
-        .where("agent_id", "=", id)
-        .where("operation_id", "=", operationId),
-    );
-    completed = Number(result.numAffectedRows ?? 0) > 0;
-  }, options);
-  return completed;
+  ensureAgentDeletionJournalSchema(database.db);
+  const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
+  const result = executeSqliteQuerySync(
+    database.db,
+    db
+      .updateTable("agent_deletion_journal")
+      .set({ cleanup_completed: 1 })
+      .where("agent_id", "=", id)
+      .where("operation_id", "=", operationId),
+  );
+  return Number(result.numAffectedRows ?? 0) > 0;
 }
 
 export function removeAgentDeletionJournal(


### PR DESCRIPTION
## What problem this solves

Claw removal completed its deletion journal after roster and exec-approval commit. Session, package, workspace, and filesystem cleanup still ran later. A new Claw with the same ID could claim the completed tombstone while old cleanup could still remove its fresh state.

## Root cause

The Claw config-removal helper owned `deletion.finish()`, but it did not own the later cleanup sequence. Generic agent deletion already keeps this fence active through cleanup.

## Fix

The config-removal helper now returns the deletion completion operation to the Claw removal owner. Successful cleanup completes the journal in the same SQLite transaction that releases the durable Claw retry rows. Partial or interrupted cleanup keeps both the fence and retry owner.

The state database selected by a caller now flows through journal and exec-approval removal so every step uses the same owner.

## Evidence

- Exact main `2d642e8a40d4`: the production-boundary lifecycle run paused filesystem cleanup. Same-ID creation returned `created`, and the journal was already complete.
- Exact head `8d5fb123c83a`: the same run returned `deletion-pending` during cleanup. The journal stayed incomplete until cleanup finished. Same-ID creation then returned `created`.
- The committed regression test fails on main with `created` instead of `deletion-pending` and passes on the head.
- Focused and sibling coverage: 87 tests passed.
- Formatting, syntax lint, database rules, line limits, assertions, imports, deprecated API checks, dead-code checks, and `git diff --check` passed.
- No TypeScript typecheck or build ran on this host. Hosted CI owns those checks.

## Scope

- Production: `+118/-65`, net `+53`.
- Tests: `+105/-10`, net `+95`.
- The production growth carries the caller-selected state database through the existing approval fence and adds the transaction-local journal completion operation. No schema, config, or public API changes.
