### PR TITLE
fix(gateway): reclaim cloud workers before session recovery

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3091,7 +3091,7 @@ src/gateway/session-companion-rpc.ts	3
 src/gateway/session-history-state.ts	3
 src/gateway/session-lifecycle-state.ts	1
 src/gateway/session-observer-rpc.ts	1
-src/gateway/session-recovery-service.ts	3
+src/gateway/session-recovery-service.ts	2
 src/gateway/session-sharing-target-input.ts	2
 src/gateway/session-sharing.ts	1
 src/gateway/session-transcript-derived-readers.ts	2

--- a/src/config/sessions/session-accessor.recovery.test.ts
+++ b/src/config/sessions/session-accessor.recovery.test.ts
@@ -135,13 +135,17 @@ describe("recoverSessionEntryFromRestartTombstone", () => {
     });
   });
 
-  it("does not archive or copy when the recovery revision changed", async () => {
+  it.each([
+    { name: "recovery", revision: 3 },
+    { name: "lifecycle", revision: 4, lifecycleRevision: "different-generation" },
+  ])("does not archive or copy when the $name revision changed", async (expected) => {
     const fixture = await createFixture();
     const result = await recoverSessionEntryFromRestartTombstone({
       agentId: "main",
       expected: {
         cycleId: "cycle-1",
-        revision: 3,
+        revision: expected.revision,
+        ...(expected.lifecycleRevision ? { lifecycleRevision: expected.lifecycleRevision } : {}),
         sessionId: fixture.sourceSessionId,
         pluginOwnerId: "codex",
       },

--- a/src/config/sessions/session-accessor.sqlite-recovery.ts
+++ b/src/config/sessions/session-accessor.sqlite-recovery.ts
@@ -55,6 +55,7 @@ export async function recoverSessionEntryFromRestartTombstone(params: {
   archivedBy?: SessionCreatedActor;
   expected: {
     cycleId: string;
+    lifecycleRevision?: string;
     pluginOwnerId?: string;
     revision: number;
     sessionId: string;
@@ -123,6 +124,7 @@ export async function recoverSessionEntryFromRestartTombstone(params: {
 
       if (
         source.sessionId !== params.expected.sessionId ||
+        source.lifecycleRevision !== params.expected.lifecycleRevision ||
         recovery.cycleId !== params.expected.cycleId ||
         recovery.revision !== params.expected.revision ||
         source.pluginOwnerId !== params.expected.pluginOwnerId

--- a/src/gateway/server-methods/sessions-recover.ts
+++ b/src/gateway/server-methods/sessions-recover.ts
@@ -3,6 +3,7 @@ import {
   type SessionsRecoverResult,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { recoverGatewaySession } from "../session-recovery-service.js";
+import { resolveSessionWorkerPlacementContext } from "../session-worker-placement-context.js";
 import { createAgentRuntimeAuthorityGuard } from "./agent-runtime-authority.js";
 import { emitSessionArchived, emitSessionsChanged } from "./session-change-event.js";
 import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
@@ -44,6 +45,7 @@ export const sessionRecoverHandlers: GatewayRequestHandlers = {
         : {}),
       authorizedPluginId: client?.internal?.pluginRuntimeOwnerId,
       ...(commitGuard ? { commitGuard } : {}),
+      workerPlacementContext: resolveSessionWorkerPlacementContext(context),
       launchContinuation: async (continuation) =>
         await launchSessionRecoveryContinuation({
           ...continuation,

--- a/src/gateway/server-worker-placement-reclaim.ts
+++ b/src/gateway/server-worker-placement-reclaim.ts
@@ -107,7 +107,7 @@ export function createGatewayWorkerPlacementReclaimBarriers(
         // immediately before drain so revoked callers cannot commit stale placement authority.
         authorize?.();
         const drainingPlacement = begin();
-        reclaimedPlacement = await reclaim(worktreePath, drainingPlacement);
+        reclaimedPlacement = await reclaim(worktreePath, drainingPlacement, authorize);
         params.revokeSessionAuthority({ sessionId, sessionKeys: lifecycleIdentities });
       },
     });
@@ -152,7 +152,7 @@ export function createGatewayWorkerPlacementReclaimBarriers(
           // Failed teardown is still a session mutation: reauthorize inside the shared lifecycle
           // fence before provider cleanup or the failed-to-local transition becomes durable.
           authorize?.();
-          reclaimedPlacement = await reclaim();
+          reclaimedPlacement = await reclaim(authorize);
         },
       });
       if (!reclaimedPlacement) {

--- a/src/gateway/server.sessions.archive-worker-placement.test.ts
+++ b/src/gateway/server.sessions.archive-worker-placement.test.ts
@@ -197,6 +197,33 @@ test("sessions.patch rejects a mismatched reclaimed identity without archiving",
   expect(loadSessionEntry({ storePath, sessionKey })?.archivedAt).toBeUndefined();
 });
 
+test("sessions.patch rejects a reclaimed return when its authoritative placement stayed active", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sessionKey = "agent:main:archive-cloud-stale-reclaim";
+  const sessionId = "session-archive-cloud-stale-reclaim";
+  await writeSessionStore({ entries: { [sessionKey]: sessionStoreEntry(sessionId) } });
+  const placement = workerPlacement({ sessionId, sessionKey, state: "active" });
+  const reclaim = vi.fn(async () => workerPlacement({ sessionId, sessionKey, state: "reclaimed" }));
+
+  const archived = await directSessionReq(
+    "sessions.patch",
+    { key: sessionKey, archived: true, expectedSessionId: sessionId },
+    {
+      context: {
+        workerSessionPlacementService: placementReader(() => placement),
+        workerPlacementDispatchService: { dispatch: vi.fn(), reclaim },
+      },
+    },
+  );
+
+  expect(archived).toMatchObject({
+    ok: false,
+    error: { code: "UNAVAILABLE", retryable: true },
+  });
+  expect(reclaim).toHaveBeenCalledOnce();
+  expect(loadSessionEntry({ storePath, sessionKey })?.archivedAt).toBeUndefined();
+});
+
 test("sessions.patch rejects a placement identity changed during the runtime drain", async () => {
   const { storePath } = await createSessionStoreDir();
   const sessionKey = "agent:main:archive-cloud-fresh-placement";

--- a/src/gateway/server.sessions.recover.test.ts
+++ b/src/gateway/server.sessions.recover.test.ts
@@ -1,14 +1,31 @@
-import { expect, test } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+import { managedWorktrees } from "../agents/worktrees/service.js";
+import {
+  initializeManagedWorktreeTestRepository,
+  materializeManagedWorktreeFixture,
+} from "../agents/worktrees/service.test-support.js";
 import { getRuntimeConfig } from "../config/io.js";
-import { loadSessionEntry, loadTranscriptEvents } from "../config/sessions/session-accessor.js";
+import {
+  loadSessionEntry,
+  loadTranscriptEvents,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { addSessionMember, removeSessionMember } from "../config/sessions/session-sharing-store.js";
 import { runExclusiveSessionLifecycleMutation } from "../sessions/session-lifecycle-admission.js";
 import { createDeferredCore } from "../shared/deferred.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profiles.js";
+import { createGatewayWorkerPlacementReclaimBarriers } from "./server-worker-placement-reclaim.js";
 import {
   resolveSessionMutationAuthorization,
   SessionMutationAuthorizationChangedError,
 } from "./session-sharing.js";
+import {
+  resolveCanonicalSessionEntryFromStoreKeys,
+  resolveGatewaySessionStoreTargetWithStore,
+} from "./session-utils.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
@@ -16,8 +33,362 @@ import {
   sessionStoreEntry,
   setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
+import type { WorkerSessionPlacementRecord } from "./worker-environments/placement-record.js";
 
 const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+function recoveryWorkerPlacement(params: {
+  sessionId: string;
+  sessionKey: string;
+  state: WorkerSessionPlacementRecord["state"];
+  generation?: number;
+}): WorkerSessionPlacementRecord {
+  return {
+    ...params,
+    agentId: "main",
+    generation: params.generation ?? 2,
+    turnClaim: null,
+    environmentId: params.state === "local" || params.state === "requested" ? null : "worker-env",
+  } as WorkerSessionPlacementRecord;
+}
+
+function recoveryPlacementReader(current: () => WorkerSessionPlacementRecord | undefined) {
+  return {
+    getMany(sessionIds: readonly string[]) {
+      const placement = current();
+      return new Map(
+        placement && sessionIds.includes(placement.sessionId)
+          ? [[placement.sessionId, placement]]
+          : [],
+      );
+    },
+  };
+}
+
+async function seedRecoverableSession(params: {
+  sourceKey: string;
+  sourceSessionId: string;
+  storePath: string;
+  overrides?: Parameters<typeof sessionStoreEntry>[1];
+}) {
+  await writeSessionStore({
+    entries: {
+      [params.sourceKey]: sessionStoreEntry(params.sourceSessionId, {
+        status: "failed",
+        abortedLastRun: true,
+        mainRestartRecovery: {
+          cycleId: `cycle-${params.sourceSessionId}`,
+          revision: 1,
+          chargedAttempts: 3,
+          tombstone: { reason: "automatic recovery exhausted" },
+        },
+        ...params.overrides,
+      }),
+    },
+  });
+  await seedSessionTranscript({
+    agentId: "main",
+    sessionId: params.sourceSessionId,
+    sessionKey: params.sourceKey,
+    storePath: params.storePath,
+    messages: [{ role: "user", content: "recover the interrupted cloud workspace" }],
+  });
+}
+
+test("sessions.recover settles its active placement before archiving a real session-owned worktree", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
+  const sourceKey = "agent:main:dashboard:recovery-cloud-active";
+  const sourceSessionId = "recovery-cloud-active-source";
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!stateDir) {
+    throw new Error("gateway test state directory is unavailable");
+  }
+  const repoRoot = await initializeManagedWorktreeTestRepository(dir);
+  const worktree = await materializeManagedWorktreeFixture({
+    env: process.env,
+    name: "recovery-cloud-active",
+    now: Date.now(),
+    ownerKind: "session",
+    ownerId: sourceKey,
+    repoRoot,
+    stateDir,
+  });
+  const unsyncedPath = path.join(worktree.path, "unsynced.txt");
+  await fs.writeFile(unsyncedPath, "preserve local work\n");
+  await seedRecoverableSession({
+    sourceKey,
+    sourceSessionId,
+    storePath,
+    overrides: {
+      spawnedCwd: worktree.path,
+      worktree: {
+        id: worktree.id,
+        branch: worktree.branch,
+        repoRoot: worktree.repoRoot,
+        canonicalWorkspaceDir: repoRoot,
+      },
+    },
+  });
+
+  let placement = recoveryWorkerPlacement({
+    sessionId: sourceSessionId,
+    sessionKey: sourceKey,
+    state: "active",
+  });
+  const reclaimStarted = createDeferredCore();
+  const reclaimGate = createDeferredCore();
+  const barriers = createGatewayWorkerPlacementReclaimBarriers({
+    placements: {
+      get: () => placement,
+      waitForTurnClaimRelease: vi.fn(async () => {}),
+    },
+    loadSessionRuntime: async () => ({
+      managedWorktrees,
+      resolveCanonicalSessionEntryFromStoreKeys,
+      resolveGatewaySessionStoreTargetWithStore,
+    }),
+    revokeSessionAuthority: vi.fn(),
+  });
+  const reclaim = vi.fn(
+    async (
+      request: { agentId: string; sessionId: string; sessionKey: string },
+      authorize?: () => void,
+    ) =>
+      await barriers.runReclaimBarrier({
+        ...request,
+        ...(authorize ? { authorize } : {}),
+        begin: () => {
+          placement = recoveryWorkerPlacement({
+            sessionId: sourceSessionId,
+            sessionKey: sourceKey,
+            state: "draining",
+            generation: placement.generation + 1,
+          });
+          return placement as Extract<WorkerSessionPlacementRecord, { state: "draining" }>;
+        },
+        reclaim: async (worktreePath) => {
+          expect(worktreePath).toBe(worktree.path);
+          reclaimStarted.resolve();
+          await reclaimGate.promise;
+          await fs.appendFile(unsyncedPath, "final worker sync\n");
+          placement = recoveryWorkerPlacement({
+            sessionId: sourceSessionId,
+            sessionKey: sourceKey,
+            state: "reclaimed",
+            generation: placement.generation + 1,
+          });
+          return placement as Extract<WorkerSessionPlacementRecord, { state: "reclaimed" }>;
+        },
+      }),
+  );
+  const context = {
+    workerSessionPlacementService: recoveryPlacementReader(() => placement),
+    workerPlacementDispatchService: { dispatch: vi.fn(), reclaim },
+  };
+
+  const recovering = directSessionReq<{ key: string; sessionId: string }>(
+    "sessions.recover",
+    { agentId: "main", key: sourceKey },
+    { context },
+  );
+  const committedBeforeReclaim = await Promise.race([
+    reclaimStarted.promise.then(() => false),
+    recovering.then(() => true),
+  ]);
+  expect(committedBeforeReclaim).toBe(false);
+  expect(reclaim).toHaveBeenCalledWith({
+    agentId: "main",
+    sessionId: sourceSessionId,
+    sessionKey: sourceKey,
+  });
+  const unsettledSource = loadSessionEntry({ agentId: "main", sessionKey: sourceKey, storePath });
+  expect(unsettledSource?.archivedAt).toBeUndefined();
+  expect(unsettledSource?.mainRestartRecovery?.tombstone?.recoveredSessionKey).toBeUndefined();
+  reclaimGate.resolve();
+
+  const recovered = await recovering;
+  expect(recovered).toMatchObject({ ok: true, payload: { key: expect.any(String) } });
+  expect(placement.state).toBe("reclaimed");
+  expect(loadSessionEntry({ agentId: "main", sessionKey: sourceKey, storePath })).toMatchObject({
+    archivedAt: expect.any(Number),
+    worktree: { id: worktree.id },
+  });
+  expect(managedWorktrees.findLiveByOwner("session", sourceKey)).toMatchObject({
+    id: worktree.id,
+    ownerId: sourceKey,
+  });
+  expect(managedWorktrees.findLiveByOwner("session", recovered.payload?.key ?? "")).toBeUndefined();
+  expect(
+    loadSessionEntry({
+      agentId: "main",
+      sessionKey: recovered.payload?.key ?? "",
+      storePath,
+    })?.worktree,
+  ).toBeUndefined();
+  await expect(fs.readFile(unsyncedPath, "utf8")).resolves.toBe(
+    "preserve local work\nfinal worker sync\n",
+  );
+
+  await expect(
+    directSessionReq("sessions.recover", { agentId: "main", key: sourceKey }, { context }),
+  ).resolves.toMatchObject({ ok: true, payload: { key: recovered.payload?.key } });
+  expect(reclaim).toHaveBeenCalledOnce();
+});
+
+test.each(["rejected", "unavailable", "stale-result"] as const)(
+  "sessions.recover leaves its source and successor untouched when cloud reclaim is %s",
+  async (failure) => {
+    const { storePath } = await createSessionStoreDir();
+    const sourceKey = `agent:main:dashboard:recovery-cloud-${failure}`;
+    const sourceSessionId = `recovery-cloud-${failure}-source`;
+    await seedRecoverableSession({ sourceKey, sourceSessionId, storePath });
+    const placement = recoveryWorkerPlacement({
+      sessionId: sourceSessionId,
+      sessionKey: sourceKey,
+      state: "active",
+    });
+    const reclaim = vi.fn(async () => {
+      if (failure === "rejected") {
+        throw new Error("final workspace reconciliation rejected");
+      }
+      return recoveryWorkerPlacement({
+        sessionId: sourceSessionId,
+        sessionKey: sourceKey,
+        state: "reclaimed",
+      });
+    });
+
+    const recovered = await directSessionReq(
+      "sessions.recover",
+      { agentId: "main", key: sourceKey },
+      {
+        context: {
+          workerSessionPlacementService: recoveryPlacementReader(() => placement),
+          workerPlacementDispatchService:
+            failure === "unavailable" ? { dispatch: vi.fn() } : { dispatch: vi.fn(), reclaim },
+        },
+      },
+    );
+
+    expect(recovered).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        retryable: true,
+        message: expect.stringContaining("sessions.reclaim"),
+      },
+    });
+    const source = loadSessionEntry({ agentId: "main", sessionKey: sourceKey, storePath });
+    expect(source?.archivedAt).toBeUndefined();
+    expect(source?.mainRestartRecovery?.tombstone?.recoveredSessionId).toBeUndefined();
+    expect(reclaim).toHaveBeenCalledTimes(failure === "unavailable" ? 0 : 1);
+  },
+);
+
+test.each([
+  "requested",
+  "provisioning",
+  "syncing",
+  "starting",
+  "draining",
+  "reconciling",
+  "failed",
+] as const)("sessions.recover rejects an unsettled %s cloud placement", async (state) => {
+  const { storePath } = await createSessionStoreDir();
+  const sourceKey = `agent:main:dashboard:recovery-cloud-${state}`;
+  const sourceSessionId = `recovery-cloud-${state}-source`;
+  await seedRecoverableSession({ sourceKey, sourceSessionId, storePath });
+  const placement = recoveryWorkerPlacement({
+    sessionId: sourceSessionId,
+    sessionKey: sourceKey,
+    state,
+  });
+  const reclaim = vi.fn();
+
+  const recovered = await directSessionReq(
+    "sessions.recover",
+    { agentId: "main", key: sourceKey },
+    {
+      context: {
+        workerSessionPlacementService: recoveryPlacementReader(() => placement),
+        workerPlacementDispatchService: { dispatch: vi.fn(), reclaim },
+      },
+    },
+  );
+
+  expect(recovered).toMatchObject({
+    ok: false,
+    error: { code: "UNAVAILABLE", retryable: true, message: expect.stringContaining(state) },
+  });
+  expect(reclaim).not.toHaveBeenCalled();
+  expect(
+    loadSessionEntry({ agentId: "main", sessionKey: sourceKey, storePath })?.archivedAt,
+  ).toBeUndefined();
+});
+
+test.each(["session-id", "lifecycle-revision"] as const)(
+  "sessions.recover rejects a source %s changed while its placement is reclaiming",
+  async (changedIdentity) => {
+    const { storePath } = await createSessionStoreDir();
+    const sourceKey = `agent:main:dashboard:recovery-cloud-race-${changedIdentity}`;
+    const sourceSessionId = `recovery-cloud-race-${changedIdentity}-source`;
+    await seedRecoverableSession({
+      sourceKey,
+      sourceSessionId,
+      storePath,
+      overrides: { lifecycleRevision: "original-lifecycle" },
+    });
+    let placement = recoveryWorkerPlacement({
+      sessionId: sourceSessionId,
+      sessionKey: sourceKey,
+      state: "active",
+    });
+    const reclaim = vi.fn(async () => {
+      const current = loadSessionEntry({ agentId: "main", sessionKey: sourceKey, storePath });
+      if (!current) {
+        throw new Error("recovery source disappeared");
+      }
+      await replaceSessionEntry(
+        { agentId: "main", sessionKey: sourceKey, storePath },
+        {
+          ...current,
+          ...(changedIdentity === "session-id"
+            ? { sessionId: "replacement-session" }
+            : { lifecycleRevision: "replacement-lifecycle" }),
+        },
+      );
+      placement = recoveryWorkerPlacement({
+        sessionId: sourceSessionId,
+        sessionKey: sourceKey,
+        state: "reclaimed",
+      });
+      return placement;
+    });
+
+    const recovered = await directSessionReq(
+      "sessions.recover",
+      { agentId: "main", key: sourceKey },
+      {
+        context: {
+          workerSessionPlacementService: recoveryPlacementReader(() => placement),
+          workerPlacementDispatchService: { dispatch: vi.fn(), reclaim },
+        },
+      },
+    );
+
+    expect(recovered).toMatchObject({
+      ok: false,
+      error: { code: "INVALID_REQUEST", message: expect.stringContaining("changed") },
+    });
+    const source = loadSessionEntry({ agentId: "main", sessionKey: sourceKey, storePath });
+    expect(source?.archivedAt).toBeUndefined();
+    expect(source?.mainRestartRecovery?.tombstone?.recoveredSessionId).toBeUndefined();
+  },
+);
 
 test("sessions.recover rolls over one tombstone and returns its continuation outcome", async () => {
   const { storePath } = await createSessionStoreDir();
@@ -316,6 +687,56 @@ test("sessions.recover revalidates participation at the recovery writer commit",
   expect(source?.archivedAt).toBeUndefined();
   expect(source?.mainRestartRecovery?.tombstone).not.toHaveProperty("recoveredSessionKey");
   expect(source?.mainRestartRecovery?.tombstone).not.toHaveProperty("recoveredSessionId");
+});
+
+test("sessions.recover revalidates runtime authority after its cloud placement reclaim", async () => {
+  const { storePath } = await createSessionStoreDir();
+  const sourceKey = "agent:main:dashboard:recovery-cloud-authority-race";
+  const sourceSessionId = "recovery-cloud-authority-race-source";
+  await seedRecoverableSession({ sourceKey, sourceSessionId, storePath });
+  let authorityActive = true;
+  let placement = recoveryWorkerPlacement({
+    sessionId: sourceSessionId,
+    sessionKey: sourceKey,
+    state: "active",
+  });
+  const reclaim = vi.fn(async (_request: unknown, authorize?: () => void) => {
+    authorize?.();
+    authorityActive = false;
+    placement = recoveryWorkerPlacement({
+      sessionId: sourceSessionId,
+      sessionKey: sourceKey,
+      state: "reclaimed",
+    });
+    return placement;
+  });
+
+  const recovered = await directSessionReq(
+    "sessions.recover",
+    { agentId: "main", key: sourceKey },
+    {
+      client: {
+        connect: { scopes: ["operator.write"] },
+        internal: {
+          agentRuntimeIdentity: { kind: "agentRuntime", agentId: "main", sessionKey: sourceKey },
+        },
+      } as never,
+      context: {
+        validateAgentRuntimeApprovalAuthority: () => authorityActive,
+        workerSessionPlacementService: recoveryPlacementReader(() => placement),
+        workerPlacementDispatchService: { dispatch: vi.fn(), reclaim },
+      },
+    },
+  );
+
+  expect(recovered).toMatchObject({
+    ok: false,
+    error: { code: "INVALID_REQUEST", message: "agent runtime authority is no longer active" },
+  });
+  expect(reclaim).toHaveBeenCalledOnce();
+  const source = loadSessionEntry({ agentId: "main", sessionKey: sourceKey, storePath });
+  expect(source?.archivedAt).toBeUndefined();
+  expect(source?.mainRestartRecovery?.tombstone?.recoveredSessionId).toBeUndefined();
 });
 
 test("sessions.recover rejects continuation launch after runtime authority closes", async () => {

--- a/src/gateway/server.sessions.recover.test.ts
+++ b/src/gateway/server.sessions.recover.test.ts
@@ -170,10 +170,11 @@ test("sessions.recover settles its active placement before archiving a real sess
           });
           return placement as Extract<WorkerSessionPlacementRecord, { state: "draining" }>;
         },
-        reclaim: async (worktreePath) => {
+        reclaim: async (worktreePath, _placement, reauthorize) => {
           expect(worktreePath).toBe(worktree.path);
           reclaimStarted.resolve();
           await reclaimGate.promise;
+          reauthorize?.();
           await fs.appendFile(unsyncedPath, "final worker sync\n");
           placement = recoveryWorkerPlacement({
             sessionId: sourceSessionId,

--- a/src/gateway/session-recovery-service.ts
+++ b/src/gateway/session-recovery-service.ts
@@ -12,6 +12,7 @@ import { recoverSessionEntryFromRestartTombstone } from "../config/sessions/sess
 import type { SessionCreatedActor } from "../config/sessions/session-entry-provenance.js";
 import type { InternalSessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   isSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
@@ -26,6 +27,10 @@ import {
   loadGatewaySessionEntryReadOnly,
   resolveGatewaySessionStoreTarget,
 } from "./session-utils.js";
+import {
+  prepareSessionWorkerPlacementForArchive,
+  type SessionWorkerPlacementContext,
+} from "./worker-environments/session-placement-lifecycle.js";
 
 export type SessionRecoveryContinuationOutcome = SessionsRecoverResult["continuation"];
 
@@ -62,6 +67,7 @@ export async function recoverGatewaySession(params: {
   key: string;
   requestingOperatorProfileId?: string;
   operatorRoleActor?: GatewayOperatorRoleActor;
+  workerPlacementContext: SessionWorkerPlacementContext;
   launchContinuation: (params: {
     agentId: string;
     idempotencyKey: string;
@@ -74,9 +80,18 @@ export async function recoverGatewaySession(params: {
     key: params.key,
     ...(params.agentId ? { agentId: params.agentId } : {}),
   });
-  const initialSource = loadGatewaySessionEntryReadOnly(sourceTarget.canonicalKey, {
-    agentId: sourceTarget.agentId,
-  }).entry as InternalSessionEntry | undefined;
+  const readSource = () =>
+    loadGatewaySessionEntryReadOnly(sourceTarget.canonicalKey, {
+      agentId: sourceTarget.agentId,
+    }).entry as InternalSessionEntry | undefined;
+  const initialSource = readSource();
+  const checkOwnership = (entry: InternalSessionEntry | undefined) =>
+    resolvePluginSessionOwnershipError({
+      action: "recover",
+      entry,
+      key: sourceTarget.canonicalKey,
+      pluginOwnerId: params.authorizedPluginId,
+    });
   if (!initialSource?.sessionId) {
     return {
       ok: false,
@@ -93,12 +108,7 @@ export async function recoverGatewaySession(params: {
       ),
     };
   }
-  const ownershipError = resolvePluginSessionOwnershipError({
-    action: "recover",
-    entry: initialSource,
-    key: sourceTarget.canonicalKey,
-    pluginOwnerId: params.authorizedPluginId,
-  });
+  const ownershipError = checkOwnership(initialSource);
   if (ownershipError) {
     return { ok: false, error: ownershipError };
   }
@@ -134,7 +144,7 @@ export async function recoverGatewaySession(params: {
     targets: [
       {
         scope: sourceTarget.storePath,
-        identities: [sourceTarget.canonicalKey, initialSource.sessionId],
+        identities: [...sourceTarget.storeKeys, sourceTarget.canonicalKey, initialSource.sessionId],
       },
       {
         scope: successorTarget.storePath,
@@ -142,26 +152,13 @@ export async function recoverGatewaySession(params: {
       },
     ],
     run: async () => {
-      const currentSource = loadGatewaySessionEntryReadOnly(sourceTarget.canonicalKey, {
-        agentId: sourceTarget.agentId,
-      }).entry as InternalSessionEntry | undefined;
-      const currentOwnershipError = resolvePluginSessionOwnershipError({
-        action: "recover",
-        entry: currentSource,
-        key: sourceTarget.canonicalKey,
-        pluginOwnerId: params.authorizedPluginId,
-      });
+      let currentSource = readSource();
+      const currentOwnershipError = checkOwnership(currentSource);
       if (currentOwnershipError) {
         return { ok: false as const, error: currentOwnershipError };
       }
       if (!currentSource?.sessionId) {
-        return {
-          ok: false as const,
-          error: errorShape(
-            ErrorCodes.INVALID_REQUEST,
-            "Session changed before recovery; refresh and retry.",
-          ),
-        };
+        return { ok: false as const, error: recoveryConflictError("source-changed") };
       }
       if (!currentSource.mainRestartRecovery?.tombstone?.recoveredSessionKey) {
         const creationError = authorizeGatewaySessionCreation({
@@ -190,6 +187,45 @@ export async function recoverGatewaySession(params: {
           ),
         };
       }
+      const alreadyRecovered = currentSource.mainRestartRecovery?.tombstone?.recoveredSessionKey;
+      const placement = params.workerPlacementContext.workerSessionPlacementService
+        ?.getMany([currentSource.sessionId])
+        .get(currentSource.sessionId);
+      if (placement && !alreadyRecovered) {
+        try {
+          await prepareSessionWorkerPlacementForArchive({
+            agentId: sourceTarget.agentId,
+            ...(params.commitGuard ? { authorize: params.commitGuard } : {}),
+            context: params.workerPlacementContext,
+            reclaimActive: true,
+            sessionId: currentSource.sessionId,
+            sessionKey: sourceTarget.canonicalKey,
+          });
+        } catch (error) {
+          params.commitGuard?.();
+          return {
+            ok: false as const,
+            error: errorShape(
+              ErrorCodes.UNAVAILABLE,
+              `Session recovery cannot safely stop/reclaim its cloud worker: ${formatErrorMessage(error)} Stop cloud worker or call sessions.reclaim, then retry recovery.`,
+              { retryable: true },
+            ),
+          };
+        }
+        params.commitGuard?.();
+        const settledSource = readSource();
+        if (
+          settledSource?.sessionId !== currentSource.sessionId ||
+          settledSource.lifecycleRevision !== currentSource.lifecycleRevision
+        ) {
+          return { ok: false as const, error: recoveryConflictError("source-changed") };
+        }
+        const settledOwnershipError = checkOwnership(settledSource);
+        if (settledOwnershipError) {
+          return { ok: false as const, error: settledOwnershipError };
+        }
+        currentSource = settledSource;
+      }
       const successorEntry = buildRestartRecoverySuccessorEntry({
         sessionId: successorSessionId,
         source: currentSource,
@@ -202,6 +238,7 @@ export async function recoverGatewaySession(params: {
         ...(params.commitGuard ? { commitGuard: params.commitGuard } : {}),
         expected: {
           cycleId: recovery.cycleId,
+          lifecycleRevision: initialSource.lifecycleRevision,
           revision: recovery.revision,
           sessionId: initialSource.sessionId,
           ...(normalizeOptionalString(initialSource.pluginOwnerId)

--- a/src/gateway/worker-environments/placement-dispatch-authority.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-authority.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { type PlacementStore, REQUEST } from "./placement-dispatch-test-fixtures.js";
+import { createHarness } from "./placement-dispatch-test-harness.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+
+describe("worker placement reclaim authority", () => {
+  let root: string;
+  let database: OpenClawStateDatabase;
+  let placementStore: PlacementStore;
+
+  const createTestHarness = (options: Parameters<typeof createHarness>[1] = {}) =>
+    createHarness(placementStore, { workspacePath: path.join(root, "workspace"), ...options });
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-reclaim-auth-"));
+    database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+    placementStore = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+  });
+
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("stops final effects when authority closes during workspace reconciliation", async () => {
+    let authorized = true;
+    const harness = createTestHarness({
+      afterReconcile: () => {
+        authorized = false;
+      },
+    });
+    await harness.service.dispatch(REQUEST);
+
+    await expect(
+      harness.service.reclaim(REQUEST, () => {
+        if (!authorized) {
+          throw new Error("session recovery authority closed");
+        }
+      }),
+    ).rejects.toThrow("session recovery authority closed");
+
+    expect(harness.log).toContain("workspace:reconcile");
+    expect(harness.log).toContain("workspace:resume");
+    expect(harness.log).not.toContain("teardown:destroy");
+    expect(harness.log).not.toContain("placement:reclaimed");
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+    expect(harness.placements.current()).toMatchObject({ state: "draining" });
+  });
+
+  it("finishes durable placement completion when authority closes during destroy", async () => {
+    let authorized = true;
+    const harness = createTestHarness({
+      afterDestroy: () => {
+        authorized = false;
+      },
+    });
+    await harness.service.dispatch(REQUEST);
+
+    await expect(
+      harness.service.reclaim(REQUEST, () => {
+        if (!authorized) {
+          throw new Error("session recovery authority closed");
+        }
+      }),
+    ).resolves.toMatchObject({ state: "reclaimed" });
+
+    expect(harness.environments.destroy).toHaveBeenCalledOnce();
+    expect(harness.placements.current()).toMatchObject({ state: "reclaimed" });
+  });
+
+  it("stops failed-placement teardown when authority closes after tunnel cleanup", async () => {
+    let authorized = true;
+    let revokeAfterStop = false;
+    const harness = createTestHarness({
+      failAt: "activation",
+      destroyFailureCount: 1,
+      afterStopTunnel: () => {
+        if (revokeAfterStop) {
+          authorized = false;
+        }
+      },
+    });
+    await expect(harness.service.dispatch(REQUEST)).rejects.toThrow("activation failed");
+    expect(harness.placements.current()).toMatchObject({ state: "failed" });
+
+    revokeAfterStop = true;
+    await expect(
+      harness.service.reclaim(REQUEST, () => {
+        if (!authorized) {
+          throw new Error("session recovery authority closed");
+        }
+      }),
+    ).rejects.toThrow("session recovery authority closed");
+
+    expect(harness.environments.destroy).toHaveBeenCalledTimes(1);
+    expect(harness.placements.current()).toMatchObject({ state: "failed" });
+  });
+
+  it("finishes failed-placement bookkeeping when authority closes during destroy", async () => {
+    let authorized = true;
+    const harness = createTestHarness({
+      failAt: "activation",
+      destroyFailureCount: 1,
+      afterDestroy: () => {
+        authorized = false;
+      },
+    });
+    await expect(harness.service.dispatch(REQUEST)).rejects.toThrow("activation failed");
+    expect(harness.placements.current()).toMatchObject({ state: "failed" });
+
+    await expect(
+      harness.service.reclaim(REQUEST, () => {
+        if (!authorized) {
+          throw new Error("session recovery authority closed");
+        }
+      }),
+    ).resolves.toMatchObject({ state: "local" });
+
+    expect(harness.environments.destroy).toHaveBeenCalledTimes(2);
+    expect(harness.placements.current()).toMatchObject({ state: "local" });
+  });
+});

--- a/src/gateway/worker-environments/placement-dispatch-authority.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-authority.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -10,6 +10,8 @@ import {
 import { type PlacementStore, REQUEST } from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("worker placement reclaim authority", () => {
   let root: string;
@@ -20,7 +22,7 @@ describe("worker placement reclaim authority", () => {
     createHarness(placementStore, { workspacePath: path.join(root, "workspace"), ...options });
 
   beforeEach(async () => {
-    root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-reclaim-auth-"));
+    root = tempDirs.make("openclaw-reclaim-auth-");
     database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
     placementStore = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
   });

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -147,13 +147,16 @@ export function createPlacementFailureActions(deps: {
   const cleanupEnvironment = async (params: {
     environmentId: string;
     ownerEpoch: number | null;
+    authorize?: WorkerPlacementAuthorization;
   }): Promise<string[]> => {
     const teardownErrors: string[] = [];
+    params.authorize?.();
     try {
       await environments.stopTunnel(params.environmentId, params.ownerEpoch ?? undefined);
     } catch (error) {
       teardownErrors.push(`tunnel stop: ${boundedError(error)}`);
     }
+    params.authorize?.();
     try {
       await environments.destroy(params.environmentId);
     } catch (error) {
@@ -182,7 +185,10 @@ export function createPlacementFailureActions(deps: {
     );
   };
 
-  const retryFailedTeardown = async (placement: WorkerFailedDispatchPlacement): Promise<void> => {
+  const retryFailedTeardown = async (
+    placement: WorkerFailedDispatchPlacement,
+    authorize?: WorkerPlacementAuthorization,
+  ): Promise<void> => {
     if (!placement.environmentId) {
       return;
     }
@@ -198,6 +204,7 @@ export function createPlacementFailureActions(deps: {
     const teardownErrors = await cleanupEnvironment({
       environmentId: placement.environmentId,
       ownerEpoch: placement.activeOwnerEpoch,
+      ...(authorize ? { authorize } : {}),
     });
     if (teardownErrors.length > 0) {
       const recoveryError = [placement.recoveryError, ...teardownErrors].filter(Boolean).join("; ");

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -61,6 +61,9 @@ export function createHarness(
     >[0]["publishAcceptedWorkspace"];
     beforeMoveBegin?: (abandoned: { runId: string } | undefined) => Promise<void>;
     afterMoveBegin?: () => void;
+    afterDestroy?: () => Promise<void> | void;
+    afterReconcile?: () => Promise<void> | void;
+    afterStopTunnel?: () => Promise<void> | void;
     deviceRunnerAvailable?: boolean;
   } = {},
 ) {
@@ -257,6 +260,7 @@ export function createHarness(
       if (options.reconcileConflictPaths?.length && request.stagedResult) {
         request.stagedResult.record(request.stagedResult.ref);
       }
+      await options.afterReconcile?.();
       return {
         manifestRef: reconciledManifestRef,
         changed: options.reconcileChanged ?? true,
@@ -344,6 +348,7 @@ export function createHarness(
     }),
     stopTunnel: vi.fn(async () => {
       log.push("teardown:stop");
+      await options.afterStopTunnel?.();
     }),
     destroy: vi.fn(async () => {
       log.push("teardown:destroy");
@@ -362,6 +367,7 @@ export function createHarness(
       }
       const destroyed = destroyedEnvironment((currentEnvironment?.ownerEpoch ?? 1) + 1);
       currentEnvironment = destroyed;
+      await options.afterDestroy?.();
       return destroyed;
     }),
     reconcileOnce: vi.fn(async () => {
@@ -439,11 +445,11 @@ export function createHarness(
         : { requiredNodeCommands: [], consumesWorkerSlot: true },
     runReclaimBarrier: async ({ authorize, begin, reclaim }) => {
       authorize?.();
-      return await reclaim(options.workspacePath ?? "/gateway/workspace", begin());
+      return await reclaim(options.workspacePath ?? "/gateway/workspace", begin(), authorize);
     },
     runFailedReclaimBarrier: async ({ authorize, reclaim }) => {
       authorize?.();
-      return await reclaim();
+      return await reclaim(authorize);
     },
     resolveWorkspacePath: async () => {
       fail("workspace");

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -72,6 +72,7 @@ type WorkerPlacementReclaimBarrier = (
     reclaim: (
       localPath: string,
       placement: WorkerDrainingDispatchPlacement,
+      authorize?: WorkerPlacementAuthorization,
     ) => Promise<WorkerReclaimPlacement>;
   },
 ) => Promise<WorkerReclaimPlacement>;
@@ -79,7 +80,7 @@ type WorkerPlacementReclaimBarrier = (
 type WorkerPlacementFailedReclaimBarrier = (
   params: WorkerPlacementReclaimRequest & {
     authorize?: WorkerPlacementAuthorization;
-    reclaim: () => Promise<WorkerReclaimPlacement>;
+    reclaim: (authorize?: WorkerPlacementAuthorization) => Promise<WorkerReclaimPlacement>;
   },
 ) => Promise<WorkerReclaimPlacement>;
 
@@ -332,7 +333,7 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
         }
         return draining;
       },
-      reclaim: async (localPath, current) => {
+      reclaim: async (localPath, current, reauthorize) => {
         const journalOwner = {
           sessionId: current.sessionId,
           environmentId: current.environmentId,
@@ -412,9 +413,12 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
         const finishReclaim = async (): Promise<WorkerReclaimPlacement> => {
           const pending = journal.load();
           if (pending) {
+            reauthorize?.();
             await recoverWorkerWorkspaceReconciliation({ root: localPath, journal: pending });
+            reauthorize?.();
             journal.abort();
           }
+          reauthorize?.();
           const tunnel = await environments.startTunnel({
             environmentId: current.environmentId,
             ownerEpoch: current.activeOwnerEpoch,
@@ -422,6 +426,9 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
           const reclaimed = await options.workspaceOperations.run(
             current.environmentId,
             async () => {
+              // Lock acquisition and every remote/filesystem step may yield; stale callers must
+              // fail before the next reclaim effect, not only after teardown has completed.
+              reauthorize?.();
               const owned = placements.get(current.sessionId);
               if (
                 owned?.state !== "draining" ||
@@ -432,9 +439,11 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
               ) {
                 throw new Error("Cloud worker stop lost its placement owner before reconciliation");
               }
+              reauthorize?.();
               const quiescence = await tunnel.quiesceWorkspace(current.remoteWorkspaceDir);
               let destroyed = false;
               try {
+                reauthorize?.();
                 const reconciliation = await tunnel.reconcileWorkspace({
                   localPath,
                   remoteWorkspaceDir: current.remoteWorkspaceDir,
@@ -449,6 +458,7 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
                 if (reconciliation.changed && !manifestAccepted) {
                   throw new Error("Cloud worker stop did not commit its reconciled workspace");
                 }
+                reauthorize?.();
                 placements.acceptWorkspaceResult(reclaimClaim);
                 const recordedStagedResultRef = placements
                   .listPendingWorkspaceResults()
@@ -469,6 +479,7 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
                     sessionKey: current.sessionKey,
                     agentId: current.agentId,
                   }));
+                reauthorize?.();
                 const finalized = await finalizeWorkspaceResultConflicts({
                   placements,
                   turnClaim: reclaimClaim,
@@ -486,6 +497,7 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
                       ...report,
                     }),
                 });
+                reauthorize?.();
                 return await settleStagedWorkspaceResult({
                   placements,
                   turnClaim: reclaimClaim,
@@ -493,11 +505,14 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
                   stagedResultRef: recordedStagedResultRef,
                   conflictRetained: finalized.conflictRetained,
                   beforeComplete: async () => {
+                    reauthorize?.();
                     await environments.destroy(current.environmentId);
                     destroyed = true;
                   },
-                  complete: () =>
-                    moveIntent
+                  complete: () => {
+                    // Destroy is the final privileged effect. Once it commits, durable placement
+                    // completion must finish even if caller authority closes during the await.
+                    return moveIntent
                       ? completeMovedWorkspaceTeardown({
                           placements,
                           turnClaim: reclaimClaim,
@@ -510,7 +525,8 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
                           turnClaim: reclaimClaim,
                           environmentId: current.environmentId,
                           ownerEpoch: current.activeOwnerEpoch,
-                        }),
+                        });
+                  },
                   validateCompleted: (completed) => {
                     const expectedState = moveIntent ? "local" : "reclaimed";
                     if (completed.state !== expectedState) {
@@ -584,12 +600,12 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
         return await options.runFailedReclaimBarrier({
           ...request,
           authorize,
-          reclaim: async () => {
+          reclaim: async (reauthorize) => {
             const failedPlacement = placements.get(request.sessionId);
             if (failedPlacement?.state !== "failed") {
               throw new Error("Failed cloud worker placement changed during reclaim");
             }
-            await failure.retryFailedTeardown(failedPlacement);
+            await failure.retryFailedTeardown(failedPlacement, reauthorize);
             const failed = placements.get(request.sessionId);
             if (failed?.state !== "failed") {
               throw new Error("Failed cloud worker placement changed during reclaim");

--- a/src/gateway/worker-environments/session-placement-lifecycle.ts
+++ b/src/gateway/worker-environments/session-placement-lifecycle.ts
@@ -158,6 +158,7 @@ export function resolveSessionWorkerPlacementMutationError(
 
 export async function prepareSessionWorkerPlacementForArchive(params: {
   agentId: string;
+  authorize?: () => void;
   context: SessionWorkerPlacementContext;
   reclaimActive: boolean;
   sessionId?: string;
@@ -191,8 +192,17 @@ export async function prepareSessionWorkerPlacementForArchive(params: {
   if (!context.workerPlacementDispatchService?.reclaim) {
     throw new Error(`Session ${sessionKey} cloud worker reclaim is unavailable.`);
   }
-  const reclaimed: Placement = await context.workerPlacementDispatchService.reclaim(request);
-  if (reclaimed.state !== "reclaimed" || !matches(reclaimed)) {
+  const reclaimed: Placement = params.authorize
+    ? await context.workerPlacementDispatchService.reclaim(request, params.authorize)
+    : await context.workerPlacementDispatchService.reclaim(request);
+  const settled = context.workerSessionPlacementService?.getMany([sessionId]).get(sessionId);
+  if (
+    reclaimed.state !== "reclaimed" ||
+    !matches(reclaimed) ||
+    settled?.state !== "reclaimed" ||
+    !matches(settled) ||
+    settled.generation !== reclaimed.generation
+  ) {
     throw new Error(`Session ${sessionKey} cloud worker reclaim identity changed.`);
   }
 }


### PR DESCRIPTION
Closes #128596

## What Problem This Solves

Fixes an issue where restart recovery could archive a source session and create its successor while the source still owned an active cloud worker. That could leave remote execution and final workspace changes attached to a session identity the Gateway had already retired.

## Why This Change Was Made

Recovery now settles the source placement through the canonical archive/reclaim boundary before committing the SQLite source archive. Reclaim carries the runtime authority guard to each post-await workspace, tunnel, and environment effect; if authority closes before an effect, the placement stays retryable. Once environment destruction commits, durable local/reclaimed bookkeeping finishes even if authority closes during that await, avoiding a placement that points at a deleted environment. Recovery then re-reads the authoritative session, placement generation, owner epoch, environment, and lifecycle revision before the SQLite compare-and-swap.

Production LOC: +112/-38 (net +74) | Tests/test support: +597/-6 | Tooling baseline: +1/-1

The production growth establishes two coupled authority boundaries: recovery coordinates async placement reclaim outside the transaction, and the canonical reclaim owner fences every privileged final effect while preserving crash-safe completion after destruction. A downstream guard or post-archive cleanup cannot safely express either ordering.

AI-assisted: yes. I reviewed restart tombstones, session recovery ownership, placement reclaim/final synchronization, generation and owner-epoch checks, SQLite compare-and-swap inputs, archive lifecycle reuse, and failure guidance and understand the change.

## User Impact

Recovering a cloud-backed session now either safely reclaims and synchronizes its worker before creating the successor, or fails visibly with instructions to stop/reclaim the worker and retry. Recovery no longer silently retires a session that still has a live remote owner.

## Evidence

- Pre-fix regression failed because recovery committed the source archive before placement reclaim.
- Final post-rebase focused proof: 92 Gateway recovery/archive/reclaim tests and 3 SQLite recovery tests passed.
- Full changed-file gate: `node scripts/check-changed.mjs` passed with no new temp-directory, max-lines, type, lint, architecture, or database warnings.
- ClawSweeper’s P1 was accepted and fixed at the canonical reclaim owner: authority now revalidates before workspace reconciliation, result acceptance, environment teardown, and failed-placement teardown.
- Crash-safe regressions prove revocation before destroy blocks the effect, while revocation during successful destroy still completes durable placement bookkeeping.
- Fresh post-fix autoreview: no accepted/actionable P0/P1 findings (0.90).
- Coverage also includes reclaim failure guidance, canonical persisted placement mismatch, generation/epoch/environment replacement, source lifecycle revision changes, idempotent already-recovered calls, archive reuse, and final workspace synchronization.
