### PR TITLE
fix(gateway): preserve active cloud sessions during maintenance

### DIFF
--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -445,7 +445,16 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
       identities: ["agent:main:subagent:child"],
       activeSessionKey: undefined,
     },
-  ] as const)("$name", async ({ storeName, preserved, identities, activeSessionKey }) => {
+    {
+      name: "preserves a cloud-owned session independently of the active writer",
+      storeName: "active-cloud-placement",
+      preserved: [["agent:main:explicit:cloud-owned", "cloud-placement-session"]],
+      identities: ["unrelated-writer-session"],
+      activeSessionKey: undefined,
+      providerKeys: ["agent:main:explicit:cloud-owned"],
+    },
+  ] as const)("$name", async (scenario) => {
+    const { storeName, preserved, identities, activeSessionKey } = scenario;
     const now = Date.now();
     const storePath = `/tmp/openclaw-sessions/${storeName}.json`;
     const store = makeStore([
@@ -461,6 +470,10 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
       identities: [...identities],
       assertAllowed: () => {},
     });
+    const unregisterProvider =
+      "providerKeys" in scenario
+        ? registerSessionMaintenancePreserveKeysProvider(() => scenario.providerKeys)
+        : undefined;
 
     try {
       await applyFileBackedSessionStoreMaintenance({
@@ -486,6 +499,7 @@ describe("applyFileBackedSessionStoreMaintenance", () => {
       expect(store["removable-recent"]).toBeUndefined();
     } finally {
       admission.release();
+      unregisterProvider?.();
     }
   });
 

--- a/src/gateway/server-worker-placement-startup-cleanup.test.ts
+++ b/src/gateway/server-worker-placement-startup-cleanup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { collectSessionMaintenancePreserveKeys } from "../config/sessions/store-maintenance-preserve.js";
 import { createDeferredCore } from "../shared/deferred.js";
 
 const runtimeFactoryMocks = vi.hoisted(() => ({
@@ -121,6 +122,10 @@ describe("worker placement startup cleanup ownership", () => {
         activeOwnerEpoch: claimLocalTurn ? null : 1,
         turnClaim: claimLocalTurn ? expect.objectContaining({ owner: "local" }) : null,
       });
+      const failedSessionKey = failed?.sessionKey;
+      if (!failedSessionKey) {
+        throw new Error("failed placement fixture is missing its session key");
+      }
       runtimeFactoryMocks.createSessionEvidenceResolver.mockResolvedValue(async () => "current");
       runtimeFactoryMocks.createDiskSpace.mockReturnValue({
         read: vi.fn(),
@@ -141,6 +146,7 @@ describe("worker placement startup cleanup ownership", () => {
       });
       try {
         expect(sidecar).not.toBeNull();
+        expect(collectSessionMaintenancePreserveKeys()?.has(failedSessionKey)).toBe(true);
         await environments.reconcileOnce();
         expect(provision).not.toHaveBeenCalled();
         expect(inspect).not.toHaveBeenCalled();
@@ -150,9 +156,16 @@ describe("worker placement startup cleanup ownership", () => {
           leaseId: null,
           destroyRequestedAtMs: expect.any(Number),
         });
+        workerEnvironmentSupport.testState.store.transition({
+          environmentId,
+          from: "provisioning",
+          to: "failed",
+        });
+        expect(collectSessionMaintenancePreserveKeys()?.has(failedSessionKey)).not.toBe(true);
       } finally {
         await sidecar?.stop();
       }
+      expect(collectSessionMaintenancePreserveKeys()?.has(failedSessionKey)).not.toBe(true);
     },
   );
 

--- a/src/gateway/server-worker-placement-startup-maintenance.test.ts
+++ b/src/gateway/server-worker-placement-startup-maintenance.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadSessionEntry, patchSessionEntryCore } from "../config/sessions/session-accessor.js";
+import { collectSessionMaintenancePreserveKeys } from "../config/sessions/store-maintenance-preserve.js";
+import { resolveMaintenanceConfigFromInput } from "../config/sessions/store-maintenance.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import type { WorkerSessionPlacementRecord } from "./worker-environments/placement-record.js";
+
+const runtimeFactoryMocks = vi.hoisted(() => ({
+  createDispatch: vi.fn(),
+  createDiskSpace: vi.fn(),
+  createSessionEvidenceResolver: vi.fn(),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config.js")>()),
+  getRuntimeConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("./worker-environments/placement-dispatch.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./worker-environments/placement-dispatch.js")>()),
+  createWorkerPlacementDispatchService: runtimeFactoryMocks.createDispatch,
+}));
+
+vi.mock("./server-worker-placement-session-evidence.js", () => ({
+  createWorkerPlacementSessionEvidenceResolver: runtimeFactoryMocks.createSessionEvidenceResolver,
+}));
+
+vi.mock("./worker-environments/placement-disk-space.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./worker-environments/placement-disk-space.js")>()),
+  createWorkerPlacementDiskSpaceMonitor: runtimeFactoryMocks.createDiskSpace,
+}));
+
+import { createGatewayWorkerPlacementRuntime } from "./server-worker-placement-startup.js";
+
+type PlacementFixture = {
+  sessionId: string;
+  sessionKey: string;
+  agentId: string;
+  state: WorkerSessionPlacementRecord["state"];
+  generation: number;
+  environmentId: string | null;
+  activeOwnerEpoch: number | null;
+  turnClaim: null;
+};
+
+function createPlacementFixture(
+  sessionKey: string,
+  state: WorkerSessionPlacementRecord["state"] = "active",
+): PlacementFixture {
+  const sessionId = `session-${sessionKey.slice(sessionKey.lastIndexOf(":") + 1)}`;
+  return {
+    sessionId,
+    sessionKey,
+    agentId: "main",
+    state,
+    generation: 1,
+    environmentId: state === "local" || state === "requested" ? null : `environment-${sessionId}`,
+    activeOwnerEpoch: state === "active" || state === "draining" ? 1 : null,
+    turnClaim: null,
+  };
+}
+
+function createMaintenanceRuntime(params: {
+  placements: PlacementFixture[];
+  onRecovery?: () => void;
+  recoveryError?: Error;
+  stopError?: Error;
+}) {
+  const forceDestroyEnvironment = vi.fn().mockResolvedValue(undefined);
+  const goneEnvironmentIds = new Set<string>();
+  runtimeFactoryMocks.createDiskSpace.mockReturnValue({
+    read: vi.fn(),
+    version: vi.fn(() => 0),
+    sweep: vi.fn().mockResolvedValue(undefined),
+  });
+  runtimeFactoryMocks.createDispatch.mockReturnValue({
+    dispatch: vi.fn(),
+    forceDestroyEnvironment,
+    reclaim: vi.fn(),
+    reconcile: vi.fn().mockResolvedValue(undefined),
+    reconcileActive: vi.fn().mockResolvedValue(undefined),
+  });
+  runtimeFactoryMocks.createSessionEvidenceResolver.mockResolvedValue(async () => "current");
+  const stop = vi.fn().mockResolvedValue(undefined);
+  if (params.stopError) {
+    stop.mockRejectedValueOnce(params.stopError);
+  }
+  const environments = {
+    get: (environmentId: string) =>
+      goneEnvironmentIds.has(environmentId)
+        ? { state: "destroyed" as const, leaseId: null }
+        : { state: "attached" as const, leaseId: "cloud-lease" },
+    installReconcileEnvironmentGuard: vi.fn(() => vi.fn()),
+    start: vi.fn(),
+    stop,
+  };
+  const runtime = createGatewayWorkerPlacementRuntime({
+    placements: {
+      workspaceResultInstanceId: () => "gateway-test",
+      get: (sessionId: string) =>
+        params.placements.find((placement) => placement.sessionId === sessionId),
+      list: () => params.placements,
+      listForReconcile: () =>
+        params.placements.filter(
+          (placement) => placement.state !== "local" && placement.state !== "reclaimed",
+        ),
+      retireSessionPlacement: vi.fn(),
+      pruneOrphanedWorkspaceReconciliations: () => {
+        params.onRecovery?.();
+        if (params.recoveryError) {
+          throw params.recoveryError;
+        }
+        return [];
+      },
+      listWorkspaceReconciliationOwners: () => [],
+      listPendingWorkspaceResults: () => [],
+    } as never,
+    environments: environments as never,
+    gatewayNamespace: "gateway-test",
+    revokeSessionAuthority: vi.fn(),
+    warn: vi.fn(),
+  });
+  return { environments, forceDestroyEnvironment, goneEnvironmentIds, runtime };
+}
+
+async function startMaintenanceRuntime(
+  runtime: ReturnType<typeof createGatewayWorkerPlacementRuntime>,
+) {
+  const sidecar = await runtime.startRuntime({
+    isClosePreludeStarted: () => false,
+    registerSidecar: vi.fn(),
+    unregisterSidecar: vi.fn(),
+  });
+  if (!sidecar) {
+    throw new Error("worker placement runtime did not start");
+  }
+  return sidecar;
+}
+
+describe("worker placement session maintenance ownership", () => {
+  it.each([
+    { maintenance: "dashboard archive", sessionKey: "agent:main:dashboard:cloud-owned" },
+    { maintenance: "stale pruning", sessionKey: "agent:main:explicit:cloud-owned-prune" },
+    { maintenance: "entry capping", sessionKey: "agent:main:explicit:cloud-owned-cap" },
+  ] as const)(
+    "preserves active placements during write-triggered $maintenance and releases them on stop",
+    async ({ maintenance, sessionKey }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+        const now = Date.now();
+        const placement = createPlacementFixture(sessionKey);
+        const storePath = resolveOpenClawAgentSqlitePath({ agentId: "main", env: state.env });
+        const sessionScope = (key: string) => ({
+          agentId: "main",
+          env: state.env,
+          sessionKey: key,
+          storePath,
+        });
+        const entry = {
+          sessionId: placement.sessionId,
+          updatedAt: maintenance === "entry capping" ? now - 1_000 : now - 31 * 86_400_000,
+        };
+        await patchSessionEntryCore(sessionScope(sessionKey), () => entry, {
+          fallbackEntry: entry,
+          replaceEntry: true,
+          skipMaintenance: true,
+        });
+        const { forceDestroyEnvironment, runtime } = createMaintenanceRuntime({
+          placements: [placement],
+        });
+        runtimeFactoryMocks.createSessionEvidenceResolver.mockImplementation(
+          async () => async (candidate: { sessionKey: string }) =>
+            loadSessionEntry(sessionScope(candidate.sessionKey)) ? "current" : "absent",
+        );
+        const sidecar = await startMaintenanceRuntime(runtime);
+        const triggerEntry = { sessionId: "maintenance-trigger", updatedAt: now };
+        const maintenanceConfig = resolveMaintenanceConfigFromInput({
+          mode: "enforce",
+          archiveDashboardAfter: "7d",
+          pruneAfter: "30d",
+          maxEntries: maintenance === "entry capping" ? 1 : 500,
+          maxDiskBytes: false,
+        });
+        const triggerMaintenance = async () =>
+          await patchSessionEntryCore(
+            sessionScope("agent:main:explicit:maintenance-trigger"),
+            () => triggerEntry,
+            { fallbackEntry: triggerEntry, maintenanceConfig },
+          );
+
+        try {
+          await triggerMaintenance();
+          expect(loadSessionEntry(sessionScope(sessionKey))).toMatchObject({
+            sessionId: placement.sessionId,
+          });
+          expect(loadSessionEntry(sessionScope(sessionKey))?.archivedAt).toBeUndefined();
+          expect(forceDestroyEnvironment).not.toHaveBeenCalled();
+          expect(collectSessionMaintenancePreserveKeys()?.has(sessionKey)).toBe(true);
+
+          await sidecar.stop();
+          expect(collectSessionMaintenancePreserveKeys()?.has(sessionKey)).not.toBe(true);
+          await triggerMaintenance();
+          if (maintenance === "dashboard archive") {
+            expect(loadSessionEntry(sessionScope(sessionKey))?.archivedAt).toEqual(
+              expect.any(Number),
+            );
+          } else {
+            expect(loadSessionEntry(sessionScope(sessionKey))).toBeUndefined();
+          }
+        } finally {
+          await sidecar.stop();
+        }
+      });
+    },
+  );
+
+  it("preserves every remote-owning state and releases failed placements once their environment is gone", async () => {
+    const remoteOwningStates = [
+      "requested",
+      "provisioning",
+      "syncing",
+      "starting",
+      "active",
+      "draining",
+      "reconciling",
+    ] as const;
+    const protectedPlacements = remoteOwningStates.map((placementState) =>
+      createPlacementFixture(`agent:main:placement-${placementState}`, placementState),
+    );
+    const failedLive = createPlacementFixture("agent:main:failed-live", "failed");
+    const failedGone = createPlacementFixture("agent:main:failed-gone", "failed");
+    const local = createPlacementFixture("agent:main:placement-local", "local");
+    const reclaimed = createPlacementFixture("agent:main:placement-reclaimed", "reclaimed");
+    const { goneEnvironmentIds, runtime } = createMaintenanceRuntime({
+      placements: [...protectedPlacements, failedLive, failedGone, local, reclaimed],
+    });
+    if (!failedLive.environmentId || !failedGone.environmentId) {
+      throw new Error("failed placement fixtures are missing environment identities");
+    }
+    goneEnvironmentIds.add(failedGone.environmentId);
+    const sidecar = await startMaintenanceRuntime(runtime);
+
+    try {
+      const preserveKeys = collectSessionMaintenancePreserveKeys();
+      for (const placement of [...protectedPlacements, failedLive]) {
+        expect(preserveKeys?.has(placement.sessionKey)).toBe(true);
+      }
+      for (const placement of [local, reclaimed, failedGone]) {
+        expect(preserveKeys?.has(placement.sessionKey)).not.toBe(true);
+      }
+
+      goneEnvironmentIds.add(failedLive.environmentId);
+      expect(collectSessionMaintenancePreserveKeys()?.has(failedLive.sessionKey)).not.toBe(true);
+    } finally {
+      await sidecar.stop();
+    }
+    expect(collectSessionMaintenancePreserveKeys()?.has("agent:main:placement-requested")).not.toBe(
+      true,
+    );
+  });
+
+  it("unregisters preservation synchronously when environment stop fails and is retried", async () => {
+    const stopError = new Error("tunnel cleanup failed");
+    const placement = createPlacementFixture("agent:main:failed-stop");
+    const { environments, runtime } = createMaintenanceRuntime({
+      placements: [placement],
+      stopError,
+    });
+    const sidecar = await startMaintenanceRuntime(runtime);
+
+    expect(collectSessionMaintenancePreserveKeys()?.has(placement.sessionKey)).toBe(true);
+    const firstStop = sidecar.stop();
+    expect(collectSessionMaintenancePreserveKeys()?.has(placement.sessionKey)).not.toBe(true);
+    expect(sidecar.stop()).toBe(firstStop);
+    await expect(firstStop).rejects.toBe(stopError);
+    await expect(sidecar.stop()).resolves.toBeUndefined();
+    expect(environments.stop).toHaveBeenCalledTimes(2);
+  });
+
+  it("unregisters preservation and its sidecar when initial workspace recovery fails", async () => {
+    const recoveryError = new Error("workspace reconciliation inventory failed");
+    const placement = createPlacementFixture("agent:main:failed-recovery");
+    let protectedDuringRecovery = false;
+    const { environments, runtime } = createMaintenanceRuntime({
+      placements: [placement],
+      recoveryError,
+      onRecovery: () => {
+        protectedDuringRecovery =
+          collectSessionMaintenancePreserveKeys()?.has(placement.sessionKey) === true;
+      },
+    });
+    const registerSidecar = vi.fn();
+    const unregisterSidecar = vi.fn();
+
+    await expect(
+      runtime.startRuntime({
+        isClosePreludeStarted: () => false,
+        registerSidecar,
+        unregisterSidecar,
+      }),
+    ).rejects.toBe(recoveryError);
+
+    expect(protectedDuringRecovery).toBe(true);
+    expect(registerSidecar).toHaveBeenCalledOnce();
+    expect(unregisterSidecar).toHaveBeenCalledWith(registerSidecar.mock.calls[0]?.[0]);
+    expect(environments.stop).toHaveBeenCalledOnce();
+    expect(collectSessionMaintenancePreserveKeys()?.has(placement.sessionKey)).not.toBe(true);
+  });
+});

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -2,6 +2,7 @@ import { resolveConfiguredGitHubToolIdentity } from "../agents/github-tool-ident
 import { installSessionPlacementAdmissionProvider } from "../agents/session-placement-admission.js";
 import { clearSessionQueues } from "../auto-reply/reply/queue/cleanup.js";
 import { getRuntimeConfig } from "../config/config.js";
+import { registerSessionMaintenancePreserveKeysProvider } from "../config/sessions/store-maintenance-preserve.js";
 import { runExclusiveSessionStoreWrite } from "../config/sessions/store-writer.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -36,6 +37,7 @@ import { createPlacementSessionRetirement } from "./worker-environments/placemen
 import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
 import { createReclaimedPlacementRedispatch } from "./worker-environments/reclaimed-placement-redispatch.js";
 import type { WorkerEnvironmentService } from "./worker-environments/service.js";
+import { isFailedWorkerPlacementEnvironmentGone } from "./worker-environments/session-placement-lifecycle.js";
 import { createWorkerSessionTurnPlacementProvider } from "./worker-environments/worker-turn-launcher.js";
 import { createWorkerWorkspaceOperationCoordinator } from "./worker-environments/workspace-operation-coordinator.js";
 import { recoverWorkerWorkspaceReconciliation } from "./worker-environments/workspace-reconcile.js";
@@ -506,6 +508,19 @@ export function createGatewayWorkerPlacementRuntime(
       dispatch: dispatchService,
       isStopping: () => stopped,
     });
+    // Session evidence must survive until its remote owner has been reclaimed or proven gone.
+    const uninstallSessionMaintenancePreservation = registerSessionMaintenancePreserveKeysProvider(
+      () =>
+        params.placements.listForReconcile().flatMap((placement) =>
+          placement.state === "failed" &&
+          isFailedWorkerPlacementEnvironmentGone({
+            environmentService: params.environments,
+            placement,
+          })
+            ? []
+            : [placement.sessionKey],
+        ),
+    );
     const trackOperation = (
       slot: { current: Promise<void> | undefined },
       current: Promise<void>,
@@ -580,6 +595,7 @@ export function createGatewayWorkerPlacementRuntime(
           clearInterval(placementReconcileInterval);
           placementReconcileInterval = undefined;
           uninstallSessionIdentityMutation();
+          uninstallSessionMaintenancePreservation();
           uninstallPlacementAdmission();
         }
         const currentStop = (async () => {
@@ -608,26 +624,26 @@ export function createGatewayWorkerPlacementRuntime(
       hooks.unregisterSidecar(sidecar);
       return null;
     };
-    // Track startup reconciliation in the placement slot so a concurrent
-    // close prelude drains it before uninstalling guards and stopping environments.
-    const startupRecovery = recoverPendingWorkspaceReconciliations();
-    placementReconcile.current = startupRecovery;
     try {
-      await startupRecovery;
-    } finally {
-      if (placementReconcile.current === startupRecovery) {
-        placementReconcile.current = undefined;
+      // Track startup reconciliation in the placement slot so a concurrent
+      // close prelude drains it before uninstalling guards and stopping environments.
+      const startupRecovery = recoverPendingWorkspaceReconciliations();
+      placementReconcile.current = startupRecovery;
+      try {
+        await startupRecovery;
+      } finally {
+        if (placementReconcile.current === startupRecovery) {
+          placementReconcile.current = undefined;
+        }
       }
-    }
-    if (hooks.isClosePreludeStarted()) {
-      return await stopBeforeReady();
-    }
-    const startupReconcile = (async () => {
-      await dispatchService.reconcile("startup");
-      await reconcilePublications();
-    })();
-    placementReconcile.current = startupReconcile;
-    try {
+      if (hooks.isClosePreludeStarted()) {
+        return await stopBeforeReady();
+      }
+      const startupReconcile = (async () => {
+        await dispatchService.reconcile("startup");
+        await reconcilePublications();
+      })();
+      placementReconcile.current = startupReconcile;
       try {
         await startupReconcile;
       } finally {


### PR DESCRIPTION
Closes #128585

## What Problem This Solves

Fixes an issue where automatic session maintenance could archive or delete a session that still owned an active or recoverable cloud-worker placement. That left the external worker lifecycle referring to a session the operator could no longer access.

## Why This Change Was Made

The placement startup owner now registers its live session keys with the existing session-maintenance preserve boundary and unregisters them during shutdown. It preserves requested through reconciling placements, plus failed placements whose environment is not authoritatively gone, while allowing local, reclaimed, and environment-gone failures to age out. The same startup owner now also keeps initial workspace recovery inside its cleanup-protected boundary so partial startup cannot leak placement resources.

Production LOC: +34/-18 (net +16) | Tests: +337/-1

The production growth establishes a lifecycle ownership boundary that did not exist: session maintenance can now ask the active placement runtime which session rows must remain reachable, and startup cleanup covers the recovery operation it owns.

AI-assisted: yes. I reviewed session maintenance triggers, runtime preserve-key registration, placement terminal states, environment-gone handling, startup cleanup, and shutdown ordering and understand the change.

## User Impact

Cloud sessions remain visible and recoverable while their worker placement is active. Once placement ownership has actually settled, normal archive, prune, and cap maintenance resumes without retaining stale sessions forever.

## Evidence

- Pre-fix SQLite-write regressions reproduced all three destructive maintenance paths: stale dashboard archive, stale pruning, and max-entry capping.
- Post-rebase focused proof: 9 Gateway placement/startup tests and 56 session-maintenance tests passed.
- Full changed-file gate: `node scripts/check-changed.mjs` passed.
- Fresh autoreview before the patch-identical rebase: no accepted/actionable findings (0.96).
- Coverage includes requested, provisioning, syncing, starting, active, draining, reconciling, recoverable failed, environment-gone failed, local, and reclaimed placement states, plus unregister-on-stop and initial-recovery cleanup.
