### PR TITLE
fix(cli): render agents add JSON failures

### DIFF
--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -334,50 +334,55 @@ describe("agents add command", () => {
     );
   }
 
-  it("requires --workspace when flags are present", async () => {
-    readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
-
-    await agentsAddCommand({ name: "Work" }, runtime, { hasAutomationFlags: true });
-
-    expect(runtime.error).toHaveBeenCalledOnce();
-    expect(runtime.error).toHaveBeenCalledWith(
-      `Non-interactive agent creation requires --workspace. Re-run ${formatCliCommand("openclaw agents add <id> --workspace <path>")} or omit flags to use the wizard.`,
-    );
-    expect(runtime.exit).toHaveBeenCalledWith(1);
-    expect(writeConfigFileMock).not.toHaveBeenCalled();
-  });
-
-  it("requires --workspace in non-interactive mode", async () => {
-    readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
-
-    await agentsAddCommand({ name: "Work", nonInteractive: true }, runtime, {
-      hasAutomationFlags: false,
-    });
-
-    expect(runtime.error).toHaveBeenCalledOnce();
-    expect(runtime.error).toHaveBeenCalledWith(
-      `Non-interactive agent creation requires --workspace. Re-run ${formatCliCommand("openclaw agents add <id> --workspace <path>")} or omit flags to use the wizard.`,
-    );
-    expect(runtime.exit).toHaveBeenCalledWith(1);
-    expect(writeConfigFileMock).not.toHaveBeenCalled();
-  });
-
-  it.each(RESERVED_SYSTEM_AGENT_IDS_FOR_TEST)(
-    "rejects reserved system-agent id %s",
-    async (name) => {
-      readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
-
-      await agentsAddCommand({ name, workspace: "/tmp/reserved" }, runtime, {
-        hasAutomationFlags: true,
-      });
-
-      expect(runtime.error).toHaveBeenCalledWith(
-        `"${name}" is reserved. Choose another name, or run ${formatCliCommand("openclaw agents list")} to inspect configured agents.`,
-      );
-      expect(runtime.exit).toHaveBeenCalledWith(1);
-      expect(writeConfigFileMock).not.toHaveBeenCalled();
+  it.each([
+    {
+      name: "a missing workspace with automation flags",
+      options: { name: "Work" },
+      flags: { hasAutomationFlags: true },
+      message: `Non-interactive agent creation requires --workspace. Re-run ${formatCliCommand("openclaw agents add <id> --workspace <path>")} or omit flags to use the wizard.`,
     },
-  );
+    {
+      name: "a missing workspace with explicit non-interactive mode",
+      options: { name: "Work", nonInteractive: true },
+      flags: { hasAutomationFlags: false },
+      message: `Non-interactive agent creation requires --workspace. Re-run ${formatCliCommand("openclaw agents add <id> --workspace <path>")} or omit flags to use the wizard.`,
+    },
+    {
+      name: "a missing name after a valid workspace",
+      options: { workspace: "/tmp/work" },
+      flags: { hasAutomationFlags: true },
+      message: `Agent name is required in non-interactive mode. Run ${formatCliCommand("openclaw agents add <id> --workspace <path>")}.`,
+    },
+    {
+      name: "an unrepresentable non-interactive name",
+      options: { name: "агент✨", workspace: "/tmp/work" },
+      flags: { hasAutomationFlags: true },
+      message:
+        'Agent name "агент✨" has no valid id characters. Use at least one letter a-z or digit.',
+    },
+    ...RESERVED_SYSTEM_AGENT_IDS_FOR_TEST.map((agentId) => ({
+      name: `reserved system-agent id ${agentId}`,
+      options: { name: agentId, workspace: "/tmp/reserved" },
+      flags: { hasAutomationFlags: true },
+      message: `"${agentId}" is reserved. Choose another name, or run ${formatCliCommand("openclaw agents list")} to inspect configured agents.`,
+    })),
+  ])("rejects $name through the root failure owner before mutation", async (testCase) => {
+    readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot });
+
+    await expect(agentsAddCommand(testCase.options, runtime, testCase.flags)).rejects.toMatchObject(
+      {
+        name: "ExpectedCliError",
+        message: testCase.message,
+        humanOutput: testCase.message,
+        machineOutput: testCase.message,
+      },
+    );
+
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(createAgentMock).not.toHaveBeenCalled();
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
 
   it("rejects an unrepresentable positional name before targeting an existing agent", async () => {
     readConfigFileSnapshotMock.mockResolvedValue({
@@ -459,14 +464,20 @@ describe("agents add command", () => {
         outro: vi.fn(),
       });
 
-      await agentsAddCommand({ json }, runtime);
+      const message =
+        "Agent creation needs an interactive TTY. Use `openclaw agents add <id> --non-interactive --workspace <dir>` for automation.";
+      await expect(agentsAddCommand({ json }, runtime)).rejects.toMatchObject({
+        name: "ExpectedCliError",
+        message,
+        humanOutput: message,
+        machineOutput: message,
+      });
 
-      expect(runtime.error).toHaveBeenCalledWith(
-        "Agent creation needs an interactive TTY. Use `openclaw agents add <id> --non-interactive --workspace <dir>` for automation.",
-      );
-      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.exit).not.toHaveBeenCalled();
       expect(runtime.log).not.toHaveBeenCalled();
       expect(terminalMocks.isTerminalInteractive).toHaveBeenCalledWith(output);
+      expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
       expect(wizardMocks.createClackPrompter).not.toHaveBeenCalled();
       expect(createAgentMock).not.toHaveBeenCalled();
       expect(writeConfigFileMock).not.toHaveBeenCalled();
@@ -1006,26 +1017,49 @@ describe("agents add command", () => {
       expect(terminalMocks.isTerminalInteractive).not.toHaveBeenCalled();
     });
 
-    it("reports a duplicate rejected by the canonical service", async () => {
+    it.each([
+      {
+        name: "a duplicate agent",
+        result: {
+          status: "error" as const,
+          reason: "already-exists",
+          agentId: "work",
+          message: 'agent "work" already exists',
+        },
+        message: 'Agent "work" already exists.',
+      },
+      {
+        name: "a rejected binding",
+        result: {
+          status: "error" as const,
+          reason: "invalid-bindings",
+          agentId: "work",
+          message: 'Invalid binding "telegram:". Account id is empty.',
+        },
+        message: 'Invalid binding "telegram:". Account id is empty.',
+      },
+    ])("reports $name through the root failure owner", async (testCase) => {
       readConfigFileSnapshotMock.mockResolvedValue({
         ...baseConfigSnapshot,
         config: { agents: { list: [{ id: "main", default: true }] } },
         sourceConfig: { agents: { list: [{ id: "main", default: true }] } },
       });
-      createAgentMock.mockResolvedValueOnce({
-        status: "error",
-        reason: "already-exists",
-        agentId: "work",
-        message: 'agent "work" already exists',
-      });
+      createAgentMock.mockResolvedValueOnce(testCase.result);
 
-      await agentsAddCommand({ name: "Work", workspace: "/tmp/work" }, runtime, {
-        hasAutomationFlags: true,
+      await expect(
+        agentsAddCommand({ name: "Work", workspace: "/tmp/work" }, runtime, {
+          hasAutomationFlags: true,
+        }),
+      ).rejects.toMatchObject({
+        name: "ExpectedCliError",
+        message: testCase.message,
+        humanOutput: testCase.message,
+        machineOutput: testCase.message,
       });
 
       expect(writeConfigFileMock).not.toHaveBeenCalled();
-      expect(runtime.error).toHaveBeenCalledWith('Agent "work" already exists.');
-      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.exit).not.toHaveBeenCalled();
     });
 
     it("reports binding conflicts from the committed mutation", async () => {

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -29,6 +29,7 @@ import {
 } from "../agents/auth-profiles/sqlite.js";
 import { loadAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-profiles/store.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { ExpectedCliError } from "../cli/failure-output.js";
 import { isTerminalInteractive } from "../cli/terminal-interactivity.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { createChannelSetupTransaction } from "../flows/channel-setup.js";
@@ -66,6 +67,10 @@ type AgentsAddOptions = {
 
 type AgentBindingResult = ReturnType<typeof applyAgentBindings>;
 
+function failAgentsAdd(message: string): never {
+  throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
+}
+
 function emptyBindingResult(config: Parameters<typeof applyAgentBindings>[0]): AgentBindingResult {
   return { config, added: [], updated: [], skipped: [], conflicts: [] };
 }
@@ -101,11 +106,9 @@ export async function agentsAddCommand(
   const nonInteractive = opts.nonInteractive === true || hasAutomationFlags;
   const wizardOutput = opts.json ? process.stderr : process.stdout;
   if (!nonInteractive && !isTerminalInteractive(wizardOutput)) {
-    runtime.error(
+    failAgentsAdd(
       `Agent creation needs an interactive TTY. Use \`${formatCliCommand("openclaw agents add <id> --non-interactive --workspace <dir>")}\` for automation.`,
     );
-    runtime.exit(1);
-    return;
   }
 
   const configSnapshot = await requireValidConfigFileSnapshot(runtime);
@@ -120,28 +123,22 @@ export async function agentsAddCommand(
 
   if (nonInteractive) {
     if (!workspaceFlag) {
-      runtime.error(
+      failAgentsAdd(
         `Non-interactive agent creation requires --workspace. Re-run ${formatCliCommand("openclaw agents add <id> --workspace <path>")} or omit flags to use the wizard.`,
       );
-      runtime.exit(1);
-      return;
     }
     if (!nameInput) {
-      runtime.error(
+      failAgentsAdd(
         `Agent name is required in non-interactive mode. Run ${formatCliCommand("openclaw agents add <id> --workspace <path>")}.`,
       );
-      runtime.exit(1);
-      return;
     }
     const validation = validateAgentIdInput(nameInput);
     if (!validation.ok) {
-      runtime.error(
+      failAgentsAdd(
         validation.reason === "reserved-id"
           ? `"${validation.agentId}" is reserved. Choose another name, or run ${formatCliCommand("openclaw agents list")} to inspect configured agents.`
           : validation.message,
       );
-      runtime.exit(1);
-      return;
     }
     const agentId = validation.agentId;
     if (agentId !== nameInput) {
@@ -159,15 +156,13 @@ export async function agentsAddCommand(
       });
     });
     if (created.status === "error") {
-      runtime.error(
+      failAgentsAdd(
         created.reason === "reserved-id"
           ? `"${created.agentId}" is reserved. Choose another name, or run ${formatCliCommand("openclaw agents list")} to inspect configured agents.`
           : created.reason === "already-exists"
             ? `Agent "${created.agentId}" already exists.`
             : created.message,
       );
-      runtime.exit(1);
-      return;
     }
 
     const bindingResult = created.bindingResult ?? emptyBindingResult(cfg);

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -54,6 +54,126 @@ async function seedTrajectorySession(tempHome: string, sessionKey: string) {
 describe("cli json stdout contract", () => {
   it.each([
     {
+      name: "add without an interactive terminal in human mode",
+      args: ["agents", "add", "work"],
+      message:
+        "Agent creation needs an interactive TTY. Use `openclaw agents add <id> --non-interactive --workspace <dir>` for automation.",
+      human: true,
+    },
+    {
+      name: "add without an interactive terminal in JSON wizard mode",
+      args: ["agents", "add", "work", "--json"],
+      message:
+        "Agent creation needs an interactive TTY. Use `openclaw agents add <id> --non-interactive --workspace <dir>` for automation.",
+    },
+    {
+      name: "add without a workspace in human mode",
+      args: ["agents", "add", "work", "--non-interactive"],
+      message:
+        "Non-interactive agent creation requires --workspace. Re-run openclaw agents add <id> --workspace <path> or omit flags to use the wizard.",
+      human: true,
+    },
+    {
+      name: "add without a workspace in explicit non-interactive mode",
+      args: ["agents", "add", "work", "--non-interactive", "--json"],
+      message:
+        "Non-interactive agent creation requires --workspace. Re-run openclaw agents add <id> --workspace <path> or omit flags to use the wizard.",
+    },
+    {
+      name: "add without a workspace when a model selects automation",
+      args: ["agents", "add", "work", "--model", "openai/gpt-5.6-luna", "--json"],
+      message:
+        "Non-interactive agent creation requires --workspace. Re-run openclaw agents add <id> --workspace <path> or omit flags to use the wizard.",
+    },
+    {
+      name: "add without a workspace before its missing name",
+      args: ["agents", "add", "--non-interactive", "--json"],
+      message:
+        "Non-interactive agent creation requires --workspace. Re-run openclaw agents add <id> --workspace <path> or omit flags to use the wizard.",
+    },
+    {
+      name: "add without a name after a valid workspace",
+      args: ["agents", "add", "--workspace", "$WORKSPACE", "--json"],
+      message:
+        "Agent name is required in non-interactive mode. Run openclaw agents add <id> --workspace <path>.",
+    },
+    {
+      name: "add with an invalid agent id",
+      args: ["agents", "add", "агент✨", "--workspace", "$WORKSPACE", "--json"],
+      message:
+        'Agent name "агент✨" has no valid id characters. Use at least one letter a-z or digit.',
+    },
+    ...["openclaw", "crestodian"].map((agentId) => ({
+      name: `add with reserved system-agent id ${agentId}`,
+      args: ["agents", "add", agentId, "--workspace", "$WORKSPACE", "--json"],
+      message: `"${agentId}" is reserved. Choose another name, or run openclaw agents list to inspect configured agents.`,
+    })),
+    {
+      name: "add with an already-configured agent",
+      args: ["agents", "add", "main", "--workspace", "$WORKSPACE", "--json"],
+      message: 'Agent "main" already exists.',
+    },
+    {
+      name: "add with a malformed binding",
+      args: ["agents", "add", "work", "--workspace", "$WORKSPACE", "--bind", "telegram:", "--json"],
+      message:
+        'Invalid binding "telegram:". Account id is empty. Use <channel>:<account>, for example telegram:default.',
+    },
+    {
+      name: "add with multiple malformed bindings in input order",
+      args: [
+        "agents",
+        "add",
+        "work",
+        "--workspace",
+        "$WORKSPACE",
+        "--bind",
+        "telegram:",
+        "--bind",
+        "telegram:work:extra",
+        "--json",
+      ],
+      message: [
+        'Invalid binding "telegram:". Account id is empty. Use <channel>:<account>, for example telegram:default.',
+        'Invalid binding "telegram:work:extra". Account id cannot contain ":". Use <channel>:<account>, for example telegram:default.',
+      ].join("\n"),
+    },
+    {
+      name: "add with an unknown binding channel",
+      args: [
+        "agents",
+        "add",
+        "work",
+        "--workspace",
+        "$WORKSPACE",
+        "--bind",
+        "definitely-not-a-channel",
+        "--json",
+      ],
+      message:
+        'Unknown channel "definitely-not-a-channel". Run `openclaw channels list --all` to see configured and installable channels.',
+    },
+    {
+      name: "add with a normalized id before a malformed binding",
+      args: ["agents", "add", "Work", "--workspace", "$WORKSPACE", "--bind", "telegram:", "--json"],
+      message:
+        'Invalid binding "telegram:". Account id is empty. Use <channel>:<account>, for example telegram:default.',
+    },
+    {
+      name: "add without a workspace through dual-TTY finalization",
+      args: ["agents", "add", "work", "--non-interactive", "--json"],
+      message:
+        "Non-interactive agent creation requires --workspace. Re-run openclaw agents add <id> --workspace <path> or omit flags to use the wizard.",
+      tty: true,
+    },
+    {
+      name: "add with a malformed binding through dual-TTY finalization",
+      args: ["agents", "add", "work", "--workspace", "$WORKSPACE", "--bind", "telegram:", "--json"],
+      message:
+        'Invalid binding "telegram:". Account id is empty. Use <channel>:<account>, for example telegram:default.',
+      tty: true,
+    },
+    {
       name: "bindings with an invalid agent",
       args: ["agents", "bindings", "--agent", "агент✨", "--json"],
       message: 'Agent "агент✨" not found. Run openclaw agents list to see configured agents.',
@@ -135,14 +255,18 @@ describe("cli json stdout contract", () => {
       message: "Provide at least one --bind <channel[:accountId]>.",
       tty: true,
     },
-  ])("renders agent binding $name through the canonical failure owner", async (testCase) => {
+  ])("renders agent management $name through the canonical failure owner", async (testCase) => {
     await withTempHome(
       async (tempHome) => {
         const configPath = path.join(tempHome, "missing-openclaw.json");
+        const workspace = path.join(tempHome, "workspace");
         const preload = `data:text/javascript,${encodeURIComponent(
           'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true }); Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });',
         )}`;
-        const result = runBuiltCli(tempHome, testCase.args, {
+        const args = testCase.args.map((argument) =>
+          argument === "$WORKSPACE" ? workspace : argument,
+        );
+        const result = runBuiltCli(tempHome, args, {
           OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
           OPENCLAW_CONFIG_PATH: configPath,
           ...("tty" in testCase ? { NODE_OPTIONS: `--import=${preload}`, FORCE_COLOR: "1" } : {}),
@@ -164,8 +288,9 @@ describe("cli json stdout contract", () => {
           expect(result.stderr).toContain("\u001B[?25h");
         }
         await expect(fs.access(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(fs.access(workspace)).rejects.toMatchObject({ code: "ENOENT" });
       },
-      { prefix: "openclaw-agent-bindings-json-failure-e2e-" },
+      { prefix: "openclaw-agent-management-json-failure-e2e-" },
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw agents add ... --json` returned exit code 1 with empty stdout for command-owned validation failures. TTY admission, missing automation requirements, invalid or reserved identifiers, duplicate agents, and binding errors therefore left automation with an unrelated JSON parse error.

Fixes https://github.com/openclaw/openclaw/issues/128516.

## Why This Change Was Made

The agent-creation command owner now routes its pre-mutation failure branches through one `ExpectedCliError` helper. The existing root CLI renderer owns human/JSON output, exit status, and terminal finalization. Interactive wizard cancellation and guided setup, validation order, normalized-ID stderr guidance, successful creation summaries, authentication/channel setup, and post-mutation outcomes remain unchanged.

Production delta: +10/-15, net -5 lines. Tests: +216/-57, net +159 lines.

## User Impact

JSON consumers receive exactly one canonical `cli_error` document for agent-creation validation failures. Human diagnostics and successful interactive/non-interactive creation behavior remain unchanged.

## Evidence

- Pre-fix: 12 owner regressions and three built-process regressions failed because stdout was empty.
- Focused owner/sibling proof: 120 tests passed across agent creation, registration, binding, deletion, and failure rendering.
- Built-process proof: 37 JSON/human/dual-TTY cases passed, covering TTY selection, workspace-before-name ordering, invalid/reserved/duplicate identifiers, malformed/unknown bindings, normalized identifiers, successful and sibling domain payloads, and filesystem/config immutability.
- Full production build and complete changed-file gates passed.
- Fresh P1 autoreview: no accepted/actionable findings.
- `git diff --check`: passed.
