### PR TITLE
fix(agents): surface failed subagent completion notices

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
@@ -15,6 +15,7 @@ import {
 } from "../../embedded-agent-runner/delivery-evidence.js";
 import type { AgentInternalEvent } from "../../internal-events.js";
 import {
+  SourceOwnerChangedError,
   sourceOwnerChangedResult,
   summarizeDeliveryError,
 } from "./subagent-announce-delivery-retry.js";
@@ -24,6 +25,9 @@ import {
 } from "./subagent-announce-delivery.runtime.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 import { inferDeliveryTargetChatType } from "./subagent-announce-origin.js";
+
+const FAILED_COMPLETION_NOTICE =
+  "A delegated task failed before it could report a result. Please retry the task.";
 
 export function isGatewayAgentRunPending(response: unknown): boolean {
   if (!response || typeof response !== "object") {
@@ -47,7 +51,13 @@ export function isDirectMessageDeliveryTarget(
   return deriveSessionChatTypeFromKey(requesterSessionKey) === "direct";
 }
 
-function resolveTextCompletionDirectFallback(events: readonly AgentInternalEvent[] | undefined) {
+function resolveTextCompletionDirectFallback(
+  events: readonly AgentInternalEvent[] | undefined,
+  contentKind: "completed_result" | "failed_notice",
+) {
+  if (contentKind === "failed_notice") {
+    return FAILED_COMPLETION_NOTICE;
+  }
   for (let index = (events?.length ?? 0) - 1; index >= 0; index -= 1) {
     const event = events?.[index];
     if (event?.type !== "task_completion" || event.source !== "subagent") {
@@ -94,10 +104,12 @@ export async function deliverCompletionDirect(params: {
     threadId?: string;
   };
   internalEvents?: readonly AgentInternalEvent[];
+  contentKind: "completed_result" | "failed_notice";
+  signal?: AbortSignal;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   isSourceSessionEffectsAllowed?: () => boolean;
 }): Promise<SubagentAnnounceDeliveryResult | undefined> {
-  const content = resolveTextCompletionDirectFallback(params.internalEvents);
+  const content = resolveTextCompletionDirectFallback(params.internalEvents, params.contentKind);
   if (
     !content ||
     !params.deliveryTarget.deliver ||
@@ -121,6 +133,9 @@ export async function deliverCompletionDirect(params: {
     if (params.isSourceSessionEffectsAllowed?.() === false) {
       return sourceOwnerChangedResult();
     }
+    if (params.signal?.aborted) {
+      return { delivered: false, path: "none" };
+    }
     const sendResult = await sendSubagentAnnounceMessage({
       cfg: params.cfg,
       channel: params.deliveryTarget.channel,
@@ -132,6 +147,14 @@ export async function deliverCompletionDirect(params: {
       conversationType: "direct",
       content,
       idempotencyKey,
+      skipQueue: true,
+      abortSignal: params.signal,
+      onPlatformSendDispatch: async () => {
+        params.signal?.throwIfAborted();
+        if (params.isSourceSessionEffectsAllowed?.() === false) {
+          throw new SourceOwnerChangedError();
+        }
+      },
       onDeliveryResult: () => {
         if (committedDelivery) {
           return;
@@ -169,6 +192,12 @@ export async function deliverCompletionDirect(params: {
       // Post-send bookkeeping must never turn an identified delivery into a
       // retryable failure and send the same completion twice.
       return committedDelivery;
+    }
+    if (err instanceof SourceOwnerChangedError) {
+      return sourceOwnerChangedResult();
+    }
+    if (params.signal?.aborted) {
+      return { delivered: false, path: "none" };
     }
     return {
       delivered: false,

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -355,6 +355,7 @@ async function deliverSlackThreadAnnouncement(params: {
   queueEmbeddedAgentMessageWithOutcome?: QueueEmbeddedAgentMessageWithOutcome;
   sendMessage?: typeof runtimeSendMessage;
   internalEvents?: AgentInternalEvent[];
+  sourceSessionKey?: string;
   sourceTool?: string;
   requesterAbandoned?: boolean;
   isSourceSessionEffectsAllowed?: () => boolean;
@@ -416,6 +417,7 @@ async function deliverSlackThreadAnnouncement(params: {
     directIdempotencyKey: params.directIdempotencyKey,
     internalEvents: params.internalEvents,
     sourceRunId: "run-generated-media",
+    sourceSessionKey: params.sourceSessionKey,
     sourceTool: params.sourceTool,
     isSourceSessionEffectsAllowed: params.isSourceSessionEffectsAllowed,
     isCompletionOwnedByRequesterYield: params.isCompletionOwnedByRequesterYield,
@@ -1948,6 +1950,134 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       reason: "visible_reply_missing",
       error: "completion agent did not produce a visible reply",
     });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it.each(["error", "timeout", "unknown"] as const)(
+    "sends one generic direct notice when requester synthesis repeats a %s child completion",
+    async (status) => {
+      const childSessionKey = `agent:worker:subagent:${status}-child`;
+      const providerFailure = "provider rejected private-model-alias with status 400";
+      const childResult = "private child output must not reach the requester";
+      const callGateway = vi.fn(async () => {
+        throw new Error(providerFailure);
+      }) as unknown as typeof runtimeCallGateway;
+      const sendMessage = createSendMessageMock();
+
+      const result = await deliverDiscordDirectMessageCompletion({
+        callGateway,
+        sendMessage,
+        sourceSessionKey: childSessionKey,
+        sourceTool: "subagent_announce",
+        internalEvents: taskCompletionEvents({
+          childSessionKey,
+          childSessionId: `${status}-child-session-id`,
+          status,
+          statusLabel: `${status}: ${providerFailure}`,
+          result: childResult,
+        }),
+      });
+
+      expectRecordFields(result, { delivered: true, path: "direct" });
+      expect(callGateway).toHaveBeenCalledOnce();
+      expect(sendMessage).toHaveBeenCalledOnce();
+      const content = mockCallArg(sendMessage, 0, 0).content;
+      expect(content).toBe(
+        "A delegated task failed before it could report a result. Please retry the task.",
+      );
+      expect(content).not.toContain(providerFailure);
+      expect(content).not.toContain(childResult);
+    },
+  );
+
+  it.each(["cancelled", "source owner changed"] as const)(
+    "stops a failed-child notice when %s at platform dispatch",
+    async (blockedBy) => {
+      const childSessionKey = `agent:worker:subagent:${blockedBy.replaceAll(" ", "-")}`;
+      const controller = new AbortController();
+      let sourceEffectsAllowed = true;
+      const platformSend = vi.fn();
+      const callGateway = vi.fn(async () => {
+        throw new Error("provider rejected requester synthesis");
+      }) as unknown as typeof runtimeCallGateway;
+      const sendMessage = vi.fn(async (params: Parameters<typeof runtimeSendMessage>[0]) => {
+        expect(params.skipQueue).toBe(true);
+        expect(params.abortSignal).toBe(controller.signal);
+        if (blockedBy === "cancelled") {
+          controller.abort();
+        } else {
+          sourceEffectsAllowed = false;
+        }
+        await params.onPlatformSendDispatch?.();
+        platformSend();
+        return {
+          channel: "discord",
+          to: "dm:U123",
+          via: "direct" as const,
+          mediaUrl: null,
+          result: { messageId: "msg-after-stale-dispatch" },
+        };
+      }) as unknown as typeof runtimeSendMessage;
+
+      const result = await deliverDiscordDirectMessageCompletion({
+        callGateway,
+        sendMessage,
+        signal: controller.signal,
+        sourceSessionKey: childSessionKey,
+        sourceTool: "subagent_announce",
+        isSourceSessionEffectsAllowed: () => sourceEffectsAllowed,
+        internalEvents: taskCompletionEvents({
+          childSessionKey,
+          status: "error",
+          statusLabel: "failed before fallback dispatch",
+          result: "private child output",
+        }),
+      });
+
+      expect(result).toMatchObject(
+        blockedBy === "cancelled"
+          ? { delivered: false, path: "none" }
+          : { delivered: false, path: "none", reason: "source_owner_changed", terminal: true },
+      );
+      expect(sendMessage).toHaveBeenCalledOnce();
+      expect(platformSend).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not send a failed-child notice for an untrusted event or non-direct target", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("provider rejected requester synthesis");
+    }) as unknown as typeof runtimeCallGateway;
+    const sendMessage = createSendMessageMock();
+
+    const untrusted = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      sourceSessionKey: "agent:worker:subagent:expected-child",
+      sourceTool: "subagent_announce",
+      internalEvents: taskCompletionEvents({
+        childSessionKey: "agent:worker:subagent:other-child",
+        status: "error",
+        statusLabel: "failed: provider rejected child run",
+        result: "private child output",
+      }),
+    });
+    const nonDirect = await deliverSlackThreadAnnouncement({
+      callGateway,
+      sendMessage,
+      directIdempotencyKey: "announce-failed-thread-child",
+      sourceSessionKey: "agent:worker:subagent:failed-thread-child",
+      sourceTool: "subagent_announce",
+      internalEvents: taskCompletionEvents({
+        childSessionKey: "agent:worker:subagent:failed-thread-child",
+        status: "error",
+        statusLabel: "failed: provider rejected child run",
+        result: "private child output",
+      }),
+    });
+
+    expectRecordFields(untrusted, { delivered: false, path: "direct" });
+    expectRecordFields(nonDirect, { delivered: false, path: "direct" });
     expect(sendMessage).not.toHaveBeenCalled();
   });
 

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -169,6 +169,8 @@ export async function sendSubagentAnnounceDirectly(params: {
       subagentCompletionEvents[0]?.childSessionKey === params.sourceSessionKey
         ? subagentCompletionEvents[0]
         : undefined;
+    const hasFailedTrustedSubagentCompletion =
+      trustedCompletionEvent !== undefined && trustedCompletionEvent.status !== "ok";
     const hasRequiredSubagentNoOutputCompletion =
       params.expectsCompletionMessage &&
       isSubagentCompletion &&
@@ -223,7 +225,9 @@ export async function sendSubagentAnnounceDirectly(params: {
         disposition: "intentional_non_delivery",
       };
     }
-    const tryTextCompletionDirectDelivery = () =>
+    const tryTextCompletionDirectDelivery = (
+      contentKind: "completed_result" | "failed_notice" = "completed_result",
+    ) =>
       deliverCompletionDirect({
         cfg,
         requesterSessionKey: canonicalRequesterSessionKey,
@@ -231,6 +235,8 @@ export async function sendSubagentAnnounceDirectly(params: {
         directIdempotencyKey: params.directIdempotencyKey,
         deliveryTarget,
         internalEvents: params.internalEvents,
+        contentKind,
+        signal: params.signal,
         onDeliveryResult: params.onDeliveryResult,
         isSourceSessionEffectsAllowed: isCompletionDeliveryAllowed,
       });
@@ -400,13 +406,21 @@ export async function sendSubagentAnnounceDirectly(params: {
       if (hasAnnounceSendEvidence(err)) {
         throw err;
       }
+      if (params.signal?.aborted) {
+        return { delivered: false, path: "none" };
+      }
+      const directCompletionFallbackKind = hasFailedTrustedSubagentCompletion
+        ? "failed_notice"
+        : isIncompleteAnnounceAgentResultError(err)
+          ? "completed_result"
+          : undefined;
       if (
         params.expectsCompletionMessage &&
         (shouldDeliverAgentFinal || subagentDirectMessageCompletionRequiresMessageTool) &&
         isSubagentCompletion &&
-        isIncompleteAnnounceAgentResultError(err)
+        directCompletionFallbackKind
       ) {
-        const textDelivery = await tryTextCompletionDirectDelivery();
+        const textDelivery = await tryTextCompletionDirectDelivery(directCompletionFallbackKind);
         if (textDelivery) {
           return textDelivery;
         }


### PR DESCRIPTION
Related to #128449. This pull request fixes the silent direct-notice path only. The issue stays open for its separate attempt-telemetry classification.

## What Problem This Solves

A failed subagent can leave a direct requester with no terminal message when requester synthesis fails on the same provider path.

Shipped documentation requires terminal failed subagent runs to announce failure status without replaying captured child text.

## Why This Change Was Made

The direct completion fallback accepted only successful child events. The delivery owner already had the trusted child identity, direct target, idempotency key, abort signal, and current source-owner check, but it did not project a failed child into safe fallback content.

The repair:

- selects the fallback only for one trusted child event with `status !== "ok"`;
- sends a fixed generic notice through the existing direct completion sender;
- revalidates cancellation and source ownership immediately before platform delivery; and
- keeps untrusted, nested, channel, and threaded completions on their existing paths.

## User Impact

Direct requesters receive a generic terminal failure notice when both the delegated task and requester-side synthesis fail. The notice does not expose captured child output or provider errors, and non-direct delivery behavior is unchanged.

## Evidence

An authenticated ephemeral Gateway ran the production subagent completion flow with a failed child and a requester provider that returned HTTP 500.

| Revision | Direct result | Outbound notices | Private child/provider text | Non-direct extra sends |
| --- | --- | ---: | --- | ---: |
| Exact main `8e1cda9854ad1cbbb52914d777be9dadd91d0ff9` | Retryable and silent | 0 | Absent | 0 |
| Exact head `947a45c4c45b650f57dff8971e753789e229928c` | Delivered | 1 generic notice | Absent | 0 |

The exact notice was: `A delegated task failed before it could report a result. Please retry the task.`

Focused tests: `214/214` passed across the completion delivery owner and subagent announcement coordinator.

Telegram Test Server proof on the exact head drove the same failed-child and failed-requester-synthesis path through a real direct message. The recorder observed the 79-character generic notice exactly once at 6.0 seconds. Ten provider requests included repeated child and requester failures, and neither injected private error string appeared in any Telegram event.

Local E2E setup could not start because the existing worktree dependency tree lacked two build tools. Exact-head CI owns those repository-wide gates.

Scope and risk:

- Production: `+43` net lines across the two existing announcement owners.
- Tests: `+130` lines in the existing delivery-owner suite.
- No configuration, schema, protocol, persistence, or documented behavior change.

## AI Assistance

Codex assisted with repository investigation, implementation, focused validation, and review. No transcript is attached.
