### PR TITLE
fix(agents): prevent false reminder warnings after compaction

### DIFF
--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -1658,15 +1658,14 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
   });
 
-  it("preserves deterministic side-effect liveness across compaction retries", () => {
+  it("preserves successful cron evidence and liveness across compaction retries", async () => {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();
 
-    subscribeEmbeddedAgentSession({
+    const subscription = subscribeEmbeddedAgentSession({
       session,
       runId: "run-cron-side-effect-compaction",
       onAgentEvent,
-      sessionKey: "test-session",
     });
 
     emitToolRun({
@@ -1677,7 +1676,12 @@ describe("subscribeEmbeddedAgentSession", () => {
       isError: false,
       result: { details: { status: "ok" } },
     });
+    await subscription.waitForPendingEvents();
+    expect(subscription.getSuccessfulCronAdds()).toBe(1);
     emit(retryingCompactionEnd());
+    await subscription.waitForPendingEvents();
+    expect(subscription.isCompacting()).toBe(true);
+    expect(subscription.getSuccessfulCronAdds()).toBe(1);
     emit({ type: "agent_end" });
 
     const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -435,7 +435,6 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     messagingToolSentMediaUrls.length = 0;
     pendingMessagingTexts.clear();
     pendingMessagingTargets.clear();
-    state.successfulCronAdds = 0;
     state.heartbeatToolResponse = undefined;
     state.pendingMessagingMediaUrls.clear();
     state.pendingToolMediaUrls = [];


### PR DESCRIPTION
Closes #43292

## What Problem This Solves

Fixes an issue where users who successfully scheduled an isolated-session reminder would receive a contradictory "I did not schedule a reminder" warning when context compaction retried the same agent turn.

## Why This Change Was Made

A successful cron addition is a committed, turn-wide side effect. Compaction can reset transient presentation state, but must preserve the recorded successful-add fact that the reminder guard consumes. The existing session-specific persisted-job check and unrelated-job isolation remain unchanged.

Maintainer scope decision: both concrete reproductions in #43292 require a successful current-turn cron add followed by compaction, and this change repairs both at the shared state owner. The issue's separate suggestion to match any prior isolated cron by agent ID is intentionally declined: an unrelated cron for the same agent would then suppress a truthful warning for another session, and there is no established persisted origin-session provenance contract. This preserves the issue review's existing recommendation to keep persisted-job matching session-specific while fixing and closing the actual reported same-turn bug.

## User Impact

Successfully scheduled reminders no longer produce false unscheduled-reminder warnings after context compaction. Genuine unscheduled reminders and reminders belonging to unrelated sessions retain their existing safeguards.

## Evidence

- Strengthened the existing owner-boundary compaction regression to record a successful cron add, drain pending events, prove compaction actually retried, and verify the successful-add count remains `1`.
- Before the production fix, that regression fails with `AssertionError: expected +0 to be 1`; after the one-line deletion, it passes.
- Four owner, cron-tool, compaction, and user-facing reminder test files passed: **364 tests**.
- Production type-check passed as part of the local changed-file gate.
- The exact agent-owner test type shard passed: `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.agents-root.json --builders 1`.
- Focused lint passed for both changed files: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts src/agents/embedded-agent-subscribe.ts`.
- The local changed-file gate passed 17 policy, formatting, and production-type checks, but its unrelated UI test shards hit existing missing `@panzoom/panzoom`/`@types/pako` dependencies and a pre-existing `ui/src/pages/chat/route-loader.ts` type error. Its optional dead-export scan was skipped with the documented `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1`; this change adds no exports.
- Independent source review and fresh Codex autoreview found no actionable issues.
- ClawSweeper independently ran the owner suite twice with **88/88 tests passing each time**. Its displayed live-verification failure is a reporter-only false negative: the harness searched standard Vitest output for an individual test title that the default reporter does not print; its own attached transcript shows both successful suite runs.
- Exact-head hosted CI passed, including the required `openclaw/ci-gate`, all production and test type-check stripes, lint, policy guards, and relevant test shards.
- Production diff: **+0/-1**; test diff: **+7/-3**.
