### PR TITLE
fix(discord): classify announcement threads consistently

### DIFF
--- a/extensions/discord/src/actions/runtime.guild.ts
+++ b/extensions/discord/src/actions/runtime.guild.ts
@@ -1,7 +1,8 @@
 // Discord plugin module implements runtime.guild behavior.
-import { ChannelType, PermissionFlagsBits } from "discord-api-types/v10";
+import { PermissionFlagsBits } from "discord-api-types/v10";
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import { resolveDefaultDiscordAccountId } from "../accounts.js";
+import { isDiscordThreadChannelType } from "../channel-type.js";
 import { getGateway } from "../monitor/gateway-registry.js";
 import { getPresence } from "../monitor/presence-cache.js";
 import {
@@ -106,14 +107,6 @@ const guildAdminActionGuards: Partial<Record<string, GuildAdminActionGuard>> = {
   channelPermissionRemove: channelPermissionGuard,
 };
 
-function isThreadChannelType(channelType: number | undefined) {
-  return (
-    channelType === ChannelType.GuildNewsThread ||
-    channelType === ChannelType.GuildPublicThread ||
-    channelType === ChannelType.GuildPrivateThread
-  );
-}
-
 function isLockedThreadChannel(channel: unknown) {
   if (!channel || typeof channel !== "object") {
     return false;
@@ -186,7 +179,7 @@ async function resolveGuildAdminActionPermissions(params: {
     createDiscordActionOptions({ cfg: params.cfg, accountId: params.accountId }),
   );
   const channelType = "type" in channel ? channel.type : undefined;
-  if (!isThreadChannelType(channelType)) {
+  if (!isDiscordThreadChannelType(channelType)) {
     return params.guard.permissions;
   }
 

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements runtime.messaging.send behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { isDiscordThreadChannelType } from "../channel-type.js";
 import {
   createReusableDiscordReplyReference,
   resolveDiscordReplyReference,
@@ -13,7 +14,6 @@ import {
   readStringParam,
 } from "../runtime-api.js";
 import { DiscordThreadInitialMessageError } from "../send.js";
-import { isThreadChannelType } from "../send.permissions.js";
 import type { DiscordSendComponents, DiscordSendEmbeds } from "../send.shared.js";
 import { discordMessagingActionRuntime } from "./runtime.messaging.runtime.js";
 import type { DiscordMessagingActionContext } from "./runtime.messaging.shared.js";
@@ -144,7 +144,7 @@ async function appendDiscordThreadRenameResult(
       channelId,
       ctx.withOpts(),
     );
-    if (!isThreadChannelType(channel.type)) {
+    if (!isDiscordThreadChannelType(channel.type)) {
       return {
         ...params.payload,
         warning: "Discord threadName was ignored because the send target is not a thread.",

--- a/extensions/discord/src/actions/runtime.messaging.shared.ts
+++ b/extensions/discord/src/actions/runtime.messaging.shared.ts
@@ -4,6 +4,7 @@ import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-co
 // Discord plugin module implements runtime.messaging.shared behavior.
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import { mergeDiscordAccountConfig, resolveDefaultDiscordAccountId } from "../accounts.js";
+import { isDiscordThreadChannelType } from "../channel-type.js";
 import { createDiscordRuntimeAccountContext } from "../client.js";
 import {
   isDiscordGroupAllowedByPolicy,
@@ -192,8 +193,7 @@ function readDiscordChannelType(value: unknown): number | undefined {
 }
 
 function isDiscordThreadChannel(value: unknown): boolean {
-  const type = readDiscordChannelType(value);
-  return type === 10 || type === 11 || type === 12;
+  return isDiscordThreadChannelType(readDiscordChannelType(value));
 }
 
 function isDiscordReadAncestryAllowed(params: {

--- a/extensions/discord/src/channel-type.ts
+++ b/extensions/discord/src/channel-type.ts
@@ -1,0 +1,9 @@
+import { ChannelType } from "discord-api-types/v10";
+
+export function isDiscordThreadChannelType(channelType: unknown): boolean {
+  return (
+    channelType === ChannelType.AnnouncementThread ||
+    channelType === ChannelType.PublicThread ||
+    channelType === ChannelType.PrivateThread
+  );
+}

--- a/extensions/discord/src/monitor/agent-components-context.ts
+++ b/extensions/discord/src/monitor/agent-components-context.ts
@@ -2,6 +2,7 @@
 import { ChannelType } from "discord-api-types/v10";
 import { logError } from "openclaw/plugin-sdk/logging-core";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { isDiscordThreadChannelType } from "../channel-type.js";
 import type {
   AgentComponentContext,
   AgentComponentInteraction,
@@ -17,14 +18,6 @@ function formatUsername(user: { username: string; discriminator?: string | null 
     return `${user.username}#${user.discriminator}`;
   }
   return user.username;
-}
-
-function isThreadChannelType(channelType: number | undefined): boolean {
-  return (
-    channelType === ChannelType.PublicThread ||
-    channelType === ChannelType.PrivateThread ||
-    channelType === ChannelType.AnnouncementThread
-  );
 }
 
 export function resolveAgentComponentRoute(params: {
@@ -86,7 +79,7 @@ export function resolveDiscordChannelContext(
   const channelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
   const displayChannelSlug = channelName ? normalizeDiscordDisplaySlug(channelName) : "";
   const channelType = channelInfo.type;
-  const isThread = isThreadChannelType(channelType);
+  const isThread = isDiscordThreadChannelType(channelType);
 
   let parentId: string | undefined;
   let parentName: string | undefined;

--- a/extensions/discord/src/monitor/message-handler.preflight-helpers.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-helpers.ts
@@ -5,7 +5,8 @@ import {
 } from "openclaw/plugin-sdk/channel-inbound";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { findCodeRegions, isInsideCode } from "openclaw/plugin-sdk/text-chunking";
-import { ChannelType, type Message } from "../internal/discord.js";
+import { isDiscordThreadChannelType } from "../channel-type.js";
+import type { Message } from "../internal/discord.js";
 import type { DiscordMessagePreflightParams } from "./message-handler.preflight.types.js";
 import type { DiscordChannelInfo } from "./message-utils.js";
 
@@ -32,14 +33,6 @@ type BoundThreadLookupRecordLike = {
     webhookId?: string | null;
   };
 };
-
-function isDiscordThreadChannelType(type: ChannelType | undefined): boolean {
-  return (
-    type === ChannelType.PublicThread ||
-    type === ChannelType.PrivateThread ||
-    type === ChannelType.AnnouncementThread
-  );
-}
 
 export function isDiscordThreadChannelMessage(params: {
   isGuildMessage: boolean;

--- a/extensions/discord/src/monitor/thread-bindings.discord-api.ts
+++ b/extensions/discord/src/monitor/thread-bindings.discord-api.ts
@@ -1,9 +1,9 @@
 // Discord API module exposes the plugin public contract.
-import { ChannelType } from "discord-api-types/v10";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isDiscordThreadChannelType } from "../channel-type.js";
 import { createDiscordRestClient } from "../client.js";
 import { createChannelWebhook, getChannel } from "../internal/discord.js";
 import { sendMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
@@ -45,14 +45,6 @@ export function isThreadArchived(raw: unknown): boolean {
     return true;
   }
   return false;
-}
-
-function isThreadChannelType(type: unknown): boolean {
-  return (
-    type === ChannelType.PublicThread ||
-    type === ChannelType.PrivateThread ||
-    type === ChannelType.AnnouncementThread
-  );
 }
 
 function normalizeDiscordBindingChannelId(raw?: string | null): string | null {
@@ -263,7 +255,7 @@ export async function resolveChannelIdForBinding(params: {
     const parentId = normalizeOptionalString(channelInfo.parentId) ?? "";
     // Only thread channels should resolve to their parent channel.
     // Non-thread channels (text/forum/media) must keep their own ID.
-    if (parentId && isThreadChannelType(type)) {
+    if (parentId && isDiscordThreadChannelType(type)) {
       return parentId;
     }
     return channelId || null;

--- a/extensions/discord/src/monitor/thread-channel-context.ts
+++ b/extensions/discord/src/monitor/thread-channel-context.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements thread channel context behavior.
-import { ChannelType } from "../internal/discord.js";
+import { isDiscordThreadChannelType } from "../channel-type.js";
+import type { ChannelType } from "../internal/discord.js";
 import { normalizeDiscordSlug } from "./allow-list.js";
 import {
   resolveDiscordChannelIdSafe,
@@ -25,14 +26,6 @@ type DiscordThreadLikeChannelContext = {
   threadParentSlug: string;
   channelInfo: DiscordChannelInfo | null;
 };
-
-function isDiscordThreadChannelType(type: ChannelType | number | undefined): boolean {
-  return (
-    type === ChannelType.PublicThread ||
-    type === ChannelType.PrivateThread ||
-    type === ChannelType.AnnouncementThread
-  );
-}
 
 function buildFetchedChannelInfo(channel: unknown): DiscordChannelInfo | null {
   const channelInfo = resolveDiscordChannelInfoSafe(channel);

--- a/extensions/discord/src/monitor/threading.starter.ts
+++ b/extensions/discord/src/monitor/threading.starter.ts
@@ -3,6 +3,7 @@ import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-reference";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { isDiscordThreadChannelType } from "../channel-type.js";
 import { ChannelType, getChannelMessage, type Client } from "../internal/discord.js";
 import {
   resolveDiscordChannelIdSafe,
@@ -31,14 +32,6 @@ import type {
   DiscordThreadStarterRestMessage,
 } from "./threading.types.js";
 
-function isDiscordThreadType(type: ChannelType | undefined): boolean {
-  return (
-    type === ChannelType.PublicThread ||
-    type === ChannelType.PrivateThread ||
-    type === ChannelType.AnnouncementThread
-  );
-}
-
 function isDiscordForumParentType(parentType: ChannelType | undefined): boolean {
   return parentType === ChannelType.GuildForum || parentType === ChannelType.GuildMedia;
 }
@@ -63,7 +56,7 @@ export function resolveDiscordThreadChannel(params: {
   if (isThreadChannel) {
     return channel as unknown as DiscordThreadChannel;
   }
-  if (!isDiscordThreadType(channelInfo?.type)) {
+  if (!isDiscordThreadChannelType(channelInfo?.type)) {
     return null;
   }
   const messageChannelId =

--- a/extensions/discord/src/resolve-channels.test.ts
+++ b/extensions/discord/src/resolve-channels.test.ts
@@ -1,4 +1,5 @@
 // Discord tests cover resolve channels plugin behavior.
+import { ChannelType } from "discord-api-types/v10";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import { resolveDiscordChannelAllowlist } from "./resolve-channels.js";
@@ -67,7 +68,11 @@ describe("resolveDiscordChannelAllowlist", () => {
     expect(res[0]?.guildId).toBe("111");
   }
 
-  it("resolves guild/channel by name", async () => {
+  it.each([
+    ["announcement", ChannelType.AnnouncementThread],
+    ["public", ChannelType.PublicThread],
+    ["private", ChannelType.PrivateThread],
+  ])("prefers a matching guild channel over a %s thread", async (_kind, threadType) => {
     const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
       const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
@@ -75,6 +80,7 @@ describe("resolveDiscordChannelAllowlist", () => {
       }
       if (url.endsWith("/guilds/g1/channels")) {
         return jsonResponse([
+          { id: "thread-1", name: "general", guild_id: "g1", type: threadType },
           { id: "c1", name: "general", guild_id: "g1", type: 0 },
           { id: "c2", name: "random", guild_id: "g1", type: 0 },
         ]);

--- a/extensions/discord/src/resolve-channels.ts
+++ b/extensions/discord/src/resolve-channels.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements resolve channels behavior.
 import { DISCORD_DIRECTORY_LOOKUP_TIMEOUT_MS, DiscordApiError, fetchDiscord } from "./api.js";
+import { isDiscordThreadChannelType } from "./channel-type.js";
 import { listGuilds } from "./guilds.js";
 import { normalizeDiscordSlug } from "./monitor/allow-list.js";
 import {
@@ -145,7 +146,7 @@ function preferActiveMatch(candidates: DiscordChannelSummary[]): DiscordChannelS
     return undefined;
   }
   const scored = candidates.map((channel) => {
-    const isThread = channel.type === 11 || channel.type === 12;
+    const isThread = isDiscordThreadChannelType(channel.type);
     const archived = Boolean(channel.archived);
     const score = (archived ? 0 : 2) + (isThread ? 0 : 1);
     return { channel, score };

--- a/extensions/discord/src/send.permissions.ts
+++ b/extensions/discord/src/send.permissions.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements send.permissions behavior.
 import type { APIChannel, APIGuild, APIGuildMember, APIRole } from "discord-api-types/v10";
 import { ChannelType, PermissionFlagsBits } from "discord-api-types/v10";
+import { isDiscordThreadChannelType } from "./channel-type.js";
 import { resolveDiscordRest } from "./client.js";
 import {
   getChannel,
@@ -44,14 +45,6 @@ function hasAdministrator(bitfield: bigint) {
 
 function hasPermissionBit(bitfield: bigint, permission: bigint) {
   return (bitfield & permission) === permission;
-}
-
-export function isThreadChannelType(channelType?: number) {
-  return (
-    channelType === ChannelType.GuildNewsThread ||
-    channelType === ChannelType.GuildPublicThread ||
-    channelType === ChannelType.GuildPrivateThread
-  );
 }
 
 async function fetchBotUserId(rest: RequestClient) {
@@ -146,7 +139,7 @@ function resolveMemberChannelPermissionBits(params: {
 async function resolveChannelPermissionSubject(rest: RequestClient, channel: APIChannel) {
   const channelType = "type" in channel ? channel.type : undefined;
   const parentId = "parent_id" in channel ? channel.parent_id : undefined;
-  if (isThreadChannelType(channelType) && parentId) {
+  if (isDiscordThreadChannelType(channelType) && parentId) {
     return await getChannel(rest, parentId);
   }
   return channel;
@@ -207,7 +200,7 @@ export async function canViewDiscordGuildChannel(
     if (!hasPermissionBit(permissions, PermissionFlagsBits.ViewChannel)) {
       return false;
     }
-    if ("type" in channel && channel.type === ChannelType.GuildPrivateThread) {
+    if ("type" in channel && channel.type === ChannelType.PrivateThread) {
       if (hasPermissionBit(permissions, PermissionFlagsBits.ManageThreads)) {
         return true;
       }

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -17,6 +17,7 @@ import type { ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import { resolveTextChunksWithFallback } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
+import { isDiscordThreadChannelType } from "./channel-type.js";
 import { chunkDiscordTextWithMode } from "./chunk.js";
 import { createDiscordClient, resolveDiscordRest, type DiscordClientOpts } from "./client.js";
 import {
@@ -36,7 +37,7 @@ import {
   type DiscordAllowedMentions,
   type DiscordSendEmbeds,
 } from "./send.message-request.js";
-import { fetchChannelPermissionsDiscord, isThreadChannelType } from "./send.permissions.js";
+import { fetchChannelPermissionsDiscord } from "./send.permissions.js";
 import { DiscordSendError } from "./send.types.js";
 
 const DISCORD_TEXT_LIMIT = 2000;
@@ -209,7 +210,7 @@ async function buildDiscordSendError(
     probedChannelType = permissions.channelType;
     const current = new Set(permissions.permissions);
     const required = ["ViewChannel", "SendMessages"];
-    if (isThreadChannelType(probedChannelType)) {
+    if (isDiscordThreadChannelType(probedChannelType)) {
       required.push("SendMessagesInThreads");
     }
     if (ctx.hasMedia) {
@@ -225,7 +226,7 @@ async function buildDiscordSendError(
     .filter(Boolean)
     .join(" ");
   const probedPermissions = ["ViewChannel", "SendMessages"];
-  if (isThreadChannelType(probedChannelType)) {
+  if (isDiscordThreadChannelType(probedChannelType)) {
     probedPermissions.push("SendMessagesInThreads");
   }
   if (ctx.hasMedia) {


### PR DESCRIPTION
## What Problem This Solves

Discord thread recognition was independently implemented across message delivery, authorization, permission checks, thread bindings, incoming-message handling, interactive components, and channel-name resolution. One inconsistent copy omitted announcement threads, causing setup and allowlist resolution to choose an identically named announcement thread over the actual channel.

## Why This Change Was Made

Use one lightweight, Discord-plugin-private thread classifier for announcement, public, and private threads. Move every existing caller to that owner, including read authorization and channel-match ranking; delete duplicate predicates and replace deprecated Discord enum aliases with their identical current values. No public plugin or SDK contract changes, and authorization retains the existing closed numeric-channel-type boundary.

## User Impact

Discord setup and allowlist resolution now consistently prefer an actual channel over an announcement, public, or private thread with the same name. Existing thread routing, bindings, interactive context, guild actions, and private-thread authorization retain their behavior with less production code and cleaner ownership.

## Evidence

- Maintainer-requested, AI-assisted owner-boundary cleanup and announcement-thread resolution repair; production remains net-negative.
- Before the production fix, the existing channel-resolution behavior test was extended across announcement/public/private threads and failed only for announcement threads: expected regular channel `c1`, received `thread-1`. The repaired owner now passes all three cases.
- Focused Discord regression coverage includes channel allowlist resolution, provider setup, private-thread authorization, guild/messaging actions, thread bindings, inbound preflight, component interactions, thread starters, and outbound delivery.
- Direct runtime probe confirms announcement/public/private threads and all three deprecated enum aliases remain accepted while text channels, forums, strings, null, and undefined are rejected.
- Independent source review verified the upstream Discord enum aliases share exact values 10/11/12, thread-classification owners use the private leaf, and authorization/private-thread membership checks retain their security boundary.
- Eleven changed-file guard and formatting steps passed. The first full local gate stopped when nested Vitest attempted to write through shared read-only dependencies; its owner suites then passed after redirecting Vite's temporary files (two files, five tests). Broader local typecheck is blocked by independently reproduced stale mixed-checkout dependency errors unrelated to this change, so exact-head hosted CI and the native Testbox prepare gate provide the authoritative clean-environment full verification.
- Structured pre-commit autoreview passed cleanly with no actionable findings.
