### PR TITLE
fix(gateway): refresh prepared runtime on noop config commits

### DIFF
--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1043,6 +1043,44 @@ describe("managed reload transaction ownership", () => {
     expect(hoisted.applyLoggingConfig).toHaveBeenCalledExactlyOnceWith({ level: "debug" });
   });
 
+  it("requests recovery restart when no-op prepared model runtime refresh fails after publication", async () => {
+    const refreshError = new Error("prepared owner rebuild failed");
+    hoisted.refreshPreparedModelRuntimeSnapshots.mockRejectedValueOnce(refreshError);
+
+    const result = await runManagedOwnershipScenario({ kind: "noop", queueRevert: false });
+
+    expect(result.commitTerminalConfig).toHaveBeenCalledOnce();
+    expect(hoisted.refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledOnce();
+    expect(result.requestRecoveryRestart).toHaveBeenCalledExactlyOnceWith(
+      "hot reload recovery: prepared model runtime reload",
+    );
+    expect(result.acceptTerminalConfig).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes prepared model runtime owners for an applied no-op config publication", async () => {
+    const result = await runManagedOwnershipScenario({ kind: "noop", queueRevert: false });
+
+    expect(result.activateRuntimeSecrets).toHaveBeenCalledOnce();
+    expect(hoisted.markPreparedModelRuntimeSnapshotsStale).toHaveBeenCalledOnce();
+    expect(hoisted.markPreparedModelRuntimeSnapshotsStale).toHaveBeenCalledWith(
+      "prepared model runtime owner is stale before no-op config publication",
+      { waitForReplacement: true },
+    );
+    expect(hoisted.refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledExactlyOnceWith(
+      result.configA,
+      { allowGatewaySubagentBinding: true, catalogMode: "static" },
+    );
+    expect(result.prepareTerminalConfig).toHaveBeenCalledBefore(
+      hoisted.markPreparedModelRuntimeSnapshotsStale,
+    );
+    expect(hoisted.markPreparedModelRuntimeSnapshotsStale).toHaveBeenCalledBefore(
+      result.commitTerminalConfig,
+    );
+    expect(hoisted.markPreparedModelRuntimeSnapshotsStale).toHaveBeenCalledBefore(
+      hoisted.refreshPreparedModelRuntimeSnapshots,
+    );
+  });
+
   it.each(["noop", "hot", "restart"] as const)(
     "yields stale config A when queued %s config B reverts to the old source",
     async (kind) => {

--- a/src/gateway/server-reload-managed-secrets.ts
+++ b/src/gateway/server-reload-managed-secrets.ts
@@ -1,10 +1,17 @@
 import { isDeepStrictEqual } from "node:util";
 import { refreshContextWindowCache } from "../agents/context.js";
 import {
+  markPreparedModelRuntimeSnapshotsStale,
+  refreshPreparedModelRuntimeSnapshots,
+  rejectPendingPreparedModelRuntimeReplacement,
+  type PreparedModelRuntimeReplacementGateId,
+} from "../agents/prepared-model-runtime.js";
+import {
   getRuntimeConfigSnapshotMetadata,
   getRuntimeConfigSourceSnapshot,
 } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   clearSecretsRuntimeSnapshotState,
   getActiveSecretsRuntimeSnapshotState,
@@ -298,27 +305,80 @@ export function createManagedReloadSecretHandlers(options: {
         throw new GatewayConfigReloadSupersededError();
       }
       const activateIfCurrent = params.activateRuntimeSecrets.activatePreparedSnapshotIfCurrent;
+      let runtimeCommitted = false;
       const publishTerminalConfig = () => {
         transactionOwnership.publishRuntimeEnv();
         transactionOwnership.markRuntimeCommitted(prepared.config, plan);
         params.reconcileTerminalSessions(plan, prepared.config);
+        runtimeCommitted = true;
       };
-      const activated = activateIfCurrent
-        ? await activateIfCurrent(
-            prepared,
-            previousSnapshotRevision,
-            { reason: "reload", activate: true },
-            publishTerminalConfig,
-            transactionOwnership.isCurrent,
-          )
-        : (await activateSecretsRuntimeSnapshotIfCurrent(prepared, previousSnapshotRevision, {
-              canActivate: transactionOwnership.isCurrent,
-              onActivated: publishTerminalConfig,
-            }))
-          ? prepared
-          : null;
-      if (activated) {
-        return;
+      const scheduleNoopRecoveryRestart = (surface: string, error: unknown): boolean => {
+        if (!runtimeCommitted) {
+          return false;
+        }
+        const detail = `: ${formatErrorMessage(error)}`;
+        if (!transactionOwnership.isCurrent()) {
+          params.logReload.warn(
+            `${surface} failed after no-op config publication supersession${detail}; recovery deferred to the newer config`,
+          );
+          return true;
+        }
+        if (params.restartRecoveryAvailable === false || !params.requestRecoveryRestart) {
+          params.logReload.error?.(
+            `no-op config publication committed with unrecovered ${surface} failure${detail}; gateway restart recovery is unavailable; runtime may be inconsistent`,
+          );
+          throw new GatewayHotReloadRecoveryError(surface);
+        }
+        params.logReload.warn(
+          `${surface} failed after no-op config publication${detail}; restarting gateway`,
+        );
+        const restartResult = params.requestRecoveryRestart(`hot reload recovery: ${surface}`);
+        if (restartResult.status === "failed") {
+          throw new GatewayHotReloadRecoveryError(surface);
+        }
+        return true;
+      };
+      let preparedModelRuntimeReplacementGateId: PreparedModelRuntimeReplacementGateId | undefined;
+      try {
+        // No-op reload plans still publish a new runtime config generation. Prepared model owners
+        // intentionally compare the full runtime config hash, so retire the previous owners before
+        // activation and keep readers behind the replacement gate until the matching generation is
+        // rebuilt. This mirrors hot reload's atomic config/prepared-runtime publication boundary.
+        preparedModelRuntimeReplacementGateId = markPreparedModelRuntimeSnapshotsStale(
+          "prepared model runtime owner is stale before no-op config publication",
+          { waitForReplacement: true },
+        );
+        const activated = activateIfCurrent
+          ? await activateIfCurrent(
+              prepared,
+              previousSnapshotRevision,
+              { reason: "reload", activate: true },
+              publishTerminalConfig,
+              transactionOwnership.isCurrent,
+            )
+          : (await activateSecretsRuntimeSnapshotIfCurrent(prepared, previousSnapshotRevision, {
+                canActivate: transactionOwnership.isCurrent,
+                onActivated: publishTerminalConfig,
+              }))
+            ? prepared
+            : null;
+        if (activated) {
+          await refreshPreparedModelRuntimeSnapshots(prepared.config, {
+            catalogMode: "static",
+            allowGatewaySubagentBinding: true,
+          });
+          return;
+        }
+        rejectPendingPreparedModelRuntimeReplacement(
+          preparedModelRuntimeReplacementGateId,
+          new GatewayConfigReloadSupersededError(),
+        );
+      } catch (error) {
+        rejectPendingPreparedModelRuntimeReplacement(preparedModelRuntimeReplacementGateId, error);
+        if (scheduleNoopRecoveryRestart("prepared model runtime reload", error)) {
+          return;
+        }
+        throw error;
       }
     }
   };


### PR DESCRIPTION
Closes #128515

## What Problem This Solves

Fixes a Gateway no-op config publication path that updated the runtime config generation without replacing prepared model runtime owners. Consumers such as `/models` and background model catalog readers could then observe the new config while the prepared owners were still keyed to the previous full config hash.

## Why This Change Was Made

Hot reload already treats config, plugin hooks, and prepared model stores as a single generation by retiring old owners at commit time and rebuilding the matching owners after publication. No-op config commits also publish a new runtime config snapshot, so they now use the same prepared-runtime replacement boundary instead of leaving old owners visible.

If prepared-runtime replacement fails after the no-op config has already published, the Gateway now requests the same recovery-restart path used by committed hot reload failures; if recovery cannot be scheduled, it raises a recovery error instead of silently leaving the runtime inconsistent.

## User Impact

Hot-reloaded config writes that do not restart Gateway subsystems no longer leave prepared-model consumers stuck until a process restart. If the replacement itself fails, Gateway moves to restart recovery instead of serving stale/missing prepared owners indefinitely.

## Evidence

- `pnpm test src/gateway/server-reload-handlers.test.ts src/gateway/config-reload.test.ts src/agents/prepared-model-catalog.test.ts`
- `pnpm check:changed -- src/gateway/server-reload-managed-secrets.ts src/gateway/server-reload-handlers.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine pi --thinking high` → clean

Focused regression proof:

- no-op config publication marks prepared model owners stale before the runtime commit and refreshes owners for the accepted config generation.
- no-op prepared-runtime refresh failure after publication calls `requestRecoveryRestart("hot reload recovery: prepared model runtime reload")`.

Real Gateway proof, isolated state dir `/tmp/openclaw-pr128569-proof`, port `39415`, channels/providers skipped:

```text
OPENCLAW_STATE_DIR=/tmp/openclaw-pr128569-proof \
  OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_PROVIDERS=1 \
  pnpm openclaw gateway run --dev --reset --auth none --port 39415 --force

[gateway] http server listening (... port=39415 ...)
[gateway] ready

OPENCLAW_STATE_DIR=/tmp/openclaw-pr128569-proof \
  pnpm openclaw config set messages.visibleReplies message_tool
Updated messages.visibleReplies. No gateway restart needed.

Gateway log after the no-op publication:
[reload] config change detected; evaluating reload (messages)

OPENCLAW_STATE_DIR=/tmp/openclaw-pr128569-proof \
  pnpm openclaw gateway health --port 39415 --json
{ "ok": true, "configReload": { "hotReloadStatus": "active" }, ... }

OPENCLAW_STATE_DIR=/tmp/openclaw-pr128569-proof \
  pnpm openclaw gateway call models.list --port 39415 --json --params '{"view":"configured"}'
{ "models": [] }

OPENCLAW_STATE_DIR=/tmp/openclaw-pr128569-proof \
  pnpm openclaw gateway call sessions.list --port 39415 --json --params '{"limit":1}'
{ "defaults": { "modelProvider": "openai", "model": "gpt-5.6-sol", ... }, "sessions": [] }
```

This demonstrates the real Gateway remains healthy after the no-op config publication and prepared model readers return normally without a process restart.

AI-assisted implementation; I reviewed the config publication / prepared model runtime boundary and validation output.
