### PR TITLE
fix(cli): render agent identity JSON failures

### DIFF
--- a/src/commands/agents.commands.identity.ts
+++ b/src/commands/agents.commands.identity.ts
@@ -10,6 +10,7 @@ import {
 } from "../agents/agent-scope.js";
 import { loadAgentIdentityFromFile } from "../agents/identity-file.js";
 import { DEFAULT_IDENTITY_FILENAME } from "../agents/workspace.js";
+import { ExpectedCliError } from "../cli/failure-output.js";
 import { replaceConfigFile } from "../config/config.js";
 import { migratePersistedImplicitMainRoster } from "../config/legacy.roster.js";
 import { logConfigUpdated } from "../config/logging.js";
@@ -40,6 +41,10 @@ type AgentsSetIdentityOptions = {
 };
 
 const normalizeWorkspacePath = (input: string) => path.resolve(resolveUserPath(input));
+
+function failAgentIdentity(message: string): never {
+  throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
+}
 
 function resolveAgentIdByWorkspace(
   cfg: Parameters<typeof resolveAgentWorkspaceDir>[0],
@@ -81,9 +86,7 @@ export async function agentsSetIdentityCommand(
   const wantsIdentityFile = Boolean(opts.fromIdentity || identityFileRaw || !hasExplicitIdentity);
   const normalizedAgent = opts.agent === undefined ? null : normalizeAgentIdStrict(opts.agent);
   if (normalizedAgent && !normalizedAgent.ok) {
-    runtime.error(`Agent "${opts.agent}" not found. Create it with \`openclaw agents add\`.`);
-    runtime.exit(1);
-    return;
+    failAgentIdentity(`Agent "${opts.agent}" not found. Create it with \`openclaw agents add\`.`);
   }
   let agentId = normalizedAgent?.value;
 
@@ -102,25 +105,17 @@ export async function agentsSetIdentityCommand(
   }
 
   if (!agentId) {
-    if (!workspaceDir) {
-      runtime.error("Select an agent with --agent or provide a workspace via --workspace.");
-      runtime.exit(1);
-      return;
-    }
-    const matches = resolveAgentIdByWorkspace(cfg, workspaceDir);
+    const resolvedWorkspace = expectDefined(workspaceDir, "agent workspace");
+    const matches = resolveAgentIdByWorkspace(cfg, resolvedWorkspace);
     if (matches.length === 0) {
-      runtime.error(
-        `No agent workspace matches ${shortenHomePath(workspaceDir)}. Pass --agent to target a specific agent.`,
+      failAgentIdentity(
+        `No agent workspace matches ${shortenHomePath(resolvedWorkspace)}. Pass --agent to target a specific agent.`,
       );
-      runtime.exit(1);
-      return;
     }
     if (matches.length > 1) {
-      runtime.error(
-        `Multiple agents match ${shortenHomePath(workspaceDir)}: ${matches.join(", ")}. Pass --agent to choose one.`,
+      failAgentIdentity(
+        `Multiple agents match ${shortenHomePath(resolvedWorkspace)}: ${matches.join(", ")}. Pass --agent to choose one.`,
       );
-      runtime.exit(1);
-      return;
     }
     agentId = matches[0];
   }
@@ -128,9 +123,9 @@ export async function agentsSetIdentityCommand(
   const resolvedAgentId = expectDefined(agentId, "agent id");
   const resolvedAgentIds = listAgentIds(cfg).map((id) => normalizeAgentId(id));
   if (!resolvedAgentIds.includes(resolvedAgentId)) {
-    runtime.error(`Agent "${resolvedAgentId}" not found. Create it with \`openclaw agents add\`.`);
-    runtime.exit(1);
-    return;
+    failAgentIdentity(
+      `Agent "${resolvedAgentId}" not found. Create it with \`openclaw agents add\`.`,
+    );
   }
   const list = listAgentEntries(cfg);
   const index = findAgentEntryIndex(list, resolvedAgentId);
@@ -141,9 +136,7 @@ export async function agentsSetIdentityCommand(
       try {
         identityFromFile = await loadAgentIdentityFromFile(identityFilePath);
       } catch (error) {
-        runtime.error(formatErrorMessage(error));
-        runtime.exit(1);
-        return;
+        failAgentIdentity(formatErrorMessage(error));
       }
     } else if (workspaceDir) {
       identityFromFile = loadAgentIdentity(workspaceDir);
@@ -152,9 +145,7 @@ export async function agentsSetIdentityCommand(
       const targetPath =
         identityFilePath ??
         (workspaceDir ? path.join(workspaceDir, DEFAULT_IDENTITY_FILENAME) : "IDENTITY.md");
-      runtime.error(`No identity data found in ${shortenHomePath(targetPath)}.`);
-      runtime.exit(1);
-      return;
+      failAgentIdentity(`No identity data found in ${shortenHomePath(targetPath)}.`);
     }
   }
 
@@ -168,19 +159,6 @@ export async function agentsSetIdentityCommand(
       ? { avatar: avatarRaw ?? identityFromFile?.avatar }
       : {}),
   };
-
-  if (
-    !incomingIdentity.name &&
-    !incomingIdentity.emoji &&
-    !incomingIdentity.theme &&
-    !incomingIdentity.avatar
-  ) {
-    runtime.error(
-      "No identity fields provided. Use --name/--emoji/--theme/--avatar or --from-identity.",
-    );
-    runtime.exit(1);
-    return;
-  }
 
   const base: AgentConfig =
     index >= 0 ? expectDefined(list[index], "agent config") : { id: resolvedAgentId };

--- a/src/commands/agents.identity.test.ts
+++ b/src/commands/agents.identity.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExpectedCliError } from "../cli/failure-output.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import {
   baseConfigSnapshot,
@@ -64,6 +65,21 @@ async function runIdentityCommandFromWorkspace(workspace: string, fromIdentity =
     config: { agents: { entries: { main: { workspace } } } },
   });
   await agentsSetIdentityCommand({ workspace, fromIdentity }, runtime);
+}
+
+async function expectIdentityCommandFailure(
+  options: Parameters<typeof agentsSetIdentityCommand>[0],
+  message: string,
+) {
+  await expect(agentsSetIdentityCommand(options, runtime)).rejects.toMatchObject({
+    name: "ExpectedCliError",
+    message,
+    humanOutput: message,
+    machineOutput: message,
+  });
+  expect(runtime.error).not.toHaveBeenCalled();
+  expect(runtime.exit).not.toHaveBeenCalled();
+  expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
 }
 
 describe("agents set-identity command", () => {
@@ -130,7 +146,8 @@ describe("agents set-identity command", () => {
 
   it("errors when multiple agents match the same workspace", async () => {
     const { workspace } = await createIdentityWorkspace("shared");
-    await writeIdentityFile(workspace, ["- Name: Echo"]);
+    const identityPath = await writeIdentityFile(workspace, ["- Name: Echo"]);
+    const originalIdentity = await fs.readFile(identityPath, "utf8");
 
     configMocks.readConfigFileSnapshot.mockResolvedValue({
       ...baseConfigSnapshot,
@@ -141,13 +158,28 @@ describe("agents set-identity command", () => {
       },
     });
 
-    await agentsSetIdentityCommand({ workspace }, runtime);
-
-    expect(runtime.error).toHaveBeenCalledWith(
+    await expectIdentityCommandFailure(
+      { workspace },
       `Multiple agents match ${workspace}: main, ops. Pass --agent to choose one.`,
     );
-    expect(runtime.exit).toHaveBeenCalledWith(1);
-    expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    await expect(fs.readFile(identityPath, "utf8")).resolves.toBe(originalIdentity);
+  });
+
+  it("rejects an unmatched workspace before reading or changing its identity file", async () => {
+    const { workspace } = await createIdentityWorkspace("unmatched");
+    const identityPath = await writeIdentityFile(workspace, ["- Name: Untouched"]);
+    const originalIdentity = await fs.readFile(identityPath, "utf8");
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: { agents: { entries: { main: {} } } },
+    });
+
+    await expectIdentityCommandFailure(
+      { workspace, name: "Override", json: true },
+      `No agent workspace matches ${workspace}. Pass --agent to target a specific agent.`,
+    );
+
+    await expect(fs.readFile(identityPath, "utf8")).resolves.toBe(originalIdentity);
   });
 
   it("overrides identity file values with explicit flags", async () => {
@@ -269,13 +301,10 @@ describe("agents set-identity command", () => {
         config: { agents: { entries: { main: {} } } },
       });
 
-      await agentsSetIdentityCommand({ agent, name: "Ghost" }, runtime);
-
-      expect(runtime.error).toHaveBeenCalledWith(
+      await expectIdentityCommandFailure(
+        { agent, name: "Ghost", json: true },
         `Agent "${agent}" not found. Create it with \`openclaw agents add\`.`,
       );
-      expect(runtime.exit).toHaveBeenCalledWith(1);
-      expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
     },
   );
 
@@ -287,15 +316,25 @@ describe("agents set-identity command", () => {
         config: { agents: { entries: { ops: {} } } },
       });
 
-      await agentsSetIdentityCommand({ agent: agentId, name: "Hijack" }, runtime);
-
-      expect(runtime.error).toHaveBeenCalledWith(
+      await expectIdentityCommandFailure(
+        { agent: agentId, name: "Hijack" },
         `Agent "${agentId}" not found. Create it with \`openclaw agents add\`.`,
       );
-      expect(runtime.exit).toHaveBeenCalledWith(1);
-      expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
     },
   );
+
+  it("rejects an unknown agent before attempting to read its explicit identity file", async () => {
+    const { workspace } = await createIdentityWorkspace();
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: { agents: { entries: { main: { workspace } } } },
+    });
+
+    await expectIdentityCommandFailure(
+      { agent: "ghost", identityFile: path.join(workspace, "missing.md"), json: true },
+      'Agent "ghost" not found. Create it with `openclaw agents add`.',
+    );
+  });
 
   it("still updates a real existing agent", async () => {
     configMocks.readConfigFileSnapshot.mockResolvedValue({
@@ -353,27 +392,55 @@ describe("agents set-identity command", () => {
       config: { agents: { entries: { main: {} } } },
     });
 
-    await agentsSetIdentityCommand({ agent: "main", identityFile: identityPath }, runtime);
+    const originalIdentity = await fs.readFile(identityPath, "utf8");
+    const error = await agentsSetIdentityCommand(
+      { agent: "main", identityFile: identityPath, json: true },
+      runtime,
+    ).catch((caught: unknown) => caught);
 
-    const renderedError = String(runtime.error.mock.calls[0]?.[0]);
+    expect(error).toBeInstanceOf(ExpectedCliError);
+    const renderedError = (error as ExpectedCliError).message;
     expect(renderedError).toContain(
       `Identity file ${identityPath} exceeds the maximum size of ${TEST_MAX_IDENTITY_FILE_BYTES} bytes`,
     );
     expect(renderedError).toContain(`File exceeds ${TEST_MAX_IDENTITY_FILE_BYTES} bytes:`);
     expect(renderedError).toContain("too-large");
-    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect((error as ExpectedCliError).humanOutput).toBe(renderedError);
+    expect((error as ExpectedCliError).machineOutput).toBe(renderedError);
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
     expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    await expect(fs.readFile(identityPath, "utf8")).resolves.toBe(originalIdentity);
   });
 
   it("errors when identity data is missing", async () => {
     const { workspace } = await createIdentityWorkspace();
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: { agents: { entries: { main: { workspace } } } },
+    });
 
-    await runIdentityCommandFromWorkspace(workspace);
-
-    expect(runtime.error).toHaveBeenCalledWith(
+    await expectIdentityCommandFailure(
+      { workspace, fromIdentity: true, json: true },
       `No identity data found in ${path.join(workspace, "IDENTITY.md")}.`,
     );
-    expect(runtime.exit).toHaveBeenCalledWith(1);
-    expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    await expect(fs.access(path.join(workspace, "IDENTITY.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("leaves unexpected configuration write failures with the shared root owner", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: { agents: { entries: { main: {} } } },
+    });
+    const writeFailure = new Error("configuration storage is unavailable");
+    configMocks.replaceConfigFile.mockRejectedValueOnce(writeFailure);
+
+    await expect(
+      agentsSetIdentityCommand({ agent: "main", name: "Updated", json: true }, runtime),
+    ).rejects.toBe(writeFailure);
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
   });
 });

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -255,6 +255,60 @@ describe("cli json stdout contract", () => {
       message: "Provide at least one --bind <channel[:accountId]>.",
       tty: true,
     },
+    {
+      name: "set-identity with an unknown agent in human mode",
+      args: ["agents", "set-identity", "--agent", "ghost", "--name", "Ghost"],
+      message: 'Agent "ghost" not found. Create it with `openclaw agents add`.',
+      human: true,
+    },
+    {
+      name: "set-identity with an unknown agent in JSON mode",
+      args: ["agents", "set-identity", "--agent", "ghost", "--name", "Ghost", "--json"],
+      message: 'Agent "ghost" not found. Create it with `openclaw agents add`.',
+    },
+    {
+      name: "set-identity with an invalid agent before identity-file resolution",
+      args: ["agents", "set-identity", "--agent", "агент✨", "--from-identity", "--json"],
+      message: 'Agent "агент✨" not found. Create it with `openclaw agents add`.',
+    },
+    {
+      name: "set-identity with an unmatched workspace",
+      args: ["agents", "set-identity", "--workspace", "$WORKSPACE", "--name", "Ghost", "--json"],
+      message: "No agent workspace matches ~/workspace. Pass --agent to target a specific agent.",
+    },
+    {
+      name: "set-identity with a missing workspace identity file",
+      args: [
+        "agents",
+        "set-identity",
+        "--agent",
+        "main",
+        "--workspace",
+        "$WORKSPACE",
+        "--from-identity",
+        "--json",
+      ],
+      message: "No identity data found in ~/workspace/IDENTITY.md.",
+    },
+    {
+      name: "set-identity with a missing explicit identity file",
+      args: [
+        "agents",
+        "set-identity",
+        "--agent",
+        "main",
+        "--identity-file",
+        "$WORKSPACE",
+        "--json",
+      ],
+      message: "No identity data found in ~/workspace.",
+    },
+    {
+      name: "set-identity with an unknown agent through dual-TTY finalization",
+      args: ["agents", "set-identity", "--agent", "ghost", "--name", "Ghost", "--json"],
+      message: 'Agent "ghost" not found. Create it with `openclaw agents add`.',
+      tty: true,
+    },
   ])("renders agent management $name through the canonical failure owner", async (testCase) => {
     await withTempHome(
       async (tempHome) => {
@@ -291,6 +345,44 @@ describe("cli json stdout contract", () => {
         await expect(fs.access(workspace)).rejects.toMatchObject({ code: "ENOENT" });
       },
       { prefix: "openclaw-agent-management-json-failure-e2e-" },
+    );
+  });
+
+  it("leaves existing config and IDENTITY.md untouched when set-identity rejects an agent", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const configPath = path.join(tempHome, "openclaw.json");
+        const workspace = path.join(tempHome, "workspace");
+        const identityPath = path.join(workspace, "IDENTITY.md");
+        const originalConfig = `${JSON.stringify({
+          agents: { entries: { main: { workspace, identity: { name: "Original" } } } },
+        })}\n`;
+        const originalIdentity = "- Name: Original workspace identity\n";
+        await fs.mkdir(workspace, { recursive: true });
+        await fs.writeFile(configPath, originalConfig, "utf8");
+        await fs.writeFile(identityPath, originalIdentity, "utf8");
+
+        const result = runBuiltCli(
+          tempHome,
+          ["agents", "set-identity", "--agent", "ghost", "--name", "Ghost", "--json"],
+          {
+            OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+            OPENCLAW_CONFIG_PATH: configPath,
+          },
+        );
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message: 'Agent "ghost" not found. Create it with `openclaw agents add`.',
+          },
+        });
+        await expect(fs.readFile(configPath, "utf8")).resolves.toBe(originalConfig);
+        await expect(fs.readFile(identityPath, "utf8")).resolves.toBe(originalIdentity);
+      },
+      { prefix: "openclaw-agent-identity-json-failure-e2e-" },
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw agents set-identity ... --json` returned exit code 1 with empty stdout for command-owned validation failures. Malformed or missing agents, unmatched or ambiguous workspaces, missing identity data, and oversized identity files therefore left automation with an unrelated JSON parse error.

Fixes https://github.com/openclaw/openclaw/issues/128587.

## Why This Change Was Made

The identity command owner now routes its validation failures through one `ExpectedCliError` helper, allowing the existing root CLI renderer to own human/JSON output, exit status, and terminal finalization. Agent/workspace/identity-file target precedence, validation order, detailed oversized-file diagnostics, successful JSON updates, and unexpected configuration-write failure propagation remain unchanged. Two unreachable validation branches are removed.

Production delta: +17/-39, net -22 lines. Tests: +183/-24, net +159 lines.

## User Impact

JSON consumers receive exactly one canonical `cli_error` document for identity validation failures. Human diagnostics and successful identity updates remain unchanged, and rejected requests do not alter configuration or `IDENTITY.md` files.

## Evidence

- Pre-fix: seven built-process regressions failed because stdout was empty; the human-mode control passed.
- Focused owner/sibling proof: 124 tests passed across identity, registration, add, bind, delete, and failure rendering.
- Built-process proof: 45 agent-management cases passed, including human/JSON output, dual-TTY finalization, target precedence, missing/oversized files, non-mutation, and successful domain payloads.
- Full production build and complete changed-file gates passed.
- Fresh P1 autoreview: no accepted/actionable findings.
- `git diff --check`: passed.
