### PR TITLE
fix(cron): stop reporting suppressed scheduled messages as delivered

### DIFF
--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -112,6 +112,44 @@ describe("sendCronAnnouncePayloadStrict", () => {
     expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { reason: "no_visible_result", recipientReached: false },
+    { reason: "no_visible_payload", recipientReached: false },
+    { reason: "cancelled_by_message_sending_hook", recipientReached: false },
+    { reason: "cancelled_by_reply_payload_sending_hook", recipientReached: false },
+    { reason: "empty_after_message_sending_hook", recipientReached: false },
+    { reason: "empty_after_reply_payload_sending_hook", recipientReached: false },
+    { reason: "adapter_returned_no_identity", recipientReached: true },
+  ] as const)(
+    "preserves terminal $reason suppression and authoritative recipient reach",
+    async ({ reason, recipientReached }) => {
+      mocks.deliverOutboundPayloads.mockImplementationOnce(
+        async (params: { onPayloadDeliveryOutcome?: (outcome: unknown) => void }) => {
+          if (reason !== "no_visible_result") {
+            params.onPayloadDeliveryOutcome?.({ index: 0, status: "suppressed", reason });
+          }
+          return [];
+        },
+      );
+      const onDeliveryAttempt = vi.fn();
+
+      const result = await sendCronAnnouncePayloadStrict({
+        deps: {} as never,
+        cfg: {} as never,
+        agentId: "main",
+        jobId: "job-1",
+        target: { channel: "telegram", to: "123" },
+        payload: { text: "Scheduled result" },
+        abortSignal: new AbortController().signal,
+        onDeliveryAttempt,
+      });
+
+      expect(result).toMatchObject({ status: "suppressed", reason, results: [] });
+      expect(onDeliveryAttempt).toHaveBeenCalledExactlyOnceWith(recipientReached);
+      expect(mocks.deliverOutboundPayloads).toHaveBeenCalledOnce();
+    },
+  );
+
   it.each(["raw-partial", "wrapped-partial", "failed-after-send"] as const)(
     "preserves recipient-reached evidence across a %s failure",
     async (failureKind) => {

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -31,6 +31,10 @@ type CronAnnounceTarget = {
 };
 
 type SuccessfulDeliveryTarget = Extract<DeliveryTargetResolution, { ok: true }>;
+type CronAnnounceDeliveryOutcome = Extract<
+  Awaited<ReturnType<typeof sendDurableMessageBatchCore>>,
+  { status: "sent" | "suppressed" }
+>;
 
 async function resolveCronAnnounceDelivery(params: {
   cfg: OpenClawConfig;
@@ -96,7 +100,7 @@ async function deliverCronAnnouncePayload(params: {
   payload: ReplyPayload;
   abortSignal: AbortSignal;
   onDeliveryAttempt?: (reachedRecipient: boolean) => void;
-}): Promise<void> {
+}): Promise<CronAnnounceDeliveryOutcome> {
   // Cron delivery is durable and non-best-effort for primary announces; partial
   // channel failure must surface as a cron run failure.
   const send = await sendDurableMessageBatchCore({
@@ -116,6 +120,7 @@ async function deliverCronAnnouncePayload(params: {
   if (send.status === "failed" || send.status === "partial_failed") {
     throw send.error;
   }
+  return send;
 }
 
 /** Sends a cron announce payload and throws if target resolution or delivery fails. */
@@ -128,7 +133,7 @@ export async function sendCronAnnouncePayloadStrict(params: {
   payload: ReplyPayload;
   abortSignal: AbortSignal;
   onDeliveryAttempt?: (reachedRecipient: boolean) => void;
-}): Promise<void> {
+}): Promise<CronAnnounceDeliveryOutcome> {
   const delivery = await resolveCronAnnounceDelivery(params);
   if (!delivery.ok) {
     throw delivery.error;
@@ -136,7 +141,7 @@ export async function sendCronAnnouncePayloadStrict(params: {
   // Resolution can settle after its caller's deadline; never start plugin
   // delivery once the Gateway has released ownership of the timed-out work.
   params.abortSignal.throwIfAborted();
-  await deliverCronAnnouncePayload({
+  return await deliverCronAnnouncePayload({
     deps: params.deps,
     cfg: params.cfg,
     delivery,

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -54,7 +54,18 @@ const {
   >(async () => ({ status: "ran", durationMs: 1 })),
   loadConfigMock: vi.fn(),
   fetchWithSsrFGuardMock: vi.fn(),
-  sendCronAnnouncePayloadStrictMock: vi.fn(async () => {}),
+  sendCronAnnouncePayloadStrictMock: vi.fn<
+    typeof import("../cron/delivery.js").sendCronAnnouncePayloadStrict
+  >(async () => ({
+    status: "sent",
+    results: [{ channel: "telegram", messageId: "cron-message" }],
+    receipt: {
+      primaryPlatformMessageId: "cron-message",
+      platformMessageIds: ["cron-message"],
+      parts: [{ platformMessageId: "cron-message", kind: "text", index: 0 }],
+      sentAt: 0,
+    },
+  })),
   runCronIsolatedAgentTurnMock: vi.fn<RunCronIsolatedAgentTurnMock>(async () => ({
     status: "ok",
     summary: "ok",
@@ -1753,6 +1764,102 @@ describe("buildGatewayCronService", () => {
       } finally {
         state.cron.stop();
         vi.unstubAllEnvs();
+      }
+    },
+  );
+
+  it.each(
+    (
+      [
+        { reason: "no_visible_result", recipientReached: false },
+        { reason: "no_visible_payload", recipientReached: false },
+        { reason: "cancelled_by_message_sending_hook", recipientReached: false },
+        { reason: "adapter_returned_no_identity", recipientReached: true },
+      ] as const
+    ).flatMap((suppression) =>
+      (["command", "script"] as const).flatMap((payloadKind) =>
+        (["default", "optional", "required"] as const).map((policy) => ({
+          reason: suppression.reason,
+          recipientReached: suppression.recipientReached,
+          payloadKind,
+          policy,
+        })),
+      ),
+    ),
+  )(
+    "records $payloadKind $reason suppression without retry under $policy delivery",
+    async ({ reason, recipientReached, payloadKind, policy }) => {
+      const cfg = createCronConfig(`cron-${payloadKind}-${reason}-${policy}`);
+      cfg.cron = { ...cfg.cron, triggers: { enabled: true } };
+      loadConfigMock.mockReturnValue(cfg);
+      cronScriptExecutorMock.mockResolvedValueOnce({
+        kind: "completed",
+        notify: "scheduled result",
+        stateChanged: false,
+      });
+      sendCronAnnouncePayloadStrictMock.mockImplementationOnce(async (...args: unknown[]) => {
+        const attempt = requireRecord(args[0], "suppressed cron announcement");
+        if (typeof attempt.onDeliveryAttempt === "function") {
+          attempt.onDeliveryAttempt(recipientReached);
+        }
+        return {
+          status: "suppressed",
+          reason,
+          results: [],
+          receipt: { platformMessageIds: [], parts: [], sentAt: 0 },
+        };
+      });
+
+      const state = buildGatewayCronService({ cfg, deps: {} as CliDeps, broadcast: () => {} });
+      try {
+        const job = await state.cron.add({
+          name: `${payloadKind} ${reason} ${policy}`,
+          enabled: true,
+          deleteAfterRun: true,
+          schedule: { kind: "at", at: new Date(1).toISOString() },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload:
+            payloadKind === "command"
+              ? {
+                  kind: "command" as const,
+                  argv: [process.execPath, "-e", "process.stdout.write('scheduled result')"],
+                }
+              : { kind: "script" as const, script: "return { notify: 'scheduled result' }" },
+          delivery: {
+            mode: "announce",
+            channel: "telegram",
+            to: "123",
+            ...(policy === "default" ? {} : { bestEffort: policy === "optional" }),
+          },
+        });
+
+        await state.cron.run(job.id, "force");
+
+        expect(sendCronAnnouncePayloadStrictMock).toHaveBeenCalledOnce();
+        const expectedDeliveryStatus = recipientReached ? "unknown" : "not-delivered";
+        const required = policy === "required";
+        const updated = state.cron.getJob(job.id);
+        expect(Boolean(updated)).toBe(required);
+        if (updated) {
+          expect(updated.state.lastDeliveryStatus).toBe(expectedDeliveryStatus);
+          expect(updated.state.lastDeliveryError).toBeUndefined();
+        }
+        const finished = runCronChangedMock.mock.calls
+          .map(([event]) => requireRecord(event, "cron_changed event"))
+          .find((event) => event.action === "finished" && event.jobId === job.id);
+        expect(finished).toMatchObject({
+          status: "ok",
+          completionStatus: required ? (recipientReached ? "unknown" : "failed") : "succeeded",
+          deliveryStatus: expectedDeliveryStatus,
+        });
+        if (recipientReached) {
+          expect(finished).not.toHaveProperty("delivered");
+        } else {
+          expect(finished).toHaveProperty("delivered", false);
+        }
+      } finally {
+        state.cron.stop();
       }
     },
   );

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -260,7 +260,7 @@ async function finalizeCronCompletionAnnouncement(params: {
   const abortSignal = params.abortSignal ?? new AbortController().signal;
   let deliveryMayHaveReachedRecipient = false;
   try {
-    await retryTransientDirectCronDelivery({
+    const result = await retryTransientDirectCronDelivery({
       jobId: params.job.id,
       label: params.label,
       signal: abortSignal,
@@ -285,10 +285,12 @@ async function finalizeCronCompletionAnnouncement(params: {
           },
         }),
     });
+    const delivered =
+      result.status === "sent" ? true : deliveryMayHaveReachedRecipient ? undefined : false;
     return {
       deliveryAttempted: true,
-      delivered: true,
-      delivery: { ...delivery, delivered: true },
+      delivered,
+      delivery: { ...delivery, delivered },
     };
   } catch (err) {
     const deliveryError = formatErrorMessage(err);

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -35,7 +35,16 @@ const fetchWithSsrFGuardMock = vi.hoisted(() =>
 );
 
 const sendCronAnnouncePayloadStrictMock = vi.hoisted(() =>
-  vi.fn<typeof import("../cron/delivery.js").sendCronAnnouncePayloadStrict>(async () => undefined),
+  vi.fn<typeof import("../cron/delivery.js").sendCronAnnouncePayloadStrict>(async () => ({
+    status: "sent",
+    results: [{ channel: "telegram", messageId: "cron-message" }],
+    receipt: {
+      primaryPlatformMessageId: "cron-message",
+      platformMessageIds: ["cron-message"],
+      parts: [{ platformMessageId: "cron-message", kind: "text", index: 0 }],
+      sentAt: 0,
+    },
+  })),
 );
 const closeTrackedBrowserTabsForSessionsMock = vi.hoisted(() => vi.fn(async () => 0));
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scheduled command and script announcements were reported as delivered even when a channel hook intentionally suppressed the message, no visible message was produced, or a channel adapter returned no platform receipt. Explicitly required one-shot jobs could therefore be deleted despite never having confirmed delivery.

## Why This Change Was Made

Carry the channel owner's existing closed durable-delivery outcome across the strict cron-announcement boundary instead of discarding it. Scheduled completion now records actual sent messages as delivered, intentional hook/content suppression as not delivered, and missing platform identity as unknown because the recipient may already have received the message. Suppression remains terminal without throwing or retrying, the existing recipient-reach retry fence remains authoritative, and failure-notification delivery remains unchanged.

The production change is +7 net lines: preserving the actual existing sent/suppressed owner result across the Gateway boundary cannot be expressed through the old void contract without recreating or guessing recipient custody downstream. No public outcome, configuration, persistence/schema, API, authentication, or security surface changes.

## User Impact

Operators see truthful delivery status for scheduled command and script runs. Explicitly required one-shot jobs are retained when delivery was suppressed or could not be confirmed, while default and best-effort one-shot jobs preserve their existing successful-completion/deletion behavior. Intentional hooks are honored without retries, and potentially delivered messages are never sent again.

## Evidence

Authentic pre-fix RED to post-fix GREEN:

- The real strict cron owner and durable sender reproduce all seven terminal suppression reasons: no visible result, no visible payload, both message/reply hook cancellations, both empty-after-hook outcomes, and an adapter returning no platform identity.
- The real Gateway scheduled execution reproduces 24 command/script combinations across no visible output, hook cancellation, missing payload, missing adapter identity, and default/optional/required delivery policies. Before the fix all 24 incorrectly projected delivered; afterwards all 24 record not-delivered or unknown correctly and preserve the existing one-shot lifecycle.
- Independent first-class reviewer separately executed the actual owner suite (14/14) and Gateway policy matrix (24/24) and confirmed no actionable findings. Fresh authenticated review of the exact committed branch also reported no actionable findings.

Focused terminal proof:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts --configLoader runner \
  src/gateway/server-cron.test.ts src/gateway/server.cron.test.ts \
  src/gateway/server-cron-notifications.test.ts \
  src/gateway/server-cron-primary-webhook.test.ts \
  src/gateway/server-cron-notifications.presentation.test.ts
Test Files  5 passed
Tests       164 passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts --configLoader runner \
  src/cron/delivery.failure-notify.test.ts src/cron/delivery.test.ts \
  src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts \
  src/cron/service.persists-delivered-status.test.ts
Test Files  4 passed
Tests       239 passed

Core TypeScript, Gateway integration-test TypeScript, cron/services-test TypeScript: passed
Changed-file formatting, lint, max-lines ratchet, assertion-safety ratchet: passed
Total focused real-owner, Gateway integration, failure-alert, retry-fence, and sibling proof: 403 tests passed
```

A live external channel was not exercised: deterministically injecting all seven hook/no-content/missing-receipt outcomes into the actual durable owner and real scheduled Gateway execution gives direct boundary proof, while sending those cases to a real channel could create unwanted or duplicate messages. Exact-head required CI will provide the additional hosted validation.
