### PR TITLE
fix(location): reject future-dated cached fixes

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt
@@ -83,7 +83,7 @@ class LocationCaptureManager(
     }
     val now = System.currentTimeMillis()
     val candidates =
-      providers.mapNotNull { provider -> manager.getLastKnownLocation(provider) }
+      providers.mapNotNull { provider -> manager.getLastKnownLocation(provider) }.filter { it.time <= now }
     val freshest = candidates.maxByOrNull { it.time } ?: return null
     // maxAgeMs is a caller contract; stale cached fixes force a live provider request.
     if (maxAgeMs != null && now - freshest.time > maxAgeMs) return null

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/LocationCaptureManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/LocationCaptureManagerTest.kt
@@ -1,0 +1,68 @@
+package ai.openclaw.app.node
+
+import android.Manifest
+import android.content.Context
+import android.location.Location
+import android.location.LocationManager
+import android.os.Looper
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class LocationCaptureManagerTest : NodeHandlerRobolectricTest() {
+  @Test(timeout = 5_000)
+  fun getLocation_ignoresFutureCachedFixWhenCurrentProviderFixExists() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
+    val manager = app.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    val shadowManager = shadowOf(manager)
+    shadowManager.setProviderEnabled(LocationManager.GPS_PROVIDER, true)
+    shadowManager.setProviderEnabled(LocationManager.NETWORK_PROVIDER, true)
+    val now = System.currentTimeMillis()
+    shadowManager.simulateLocation(
+      LocationManager.GPS_PROVIDER,
+      Location(LocationManager.GPS_PROVIDER).apply {
+        latitude = 1.0
+        longitude = 1.0
+        accuracy = 5f
+        time = now + 5_000L
+      },
+    )
+    shadowManager.simulateLocation(
+      LocationManager.NETWORK_PROVIDER,
+      Location(LocationManager.NETWORK_PROVIDER).apply {
+        latitude = 2.0
+        longitude = 2.0
+        accuracy = 5f
+        time = now
+      },
+    )
+
+    val executor = Executors.newSingleThreadExecutor()
+    try {
+      val result =
+        executor.submit<LocationCaptureManager.Payload> {
+          runBlocking {
+            LocationCaptureManager(app).getLocation(
+              desiredProviders = listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER),
+              maxAgeMs = 1_000L,
+              timeoutMs = 1_000L,
+              isPrecise = true,
+            )
+          }
+        }
+      val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
+      while (!result.isDone && System.nanoTime() < deadline) {
+        shadowOf(Looper.getMainLooper()).idle()
+      }
+
+      assertTrue(result.get(1, TimeUnit.SECONDS).payloadJson.contains("\"lat\":2.0"))
+    } finally {
+      executor.shutdownNow()
+    }
+  }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/LocationCurrentRequest.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/LocationCurrentRequest.swift
@@ -18,6 +18,7 @@ public enum LocationCurrentRequest {
         let now = Date()
         if let maxAgeMs,
            let cached = manager.location,
+           cached.timestamp <= now,
            now.timeIntervalSince(cached.timestamp) * 1000 <= Double(maxAgeMs)
         {
             return cached

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/LocationCurrentRequestTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/LocationCurrentRequestTests.swift
@@ -1,0 +1,72 @@
+import CoreLocation
+import Foundation
+import Testing
+@testable import OpenClawKit
+
+private final class CachedLocationManager: CLLocationManager, @unchecked Sendable {
+    private let cachedLocation: CLLocation?
+
+    init(cachedLocation: CLLocation?) {
+        self.cachedLocation = cachedLocation
+        super.init()
+    }
+
+    override var location: CLLocation? {
+        self.cachedLocation
+    }
+}
+
+struct LocationCurrentRequestTests {
+    @Test(arguments: [0, 1000])
+    @MainActor
+    func `future cached locations never satisfy a maximum age`(maxAgeMs: Int) async throws {
+        let cached = self.location(timestamp: Date().addingTimeInterval(5))
+        let fresh = CLLocation(latitude: 3, longitude: 4)
+
+        let result = try await self.resolve(cached: cached, fresh: fresh, maxAgeMs: maxAgeMs)
+
+        #expect(result === fresh)
+    }
+
+    @Test
+    @MainActor
+    func `recent past cached locations still satisfy their maximum age`() async throws {
+        let cached = self.location(timestamp: Date().addingTimeInterval(-0.2))
+        let fresh = CLLocation(latitude: 3, longitude: 4)
+
+        let result = try await self.resolve(cached: cached, fresh: fresh, maxAgeMs: 1000)
+
+        #expect(result === cached)
+    }
+
+    @Test
+    @MainActor
+    func `expired cached locations request a fresh fix`() async throws {
+        let cached = self.location(timestamp: Date().addingTimeInterval(-2))
+        let fresh = CLLocation(latitude: 3, longitude: 4)
+
+        let result = try await self.resolve(cached: cached, fresh: fresh, maxAgeMs: 1000)
+
+        #expect(result === fresh)
+    }
+
+    private func location(timestamp: Date) -> CLLocation {
+        CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 2),
+            altitude: 0,
+            horizontalAccuracy: 1,
+            verticalAccuracy: 1,
+            timestamp: timestamp)
+    }
+
+    @MainActor
+    private func resolve(cached: CLLocation, fresh: CLLocation, maxAgeMs: Int) async throws -> CLLocation {
+        try await LocationCurrentRequest.resolve(
+            manager: CachedLocationManager(cachedLocation: cached),
+            desiredAccuracy: .balanced,
+            maxAgeMs: maxAgeMs,
+            timeoutMs: 1000,
+            request: { fresh },
+            withTimeout: { _, operation in try await operation() })
+    }
+}

--- a/extensions/linux-node/src/commands.test.ts
+++ b/extensions/linux-node/src/commands.test.ts
@@ -290,6 +290,26 @@ describe("linux-node commands", () => {
     expect(payload.timestamp).toBe("2026-07-13T12:00:05.000Z");
   });
 
+  it("keeps GeoClue running past a future-dated fix until a current update arrives", async () => {
+    const fix = (lat: number, epochSeconds: number) =>
+      `\nNew location:\nLatitude: ${lat}\nLongitude: 16\nAccuracy: 25 meters\nTimestamp: now (${epochSeconds} seconds since the Epoch)\n`;
+    const future = fix(47, Date.parse("2026-07-13T12:00:15.000Z") / 1000);
+    const current = fix(48, Date.parse("2026-07-13T12:00:09.000Z") / 1000);
+    const runCommand = vi.fn(async (_argv: string[], options: CommandOptions) => {
+      expect(options.onOutputChunk?.(Buffer.from(future), "stdout")).toBe(true);
+      expect(options.onOutputChunk?.(Buffer.from(current), "stdout")).toBe(false);
+      return success(`${future}${current}`);
+    });
+    const { command } = createHarness({ runCommand });
+
+    const payload = JSON.parse(
+      await command("location.get").handle(JSON.stringify({ maxAgeMs: 2000 })),
+    ) as Record<string, unknown>;
+
+    expect(payload.lat).toBe(48);
+    expect(payload.timestamp).toBe("2026-07-13T12:00:09.000Z");
+  });
+
   it("accounts for GeoClue second precision when maxAgeMs is zero", async () => {
     const output = `\nNew location:\nLatitude: 48\nLongitude: 16\nAccuracy: 25 meters\nTimestamp: now (1783944010 seconds since the Epoch)\n`;
     const harness = createHarness({

--- a/extensions/linux-node/src/location.ts
+++ b/extensions/linux-node/src/location.ts
@@ -74,9 +74,10 @@ function parseLocationOutput(
     const timestamp = epochSeconds
       ? new Date(Number(epochSeconds) * 1000).toISOString()
       : now().toISOString();
+    const ageMs = now().getTime() - Date.parse(timestamp);
     if (
       maxAgeMs !== undefined &&
-      now().getTime() - Date.parse(timestamp) >= maxAgeMs + GEOCLUE_TIMESTAMP_RESOLUTION_MS
+      (ageMs < 0 || ageMs >= maxAgeMs + GEOCLUE_TIMESTAMP_RESOLUTION_MS)
     ) {
       continue;
     }


### PR DESCRIPTION
Closes #127588.

## What Problem This Solves

After a clock rollback, a location fix with a timestamp in the future has a negative age and incorrectly satisfies every requested maximum age. The same owner-level mistake existed in the shared Apple request path, Android cached-provider selection, and Linux GeoClue streaming.

## Why This Change Was Made

Reject future-dated fixes where each platform owns cache admission. Android filters invalid provider candidates before choosing the freshest valid location; Linux continues listening until GeoClue supplies a current sample while preserving its existing one-second timestamp-resolution allowance; the shared Apple implementation requests a fresh fix instead of returning an invalid cached one.

Production delta: four added lines and two removed lines across the three platform owners, for a net increase of two lines. No configuration, protocol, persistence, or compatibility surface changes.

## User Impact

`location.get` no longer returns a stale future-dated cached coordinate after the device clock changes. A valid current fix from another Android provider remains usable, and valid recent fixes retain their existing behavior.

## Evidence

Each platform regression was first run against the unchanged production code and failed for the reported reason, then passed after the owner-level fix:

- Shared Apple Swift package: parameterized future-fix regressions for zero and positive maximum ages, plus valid recent and expired control cases.
- Android: real Robolectric `LocationManager` providers prove a valid network fix wins over an invalid future-dated GPS fix; existing location-handler tests also pass.
- Linux: the full plugin command suite proves GeoClue ignores a future update, accepts the subsequent current update, and preserves existing whole-second precision behavior.
- Android Kotlin formatting, Swift formatting, and TypeScript formatting passed. Seventeen changed-file gate checks, including owner tests, dependency/security guards, and zero-entry dead-code scans, also passed; its full extension typecheck is blocked by two unrelated errors reproduced identically in a clean current-main checkout.
- The first hosted CI attempt also encountered an unrelated audit-event-writer timing flake (278 ms against its 250 ms limit); the exact-head failure will be rerun before landing.
- Independent structured code review completed without actionable findings.
