### PR TITLE
fix(msteams): use one Teams API runtime entrypoint

### DIFF
--- a/extensions/msteams/src/sdk-proactive.process.test.ts
+++ b/extensions/msteams/src/sdk-proactive.process.test.ts
@@ -1,18 +1,84 @@
 // Microsoft Teams process coverage protects real SDK CommonJS import ordering.
 import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
+import { buildPluginNpmRuntime } from "../../../scripts/lib/plugin-npm-runtime-build.mts";
 
 const execFileAsync = promisify(execFile);
 
 describe("sendMSTeamsActivityWithReference SDK import ordering", () => {
   it("keeps root exports intact when quoted behavior is the first SDK access", async () => {
-    const proactiveModuleUrl = new URL("./sdk-proactive.ts", import.meta.url).href;
+    const build = await buildPluginNpmRuntime({
+      repoRoot: process.cwd(),
+      packageDir: "extensions/msteams",
+      logLevel: "warn",
+    });
+    if (!build || build.runtimeFormat !== "cjs") {
+      throw new Error("Microsoft Teams did not produce a CommonJS runtime build");
+    }
+    const proactiveArtifact = fs
+      .readdirSync(build.outDir)
+      .filter((entry) => entry.endsWith(".cjs"))
+      .map((entry) => path.join(build.outDir, entry))
+      .find((entry) =>
+        fs
+          .readFileSync(entry, "utf8")
+          .includes('Object.defineProperty(exports, "sendMSTeamsActivityWithReference"'),
+      );
+    if (!proactiveArtifact) {
+      throw new Error("Microsoft Teams CommonJS runtime omitted the proactive send helper");
+    }
+    const proactiveArtifactSource = fs.readFileSync(proactiveArtifact, "utf8");
+    expect(proactiveArtifactSource).toContain('import("@microsoft/teams.api")');
+    expect(proactiveArtifactSource).not.toContain("@microsoft/teams.api/dist/");
+
     const fixture = `
       import assert from "node:assert/strict";
+      import { createRequire } from "node:module";
+
+      const require = createRequire(import.meta.url);
+      const Module = require("node:module");
+      const originalLoad = Module._load;
+      const universalStub = new Proxy(
+        function universalStub() {
+          return universalStub;
+        },
+        {
+          apply: () => universalStub,
+          construct: () => universalStub,
+          get: () => universalStub,
+        },
+      );
+      const hostSdkStub = new Proxy(
+        {},
+        {
+          get: (_target, key) => {
+            if (key === "createLazyRuntimeModule") {
+              return (importer) => {
+                let pending;
+                return () => (pending ??= importer());
+              };
+            }
+            if (key === "getOrCreateGlobalSingleton") {
+              return (_key, create) => create();
+            }
+            return universalStub;
+          },
+        },
+      );
+      // The built plugin expects an installed OpenClaw host. Stub unrelated host SDK exports so
+      // this child isolates the emitted Teams loader and the real pinned Teams CommonJS package.
+      Module._load = function load(request, parent, isMain) {
+        if (request.startsWith("openclaw/plugin-sdk/")) {
+          return hostSdkStub;
+        }
+        return originalLoad.call(this, request, parent, isMain);
+      };
 
       const { sendMSTeamsActivityWithReference } =
-        await import(process.env.OPENCLAW_MSTEAMS_PROACTIVE_MODULE);
+        require(process.env.OPENCLAW_MSTEAMS_PROACTIVE_ARTIFACT);
       const quotedCreates = [];
       const posts = [];
       const app = {
@@ -90,7 +156,7 @@ describe("sendMSTeamsActivityWithReference SDK import ordering", () => {
         env: {
           ...process.env,
           NODE_DISABLE_COMPILE_CACHE: "1",
-          OPENCLAW_MSTEAMS_PROACTIVE_MODULE: proactiveModuleUrl,
+          OPENCLAW_MSTEAMS_PROACTIVE_ARTIFACT: proactiveArtifact,
           VITEST: undefined,
         },
       },
@@ -98,5 +164,5 @@ describe("sendMSTeamsActivityWithReference SDK import ordering", () => {
 
     expect(stderr).toBe("");
     expect(stdout).toBe("root-sdk-ok");
-  });
+  }, 30_000);
 });

--- a/extensions/msteams/src/sdk-proactive.process.test.ts
+++ b/extensions/msteams/src/sdk-proactive.process.test.ts
@@ -4,24 +4,21 @@ import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
-import { buildPluginNpmRuntime } from "../../../scripts/lib/plugin-npm-runtime-build.mts";
 
 const execFileAsync = promisify(execFile);
 
 describe("sendMSTeamsActivityWithReference SDK import ordering", () => {
   it("keeps root exports intact when quoted behavior is the first SDK access", async () => {
-    const build = await buildPluginNpmRuntime({
-      repoRoot: process.cwd(),
-      packageDir: "extensions/msteams",
-      logLevel: "warn",
-    });
-    if (!build || build.runtimeFormat !== "cjs") {
-      throw new Error("Microsoft Teams did not produce a CommonJS runtime build");
-    }
+    await execFileAsync(
+      process.execPath,
+      ["scripts/lib/plugin-npm-runtime-build.mjs", "extensions/msteams"],
+      { cwd: process.cwd() },
+    );
+    const outDir = path.join(process.cwd(), "extensions/msteams/dist");
     const proactiveArtifact = fs
-      .readdirSync(build.outDir)
+      .readdirSync(outDir)
       .filter((entry) => entry.endsWith(".cjs"))
-      .map((entry) => path.join(build.outDir, entry))
+      .map((entry) => path.join(outDir, entry))
       .find((entry) =>
         fs
           .readFileSync(entry, "utf8")

--- a/extensions/msteams/src/sdk-proactive.process.test.ts
+++ b/extensions/msteams/src/sdk-proactive.process.test.ts
@@ -1,0 +1,102 @@
+// Microsoft Teams process coverage protects real SDK CommonJS import ordering.
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("sendMSTeamsActivityWithReference SDK import ordering", () => {
+  it("keeps root exports intact when quoted behavior is the first SDK access", async () => {
+    const proactiveModuleUrl = new URL("./sdk-proactive.ts", import.meta.url).href;
+    const fixture = `
+      import assert from "node:assert/strict";
+
+      const { sendMSTeamsActivityWithReference } =
+        await import(process.env.OPENCLAW_MSTEAMS_PROACTIVE_MODULE);
+      const quotedCreates = [];
+      const posts = [];
+      const app = {
+        client: {
+          request: async () => ({}),
+          post: async (url, activity) => {
+            posts.push({ url, activity });
+            return { data: { id: "normal-proactive" } };
+          },
+        },
+        api: {
+          serviceUrl: "https://smba.trafficmanager.net/amer",
+          conversations: {
+            activities: () => ({
+              create: async (activity) => {
+                quotedCreates.push(activity);
+                return { id: "quoted-replay" };
+              },
+              update: async () => ({}),
+              delete: async () => ({}),
+            }),
+          },
+        },
+      };
+      const reference = {
+        agent: { id: "28:bot", role: "bot" },
+        user: { id: "29:user" },
+        conversation: {
+          id: "19:conversation@thread.v2",
+          conversationType: "groupChat",
+        },
+      };
+
+      // The structural app selects the quote path without loading the full Teams app first.
+      await sendMSTeamsActivityWithReference(
+        app,
+        { ...reference, serviceUrl: "https://smba.trafficmanager.net/amer" },
+        { type: "message", text: "Recovered reply" },
+        { quoteActivityId: "incoming-activity" },
+      );
+      assert.equal(
+        quotedCreates[0].text,
+        '<quoted messageId="incoming-activity"/> Recovered reply',
+      );
+
+      const api = await import("@microsoft/teams.api");
+      assert.equal(typeof api.Client, "function");
+      assert.equal(typeof api.MessageActivityInput, "function");
+      assert.equal(typeof api.toActivityParams, "function");
+      assert.doesNotThrow(() =>
+        api.toActivityParams({ type: "message", text: "Direct conversion" }),
+      );
+
+      await assert.doesNotReject(() =>
+        sendMSTeamsActivityWithReference(
+          app,
+          { ...reference, serviceUrl: "https://smba.trafficmanager.net/teams" },
+          { type: "message", text: "Normal send" },
+        ),
+      );
+      assert.equal(posts.length, 1);
+      assert.equal(
+        posts[0].url,
+        "https://smba.trafficmanager.net/teams/v3/conversations/19:conversation@thread.v2/activities",
+      );
+      assert.equal(posts[0].activity.text, "Normal send");
+      process.stdout.write("root-sdk-ok");
+    `;
+
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", fixture],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          NODE_DISABLE_COMPILE_CACHE: "1",
+          OPENCLAW_MSTEAMS_PROACTIVE_MODULE: proactiveModuleUrl,
+          VITEST: undefined,
+        },
+      },
+    );
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("root-sdk-ok");
+  });
+});

--- a/extensions/msteams/src/sdk-proactive.ts
+++ b/extensions/msteams/src/sdk-proactive.ts
@@ -64,7 +64,7 @@ type MSTeamsProactiveOptions = {
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
 };
 
-// Root-only runtime imports avoid 2.0.14 CJS leaf-first barrel poisoning; the deep type keeps tsgo accurate.
+// SAFETY: the 2.0.14 CJS root exports MessageActivityInput, while its declarations omit that export.
 const loadMSTeamsApiModule = createLazyRuntimeModule(
   () =>
     import("@microsoft/teams.api") as unknown as Promise<

--- a/extensions/msteams/src/sdk-proactive.ts
+++ b/extensions/msteams/src/sdk-proactive.ts
@@ -64,9 +64,9 @@ type MSTeamsProactiveOptions = {
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
 };
 
-// SAFETY: the 2.0.14 CJS root exports MessageActivityInput, while its declarations omit that export.
 const loadMSTeamsApiModule = createLazyRuntimeModule(
   () =>
+    // SAFETY: the 2.0.14 CJS root exports MessageActivityInput, while its declarations omit it.
     import("@microsoft/teams.api") as unknown as Promise<
       typeof import("@microsoft/teams.api") & {
         MessageActivityInput: typeof import("@microsoft/teams.api/dist/activities/message/message.js").MessageActivityInput;

--- a/extensions/msteams/src/sdk-proactive.ts
+++ b/extensions/msteams/src/sdk-proactive.ts
@@ -64,21 +64,21 @@ type MSTeamsProactiveOptions = {
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
 };
 
-const loadMSTeamsApiClient = createLazyRuntimeModule(() =>
-  import("@microsoft/teams.api").then((api) => ({ Client: api.Client })),
-);
-
-const loadMSTeamsQuoteModule = createLazyRuntimeModule(() =>
-  import("@microsoft/teams.api/dist/activities/message/message.js").then((message) => ({
-    MessageActivityInput: message.MessageActivityInput,
-  })),
+// Root-only runtime imports avoid 2.0.14 CJS leaf-first barrel poisoning; the deep type keeps tsgo accurate.
+const loadMSTeamsApiModule = createLazyRuntimeModule(
+  () =>
+    import("@microsoft/teams.api") as unknown as Promise<
+      typeof import("@microsoft/teams.api") & {
+        MessageActivityInput: typeof import("@microsoft/teams.api/dist/activities/message/message.js").MessageActivityInput;
+      }
+    >,
 );
 
 async function quoteMSTeamsActivity(
   activity: MSTeamsActivityLike,
   messageId: string,
 ): Promise<unknown> {
-  const { MessageActivityInput } = await loadMSTeamsQuoteModule();
+  const { MessageActivityInput } = await loadMSTeamsApiModule();
   if (typeof activity === "string") {
     return new MessageActivityInput(activity).prependQuote(messageId);
   }
@@ -203,7 +203,7 @@ async function getApiClientForReference(
     return api;
   }
 
-  const { Client } = await loadMSTeamsApiClient();
+  const { Client } = await loadMSTeamsApiModule();
   return new Client(ref.serviceUrl, httpClient) as unknown as MSTeamsApiClient;
 }
 


### PR DESCRIPTION
Related: #126169

## What Problem This Solves

Fixes a deterministic Microsoft Teams test-process regression in the repository's non-isolated Vitest extension shard.

In [run 32693644948](https://github.com/openclaw/openclaw/actions/runs/32693644948/job/97331863323), quote/replay-oriented tests reached a deep CommonJS SDK leaf before later real-SDK send tests loaded the package root. The later sends then failed at the upstream `activity instanceof MessageActivity` check with `Right-hand side of 'instanceof' is not an object`: 20 failed, 1434 passed.

No production or user-visible outage has been demonstrated. The structural app in the new process test is only a controlled trigger for making quoted behavior the first SDK access.

## Why This Change Was Made

Loads `Client` and `MessageActivityInput` through one cached lazy import of `@microsoft/teams.api`. The deep path remains type-only because tsgo does not resolve every chained root-barrel declaration.

The exact `@microsoft/teams.api@2.0.14` CommonJS hazard is:

1. A leaf-first load of `activities/message/message.js` enters `message.ts`, which imports `../utils`.
2. `utils` exports `toActivityParams`, which imports the `../message` barrel while the leaf is still initializing.
3. The generated CommonJS barrel enumerates the then-incomplete leaf exports. Later root loads reuse that cached incomplete barrel, so `MessageActivity` is `undefined` at the upstream [`instanceof` line](https://github.com/microsoft/teams.ts/blob/bd3c3bab009ecad187c5fd130a0e60f3bd40cb59/packages/api/src/activities/utils/to-activity-params.ts#L20-L31).

Upstream source also confirms that the supported package root re-exports [clients, models, activities, and auth](https://github.com/microsoft/teams.ts/blob/bd3c3bab009ecad187c5fd130a0e60f3bd40cb59/packages/api/src/index.ts#L1-L4), and the activities barrel re-exports both [messages and utilities](https://github.com/microsoft/teams.ts/blob/bd3c3bab009ecad187c5fd130a0e60f3bd40cb59/packages/api/src/activities/index.ts#L22-L32).

Provenance: #126169 introduced the split root/deep lazy loaders in `a6b77ffc074ce61f5e31c229ded1986f84562b75` on August 19, 2026.

No dependency bump, retries, test reordering, or timeout inflation.

## User Impact

No demonstrated user-visible impact. Maintainers regain deterministic Microsoft Teams extension CI when quote/replay coverage runs before real SDK send coverage in the same Vitest process.

## Evidence

Exact head: `5bd822adb202ad6144dc3eb1351188a6ca2329cc`

- Packaged CommonJS regression: the test executes the canonical Microsoft Teams plugin runtime build CLI, locates the emitted `.cjs` chunk, rejects deep Teams API runtime imports, and executes quoted behavior as the first SDK access through that artifact. The child then loads the actual CommonJS root `Client`, `MessageActivityInput`, and `toActivityParams`, verifies direct conversion, and completes a normal proactive send without the `instanceof` failure.
- `node scripts/run-vitest.mjs extensions/msteams/src/sdk-proactive.process.test.ts extensions/msteams/src/sdk-proactive.test.ts extensions/msteams/src/sdk.test.ts extensions/msteams/src/send.threaded-attachments.test.ts extensions/msteams/src/msteams-ingress.test.ts` - 57 passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` - passed.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` - passed.
- `node scripts/run-oxlint.mjs extensions/msteams/src/sdk-proactive.ts extensions/msteams/src/sdk-proactive.process.test.ts` - passed.
- Assertion-safety count against CI's prepared base `235b693ea450ac829c176c518d43e89ca6723917` is unchanged at 7; the exact loader assertion now carries the adjacent dependency invariant marker.
- `node --import tsx scripts/check-plugin-npm-runtime-builds.mts --package extensions/msteams` - built the package's declared CommonJS runtime; emitted artifacts contain one proactive `import("@microsoft/teams.api")` and no `@microsoft/teams.api/dist` runtime imports.
- `git diff --check`, current-main ancestry, and the ED25519 commit signature - verified.

Production LOC: `+10/-10` (net 0). Tests: `+165/-0`.
