### PR TITLE
docs(install): use managed gateway restart in Ansible guide

### DIFF
--- a/docs/install/ansible.md
+++ b/docs/install/ansible.md
@@ -88,13 +88,15 @@ sudo systemctl status openclaw
 # View live logs
 sudo journalctl -u openclaw -f
 
-# Restart gateway
-sudo systemctl restart openclaw
+# Restart gateway (run as openclaw user)
+openclaw gateway restart
 
 # Channel login (run as openclaw user)
 sudo -i -u openclaw
 openclaw channels login --channel <name>
 ```
+
+`openclaw gateway restart` records managed restart intent. For a system-scope service, follow the exact `sudo systemctl restart <unit>` command it prints.
 
 ## Security architecture
 


### PR DESCRIPTION
Related: #87577

## What Problem This Solves

Resolves a documentation mismatch where the Ansible guide told operators to bypass OpenClaw's managed gateway restart flow with a raw `systemctl` command.

## Why This Change Was Made

The quick-command guide now runs `openclaw gateway restart` as the `openclaw` user, explains that the command records managed restart intent, and tells system-scope operators to follow the exact unit-specific `sudo systemctl restart` command printed by OpenClaw.

The managed systemd behavior and live root/non-root systemd proof landed in https://github.com/openclaw/openclaw/pull/87618.

## User Impact

Ansible deployments now use the canonical managed restart path. System-scope installations still receive explicit, privilege-aware restart guidance for their actual unit name.

## Evidence

- `pnpm format:docs:check`
- `pnpm docs:check-mdx`
- `git diff --check`
- Focused word diff: one file, 4 additions, 2 deletions
- Autoreview: clean, no accepted/actionable findings
- Runtime contract and live systemd proof: https://github.com/openclaw/openclaw/pull/87618

AI-assisted: yes. The final diff and command contract were independently reviewed.

Punchcard-Session: clear-meadow-workshop-qv
