### PR TITLE
fix(cli): reject nonexistent transcript summary paths

### DIFF
--- a/src/cli/program/register.transcripts.test.ts
+++ b/src/cli/program/register.transcripts.test.ts
@@ -130,7 +130,15 @@ describe("transcripts CLI", () => {
       session: { sessionId: "active-session" },
       summary: null,
     });
+    expect(JSON.parse(await runTranscriptsCli(["path", "active-session", "--json"]))).toMatchObject(
+      {
+        exists: false,
+      },
+    );
     await expect(runTranscriptsCli(["show", "active-session"])).rejects.toThrow(
+      "summary.md not found",
+    );
+    await expect(runTranscriptsCli(["path", "active-session"])).rejects.toThrow(
       "summary.md not found",
     );
   });

--- a/src/cli/program/register.transcripts.ts
+++ b/src/cli/program/register.transcripts.ts
@@ -50,14 +50,6 @@ function formatSessionLine(entry: TranscriptsSessionEntry): string {
   return `${entry.selector}\t${started}\t${title}\t${summary}`;
 }
 
-async function requireStoredSession(selector: string): Promise<TranscriptsSessionEntry> {
-  const session = await createStore().readSessionEntry(selector);
-  if (!session) {
-    throw new Error(`transcripts session not found: ${selector}`);
-  }
-  return session;
-}
-
 async function listCommand(options: TranscriptsCliOptions): Promise<void> {
   const sessions = await createStore().listSessionEntries();
   if (options.json) {
@@ -132,7 +124,10 @@ function selectedArtifactKind(options: TranscriptsPathOptions): TranscriptArtifa
 
 async function pathCommand(selector: string, options: TranscriptsPathOptions): Promise<void> {
   const store = createStore();
-  const entry = await requireStoredSession(selector);
+  const entry = await store.readSessionEntry(selector);
+  if (!entry) {
+    throw new Error(`transcripts session not found: ${selector}`);
+  }
   const kind = selectedArtifactKind(options);
   const artifacts = await store.materializeSessionArtifacts(entry.session, kind);
   const selectedPath = options.dir
@@ -151,6 +146,9 @@ async function pathCommand(selector: string, options: TranscriptsPathOptions): P
       exists,
     });
     return;
+  }
+  if (!exists) {
+    throw new Error(`summary.md not found for transcripts session: ${selector}`);
   }
   writeLine(selectedPath);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw transcripts path <session>` for an active session without a summary would receive a successful command and a nonexistent `summary.md` path. This silently misled operators and downstream shell commands into treating an unavailable export as real.

## Why This Change Was Made

Make the plain-text path command honor the same missing-summary contract as its sibling `transcripts show` command while preserving the documented machine-readable `path --json` response with `exists: false`. Reuse the path command's existing transcript store for both session lookup and export, removing a redundant helper and a second store opening.

## User Impact

The normal transcript summary path command now clearly reports when a summary has not been created, while JSON consumers continue receiving the existing availability field. Metadata, raw transcript, session-directory exports, ambiguous selectors, and valid completed summaries retain their existing behavior.

## Evidence

- Extended the existing real CLI-parser active-session fixture to verify both `path --json` reporting `exists: false` and plain `path` rejecting the missing summary. The new plain-text assertion fails against current main because the command resolves successfully with a nonexistent path.
- Run `node scripts/run-vitest.mjs src/cli/program/register.transcripts.test.ts src/transcripts/store.test.ts`: 30 CLI and artifact-owner tests pass across both actual Vitest lanes.
- Run `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile /private/tmp/openclaw-transcript-core.tsbuildinfo` and `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.config-cli.json --builders 1`: core production and CLI-test type checks both pass.
- Run `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/program/register.transcripts.ts src/cli/program/register.transcripts.test.ts`, targeted `oxfmt --check`, and `git diff --check`.
- Fresh independent read-only local review confirms valid/missing/ambiguous sessions, JSON output, metadata/transcript/directory exports, sibling show behavior, and existing environment/database cleanup: CLEAN, no actionable findings.
- Production delta: +7/-9, net **-2** lines. Only the CLI owner and its existing colocated test change; no storage implementation, database schema, configuration, public flags, authentication, or protocol changes.
