### PR TITLE
fix(agents): reject hidden output across model verification and system turns

### DIFF
--- a/src/agents/agent-run-result.ts
+++ b/src/agents/agent-run-result.ts
@@ -1,6 +1,9 @@
 /** Minimal agent-run result projection shared by setup and diagnostic probes. */
+import { isReplyPayloadTerminalContent, type ReplyPayload } from "../auto-reply/reply-payload.js";
+import { isSilentReplyPayloadText } from "../auto-reply/tokens.js";
+
 export type AgentRunResultView = {
-  payloads?: Array<{ text?: string; isError?: boolean; isReasoning?: boolean }>;
+  payloads?: Array<ReplyPayload & { visible?: boolean }>;
   meta?: {
     executionTrace?: { winnerProvider?: string; winnerModel?: string };
     finalAssistantVisibleText?: string;
@@ -11,13 +14,21 @@ export type AgentRunResultView = {
 };
 
 export function extractAgentRunText(result: AgentRunResultView): string | undefined {
+  const visibleText = result.meta?.finalAssistantVisibleText?.trim();
+  if (visibleText) {
+    return isSilentReplyPayloadText(visibleText) ? undefined : visibleText;
+  }
   return (
-    result.meta?.finalAssistantVisibleText ??
-    result.meta?.finalAssistantRawText ??
     result.payloads
-      ?.map((payload) => payload.text?.trim())
-      .filter(Boolean)
-      .join("\n")
+      ?.filter(
+        (payload) =>
+          payload.visible !== false &&
+          payload.isError !== true &&
+          isReplyPayloadTerminalContent(payload),
+      )
+      .map((payload) => payload.text?.trim())
+      .filter((text): text is string => Boolean(text) && !isSilentReplyPayloadText(text))
+      .join("\n") || undefined
   );
 }
 
@@ -40,13 +51,5 @@ export function extractAgentRunTerminalError(result: AgentRunResultView): string
 }
 
 export function agentRunHasVisibleReply(result: AgentRunResultView): boolean {
-  if (result.meta?.finalAssistantVisibleText?.trim()) {
-    return true;
-  }
-  return (
-    result.payloads?.some(
-      (payload) =>
-        payload.isError !== true && payload.isReasoning !== true && Boolean(payload.text?.trim()),
-    ) === true
-  );
+  return Boolean(extractAgentRunText(result));
 }

--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -909,6 +909,38 @@ describe("runSystemAgentTurn", () => {
       name: "empty model output",
       runEmbeddedAgent: async () => ({ payloads: [] }),
     },
+    {
+      name: "hidden reasoning",
+      runEmbeddedAgent: async () => ({
+        payloads: [{ text: "Considering the answer", isReasoning: true }],
+      }),
+    },
+    {
+      name: "hidden commentary",
+      runEmbeddedAgent: async () => ({
+        payloads: [{ text: "Checking the gateway", isCommentary: true }],
+      }),
+    },
+    {
+      name: "explicitly hidden output",
+      runEmbeddedAgent: async () => ({
+        payloads: [{ text: "Private model output", visible: false }],
+      }),
+    },
+    {
+      name: "status notice",
+      runEmbeddedAgent: async () => ({
+        payloads: [{ text: "Still working", isStatusNotice: true }],
+      }),
+    },
+    {
+      name: "silent reply",
+      runEmbeddedAgent: async () => ({ payloads: [{ text: "NO_REPLY" }] }),
+    },
+    {
+      name: "raw-only hidden metadata",
+      runEmbeddedAgent: async () => ({ meta: { finalAssistantRawText: "Hidden draft" } }),
+    },
   ])("clears partial session state after $name", async ({ runEmbeddedAgent }) => {
     useTempStateDir();
     const config: OpenClawConfig = {

--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { prepareSystemAgentRunAdmission } from "../agents/admitted-run-context.js";
+import { extractAgentRunText, type AgentRunResultView } from "../agents/agent-run-result.js";
 import { resolveCliBackendConfig, type ResolvedCliBackend } from "../agents/cli-backends.js";
 import { normalizeCliModel } from "../agents/cli-runner/helpers.js";
 import { SessionManager } from "../agents/sessions/index.js";
@@ -102,28 +103,14 @@ type SystemAgentTurnDeps = SystemAgentVerifiedInferenceDeps & {
   readConfigFileSnapshot?: typeof import("../config/config.js").readConfigFileSnapshot;
 };
 
-type EmbeddedRunResult = {
-  payloads?: Array<{ text?: string }>;
+type EmbeddedRunResult = AgentRunResultView & {
   meta?: {
-    finalAssistantVisibleText?: string;
-    finalAssistantRawText?: string;
     agentMeta?: {
       cliSessionBinding?: CliSessionBinding;
       clearCliSessionBinding?: boolean;
     };
   };
 };
-
-function extractRunText(result: EmbeddedRunResult): string | undefined {
-  return (
-    result.meta?.finalAssistantVisibleText ??
-    result.meta?.finalAssistantRawText ??
-    result.payloads
-      ?.map((payload) => payload.text?.trim())
-      .filter(Boolean)
-      .join("\n")
-  );
-}
 
 async function ensureSystemAgentDirs(): Promise<{ workspaceDir: string }> {
   const base = path.join(resolveStateDir(), "openclaw");
@@ -430,7 +417,7 @@ async function runSystemAgentTurnWithDeps(
     if (!currentRoute) {
       throw new SystemAgentInferenceUnavailableError("agent-turn");
     }
-    const text = extractRunText(result)?.trim();
+    const text = extractAgentRunText(result)?.trim();
     if (!text) {
       throw new SystemAgentInferenceUnavailableError("agent-turn");
     }

--- a/src/system-agent/assistant.configured.test.ts
+++ b/src/system-agent/assistant.configured.test.ts
@@ -355,7 +355,11 @@ describe("OpenClaw configured-model planner", () => {
       },
     };
     const runEmbeddedAgent = vi.fn(async () => ({
-      payloads: [{ text: '{"reply":"Ready.","command":"gateway status"}' }],
+      payloads: [
+        { text: "Considering the gateway", isReasoning: true },
+        { text: "Checking the gateway", isCommentary: true },
+        { text: '{"reply":"Ready.","command":"gateway status"}' },
+      ],
     }));
     const { binding, deps } = await createSystemAgentVerifiedInferenceTestFixture(config);
     useFastVerifiedInference(binding);

--- a/src/system-agent/assistant.ts
+++ b/src/system-agent/assistant.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { prepareSystemAgentRunAdmission } from "../agents/admitted-run-context.js";
+import { extractAgentRunText } from "../agents/agent-run-result.js";
 import { SessionManager } from "../agents/sessions/session-manager.js";
 import {
   SYSTEM_AGENT_ASSISTANT_SYSTEM_PROMPT,
@@ -204,7 +205,7 @@ async function runConfiguredSystemAgentText(params: {
             cleanupBundleMcpOnRunEnd: true,
             ...(route.authProfileId ? { authProfileIdSource: "user" as const } : {}),
           });
-    text = extractPlannerResultText(result)?.trim();
+    text = extractAgentRunText(result)?.trim();
   } catch (error) {
     if (error instanceof SystemAgentInferenceUnavailableError) {
       throw error;
@@ -247,21 +248,4 @@ async function createTempPlannerDir(): Promise<string> {
 
 async function removeTempPlannerDir(dir: string): Promise<void> {
   await fs.rm(dir, { recursive: true, force: true });
-}
-
-function extractPlannerResultText(result: {
-  payloads?: Array<{ text?: string }>;
-  meta?: {
-    finalAssistantVisibleText?: string;
-    finalAssistantRawText?: string;
-  };
-}): string | undefined {
-  return (
-    result.meta?.finalAssistantVisibleText ??
-    result.meta?.finalAssistantRawText ??
-    result.payloads
-      ?.map((payload) => payload.text?.trim())
-      .filter(Boolean)
-      .join("\n")
-  );
 }

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -2447,11 +2447,46 @@ describe("activateSetupInference", () => {
     expect(transformConfig).not.toHaveBeenCalled();
   });
 
-  it("treats an empty model reply as a failure with bounded probe identifiers", async () => {
+  it.each([
+    { name: "empty payload", runResult: { payloads: [] } },
+    {
+      name: "reasoning payload",
+      runResult: { payloads: [{ text: "Considering the answer", isReasoning: true }] },
+    },
+    {
+      name: "commentary payload",
+      runResult: { payloads: [{ text: "Checking the model", isCommentary: true }] },
+    },
+    {
+      name: "explicitly hidden payload",
+      runResult: { payloads: [{ text: "Private model output", visible: false }] },
+    },
+    {
+      name: "status notice",
+      runResult: { payloads: [{ text: "Still working", isStatusNotice: true }] },
+    },
+    {
+      name: "compaction notice",
+      runResult: { payloads: [{ text: "Compacting context", isCompactionNotice: true }] },
+    },
+    {
+      name: "fallback notice",
+      runResult: { payloads: [{ text: "Trying another model", isFallbackNotice: true }] },
+    },
+    { name: "silent payload", runResult: { payloads: [{ text: "NO_REPLY" }] } },
+    {
+      name: "silent visible metadata",
+      runResult: { meta: { finalAssistantVisibleText: "NO_REPLY" } },
+    },
+    {
+      name: "raw-only hidden metadata",
+      runResult: { meta: { finalAssistantRawText: "Hidden draft" } },
+    },
+  ])("rejects a $name as a model reply with bounded probe identifiers", async ({ runResult }) => {
     const transformConfig = vi.fn();
-    const runEmbeddedAgent = vi.fn(async (_params: { runId?: string; sessionId?: string }) => ({
-      payloads: [],
-    }));
+    const runEmbeddedAgent = vi.fn(
+      async (_params: { runId?: string; sessionId?: string }) => runResult,
+    );
     const result = await activateSetupInference({
       kind: "anthropic-api-key",
       deps: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where onboarding model verification, model diagnostics, system-agent planning, and system-agent replies could accept explicitly hidden payloads, hidden reasoning, commentary, transient status notices, silent `NO_REPLY` tokens, or raw-only drafts as real assistant answers. This could report a broken model as healthy, accept unusable onboarding output, or expose internal text as an operator-visible reply.

## Why This Change Was Made

Consolidate three divergent answer extractors into the existing shared agent-result owner and reuse canonical terminal-payload and silent-reply classification. Setup, diagnostics, planning, and system-agent conversations now agree on what counts as a visible assistant answer; obsolete duplicate extractors are removed.

Production LOC decreases by 26 lines. No public configuration, protocol, persistence schema, plugin SDK, model routing, authorization, or provider contract changes.

## User Impact

Model verification fails visibly when no real answer was produced, onboarding does not accept hidden output, system-agent chat cannot return internal notices or `NO_REPLY`, and planning ignores commentary/reasoning while preserving actual final answers.

## Evidence

- Authentic pre-fix behavior: 15 actual onboarding and system-agent chat cases failed across explicitly hidden payloads, hidden reasoning, commentary, status/compaction/fallback notices, silent tokens, and raw-only drafts; setup cases also prove no configuration persistence.
- `node scripts/run-vitest.mjs src/system-agent/setup-inference.test.ts src/system-agent/assistant.configured.test.ts src/system-agent/agent-turn.test.ts src/commands/models/list.probe.test.ts` — 175 tests passed across real setup, planner, chat, and model-probe suites.
- Core production TypeScript and affected agents/commands/system-agent test projects passed; focused formatting/lint, max-lines and assertion-safety ratchets, and zero runtime import cycles.
- Production delta `+23/-49`, net `-26`; obsolete planner and system-agent local extractors removed; fresh independent source-aware owner/sibling review.
