### PR TITLE
fix(cron): deliver failure alerts outside failed message threads

### DIFF
--- a/src/cron/service/failure-alerts.account-routing.test.ts
+++ b/src/cron/service/failure-alerts.account-routing.test.ts
@@ -109,6 +109,127 @@ describe("cron failure alert account routing", () => {
       },
     },
     {
+      name: "keeps an explicitly unthreaded same-chat failure destination separate",
+      globalAlert: { enabled: true, after: 1 },
+      jobAlert: undefined,
+      failureDestination: {
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+      },
+      expected: {
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+        threadId: undefined,
+        alternateRoute: true,
+      },
+    },
+    {
+      name: "keeps an aliased unthreaded same-chat failure destination separate",
+      globalAlert: { enabled: true, after: 1 },
+      jobAlert: undefined,
+      failureDestination: {
+        channel: "telegram",
+        to: "tg:19098680",
+        accountId: "telegram-bot",
+      },
+      expected: {
+        channel: "telegram",
+        to: "tg:19098680",
+        accountId: "telegram-bot",
+        threadId: undefined,
+        alternateRoute: true,
+      },
+    },
+    {
+      name: "keeps numeric zero as a distinct primary thread",
+      globalAlert: { enabled: true, after: 1 },
+      jobAlert: undefined,
+      deliveryThreadId: 0,
+      failureDestination: {
+        channel: "telegram",
+        to: "tg:19098680",
+        accountId: "telegram-bot",
+      },
+      expected: {
+        channel: "telegram",
+        to: "tg:19098680",
+        accountId: "telegram-bot",
+        threadId: undefined,
+        alternateRoute: true,
+      },
+    },
+    {
+      name: "does not classify an unthreaded provider alias as an alternate route",
+      globalAlert: { enabled: true, after: 1 },
+      jobAlert: undefined,
+      deliveryThreadId: undefined,
+      failureDestination: {
+        channel: "telegram",
+        to: "tg:19098680",
+        accountId: "telegram-bot",
+      },
+      expected: {
+        channel: "telegram",
+        to: "tg:19098680",
+        accountId: "telegram-bot",
+        threadId: undefined,
+        alternateRoute: false,
+      },
+    },
+    {
+      name: "lets an explicit alert route override an unthreaded failure destination",
+      globalAlert: { enabled: true, after: 1 },
+      jobAlert: { to: "tg:19098680" },
+      failureDestination: {
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+      },
+      expected: {
+        channel: "telegram",
+        to: "tg:19098680",
+        accountId: "telegram-bot",
+        threadId: 42,
+        alternateRoute: false,
+      },
+    },
+    {
+      name: "preserves an unthreaded failure destination when the alert only selects its account",
+      globalAlert: { enabled: true, after: 1 },
+      jobAlert: { accountId: "telegram-bot" },
+      failureDestination: {
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+      },
+      expected: {
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+        threadId: undefined,
+        alternateRoute: true,
+      },
+    },
+    {
+      name: "preserves an unthreaded failure destination when the alert only selects its mode",
+      globalAlert: { enabled: true, after: 1 },
+      jobAlert: { mode: "announce" as const },
+      failureDestination: {
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+      },
+      expected: {
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+        threadId: undefined,
+        alternateRoute: true,
+      },
+    },
+    {
       name: "inherits the primary account and topic through a provider target alias",
       globalAlert: { enabled: true, after: 1 },
       jobAlert: { to: "tg:19098680" },
@@ -299,13 +420,118 @@ describe("cron failure alert account routing", () => {
         channel: "deliveryChannel" in testCase ? testCase.deliveryChannel : "telegram",
         to: "deliveryTo" in testCase ? testCase.deliveryTo : "telegram:19098680",
         accountId: "telegram-bot",
-        threadId: 42,
+        threadId: "deliveryThreadId" in testCase ? testCase.deliveryThreadId : 42,
+        ...("failureDestination" in testCase
+          ? { failureDestination: testCase.failureDestination }
+          : {}),
       },
       ...(jobAlert ? { failureAlert: jobAlert } : {}),
       state: {},
     };
 
     expect(resolveFailureAlert(state, job)).toMatchObject(expected);
+  });
+
+  it.each([
+    {
+      name: "required primary delivery failure",
+      result: {
+        status: "ok" as const,
+        deliveryAttempted: true,
+        delivered: false,
+        deliveryError: "topic closed",
+        startedAt: 1_000,
+        endedAt: 2_000,
+      },
+      expectedText: 'Automation "Topic-routed job" delivery failed',
+      expectAlert: true,
+    },
+    {
+      name: "execution failure",
+      result: {
+        status: "error" as const,
+        error: "provider unavailable",
+        startedAt: 1_000,
+        endedAt: 2_000,
+      },
+      expectedText: 'Automation "Topic-routed job" failed 1 times',
+      expectAlert: true,
+    },
+    {
+      name: "unthreaded primary delivery failure with an equivalent provider alias",
+      result: {
+        status: "ok" as const,
+        deliveryAttempted: true,
+        delivered: false,
+        deliveryError: "recipient unavailable",
+        startedAt: 1_000,
+        endedAt: 2_000,
+      },
+      deliveryThreadId: undefined,
+      failureTo: "tg:19098680",
+      expectedText: "",
+      expectAlert: false,
+    },
+  ])("handles failure alert routing after $name", (testCase) => {
+    const { result, expectedText, expectAlert } = testCase;
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const state = createCronServiceState({
+      storePath: "/tmp/openclaw-cron-unthreaded-failure-destination.json",
+      cronEnabled: true,
+      cronConfig: { failureAlert: { enabled: true, after: 1 } },
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      sendCronFailureAlert,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    const job: CronJob = {
+      id: "topic-routed-job",
+      name: "Topic-routed job",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "report" },
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+        threadId: "deliveryThreadId" in testCase ? testCase.deliveryThreadId : 42,
+        bestEffort: false,
+        failureDestination: {
+          channel: "telegram",
+          to: "failureTo" in testCase ? testCase.failureTo : "telegram:19098680",
+          accountId: "telegram-bot",
+        },
+      },
+      state: {},
+    };
+    const deferredNotifications: DeferredCronNotifications = [];
+
+    applyJobResult(state, job, result, { deferredNotifications });
+
+    expect(deferredNotifications).toHaveLength(expectAlert ? 1 : 0);
+    expect(sendCronFailureAlert).not.toHaveBeenCalled();
+    if (!expectAlert) {
+      return;
+    }
+    deferredNotifications[0]?.();
+    expect(sendCronFailureAlert).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        channel: "telegram",
+        to: "telegram:19098680",
+        accountId: "telegram-bot",
+        threadId: undefined,
+        inheritSessionThread: false,
+        payload: expect.objectContaining({
+          text: `${expectedText}\nCheck automation history for details.`,
+        }),
+      }),
+    );
   });
 
   it.each([

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -165,8 +165,15 @@ export function resolveFailureAlert(
   const accountId =
     normalizeOptionalString(route?.accountId) ??
     (primaryRecipientMatches ? primaryAnnounceRoute?.accountId : undefined);
+  // A configured failure destination has no thread and stays distinct from a
+  // threaded primary peer unless a job alert names its own recipient.
   const primaryRouteMatches =
-    primaryRecipientMatches && accountId === primaryAnnounceRoute?.accountId;
+    primaryRecipientMatches &&
+    accountId === primaryAnnounceRoute?.accountId &&
+    (alternateRoute === null ||
+      !job.delivery?.failureDestination ||
+      primaryAnnounceRoute?.threadId == null ||
+      jobConfig?.to !== undefined);
 
   return {
     after: clampPositiveInt(jobConfig?.after ?? globalConfig?.after, DEFAULT_FAILURE_ALERT_AFTER),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an automation delivering into a chat thread silently drops its configured failure alert when the fallback destination is the same chat outside that thread. Execution-failure alerts were also incorrectly sent back into the failed thread instead of the operator-configured unthreaded destination.

This restores the distinct threaded/unthreaded destination contract already protected by #95794, which was lost when scheduler-owned failure routing was consolidated in #126483.

## Why This Change Was Made

Preserve the existing canonical failure-destination owner's distinction between a threaded primary recipient and an explicitly configured unthreaded fallback in the scheduler's final alert-route decision. Only a real primary thread makes those destinations distinct; equivalent unthreaded provider aliases remain deduplicated, numeric thread zero stays valid, account/mode-only alert overrides do not steal the fallback destination, and an explicitly overridden alert recipient keeps its existing topic inheritance.

The production delta is +7 lines, including the required owner-boundary invariant comment: it encodes the existing private route distinction and exact-once recipient fence without adding configuration, public APIs, persistence/schema, security, or alternate delivery paths.

## User Impact

Operators receive required-delivery failure alerts in their explicitly selected chat outside the failed topic. Execution errors also reach that unthreaded destination. The scheduler never retries a failed recipient through an equivalent alias, and existing account routing, topic inheritance, alert thresholds, cooldowns, and failure policies remain unchanged.

## Evidence

Authentic scheduler-owner RED to GREEN:

- Before the fix, direct and provider-aliased same-chat unthreaded failure destinations were incorrectly assigned the primary thread; the real scheduler queued zero required-delivery failure alerts and misrouted execution alerts back into that thread.
- Independent review exposed two additional real edge cases before publication: an equivalent unthreaded alias must never resend to the failed recipient, and account/mode-only alert overrides must not replace an explicit unthreaded destination. Both were reproduced as failing real-owner cases and corrected.
- Final owner coverage includes numeric thread zero, aliased destinations, required-delivery notification, execution notification, no duplicate recipient sends, account/mode-only overrides, and explicit recipient overrides.

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts --configLoader runner \
  src/cron/service/failure-alerts.account-routing.test.ts src/cron/delivery.test.ts \
  src/cron/service.failure-alert.test.ts src/cron/service.failure-alert-silent-reply.test.ts \
  src/cron/service/failure-alerts.persistence.test.ts \
  src/cron/service.persists-delivered-status.test.ts \
  src/cron/service/timer-outcome-finalization.receipts.test.ts
Test Files  7 passed
Tests       166 passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts --configLoader runner \
  src/gateway/server-cron.test.ts src/gateway/server.cron.test.ts \
  src/gateway/server-cron-notifications.test.ts \
  src/gateway/server-cron-notifications.presentation.test.ts
Test Files  4 passed
Tests       163 passed

Independent scheduler/delivery-owner verification: 101 passed
Fresh committed scheduler/delivery-owner verification: 101 passed
Core, Gateway-test, and services-test TypeScript; formatting; lint; max-lines; assertion safety: passed
Total focused scheduler and Gateway integration proof: 329 tests passed
Independent review and fresh authenticated full committed-branch review: no actionable findings
```

The real scheduler finalizer and notification transport were exercised directly without sending messages to external user channels.
