### PR TITLE
fix(discord): report the messages actually delivered

### DIFF
--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -208,6 +208,17 @@ export async function sendMessageDiscord(
 
   // Forum/Media channels reject POST /messages; auto-create a thread post instead.
   const channel = await resolveDiscordChannel(rest, channelId);
+  const deliveredResults: DiscordSendResult[] = [];
+  let deliveryThreadId: string | undefined;
+  const reportResult: DiscordSendProgress = async (progressResult, kind, replyToId) => {
+    const deliveredResult = toDiscordSendResult(progressResult, deliveryThreadId ?? channelId, {
+      kind,
+      threadId: deliveryThreadId,
+      reply: createReusableDiscordReplyReference(replyToId),
+    });
+    deliveredResults.push(deliveredResult);
+    await opts.onDeliveryResult?.(deliveredResult);
+  };
 
   if (isForumLikeChannel(channel)) {
     if (((channel.flags ?? 0) & DISCORD_FORUM_REQUIRE_TAG_FLAG) !== 0) {
@@ -275,6 +286,7 @@ export async function sendMessageDiscord(
     }
 
     const threadId = threadRes.id;
+    deliveryThreadId = threadId;
     const messageId = threadRes.message?.id ?? threadId;
     const resultChannelId = threadRes.message?.channel_id ?? threadId;
     const remainingChunks = chunks.slice(1);
@@ -286,13 +298,8 @@ export async function sendMessageDiscord(
       channelId,
       { kind: "text", threadId },
     );
-    const deliveredResults: DiscordSendResult[] = [starterResult];
+    deliveredResults.push(starterResult);
     await opts.onDeliveryResult?.(starterResult);
-    const reportThreadResult: DiscordSendProgress = async (result, kind) => {
-      const deliveredResult = toDiscordSendResult(result, threadId, { kind, threadId });
-      deliveredResults.push(deliveredResult);
-      await opts.onDeliveryResult?.(deliveredResult);
-    };
 
     try {
       if (opts.mediaUrl) {
@@ -314,7 +321,7 @@ export async function sendMessageDiscord(
           suppressEmbeds,
           allowedMentions: opts.allowedMentions,
           maxChars: textLimit,
-          onResult: reportThreadResult,
+          onResult: reportResult,
           onPlatformSendDispatch: opts.onPlatformSendDispatch,
         });
         await sendDiscordThreadTextChunks({
@@ -328,7 +335,7 @@ export async function sendMessageDiscord(
           silent: opts.silent,
           suppressEmbeds,
           allowedMentions: opts.allowedMentions,
-          onResult: reportThreadResult,
+          onResult: reportResult,
           onPlatformSendDispatch: opts.onPlatformSendDispatch,
         });
       } else {
@@ -343,7 +350,7 @@ export async function sendMessageDiscord(
           silent: opts.silent,
           suppressEmbeds,
           allowedMentions: opts.allowedMentions,
-          onResult: reportThreadResult,
+          onResult: reportResult,
           onPlatformSendDispatch: opts.onPlatformSendDispatch,
         });
       }
@@ -369,14 +376,6 @@ export async function sendMessageDiscord(
   }
 
   let result: DiscordChannelMessageResult;
-  const reportResult: DiscordSendProgress = async (progressResult, kind, replyToId) => {
-    await opts.onDeliveryResult?.(
-      toDiscordSendResult(progressResult, channelId, {
-        kind,
-        reply: createReusableDiscordReplyReference(replyToId),
-      }),
-    );
-  };
   try {
     if (opts.mediaUrl) {
       result = await sendDiscordMedia({
@@ -436,10 +435,11 @@ export async function sendMessageDiscord(
     accountId: accountInfo.accountId,
     direction: "outbound",
   });
-  return toDiscordSendResult(result, channelId, {
-    kind: opts.mediaUrl ? "media" : opts.components || opts.embeds ? "card" : "text",
-    reply: opts.reply,
-  });
+  return {
+    messageId: result.id || "unknown",
+    channelId: result.channel_id ?? channelId,
+    receipt: createDiscordSendReceiptFromResults({ results: deliveredResults }),
+  };
 }
 
 export async function sendStickerDiscord(

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -392,7 +392,7 @@ describe("sendMessageDiscord", () => {
     ];
     const onDeliveryResult = vi.fn();
 
-    await sendMessageDiscord("channel:789", "a".repeat(2_500), {
+    const result = await sendMessageDiscord("channel:789", "a".repeat(2_500), {
       rest,
       token: "t",
       cfg: DISCORD_TEST_CFG,
@@ -415,6 +415,7 @@ describe("sendMessageDiscord", () => {
       "card",
       "text",
     ]);
+    expect(result.receipt.parts.map(({ kind }) => kind)).toEqual(["card", "text"]);
   });
 
   it("delivers embed-only and native Components V2 messages over real HTTP", async () => {
@@ -1008,6 +1009,7 @@ describe("sendMessageDiscord", () => {
     });
 
     expect(res.messageId).toBe("fallback-msg");
+    expectSingleReceiptPart(res.receipt, { platformMessageId: "fallback-msg", kind: "text" });
     expect(postMock).toHaveBeenCalledTimes(2);
     expectBodyFileName(requireRestBody(postMock, 0), "photo.jpg");
     const fallbackBody = requireRestBody(postMock, 1);
@@ -1199,17 +1201,20 @@ describe("sendMessageDiscord", () => {
       name: "preserves reply reference across all text chunks by default",
       params: { text: "a".repeat(2001) },
       expectsSecondReply: true,
+      expectedKinds: ["text", "text"],
     },
     {
       name: "limits reply reference to the first text chunk when requested",
       params: { text: "a".repeat(2001), replyScope: "first" as const },
       expectsSecondReply: false,
       checksReceipt: true,
+      expectedKinds: ["text", "text"],
     },
     {
       name: "preserves reply reference for follow-up text chunks after media caption split by default",
       params: { text: "a".repeat(2500), mediaUrl: "file:///tmp/photo.jpg" },
       expectsSecondReply: true,
+      expectedKinds: ["media", "text"],
     },
     {
       name: "limits media caption reply reference to the first physical message when requested",
@@ -1219,9 +1224,11 @@ describe("sendMessageDiscord", () => {
         replyScope: "first" as const,
       },
       expectsSecondReply: false,
+      expectedKinds: ["media", "text"],
     },
-  ])("$name", async ({ params, expectsSecondReply, checksReceipt }) => {
+  ])("$name", async ({ params, expectsSecondReply, checksReceipt, expectedKinds }) => {
     const { firstBody, secondBody, result } = await sendChunkedReplyAndCollectBodies(params);
+    expect(result.receipt.parts.map(({ kind }) => kind)).toEqual(expectedKinds);
     expectReplyReference(firstBody, "orig-123");
     if (expectsSecondReply) {
       expectReplyReference(secondBody, "orig-123");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord delivery receipts incorrectly reported the kind of messages users actually received. Rejected uploads that fell back to explanatory text were marked as delivered media, later plain-text chunks after an attachment were marked as media, and follow-up text after interactive content was marked as another card.

## Why This Change Was Made

The Discord sender already knows the authoritative type and reply target of each successfully delivered platform message, and forum sends already aggregate those concrete results correctly. Reuse one delivery-result collector for both forum and normal channel sends, then build each final receipt from the real delivered results instead of reconstructing every part from the original request.

## User Impact

Discord message receipts now accurately reflect text-only upload fallbacks, mixed media/text messages, interactive card/text messages, message ordering, and per-message reply references. Downstream delivery tracking sees what Discord actually accepted rather than what the sender originally attempted.

## Evidence

- Extended existing sender regressions instead of adding duplicate fixtures. Four assertions fail against current main: upload fallback reports `media` instead of `text`, card-plus-text reports `card, card`, and both media reply scopes report `media, media`.
- Run `node scripts/run-vitest.mjs extensions/discord/src/send.sends-basic-channel-messages.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/outbound-adapter.interactive-order.test.ts`: 137 tests passed, including real local Discord REST loopback HTTP requests, forum thread receipts, both reply scopes, upload fallback, and adapter delivery.
- Run `node scripts/run-tsgo.mjs -p extensions/discord/tsconfig.json --noEmit --incremental --tsBuildInfoFile /private/tmp/openclaw-discord-plugin.tsbuildinfo`: the complete touched Discord plugin type-checks successfully.
- Run `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/discord/src/send.outbound.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts`, targeted `oxfmt --check`, and `git diff --check`.
- Broad local all-plugin production/test type checks are currently blocked by pre-existing unrelated `extensions/acpx` type errors from the shared installed dependency cache; the isolated Discord package is clean, and exact-head hosted CI provides the clean-environment gate.
- Independent read-only local review covers the actual outbound caller, ordinary and forum owners, concrete REST result kinds, starter/thread metadata, first/all reply references, optional progress ordering, and error behavior: CLEAN, with no actionable findings.
- Production delta is exactly neutral: +21/-21. The change removes one duplicate progress callback and the request-based guessed-kind branch without touching authentication, configuration, persistent state, public plugin contracts, external API behavior, or protocol.
- Real HTTP loopback evidence is included in the existing sender suite. A live operator-owned Discord channel was not used because it would send unsolicited external messages; the disposable loopback exercises the actual Discord request serialization and response path safely.
