### PR TITLE
fix(gateway): revalidate node command policy at the transport handoff

### DIFF
--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -55,6 +55,10 @@ function createNodeSession(): NodeSession {
   };
 }
 
+function nodeCommandsConfig(commands: { allow?: string[]; deny?: string[] }) {
+  return { gateway: { nodes: { commands } } };
+}
+
 function createContext(opts?: {
   pluginApprovalManager?: ExecApprovalManager<PluginApprovalRequestPayload>;
   getApprovalClientConnIds?: GatewayRequestContext["getApprovalClientConnIds"];
@@ -84,8 +88,7 @@ function createContext(opts?: {
   return {
     context: {
       getRuntimeConfig:
-        opts?.getRuntimeConfig ??
-        (() => ({ gateway: { nodes: { commands: { allow: [DEMO_COMMAND] } } } })),
+        opts?.getRuntimeConfig ?? (() => nodeCommandsConfig({ allow: [DEMO_COMMAND] })),
       nodeRegistry: {
         get: () => nodeSession,
         getForPairingGeneration: () => nodeSession,
@@ -291,6 +294,9 @@ describe("applyPluginNodeInvokePolicy", () => {
       isDispatchAuthorized: expect.any(Function),
       onDispatchReady: expect.any(Function),
     });
+    expect(invoke.mock.calls[0]?.[0]?.isDispatchAuthorized?.()).toBe(true);
+    context.getRuntimeConfig = () => nodeCommandsConfig({ deny: [DEMO_COMMAND] });
+    expect(invoke.mock.calls[0]?.[0]?.isDispatchAuthorized?.()).toBe(false);
   });
 
   it("preserves session identity through approved dangerous streaming transport", async () => {
@@ -534,13 +540,8 @@ describe("applyPluginNodeInvokePolicy", () => {
       }),
     ]);
     const { context, invoke } = createContext({
-      getRuntimeConfig: () => ({
-        gateway: {
-          nodes: {
-            commands: allowCommand ? { allow: [DEMO_COMMAND] } : { deny: [DEMO_COMMAND] },
-          },
-        },
-      }),
+      getRuntimeConfig: () =>
+        nodeCommandsConfig(allowCommand ? { allow: [DEMO_COMMAND] } : { deny: [DEMO_COMMAND] }),
     });
 
     const result = await invokeDemoPolicy(context);

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -411,16 +411,16 @@ export async function applyPluginNodeInvokePolicy(params: {
         message: "node pairing changed before dispatch",
       });
     }
-    const currentConfig = params.context.getRuntimeConfig();
-    const allowlist = resolveNodeCommandAllowlist(currentConfig, {
-      ...currentNode,
-      approvedCommands: currentNode.commands,
-    });
-    const allowed = isNodeCommandAllowed({
-      command: params.command,
-      declaredCommands: currentNode.commands,
-      allowlist,
-    });
+    const resolveCommandAuthorization = () =>
+      isNodeCommandAllowed({
+        command: params.command,
+        declaredCommands: currentNode.commands,
+        allowlist: resolveNodeCommandAllowlist(params.context.getRuntimeConfig(), {
+          ...currentNode,
+          approvedCommands: currentNode.commands,
+        }),
+      });
+    const allowed = resolveCommandAuthorization();
     if (!allowed.ok) {
       return deny("node_command_revoked", {
         ok: false,
@@ -492,7 +492,8 @@ export async function applyPluginNodeInvokePolicy(params: {
         (params.nodeInvokeStream?.isRuntimeCurrent() ?? true) &&
         (!callerIdentity ||
           params.context.validateAgentRuntimeApprovalAuthority?.(callerIdentity) === true) &&
-        params.isApprovalAuthorityActive?.() !== false,
+        params.isApprovalAuthorityActive?.() !== false &&
+        resolveCommandAuthorization().ok,
       onDispatchReady: (invokeId) => {
         // Only the registry knows that the transport send succeeded. Preserve
         // pre-send failures as retry-safe while making later failures ambiguous.

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -983,6 +983,38 @@ describe("gateway/node-registry", () => {
     expect(frames).toEqual([]);
   });
 
+  it("fails closed without dispatching when the pairing store is unavailable during invoke", async () => {
+    const frames: string[] = [];
+    const registry = createNodeRegistry({
+      resolveCurrentPairingState: async () => {
+        throw new Error("pairing store unavailable");
+      },
+    });
+    registerNodeSession(registry, makeClient("conn-lease", "node-lease", frames), {
+      pairingIdentity: "identity-a",
+      pairingGeneration: "generation-a",
+    });
+    const isDispatchAuthorized = vi.fn(() => true);
+    const onDispatchReady = vi.fn();
+
+    await expect(
+      registry.invoke({
+        nodeId: "node-lease",
+        expectedConnId: "conn-lease",
+        expectedPairingGeneration: "generation-a",
+        command: "system.which",
+        isDispatchAuthorized,
+        onDispatchReady,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: { code: "UNAVAILABLE", message: "node pairing state unavailable before dispatch" },
+    });
+    expect(frames).toEqual([]);
+    expect(isDispatchAuthorized).not.toHaveBeenCalled();
+    expect(onDispatchReady).not.toHaveBeenCalled();
+  });
+
   it("revalidates persistent generation ownership for inbound node RPCs", async () => {
     const resolveCurrentPairingState = vi.fn().mockResolvedValue({
       identity: "identity-a",
@@ -1874,7 +1906,7 @@ describe("gateway/node-registry", () => {
     }
   });
 
-  it("returns unavailable without dispatching an invoke to a closing node websocket", async () => {
+  it("fails closed without dispatching system.which to a closing node websocket", async () => {
     const registry = createNodeRegistry();
     const frames: string[] = [];
     const socket = createTestNodeSocket(frames, WebSocket.CLOSING);
@@ -1884,7 +1916,7 @@ describe("gateway/node-registry", () => {
     await expect(
       registry.invoke({
         nodeId: "node-1",
-        command: "debug.ping",
+        command: "system.which",
         timeoutMs: 0,
         onDispatchReady,
       }),

--- a/src/gateway/server-methods/nodes.invoke-wake.test.ts
+++ b/src/gateway/server-methods/nodes.invoke-wake.test.ts
@@ -1558,6 +1558,81 @@ describe("node.invoke APNs wake path", () => {
     expect(nodeRegistry.invoke).not.toHaveBeenCalled();
   });
 
+  it("does not dispatch system.which when policy changes during final pairing validation", async () => {
+    let runtimeConfig: MockNodeConfig = {
+      gateway: { nodes: { commands: { allow: ["system.which"] } } },
+    };
+    mocks.getRuntimeConfig.mockImplementation(() => runtimeConfig);
+    mocks.resolveNodeCommandAllowlist.mockImplementation((cfg) => {
+      const allowlist = new Set(cfg.gateway?.nodes?.commands?.allow ?? []);
+      for (const denied of cfg.gateway?.nodes?.commands?.deny ?? []) {
+        allowlist.delete(denied);
+      }
+      return allowlist;
+    });
+    mocks.isNodeCommandAllowed.mockImplementation(({ command, allowlist }) =>
+      allowlist.has(command) ? { ok: true } : { ok: false, reason: "command not allowlisted" },
+    );
+
+    const dispatch = vi.fn();
+    let releasePairingValidation!: () => void;
+    const nodeRegistry = {
+      get: vi.fn(() => ({
+        nodeId: "mac-node-final-policy-reload",
+        connId: "mac-node-final-policy-connection",
+        commands: ["system.which"],
+        platform: "macOS 26.0.0",
+      })),
+      invoke: vi.fn(
+        async (params: {
+          nodeId: string;
+          command: string;
+          isDispatchAuthorized?: () => boolean;
+        }) => {
+          await new Promise<void>((resolve) => {
+            releasePairingValidation = resolve;
+          });
+          if (!params.isDispatchAuthorized?.()) {
+            return {
+              ok: false,
+              error: {
+                code: "APPROVAL_AUTHORITY_CLOSED",
+                message: "runtime authority closed before node dispatch",
+              },
+            };
+          }
+          dispatch();
+          return { ok: true, payload: { path: "/usr/bin/git" } };
+        },
+      ),
+    };
+
+    const invocation = invokeNode({
+      nodeRegistry,
+      requestParams: {
+        nodeId: "mac-node-final-policy-reload",
+        command: "system.which",
+        params: { bins: ["git"] },
+        idempotencyKey: "idem-final-policy-reload",
+      },
+    });
+    await vi.waitFor(() => expect(nodeRegistry.invoke).toHaveBeenCalledOnce());
+    runtimeConfig = { gateway: { nodes: { commands: { deny: ["system.which"] } } } };
+    releasePairingValidation();
+
+    expect(firstRespondCall(await invocation)).toMatchObject([
+      false,
+      undefined,
+      {
+        details: {
+          nodeError: { code: "APPROVAL_AUTHORITY_CLOSED" },
+          nodeCommandDispatched: false,
+        },
+      },
+    ]);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
   it("does not retroactively grant a command enabled while waiting for reconnect", async () => {
     vi.useFakeTimers();
     mockDirectWakeConfig("mac-node-policy-grant");
@@ -1767,13 +1842,23 @@ describe("node.invoke APNs wake path", () => {
   it("rejects an invoke admitted after pairing removal without waking or dispatching", async () => {
     const nodeId = "ios-node-removed-before-invoke";
     mocks.captureNodePairingGeneration.mockResolvedValueOnce(null);
+    mocks.getRuntimeConfig.mockReturnValue({
+      gateway: { nodes: { commands: { deny: ["system.which"] } } },
+    });
     const nodeRegistry = createMissingNodeRegistry();
 
     const respond = await invokeNode({
       nodeRegistry,
-      requestParams: { nodeId, idempotencyKey: "idem-removed-before-invoke" },
+      requestParams: {
+        nodeId,
+        command: "system.which",
+        idempotencyKey: "idem-removed-before-invoke",
+      },
     });
 
+    expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
+    expect(mocks.resolveNodeCommandAllowlist).not.toHaveBeenCalled();
+    expect(mocks.isNodeCommandAllowed).not.toHaveBeenCalled();
     expect(mocks.loadApnsRegistration).not.toHaveBeenCalled();
     expect(mocks.sendApnsBackgroundWake).not.toHaveBeenCalled();
     expect(nodeRegistry.invoke).not.toHaveBeenCalled();
@@ -1785,6 +1870,32 @@ describe("node.invoke APNs wake path", () => {
         details: { code: "PAIRING_CHANGED" },
       },
     ]);
+  });
+
+  it("fails closed before policy evaluation when system.which pairing lookup fails", async () => {
+    const nodeId = "mac-node-pairing-transport-failure";
+    mocks.captureNodePairingGeneration.mockRejectedValueOnce(
+      new Error("pairing transport unavailable"),
+    );
+    const nodeRegistry = createMissingNodeRegistry();
+
+    const respond = await invokeNode({
+      nodeRegistry,
+      requestParams: {
+        nodeId,
+        command: "system.which",
+        idempotencyKey: "idem-pairing-transport-failure",
+      },
+    });
+
+    expect(firstRespondCall(respond)).toMatchObject([
+      false,
+      undefined,
+      { code: ErrorCodes.UNAVAILABLE, message: "Error: pairing transport unavailable" },
+    ]);
+    expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
+    expect(mocks.resolveNodeCommandAllowlist).not.toHaveBeenCalled();
+    expect(nodeRegistry.invoke).not.toHaveBeenCalled();
   });
 
   it("forces one retry wake when the first wake still fails to reconnect", async () => {

--- a/src/gateway/server-methods/nodes.invoke.ts
+++ b/src/gateway/server-methods/nodes.invoke.ts
@@ -525,16 +525,17 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
           );
           return;
         }
+        const resolveDispatchAuthorization = (dispatchCfg: typeof cfg) =>
+          isNodeCommandAllowed({
+            command,
+            declaredCommands: dispatchSession.commands,
+            allowlist: resolveNodeCommandAllowlist(dispatchCfg, {
+              ...dispatchSession,
+              approvedCommands: dispatchSession.commands,
+            }),
+          });
         const dispatchCfg = context.getRuntimeConfig();
-        const dispatchAllowlist = resolveNodeCommandAllowlist(dispatchCfg, {
-          ...dispatchSession,
-          approvedCommands: dispatchSession.commands,
-        });
-        const dispatchAllowed = isNodeCommandAllowed({
-          command,
-          declaredCommands: dispatchSession.commands,
-          allowlist: dispatchAllowlist,
-        });
+        const dispatchAllowed = resolveDispatchAuthorization(dispatchCfg);
         if (!dispatchAllowed.ok) {
           respond(
             false,
@@ -594,7 +595,8 @@ export const nodeInvokeHandlers: GatewayRequestHandlers = {
               context,
               client,
               approvalAuthority: forwardedParams.approvalAuthority,
-            }) === undefined,
+            }) === undefined &&
+            resolveDispatchAuthorization(context.getRuntimeConfig()).ok,
           onDispatchReady: (invokeId) => {
             nodeCommandDispatched = true;
             nodeInvokeStream?.onDispatchReady(invokeId);


### PR DESCRIPTION
## What Problem This Solves

A node command revoked by config reload during an in-flight `node.invoke` could still dispatch: both dispatch sites computed the command-allowlist decision *before* `registry.invoke`, and the registry's final authorization closure — evaluated after an async pairing-lease revalidation — rechecked runtime/approval authority but not command policy. Reproduced on baseline: revoking `system.which` via `gateway.nodes.commands` during the await still dispatched the command and returned `ok: true`.

This settles Microsoft's Lobster fork patch 0046 ("live system.which authorization"). Assessment showed the other three claimed sub-invariants (pairing checked before policy denial, transport failure fails closed, allowed commands dispatch) were already enforced on main — two of them unpinned, now pinned.

## Why This Change Was Made

The command-authorization resolution is extracted into a closure and re-evaluated against `context.getRuntimeConfig()` inside the registry's `isDispatchAuthorized` gate at both sites (server-methods dispatch and plugin-policy dispatch), so the decision the transport handoff acts on is live, not captured. Fail-closed on any mismatch; no new config, no protocol changes; a policy revocation caught at the handoff surfaces as the existing pre-send retry-safe closure error.

## User Impact

Revoking a node command in config takes effect even for invocations already past admission — the window where a denied command could still reach a node is closed.

## Evidence

Failing-first proof for the gap (baseline dispatched after revocation; both new tests failed for exactly that reason) plus pins for the previously untested sub-invariants: pairing-before-policy ordering (config readers asserted never called after pairing removal), pairing-store transport failure fails closed without dispatch, and registry-side authority-flip during lease. 292 tests across 7 node/gateway files green post-rebase; `check:changed` green; autoreview clean (0.97). Production +3 net; tests +156/−12.

Live-proof note: the race window (config reload during the pairing-lease await) is not deterministically reproducible on a live gateway; the regressions exercise the production handler and registry code end-to-end in-process, which is the strongest available evidence for this timing-dependent boundary.

Assessment of Microsoft's Lobster patch 0046 via giodl73-repo/lobster-plugins-and-patches (their Passport/runtime policy intentionally excluded; generic fail-closed fence only).
