### PR TITLE
fix(gateway): stop secure link creation from hanging

### DIFF
--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -442,48 +442,61 @@ describe("attachGatewayWsConnectionHandler", () => {
     },
   );
 
-  it("rejects a real closing WebSocket before ws can silently buffer a lost response", async () => {
-    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
-    await once(server, "listening");
-    const accepted = once(server, "connection");
-    const peer = new WebSocket(`ws://127.0.0.1:${(server.address() as AddressInfo).port}`);
-    await once(peer, "open");
-    const [socket] = (await accepted) as [WebSocket];
+  it.each(["closing", "failed-send"] as const)(
+    "retires a real %s WebSocket without silently losing its peer",
+    async (failure) => {
+      const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+      await once(server, "listening");
+      const accepted = once(server, "connection");
+      const peer = new WebSocket(`ws://127.0.0.1:${(server.address() as AddressInfo).port}`);
+      await once(peer, "open");
+      const [socket] = (await accepted) as [WebSocket];
 
-    try {
-      const { clients, passed } = await connectTestWs({
-        socket: socket as unknown as GatewayWsTestSocket,
-      });
-      const handlerParams = passed as {
-        send: (frame: unknown) => { kind: string };
-        setClient: (client: unknown) => boolean;
-      };
-      handlerParams.setClient({
-        socket,
-        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
-        connId: "real-closing-client",
-        usesSharedGatewayAuth: false,
-      });
+      try {
+        const { clients, passed } = await connectTestWs({
+          socket: socket as unknown as GatewayWsTestSocket,
+        });
+        const handlerParams = passed as {
+          send: (frame: unknown) => { kind: string };
+          setClient: (client: unknown) => boolean;
+        };
+        handlerParams.setClient({
+          socket,
+          connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+          connId: "real-closing-client",
+          usesSharedGatewayAuth: false,
+        });
 
-      socket.close(1000, "real close race");
-      expect(socket.readyState).toBe(WebSocket.CLOSING);
-      const bufferedAtClose = socket.bufferedAmount;
+        if (failure === "closing") {
+          socket.close(1000, "real close race");
+          expect(socket.readyState).toBe(WebSocket.CLOSING);
+        } else {
+          vi.spyOn(socket, "send").mockImplementationOnce(() => {
+            throw new Error("response transport unavailable");
+          });
+          vi.spyOn(socket, "close").mockImplementationOnce(() => {
+            throw new Error("closing handshake unavailable");
+          });
+        }
+        const bufferedAtClose = socket.bufferedAmount;
 
-      expect(handlerParams.send({ type: "res", id: "real-closing-request", ok: true })).toEqual({
-        kind: "unavailable",
-      });
-      expect(socket.bufferedAmount).toBe(bufferedAtClose);
-      expect(clients.size).toBe(0);
-    } finally {
-      peer.terminate();
-      for (const activeSocket of server.clients) {
-        activeSocket.terminate();
+        expect(handlerParams.send({ type: "res", id: "real-closing-request", ok: true })).toEqual({
+          kind: "unavailable",
+        });
+        expect(socket.bufferedAmount).toBe(bufferedAtClose);
+        expect(clients.size).toBe(0);
+        await vi.waitFor(() => expect(peer.readyState).toBe(WebSocket.CLOSED));
+      } finally {
+        peer.terminate();
+        for (const activeSocket of server.clients) {
+          activeSocket.terminate();
+        }
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
       }
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
-  });
+    },
+  );
 
   it("keeps a closing node discoverable throughout pending lifecycle dispatch and fanout", async () => {
     const unregister = vi.fn(() => "draining-node");
@@ -576,11 +589,20 @@ describe("attachGatewayWsConnectionHandler", () => {
   });
 
   it("distinguishes serialization failure from unavailable transports", async () => {
-    const socket = createGatewayWsTestSocket();
-    const { passed } = await connectTestWs({ socket });
+    const socket = Object.assign(createGatewayWsTestSocket(), { terminate: vi.fn() });
+    const { clients, passed } = await connectTestWs({ socket });
     const handlerParams = passed as {
       send: (frame: unknown) => { kind: string; error?: unknown };
+      setClient: (client: unknown) => boolean;
     };
+    expect(
+      handlerParams.setClient({
+        socket,
+        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+        connId: "failed-response-client",
+        usesSharedGatewayAuth: false,
+      }),
+    ).toBe(true);
     socket.send.mockClear();
 
     const cyclic: { self?: unknown } = {};
@@ -590,13 +612,20 @@ describe("attachGatewayWsConnectionHandler", () => {
       error: expect.any(TypeError),
     });
     expect(socket.send).not.toHaveBeenCalled();
+    expect(clients.size).toBe(1);
 
     socket.send.mockImplementationOnce(() => {
       throw new Error("socket unavailable");
     });
-    expect(handlerParams.send({ type: "event", event: "tick" })).toEqual({
+    socket.close.mockImplementationOnce(() => {
+      throw new Error("closing handshake unavailable");
+    });
+    expect(handlerParams.send({ type: "res", id: "pair-setup", ok: true })).toEqual({
       kind: "unavailable",
     });
+    expect(socket.close).toHaveBeenCalledWith(1000, undefined);
+    expect(socket.terminate).toHaveBeenCalledOnce();
+    expect(clients.size).toBe(0);
 
     socket.emit("close", 1000, Buffer.from("done"));
     expect(handlerParams.send({ type: "event", event: "tick" })).toEqual({

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -330,6 +330,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     };
 
     const close = (code = 1000, reason?: string) => {
+      retainClientUntilNodeDrain ||=
+        !closed && client?.connect.role === "node" && nodeLifecycleDispatch.hasActive();
       retireTransport(code, reason);
       if (client && !retainClientUntilNodeDrain) {
         clients.delete(client);
@@ -341,9 +343,6 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         return { kind: "unavailable" } as const;
       }
       if (socket.readyState !== WEBSOCKET_OPEN_READY_STATE) {
-        if (client?.connect.role === "node" && nodeLifecycleDispatch.hasActive()) {
-          retainClientUntilNodeDrain = true;
-        }
         close();
         return { kind: "unavailable" } as const;
       }
@@ -371,6 +370,8 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         socket.send(encoded);
         return { kind: "sent" } as const;
       } catch {
+        socket.terminate();
+        close();
         return { kind: "unavailable" } as const;
       }
     };

--- a/ui/src/app/overlays-access.test-support.ts
+++ b/ui/src/app/overlays-access.test-support.ts
@@ -207,7 +207,7 @@ export function registerOverlayPairingAccessTests() {
         await flushMicrotasks();
 
         expect(overlays.snapshot.devicePairPendingCount).toBe(2);
-        expect(request).not.toHaveBeenCalledWith("device.pair.setupCode", {});
+        expect(request.mock.calls.map(([method]) => method)).not.toContain("device.pair.setupCode");
       } finally {
         stalePending.resolve({ pending: [] });
         overlays.dispose();
@@ -252,7 +252,7 @@ export function registerOverlayPairingAccessTests() {
       expect(request.mock.calls.filter(([method]) => method === "device.pair.list")).toHaveLength(
         2,
       );
-      expect(request).not.toHaveBeenCalledWith("device.pair.setupCode", {});
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("device.pair.setupCode");
       overlays.dispose();
     });
 
@@ -276,7 +276,10 @@ export function registerOverlayPairingAccessTests() {
       const overlays = createApplicationOverlays(harness.gateway);
       await overlays.openDevicePairSetup();
       const mintingSetup = overlays.refreshDevicePairSetup();
-      expect(request).toHaveBeenCalledWith("device.pair.setupCode", {});
+      expect(overlays.snapshot.devicePairSetupLifecycle).toEqual({
+        phase: "loading",
+        access: "full",
+      });
 
       harness.update({
         hello: {
@@ -339,7 +342,7 @@ export function registerOverlayPairingAccessTests() {
         access: "full",
       });
       expect(overlays.snapshot.devicePairPendingCount).toBe(0);
-      expect(request).not.toHaveBeenCalledWith("device.pair.setupCode", {});
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("device.pair.setupCode");
       overlays.dispose();
     });
 
@@ -359,7 +362,7 @@ export function registerOverlayPairingAccessTests() {
       await overlays.refreshDevicePairSetup();
 
       expect(request).not.toHaveBeenCalledWith("device.pair.list", {});
-      expect(request).not.toHaveBeenCalledWith("device.pair.setupCode", {});
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("device.pair.setupCode");
       expect(overlays.snapshot.devicePairSetupOpen).toBe(false);
       overlays.dispose();
     });
@@ -380,7 +383,7 @@ export function registerOverlayPairingAccessTests() {
       await overlays.refreshDevicePairSetup();
 
       expect(request).toHaveBeenCalledWith("device.pair.list", {});
-      expect(request).not.toHaveBeenCalledWith("device.pair.setupCode", {});
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("device.pair.setupCode");
       overlays.dispose();
     });
 

--- a/ui/src/e2e/mobile-pairing.e2e.test.ts
+++ b/ui/src/e2e/mobile-pairing.e2e.test.ts
@@ -1,6 +1,7 @@
 // Control UI tests cover mobile pairing setup through the mocked Gateway.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
 import type { Page } from "playwright";
 import qrcode from "qrcode";
 import { expect, it } from "vitest";
@@ -389,6 +390,19 @@ suite.define(() => {
           "device.pair.setupCode",
           setupResult("setup-recovered", "full"),
         );
+        await page.getByRole("button", { name: "Reload" }).click();
+        await qr.waitFor();
+
+        await page.clock.install();
+        await gateway.deferNext("device.pair.setupCode");
+        await page.getByRole("button", { name: "New code" }).click();
+        await page.clock.fastForward(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS + 1);
+        await page.clock.runFor(100);
+        expect(
+          await error
+            .getByText("gateway request timed out after 30000ms: device.pair.setupCode")
+            .isVisible(),
+        ).toBe(true);
         await page.getByRole("button", { name: "Reload" }).click();
         await qr.waitFor();
         await page.locator(".device-pair-setup__close").click();

--- a/ui/src/e2e/new-session-page.connect-machine.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.connect-machine.e2e.test.ts
@@ -1,5 +1,6 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
 import { expect, it } from "vitest";
 import {
   captureUiProofEnabled,
@@ -123,6 +124,55 @@ suite.define(() => {
       await place.getByRole("button", { name: "Local" }).waitFor();
       expect(await place.getByRole("button", { name: "Connect a machine…" }).count()).toBe(0);
       expect(await gateway.getRequests("device.pair.setupCode")).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("shows a retryable error when connection-link creation never responds", async () => {
+    const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const joinUrl = "https://gateway.example.com/j/retried-code";
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "device.pair.setupCode": {
+          setupCode: "RETRIED",
+          joinUrl,
+          gatewayUrl: "wss://gateway.example.com",
+          auth: "token",
+          urlSource: "test",
+          access: "node",
+          expiresAtMs: Date.now() + 10 * 60_000,
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      await page.clock.install();
+      await gateway.deferNext("device.pair.setupCode");
+      await page.locator("#new-session-where-trigger").click();
+      await page.getByRole("button", { name: "Connect a machine…" }).click();
+      await gateway.waitForRequest("device.pair.setupCode");
+      const dialog = page.locator('openclaw-modal-dialog[label="Connect a machine"]');
+      await dialog.getByText("Creating a secure connection link…", { exact: true }).waitFor();
+      await captureProof(page, "03-connect-loading.png");
+
+      await page.clock.fastForward(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS + 1);
+      await page.clock.runFor(100);
+
+      await dialog
+        .getByRole("alert")
+        .filter({ hasText: "gateway request timed out after 30000ms: device.pair.setupCode" })
+        .waitFor();
+      expect(
+        await dialog.getByText("Creating a secure connection link…", { exact: true }).count(),
+      ).toBe(0);
+      await captureProof(page, "04-connect-timeout.png");
+      const retry = dialog.getByRole("button", { name: "Mint fresh code" });
+      await retry.click();
+      await dialog.getByText(`npx openclaw connect ${joinUrl}`, { exact: true }).waitFor();
+      expect(await gateway.getRequests("device.pair.setupCode")).toHaveLength(2);
     } finally {
       await context.close();
     }

--- a/ui/src/lib/device-pair-setup.test.ts
+++ b/ui/src/lib/device-pair-setup.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   closeDevicePairSetup,
@@ -77,10 +78,11 @@ describe("device pairing setup state", () => {
     await expect(requestDevicePairJoinSetup({ request })).resolves.toMatchObject({
       joinUrl: "https://gateway.example.com/j/fresh-code",
     });
-    expect(request).toHaveBeenCalledWith("device.pair.setupCode", {
-      includeQr: false,
-      joinUrl: true,
-    });
+    expect(request).toHaveBeenCalledWith(
+      "device.pair.setupCode",
+      { includeQr: false, joinUrl: true },
+      { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+    );
   });
 
   it("opens in access selection without minting a setup credential", async () => {
@@ -182,9 +184,10 @@ describe("device pairing setup state", () => {
     expect(request).not.toHaveBeenCalled();
     await refreshDevicePairSetup(state);
 
-    expect(request).toHaveBeenCalledWith("device.pair.setupCode", {
-      bootstrapProfile: "limited",
-    });
+    expect(request.mock.calls.at(-1)?.slice(0, 2)).toEqual([
+      "device.pair.setupCode",
+      { bootstrapProfile: "limited" },
+    ]);
     expect(state.devicePairSetupLifecycle).toMatchObject({
       phase: "waiting",
       access: "limited",
@@ -195,7 +198,7 @@ describe("device pairing setup state", () => {
     state.devicePairSetupOpen = true;
     request.mockResolvedValueOnce(setupResult("full-setup", "FULL"));
     await refreshDevicePairSetup(state);
-    expect(request).toHaveBeenLastCalledWith("device.pair.setupCode", {});
+    expect(request.mock.calls.at(-1)?.slice(0, 2)).toEqual(["device.pair.setupCode", {}]);
     closeDevicePairSetup(state);
   });
 
@@ -208,10 +211,10 @@ describe("device pairing setup state", () => {
     await setDevicePairSetupAccess(state, "node");
     await refreshDevicePairSetup(state);
 
-    expect(request).toHaveBeenCalledWith("device.pair.setupCode", {
-      bootstrapProfile: "node",
-      includeQr: false,
-    });
+    expect(request.mock.calls.at(-1)?.slice(0, 2)).toEqual([
+      "device.pair.setupCode",
+      { bootstrapProfile: "node", includeQr: false },
+    ]);
     expect(state.devicePairSetupLifecycle).toMatchObject({ phase: "waiting", access: "node" });
     closeDevicePairSetup(state);
   });

--- a/ui/src/lib/device-pair-setup.ts
+++ b/ui/src/lib/device-pair-setup.ts
@@ -1,6 +1,11 @@
 // Shared mobile pairing setup state for app-level entry points.
+import {
+  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+  type GatewayProtocolRequestOptions,
+} from "@openclaw/gateway-client/browser";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type {
+  DevicePairSetupCodeParams,
   DevicePairSetupCodeResult,
   DevicePairSetupCompletedEvent,
   DevicePairSetupDeliveryUncertainEvent,
@@ -9,7 +14,11 @@ import type {
 import { formatUiError } from "./format-error.ts";
 
 type GatewayRequestClient = {
-  request<T = unknown>(method: string, params?: unknown): Promise<T>;
+  request<T = unknown>(
+    method: string,
+    params?: unknown,
+    options?: GatewayProtocolRequestOptions,
+  ): Promise<T>;
 };
 
 export type DevicePairSetup = DevicePairSetupCodeResult & {
@@ -54,11 +63,15 @@ export type DevicePairSetupLifecycle =
       access: DevicePairSetupDeliveryUncertain["access"];
     }
   | { phase: "expired"; access: DevicePairSetupAccess };
-export function requestDevicePairJoinSetup(client: GatewayRequestClient) {
-  return client.request<DevicePairSetup>("device.pair.setupCode", {
-    includeQr: false,
-    joinUrl: true,
+
+function requestDevicePairSetup(client: GatewayRequestClient, params: DevicePairSetupCodeParams) {
+  return client.request<DevicePairSetup>("device.pair.setupCode", params, {
+    timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
   });
+}
+
+export function requestDevicePairJoinSetup(client: GatewayRequestClient) {
+  return requestDevicePairSetup(client, { includeQr: false, joinUrl: true });
 }
 
 type DevicePairSetupState = {
@@ -345,8 +358,8 @@ export async function refreshDevicePairSetup(state: DevicePairSetupState) {
   clearDevicePairSetupExpiry(state);
   state.devicePairSetupLifecycle = { phase: "loading", access };
   try {
-    const result = await client.request<DevicePairSetup>(
-      "device.pair.setupCode",
+    const result = await requestDevicePairSetup(
+      client,
       access === "full"
         ? {}
         : access === "node"


### PR DESCRIPTION
Closes #128544

AI-assisted; implementation and proof were independently reviewed before publication.

## What Problem This Solves

Fixes an issue where administrators using **New session → Connect a machine…** or the device-pairing overlay could remain on “Creating a secure connection link…” forever when the Gateway failed to deliver the setup-code response.

## Why This Change Was Made

A synchronous WebSocket send failure was reported as unavailable but left the broken transport registered and open, so the browser received neither a response nor a disconnect. Failed sends now terminate and retire that transport while preserving active node lifecycle draining. Both setup-code entry points also use the existing 30-second request deadline, producing the existing visible error and retry flow without changing global RPC defaults.

Production LOC: +24/-10 (net +14). The growth establishes one timeout-owning setup-code helper and closes the transport lifecycle; tests are counted separately.

## User Impact

Machine-link and device-pairing requests now always reach a visible outcome: a generated command, a disconnect/reconnect, or a bounded retryable error. A failed response can no longer leave the UI spinning indefinitely.

## Evidence

- Pre-fix owner-boundary reproduction: an OPEN WebSocket whose `send()` throws leaves its peer open and the setup request unresolved.
- Post-fix real-WebSocket regression: even when both send and graceful close fail, the peer observes disconnection and the Gateway client registry is retired.
- Real isolated Gateway/browser run: `device.pair.setupCode` minted a one-paste machine connection command using an explicit test public URL; the attached recording and screenshot show the rendered command.
- Deterministic Chromium before/after: attached captures show the pending spinner, then the 30-second visible error and successful **Mint fresh code** retry.
- `pnpm build`
- `node scripts/run-vitest.mjs src/gateway/server/ws-connection.test.ts ui/src/lib/device-pair-setup.test.ts ui/src/app/overlays.test.ts` — 131 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mobile-pairing.e2e.test.ts ui/src/e2e/new-session-page.connect-machine.e2e.test.ts` — 6 Chromium tests passed
- `node scripts/check-changed.mjs -- <7 changed paths>` — passed
- `git diff --check` — passed
- Codex autoreview — no accepted/actionable findings

Provenance: carried forward by #128144, which correctly rejected responses once a socket was already closing but did not retire an OPEN transport when `send()` itself failed.

![Before: connection-link creation remains pending](https://github.com/user-attachments/assets/677ff19d-4004-4fb9-9728-870792df608e)

![After: bounded timeout with a retry action](https://github.com/user-attachments/assets/9cbba946-95e2-4b6d-9e33-17820bbf56f5)

![Live isolated Gateway: generated machine connection command](https://github.com/user-attachments/assets/bacf18a0-24f1-407d-bf90-f153e3a73648)

https://github.com/user-attachments/assets/e85cb41e-3645-4bc5-aded-1382cb5e09d1