### PR TITLE
docs(onboarding): preserve the selected model in setup guide

### DIFF
--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -120,7 +120,6 @@ Example:
   logging: { level: "info" },
   agents: {
     defaults: {
-      model: { primary: "anthropic/claude-opus-5" },
       workspace: "~/.openclaw/workspace",
       thinkingDefault: "high",
       timeoutSeconds: 1800,


### PR DESCRIPTION
Fixes #62529

## What Problem This Solves

Fixes an issue where users following the post-onboarding personal assistant setup guide would overwrite the model they had just selected with a hardcoded Anthropic model when copying its example configuration.

## Why This Change Was Made

Remove the unnecessary model override from the existing whole-configuration example. The selected model is already owned by onboarding, the schema makes `agents.defaults.model` optional, and substituting another provider would merely repeat the same problem.

## User Impact

The setup guide preserves whichever provider and model the operator selected during onboarding instead of silently changing it.

## Evidence

- Parsed the complete edited JSON5 example and verified that its model override is absent.
- Merged the example defaults onto an existing `openai/gpt-5.6-sol` selection and confirmed the selected model remains unchanged.
- Confirmed `src/config/zod-schema.agent-defaults.ts` declares the model field optional.
- `git diff --check`
- Targeted `oxfmt --check docs/start/openclaw.md` passed.
- Scope: one documentation line deleted; no production code, tests, configuration defaults, or runtime behavior changed.

Reported by @MadanChaollaPark. Prepared with AI assistance.
