### PR TITLE
fix(sessions): skip inherited auto fallback overrides

### DIFF
--- a/src/config/sessions/model-override-provenance.test.ts
+++ b/src/config/sessions/model-override-provenance.test.ts
@@ -4,6 +4,15 @@ import { hasSessionActiveAutoModelFallback } from "./model-override-provenance.j
 describe("hasSessionActiveAutoModelFallback", () => {
   it.each([
     {
+      name: "legacy source auto without provenance",
+      entry: {
+        providerOverride: "fallback",
+        modelOverride: "secondary",
+        modelOverrideSource: "auto" as const,
+      },
+      expected: true,
+    },
+    {
       name: "different automatic selection",
       entry: {
         providerOverride: "fallback",

--- a/src/config/sessions/model-override-provenance.test.ts
+++ b/src/config/sessions/model-override-provenance.test.ts
@@ -4,13 +4,13 @@ import { hasSessionActiveAutoModelFallback } from "./model-override-provenance.j
 describe("hasSessionActiveAutoModelFallback", () => {
   it.each([
     {
-      name: "legacy source auto without provenance",
+      name: "configured automatic selection without fallback provenance",
       entry: {
         providerOverride: "fallback",
         modelOverride: "secondary",
         modelOverrideSource: "auto" as const,
       },
-      expected: true,
+      expected: false,
     },
     {
       name: "different automatic selection",

--- a/src/config/sessions/model-override-provenance.ts
+++ b/src/config/sessions/model-override-provenance.ts
@@ -60,20 +60,14 @@ export function hasSessionActiveAutoModelFallback(
   if (!entry) {
     return false;
   }
-  const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
-  const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
-  if (entry.modelOverrideSource === "auto" && (!originProvider || !originModel)) {
-    return Boolean(
-      normalizeOptionalString(entry.providerOverride) ||
-      normalizeOptionalString(entry.modelOverride),
-    );
-  }
   if (
     !hasSessionAutoModelFallbackProvenance(entry) ||
     (entry.modelOverrideSource !== undefined && entry.modelOverrideSource !== "auto")
   ) {
     return false;
   }
+  const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
+  const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
   const overrideProvider = normalizeOptionalString(entry.providerOverride) ?? originProvider;
   const overrideModel = normalizeOptionalString(entry.modelOverride) ?? originModel;
   // Configured subagent selections deliberately carry self-origin metadata so cleanup preserves

--- a/src/config/sessions/model-override-provenance.ts
+++ b/src/config/sessions/model-override-provenance.ts
@@ -60,14 +60,20 @@ export function hasSessionActiveAutoModelFallback(
   if (!entry) {
     return false;
   }
+  const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
+  const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
+  if (entry.modelOverrideSource === "auto" && (!originProvider || !originModel)) {
+    return Boolean(
+      normalizeOptionalString(entry.providerOverride) ||
+      normalizeOptionalString(entry.modelOverride),
+    );
+  }
   if (
     !hasSessionAutoModelFallbackProvenance(entry) ||
     (entry.modelOverrideSource !== undefined && entry.modelOverrideSource !== "auto")
   ) {
     return false;
   }
-  const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
-  const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
   const overrideProvider = normalizeOptionalString(entry.providerOverride) ?? originProvider;
   const overrideModel = normalizeOptionalString(entry.modelOverride) ?? originModel;
   // Configured subagent selections deliberately carry self-origin metadata so cleanup preserves

--- a/src/config/sessions/session-entry-selection.test.ts
+++ b/src/config/sessions/session-entry-selection.test.ts
@@ -29,9 +29,21 @@ describe("inheritSessionSelection", () => {
     });
     expect(automatic.authProfileOverrideCompactionCount).toBeUndefined();
   });
-});
+  it("does not persist legacy source:auto model overrides into child entries", () => {
+    expect(
+      inheritSessionSelection({
+        sessionId: "legacy-auto-model",
+        updatedAt: 1,
+        providerOverride: "google-vertex",
+        modelOverride: "gemini-fallback",
+        modelOverrideSource: "auto",
+      }),
+    ).not.toMatchObject({
+      providerOverride: expect.any(String),
+      modelOverride: expect.any(String),
+    });
+  });
 
-describe("SessionLabelOwnerIndex", () => {
   it("indexes the store once and answers repeated conflicts without rescanning entries", () => {
     const labelReads = vi.fn();
     const entry = (sessionId: string, label: string): SessionEntry => {

--- a/src/config/sessions/session-entry-selection.test.ts
+++ b/src/config/sessions/session-entry-selection.test.ts
@@ -29,21 +29,40 @@ describe("inheritSessionSelection", () => {
     });
     expect(automatic.authProfileOverrideCompactionCount).toBeUndefined();
   });
-  it("does not persist legacy source:auto model overrides into child entries", () => {
-    expect(
-      inheritSessionSelection({
+  it.each([
+    { source: "auto" as const, profile: "google-vertex:fallback", inheritedProfile: undefined },
+    { source: "user" as const, profile: "openai:work", inheritedProfile: "openai:work" },
+  ])(
+    "drops fallback model state while preserving only $source auth intent",
+    ({ source, profile, inheritedProfile }) => {
+      const inherited = inheritSessionSelection({
         sessionId: "legacy-auto-model",
         updatedAt: 1,
         providerOverride: "google-vertex",
         modelOverride: "gemini-fallback",
         modelOverrideSource: "auto",
-      }),
-    ).not.toMatchObject({
-      providerOverride: expect.any(String),
-      modelOverride: expect.any(String),
-    });
-  });
+        modelOverrideFallbackOriginProvider: "openai",
+        modelOverrideFallbackOriginModel: "gpt-primary",
+        agentRuntimeOverride: "vertex-runtime",
+        contextWindow: "1m",
+        authProfileOverride: profile,
+        authProfileOverrideSource: source,
+        thinkingLevel: "high",
+      });
 
+      expect(inherited.providerOverride).toBeUndefined();
+      expect(inherited.modelOverride).toBeUndefined();
+      expect(inherited.modelOverrideSource).toBeUndefined();
+      expect(inherited.agentRuntimeOverride).toBeUndefined();
+      expect(inherited.contextWindow).toBe("1m");
+      expect(inherited.authProfileOverride).toBe(inheritedProfile);
+      expect(inherited.authProfileOverrideSource).toBe(inheritedProfile ? "user" : undefined);
+      expect(inherited.thinkingLevel).toBe("high");
+    },
+  );
+});
+
+describe("SessionLabelOwnerIndex", () => {
   it("indexes the store once and answers repeated conflicts without rescanning entries", () => {
     const labelReads = vi.fn();
     const entry = (sessionId: string, label: string): SessionEntry => {

--- a/src/config/sessions/session-entry-selection.ts
+++ b/src/config/sessions/session-entry-selection.ts
@@ -1,4 +1,5 @@
 import { resolveSessionAuthProfileOverrideSource } from "./auth-profile-override-provenance.js";
+import { hasSessionActiveAutoModelFallback } from "./model-override-provenance.js";
 import type { SessionPatchProjectionSnapshot } from "./session-accessor.types.js";
 import type { InternalSessionEntry, SessionEntry } from "./types.js";
 
@@ -62,16 +63,21 @@ export function inheritSessionSelection(
     return {};
   }
   const authProfileOverrideSource = resolveSessionAuthProfileOverrideSource(parentEntry);
+  const inheritModelSelection = !hasSessionActiveAutoModelFallback(parentEntry);
   return {
-    ...(parentEntry.providerOverride ? { providerOverride: parentEntry.providerOverride } : {}),
-    ...(parentEntry.modelOverride ? { modelOverride: parentEntry.modelOverride } : {}),
-    ...(parentEntry.modelOverrideSource
+    ...(inheritModelSelection && parentEntry.providerOverride
+      ? { providerOverride: parentEntry.providerOverride }
+      : {}),
+    ...(inheritModelSelection && parentEntry.modelOverride
+      ? { modelOverride: parentEntry.modelOverride }
+      : {}),
+    ...(inheritModelSelection && parentEntry.modelOverrideSource
       ? { modelOverrideSource: parentEntry.modelOverrideSource }
       : {}),
-    ...(parentEntry.modelOverrideRouteResolution
+    ...(inheritModelSelection && parentEntry.modelOverrideRouteResolution
       ? { modelOverrideRouteResolution: parentEntry.modelOverrideRouteResolution }
       : {}),
-    ...(parentEntry.agentRuntimeOverride
+    ...(inheritModelSelection && parentEntry.agentRuntimeOverride
       ? { agentRuntimeOverride: parentEntry.agentRuntimeOverride }
       : {}),
     ...(parentEntry.contextWindow ? { contextWindow: parentEntry.contextWindow } : {}),

--- a/src/config/sessions/session-entry-selection.ts
+++ b/src/config/sessions/session-entry-selection.ts
@@ -64,6 +64,7 @@ export function inheritSessionSelection(
   }
   const authProfileOverrideSource = resolveSessionAuthProfileOverrideSource(parentEntry);
   const inheritModelSelection = !hasSessionActiveAutoModelFallback(parentEntry);
+  const inheritAuthProfile = inheritModelSelection || authProfileOverrideSource === "user";
   return {
     ...(inheritModelSelection && parentEntry.providerOverride
       ? { providerOverride: parentEntry.providerOverride }
@@ -88,10 +89,10 @@ export function inheritSessionSelection(
     ...(parentEntry.traceLevel ? { traceLevel: parentEntry.traceLevel } : {}),
     ...(parentEntry.reasoningLevel ? { reasoningLevel: parentEntry.reasoningLevel } : {}),
     ...(parentEntry.elevatedLevel ? { elevatedLevel: parentEntry.elevatedLevel } : {}),
-    ...(authProfileOverrideSource && parentEntry.authProfileOverride
+    ...(inheritAuthProfile && authProfileOverrideSource && parentEntry.authProfileOverride
       ? { authProfileOverride: parentEntry.authProfileOverride }
       : {}),
-    ...(authProfileOverrideSource ? { authProfileOverrideSource } : {}),
+    ...(inheritAuthProfile && authProfileOverrideSource ? { authProfileOverrideSource } : {}),
   };
 }
 

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -3827,6 +3827,11 @@ test("sessions.create skips inherited active auto fallback model overrides", asy
         modelOverrideSource: "auto",
         modelOverrideFallbackOriginProvider: "openai",
         modelOverrideFallbackOriginModel: "gpt-primary",
+        agentRuntimeOverride: "vertex-runtime",
+        contextWindow: "1m",
+        authProfileOverride: "google-vertex:fallback",
+        authProfileOverrideSource: "auto",
+        thinkingLevel: "high",
       }),
     },
   });
@@ -3839,6 +3844,11 @@ test("sessions.create skips inherited active auto fallback model overrides", asy
       providerOverride?: string;
       modelOverride?: string;
       modelOverrideSource?: string;
+      agentRuntimeOverride?: string;
+      contextWindow?: string;
+      authProfileOverride?: string;
+      authProfileOverrideSource?: string;
+      thinkingLevel?: string;
     };
   }>("sessions.create", {
     agentId: "main",
@@ -3850,6 +3860,11 @@ test("sessions.create skips inherited active auto fallback model overrides", asy
   expect(created.payload?.entry?.providerOverride).toBeUndefined();
   expect(created.payload?.entry?.modelOverride).toBeUndefined();
   expect(created.payload?.entry?.modelOverrideSource).toBeUndefined();
+  expect(created.payload?.entry?.agentRuntimeOverride).toBeUndefined();
+  expect(created.payload?.entry?.contextWindow).toBe("1m");
+  expect(created.payload?.entry?.authProfileOverride).toBeUndefined();
+  expect(created.payload?.entry?.authProfileOverrideSource).toBeUndefined();
+  expect(created.payload?.entry?.thinkingLevel).toBe("high");
   expect(created.payload?.resolved).toEqual({ modelProvider: "openai", model: "gpt-primary" });
 
   const key = created.payload?.key as string;
@@ -3857,6 +3872,11 @@ test("sessions.create skips inherited active auto fallback model overrides", asy
   expect(storedEntry?.parentSessionKey).toBe("agent:main:main");
   expect(storedEntry?.providerOverride).toBeUndefined();
   expect(storedEntry?.modelOverride).toBeUndefined();
+  expect(storedEntry?.agentRuntimeOverride).toBeUndefined();
+  expect(storedEntry?.contextWindow).toBe("1m");
+  expect(storedEntry?.authProfileOverride).toBeUndefined();
+  expect(storedEntry?.authProfileOverrideSource).toBeUndefined();
+  expect(storedEntry?.thinkingLevel).toBe("high");
 });
 
 test("sessions.create resolves the current default instead of inherited runtime identity", async () => {

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -3816,6 +3816,49 @@ test("sessions.create inherits explicit selection without runtime model identity
   expect(storedEntry?.parentSessionKey).toBe("agent:main:main");
 });
 
+test("sessions.create skips inherited active auto fallback model overrides", async () => {
+  const { storePath } = await createSessionStoreDir();
+  testState.agentConfig = { model: { primary: "openai/gpt-primary" } };
+  await writeSessionStore({
+    entries: {
+      main: sessionStoreEntry("sess-parent-auto-fallback", {
+        providerOverride: "google-vertex",
+        modelOverride: "gemini-fallback",
+        modelOverrideSource: "auto",
+        modelOverrideFallbackOriginProvider: "openai",
+        modelOverrideFallbackOriginModel: "gpt-primary",
+      }),
+    },
+  });
+
+  const created = await directSessionReq<{
+    key?: string;
+    resolved?: { modelProvider?: string; model?: string };
+    entry?: {
+      parentSessionKey?: string;
+      providerOverride?: string;
+      modelOverride?: string;
+      modelOverrideSource?: string;
+    };
+  }>("sessions.create", {
+    agentId: "main",
+    parentSessionKey: "main",
+  });
+
+  expect(created.ok).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:main");
+  expect(created.payload?.entry?.providerOverride).toBeUndefined();
+  expect(created.payload?.entry?.modelOverride).toBeUndefined();
+  expect(created.payload?.entry?.modelOverrideSource).toBeUndefined();
+  expect(created.payload?.resolved).toEqual({ modelProvider: "openai", model: "gpt-primary" });
+
+  const key = created.payload?.key as string;
+  const storedEntry = loadSessionEntry({ agentId: "main", sessionKey: key, storePath });
+  expect(storedEntry?.parentSessionKey).toBe("agent:main:main");
+  expect(storedEntry?.providerOverride).toBeUndefined();
+  expect(storedEntry?.modelOverride).toBeUndefined();
+});
+
 test("sessions.create resolves the current default instead of inherited runtime identity", async () => {
   const { storePath } = await createSessionStoreDir();
   testState.agentConfig = { model: { primary: "anthropic/current-model" } };

--- a/src/sessions/stored-model-overrides.test.ts
+++ b/src/sessions/stored-model-overrides.test.ts
@@ -45,4 +45,47 @@ describe("resolveStoredModelOverride", () => {
     });
     expect(loadSessionEntry).toHaveBeenCalledWith("agent:main:telegram:dm:parent");
   });
+
+  it("does not inherit active automatic fallback overrides from parent sessions", () => {
+    expect(
+      resolveStoredModelOverride({
+        defaultProvider: "openai",
+        sessionKey: "agent:main:discord:channel:root:thread:child",
+        sessionStore: {
+          "agent:main:discord:channel:root": {
+            sessionId: "parent-session",
+            updatedAt: 1,
+            providerOverride: "google-vertex",
+            modelOverride: "gemini-fallback",
+            modelOverrideSource: "auto",
+            modelOverrideFallbackOriginProvider: "openai",
+            modelOverrideFallbackOriginModel: "gpt-primary",
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("continues to inherit deliberate parent model pins", () => {
+    expect(
+      resolveStoredModelOverride({
+        defaultProvider: "openai",
+        sessionKey: "agent:main:discord:channel:root:thread:child",
+        sessionStore: {
+          "agent:main:discord:channel:root": {
+            sessionId: "parent-session",
+            updatedAt: 1,
+            providerOverride: "anthropic",
+            modelOverride: "claude-sonnet-4-6",
+            modelOverrideSource: "user",
+          },
+        },
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      source: "parent",
+      routeResolution: "raw",
+    });
+  });
 });

--- a/src/sessions/stored-model-overrides.test.ts
+++ b/src/sessions/stored-model-overrides.test.ts
@@ -66,6 +66,24 @@ describe("resolveStoredModelOverride", () => {
     ).toBeNull();
   });
 
+  it("does not inherit legacy source:auto overrides without provenance", () => {
+    expect(
+      resolveStoredModelOverride({
+        defaultProvider: "openai",
+        sessionKey: "agent:main:discord:channel:root:thread:child",
+        sessionStore: {
+          "agent:main:discord:channel:root": {
+            sessionId: "legacy-parent-session",
+            updatedAt: 1,
+            providerOverride: "google-vertex",
+            modelOverride: "gemini-fallback",
+            modelOverrideSource: "auto",
+          },
+        },
+      }),
+    ).toBeNull();
+  });
+
   it("continues to inherit deliberate parent model pins", () => {
     expect(
       resolveStoredModelOverride({

--- a/src/sessions/stored-model-overrides.test.ts
+++ b/src/sessions/stored-model-overrides.test.ts
@@ -66,7 +66,7 @@ describe("resolveStoredModelOverride", () => {
     ).toBeNull();
   });
 
-  it("does not inherit legacy source:auto overrides without provenance", () => {
+  it("inherits configured automatic selections without fallback provenance", () => {
     expect(
       resolveStoredModelOverride({
         defaultProvider: "openai",
@@ -81,7 +81,12 @@ describe("resolveStoredModelOverride", () => {
           },
         },
       }),
-    ).toBeNull();
+    ).toEqual({
+      provider: "google-vertex",
+      model: "gemini-fallback",
+      source: "parent",
+      routeResolution: "raw",
+    });
   });
 
   it("continues to inherit deliberate parent model pins", () => {

--- a/src/sessions/stored-model-overrides.ts
+++ b/src/sessions/stored-model-overrides.ts
@@ -6,7 +6,10 @@ import {
   resolvePersistedOverrideModelRef,
 } from "../agents/model-selection-persisted.js";
 import { resolveSessionParentSessionKey } from "../channels/plugins/session-conversation.js";
-import { resolveSessionModelOverrideRouteResolution } from "../config/sessions/model-override-provenance.js";
+import {
+  hasSessionActiveAutoModelFallback,
+  resolveSessionModelOverrideRouteResolution,
+} from "../config/sessions/model-override-provenance.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 
 /** Model override loaded from the current session or its parent session. */
@@ -90,8 +93,12 @@ export function resolveStoredModelOverride(params: {
   if (!parentKey) {
     return null;
   }
+  const parentEntry = params.loadSessionEntry?.(parentKey) ?? params.sessionStore?.[parentKey];
+  if (hasSessionActiveAutoModelFallback(parentEntry)) {
+    return null;
+  }
   return resolveStoredOverrideFromEntry({
-    entry: params.loadSessionEntry?.(parentKey) ?? params.sessionStore?.[parentKey],
+    entry: parentEntry,
     defaultProvider: params.defaultProvider,
     source: "parent",
   });


### PR DESCRIPTION
Closes #126332

## What Problem This Solves

A fresh child session could inherit its parent's temporary automatic provider-fallback model and remain on the emergency provider after the configured primary recovered. The original candidate also detached the fallback model without clearing its automatically selected credentials, which could pair a recovered OpenAI model with Google Vertex authentication.

## Why This Change Was Made

Both actual inheritance owners now consult the existing, provenance-backed `hasSessionActiveAutoModelFallback` contract: `resolveStoredModelOverride(...)` skips a parent's proven fallback at read time, and `inheritSessionSelection(...)` excludes fallback model/provider/runtime state when creating, forking, or recovering a child.

When a proven fallback selection is omitted, automatically selected fallback credentials are omitted with it. Explicit user-selected credentials still inherit and existing runtime compatibility validation remains authoritative. User-selected context-window and thinking preferences also survive; the context-window value has no model-origin provenance and can represent the operator's intentional selection for the recovered primary.

`modelOverrideSource: "auto"` alone is deliberately **not** treated as fallback evidence. The voice-call plugin persists its documented, configured `responseModel` as an automatic selection without fallback-origin metadata. The shared predicate therefore remains unchanged, and legitimate configured automatic selections continue to inherit normally.

## User Impact

New child/thread sessions return to the configured primary after an automatic provider fallback, without inheriting stale fallback-provider credentials. Deliberate parent model pins, configured voice-call response models, user-selected authentication profiles, context-window choices, and thinking preferences remain intact.

## Evidence

Regression-first proof on the contributor head:

- The canonical session-selection owner failed with `expected 'google-vertex:fallback' to be undefined` when a provenance-backed fallback's automatic credentials leaked into the child.
- The actual `sessions.create` Gateway boundary failed with the same leaked `google-vertex:fallback` credential on the returned child entry.

After the owner repair:

```text
parent session:
  providerOverride: google-vertex
  modelOverride: gemini-fallback
  modelOverrideSource: auto
  modelOverrideFallbackOriginProvider: openai
  modelOverrideFallbackOriginModel: gpt-primary
  authProfileOverride: google-vertex:fallback
  authProfileOverrideSource: auto
  contextWindow: 1m
  thinkingLevel: high

sessions.create(parentSessionKey=main):
  resolved: { modelProvider: openai, model: gpt-primary }
  providerOverride: undefined
  modelOverride: undefined
  agentRuntimeOverride: undefined
  authProfileOverride: undefined
  authProfileOverrideSource: undefined
  contextWindow: 1m
  thinkingLevel: high

persisted child session: the same model/auth cleanup and preference preservation
```

Focused owner, original CI sibling, and documented voice-call producer: **115 tests passed**.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/config/sessions/model-override-provenance.test.ts \
  src/config/sessions/session-entry-selection.test.ts \
  src/sessions/stored-model-overrides.test.ts \
  src/auto-reply/reply/model-selection.test.ts \
  extensions/voice-call/src/response-generator.test.ts
```

Entire actual Gateway session-creation owner suite: **115 tests passed**, including recovered fallback, explicit user selection, durable child-session state, and sibling session-creation contracts. Combined with the focused owner/reply/voice-call checks above, **230 targeted tests passed**.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/gateway/server.sessions.create.test.ts
```

Full scoped changed gate passed, including core and core-test typechecks, formatting, lint, import-cycle, persistence, and architecture guards:

```bash
node scripts/check-changed.mjs -- \
  src/config/sessions/model-override-provenance.ts \
  src/config/sessions/model-override-provenance.test.ts \
  src/config/sessions/session-entry-selection.ts \
  src/config/sessions/session-entry-selection.test.ts \
  src/sessions/stored-model-overrides.ts \
  src/sessions/stored-model-overrides.test.ts \
  src/gateway/server.sessions.create.test.ts
```

Two independent source reviews and a fresh Codex autoreview reported no accepted/actionable findings. The final production delta is +23/-9 (net +14) across the two required inheritance owners; the additional lines enforce authoritative fallback provenance and model/authentication coupling.

AI-assisted implementation; maintainer review covered the model-selection, fallback-provenance, voice-call, authentication, and Gateway session-creation contracts.
