### PR TITLE
fix(ui): propagate user accent to Talk Mode and widget frames

### DIFF
--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -1118,6 +1118,26 @@ describe("talk.config handler", () => {
     },
   );
 
+  it("prefers the user accent over the operator seam color", async () => {
+    markTalkOwnerCold("tts");
+    const runtimeConfig = createTalkConfig("healthy-talk-key");
+    mocks.getSpeechProvider.mockReturnValue({ id: "acme" });
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      config: { ...runtimeConfig, ui: { seamColor: "#123456", prefs: { accent: "#52c99a" } } },
+    });
+    const respond = vi.fn();
+
+    await callTalkHandler("talk.config", {
+      params: {},
+      client: { connect: { scopes: ["operator.read"] } },
+      respond,
+      context: { getRuntimeConfig: () => runtimeConfig },
+    });
+
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    expect(respond.mock.calls[0]?.[1]?.config?.ui).toEqual({ seamColor: "#52c99a" });
+  });
+
   it("projects the runtime realtime transport when source config is invalid", async () => {
     mocks.readConfigFileSnapshot.mockResolvedValue({
       path: "/tmp/openclaw.json",

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -802,7 +802,9 @@ export const talkHandlers: GatewayRequestHandlers = {
       configPayload.session = { mainKey: sessionMainKey };
     }
 
-    const seamColor = snapshot.config.ui?.seamColor;
+    // User accent wins over the operator seam color, matching Control UI
+    // precedence (ui.prefs.accent -> ui.seamColor -> theme default).
+    const seamColor = snapshot.config.ui?.prefs?.accent ?? snapshot.config.ui?.seamColor;
     if (typeof seamColor === "string") {
       configPayload.ui = { seamColor };
     }

--- a/ui/src/lib/widget-theme.ts
+++ b/ui/src/lib/widget-theme.ts
@@ -94,6 +94,8 @@ export function installWidgetThemeObserver(): void {
     }
   }).observe(root, {
     attributes: true,
-    attributeFilter: ["data-theme", "data-theme-mode"],
+    // "style" carries the accent override (inline custom properties on <html>);
+    // without it a user accent change would only reach frames incidentally.
+    attributeFilter: ["data-theme", "data-theme-mode", "style"],
   });
 }

--- a/ui/src/pages/chat/components/widget-theme.test.ts
+++ b/ui/src/pages/chat/components/widget-theme.test.ts
@@ -130,7 +130,7 @@ describe("widget theme bridge", () => {
       document.documentElement,
       {
         attributes: true,
-        attributeFilter: ["data-theme", "data-theme-mode"],
+        attributeFilter: ["data-theme", "data-theme-mode", "style"],
       },
     );
     FakeMutationObserver.instances[0]?.trigger({
@@ -138,6 +138,13 @@ describe("widget theme bridge", () => {
     } as MutationRecord);
     expect(chatPost).toHaveBeenCalledOnce();
     expect(boardPost).toHaveBeenCalledOnce();
+    expect(unrelatedPost).not.toHaveBeenCalled();
+    // Accent overrides land as inline style mutations on <html>.
+    FakeMutationObserver.instances[0]?.trigger({
+      attributeName: "style",
+    } as MutationRecord);
+    expect(chatPost).toHaveBeenCalledTimes(2);
+    expect(boardPost).toHaveBeenCalledTimes(2);
     expect(unrelatedPost).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #128432 (user-selectable accent color). An adaptivity audit of remaining surfaces found two places the user accent never reached:

1. **Native Talk Mode**: `talk.config` forwarded only the operator `ui.seamColor`, so a user-selected `ui.prefs.accent` was ignored by the native voice overlay — silently diverging from every other surface.
2. **Widget iframes**: the widget-theme observer watched only `data-theme`/`data-theme-mode` attribute mutations. Accent overrides land as inline `style` mutations on `<html>`; frames were only refreshed incidentally because theme application happens to re-set the data attributes.

## Why This Change Was Made

The accent precedence (user `ui.prefs.accent` → operator `ui.seamColor` → theme default) was confirmed as the product model in #128432; these two consumers must follow the same rule rather than each picking their own source.

## User Impact

- The native Talk overlay now uses the user's chosen accent when set, falling back to the operator seam color as before.
- Embedded widget iframes now receive theme token updates explicitly whenever the accent changes, instead of relying on incidental attribute re-sets.

## Evidence

- Regression test `talk.config prefers the user accent over the operator seam color` — proven to FAIL on pre-fix code, passes after; full `src/gateway/server-methods/talk.test.ts` suite green.
- Widget-theme unit test extended: observer options assert the `style` filter and a style-attribute mutation reposts theme to widget frames only.
- `pnpm check:changed`, `pnpm ui:build`, `ui/src/components/mcp-app-view.test.ts` (adjacent bridge) all green locally.
- Codex autoreview: clean pass (0.99), no actionable findings.
- Proof gap, stated: no live native Talk overlay capture — the change is a bounded deterministic config projection covered by the failing/passing regression test; the native app consumes the same `talk.config` payload key (`seamColor`) unchanged.
- Production LOC: +7/−3 (two-line precedence change + one observer filter entry + comments); tests +34/−3.


### UI-proof infeasibility (concrete)

Visual capture cannot discriminate this fix, so none is attached:

- **Widget frames**: pre-fix code already refreshed frames incidentally — `applyThemePresentation` re-sets `data-theme` in the same `theme.refresh()` publish that changes the accent, and attribute sets fire the observer even when values are unchanged. Before/after recordings are therefore pixel-identical; the fix removes the *incidental* coupling, and the discriminating evidence is the unit test asserting the explicit `style` attributeFilter and the repost on a style-only mutation.
- **Native Talk Mode**: the change is a server-side `talk.config` projection; the native overlay consumes the same `seamColor` payload key unchanged, so a capture would prove the (untouched) native renderer, not this diff. The discriminating evidence is the regression test proven to FAIL on pre-fix code.
