### PR TITLE
fix(gateway): retain completed status in streamed tool snapshots

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -3011,6 +3011,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
       "activate_graph",
       "get_status",
     ]);
+    expect(response?.output?.slice(1)).toEqual(doneFunctionCalls.map(({ item }) => item));
     expect(events.map((event) => event.data)).toContain("[DONE]");
   });
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1337,7 +1337,7 @@ export async function handleOpenResponsesHttpRequest(
             output_index: nextStreamOutputIndex,
             item: completedFunctionCallItem,
           });
-          functionCallItems.push(functionCallItem);
+          functionCallItems.push(completedFunctionCallItem);
           nextStreamOutputIndex += 1;
         }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clients consuming streamed Responses API function calls received final response snapshots without the required completed status, even though each preceding tool-call completion event already contained it.

## Why This Change Was Made

Keep the canonical completed function-call item in the final response rather than its earlier incomplete event object. This preserves identical output item IDs, call order, arguments, event ordering, and official SDK compatibility with zero production LOC growth.

## User Impact

Streaming API clients and SDK consumers now see the same complete tool-call state in individual completion events and the final response snapshot, including responses containing multiple function calls.

## Evidence

- Authentic pre-fix real Gateway HTTP regression failed in both normal and isolated server projects: all three final function calls omitted their previously emitted `status: "completed"`.
- Directly inspected installed official SDK `ResponseFunctionToolCallItem.status` contract, which requires the returned tool-call status.
- `node scripts/run-vitest.mjs src/gateway/openresponses-http.test.ts src/gateway/openai-http.test.ts` — 260 real Gateway/SDK Responses and chat-completions tests passed.
- Core and Gateway-test TypeScript, focused lint/format, assertion-safety and max-lines ratchets passed.
- Production LOC `+1/-1`; authentic existing-boundary regression `+1` test line; fresh independent source-aware review.
