### PR TITLE
improve(gateway): cut warm session maintenance latency

### DIFF
--- a/src/config/sessions/session-canonical-key.ts
+++ b/src/config/sessions/session-canonical-key.ts
@@ -10,6 +10,11 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../../routing/session-key.js";
+import {
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+  type OpenClawAgentDatabaseOptions,
+} from "../../state/openclaw-agent-db-contract.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import { parseSqliteSessionEntryRecord } from "./session-entry-json.js";
 import { projectCanonicalSessionEntryShape } from "./store-entry-shape.js";
@@ -22,7 +27,7 @@ import type { SessionEntry } from "./types.js";
 const SESSION_CANONICAL_KEY_REPAIR_COMMAND = "openclaw doctor --fix";
 type CanonicalSessionDatabase = Pick<
   OpenClawAgentKyselyDatabase,
-  "session_key_contract" | "session_nodes" | "session_windows"
+  "schema_meta" | "session_key_contract" | "session_nodes" | "session_windows"
 >;
 const validatedDatabases = new WeakSet<DatabaseSync>();
 
@@ -260,4 +265,29 @@ export function setCanonicalSqliteSessionMainKey(
       ),
   );
   validatedDatabases.delete(database.db);
+}
+
+/** Checks the startup contract without joining the writable database lifecycle. */
+export function isCanonicalSqliteSessionMainKeyCurrent(
+  options: OpenClawAgentDatabaseOptions,
+  mainKey: string | undefined,
+): boolean {
+  const canonicalMainKey = normalizeMainKey(mainKey);
+  const result = withOpenClawAgentDatabaseReadOnly((database) => {
+    const db = getNodeSqliteKysely<CanonicalSessionDatabase>(database.db);
+    const schema = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db.selectFrom("schema_meta").select("schema_version").where("meta_key", "=", "primary"),
+    );
+    if (schema?.schema_version !== OPENCLAW_AGENT_SCHEMA_VERSION) {
+      return false;
+    }
+    return (
+      executeSqliteQueryTakeFirstSync(
+        database.db,
+        db.selectFrom("session_key_contract").select("main_key").where("id", "=", 1),
+      )?.main_key === canonicalMainKey
+    );
+  }, options);
+  return result.found && result.value;
 }

--- a/src/config/sessions/startup-migration.registry-recovery.test.ts
+++ b/src/config/sessions/startup-migration.registry-recovery.test.ts
@@ -28,6 +28,50 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
+it("does not create a missing configured agent database during startup maintenance", async () => {
+  const root = fs.realpathSync.native(tempDirs.make("openclaw-startup-missing-agent-db-"));
+  const stateDir = path.join(root, "state");
+  const storePath = path.join(stateDir, "agents", "idle", "sessions", "sessions.json");
+  const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  const cfg: OpenClawConfig = {
+    agents: { entries: { idle: { default: true } } },
+    session: { store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json") },
+  };
+  const sqlitePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+    agentId: "idle",
+    env,
+  }).path;
+  const migrateManagedWorktreeCanonicalWorkspaces = vi.fn(async () => 0);
+  const sweepOrphanSessionStoreTemps = vi.fn(async () => 0);
+
+  await runSessionStartupMigration({
+    cfg,
+    env,
+    log: { info: vi.fn(), warn: vi.fn() },
+    deps: {
+      migrateLegacyMainSessionKeys: vi.fn(async () => ({
+        armed: false,
+        changes: [],
+        complete: false,
+        ledgerComplete: false,
+        legacyAgentId: "main",
+        mainKey: "main",
+        outcomes: [{ kind: "not-armed" as const }],
+        warnings: [],
+      })),
+      migrateManagedWorktreeCanonicalWorkspaces,
+      migrateOrphanedSessionKeys: vi.fn(async () => ({ changes: [], warnings: [] })),
+      prepareLegacySessionSurfaces: () => EMPTY_LEGACY_SESSION_SURFACES,
+      resolveAllAgentSessionStoreTargetsSync: () => [{ agentId: "idle", storePath }],
+      sweepOrphanSessionStoreTemps,
+    },
+  });
+
+  expect(fs.existsSync(sqlitePath)).toBe(false);
+  expect(migrateManagedWorktreeCanonicalWorkspaces).not.toHaveBeenCalled();
+  expect(sweepOrphanSessionStoreTemps).toHaveBeenCalledWith({ storePath });
+});
+
 it("re-registers durable lineage children before configured-only runtime reads", async () => {
   const root = fs.realpathSync.native(tempDirs.make("openclaw-startup-registry-recovery-"));
   const stateDir = path.join(root, "state");

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -1,6 +1,8 @@
+import fs from "node:fs";
 import { resolveAgentSessionDirs } from "../../agents/session-dirs.js";
 import { migrateOrphanedSessionKeys } from "../../infra/state-migrations.session-store.js";
 import type { PreparedLegacySessionSurfaces } from "../../plugins/legacy-session-surfaces.types.js";
+import { listOpenClawRegisteredAgentDatabases } from "../../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   isOpenClawAgentDatabaseOpen,
@@ -9,7 +11,10 @@ import {
 import { resolveStateDir } from "../paths.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { migrateLegacyMainSessionKeys } from "./legacy-main-session-migration.js";
-import { setCanonicalSqliteSessionMainKey } from "./session-canonical-key.js";
+import {
+  isCanonicalSqliteSessionMainKeyCurrent,
+  setCanonicalSqliteSessionMainKey,
+} from "./session-canonical-key.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { sweepOrphanSessionStoreTemps } from "./store-temp-cleanup.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "./targets.js";
@@ -22,6 +27,12 @@ type PrepareLegacySessionSurfaces = (params: {
   env?: NodeJS.ProcessEnv;
 }) => PreparedLegacySessionSurfaces;
 
+type SessionSqliteDatabaseExists = (params: {
+  agentId: string;
+  env?: NodeJS.ProcessEnv;
+  path?: string;
+}) => boolean;
+
 /** Runs best-effort session migration and orphan-temp cleanup before runtime reads. */
 export async function runSessionStartupMigration(params: {
   cfg: OpenClawConfig;
@@ -33,6 +44,7 @@ export async function runSessionStartupMigration(params: {
     prepareLegacySessionSurfaces?: PrepareLegacySessionSurfaces;
     migrateManagedWorktreeCanonicalWorkspaces?: typeof migrateManagedWorktreeCanonicalWorkspaces;
     resolveAllAgentSessionStoreTargetsSync?: typeof resolveAllAgentSessionStoreTargetsSync;
+    sessionSqliteDatabaseExists?: SessionSqliteDatabaseExists;
     sweepOrphanSessionStoreTemps?: typeof sweepOrphanSessionStoreTemps;
   };
 }): Promise<boolean> {
@@ -64,7 +76,11 @@ export async function runSessionStartupMigration(params: {
       const result = await migrate({
         cfg: params.cfg,
         env,
-        legacySessionSurfaces: prepareSurfaces({ config: params.cfg, env }),
+        legacySessionSurfaces: () =>
+          prepareSurfaces({
+            config: params.cfg,
+            env,
+          }),
       });
       if (result.changes.length > 0) {
         params.log.info(
@@ -109,17 +125,45 @@ export async function runSessionStartupMigration(params: {
   }
 
   const sweepTemps = params.deps?.sweepOrphanSessionStoreTemps ?? sweepOrphanSessionStoreTemps;
+  const databaseExists =
+    params.deps?.sessionSqliteDatabaseExists ??
+    ((input: Parameters<SessionSqliteDatabaseExists>[0]) =>
+      input.path !== undefined && fs.existsSync(input.path));
   try {
     let removedFiles = 0;
     let migratedWorktreeSessions = 0;
+    const registeredDatabases = new Set(
+      listOpenClawRegisteredAgentDatabases({ env }).map(
+        (entry) => `${entry.agentId}\0${entry.path}`,
+      ),
+    );
     for (const target of targets) {
       const path = resolveSqliteTargetFromSessionStorePath(target.storePath, {
         agentId: target.agentId,
         env: params.env,
       }).path;
+      if (
+        !databaseExists({
+          agentId: target.agentId,
+          ...(params.env ? { env: params.env } : {}),
+          path,
+        })
+      ) {
+        removedFiles += await sweepTemps({ storePath: target.storePath });
+        continue;
+      }
       const alreadyOpen = isOpenClawAgentDatabaseOpen(path);
-      const database = openOpenClawAgentDatabase({ agentId: target.agentId, path });
-      setCanonicalSqliteSessionMainKey(database, params.cfg.session?.mainKey);
+      const isRegistered = registeredDatabases.has(`${target.agentId}\0${path}`);
+      if (
+        !isRegistered ||
+        !isCanonicalSqliteSessionMainKeyCurrent(
+          { agentId: target.agentId, env, path },
+          params.cfg.session?.mainKey,
+        )
+      ) {
+        const database = openOpenClawAgentDatabase({ agentId: target.agentId, env, path });
+        setCanonicalSqliteSessionMainKey(database, params.cfg.session?.mainKey);
+      }
       const migrateWorktreeSessions =
         params.deps?.migrateManagedWorktreeCanonicalWorkspaces ??
         migrateManagedWorktreeCanonicalWorkspaces;
@@ -135,7 +179,7 @@ export async function runSessionStartupMigration(params: {
           `session: managed-worktree workspace migration failed for ${target.agentId}; continuing: ${String(error)}`,
         );
       }
-      if (!alreadyOpen) {
+      if (!alreadyOpen && isOpenClawAgentDatabaseOpen(path)) {
         closeOpenClawAgentDatabaseByPath(path);
       }
       removedFiles += await sweepTemps({ storePath: target.storePath });

--- a/src/config/sessions/startup-migration.worktree-workspace.test.ts
+++ b/src/config/sessions/startup-migration.worktree-workspace.test.ts
@@ -32,6 +32,7 @@ it("backfills a nested requested workspace once instead of using the agent defau
   const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
   const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
   const sessionKey = "agent:main:dashboard:legacy-worktree";
+  const ordinarySessionKey = "agent:main:dashboard:ordinary";
   const cfg: OpenClawConfig = {
     agents: { list: [{ id: "main", default: true, workspace: agentWorkspace }] },
     session: { store: storePath },
@@ -58,6 +59,16 @@ it("backfills a nested requested workspace once instead of using the agent defau
       worktree: { id: "legacy", branch: "openclaw/legacy", repoRoot },
     },
   );
+  await replaceSessionEntry(
+    { agentId: "main", env, sessionKey: ordinarySessionKey, storePath },
+    { sessionId: "ordinary-session", updatedAt: 20 },
+  );
+  const ordinaryBefore = loadSessionEntry({
+    agentId: "main",
+    env,
+    sessionKey: ordinarySessionKey,
+    storePath,
+  });
 
   const runMigration = async () =>
     await migrateManagedWorktreeCanonicalWorkspaces({
@@ -74,4 +85,7 @@ it("backfills a nested requested workspace once instead of using the agent defau
 
   await runMigration();
   expect(loadSessionEntry({ agentId: "main", env, sessionKey, storePath })).toEqual(first);
+  expect(
+    loadSessionEntry({ agentId: "main", env, sessionKey: ordinarySessionKey, storePath }),
+  ).toEqual(ordinaryBefore);
 });

--- a/src/config/sessions/worktree-workspace-migration.ts
+++ b/src/config/sessions/worktree-workspace-migration.ts
@@ -1,9 +1,18 @@
 import path from "node:path";
+import { sql } from "kysely";
 import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { listRegistryWorktreesForMigration } from "../../agents/worktrees/registry.js";
+import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import { resolveProjectRegistry } from "../../projects/project-registry.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
-import { listSessionEntriesReadOnly, patchSessionEntryCore } from "./session-accessor.js";
+import { patchSessionEntryCore } from "./session-accessor.js";
+import { parseReadableSqliteSessionEntryRow } from "./session-accessor.sqlite-entry-store.js";
+import {
+  getSessionKysely,
+  resolveSqliteScope,
+  toDatabaseOptions,
+} from "./session-accessor.sqlite-scope.js";
 import type { SessionEntry } from "./types.js";
 
 function isInside(root: string, target: string): boolean {
@@ -48,6 +57,40 @@ function resolveLegacyCanonicalWorkspace(params: {
   return agentWorkspace && agentWorkspace === recordedRepoRoot ? agentWorkspace : undefined;
 }
 
+function listLegacyWorktreeSessionEntries(params: {
+  agentId: string;
+  env: NodeJS.ProcessEnv;
+  storePath: string;
+}): Array<{ entry: SessionEntry; sessionKey: string }> {
+  const resolved = resolveSqliteScope({ ...params, sessionKey: "" });
+  const result = withOpenClawAgentDatabaseReadOnly((database) => {
+    const db = getSessionKysely(database.db);
+    const rows = executeSqliteQuerySync(
+      database.db,
+      db
+        .selectFrom("session_nodes")
+        .selectAll()
+        .where(
+          /* kysely-allow-raw: Startup migration targets the retired JSON shape without materializing every session. */
+          sql<boolean>`session_nodes.entry_valid != 1 OR (
+            json_valid(session_nodes.entry_json)
+            AND json_type(session_nodes.entry_json, '$.worktree') = 'object'
+            AND (
+              json_type(session_nodes.entry_json, '$.worktree.canonicalWorkspaceDir') IS NULL
+              OR json_extract(session_nodes.entry_json, '$.worktree.canonicalWorkspaceDir') = ''
+            )
+          )`,
+        )
+        .orderBy("session_key", "asc"),
+    ).rows;
+    return rows.flatMap((row) => {
+      const entry = parseReadableSqliteSessionEntryRow(database, row);
+      return entry ? [{ entry, sessionKey: row.session_key }] : [];
+    });
+  }, toDatabaseOptions(resolved));
+  return result.found ? result.value : [];
+}
+
 export async function migrateManagedWorktreeCanonicalWorkspaces(params: {
   agentId: string;
   cfg: OpenClawConfig;
@@ -57,11 +100,10 @@ export async function migrateManagedWorktreeCanonicalWorkspaces(params: {
   const env = params.env ?? process.env;
   const worktrees = listRegistryWorktreesForMigration(env);
   let migrated = 0;
-  for (const { entry, sessionKey } of listSessionEntriesReadOnly({
+  for (const { entry, sessionKey } of listLegacyWorktreeSessionEntries({
     agentId: params.agentId,
     env,
     storePath: params.storePath,
-    readConsistency: "latest",
   })) {
     const canonicalWorkspaceDir = resolveLegacyCanonicalWorkspace({
       agentId: params.agentId,

--- a/src/gateway/server-startup-session-migration.test-support.ts
+++ b/src/gateway/server-startup-session-migration.test-support.ts
@@ -56,7 +56,9 @@ function makeDeps(
       .mockResolvedValue(0),
     runDoctorSessionSqlite,
     reconcileSessionTranscriptIndexes,
-    sessionSqliteDatabaseExists: vi.fn<SessionSqliteDatabaseExists>().mockReturnValue(true),
+    sessionSqliteDatabaseExists: vi
+      .fn<SessionSqliteDatabaseExists>()
+      .mockImplementation((params) => params.path === undefined),
   };
 }
 

--- a/src/gateway/server-startup-session-migration.ts
+++ b/src/gateway/server-startup-session-migration.ts
@@ -33,6 +33,7 @@ type SessionSqliteStartupFailureReportWriter = (
 type SessionSqliteDatabaseExists = (params: {
   agentId: string;
   env?: NodeJS.ProcessEnv;
+  path?: string;
 }) => boolean;
 
 type SessionMigrationDeps = Parameters<typeof runSessionStartupMigration>[0]["deps"] & {

--- a/src/infra/state-migrations.orphan-keys.test.ts
+++ b/src/infra/state-migrations.orphan-keys.test.ts
@@ -727,6 +727,21 @@ describe("migrateOrphanedSessionKeys", () => {
     });
   });
 
+  it("does not prepare channel migration surfaces without a legacy store", async () => {
+    await withStateFixture(async ({ stateDir }) => {
+      const prepareLegacySessionSurfaces = vi.fn(() => EMPTY_LEGACY_SESSION_SURFACES);
+
+      const result = await migrateOrphanedSessionKeys({
+        cfg: OPS_WORK_CONFIG,
+        env: { OPENCLAW_STATE_DIR: stateDir },
+        legacySessionSurfaces: prepareLegacySessionSurfaces,
+      });
+
+      expect(result).toEqual({ changes: [], warnings: [] });
+      expect(prepareLegacySessionSurfaces).not.toHaveBeenCalled();
+    });
+  });
+
   it("is idempotent — running twice produces same result", async () => {
     await withStateFixture(async ({ stateDir }) => {
       const storePath = opsSessionStorePath(stateDir);

--- a/src/infra/state-migrations.session-store.ts
+++ b/src/infra/state-migrations.session-store.ts
@@ -599,17 +599,17 @@ export async function migrateOrphanedSessionKeys(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   additionalAgentIds?: readonly string[];
-  legacySessionSurfaces: PreparedLegacySessionSurfaces;
+  legacySessionSurfaces: PreparedLegacySessionSurfaces | (() => PreparedLegacySessionSurfaces);
 }): Promise<{ changes: string[]; warnings: string[] }> {
   const changes: string[] = [];
   const warnings: string[] = [];
   const env = params.env ?? process.env;
-  if (params.legacySessionSurfaces.failures.length > 0) {
-    return {
-      changes,
-      warnings: [...params.legacySessionSurfaces.failures],
-    };
-  }
+  let preparedLegacySessionSurfaces: PreparedLegacySessionSurfaces | undefined;
+  const resolveLegacySessionSurfaces = () =>
+    (preparedLegacySessionSurfaces ??=
+      typeof params.legacySessionSurfaces === "function"
+        ? params.legacySessionSurfaces()
+        : params.legacySessionSurfaces);
   const stateDir = resolveStateDir(env);
   const mainKey = normalizeMainKey(params.cfg.session?.mainKey);
   const scope = params.cfg.session?.scope as SessionScope | undefined;
@@ -721,6 +721,10 @@ export async function migrateOrphanedSessionKeys(params: {
     ) {
       continue;
     }
+    const legacySessionSurfaces = resolveLegacySessionSurfaces();
+    if (legacySessionSurfaces.failures.length > 0) {
+      return { changes, warnings: [...warnings, ...legacySessionSurfaces.failures] };
+    }
     // A physical store can have several owners. Canonicalize valid scoped rows
     // within their declared owner on every pass so iteration order cannot move
     // one agent's history into another namespace.
@@ -768,7 +772,7 @@ export async function migrateOrphanedSessionKeys(params: {
         preserveCanonicalAgentOwner: true,
         preserveAmbiguousKeys,
         preserveForeignMainAliases: pluginForeignMainAliasRisk,
-        legacySessionSurfaces: params.legacySessionSurfaces.surfaces,
+        legacySessionSurfaces: legacySessionSurfaces.surfaces,
       });
       working = canonicalized;
       // Each pass only counts keys it changed from the current working store, so


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators with many configured agents paid 1.1-2.2 seconds of blocking session maintenance on every warm Gateway boot, even when all session stores were already migrated. On a real-shaped 21-agent copied state directory, the maintenance path also blocked the event loop for up to 1.49 seconds.

## Why This Change Was Made

Startup now skips missing agent databases instead of creating them, preserves one-time registration repair for existing unregistered databases, checks the canonical main-key contract through a read-only probe before joining the writable database lifecycle, and narrows the managed-worktree backfill to a SQLite JSON predicate that returns only legacy candidates. Legacy channel surfaces are prepared lazily by the orphan-key migration only after it finds an actual legacy store that needs canonicalization.

The migration still completes before runtime session access. No schema version, SQLite schema, config option, readiness ordering, or post-ready behavior changes.

AI-assisted: yes. The implementation and evidence were produced with Codex and independently checked with the repository autoreview workflow.

## User Impact

Warm Gateway boots with many agent databases spend about 0.18-0.21 seconds in startup maintenance instead of 1.14-2.18 seconds on the measured state shape. Configured agents without a database no longer get an empty database created as a startup side effect.

## Evidence

All runs used the built `dist/` CLI, `OPENCLAW_GATEWAY_STARTUP_TRACE=1`, skipped channel transports, and an APFS copy of the supplied 21-agent state directory. The operator's live state directory was never read or mutated.

### Before/after startup trace

| Build | Boot | `startup.maintenance` | `eventLoopMax` |
| --- | ---: | ---: | ---: |
| `origin/main` before fix | 1 | 1136.8 ms | 518.0 ms |
| `origin/main` before fix | 2 | 2175.5 ms | 1487.9 ms |
| PR head `bb24ca785076f9c1e6d3408a61b120f84542df63` | 1 | 184.4 ms | 106.7 ms |
| PR head `bb24ca785076f9c1e6d3408a61b120f84542df63` | 2 | 210.4 ms | 120.0 ms |

### Temporary pre-fix instrumentation

| Session-maintenance bucket | Boot 1 | Boot 2 |
| --- | ---: | ---: |
| resolve targets | 3.3 ms | 5.6 ms |
| prepare legacy plugin surfaces | 369.3 ms | 1311.2 ms |
| orphan-key migration | 111.5 ms | 119.4 ms |
| open/schema/integrity lifecycle for 21 DBs | 565.8 ms | 633.5 ms |
| canonical main-key checks | 1.2 ms | 1.3 ms |
| managed-worktree scan | 8.4 ms | 9.0 ms |
| close DB handles | 23.8 ms | 26.2 ms |
| stale temp sweep | 6.8 ms | 9.4 ms |
| SQLite import | 10.5 ms | 12.5 ms |
| transcript reconcile | 23.2 ms | 24.7 ms |

The pairing migrations ran concurrently with session maintenance; their apparent wall time was event-loop starvation from these synchronous database/plugin buckets, not independent pairing work.

### Regression and validation proof

- The new missing-DB regression failed before the fix because startup created the SQLite file, then passed after the owner repair.
- `node scripts/run-vitest.mjs src/config/sessions/` — 86 files, 941 tests passed.
- Focused gateway + orphan-key + startup migration run — 5 files, 104 tests passed.
- `pnpm build` — passed on the rebased PR head.
- `node scripts/check-changed.mjs` — hosted Testbox sync timed out before running checks; authorized local fallback passed all selected core/coreTests checks, including prod/test types, lint, database-first, schema-version, dead-export, and import-cycle guards.
- `.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.

### LOC and compatibility

Production: +138/-17 (net +121). Tests/test support: +76/-1 (net +75). The production growth is the explicit read-only canonical-contract probe, missing/registration lifecycle gate, targeted SQLite JSON candidate query, and lazy migration-surface boundary needed to remove the unconditional writable lifecycle and eager plugin loading without weakening migration ordering.

The managed-worktree legacy shape landed in #125737 and reached `v2026.8.1-beta.3`; no stable release contains it. The backfill remains intact for beta/current-state users and retains regression coverage for a real legacy row.
