### PR TITLE
fix(install): preserve Git command when npm verification fails

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3418,12 +3418,6 @@ install_openclaw() {
         fi
     fi
 
-    if ! commit_openclaw_bin_backup; then
-        restore_openclaw_bin_backup || true
-        return 1
-    fi
-
-    ui_success "OpenClaw installed"
 }
 
 # Run doctor for migrations (safe, non-interactive)
@@ -3805,8 +3799,14 @@ main() {
         npm_candidate="$(resolve_installed_openclaw_bin || true)"
         if [[ -z "$npm_candidate" ]] || ! "$npm_candidate" --version >/dev/null 2>&1; then
             ui_error "npm replacement failed verification"
+            restore_openclaw_bin_backup || ui_error "Could not restore the previous openclaw command"
             return 1
         fi
+        if ! commit_openclaw_bin_backup; then
+            restore_openclaw_bin_backup || ui_error "Could not restore the previous openclaw command"
+            return 1
+        fi
+        ui_success "OpenClaw installed"
         retire_git_wrapper_after_npm_install || return $?
     fi
 

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -1022,6 +1022,7 @@ NODE
       const result = runInstallShell(`
         set -euo pipefail
         source "${SCRIPT_PATH}"
+        env() { /usr/bin/env "$@"; }
         root="$(mktemp -d)"
         repo="$root/repo"
         npm_root="$root/lib/node_modules"
@@ -1065,6 +1066,9 @@ EOF
         install_openclaw
         status=$?
         set -e
+        if (( status == 0 )); then
+          commit_openclaw_bin_backup
+        fi
         cleanup_tmpfiles
         printf 'status=%s version=%s link=%s\n' "$status" "$("$bin/openclaw" --version)" "$([[ -L "$bin/openclaw" ]] && echo yes || echo no)"
       `);
@@ -1077,6 +1081,86 @@ EOF
       }
     },
   );
+
+  it("restores the same-bin git wrapper when final npm verification fails", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      root="$HOME/fixture"
+      repo="$root/repo"
+      npm_root="$root/lib/node_modules"
+      bin="$HOME/.local/bin"
+      launcher="$npm_root/openclaw/openclaw.mjs"
+      calls="$root/candidate-calls"
+      mkdir -p "$repo/dist" "$npm_root/openclaw" "$bin"
+      printf '%s\n' 'process.stdout.write("git-version\\n")' > "$repo/dist/entry.js"
+      cat > "$bin/openclaw" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+exec ${process.execPath} $repo/dist/entry.js "\\$@"
+EOF
+      chmod +x "$bin/openclaw"
+      cat > "$launcher" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+count=0
+[[ ! -f "$NPM_CANDIDATE_CALLS" ]] || count="$(cat "$NPM_CANDIDATE_CALLS")"
+count=$((count + 1))
+printf '%s\n' "$count" > "$NPM_CANDIDATE_CALLS"
+(( count < 3 )) || exit 9
+printf 'npm-version\n'
+EOF
+      chmod +x "$launcher"
+      fake_npm="$root/npm"
+      cat > "$fake_npm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "\${1:-}" in
+  --version) printf '12.0.0\n' ;;
+  root) printf '%s\n' "$NPM_FAKE_ROOT" ;;
+  prefix) printf '%s\n' "$NPM_FAKE_PREFIX" ;;
+  config) printf 'null\n' ;;
+  *) exit 1 ;;
+esac
+EOF
+      chmod +x "$fake_npm"
+      npm() { "$fake_npm" "$@"; }
+      npm_command_path() { printf '%s\n' "$fake_npm"; }
+      install_openclaw_npm() { return 0; }
+      bootstrap_gum_temp() { :; }
+      print_installer_banner() { :; }
+      print_gum_status() { :; }
+      detect_os_or_die() { OS=linux; }
+      detect_openclaw_checkout() { return 1; }
+      show_install_plan() { :; }
+      check_existing_openclaw() { return 0; }
+      configure_install_stage_total() { :; }
+      ui_stage() { :; }
+      load_nvm_for_node_detection() { :; }
+      check_node() { return 0; }
+      activate_supported_node_on_path() { :; }
+      ensure_default_node_active_shell() { return 0; }
+      check_git() { return 0; }
+      fix_npm_permissions() { :; }
+      ui_info() { :; }
+      ui_warn() { :; }
+      ui_error() { :; }
+      ui_success() { :; }
+      INSTALL_METHOD=npm
+      OPENCLAW_VERSION="$root/candidate.tgz"
+      export NPM_CANDIDATE_CALLS="$calls" NPM_FAKE_ROOT="$npm_root" NPM_FAKE_PREFIX="$HOME/.local"
+      set +e
+      (set -e; main)
+      status=$?
+      set -e
+      version="$("$bin/openclaw" --version 2>/dev/null || printf unavailable)"
+      printf 'status=%s version=%s link=%s calls=%s\n' \
+        "$status" "$version" "$([[ -L "$bin/openclaw" ]] && echo yes || echo no)" "$(cat "$calls")"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout, result.stderr).toContain("status=1 version=git-version link=no calls=3");
+  });
 
   it("restores an active shim backup when installation is interrupted", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-shim-signal-"));


### PR DESCRIPTION
Fixes #127410.

## What Problem This Solves

Fixes an issue where users switching a Git installation to npm could lose their working `openclaw` command when the npm package installed but the installer's final CLI verification failed. The installer discarded its rollback backup before that final check, leaving the failed npm link in place.

## Why This Change Was Made

The outer npm install transaction now owns the command backup through its final `--version` probe: it restores the previous command on failure and commits the backup only after the probe succeeds. `install_openclaw` still owns package installation and link publication, but no longer ends a transaction whose final verification belongs to `main`.

The open same-file changes in #118927, #112754, #110657, and #128407 touch security guards, Git target validation, download timeouts, or explicit Git selection; none changes this backup/final-probe transaction.

## User Impact

An npm migration that fails final verification now leaves the previously working Git wrapper restored instead of an unusable npm symlink. Successful migrations still publish and retain the npm command.

## Evidence

- Head: `3cf0c89766ffb372776b6fbb7deee13ea214eb0b`
- Base: `6178409d9a0fa9284eb7c5c0c0594cb3b86de102`
- Production delta: `scripts/install.sh` `+6/-6` (net 0)
- Test delta: `test/scripts/install-sh.test.ts` `+84/-0`

Parent reproduction on `055a7302c4a4e11a5233bd5ed3abcfa17f456923`:

```text
node scripts/run-vitest.mjs test/scripts/install-sh.test.ts -t 'restores the same-bin git wrapper when final npm verification fails'
Tests 1 failed | 140 skipped
expected: status=1 version=git-version link=no calls=3
received: status=1 version=unavailable link=yes calls=4
```

The same production-boundary scenario on this head:

```text
Tests 1 passed | 140 skipped
status=1 version=git-version link=no calls=3
```

This proof runs the real Bash `main` flow against a temporary HOME, a real executable Git wrapper, a real npm launcher, and an actual filesystem symlink. The third and final npm candidate probe fails; the assertion reads the restored executable from disk and invokes it.

Affected sibling checks:

```text
- same-bin success + lifecycle-guard failure: 2 passed
- final-probe failure + signal restoration: 2 passed
- bash -n scripts/install.sh: passed
- formatter and git diff --check: passed
```

The same-bin success/guard fixture also passed against the parent production code after making its `env` command hermetic (`2 passed`), so the fixture adjustment is independent from the production fix.

AI disclosure: This change was developed with Codex assistance. The reported failure, owner boundary, competitor state, parent failure, fixed behavior, and commit identity were verified directly.

Limitations: The proof uses a local fake npm executable rather than mutating a machine-wide npm installation or contacting the registry. It exercises the real installer transaction and real filesystem rollback boundary; unrelated tests in this file were not used as evidence.
