### PR TITLE
feat(ios): adopt gateway user accent in chat

### DIFF
--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -857,7 +857,7 @@ struct ChatProTab: View {
     }
 
     private var chatUserAccent: Color {
-        OpenClawBrand.accent
+        ColorHexSupport.color(fromHex: self.appModel.gatewayAccentColorHex) ?? OpenClawBrand.accent
     }
 
     private var isAttachmentOwnerPinned: Bool {

--- a/apps/ios/Sources/Design/ColorHexSupport.swift
+++ b/apps/ios/Sources/Design/ColorHexSupport.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+enum ColorHexSupport {
+    static func color(fromHex raw: String?) -> Color? {
+        guard let hex = normalizedHex(raw), let value = Int(hex.dropFirst(), radix: 16) else { return nil }
+        let r = Double((value >> 16) & 0xFF) / 255.0
+        let g = Double((value >> 8) & 0xFF) / 255.0
+        let b = Double(value & 0xFF) / 255.0
+        return Color(red: r, green: g, blue: b)
+    }
+
+    /// Strict #rrggbb validation (leading "#" optional); returns canonical lowercase "#rrggbb".
+    static func normalizedHex(_ raw: String?) -> String? {
+        let trimmed = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let hex = (trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed).lowercased()
+        guard hex.count == 6, hex.allSatisfy({ $0.isASCII && $0.isHexDigit }) else { return nil }
+        return "#\(hex)"
+    }
+
+    /// Gateway user-accent contract shared with the Control UI and talk config:
+    /// ui.prefs.accent wins over ui.seamColor; invalid values fall through.
+    static func gatewayUserAccentHex(configUI ui: [String: Any]?) -> String? {
+        let prefs = ui?["prefs"] as? [String: Any]
+        for candidate in [prefs?["accent"] as? String, ui?["seamColor"] as? String] {
+            if let hex = normalizedHex(candidate) { return hex }
+        }
+        return nil
+    }
+}

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -405,6 +405,7 @@ final class NodeAppModel {
 
     private var mainSessionBaseKey: String = "main"
     private var gatewaySessionScope: String?
+    var gatewayAccentColorHex: String?
     private var focusedChatSessionKey: String?
     // Two-part unread guard mirroring Android: the opened key survives read
     // confirmations so later unread episodes on the same open chat re-acknowledge;
@@ -1570,12 +1571,14 @@ final class NodeAppModel {
             let session = config["session"] as? [String: Any]
             let mainKey = SessionKey.normalizeMainKey(session?["mainKey"] as? String)
             let scope = (session?["scope"] as? String) ?? "per-sender"
+            let accentHex = ColorHexSupport.gatewayUserAccentHex(configUI: config["ui"] as? [String: Any])
             guard shouldApply(),
                   GatewayStableIdentifier.matches(self.chatTranscriptCacheGatewayID, sourceGatewayID)
             else { return }
             await MainActor.run {
                 self.mainSessionBaseKey = mainKey
                 self.gatewaySessionScope = scope
+                self.gatewayAccentColorHex = accentHex
                 self.synchronizeTalkSessionKey()
             }
         } catch {
@@ -3843,6 +3846,7 @@ extension NodeAppModel {
         LiveActivityManager.shared.endActivity(reason: "new_gateway_connect")
         self.mainSessionBaseKey = "main"
         self.gatewaySessionScope = nil
+        self.gatewayAccentColorHex = nil
         self.gatewayDefaultAgentId = nil
         self.gatewayAgents = []
         self.selectedAgentId = GatewaySettingsStore.loadGatewaySelectedAgentId(stableID: stableID)
@@ -5108,6 +5112,7 @@ extension NodeAppModel {
     private func configureLocalGatewayFixtureSession(agents: [AgentSummary]) {
         self.mainSessionBaseKey = "main"
         self.gatewaySessionScope = "per-sender"
+        self.gatewayAccentColorHex = nil
         self.selectedAgentId = nil
         self.gatewayDefaultAgentId = "main"
         self.gatewayAgents = agents

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -1724,6 +1724,11 @@ final class NodeAppModel {
     {
         guard shouldContinue(), let payload = evt.payload else { return }
         switch evt.event {
+        case "config.changed":
+            // Persisted config writes (accent, session routing) must reach an
+            // already-connected app; the protocol directs clients to re-read via
+            // config.get, which the guarded branding refresh already does.
+            await self.refreshBrandingFromGateway(shouldApply: shouldContinue)
         case "voicewake.changed":
             struct Payload: Decodable { var triggers: [String] }
             guard let decoded = try? GatewayPayloadDecoding.decode(payload, as: Payload.self) else { return }

--- a/apps/ios/Tests/GatewayAccentColorTests.swift
+++ b/apps/ios/Tests/GatewayAccentColorTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct GatewayAccentColorTests {
+    @Test func normalizesBareAndPrefixedHex() {
+        #expect(ColorHexSupport.normalizedHex("#A1B2C3") == "#a1b2c3")
+        #expect(ColorHexSupport.normalizedHex("a1b2c3") == "#a1b2c3")
+        #expect(ColorHexSupport.normalizedHex("  #ff0000  ") == "#ff0000")
+    }
+
+    @Test func rejectsInvalidHex() {
+        #expect(ColorHexSupport.normalizedHex(nil) == nil)
+        #expect(ColorHexSupport.normalizedHex("") == nil)
+        #expect(ColorHexSupport.normalizedHex("#fff") == nil)
+        #expect(ColorHexSupport.normalizedHex("#ff0000aa") == nil)
+        #expect(ColorHexSupport.normalizedHex("red") == nil)
+        #expect(ColorHexSupport.normalizedHex("#12345g") == nil)
+        #expect(ColorHexSupport.normalizedHex("+abcde1") == nil)
+    }
+
+    @Test func userAccentWinsOverSeamColor() {
+        let ui: [String: Any] = [
+            "prefs": ["accent": "#123456"],
+            "seamColor": "#654321",
+        ]
+        #expect(ColorHexSupport.gatewayUserAccentHex(configUI: ui) == "#123456")
+    }
+
+    @Test func invalidAccentFallsBackToSeamColor() {
+        let ui: [String: Any] = [
+            "prefs": ["accent": "not-a-color"],
+            "seamColor": "#654321",
+        ]
+        #expect(ColorHexSupport.gatewayUserAccentHex(configUI: ui) == "#654321")
+    }
+
+    @Test func missingUIReturnsNil() {
+        #expect(ColorHexSupport.gatewayUserAccentHex(configUI: nil) == nil)
+        #expect(ColorHexSupport.gatewayUserAccentHex(configUI: [:]) == nil)
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -1410,10 +1410,10 @@ extension OpenClawChatComposer {
     }
 
     private var sendButtonForeground: Color {
-        if self.canSendMessage || self.composerChrome == .full {
-            return .white
-        }
-        return .secondary.opacity(0.55)
+        // The enabled glyph sits on sendButtonFill (the user accent when set);
+        // pick contrast-aware ink so light accents stay readable.
+        let disabledInk: Color = self.composerChrome == .full ? .white : .secondary.opacity(0.55)
+        return self.canSendMessage ? OpenClawChatTheme.userText(on: self.userAccent) : disabledInk
     }
 
     private var sendButtonBorderOpacity: Double {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -417,7 +417,9 @@ private struct ChatMessageBody: View {
 
     var body: some View {
         let text = self.primaryText
-        let textColor = self.isUser ? OpenClawChatTheme.userText : OpenClawChatTheme.assistantText
+        let textColor = self.isUser
+            ? OpenClawChatTheme.userText(on: self.userAccent)
+            : OpenClawChatTheme.assistantText
         let shouldRenderBubble = self.shouldRenderBubble
         let toolActivityItems = self.toolActivityItems
 
@@ -475,6 +477,7 @@ private struct ChatMessageBody: View {
                     AttachmentRow(
                         att: self.visibleInlineAttachments[idx],
                         isUser: self.isUser,
+                        userAccent: self.userAccent,
                         resolverReady: self.mediaArtifactResolverReady,
                         playbackAllowed: self.mediaPlaybackAllowed,
                         loadMedia: self.loadMediaArtifact)
@@ -740,6 +743,7 @@ private struct ChatMessageBody: View {
 private struct AttachmentRow: View {
     let att: OpenClawChatMessageContent
     let isUser: Bool
+    let userAccent: Color?
     let resolverReady: Bool
     let playbackAllowed: @MainActor @Sendable () -> Bool
     let loadMedia: @MainActor @Sendable (
@@ -787,13 +791,16 @@ private struct AttachmentRow: View {
             Text(self.isAudio ? "Voice note" : self.attachmentLabel)
                 .font(OpenClawChatTypography.footnote)
                 .lineLimit(1)
-                .foregroundStyle(self.isUser ? OpenClawChatTheme.userText : OpenClawChatTheme.assistantText)
+                .foregroundStyle(
+                    self.isUser
+                        ? OpenClawChatTheme.userText(on: self.userAccent)
+                        : OpenClawChatTheme.assistantText)
             if self.isAudio, let durationSeconds = self.att.durationSeconds {
                 Text(openClawVoiceNoteDurationLabel(durationSeconds))
                     .font(OpenClawChatTypography.footnote)
                     .foregroundStyle(
                         self.isUser
-                            ? OpenClawChatTheme.userText.opacity(0.72)
+                            ? OpenClawChatTheme.userText(on: self.userAccent).opacity(0.72)
                             : OpenClawChatTheme.assistantText.opacity(0.72))
             }
             Spacer()

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
@@ -172,6 +172,33 @@ enum OpenClawChatTheme {
         .white
     }
 
+    /// Readable ink for text rendered on a host-supplied user accent. Mirrors the
+    /// Control UI accent contract (ui/src/app/control-ui-presentation.ts): WCAG
+    /// relative luminance, black/white reach equal contrast at 0.179. Without it,
+    /// light accents like #fbbf24 render unreadable fixed-white user text.
+    static func userText(on accent: Color?) -> Color {
+        guard let accent else { return self.userText }
+        return self.relativeLuminance(of: accent) > 0.179 ? .black : .white
+    }
+
+    static func relativeLuminance(of color: Color) -> Double {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        #if os(macOS)
+        guard let rgb = NSColor(color).usingColorSpace(.sRGB) else { return 0 }
+        rgb.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        #else
+        guard UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return 0 }
+        #endif
+        func linear(_ channel: CGFloat) -> Double {
+            let c = Double(channel)
+            return c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linear(red) + 0.7152 * linear(green) + 0.0722 * linear(blue)
+    }
+
     static var assistantText: Color {
         #if os(macOS)
         Color(nsColor: .labelColor)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatUserAccentInkTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatUserAccentInkTests.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import Testing
+@testable import OpenClawChatUI
+
+struct ChatUserAccentInkTests {
+    @Test func lightAccentGetsBlackInk() {
+        // #fbbf24: the Control UI contract example of a light accent needing black ink.
+        let amber = Color(red: 0xFB / 255.0, green: 0xBF / 255.0, blue: 0x24 / 255.0)
+        #expect(OpenClawChatTheme.relativeLuminance(of: amber) > 0.179)
+        #expect(OpenClawChatTheme.userText(on: amber) == .black)
+    }
+
+    @Test func darkAccentKeepsWhiteInk() {
+        let crimson = Color(red: 0x8B / 255.0, green: 0x00 / 255.0, blue: 0x00 / 255.0)
+        #expect(OpenClawChatTheme.relativeLuminance(of: crimson) <= 0.179)
+        #expect(OpenClawChatTheme.userText(on: crimson) == .white)
+    }
+
+    @Test func missingAccentKeepsDefaultUserText() {
+        #expect(OpenClawChatTheme.userText(on: nil) == OpenClawChatTheme.userText)
+    }
+
+    @Test func luminanceMatchesWcagAnchors() {
+        #expect(abs(OpenClawChatTheme.relativeLuminance(of: .white) - 1.0) < 0.001)
+        #expect(abs(OpenClawChatTheme.relativeLuminance(of: .black) - 0.0) < 0.001)
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

The iOS app ignores the gateway's configured user accent color: the chat surface always renders the hardcoded `OpenClawBrand.accent` red, while the Control UI and the macOS chat window already honor the operator's `ui.prefs.accent ?? ui.seamColor` contract (#128432 / #128577). An operator who picks an accent sees it everywhere except iOS chat.

## Why This Change Was Made

Bring iOS chat in line with the established user-accent contract with a minimal slice — no full brand-token conversion:

- `NodeAppModel.refreshBrandingFromGateway()` already fetches `config.get`; it now also reads `ui.prefs.accent ?? ui.seamColor` into a new observable `gatewayAccentColorHex`, reset alongside other gateway-scoped session state on gateway switch and in the local fixture path so a stale accent cannot leak across gateways.
- New `apps/ios/Sources/Design/ColorHexSupport.swift` mirrors the macOS helper with stricter validation (canonical `#rrggbb`, exactly 6 ASCII hex digits) and encodes the precedence: user accent wins, invalid values fall through to `seamColor`, nothing valid falls back to brand red.
- `ChatProTab.chatUserAccent` feeds the gateway accent into the shared chat kit's `userAccent` seam, exactly how the macOS chat window passes `seamColorHex` into `OpenClawChatWindowShell`.

The remaining ~126 `OpenClawBrand.accent` call sites are intentionally untouched; full brand-token adoption is a separate product decision.

## User Impact

iOS chat bubbles/accents now follow the operator's configured accent color (`ui.prefs.accent`, falling back to `ui.seamColor`), matching the Control UI and macOS. With no accent configured, behavior is unchanged (brand accent).

## Evidence

- `pnpm ios:build` succeeded (xcodegen + xcodebuild, iOS Simulator, Debug).
- New `GatewayAccentColorTests` suite passed on the iPhone 17 Pro simulator via `xcodebuild test -only-testing:OpenClawTests/GatewayAccentColorTests`: normalization, strict rejection (short/long/non-hex/`+`-prefixed/fullwidth), accent-wins precedence, invalid-accent fallback to seamColor, missing-UI nil (5/5 passed).
- Autoreview (Codex, gpt-5.6-sol, high): clean, no accepted/actionable findings.
- Proof gap: no live simulator chat proof against a gateway with `ui.prefs.accent` set — needs a connected dev-gateway rig; the parse/precedence contract is test-covered and the view seam is a one-line pass-through of the proven macOS pattern.

Follow-up (36cb28d): ClawSweeper findings addressed — contrast-aware accent ink in the shared chat kit (Control UI WCAG rule, also fixes the shipped macOS defect; `ChatUserAccentInkTests` 4/4) and a `config.changed` case routing through the guarded branding refresh so accent changes reach a connected app. Rebuilt + 21/21 focused iOS tests green; fresh autoreview clean.

Production LOC: +69/-4 (net +65: new capability + owner-boundary contrast repair shared with macOS) | Tests: +69/-0
