### PR TITLE
fix(cron): fence stale execution generations

### DIFF
--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -252,6 +252,7 @@ export function createMockCronStateForJobs(params: {
     running: false,
     activeTimerTicks: 0,
     stopped: false,
+    lifecycleGeneration: 0,
     schedulingPaused: false,
     schedulerStarted: false,
     activeManualRunJobIds: new Set<string>(),

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -28,14 +28,13 @@ export class CronService implements CronServiceContract {
   private readonly state;
   private startInProgress = 0;
   private startState: { generation: number; promise: Promise<void> } | null = null;
-  private lifecycleGeneration = 0;
 
   constructor(deps: CronServiceDeps) {
     this.state = createCronServiceState(deps);
   }
 
   async start() {
-    const generation = this.lifecycleGeneration;
+    const generation = this.state.lifecycleGeneration;
     const pending = this.startState;
     if (pending) {
       try {
@@ -67,7 +66,7 @@ export class CronService implements CronServiceContract {
     this.state.schedulerStarted = false;
     try {
       await lifecycleOps.start(this.state);
-      if (generation !== this.lifecycleGeneration) {
+      if (generation !== this.state.lifecycleGeneration) {
         lifecycleOps.stop(this.state);
         return;
       }
@@ -78,7 +77,6 @@ export class CronService implements CronServiceContract {
   }
 
   stop() {
-    this.lifecycleGeneration += 1;
     lifecycleOps.stop(this.state);
   }
 

--- a/src/cron/service/ops-lifecycle.ts
+++ b/src/cron/service/ops-lifecycle.ts
@@ -213,6 +213,7 @@ export async function start(state: CronServiceState): Promise<void> {
 
 /** Stops the cron service timer without mutating persisted job state. */
 export function stop(state: CronServiceState) {
+  state.lifecycleGeneration += 1;
   state.stopped = true;
   cancelCronRunAdmissionWaiters(state);
   state.schedulerStarted = false;

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -14,6 +14,7 @@ import {
   onCronJobInactive,
   requestActiveCronJobCancellation,
 } from "../active-jobs.js";
+import { resolveCronJobConfigRevision } from "../config-revision.js";
 import { isHeartbeatTaskDeclarationKey } from "../heartbeat-task.js";
 import { cloneCronRuntimeAuthority, type CronRuntimeAuthority } from "../runtime-authority.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
@@ -203,6 +204,13 @@ async function persistUpdatedJob(params: {
   nextJob: CronJob;
 }) {
   const { state, snapshot, previousJob, nextJob } = params;
+  if (
+    nextJob.state.queuedAtMs !== undefined &&
+    resolveCronJobConfigRevision(previousJob) !== resolveCronJobConfigRevision(nextJob)
+  ) {
+    // Retire the occurrence with its owning edit; A→B→A cannot revive a queued snapshot.
+    delete nextJob.state.queuedAtMs;
+  }
   if (state.store) {
     const index = state.store.jobs.findIndex((entry) => entry.id === nextJob.id);
     if (index >= 0) {

--- a/src/cron/service/ops-run-preparation.ts
+++ b/src/cron/service/ops-run-preparation.ts
@@ -539,7 +539,10 @@ async function releasePreparedManualReservation(
   state: CronServiceState,
   prepared: Pick<Extract<PreparedManualRun, { ran: true }>, "jobId" | "reservationIdentity">,
 ): Promise<void> {
-  if (!isQueuedCronRunReservationCurrent(state, prepared.jobId, prepared.reservationIdentity)) {
+  if (
+    state.queuedRunReservationsByJobId.get(prepared.jobId)?.identity !==
+    prepared.reservationIdentity
+  ) {
     return;
   }
   const committedJob = commitCronRuntimeRows({
@@ -549,7 +552,7 @@ async function releasePreparedManualReservation(
     mutate: ({ database, jobs }) => {
       const job = jobs.get(prepared.jobId);
       const ownership = state.queuedRunReservationsByJobId.get(prepared.jobId);
-      if (!job || ownership?.identity !== prepared.reservationIdentity) {
+      if (ownership?.identity !== prepared.reservationIdentity) {
         return { value: undefined };
       }
       finishCronRunReceiptInDatabase({
@@ -559,6 +562,9 @@ async function releasePreparedManualReservation(
         finishedAtMs: state.deps.nowMs(),
         error: "cron manual reservation abandoned before completion",
       });
+      if (!job) {
+        return { value: undefined };
+      }
       const queuedMatches = ownership.markerAtMs === job.state.queuedAtMs;
       const runningMatches = ownership.markerAtMs === job.state.runningAtMs;
       if (!queuedMatches && !runningMatches) {

--- a/src/cron/service/ops.run-admission-cleanup.test.ts
+++ b/src/cron/service/ops.run-admission-cleanup.test.ts
@@ -18,7 +18,7 @@ import { CommandLane } from "../../process/lanes.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import { cronStoreKey } from "../store/key.js";
-import { stop } from "./ops-lifecycle.js";
+import { start, stop } from "./ops-lifecycle.js";
 import { update } from "./ops-mutations.js";
 import { enqueueRun, run } from "./ops-run.js";
 import { runWithCronAdmission } from "./run-admission.js";
@@ -512,6 +512,112 @@ describe("cron service run admission cleanup", () => {
       expect(persistedJob?.state.lastError).toBe("prior failure");
     },
   );
+
+  it("does not revive a pre-stop manual activation when the scheduler immediately restarts", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:03.125Z");
+    const job = createDueIsolatedJob({
+      id: "manual-activation-retired-by-restart",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt + 3_600_000,
+    });
+    job.state.lastError = "prior failure";
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    let now = dueAt;
+    let restart: Promise<void> | undefined;
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    const stopObserving = observeCronJobWrites(job.id, ({ queuedAtMs, runningAtMs }) => {
+      if (queuedAtMs === dueAt) {
+        now = dueAt + 1;
+      } else if (runningAtMs === dueAt + 1 && !restart) {
+        stop(state);
+        restart = start(state);
+      }
+    });
+
+    try {
+      await expect(run(state, job.id, "force")).resolves.toEqual({
+        ok: true,
+        ran: false,
+        reason: "stopped",
+      });
+      await restart;
+
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(state.queuedRunReservationsByJobId.has(job.id)).toBe(false);
+      const persisted = (await loadCronStore(store.storePath)).jobs.find(
+        (entry) => entry.id === job.id,
+      );
+      expect(persisted?.state.runningAtMs).toBeUndefined();
+      expect(persisted?.state.lastError).toBe("prior failure");
+      const receipt = openOpenClawStateDatabase()
+        .db.prepare(
+          "SELECT status FROM cron_run_receipts WHERE store_key = ? AND job_id = ? ORDER BY started_at_ms DESC LIMIT 1",
+        )
+        .get(cronStoreKey(store.storePath), job.id) as { status: string } | undefined;
+      expect(receipt?.status).toBe("skipped");
+    } finally {
+      stopObserving();
+      await restart;
+      stop(state);
+    }
+  });
+
+  it("rejects an activated manual run when its scheduler restarts before payload dispatch", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const dueAt = Date.parse("2026-02-06T10:05:03.150Z");
+    const job = createDueIsolatedJob({
+      id: "manual-dispatch-retired-by-restart",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt + 3_600_000,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    let restart: Promise<void> | undefined;
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+      onEvent: (event) => {
+        if (event.action === "started" && !restart) {
+          stop(state);
+          restart = start(state);
+        }
+      },
+    });
+
+    try {
+      await expect(run(state, job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+      await restart;
+
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(state.queuedRunReservationsByJobId.has(job.id)).toBe(false);
+      const receipt = openOpenClawStateDatabase()
+        .db.prepare(
+          "SELECT status FROM cron_run_receipts WHERE store_key = ? AND job_id = ? ORDER BY started_at_ms DESC LIMIT 1",
+        )
+        .get(cronStoreKey(store.storePath), job.id) as { status: string } | undefined;
+      expect(receipt?.status).toBe("error");
+    } finally {
+      await restart;
+      stop(state);
+    }
+  });
 
   it.each(["manual", "scheduled", "startup"] as const)(
     "retries %s cleanup when stop wins the reservation write",

--- a/src/cron/service/ops.run-admission.test.ts
+++ b/src/cron/service/ops.run-admission.test.ts
@@ -21,7 +21,7 @@ import { cronStoreKey } from "../store/key.js";
 import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.js";
 import { cronStreamScheduleKey } from "../stream-schedule.js";
 import { recomputeNextRunsForMaintenance } from "./jobs-scheduling.js";
-import { update } from "./ops-mutations.js";
+import { remove, update } from "./ops-mutations.js";
 import { list } from "./ops-read.js";
 import { enqueueRun, run } from "./ops-run.js";
 import { createCronServiceState } from "./state.js";
@@ -303,6 +303,91 @@ describe("cron service run admission", () => {
       .get(cronStoreKey(store.storePath), waitingJob.id) as { status: string } | undefined;
     expect(receipt?.status).toBe("skipped");
   });
+
+  it.each(["edited-and-restored", "removed"] as const)(
+    "fences and settles a queued manual run after its job is %s",
+    async (mutation) => {
+      const store = opsRegressionFixtures.makeStorePath();
+      const dueAt = Date.parse("2026-02-06T10:05:06.050Z");
+      const activeJob = createDueIsolatedJob({
+        id: `active-before-${mutation}`,
+        nowMs: dueAt,
+        nextRunAtMs: dueAt + 3_600_000,
+      });
+      const waitingJob = createDueIsolatedJob({
+        id: `queued-before-${mutation}`,
+        nowMs: dueAt,
+        nextRunAtMs: dueAt + 3_600_000,
+      });
+      await saveCronStore(store.storePath, { version: 1, jobs: [activeJob, waitingJob] });
+
+      const activeStarted = createDeferred();
+      const releaseActive = createDeferred<{ status: "ok"; summary: string }>();
+      const runIsolatedAgentJob = vi.fn(async ({ job }: { job: { id: string } }) => {
+        if (job.id === activeJob.id) {
+          activeStarted.resolve();
+          return await releaseActive.promise;
+        }
+        return { status: "ok" as const, summary: "replacement" };
+      });
+      const state = createAdmissionTestState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        testAdmissionLimit: 1,
+        log: noopLogger,
+        nowMs: () => dueAt,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+      });
+
+      const activeRun = run(state, activeJob.id, "force");
+      await activeStarted.promise;
+      const waitingRun = run(state, waitingJob.id, "force");
+      await vi.waitFor(() => {
+        expect(state.queuedRunReservationsByJobId.has(waitingJob.id)).toBe(true);
+      });
+      const staleReceipt = inspectActiveCronRunReceipt({
+        storePath: store.storePath,
+        jobId: waitingJob.id,
+      });
+      if (!staleReceipt) {
+        throw new Error("Expected the queued run to own a durable receipt");
+      }
+
+      if (mutation === "removed") {
+        await remove(state, waitingJob.id);
+      } else {
+        await update(state, waitingJob.id, {
+          payload: { kind: "agentTurn", message: "replacement generation" },
+        });
+        await update(state, waitingJob.id, { payload: waitingJob.payload });
+      }
+
+      releaseActive.resolve({ status: "ok", summary: "active" });
+      await activeRun;
+      await expect(waitingRun).resolves.toEqual({ ok: true, ran: false, reason: "not-due" });
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      expect(state.queuedRunReservationsByJobId.has(waitingJob.id)).toBe(false);
+      const receipt = openOpenClawStateDatabase()
+        .db.prepare("SELECT status FROM cron_run_receipts WHERE receipt_id = ?")
+        .get(staleReceipt.receiptId) as { status: string } | undefined;
+      expect(receipt?.status).toBe("skipped");
+
+      if (mutation === "edited-and-restored") {
+        const persisted = (await loadCronStore(store.storePath)).jobs.find(
+          (job) => job.id === waitingJob.id,
+        );
+        expect(persisted?.state.queuedAtMs).toBeUndefined();
+        expect(persisted?.state.runningAtMs).toBeUndefined();
+        await expect(run(state, waitingJob.id, "force")).resolves.toEqual({
+          ok: true,
+          ran: true,
+        });
+        expect(runIsolatedAgentJob).toHaveBeenCalledTimes(2);
+      }
+    },
+  );
 
   it("cancels a queued stream batch after an A-to-B-to-A source replacement", async () => {
     const store = opsRegressionFixtures.makeStorePath();

--- a/src/cron/service/run-admission.ts
+++ b/src/cron/service/run-admission.ts
@@ -128,6 +128,7 @@ export function reserveQueuedCronRun(
   const identity = {};
   state.queuedRunReservationsByJobId.set(jobId, {
     identity,
+    lifecycleGeneration: state.lifecycleGeneration,
     markerAtMs: reservationAt,
     runReceipt: opts.runReceipt,
     preserveWhenDisabled: opts?.preserveWhenDisabled === true,
@@ -153,7 +154,11 @@ export function isQueuedCronRunReservationCurrent(
   jobId: string,
   identity: object,
 ): boolean {
-  return state.queuedRunReservationsByJobId.get(jobId)?.identity === identity;
+  const reservation = state.queuedRunReservationsByJobId.get(jobId);
+  return (
+    reservation?.identity === identity &&
+    reservation.lifecycleGeneration === state.lifecycleGeneration
+  );
 }
 
 type QueuedCronRunReservation = {
@@ -496,7 +501,7 @@ export async function activateQueuedCronRun(params: {
     reservation.runReceipt = activatedReceipt!;
     reservation.activationPreviousLastError = { value: previousLastError };
   }
-  if (!state.stopped) {
+  if (!state.stopped && reservation.lifecycleGeneration === state.lifecycleGeneration) {
     return { kind: "activated", job: activatedJob, startedAt, runReceipt: activatedReceipt! };
   }
 
@@ -535,10 +540,7 @@ export async function activateQueuedCronRun(params: {
     releaseLocalCronRunReceiptOwnership(activatedReceipt!);
   }
   releaseQueuedCronRun(state, job.id, reservationIdentity);
-  return {
-    kind: "unavailable",
-    reason: "stopped",
-  };
+  return { kind: "unavailable", reason: "stopped" };
 }
 
 /** Apply one service-level cap to every cron execution source. Queue waiters
@@ -547,22 +549,12 @@ export async function activateQueuedCronRun(params: {
 export async function runWithCronAdmission<T>(
   state: CronServiceState,
   execute: () => Promise<T>,
+  acquiredRelease?: () => void,
 ): Promise<{ kind: "admitted"; value: T } | { kind: "stopped" }> {
-  const release = await acquireCronRunAdmission(state);
+  const release = acquiredRelease ?? (await acquireCronRunAdmission(state));
   if (!release) {
     return { kind: "stopped" };
   }
-  try {
-    return { kind: "admitted", value: await execute() };
-  } finally {
-    release();
-  }
-}
-
-async function runWithAcquiredCronAdmission<T>(
-  release: () => void,
-  execute: () => Promise<T>,
-): Promise<{ kind: "admitted"; value: T }> {
   try {
     return { kind: "admitted", value: await execute() };
   } finally {
@@ -606,6 +598,14 @@ export async function executeQueuedCronRun(params: {
         job.state.queuedAtMs !== params.reservedAtMs
       ) {
         const ownership = state.queuedRunReservationsByJobId.get(params.jobId);
+        if (
+          job &&
+          ownership?.identity === params.reservationIdentity &&
+          job.state.queuedAtMs === params.reservedAtMs
+        ) {
+          await params.onNotRunnable(job);
+          return undefined;
+        }
         if (ownership?.identity === params.reservationIdentity) {
           // A concurrent disable/remove wiped the queued marker while this
           // reservation waited on admission. Its receipt is still running and
@@ -724,10 +724,10 @@ export async function executeQueuedCronRun(params: {
     }
     return { outcome, handled: (await params.onCompleted?.(outcome)) === true };
   };
-  const admission = await (
-    params.admissionRelease
-      ? runWithAcquiredCronAdmission(params.admissionRelease, executeAdmitted)
-      : runWithCronAdmission(state, executeAdmitted)
+  const admission = await runWithCronAdmission(
+    state,
+    executeAdmitted,
+    params.admissionRelease,
   ).catch(async (error: unknown) => {
     if (activated) {
       await cleanupQueuedCronRunReservations({

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -282,6 +282,7 @@ type CronRunAdmission = {
 
 type QueuedCronRunReservation = {
   identity: object;
+  lifecycleGeneration: number;
   markerAtMs: number;
   runReceipt: CronRunReceiptHandle;
   preserveWhenDisabled: boolean;
@@ -300,6 +301,8 @@ export type CronServiceState = {
   /** Number of timer batches currently executing admitted scheduled work. */
   activeTimerTicks: number;
   stopped: boolean;
+  /** Rotates synchronously on stop so an immediate restart cannot revive old work. */
+  lifecycleGeneration: number;
   schedulingPaused: boolean;
   schedulerStarted: boolean;
   activeManualRunJobIds: Set<string>;
@@ -337,6 +340,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     running: false,
     activeTimerTicks: 0,
     stopped: false,
+    lifecycleGeneration: 0,
     schedulingPaused: false,
     schedulerStarted: false,
     activeManualRunJobIds: new Set<string>(),

--- a/src/cron/service/timer-job-runner.ts
+++ b/src/cron/service/timer-job-runner.ts
@@ -226,7 +226,13 @@ async function executeJobCoreWithTimeoutUnfinalized(
       error: `cron webhook delivery cancelled: ${error}`,
     });
   };
-  if (!isCronActiveJobMarkerCurrent(opts?.activeJobMarker)) {
+  const reservation = opts?.runReceipt ? state.queuedRunReservationsByJobId.get(job.id) : undefined;
+  if (
+    !isCronActiveJobMarkerCurrent(opts?.activeJobMarker) ||
+    (opts?.runReceipt &&
+      (reservation?.runReceipt.receiptId !== opts.runReceipt.receiptId ||
+        reservation.lifecycleGeneration !== state.lifecycleGeneration))
+  ) {
     runAbortController.abort("Gateway restarting.");
     return createOperatorCancellationOutcome();
   }


### PR DESCRIPTION
## What Problem This Solves

A cron run admitted under one lifecycle generation could still execute after the world changed underneath it: a queued occurrence survived scheduler replacement, survived job edits (including A→B→A config round-trips that revived a stale queued snapshot), and execution did not revalidate the scheduler generation after restart-adjacent races. Assessment of Microsoft's Lobster fork patch 0008 ("cron execution fence") against current main confirmed three of its four staleness vectors were genuinely unfenced; the fourth (duplicate timer fire) was already owned by atomic receipt ownership.

## Why This Change Was Made

Reservations now capture the service lifecycle generation and are only current when it still matches; activation revalidates the generation before returning an activated run; and a config-revision comparison (existing `resolveCronJobConfigRevision` helper) retires a queued occurrence with the edit that owned it, so A→B→A cannot revive it. No new storage, schema, or config; exactly-once receipt settlement semantics unchanged; a small admission-helper consolidation came out net-simpler.

## User Impact

Automations can no longer execute a stale occurrence after their job was edited, deleted, or the scheduler was replaced — the queued work is retired or re-admitted under current state instead of firing with outdated configuration.

## Evidence

Failing-first regressions per fenced vector (scheduler replacement, edit/delete incl. A→B→A, pre-dispatch generation revalidation); 2,409 cron tests plus 91 focused ownership tests green; `check:changed` green; autoreview clean. Production +37/−31 (net +6); tests +195.

Assessment of Microsoft's Lobster patch 0008 via giodl73-repo/lobster-plugins-and-patches (Passport/Lobster policy intentionally excluded; generic fence only).
