### PR TITLE
refactor(gateway): remove duplicate startup service lifecycle

### DIFF
--- a/src/gateway/server-core-runtime.ts
+++ b/src/gateway/server-core-runtime.ts
@@ -243,7 +243,7 @@ export async function startGatewayCoreRuntime(input: {
   );
   kernel.setEarlyRuntimeHandles(earlyRuntime);
 
-  const [{ startGatewayEventSubscriptions }, { startGatewayRuntimeServices }] =
+  const [{ startGatewayEventSubscriptions }, { startGatewayChannelHealthMonitor }] =
     await startupTrace.measure("runtime.post-early-imports", () =>
       Promise.all([
         import("./server-runtime-subscriptions.js"),
@@ -279,15 +279,9 @@ export async function startGatewayCoreRuntime(input: {
     await startupTrace.measure("runtime.subscriptions", () => eventSubscriptionsResident.start());
   Object.assign(runtimeState, runtimeSubscriptionUnsubs);
 
-  const runtimeServices = await startupTrace.measure("runtime.services", () =>
-    startGatewayRuntimeServices({
-      minimalTestGateway,
-      cfgAtStart,
-      channelManager,
-      log,
-    }),
+  await startupTrace.measure("runtime.services", () =>
+    kernel.setChannelHealthMonitor(startGatewayChannelHealthMonitor({ channelManager })),
   );
-  Object.assign(runtimeState, runtimeServices);
 
   const { createOperatorApprovalSessionEventRuntime } =
     await import("./operator-approval-session-events.js");

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -167,11 +167,8 @@ export function startManagedGatewayConfigReloader(
           assertOpenClawDatabasesReadyForRestart({ env: process.env }),
       ),
     restartRecoveryAvailable,
-    createHealthMonitor: (config) =>
-      startGatewayChannelHealthMonitor({
-        cfg: config,
-        channelManager: params.channelManager,
-      }),
+    createHealthMonitor: () =>
+      startGatewayChannelHealthMonitor({ channelManager: params.channelManager }),
   });
   const runManagedRestart = async (
     plan: GatewayReloadPlan,

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -1,6 +1,5 @@
 // Gateway mutable runtime handles.
 // Provides stop-safe defaults for timers, sidecars, subscriptions, and services.
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
 import type { GatewayHotReloadStatus } from "./config-reload-status.types.js";
@@ -9,6 +8,7 @@ import {
   type MediaCleanupStopResult,
   waitForMediaCleanupDrains,
 } from "./server-media-cleanup-lifecycle.js";
+import { createNoopHeartbeatRunner } from "./server-runtime-service-shared.js";
 import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
 
 // Mutable server handles track timers, sidecars, subscriptions, and service
@@ -67,10 +67,7 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
     stopMediaCleanup: () => waitForMediaCleanupDrains({ timeoutMs: MEDIA_CLEANUP_STOP_TIMEOUT_MS }),
     worktreeCleanup: null as ReturnType<typeof setInterval> | null,
     skillCuratorCleanup: () => {},
-    heartbeatRunner: {
-      stop: () => {},
-      updateConfig: (_cfg: OpenClawConfig) => {},
-    } satisfies HeartbeatRunner,
+    heartbeatRunner: createNoopHeartbeatRunner(),
     stopOutboundDeliveryRecovery: async () => {},
     stopGatewayUpdateCheck: () => {},
     tailscaleCleanup: null as (() => Promise<void>) | null,

--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -125,7 +125,6 @@ const {
   scheduleGatewayPostReadyMaintenance,
   startGatewayChannelHealthMonitor,
   startGatewayCronWithLogging,
-  startGatewayRuntimeServices,
 } = await import("./server-runtime-services.js");
 
 describe("server-runtime-services", () => {
@@ -174,32 +173,25 @@ describe("server-runtime-services", () => {
     resetGatewayWorkAdmission();
   });
 
-  it("keeps scheduled services inert during initial runtime setup", () => {
-    const services = startGatewayRuntimeServices({
-      minimalTestGateway: false,
-      cfgAtStart: {} as never,
+  it("starts channel health without activating scheduled services", () => {
+    startGatewayChannelHealthMonitor({
       channelManager: {
         getRuntimeSnapshot: vi.fn(),
         isHealthMonitorEnabled: vi.fn(),
         isManuallyStopped: vi.fn(),
       } as never,
-      log: createLog(),
     });
 
     expect(hoisted.startChannelHealthMonitor).toHaveBeenCalledTimes(1);
     expect(hoisted.startHeartbeatRunner).not.toHaveBeenCalled();
     expect(hoisted.startSessionUpstreamMonitor).not.toHaveBeenCalled();
     expect(hoisted.recoverPendingDeliveries).not.toHaveBeenCalled();
-
-    services.heartbeatRunner.stop();
-    expect(hoisted.heartbeatRunner.stop).not.toHaveBeenCalled();
   });
 
   it.each(["OPENCLAW_SKIP_CHANNELS", "OPENCLAW_SKIP_PROVIDERS"])(
     "keeps channel health recovery disabled when %s suppresses startup",
     (envKey) => {
       const monitor = startGatewayChannelHealthMonitor({
-        cfg: {} as never,
         channelManager: {} as never,
         env: { [envKey]: "1" },
       });

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -37,7 +37,6 @@ import {
 export { scheduleGatewayIdleTask, type GatewayIdleTaskHandle } from "./server-idle-task.js";
 export {
   startGatewayChannelHealthMonitor,
-  startGatewayRuntimeServices,
   type GatewayChannelManager,
 } from "./server-runtime-startup-services.js";
 

--- a/src/gateway/server-runtime-startup-services.ts
+++ b/src/gateway/server-runtime-startup-services.ts
@@ -1,24 +1,15 @@
 // Gateway startup-time runtime services.
-// Starts mode-dependent background monitors with inert handles for disabled paths.
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+// Starts mode-dependent background monitors for enabled channel paths.
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
-import {
-  createNoopHeartbeatRunner,
-  type GatewayRuntimeServiceLogger,
-} from "./server-runtime-service-shared.js";
 
-// Runtime startup services start only the background services needed by the
-// current gateway mode. Channel health is configurable; heartbeat/model pricing
-// currently use inert handles here and are wired by other startup paths.
 export type GatewayChannelManager = Parameters<
   typeof startChannelHealthMonitor
 >[0]["channelManager"];
 
-/** Starts channel health monitoring when gateway config enables it. */
+/** Starts channel health monitoring unless process configuration suppresses channels. */
 export function startGatewayChannelHealthMonitor(params: {
-  cfg: OpenClawConfig;
   channelManager: GatewayChannelManager;
   env?: NodeJS.ProcessEnv;
 }): ChannelHealthMonitor | null {
@@ -34,25 +25,4 @@ export function startGatewayChannelHealthMonitor(params: {
   return startChannelHealthMonitor({
     channelManager: params.channelManager,
   });
-}
-
-/** Starts background runtime services and returns their stop/update handles. */
-export function startGatewayRuntimeServices(params: {
-  minimalTestGateway: boolean;
-  cfgAtStart: OpenClawConfig;
-  channelManager: GatewayChannelManager;
-  log: GatewayRuntimeServiceLogger;
-}): {
-  heartbeatRunner: ReturnType<typeof createNoopHeartbeatRunner>;
-  channelHealthMonitor: ChannelHealthMonitor | null;
-} {
-  const channelHealthMonitor = startGatewayChannelHealthMonitor({
-    cfg: params.cfgAtStart,
-    channelManager: params.channelManager,
-  });
-
-  return {
-    heartbeatRunner: createNoopHeartbeatRunner(),
-    channelHealthMonitor,
-  };
 }


### PR DESCRIPTION
## What Problem This Solves

Gateway startup maintained two separate inert heartbeat handles and an extra runtime-service wrapper that carried unused startup configuration, logging, and test-mode arguments. Its channel health monitor also bypassed the existing lifecycle-owned publication boundary.

## Why This Change Was Made

Keep the original lifecycle-owned inert heartbeat until scheduled services activate, reuse its existing canonical constructor, and publish the channel health monitor directly through the Gateway kernel. Startup tracing, lazy loading, channel suppression, hot-reload replacement ordering, and shutdown ownership stay unchanged.

## User Impact

No user-visible behavior changes. Gateway startup and hot reload retain their existing behavior with one canonical heartbeat owner, a narrower monitor contract, and 43 fewer lines of production code.

## Evidence

- Production: +9/-52 (net -43); tests: +2/-10 (net -8).
- Focused Gateway proof: 310 tests across runtime services, mutable runtime handles, reload handlers, shutdown, and an actual isolated minimal Gateway boot all passed.
- Focused command: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-cleanup-lane4-vitest-cache node scripts/run-vitest.mjs --configLoader runner src/gateway/server-runtime-services.test.ts src/gateway/server-runtime-handles.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/server-close.test.ts src/gateway/server-startup-minimal-boot.test.ts`
- Local changed-gate routing was verified for the six touched core production/test files. The complete local gate cannot provide valid baseline evidence because this isolated worktree reuses an older checkout's dependency install, which lacks current unrelated UI dependencies and links stale workspace-package exports; use clean-source, exact-head hosted CI and the repository's mandatory hosted `scripts/pr prepare-run` gate instead.
- Structured autoreview: clean, with no accepted or actionable findings.
- Independent lifecycle review: accepted after verifying startup-failure unwind, minimal-mode suppression, hot-reload stop/wait/create/publish ordering, heartbeat updates, and shutdown ownership.
