### PR TITLE
fix(ci): prepare gateway profile live startup

### DIFF
--- a/scripts/test-live-shard.mts
+++ b/scripts/test-live-shard.mts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { asSafeIntegerInRange } from "../packages/normalization-core/src/number-coercion.ts";
 import { isRecord as isUnknownRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import { parsePermissiveBooleanToken } from "./lib/arg-utils.mts";
+import { RUNTIME_POSTBUILD_STAMP_FILE } from "./lib/local-build-metadata-paths.mts";
 import { spawnPnpmRunner, type PnpmRunnerParams } from "./pnpm-runner.mts";
 import {
   createVitestProcessCompletion,
@@ -53,7 +54,14 @@ const OPTIONAL_LIVE_SHARD_FILE_ENVS = new Map([
 const SKIPPED_ASSERTION_STATUSES = new Set(["disabled", "pending", "skipped", "todo"]);
 const QA_RUNTIME_LIVE_TEST = "extensions/qa-lab/src/matrix-channel-driver.lifecycle.live.test.ts";
 const QA_RUNTIME_ARTIFACT = "dist/extensions/qa-lab/runtime-api.js";
+const SOURCE_PERFORMANCE_ARTIFACT = `dist/${RUNTIME_POSTBUILD_STAMP_FILE}`;
 type ProcessSignal = `SIG${string}`;
+type LiveShardPreparation = {
+  env: NodeJS.ProcessEnv;
+  profile: string;
+  requiredArtifact: string;
+  runtimeEnv?: NodeJS.ProcessEnv;
+};
 
 /** Live-test shards included in release validation. */
 export const RELEASE_LIVE_TEST_SHARDS = Object.freeze([
@@ -387,14 +395,29 @@ export function buildLiveShardPnpmArgs(files: string[], passthroughArgs: string[
 /**
  * Resolves build profiles required by selected live tests.
  */
-export function resolveLiveShardPreparation(files: string[]) {
-  return files.includes(QA_RUNTIME_LIVE_TEST)
-    ? {
-        env: { OPENCLAW_BUILD_PRIVATE_QA: "1" },
-        profile: "qaRuntime",
-        requiredArtifact: QA_RUNTIME_ARTIFACT,
-      }
-    : null;
+export function resolveLiveShardPreparation(files: string[]): LiveShardPreparation | null {
+  if (files.some(isGatewayProfilesLiveTest)) {
+    return {
+      env: {},
+      profile: "sourcePerformance",
+      requiredArtifact: SOURCE_PERFORMANCE_ARTIFACT,
+      runtimeEnv: {
+        OPENCLAW_DISABLE_BONJOUR: "1",
+        OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
+        OPENCLAW_LIVE_TEST_QUIET: "0",
+        OPENCLAW_LOG_LEVEL: "info",
+        OPENCLAW_PLUGIN_LIFECYCLE_TRACE: "1",
+      },
+    };
+  }
+  if (files.includes(QA_RUNTIME_LIVE_TEST)) {
+    return {
+      env: { OPENCLAW_BUILD_PRIVATE_QA: "1" },
+      profile: "qaRuntime",
+      requiredArtifact: QA_RUNTIME_ARTIFACT,
+    };
+  }
+  return null;
 }
 
 /**
@@ -661,10 +684,14 @@ function validateLiveShardReport(
 /**
  * Builds spawn options for the live-shard Vitest child.
  */
-export function buildLiveShardSpawnParams(env = process.env, platform = process.platform) {
+export function buildLiveShardSpawnParams(
+  env = process.env,
+  platform = process.platform,
+  runtimeEnv?: NodeJS.ProcessEnv,
+) {
   return {
     detached: shouldUseDetachedVitestProcessGroup(platform),
-    env,
+    env: { ...env, ...runtimeEnv },
     stdio: "inherit",
   } satisfies Pick<PnpmRunnerParams, "detached" | "env" | "stdio">;
 }
@@ -750,7 +777,11 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
   const reportPath = buildLiveShardReportPath(shard, process.env);
   fs.mkdirSync(path.dirname(reportPath), { recursive: true });
   removeLiveShardReportFile(reportPath);
-  const spawnParams = buildLiveShardSpawnParams(process.env);
+  const spawnParams = buildLiveShardSpawnParams(
+    process.env,
+    process.platform,
+    preparation?.runtimeEnv,
+  );
   const child = spawnPnpmRunner({
     pnpmArgs: buildLiveShardPnpmArgs(files, addLiveShardReportArgs(passthroughArgs, reportPath)),
     ...spawnParams,

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -244,6 +244,28 @@ describe("scripts/test-live-shard", () => {
     ).toBeNull();
   });
 
+  it("prepares gateway profile shards with observable source-runtime diagnostics", () => {
+    const preparation = resolveLiveShardPreparation(
+      selectLiveShardFiles("native-live-src-gateway-profiles", allFiles),
+    );
+
+    expect(preparation).toEqual({
+      env: {},
+      profile: "sourcePerformance",
+      requiredArtifact: "dist/.runtime-postbuildstamp",
+      runtimeEnv: {
+        OPENCLAW_DISABLE_BONJOUR: "1",
+        OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
+        OPENCLAW_LIVE_TEST_QUIET: "0",
+        OPENCLAW_LOG_LEVEL: "info",
+        OPENCLAW_PLUGIN_LIFECYCLE_TRACE: "1",
+      },
+    });
+    expect(
+      resolveLiveShardPreparation(selectLiveShardFiles("native-live-src-gateway-core", allFiles)),
+    ).toBeNull();
+  });
+
   it("fails live shard reports with no passing tests", () => {
     expect(validateLiveShardReportPayload({ numPassedTests: 1, numTotalTests: 3 })).toEqual({
       ok: true,
@@ -556,6 +578,26 @@ describe("scripts/test-live-shard", () => {
     expect(buildLiveShardSpawnParams({ PATH: "/usr/bin" }, "win32")).toEqual({
       detached: false,
       env: { PATH: "/usr/bin" },
+      stdio: "inherit",
+    });
+    expect(
+      buildLiveShardSpawnParams({ OPENCLAW_LOG_LEVEL: "warn", PATH: "/usr/bin" }, "darwin", {
+        OPENCLAW_DISABLE_BONJOUR: "1",
+        OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
+        OPENCLAW_LIVE_TEST_QUIET: "0",
+        OPENCLAW_LOG_LEVEL: "info",
+        OPENCLAW_PLUGIN_LIFECYCLE_TRACE: "1",
+      }),
+    ).toEqual({
+      detached: true,
+      env: {
+        OPENCLAW_DISABLE_BONJOUR: "1",
+        OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
+        OPENCLAW_LIVE_TEST_QUIET: "0",
+        OPENCLAW_LOG_LEVEL: "info",
+        OPENCLAW_PLUGIN_LIFECYCLE_TRACE: "1",
+        PATH: "/usr/bin",
+      },
       stdio: "inherit",
     });
   });


### PR DESCRIPTION
Related: #128428

## What Problem This Solves

Fixes an issue where source-transformed gateway profile live suites could spend the unchanged 90-second startup allowance preparing an incomplete runtime, then fail before either selected provider candidate ran.

The exact-head MiniMax proof on #128428 showed that moving the shard to a larger runner did not solve the failure: gateway startup completed only after 167 seconds and provider coverage never began.

## Why This Change Was Made

The live-shard harness now recognizes gateway profile files at its existing preparation boundary, builds the canonical `sourcePerformance` profile, and requires `dist/.runtime-postbuildstamp` before starting Vitest.

Startup and plugin lifecycle traces, visible live output, disabled Bonjour, and info-level logging are applied only to the live Vitest process. They do not leak into or alter the build environment. Unrelated gateway/core shards keep their existing behavior.

This replaces the runner-routing mitigation proposed by Dallin Romney in #128428 with the startup-owner repair proven necessary by that PR's focused run. Dallin is preserved as a co-author in the commit.

## User Impact

Release validation can diagnose and exercise gateway profile providers without weakening the 90-second startup contract or changing product runtime behavior.

## Evidence

- Before: `native-live-src-gateway-profiles` selected both profile files but `resolveLiveShardPreparation(...)` returned `null`.
- `node scripts/run-vitest.mjs test/scripts/test-live-shard.test.ts` - 24 tests passed.
- `node scripts/check-changed.mjs -- scripts/test-live-shard.mts test/scripts/test-live-shard.test.ts` - passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/test-live-shard.mts` - passed.
- `node_modules/.bin/oxfmt --check scripts/test-live-shard.mts test/scripts/test-live-shard.test.ts` - passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` - clean; no accepted/actionable findings.
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/32704645073 - passed.
- Exact-head MiniMax live proof: https://github.com/openclaw/openclaw/actions/runs/32705739884 - the harness/startup repair is proven, but the focused suite is terminal red on distinct downstream provider/runtime failures. `sourcePerformance` prepared the required `dist/.runtime-postbuildstamp`; the canonical build completed in 49.1s; startup and plugin lifecycle traces were visible; gateway reached ready in 9.581s under the unchanged 90s bound; runner CPU count was 2; selection reached `wanted=2`, `candidates=2`, `skipped=0`, and both candidates executed. `minimax/MiniMax-M3` called the configured MiniMax responses endpoint and received 404 `model_not_found`; `minimax-portal/MiniMax-M3` then failed after auth rewarm could not load the source-checkout `.js` auth worker and the prepared model runtime generation was superseded. Per the bounded proof contract, this run was not retried.

AI-assisted: yes. The implementation and evidence were manually inspected.

