### PR TITLE
fix(agents): preserve plugin tool termination

### DIFF
--- a/src/agents/embedded-agent-runner.extensions.test.ts
+++ b/src/agents/embedded-agent-runner.extensions.test.ts
@@ -62,6 +62,7 @@ describe("buildEmbeddedExtensionFactories", () => {
         result: {
           content: [{ type: "text" as const, text: "middleware-observed" }],
           details: { observedTool: event.toolName },
+          terminate: true,
         },
       }),
     );
@@ -127,6 +128,7 @@ describe("buildEmbeddedExtensionFactories", () => {
     expect(result).toMatchObject({
       content: [{ type: "text", text: "middleware-observed" }],
       details: { observedTool: "read" },
+      terminate: true,
     });
   });
 

--- a/src/agents/embedded-agent-runner/extensions.ts
+++ b/src/agents/embedded-agent-runner/extensions.ts
@@ -126,6 +126,7 @@ function buildAgentToolResultMiddlewareFactory(
       return {
         content: result.content,
         details: result.details,
+        ...(result.terminate !== undefined ? { terminate: result.terminate } : {}),
         ...(isError ? { isError: true } : {}),
         ...(clearsAcceptedSessionSpawnError ? { isError: false } : {}),
       };

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -271,6 +271,7 @@ export abstract class AgentSessionBase {
             content: result.content,
             details: result.details,
             isError,
+            ...(result.terminate !== undefined ? { terminate: result.terminate } : {}),
           }),
       );
 
@@ -280,8 +281,7 @@ export abstract class AgentSessionBase {
       this.extensionModifiedToolResultIds.add(toolCall.id);
 
       return {
-        content: hookResult.content,
-        details: hookResult.details,
+        ...hookResult,
         isError: hookResult.isError ?? isError,
       };
     };

--- a/src/agents/sessions/agent-session-loop-correctness.test.ts
+++ b/src/agents/sessions/agent-session-loop-correctness.test.ts
@@ -1,3 +1,4 @@
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   createAssistantMessageEventStream,
@@ -33,6 +34,7 @@ import {
   createResourceLoader,
 } from "./agent-session-loop-resource-loader.test-support.js";
 import type { AgentSessionEvent } from "./agent-session-types.js";
+import { clearExtensionCache, loadExtensionsCached } from "./extensions/loader.js";
 import type { ToolDefinition } from "./extensions/types.js";
 import { SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
@@ -575,6 +577,79 @@ describe("AgentSession loop correctness", () => {
 
     expect(streamMocks.streamSimple).toHaveBeenCalledOnce();
     expect(compactionEvents).toEqual([]);
+  });
+
+  it.each([
+    {
+      label: "stops after a plugin terminates a normal result",
+      toolTerminate: undefined,
+      pluginTerminate: true,
+      expectedModelTurns: 1,
+    },
+    {
+      label: "continues after a plugin clears terminal state",
+      toolTerminate: true,
+      pluginTerminate: false,
+      expectedModelTurns: 2,
+    },
+  ])("$label", async ({ toolTerminate, pluginTerminate, expectedModelTurns }) => {
+    const passthroughTool: ToolDefinition = {
+      name: "finish_via_middleware",
+      label: "Finish via middleware",
+      description: "returns a tool result that middleware can update",
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: "text", text: "raw tool result" }],
+        details: {},
+        ...(toolTerminate === undefined ? {} : { terminate: toolTerminate }),
+      }),
+    };
+    const pluginDir = tempDirs.make("openclaw-terminate-plugin-");
+    const pluginPath = path.join(pluginDir, "extension.mjs");
+    await writeFile(
+      pluginPath,
+      `export default async function(api) {
+  api.on("tool_result", async event => ({ ...event, terminate: ${pluginTerminate} }));
+}
+`,
+    );
+    clearExtensionCache();
+    const loaded = await loadExtensionsCached([pluginPath], pluginDir);
+    expect(loaded.errors).toEqual([]);
+    expect(loaded.extensions).toHaveLength(1);
+    expect(loaded.extensions[0]?.handlers.get("tool_result")).toHaveLength(1);
+    const resourceLoader = {
+      ...createResourceLoader(),
+      getExtensions: () => loaded,
+    };
+    let modelTurns = 0;
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) => {
+      modelTurns += 1;
+      return createAssistantResultStream(
+        createAssistant(
+          activeModel,
+          modelTurns === 1
+            ? [
+                {
+                  type: "toolCall",
+                  id: "call-finish-via-middleware",
+                  name: "finish_via_middleware",
+                  arguments: {},
+                },
+              ]
+            : [{ type: "text", text: "continued" }],
+          modelTurns === 1 ? "toolUse" : "stop",
+        ),
+      );
+    });
+    const { session } = await createTestSession({
+      resourceLoader,
+      customTools: [passthroughTool],
+    });
+
+    await session.prompt("finish through loaded middleware");
+
+    expect(modelTurns).toBe(expectedModelTurns);
   });
 
   it("does not retry a high-usage turn terminated by a tool result", async () => {

--- a/src/agents/sessions/extensions/runner.ts
+++ b/src/agents/sessions/extensions/runner.ts
@@ -769,6 +769,10 @@ export class ExtensionRunner {
         currentEvent.isError = handlerResult.isError;
         modified = true;
       }
+      if (handlerResult?.terminate !== undefined) {
+        currentEvent.terminate = handlerResult.terminate;
+        modified = true;
+      }
     });
 
     if (!modified) {
@@ -779,6 +783,7 @@ export class ExtensionRunner {
       content: currentEvent.content,
       details: currentEvent.details,
       isError: currentEvent.isError,
+      terminate: currentEvent.terminate,
     };
   }
 

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -923,6 +923,7 @@ interface ToolResultEventBase {
   input: Record<string, unknown>;
   content: (TextContent | ImageContent)[];
   isError: boolean;
+  terminate?: boolean;
 }
 
 interface BashToolResultEvent extends ToolResultEventBase {
@@ -1104,6 +1105,7 @@ export interface ToolResultEventResult {
   content?: (TextContent | ImageContent)[];
   details?: unknown;
   isError?: boolean;
+  terminate?: boolean;
 }
 
 export interface MessageEndEventResult {


### PR DESCRIPTION
Closes #127807

## What Problem This Solves

Plugin tool-result middleware could return the existing `terminate` field, but the session result adapters dropped it. The agent then requested another model turn after the plugin had already marked the result terminal.

## Root cause

The public middleware adapter, extension runner, and `AgentSession` callback copied `content`, `details`, and `isError` but omitted `terminate`.

## Fix

Preserve the optional terminal boolean through the same canonical result path as its sibling fields. The session owner now forwards the allowlisted hook result as one object, so later result fields cannot drift across a second copy list.

## Evidence

- On exact main `eeec0d4b2a0cada60046aba548d005cd7ace125a`, an isolated test loaded a temporary plugin through the real extension loader and ran an actual `AgentSession`. It failed with two model turns after the plugin returned `terminate: true`.
- On exact head `a812b4104de61b07081911c07ae7ca3b220577c7`, the same flow stopped after one model turn.
- The session owner suite passed 28 of 28 tests, including explicit `terminate: false` overriding an existing terminal result.
- The embedded middleware owner suite passed 15 of 15 tests, including `terminate`, `content`, and `details` preservation.
- Focused lint, formatting, diff checks, and all permitted changed-file guards passed. Hosted CI owns the required type-check gates.

## ClawSweeper rank-up moves

- Maintainer confirmation is satisfied by the exact-head replacement commit authored by @obviyus and this maintainer landing run. The change restores the existing terminal-result contract; it does not add a second stop mechanism.
- Provider-client transport proof is skipped because provider transport is not the changed owner boundary. The exact-main and exact-head runs use the real extension loader and an actual `AgentSession`, while a controlled model stream isolates and counts the continuation decision. Explicit `terminate: false` is covered at that same session hook.
