### PR TITLE
feat(channels): matrix custom emote discovery, discord guild-emoji cache

### DIFF
--- a/docs/channels/googlechat.md
+++ b/docs/channels/googlechat.md
@@ -203,6 +203,8 @@ Notes:
 - Inbound attachments (first attachment per message) are downloaded through the Chat API into the media pipeline, capped by `mediaMaxMb` (default 20).
 - Bot-authored messages are ignored by default. With `allowBots: true`, accepted bot messages use shared [bot loop protection](/channels/bot-loop-protection): configure `channels.defaults.botLoopProtection`, then override with `channels.googlechat.botLoopProtection` or `channels.googlechat.groups.<space>.botLoopProtection`.
 
+Custom emoji listing is unavailable because Google Chat's `customEmojis.list` endpoint requires user authentication with the `chat.customemojis` or `chat.customemojis.readonly` scope. This plugin authenticates exclusively as a service account with the `chat.bot` scope, which cannot access that endpoint.
+
 Secrets reference details: [Secrets Management](/gateway/secrets).
 
 ## Troubleshooting

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -587,8 +587,11 @@ Outbound reaction tooling is gated by `channels.matrix.actions.reactions`:
 
 - `react` adds a reaction to a Matrix event.
 - `reactions` lists the current reaction summary for a Matrix event.
+- `emoji-list` discovers custom emoji from the current conversation's room packs and your personal pack.
 - `emoji=""` removes the bot's own reactions on that event.
 - `remove: true` removes only the specified emoji reaction from the bot.
+
+`emoji-list` reads MSC2545 `im.ponies.room_emotes` packs from the authorized current room and `im.ponies.user_emotes` account data. It returns up to 100 sorted entries such as `{ "name": "party", "identifier": "party", "url": "mxc://example.org/party" }`; sticker-only entries are excluded. Pass `identifier` to `react`: it is the plain shortcode stored directly as the Matrix reaction's `m.relates_to.key`, not the `mxc://` media URL. Custom-reaction rendering depends on the Matrix client, so `url` is included separately for clients or agents that need the image.
 
 **Resolution order** (first defined value wins):
 

--- a/extensions/discord/src/actions/runtime.guild.ts
+++ b/extensions/discord/src/actions/runtime.guild.ts
@@ -2,6 +2,7 @@
 import { ChannelType, PermissionFlagsBits } from "discord-api-types/v10";
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import { resolveDefaultDiscordAccountId } from "../accounts.js";
+import { getGateway } from "../monitor/gateway-registry.js";
 import { getPresence } from "../monitor/presence-cache.js";
 import {
   type ActionGate,
@@ -383,18 +384,25 @@ export async function handleDiscordGuildAction(
       }
       await assertGuildMetadataReadAllowed(guildId);
       const limit = Math.min(readPositiveIntegerParam(params, "limit") ?? 100, 100);
-      const emojis = (await discordGuildActionRuntime.listGuildEmojisDiscord(guildId, withOpts()))
-        .flatMap(({ name, id, animated }) =>
-          name && id
-            ? [{ name, identifier: `${name}:${id}`, ...(animated ? { animated } : {}) }]
-            : [],
-        )
-        .toSorted(
-          (left, right) =>
-            left.name.localeCompare(right.name) || left.identifier.localeCompare(right.identifier),
-        )
-        .slice(0, limit);
-      return jsonResult({ ok: true, emojis });
+      const fetchEmojis = async () =>
+        (await discordGuildActionRuntime.listGuildEmojisDiscord(guildId, withOpts()))
+          .flatMap(({ name, id, animated }) =>
+            name && id
+              ? [{ name, identifier: `${name}:${id}`, ...(animated ? { animated } : {}) }]
+              : [],
+          )
+          .toSorted(
+            (left, right) =>
+              left.name.localeCompare(right.name) ||
+              left.identifier.localeCompare(right.identifier),
+          );
+      // The account GatewayPlugin owns this bounded client cache and invalidates
+      // guild emoji entries on GuildEmojisUpdate; gateway-free CLI reads stay uncached.
+      const gateway = getGateway(accountId ?? resolveDefaultDiscordAccountId(cfg));
+      const emojis = gateway
+        ? await gateway.fetchGuildEmojis(guildId, fetchEmojis)
+        : await fetchEmojis();
+      return jsonResult({ ok: true, emojis: emojis.slice(0, limit) });
     }
     case "emojiUpload": {
       if (!isActionEnabled("emojiUploads")) {

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -8,6 +8,9 @@ import {
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig, DiscordActionConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayPlugin } from "../internal/gateway.js";
+import { createInternalTestClient } from "../internal/test-builders.test-support.js";
+import { registerGateway, unregisterGateway } from "../monitor/gateway-registry.js";
 import { clearPresences, setPresence } from "../monitor/presence-cache.js";
 import { DiscordThreadInitialMessageError } from "../send.js";
 import { handleDiscordMessageAction } from "./handle-action.js";
@@ -2750,6 +2753,45 @@ describe("handleDiscordGuildAction", () => {
         { name: "beta", identifier: "beta:2" },
       ],
     });
+  });
+
+  it("reuses the gateway-owned normalized emoji list across requests with different limits", async () => {
+    const client = createInternalTestClient();
+    registerGateway("default", {
+      fetchGuildEmojis: client.fetchGuildEmojis.bind(client),
+    } as GatewayPlugin);
+    listGuildEmojisDiscord.mockResolvedValueOnce([
+      { id: "2", name: "beta" },
+      { id: "1", name: "alpha" },
+    ]);
+
+    try {
+      const first = await handleGuildAction(
+        "emojiList",
+        { guildId: "G1", limit: 1 },
+        enableAllActions,
+      );
+      const second = await handleGuildAction(
+        "emojiList",
+        { guildId: "G1", limit: 2 },
+        enableAllActions,
+      );
+
+      expect(first.details).toEqual({
+        ok: true,
+        emojis: [{ name: "alpha", identifier: "alpha:1" }],
+      });
+      expect(second.details).toEqual({
+        ok: true,
+        emojis: [
+          { name: "alpha", identifier: "alpha:1" },
+          { name: "beta", identifier: "beta:2" },
+        ],
+      });
+      expect(listGuildEmojisDiscord).toHaveBeenCalledTimes(1);
+    } finally {
+      unregisterGateway("default");
+    }
   });
 
   it("bounds emoji-list output even when a larger limit is requested", async () => {

--- a/extensions/discord/src/internal/client.ts
+++ b/extensions/discord/src/internal/client.ts
@@ -164,6 +164,10 @@ export class Client {
     return await this.entityCache.fetchMember(guildId, userId);
   }
 
+  async fetchGuildEmojis<T>(guildId: string, fetcher: () => Promise<T>): Promise<T> {
+    return await this.entityCache.fetchGuildEmojis(guildId, fetcher);
+  }
+
   async deployCommands(options: DeployCommandOptions = {}) {
     return await this.commandDeployer.deploy(options);
   }

--- a/extensions/discord/src/internal/entity-cache.test.ts
+++ b/extensions/discord/src/internal/entity-cache.test.ts
@@ -77,6 +77,23 @@ describe("DiscordEntityCache eviction", () => {
     expect(cache.size).toBe(0);
   });
 
+  it("reuses normalized guild emojis until their cache entry expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const { cache } = makeCache({ ttlMs: 30_000 });
+    const fetchEmojis = vi.fn(async () => [{ name: "party", identifier: "party:1" }]);
+
+    expect(await cache.fetchGuildEmojis("g1", fetchEmojis)).toEqual([
+      { name: "party", identifier: "party:1" },
+    ]);
+    await cache.fetchGuildEmojis("g1", fetchEmojis);
+    expect(fetchEmojis).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(30_000);
+    await cache.fetchGuildEmojis("g1", fetchEmojis);
+    expect(fetchEmojis).toHaveBeenCalledTimes(2);
+  });
+
   it.each([
     ["updated", GatewayDispatchEvents.ThreadUpdate],
     ["deleted", GatewayDispatchEvents.ThreadDelete],
@@ -95,6 +112,19 @@ describe("DiscordEntityCache eviction", () => {
 });
 
 describe("DiscordEntityCache gateway invalidation", () => {
+  it("invalidates only the updated guild's normalized emoji list", async () => {
+    const { cache } = makeCache({ ttlMs: 60_000 });
+    const fetchEmojis = vi.fn(async () => [{ name: "party", identifier: "party:1" }]);
+
+    await cache.fetchGuildEmojis("g1", fetchEmojis);
+    await cache.fetchGuildEmojis("g2", fetchEmojis);
+    cache.invalidateForGatewayEvent(GatewayDispatchEvents.GuildEmojisUpdate, { guild_id: "g1" });
+    await cache.fetchGuildEmojis("g1", fetchEmojis);
+    await cache.fetchGuildEmojis("g2", fetchEmojis);
+
+    expect(fetchEmojis).toHaveBeenCalledTimes(3);
+  });
+
   it.each([
     GatewayDispatchEvents.GuildMemberAdd,
     GatewayDispatchEvents.GuildMemberRemove,

--- a/extensions/discord/src/internal/entity-cache.ts
+++ b/extensions/discord/src/internal/entity-cache.ts
@@ -63,6 +63,10 @@ export class DiscordEntityCache {
     });
   }
 
+  async fetchGuildEmojis<T>(guildId: string, fetcher: () => Promise<T>): Promise<T> {
+    return await this.fetchCached(`guild-emojis:${guildId}`, fetcher);
+  }
+
   invalidateForGatewayEvent(type: string, data: unknown): void {
     const raw = data && typeof data === "object" ? (data as Record<string, unknown>) : {};
     const channelUpdate: string = GatewayDispatchEvents.ChannelUpdate;
@@ -70,6 +74,7 @@ export class DiscordEntityCache {
     const threadUpdate: string = GatewayDispatchEvents.ThreadUpdate;
     const threadDelete: string = GatewayDispatchEvents.ThreadDelete;
     const guildUpdate: string = GatewayDispatchEvents.GuildUpdate;
+    const guildEmojisUpdate: string = GatewayDispatchEvents.GuildEmojisUpdate;
     const guildMemberAdd: string = GatewayDispatchEvents.GuildMemberAdd;
     const guildMemberRemove: string = GatewayDispatchEvents.GuildMemberRemove;
     const guildMemberUpdate: string = GatewayDispatchEvents.GuildMemberUpdate;
@@ -83,6 +88,9 @@ export class DiscordEntityCache {
     }
     if (type === guildUpdate) {
       this.deleteId("guild", raw.id);
+    }
+    if (type === guildEmojisUpdate) {
+      this.deleteId("guild-emojis", raw.guild_id);
     }
     if (type === guildMemberAdd || type === guildMemberRemove || type === guildMemberUpdate) {
       const guildId = raw.guild_id;

--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -124,6 +124,10 @@ export class GatewayPlugin extends Plugin {
     return this.voiceStateCache.listVoiceChannelStates(guildId, channelId);
   }
 
+  async fetchGuildEmojis<T>(guildId: string, fetcher: () => Promise<T>): Promise<T> {
+    return this.client ? await this.client.fetchGuildEmojis(guildId, fetcher) : await fetcher();
+  }
+
   takeVoiceStateTransition(state: APIVoiceState): DiscordGatewayVoiceStateTransition | null {
     return this.voiceStateCache.takeTransition(state);
   }

--- a/extensions/discord/src/monitor/gateway-plugin.test.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.test.ts
@@ -18,6 +18,7 @@ const { GatewayIntents, GatewayPlugin } = vi.hoisted(() => {
     GuildPresences: 1 << 6,
     GuildMembers: 1 << 7,
     GuildVoiceStates: 1 << 8,
+    GuildExpressions: 1 << 9,
   } as const;
 
   class TestEmitter {
@@ -106,8 +107,11 @@ describe("createDiscordGatewayPlugin", () => {
     });
   }
 
-  it("omits GuildVoiceStates by default for text-only Discord configs", () => {
-    expect(resolveDiscordGatewayIntents() & GatewayIntents.GuildVoiceStates).toBe(0);
+  it("subscribes to guild emoji changes without enabling voice by default", () => {
+    const intents = resolveDiscordGatewayIntents();
+
+    expect(intents & GatewayIntents.GuildExpressions).toBe(GatewayIntents.GuildExpressions);
+    expect(intents & GatewayIntents.GuildVoiceStates).toBe(0);
   });
 
   it("includes GuildVoiceStates when voice is enabled", () => {
@@ -255,6 +259,7 @@ describe("createDiscordGatewayPlugin", () => {
       autoInteractions: false,
       intents:
         GatewayIntents.Guilds |
+        GatewayIntents.GuildExpressions |
         GatewayIntents.GuildMessages |
         GatewayIntents.MessageContent |
         GatewayIntents.DirectMessages |

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -171,6 +171,7 @@ export function resolveDiscordGatewayIntents(params?: ResolveDiscordGatewayInten
   const voiceStatesEnabled = intentsConfig?.voiceStates ?? voiceEnabled ?? false;
   let intents =
     discordGateway.GatewayIntents.Guilds |
+    discordGateway.GatewayIntents.GuildExpressions |
     discordGateway.GatewayIntents.GuildMessages |
     discordGateway.GatewayIntents.DirectMessages |
     discordGateway.GatewayIntents.GuildMessageReactions |

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -78,6 +78,7 @@ const {
     GuildPresences: 1 << 6,
     GuildMembers: 1 << 7,
     GuildVoiceStates: 1 << 8,
+    GuildExpressions: 1 << 9,
   } as const;
 
   class GatewayPluginLocal {

--- a/extensions/matrix/src/actions.account-propagation.test.ts
+++ b/extensions/matrix/src/actions.account-propagation.test.ts
@@ -340,4 +340,48 @@ describe("matrixMessageActions account propagation", () => {
       },
     });
   });
+
+  it("defaults custom-emote discovery to the bound current Matrix conversation", async () => {
+    await matrixMessageActions.handleAction?.(
+      createContext({
+        action: "emoji-list",
+        accountId: "ops",
+        requesterAccountId: "ops",
+        params: { limit: 3 },
+        toolContext: {
+          currentChannelId: "room:!current:example.org",
+          currentChannelProvider: "matrix",
+          currentChatType: "group",
+        },
+      }),
+    );
+
+    expect(matrixActionCall().input).toMatchObject({
+      action: "emoji-list",
+      accountId: "ops",
+      roomId: "room:!current:example.org",
+      limit: 3,
+    });
+    expect(matrixActionCall().options.readContext).toMatchObject({
+      requesterAccountId: "ops",
+      currentChannelId: "room:!current:example.org",
+      currentChannelProvider: "matrix",
+    });
+  });
+
+  it("rejects custom-emote discovery without an explicit room or bound Matrix conversation", async () => {
+    await expect(
+      matrixMessageActions.handleAction?.(
+        createContext({
+          action: "emoji-list",
+          params: {},
+          toolContext: {
+            currentChannelId: "room:!foreign:example.org",
+            currentChannelProvider: "slack",
+          },
+        }),
+      ),
+    ).rejects.toThrow("Matrix emoji-list requires a roomId or current Matrix conversation.");
+    expect(mocks.handleMatrixAction).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/matrix/src/actions.test.ts
+++ b/extensions/matrix/src/actions.test.ts
@@ -90,7 +90,10 @@ describe("matrixMessageActions", () => {
     if (!schema) {
       throw new Error("matrix schema missing");
     }
-    const properties = (schema as { properties?: Record<string, unknown> }).properties ?? {};
+    const profileSchema = Array.isArray(schema)
+      ? schema.find((contribution) => contribution.actions?.includes("set-profile"))
+      : schema;
+    const properties = profileSchema?.properties ?? {};
 
     expect(actions).toContain(profileAction);
     expect(supportsAction({ action: profileAction } as never)).toBe(true);
@@ -108,6 +111,32 @@ describe("matrixMessageActions", () => {
     expect(properties.displayName).toHaveProperty("type", "string");
     expect(properties.avatarUrl).toHaveProperty("type", "string");
     expect(properties.avatarPath).toHaveProperty("type", "string");
+  });
+
+  it("advertises custom-emote discovery and its reaction hint only when reactions are enabled", () => {
+    const cfg = createConfiguredMatrixConfig();
+    const enabled = matrixMessageActions.describeMessageTool({ cfg } as never);
+    const disabled = matrixMessageActions.describeMessageTool({
+      cfg: {
+        channels: {
+          matrix: { ...cfg.channels?.matrix, actions: { reactions: false } },
+        },
+      },
+    } as never);
+
+    expect(enabled?.actions).toContain("emoji-list");
+    expect(matrixMessageActions.supportsAction?.({ action: "emoji-list" } as never)).toBe(true);
+    expect(enabled?.schema).toMatchObject({
+      actions: ["react", "reactions"],
+      properties: {
+        emoji: {
+          description: expect.stringContaining('action:"emoji-list"'),
+        },
+      },
+    });
+    expect(disabled?.actions).not.toContain("emoji-list");
+    expect(disabled?.actions).not.toContain("react");
+    expect(disabled?.schema).toBeNull();
   });
 
   it("hides self-profile updates without owner identity context", () => {
@@ -270,7 +299,9 @@ describe("matrixMessageActions", () => {
 
     expect(assistantActions).not.toContain("react");
     expect(assistantActions).not.toContain("reactions");
+    expect(assistantActions).not.toContain("emoji-list");
     expect(opsActions).toContain("react");
     expect(opsActions).toContain("reactions");
+    expect(opsActions).toContain("emoji-list");
   });
 });

--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -9,7 +9,7 @@ import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionContext,
   ChannelMessageActionName,
-  ChannelMessageToolDiscovery,
+  ChannelMessageToolSchemaContribution,
 } from "openclaw/plugin-sdk/channel-contract";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
@@ -23,6 +23,7 @@ const MATRIX_PLUGIN_HANDLED_ACTIONS = new Set<ChannelMessageActionName>([
   "poll-vote",
   "react",
   "reactions",
+  "emoji-list",
   "read",
   "edit",
   "delete",
@@ -77,6 +78,7 @@ function createMatrixExposedActions(params: {
   if (params.gate("reactions")) {
     actions.add("react");
     actions.add("reactions");
+    actions.add("emoji-list");
   }
   if (params.gate("pins")) {
     actions.add("pin");
@@ -98,7 +100,7 @@ function createMatrixExposedActions(params: {
   return actions;
 }
 
-function buildMatrixProfileToolSchema(): NonNullable<ChannelMessageToolDiscovery["schema"]> {
+function buildMatrixProfileToolSchema(): ChannelMessageToolSchemaContribution {
   return {
     actions: ["set-profile"],
     properties: {
@@ -143,10 +145,26 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
       senderIsOwner,
     });
     const listedActions = Array.from(actions);
+    const schema: ChannelMessageToolSchemaContribution[] = [];
+    if (actions.has("set-profile")) {
+      schema.push(buildMatrixProfileToolSchema());
+    }
+    if (actions.has("react")) {
+      schema.push({
+        actions: ["react", "reactions"],
+        properties: {
+          emoji: Type.Optional(
+            Type.String({
+              description: `Unicode emoji or custom emote shortcode.${actions.has("emoji-list") ? ' Discover room and personal custom emotes with action:"emoji-list".' : ""}`,
+            }),
+          ),
+        },
+      });
+    }
     return {
       actions: listedActions,
       capabilities: ["presentation"],
-      schema: listedActions.includes("set-profile") ? buildMatrixProfileToolSchema() : null,
+      schema: schema.length > 1 ? schema : (schema[0] ?? null),
       mediaSourceParams: listedActions.includes("set-profile")
         ? { "set-profile": MATRIX_PROFILE_MEDIA_SOURCE_PARAMS }
         : null,
@@ -256,6 +274,23 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
         messageId,
         limit,
       });
+    }
+
+    if (action === "emoji-list") {
+      const roomId =
+        readStringParam(params, "roomId") ??
+        readStringParam(params, "channelId") ??
+        readStringParam(params, "to") ??
+        (ctx.toolContext?.currentChannelProvider === "matrix"
+          ? ctx.toolContext.currentChannelId
+          : undefined);
+      if (!roomId) {
+        throw new Error("Matrix emoji-list requires a roomId or current Matrix conversation.");
+      }
+      const limit = readPositiveIntegerParam(params, "limit", {
+        message: "limit must be a positive integer.",
+      });
+      return await dispatch({ action: "emoji-list", roomId, limit });
     }
 
     if (action === "read") {

--- a/extensions/matrix/src/matrix/actions.ts
+++ b/extensions/matrix/src/matrix/actions.ts
@@ -6,7 +6,11 @@ export {
   readMatrixMessages,
 } from "./actions/messages.js";
 export { voteMatrixPoll } from "./actions/polls.js";
-export { listMatrixReactions, removeMatrixReactions } from "./actions/reactions.js";
+export {
+  listMatrixEmojis,
+  listMatrixReactions,
+  removeMatrixReactions,
+} from "./actions/reactions.js";
 export { pinMatrixMessage, unpinMatrixMessage, listMatrixPins } from "./actions/pins.js";
 export { getMatrixMemberInfo, getMatrixRoomInfo } from "./actions/room.js";
 export {

--- a/extensions/matrix/src/matrix/actions/reactions.test.ts
+++ b/extensions/matrix/src/matrix/actions/reactions.test.ts
@@ -1,7 +1,7 @@
 // Matrix tests cover reactions plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import type { MatrixClient } from "../sdk.js";
-import { listMatrixReactions, removeMatrixReactions } from "./reactions.js";
+import { listMatrixEmojis, listMatrixReactions, removeMatrixReactions } from "./reactions.js";
 
 function createReactionsClient(params: {
   chunk: Array<{
@@ -48,6 +48,90 @@ function createReactionsClient(params: {
 }
 
 describe("matrix reaction actions", () => {
+  it("lists sorted room and personal MSC2545 emoticons while rejecting malformed and sticker-only images", async () => {
+    const doRequest = vi.fn(async () => [
+      {
+        type: "im.ponies.room_emotes",
+        state_key: "",
+        content: {
+          images: {
+            zebra: { url: "mxc://example.org/zebra" },
+            sticker: { url: "mxc://example.org/sticker", usage: ["sticker"] },
+            wrongUrl: { url: "https://example.org/wrong" },
+            incompleteMxc: { url: "mxc://example.org" },
+            wrongUsage: { url: "mxc://example.org/wrong-usage", usage: "emoticon" },
+            malformed: null,
+          },
+        },
+      },
+      {
+        type: "im.ponies.room_emotes",
+        state_key: "extra-pack",
+        content: {
+          pack: { usage: ["sticker"] },
+          images: {
+            hidden: { url: "mxc://example.org/hidden" },
+            alpha: { url: "mxc://example.org/alpha", usage: ["emoticon", "sticker"] },
+          },
+        },
+      },
+      { type: "im.ponies.room_emotes", state_key: "broken", content: { images: [] } },
+      { type: "m.room.name", state_key: "", content: { images: { ignored: {} } } },
+    ]);
+    const getAccountData = vi.fn(async () => ({
+      images: { middle: { url: "mxc://example.org/middle", usage: ["emoticon"] } },
+    }));
+    const client = { doRequest, getAccountData, stop: vi.fn() } as unknown as MatrixClient;
+
+    await expect(listMatrixEmojis("!room:example.org", { client })).resolves.toStrictEqual([
+      { name: "alpha", identifier: "alpha", url: "mxc://example.org/alpha" },
+      { name: "middle", identifier: "middle", url: "mxc://example.org/middle" },
+      { name: "zebra", identifier: "zebra", url: "mxc://example.org/zebra" },
+    ]);
+    expect(doRequest).toHaveBeenCalledWith(
+      "GET",
+      "/_matrix/client/v3/rooms/!room%3Aexample.org/state",
+    );
+    expect(getAccountData).toHaveBeenCalledWith("im.ponies.user_emotes");
+  });
+
+  it("caps sorted custom-emote results at 100 and accepts a missing personal pack", async () => {
+    const images = Object.fromEntries(
+      Array.from({ length: 105 }, (_, index) => {
+        const shortcode = `emoji_${String(index).padStart(3, "0")}`;
+        return [shortcode, { url: `mxc://example.org/${shortcode}` }];
+      }),
+    );
+    const client = {
+      doRequest: vi.fn(async () => [
+        { type: "im.ponies.room_emotes", state_key: "", content: { images } },
+      ]),
+      getAccountData: vi.fn(async () => undefined),
+      stop: vi.fn(),
+    } as unknown as MatrixClient;
+
+    const emojis = await listMatrixEmojis("!room:example.org", { client, limit: 500 });
+
+    expect(emojis).toHaveLength(100);
+    expect(emojis[0]?.name).toBe("emoji_000");
+    expect(emojis.at(-1)?.name).toBe("emoji_099");
+    await expect(listMatrixEmojis("!room:example.org", { client, limit: 2 })).resolves.toHaveLength(
+      2,
+    );
+  });
+
+  it("fails visibly when the room-state response is malformed", async () => {
+    const client = {
+      doRequest: vi.fn(async () => ({ state: [] })),
+      getAccountData: vi.fn(async () => undefined),
+      stop: vi.fn(),
+    } as unknown as MatrixClient;
+
+    await expect(listMatrixEmojis("!room:example.org", { client })).rejects.toThrow(
+      "Matrix room state response is invalid.",
+    );
+  });
+
   it("aggregates reactions by key and unique sender", async () => {
     const { client, doRequest } = createReactionsClient({
       chunk: [

--- a/extensions/matrix/src/matrix/actions/reactions.ts
+++ b/extensions/matrix/src/matrix/actions/reactions.ts
@@ -1,14 +1,78 @@
 // Matrix plugin module implements reactions behavior.
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildMatrixReactionRelationsPath,
   selectOwnMatrixReactionEventIds,
   summarizeMatrixReactionEvents,
 } from "../reaction-common.js";
+import { parseMxc } from "../sdk/event-helpers.js";
 import { withResolvedRoomAction } from "./client.js";
 import { resolveMatrixActionLimit } from "./limits.js";
 import type { MatrixActionClientOpts, MatrixRawEvent, MatrixReactionSummary } from "./types.js";
 
 type ActionClient = NonNullable<MatrixActionClientOpts["client"]>;
+type MatrixEmoji = { name: string; identifier: string; url: string };
+
+export async function listMatrixEmojis(
+  roomId: string,
+  opts: MatrixActionClientOpts & { limit?: number } = {},
+): Promise<MatrixEmoji[]> {
+  return await withResolvedRoomAction(roomId, opts, async (client, resolvedRoom) => {
+    const [roomState, personalPack] = await Promise.all([
+      client.doRequest("GET", `/_matrix/client/v3/rooms/${encodeURIComponent(resolvedRoom)}/state`),
+      client.getAccountData("im.ponies.user_emotes"),
+    ]);
+    if (!Array.isArray(roomState)) {
+      throw new Error("Matrix room state response is invalid.");
+    }
+
+    const packs = roomState
+      .filter(
+        (event): event is Record<string, unknown> =>
+          isRecord(event) &&
+          event.type === "im.ponies.room_emotes" &&
+          typeof event.state_key === "string",
+      )
+      .map((event) => event.content);
+    if (personalPack) {
+      packs.push(personalPack);
+    }
+
+    const emojis: MatrixEmoji[] = [];
+    for (const pack of packs) {
+      if (!isRecord(pack) || !isRecord(pack.images)) {
+        continue;
+      }
+      const packUsage = isRecord(pack.pack) ? pack.pack.usage : undefined;
+      for (const [rawName, image] of Object.entries(pack.images)) {
+        const name = rawName.trim();
+        if (!name || !isRecord(image) || typeof image.url !== "string") {
+          continue;
+        }
+        const url = image.url.trim();
+        const usage = image.usage === undefined ? packUsage : image.usage;
+        if (
+          !parseMxc(url) ||
+          (usage !== undefined &&
+            (!Array.isArray(usage) ||
+              usage.some((value) => typeof value !== "string") ||
+              !usage.includes("emoticon")))
+        ) {
+          continue;
+        }
+        // Matrix reactions send the annotation key literally; MSC2545 supplies no
+        // universal custom-reaction key, so preserve its shortcode and expose the MXC URI.
+        emojis.push({ name, identifier: name, url });
+      }
+    }
+
+    return emojis
+      .toSorted(
+        (left, right) => left.name.localeCompare(right.name) || left.url.localeCompare(right.url),
+      )
+      .slice(0, Math.min(resolveMatrixActionLimit(opts.limit, 100), 100));
+  });
+}
 
 async function listMatrixReactionEvents(
   client: ActionClient,

--- a/extensions/matrix/src/tool-actions.test.ts
+++ b/extensions/matrix/src/tool-actions.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   editMatrixMessage: vi.fn(),
   deleteMatrixMessage: vi.fn(),
   readMatrixMessages: vi.fn(),
+  listMatrixEmojis: vi.fn(),
   listMatrixReactions: vi.fn(),
   removeMatrixReactions: vi.fn(),
   sendMatrixMessage: vi.fn(),
@@ -32,6 +33,7 @@ vi.mock("./matrix/actions.js", () => {
     editMatrixMessage: mocks.editMatrixMessage,
     getMatrixMemberInfo: mocks.getMatrixMemberInfo,
     getMatrixRoomInfo: mocks.getMatrixRoomInfo,
+    listMatrixEmojis: mocks.listMatrixEmojis,
     listMatrixReactions: mocks.listMatrixReactions,
     pinMatrixMessage: mocks.pinMatrixMessage,
     unpinMatrixMessage: mocks.unpinMatrixMessage,
@@ -75,6 +77,9 @@ describe("handleMatrixAction pollVote", () => {
       maxSelections: 2,
     });
     mocks.listMatrixReactions.mockResolvedValue([{ key: "👍", count: 1, users: ["@u:example"] }]);
+    mocks.listMatrixEmojis.mockResolvedValue([
+      { name: "party", identifier: "party", url: "mxc://example.org/party" },
+    ]);
     mocks.listMatrixPins.mockResolvedValue({ pinned: ["$pin"], events: [] });
     mocks.pinMatrixMessage.mockResolvedValue({ pinned: ["$existing", "$pin"] });
     mocks.unpinMatrixMessage.mockResolvedValue({ pinned: ["$existing"] });
@@ -238,6 +243,51 @@ describe("handleMatrixAction pollVote", () => {
       accountId: "ops",
       client: mocks.matrixClient,
     });
+  });
+
+  it("lists custom emotes only after authorizing the selected Matrix room", async () => {
+    const cfg = { channels: { matrix: { actions: { reactions: true } } } } as CoreConfig;
+    const result = await handleMatrixAction(
+      { action: "emoji-list", accountId: "ops", roomId: "room:!room:example", limit: 5 },
+      cfg,
+      {
+        readContext: {
+          requesterAccountId: "ops",
+          currentChannelId: "room:!room:example",
+          currentChannelProvider: "matrix",
+        },
+      },
+    );
+
+    expect(mocks.listMatrixEmojis).toHaveBeenCalledWith("!room:example", {
+      cfg,
+      accountId: "ops",
+      client: mocks.matrixClient,
+      limit: 5,
+    });
+    expect(result.details).toEqual({
+      ok: true,
+      emojis: [{ name: "party", identifier: "party", url: "mxc://example.org/party" }],
+    });
+  });
+
+  it("rejects custom-emote discovery when reactions or room access are disabled", async () => {
+    const params = { action: "emoji-list", roomId: "!blocked:example" };
+
+    await expect(
+      handleMatrixAction(params, {
+        channels: { matrix: { actions: { reactions: false } } },
+      } as CoreConfig),
+    ).rejects.toThrow("Matrix reactions are disabled.");
+    expect(mocks.withAuthorizedMatrixReadTarget).not.toHaveBeenCalled();
+
+    mocks.withAuthorizedMatrixReadTarget.mockRejectedValueOnce(
+      new Error("Matrix read target is not allowed."),
+    );
+    await expect(handleMatrixAction(params, {} as CoreConfig)).rejects.toThrow(
+      "Matrix read target is not allowed.",
+    );
+    expect(mocks.listMatrixEmojis).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -17,6 +17,7 @@ import {
   getMatrixMemberInfo,
   getMatrixRoomInfo,
   getMatrixVerificationSas,
+  listMatrixEmojis,
   listMatrixPins,
   listMatrixReactions,
   listMatrixVerifications,
@@ -49,7 +50,7 @@ import {
 import type { CoreConfig } from "./types.js";
 
 const messageActions = new Set(["sendMessage", "editMessage", "deleteMessage", "readMessages"]);
-const reactionActions = new Set(["react", "reactions"]);
+const reactionActions = new Set(["react", "reactions", "emoji-list"]);
 const pinActions = new Set(["pinMessage", "unpinMessage", "listPins"]);
 const pollActions = new Set(["pollVote"]);
 const profileActions = new Set(["setProfile"]);
@@ -193,6 +194,19 @@ export async function handleMatrixAction(
       throw new Error("Matrix reactions are disabled.");
     }
     const roomId = readRoomId(params);
+    if (action === "emoji-list") {
+      const limit = readPositiveIntegerParam(params, "limit", {
+        message: "limit must be a positive integer.",
+      });
+      const emojis = await withReadTarget(roomId, async (target) =>
+        listMatrixEmojis(target.roomId, {
+          ...clientOpts,
+          client: target.client,
+          limit,
+        }),
+      );
+      return jsonResult({ ok: true, emojis });
+    }
     const messageId = readStringParam(params, "messageId", { required: true });
     if (action === "react") {
       const { emoji, remove, isEmpty } = readReactionParams(params, {


### PR DESCRIPTION
## What Problem This Solves

Follow-ups from #128435 (custom emoji discovery on Discord/Slack/Telegram): Matrix had no custom-emote discovery at all, Discord's `emoji-list` re-fetched the guild emoji roster on every call, and the Google Chat skip existed only in a PR body rather than user-facing docs.

## Why This Change Was Made

- **Matrix `emoji-list` (MSC2545)**: lists custom emotes from room-state `im.ponies.room_emotes` packs (any state key, default pack included) plus the personal `im.ponies.user_emotes` account-data pack, via the channel's existing reaction gate, `withReadTarget` room authorization, and current-conversation defaulting. Sticker-only and malformed entries (non-`mxc://` URLs, bad `usage` arrays) are excluded; results are sorted and capped at 100. `identifier` is the literal shortcode because our Matrix react path places the value unchanged into `m.relates_to.key` and MSC2545 defines no universal custom-reaction encoding; the `mxc://` URL is exposed alongside so the model has both (contract comment at the site). The Matrix react `emoji` schema description is now gate-aware, referencing `emoji-list` only when advertised — same pattern as Discord/Slack.
- **Discord guild-emoji cache**: `emoji-list` results now ride the existing lifecycle-owned bounded `DiscordEntityCache` (30s TTL, 5000-entry cap, periodic sweep), keyed per guild and invalidated on `GuildEmojisUpdate`; gateway-free CLI invocations stay uncached. Tracing real event delivery surfaced a dependency-contract gap: Discord only sends `GUILD_EMOJIS_UPDATE` when the **non-privileged** `GuildExpressions` intent (bit 8 in vendored `discord-api-types`) is subscribed, so it is added to the default gateway intents — no operator action or Developer-Portal toggle required.
- **Google Chat**: verified against Google's REST reference that `customEmojis.list` requires **user** authentication (`chat.customemojis` / `chat.customemojis.readonly`), which the plugin — a `chat.bot` service-account channel that explicitly rejects user-OAuth features — cannot satisfy. Documented in `docs/channels/googlechat.md`; no code.

No new SDK subpaths, config keys, or storage; the cache is the pre-existing lifecycle-owned structure with one new entry kind.

## User Impact

Matrix agents can discover room and personal custom emotes with `action:"emoji-list"` and use the shortcodes in reactions. Discord emoji listing stops hammering the REST API on repeat calls and stays fresh via gateway invalidation. Google Chat operators now find the custom-emoji limitation documented instead of hitting a silent gap.

## Evidence

- `node scripts/check-changed.mjs` — full changed-file gate green (format, tsgo lanes, lint, guards, import cycles, plugin-boundary report).
- `node scripts/run-vitest.mjs` over the Matrix suite, Discord cache/runtime/gateway tests, and the plugin-shape contract suite — **539 tests passed**, including new coverage for pack extraction (default + named packs, sticker-only exclusion, malformed-content rejection), gating, current-room defaulting, cache hit/expiry, `GuildEmojisUpdate` invalidation dropping the entry, and the intent addition.
- `pnpm build` equivalent full build green (9m37s, all external plugin builds + SDK export checks).
- Structured Codex autoreview (gpt-5.6-sol, high) on the full diff: clean, no actionable findings.
- Dependency contracts inspected directly: `GuildExpressions = 8` / `GuildEmojisUpdate` grounded in vendored `discord-api-types/gateway/v10.d.ts`; `customEmojis.list` auth requirement verified against Google's live REST reference; MSC2545 event shapes cited in code.
- Live Matrix/Discord channel runs not performed from this environment; the changed paths are covered by the boundary tests above, and the Discord cache does not alter the action's observable contract.

Production +142 / tests +287 / docs +5. The production growth is the new Matrix capability; the Discord cache is +25 on the existing lifecycle-owned structure.
