### PR TITLE
docs(tokenjuice): clarify native codex-rs bash/exec results are not compacted

### DIFF
--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -322,7 +322,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[tlon](/plugins/reference/tlon)** (`@openclaw/tlon`) - npm; ClawHub. OpenClaw Tlon/Urbit channel plugin for chat workflows.
 
-- **[tokenjuice](/plugins/reference/tokenjuice)** (`@openclaw/tokenjuice`) - npm; ClawHub: `clawhub:@openclaw/tokenjuice`. Compacts exec and bash tool results with tokenjuice reducers.
+- **[tokenjuice](/plugins/reference/tokenjuice)** (`@openclaw/tokenjuice`) - npm; ClawHub: `clawhub:@openclaw/tokenjuice`. Compacts exec and bash tool results for OpenClaw-embedded runs and OpenClaw dynamic tools in the Codex app-server harness. Native codex-rs bash/exec results are returned unchanged.
 
 - **[twitch](/plugins/reference/twitch)** (`@openclaw/twitch`) - npm; ClawHub. OpenClaw Twitch channel plugin for chat and moderation workflows.
 

--- a/docs/plugins/reference/tokenjuice.md
+++ b/docs/plugins/reference/tokenjuice.md
@@ -1,5 +1,5 @@
 ---
-summary: "Compacts exec and bash tool results with tokenjuice reducers."
+summary: "Compacts exec and bash tool results for OpenClaw-embedded runs and OpenClaw dynamic tools in the Codex app-server harness. Native codex-rs bash/exec results are returned unchanged."
 read_when:
   - You are installing, configuring, or auditing the tokenjuice plugin
 title: "Tokenjuice plugin"
@@ -7,7 +7,7 @@ title: "Tokenjuice plugin"
 
 # Tokenjuice plugin
 
-Compacts exec and bash tool results with tokenjuice reducers.
+Compacts exec and bash tool results for OpenClaw-embedded runs and OpenClaw dynamic tools in the Codex app-server harness. Native codex-rs bash/exec results are returned unchanged.
 
 ## Distribution
 

--- a/docs/tools/tokenjuice.md
+++ b/docs/tools/tokenjuice.md
@@ -1,4 +1,5 @@
 ---
+doc-schema-version: 1
 summary: "Compact noisy exec and bash tool results with the optional Tokenjuice plugin"
 title: "Tokenjuice"
 read_when:
@@ -14,8 +15,10 @@ It changes the returned `tool_result`, not the command itself. Tokenjuice does
 not rewrite shell input, rerun commands, or change exit codes.
 
 Today this applies to OpenClaw embedded runs and OpenClaw dynamic tools in the Codex
-app-server harness. Tokenjuice hooks OpenClaw's tool-result middleware and
-trims the output before it goes back into the active harness session.
+app-server harness. Native codex-rs `bash`/`exec` results mirrored from the Codex
+app-server harness are not compacted: they pass through the middleware, but the
+codex-rs protocol has no hook to replace the tool response, so the trimmed output
+is discarded and the original result is returned to the session.
 
 ## Enable the plugin
 
@@ -61,9 +64,12 @@ If you prefer editing config directly:
 ## Verify it is working
 
 1. Enable the plugin.
-2. Start a session that can call `exec`.
+2. Start a session that can call `exec` on the OpenClaw-embedded path.
 3. Run a noisy command such as `git status`.
 4. Check that the returned tool result is shorter and more structured than the raw shell output.
+
+This check only applies to OpenClaw-embedded or OpenClaw dynamic tools. Native
+codex-rs `bash`/`exec` results in the Codex app-server harness are not compacted.
 
 ## Disable the plugin
 

--- a/extensions/tokenjuice/README.md
+++ b/extensions/tokenjuice/README.md
@@ -2,7 +2,7 @@
 
 Official Tokenjuice output compaction plugin for OpenClaw.
 
-Tokenjuice compacts noisy `exec` and `bash` tool results after commands run, before the result is fed back into the active agent session. It does not rewrite commands, rerun commands, or change exit codes.
+Tokenjuice compacts noisy `exec` and `bash` tool results after commands run for OpenClaw-embedded runs and OpenClaw dynamic tools. Native codex-rs `bash`/`exec` results mirrored from the Codex app-server harness are not compacted. It does not rewrite commands, rerun commands, or change exit codes.
 
 ## Install
 

--- a/extensions/tokenjuice/index.ts
+++ b/extensions/tokenjuice/index.ts
@@ -5,7 +5,8 @@ import { createTokenjuiceAgentToolResultMiddleware } from "./tool-result-middlew
 export default definePluginEntry({
   id: "tokenjuice",
   name: "tokenjuice",
-  description: "Compacts exec and bash tool results with tokenjuice reducers.",
+  description:
+    "Compacts exec and bash tool results for OpenClaw-embedded runs and OpenClaw dynamic tools in the Codex app-server harness. Native codex-rs bash/exec results are returned unchanged.",
   register(api) {
     api.registerAgentToolResultMiddleware(createTokenjuiceAgentToolResultMiddleware(), {
       runtimes: ["openclaw", "codex"],

--- a/extensions/tokenjuice/openclaw.plugin.json
+++ b/extensions/tokenjuice/openclaw.plugin.json
@@ -4,7 +4,7 @@
     "onStartup": false
   },
   "name": "tokenjuice",
-  "description": "Compacts exec and bash tool results with tokenjuice reducers.",
+  "description": "Compacts exec and bash tool results for OpenClaw-embedded runs and OpenClaw dynamic tools in the Codex app-server harness. Native codex-rs bash/exec results are returned unchanged.",
   "catalog": { "featured": true, "order": 60 },
   "contracts": {
     "agentToolResultMiddleware": ["openclaw", "codex"]


### PR DESCRIPTION
Closes openclaw/openclaw#120469

## What Problem This Solves

Tokenjuice's docs and plugin metadata say it "compacts exec and bash tool results" without qualification, but that is only true for some execution paths. In the Codex app-server harness, native codex-rs `bash`/`exec` results are **not** compacted: the plugin's tool-result middleware still runs, but its transformed output is discarded and the original result reaches the model. A user enabling tokenjuice to trim noisy native shell output sees no effect and no error, while the plugin inventory and reference docs oversell the behavior.

## Root cause

The codex-rs hook protocol is observe-only for post-tool results. From `codex-rs/hooks/src/events/post_tool_use.rs` (openai/codex, verified 2026-08-24), the PostToolUse hook outcome is:

```rust
pub struct PostToolUseOutcome {
    pub hook_events: Vec<HookCompletedEvent>,
    pub should_block: bool,
    pub additional_contexts: Vec<String>,
    pub feedback_message: Option<String>,
}
```

There is no field that can replace `tool_response` — a PostToolUse hook can block, add context, or leave feedback, but it cannot swap the tool result. OpenClaw's native hook relay honors that contract (`src/agents/harness/native-hook-relay-events.ts`): it applies the registered tool-result middleware, feeds the transformed result to `after_tool_call` observers only, then returns a no-op response, so the original native result stands. OpenClaw dynamic tools take a different path (`extensions/codex/src/app-server/dynamic-tools.ts`): there the middleware's return value becomes the tool result the model sees.

Compaction boundary: OpenClaw-embedded runs and OpenClaw dynamic tools → compacted; native codex-rs `bash`/`exec` → returned unchanged.

## Fix

Docs + metadata only; no code paths changed:

- `docs/tools/tokenjuice.md`: states the native-vs-dynamic boundary, explains why (the protocol has no response-replacement hook), and scopes the "Verify it is working" check to the embedded/dynamic path.
- `extensions/tokenjuice/openclaw.plugin.json` + `extensions/tokenjuice/index.ts`: the description carries the same caveat so runtime-loaded discovery metadata matches the docs.
- `extensions/tokenjuice/README.md`: same caveat.
- Regenerated `docs/plugins/reference/tokenjuice.md` and `docs/plugins/plugin-inventory.md` via `pnpm plugins:inventory:gen`.

## Evidence

All local runs below executed on this PR's head `a611f97051a857d89bb3dc45635434cea6dd9d25` (fresh shallow clone at that commit, `pnpm install`, repo vitest runners).

### 1. Native codex-rs result stays raw (observe-only middleware)

```text
$ node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts \
    extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Duration  75.37s
```

The first test in that file, "relays native tool results through Codex result middleware", starts a real codex app-server thread harness with the native hook relay enabled for `post_tool_use`, registers a tool-result middleware (pluginId `tokenjuice`, runtimes `["codex"]`), and posts a real native `Bash` PostToolUse payload (`tool_response: { "output": "ok", "exit_code": 0 }`) through `invokeNativeHookRelay`. It asserts the middleware receives the native result — and the relay's PostToolUse handler then returns its no-op response, so the model-visible result is the original one.

### 2. OpenClaw dynamic tool result is replaced (compaction works on this path)

```text
$ node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.extension-codex.config.ts \
    codex/src/app-server/dynamic-tools.test.ts \
    -t "preserves an accepted sessions_spawn after result middleware strips its details"

 Test Files  1 passed (1)
      Tests  1 passed | 152 skipped (153)
   Duration  75.61s
```

That test registers a `result-compactor` middleware (runtimes `["codex"]`) and calls a dynamic tool whose raw result is "Accepted: launching child session.". The middleware rewrites it to "Child launch recorded.", and the assertion on the returned result is `expect(result).toEqual(expectInputText("Child launch recorded."))` — the rewritten result is what goes back to the model.

### 3. Tokenjuice plugin registration on this head

```text
$ node scripts/run-vitest.mjs run \
    --config test/vitest/vitest.extensions.config.ts \
    tokenjuice/index.test.ts tokenjuice/manifest.test.ts

 Test Files  2 passed (2)
      Tests  14 passed (14)
   Duration  52.25s
```

Covers: opt-in by default, middleware registered for runtimes `["openclaw", "codex"]`, the manifest contract, and the updated runtime description.

### 4. Direct codex-rs protocol verification

The `PostToolUseOutcome` struct quoted in Root cause is read directly from the public openai/codex source (`codex-rs/hooks/src/events/post_tool_use.rs`): it has no result-replacement field, confirming the protocol claim independently of OpenClaw's own source comments.

### 5. Runtime inspection output for the changed description (after-fix, this head)

The 12:25Z ClawSweeper re-review reported its live `expect_output` step as FAIL (partial): its 30-second assertion window expires while the fresh-checkout dist build is still running, so the JSON arrives after the assertion gives up (the description string is visible in ClawSweeper's own captured, truncated transcript). To leave no ambiguity, the after-fix runtime inspection from this head directly — the same command implementation ClawSweeper runs, `openclaw plugins inspect tokenjuice --runtime --json`, invoked via its `runPluginsInspectCommand("tokenjuice", { runtime: true, json: true })` entry point on a repo checkout at this PR's head (dist-rebuild gate bypassed by calling the command module directly; runtime plugin loading unchanged):

```text
$ git rev-parse HEAD
a611f97051a857d89bb3dc45635434cea6dd9d25

$ node --import tsx scratch-inspect-tokenjuice.mts
{
  "plugin": {
    "id": "tokenjuice",
    "name": "tokenjuice",
    "description": "Compacts exec and bash tool results for OpenClaw-embedded runs and OpenClaw dynamic tools in the Codex app-server harness. Native codex-rs bash/exec results are returned unchanged.",
    "source": "/mnt/data/open-source/openclaw/extensions/tokenjuice/index.ts",
    "origin": "bundled",
    "enabled": false,
    "explicitlyEnabled": false,
    "activated": false,
    "status": "disabled"
  }
}
```

The `description` is loaded from the runtime entry module (`extensions/tokenjuice/index.ts`) — the loader gives the entry-module description precedence over the manifest — and carries the changed capability statement `Native codex-rs bash/exec results are returned unchanged.`

### Docs checks (from the original submission)

- `pnpm format:docs:check` passed (761 files)
- `pnpm docs:check-mdx` passed (777 files)
- `pnpm docs:check-links` passed (0 broken)
- `pnpm docs:check-i18n-glossary` passed

## Risks

Docs/metadata only. The one runtime-visible string is the plugin `description` used in discovery surfaces; it stays within manifest norms and is regenerated consistently in the reference docs. No behavior, config, or protocol changes.

Co-Authored-By: Paperclip <noreply@paperclip.ing>

