### PR TITLE
fix(workers): resolve catalog models on dispatched turns

### DIFF
--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -190,6 +190,7 @@ function providerStream(message = finalMessage(), options: { omitToolEnd?: boole
 function setup(
   entry: SessionEntry = sessionEntry,
   options: {
+    catalogOnlyModel?: boolean;
     pluginRegistry?: PluginRegistry;
     afterModelPreparation?: () => void;
     observeStage?: (
@@ -231,6 +232,9 @@ function setup(
     return {} as Awaited<ReturnType<Deps["resolveModel"]>>;
   });
   const prepareModel = vi.fn<Deps["prepareModel"]>(async (modelParams) => {
+    if (options.catalogOnlyModel && !modelParams.allowBundledStaticCatalogFallback) {
+      return { error: `Unknown model: ${modelParams.provider}/${modelParams.modelId}` };
+    }
     scope.agentRuntime = modelParams.agentRuntimeId;
     scope.preparedModelRuntime = modelParams.preparedModelRuntime === leasedPreparedModelRuntime;
     scope.prepareWorkspace = modelParams.workspaceDir;
@@ -343,6 +347,38 @@ const MODEL_ERROR = {
 };
 
 describe("worker inference provider runtime", () => {
+  it("prepares an approved model available only from the bundled static catalog", async () => {
+    const runtime = setup(sessionEntry, { catalogOnlyModel: true });
+
+    await expect(runtime.executor(params(request(MODEL), vi.fn()))).resolves.toMatchObject({
+      type: "done",
+      message: { provider: PROVIDER, model: MODEL },
+    });
+    expect(runtime.stream).toHaveBeenCalledOnce();
+    expect(runtime.releaseRuntime).toHaveBeenCalledOnce();
+  });
+
+  it("returns bounded, redacted model preparation guidance", async () => {
+    const runtime = setup();
+    const secret = `worker-preparation-secret-${"a".repeat(48)}`;
+    runtime.prepareModel.mockResolvedValueOnce({
+      error: `Auth lookup failed for provider "anthropic": configure the selected auth profile. Authorization: Bearer ${secret}. ${"diagnostic ".repeat(40)}`,
+    });
+
+    const outcome = await runtime.executor(params(request(), vi.fn()));
+
+    expect(outcome).toMatchObject({ type: "error", reason: "provider-error" });
+    if (outcome.type !== "error") {
+      throw new Error("expected model preparation to fail");
+    }
+    expect(outcome.message).toContain("configure the selected auth profile");
+    expect(outcome.message).not.toContain(secret);
+    expect(outcome.message.length).toBeLessThanOrEqual(256);
+    expect(validateWorkerInferenceTerminalOutcome(outcome)).toBe(true);
+    expect(runtime.stream).not.toHaveBeenCalled();
+    expect(runtime.releaseRuntime).toHaveBeenCalledOnce();
+  });
+
   it("keeps provider construction and execution on the leased generation", async () => {
     const generationA = createEmptyPluginRegistry();
     const generationB = createEmptyPluginRegistry();

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -73,6 +73,7 @@ import {
 } from "./inference-terminal-message.js";
 import { createWorkerToolCallStream } from "./inference-tool-call-stream.js";
 import { resolveWorkerSessionTarget, type ResolvedWorkerSessionTarget } from "./session-target.js";
+import { boundedWorkerError } from "./worker-error.js";
 
 type WorkerInferenceStreamEvent = WorkerInferenceEventParams["event"];
 export type WorkerInferenceExecutor = import("./inference.js").WorkerInferenceExecutor;
@@ -496,6 +497,7 @@ async function resolveApprovedModel(params: {
         ...(selectedProfileId ? { preferredProfile: selectedProfileId } : {}),
         ...(selectedProfileId ? { bindAuthOwner: true } : {}),
         allowMissingApiKeyModes: ["aws-sdk"],
+        allowBundledStaticCatalogFallback: true,
         modelResolver: dependencies.resolveModel,
         preparedModelRuntime: runtimeSnapshot,
         workspaceDir,
@@ -558,7 +560,11 @@ export function createWorkerInferenceExecutor(
     return await withPluginRuntimeGenerationScope(approved.runtimeSnapshot, async () => {
       try {
         if ("error" in approved.prepared) {
-          return inferenceError("provider-error");
+          return inferenceError(
+            "provider-error",
+            undefined,
+            boundedWorkerError(approved.prepared.error, 256),
+          );
         }
         // Keep logical identity separate from transport endpoint encoding.
         const modelIdentity: WorkerInferenceModelIdentity = {


### PR DESCRIPTION
Closes #128445

## What Problem This Solves

Fixes an issue where users dispatching a session to a paired worker could see a model-provider failure even though the same configured model worked for local turns. When model preparation did fail, the worker also discarded the actionable configuration guidance and returned only a generic error.

## Why This Change Was Made

Worker inference now uses the same bundled static catalog fallback as the local embedded runner while preserving the existing approved-route and selected-auth-profile boundaries. Preparation failures retain a bounded, redacted diagnostic so operators receive useful next steps without exposing credentials.

Production LOC: +7/-1 (net +6) | Tests: +36/-0

AI-assisted: yes. I reviewed the model-resolution, auth-route, worker terminal-outcome, redaction, and cleanup boundaries and understand the change.

## User Impact

Configured provider-plugin catalog models now behave consistently before and after a session is dispatched. If preparation still fails, the visible failure can explain the configuration problem instead of dead-ending at “Model provider request failed.”

## Evidence

- Pre-fix regression: the new worker-turn catalog-only case failed because worker preparation omitted the bundled static catalog fallback; the diagnostic case failed because the preparation error was discarded.
- Focused post-fix proof: 82 tests passed across worker inference, agents core, and embedded-agent model-resolution consistency.
- Full changed-file gate: `node scripts/check-changed.mjs` passed.
- Build: `pnpm build` passed on the rebased branch.
- Fresh autoreview: no accepted/actionable findings (0.99).
- Live authenticated A/B on head `491e862de019821b297cd4ac956dd20e8126e94b`: an isolated QA Gateway ran `anthropic/claude-haiku-4-5` locally and then on a paired worker without a `models.providers.anthropic.models[]` entry. Both turns returned their requested markers, placement reached `active`, `sessions.reclaim` settled to `reclaimed`, and cleanup reported no failures.
- Live proof did not touch the operator Gateway or create a paid cloud lease; the paired node and Gateway were isolated local processes, and the API credential was removed before worker startup.
