### PR TITLE
refactor(command-explainer): unify argument projection

### DIFF
--- a/src/infra/command-explainer/extract.test.ts
+++ b/src/infra/command-explainer/extract.test.ts
@@ -279,6 +279,35 @@ describe("command explainer tree-sitter runtime", () => {
     expect(doubleBracket.topLevelCommands[0]?.argv).toEqual(["[[", "-f", "package.json"]);
   });
 
+  it.each([
+    ["echo 42 $VALUE", ["echo", "42", "$VALUE"], "echo", 2, "$VALUE"],
+    [
+      "export COUNT=42 NEXT=$VALUE",
+      ["export", "COUNT=42", "NEXT=$VALUE"],
+      "export",
+      2,
+      "NEXT=$VALUE",
+    ],
+    ["[[ 42 -gt $LIMIT ]]", ["[[", "42", "-gt", "$LIMIT"], "[[", 3, "$LIMIT"],
+  ] as const)("projects command arguments for %s", async (source, argv, command, index, text) => {
+    const explanation = await explainShellCommand(source);
+
+    expect(explanation.topLevelCommands[0]?.argv).toEqual(argv);
+    const risk = expectRisk(explanation.risks, {
+      kind: "dynamic-argument",
+      command,
+      argumentIndex: index,
+      text,
+    });
+    const startIndex = source.indexOf(text);
+    expect(risk.span).toEqual({
+      startIndex,
+      endIndex: startIndex + text.length,
+      startPosition: { row: 0, column: startIndex },
+      endPosition: { row: 0, column: startIndex + text.length },
+    });
+  });
+
   it("detects shell wrappers", async () => {
     const explanation = await explainShellCommand('bash -lc "echo hi | wc -c"');
 

--- a/src/infra/command-explainer/extract.ts
+++ b/src/infra/command-explainer/extract.ts
@@ -509,6 +509,21 @@ function shellWordValue(node: TreeSitterNode): ShellWordValue {
   }
 }
 
+function appendCommandArgument(node: TreeSitterNode, parsed: CommandArgv, state: WalkState): void {
+  const value = shellWordValue(node);
+  const argument = argumentFromNode(parsed.argv.length, node, value, state.spanBase);
+  parsed.arguments.push(argument);
+  if (value.kind === "dynamic") {
+    parsed.dynamicArguments.push({
+      index: argument.index,
+      text: argument.text,
+      value: argument.value,
+      span: argument.span,
+    });
+  }
+  parsed.argv.push(value.value);
+}
+
 function argvFromCommand(
   node: TreeSitterNode,
   nameNode: TreeSitterNode,
@@ -525,24 +540,14 @@ function argvFromCommand(
   const argv = [executable.value];
   const argumentsList: CommandArgument[] = [];
   const dynamicArguments: DynamicArgument[] = [];
+  const parsed: CommandArgv = { argv, arguments: argumentsList, dynamicArguments };
   for (const child of node.childrenForFieldName("argument")) {
     if (!COMMAND_ARGUMENT_NODE_TYPES.has(child.type)) {
       continue;
     }
-    const value = shellWordValue(child);
-    const argument = argumentFromNode(argv.length, child, value, state.spanBase);
-    argumentsList.push(argument);
-    if (value.kind === "dynamic") {
-      dynamicArguments.push({
-        index: argument.index,
-        text: argument.text,
-        value: argument.value,
-        span: argument.span,
-      });
-    }
-    argv.push(value.value);
+    appendCommandArgument(child, parsed, state);
   }
-  return { argv, arguments: argumentsList, dynamicArguments };
+  return parsed;
 }
 
 function firstShellToken(text: string): string {
@@ -557,50 +562,27 @@ function argvFromDeclarationCommand(node: TreeSitterNode, state: WalkState): Com
   const argv = [executable];
   const argumentsList: CommandArgument[] = [];
   const dynamicArguments: DynamicArgument[] = [];
+  const parsed: CommandArgv = { argv, arguments: argumentsList, dynamicArguments };
   for (const child of node.namedChildren) {
     if (!COMMAND_ARGUMENT_NODE_TYPES.has(child.type) && child.type !== "variable_assignment") {
       continue;
     }
-    const value = shellWordValue(child);
-    const argument = argumentFromNode(argv.length, child, value, state.spanBase);
-    argumentsList.push(argument);
-    if (value.kind === "dynamic") {
-      dynamicArguments.push({
-        index: argument.index,
-        text: argument.text,
-        value: argument.value,
-        span: argument.span,
-      });
-    }
-    argv.push(value.value);
+    appendCommandArgument(child, parsed, state);
   }
-  return { argv, arguments: argumentsList, dynamicArguments };
+  return parsed;
 }
 
 function appendTestCommandArguments(
   node: TreeSitterNode,
-  argv: string[],
-  argumentsList: CommandArgument[],
-  dynamicArguments: DynamicArgument[],
+  parsed: CommandArgv,
   state: WalkState,
 ): void {
   if (node.type === "test_operator" || COMMAND_ARGUMENT_NODE_TYPES.has(node.type)) {
-    const value = shellWordValue(node);
-    const argument = argumentFromNode(argv.length, node, value, state.spanBase);
-    argumentsList.push(argument);
-    if (value.kind === "dynamic") {
-      dynamicArguments.push({
-        index: argument.index,
-        text: argument.text,
-        value: argument.value,
-        span: argument.span,
-      });
-    }
-    argv.push(value.value);
+    appendCommandArgument(node, parsed, state);
     return;
   }
   for (const child of node.namedChildren) {
-    appendTestCommandArguments(child, argv, argumentsList, dynamicArguments, state);
+    appendTestCommandArguments(child, parsed, state);
   }
 }
 
@@ -613,10 +595,11 @@ function argvFromTestCommand(node: TreeSitterNode, state: WalkState): CommandArg
   const argv = [executable];
   const argumentsList: CommandArgument[] = [];
   const dynamicArguments: DynamicArgument[] = [];
+  const parsed: CommandArgv = { argv, arguments: argumentsList, dynamicArguments };
   for (const child of node.namedChildren) {
-    appendTestCommandArguments(child, argv, argumentsList, dynamicArguments, state);
+    appendTestCommandArguments(child, parsed, state);
   }
-  return { argv, arguments: argumentsList, dynamicArguments };
+  return parsed;
 }
 
 function isCommandLikeNode(node: TreeSitterNode): boolean {


### PR DESCRIPTION
## What Problem This Solves

The command explainer projected parsed shell arguments through three duplicated code paths for ordinary commands, declaration commands, and test commands. That duplication made argument indexes, source spans, decoded values, and dynamic-argument risks easier to change inconsistently.

## Why This Change Was Made

Argument projection now has one private owner that appends the decoded argv value, structured argument metadata, and optional dynamic risk metadata. Each parser path still owns its traversal, filtering, recursion, executable detection, and rejection policy.

Removed duplication: the three inline node-to-argument projection blocks.

Production LOC: +27/-44 (net -17). Test LOC: +29/-0.

## User Impact

No user-visible behavior changes. Command explanations retain their existing argv values, numeric-string handling, argument order, source spans, decoded offsets, and dynamic-risk reporting with less duplicated policy.

## Evidence

- `node scripts/run-vitest.mjs src/infra/command-explainer/extract.test.ts` - 26 passed
- command-explainer and authorization consumer suites - 85 passed across 7 files
- `node scripts/check-changed.mjs -- src/infra/command-explainer/extract.ts src/infra/command-explainer/extract.test.ts` - all scoped checks passed; the dead-export scan was rerun directly after materializing the tracked sparse `ui/config` sources and passed with zero entries
- targeted `oxfmt` check and `git diff --check` passed
- autoreview reported no accepted or actionable findings

AI-assisted: yes.

## Maintainer Validation

- Independent exact-head review: GO with no findings; 111/111 local and reviewer suites passed.
- Testbox: https://github.com/openclaw/openclaw/actions/runs/32699754500 - 111/111 focused tests; exact two-file changed gate 28/28; format, type, lint, dead-code, and diff checks green.
- Direct AWS Crabbox: https://crabbox.openclaw.ai/portal/runs/run_f03cf527f99b - 111/111 focused tests; exact changed gate and diff check green.
- Hosted CI is green on exact head `ed3a2fb21b470cfca0032cbb5ba5211586dedb71`.
- Current-main integration: both target blobs remain byte-identical to the reviewed parent anchor, GitHub reports the branch mergeable, and the synthetic merge applies cleanly. The optional no-op rebase is explicitly skipped in the maintainer decision comment.
