### PR TITLE
refactor(tooling): reuse shared positive integer parsing

### DIFF
--- a/scripts/profile-extension-memory.mts
+++ b/scripts/profile-extension-memory.mts
@@ -13,6 +13,7 @@ import pMap from "p-map";
 import { ensureExtensionMemoryBuild } from "./ensure-extension-memory-build.mts";
 import { stripLeadingPackageManagerSeparator } from "./lib/arg-utils.mts";
 import { formatErrorMessage } from "./lib/error-format.mts";
+import { parsePositiveInt } from "./lib/numeric-options.mjs";
 
 const DEFAULT_CONCURRENCY = 6;
 const DEFAULT_TIMEOUT_MS = 90_000;
@@ -78,18 +79,6 @@ Examples:
 `);
 }
 
-function parsePositiveInt(raw: unknown, flagName: string): number {
-  const text = typeof raw === "string" || typeof raw === "number" ? String(raw).trim() : "";
-  if (!/^\d+$/u.test(text)) {
-    throw new Error(`${flagName} must be a positive integer`);
-  }
-  const parsed = Number(text);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`${flagName} must be a positive integer`);
-  }
-  return parsed;
-}
-
 /**
  * Parses extension memory profiler options after pnpm's optional separator.
  */
@@ -129,19 +118,19 @@ export function parseArgs(argv: string[]): {
         break;
       }
       case "--concurrency":
-        options.concurrency = parsePositiveInt(args[index + 1], arg);
+        options.concurrency = parsePositiveInt(args[index + 1] ?? "", arg);
         index += 1;
         break;
       case "--timeout-ms":
-        options.timeoutMs = parsePositiveInt(args[index + 1], arg);
+        options.timeoutMs = parsePositiveInt(args[index + 1] ?? "", arg);
         index += 1;
         break;
       case "--combined-timeout-ms":
-        options.combinedTimeoutMs = parsePositiveInt(args[index + 1], arg);
+        options.combinedTimeoutMs = parsePositiveInt(args[index + 1] ?? "", arg);
         index += 1;
         break;
       case "--top":
-        options.top = parsePositiveInt(args[index + 1], arg);
+        options.top = parsePositiveInt(args[index + 1] ?? "", arg);
         index += 1;
         break;
       case "--json": {

--- a/scripts/run-with-env.mts
+++ b/scripts/run-with-env.mts
@@ -1,6 +1,7 @@
 // Runs a command with inline KEY=value assignments while preserving signal behavior.
 import { spawn } from "node:child_process";
 import { terminateManagedChild } from "./lib/managed-child-process.mts";
+import { parsePositiveInt } from "./lib/numeric-options.mjs";
 
 const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=/u;
 const USAGE =
@@ -83,13 +84,7 @@ export function resolveForceKillDelayMs(env: NodeJS.ProcessEnv = process.env) {
   if (!text) {
     return 5_000;
   }
-  if (!/^\d+$/u.test(text)) {
-    throw new Error("OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS must be a positive integer");
-  }
-  const parsed = Number(text);
-  if (!Number.isSafeInteger(parsed) || parsed < 1) {
-    throw new Error("OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS must be a positive integer");
-  }
+  const parsed = parsePositiveInt(text, "OPENCLAW_RUN_WITH_ENV_FORCE_KILL_MS");
   return Math.min(parsed, MAX_TIMER_TIMEOUT_MS);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Repository maintenance tools independently implemented the same positive-integer validation in the plugin memory profiler and environment-wrapping command runner. Keeping separate copies makes numeric parsing easier to change inconsistently across developer workflows.

## Why This Change Was Made

Both scripts now use the existing dependency-free shared numeric option parser. The refactor preserves every existing default, whitespace and leading-zero rule, safe-integer bound, validation message, process exit behavior, and force-kill timeout clamp. The profiler already loaded this helper transitively, so the change does not expand its runtime dependency closure.

## User Impact

No user-visible behavior changes. Maintainers get one canonical positive-integer validation path and less duplicated tooling code.

## Evidence

- Production tooling: +7/-23 lines, net -16; no test changes.
- Focused owner and shared-helper suites: 47 tests passed across three files and two Vitest shards:
  `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-cleanup-lane5-vitest-cache node scripts/run-vitest.mjs --configLoader runner test/scripts/profile-extension-memory.test.ts test/scripts/run-with-env.test.ts test/scripts/numeric-options.test.ts`
- Real command-line probes preserved profiler rejection for malformed and missing values, environment-wrapper command passthrough, and exit-2 rejection of malformed force-kill settings.
- Independent review exercised all four profiler numeric flags against missing, blank, whitespace, zero, negative, exponent, hexadecimal, safe-limit, and unsafe-limit values; also verified wrapper defaults, leading zeros, the maximum timer clamp, exact messages, and import closure.
- Automated pre-commit review: clean, with no accepted or actionable findings.
- Targeted formatting and `git diff --check` both passed.
- Local whole-repository validation cannot represent this frozen source tree because the shared dependency install belongs to an older, independently dirty checkout and lacks this revision's UI dependencies. Exact-head hosted CI and the native Testbox-backed PR prepare gate provide the authoritative clean-checkout validation instead.
