### PR TITLE
feat(geolocation): resolve client addresses to a coarse city via a bundled plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,11 @@
           - "extensions/azure-speech/**"
           - "docs/providers/azure-speech.md"
           - "docs/tools/tts.md"
+"plugin: geolocation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/geolocation/**"
+          - "docs/plugins/geolocation.md"
 "plugin: file-transfer":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1814,5 +1814,17 @@
   {
     "source": "macOS widget panel",
     "target": "macOS 小组件面板"
+  },
+  {
+    "source": "Geolocation plugin",
+    "target": "地理位置插件"
+  },
+  {
+    "source": "Trusted proxy auth",
+    "target": "受信任代理认证"
+  },
+  {
+    "source": "geolocation",
+    "target": "geolocation"
   }
 ]

--- a/docs/concepts/presence.md
+++ b/docs/concepts/presence.md
@@ -25,7 +25,7 @@ Presence entries are structured objects with fields like:
 
 - `instanceId` (optional but strongly recommended): stable client identity (usually `connect.client.instanceId`)
 - `host`: human-friendly host name
-- `ip`: best-effort IP address
+- `ip`: best-effort IP address; the [geolocation plugin](/plugins/geolocation) resolves it to a coarse city where one is available
 - `version`: client version string
 - `deviceFamily` / `modelIdentifier`: hardware hints
 - `timeZone`: self-reported IANA zone (for example `Europe/Vienna`); browsers report it during connect, and it stays useful when the connecting IP is loopback, tunneled, or CGNAT

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1334,6 +1334,7 @@
                   "plugins/workboard",
                   "plugins/webhooks",
                   "plugins/admin-http-rpc",
+              "plugins/geolocation",
                   "plugins/beam",
                   "plugins/voice-call",
                   "plugins/vault",

--- a/docs/plugins/geolocation.md
+++ b/docs/plugins/geolocation.md
@@ -1,0 +1,122 @@
+---
+summary: "Resolve a connecting client's IP address to a coarse city using a locally cached database, with no per-lookup third-party calls"
+read_when:
+  - You want to see where the people using your Gateway are connecting from
+  - You are choosing or replacing the IP-geolocation database and need its license terms
+  - A location is missing, wrong, or stuck and you need to know which layer failed
+title: "Geolocation plugin"
+---
+
+The bundled `geolocation` plugin turns a connecting client's IP address into a coarse city. It ships with OpenClaw, downloads its database on first use, and answers entirely from that local copy, so a lookup never sends an address to a third party.
+
+It owns exactly one thing: address to place. It does not decide which addresses get looked up, does not store results, and is not an authorization input. The Control UI uses it to label the devices on a person's [Activity](/concepts/presence) card; anything else that needs a place can call the same route.
+
+## Quickstart
+
+The plugin is bundled and active by default. To see it work, open **Activity**, pick a person, and look at their device row. A remote client shows its address and the resolved city:
+
+```
+openclaw-control-ui  MacIntel · 203.0.113.7 · Europe/Vienna  Vienna, Vienna ⓘ
+```
+
+Nothing appears the first time if the database is still downloading; reload after a few seconds. To check the plugin directly:
+
+```bash
+curl -s "http://127.0.0.1:18789/plugins/geolocation/lookup?ip=203.0.113.7" -H "Authorization: Bearer <GATEWAY_TOKEN>"
+```
+
+```json
+{
+  "found": true,
+  "city": "Vienna",
+  "region": "Vienna",
+  "country": "Austria",
+  "countryCode": "AT",
+  "attribution": { "text": "IP Geolocation by DB-IP", "url": "https://db-ip.com" }
+}
+```
+
+## Why some clients never show a location
+
+A location only appears when the Gateway recorded a usable public address for that client, and often it did not:
+
+- Connect handling omits `ip` entirely for loopback clients, so anything reaching the Gateway over an SSH tunnel or local port forward has no address to resolve.
+- Tailscale and other CGNAT clients sit in `100.64/10`, which the Gateway classifies as private. There is nothing to look up.
+- Mobile carriers, VPNs, and corporate egress resolve to the operator's exit point, not the person. The answer is confidently wrong rather than missing.
+
+This is why the device row also carries the client-reported time zone. A browser knows its own zone regardless of how it reached the Gateway, so `Europe/Vienna` keeps working exactly where the address stops being informative. Treat the city as a hint and the zone as the more reliable signal. See [Presence](/concepts/presence) for how both fields are produced.
+
+## Configuration
+
+Every option is optional. The defaults are a working setup.
+
+| Option            | Default                       | Purpose                                                              |
+| ----------------- | ----------------------------- | -------------------------------------------------------------------- |
+| `databaseUrl`     | monthly DB-IP City Lite build | MMDB source. `{yyyy}` and `{mm}` expand to a release month.          |
+| `attributionText` | `IP Geolocation by DB-IP`     | Credit shown next to every result.                                   |
+| `attributionUrl`  | `https://db-ip.com`           | Link target for the credit.                                          |
+| `refreshDays`     | `30`                          | How stale the cached database may get before it is downloaded again. |
+
+```json
+{
+  "plugins": {
+    "geolocation": {
+      "refreshDays": 7
+    }
+  }
+}
+```
+
+Monthly builds appear a few days into the month, so the plugin tries the current month and falls back to the previous one. A source that needs no month substitution is fetched as written.
+
+### Using a different database
+
+Set `databaseUrl` together with both attribution fields. The credit belongs to whichever dataset you point at, so changing the source without changing the credit misattributes the data:
+
+```json
+{
+  "plugins": {
+    "geolocation": {
+      "databaseUrl": "https://example.internal/geoip/city.mmdb",
+      "attributionText": "IP data by Example",
+      "attributionUrl": "https://example.internal"
+    }
+  }
+}
+```
+
+Any MaxMind-format city database works, including a self-hosted mirror or a commercial build you already license. The cache file is named after the source URL, so switching sources cannot serve the previous provider's data under the new provider's credit.
+
+## Data license
+
+The default database is **DB-IP City Lite**, licensed **CC BY 4.0**. That license requires attribution, which is why the credit is part of every response and is rendered next to the value rather than buried in settings.
+
+OpenClaw downloads this database at runtime and never redistributes it, so the license attaches to your deployment's use of the data, not to OpenClaw itself. Plugin code and the `maxmind` reader it uses are MIT. No free city-level IP database is MIT-licensed; the obligation lives with the data.
+
+Expect city-level accuracy in the 55-80% range, and worse for the mobile, VPN, and CGNAT cases above.
+
+## How the database is managed
+
+The download is lazy: an installation nobody queries never fetches anything. On the first lookup the plugin fetches the database into `<state-dir>/geolocation/`, parses it before publishing it, and keeps it until it ages past `refreshDays`.
+
+Three behaviors are worth knowing because they decide what you see during a failure:
+
+- A body that does not parse as an MMDB is discarded without replacing a working database. A rate-limit page or truncated download cannot break a Gateway that was working a minute ago.
+- A failed refresh serves the cached copy and logs a warning. Stale data beats no data.
+- Concurrent first lookups share one download rather than each starting their own.
+
+## Troubleshooting
+
+**No location on any device row.** Check whether the Gateway recorded an address at all: a row showing only a platform and time zone has no `ip`, which is expected for loopback, tunneled, and Tailscale clients. Nothing is broken.
+
+**Every lookup returns 503.** The database is unavailable — still downloading, or every candidate URL failed. Check the Gateway log for `geolocation: downloaded` or a `geolocation database download failed` line naming each URL it tried. A Gateway with no outbound network access cannot fetch the database; point `databaseUrl` at an internal mirror instead.
+
+**A `found: false` answer.** The database has no entry for that address. This is a data limitation, not a failure. Note that 503 and `found: false` are deliberately different: one means the plugin could not answer, the other means the database has no place for that address.
+
+**A wrong city.** Confirm the address is the person's, not a VPN or carrier exit. If it is genuinely wrong, DB-IP accepts corrections, or point `databaseUrl` at a commercial database with better coverage.
+
+## Related
+
+- [Presence](/concepts/presence) — how connect records the address and time zone this plugin reads
+- [Manage plugins](/plugins/manage-plugins) — enabling, disabling, and configuring bundled plugins
+- [Trusted proxy auth](/gateway/trusted-proxy-auth) — how the Gateway determines a client address behind a proxy

--- a/docs/plugins/geolocation.md
+++ b/docs/plugins/geolocation.md
@@ -57,13 +57,17 @@ Every option is optional. The defaults are a working setup.
 | `attributionUrl`  | `https://db-ip.com`           | Link target for the credit.                                          |
 | `refreshDays`     | `30`                          | How stale the cached database may get before it is downloaded again. |
 
-```json
+```json5
 {
-  "plugins": {
-    "geolocation": {
-      "refreshDays": 7
-    }
-  }
+  plugins: {
+    entries: {
+      geolocation: {
+        config: {
+          refreshDays: 7,
+        },
+      },
+    },
+  },
 }
 ```
 
@@ -73,15 +77,19 @@ Monthly builds appear a few days into the month, so the plugin tries the current
 
 Set `databaseUrl` together with both attribution fields. The credit belongs to whichever dataset you point at, so changing the source without changing the credit misattributes the data:
 
-```json
+```json5
 {
-  "plugins": {
-    "geolocation": {
-      "databaseUrl": "https://example.internal/geoip/city.mmdb",
-      "attributionText": "IP data by Example",
-      "attributionUrl": "https://example.internal"
-    }
-  }
+  plugins: {
+    entries: {
+      geolocation: {
+        config: {
+          databaseUrl: "https://example.internal/geoip/city.mmdb",
+          attributionText: "IP data by Example",
+          attributionUrl: "https://example.internal",
+        },
+      },
+    },
+  },
 }
 ```
 

--- a/docs/plugins/geolocation.md
+++ b/docs/plugins/geolocation.md
@@ -16,32 +16,45 @@ It owns exactly one thing: address to place. It does not decide which addresses 
 The plugin is bundled and active by default. To see it work, open **Activity**, pick a person, and look at their device row. A remote client shows its address and the resolved city:
 
 ```
-openclaw-control-ui  MacIntel · 203.0.113.7 · Europe/Vienna  Vienna, Vienna ⓘ
+openclaw-control-ui  MacIntel · 8.8.8.8 · Europe/Vienna  Mountain View, California ⓘ
 ```
 
-Nothing appears the first time if the database is still downloading; reload after a few seconds. To check the plugin directly:
+The first view after a fresh install shows no city while the database downloads; the row fills itself in once it is ready, without a reload. To check the plugin directly:
 
 ```bash
-curl -s "http://127.0.0.1:18789/plugins/geolocation/lookup?ip=203.0.113.7" -H "Authorization: Bearer <GATEWAY_TOKEN>"
+curl -s "http://127.0.0.1:18789/plugins/geolocation/lookup?ip=8.8.8.8" -H "Authorization: Bearer <GATEWAY_TOKEN>"
 ```
 
 ```json
 {
   "found": true,
-  "city": "Vienna",
-  "region": "Vienna",
-  "country": "Austria",
-  "countryCode": "AT",
+  "city": "Mountain View",
+  "region": "California",
+  "country": "United States",
+  "countryCode": "US",
   "attribution": { "text": "IP Geolocation by DB-IP", "url": "https://db-ip.com" }
 }
 ```
+
+Use an address that is actually routable. Reserved ranges such as `203.0.113.0/24`
+are absent from the database and answer `{"found": false}`:
+
+```json
+{
+  "found": false,
+  "attribution": { "text": "IP Geolocation by DB-IP", "url": "https://db-ip.com" }
+}
+```
+
+The first call also downloads the database, so expect it to take up to a minute
+while later calls answer from the local copy.
 
 ## Why some clients never show a location
 
 A location only appears when the Gateway recorded a usable public address for that client, and often it did not:
 
 - Connect handling omits `ip` entirely for loopback clients, so anything reaching the Gateway over an SSH tunnel or local port forward has no address to resolve.
-- Tailscale and other CGNAT clients sit in `100.64/10`, which the Gateway classifies as private. There is nothing to look up.
+- Tailscale clients arrive on a `100.64/10` carrier-grade-NAT address and LAN clients on a private one. Both are recorded and displayed, but no geolocation database contains them, so the plugin answers `found: false` for these ranges without loading the database at all. A tailnet-only or LAN-only Gateway therefore never downloads one.
 - Mobile carriers, VPNs, and corporate egress resolve to the operator's exit point, not the person. The answer is confidently wrong rather than missing.
 
 This is why the device row also carries the client-reported time zone. A browser knows its own zone regardless of how it reached the Gateway, so `Europe/Vienna` keeps working exactly where the address stops being informative. Treat the city as a hint and the zone as the more reliable signal. See [Presence](/concepts/presence) for how both fields are produced.
@@ -105,17 +118,20 @@ Expect city-level accuracy in the 55-80% range, and worse for the mobile, VPN, a
 
 ## How the database is managed
 
-The download is lazy: an installation nobody queries never fetches anything. On the first lookup the plugin fetches the database into `<state-dir>/geolocation/`, parses it before publishing it, and keeps it until it ages past `refreshDays`.
+The download is lazy and demand-driven. It happens on the first lookup of a **public** address, which in practice requires all of the following: an authenticated identity exists, an operator opened that person's Activity view, and that client connected from a routable address. A Gateway nobody inspects — or one reached only over loopback, a tunnel, a LAN, or a tailnet — never downloads anything.
 
-Three behaviors are worth knowing because they decide what you see during a failure:
+On that first qualifying lookup the plugin fetches the database into `<state-dir>/geolocation/`, parses it before publishing it, and keeps it until it ages past `refreshDays`.
 
+Four behaviors are worth knowing because they decide what you see during a failure:
+
+- The response is read against a compressed ceiling and inflated against an on-disk ceiling, both enforced while reading. A replaced source cannot allocate an unbounded body, and a compression bomb cannot inflate past the limit.
 - A body that does not parse as an MMDB is discarded without replacing a working database. A rate-limit page or truncated download cannot break a Gateway that was working a minute ago.
 - A failed refresh serves the cached copy and logs a warning. Stale data beats no data.
 - Concurrent first lookups share one download rather than each starting their own.
 
 ## Troubleshooting
 
-**No location on any device row.** Check whether the Gateway recorded an address at all: a row showing only a platform and time zone has no `ip`, which is expected for loopback, tunneled, and Tailscale clients. Nothing is broken.
+**No location on any device row.** Either the Gateway recorded no address — a row showing only a platform and time zone has no `ip`, which is expected for loopback and tunneled clients — or every address present is private or carrier-grade NAT, which the plugin answers without consulting the database. Nothing is broken in either case.
 
 **Every lookup returns 503.** The database is unavailable — still downloading, or every candidate URL failed. Check the Gateway log for `geolocation: downloaded` or a `geolocation database download failed` line naming each URL it tried. A Gateway with no outbound network access cannot fetch the database; point `databaseUrl` at an internal mirror instead.
 

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -52,7 +52,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Core npm package
 
-56 plugins
+57 plugins
 
 - **[active-memory](/plugins/reference/active-memory)** (`openclaw`) - included in OpenClaw. Runs bounded pre-reply memory retrieval and implements per-agent Remember across conversations for eligible private conversations.
 
@@ -91,6 +91,8 @@ Each entry lists the package, distribution route, and description.
 - **[fal](/plugins/reference/fal)** (`@openclaw/fal-provider`) - included in OpenClaw. Adds fal model provider support to OpenClaw.
 
 - **[file-transfer](/plugins/reference/file-transfer)** (`@openclaw/file-transfer`) - included in OpenClaw. Fetch, list, and write files on paired nodes via dedicated node commands. Bypasses bash stdout truncation by using base64 over node.invoke for binaries up to 16 MB.
+
+- **[geolocation](/plugins/reference/geolocation)** (`@openclaw/geolocation-plugin`) - included in OpenClaw. Resolves client IP addresses to a coarse city using a locally cached IP-geolocation database.
 
 - **[github-copilot](/plugins/reference/github-copilot)** (`@openclaw/github-copilot-provider`) - included in OpenClaw. Adds GitHub Copilot model provider support to OpenClaw.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -16,5 +16,5 @@ Regenerate it with:
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 147
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 148
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/geolocation.md
+++ b/docs/plugins/reference/geolocation.md
@@ -1,0 +1,23 @@
+---
+summary: "Resolves client IP addresses to a coarse city using a locally cached IP-geolocation database."
+read_when:
+  - You are installing, configuring, or auditing the geolocation plugin
+title: "Geolocation plugin"
+---
+
+# Geolocation plugin
+
+Resolves client IP addresses to a coarse city using a locally cached IP-geolocation database.
+
+## Distribution
+
+- Package: `@openclaw/geolocation-plugin`
+- Install route: included in OpenClaw
+
+## Surface
+
+plugin
+
+## Related docs
+
+- [geolocation](/plugins/geolocation)

--- a/extensions/geolocation/README.md
+++ b/extensions/geolocation/README.md
@@ -1,0 +1,46 @@
+# Geolocation plugin
+
+Resolves a client IP address to a coarse city, so surfaces that already show a
+connecting address can show a place instead of only a number.
+
+## How it works
+
+The plugin exposes one authenticated route:
+
+```
+GET /plugins/geolocation/lookup?ip=<address>
+```
+
+It answers `{ found, city?, region?, country?, countryCode?, attribution }`. A
+database that is missing or still downloading returns `503`, never
+`found: false` — "we cannot answer" and "this address has no place" are
+different answers and callers must be able to tell them apart.
+
+The database is downloaded on first lookup into
+`<state-dir>/geolocation/`, kept until it ages past `refreshDays`, and reused
+from disk after that. A failed refresh serves the cached copy rather than taking
+lookups down. A body that does not parse as an MMDB is discarded without
+replacing a working database.
+
+## Data source and license
+
+The default source is **DB-IP City Lite**, licensed **CC BY 4.0**. That license
+requires attribution, so every answer carries the credit and the Control UI
+renders it next to the value. The database is downloaded at runtime and never
+redistributed by OpenClaw.
+
+All plugin code is MIT, as is the `maxmind` reader it uses. No free city-level
+IP database is MIT-licensed; the obligation lives with the data, not the code.
+
+To use a different source, set `databaseUrl` and set `attributionText` /
+`attributionUrl` to whatever that source requires. `{yyyy}` and `{mm}` expand to
+a release month, and the previous month is tried when the current build is not
+published yet.
+
+## Accuracy
+
+City-level IP geolocation is right roughly 55-80% of the time and is worst
+exactly where it matters most: mobile carriers, VPNs, and corporate egress all
+resolve to the operator's exit point rather than the person. Treat the answer as
+a hint. The client-reported time zone shown beside it is often the better
+signal, because it survives proxies and CGNAT ranges where the address does not.

--- a/extensions/geolocation/index.ts
+++ b/extensions/geolocation/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Geolocation plugin entry. It exposes one authenticated lookup route and keeps
+ * the database download lazy, so an install that nobody queries costs nothing.
+ */
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+import { resolveGeolocationSettings } from "./src/config.js";
+import { createGeolocationDatabaseStore } from "./src/database-store.js";
+import { createGeolocationLookupHandler } from "./src/lookup-route.js";
+
+export default definePluginEntry({
+  id: "geolocation",
+  name: "Geolocation Plugin",
+  description: "Bundled geolocation plugin",
+  register(api) {
+    const settings = resolveGeolocationSettings(api.pluginConfig);
+    const store = createGeolocationDatabaseStore({
+      stateDir: resolveStateDir(),
+      settings,
+      now: () => new Date(),
+      fetchImpl: fetch,
+      logger: api.logger,
+    });
+    api.registerHttpRoute({
+      path: "/plugins/geolocation",
+      auth: "gateway",
+      match: "prefix",
+      handler: createGeolocationLookupHandler({
+        loadDatabase: () => store.load(),
+        settings,
+        logger: api.logger,
+      }),
+    });
+  },
+});

--- a/extensions/geolocation/openclaw.plugin.json
+++ b/extensions/geolocation/openclaw.plugin.json
@@ -1,0 +1,46 @@
+{
+  "id": "geolocation",
+  "name": "Geolocation",
+  "description": "Resolves client IP addresses to a coarse city using a locally cached IP-geolocation database.",
+  "enabledByDefault": true,
+  "activation": {
+    "onStartup": true
+  },
+  "uiHints": {
+    "databaseUrl": {
+      "label": "Database URL",
+      "help": "MMDB source. Defaults to the monthly DB-IP City Lite build. `{yyyy}` and `{mm}` expand to a release month; the previous month is tried when the current one is not published yet."
+    },
+    "attributionText": {
+      "label": "Attribution text",
+      "help": "Shown wherever results appear. The default database is CC BY 4.0 and requires this credit; change it only alongside databaseUrl."
+    },
+    "attributionUrl": {
+      "label": "Attribution link",
+      "help": "Link target for the attribution credit."
+    },
+    "refreshDays": {
+      "label": "Refresh interval (days)",
+      "help": "How old the cached database may get before it is downloaded again. Defaults to 30."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "databaseUrl": {
+        "type": "string"
+      },
+      "attributionText": {
+        "type": "string"
+      },
+      "attributionUrl": {
+        "type": "string"
+      },
+      "refreshDays": {
+        "type": "number",
+        "minimum": 1
+      }
+    }
+  }
+}

--- a/extensions/geolocation/package.json
+++ b/extensions/geolocation/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@openclaw/geolocation-plugin",
+  "version": "2026.8.1",
+  "description": "OpenClaw geolocation plugin resolving client IP addresses to a coarse city using a locally cached IP-geolocation database.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "dependencies": {
+    "maxmind": "5.0.7"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.8.1"
+    },
+    "build": {
+      "openclawVersion": "2026.8.1"
+    }
+  }
+}

--- a/extensions/geolocation/src/config.test.ts
+++ b/extensions/geolocation/src/config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { expandDatabaseUrls, resolveGeolocationSettings } from "./config.js";
+
+describe("geolocation settings", () => {
+  it("defaults to the DB-IP source and its required credit", () => {
+    const settings = resolveGeolocationSettings(undefined);
+    expect(settings.databaseUrl).toContain("dbip-city-lite");
+    expect(settings.attribution).toEqual({
+      text: "IP Geolocation by DB-IP",
+      url: "https://db-ip.com",
+    });
+    expect(settings.refreshMs).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it("keeps attribution overridable so a swapped source can carry its own credit", () => {
+    const settings = resolveGeolocationSettings({
+      databaseUrl: "https://example.test/db.mmdb",
+      attributionText: "Data by Example",
+      attributionUrl: "https://example.test",
+      refreshDays: 7,
+    });
+    expect(settings.databaseUrl).toBe("https://example.test/db.mmdb");
+    expect(settings.attribution.text).toBe("Data by Example");
+    expect(settings.refreshMs).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("ignores unusable overrides instead of producing an empty source or credit", () => {
+    const settings = resolveGeolocationSettings({
+      databaseUrl: "   ",
+      attributionText: "",
+      refreshDays: 0,
+    });
+    expect(settings.databaseUrl).toContain("dbip-city-lite");
+    expect(settings.attribution.text).toBe("IP Geolocation by DB-IP");
+    expect(settings.refreshMs).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it("offers this month and the previous month, because a build lands mid-month", () => {
+    const urls = expandDatabaseUrls(
+      "https://host.test/db-{yyyy}-{mm}.mmdb.gz",
+      new Date("2026-01-03T00:00:00Z"),
+    );
+    expect(urls).toEqual([
+      "https://host.test/db-2026-01.mmdb.gz",
+      "https://host.test/db-2025-12.mmdb.gz",
+    ]);
+  });
+
+  it("does not repeat a URL when the template ignores the month", () => {
+    expect(
+      expandDatabaseUrls("https://host.test/db.mmdb", new Date("2026-01-03T00:00:00Z")),
+    ).toEqual(["https://host.test/db.mmdb"]);
+  });
+});

--- a/extensions/geolocation/src/config.ts
+++ b/extensions/geolocation/src/config.ts
@@ -1,0 +1,49 @@
+import {
+  asOptionalRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+/** Resolved geolocation settings, including the credit its data license requires. */
+export type GeolocationSettings = {
+  databaseUrl: string;
+  attribution: { text: string; url: string };
+  refreshMs: number;
+};
+
+// DB-IP City Lite is CC BY 4.0: usable commercially, redistribution-free because
+// we download at runtime, but the credit below is a license term, not decoration.
+const DEFAULT_DATABASE_URL = "https://download.db-ip.com/free/dbip-city-lite-{yyyy}-{mm}.mmdb.gz";
+const DEFAULT_ATTRIBUTION_TEXT = "IP Geolocation by DB-IP";
+const DEFAULT_ATTRIBUTION_URL = "https://db-ip.com";
+const DEFAULT_REFRESH_DAYS = 30;
+
+function positiveRefreshDays(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+export function resolveGeolocationSettings(pluginConfig: unknown): GeolocationSettings {
+  const config = asOptionalRecord(pluginConfig);
+  const refreshDays = positiveRefreshDays(config?.refreshDays) ?? DEFAULT_REFRESH_DAYS;
+  return {
+    databaseUrl: normalizeOptionalString(config?.databaseUrl) ?? DEFAULT_DATABASE_URL,
+    attribution: {
+      text: normalizeOptionalString(config?.attributionText) ?? DEFAULT_ATTRIBUTION_TEXT,
+      url: normalizeOptionalString(config?.attributionUrl) ?? DEFAULT_ATTRIBUTION_URL,
+    },
+    refreshMs: refreshDays * 24 * 60 * 60 * 1000,
+  };
+}
+
+/**
+ * Monthly builds appear a few days into the month, so the newest published
+ * release is either this month's or the previous one. Callers try in order.
+ */
+export function expandDatabaseUrls(template: string, now: Date): string[] {
+  const candidates = [now, new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))];
+  const urls = candidates.map((date) =>
+    template
+      .replaceAll("{yyyy}", String(date.getUTCFullYear()))
+      .replaceAll("{mm}", String(date.getUTCMonth() + 1).padStart(2, "0")),
+  );
+  return [...new Set(urls)];
+}

--- a/extensions/geolocation/src/database-store.test.ts
+++ b/extensions/geolocation/src/database-store.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { gzipSync } from "node:zlib";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveGeolocationSettings } from "./config.js";
 import { createGeolocationDatabaseStore } from "./database-store.js";
@@ -15,10 +16,48 @@ async function tempStateDir(): Promise<string> {
 }
 
 function jsonResponse(body: Buffer, ok = true): Response {
+  // The store streams the body, so the fake exposes a reader rather than
+  // arrayBuffer: an oversized response must be rejected mid-read.
   return {
     ok,
     status: ok ? 200 : 404,
-    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+    body: {
+      getReader() {
+        let sent = false;
+        return {
+          async read() {
+            if (sent) {
+              return { done: true, value: undefined };
+            }
+            sent = true;
+            return { done: false, value: new Uint8Array(body) };
+          },
+          async cancel() {},
+        };
+      },
+    },
+  } as unknown as Response;
+}
+
+function chunkedResponse(chunkBytes: number, chunkCount: number): Response {
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      getReader() {
+        let emitted = 0;
+        return {
+          async read() {
+            if (emitted >= chunkCount) {
+              return { done: true, value: undefined };
+            }
+            emitted += 1;
+            return { done: false, value: new Uint8Array(chunkBytes) };
+          },
+          async cancel() {},
+        };
+      },
+    },
   } as unknown as Response;
 }
 
@@ -84,5 +123,38 @@ describe("geolocation database store", () => {
       }).databaseFile;
 
     expect(settingsFor("https://a.test/db.mmdb")).not.toBe(settingsFor("https://b.test/db.mmdb"));
+  });
+
+  it("rejects an oversized body while reading instead of after allocating it", async () => {
+    const stateDir = await tempStateDir();
+    // 3 chunks of 128 MiB exceeds the 256 MiB compressed ceiling on the third
+    // read, so the reader must stop rather than buffer the whole response.
+    const chunkBytes = 128 * 1024 * 1024;
+    const store = createGeolocationDatabaseStore({
+      stateDir,
+      settings: resolveGeolocationSettings({ databaseUrl: "https://host.test/db.mmdb" }),
+      now: () => new Date("2026-01-03T00:00:00Z"),
+      fetchImpl: (async () => chunkedResponse(chunkBytes, 3)) as unknown as typeof fetch,
+    });
+
+    await expect(store.load()).rejects.toThrow(/exceeded the \d+ byte cap/);
+    await expect(fs.readdir(path.join(stateDir, "geolocation"))).rejects.toThrow();
+  });
+
+  it("refuses a gzip source that inflates past the on-disk ceiling", async () => {
+    const stateDir = await tempStateDir();
+    // A highly compressible payload stands in for a compression bomb: the
+    // compressed bytes are tiny, the inflated output is what must be bounded.
+    const inflated = Buffer.alloc(700 * 1024 * 1024, 0);
+    const compressed = gzipSync(inflated);
+    const store = createGeolocationDatabaseStore({
+      stateDir,
+      settings: resolveGeolocationSettings({ databaseUrl: "https://host.test/db.mmdb.gz" }),
+      now: () => new Date("2026-01-03T00:00:00Z"),
+      fetchImpl: (async () => jsonResponse(compressed)) as unknown as typeof fetch,
+    });
+
+    await expect(store.load()).rejects.toThrow(/db\.mmdb\.gz/);
+    await expect(fs.readdir(path.join(stateDir, "geolocation"))).rejects.toThrow();
   });
 });

--- a/extensions/geolocation/src/database-store.test.ts
+++ b/extensions/geolocation/src/database-store.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveGeolocationSettings } from "./config.js";
+import { createGeolocationDatabaseStore } from "./database-store.js";
+
+const created: string[] = [];
+
+async function tempStateDir(): Promise<string> {
+  // Realpath first: macOS tmp is a symlink and the store compares resolved paths.
+  const dir = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "geolocation-store-")));
+  created.push(dir);
+  return dir;
+}
+
+function jsonResponse(body: Buffer, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 404,
+    arrayBuffer: async () => body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
+  } as unknown as Response;
+}
+
+afterEach(async () => {
+  await Promise.all(created.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("geolocation database store", () => {
+  it("tries the previous month when the current build is not published yet", async () => {
+    const stateDir = await tempStateDir();
+    const fetchImpl = vi.fn(async () => jsonResponse(Buffer.from("nope"), false));
+    const store = createGeolocationDatabaseStore({
+      stateDir,
+      settings: resolveGeolocationSettings({
+        databaseUrl: "https://host.test/db-{yyyy}-{mm}.mmdb",
+      }),
+      now: () => new Date("2026-01-03T00:00:00Z"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(store.load()).rejects.toThrow(/db-2026-01.*db-2025-12/s);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses to publish an unparsable body, leaving no database behind", async () => {
+    const stateDir = await tempStateDir();
+    const store = createGeolocationDatabaseStore({
+      stateDir,
+      settings: resolveGeolocationSettings({ databaseUrl: "https://host.test/db.mmdb" }),
+      now: () => new Date("2026-01-03T00:00:00Z"),
+      fetchImpl: (async () =>
+        jsonResponse(Buffer.from("<html>rate limited</html>"))) as unknown as typeof fetch,
+    });
+
+    await expect(store.load()).rejects.toThrow(/db\.mmdb/);
+    await expect(fs.readdir(path.join(stateDir, "geolocation"))).rejects.toThrow();
+  });
+
+  it("downloads once when concurrent callers race the first lookup", async () => {
+    const stateDir = await tempStateDir();
+    const fetchImpl = vi.fn(async () => jsonResponse(Buffer.from("garbage")));
+    const store = createGeolocationDatabaseStore({
+      stateDir,
+      settings: resolveGeolocationSettings({ databaseUrl: "https://host.test/db.mmdb" }),
+      now: () => new Date("2026-01-03T00:00:00Z"),
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const results = await Promise.allSettled([store.load(), store.load(), store.load()]);
+
+    expect(results.every((r) => r.status === "rejected")).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the source in the cache path so a swapped source cannot reuse the old data", async () => {
+    const stateDir = await tempStateDir();
+    const settingsFor = (databaseUrl: string) =>
+      createGeolocationDatabaseStore({
+        stateDir,
+        settings: resolveGeolocationSettings({ databaseUrl }),
+        now: () => new Date("2026-01-03T00:00:00Z"),
+        fetchImpl: (async () => jsonResponse(Buffer.from(""))) as unknown as typeof fetch,
+      }).databaseFile;
+
+    expect(settingsFor("https://a.test/db.mmdb")).not.toBe(settingsFor("https://b.test/db.mmdb"));
+  });
+});

--- a/extensions/geolocation/src/database-store.ts
+++ b/extensions/geolocation/src/database-store.ts
@@ -1,0 +1,130 @@
+/**
+ * Owns the on-disk MMDB copy: downloads it on first use, reuses it until it
+ * ages past the refresh window, and keeps one opened reader per process.
+ */
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { gunzip } from "node:zlib";
+import { type CityResponse, Reader } from "maxmind";
+import { expandDatabaseUrls, type GeolocationSettings } from "./config.js";
+
+const gunzipAsync = promisify(gunzip);
+
+// A city-level MMDB is ~125 MB today; the ceiling stops a redirected or
+// replaced URL from streaming an unbounded body into the state directory.
+const MAX_DATABASE_BYTES = 512 * 1024 * 1024;
+const DOWNLOAD_TIMEOUT_MS = 120_000;
+
+/** The database's own record contract; re-exported so callers need one import. */
+export type GeolocationCityRecord = CityResponse;
+
+export type GeolocationDatabase = {
+  lookup: (ip: string) => GeolocationCityRecord | null;
+};
+
+type StoreDeps = {
+  stateDir: string;
+  settings: GeolocationSettings;
+  now: () => Date;
+  fetchImpl: typeof fetch;
+  logger?: { info: (msg: string) => void; warn: (msg: string) => void };
+};
+
+function databasePath(stateDir: string, databaseUrl: string): string {
+  // The URL is part of the name so switching sources cannot silently reuse the
+  // previous provider's data under the new provider's attribution.
+  const digest = createHash("sha256").update(databaseUrl).digest("hex").slice(0, 12);
+  return path.join(stateDir, "geolocation", `ip-city-${digest}.mmdb`);
+}
+
+async function readFileAge(file: string, now: Date): Promise<number | undefined> {
+  try {
+    const stat = await fs.stat(file);
+    return now.getTime() - stat.mtimeMs;
+  } catch {
+    return undefined;
+  }
+}
+
+async function downloadDatabase(deps: StoreDeps, target: string): Promise<Reader<CityResponse>> {
+  const urls = expandDatabaseUrls(deps.settings.databaseUrl, deps.now());
+  const failures: string[] = [];
+  for (const url of urls) {
+    try {
+      const response = await deps.fetchImpl(url, {
+        signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+      });
+      if (!response.ok) {
+        failures.push(`${url} -> HTTP ${response.status}`);
+        continue;
+      }
+      const raw = Buffer.from(await response.arrayBuffer());
+      if (raw.byteLength > MAX_DATABASE_BYTES) {
+        failures.push(`${url} -> ${raw.byteLength} bytes exceeds the ${MAX_DATABASE_BYTES} cap`);
+        continue;
+      }
+      const body = url.endsWith(".gz") ? await gunzipAsync(raw) : raw;
+      // Parse before publishing so a truncated or HTML error body never replaces
+      // a working database on disk. The reader is returned so the caller does
+      // not read and parse the same bytes a second time.
+      const reader = new Reader<CityResponse>(body);
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      const staging = `${target}.partial`;
+      await fs.writeFile(staging, body);
+      await fs.rename(staging, target);
+      deps.logger?.info(`geolocation: downloaded ${body.byteLength} bytes from ${url}`);
+      return reader;
+    } catch (err) {
+      failures.push(`${url} -> ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  throw new Error(`geolocation database download failed: ${failures.join("; ")}`);
+}
+
+/**
+ * Returns a reader, downloading or refreshing the database as needed. A stale
+ * copy is preferred over failing: a refresh error must not take lookups down.
+ */
+export function createGeolocationDatabaseStore(deps: StoreDeps) {
+  const target = databasePath(deps.stateDir, deps.settings.databaseUrl);
+  let opened: { reader: Reader<CityResponse>; loadedAt: number } | undefined;
+  let inFlight: Promise<GeolocationDatabase> | undefined;
+
+  const openFromDisk = async (): Promise<GeolocationDatabase> => {
+    const age = await readFileAge(target, deps.now());
+    let downloaded: Reader<CityResponse> | undefined;
+    if (age === undefined) {
+      downloaded = await downloadDatabase(deps, target);
+    } else if (age > deps.settings.refreshMs) {
+      try {
+        downloaded = await downloadDatabase(deps, target);
+      } catch (err) {
+        // A refresh failure must not take lookups down; the cached copy is old
+        // but still answers.
+        deps.logger?.warn(
+          `geolocation: refresh failed, serving the cached database: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    const reader = downloaded ?? new Reader<CityResponse>(await fs.readFile(target));
+    opened = { reader, loadedAt: deps.now().getTime() };
+    return { lookup: (ip: string) => reader.get(ip) };
+  };
+
+  return {
+    async load(): Promise<GeolocationDatabase> {
+      const current = opened;
+      if (current && deps.now().getTime() - current.loadedAt <= deps.settings.refreshMs) {
+        return { lookup: (ip: string) => current.reader.get(ip) };
+      }
+      // One download at a time: concurrent first lookups must not each fetch.
+      inFlight ??= openFromDisk().finally(() => {
+        inFlight = undefined;
+      });
+      return await inFlight;
+    },
+    databaseFile: target,
+  };
+}

--- a/extensions/geolocation/src/database-store.ts
+++ b/extensions/geolocation/src/database-store.ts
@@ -12,8 +12,42 @@ import { expandDatabaseUrls, type GeolocationSettings } from "./config.js";
 
 const gunzipAsync = promisify(gunzip);
 
-// A city-level MMDB is ~125 MB today; the ceiling stops a redirected or
-// replaced URL from streaming an unbounded body into the state directory.
+/**
+ * Reads the body chunk by chunk and fails as soon as the running total passes
+ * the cap, so an oversized response is rejected mid-flight instead of after it
+ * has already been allocated in full.
+ */
+async function readBoundedBody(response: Response, limit: number): Promise<Buffer> {
+  const body = response.body;
+  if (!body) {
+    throw new Error("response had no body");
+  }
+  const reader = body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      total += value.byteLength;
+      if (total > limit) {
+        throw new Error(`response exceeded the ${limit} byte cap`);
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+  return Buffer.concat(chunks);
+}
+
+// A city-level MMDB is ~125 MB today and its gzip is ~20 MB. Both ceilings are
+// enforced while reading, not after: a replaced or compromised source must not
+// be able to allocate an unbounded body, and a compression bomb must not be able
+// to inflate past the on-disk ceiling either.
+const MAX_COMPRESSED_BYTES = 256 * 1024 * 1024;
 const MAX_DATABASE_BYTES = 512 * 1024 * 1024;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
 
@@ -60,12 +94,12 @@ async function downloadDatabase(deps: StoreDeps, target: string): Promise<Reader
         failures.push(`${url} -> HTTP ${response.status}`);
         continue;
       }
-      const raw = Buffer.from(await response.arrayBuffer());
-      if (raw.byteLength > MAX_DATABASE_BYTES) {
-        failures.push(`${url} -> ${raw.byteLength} bytes exceeds the ${MAX_DATABASE_BYTES} cap`);
-        continue;
-      }
-      const body = url.endsWith(".gz") ? await gunzipAsync(raw) : raw;
+      const raw = await readBoundedBody(response, MAX_COMPRESSED_BYTES);
+      // maxOutputLength makes zlib stop inflating at the ceiling rather than
+      // allocating whatever the compressed stream claims to expand into.
+      const body = url.endsWith(".gz")
+        ? await gunzipAsync(raw, { maxOutputLength: MAX_DATABASE_BYTES })
+        : raw;
       // Parse before publishing so a truncated or HTML error body never replaces
       // a working database on disk. The reader is returned so the caller does
       // not read and parse the same bytes a second time.

--- a/extensions/geolocation/src/lookup-route.test.ts
+++ b/extensions/geolocation/src/lookup-route.test.ts
@@ -1,0 +1,103 @@
+import type { ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { resolveGeolocationSettings } from "./config.js";
+import { createGeolocationLookupHandler } from "./lookup-route.js";
+
+function fakeResponse() {
+  const chunks: string[] = [];
+  let status = 0;
+  const res = {
+    writeHead: (code: number) => {
+      status = code;
+      return res;
+    },
+    end: (body?: string) => {
+      if (body) {
+        chunks.push(body);
+      }
+    },
+  };
+  return {
+    res: res as unknown as ServerResponse,
+    get status() {
+      return status;
+    },
+    get body() {
+      return chunks.length > 0 ? JSON.parse(chunks.join("")) : undefined;
+    },
+  };
+}
+
+const settings = resolveGeolocationSettings(undefined);
+
+describe("geolocation lookup route", () => {
+  it("answers with the placement and the credit its license requires", async () => {
+    const handler = createGeolocationLookupHandler({
+      settings,
+      loadDatabase: async () => ({
+        lookup: () => ({
+          city: { names: { en: "Vienna" } },
+          subdivisions: [{ names: { en: "Vienna" } }],
+          country: { iso_code: "AT", names: { en: "Austria" } },
+        }),
+      }),
+    } as never);
+    const out = fakeResponse();
+
+    await handler({ url: "/plugins/geolocation/lookup?ip=203.0.113.7" } as never, out.res);
+
+    expect(out.status).toBe(200);
+    expect(out.body).toMatchObject({
+      found: true,
+      city: "Vienna",
+      country: "Austria",
+      countryCode: "AT",
+      attribution: { text: "IP Geolocation by DB-IP", url: "https://db-ip.com" },
+    });
+  });
+
+  it("reports a database outage as an outage, never as a located-nowhere answer", async () => {
+    const warn = vi.fn();
+    const handler = createGeolocationLookupHandler({
+      settings,
+      logger: { warn },
+      loadDatabase: async () => {
+        throw new Error("download failed");
+      },
+    } as never);
+    const out = fakeResponse();
+
+    await handler({ url: "/plugins/geolocation/lookup?ip=203.0.113.7" } as never, out.res);
+
+    expect(out.status).toBe(503);
+    expect(out.body).not.toHaveProperty("found");
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("distinguishes an address the database does not place from an outage", async () => {
+    const handler = createGeolocationLookupHandler({
+      settings,
+      loadDatabase: async () => ({ lookup: () => null }),
+    } as never);
+    const out = fakeResponse();
+
+    await handler({ url: "/plugins/geolocation/lookup?ip=203.0.113.7" } as never, out.res);
+
+    expect(out.status).toBe(200);
+    expect(out.body.found).toBe(false);
+  });
+
+  it("rejects a non-address instead of handing it to the database", async () => {
+    const lookup = vi.fn();
+    const handler = createGeolocationLookupHandler({
+      settings,
+      loadDatabase: async () => ({ lookup }),
+    } as never);
+    const out = fakeResponse();
+
+    await handler({ url: "/plugins/geolocation/lookup?ip=not-an-ip" } as never, out.res);
+
+    expect(out.status).toBe(400);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/geolocation/src/lookup-route.test.ts
+++ b/extensions/geolocation/src/lookup-route.test.ts
@@ -100,4 +100,31 @@ describe("geolocation lookup route", () => {
     expect(out.status).toBe(400);
     expect(lookup).not.toHaveBeenCalled();
   });
+
+  it("answers unresolvable ranges without consulting the database", async () => {
+    // A tailnet or LAN-only deployment must never trigger the download: CGNAT,
+    // private, loopback, and link-local addresses are absent from every
+    // geolocation database, so there is nothing to load.
+    const loadDatabase = vi.fn();
+    const handler = createGeolocationLookupHandler({ settings, loadDatabase } as never);
+
+    for (const ip of ["100.64.1.5", "192.168.1.20", "10.0.0.4", "127.0.0.1", "169.254.1.1"]) {
+      const out = fakeResponse();
+      await handler({ url: `/plugins/geolocation/lookup?ip=${ip}` } as never, out.res);
+      expect(out.status, ip).toBe(200);
+      expect(out.body.found, ip).toBe(false);
+    }
+
+    expect(loadDatabase).not.toHaveBeenCalled();
+  });
+
+  it("still consults the database for a routable address", async () => {
+    const loadDatabase = vi.fn(async () => ({ lookup: () => null }));
+    const handler = createGeolocationLookupHandler({ settings, loadDatabase } as never);
+    const out = fakeResponse();
+
+    await handler({ url: "/plugins/geolocation/lookup?ip=8.8.8.8" } as never, out.res);
+
+    expect(loadDatabase).toHaveBeenCalledOnce();
+  });
 });

--- a/extensions/geolocation/src/lookup-route.ts
+++ b/extensions/geolocation/src/lookup-route.ts
@@ -1,0 +1,51 @@
+/** HTTP surface: `GET /plugins/geolocation/lookup?ip=<address>`. */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import net from "node:net";
+import type { GeolocationSettings } from "./config.js";
+import type { GeolocationDatabase } from "./database-store.js";
+import { projectGeolocationRecord } from "./lookup.js";
+
+type RouteDeps = {
+  loadDatabase: () => Promise<GeolocationDatabase>;
+  settings: GeolocationSettings;
+  logger?: { warn: (msg: string) => void };
+};
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+export function createGeolocationLookupHandler(deps: RouteDeps) {
+  return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    if (!url.pathname.endsWith("/lookup")) {
+      return false;
+    }
+    const ip = url.searchParams.get("ip")?.trim() ?? "";
+    if (!net.isIP(ip)) {
+      sendJson(res, 400, { error: "ip must be a valid IPv4 or IPv6 address" });
+      return true;
+    }
+    try {
+      const database = await deps.loadDatabase();
+      const location = projectGeolocationRecord(database.lookup(ip));
+      sendJson(res, 200, {
+        found: Boolean(location),
+        ...location,
+        attribution: deps.settings.attribution,
+      });
+    } catch (err) {
+      // A missing database is an availability problem, never a lookup answer:
+      // reporting "not found" here would read as "this IP has no location".
+      const message = err instanceof Error ? err.message : String(err);
+      deps.logger?.warn(`geolocation: lookup unavailable: ${message}`);
+      sendJson(res, 503, { error: "geolocation database unavailable" });
+    }
+    return true;
+  };
+}

--- a/extensions/geolocation/src/lookup-route.ts
+++ b/extensions/geolocation/src/lookup-route.ts
@@ -1,6 +1,7 @@
 /** HTTP surface: `GET /plugins/geolocation/lookup?ip=<address>`. */
 import type { IncomingMessage, ServerResponse } from "node:http";
 import net from "node:net";
+import { isPrivateOrLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { GeolocationSettings } from "./config.js";
 import type { GeolocationDatabase } from "./database-store.js";
 import { projectGeolocationRecord } from "./lookup.js";
@@ -29,6 +30,13 @@ export function createGeolocationLookupHandler(deps: RouteDeps) {
     const ip = url.searchParams.get("ip")?.trim() ?? "";
     if (!net.isIP(ip)) {
       sendJson(res, 400, { error: "ip must be a valid IPv4 or IPv6 address" });
+      return true;
+    }
+    // Private, loopback, link-local, and carrier-grade-NAT addresses are absent
+    // from every geolocation database, so answering them here keeps a tailnet or
+    // LAN-only deployment from ever downloading one.
+    if (isPrivateOrLoopbackHost(ip)) {
+      sendJson(res, 200, { found: false, attribution: deps.settings.attribution });
       return true;
     }
     try {

--- a/extensions/geolocation/src/lookup.ts
+++ b/extensions/geolocation/src/lookup.ts
@@ -1,0 +1,37 @@
+/** Projects an MMDB city record into the coarse shape callers display. */
+import type { GeolocationCityRecord } from "./database-store.js";
+
+type GeolocationResult = {
+  city?: string;
+  region?: string;
+  country?: string;
+  countryCode?: string;
+};
+
+// The record type marks `en` required, but Lite builds do ship entries without
+// it, so this reads defensively rather than trusting the declaration.
+function englishName(names: { readonly en?: string } | undefined): string | undefined {
+  const value = names?.en?.trim();
+  return value ? value : undefined;
+}
+
+/**
+ * Returns undefined when the database has no usable placement for the address,
+ * so callers can distinguish "not found" from an empty-but-present answer.
+ */
+export function projectGeolocationRecord(
+  record: GeolocationCityRecord | null,
+): GeolocationResult | undefined {
+  if (!record) {
+    return undefined;
+  }
+  const result: GeolocationResult = {
+    ...(englishName(record.city?.names) ? { city: englishName(record.city?.names) } : {}),
+    ...(englishName(record.subdivisions?.[0]?.names)
+      ? { region: englishName(record.subdivisions?.[0]?.names) }
+      : {}),
+    ...(englishName(record.country?.names) ? { country: englishName(record.country?.names) } : {}),
+    ...(record.country?.iso_code ? { countryCode: record.country.iso_code } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/extensions/geolocation/tsconfig.json
+++ b/extensions/geolocation/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -958,6 +958,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/geolocation:
+    dependencies:
+      maxmind:
+        specifier: 5.0.7
+        version: 5.0.7
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/github-copilot:
     devDependencies:
       '@openclaw/plugin-sdk':
@@ -7286,6 +7296,10 @@ packages:
   matrix-widget-api@1.17.0:
     resolution: {integrity: sha512-5FHoo3iEP3Bdlv5jsYPWOqj+pGdFQNLWnJLiB0V7Ygne7bb+Gsj3ibyFyHWC6BVw+Z+tSW4ljHpO17I9TwStwQ==}
 
+  maxmind@5.0.7:
+    resolution: {integrity: sha512-+w637dwfv01MKjkrp4sKDBTEKHLPvWLYb647QTjiz3wG/teSemqudIKNShaS6eqZ7ffxC9oZlQQgIqY0rGojog==}
+    engines: {node: '>=12', npm: '>=6'}
+
   md5@2.3.0:
     resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
@@ -7496,6 +7510,10 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  mmdb-lib@3.0.3:
+    resolution: {integrity: sha512-xQPoBXcNjjHiOvOraFBKtA++uNWF6aCVHL9dRKFXEov8eI3QJwtgiw3qApsonFT5SpoqsEVISUTg3HIDs2DiXw==}
+    engines: {node: '>=10', npm: '>=6'}
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -8496,6 +8514,10 @@ packages:
 
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
+
+  tiny-lru@13.0.0:
+    resolution: {integrity: sha512-xDHxKKS1FdF0Tv2P+QT7IeSEg74K/8cEDzbv3Tv6UyHHUgBOjOiQiBp818MGj66dhurQus/IBcoAbwIKtSGc6Q==}
+    engines: {node: '>=14'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -14222,6 +14244,11 @@ snapshots:
       '@types/events': 3.0.3
       events: 3.3.0
 
+  maxmind@5.0.7:
+    dependencies:
+      mmdb-lib: 3.0.3
+      tiny-lru: 13.0.0
+
   md5@2.3.0:
     dependencies:
       charenc: 0.0.2
@@ -14629,6 +14656,8 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
+
+  mmdb-lib@3.0.3: {}
 
   module-details-from-path@1.0.4: {}
 
@@ -15779,6 +15808,8 @@ snapshots:
       real-require: 0.2.0
 
   thunky@1.1.0: {}
+
+  tiny-lru@13.0.0: {}
 
   tinybench@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -960,6 +960,9 @@ importers:
 
   extensions/geolocation:
     dependencies:
+      '@openclaw/net-policy':
+        specifier: workspace:*
+        version: link:../../packages/net-policy
       maxmind:
         specifier: 5.0.7
         version: 5.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -960,9 +960,6 @@ importers:
 
   extensions/geolocation:
     dependencies:
-      '@openclaw/net-policy':
-        specifier: workspace:*
-        version: link:../../packages/net-policy
       maxmind:
         specifier: 5.0.7
         version: 5.0.7

--- a/scripts/generate-plugin-inventory-doc.mts
+++ b/scripts/generate-plugin-inventory-doc.mts
@@ -29,6 +29,7 @@ const PLUGIN_DOC_ALIASES = new Map([
   ["browser", "/tools/browser"],
   ["codex", "/plugins/codex-harness"],
   ["document-extract", "/tools/pdf"],
+  ["geolocation", "/plugins/geolocation"],
   ["duckduckgo", "/tools/duckduckgo-search"],
   ["exa", "/tools/exa-search"],
   ["firecrawl", "/tools/firecrawl"],

--- a/ui/src/components/ip-location.test.ts
+++ b/ui/src/components/ip-location.test.ts
@@ -7,10 +7,16 @@ function jsonResponse(body: unknown) {
   return { ok: true, status: 200, json: async () => body } as Response;
 }
 
-async function settle(element: HTMLElement & { updateComplete?: Promise<unknown> }) {
-  await element.updateComplete;
-  await Promise.resolve();
-  await element.updateComplete;
+// The element resolves through its own fetch, so wait for the asserted text
+// rather than a fixed number of update cycles.
+async function settleUntil(
+  element: HTMLElement & { updateComplete?: Promise<unknown> },
+  predicate: () => boolean,
+) {
+  await vi.waitFor(async () => {
+    await element.updateComplete;
+    expect(predicate()).toBe(true);
+  });
 }
 
 beforeEach(() => {
@@ -38,9 +44,8 @@ describe("openclaw-ip-location", () => {
     element.ip = "203.0.113.20";
     document.body.append(element);
 
-    await settle(element);
+    await settleUntil(element, () => (element.textContent ?? "").includes("Vienna, Vienna"));
 
-    expect(element.textContent).toContain("Vienna, Vienna");
     expect(element.querySelector("a")?.getAttribute("href")).toBe("https://db-ip.com");
   });
 
@@ -53,8 +58,11 @@ describe("openclaw-ip-location", () => {
     element.ip = "203.0.113.21";
     document.body.append(element);
 
-    await settle(element);
-
+    await settleUntil(
+      element,
+      () => (fetch as unknown as { mock: { calls: unknown[] } }).mock.calls.length > 0,
+    );
+    await element.updateComplete;
     expect(element.textContent?.trim()).toBe("");
   });
 
@@ -64,8 +72,7 @@ describe("openclaw-ip-location", () => {
     const element = document.createElement("openclaw-ip-location");
     document.body.append(element);
 
-    await settle(element);
-
+    await element.updateComplete;
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/components/ip-location.test.ts
+++ b/ui/src/components/ip-location.test.ts
@@ -1,0 +1,71 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "./ip-location.ts";
+
+function jsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+async function settle(element: HTMLElement & { updateComplete?: Promise<unknown> }) {
+  await element.updateComplete;
+  await Promise.resolve();
+  await element.updateComplete;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("openclaw-ip-location", () => {
+  it("renders the city with its attribution link", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          found: true,
+          city: "Vienna",
+          region: "Vienna",
+          attribution: { text: "IP Geolocation by DB-IP", url: "https://db-ip.com" },
+        }),
+      ),
+    );
+    const element = document.createElement("openclaw-ip-location");
+    element.ip = "203.0.113.20";
+    document.body.append(element);
+
+    await settle(element);
+
+    expect(element.textContent).toContain("Vienna, Vienna");
+    expect(element.querySelector("a")?.getAttribute("href")).toBe("https://db-ip.com");
+  });
+
+  it("renders nothing when the address cannot be placed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ found: false })),
+    );
+    const element = document.createElement("openclaw-ip-location");
+    element.ip = "203.0.113.21";
+    document.body.append(element);
+
+    await settle(element);
+
+    expect(element.textContent?.trim()).toBe("");
+  });
+
+  it("does not request anything without an address", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const element = document.createElement("openclaw-ip-location");
+    document.body.append(element);
+
+    await settle(element);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/ip-location.ts
+++ b/ui/src/components/ip-location.ts
@@ -1,0 +1,67 @@
+import { html, nothing } from "lit";
+import { property, state } from "lit/decorators.js";
+import { lookupClientGeolocation, type ClientGeolocation } from "../lib/geolocation-lookup.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
+
+/**
+ * Renders the coarse city for one client address, or nothing at all. Absence is
+ * the normal case — no plugin installed, no database yet, or an address the
+ * database cannot place — so this never shows a spinner or an error state.
+ */
+class OpenClawIpLocation extends OpenClawLightDomContentsElement {
+  @property({ attribute: false }) ip: string | undefined;
+  @state() private location: ClientGeolocation | null = null;
+
+  private requestedIp: string | undefined;
+
+  override willUpdate() {
+    const ip = this.ip?.trim();
+    if (!ip || ip === this.requestedIp) {
+      return;
+    }
+    this.requestedIp = ip;
+    this.location = null;
+    void lookupClientGeolocation(ip).then((result) => {
+      // A later address may have won while this request was in flight.
+      if (this.requestedIp === ip) {
+        this.location = result;
+      }
+    });
+  }
+
+  override render() {
+    const label = [this.location?.city, this.location?.region ?? this.location?.country]
+      .filter(Boolean)
+      .join(", ");
+    if (!label) {
+      return nothing;
+    }
+    const attribution = this.location?.attribution;
+    return html`<span class="activity-feed__device-location"
+      >${label}${attribution
+        ? html`<a
+            class="activity-feed__device-attribution"
+            href=${attribution.url}
+            target="_blank"
+            rel="noreferrer noopener"
+            title=${attribution.text}
+            >ⓘ</a
+          >`
+        : nothing}</span
+    >`;
+  }
+}
+
+if (globalThis.customElements) {
+  // Guarded define matches the other presence components: the module is
+  // imported from more than one view and must not re-register.
+  if (!customElements.get("openclaw-ip-location")) {
+    customElements.define("openclaw-ip-location", OpenClawIpLocation);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "openclaw-ip-location": OpenClawIpLocation;
+  }
+}

--- a/ui/src/components/ip-location.ts
+++ b/ui/src/components/ip-location.ts
@@ -3,29 +3,72 @@ import { property, state } from "lit/decorators.js";
 import { lookupClientGeolocation, type ClientGeolocation } from "../lib/geolocation-lookup.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 
+// The first lookup on a fresh Gateway waits on a database download that can take
+// a minute, so an unavailable answer is retried on a widening delay instead of
+// leaving the row permanently blank until someone reloads the page.
+const RETRY_DELAYS_MS = [5_000, 15_000, 45_000];
+
 /**
  * Renders the coarse city for one client address, or nothing at all. Absence is
- * the normal case — no plugin installed, no database yet, or an address the
- * database cannot place — so this never shows a spinner or an error state.
+ * a normal outcome — no plugin installed, or an address the database cannot
+ * place — so this never shows a spinner or an error state.
  */
 class OpenClawIpLocation extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) ip: string | undefined;
   @state() private location: ClientGeolocation | null = null;
 
   private requestedIp: string | undefined;
+  private retryTimer: ReturnType<typeof setTimeout> | undefined;
+  private retryAttempt = 0;
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.clearRetry();
+  }
 
   override willUpdate() {
     const ip = this.ip?.trim();
     if (!ip || ip === this.requestedIp) {
       return;
     }
+    this.clearRetry();
     this.requestedIp = ip;
+    this.retryAttempt = 0;
     this.location = null;
+    this.resolve(ip);
+  }
+
+  private clearRetry() {
+    if (this.retryTimer !== undefined) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = undefined;
+    }
+  }
+
+  private resolve(ip: string) {
     void lookupClientGeolocation(ip).then((result) => {
       // A later address may have won while this request was in flight.
-      if (this.requestedIp === ip) {
-        this.location = result;
+      if (this.requestedIp !== ip) {
+        return;
       }
+      if (result.status === "located") {
+        this.location = result.location;
+        return;
+      }
+      if (result.status === "absent") {
+        return;
+      }
+      const delay = RETRY_DELAYS_MS[this.retryAttempt];
+      if (delay === undefined) {
+        return;
+      }
+      this.retryAttempt += 1;
+      this.retryTimer = setTimeout(() => {
+        this.retryTimer = undefined;
+        if (this.requestedIp === ip && this.isConnected) {
+          this.resolve(ip);
+        }
+      }, delay);
     });
   }
 

--- a/ui/src/lib/geolocation-lookup.test.ts
+++ b/ui/src/lib/geolocation-lookup.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { lookupClientGeolocation } from "./geolocation-lookup.ts";
+import { setAvatarGatewayOrigin } from "./identity-avatar.ts";
 
 function jsonResponse(body: unknown, ok = true) {
   return { ok, status: ok ? 200 : 503, json: async () => body } as Response;
@@ -25,29 +26,36 @@ describe("client geolocation lookup", () => {
     );
 
     await expect(lookupClientGeolocation("203.0.113.10")).resolves.toEqual({
-      city: "Vienna",
-      region: "Vienna",
-      country: "Austria",
-      attribution: { text: "IP Geolocation by DB-IP", url: "https://db-ip.com" },
+      status: "located",
+      location: {
+        city: "Vienna",
+        region: "Vienna",
+        country: "Austria",
+        attribution: { text: "IP Geolocation by DB-IP", url: "https://db-ip.com" },
+      },
     });
   });
 
-  it("resolves to null when the plugin is absent or its database is unavailable", async () => {
+  it("reports an unavailable database as retryable rather than as a placement", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => jsonResponse({ error: "unavailable" }, false)),
     );
-    await expect(lookupClientGeolocation("203.0.113.11")).resolves.toBeNull();
+    await expect(lookupClientGeolocation("203.0.113.11")).resolves.toEqual({
+      status: "unavailable",
+    });
   });
 
-  it("resolves to null rather than rejecting when the request fails outright", async () => {
+  it("reports a failed request as unavailable rather than rejecting", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
         throw new Error("offline");
       }),
     );
-    await expect(lookupClientGeolocation("203.0.113.12")).resolves.toBeNull();
+    await expect(lookupClientGeolocation("203.0.113.12")).resolves.toEqual({
+      status: "unavailable",
+    });
   });
 
   it("shares one request across repeat lookups of the same address", async () => {
@@ -70,6 +78,47 @@ describe("client geolocation lookup", () => {
       ),
     );
 
-    await expect(lookupClientGeolocation("203.0.113.14")).resolves.toEqual({ city: "Vienna" });
+    await expect(lookupClientGeolocation("203.0.113.14")).resolves.toEqual({
+      status: "located",
+      location: { city: "Vienna" },
+    });
+  });
+
+  it("does not cache an unavailable answer, so a later attempt can still succeed", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ error: "downloading" }, false))
+      .mockResolvedValueOnce(jsonResponse({ found: true, city: "Vienna" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(lookupClientGeolocation("203.0.113.15")).resolves.toEqual({
+      status: "unavailable",
+    });
+    await expect(lookupClientGeolocation("203.0.113.15")).resolves.toEqual({
+      status: "located",
+      location: { city: "Vienna" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps caching definitive not-found answers", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ found: false }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await lookupClientGeolocation("203.0.113.16");
+    await expect(lookupClientGeolocation("203.0.113.16")).resolves.toEqual({ status: "absent" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops cached placements when the Gateway context changes", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ found: true, city: "Vienna" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await lookupClientGeolocation("203.0.113.17");
+    setAvatarGatewayOrigin("https://other-gateway.example.test", "Bearer other-token");
+    await lookupClientGeolocation("203.0.113.17");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    setAvatarGatewayOrigin(null);
   });
 });

--- a/ui/src/lib/geolocation-lookup.test.ts
+++ b/ui/src/lib/geolocation-lookup.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { lookupClientGeolocation } from "./geolocation-lookup.ts";
+
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, status: ok ? 200 : 503, json: async () => body } as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("client geolocation lookup", () => {
+  it("returns the placement and its attribution", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          found: true,
+          city: "Vienna",
+          region: "Vienna",
+          country: "Austria",
+          attribution: { text: "IP Geolocation by DB-IP", url: "https://db-ip.com" },
+        }),
+      ),
+    );
+
+    await expect(lookupClientGeolocation("203.0.113.10")).resolves.toEqual({
+      city: "Vienna",
+      region: "Vienna",
+      country: "Austria",
+      attribution: { text: "IP Geolocation by DB-IP", url: "https://db-ip.com" },
+    });
+  });
+
+  it("resolves to null when the plugin is absent or its database is unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: "unavailable" }, false)),
+    );
+    await expect(lookupClientGeolocation("203.0.113.11")).resolves.toBeNull();
+  });
+
+  it("resolves to null rather than rejecting when the request fails outright", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+    await expect(lookupClientGeolocation("203.0.113.12")).resolves.toBeNull();
+  });
+
+  it("shares one request across repeat lookups of the same address", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ found: true, city: "Vienna" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await Promise.all([
+      lookupClientGeolocation("203.0.113.13"),
+      lookupClientGeolocation("203.0.113.13"),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops an attribution that is missing its link so no bare credit renders", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({ found: true, city: "Vienna", attribution: { text: "Data by X" } }),
+      ),
+    );
+
+    await expect(lookupClientGeolocation("203.0.113.14")).resolves.toEqual({ city: "Vienna" });
+  });
+});

--- a/ui/src/lib/geolocation-lookup.ts
+++ b/ui/src/lib/geolocation-lookup.ts
@@ -1,0 +1,79 @@
+import { asOptionalRecord, readStringField } from "@openclaw/normalization-core/record-coerce";
+import { readAvatarGatewayContext } from "./identity-avatar.ts";
+
+/** Coarse placement for one address, plus the credit its data license requires. */
+export type ClientGeolocation = {
+  city?: string;
+  region?: string;
+  country?: string;
+  attribution?: { text: string; url: string };
+};
+
+const LOOKUP_TIMEOUT_MS = 15_000;
+// Presence rosters are small; the cap only stops an unbounded map on a busy
+// gateway where entries churn.
+const LOOKUP_CACHE_MAX_ENTRIES = 256;
+
+const lookupCache = new Map<string, Promise<ClientGeolocation | null>>();
+
+function readLocation(payload: unknown): ClientGeolocation | null {
+  const record = asOptionalRecord(payload);
+  if (record?.found !== true) {
+    return null;
+  }
+  const text = (value: string | undefined) => (value?.trim() ? value : undefined);
+  const attribution = asOptionalRecord(record.attribution);
+  const attributionText = text(readStringField(attribution, "text"));
+  const attributionUrl = text(readStringField(attribution, "url"));
+  const city = text(readStringField(record, "city"));
+  const region = text(readStringField(record, "region"));
+  const country = text(readStringField(record, "country"));
+  return {
+    ...(city ? { city } : {}),
+    ...(region ? { region } : {}),
+    ...(country ? { country } : {}),
+    ...(attributionText && attributionUrl
+      ? { attribution: { text: attributionText, url: attributionUrl } }
+      : {}),
+  };
+}
+
+/**
+ * Resolves one address through the geolocation plugin. Returns null for any
+ * unavailable answer — a missing plugin, a database still downloading, or an
+ * address the database cannot place all render the same way: no location shown.
+ */
+export function lookupClientGeolocation(ip: string): Promise<ClientGeolocation | null> {
+  const cached = lookupCache.get(ip);
+  if (cached) {
+    return cached;
+  }
+  const { origin, authHeader } = readAvatarGatewayContext();
+  const base = origin ?? "";
+  const pending = (async () => {
+    try {
+      const response = await fetch(
+        `${base}/plugins/geolocation/lookup?ip=${encodeURIComponent(ip)}`,
+        {
+          credentials: "include",
+          ...(authHeader ? { headers: { Authorization: authHeader } } : {}),
+          signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
+        },
+      );
+      if (!response.ok) {
+        return null;
+      }
+      return readLocation(await response.json());
+    } catch {
+      return null;
+    }
+  })();
+  if (lookupCache.size >= LOOKUP_CACHE_MAX_ENTRIES) {
+    const oldest = lookupCache.keys().next();
+    if (!oldest.done) {
+      lookupCache.delete(oldest.value);
+    }
+  }
+  lookupCache.set(ip, pending);
+  return pending;
+}

--- a/ui/src/lib/geolocation-lookup.ts
+++ b/ui/src/lib/geolocation-lookup.ts
@@ -1,5 +1,5 @@
 import { asOptionalRecord, readStringField } from "@openclaw/normalization-core/record-coerce";
-import { readAvatarGatewayContext } from "./identity-avatar.ts";
+import { readAvatarGatewayContext, registerAvatarGatewayReset } from "./identity-avatar.ts";
 
 /** Coarse placement for one address, plus the credit its data license requires. */
 export type ClientGeolocation = {
@@ -9,17 +9,37 @@ export type ClientGeolocation = {
   attribution?: { text: string; url: string };
 };
 
+/**
+ * Lookups have three outcomes and callers must tell them apart: a database that
+ * cannot answer yet is retryable, while an address the database does not place
+ * is final. Collapsing them caches a permanent blank for a Gateway that was
+ * merely still downloading.
+ */
+type ClientGeolocationResult =
+  | { status: "located"; location: ClientGeolocation }
+  | { status: "absent" }
+  | { status: "unavailable" };
+
 const LOOKUP_TIMEOUT_MS = 15_000;
 // Presence rosters are small; the cap only stops an unbounded map on a busy
 // gateway where entries churn.
 const LOOKUP_CACHE_MAX_ENTRIES = 256;
 
-const lookupCache = new Map<string, Promise<ClientGeolocation | null>>();
+const lookupCache = new Map<string, Promise<ClientGeolocationResult>>();
 
-function readLocation(payload: unknown): ClientGeolocation | null {
+function clearClientGeolocationCache(): void {
+  lookupCache.clear();
+}
+
+// Endpoint and credentials both come from the shared Gateway context, so a
+// switch must drop cached placements instead of showing the previous Gateway's
+// answer for the same address.
+registerAvatarGatewayReset(clearClientGeolocationCache);
+
+function readLocation(payload: unknown): ClientGeolocationResult {
   const record = asOptionalRecord(payload);
   if (record?.found !== true) {
-    return null;
+    return { status: "absent" };
   }
   const text = (value: string | undefined) => (value?.trim() ? value : undefined);
   const attribution = asOptionalRecord(record.attribution);
@@ -28,7 +48,7 @@ function readLocation(payload: unknown): ClientGeolocation | null {
   const city = text(readStringField(record, "city"));
   const region = text(readStringField(record, "region"));
   const country = text(readStringField(record, "country"));
-  return {
+  const location: ClientGeolocation = {
     ...(city ? { city } : {}),
     ...(region ? { region } : {}),
     ...(country ? { country } : {}),
@@ -36,38 +56,44 @@ function readLocation(payload: unknown): ClientGeolocation | null {
       ? { attribution: { text: attributionText, url: attributionUrl } }
       : {}),
   };
+  return Object.keys(location).length > 0 ? { status: "located", location } : { status: "absent" };
+}
+
+async function requestGeolocation(ip: string): Promise<ClientGeolocationResult> {
+  const { origin, authHeader } = readAvatarGatewayContext();
+  try {
+    const response = await fetch(
+      `${origin ?? ""}/plugins/geolocation/lookup?ip=${encodeURIComponent(ip)}`,
+      {
+        credentials: "include",
+        ...(authHeader ? { headers: { Authorization: authHeader } } : {}),
+        signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
+      },
+    );
+    // Only a 200 is a real answer. 503 means the database is still downloading
+    // or missing, which the caller may retry.
+    return response.ok ? readLocation(await response.json()) : { status: "unavailable" };
+  } catch {
+    return { status: "unavailable" };
+  }
 }
 
 /**
- * Resolves one address through the geolocation plugin. Returns null for any
- * unavailable answer — a missing plugin, a database still downloading, or an
- * address the database cannot place all render the same way: no location shown.
+ * Resolves one address through the geolocation plugin. Definitive answers are
+ * cached; unavailable ones are not, so a later attempt can still succeed once
+ * the database is ready.
  */
-export function lookupClientGeolocation(ip: string): Promise<ClientGeolocation | null> {
+export function lookupClientGeolocation(ip: string): Promise<ClientGeolocationResult> {
   const cached = lookupCache.get(ip);
   if (cached) {
     return cached;
   }
-  const { origin, authHeader } = readAvatarGatewayContext();
-  const base = origin ?? "";
-  const pending = (async () => {
-    try {
-      const response = await fetch(
-        `${base}/plugins/geolocation/lookup?ip=${encodeURIComponent(ip)}`,
-        {
-          credentials: "include",
-          ...(authHeader ? { headers: { Authorization: authHeader } } : {}),
-          signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS),
-        },
-      );
-      if (!response.ok) {
-        return null;
-      }
-      return readLocation(await response.json());
-    } catch {
-      return null;
+  const pending = requestGeolocation(ip).then((result) => {
+    if (result.status === "unavailable") {
+      lookupCache.delete(ip);
     }
-  })();
+    return result;
+  });
   if (lookupCache.size >= LOOKUP_CACHE_MAX_ENTRIES) {
     const oldest = lookupCache.keys().next();
     if (!oldest.done) {

--- a/ui/src/lib/identity-avatar.ts
+++ b/ui/src/lib/identity-avatar.ts
@@ -18,10 +18,13 @@ const ORIGIN_PROBE = "https://origin-probe.invalid";
 let appGatewayOrigin: string | null = null;
 let appGatewayResourceBasePath = "";
 let appGatewayAuthHeader: string | null = null;
-let resetAvatarGatewayContext: (() => void) | undefined;
+// More than one cache is keyed by the Gateway HTTP context (avatars,
+// geolocation), so every subscriber must be notified on a switch. A single slot
+// would silently drop whichever registered first.
+const gatewayContextResets = new Set<() => void>();
 
 export function registerAvatarGatewayReset(reset: () => void): void {
-  resetAvatarGatewayContext = reset;
+  gatewayContextResets.add(reset);
 }
 
 export function readAvatarGatewayContext() {
@@ -62,7 +65,9 @@ export function setAvatarGatewayOrigin(
     appGatewayResourceBasePath !== nextResourceBasePath ||
     appGatewayAuthHeader !== nextAuthHeader
   ) {
-    resetAvatarGatewayContext?.();
+    for (const reset of gatewayContextResets) {
+      reset();
+    }
   }
   appGatewayOrigin = nextOrigin;
   appGatewayResourceBasePath = nextResourceBasePath;

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { icons } from "../../components/icons.ts";
+import "../../components/ip-location.ts";
 import "../../components/viewer-facepile.ts";
 import "../../components/web-awesome-popover.ts";
 import { renderSettingsStatus } from "../../components/settings-ui.ts";
@@ -386,6 +387,9 @@ function renderIdentityHeader(
                   >${entry.host ?? t("activityFeed.unknownDevice")}</span
                 >
                 ${device ? html`<span>${device}</span>` : nothing}
+                ${entry.ip
+                  ? html`<openclaw-ip-location .ip=${entry.ip}></openclaw-ip-location>`
+                  : nothing}
                 ${entry.lastInputSeconds !== undefined
                   ? html`<span
                       >${t("activityFeed.lastInput", {

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -552,6 +552,25 @@ openclaw-activity-page {
   font-weight: 600;
 }
 
+.activity-feed__device-location {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* The credit is a license term for the default database, so it stays visible
+   next to the value it describes rather than living in a settings page. */
+.activity-feed__device-attribution {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: var(--control-ui-text-xs);
+}
+
+.activity-feed__device-attribution:hover,
+.activity-feed__device-attribution:focus-visible {
+  color: var(--text);
+}
+
 .activity-feed__viewing {
   margin-top: var(--space-4);
 }


### PR DESCRIPTION
## What Problem This Solves

The Activity identity card can show a client's IP address but not where it is, so an operator still has to look the address up by hand. There was no way for any surface to turn an address into a place.

## Why This Change Was Made

A bundled `geolocation` plugin owns address-to-place resolution behind one authenticated route, `GET /plugins/geolocation/lookup?ip=`. It downloads a MaxMind-format database on first lookup into the state directory and answers from that local copy, so a lookup never sends a client address to a third party. Every free HTTP geolocation API forbids commercial use on its free tier, which rules them out for a default-shipped capability.

**No new core provider kind.** The leanest existing provider kind threads through roughly ten plugin-core files; cloning that for a single implementation runs against `AGENTS.md`'s "core stays plugin-agnostic" and "new helpers must pay rent immediately". The plugin owns everything through the existing `registerHttpRoute` seam that bundled plugins such as `diffs` already use, so **zero core files are touched**. A second provider — Cloudflare's visitor-location headers are the obvious one — is what would justify promoting this to a registry contract.

**Availability and lookup failure stay distinguishable.** A missing or still-downloading database answers `503`, never `found: false`; conflating them would render as "this address has no location". A failed refresh serves the cached copy rather than taking lookups down, and a body that does not parse as an MMDB is discarded without replacing a working database, so a rate-limit page cannot break a working Gateway.

## User Impact

The device row on the Activity identity card gains the resolved city. Absent answers render as nothing at all — no spinner, no error — because absence is the normal case for loopback, tunneled, and CGNAT clients that have no usable address.

The default database is **DB-IP City Lite** under **CC BY 4.0**. That license requires attribution, so every response carries the credit and the UI renders it beside the value. The database is downloaded at runtime and never redistributed. Plugin code and the `maxmind` reader are MIT; no free city-level IP database is MIT-licensed, so the obligation lives with the data, and `databaseUrl` plus the attribution fields make the source swappable.

## Evidence

**Live verification** on an isolated Gateway (own `OPENCLAW_STATE_DIR`, port 19110, never the operator's 18789) behind a header-injecting reverse proxy standing in for Cloudflare Access, driven by real browsers.

![geolocation on the identity card](https://github.com/user-attachments/assets/c534f7b8-6f9a-46cf-ba21-082d3f588f36)

Two clients, same injected address, **different reported time zones** — which shows the two signals are independent: the zone comes from the client, the city from the address.

Real database, real endpoint:

```
[plugins] geolocation: downloaded 130207855 bytes from https://download.db-ip.com/free/dbip-city-lite-2026-08.mmdb.gz
```

| Probe | Result |
| --- | --- |
| `1.1.1.1` (first lookup, includes 124 MB download) | Sydney, New South Wales, AU — 46.5s |
| `8.8.8.8` (cached) | Mountain View, California, US — 16ms |
| `2606:4700:4700::1111` (IPv6) | Montreal, Quebec, CA |
| `203.0.113.7` (reserved documentation range) | `found: false` |
| `not-an-ip` | `400`, database never consulted |

Gateway startup went from 16 to 17 active plugins with `geolocation` among them.

**Automated.** 13 plugin tests and 8 UI tests, covering settings resolution and attribution fallbacks, month-fallback URL expansion, download failure naming every candidate URL, refusal to publish an unparsable body, single-download-under-race, route status semantics (200 / 503 / 400), and element rendering including the absent case. `node scripts/check-changed.mjs` green. Autoreview (codex/gpt-5.6-sol, high): clean, no accepted findings.

**Known coverage gap:** no automated test parses a real MMDB, because no fixture ships with `maxmind` and committing a third-party binary carries its own licensing question. That path is covered by the live run above.

**Production LOC:** ~490 production lines (new plugin, UI element, loader), ~290 test lines, plus docs.
