### PR TITLE
fix(gateway): removed channel plugins remain falsely healthy after reload

### DIFF
--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -48,7 +48,7 @@ function cachedLifecycleDiffersFromRuntime(params: {
       return true;
     }
   }
-  return false;
+  return params.cachedAccount === undefined;
 }
 
 /** Checks whether cached channel health is stale against the live runtime snapshot. */
@@ -97,7 +97,12 @@ function cachedHealthDiffersFromRuntime(
     }
   }
 
-  return false;
+  // Hot-unloaded plugins vanish from both runtime maps before cached health expires.
+  return Object.keys(cached.channels).some(
+    (channelId) =>
+      !Object.hasOwn(runtime.channels, channelId) &&
+      !Object.hasOwn(runtime.channelAccounts, channelId),
+  );
 }
 
 /** Merges cheap live runtime facts into a cached health summary before responding. */

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4912,80 +4912,102 @@ describe("gateway healthHandlers.health cache freshness", () => {
     expect(payload?.configReload?.hotReloadStatus).toBe("disabled");
   });
 
-  it("refreshes cached health when a runtime account is missing from the cached account summary", async () => {
-    const cached = createSingleChannelHealthSnapshot({
-      channelId: "discord",
-      label: "Discord",
-      running: true,
-      connected: true,
-    });
-    const fresh = {
-      ...cached,
-      ts: cached.ts + 1,
-      channels: {
-        discord: {
-          ...cached.channels.discord,
-          accounts: {
-            ...cached.channels.discord.accounts,
-            work: channelHealthAccount({ accountId: "work", running: true, connected: true }),
-          },
-        },
-      },
-    };
-    const { respond, refreshHealthSnapshot } = await requestHealthSnapshot({
-      cached,
-      fresh,
-      runtimeSnapshot: {
-        channels: {},
-        channelAccounts: {
-          discord: { work: { accountId: "work", running: true, connected: true } },
-        },
-      },
-    });
+  it.each([
+    {
+      change: "adds a running account",
+      previousAccountIds: ["default"],
+      nextAccountIds: ["default", "work"],
+    },
+    {
+      change: "adds an uninitialized account",
+      previousAccountIds: ["default"],
+      nextAccountIds: ["default", "work"],
+      uninitializedAccountId: "work",
+    },
+    {
+      change: "removes a runtime account",
+      previousAccountIds: ["default", "work"],
+      nextAccountIds: ["default"],
+    },
+    {
+      change: "removes an entire channel plugin",
+      previousAccountIds: ["default"],
+      nextAccountIds: [],
+    },
+    {
+      change: "re-adds an uninitialized channel plugin",
+      previousAccountIds: [],
+      nextAccountIds: ["default"],
+      uninitializedAccountId: "default",
+    },
+  ])(
+    "refreshes cached health after hot reload $change",
+    async ({ previousAccountIds, nextAccountIds, uninitializedAccountId }) => {
+      const current = createSingleChannelHealthSnapshot({
+        channelId: "discord",
+        label: "Discord",
+        running: true,
+        connected: true,
+      });
+      const account = (accountId: string) =>
+        channelHealthAccount({ accountId, running: true, connected: true });
+      const summary = (accountIds: string[]) =>
+        accountIds.length === 0
+          ? createHealthSnapshot({})
+          : {
+              ...current,
+              channels: {
+                discord: {
+                  ...current.channels.discord,
+                  accounts: Object.fromEntries(accountIds.map((id) => [id, account(id)])),
+                },
+              },
+            };
+      const runtime = (accountIds: string[], uninitialized?: string) => ({
+        channels:
+          previousAccountIds.length === 0 && accountIds.length > 0
+            ? { discord: { accountId: accountIds[0] } }
+            : {},
+        channelAccounts:
+          accountIds.length === 0
+            ? {}
+            : {
+                discord: Object.fromEntries(
+                  accountIds.map((id) => [
+                    id,
+                    id === uninitialized ? { accountId: id } : account(id),
+                  ]),
+                ),
+              },
+      });
+      const cached = summary(previousAccountIds);
+      const fresh = summary(nextAccountIds);
+      const refreshHealthSnapshot = vi
+        .fn()
+        .mockResolvedValueOnce(cached)
+        .mockResolvedValueOnce(fresh);
 
-    expect(refreshHealthSnapshot).toHaveBeenCalledWith({
-      probe: false,
-      includeSensitive: false,
-    });
-    expect(respond).toHaveBeenCalledWith(true, fresh, undefined);
-  });
+      await requestHealthSnapshot({
+        cached,
+        refreshHealthSnapshot,
+        runtimeSnapshot: runtime(previousAccountIds),
+      });
+      expect(refreshHealthSnapshot).toHaveBeenCalledOnce();
 
-  it("refreshes cached health after hot reload removes a runtime account", async () => {
-    const current = createSingleChannelHealthSnapshot({
-      channelId: "discord",
-      label: "Discord",
-      running: true,
-      connected: true,
-    });
-    const cached = {
-      ...current,
-      channels: {
-        discord: {
-          ...current.channels.discord,
-          accounts: {
-            ...current.channels.discord.accounts,
-            work: channelHealthAccount({ accountId: "work", running: true, connected: true }),
-          },
-        },
-      },
-    };
-    const { respond, refreshHealthSnapshot } = await requestHealthSnapshot({
-      cached,
-      fresh: current,
-      runtimeSnapshot: {
-        channels: {},
-        channelAccounts: {
-          discord: { default: { accountId: "default", running: true, connected: true } },
-        },
-      },
-    });
+      const { respond } = await requestHealthSnapshot({
+        cached,
+        refreshHealthSnapshot,
+        runtimeSnapshot: runtime(nextAccountIds, uninitializedAccountId),
+      });
 
-    expect(refreshHealthSnapshot).toHaveBeenCalledWith({
-      probe: false,
-      includeSensitive: false,
-    });
-    expect(respond).toHaveBeenCalledWith(true, current, undefined);
-  });
+      expect(refreshHealthSnapshot).toHaveBeenCalledTimes(2);
+      expect(refreshHealthSnapshot).toHaveBeenLastCalledWith({
+        probe: false,
+        includeSensitive: false,
+      });
+      expect(respond).toHaveBeenCalledWith(true, fresh, undefined);
+    },
+  );
 });
 
 describe("logs.tail", () => {


### PR DESCRIPTION
Related: #122620

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Gateway operators who removed a channel plugin through hot reload would continue to see that nonexistent channel reported as healthy for up to a minute. Re-added channels and newly added accounts could also remain invisible while their runtime lifecycle fields had not initialized.

## Why This Change Was Made

The Gateway health owner now validates channel membership in both directions across its two authoritative runtime maps and treats newly observed channels or accounts as stale even before they publish lifecycle fields. This preserves intentionally sparse runtime snapshots, existing account-removal behavior, normal request-refresh throttling, and the previously fixed clock-rollback safeguards. The five additional production lines are needed to recognize whole-plugin removal, which the existing account-level comparison cannot observe.

## User Impact

Gateway health immediately reflects channels and accounts added or removed during supported in-process plugin reloads. Removed channels no longer remain falsely healthy, and newly added channels become visible immediately. Authentication, public APIs, configuration, protocol, and persistence behavior are unchanged.

## Evidence

- Before the fix, the actual Gateway health RPC failed three independent hot-reload transitions in both real Gateway Vitest projects: removing an entire channel plugin, re-adding an uninitialized channel plugin, and adding an uninitialized account. Each failure reproduced the real request order with an already-primed refresh throttle.
- After the fix, all five table-driven transitions pass in both projects, including existing initialized-account addition and account-removal controls.
- The complete affected health-handler owner suite passes: **40 tests across two Gateway test projects**, with 394 unrelated tests intentionally filtered:

  ```sh
  OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-health-vitest-cache \
    node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts \
    --configLoader runner -t 'gateway healthHandlers.health cache freshness'
  ```

  ```text
  Test Files  2 passed (2)
       Tests  40 passed | 394 skipped (434)
  ```

- Core production typechecking, Gateway test-graph typechecking, targeted lint, formatting, the max-lines ratchet, and the assertion-safety ratchet all pass.
- An independent source review and fresh authenticated Codex reviews of both the uncommitted change and exact committed branch reported no actionable findings.
