### PR TITLE
fix(telegram): show answered status on media-caption questions

### DIFF
--- a/extensions/telegram/src/caption.ts
+++ b/extensions/telegram/src/caption.ts
@@ -1,7 +1,9 @@
 // Telegram plugin module implements caption behavior.
 import { countTelegramHtmlVisibleCharacters, resolveTelegramHtmlVisibleText } from "./format.js";
 
-const TELEGRAM_MAX_CAPTION_LENGTH = 1024;
+export const TELEGRAM_MAX_CAPTION_LENGTH = 1024;
+// Accepted metadata identity survives result wrappers without expanding the public contract.
+export const telegramCaptionDeliveryMetadata = new WeakSet<object>();
 
 export function splitTelegramCaption(
   text?: string,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -20,6 +20,7 @@ import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { mergeTelegramAccountConfig, resolveDefaultTelegramAccountId } from "./accounts.js";
 import { resolveTelegramInlineButtons, type TelegramInlineButtons } from "./button-types.js";
+import { TELEGRAM_MAX_CAPTION_LENGTH, telegramCaptionDeliveryMetadata } from "./caption.js";
 import { splitTelegramHtmlChunks } from "./format.js";
 import {
   canonicalizeTelegramPresentationPayload,
@@ -525,13 +526,21 @@ export function createTelegramOutboundAdapter(
           : normalizeTelegramOutboundTarget(target.to);
       const messageId = result.messageId;
       const accountId = target.accountId ?? undefined;
+      const deliveredPart = result.receipt?.parts.find(
+        (part) => part.platformMessageId === messageId,
+      );
+      const isCaptionDelivery =
+        deliveredPart?.kind === "media" ||
+        (deliveredPart?.kind !== "text" &&
+          result.meta !== undefined &&
+          telegramCaptionDeliveryMetadata.has(result.meta));
       registerTelegramQuestionDelivery({
         accountId,
         chatId,
         messageId,
         payload,
         text,
-        textLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
+        textLimit: isCaptionDelivery ? TELEGRAM_MAX_CAPTION_LENGTH : TELEGRAM_TEXT_CHUNK_LIMIT,
         clearButtons: async () => {
           const { editMessageReplyMarkupTelegram } = await loadSendModule();
           await editMessageReplyMarkupTelegram(chatId, messageId, [], {
@@ -546,6 +555,7 @@ export function createTelegramOutboundAdapter(
             cfg,
             accountId,
             verbose: false,
+            ...(isCaptionDelivery ? { editMode: "caption" } : {}),
           });
         },
       });

--- a/extensions/telegram/src/question-finalization.test.ts
+++ b/extensions/telegram/src/question-finalization.test.ts
@@ -1,5 +1,5 @@
 // Covers Telegram question delivery capture and native final edit.
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   edit: vi.fn(),
@@ -26,18 +26,31 @@ vi.mock("./send.js", () => ({
   editMessageTelegram: hoisted.edit,
 }));
 
+import { telegramCaptionDeliveryMetadata } from "./caption.js";
 import { createTelegramOutboundAdapter } from "./outbound-adapter.js";
 
 describe("Telegram question finalization", () => {
+  beforeEach(() => {
+    hoisted.edit.mockReset();
+    hoisted.editMarkup.mockReset();
+    hoisted.registration = undefined;
+  });
+
   it("removes buttons and appends terminal status", async () => {
     const deliveredText = "x".repeat(5000);
     const statusLine = `Answered: ${"y".repeat(600)}`;
+    const deliveredMeta = {
+      telegramDeliveredText: deliveredText,
+      telegramHasInlineKeyboard: true,
+    };
+    telegramCaptionDeliveryMetadata.add(deliveredMeta);
     const outbound = createTelegramOutboundAdapter();
     await outbound.afterDeliverPayload?.({
       cfg: {},
       target: { channel: "telegram", to: "123", accountId: "default" },
       payload: {
         text: "Long preface\n\nPick one",
+        mediaUrls: ["https://example.com/photo.jpg"],
         channelData: {
           askUser: { questionId: "ask_0123456789abcdef0123456789abcdef" },
         },
@@ -53,7 +66,16 @@ describe("Telegram question finalization", () => {
           channel: "telegram",
           messageId: "55",
           target: { kind: "chat", id: "123" },
-          meta: { telegramDeliveredText: deliveredText, telegramHasInlineKeyboard: true },
+          meta: deliveredMeta,
+          receipt: {
+            primaryPlatformMessageId: "55",
+            platformMessageIds: ["54", "55"],
+            parts: [
+              { platformMessageId: "54", index: 0, kind: "media" },
+              { platformMessageId: "55", index: 1, kind: "text" },
+            ],
+            sentAt: 0,
+          },
         },
       ],
     });
@@ -67,6 +89,93 @@ describe("Telegram question finalization", () => {
     const annotatedText = hoisted.edit.mock.calls[0]?.[2] as string;
     expect(annotatedText.length).toBeLessThanOrEqual(4000);
     expect(annotatedText).toContain("\n\nAnswered: ");
+    expect(hoisted.edit.mock.calls[0]?.[3]).not.toHaveProperty("editMode");
+    expect(hoisted.editMarkup.mock.invocationCallOrder[0]).toBeLessThan(
+      hoisted.edit.mock.invocationCallOrder[0] ?? Infinity,
+    );
+  });
+
+  it("finalizes an unthreaded caption without changing its public delivery metadata", async () => {
+    const meta = { telegramDeliveredText: "Choose one", telegramHasInlineKeyboard: true };
+    telegramCaptionDeliveryMetadata.add(meta);
+    const outbound = createTelegramOutboundAdapter();
+
+    await outbound.afterDeliverPayload?.({
+      cfg: {},
+      target: { channel: "telegram", to: "123" },
+      payload: {
+        text: "Choose one",
+        mediaUrls: ["https://example.com/photo.jpg"],
+        channelData: {
+          askUser: { questionId: "ask_0123456789abcdef0123456789abcdef" },
+        },
+      },
+      results: [{ channel: "telegram", messageId: "70", meta }],
+    });
+
+    await hoisted.registration?.finalize("Answered: yes");
+
+    expect(hoisted.edit).toHaveBeenCalledWith(
+      "123",
+      "70",
+      "Choose one\n\nAnswered: yes",
+      expect.objectContaining({ editMode: "caption" }),
+    );
+    expect(Object.keys(meta)).toEqual(["telegramDeliveredText", "telegramHasInlineKeyboard"]);
+  });
+
+  it.each([
+    { kind: "photo", fileName: "photo.jpg" },
+    { kind: "document", fileName: "document.pdf" },
+    { kind: "video", fileName: "video.mp4" },
+  ])("finalizes $kind questions as bounded media captions", async ({ fileName }) => {
+    const deliveredText = "Q".repeat(1000);
+    const statusLine = `Answered: ${"A".repeat(190)}`;
+    const outbound = createTelegramOutboundAdapter();
+
+    await outbound.afterDeliverPayload?.({
+      cfg: {},
+      target: { channel: "telegram", to: "-100123:topic:77", accountId: "default" },
+      payload: {
+        text: deliveredText,
+        mediaUrls: [`https://example.com/${fileName}`],
+        channelData: {
+          askUser: { questionId: "ask_0123456789abcdef0123456789abcdef" },
+        },
+      },
+      results: [
+        {
+          channel: "telegram",
+          messageId: "70",
+          target: { kind: "chat", id: "-100123" },
+          meta: { telegramDeliveredText: deliveredText, telegramHasInlineKeyboard: true },
+          receipt: {
+            primaryPlatformMessageId: "70",
+            platformMessageIds: ["70"],
+            parts: [{ platformMessageId: "70", index: 0, kind: "media", threadId: "77" }],
+            threadId: "77",
+            sentAt: 0,
+          },
+        },
+      ],
+    });
+
+    await hoisted.registration?.finalize(statusLine);
+
+    expect(hoisted.editMarkup).toHaveBeenCalledWith("-100123", "70", [], {
+      cfg: {},
+      accountId: "default",
+      verbose: false,
+    });
+    expect(hoisted.edit).toHaveBeenCalledWith(
+      "-100123",
+      "70",
+      expect.any(String),
+      expect.objectContaining({ editMode: "caption" }),
+    );
+    const annotatedCaption = hoisted.edit.mock.calls[0]?.[2] as string;
+    expect(annotatedCaption.length).toBeLessThanOrEqual(1024);
+    expect(annotatedCaption).toContain(`\n\n${statusLine}`);
     expect(hoisted.editMarkup.mock.invocationCallOrder[0]).toBeLessThan(
       hoisted.edit.mock.invocationCallOrder[0] ?? Infinity,
     );

--- a/extensions/telegram/src/send-caption-editing.test.ts
+++ b/extensions/telegram/src/send-caption-editing.test.ts
@@ -1,14 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   getTelegramSendTestMocks,
   importTelegramSendModule,
   installTelegramSendTestHooks,
+  makeTelegramApiTestMock,
 } from "./send.test-harness.js";
 
 installTelegramSendTestHooks();
 
-const { botApi, loadConfig } = getTelegramSendTestMocks();
-const { editMessageTelegram } = await importTelegramSendModule();
+const { botApi, loadConfig, loadWebMedia } = getTelegramSendTestMocks();
+const { editMessageTelegram, sendMessageTelegram } = await importTelegramSendModule();
+const { telegramCaptionDeliveryMetadata } = await import("./caption.js");
 
 describe("Telegram caption edits", () => {
   it.each([
@@ -46,4 +48,76 @@ describe("Telegram caption edits", () => {
       });
     },
   );
+});
+
+describe("Telegram caption delivery facts", () => {
+  it.each([
+    { kind: "photo", contentType: "image/jpeg", fileName: "photo.jpg" },
+    { kind: "document", contentType: "application/pdf", fileName: "document.pdf" },
+    { kind: "video", contentType: "video/mp4", fileName: "video.mp4" },
+  ])("preserves accepted $kind caption and keyboard facts in its result", async (media) => {
+    const sendMedia = vi.fn().mockResolvedValue({ message_id: 70, chat: { id: "123" } });
+    const api = makeTelegramApiTestMock({
+      sendPhoto: sendMedia,
+      sendDocument: sendMedia,
+      sendVideo: sendMedia,
+    });
+    loadWebMedia.mockResolvedValue({
+      buffer: Buffer.from("media"),
+      contentType: media.contentType,
+      fileName: media.fileName,
+    });
+    const onDeliveryResult = vi.fn((delivery: { meta?: object }) => {
+      expect(delivery.meta && telegramCaptionDeliveryMetadata.has(delivery.meta)).toBe(true);
+    });
+
+    const result = await sendMessageTelegram("123", "Choose **one**", {
+      cfg: {},
+      token: "42:test-token",
+      api,
+      mediaUrl: `https://example.com/${media.fileName}`,
+      buttons: [[{ text: "Choose", callback_data: "choice" }]],
+      onDeliveryResult,
+    });
+
+    expect(sendMedia).toHaveBeenCalledOnce();
+    expect(result.meta).toEqual({
+      telegramDeliveredText: "Choose **one**",
+      telegramHasInlineKeyboard: true,
+    });
+    expect(result.meta).toBe(onDeliveryResult.mock.calls[0]?.[0]?.meta);
+    expect(Object.keys(result.meta ?? {})).toEqual([
+      "telegramDeliveredText",
+      "telegramHasInlineKeyboard",
+    ]);
+  });
+
+  it("retains the accepted caption identity when inline controls are retrofitted", async () => {
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 70, chat: { id: "123" } });
+    const sendMessage = vi.fn().mockRejectedValue(new Error("Bad Request: text must be non-empty"));
+    const editMessageReplyMarkup = vi.fn().mockResolvedValue({ message_id: 70 });
+    loadWebMedia.mockResolvedValue({
+      buffer: Buffer.from("photo"),
+      contentType: "image/jpeg",
+      fileName: "photo.jpg",
+    });
+    const onDeliveryResult = vi.fn();
+
+    const result = await sendMessageTelegram("123", "\u200B".repeat(1025), {
+      cfg: {},
+      token: "42:test-token",
+      api: makeTelegramApiTestMock({ sendPhoto, sendMessage, editMessageReplyMarkup }),
+      textMode: "html",
+      mediaUrl: "https://example.com/photo.jpg",
+      buttons: [[{ text: "Choose", callback_data: "choice" }]],
+      onDeliveryResult,
+    });
+
+    expect(result.meta).toEqual({ telegramHasInlineKeyboard: true });
+    expect(result.meta && telegramCaptionDeliveryMetadata.has(result.meta)).toBe(true);
+    expect(onDeliveryResult.mock.calls[0]?.[0]?.meta).toEqual({
+      telegramHasInlineKeyboard: false,
+    });
+    expect(editMessageReplyMarkup).toHaveBeenCalledOnce();
+  });
 });

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -7,6 +7,7 @@ import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/cha
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import { telegramCaptionDeliveryMetadata } from "./caption.js";
 import { renderTelegramHtmlText } from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
 import {
@@ -349,14 +350,16 @@ async function sendMessageTelegramWithContext(
     let mediaPromptRecorded = false;
     const reportMediaDelivery = async (hasInlineKeyboard: boolean) => {
       try {
+        const meta = {
+          ...(deliveredCaption ? { telegramDeliveredText: deliveredCaption } : {}),
+          telegramHasInlineKeyboard: hasInlineKeyboard,
+        };
+        telegramCaptionDeliveryMetadata.add(meta);
         mediaDeliveryResult = await reportDelivery(
           mediaMessageId,
           resolvedChatId,
           result,
-          {
-            ...(deliveredCaption ? { telegramDeliveredText: deliveredCaption } : {}),
-            telegramHasInlineKeyboard: hasInlineKeyboard,
-          },
+          meta,
           "media",
           (delivery) => {
             mediaDeliveryResult = delivery;
@@ -444,15 +447,12 @@ async function sendMessageTelegramWithContext(
             messageId: String(mediaMessageId),
             chatId: resolvedChatId,
           };
-          return hasInlineKeyboard
-            ? {
-                ...finalMediaResult,
-                meta: {
-                  ...finalMediaResult.meta,
-                  telegramHasInlineKeyboard: true,
-                },
-              }
-            : finalMediaResult;
+          if (!hasInlineKeyboard) {
+            return finalMediaResult;
+          }
+          const meta = { ...finalMediaResult.meta, telegramHasInlineKeyboard: true };
+          telegramCaptionDeliveryMetadata.add(meta);
+          return { ...finalMediaResult, meta };
         }
         await recordMediaPromptContext(false);
         const textMessageIds = isChannelPartialDeliveryError(error)
@@ -490,13 +490,13 @@ async function sendMessageTelegramWithContext(
       };
     }
 
-    return mediaDeliveryResult?.receipt
-      ? {
-          messageId: mediaDeliveryResult.messageId,
-          chatId: mediaDeliveryResult.chatId,
-          receipt: mediaDeliveryResult.receipt,
-        }
-      : { messageId: String(mediaMessageId), chatId: resolvedChatId };
+    return mediaDeliveryResult?.meta?.telegramHasInlineKeyboard
+      ? mediaDeliveryResult
+      : {
+          messageId: String(mediaMessageId),
+          chatId: resolvedChatId,
+          ...(mediaDeliveryResult?.receipt ? { receipt: mediaDeliveryResult.receipt } : {}),
+        };
   }
 
   if (!text || !text.trim()) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users answering a Telegram question attached to a photo,
document, or video would see its buttons disappear without any answered status.
Long answers could also exceed Telegram's 1,024-character caption limit.

## Why This Change Was Made

The Telegram delivery owner now preserves its existing accepted-media facts for
interactive messages and carries the media identity across result wrappers in
a private, garbage-collected identity marker. Question finalization selects the
actual delivered message, edits
caption-bearing media through Telegram's caption endpoint, and applies the
canonical caption limit while leaving ordinary media results, text follow-ups,
forum topics, voice fallbacks, and public SDK contracts unchanged.

The production delta is +12 lines: the existing sender remains net-neutral;
the additional private producer-to-finalizer ownership boundary avoids adding
public metadata, configuration, compatibility paths, or persistent state.

## User Impact

Telegram questions attached to photos, documents, and videos now visibly show
their answered status after the controls disappear, including in forum topics
and ordinary chats. Long answers remain within Telegram's caption limit.
Noninteractive messages and caption-follow-up text retain their prior behavior.

## Evidence

- Authentic pre-fix owner regressions: photo, document, and video sends each
  lost accepted caption metadata, and all three question finalizers attempted
  text edits with overlong captions.
- Independent review also exposed two existing ordinary-media public-shape
  regressions; both now pass unchanged, and all 13 independent focused owner
  checks pass.
- Direct upstream Telegram client types confirm that text and caption edits use
  distinct Bot API operations and that captions are limited to 1,024 characters.
- Full sender, caption, question, streaming, and delivery lifecycle proof:

  ```text
  node scripts/run-vitest.mjs extensions/telegram/src/question-finalization.test.ts extensions/telegram/src/send-caption-editing.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot-message-dispatch.draft-finalization.test.ts extensions/telegram/src/bot/delivery.test.ts
  Test Files  5 passed (5)
       Tests  386 passed (386)
  ```

- Type-aware changed-file lint, formatting, assertion-safety and maximum-lines
  ratchets, independent owner review, and authenticated committed-branch
  review all pass. Full-repository typechecks currently report existing,
  unrelated ACPX errors only; no touched Telegram file has a type error.
- Live Telegram delivery was not run because this isolated QA lane has no
  authorized live channel or bot session; the owner suites exercise the actual
  Telegram sender and mocked Bot API caption/edit endpoints instead.
