### PR TITLE
perf(startup): short-circuit dist-internal ESM resolution with explicit module format

### DIFF
--- a/src/entry.esm-resolve-fast-path.test.ts
+++ b/src/entry.esm-resolve-fast-path.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { installDistEsmResolveFastPath } from "./entry.esm-resolve-fast-path.js";
+
+type ResolveHook = (
+  specifier: string,
+  context: { parentURL?: string; conditions?: readonly string[] },
+  nextResolve: (specifier: string) => { url: string },
+) => { url: string; format?: string | null; shortCircuit?: boolean };
+
+const DIST_ROOT = "file:///opt/openclaw/dist/";
+
+function installCapturedHook(entryFileUrl: string): ResolveHook {
+  let hook: ResolveHook | undefined;
+  const installed = installDistEsmResolveFastPath(entryFileUrl, {
+    registerHooks: (options) => {
+      hook = options.resolve as ResolveHook;
+      return { deregister: () => {} };
+    },
+  });
+  expect(installed).toBe(true);
+  if (!hook) {
+    throw new Error("resolve hook was not registered");
+  }
+  return hook;
+}
+
+function runHook(
+  hook: ResolveHook,
+  specifier: string,
+  context: { parentURL?: string; conditions?: readonly string[] } = {},
+) {
+  const resolvedContext = {
+    parentURL: "parentURL" in context ? context.parentURL : `${DIST_ROOT}entry.js`,
+    conditions: context.conditions ?? ["node", "import"],
+  };
+  let deferred = false;
+  const result = hook(specifier, resolvedContext, () => {
+    deferred = true;
+    return { url: "next:resolved" };
+  });
+  return { deferred, result };
+}
+
+describe("installDistEsmResolveFastPath resolve hook", () => {
+  const hook = installCapturedHook(`${DIST_ROOT}entry.js`);
+
+  it("short-circuits dist-internal relative .js imports with module format", () => {
+    const direct = runHook(hook, "./chunk-abc.js");
+    expect(direct.deferred).toBe(false);
+    expect(direct.result).toStrictEqual({
+      url: `${DIST_ROOT}chunk-abc.js`,
+      format: "module",
+      shortCircuit: true,
+    });
+    const fromExtension = runHook(hook, "../../plugin-entry.js", {
+      parentURL: `${DIST_ROOT}extensions/telegram/index.js`,
+    });
+    expect(fromExtension.result.url).toBe(`${DIST_ROOT}plugin-entry.js`);
+  });
+
+  it("defers require() resolutions to the default CJS path", () => {
+    expect(runHook(hook, "./chunk.js", { conditions: ["node", "require"] }).deferred).toBe(true);
+  });
+
+  it("defers bare, absolute, and non-.js specifiers", () => {
+    for (const specifier of [
+      "openclaw/plugin-sdk/plugin-entry",
+      "node:path",
+      "/opt/openclaw/dist/chunk.js",
+      "./chunk.mjs",
+      "./chunk.cjs",
+      "./manifest.json",
+      "./chunk.js?query",
+      ".js",
+    ]) {
+      expect(runHook(hook, specifier).deferred, specifier).toBe(true);
+    }
+  });
+
+  it("defers parents outside the dist root and missing parents", () => {
+    expect(runHook(hook, "./chunk.js", { parentURL: "file:///opt/other/entry.js" }).deferred).toBe(
+      true,
+    );
+    expect(runHook(hook, "./chunk.js", { parentURL: undefined }).deferred).toBe(true);
+  });
+
+  it("defers relative targets that escape the dist root", () => {
+    expect(runHook(hook, "../outside/chunk.js").deferred).toBe(true);
+  });
+});
+
+describe("installDistEsmResolveFastPath gating", () => {
+  it("registers one hook per dist root and stays idempotent", () => {
+    let registered = 0;
+    const registerHooks = () => {
+      registered += 1;
+      return { deregister: () => {} };
+    };
+    const root = "file:///opt/openclaw-idempotent/dist/";
+    expect(installDistEsmResolveFastPath(`${root}entry.js`, { registerHooks })).toBe(true);
+    expect(installDistEsmResolveFastPath(`${root}index.js`, { registerHooks })).toBe(true);
+    expect(registered).toBe(1);
+  });
+
+  it("declines outside dist layouts and without registerHooks support", () => {
+    let registered = 0;
+    const registerHooks = () => {
+      registered += 1;
+      return { deregister: () => {} };
+    };
+    expect(
+      installDistEsmResolveFastPath("file:///opt/openclaw/src/entry.ts", { registerHooks }),
+    ).toBe(false);
+    expect(registered).toBe(0);
+    expect(
+      installDistEsmResolveFastPath("file:///opt/openclaw-two/dist/entry.js", {
+        registerHooks: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/entry.esm-resolve-fast-path.ts
+++ b/src/entry.esm-resolve-fast-path.ts
@@ -1,0 +1,106 @@
+/**
+ * Short-circuits Node's ESM resolution for dist-internal relative imports.
+ *
+ * Node's default resolver calls getPackageScopeConfig() for every file: URL to
+ * pick a module format, and each call re-materializes the package.json
+ * `exports` map. With openclaw's 300+ subpath exports that costs ~0.1ms per
+ * resolution and multiple seconds across the ~15k module edges of a gateway
+ * boot. Every built dist file is ESM (all dist package.json files declare
+ * "type": "module"), so a relative "./chunk.js" import inside dist can resolve
+ * by URL join with format "module" without consulting the package scope at
+ * all. This hook removes only resolver cost; the resolved URL and format are
+ * byte-identical to Node's default resolution.
+ */
+import Module from "node:module";
+
+type SyncResolveResult = { url: string; format?: string | null; shortCircuit?: boolean };
+type SyncResolveContext = { parentURL?: string; conditions?: readonly string[] };
+type SyncResolveHook = (
+  specifier: string,
+  context: SyncResolveContext,
+  nextResolve: (specifier: string, context?: SyncResolveContext) => SyncResolveResult,
+) => SyncResolveResult;
+type RegisterModuleHooks = (options: { resolve?: SyncResolveHook }) => { deregister: () => void };
+
+// SAFETY: Module.registerHooks ships in every supported Node runtime but is missing from the bundled type declarations; the optional member keeps callers probing before use (Bun lacks it).
+const moduleWithHooks = Module as typeof Module & {
+  registerHooks?: RegisterModuleHooks;
+};
+
+const installedDistRootUrls = new Set<string>();
+
+/**
+ * Resolves a dist-internal relative ESM specifier to its final file URL, or
+ * returns null when the specifier must go through Node's default resolution.
+ * Only relative ".js" specifiers whose parent and target both live under the
+ * dist root qualify; require() resolutions stay on the default path because
+ * the CJS loader does not pay the eager format-detection cost this bypasses.
+ */
+function resolveDistEsmFastPathUrl(params: {
+  specifier: string;
+  parentUrl: string | undefined;
+  conditions: readonly string[] | undefined;
+  distRootUrl: string;
+}): string | null {
+  const { specifier, parentUrl } = params;
+  if (
+    specifier.charCodeAt(0) !== 46 /* "." */ ||
+    !specifier.endsWith(".js") ||
+    parentUrl === undefined ||
+    !parentUrl.startsWith(params.distRootUrl) ||
+    params.conditions?.includes("require") === true ||
+    (specifier.charCodeAt(1) !== 47 /* "/" */ &&
+      (specifier.charCodeAt(1) !== 46 /* "." */ || specifier.charCodeAt(2) !== 47))
+  ) {
+    return null;
+  }
+  let resolved: string;
+  try {
+    resolved = new URL(specifier, parentUrl).href;
+  } catch {
+    return null;
+  }
+  // "../" chains can leave the built output tree; those targets may live in a
+  // different package scope, so they keep Node's default format detection.
+  return resolved.startsWith(params.distRootUrl) ? resolved : null;
+}
+
+/**
+ * Installs the dist-relative ESM resolve fast path for a built entry file.
+ * No-ops (returns false) outside a dist layout — source checkouts run through
+ * tsx/vitest resolvers that must keep owning ".js" specifier rewrites — and
+ * on runtimes without Module.registerHooks.
+ */
+export function installDistEsmResolveFastPath(
+  entryFileUrl: string,
+  deps: { registerHooks?: RegisterModuleHooks | undefined } = {},
+): boolean {
+  const registerHooks =
+    "registerHooks" in deps ? deps.registerHooks : moduleWithHooks.registerHooks;
+  if (typeof registerHooks !== "function") {
+    return false;
+  }
+  const distRootUrl = new URL("./", entryFileUrl).href;
+  if (!distRootUrl.endsWith("/dist/")) {
+    return false;
+  }
+  if (installedDistRootUrls.has(distRootUrl)) {
+    return true;
+  }
+  registerHooks({
+    resolve(specifier, context, nextResolve) {
+      const url = resolveDistEsmFastPathUrl({
+        specifier,
+        parentUrl: context.parentURL,
+        conditions: context.conditions,
+        distRootUrl,
+      });
+      if (url !== null) {
+        return { url, format: "module", shortCircuit: true };
+      }
+      return nextResolve(specifier, context);
+    },
+  });
+  installedDistRootUrls.add(distRootUrl);
+  return true;
+}

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -24,6 +24,7 @@ import {
   resolveEntryInstallRoot,
   respawnWithoutOpenClawCompileCacheIfNeeded,
 } from "./entry.compile-cache.js";
+import { installDistEsmResolveFastPath } from "./entry.esm-resolve-fast-path.js";
 import { buildCliRespawnPlan, runCliRespawnPlan } from "./entry.respawn.js";
 import { tryHandleRootVersionFastPath } from "./entry.version-fast-path.js";
 import { normalizeEnv } from "./infra/env.js";
@@ -119,6 +120,7 @@ if (
 } else {
   const entryFile = fileURLToPath(import.meta.url);
   const installRoot = resolveEntryInstallRoot(entryFile);
+  installDistEsmResolveFastPath(import.meta.url);
   process.title = "openclaw";
   ensureOpenClawExecMarkerOnProcess();
   installProcessWarningFilter();

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "./cli/failure-output.js";
 import { isJsonOutputModeActive } from "./cli/json-output-mode.js";
 import { runCliWithExitFinalization } from "./cli/one-shot-exit.js";
+import { installDistEsmResolveFastPath } from "./entry.esm-resolve-fast-path.js";
 import { tryHandleRootVersionFastPath } from "./entry.version-fast-path.js";
 import { formatUncaughtError } from "./infra/errors.js";
 import { runFatalErrorHooks } from "./infra/fatal-error-hooks.js";
@@ -76,6 +77,9 @@ export async function runLegacyCliEntry(
 const isMain = isMainModule({
   currentFile: fileURLToPath(import.meta.url),
 });
+if (isMain) {
+  installDistEsmResolveFastPath(import.meta.url);
+}
 const handledRootVersion = isMain && tryHandleRootVersionFastPath(process.argv);
 
 if (!isMain) {


### PR DESCRIPTION
## What Problem This Solves

Warm `gateway run` startup burned 1.3–2.6s of CPU inside Node's ESM resolver. Profiles attributed it to `dist/plugin-module-loader-cache-*.js` (`resolve` ~1.9s), but that hook was only sitting in the stack: the real cost is Node's `getPackageScopeConfig()`, which runs for every `file:` URL it resolves to pick a module format and re-materializes package.json on each call — re-parsing openclaw's 318-key (~124KB) `exports` map every time (~93µs/call, measured on Node 26.5.0). A gateway boot resolves ~17k module edges across 8,368 dist files, so this scales with both graph size and exports size.

## Why This Change Was Made

Every built dist file is ESM: all 145 package.json files under `dist/` declare `"type": "module"`, and a scan of all 8,368 dist `.js` files found zero CJS-syntax files. So for a relative `./chunk.js` import inside `dist/`, Node's format detection can only ever conclude `"module"` — the scope walk is pure waste. The new `src/entry.esm-resolve-fast-path.ts` registers a `Module.registerHooks` resolve hook from the main-module branches of `entry.ts` and `index.ts` that short-circuits exactly those resolutions with the URL-joined target and `format: "module"`, which also skips format detection at load. Everything else defers to `nextResolve`: `require()` conditions, bare specifiers, non-`.js` targets, parents outside dist, and `../` chains that escape the dist root. Source checkouts (tsx/vitest own `.js`→`.ts` rewrites) and runtimes without `registerHooks` (Bun) are gated out, and the hook is idempotent per dist root.

## User Impact

Roughly halves warm gateway boot. Interleaved same-dist A/B (hook env-gated on/off, isolated `OPENCLAW_STATE_DIR`, macOS, Node 26.5.0, 16 bundled plugins):

| Metric | Hook off | Hook on |
| --- | ---: | ---: |
| Self-reported "listening" time | 3.3–6.6s | stable 2.1s |
| User CPU to `[gateway] ready` | ~5.2s | ~2.9s |
| `package_json_reader.get` profile self time | 1.28s | absent |

All CLI commands benefit too (both `openclaw.mjs` and direct `dist/index.js` entry install the hook). Resolution results are byte-identical to Node's defaults — this deletes cost, not behavior.

Production LOC is positive (+~110 incl. doc comments): a new capability at the entry-bootstrap owner boundary (sibling to `entry.compile-cache.ts`); there is no existing structure that can absorb it.

## Evidence

- Micro-benchmark: `getPackageScopeConfig` = 92.9µs/call against this repo root (Node 26.5.0, warm), eagerly materializing all 318 export entries per call.
- Baseline profile: `package_json_reader.get` 1279ms self + `getPackageScopeConfig` chains under `defaultResolve`; final profile after the change: frame absent, boot profile duration 7.2s → 4.2s.
- Boot proof: `openclaw.mjs gateway run` on the rebuilt dist reaches listening in 2.1s with the same 16 plugins and no errors; `plugins list`/`--version` smoke pass.
- Safety proof: all 145 dist package.jsons are `"type": "module"`; 8,368 dist `.js` files scanned, zero CJS-syntax.
- Tests: `src/entry.esm-resolve-fast-path.test.ts` (7 tests) exercises the registered hook via an injected `registerHooks` stub: short-circuit shape, require-condition/bare/absolute/non-.js/out-of-root/escaping deferrals, idempotence, and non-dist/Bun gating. Entry test surface (`entry.*.test.ts`) green; `check-changed` exit 0; `pnpm build` green; fresh Codex autoreview clean (0 findings, "patch is correct 0.98").
