### PR TITLE
fix(ui): markdown preview in chat sidebar fails to scroll and cuts off content

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1944,12 +1944,20 @@ openclaw-session-discussion {
 .sidebar-markdown-reader {
   --md-preview-serif: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
   position: relative;
+  max-height: calc(100dvh - var(--shell-topbar-height, 44px) - 76px - var(--safe-area-bottom, 0px));
   padding: 20px 18px 24px;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--secondary) 54%, transparent);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  clip-path: inset(0 round var(--radius-lg));
+}
+
+.sidebar-markdown-reader::-webkit-scrollbar-track {
+  margin-block: 8px;
 }
 
 .sidebar-markdown-reader::before {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users viewing rendered markdown documents (such as `AGENTS.md` or session artifacts) in the chat sidebar detail panel could not scroll down, causing content past the initial viewport to be completely inaccessible.

## Why This Change Was Made

Applies viewport-bounded `max-height` and `overflow-y: auto` directly to `.sidebar-markdown-reader`, paired with `clip-path: inset(0 round var(--radius-lg))` and scrollbar track margins so the scrollbar activates properly while respecting the card's rounded corners.

## User Impact

Users can now scroll through long markdown previews in the chat sidebar without content being cut off or scrollbar elements bleeding outside the card's rounded corners.

## Evidence

- Tested in the live Control UI by opening long multi-section documents (`AGENTS.md`) in the sidebar markdown preview.
- Verified that vertical scrolling activates across the entire document length.
- Confirmed the scrollbar track and thumb stay cleanly clipped inside the card's rounded border without visual overflow.

Before: The markdown file like `agent.md` is not scrollable.
<img width="2560" height="1288" alt="image" src="https://github.com/user-attachments/assets/0a398c49-785d-4de7-980c-ed60f72f146b" />

After: A scroll bar appear on the right side and the markdown file is scrollable 
<img width="2560" height="1288" alt="image" src="https://github.com/user-attachments/assets/7f0f3848-6d22-4987-9c02-6a8b1c2fafa7" />>