### PR TITLE
fix(cli): print inference results alongside input paths

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1585,6 +1585,22 @@ describe("capability cli", () => {
     expect(outputs[0]?.kind).toBe("image.description");
   });
 
+  it.each([
+    { domain: "audio", action: "transcribe", file: "memo.m4a", result: "meeting notes" },
+    { domain: "image", action: "describe", file: "photo.jpg", result: "friendly lobster" },
+    { domain: "image", action: "describe-many", file: "photo.jpg", result: "friendly lobster" },
+    { domain: "video", action: "describe", file: "clip.mp4", result: "friendly lobster" },
+  ])(
+    "prints both the input path and result for $domain $action by default",
+    async ({ domain, action, file, result }) => {
+      await runCapability(domain, action, "--file", file);
+
+      const output = mocks.runtime.log.mock.calls.at(-1)?.[0];
+      expect(output).toContain(path.resolve(file));
+      expect(output).toContain(result);
+    },
+  );
+
   it("keeps encoded image describe HTTP URLs intact", async () => {
     const mediaUrl = "https://cdn.example.com/clip%2Emp4?download=1#preview";
     await runCapability("image", "describe", "--file", mediaUrl, "--json");

--- a/src/cli/capability-cli/shared.ts
+++ b/src/cli/capability-cli/shared.ts
@@ -79,10 +79,8 @@ export function formatEnvelopeForText(value: unknown): string {
   for (const output of envelope.outputs) {
     const pathValue = typeof output.path === "string" ? output.path : undefined;
     const textValue = typeof output.text === "string" ? output.text : undefined;
-    if (pathValue) {
-      lines.push(pathValue);
-    } else if (textValue) {
-      lines.push(textValue);
+    if (pathValue || textValue) {
+      lines.push(...[pathValue, textValue].filter((entry): entry is string => Boolean(entry)));
     } else {
       lines.push(JSON.stringify(output));
     }


### PR DESCRIPTION
## What Problem This Solves

Makes ordinary inference commands actually print their requested results: audio transcripts, image descriptions, multiple-image descriptions, and video descriptions.

## Root Cause and Repair

The shared human-readable capability envelope formatter treated an input path and generated result text as mutually exclusive. Every media-understanding producer intentionally supplies both, so the default CLI printed the filename and silently discarded the transcript or description. Preserve both meaningful fields at their shared formatting owner while retaining path-only, text-only, JSON, and unknown-output behavior.

## Evidence

- Authentic pre-fix regressions independently failed for `audio transcribe`, `image describe`, `image describe-many`, and `video describe`: each output contained its source path but omitted the requested text.
- `node scripts/run-vitest.mjs src/cli/capability-cli.test.ts`: all 186 capability CLI tests pass, including all four real-parser regressions.
- Independent read-only local review inspected the complete shared formatter plus audio, image, video, model, embedding, speech, and web consumers; no actionable findings.
- Focused formatter and `git diff --check` passed.
- Production +2/-4, net minus two lines; regression tests +16.
- Ordinary display-only fix: no provider, credentials, configuration, protocol, or persistence changes.
