### PR TITLE
refactor(ui): remove retired Control UI stylesheet rules

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -90,8 +90,7 @@
 }
 
 openclaw-chat-sidebar-region,
-.sidebar-region__right-runtime,
-.sidebar-region__panels-runtime {
+.sidebar-region__right-runtime {
   display: contents;
 }
 
@@ -725,14 +724,6 @@ openclaw-chat-sidebar-region,
   line-height: 1.25;
 }
 
-.side-panel-empty__description {
-  max-width: 40ch;
-  margin: 8px 0 0;
-  color: var(--muted);
-  font-size: var(--control-ui-text-sm);
-  line-height: 1.4;
-}
-
 .side-panel-empty--selector .side-panel-empty__title {
   margin-top: 0;
   font-size: var(--control-ui-text-md);
@@ -740,13 +731,6 @@ openclaw-chat-sidebar-region,
 
 .side-panel-empty--selector {
   transform: translateY(-18px);
-}
-
-.side-panel-empty--selector .side-panel-empty__description {
-  max-width: none;
-  margin-top: 4px;
-  line-height: 1.3;
-  white-space: nowrap;
 }
 
 .side-panel-empty__types {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -196,29 +196,9 @@ openclaw-session-owner-chip {
   color: var(--accent);
 }
 
-.connect-splash__logo {
-  width: 44px;
-  height: 44px;
-  animation: connect-splash-wiggle 1.8s ease-in-out infinite;
-}
-
-@keyframes connect-splash-wiggle {
-  0%,
-  100% {
-    transform: rotate(-6deg);
-  }
-  50% {
-    transform: rotate(6deg);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .connect-splash {
     opacity: 1;
-    animation: none;
-  }
-
-  .connect-splash__logo {
     animation: none;
   }
 }

--- a/ui/src/styles/debug.css
+++ b/ui/src/styles/debug.css
@@ -153,13 +153,6 @@ openclaw-debug-overlay {
   border-color: color-mix(in srgb, var(--danger) 35%, var(--border));
 }
 
-.debug-overlay__head {
-  display: flex;
-  gap: 6px;
-  align-items: baseline;
-  justify-content: space-between;
-}
-
 .debug-vital__label {
   overflow: hidden;
   color: var(--muted);

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3912,29 +3912,6 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
   height: 16px;
 }
 
-.sidebar-agent-menu__filter {
-  padding: 2px 8px 6px;
-}
-
-.sidebar-agent-menu__filter input {
-  --control-ui-touch-input-size: var(--control-ui-text-sm);
-
-  width: 100%;
-  padding: 5px 8px;
-  border-radius: 6px;
-  border: 1px solid var(--border);
-  background: var(--bg);
-  color: inherit;
-  font: inherit;
-  font-size: var(--control-ui-text-sm);
-}
-
-.sidebar-agent-menu__empty {
-  padding: 6px 8px;
-  font-size: var(--control-ui-text-sm);
-  color: var(--muted);
-}
-
 /* Identity-menu strip: build identity left, theme switch right. */
 .sidebar-identity-menu__footer {
   display: flex;

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -904,12 +904,6 @@ h3.plugins-subheader {
 
 /* ---------- responsive ---------- */
 
-@media (max-width: 768px) {
-  .plugins-content-header {
-    display: flex;
-  }
-}
-
 @media (max-width: 560px) {
   .plugins-toolbar--fields > .settings-segmented {
     height: auto;

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -721,9 +721,3 @@
 .sidebar-approval-row__message--error {
   color: var(--danger);
 }
-
-.exec-approval-description {
-  overflow-wrap: anywhere;
-  color: var(--muted-strong);
-  line-height: 1.4;
-}


### PR DESCRIPTION
## What Problem This Solves

The Control UI still ships stylesheet rules for retired connection-splash artwork, chat side-panel content, sidebar agent filtering, debug headers, plugin-page headers, and approval descriptions. None of those selectors has a production DOM producer anymore, so they add dead styling and obscure the current component ownership.

## Why This Change Was Made

Remove only the orphaned selectors, their now-unreferenced animation, and an otherwise-empty responsive block. Preserve the live mascot, reduced-motion accessibility rules, active chat/sidebar selectors, dynamically generated resize and plugin artwork classes, and the remaining mobile breakpoint.

## User Impact

No user-visible behavior or appearance changes. The Control UI ships 78 fewer lines of production CSS, with no new dependencies, configuration, or compatibility paths.

## Evidence

- Production CSS: `+1/-79` (net `-78`) across six stylesheets; no test or runtime source changes.
- Focused owner-boundary tests: `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-cleanup-lane6-vitest-cache node scripts/run-vitest.mjs --configLoader runner ui/src/components/app-sidebar.test.ts ui/src/pages/debug/view.test.ts ui/src/pages/plugins/plugins-page.test.ts ui/src/pages/plugins/view.test.ts ui/src/components/exec-approval-card.test.ts` — **5 files, 366 tests passed**.
- Targeted stylesheet lint: `node --import tsx scripts/run-stylelint.mts ui/src/styles/components.css ui/src/styles/chat/sidebar.css ui/src/styles/layout.css ui/src/styles/debug.css ui/src/styles/plugins.css ui/src/styles/sidebar-issues.css` — passed.
- Targeted formatting and `git diff --check` — passed.
- `node --import tsx scripts/audit-control-ui-dead-css.mts` — only the intentionally retained existing approval bootstrap selector remains.
- Two independent source reviews and structured autoreview reported no actionable findings.
- Local chat-sidebar suite requires `@panzoom/panzoom@4.6.2`, which is correctly declared on this head but missing from the older shared linked-worktree dependency installation; its existing owner test explicitly asserts the removed description is absent. Exact-head hosted CI and native clean-environment validation provide the authoritative complete-head proof.
- Exact head: `a0fd3405968f6095ecc1996b98fa282550ef02ec`.
