### PR TITLE
fix(cli): show human errors when required values consume --json

### DIFF
--- a/src/cli/program/commander-parse-facts.ts
+++ b/src/cli/program/commander-parse-facts.ts
@@ -40,11 +40,12 @@ function requiresFollowingValue(token: string, options: readonly Option[]): bool
   return false;
 }
 
-/** Return whether Commander consumed one of the supplied argv tokens as a required option value. */
-export function hasCommanderOptionValue(
+/** Match an argv token in its actual Commander role rather than its spelling alone. */
+export function hasCommanderOptionToken(
   command: Command,
   argv: readonly string[],
   tokens: ReadonlySet<string>,
+  kind: "flag" | "value",
 ): boolean {
   const hierarchy = getCommandHierarchy(command);
   const args = argv.slice(2);
@@ -63,10 +64,14 @@ export function hasCommanderOptionValue(
     // parses only the active command's options; ancestor flags there never reach pre-action.
     if (requiresFollowingValue(arg, hierarchy[commandIndex]?.options ?? [])) {
       const value = args[index + 1];
-      if (value && tokens.has(value)) {
+      if (kind === "value" && value && tokens.has(value)) {
         return true;
       }
       index += 1;
+      continue;
+    }
+    if (kind === "flag" && tokens.has(arg.split("=")[0] ?? arg)) {
+      return true;
     }
   }
   return false;

--- a/src/cli/program/error-output.test.ts
+++ b/src/cli/program/error-output.test.ts
@@ -1,6 +1,11 @@
 // Error output tests cover program-level error display and exit messaging.
-import { CommanderError } from "commander";
+import { CommanderError, InvalidArgumentError } from "commander";
 import { describe, expect, it } from "vitest";
+import { ExpectedCliError } from "../failure-output.js";
+import {
+  isJsonOutputModeActive,
+  withConsoleLogsRoutedToStderrForJson,
+} from "../json-output-mode.js";
 import {
   getCommanderErrorCommandNames,
   getCommanderErrorCommandPath,
@@ -65,6 +70,128 @@ async function parseLazyGroupError(params: {
 }
 
 describe("formatCliParseErrorOutput", () => {
+  it.each([
+    { label: "JSON spelling", value: "--json", supportsJson: true },
+    { label: "true-valued JSON spelling", value: "--json=true", supportsJson: true },
+    { label: "false-valued JSON spelling", value: "--json=false", supportsJson: true },
+    { label: "command without JSON output", value: "--json", supportsJson: false },
+    {
+      label: "JSON spelling before a positional terminator",
+      value: "--json",
+      supportsJson: true,
+      suffix: ["--", "--json"],
+    },
+    {
+      label: "JSON spelling after a short option alias",
+      value: "--json",
+      supportsJson: true,
+      flag: "-l",
+    },
+  ])("keeps a consumed $label as a human parse error", async (testCase) => {
+    const { value, supportsJson } = testCase;
+    const originalArgv = process.argv;
+    process.argv = [
+      "node",
+      "openclaw",
+      "--profile",
+      "work",
+      "p",
+      "s",
+      testCase.flag ?? "--limit",
+      value,
+      ...(testCase.suffix ?? []),
+    ];
+    let stderr = "";
+    try {
+      const program = new OpenClawCommand()
+        .name("openclaw")
+        .enablePositionalOptions()
+        .option("--profile <name>")
+        .exitOverride();
+      program.configureOutput({
+        writeErr: (output) => {
+          stderr += output;
+        },
+      });
+      const command = program
+        .command("plugins")
+        .alias("p")
+        .command("search")
+        .alias("s")
+        .option("-l, --limit <value>", "Result limit", () => {
+          throw new InvalidArgumentError("--limit must be a positive integer.");
+        });
+      if (supportsJson) {
+        command.option("--json", "Output JSON");
+      }
+
+      await withConsoleLogsRoutedToStderrForJson(
+        process.argv,
+        async () => {
+          const error = await program.parseAsync(process.argv).catch((cause: unknown) => cause);
+
+          expect(error).toBeInstanceOf(CommanderError);
+          expect(error).not.toBeInstanceOf(ExpectedCliError);
+          expect((error as CommanderError).exitCode).toBe(1);
+          expect(stderr).toContain("--limit must be a positive integer.");
+          expect(isJsonOutputModeActive(process.argv)).toBe(false);
+        },
+        { restoreChanges: true },
+      );
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it.each([
+    { label: "before an invalid value", args: ["--json", "--limit", "bad"] },
+    { label: "after an invalid value", args: ["--limit", "bad", "--json"] },
+    { label: "before a consumed JSON value", args: ["--json", "--limit", "--json"] },
+    { label: "after a consumed JSON value", args: ["--limit", "--json", "--json"] },
+    { label: "after a consumed valued JSON token", args: ["--limit", "--json=true", "--json"] },
+  ])("preserves a genuine JSON request $label", async ({ args }) => {
+    const originalArgv = process.argv;
+    process.argv = ["node", "openclaw", "plugins", "search", ...args];
+    try {
+      const program = new OpenClawCommand().name("openclaw").exitOverride();
+      program.configureOutput({ writeErr: () => {} });
+      program
+        .command("plugins")
+        .command("search")
+        .option("--json", "Output JSON")
+        .option("--limit <value>", "Result limit", () => {
+          throw new InvalidArgumentError("--limit must be a positive integer.");
+        });
+
+      const error = await program.parseAsync(process.argv).catch((cause: unknown) => cause);
+
+      expect(error).toBeInstanceOf(ExpectedCliError);
+      expect((error as ExpectedCliError).message).toContain("--limit must be a positive integer.");
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it("preserves JSON diagnostics for an unsupported but genuine output flag", async () => {
+    const originalArgv = process.argv;
+    process.argv = ["node", "openclaw", "fleet", "logs", "--json"];
+    try {
+      const program = new OpenClawCommand().name("openclaw").exitOverride();
+      program.configureOutput({ writeErr: () => {} });
+      program
+        .command("fleet")
+        .command("logs")
+        .action(() => {});
+
+      const error = await program.parseAsync(process.argv).catch((cause: unknown) => cause);
+
+      expect(error).toBeInstanceOf(ExpectedCliError);
+      expect((error as ExpectedCliError).message).toContain("--json");
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
   it("uses the same structured root diagnostic as the human renderer", () => {
     const error = createCliUnknownCommandError("pairng", {
       argv: ["node", "openclaw", "pairng", "--json"],

--- a/src/cli/program/json-mode.ts
+++ b/src/cli/program/json-mode.ts
@@ -5,7 +5,7 @@ import {
   isMachineOutputStdoutTTY,
   type MachineOutputResolverParams,
 } from "../machine-output-argv.js";
-import { hasCommanderOptionValue } from "./commander-parse-facts.js";
+import { hasCommanderOptionToken } from "./commander-parse-facts.js";
 
 const jsonModeSymbol = Symbol("openclaw.cli.jsonMode");
 const JSON_FLAG = new Set(["--json"]);
@@ -33,7 +33,8 @@ function getCommandJsonMode(
   command: Command,
   argv: string[] = process.argv,
 ): CommandJsonMode | null {
-  const rawJsonFlag = hasFlag(argv, "--json") && !hasCommanderOptionValue(command, argv, JSON_FLAG);
+  const rawJsonFlag =
+    hasFlag(argv, "--json") && !hasCommanderOptionToken(command, argv, JSON_FLAG, "value");
   const literalJsonMode =
     command.optsWithGlobals<{ json?: unknown }>().json === true || rawJsonFlag;
   for (let current: Command | null = command; current; current = current.parent ?? null) {

--- a/src/cli/program/openclaw-command.ts
+++ b/src/cli/program/openclaw-command.ts
@@ -1,10 +1,11 @@
 // Commander subclass that preserves the exact failing command for parse-error guidance.
 import { Command, CommanderError, type ErrorOptions } from "commander";
-import { isJsonOutputModeActive } from "../json-output-mode.js";
+import { applyResolvedCommandOutputMode, isJsonOutputModeActive } from "../json-output-mode.js";
 import {
   getCommanderErrorCommandNames,
   getCommanderErrorCommandPath,
   getCommanderSubcommandFact,
+  hasCommanderOptionToken,
   setCommanderErrorCommand,
 } from "./commander-parse-facts.js";
 import { createCliParseError } from "./error-output.js";
@@ -33,6 +34,10 @@ export class OpenClawCommand extends Command {
         error.exitCode !== 0 &&
         isJsonOutputModeActive(process.argv)
       ) {
+        if (!hasCommanderOptionToken(this, process.argv, new Set(["--json"]), "flag")) {
+          applyResolvedCommandOutputMode(false);
+          throw error;
+        }
         throw createCliParseError(
           message,
           {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -18,7 +18,7 @@ import {
   resolvePluginInstallInvalidConfigPolicy,
   resolvePluginInstallPreactionRequest,
 } from "../plugin-install-config-policy.js";
-import { getCommanderCommandPath, hasCommanderOptionValue } from "./commander-parse-facts.js";
+import { getCommanderCommandPath, hasCommanderOptionToken } from "./commander-parse-facts.js";
 import { isCommandJsonOutputMode } from "./json-mode.js";
 import { isParentDefaultHelpAction } from "./parent-default-help.js";
 
@@ -117,10 +117,11 @@ export function registerPreActionHooks(program: Command, programVersion: string)
   program.hook("preAction", async (_thisCommand, actionCommand) => {
     setProcessTitleForCommand(actionCommand);
     const argv = process.argv;
-    const helpOrVersionWasOptionValue = hasCommanderOptionValue(
+    const helpOrVersionWasOptionValue = hasCommanderOptionToken(
       actionCommand,
       argv,
       HELP_OR_VERSION_FLAGS,
+      "value",
     );
     if (
       (isHelpOrVersionInvocation(argv) && !helpOrVersionWasOptionValue) ||


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running commands such as `openclaw plugins search --limit --json`, `openclaw skills search --limit --json`, or `openclaw fleet logs --tail --json` would receive an unexpected machine-readable JSON error instead of the normal actionable human error when `--json` was actually consumed as the invalid value for a required option.

## Why This Change Was Made

Commander treats the next token as the value of a required option even when the token looks like a flag. The existing private Commander token scanner now records whether an option-shaped token is a genuine flag or a consumed value, and the authoritative parse-error owner publishes the resolved human output mode before the normal dispatcher handles the error. The two existing token-scanner consumers use the same canonical implementation; no public options, configuration, compatibility aliases, or downstream workarounds are introduced.

## User Impact

Invalid option values now reliably produce the existing human-readable command guidance on stderr without spurious JSON on stdout. Genuine explicit JSON requests continue to emit their existing structured error envelopes, including unsupported flags, unknown commands, duplicates, aliases, option-valued spellings, and positional terminators.

## Evidence

- Captured failing regression tests against both the initial parser misclassification and the outer output-mode dispatch lifecycle before fixing the canonical owner.
- Ten CLI owner and sibling test files passed: **480 tests**; independent focused verification passed **29 tests**.
- Revalidated the committed branch with four owner/output-mode test files: **114 tests**.
- Executed **16 separate actual dist-backed CLI processes** across plugin, skills, fleet, duplicate-option, unsupported-command, unknown-command, and terminator cases; every process returned the expected exit code and exact human-versus-JSON stdout behavior.
- Production core type checking, the exact canonical CLI test-type shard, targeted lint, formatting, max-lines ratchet, assertion-safety ratchet, independent review, and authenticated full-branch Codex review passed.
- The broader aggregate test-type command reaches an unrelated UI shard whose existing shared dependency installation is missing `@panzoom/panzoom` and `@types/pako`; all preceding core-source shards and the exact affected CLI shard pass.
- Production delta: **+12 lines**, required for the canonical token-role and output-lifecycle ownership boundary; regression coverage: **+127 lines**.
