### PR TITLE
fix(onboard): reject invalid provider choices without silent success

### DIFF
--- a/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.test.ts
@@ -506,28 +506,82 @@ describe("applyNonInteractivePluginProviderChoice", () => {
     expect(resolveProviderInstallCatalogEntry).not.toHaveBeenCalled();
   });
 
-  it("fails explicitly when a provider-plugin auth choice resolves to no trusted setup provider", async () => {
-    const runtime = createRuntime();
+  it.each([false, true])(
+    "rejects an unmatched provider-plugin auth choice while honoring json=%s",
+    async (json) => {
+      const runtime = createRuntime();
 
-    const result = await applyNonInteractivePluginProviderChoice({
-      nextConfig: { agents: { defaults: {} } } as OpenClawConfig,
-      authChoice: "provider-plugin:workspace-provider:api-key",
-      opts: {} as never,
-      runtime: runtime as never,
-      baseConfig: { agents: { defaults: {} } } as OpenClawConfig,
-      target,
-      resolveApiKey: vi.fn(),
-      toApiKeyCredential: vi.fn(),
-    });
+      const result = await applyNonInteractivePluginProviderChoice({
+        nextConfig: { agents: { defaults: {} } } as OpenClawConfig,
+        authChoice: "provider-plugin:workspace-provider:api-key",
+        opts: { json } as never,
+        runtime: runtime as never,
+        baseConfig: { agents: { defaults: {} } } as OpenClawConfig,
+        target,
+        resolveApiKey: vi.fn(),
+        toApiKeyCredential: vi.fn(),
+      });
 
-    expect(result).toBeNull();
-    expect(resolvePreferredProviderForAuthChoice).not.toHaveBeenCalled();
-    expectRuntimeErrorIncludes(
-      runtime,
-      'Auth choice "provider-plugin:workspace-provider:api-key" was not matched to a trusted provider plugin.',
-    );
-    expect(runtime.exit).toHaveBeenCalledWith(1);
-  });
+      expect(result).toBeNull();
+      expect(resolvePreferredProviderForAuthChoice).not.toHaveBeenCalled();
+      expectRuntimeErrorIncludes(
+        runtime,
+        'Auth choice "provider-plugin:workspace-provider:api-key" was not matched to a trusted provider plugin.',
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      if (json) {
+        expect(runtime.log).toHaveBeenCalledOnce();
+        expect(JSON.parse(String(runtime.log.mock.calls[0]?.[0]))).toEqual({
+          ok: false,
+          phase: "options",
+          message: expect.stringContaining("was not matched to a trusted provider plugin"),
+        });
+      } else {
+        expect(runtime.log).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each([
+    { authChoice: "provider-plugin:", json: false },
+    { authChoice: "provider-plugin:", json: true },
+    { authChoice: "provider-plugin:   ", json: false },
+    { authChoice: "provider-plugin::method", json: false },
+  ])(
+    "rejects a missing provider id before provider discovery (%j)",
+    async ({ authChoice, json }) => {
+      const runtime = createRuntime();
+      const nextConfig = { agents: { defaults: {} } } as OpenClawConfig;
+
+      const result = await applyNonInteractivePluginProviderChoice({
+        nextConfig,
+        authChoice,
+        opts: { json } as never,
+        runtime: runtime as never,
+        baseConfig: nextConfig,
+        target,
+        resolveApiKey: vi.fn(),
+        toApiKeyCredential: vi.fn(),
+      });
+
+      expect(result).toBeNull();
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expectRuntimeErrorIncludes(runtime, "is missing a provider id");
+      expectRuntimeErrorIncludes(runtime, '"provider-plugin:<provider-id>"');
+      expect(resolvePluginProvidersCore).not.toHaveBeenCalled();
+      expect(resolvePreferredProviderForAuthChoice).not.toHaveBeenCalled();
+      if (json) {
+        expect(runtime.log).toHaveBeenCalledOnce();
+        expect(JSON.parse(String(runtime.log.mock.calls[0]?.[0]))).toEqual({
+          ok: false,
+          phase: "options",
+          message: expect.stringContaining("is missing a provider id"),
+        });
+      } else {
+        expect(runtime.log).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("fails explicitly when a non-prefixed auth choice resolves only with untrusted providers", async () => {
     const runtime = createRuntime();

--- a/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts
@@ -33,6 +33,7 @@ import {
   projectAgentModelDefaults,
   type OnboardingAgentTarget,
 } from "../../onboard-agent-target.js";
+import { rejectOnboardingOption } from "../../onboard-options.js";
 import type { OnboardOptions } from "../../onboard-types.js";
 
 const PROVIDER_PLUGIN_CHOICE_PREFIX = "provider-plugin:";
@@ -64,10 +65,20 @@ export async function applyNonInteractivePluginProviderChoice(params: {
   ) => ApiKeyCredential | null;
 }): Promise<OpenClawConfig | null | undefined> {
   const { agentDir, workspaceDir } = params.target;
+  const reject = (message: string): null => {
+    rejectOnboardingOption(params.opts, params.runtime, message);
+    return null;
+  };
   let nextConfig = params.nextConfig;
   const prefixedProviderId = params.authChoice.startsWith(PROVIDER_PLUGIN_CHOICE_PREFIX)
     ? params.authChoice.slice(PROVIDER_PLUGIN_CHOICE_PREFIX.length).split(":", 1)[0]?.trim()
     : undefined;
+  // Prefixed choices bypass generic validation, so reject empty IDs before provider discovery.
+  if (prefixedProviderId === "") {
+    return reject(
+      `Auth choice ${JSON.stringify(params.authChoice)} is missing a provider id. Use "${PROVIDER_PLUGIN_CHOICE_PREFIX}<provider-id>".`,
+    );
+  }
   const preferredProviderId =
     prefixedProviderId ||
     (await resolvePreferredProviderForAuthChoice({
@@ -105,14 +116,12 @@ export async function applyNonInteractivePluginProviderChoice(params: {
     if (prefixedProviderId) {
       // Explicit provider-plugin choices are user intent; fail closed if the
       // target provider is unavailable rather than falling back to core auth.
-      params.runtime.error(
+      return reject(
         [
           `Auth choice "${params.authChoice}" was not matched to a trusted provider plugin.`,
           "If this provider comes from a workspace plugin, trust/allow it first and retry.",
         ].join("\n"),
       );
-      params.runtime.exit(1);
-      return null;
     }
     // Keep mismatch diagnostics metadata-only so untrusted workspace plugins are not loaded.
     const trustedManifestMatch = resolveManifestProviderAuthChoice(params.authChoice, {
@@ -130,14 +139,12 @@ export async function applyNonInteractivePluginProviderChoice(params: {
     if (untrustedOnlyManifestMatch) {
       // Manifest metadata can identify untrusted matches without loading the
       // plugin implementation, preserving workspace trust boundaries.
-      params.runtime.error(
+      return reject(
         [
           `Auth choice "${params.authChoice}" matched a provider plugin that is not trusted or enabled for setup.`,
           "If this provider comes from a workspace plugin, trust/allow it first and retry.",
         ].join("\n"),
       );
-      params.runtime.exit(1);
-      return null;
     }
     const installCatalogParams = {
       config: nextConfig,
@@ -149,11 +156,9 @@ export async function applyNonInteractivePluginProviderChoice(params: {
       installCatalogParams,
     );
     if (deprecatedInstallCatalogEntry) {
-      params.runtime.error(
+      return reject(
         `${JSON.stringify(params.authChoice)} is no longer supported. Use --auth-choice ${JSON.stringify(deprecatedInstallCatalogEntry.choiceId)} instead.`,
       );
-      params.runtime.exit(1);
-      return null;
     }
     const installCatalogEntry = resolveProviderInstallCatalogEntry(
       params.authChoice,
@@ -182,11 +187,9 @@ export async function applyNonInteractivePluginProviderChoice(params: {
       promptInstall: false,
     });
     if (!installResult.installed) {
-      params.runtime.error(
+      return reject(
         `Unable to install the ${installCatalogEntry.label} plugin for non-interactive setup.`,
       );
-      params.runtime.exit(1);
-      return null;
     }
     nextConfig = installResult.cfg;
     providerChoice = resolveProviderPluginChoice({
@@ -201,11 +204,9 @@ export async function applyNonInteractivePluginProviderChoice(params: {
       choice: params.authChoice,
     });
     if (!providerChoice) {
-      params.runtime.error(
+      return reject(
         `Installed plugin "${installCatalogEntry.label}" did not expose auth choice "${params.authChoice}".`,
       );
-      params.runtime.exit(1);
-      return null;
     }
   }
 
@@ -214,25 +215,21 @@ export async function applyNonInteractivePluginProviderChoice(params: {
     providerChoice.provider.pluginId ?? providerChoice.provider.id,
   );
   if (!enableResult.enabled) {
-    params.runtime.error(
+    return reject(
       `${providerChoice.provider.label} plugin is disabled (${enableResult.reason ?? "blocked"}).`,
     );
-    params.runtime.exit(1);
-    return null;
   }
 
   const method = providerChoice.method;
   if (!method.runNonInteractive) {
     // Interactive-only plugin setup methods may prompt, so non-interactive
     // setup must reject them before entering plugin code.
-    params.runtime.error(
+    return reject(
       [
         `Auth choice "${params.authChoice}" requires interactive mode.`,
         `The ${providerChoice.provider.label} provider plugin does not implement non-interactive setup.`,
       ].join("\n"),
     );
-    params.runtime.exit(1);
-    return null;
   }
 
   const agentScopedModels = enableResult.config.agents?.ownership === "explicit";


### PR DESCRIPTION
Supersedes #116168. Related: #127976.

## What Problem This Solves

Fixes an issue where operators running non-interactive onboarding with a malformed `--auth-choice provider-plugin:` value would receive a successful exit even though no model provider was configured. Existing plugin-provider failures also bypassed the documented `--json` error contract, leaving automation without a machine-readable result.

## Why This Change Was Made

The plugin-provider onboarding owner already parses provider IDs and owns provider setup failures. It now rejects empty IDs before provider discovery and routes every existing provider rejection through the canonical onboarding option error contract. This preserves normal text errors, exit status, plugin trust checks, and valid provider setup while removing duplicated error/exit handling.

This focused replacement preserves the original contribution from @masatohoshino in #116168 and the related structured-error contribution from @wangmiao0668000666 in #127976. The original PR acquired an obsolete base and was automatically closed after unrelated historical changes confused its labeler; this replacement contains only the two plugin-provider owner files.

## User Impact

Malformed provider choices fail immediately with a clear correction, without creating a configuration file or workspace. With `--json`, all plugin-provider onboarding rejections now emit one structured `{ "ok": false, "phase": "options", "message": "..." }` result. Valid onboarding choices continue to work unchanged.

## Evidence

- Focused regression on unchanged `main`: 5 intended failures and 26 passing existing cases.
- The same focused suite after the fix: all 31 cases pass, including bare IDs, whitespace-only IDs, empty IDs with a method, JSON/text output, and preserved valid provider setup.
- Command: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-onboard-provider-116168/.vitest-cache node scripts/run-vitest.mjs src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.test.ts --configLoader runner`.
- Actual source-backed Commander registration, argument parsing, and onboarding dispatch were exercised with isolated state/config directories. Bare, whitespace-only, and empty-method provider choices exit 1; JSON cases emit the documented options error object; none creates a configuration file or workspace. A valid `--auth-choice skip --json` control exits 0 and creates both.
- Targeted formatting and core lint checks pass, and independent source review plus automated review report no actionable findings.
- Production: +18/-21 lines, net -3. Tests: +74/-20 lines, net +54.
- No provider API, plugin trust rule, configuration surface, persisted-data shape, or database schema changes.
