### PR TITLE
fix(cli): return JSON for curator and workshop failures

### DIFF
--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -70,7 +70,7 @@ import { CONFIG_DIR } from "../utils.js";
 import { resolveClawHubRiskAcknowledgementCliOptions } from "./clawhub-risk-acknowledgement.js";
 import { resolveOptionFromCommand, runCommandWithRuntime } from "./cli-utils.js";
 import { inheritOptionFromParent } from "./command-options.js";
-import { formatCliJsonFailure, rethrowExpectedCliError } from "./failure-output.js";
+import { formatCliJsonFailure } from "./failure-output.js";
 import { resolveInstallPolicyWarningAcknowledgementCliOptions } from "./install-policy-warning-acknowledgement.js";
 import { parseStrictPositiveIntOption } from "./program/helpers.js";
 import { setCommandJsonMode } from "./program/json-mode.js";
@@ -972,18 +972,14 @@ export function registerSkillsCli(program: Command) {
     .option("--json", "Output as JSON", false);
 
   const showCuratorStatus = async (opts: { json?: boolean }, command: Command) => {
-    try {
+    await runCommandWithRuntime(defaultRuntime, async () => {
       const status = await loadSkillCuratorStatus();
       if (hasJsonOutput(opts) || inheritOptionFromParent<boolean>(command, "json")) {
         defaultRuntime.writeJson(status);
         return;
       }
       defaultRuntime.writeStdout(formatSkillCuratorStatus(status));
-    } catch (err) {
-      rethrowExpectedCliError(err);
-      defaultRuntime.error(formatErrorMessage(err));
-      defaultRuntime.exit(1);
-    }
+    });
   };
 
   curator
@@ -997,7 +993,7 @@ export function registerSkillsCli(program: Command) {
       .description(`${action} a curated skill`)
       .argument("<skill>", "Skill name or key")
       .action(async (skill: string, opts: { json?: boolean }, command: Command) => {
-        try {
+        await runCommandWithRuntime(defaultRuntime, async () => {
           const result = await runSkillCuratorMutation(action, skill);
           if (hasJsonOutput(opts) || inheritOptionFromParent<boolean>(command, "json")) {
             defaultRuntime.writeJson(result);
@@ -1006,11 +1002,7 @@ export function registerSkillsCli(program: Command) {
           defaultRuntime.writeStdout(
             `${action[0]?.toUpperCase()}${action.slice(1)} ${result.skillKey}\n`,
           );
-        } catch (err) {
-          rethrowExpectedCliError(err);
-          defaultRuntime.error(formatErrorMessage(err));
-          defaultRuntime.exit(1);
-        }
+        });
       });
   }
   for (const command of curator.commands) {
@@ -1033,18 +1025,14 @@ export function registerSkillsCli(program: Command) {
     action: (resolved: ResolvedSkillsWorkspace) => Promise<T>,
     format: (result: T) => string,
   ): Promise<void> => {
-    try {
+    await runCommandWithRuntime(defaultRuntime, async () => {
       const result = await action(resolveSkillsWorkspaceForCommand(command, opts));
       if (hasJsonOutput(opts)) {
         defaultRuntime.writeJson(result);
         return;
       }
       defaultRuntime.writeStdout(format(result));
-    } catch (err) {
-      rethrowExpectedCliError(err);
-      defaultRuntime.error(formatErrorMessage(err));
-      defaultRuntime.exit(1);
-    }
+    });
   };
 
   const runWorkshopDraftAction = (
@@ -1095,26 +1083,19 @@ export function registerSkillsCli(program: Command) {
     .description("Inspect a skill proposal")
     .argument("<proposal-id>", "Skill proposal id")
     .option("--json", "Output as JSON", false)
-    .action(
-      async (proposalId: string, opts: { json?: boolean; agent?: string }, command: Command) => {
-        try {
-          const { agentId, workspaceDir } = resolveSkillsWorkspaceForCommand(command, opts);
+    .action((proposalId: string, opts: { json?: boolean; agent?: string }, command: Command) =>
+      runWorkshopAction(
+        opts,
+        command,
+        async ({ agentId, workspaceDir }) => {
           const proposal = await inspectSkillProposal(proposalId, { agentId, workspaceDir });
           if (!proposal) {
-            defaultRuntime.error(`Skill proposal not found: ${proposalId}`);
-            defaultRuntime.exit(1);
-            return;
+            throw new Error(`Skill proposal not found: ${proposalId}`);
           }
-          if (hasJsonOutput(opts)) {
-            defaultRuntime.writeJson(proposal);
-            return;
-          }
-          defaultRuntime.writeStdout(formatSkillProposalInspect(proposal));
-        } catch (err) {
-          defaultRuntime.error(formatErrorMessage(err));
-          defaultRuntime.exit(1);
-        }
-      },
+          return proposal;
+        },
+        formatSkillProposalInspect,
+      ),
     );
 
   workshop

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -1556,6 +1556,21 @@ describe("cli json stdout contract", () => {
       args: ["skills", "--json", "--agent", ""],
       message: "--agent must not be blank",
     },
+    {
+      name: "curator mutation",
+      args: ["skills", "curator", "pin", "missing-skill", "--json"],
+      message: "Curated skill not found: missing-skill",
+    },
+    {
+      name: "workshop mutation",
+      args: ["skills", "workshop", "reject", "missing-proposal", "--json"],
+      message: "Skill proposal not found: missing-proposal",
+    },
+    {
+      name: "workshop inspection",
+      args: ["skills", "workshop", "inspect", "missing-proposal", "--json"],
+      message: "Skill proposal not found: missing-proposal",
+    },
   ])("returns one canonical JSON document when skills $name fails", async (testCase) => {
     await withTempHome(
       async (tempHome) => {

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -1562,6 +1562,16 @@ describe("cli json stdout contract", () => {
       message: "Curated skill not found: missing-skill",
     },
     {
+      name: "curator mutation with parent JSON",
+      args: ["skills", "curator", "--json", "pin", "missing-skill"],
+      message: "Curated skill not found: missing-skill",
+    },
+    {
+      name: "workshop workspace validation with parent JSON",
+      args: ["skills", "--json", "workshop", "list", "--agent", ""],
+      message: "--agent must not be blank",
+    },
+    {
       name: "workshop mutation",
       args: ["skills", "workshop", "reject", "missing-proposal", "--json"],
       message: "Skill proposal not found: missing-proposal",


### PR DESCRIPTION
Closes #126996

## What Problem This Solves

Fixes an issue where `openclaw skills ... --json` returned an empty stdout document when curator mutations, workshop mutations, or workshop inspection failed. Automation could see the nonzero exit code but could not parse the requested JSON error.

## Why This Change Was Made

Routes the remaining curator and workshop catches through the existing `runCommandWithRuntime` failure owner introduced for sibling skill commands in #127016. JSON mode now reaches the canonical entrypoint renderer, while text mode keeps its existing operator-facing stderr behavior. Workshop inspection also reuses the shared workshop action path instead of maintaining a second failure policy.

Open #112362 and #109544 touch `src/cli/skills-cli.ts` in distinct browse-config and workshop-approval paths. Open #126550 and #128590 add unrelated sessions and agent-identity cases to the shared CLI JSON E2E file.

## User Impact

Curator and workshop failures requested with `--json` now return one parseable `cli_error` document on stdout and retain exit status 1. Human-readable invocations continue to report the failure on stderr. The real built-CLI regression table also covers `--json` inherited from the curator parent and the skills root, including asynchronous mutation failure and synchronous workspace validation.

## Evidence

Original reproduction base: `3d06659e31a00ea8ee0f5159aa5e0e18f52b0503`

Current reviewed head: `ca98173b1b99ef00293cb297b3e3ec2b3ffda56a`

Production LOC: `+17/-36` (net `-19`). Test LOC: `+25/-0`.

The contributor's original real CLI subprocess proof used Node `v24.15.0` and the production source entrypoint at source head `3a5f47058c227905fff57334b50706581f06d09e`:

```text
node --import tsx src/index.ts skills curator pin missing-skill --json
node --import tsx src/index.ts skills workshop reject missing-proposal --json
node --import tsx src/index.ts skills workshop inspect missing-proposal --json
```

On the original base SHA, all three exited 1 with `stdout=0 bytes`; stderr contained the corresponding `Curated skill not found` or `Skill proposal not found` message. On the original source head, all three still exited 1 and stdout contained exactly one JSON document:

```json
{
  "ok": false,
  "error": {
    "type": "cli_error",
    "message": "Skill proposal not found: missing-proposal"
  }
}
```

The current head preserves that identical production patch and adds real built-subprocess regression cases for both inherited option positions:

```text
openclaw skills curator --json pin missing-skill
openclaw skills --json workshop list --agent ''
```

Original contributor-focused verification on source head `3a5f47058c227905fff57334b50706581f06d09e`:

```text
node scripts/run-vitest.mjs run src/cli/skills-cli.curator.test.ts src/cli/skills-cli.workshop.test.ts --maxWorkers=1
Test Files  2 passed (2)
Tests       13 passed (13)

oxfmt --check src/cli/skills-cli.ts test/cli-json-stdout.e2e.test.ts
All matched files use the correct format.

git diff --check
(clean)
```

The original head's CI run 32703035712 failed only in unrelated `src/audit/audit-event-writer.test.ts:272`, where the runner measured `eventLoopDelay=281.4316ms` against an existing `250ms` threshold. The current head does not change that test, its timeout, or production audit behavior; its normal exact-head hosted CI validates the newly extended built-CLI regression suite.

The regression cases live in the real built-CLI E2E suite. The external contributor branch was not executed on a credentialed maintainer host; exact-head hosted CI supplies current-head execution proof. The original source subprocess proof exercised the production entrypoint directly, not a mock.

AI assistance: implementation and test authoring were AI-assisted. The source subprocess proof and focused tests above were run locally by the original contributor against the separately stated original SHAs.
