### PR TITLE
fix(android): prevent expired subagent tasks from reappearing

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -63,6 +63,7 @@ private const val WEAR_AGENT_PULSE_SWARM_MAX_ROWS = 1_000
 private const val WEAR_AGENT_PULSE_SWARM_FETCH_LIMIT = WEAR_AGENT_PULSE_SWARM_MAX_ROWS + 1
 private const val WEAR_AGENT_PULSE_DIRECT_CHILDREN_GROUP = "__wear_agent_pulse_direct_children__"
 private const val SUBAGENT_ACTIVITY_RETENTION_MS = 60_000L
+private const val MAX_RETAINED_TERMINAL_SUBAGENT_TASKS = 100
 private const val SESSION_EDITOR_MAX_BASE64_CHARS = ((OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES + 2) / 3) * 4
 private val MANAGED_MEDIA_PATH_REGEX =
   Regex("^/api/chat/media/outgoing/[^/]+/([0-9a-fA-F-]{36})/full(?:\\?.*)?$")
@@ -343,7 +344,8 @@ class ChatController internal constructor(
   val pendingToolCalls: StateFlow<List<ChatPendingToolCall>> = _pendingToolCalls.asStateFlow()
 
   private val subagentActivityLock = Any()
-  private val subagentActivityExpiryJobs = mutableMapOf<String, Job>()
+  // A null job preserves an expired terminal observation without retaining its UI row.
+  private val subagentActivityExpiryJobs = mutableMapOf<String, Job?>()
   private val _subagentActivities = MutableStateFlow<Map<String, ChatSubagentActivity>>(emptyMap())
   val subagentActivities: StateFlow<Map<String, ChatSubagentActivity>> = _subagentActivities.asStateFlow()
 
@@ -6030,6 +6032,7 @@ class ChatController internal constructor(
     val now = System.currentTimeMillis()
     synchronized(subagentActivityLock) {
       val existing = _subagentActivities.value[taskId]
+      if (terminal && existing == null && subagentActivityExpiryJobs.containsKey(taskId)) return@synchronized
       val lastActivity = task["lastActivity"].asStringOrNull()?.trim()?.takeIf(String::isNotEmpty)
       val fallback =
         task["progressSummary"].asStringOrNull()?.trim()?.takeIf(String::isNotEmpty)
@@ -6075,7 +6078,12 @@ class ChatController internal constructor(
             synchronized(subagentActivityLock) {
               if (subagentActivityExpiryJobs[taskId] !== coroutineContext[Job]) return@synchronized
               _subagentActivities.value = _subagentActivities.value - taskId
-              subagentActivityExpiryJobs.remove(taskId)
+              subagentActivityExpiryJobs[taskId] = null
+              if (subagentActivityExpiryJobs.count { it.value == null } > MAX_RETAINED_TERMINAL_SUBAGENT_TASKS) {
+                subagentActivityExpiryJobs.entries.firstOrNull { it.value == null }?.let {
+                  subagentActivityExpiryJobs.remove(it.key)
+                }
+              }
             }
           }
       }
@@ -6091,7 +6099,7 @@ class ChatController internal constructor(
 
   private fun clearSubagentActivities() {
     synchronized(subagentActivityLock) {
-      subagentActivityExpiryJobs.values.forEach(Job::cancel)
+      subagentActivityExpiryJobs.values.forEach { it?.cancel() }
       subagentActivityExpiryJobs.clear()
       _subagentActivities.value = emptyMap()
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -344,6 +344,7 @@ class ChatController internal constructor(
   val pendingToolCalls: StateFlow<List<ChatPendingToolCall>> = _pendingToolCalls.asStateFlow()
 
   private val subagentActivityLock = Any()
+
   // A null job preserves an expired terminal observation without retaining its UI row.
   private val subagentActivityExpiryJobs = mutableMapOf<String, Job?>()
   private val _subagentActivities = MutableStateFlow<Map<String, ChatSubagentActivity>>(emptyMap())

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSubagentActivityTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSubagentActivityTest.kt
@@ -133,10 +133,20 @@ class ChatControllerSubagentActivityTest {
       assertTrue(controller.subagentActivities.value.isEmpty())
 
       controller.handleGatewayEvent("task", taskPayload(id = "task-1", status = "running"))
-      assertEquals("running", controller.subagentActivities.value.getValue("task-1").status)
+      assertEquals(
+        "running",
+        controller.subagentActivities.value
+          .getValue("task-1")
+          .status,
+      )
 
       controller.handleGatewayEvent("task", taskPayload(id = "task-1", status = "completed"))
-      assertEquals("completed", controller.subagentActivities.value.getValue("task-1").status)
+      assertEquals(
+        "completed",
+        controller.subagentActivities.value
+          .getValue("task-1")
+          .status,
+      )
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSubagentActivityTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSubagentActivityTest.kt
@@ -119,6 +119,82 @@ class ChatControllerSubagentActivityTest {
     }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun expiredTerminalRedeliveryStaysHiddenUntilANewWorkingLifecycle() =
+    runTest {
+      val controller = newController()
+      controller.handleGatewayEvent("task", taskPayload(id = "task-1", status = "completed"))
+
+      advanceTimeBy(60_000)
+      runCurrent()
+      assertTrue(controller.subagentActivities.value.isEmpty())
+
+      controller.handleGatewayEvent("task", taskPayload(id = "task-1", status = "completed", terminalSummary = "Late duplicate"))
+      assertTrue(controller.subagentActivities.value.isEmpty())
+
+      controller.handleGatewayEvent("task", taskPayload(id = "task-1", status = "running"))
+      assertEquals("running", controller.subagentActivities.value.getValue("task-1").status)
+
+      controller.handleGatewayEvent("task", taskPayload(id = "task-1", status = "completed"))
+      assertEquals("completed", controller.subagentActivities.value.getValue("task-1").status)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun deletionAndScopeResetsAllowANewTerminalObservation() =
+    runTest {
+      listOf("deleted", "seqGap", "session").forEach { boundary ->
+        val controller = newController()
+        controller.handleGatewayEvent("task", taskPayload(id = "task-1", status = "completed"))
+        advanceTimeBy(60_000)
+        runCurrent()
+
+        when (boundary) {
+          "deleted" -> controller.handleGatewayEvent("task", "{\"action\":\"deleted\",\"taskId\":\"task-1\"}")
+          "seqGap" -> controller.handleGatewayEvent("seqGap", null)
+          "session" -> controller.switchSession("other")
+        }
+
+        controller.handleGatewayEvent(
+          "task",
+          taskPayload(
+            id = "task-1",
+            status = "completed",
+            sessionKey = if (boundary == "session") "other" else "main",
+          ),
+        )
+        assertTrue("$boundary must clear the expired observation", "task-1" in controller.subagentActivities.value)
+      }
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun terminalObservationLimitEvictsOnlyTheOldestExpiredTasks() =
+    runTest {
+      val controller = newController()
+      controller.handleGatewayEvent("task", taskPayload(id = "still-running", status = "running"))
+      repeat(101) { index ->
+        controller.handleGatewayEvent("task", taskPayload(id = "task-$index", status = "completed"))
+      }
+
+      advanceTimeBy(1)
+      controller.handleGatewayEvent("task", taskPayload(id = "pending-expiry", status = "completed"))
+      advanceTimeBy(59_999)
+      runCurrent()
+      assertEquals(setOf("still-running", "pending-expiry"), controller.subagentActivities.value.keys)
+
+      controller.handleGatewayEvent("task", taskPayload(id = "task-1", status = "completed"))
+      assertEquals(setOf("still-running", "pending-expiry"), controller.subagentActivities.value.keys)
+
+      controller.handleGatewayEvent("task", taskPayload(id = "task-0", status = "completed"))
+      assertEquals(setOf("still-running", "pending-expiry", "task-0"), controller.subagentActivities.value.keys)
+
+      advanceTimeBy(1)
+      runCurrent()
+      assertEquals(setOf("still-running", "task-0"), controller.subagentActivities.value.keys)
+    }
+
+  @Test
   fun sessionSwitchClearsActivityButParentRunCleanupDoesNot() =
     runTest {
       val controller = newController()


### PR DESCRIPTION
Closes #122352

## What Problem This Solves

Fixes an issue where Android users would see an already-expired completed subagent reappear in chat when the Gateway delivered the same terminal task event again after the existing 60-second retention window.

## Why This Change Was Made

Keep the terminal observation at its existing Android chat lifecycle owner after the visible row expires. The current expiry-job map now retains a null marker for the latest 100 expired tasks, matching the Gateway's default task-page size and the web chat's recent-task bound; active jobs remain intact and working events, explicit deletion, session changes, Gateway resets, and sequence gaps clear the observation naturally.

This replaces the closed, unmerged approach in #122472 with one bounded owner map instead of a second unbounded collection. Credit to @licheer-zte for the original investigation and proposed regression coverage, and @Alix-007 for reporting #122352.

## User Impact

Completed, failed, canceled, and timed-out subagent rows remain visible for their existing 60 seconds and do not return when the same terminal event arrives late. A genuine new lifecycle for the same task remains visible, and active task timers are never evicted.

## Evidence

- Pre-fix: the focused Android owner suite ran 9 tests and failed both new late-redelivery and retained-terminal regressions on current main.
- Post-fix: `:app:testPlayDebugUnitTest --tests ai.openclaw.app.chat.ChatControllerSubagentActivityTest` passes all 9 tests, with 0 failures, errors, or skips.
- The regressions cover terminal replay, same-ID working reuse, explicit deletion, sequence-gap and session resets, deterministic eviction of the oldest expired marker, and preservation of an active pending expiry job across that eviction.
- Fresh independent structured code review: no P0/P1 findings; separate owner-boundary review also passed.
- Production: +11/-3 (net +8); tests: +76/-0. The production growth records the missing bounded lifecycle fact in its existing owner without new configuration, persistence, or protocol surface.
- Named follow-up: the shared Apple chat activity state has the analogous late-terminal replay gap and should be repaired separately rather than widening this Android change.
- Real API 36 Android emulator, same chat session and Gateway-shaped task event: the unfixed app showed the terminal row at 28 seconds, removed it at 1:22, and incorrectly resurrected it after duplicate delivery at 1:46. The fixed app showed the same terminal row at 27 seconds and kept it absent after the same duplicate at 1:46; the final accessibility tree contained zero matching task rows. Only the Gateway event stimulus was synthetic; `NodeRuntime`, `ChatController`, retention timing, and Compose rendering were real.

### Before: expired subagent returns after duplicate delivery

![Expired completed subagent incorrectly reappears after duplicate delivery](https://github.com/user-attachments/assets/09f3023f-49d8-4976-91de-a0ead25d81d5)

### After: duplicate delivery does not resurrect the expired subagent

![Expired completed subagent remains absent after identical duplicate delivery](https://github.com/user-attachments/assets/d50bf6e8-44d8-4be5-ba51-21d951f0e584)
