### PR TITLE
fix(reply): preserve streamed voice message order

### DIFF
--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -2,7 +2,12 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
-import { createBlockReplyContentKey, createBlockReplyPipeline } from "./block-reply-pipeline.js";
+import type { ReplyPayload } from "../types.js";
+import {
+  createAudioAsVoiceBuffer,
+  createBlockReplyContentKey,
+  createBlockReplyPipeline,
+} from "./block-reply-pipeline.js";
 
 const waitForAbort = (signal: AbortSignal | undefined): Promise<void> =>
   new Promise((resolve) => {
@@ -166,6 +171,62 @@ describe("createBlockReplyPipeline dedup with threading", () => {
       "file:///b.ogg",
       "file:///c.ogg",
     ]);
+  });
+
+  it.each([
+    {
+      name: "coalesced text on both sides of audio",
+      payloads: [{ text: "Before" }, { mediaUrl: "file:///voice.ogg" }, { text: "After" }],
+      expected: [{ text: "Before" }, { mediaUrl: "file:///voice.ogg" }, { text: "After" }],
+    },
+    {
+      name: "audio before a following image",
+      payloads: [{ mediaUrls: ["file:///voice.ogg"] }, { mediaUrls: ["file:///photo.png"] }],
+      expected: [{ mediaUrls: ["file:///voice.ogg"] }, { mediaUrls: ["file:///photo.png"] }],
+    },
+    {
+      name: "a late voice marker before following text",
+      payloads: [{ mediaUrl: "file:///voice.ogg" }, { text: "After", audioAsVoice: true }],
+      expected: [
+        { mediaUrl: "file:///voice.ogg", audioAsVoice: true },
+        { text: "After", audioAsVoice: true },
+      ],
+    },
+  ])("preserves streamed delivery order for $name", async ({ payloads, expected }) => {
+    const sent: ReplyPayload[] = [];
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async (payload) => {
+        sent.push(payload);
+      },
+      timeoutMs: 5000,
+      coalescing: {
+        minChars: 1,
+        maxChars: 200,
+        idleMs: 0,
+        joiner: " ",
+      },
+      buffer: createAudioAsVoiceBuffer({
+        isAudioPayload: (payload) =>
+          [payload.mediaUrl, ...(payload.mediaUrls ?? [])].some((url) => url?.endsWith(".ogg")),
+      }),
+    });
+
+    for (const payload of payloads) {
+      pipeline.enqueue(payload);
+    }
+    await pipeline.flush({ force: true });
+
+    expect(sent).toHaveLength(expected.length);
+    expect(sent).toMatchObject(expected);
+    expect(pipeline.getSentMediaUrls()).toEqual(
+      expected.flatMap((payload) =>
+        "mediaUrls" in payload
+          ? payload.mediaUrls
+          : "mediaUrl" in payload
+            ? [payload.mediaUrl]
+            : [],
+      ),
+    );
   });
 
   it("keeps separate deliveries for distinct rich-only payloads", async () => {

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -279,8 +279,11 @@ export function createBlockReplyPipeline(params: {
       return;
     }
     if (bufferPayload(payload)) {
+      flushBufferedAssistantBlock();
       return;
     }
+    // Buffered audio is an ordering boundary, even when voice metadata arrives later.
+    flushBuffered();
     const reply = resolveSendableOutboundReplyParts(payload);
     const hasNonTextContent = hasOutboundReplyContent(
       { ...payload, text: undefined, mediaUrl: undefined, mediaUrls: undefined },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receiving streamed replies containing voice or audio attachments would see later text or images delivered before the audio. Text from opposite sides of an audio attachment could also be incorrectly combined into a single message.

## Why This Change Was Made

The shared streaming reply pipeline buffered audio separately to preserve late-arriving voice presentation metadata, but did not treat that deferred audio as an ordering boundary. Flush earlier coalesced text when audio enters the buffer, then place buffered audio on the same ordered delivery chain before processing the next non-audio block. Late voice markers continue to apply before the audio is finalized.

## User Impact

Streamed text, voice attachments, and images now arrive in the order the agent produced them across all channel implementations using the shared reply pipeline. Text is no longer merged across an intervening audio attachment, and late voice presentation metadata remains intact.

## Evidence

- Added three real-pipeline regressions covering text/audio/text ordering, audio/image ordering through both attachment URL shapes, and late-arriving voice metadata. All three fail against current main before the owner-boundary repair.
- Run `node scripts/run-vitest.mjs src/auto-reply/reply/block-reply-pipeline.test.ts src/auto-reply/reply/reply-utils.test.ts src/auto-reply/reply/reply-delivery.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`: 227 tests passed across four owner, sibling, delivery, and real-runner suites.
- Run `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile /private/tmp/openclaw-audio-core.tsbuildinfo` and `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.messaging.json --builders 1`: core production and messaging-test types both pass.
- Run `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/block-reply-pipeline.test.ts src/auto-reply/reply/block-reply-pipeline.ts`.
- Run `./node_modules/.bin/oxfmt --check src/auto-reply/reply/block-reply-pipeline.ts src/auto-reply/reply/block-reply-pipeline.test.ts` and `git diff --check`.
- Independent read-only local review inspected the pipeline owner, actual agent-runner caller, sibling coalescer, delayed voice metadata, ordering, and duplicate handling: CLEAN, with no actionable findings.
- Production delta: +3 lines, required to enforce both sides of the audio ordering boundary while documenting the late-metadata invariant. No channel-specific policy, external API, configuration, persistent state, or protocol changes.
- Live-channel evidence was not captured because this isolated checkout has no disposable configured channel and sending test messages to an operator-owned live channel would create unsolicited external side effects. The real shared delivery owner, its delivery boundary, and the actual agent-runner integration are exercised by the focused suites instead.
