### PR TITLE
fix(agents): prevent persona drift with generic slot IDs

### DIFF
--- a/src/agents/cli-runner/helpers.system-prompt.test.ts
+++ b/src/agents/cli-runner/helpers.system-prompt.test.ts
@@ -156,15 +156,23 @@ describe("buildCliAgentSystemPrompt", () => {
   it("includes session identity in runtime when provided", () => {
     const prompt = buildCliAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      config: {
+        agents: {
+          entries: {
+            "Team Ops": { identity: { name: "Ops Navigator" } },
+          },
+        },
+      },
       tools: [],
       modelDisplay: "test/model",
-      agentId: "main",
-      sessionKey: "agent:main:telegram:direct:peer",
+      agentId: "team-ops",
+      sessionKey: "agent:team-ops:telegram:direct:peer",
       sessionId: "session-123",
     });
 
-    expect(prompt).toContain("agent=main");
-    expect(prompt).toContain("session=agent:main:telegram:direct:peer");
+    expect(prompt).toContain(
+      "Runtime: name=Ops Navigator | agent=team-ops | session=agent:team-ops:telegram:direct:peer",
+    );
     expect(prompt).toContain("sessionId=session-123");
   });
 

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -106,6 +106,9 @@ export const resolveSessionAgentIdsMock = vi.fn(() => ({
   defaultAgentId: "main",
   sessionAgentId: "main",
 }));
+export const resolveAgentConfigMock = vi.fn(
+  (_config?: unknown, _agentId?: string): unknown => undefined,
+);
 export const resolveDefaultAgentDirMock = vi.fn(() => "/tmp/agents/main/agent");
 export const estimateTokensMock = vi.fn((_message?: unknown) => 10);
 export const resolveAgentHarnessPolicyMock = vi.fn(() => ({ runtime: "openclaw" }));
@@ -490,6 +493,8 @@ export function resetCompactSessionStateMocks(): void {
   resolveSessionAgentIdMock.mockReturnValue("main");
   resolveSessionAgentIdsMock.mockReset();
   resolveSessionAgentIdsMock.mockReturnValue({ defaultAgentId: "main", sessionAgentId: "main" });
+  resolveAgentConfigMock.mockReset();
+  resolveAgentConfigMock.mockReturnValue(undefined);
   estimateTokensMock.mockReset();
   estimateTokensMock.mockReturnValue(10);
   sessionMessages.splice(0, sessionMessages.length, ...createDefaultSessionMessages());
@@ -1008,7 +1013,7 @@ export async function loadCompactHooksHarness(): Promise<{
 
   vi.doMock("../agent-scope.js", () => ({
     listAgentEntries: vi.fn(() => []),
-    resolveAgentConfig: vi.fn(() => undefined),
+    resolveAgentConfig: resolveAgentConfigMock,
     resolveAgentDir: vi.fn((_cfg: unknown, agentId: string) => `/tmp/agents/${agentId}/agent`),
     resolveAgentModelFallbacksOverride: vi.fn(() => undefined),
     resolveAgentWorkspaceDir: vi.fn(() => "/tmp"),

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -38,6 +38,7 @@ import {
   maybeCompactAgentHarnessSessionMock,
   resolveAgentHarnessPolicyMock,
   registerProviderStreamForModelMock,
+  resolveAgentConfigMock,
   resolveProviderEntryApiKeyProfileReferenceMock,
   resolveContextWindowInfoMock,
   resolveCliBackendConfigMock,
@@ -1002,10 +1003,13 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     );
   });
 
-  it("passes resolved agent context to compacted system prompt rebuilds", async () => {
+  it("passes resolved agent identity context to compacted system prompt rebuilds", async () => {
     resolveSessionAgentIdsMock.mockReturnValue({
       defaultAgentId: "main",
       sessionAgentId: "marketing-agent",
+    });
+    resolveAgentConfigMock.mockReturnValue({
+      identity: { name: "Campaign Navigator" },
     });
 
     await compactEmbeddedAgentSessionDirect({
@@ -1013,12 +1017,18 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionKey: "agent:marketing-agent:session-1",
       sessionFile: TEST_SESSION_KEY,
       workspaceDir: "/tmp/workspace",
+      config: {
+        agents: {
+          list: [{ id: "marketing-agent", identity: { name: "Campaign Navigator" } }],
+        },
+      },
     });
 
     expect(buildEmbeddedSystemPromptMock).toHaveBeenCalledWith(
       expect.objectContaining({
         runtimeInfo: expect.objectContaining({
           agentId: "marketing-agent",
+          agentName: "Campaign Navigator",
           sessionKey: "agent:marketing-agent:session-1",
         }),
       }),

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -59,6 +59,7 @@ import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
 import type { AgentRuntimePlan } from "../runtime-plan/types.js";
 import { resolveSessionPermissionExecMode } from "../session-permission-exec-mode.js";
 import { detectRuntimeShell } from "../shell-utils.js";
+import { resolveRuntimeAgentName } from "../system-prompt-params.js";
 import { toolPolicyRestrictsTools } from "../tool-policy.js";
 import {
   filterProviderNormalizableTools,
@@ -515,6 +516,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
 
     const runtimeInfo = {
       agentId: sessionAgentId,
+      agentName: params.config ? resolveRuntimeAgentName(params.config, sessionAgentId) : undefined,
       sessionKey: params.sessionKey,
       host: machineName,
       os: resolveRuntimeOsLabel(),

--- a/src/agents/embedded-agent-runner/system-prompt.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.ts
@@ -8,13 +8,13 @@ import type { MemoryCitationsMode } from "../../config/types.memory.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PreparedMemoryPromptSection } from "../../plugins/memory-state.js";
 import type { AgentPromptSurfaceKind } from "../../plugins/types.js";
-import type { ActiveProcessSessionReference } from "../bash-process-references.js";
 import type { BootstrapMode } from "../bootstrap-mode.js";
 import type { EmbeddedContextFile } from "../embedded-agent-helpers.js";
 import type { AgentTool } from "../runtime/index.js";
 import type { AgentSession } from "../sessions/index.js";
 import { buildConfiguredAgentSystemPrompt } from "../system-prompt-config.js";
 import type { ProviderSystemPromptContribution } from "../system-prompt-contribution.js";
+import type { SystemPromptRuntimeInfo } from "../system-prompt.js";
 import type { PromptMode, SilentReplyPromptMode } from "../system-prompt.types.js";
 import type { PreparedWatchedSessionsPrompt } from "../watched-sessions-prompt.js";
 import type { EmbeddedSandboxInfo } from "./types.js";
@@ -58,23 +58,16 @@ export function buildEmbeddedSystemPrompt(params: {
   nativeCommandNames?: string[];
   /** Plugin-owned prompt guidance for registered native slash commands. */
   nativeCommandGuidanceLines?: string[];
-  runtimeInfo: {
-    agentId?: string;
-    sessionKey?: string;
-    sessionId?: string;
+  runtimeInfo: SystemPromptRuntimeInfo & {
     host: string;
     os: string;
     arch: string;
     node: string;
     model: string;
     provider?: string;
-    capabilities?: string[];
-    channel?: string;
     chatType?: ChatType;
     /** Supported message actions for the current channel (e.g., react, edit, unsend) */
     channelActions?: string[];
-    activeProcessSessions?: ActiveProcessSessionReference[];
-    activeNode?: string;
   };
   messageToolHints?: string[];
   toolSchemaDirectoryPrompt?: string;

--- a/src/agents/system-prompt-params.test.ts
+++ b/src/agents/system-prompt-params.test.ts
@@ -170,9 +170,16 @@ describe("buildSystemPromptParams", () => {
 
   it("carries session identity into runtime info", () => {
     const { runtimeInfo } = buildSystemPromptParams({
-      agentId: "main",
+      config: {
+        agents: {
+          entries: {
+            "Team Ops": { identity: { name: "\nOps\u200b Navigator\r" } },
+          },
+        },
+      },
+      agentId: "team-ops",
       runtime: {
-        sessionKey: "agent:main:main",
+        sessionKey: "agent:team-ops:main",
         sessionId: "23ae7fce-3c27-4a51-b58e-d800d8ca091f",
         host: "host",
         os: "os",
@@ -182,8 +189,37 @@ describe("buildSystemPromptParams", () => {
       },
     });
 
-    expect(runtimeInfo.sessionKey).toBe("agent:main:main");
+    expect(runtimeInfo.agentName).toBe("Ops Navigator");
+    expect(runtimeInfo.sessionKey).toBe("agent:team-ops:main");
     expect(runtimeInfo.sessionId).toBe("23ae7fce-3c27-4a51-b58e-d800d8ca091f");
+  });
+
+  it.each([
+    { name: "control-only names", identityName: "\n\u200b\r", expected: undefined },
+    {
+      name: "oversized names",
+      identityName: `${"x".repeat(128)}tail`,
+      expected: "x".repeat(128),
+    },
+    { name: "the technical agent id", identityName: "main", expected: undefined },
+  ])("omits or bounds $name before model context", ({ identityName, expected }) => {
+    const { runtimeInfo } = buildSystemPromptParams({
+      config: {
+        agents: {
+          list: [{ id: "main", identity: { name: identityName } }],
+        },
+      },
+      agentId: "main",
+      runtime: {
+        host: "host",
+        os: "os",
+        arch: "arch",
+        node: "node",
+        model: "model",
+      },
+    });
+
+    expect(runtimeInfo.agentName).toBe(expected);
   });
 
   it.each([

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -67,15 +67,6 @@ export function buildSystemPromptParams(params: {
   const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
   const userDate = formatDateStamp(Date.now(), userTimezone);
   const { runId } = parseCronRunScopeSuffix(params.runtime.sessionKey);
-  const agentName =
-    params.config && params.agentId
-      ? truncateUtf16Safe(
-          sanitizeForPromptLiteral(
-            resolveAgentIdentity(params.config, params.agentId)?.name ?? "",
-          ).trim(),
-          MAX_RUNTIME_AGENT_NAME_CHARS,
-        ).trimEnd()
-      : "";
   // Exact isolated-cron URLs expose a volatile run id before prompt rendering can normalize it,
   // defeating byte-identical prompt-prefix reuse across runs of the same job.
   const sessionUrl =
@@ -89,7 +80,10 @@ export function buildSystemPromptParams(params: {
   return {
     runtimeInfo: {
       agentId: params.agentId,
-      agentName: agentName && agentName !== params.agentId ? agentName : undefined,
+      agentName:
+        params.config && params.agentId
+          ? resolveRuntimeAgentName(params.config, params.agentId)
+          : undefined,
       ...params.runtime,
       // Published links must be externally usable and bounded before entering model context.
       sessionUrl:
@@ -103,6 +97,12 @@ export function buildSystemPromptParams(params: {
     userTimezone,
     userDate,
   };
+}
+
+export function resolveRuntimeAgentName(config: OpenClawConfig, agentId: string) {
+  const name = sanitizeForPromptLiteral(resolveAgentIdentity(config, agentId)?.name ?? "").trim();
+  const bounded = truncateUtf16Safe(name, MAX_RUNTIME_AGENT_NAME_CHARS).trimEnd();
+  return bounded && bounded !== agentId ? bounded : undefined;
 }
 
 export function resolveSystemPromptRepoRoot(params: {

--- a/src/agents/system-prompt-params.ts
+++ b/src/agents/system-prompt-params.ts
@@ -6,6 +6,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { ChatType } from "../channels/chat-type.js";
 import { resolveControlUiSessionUrl } from "../config/control-ui-link-base.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -17,11 +18,15 @@ import { findGitRoot } from "../infra/git-root.js";
 import { parseCronRunScopeSuffix } from "../sessions/session-key-utils.js";
 import type { ActiveProcessSessionReference } from "./bash-process-references.js";
 import { formatDateStamp, resolveUserTimezone } from "./date-time.js";
+import { resolveAgentIdentity } from "./identity.js";
+import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 
+const MAX_RUNTIME_AGENT_NAME_CHARS = 128;
 const MAX_RUNTIME_SESSION_URL_CHARS = 512;
 
 type RuntimeInfoInput = {
   agentId?: string;
+  agentName?: string;
   sessionKey?: string;
   sessionId?: string;
   sessionUrl?: string;
@@ -51,7 +56,7 @@ type SystemPromptRuntimeParams = {
 export function buildSystemPromptParams(params: {
   config?: OpenClawConfig;
   agentId?: string;
-  runtime: Omit<RuntimeInfoInput, "agentId" | "sessionUrl">;
+  runtime: Omit<RuntimeInfoInput, "agentId" | "agentName" | "sessionUrl">;
   workspaceDir?: string;
   cwd?: string;
   preparedRepoRoot?: string | null;
@@ -62,6 +67,15 @@ export function buildSystemPromptParams(params: {
   const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
   const userDate = formatDateStamp(Date.now(), userTimezone);
   const { runId } = parseCronRunScopeSuffix(params.runtime.sessionKey);
+  const agentName =
+    params.config && params.agentId
+      ? truncateUtf16Safe(
+          sanitizeForPromptLiteral(
+            resolveAgentIdentity(params.config, params.agentId)?.name ?? "",
+          ).trim(),
+          MAX_RUNTIME_AGENT_NAME_CHARS,
+        ).trimEnd()
+      : "";
   // Exact isolated-cron URLs expose a volatile run id before prompt rendering can normalize it,
   // defeating byte-identical prompt-prefix reuse across runs of the same job.
   const sessionUrl =
@@ -75,6 +89,7 @@ export function buildSystemPromptParams(params: {
   return {
     runtimeInfo: {
       agentId: params.agentId,
+      agentName: agentName && agentName !== params.agentId ? agentName : undefined,
       ...params.runtime,
       // Published links must be externally usable and bounded before entering model context.
       sessionUrl:

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1936,6 +1936,7 @@ describe("buildAgentSystemPrompt", () => {
       workspaceDir: "/tmp/openclaw",
       runtimeInfo: {
         agentId: "work",
+        agentName: "Runt",
         sessionKey: "agent:main:main",
         sessionId: "23ae7fce-3c27-4a51-b58e-d800d8ca091f",
         sessionUrl: "https://gateway.example/control/chat/main",
@@ -1947,7 +1948,7 @@ describe("buildAgentSystemPrompt", () => {
       },
     });
 
-    expect(prompt).toContain("agent=work");
+    expect(prompt).toContain("Runtime: name=Runt | agent=work | session=agent:main:main");
     expect(prompt).toContain("session=agent:main:main");
     expect(prompt).toContain("sessionId=23ae7fce-3c27-4a51-b58e-d800d8ca091f");
     expect(prompt).toContain("sessionUrl=https://gateway.example/control/chat/main");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -101,6 +101,27 @@ type StablePromptPrefixCacheEntry = {
   value: string;
 };
 
+export type SystemPromptRuntimeInfo = {
+  agentId?: string;
+  agentName?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  sessionUrl?: string;
+  host?: string;
+  os?: string;
+  arch?: string;
+  node?: string;
+  model?: string;
+  defaultModel?: string;
+  shell?: string;
+  channel?: string;
+  chatType?: string;
+  capabilities?: string[];
+  repoRoot?: string;
+  activeProcessSessions?: ActiveProcessSessionReference[];
+  activeNode?: string;
+};
+
 function normalizeSubagentDelegationMode(mode?: SubagentDelegationMode): SubagentDelegationMode {
   return mode === "prefer" ? "prefer" : "suggest";
 }
@@ -827,25 +848,7 @@ export function buildAgentSystemPrompt(params: {
   nativeCommandNames?: string[];
   /** Plugin-owned prompt guidance for registered native slash commands. */
   nativeCommandGuidanceLines?: string[];
-  runtimeInfo?: {
-    agentId?: string;
-    sessionKey?: string;
-    sessionId?: string;
-    sessionUrl?: string;
-    host?: string;
-    os?: string;
-    arch?: string;
-    node?: string;
-    model?: string;
-    defaultModel?: string;
-    shell?: string;
-    channel?: string;
-    chatType?: string;
-    capabilities?: string[];
-    repoRoot?: string;
-    activeProcessSessions?: ActiveProcessSessionReference[];
-    activeNode?: string;
-  };
+  runtimeInfo?: SystemPromptRuntimeInfo;
   messageToolHints?: string[];
   toolSchemaDirectoryPrompt?: string;
   sandboxInfo?: EmbeddedSandboxInfo;
@@ -1592,22 +1595,7 @@ function buildActiveProcessSessionReferenceLines(
 }
 
 function buildRuntimeLine(
-  runtimeInfo?: {
-    agentId?: string;
-    sessionKey?: string;
-    sessionId?: string;
-    sessionUrl?: string;
-    host?: string;
-    os?: string;
-    arch?: string;
-    node?: string;
-    model?: string;
-    defaultModel?: string;
-    shell?: string;
-    repoRoot?: string;
-    activeProcessSessions?: ActiveProcessSessionReference[];
-    activeNode?: string;
-  },
+  runtimeInfo?: SystemPromptRuntimeInfo,
   runtimeChannel?: string,
   runtimeCapabilities: string[] = [],
   defaultThinkLevel?: ThinkLevel,
@@ -1620,6 +1608,7 @@ function buildRuntimeLine(
   const stableSessionId =
     runtimeInfo?.sessionId && runtimeInfo.sessionId !== runId ? runtimeInfo.sessionId : undefined;
   return `Runtime: ${[
+    runtimeInfo?.agentName ? `name=${runtimeInfo.agentName}` : "",
     runtimeInfo?.agentId ? `agent=${runtimeInfo.agentId}` : "",
     baseSessionKey ? `session=${sanitizeForPromptLiteral(baseSessionKey)}` : "",
     stableSessionId ? `sessionId=${sanitizeForPromptLiteral(stableSessionId)}` : "",


### PR DESCRIPTION
Thanks @zhangguiping-xydt!

Closes #81269

**Proof:** A built OpenClaw CLI used a disposable Qwen2.5 0.5B local model against exact main and the repair. Exact main exposed only `agent=main`. The repair exposed `name=Runt` before `agent=main`, and the model returned those two values in that order through embedded and CLI-backed runs. A real `sessions compact` call completed, and the next model request and answer retained the same ordered identity fields. The final head is a patch-identical rebase of the proven head.

- **Bug:** Runtime prompt metadata exposed only the technical slot ID, so a configured agent name could lose authority during normal, CLI-backed, or compacted sessions.
- **Fix:** The shared Runtime parameter owner now sanitizes and bounds the configured name, renders it before the unchanged slot ID, and supplies the same value to direct compaction.

**Example**

| Before | After |
| --- | --- |
| `Runtime: agent=main` | `Runtime: name=Runt \| agent=main` |

## What Problem This Solves

Agents configured with a distinct `identity.name` could drift toward their generic slot ID because Runtime metadata repeatedly exposed only the technical identifier. Direct compaction rebuilt Runtime metadata separately, so a normal-turn-only fix would lose the configured identity after compaction.

## Why This Change Was Made

The shared Runtime-parameter owner now resolves the configured identity through the canonical agent helper. It removes prompt-control characters, caps the value at 128 UTF-16 code units, suppresses empty or slot-identical names, and renders `name=<identity>` before the preserved `agent=<slotId>` field.

Normal embedded and CLI-backed runs share this owner. Direct compaction calls the same bounded resolver. The repair also replaces duplicate Runtime type declarations with one shared type.

The change does not add configuration, routing behavior, schemas, protocols, migrations, or persisted state.

## User Impact

Configured agents receive consistent model-facing identity metadata before and after compaction. Operators keep the technical slot ID for diagnostics and do not need prompt overrides.

## Evidence

- Seven focused regression cases pass across shared parameters, Runtime rendering, CLI prompting, direct compaction, the 128-character bound, and suppression cases.
- Both exact revisions completed full builds and built-CLI smoke checks.
- Formatting and `git diff --check` pass for all nine changed files.
- Production code is `+44/-45` (net `-1`). Tests and test support are `+70/-10` (net `+60`).
- The repair performs one configured identity lookup and bounded string normalization per prompt build. It adds no request loop, cache, network call, or persistent state.

AI-assisted. I reviewed the complete change, reproduced the failure, and verified the final behavior.
