### PR TITLE
fix(slack): prevent long message edits from silently losing text

### DIFF
--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -263,6 +263,68 @@ describe("handleSlackMessageAction", () => {
     );
   });
 
+  it.each([
+    { name: "ASCII", message: `${"x".repeat(4_000)}TAIL` },
+    { name: "multibyte", message: `${"😀".repeat(1_000)}TAIL` },
+    { name: "expanded Slack markdown", message: `${"&".repeat(801)}TAIL` },
+  ])("rejects oversized $name text-only edits before sending", async ({ message }) => {
+    const invoke = createInvokeSpy();
+
+    await expect(
+      handleSlackMessageAction({
+        providerId: "slack",
+        ctx: {
+          action: "edit",
+          cfg: {},
+          params: { channelId: "C1", messageId: "171234.567", message },
+        } as never,
+        invoke: invoke as never,
+      }),
+    ).rejects.toThrow("Slack edit exceeds the 4000-byte edit limit. Send a new message instead.");
+
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("accepts a text-only edit at Slack's exact byte limit", async () => {
+    const invoke = createInvokeSpy();
+    const message = "x".repeat(4_000);
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "edit",
+        cfg: {},
+        params: { channelId: "C1", messageId: "171234.567", message },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(firstAction(invoke)).toMatchObject({ action: "editMessage", content: message });
+  });
+
+  it("keeps oversized notification fallback for visibly rendered block edits", async () => {
+    const invoke = createInvokeSpy();
+    const message = "x".repeat(4_001);
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "edit",
+        cfg: {},
+        params: {
+          channelId: "C1",
+          messageId: "171234.567",
+          message,
+          presentation: { blocks: [{ type: "text", text: "Visible block content" }] },
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(firstAction(invoke)).toMatchObject({ action: "editMessage", content: message });
+    expect(blockAt(firstAction(invoke), 0)).toMatchObject({ type: "section" });
+  });
+
   it("edits native tables with a complete accessible text representation", async () => {
     const invoke = createInvokeSpy();
 
@@ -531,6 +593,32 @@ describe("handleSlackMessageAction", () => {
     });
 
     expect(firstAction(invoke)).toMatchObject({ content: `- ${label}`, blocks: undefined });
+  });
+
+  it("rejects presentation fallback edits that overflow after Slack markdown rendering", async () => {
+    const invoke = createInvokeSpy();
+
+    await expect(
+      handleSlackMessageAction({
+        providerId: "slack",
+        ctx: {
+          action: "edit",
+          cfg: {},
+          params: {
+            channelId: "C1",
+            messageId: "171234.567",
+            presentation: {
+              blocks: [{ type: "text", text: `${"&".repeat(801)}${"x".repeat(2_200)}` }],
+            },
+          },
+        } as never,
+        invoke: invoke as never,
+      }),
+    ).rejects.toThrow(
+      "Slack presentation fallback exceeds the 4000-byte edit limit. Send a new message instead.",
+    );
+
+    expect(invoke).not.toHaveBeenCalled();
   });
 
   it("uses complete text-only fallback when an edit exceeds fifty blocks", async () => {

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -16,6 +16,7 @@ import {
 import { resolveDefaultSlackAccountId } from "./accounts.js";
 import { SLACK_MAX_BLOCKS } from "./blocks-input.js";
 import { buildSlackPresentationBlocks, canRenderSlackPresentation } from "./blocks-render.js";
+import { normalizeSlackOutboundText } from "./format.js";
 import { SLACK_EDIT_TEXT_MAX_BYTES } from "./limits.js";
 import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
 import {
@@ -224,11 +225,15 @@ export async function handleSlackMessageAction(params: {
       ? renderSlackMessagePresentationFallbackText({ text: content, presentation })
       : resolveSlackPresentationText(content, presentation);
     if (
-      renderedPresentation.usesPresentationTextFallback &&
-      countSlackTextUtf8Bytes(accessibleContent) > SLACK_EDIT_TEXT_MAX_BYTES
+      !blocks &&
+      countSlackTextUtf8Bytes(normalizeSlackOutboundText(accessibleContent)) >
+        SLACK_EDIT_TEXT_MAX_BYTES
     ) {
+      const editSubject = renderedPresentation.usesPresentationTextFallback
+        ? "Slack presentation fallback"
+        : "Slack edit";
       throw new Error(
-        `Slack presentation fallback exceeds the ${String(SLACK_EDIT_TEXT_MAX_BYTES)}-byte edit limit. Send a new message instead.`,
+        `${editSubject} exceeds the ${String(SLACK_EDIT_TEXT_MAX_BYTES)}-byte edit limit. Send a new message instead.`,
       );
     }
     if (!accessibleContent && !blocks) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users or agents editing a Slack message received a successful result even though Slack silently lost part of the requested text whenever the final rendered message exceeded Slack's 4,000-byte edit limit. This affected long ASCII messages, multibyte characters, Markdown that expands into Slack entities, and text-only fallbacks for presentations that cannot render natively.

## Why This Change Was Made

The Slack plugin's private message-action owner now validates the actual normalized Slack Markdown UTF-8 payload before attempting a text-only edit and returns an actionable suggestion to send a new message when the complete edit cannot fit. Visible Block Kit edits retain their existing notification-fallback behavior, and public Slack helpers, draft previews, exported APIs, and existing presentation-fallback error wording remain unchanged.

## User Impact

Slack message edits no longer report success after silently discarding authored content. Oversized edits fail before any provider mutation, explain the 4,000-byte limit, and tell the agent or operator to send a new message instead; edits at the exact limit and rendered block-based edits continue to work.

## Evidence

- Authentic action-to-provider reproduction confirmed ASCII, multibyte, and escaped Markdown edits previously returned success after truncating visible text; an unrenderable presentation with 3,001 authored bytes expanded to 6,205 Slack Markdown bytes and failed the same way.
- After the fix, all four overflow variants fail before the Slack provider is called; exactly 4,000 bytes and visible Block Kit edits succeed, while the public helper's established truncation behavior remains unchanged.
- `node scripts/run-vitest.mjs extensions/slack/src/message-action-dispatch.test.ts extensions/slack/src/actions.blocks.test.ts extensions/slack/src/action-runtime.test.ts extensions/slack/src/draft-stream.test.ts extensions/slack/src/send.update.test.ts extensions/slack/src/shared-interactive.test.ts extensions/slack/src/message-tools.test.ts`: **258 tests passed across seven suites**.
- Focused type-aware lint, formatting, whitespace, conflict-marker, assertion-safety, and max-lines checks passed. Independent architectural review and an authenticated full committed-branch review reported no actionable findings.
- Production delta: **+5 lines**, confined to the Slack-private action boundary; regression coverage: **+88 lines**.
