### PR TITLE
fix(media): convert multi-frame HEIC and HEIF photos for image providers

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1262,15 +1262,34 @@ describe("applyMediaUnderstanding", () => {
     );
   });
 
-  it("normalizes HEIC images before tools.media.image provider execution", async () => {
-    const imagePath = await createTempMediaFile({
+  it.each([
+    {
+      name: "HEIC",
       fileName: "photo.heic",
-      content: "heic-source",
+      mime: "image/heic",
+      bytes: Buffer.from("heic-source"),
+    },
+    {
+      name: "HEIC sequence",
+      fileName: "photo.heic",
+      mime: "image/heic-sequence",
+      bytes: Buffer.from("000000186674797068657663000000000000000000000000", "hex"),
+    },
+    {
+      name: "HEIF sequence",
+      fileName: "photo.heif",
+      mime: "image/heif-sequence",
+      bytes: Buffer.from("00000018667479706d736631000000000000000000000000", "hex"),
+    },
+  ])("normalizes $name images before tools.media.image provider execution", async (testCase) => {
+    const imagePath = await createTempMediaFile({
+      fileName: testCase.fileName,
+      content: testCase.bytes,
     });
     const describeImage = vi.fn(async () => ({ text: "normalized image" }));
     const ctx: MsgContext = {
       Body: "",
-      media: [{ path: imagePath, contentType: "image/heic" }],
+      media: [{ path: imagePath, contentType: testCase.mime }],
     };
     const cfg: OpenClawConfig = {
       tools: {
@@ -1303,11 +1322,11 @@ describe("applyMediaUnderstanding", () => {
     });
 
     expect(result.appliedImage).toBe(true);
-    expect(mockedConvertHeicToJpeg).toHaveBeenCalledWith(Buffer.from("heic-source"));
+    expect(mockedConvertHeicToJpeg).toHaveBeenCalledWith(testCase.bytes);
     expect(describeImage).toHaveBeenCalledWith(
       expect.objectContaining({
         buffer: Buffer.from("jpeg-normalized"),
-        fileName: "photo.heic",
+        fileName: testCase.fileName,
         mime: "image/jpeg",
       }),
     );

--- a/src/media-understanding/image-input-normalize.ts
+++ b/src/media-understanding/image-input-normalize.ts
@@ -4,7 +4,7 @@ import { normalizeMimeType } from "@openclaw/media-core/mime";
 import { extractImageContentFromSource } from "../media/input-files.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
 
-const HEIC_MIME_RE = /^image\/hei[cf]$/i;
+const HEIC_MIME_RE = /^image\/hei[cf](?:-sequence)?$/i;
 const HEIC_EXT_RE = /\.(heic|heif)$/i;
 
 function isHeicInput(params: { mime?: string; fileName?: string }): boolean {

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -575,28 +575,47 @@ describe("media-understanding runtime", () => {
     );
   });
 
-  it("normalizes local HEIC explicit image descriptions before provider execution", async () => {
-    mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("heic-source") });
-
-    await describeImageFileWithModel({
-      filePath: "/tmp/sample.bin",
+  it.each([
+    {
+      name: "HEIC",
       mime: "image/heic; charset=binary",
-      provider: "zai",
-      model: "glm-4.6v",
-      prompt: "Describe it",
-      cfg: {} as OpenClawConfig,
-      agentDir: "/tmp/agent",
-    });
+      bytes: Buffer.from("heic-source"),
+    },
+    {
+      name: "HEIC sequence",
+      mime: "image/heic-sequence",
+      bytes: Buffer.from("000000186674797068657663000000000000000000000000", "hex"),
+    },
+    {
+      name: "HEIF sequence",
+      mime: "image/heif-sequence",
+      bytes: Buffer.from("00000018667479706d736631000000000000000000000000", "hex"),
+    },
+  ])(
+    "normalizes local $name explicit image descriptions before provider execution",
+    async (testCase) => {
+      mocks.readLocalFileSafely.mockResolvedValue({ buffer: testCase.bytes });
 
-    expect(mocks.convertHeicToJpeg).toHaveBeenCalledWith(Buffer.from("heic-source"));
-    expect(mocks.describeImageWithModel).toHaveBeenCalledWith(
-      expect.objectContaining({
-        buffer: Buffer.from("jpeg-normalized"),
-        fileName: "sample.bin",
-        mime: "image/jpeg",
-      }),
-    );
-  });
+      await describeImageFileWithModel({
+        filePath: "/tmp/sample.bin",
+        mime: testCase.mime,
+        provider: "zai",
+        model: "glm-4.6v",
+        prompt: "Describe it",
+        cfg: {} as OpenClawConfig,
+        agentDir: "/tmp/agent",
+      });
+
+      expect(mocks.convertHeicToJpeg).toHaveBeenCalledWith(testCase.bytes);
+      expect(mocks.describeImageWithModel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          buffer: Buffer.from("jpeg-normalized"),
+          fileName: "sample.bin",
+          mime: "image/jpeg",
+        }),
+      );
+    },
+  );
 
   it("preserves fetched metadata for explicit model URL inputs", async () => {
     await describeImageFileWithModel({

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -200,6 +200,55 @@ describe("HEIC input image normalization", () => {
       },
     },
     {
+      name: "converts sniffed HEIC sequence images using the existing HEIC allowlist",
+      source: {
+        type: "base64",
+        data: Buffer.from("heic-sequence-source").toString("base64"),
+        mediaType: "image/heic",
+      } as const,
+      limits: createImageSourceLimits(["image/heic", "image/jpeg"]),
+      detectedMime: "image/heic-sequence",
+      convertedBytes: Buffer.from("jpeg-heic-sequence"),
+      expectedImage: {
+        type: "image",
+        data: Buffer.from("jpeg-heic-sequence").toString("base64"),
+        mimeType: "image/jpeg",
+      },
+    },
+    {
+      name: "converts sniffed HEIF sequence images using the existing HEIF allowlist",
+      source: {
+        type: "base64",
+        data: Buffer.from("heif-sequence-source").toString("base64"),
+        mediaType: "image/heif",
+      } as const,
+      limits: createImageSourceLimits(["image/heif", "image/jpeg"]),
+      detectedMime: "image/heif-sequence",
+      convertedBytes: Buffer.from("jpeg-heif-sequence"),
+      expectedImage: {
+        type: "image",
+        data: Buffer.from("jpeg-heif-sequence").toString("base64"),
+        mimeType: "image/jpeg",
+      },
+    },
+    {
+      name: "converts fetched HEIC sequence images using the existing HEIC allowlist",
+      source: {
+        type: "url",
+        url: "https://example.com/photo.heic",
+      } as const,
+      limits: createImageSourceLimits(["image/heic", "image/jpeg"], true),
+      detectedMime: "image/heic-sequence",
+      convertedBytes: Buffer.from("jpeg-url-sequence"),
+      fetchedContentType: "image/heic-sequence",
+      fetchedBody: Buffer.from("heic-url-sequence"),
+      expectedImage: {
+        type: "image",
+        data: Buffer.from("jpeg-url-sequence").toString("base64"),
+        mimeType: "image/jpeg",
+      },
+    },
+    {
       name: "keeps declared MIME for non-HEIC images after validation",
       source: {
         type: "base64",
@@ -273,6 +322,7 @@ describe("HEIC input image normalization", () => {
         mediaType: "image/png",
       },
       limits: createImageSourceLimits(["image/png", "image/jpeg"]),
+      detectedMime: "application/pdf",
       expectedError: "Unsupported image MIME type: application/pdf",
     },
     {
@@ -282,13 +332,36 @@ describe("HEIC input image normalization", () => {
         url: "https://example.com/photo.png",
       },
       limits: createImageSourceLimits(["image/png", "image/jpeg"], true),
+      detectedMime: "application/pdf",
       expectedError: "Unsupported image MIME type: application/pdf",
       fetchedUrl: "https://example.com/photo.png",
       fetchedContentType: "image/png",
       fetchedBody: Buffer.from("%PDF-1.4\n"),
     },
+    {
+      name: "rejects sequence images when their canonical HEIC MIME is not allowed",
+      source: {
+        type: "base64" as const,
+        data: Buffer.from("heic-sequence-source").toString("base64"),
+        mediaType: "image/heic-sequence",
+      },
+      limits: createImageSourceLimits(["image/png", "image/jpeg"]),
+      detectedMime: "image/heic-sequence",
+      expectedError: "Unsupported image MIME type",
+    },
+    {
+      name: "rejects spoofed HEIC sequence metadata when detected bytes are not an image",
+      source: {
+        type: "base64" as const,
+        data: Buffer.from("%PDF-1.4\n").toString("base64"),
+        mediaType: "image/heic-sequence",
+      },
+      limits: createImageSourceLimits(["image/heic", "image/jpeg"]),
+      detectedMime: "application/pdf",
+      expectedError: "Unsupported image MIME type: application/pdf",
+    },
   ] as const)("$name", async (testCase) => {
-    detectMimeMock.mockResolvedValueOnce("application/pdf");
+    detectMimeMock.mockResolvedValueOnce(testCase.detectedMime);
     await expectRejectedImageMimeCase(testCase);
     expect(convertHeicToJpegMock).not.toHaveBeenCalled();
   });

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -303,7 +303,10 @@ async function normalizeInputImage(params: {
   if (declaredMime.startsWith("image/") && detectedMime && !detectedMime.startsWith("image/")) {
     throw new Error(`Unsupported image MIME type: ${detectedMime}`);
   }
-  const sourceMime = detectedMime?.startsWith("image/") ? detectedMime : declaredMime;
+  const sourceMime = (detectedMime?.startsWith("image/") ? detectedMime : declaredMime).replace(
+    /^(image\/hei[cf])-sequence$/,
+    "$1",
+  );
   if (!params.limits.allowedMimes.has(sourceMime)) {
     throw new Error(`Unsupported image MIME type: ${sourceMime}`);
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users uploading valid multi-frame HEIC or HEIF photos would see Gateway image requests rejected, or would have unsupported image bytes silently passed to image-description providers, when the image detector identified the files as HEIC/HEIF image sequences.

## Why This Change Was Made

The pinned image detector correctly distinguishes sequence variants from ordinary HEIC/HEIF images, but the existing Gateway input owner and media-understanding image detector recognized only the still-image MIME names. Normalize exactly the two existing sequence aliases at the canonical image-conversion boundary, and recognize them before image-provider execution, while preserving byte-signature validation, restrictive configured MIME allowlists, conversion limits, public MIME detection, and existing HEIC/HEIF defaults. The production change is +3 lines; it adds no configuration, dependency, public API, or accepted image family.

## User Impact

Valid HEIC and HEIF image sequences are converted into ordinary JPEG images before Gateway and image-understanding provider delivery, including inputs with opaque filenames. Spoofed non-image content and image types excluded by operator configuration remain rejected.

## Evidence

- Captured seven failing pre-fix regressions across inline and guarded-URL Gateway image input, image-description provider execution, and explicit image-model execution; all pass after the owner-boundary repair.
- Generated genuine 64x64 two-frame HEIC images and exercised the real pinned MIME detector, both production image-input paths, the real Rastermill/ImageMagick JPEG decoder, and Anthropic's actual accepted-image MIME boundary. Ordinary `heix`, HEIC-sequence `hevc`, and HEIF-sequence `msf1` inputs all produced provider-accepted JPEG bytes beginning with `ffd8ff`.
- The end-to-end proof used one explicitly disclosed Node test-module seam only to mark this host's already-broken system `sips` backend unavailable; every other executable was selected by the original trusted production resolver. Existing follow-up: on this macOS host, `sips` produces unreadable JPEG output even for ordinary previously supported HEIC, and the image dependency currently stops before its working ImageMagick backend.
- Focused owner and sibling proof: `node scripts/run-vitest.mjs src/media/input-files.fetch-guard.test.ts src/media-understanding/runtime.test.ts src/media-understanding/apply.test.ts packages/media-core/src/mime.test.ts --configLoader runner` — 311 tests passing.
- Independent owner/provider review: 320 tests passing, including restrictive allowlist and spoofed-content rejection, plus an independently repeated genuine two-frame Gateway/provider JPEG proof.
- Production typecheck: `pnpm tsgo:core`; exact touched test-owner typechecks: `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.other.json --builders 1` and `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.plugins-platform.json --builders 1`; targeted formatting and lint checks all pass.
- The unrelated complete UI test-type stripe cannot run against this host's shared dependency install because it lacks `@panzoom/panzoom` and `@types/pako`; both actual changed-owner test-type programs pass independently.
