### PR TITLE
fix: /models stops working after an unrelated config edit and never recovers

### DIFF
--- a/src/agents/prepared-model-runtime-auth.ts
+++ b/src/agents/prepared-model-runtime-auth.ts
@@ -63,3 +63,18 @@ export function getPreparedModelRuntimeAuthMaterializations(
 ): readonly RuntimeAuthMaterialization[] {
   return materializationsBySnapshot.get(snapshot) ?? [];
 }
+
+export function copyPreparedModelRuntimeAuthBindings(source: object, target: object): void {
+  const authStore = authStoreBySnapshot.get(source);
+  const authLoader = authLoaderBySnapshot.get(source);
+  const materializations = materializationsBySnapshot.get(source);
+  if (authStore) {
+    authStoreBySnapshot.set(target, authStore);
+  }
+  if (authLoader) {
+    authLoaderBySnapshot.set(target, authLoader);
+  }
+  if (materializations) {
+    materializationsBySnapshot.set(target, materializations);
+  }
+}

--- a/src/agents/prepared-model-runtime-config-stamp.test.ts
+++ b/src/agents/prepared-model-runtime-config-stamp.test.ts
@@ -1,0 +1,191 @@
+// Preserve module setup before modules that consume it.
+// oxfmt-ignore
+import {
+  getPreparedModelRuntimeMocks,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  getPreparedModelRuntimeAuthMaterializations,
+  getPreparedModelRuntimeAuthStore,
+  loadPreparedModelRuntimeAuth,
+  setPreparedModelRuntimeAuthMaterializations,
+} from "./prepared-model-runtime-auth.js";
+import {
+  advancePreparedModelRuntimeConfig,
+  loadPublishedGatewayReplyDispatchRuntime,
+  prepareModelRuntimeSnapshot,
+  refreshPreparedModelRuntimeSnapshots,
+} from "./prepared-model-runtime.js";
+
+const mocks = getPreparedModelRuntimeMocks();
+
+describe("prepared model runtime config stamps", () => {
+  beforeEach(() => {
+    resetPreparedModelRuntimeHarness();
+    mocks.configuredAgentIds = ["default"];
+  });
+
+  it("advances without rebuilding or mutating existing readers", async () => {
+    const initialConfig = {};
+    const nextConfig = { gateway: { reload: { mode: "hot" as const } } };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const input = {
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      config: initialConfig,
+    };
+    const existingReader = await prepareModelRuntimeSnapshot(input);
+    const materializations = [
+      {
+        provider: "test",
+        modelId: "model",
+        modelApi: "responses",
+        modelBaseUrl: "https://example.test",
+        requestTransportOverrides: "none" as const,
+        authMode: "api_key",
+        runtimeOwnerId: "test-owner",
+      },
+    ];
+    setPreparedModelRuntimeAuthMaterializations(existingReader, materializations);
+    const authStore = getPreparedModelRuntimeAuthStore(existingReader);
+    const loadedAuth = await loadPreparedModelRuntimeAuth(existingReader, { providerIds: [] });
+
+    advancePreparedModelRuntimeConfig(nextConfig);
+
+    const advanced = await prepareModelRuntimeSnapshot({ ...input, config: nextConfig });
+    expect(advanced).not.toBe(existingReader);
+    expect(advanced.config).toBe(nextConfig);
+    expect(existingReader.config).toBe(initialConfig);
+    expect(getPreparedModelRuntimeAuthStore(advanced)).toBe(authStore);
+    expect(getPreparedModelRuntimeAuthMaterializations(advanced)).toBe(materializations);
+    await expect(loadPreparedModelRuntimeAuth(advanced, { providerIds: [] })).resolves.toEqual(
+      loadedAuth,
+    );
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+    await expect(
+      loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+    ).resolves.toMatchObject({ config: nextConfig });
+  });
+
+  it("resolves startup config inside the serialized publication", async () => {
+    const initialConfig = {};
+    const nextConfig = { gateway: { reload: { mode: "hot" as const } } };
+    let currentConfig = initialConfig;
+
+    const publication = refreshPreparedModelRuntimeSnapshots(() => currentConfig, {
+      gatewayLifecycle: true,
+    });
+    currentConfig = nextConfig;
+    advancePreparedModelRuntimeConfig(nextConfig);
+    await publication;
+
+    await expect(
+      prepareModelRuntimeSnapshot({
+        agentId: "default",
+        agentDir: "/tmp/unused-agent",
+        inheritedAuthDir: "/tmp/unused-agent",
+        config: nextConfig,
+      }),
+    ).resolves.toMatchObject({ config: nextConfig });
+    await expect(
+      loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+    ).resolves.toMatchObject({ config: nextConfig });
+  });
+
+  it("drops an async startup config supplier superseded before it resolves", async () => {
+    const staleConfig = {};
+    const nextConfig = { gateway: { reload: { mode: "hot" as const } } };
+    const supplierReady = createDeferred();
+    const stalePublication = refreshPreparedModelRuntimeSnapshots(async () => {
+      await supplierReady.promise;
+      return staleConfig;
+    });
+    const nextPublication = refreshPreparedModelRuntimeSnapshots(nextConfig, {
+      gatewayLifecycle: true,
+    });
+
+    supplierReady.resolve();
+    await Promise.all([stalePublication, nextPublication]);
+
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+    await expect(
+      prepareModelRuntimeSnapshot({
+        agentId: "default",
+        agentDir: "/tmp/unused-agent",
+        inheritedAuthDir: "/tmp/unused-agent",
+        config: nextConfig,
+      }),
+    ).resolves.toMatchObject({ config: nextConfig });
+  });
+
+  it("drops a publication whose lifecycle claim is lost during async config resolution", async () => {
+    const initialConfig = {};
+    const staleConfig = { gateway: { reload: { mode: "off" as const } } };
+    const nextConfig = { gateway: { reload: { mode: "hot" as const } } };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const supplierStarted = createDeferred();
+    const releaseSupplier = createDeferred();
+    let claimCurrent = true;
+    const stalePublication = refreshPreparedModelRuntimeSnapshots(
+      async () => {
+        supplierStarted.resolve();
+        await releaseSupplier.promise;
+        return staleConfig;
+      },
+      {
+        gatewayLifecycle: true,
+        isPublicationCurrent: () => claimCurrent,
+      },
+    );
+
+    await supplierStarted.promise;
+    claimCurrent = false;
+    releaseSupplier.resolve();
+    await stalePublication;
+    await refreshPreparedModelRuntimeSnapshots(nextConfig, { gatewayLifecycle: true });
+
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+    await expect(
+      prepareModelRuntimeSnapshot({
+        agentId: "default",
+        agentDir: "/tmp/unused-agent",
+        inheritedAuthDir: "/tmp/unused-agent",
+        config: nextConfig,
+      }),
+    ).resolves.toMatchObject({ config: nextConfig });
+    await expect(
+      loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+    ).resolves.toMatchObject({ config: nextConfig });
+  });
+
+  it("keeps an in-flight auth publication on the advanced stamp", async () => {
+    const initialConfig = {};
+    const nextConfig = { gateway: { reload: { mode: "hot" as const } } };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    let finishAuthRefresh: (() => void) | undefined;
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
+      async () =>
+        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+          finishAuthRefresh = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+        }),
+    );
+
+    mocks.mutationListener?.({ affectsInheritedStores: true });
+    await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
+    advancePreparedModelRuntimeConfig(nextConfig);
+    finishAuthRefresh?.();
+
+    await expect(
+      prepareModelRuntimeSnapshot({
+        agentId: "default",
+        agentDir: "/tmp/unused-agent",
+        inheritedAuthDir: "/tmp/unused-agent",
+        config: nextConfig,
+      }),
+    ).resolves.toMatchObject({ config: nextConfig });
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -15,6 +15,7 @@ import { resolveSelectedAgentHarnessRuntime } from "./harness/runtime-plugin-loa
 import { resolveLegacyInheritedAuthDir } from "./legacy-inherited-auth-dir.js";
 import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
 import { resolveDefaultModelForAgent } from "./model-selection-config.js";
+import { copyPreparedModelRuntimeAuthBindings } from "./prepared-model-runtime-auth.js";
 import {
   startSerializedSnapshotBuild,
   startSerializedSnapshotBuildBatch,
@@ -209,6 +210,30 @@ export function preparedModelRuntimeConfigsMatch(
     return hashRuntimeConfigValue(left) === hashRuntimeConfigValue(right);
   } catch {
     return false;
+  }
+}
+
+function stampPreparedModelRuntimeSnapshotConfig(
+  snapshot: PreparedModelRuntimeSnapshot,
+  config: OpenClawConfig,
+): PreparedModelRuntimeSnapshot {
+  if (snapshot.config === config) {
+    return snapshot;
+  }
+  const stamped = Object.freeze({ ...snapshot, config });
+  copyPreparedModelRuntimeAuthBindings(snapshot, stamped);
+  return stamped;
+}
+
+export function advancePreparedModelRuntimeOwnerConfig(
+  owner: PreparedModelRuntimeOwner,
+  config: OpenClawConfig,
+): void {
+  owner.input = { ...owner.input, config };
+  if (owner.snapshot) {
+    // Existing leases retain their immutable snapshot. New readers receive the same prepared
+    // generation with only its planner-approved, model-neutral config stamp advanced.
+    owner.snapshot = stampPreparedModelRuntimeSnapshotConfig(owner.snapshot, config);
   }
 }
 
@@ -549,7 +574,12 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
             `prepared model runtime snapshot missing after auth refresh for ${candidate.input.agentDir}`,
           );
         }
-        candidate.owner.snapshot = result.snapshot;
+        const snapshot = stampPreparedModelRuntimeSnapshotConfig(
+          result.snapshot,
+          candidate.owner.input.config,
+        );
+        candidate.owner.snapshot = snapshot;
+        results.set(candidate.owner, { ...result, snapshot });
         candidate.owner.pluginGeneration = result.pluginGeneration;
         candidate.owner.pending = undefined;
         candidate.owner.needsRefresh = false;
@@ -635,12 +665,13 @@ export async function publishModelRuntimeSnapshot(
           `prepared model runtime publication was superseded for ${input.agentDir}`,
         );
       }
-      owner.snapshot = result.snapshot;
+      const snapshot = stampPreparedModelRuntimeSnapshotConfig(result.snapshot, owner.input.config);
+      owner.snapshot = snapshot;
       owner.pluginGeneration = result.pluginGeneration;
       owner.pendingPluginGeneration = undefined;
       owner.pending = undefined;
       owner.needsRefresh = false;
-      return result.snapshot;
+      return snapshot;
     } catch (error) {
       const refreshError = toStringifiedError(error);
       if (owner.generation === generation) {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -12,6 +12,7 @@ import {
   PreparedModelRuntimePublicationSupersededError,
   createPreparedModelRuntimeOwner,
   createPreparedModelRuntimeReplacement,
+  advancePreparedModelRuntimeOwnerConfig,
   effectiveEnvironmentFingerprint,
   hasSameLifecycleInput,
   listConfiguredOwnerInputs,
@@ -77,6 +78,18 @@ const replyDispatchPublication = new PreparedReplyDispatchPublicationOwner({
   getPendingReplacement: () => pendingModelRuntimeReplacement?.promise,
 });
 export const loadPublishedGatewayReplyDispatchRuntime = replyDispatchPublication.load;
+
+/** Advances model-neutral config identity without rebuilding prepared generation artifacts. */
+export function advancePreparedModelRuntimeConfig(config: OpenClawConfig): void {
+  for (const owner of owners.values()) {
+    // Read-only owners include the config hash in their map key and remain bound to their lease.
+    if (owner.input.readOnly) {
+      continue;
+    }
+    advancePreparedModelRuntimeOwnerConfig(owner, config);
+  }
+  replyDispatchPublication.advanceConfig(config);
+}
 
 /** Resolves a published owner or activates a standalone lifecycle owner. */
 export async function loadPreparedModelRuntimeSnapshot(
@@ -414,7 +427,7 @@ export function rejectPendingPreparedModelRuntimeReplacement(
 async function refreshPreparedModelRuntimeSnapshotsNow(
   config: OpenClawConfig,
   options: PreparedModelRuntimeRefreshOptions,
-  publicationEpoch: number,
+  isPublicationCurrent: () => boolean,
 ): Promise<void> {
   retainedGatewayRunOwners.clear(owners);
   const { defaultWorkspaceDir: workspace, allowGatewaySubagentBinding: bindings } = options;
@@ -479,10 +492,10 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
     owners,
     agentBuildCompletions,
     buildTimeoutMs: modelRuntimeBuildTimeoutMs,
-    isPublicationCurrent: () => publicationEpoch === refreshRequestEpoch,
+    isPublicationCurrent,
     // Config replacement is one transaction. Per-owner auth supersession may retire individual
     // candidates, while a newer config epoch stops every remaining build in this publication.
-    isBuildCurrent: () => publicationEpoch === refreshRequestEpoch,
+    isBuildCurrent: isPublicationCurrent,
     onBuildStats: options.onBuildStats,
     pluginMetadataSnapshot: options.pluginMetadataSnapshot,
     registerEntriesAfterBuildStart: true,
@@ -491,33 +504,38 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
 
 /** Serializes config/plugin publications so only the latest completed refresh retires owners. */
 export function refreshPreparedModelRuntimeSnapshots(
-  config: OpenClawConfig,
+  config: OpenClawConfig | (() => OpenClawConfig | Promise<OpenClawConfig>),
   options: PreparedModelRuntimeRefreshOptions = {},
 ): Promise<void> {
+  if (options.isPublicationCurrent?.() === false) {
+    return Promise.resolve();
+  }
   // Stale synchronously. Queued publication must never leave the prior generation request-visible.
   markPreparedModelRuntimeSnapshotsStale(undefined, { waitForReplacement: true });
   const requestEpoch = refreshRequestEpoch;
   const replacement = pendingModelRuntimeReplacement;
+  const isPublicationCurrent = () =>
+    requestEpoch === refreshRequestEpoch && options.isPublicationCurrent?.() !== false;
   return enqueuePreparedModelRuntimePublication(async () => {
-    if (requestEpoch !== refreshRequestEpoch) {
+    if (!isPublicationCurrent()) {
       return;
     }
-    await refreshPreparedModelRuntimeSnapshotsNow(config, options, requestEpoch);
-    if (requestEpoch !== refreshRequestEpoch) {
+    const currentConfig = typeof config === "function" ? await config() : config;
+    if (!isPublicationCurrent()) {
+      return;
+    }
+    await refreshPreparedModelRuntimeSnapshotsNow(currentConfig, options, isPublicationCurrent);
+    if (!isPublicationCurrent()) {
       return;
     }
     await drainPendingAuthMutations();
-    if (requestEpoch !== refreshRequestEpoch) {
+    if (!isPublicationCurrent()) {
       return;
     }
     replyDispatchPublication.rebuild(owners.values());
   }).then(
     () => {
-      if (
-        requestEpoch === refreshRequestEpoch &&
-        replacement &&
-        pendingModelRuntimeReplacement === replacement
-      ) {
+      if (isPublicationCurrent() && replacement && pendingModelRuntimeReplacement === replacement) {
         pendingModelRuntimeReplacement = undefined;
         replacement.resolve();
         // Publication listeners may synchronously read the committed owner. Clear the lifecycle
@@ -527,7 +545,7 @@ export function refreshPreparedModelRuntimeSnapshots(
     },
     (error: unknown) => {
       const refreshError = toStringifiedError(error);
-      if (requestEpoch === refreshRequestEpoch) {
+      if (isPublicationCurrent()) {
         // Candidate and queued auth builds may finish independently. A failed transaction must
         // leave no owner from its partially published generation request-visible.
         for (const owner of owners.values()) {
@@ -538,11 +556,7 @@ export function refreshPreparedModelRuntimeSnapshots(
           owner.pluginGeneration = undefined;
         }
       }
-      if (
-        requestEpoch === refreshRequestEpoch &&
-        replacement &&
-        pendingModelRuntimeReplacement === replacement
-      ) {
+      if (isPublicationCurrent() && replacement && pendingModelRuntimeReplacement === replacement) {
         pendingModelRuntimeReplacement = undefined;
         replacement.reject(refreshError);
         notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -116,6 +116,7 @@ export type PreparedModelRuntimeRefreshOptions = {
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void;
   allowGatewaySubagentBinding?: boolean;
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
+  isPublicationCurrent?: () => boolean;
 };
 
 export type PreparedModelRuntimeBuildStats = Readonly<{

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -1,3 +1,4 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePublishedModelCatalogOwner } from "./prepared-model-catalog-owner.js";
 import { PreparedModelRuntimeOwnerNotPublishedError } from "./prepared-model-runtime.errors.js";
 import type {
@@ -85,6 +86,14 @@ export class PreparedReplyDispatchPublicationOwner {
 
   clear(): void {
     this.#publication = EMPTY_REPLY_DISPATCH_PUBLICATION;
+  }
+
+  advanceConfig(config: OpenClawConfig): void {
+    this.#publication = Object.freeze({
+      runtimes: Object.freeze(
+        this.#publication.runtimes.map((runtime) => Object.freeze({ ...runtime, config })),
+      ),
+    });
   }
 
   rebuild(owners: Iterable<PreparedModelRuntimeOwner>): void {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -168,6 +168,8 @@ export function startGatewayConfigReloader(opts: {
   onConfigChange?: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
   /** Publishes runtime state after a hot or no-op config transaction. */
   onConfigApplied?: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
+  /** Runs synchronously when a config transaction publishes its runtime state. */
+  onRuntimeConfigCommitted?: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void;
   /** Publishes the resolved source-config revision accepted by the active runtime. */
   onConfigRevisionApplied?: (hash: string) => void;
   /** Retires rejected lifecycle work after any newer config transaction is accepted. */
@@ -509,6 +511,7 @@ export function startGatewayConfigReloader(opts: {
         // transaction. Advance the runtime diff baseline at that exact edge so
         // the newer disk config plans the reverse work instead of diffing stale state.
         commitPublishedRuntimeEnv();
+        opts.onRuntimeConfigCommitted?.(plan, runtimeConfig);
         committedRuntimeConfig = runtimeConfig;
         currentConfig = runtimeConfig;
         currentCompareConfig = nextCompareConfig;

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -956,6 +956,8 @@ async function runManagedOwnershipScenario(params: {
   loggingChanged?: boolean;
   queueRevert: boolean;
   secretProviderChanged?: boolean;
+  /** Makes secrets activation resolve to a different object than it received. */
+  resolveToDistinctConfig?: boolean;
 }) {
   const initialConfig = {
     gateway: { reload: { mode: "off" as const } },
@@ -996,6 +998,7 @@ async function runManagedOwnershipScenario(params: {
   const reconcileTerminalSessions = vi.fn();
   const requestRecoveryRestart = vi.fn(() => ({ status: "emitted" as const }));
   let queuedB = false;
+  const resolvedConfigs: OpenClawConfig[] = [];
   const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig) => {
     if (params.queueRevert && !queuedB) {
       queuedB = true;
@@ -1003,7 +1006,14 @@ async function runManagedOwnershipScenario(params: {
         createConfigWriteNotification(configB, "hash-b", 2, "runtime-b", "source-b"),
       );
     }
-    return snapshot(config);
+    if (!params.resolveToDistinctConfig) {
+      return snapshot(config);
+    }
+    // Real secret resolution returns a NEW config object. Returning the input
+    // unchanged is what let a rebuild against the source candidate look correct.
+    const resolved = { ...config } as OpenClawConfig;
+    resolvedConfigs.push(resolved);
+    return snapshot(resolved);
   });
   activateSecretsRuntimeSnapshot(snapshot(initialConfig));
   const reloader = startManagedGatewayConfigReloader({
@@ -1029,6 +1039,7 @@ async function runManagedOwnershipScenario(params: {
       configA,
       configB,
       prepareTerminalConfig,
+      resolvedConfigs,
       reconcileTerminalSessions,
       requestRecoveryRestart,
     };
@@ -1059,6 +1070,32 @@ describe("managed reload transaction ownership", () => {
       result.configA,
       { gatewayLifecycle: true },
     );
+  });
+
+  it("rebuilds a no-op secret-provider publication from the resolved committed config", async () => {
+    // Regression: the rebuild used the source-derived candidate. When secret
+    // resolution yields a different object, the rebuilt owner carries an
+    // identity no reader supplies, so every strict catalog read rejects it --
+    // reviving the failure on the very fallback meant to be safe.
+    const result = await runManagedOwnershipScenario({
+      kind: "noop",
+      queueRevert: false,
+      secretProviderChanged: true,
+      resolveToDistinctConfig: true,
+    });
+
+    const resolved = result.resolvedConfigs.at(-1);
+    expect(resolved).toBeDefined();
+    expect(resolved).not.toBe(result.configA);
+    expect(hoisted.advancePreparedModelRuntimeConfig).not.toHaveBeenCalled();
+    expect(hoisted.refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledOnce();
+    // Identity, not deep equality: the resolved config is a clone of the source
+    // candidate, so toHaveBeenCalledWith would match either object and prove
+    // nothing about which one the rebuild actually used.
+    const [rebuiltWith, options] = hoisted.refreshPreparedModelRuntimeSnapshots.mock.calls[0] ?? [];
+    expect(rebuiltWith).toBe(resolved);
+    expect(rebuiltWith).not.toBe(result.configA);
+    expect(options).toEqual({ gatewayLifecycle: true });
   });
 
   it("applies a current in-process hot config", async () => {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -953,6 +953,7 @@ afterEach(() => {
 
 async function runManagedOwnershipScenario(params: {
   kind: "noop" | "hot" | "restart";
+  getPluginMetadataSnapshot?: ManagedReloaderParams["getPluginMetadataSnapshot"];
   loggingChanged?: boolean;
   queueRevert: boolean;
   secretProviderChanged?: boolean;
@@ -1018,6 +1019,7 @@ async function runManagedOwnershipScenario(params: {
   activateSecretsRuntimeSnapshot(snapshot(initialConfig));
   const reloader = startManagedGatewayConfigReloader({
     initialConfig,
+    getPluginMetadataSnapshot: params.getPluginMetadataSnapshot,
     readSnapshot: vi.fn(async () => createValidConfigSnapshot(configB, "hash-b")) as never,
     subscribeToWrites: captureConfigWriteListener(writeListenerRef, false),
     activateRuntimeSecrets: activateRuntimeSecrets as never,
@@ -1059,16 +1061,23 @@ describe("managed reload transaction ownership", () => {
   });
 
   it("rebuilds prepared model owners for a no-op secret-provider publication", async () => {
+    const pluginMetadataSnapshot = {} as never;
     const result = await runManagedOwnershipScenario({
       kind: "noop",
       queueRevert: false,
       secretProviderChanged: true,
+      getPluginMetadataSnapshot: () => pluginMetadataSnapshot,
     });
 
     expect(hoisted.advancePreparedModelRuntimeConfig).not.toHaveBeenCalled();
     expect(hoisted.refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledExactlyOnceWith(
       result.configA,
-      { gatewayLifecycle: true },
+      {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+        allowGatewaySubagentBinding: true,
+        pluginMetadataSnapshot,
+      },
     );
   });
 
@@ -1077,11 +1086,13 @@ describe("managed reload transaction ownership", () => {
     // resolution yields a different object, the rebuilt owner carries an
     // identity no reader supplies, so every strict catalog read rejects it --
     // reviving the failure on the very fallback meant to be safe.
+    const pluginMetadataSnapshot = {} as never;
     const result = await runManagedOwnershipScenario({
       kind: "noop",
       queueRevert: false,
       secretProviderChanged: true,
       resolveToDistinctConfig: true,
+      getPluginMetadataSnapshot: () => pluginMetadataSnapshot,
     });
 
     const resolved = result.resolvedConfigs.at(-1);
@@ -1095,7 +1106,12 @@ describe("managed reload transaction ownership", () => {
     const [rebuiltWith, options] = hoisted.refreshPreparedModelRuntimeSnapshots.mock.calls[0] ?? [];
     expect(rebuiltWith).toBe(resolved);
     expect(rebuiltWith).not.toBe(result.configA);
-    expect(options).toEqual({ gatewayLifecycle: true });
+    expect(options).toEqual({
+      gatewayLifecycle: true,
+      catalogMode: "static",
+      allowGatewaySubagentBinding: true,
+      pluginMetadataSnapshot,
+    });
   });
 
   it("applies a current in-process hot config", async () => {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -261,6 +261,7 @@ const hoisted = vi.hoisted(() => ({
   reloadEvents: [] as string[],
   loadModelCatalog: vi.fn(async (_params: { config: OpenClawConfig }) => []),
   resetModelCatalogCache: vi.fn(() => {}),
+  advancePreparedModelRuntimeConfig: vi.fn((_cfg: OpenClawConfig) => {}),
   markPreparedModelRuntimeSnapshotsStale: vi.fn(
     (
       _reason?: string,
@@ -372,6 +373,8 @@ vi.mock("../agents/model-catalog.js", () => ({
 }));
 
 vi.mock("../agents/prepared-model-runtime.js", () => ({
+  advancePreparedModelRuntimeConfig: (cfg: OpenClawConfig) =>
+    hoisted.advancePreparedModelRuntimeConfig(cfg),
   markPreparedModelRuntimeSnapshotsStale: (
     reason?: string,
     options?: { waitForReplacement?: boolean; preserveReplacementWait?: boolean },
@@ -931,6 +934,7 @@ afterEach(() => {
   hoisted.runtimeConfig.value = { session: { store: "/tmp/active-sessions.json" } };
   hoisted.assertOpenClawDatabasesReadyForRestart.mockClear();
   hoisted.reloadEvents.length = 0;
+  hoisted.advancePreparedModelRuntimeConfig.mockClear();
   hoisted.markPreparedModelRuntimeSnapshotsStale.mockClear();
   hoisted.rejectPendingPreparedModelRuntimeReplacement.mockClear();
   hoisted.refreshPreparedModelRuntimeSnapshots.mockClear();
@@ -951,9 +955,13 @@ async function runManagedOwnershipScenario(params: {
   kind: "noop" | "hot" | "restart";
   loggingChanged?: boolean;
   queueRevert: boolean;
+  secretProviderChanged?: boolean;
 }) {
   const initialConfig = {
     gateway: { reload: { mode: "off" as const } },
+    ...(params.secretProviderChanged
+      ? { secrets: { providers: { default: { source: "file" as const, path: "/old" } } } }
+      : {}),
     hooks: { enabled: true, token: "test-token", path: "/old" },
   } satisfies OpenClawConfig;
   const configA = {
@@ -967,6 +975,12 @@ async function runManagedOwnershipScenario(params: {
       token: "test-token",
       path: params.kind === "noop" ? "/old" : "/a",
     },
+    ...(params.kind === "noop"
+      ? { talk: { realtime: { instructions: "updated instructions" } } }
+      : {}),
+    ...(params.secretProviderChanged
+      ? { secrets: { providers: { default: { source: "file" as const, path: "/new" } } } }
+      : {}),
     ...(params.loggingChanged ? { logging: { level: "debug" as const } } : {}),
   } satisfies OpenClawConfig;
   const configB = structuredClone(initialConfig);
@@ -1024,9 +1038,34 @@ async function runManagedOwnershipScenario(params: {
 }
 
 describe("managed reload transaction ownership", () => {
+  it("advances prepared model config stamps for a no-op publication", async () => {
+    const result = await runManagedOwnershipScenario({ kind: "noop", queueRevert: false });
+
+    expect(hoisted.advancePreparedModelRuntimeConfig).toHaveBeenCalledExactlyOnceWith(
+      result.configA,
+    );
+    expect(hoisted.refreshPreparedModelRuntimeSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds prepared model owners for a no-op secret-provider publication", async () => {
+    const result = await runManagedOwnershipScenario({
+      kind: "noop",
+      queueRevert: false,
+      secretProviderChanged: true,
+    });
+
+    expect(hoisted.advancePreparedModelRuntimeConfig).not.toHaveBeenCalled();
+    expect(hoisted.refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledExactlyOnceWith(
+      result.configA,
+      { gatewayLifecycle: true },
+    );
+  });
+
   it("applies a current in-process hot config", async () => {
     const result = await runManagedOwnershipScenario({ kind: "hot", queueRevert: false });
 
+    // Hot plans rebuild prepared owners. Advancing the stamp in place is reserved for no-op plans.
+    expect(hoisted.advancePreparedModelRuntimeConfig).not.toHaveBeenCalled();
     expect(result.activateRuntimeSecrets).toHaveBeenCalledOnce();
     expect(result.commitTerminalConfig).toHaveBeenCalledOnce();
     expect(result.acceptTerminalConfig).toHaveBeenCalledOnce();

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -1,3 +1,7 @@
+import {
+  advancePreparedModelRuntimeConfig,
+  refreshPreparedModelRuntimeSnapshots,
+} from "../agents/prepared-model-runtime.js";
 import { copyConfigResolutionFacts } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { applyLoggingConfig } from "../logging/logger.js";
@@ -5,6 +9,8 @@ import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-w
 import { getActiveSecretsRuntimeSnapshotRevisionState } from "../secrets/runtime-state.js";
 import { resetSkillSnapshotConfigFingerprintCache } from "../skills/runtime/snapshot-config-fingerprint.js";
 import { invalidateConfigGetResponseCache } from "./config-get-response.js";
+import { isNoopGatewayReloadPlan } from "./config-reload-plan.js";
+import { shouldRewarmProviderAuthState } from "./config-reload-recovery.js";
 import {
   startGatewayConfigReloader,
   type GatewayConfigReloadTransactionOwnership,
@@ -42,6 +48,10 @@ import {
   setRequiredSharedGatewaySessionGenerationIfOwned,
   type SharedGatewaySessionGenerationOwnership,
 } from "./server-shared-auth-generation.js";
+
+function canAdvancePreparedModelRuntimeConfigInPlace(plan: GatewayReloadPlan): boolean {
+  return isNoopGatewayReloadPlan(plan) && !shouldRewarmProviderAuthState(plan);
+}
 
 export function startManagedGatewayConfigReloader(
   params: ManagedGatewayConfigReloaderParams,
@@ -349,6 +359,11 @@ export function startManagedGatewayConfigReloader(
         { dropIfSlow: true },
       );
     },
+    onRuntimeConfigCommitted: (plan, nextConfig) => {
+      if (canAdvancePreparedModelRuntimeConfigInPlace(plan)) {
+        advancePreparedModelRuntimeConfig(nextConfig);
+      }
+    },
     ...(params.prepareConfigCandidate
       ? { prepareConfigCandidate: params.prepareConfigCandidate }
       : {}),
@@ -470,7 +485,12 @@ export function startManagedGatewayConfigReloader(
     },
     onConfigRevisionApplied: publishAppliedConfigHash,
     onEffectiveConfigUnchanged,
-    onNoopConfigCommit,
+    onNoopConfigCommit: async (plan, nextConfig, ownership, sourceConfig) => {
+      await onNoopConfigCommit(plan, nextConfig, ownership, sourceConfig);
+      if (!canAdvancePreparedModelRuntimeConfigInPlace(plan)) {
+        await refreshPreparedModelRuntimeSnapshots(nextConfig, { gatewayLifecycle: true });
+      }
+    },
     onHotReload,
     onRestart: runManagedRestart,
     log: {

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -500,8 +500,12 @@ export function startManagedGatewayConfigReloader(
         // candidate. `secrets.providers.*` resolves to a different object, and
         // stamping the rebuilt owner with the pre-resolution identity makes every
         // strict catalog read reject it -- the failure this fix exists to remove.
+        const pluginMetadataSnapshot = params.getPluginMetadataSnapshot?.();
         await refreshPreparedModelRuntimeSnapshots(lastCommittedRuntimeConfig ?? nextConfig, {
           gatewayLifecycle: true,
+          catalogMode: "static",
+          allowGatewaySubagentBinding: true,
+          ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
         });
       }
     },

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -334,6 +334,7 @@ export function startManagedGatewayConfigReloader(
       applyHotReload,
     });
 
+  let lastCommittedRuntimeConfig: OpenClawConfig | undefined;
   const configReloader = startGatewayConfigReloader({
     initialConfig: params.initialConfig,
     initialCompareConfig: params.initialCompareConfig,
@@ -359,9 +360,13 @@ export function startManagedGatewayConfigReloader(
         { dropIfSlow: true },
       );
     },
-    onRuntimeConfigCommitted: (plan, nextConfig) => {
+    onRuntimeConfigCommitted: (plan, committedRuntimeConfig) => {
+      // Secret resolution can make the committed runtime config a different
+      // object from the source-derived candidate. Record the committed one so a
+      // rebuild below stamps owners with the identity readers actually supply.
+      lastCommittedRuntimeConfig = committedRuntimeConfig;
       if (canAdvancePreparedModelRuntimeConfigInPlace(plan)) {
-        advancePreparedModelRuntimeConfig(nextConfig);
+        advancePreparedModelRuntimeConfig(committedRuntimeConfig);
       }
     },
     ...(params.prepareConfigCandidate
@@ -486,9 +491,18 @@ export function startManagedGatewayConfigReloader(
     onConfigRevisionApplied: publishAppliedConfigHash,
     onEffectiveConfigUnchanged,
     onNoopConfigCommit: async (plan, nextConfig, ownership, sourceConfig) => {
+      // Cleared per transaction so a rebuild can never inherit a config committed
+      // by an earlier one when this commit does not reach markRuntimeCommitted.
+      lastCommittedRuntimeConfig = undefined;
       await onNoopConfigCommit(plan, nextConfig, ownership, sourceConfig);
       if (!canAdvancePreparedModelRuntimeConfigInPlace(plan)) {
-        await refreshPreparedModelRuntimeSnapshots(nextConfig, { gatewayLifecycle: true });
+        // Rebuild against the committed runtime config, not the source-derived
+        // candidate. `secrets.providers.*` resolves to a different object, and
+        // stamping the rebuilt owner with the pre-resolution identity makes every
+        // strict catalog read reject it -- the failure this fix exists to remove.
+        await refreshPreparedModelRuntimeSnapshots(lastCommittedRuntimeConfig ?? nextConfig, {
+          gatewayLifecycle: true,
+        });
       }
     },
     onHotReload,

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { writeRestartSentinel } from "../infra/restart-sentinel.js";
 import type {
   PluginHookGatewayContext,
@@ -927,6 +928,38 @@ describe("startGatewayPostAttachRuntime", () => {
 
     releaseSidecars?.();
     await waitForGatewayTestState(() => expect(sidecarsCompleted).toBe(true));
+  });
+
+  it("uses the current runtime config for deferred model publication", async () => {
+    const startupConfig = { hooks: { internal: { enabled: false } } } as never;
+    const currentConfig = {
+      hooks: { internal: { enabled: false } },
+      ui: { theme: "dark" },
+    } as never;
+    const startGatewaySidecarsScoped = vi.fn(
+      async (_params: Parameters<typeof startGatewaySidecarsImpl>[0]) => ({
+        pluginServices: null,
+        postReadySidecars: [],
+      }),
+    );
+    const runtime = await startGatewayPostAttachRuntime(
+      createPostAttachParams({
+        sidecarStartup: "defer",
+        gatewayPluginConfigAtStart: startupConfig,
+        getConfig: () => currentConfig,
+      }),
+      createPostAttachRuntimeDeps({ startGatewaySidecars: startGatewaySidecarsScoped }),
+    );
+
+    await runtime.startupSettled;
+
+    expect(startGatewaySidecarsScoped).toHaveBeenCalledWith(
+      expect.objectContaining({ getModelRuntimeConfig: expect.any(Function) }),
+    );
+    const sidecarParams = startGatewaySidecarsScoped.mock.calls[0]?.[0] as
+      | { getModelRuntimeConfig?: () => unknown }
+      | undefined;
+    expect(sidecarParams?.getModelRuntimeConfig?.()).toBe(currentConfig);
   });
 
   it("retains a sidecar whose cleanup fails after startup logging rejects", async () => {
@@ -2561,6 +2594,104 @@ describe("startGatewayPostAttachRuntime", () => {
     });
   });
 
+  it("passes a current-config supplier after loading the prepared runtime", async () => {
+    const initialConfig = { ui: { theme: "light" } } as never;
+    const nextConfig = { ui: { theme: "dark" } } as never;
+    let currentConfig = initialConfig;
+
+    const publication = testing.publishConfiguredModelRuntimeSnapshots({
+      cfg: initialConfig,
+      getConfig: () => currentConfig,
+      log: { warn: vi.fn() },
+    } as never);
+    currentConfig = nextConfig;
+    await publication;
+
+    const getConfig = hoisted.refreshPreparedModelRuntimeSnapshots.mock.calls[0]?.[0];
+    expect(getConfig).toBeTypeOf("function");
+    await expect(Promise.resolve((getConfig as () => unknown)())).resolves.toBe(nextConfig);
+  });
+
+  it("hydrates external CLI auth from the config supplied to model publication", async () => {
+    const initialConfig = { ui: { theme: "light" } } as never;
+    const nextConfig = { ui: { theme: "dark" } } as never;
+    let currentConfig = initialConfig;
+    const depsReady = createDeferred<{
+      listAgentIds: () => string[];
+      resolveAgentDir: () => string;
+      collectConfiguredRefs: ReturnType<typeof vi.fn>;
+      hydrate: ReturnType<typeof vi.fn>;
+    }>();
+    const collectConfiguredRefs = vi.fn(() => [{ value: "openai/gpt-5.4" }]);
+    const hydrate = vi.fn();
+
+    const hydration = testing.hydrateConfiguredExternalCliAuth({
+      getConfig: () => currentConfig,
+      log: { warn: vi.fn() },
+      deps: depsReady.promise,
+    } as never);
+    currentConfig = nextConfig;
+    depsReady.resolve({
+      listAgentIds: () => ["default"],
+      resolveAgentDir: () => "/tmp/default-agent",
+      collectConfiguredRefs,
+      hydrate,
+    });
+
+    await expect(hydration).resolves.toBe(nextConfig);
+    expect(collectConfiguredRefs).toHaveBeenCalledWith(nextConfig, "default");
+    expect(hydrate).toHaveBeenCalledWith(nextConfig, "/tmp/default-agent", ["openai"]);
+  });
+
+  it("drops a stale plugin generation after loading the prepared runtime", async () => {
+    let current = true;
+    const publication = testing.publishConfiguredModelRuntimeSnapshots({
+      cfg: {},
+      isCurrent: () => current,
+      log: { warn: vi.fn() },
+    } as never);
+    current = false;
+
+    await publication;
+
+    expect(hoisted.refreshPreparedModelRuntimeSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("threads plugin claim loss through async model config publication", async () => {
+    const configStarted = createDeferred();
+    const releaseConfig = createDeferred();
+    let current = true;
+    hoisted.refreshPreparedModelRuntimeSnapshots.mockImplementationOnce(
+      async (getConfig: unknown, options: unknown) => {
+        expect(getConfig).toBeTypeOf("function");
+        const config = (getConfig as () => Promise<unknown>)();
+        await configStarted.promise;
+        expect(options).toMatchObject({ isPublicationCurrent: expect.any(Function) });
+        await config;
+        expect((options as { isPublicationCurrent: () => boolean }).isPublicationCurrent()).toBe(
+          false,
+        );
+      },
+    );
+    const publication = testing.publishConfiguredModelRuntimeSnapshots({
+      cfg: {},
+      getConfig: async () => {
+        configStarted.resolve();
+        await releaseConfig.promise;
+        return {};
+      },
+      isCurrent: () => current,
+      log: { warn: vi.fn() },
+    } as never);
+
+    await configStarted.promise;
+    current = false;
+    releaseConfig.resolve();
+    await publication;
+
+    expect(hoisted.refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledOnce();
+  });
+
   it("prepares the model runtime with the active Gateway plugin registry", async () => {
     const pluginRegistry = createPostAttachParams().pluginRegistry;
     const prewarmPrimaryModel = vi.fn(async () => {
@@ -2642,6 +2773,41 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(prewarmPrimaryModel).toHaveBeenCalledTimes(1);
     expect(startChannels).toHaveBeenCalledTimes(1);
     expect(hoisted.scheduleRestartAbortedMainSessionRecovery).not.toHaveBeenCalled();
+  });
+
+  it("skips model publication when the startup plugin generation loses ownership", async () => {
+    let current = true;
+    let releaseMarking: (() => void) | undefined;
+    hoisted.markStartupOrphanedMainSessionsForRecovery.mockImplementationOnce(
+      async () =>
+        await new Promise<{ marked: number; skipped: number }>((resolve) => {
+          releaseMarking = () => resolve({ marked: 0, skipped: 0 });
+        }),
+    );
+    const prewarmPrimaryModel = vi.fn(async () => {});
+    const sidecars = startGatewaySidecars({
+      cfg: {},
+      pluginRegistry: createPostAttachParams().pluginRegistry,
+      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      deps: {} as never,
+      startChannels: vi.fn(async () => {}),
+      log: { warn: vi.fn() },
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      prewarmPrimaryModel,
+      pluginRuntimeClaim: {
+        isCurrent: () => current,
+        waitForUnblocked: async () => current,
+        publish: () => current,
+      },
+    });
+    await waitForGatewayTestState(() => expect(releaseMarking).toBeDefined());
+    current = false;
+    releaseMarking?.();
+
+    await sidecars;
+
+    expect(prewarmPrimaryModel).not.toHaveBeenCalled();
   });
 
   it("awaits reply runtime after model publication and before channels and readiness", async () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -440,6 +440,8 @@ async function waitForAcpRuntimeBackendReady(params: {
 
 async function prewarmConfiguredPrimaryModel(params: {
   cfg: OpenClawConfig;
+  getConfig?: () => OpenClawConfig | Promise<OpenClawConfig>;
+  isCurrent?: () => boolean;
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
   workspaceDir?: string;
   log: { warn: (msg: string) => void };
@@ -452,16 +454,16 @@ type StartupExternalAuthHydrationDeps = {
   listAgentIds: (cfg: OpenClawConfig) => string[];
   resolveAgentDir: (cfg: OpenClawConfig, agentId: string) => string;
   collectConfiguredRefs: (cfg: OpenClawConfig, agentId: string) => readonly { value: string }[];
-  hydrate: (agentDir: string, providers: readonly string[]) => void;
+  hydrate: (cfg: OpenClawConfig, agentDir: string, providers: readonly string[]) => void;
 };
 
 async function hydrateConfiguredExternalCliAuth(params: {
-  cfg: OpenClawConfig;
+  getConfig: () => OpenClawConfig;
   log: { warn: (msg: string) => void };
-  deps?: StartupExternalAuthHydrationDeps;
-}): Promise<void> {
+  deps?: StartupExternalAuthHydrationDeps | Promise<StartupExternalAuthHydrationDeps>;
+}): Promise<OpenClawConfig> {
   const deps: StartupExternalAuthHydrationDeps =
-    params.deps ??
+    (await params.deps) ??
     (await Promise.all([
       import("../agents/agent-scope.js"),
       import("../agents/prepared-model-runtime.configured.js"),
@@ -471,16 +473,13 @@ async function hydrateConfiguredExternalCliAuth(params: {
       listAgentIds: scope.listAgentIds,
       resolveAgentDir: scope.resolveAgentDir,
       collectConfiguredRefs: configured.collectPreparedModelRuntimeConfiguredRefs,
-      hydrate: (agentDir: string, providers: readonly string[]) => {
-        const discovery = external.externalCliDiscoveryForProviders({
-          cfg: params.cfg,
-          providers,
-        });
+      hydrate: (cfg: OpenClawConfig, agentDir: string, providers: readonly string[]) => {
+        const discovery = external.externalCliDiscoveryForProviders({ cfg, providers });
         if (discovery.mode === "none") {
           return;
         }
         store.ensureAuthProfileStore(agentDir, {
-          config: params.cfg,
+          config: cfg,
           externalCli: discovery,
           allowKeychainPrompt: false,
           readOnly: true,
@@ -488,29 +487,33 @@ async function hydrateConfiguredExternalCliAuth(params: {
         });
       },
     })));
+  const cfg = params.getConfig();
   const hydratedDirs = new Set<string>();
-  for (const agentId of deps.listAgentIds(params.cfg)) {
-    const providers = deps.collectConfiguredRefs(params.cfg, agentId).flatMap(({ value }) => {
+  for (const agentId of deps.listAgentIds(cfg)) {
+    const providers = deps.collectConfiguredRefs(cfg, agentId).flatMap(({ value }) => {
       const separator = value.indexOf("/");
       return separator > 0 ? [value.slice(0, separator)] : [];
     });
-    const agentDir = deps.resolveAgentDir(params.cfg, agentId);
+    const agentDir = deps.resolveAgentDir(cfg, agentId);
     if (providers.length === 0 || hydratedDirs.has(agentDir)) {
       continue;
     }
     hydratedDirs.add(agentDir);
     try {
-      deps.hydrate(agentDir, providers);
+      deps.hydrate(cfg, agentDir, providers);
     } catch (error) {
       params.log.warn(
         `startup external CLI auth hydration failed for agent ${agentId}: ${String(error)}`,
       );
     }
   }
+  return cfg;
 }
 
 async function publishConfiguredModelRuntimeSnapshots(params: {
   cfg: OpenClawConfig;
+  getConfig?: () => OpenClawConfig | Promise<OpenClawConfig>;
+  isCurrent?: () => boolean;
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
   workspaceDir?: string;
   log: { warn: (msg: string) => void };
@@ -518,10 +521,14 @@ async function publishConfiguredModelRuntimeSnapshots(params: {
 }): Promise<void> {
   const { refreshPreparedModelRuntimeSnapshots } =
     await import("../agents/prepared-model-runtime.js");
-  await refreshPreparedModelRuntimeSnapshots(params.cfg, {
+  if (params.isCurrent?.() === false) {
+    return;
+  }
+  await refreshPreparedModelRuntimeSnapshots(params.getConfig ?? params.cfg, {
     gatewayLifecycle: true,
     catalogMode: "static",
     allowGatewaySubagentBinding: true,
+    ...(params.isCurrent ? { isPublicationCurrent: params.isCurrent } : {}),
     ...(params.pluginMetadataSnapshot
       ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
       : {}),
@@ -560,6 +567,8 @@ async function publishConfiguredModelRuntimeSnapshots(params: {
 async function publishStartupModelRuntime(
   params: {
     cfg: OpenClawConfig;
+    getConfig?: () => OpenClawConfig | Promise<OpenClawConfig>;
+    isCurrent?: () => boolean;
     pluginMetadataSnapshot?: PluginMetadataSnapshot;
     workspaceDir?: string;
     log: { warn: (msg: string) => void };
@@ -576,6 +585,7 @@ async function publishStartupModelRuntime(
 /** Start post-ready sidecars such as channels, hooks, plugin services, and cleanup tasks. */
 export async function startGatewaySidecars(params: {
   cfg: OpenClawConfig;
+  getModelRuntimeConfig?: () => OpenClawConfig;
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
   pluginRegistry: ReturnType<typeof loadOpenClawPlugins>;
   defaultWorkspaceDir: string;
@@ -664,27 +674,35 @@ export async function startGatewaySidecars(params: {
       );
     }
   });
-  await measureStartup(params.startupTrace, "sidecars.model-auth", () =>
-    hydrateConfiguredExternalCliAuth({ cfg: params.cfg, log: params.log }),
-  );
+  const getModelRuntimeConfig = params.getModelRuntimeConfig ?? (() => params.cfg);
   // Agent RPC remains available when transports are disabled. Publish configured/static facts before
   // accepting work; live provider catalogs stay advisory and never enter the Gateway lifecycle.
-  await measureStartup(params.startupTrace, "sidecars.model-runtime", () =>
-    withPluginRuntimeRegistryScope(params.pluginRegistry, () =>
-      publishStartupModelRuntime(
-        {
-          cfg: params.cfg,
-          ...(params.pluginMetadataSnapshot
-            ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
-            : {}),
-          workspaceDir: params.defaultWorkspaceDir,
-          log: params.log,
-          startupTrace: params.startupTrace,
-        },
-        params.prewarmPrimaryModel,
+  if ((await params.pluginRuntimeClaim?.waitForUnblocked()) !== false) {
+    await measureStartup(params.startupTrace, "sidecars.model-runtime", () =>
+      withPluginRuntimeRegistryScope(params.pluginRegistry, () =>
+        publishStartupModelRuntime(
+          {
+            cfg: params.cfg,
+            getConfig: async () =>
+              await measureStartup(params.startupTrace, "sidecars.model-auth", () =>
+                hydrateConfiguredExternalCliAuth({
+                  getConfig: getModelRuntimeConfig,
+                  log: params.log,
+                }),
+              ),
+            isCurrent: params.pluginRuntimeClaim?.isCurrent,
+            ...(params.pluginMetadataSnapshot
+              ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
+              : {}),
+            workspaceDir: params.defaultWorkspaceDir,
+            log: params.log,
+            startupTrace: params.startupTrace,
+          },
+          params.prewarmPrimaryModel,
+        ),
       ),
-    ),
-  );
+    );
+  }
   // Gateway readiness owns process-stable reply module activation so the first operator turn
   // does not become the module loader under contention.
   await measureStartup(params.startupTrace, "sidecars.reply-runtime", async () => {
@@ -1401,6 +1419,7 @@ export async function startGatewayPostAttachRuntime(
                   cfg: startupRuntimeCurrent
                     ? params.gatewayPluginConfigAtStart
                     : params.getConfig(),
+                  getModelRuntimeConfig: params.getConfig,
                   ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
                   pluginRegistry,
                   defaultWorkspaceDir: params.defaultWorkspaceDir,

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -13,6 +13,7 @@ const refreshPreparedModelRuntimeSnapshotsMock = vi.fn(
       defaultWorkspaceDir?: string;
       catalogMode?: "live" | "static";
       allowGatewaySubagentBinding?: boolean;
+      isPublicationCurrent?: () => boolean;
     },
   ) => {},
 );
@@ -32,6 +33,7 @@ vi.mock("../agents/prepared-model-runtime.js", () => ({
       defaultWorkspaceDir?: string;
       catalogMode?: "live" | "static";
       allowGatewaySubagentBinding?: boolean;
+      isPublicationCurrent?: () => boolean;
     },
   ) => refreshPreparedModelRuntimeSnapshotsMock(cfg, options),
 }));
@@ -86,7 +88,7 @@ describe("gateway startup primary model warmup", () => {
     const hydrate = vi.fn();
 
     await hydrateConfiguredExternalCliAuth({
-      cfg,
+      getConfig: () => cfg,
       log: { warn: vi.fn() },
       deps: {
         listAgentIds: () => ["main", "secondary"],
@@ -99,8 +101,8 @@ describe("gateway startup primary model warmup", () => {
     });
 
     expect(hydrate).toHaveBeenCalledTimes(2);
-    expect(hydrate).toHaveBeenCalledWith("/tmp/main", ["openai"]);
-    expect(hydrate).toHaveBeenCalledWith("/tmp/secondary", ["anthropic"]);
+    expect(hydrate).toHaveBeenCalledWith(cfg, "/tmp/main", ["openai"]);
+    expect(hydrate).toHaveBeenCalledWith(cfg, "/tmp/secondary", ["anthropic"]);
     expect(refreshPreparedModelRuntimeSnapshotsMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Related: #128515

AI-assisted: implemented by a Codex-based agent, reviewed and validated by Claude (Opus 5).

## What Problem This Solves

Fixes an issue where operators who edit a config key that needs no reload work would find `/models`
permanently broken on every chat surface until they restart the gateway.

`openclaw config set <key>` prints **"No gateway restart needed."**, the config publishes, agent
turns keep working, and `/ready` keeps returning 200 — but the model picker never appears again.
Re-running the command produces the same failure for the life of the process. The trigger key does
not have to be model-related; the reported case was `talk.realtime.instructions`.

## Why This Change Was Made

Prepared model owners are stamped with a hash of the **whole** config. A config transaction whose
reload plan is empty publishes the new runtime config but never advances that stamp, so a strict
policy read compares the newly published config against the previous stamp and is rejected. Nothing
repairs it before a restart.

This advances the model-neutral config stamp in place for no-op publications rather than rebuilding
the prepared generation — a rebuild is waste when the planner has already determined that nothing
needs doing. Existing leases keep their immutable snapshot, auth stores and materializations are
carried onto the restamped snapshot, pending builds restamp at commit, and read-only owners are left
alone. Deferred startup publication now resolves its config inside the serialized refresh and fences
a superseded plugin generation, so a no-op commit that lands mid-startup cannot publish a stamp that
is already stale.

**Boundaries.** The advance is gated on `isNoopGatewayReloadPlan` — no restart, no hot reasons, no
channel, hook, or plugin work. Hot and restart plans rebuild exactly as before. Correctness rests on
the reload rule table in `src/gateway/config-reload-plan.ts` being the single authority on what is
model-relevant; no second copy of that classification is introduced.

**Non-goal.** #128515 also reports `prepared model runtime plugin generation was superseded` from
background lanes. That is a different guard and this change is not claimed to address it.

## User Impact

`/models` and other prepared-catalog consumers keep working after a config edit that reports "No
gateway restart needed." Operators no longer have to restart the gateway to recover the model
picker. No behavior change for hot or restart reloads, and no change to what a prepared generation
contains.

## Evidence

**Regression tests fail on stock and pass patched.** Reverting only the source hunks — the tests left
in place — fails 11 assertions across 4 files:

```
 × advances without rebuilding or mutating existing readers
 × resolves startup config inside the serialized publication
 × keeps an in-flight auth publication on the advanced stamp
 × uses the current runtime config for deferred model publication
 × passes a current-config supplier after loading the prepared runtime
 × drops a stale plugin generation after loading the prepared runtime
 × skips model publication when the startup plugin generation loses ownership
 × advances prepared model config stamps for a no-op publication
 Test Files  4 failed (4)
      Tests  11 failed | 302 passed (313)
```

With the source restored, on the current `main` base:

```
 Test Files  4 passed (4)
      Tests  313 passed (313)
```

The no-op test asserts absence as well as presence — `ensureOpenClawModelsJson` is called exactly
once across the advance, so the prepared generation is demonstrably not rebuilt, and the prior
reader's `config` is unchanged.

**The `isNoopGatewayReloadPlan` gate is mutation-tested.** Removing the gate so every commit advances
the stamp left all 219 tests in `server-reload-handlers.test.ts` green, so an assertion was added
that a hot plan must not advance the stamp in place. The same mutation now fails:

```
 × applies a current in-process hot config
 Test Files  1 failed (1)
      Tests  1 failed | 218 passed (219)
```

`node scripts/check-changed.mjs` exits 0.

**Live failure on a real Gateway (before).** The reported host runs a Discord native command
surface. Editing `talk.realtime.instructions` there — the CLI printing "No gateway restart needed." —
and then invoking `/models` produced this, twice, with no recovery between attempts (paths redacted):

```
2026-08-24T11:08:26.914+08:00  discord interaction handler failed: PreparedModelCatalogConfigReplacedError:
  prepared model catalog owner config was replaced during the read (/Users/<user>/.openclaw/agents/main/agent)
2026-08-24T11:15:40.184+08:00  discord interaction handler failed: PreparedModelCatalogConfigReplacedError:
  prepared model catalog owner config was replaced during the read (/Users/<user>/.openclaw/agents/main/agent)
```

Throughout, the Gateway reported healthy, `/ready` returned 200, and ordinary agent turns worked.

**Live reproduction on a real Gateway.** Reproduced on a second, independent host running **stock
current `main`** (no part of this branch), with a full ten-provider catalog and a live Discord
channel. Sequence: restart, one ordinary agent turn to publish a prepared owner,
`openclaw config set talk.realtime.instructions ...` (which prints "No gateway restart needed."),
then `/models` as a Discord slash command:

```
2026-08-24T11:55:54.913Z ERROR [discord/monitor]
discord interaction handler failed: PreparedModelCatalogConfigReplacedError:
prepared model catalog owner config was replaced during the read
(<statedir>/agents/main/agent)
```

The command never returns; the user sees a spinner that does not resolve.

**The failure is specific to the interaction path.** Four other surfaces were tried against the same
stock build and none reproduces it: a minimal Gateway with two providers, the `chat.send` RPC with
the full catalog, a cold browse cache (restart, then a non-`/models` turn to publish the owner
before the edit), and an ordinary Discord *message* reading `/models`, which answered normally in
2.4 s. Only the native slash command, which enters through the Discord interaction dispatcher,
fails.

**Restarting the Gateway is the only recovery, and it is complete.** On the originally reporting
host, a restart at 16:01:23 ended both symptoms in the same instant:

| symptom | before restart | after |
|---|---|---|
| `plugin generation was superseded` (background lane, 30 s retry) | 1248, 11:19:43 → 16:01:07 | 0 |
| `PreparedModelCatalogConfigReplacedError` (`/models`) | 2, 11:08:26 and 11:15:40 | 0 |

**What this evidence does not establish.** The rows above are for the *unfixed* build. A matching
post-fix capture on the same surface is not included yet. Note also that the 1248-row symptom is a
different guard from the one this PR changes; it is reported in #128515 and is not claimed to be
fixed here.
