### PR TITLE
fix(test): scoped unit-fast runs execute unrelated projects and leak isolation

### DIFF
--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -40,6 +40,7 @@ import {
 import { fullSuiteVitestShards } from "./vitest/vitest.test-shards.mjs";
 import { createUiVitestConfig } from "./vitest/vitest.ui.config.ts";
 import { createUnitFastFakeTimersVitestConfig } from "./vitest/vitest.unit-fast-fake-timers.config.ts";
+import { createUnitFastIsolatedVitestConfig } from "./vitest/vitest.unit-fast-isolated.config.ts";
 import unitFastRootConfig from "./vitest/vitest.unit-fast-root.config.ts";
 import { createUnitFastVitestConfig } from "./vitest/vitest.unit-fast.config.ts";
 
@@ -118,6 +119,35 @@ describe("projects vitest config", () => {
           OPENCLAW_VITEST_INCLUDE_FILE: unrelatedIncludeFile,
         }),
       ).include,
+    ).toEqual([]);
+  });
+
+  it.each([
+    ["ordinary", createUnitFastVitestConfig, "src/plugin-sdk/provider-entry.test.ts"],
+    [
+      "isolated",
+      createUnitFastIsolatedVitestConfig,
+      "src/system-agent/assistant.configured.test.ts",
+    ],
+    ["fake timers", createUnitFastFakeTimersVitestConfig, "src/acp/control-plane/manager.test.ts"],
+  ])("limits %s unit-fast include files to the project's owned tests", (_, createConfig, owned) => {
+    const unrelated = "src/gateway/openresponses-http.test.ts";
+    const mixedIncludeFile = patternFiles.writePatternFile("mixed-unit-fast-include.json", [
+      "src/plugin-sdk/provider-entry.test.ts",
+      "src/system-agent/assistant.configured.test.ts",
+      "src/acp/control-plane/manager.test.ts",
+      unrelated,
+    ]);
+    const unrelatedIncludeFile = patternFiles.writePatternFile("unrelated-unit-fast-include.json", [
+      unrelated,
+    ]);
+
+    expect(
+      requireTestConfig(createConfig({ OPENCLAW_VITEST_INCLUDE_FILE: mixedIncludeFile })).include,
+    ).toEqual([owned]);
+    expect(
+      requireTestConfig(createConfig({ OPENCLAW_VITEST_INCLUDE_FILE: unrelatedIncludeFile }))
+        .include,
     ).toEqual([]);
   });
 

--- a/test/vitest/vitest.pattern-file.ts
+++ b/test/vitest/vitest.pattern-file.ts
@@ -219,6 +219,9 @@ export function intersectIncludePatterns(
     return null;
   }
 
+  const literalIncludes = includePatterns.every(isPlainRepoRelativePath)
+    ? new Set(includePatterns)
+    : null;
   const result: string[] = [];
   for (const candidate of candidatePatterns) {
     if (!isPlainRepoRelativePath(candidate)) {
@@ -231,7 +234,11 @@ export function intersectIncludePatterns(
       result.push(...intersection);
       continue;
     }
-    if (includePatterns.some((include) => path.matchesGlob(candidate, include))) {
+    if (
+      literalIncludes
+        ? literalIncludes.has(candidate)
+        : includePatterns.some((include) => path.matchesGlob(candidate, include))
+    ) {
       result.push(candidate);
     }
   }

--- a/test/vitest/vitest.unit-fast-fake-timers.config.ts
+++ b/test/vitest/vitest.unit-fast-fake-timers.config.ts
@@ -1,6 +1,10 @@
 // Vitest unit fast fake timers config wires the unit fast fake timers test shard.
 import { defineConfig } from "vitest/config";
-import { loadPatternListFromEnv, narrowIncludePatternsForCli } from "./vitest.pattern-file.ts";
+import {
+  intersectIncludePatterns,
+  loadPatternListFromEnv,
+  narrowIncludePatternsForCli,
+} from "./vitest.pattern-file.ts";
 import {
   nonIsolatedRunnerPath,
   resolveRepoRootPath,
@@ -14,8 +18,11 @@ export function createUnitFastFakeTimersVitestConfig(
 ) {
   const sharedTest = sharedVitestConfig.test ?? {};
   const sharedSequence = (sharedTest as { sequence?: { groupOrder?: number } }).sequence;
-  const includeFromEnv = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
   const unitFastTimerTestFiles = getUnitFastTimerTestFiles();
+  const includeFromEnv = intersectIncludePatterns(
+    unitFastTimerTestFiles,
+    loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env),
+  );
   const cliInclude = narrowIncludePatternsForCli(unitFastTimerTestFiles, options.argv);
 
   return defineConfig({

--- a/test/vitest/vitest.unit-fast-isolated.config.ts
+++ b/test/vitest/vitest.unit-fast-isolated.config.ts
@@ -1,6 +1,10 @@
 // Vitest unit fast isolated config wires audited stateful tests out of shared module caches.
 import { defineConfig } from "vitest/config";
-import { loadPatternListFromEnv, narrowIncludePatternsForCli } from "./vitest.pattern-file.ts";
+import {
+  intersectIncludePatterns,
+  loadPatternListFromEnv,
+  narrowIncludePatternsForCli,
+} from "./vitest.pattern-file.ts";
 import { resolveRepoRootPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 import { getUnitFastIsolatedTestFiles } from "./vitest.unit-fast-paths.mjs";
 
@@ -9,8 +13,11 @@ export function createUnitFastIsolatedVitestConfig(
   options: { argv?: string[] } = {},
 ) {
   const sharedTest = sharedVitestConfig.test ?? {};
-  const includeFromEnv = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
   const isolatedTestFiles = getUnitFastIsolatedTestFiles();
+  const includeFromEnv = intersectIncludePatterns(
+    isolatedTestFiles,
+    loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env),
+  );
   const cliInclude = narrowIncludePatternsForCli(isolatedTestFiles, options.argv);
 
   return defineConfig({

--- a/test/vitest/vitest.unit-fast.config.ts
+++ b/test/vitest/vitest.unit-fast.config.ts
@@ -1,6 +1,10 @@
 // Vitest unit fast config wires the unit fast test shard.
 import { defineConfig } from "vitest/config";
-import { loadPatternListFromEnv, narrowIncludePatternsForCli } from "./vitest.pattern-file.ts";
+import {
+  intersectIncludePatterns,
+  loadPatternListFromEnv,
+  narrowIncludePatternsForCli,
+} from "./vitest.pattern-file.ts";
 import { resolveRepoRootPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 import {
   getUnitFastIsolatedTestFiles,
@@ -13,11 +17,14 @@ export function createUnitFastVitestConfig(
   options: { argv?: string[]; runner?: string } = {},
 ) {
   const sharedTest = sharedVitestConfig.test ?? {};
-  const includeFromEnv = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
   const timerTestFiles = new Set(getUnitFastTimerTestFiles());
   const isolatedTestFiles = new Set(getUnitFastIsolatedTestFiles());
   const unitFastTestFiles = getUnitFastTestFiles().filter(
     (file) => !timerTestFiles.has(file) && !isolatedTestFiles.has(file),
+  );
+  const includeFromEnv = intersectIncludePatterns(
+    unitFastTestFiles,
+    loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env),
   );
   const cliInclude = narrowIncludePatternsForCli(unitFastTestFiles, options.argv);
 


### PR DESCRIPTION
Related: #128486

## What Problem This Solves

Fixes an issue where maintainers running a scoped unit-fast suite would execute the same test in all three unit-fast projects when the runner supplied its shared include-file target. Besides tripling work, this admitted ordinary tests into the stateful-isolated and serial fake-timer projects, violating their intended ownership boundaries.

## Why This Change Was Made

Intersect every unit-fast project's include file with that project's canonical owned inventory, preserving the existing isolated worker and serial fake-timer configurations. Optimize the existing shared intersection helper for fully literal inventories with validated set membership; wildcard, watch-directory, and ambiguous-pattern behavior retain their existing paths.

## User Impact

No production or user-visible behavior changes. Targeted maintainer and CI test runs avoid duplicate execution while preserving stateful isolation, fake-timer serialization, and every distinct meaningful test.

## Evidence

One task-owned Linux Testbox, one worker, distinct module caches, excluded warmup, and eight order-balanced interleaved samples of the real aggregate targeting `src/plugin-sdk/provider-entry.test.ts`:

| Measurement | Before | After |
| --- | --- | --- |
| Retained wall samples | 42.41s, 42.08s, 42.21s, 41.92s | 20.39s, 20.89s, 19.74s, 21.35s |
| Mean wall | 42.155s | 20.5925s |
| Improvement | — | **21.5625s / 51.15%** |
| Vitest projects / executions | 3 projects / 42 executions | 1 project / 14 executions |
| Distinct meaningful provider cases | 14 | 14 |
| Imported module records | 30 | 10 |
| Peak RSS range | 1,880,276–2,022,636 KiB | 1,298,988–1,424,964 KiB |

Intersecting a representative 640-file CI stripe against 1,279 ordinary-project owners improves from 2,638.678ms to 1.935–4.388ms, avoiding a routing-time regression. Live aggregate collection confirms ordinary, stateful-isolated, and fake-timer fixtures each appear only in their own project.

The new three-row owner-boundary regression failed for all three projects on unmodified main, passed after the fix, and failed again when the isolated-project intersection was deliberately removed. Owner, sibling, wildcard, watch, serialization, and isolation suites passed: **134 tests across three files**. The complete changed gate also passed, including formatting, root-test typechecking, script lint, dependency guards, and architecture guards. Fresh independent review reported no actionable findings.

All five changed files are test/tooling only; production LOC delta is **zero**. No production timeout, dependency, baseline, snapshot, or changelog changed.
