### PR TITLE
fix(cli): convert HEIC sequences in model runs

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -14,6 +14,14 @@ const PNG_1X1_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+yf7kAAAAASUVORK5CYII=";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+function createIsomBrandBuffer(brand: "hevc" | "msf1"): Buffer {
+  const buffer = Buffer.alloc(24);
+  buffer.writeUInt32BE(buffer.length, 0);
+  buffer.write("ftyp", 4, "ascii");
+  buffer.write(brand, 8, "ascii");
+  return buffer;
+}
+
 async function runCap(...argv: string[]): Promise<void> {
   const program = new Command();
   await registerCapabilityCli(program, ["node", "openclaw", ...argv]);
@@ -1282,6 +1290,54 @@ describe("capability cli", () => {
     expect(inputs).toHaveLength(1);
     expect(inputs[0]?.path).toBe(tempInput);
     expect(inputs[0]?.mimeType).toBe("image/jpeg");
+  });
+
+  it("normalizes sniffed HEIC sequences to JPEG before local model probes", async () => {
+    const source = createIsomBrandBuffer("hevc");
+    const tempInput = path.join(tempDirs.make("openclaw-model-run-heic-sequence-"), "opaque.bin");
+    await fs.writeFile(tempInput, source);
+
+    await runCapability("model", "run", "--prompt", "describe this", "--file", tempInput, "--json");
+
+    expect(mocks.convertHeicToJpeg).toHaveBeenCalledWith(source);
+    const call = firstCompletionCall();
+    expect(call?.context?.messages?.[0]?.content).toEqual([
+      { type: "text", text: "describe this" },
+      {
+        type: "image",
+        data: Buffer.from("jpeg-normalized").toString("base64"),
+        mimeType: "image/jpeg",
+      },
+    ]);
+    expect(firstJsonOutput()?.inputs).toEqual([{ path: tempInput, mimeType: "image/jpeg" }]);
+  });
+
+  it("normalizes sniffed HEIF sequences to JPEG before gateway model probes", async () => {
+    const source = createIsomBrandBuffer("msf1");
+    const tempInput = path.join(tempDirs.make("openclaw-model-run-heif-sequence-"), "opaque.bin");
+    await fs.writeFile(tempInput, source);
+
+    await runCapability(
+      "model",
+      "run",
+      "--prompt",
+      "describe this",
+      "--file",
+      tempInput,
+      "--gateway",
+      "--json",
+    );
+
+    expect(mocks.convertHeicToJpeg).toHaveBeenCalledWith(source);
+    expect(firstGatewayCall()?.params?.attachments).toEqual([
+      {
+        type: "image",
+        fileName: "opaque.bin",
+        mimeType: "image/jpeg",
+        content: Buffer.from("jpeg-normalized").toString("base64"),
+      },
+    ]);
+    expect(firstJsonOutput()?.inputs).toEqual([{ path: tempInput, mimeType: "image/jpeg" }]);
   });
 
   it("rejects non-image files for model probes", async () => {

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -53,7 +53,12 @@ import {
 } from "./shared.js";
 
 const LOCAL_MODEL_RUN_SYSTEM_PROMPT = "You are a personal assistant running inside OpenClaw.";
-const HEIC_MODEL_RUN_MIMES = new Set(["image/heic", "image/heif"]);
+const HEIC_MODEL_RUN_MIMES = new Set([
+  "image/heic",
+  "image/heic-sequence",
+  "image/heif",
+  "image/heif-sequence",
+]);
 
 async function loadModelCatalogForInspection(cfg: OpenClawConfig, agentId?: string) {
   const prepared = await loadPreparedModelCatalog({ config: cfg, agentId, readOnly: true });


### PR DESCRIPTION
Related to #128501

## What Problem This Solves

Fixes an issue where `openclaw capability model run --file` users could pass a HEIC or HEIF sequence image that was detected correctly but sent to the selected model provider without the required JPEG conversion. This affected both local and Gateway model probes.

## Why This Change Was Made

The model-run owner now treats the detector's existing `image/heic-sequence` and `image/heif-sequence` results the same as the still-image HEIC/HEIF aliases. The change reuses the established JPEG conversion path and does not add a new MIME detector, provider rule, config surface, or dependency.

## User Impact

Sequence-form HEIC and HEIF files now reach model providers as JPEG input in both local and Gateway model-run workflows, matching the behavior already established for ordinary HEIC/HEIF files.

## Evidence

- Before the production change, two focused CLI regressions used genuine ISO-BMFF `hevc` and `msf1` brands; the production detector identified the sequence MIME types, but both local and Gateway cases failed because `convertHeicToJpeg` was called zero times.
- After the change on the rebased head, `node scripts/run-vitest.mjs src/cli/capability-cli.test.ts` passed all 188 tests, including both sequence cases and the existing still-HEIC regression.
- `oxfmt --check` passed for both changed files; focused type-aware oxlint and `git diff --check` passed.
- Fresh Codex autoreview reported no accepted/actionable findings and judged the patch correct with 0.99 confidence; its TruffleHog preflight was clean.
- Testbox/Crabbox is not available on this host, so the broad remote `check:changed` lane was not run locally; exact-head GitHub CI remains the broad gate.
