### PR TITLE
perf(gateway): stop first models.authStatus call from reloading all plugins from source

### DIFF
--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -6,7 +6,10 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveModelCatalogScope } from "../agents/model-discovery-context.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
+import {
+  getLoadedRuntimePluginRegistry,
+  registryContainsRuntimePluginIds,
+} from "./active-runtime-registry.js";
 import {
   PluginLruCache,
   resolveConfigScopedRuntimeCacheValue,
@@ -227,19 +230,39 @@ export function resolveProviderPluginsForHooks(params: {
   applyAutoEnable?: boolean;
   pluginMetadataSnapshot?: PluginMetadataRegistryView;
 }): ProviderPlugin[] {
-  const generationRegistry = getPluginRuntimeGenerationRegistry();
-  if (generationRegistry) {
-    const plugins = listProviderRuntimePluginsInRegistry(generationRegistry);
+  const filterRegistryPlugins = (registry: PluginRegistry) => {
     const onlyPluginIds = params.onlyPluginIds ? new Set(params.onlyPluginIds) : undefined;
-    return plugins.filter(
+    return listProviderRuntimePluginsInRegistry(registry).filter(
       (plugin) =>
         (!onlyPluginIds || onlyPluginIds.has(plugin.pluginId)) &&
         (!params.providerRefs?.length ||
           params.providerRefs.some((providerRef) => matchesProviderPluginRef(plugin, providerRef))),
     );
+  };
+  const generationRegistry = getPluginRuntimeGenerationRegistry();
+  if (generationRegistry) {
+    return filterRegistryPlugins(generationRegistry);
   }
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
+  // Request/lifecycle scopes and the active process registry already own loaded plugin runtime.
+  // Reuse them like findProviderRuntimePluginInLoadedRegistries does: a scoped load here rebuilds
+  // plugin runtime from source on the request path and stalls the gateway event loop for seconds.
+  // Only a hit proves the prepared registry serves this query; an empty result may mean the scope
+  // never loaded these plugins, so the scoped load below stays authoritative on a miss.
+  const scopedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+  const preparedRegistry =
+    scopedRegistry && registryContainsRuntimePluginIds(scopedRegistry, params.onlyPluginIds)
+      ? scopedRegistry
+      : getLoadedRuntimePluginRegistry({
+          env,
+          workspaceDir,
+          requiredPluginIds: params.onlyPluginIds,
+        });
+  const preparedPlugins = preparedRegistry ? filterRegistryPlugins(preparedRegistry) : [];
+  if (preparedPlugins.length > 0) {
+    return preparedPlugins;
+  }
   return resolvePluginProvidersCore({
     ...params,
     workspaceDir,

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -54,6 +54,7 @@ const providerRuntimeWarnMock = vi.fn();
 
 let getAiTransportHost: typeof import("@openclaw/ai").getAiTransportHost;
 let attachModelProviderRuntimePluginHandle: typeof import("./provider-hook-runtime.js").attachModelProviderRuntimePluginHandle;
+let resolveProviderPluginsForHooks: typeof import("./provider-hook-runtime.js").resolveProviderPluginsForHooks;
 let augmentModelCatalogWithProviderPlugins: typeof import("./provider-runtime.js").augmentModelCatalogWithProviderPlugins;
 let buildProviderAuthDoctorHintWithPlugin: typeof import("./provider-runtime.js").buildProviderAuthDoctorHintWithPlugin;
 let buildProviderMissingAuthMessageWithPlugin: typeof import("./provider-runtime.js").buildProviderMissingAuthMessageWithPlugin;
@@ -343,7 +344,8 @@ describe("provider-runtime", () => {
       wrapProviderSimpleCompletionStreamFn,
       wrapProviderStreamFn,
     } = await import("./provider-runtime.js"));
-    ({ attachModelProviderRuntimePluginHandle } = await import("./provider-hook-runtime.js"));
+    ({ attachModelProviderRuntimePluginHandle, resolveProviderPluginsForHooks } =
+      await import("./provider-hook-runtime.js"));
     await import("../agents/ai-transport-runtime-host.js");
     ({ getAiTransportHost } = await import("@openclaw/ai"));
     ({ createEmptyPluginRegistry } = await import("./registry.js"));
@@ -481,11 +483,10 @@ describe("provider-runtime", () => {
     ]);
 
     expect(listProviderUsagePluginDescriptors({ env: process.env })).toEqual([
-      { provider: "declared", displayName: "Declared" },
+      { provider: "declared", displayName: "declared" },
     ]);
-    expect(resolvePluginProvidersMock).toHaveBeenCalledWith(
-      expect.objectContaining({ onlyPluginIds: ["multi-provider"] }),
-    );
+    // Manifest contracts answer discovery; descriptor listing must not load plugin runtime.
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 
   it("matches providers by hook alias for runtime hook lookup", () => {
@@ -998,6 +999,19 @@ describe("provider-runtime", () => {
     expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toBeUndefined();
 
     expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("serves hook plugin lists from the active loaded registry without a scoped load", () => {
+    const provider: ProviderPlugin = { id: DEMO_PROVIDER_ID, label: "Demo", auth: [] };
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({ id: "demo-plugin", status: "loaded" } as never);
+    registry.providers.push({ pluginId: "demo-plugin", provider, source: "demo-plugin/index.js" });
+    setActivePluginRegistry(registry, "workspace-one", "default", "/tmp/work");
+
+    const plugins = resolveProviderPluginsForHooks({ onlyPluginIds: ["demo-plugin"] });
+
+    expect(plugins.map((plugin) => plugin.id)).toEqual([DEMO_PROVIDER_ID]);
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 
   it("does not cache default runtime provider misses without active registry invalidation", () => {
@@ -2170,7 +2184,7 @@ describe("provider-runtime", () => {
     });
 
     expect(listProviderUsagePluginDescriptors({ env: process.env })).toEqual([
-      { provider: "demo", displayName: "Demo" },
+      { provider: "demo", displayName: "demo" },
     ]);
 
     expect(

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -16,6 +16,7 @@ import { unwrapSecretSentinelsForProviderEgress } from "../agents/provider-secre
 import type { ProviderSystemPromptContribution } from "../agents/system-prompt-contribution.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { providerUsageLabel } from "../infra/provider-usage.shared.js";
 import type { UsageProviderId } from "../infra/provider-usage.types.js";
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
@@ -719,27 +720,19 @@ export function listProviderUsagePluginDescriptors(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }): ProviderUsagePluginDescriptor[] {
-  const pluginContracts = resolveUsageHookProviderPluginContracts(params);
-  if (pluginContracts.length === 0) {
-    return [];
-  }
+  // Manifest contracts own usage discovery. Materializing plugin runtime here loads
+  // every bundled provider plugin on cold status RPCs; fetch-time resolution stays
+  // the runtime authority for plugins that fail to implement their declared hooks.
   const descriptors = new Map<string, ProviderUsagePluginDescriptor>();
-  for (const contract of pluginContracts) {
-    const declaredProviderIds = new Set(contract.providerIds);
-    for (const plugin of resolveProviderPluginsForHooks({
-      ...params,
-      onlyPluginIds: [contract.pluginId],
-    })) {
-      if (!plugin.resolveUsageAuth || !plugin.fetchUsageSnapshot) {
-        continue;
-      }
-      const provider = normalizeProviderId(plugin.id);
-      if (!provider || !declaredProviderIds.has(provider) || descriptors.has(provider)) {
+  for (const contract of resolveUsageHookProviderPluginContracts(params)) {
+    for (const declaredProviderId of contract.providerIds) {
+      const provider = normalizeProviderId(declaredProviderId);
+      if (!provider || descriptors.has(provider)) {
         continue;
       }
       descriptors.set(provider, {
         provider,
-        displayName: normalizeOptionalString(plugin.label) ?? provider,
+        displayName: providerUsageLabel(provider) ?? provider,
       });
     }
   }


### PR DESCRIPTION
## What Problem This Solves

After a gateway restart, the **first** Control UI websocket connection paid ~4-8s on `models.authStatus` — and because the work blocked the event loop, every concurrently queued RPC on that connection (`system.info`, etc.) stalled and released in the same flush. Later connections answered in 100-400ms. CPU profile of the request window showed the cost was jiti/babel **source-transforming the entire plugin registry on the request thread**, entered from `models.authStatus` → `getProviderUsageRuntimeSnapshot` → `listProviderUsagePluginDescriptors` → `resolveProviderPluginsForHooks` → `loadOpenClawPlugins`.

## Why This Change Was Made

Two compounding owner-level defects:

1. `resolveProviderPluginsForHooks` (src/plugins/provider-hook-runtime.ts) only had a fast path for the generation ALS scope. The gateway request envelope attaches the active plugin registry to the request scope, but this function never consulted it, and the loader's cache never matched because the narrowed `onlyPluginIds` load options produce a different cache key. Its sibling `findProviderRuntimePluginInLoadedRegistries` in the same file already had the full three-tier reuse — the list variant never got it.
2. `listProviderUsagePluginDescriptors` (src/plugins/provider-runtime.ts) materialized full plugin runtime for every plugin with a `usageProviders` manifest contract (10 bundled provider plugins) just to project `{provider, displayName}` — a control-plane question the manifest already answers.

The fix makes `resolveProviderPluginsForHooks` reuse the request-scope/active registry (verified via the existing `registryContainsRuntimePluginIds` / `getLoadedRuntimePluginRegistry` helpers, falling through to the authoritative scoped load on a miss), and makes `listProviderUsagePluginDescriptors` manifest-first using the static `providerUsageLabel` table its consumer already used as fallback. Runtime resolution remains the authority at actual usage-fetch time. Named tradeoff: a third-party usage plugin's descriptor row shows its provider id instead of its runtime display name until a real usage snapshot (which carries the plugin-authored name) arrives.

## User Impact

First dashboard paint after a gateway restart/update no longer hangs for seconds; the whole first-connect RPC batch answers at warm-path speed. This is the default out-of-box path every operator hits after every auto-update restart.

## Evidence

Live before/after on an isolated dist gateway (token auth, isolated `OPENCLAW_STATE_DIR`, own port; first WS connect, three RPCs issued concurrently):

| RPC | before | after |
| --- | --- | --- |
| models.authStatus | 8,201ms | 255ms |
| system.info (queued behind it) | 8,211ms | 267ms |
| chat.startup | 83ms | 85ms |
| second connect (all three) | ~10ms | ~10ms |

- New regression test `serves hook plugin lists from the active loaded registry without a scoped load` fails on pre-fix code (scoped load observed) and passes after; two descriptor tests updated to the manifest-first contract.
- `pnpm check:changed` green; `pnpm test:changed` green (one unrelated audit-writer timing assertion flaked under parallel build load, passes 3/3 in isolation); `pnpm build` clean.
- Codex autoreview (gpt-5.6-sol, xhigh): no accepted/actionable findings.
- Production LOC +16 (invariant comments + registry-reuse guard), tests +14.
