### PR TITLE
fix(synology-chat): reject invalid recipients and keep media captions

### DIFF
--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -223,6 +223,7 @@ type SynologyChatPlugin = Omit<
   };
   outbound: {
     deliveryMode: "gateway";
+    resolveTarget: NonNullable<ChannelOutboundAdapter["resolveTarget"]>;
     chunker: NonNullable<ChannelOutboundAdapter["chunker"]>;
     chunkerMode: NonNullable<ChannelOutboundAdapter["chunkerMode"]>;
     textChunkLimit: number;
@@ -325,13 +326,11 @@ async function sendSynologyChatMedia(
     mediaReadFile: ctx.mediaReadFile,
   });
   const dispatch = ctx.onPlatformSendDispatch;
-  const sendResult = await sendHostedFileUrl(
-    incomingUrl,
-    prepared.url,
-    ctx.to,
-    account.allowInsecureSsl,
-    ...(dispatch ? [dispatch] : []),
-  ).catch(async (error: unknown) => {
+  const sendArgs: Parameters<typeof sendHostedFileUrl> =
+    dispatch || ctx.text
+      ? [incomingUrl, prepared.url, ctx.to, account.allowInsecureSsl, dispatch, ctx.text]
+      : [incomingUrl, prepared.url, ctx.to, account.allowInsecureSsl];
+  const sendResult = await sendHostedFileUrl(...sendArgs).catch(async (error: unknown) => {
     await Promise.allSettled([prepared.cleanup()]);
     throw error;
   });
@@ -544,6 +543,12 @@ function createSynologyChatPlugin(): SynologyChatPlugin {
     },
     outbound: {
       deliveryMode: "gateway" as const,
+      resolveTarget: ({ to }) => {
+        const target = normalizeSynologyChatTarget(to ?? "");
+        return target
+          ? { ok: true as const, to: target }
+          : { ok: false as const, error: new Error("Synology Chat target must be a user ID") };
+      },
       chunker: chunkTextForOutbound,
       chunkerMode: "markdown" as const,
       textChunkLimit: SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT,

--- a/extensions/synology-chat/src/client.loopback.test.ts
+++ b/extensions/synology-chat/src/client.loopback.test.ts
@@ -60,6 +60,16 @@ describe("Synology Chat client loopback", () => {
     }
   });
 
+  it("validates and canonicalizes outbound recipients before delivery", () => {
+    expect(synologyChatPlugin.outbound.resolveTarget?.({ to: "42abc" })).toMatchObject({
+      ok: false,
+    });
+    expect(synologyChatPlugin.outbound.resolveTarget?.({ to: " synology-chat:+0042 " })).toEqual({
+      ok: true,
+      to: "42",
+    });
+  });
+
   it("retries once when a real connection refusal occurs before the listener starts", async () => {
     const port = await reserveLoopbackPort();
     const nativeSetTimeout = globalThis.setTimeout;
@@ -289,7 +299,11 @@ describe("Synology Chat client loopback", () => {
       { text: "native outbound text", user_ids: [42] },
       { file_url: hostedCapabilityUrl, user_ids: [42] },
       { text: "durable adapter text", user_ids: [42] },
-      { file_url: hostedCapabilityUrl, user_ids: [42] },
+      {
+        text: "durable adapter media",
+        file_url: hostedCapabilityUrl,
+        user_ids: [42],
+      },
     ]);
     expect(durableText).toBeDefined();
     expect(durableMedia).toBeDefined();

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -183,10 +183,14 @@ export async function sendHostedFileUrl(
   userId?: string | number,
   allowInsecureSsl = false,
   onPlatformSendDispatch?: () => Promise<void>,
+  text?: string,
 ): Promise<SynologyHostedFileSendResult> {
   let body: string;
   try {
-    body = buildWebhookBody({ file_url: assertHostedMediaUrl(fileUrl) }, userId);
+    body = buildWebhookBody(
+      { file_url: assertHostedMediaUrl(fileUrl), ...(text ? { text } : {}) },
+      userId,
+    );
   } catch {
     return { status: "not-dispatched" };
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Synology Chat sends to malformed direct recipients could omit `user_ids`, and durable media replies could drop their caption while delivering the attachment.

## Why This Change Was Made

The Synology Chat adapter now reuses its strict numeric target normalizer before outbound admission and carries the existing media text through the private hosted-file webhook payload. Shared delivery, receipt, cleanup, and plugin SDK contracts are unchanged.

## User Impact

Invalid Synology Chat recipient IDs fail before durable delivery is admitted, valid prefixed IDs are canonicalized, and media replies retain their caption beside the attachment.

## Evidence

- Pre-fix targeted regression proof failed because `outbound.resolveTarget` was absent and the real loopback media payload omitted `text`.
- Post-fix focused proof: 111/111 tests passed across `channel.test.ts`, `client.loopback.test.ts`, and `client.test.ts`.
- Full changed-file gate passed, including extension production/test typechecks, lint, plugin boundaries, dead-export checks, database/media/runtime guards, and zero runtime import cycles.
- Final branch autoreview: clean, no actionable findings, 0.99 confidence.
- No authenticated live Synology provider action was performed; the production HTTP loopback test verifies the exact webhook payload boundary.
