### PR TITLE
docs: optional barycenters adapter under Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Treat inbound messages as untrusted input. DM-capable channels pair unknown send
 
 Tools run on the host for the main session unless you configure sandboxing. Read the [security guide](https://docs.openclaw.ai/gateway/security), [exposure runbook](https://docs.openclaw.ai/gateway/security/exposure-runbook), and [sandboxing guide](https://docs.openclaw.ai/gateway/sandboxing) before connecting other users or exposing the Gateway remotely.
 
+To admit tool calls before they run, hook the Gateway tool dispatcher once (do not wrap each tool) with PyPI [`barycenters`](https://pypi.org/project/barycenters/) (`admit` / `@boundary`, shadow default). MCP is a side door: Streamable HTTP at `https://barycenters-admit.fly.dev/mcp/` (tools `admit`, `check_readiness`). Spec: [barycenters.ai/adapters](https://barycenters.ai/adapters)
+
 ## Documentation
 
 | Goal                             | Start here                                                                                                                                                                                                                                                           |

--- a/README.md
+++ b/README.md
@@ -78,10 +78,6 @@ Treat inbound messages as untrusted input. DM-capable channels pair unknown send
 
 Tools run on the host for the main session unless you configure sandboxing. Read the [security guide](https://docs.openclaw.ai/gateway/security), [exposure runbook](https://docs.openclaw.ai/gateway/security/exposure-runbook), and [sandboxing guide](https://docs.openclaw.ai/gateway/sandboxing) before connecting other users or exposing the Gateway remotely.
 
-Hook the Gateway tool dispatcher once (`before_tool_call`); call npm [`barycenters`](https://www.npmjs.com/package/barycenters) (`bary.govern` / `admit`) in shadow before the tool runs.
-Connecting MCP at `https://barycenters-admit.fly.dev/mcp/` is a side door (`admit`, `check_readiness`); it does not wrap every OpenClaw tool.
-See [https://barycenters.ai/adapters](https://barycenters.ai/adapters).
-
 ## Documentation
 
 | Goal                             | Start here                                                                                                                                                                                                                                                           |
@@ -92,6 +88,10 @@ See [https://barycenters.ai/adapters](https://barycenters.ai/adapters).
 | Run apps and device nodes        | [Platforms](https://docs.openclaw.ai/platforms) · [Nodes](https://docs.openclaw.ai/nodes)                                                                                                                                                                            |
 | Use the CLI and chat commands    | [CLI reference](https://docs.openclaw.ai/cli) · [Slash commands](https://docs.openclaw.ai/tools/slash-commands)                                                                                                                                                      |
 | Configure or operate the Gateway | [Configuration](https://docs.openclaw.ai/gateway/configuration) · [Architecture](https://docs.openclaw.ai/concepts/architecture) · [Updating](https://docs.openclaw.ai/install/updating) · [Release channels](https://docs.openclaw.ai/install/development-channels) |
+
+Optional third-party adapter — not first-party OpenClaw security guidance. Hook `before_tool_call` from an installed plugin via `api.on(...)` ([plugin hooks](https://docs.openclaw.ai/plugins/hooks)); call npm [`barycenters`](https://www.npmjs.com/package/barycenters) (`bary.govern` / `admit`) in shadow.
+MCP at `https://barycenters-admit.fly.dev/mcp/` is a side door (`admit`, `check_readiness`); it does not wrap other OpenClaw tools.
+Spec: [https://barycenters.ai/adapters](https://barycenters.ai/adapters).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Treat inbound messages as untrusted input. DM-capable channels pair unknown send
 
 Tools run on the host for the main session unless you configure sandboxing. Read the [security guide](https://docs.openclaw.ai/gateway/security), [exposure runbook](https://docs.openclaw.ai/gateway/security/exposure-runbook), and [sandboxing guide](https://docs.openclaw.ai/gateway/sandboxing) before connecting other users or exposing the Gateway remotely.
 
-To admit tool calls before they run, hook the Gateway tool dispatcher once (do not wrap each tool) with PyPI [`barycenters`](https://pypi.org/project/barycenters/) (`admit` / `@boundary`, shadow default). MCP is a side door: Streamable HTTP at `https://barycenters-admit.fly.dev/mcp/` (tools `admit`, `check_readiness`). Spec: [barycenters.ai/adapters](https://barycenters.ai/adapters)
+Hook the Gateway tool dispatcher once (`before_tool_call`); call npm [`barycenters`](https://www.npmjs.com/package/barycenters) (`bary.govern` / `admit`) in shadow before the tool runs.
+Connecting MCP at `https://barycenters-admit.fly.dev/mcp/` is a side door (`admit`, `check_readiness`); it does not wrap every OpenClaw tool.
+See [https://barycenters.ai/adapters](https://barycenters.ai/adapters).
 
 ## Documentation
 


### PR DESCRIPTION
## What Problem This Solves

The first patch put an optional third-party adapter under `## Security`, which OpenClaw uses for first-party host-tool / pairing guidance (and points vulns at SECURITY.md). ClawSweeper correctly flagged that as an unverified security-control endorsement: `before_tool_call` is a plugin hook registered with `api.on(...)`, not a Gateway dispatcher config, and MCP is a side door — it does not wrap other tools.

This revision keeps `## Security` vendor-neutral (same text as main). Three honest lines now sit under `## Documentation`:

1. Optional third-party adapter — not first-party OpenClaw security guidance. Hook `before_tool_call` from an installed plugin via `api.on(...)` ([plugin hooks](https://docs.openclaw.ai/plugins/hooks)); call npm [`barycenters`](https://www.npmjs.com/package/barycenters) (`bary.govern` / `admit`) in shadow.
2. MCP at `https://barycenters-admit.fly.dev/mcp/` is a side door (`admit`, `check_readiness`); it does not wrap other OpenClaw tools.
3. Spec: https://barycenters.ai/adapters

## Evidence

- Supported hook contract: https://docs.openclaw.ai/plugins/hooks (`before_tool_call` from a plugin via `api.on(...)`).
- Live MCP (Streamable HTTP): `https://barycenters-admit.fly.dev/mcp/` — GET 406 is protocol, not a down host. Tools: `admit`, `check_readiness`.
- Adapter spec: https://barycenters.ai/adapters
- npm `barycenters` 1.0.3: https://www.npmjs.com/package/barycenters
- ClawSweeper P1 (README.md:81-83): remove the unsupported global-admission recommendation from `## Security`. This patch does that.
- CI `check-docs` already passed on the prior head; this is docs-only wording + placement.

## Why

Operators who want an optional admission check need a pointer to the supported plugin seam and the live adapter. That pointer does not belong in first-party security guidance.
