### PR TITLE
test(gateway): disable bundled plugins in kernel fixture

### DIFF
--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -382,6 +382,7 @@ describe("createGatewayKernel", () => {
         OPENCLAW_SKIP_GMAIL_WATCHER: "1",
         OPENCLAW_SKIP_PROVIDERS: "1",
         OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
         VITEST: "1",
       },
     });


### PR DESCRIPTION
Closes #122090

## What Problem This Solves

`src/gateway/server-kernel.test.ts` still performs bundled-plugin discovery in the focused kernel test that dispatches health and an agent turn without creating a transport. The test stages an active runtime plugin registry, but plugin metadata discovery is a separate filesystem-backed path: `plugin-metadata-snapshot.ts` loads a registry snapshot that resolves the bundled plugin directory from the environment. Without an explicit disable flag, a source checkout can still scan the bundled extension tree.

That slow path is the class reported in #122090, where this test repeatedly reached the 120s timeout boundary in CI. This PR isolates only that test by setting the existing test-only `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` flag.

## Why This Change Was Made

`resolveBundledPluginsDir()` already treats `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` as an explicit request to use an empty bundled-plugin directory. Using that existing test control is narrower than increasing the timeout or changing production startup behavior.

Scope is intentionally limited to one added line in one test file; there is no production/runtime behavior change.

## Evidence

Source-level current-main check:

- the target test sets `OPENCLAW_TEST_MINIMAL_GATEWAY=1` but does not set `OPENCLAW_DISABLE_BUNDLED_PLUGINS`;
- `plugin-metadata-snapshot.ts` rebuilds metadata through the plugin registry snapshot path;
- `plugin-registry-snapshot.ts` resolves bundled plugins through `resolveBundledPluginsDir(env)` independently of the staged active runtime registry;
- `bundled-dir.ts` maps `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` to an empty bundled-plugin directory.

Contributor-side real source-checkout proof was run in the fork on GitHub-hosted Ubuntu 24.04. The workflow performed a real checkout, activated the repository-pinned pnpm, installed all 174 workspace projects with the frozen lockfile, then ran:

```text
pnpm test src/gateway/server-kernel.test.ts
```

Result:

```text
Test Files 1 passed (1)
Tests 5 passed (5)
✓ dispatches health and an agent turn without creating a transport 262ms
[test] passed 1 Vitest shard in 49.17s
```

Proof run: https://github.com/teddyli18000/openclaw/actions/runs/33505337977
Saved transcript artifact: https://github.com/teddyli18000/openclaw/actions/runs/33505337977/artifacts/9799583379

Fresh exact-head upstream PR CI for `623a651a747a529d8aaa3b842e8b41f92eb26434` then tested the merge with current main in `checks-node-changed`, targeting only `src/gateway/server-kernel.test.ts`:

```text
Test Files 1 passed (1)
Tests 5 passed (5)
✓ dispatches health and an agent turn without creating a transport 256ms
[test] passed 1 Vitest shard in 48.36s
```

Upstream CI run: https://github.com/openclaw/openclaw/actions/runs/33510657265

The historical baseline in #122090 records the same target test timing out at 120000ms in CI, with a reported local baseline of 116.6s near the timeout margin.

No contributor code was executed locally; validation used a real source checkout in fork GitHub Actions plus fresh exact-head upstream PR CI.

AI-assisted: ChatGPT helped inspect the current source path, prepare the scoped test-fixture change, and collect validation evidence.