### PR TITLE
fix(linux): truthful install failures, post-install repair, and reachable reinstall in the desktop companion

### DIFF
--- a/apps/linux/src-tauri/src/cli.rs
+++ b/apps/linux/src-tauri/src/cli.rs
@@ -16,6 +16,7 @@ pub enum CliError {
     Missing,
     Environment(String),
     Spawn(String),
+    CommandFailed(String),
     InvalidJson(String),
 }
 
@@ -23,9 +24,10 @@ impl fmt::Display for CliError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Missing => write!(formatter, "OpenClaw CLI not found"),
-            Self::Environment(message) | Self::Spawn(message) | Self::InvalidJson(message) => {
-                formatter.write_str(message)
-            }
+            Self::Environment(message)
+            | Self::Spawn(message)
+            | Self::CommandFailed(message)
+            | Self::InvalidJson(message) => formatter.write_str(message),
         }
     }
 }
@@ -102,6 +104,14 @@ impl OpenClawCli {
         S: AsRef<std::ffi::OsStr>,
     {
         let output = self.output(args)?;
+        // Failed commands own their stderr; parsing first would mislabel real
+        // failures as missing CLI dashboard support.
+        if !output.status.success() {
+            let message = output_tail(&output.stderr)
+                .or_else(|| output_tail(&output.stdout))
+                .unwrap_or_else(|| format!("OpenClaw CLI exited with {}", output.status));
+            return Err(CliError::CommandFailed(message));
+        }
         let value = serde_json::from_slice(&output.stdout).map_err(|error| {
             CliError::InvalidJson(format!("OpenClaw CLI returned invalid JSON: {error}"))
         })?;
@@ -121,6 +131,21 @@ impl OpenClawCli {
     }
 }
 
+pub(crate) fn output_tail(output: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(output);
+    let mut lines: Vec<&str> = Vec::new();
+    for line in text.lines().filter(|line| !line.trim().is_empty()) {
+        // The CLI repeats identical progress lines while waiting; one occurrence
+        // carries the same information in a user-facing failure message.
+        if lines.last() != Some(&line) {
+            lines.push(line);
+        }
+    }
+    let start = lines.len().saturating_sub(12);
+    let tail = &lines[start..];
+    (!tail.is_empty()).then(|| tail.join("\n"))
+}
+
 pub fn openclaw_home() -> Result<PathBuf, CliError> {
     #[cfg(target_os = "windows")]
     let home = env::var_os("HOME")
@@ -130,4 +155,24 @@ pub fn openclaw_home() -> Result<PathBuf, CliError> {
     let home = env::var_os("HOME").filter(|value| !value.is_empty());
     let home = home.ok_or_else(|| CliError::Environment("HOME is not set".to_string()))?;
     Ok(PathBuf::from(home).join(".openclaw"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::output_tail;
+
+    #[test]
+    fn output_tail_keeps_the_last_twelve_nonempty_lines() {
+        let output = (1..=15)
+            .map(|line| format!("message {line}"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let expected = (4..=15)
+            .map(|line| format!("message {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(output_tail(output.as_bytes()), Some(expected));
+        assert_eq!(output_tail(b"\n  \n"), None);
+    }
 }

--- a/apps/linux/src-tauri/src/gateway.rs
+++ b/apps/linux/src-tauri/src/gateway.rs
@@ -220,13 +220,14 @@ pub fn dashboard(cli: &OpenClawCli, snapshot: GatewaySnapshot) -> Result<ReadyGa
     let (response, output) =
         match cli.json::<DashboardResponse, _, _>(["dashboard", "--json", "--no-open"]) {
             Ok(result) => result,
+            // Older CLIs reject the app's own --json flag (prose on stdout, or a nonzero
+            // exit naming the flag); both mean the same missing integration, not a failure
+            // the user can repair in place.
             Err(crate::cli::CliError::InvalidJson(_)) => {
-                return Err(
-                    "The installed OpenClaw CLI does not support the desktop dashboard \
-                 integration. Update OpenClaw (for example: npm install -g openclaw@latest), \
-                 then retry."
-                        .to_string(),
-                );
+                return Err(unsupported_dashboard_integration());
+            }
+            Err(crate::cli::CliError::CommandFailed(message)) if message.contains("\"--json\"") => {
+                return Err(unsupported_dashboard_integration());
             }
             Err(error) => return Err(error.to_string()),
         };
@@ -252,6 +253,13 @@ pub fn dashboard(cli: &OpenClawCli, snapshot: GatewaySnapshot) -> Result<ReadyGa
     Err(response
         .reason
         .unwrap_or_else(|| "Dashboard is not ready.".to_string()))
+}
+
+fn unsupported_dashboard_integration() -> String {
+    "The installed OpenClaw CLI does not support the desktop dashboard integration. \
+     Choose the Beta or Development release channel and install again, or wait for \
+     the next stable release."
+        .to_string()
 }
 
 fn dashboard_token(dashboard_url: &str) -> Result<Option<String>, String> {

--- a/apps/linux/src-tauri/src/installer.rs
+++ b/apps/linux/src-tauri/src/installer.rs
@@ -105,6 +105,13 @@ pub fn install(app: &AppHandle, channel: InstallChannel) -> Result<(), String> {
                 line: &line,
             },
         );
+        // Structured step events belong to the log pane; the failure tail is
+        // shown as prose and must keep only human-readable diagnostics.
+        if serde_json::from_str::<serde_json::Value>(&line)
+            .is_ok_and(|value| value.get("event").is_some())
+        {
+            continue;
+        }
         if tail.len() == ERROR_TAIL_LINES {
             tail.pop_front();
         }

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -28,7 +28,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
-use tauri::{AppHandle, Manager, State, Url, WebviewWindow};
+use tauri::{AppHandle, Emitter, Manager, State, Url, WebviewWindow};
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_global_shortcut::{Code, Modifiers};
 
@@ -237,17 +237,50 @@ impl DesktopState {
             .lock()
             .map_err(|_| "Installer lock is unavailable.".to_string())?;
         installer::install(app, channel)?;
+        let cli = OpenClawCli::discover().map_err(|error| {
+            format!("OpenClaw is installed, but the CLI could not be found: {error}")
+        })?;
+        *self.inner.cli.lock().expect("CLI mutex poisoned") = Some(cli.clone());
+
+        // The installed CLI owns config/state migrations; repair before any
+        // Gateway readiness checks consume an outdated home.
+        let repair_error = match cli.output(["doctor", "--fix", "--non-interactive"]) {
+            Ok(output) if !output.status.success() => Some(
+                cli::output_tail(&output.stderr)
+                    .unwrap_or_else(|| format!("OpenClaw repair exited with {}", output.status)),
+            ),
+            Err(error) => Some(format!("OpenClaw repair could not start: {error}")),
+            _ => None,
+        };
+        if let Some(error) = repair_error {
+            for line in error.lines() {
+                let _ = app.emit_to(
+                    "main",
+                    "install-progress",
+                    serde_json::json!({ "stream": "stderr", "line": line }),
+                );
+            }
+        }
+
         self.inner
             .navigation
             .lock()
-            .map_err(|_| "Dashboard navigation lock is unavailable.".to_string())?
+            .map_err(|_| {
+                "OpenClaw is installed, but preparing the Gateway dashboard failed: \
+                 Dashboard navigation lock is unavailable."
+                    .to_string()
+            })?
             .mark_onboarding_pending();
-        let cli = OpenClawCli::discover().map_err(|error| error.to_string())?;
-        *self.inner.cli.lock().expect("CLI mutex poisoned") = Some(cli.clone());
-        let ready = gateway::ensure_ready(&cli)?;
+        let ready = gateway::ensure_ready(&cli).map_err(|error| {
+            format!("OpenClaw is installed, but connecting to the Gateway failed: {error}")
+        })?;
         app.state::<gateway_ws::GatewayClient>()
             .configure(app, ready.gateway_ws.clone());
-        let navigated = self.navigate_local(app, &ready.dashboard_url, false, None, true, true)?;
+        let navigated = self
+            .navigate_local(app, &ready.dashboard_url, false, None, true, true)
+            .map_err(|error| {
+                format!("OpenClaw is installed, but opening the Gateway dashboard failed: {error}")
+            })?;
         self.update_tray(&ready.snapshot);
         if navigated {
             self.start_watchdog(app.clone());

--- a/apps/linux/ui/main.js
+++ b/apps/linux/ui/main.js
@@ -63,8 +63,48 @@ function renderAction(options, action) {
   show(elements.actionControls, true);
 }
 
+function formatInstallLine(line) {
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    return line;
+  }
+  if (!event || typeof event !== "object" || !event.event) {
+    return line;
+  }
+  if (event.event === "done" && event.ok === true) {
+    return `✓ Installed${event.version ? ` ${event.version}` : ""}`;
+  }
+  if (event.event !== "step" || !event.name) {
+    return line;
+  }
+
+  const name =
+    {
+      node: "Node runtime",
+      git: "Git checkout",
+      openclaw: "OpenClaw CLI",
+      "gateway-service": "Gateway service",
+      "control-ui": "Control UI build",
+      "cli-build": "CLI build",
+    }[event.name] || event.name;
+  switch (event.status) {
+    case "start":
+      return `→ ${name}${event.version ? ` ${event.version}` : ""}…`;
+    case "ok":
+      return `✓ ${name}`;
+    case "skip":
+      return `– ${name} skipped${event.reason ? ` (${event.reason})` : ""}`;
+    case "warn":
+      return `! ${name}${event.reason ? `: ${event.reason}` : ""}`;
+    default:
+      return line;
+  }
+}
+
 function appendLog(line) {
-  elements.installLog.textContent += `${line}\n`;
+  elements.installLog.textContent += `${formatInstallLine(line)}\n`;
   elements.installLog.scrollTop = elements.installLog.scrollHeight;
 }
 
@@ -235,13 +275,13 @@ async function install() {
     await invoke("install_cli", { channel: elements.channel.value });
     elements.logStatus.textContent = "COMPLETE";
   } catch (error) {
+    const message = friendlyError(error);
     elements.logStatus.textContent = "FAILED";
-    appendLog(friendlyError(error));
+    appendLog(message);
     render({
-      description:
-        "Installation did not finish. Review the final log lines, choose a release channel, then retry.",
+      description: message,
       dot: "error",
-      eyebrow: "INSTALLATION ISSUE",
+      eyebrow: "SETUP ISSUE",
       showInstall: true,
       title: "OpenClaw needs attention",
     });
@@ -273,6 +313,9 @@ function renderRetry(message) {
       description: message,
       dot: "error",
       eyebrow: "CONNECTION ISSUE",
+      // A broken managed CLI can only be replaced by reinstalling; retry alone
+      // must never be the sole exit from a connection failure.
+      showInstall: true,
       title: "OpenClaw needs attention",
     },
     connect,

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1152,10 +1152,16 @@ ensure_pnpm() {
     emit_json "{\"event\":\"step\",\"name\":\"pnpm\",\"status\":\"start\",\"method\":\"corepack\"}"
     log "Installing pnpm via Corepack..."
     "$(node_dir)/bin/corepack" enable >/dev/null 2>&1 || true
-    "$(node_dir)/bin/corepack" prepare pnpm@11 --activate
-    if detect_pnpm_cmd && pnpm_cmd_is_ready && [[ "$("${PNPM_CMD[@]}" --version 2>/dev/null || true)" =~ ^11\. ]]; then
-      emit_json "{\"event\":\"step\",\"name\":\"pnpm\",\"status\":\"ok\"}"
-      return 0
+    # Corepack downloads fail hard on npm registry key rotation (its bundled
+    # signature set goes stale); the npm fallback below must stay reachable.
+    if "$(node_dir)/bin/corepack" prepare pnpm@11 --activate; then
+      if detect_pnpm_cmd && pnpm_cmd_is_ready && [[ "$("${PNPM_CMD[@]}" --version 2>/dev/null || true)" =~ ^11\. ]]; then
+        emit_json "{\"event\":\"step\",\"name\":\"pnpm\",\"status\":\"ok\"}"
+        return 0
+      fi
+    else
+      emit_json "{\"event\":\"step\",\"name\":\"pnpm\",\"status\":\"warn\",\"reason\":\"corepack-failed\"}"
+      log "Corepack could not provision pnpm; falling back to npm."
     fi
   fi
 
@@ -1450,7 +1456,9 @@ clone_git_checkout_transactionally() {
   fi
   TMPFILES+=("$staging_dir")
 
-  git clone "$repo_url" "$staging_dir" || clone_status=$?
+  # Blobless partial clone: the dev checkout only needs current files plus pullable
+  # history refs; full multi-gigabyte blob history would dominate install time.
+  git clone --filter=blob:none "$repo_url" "$staging_dir" || clone_status=$?
   if [[ "$clone_status" -ne 0 ]]; then
     return "$clone_status"
   fi
@@ -1624,12 +1632,25 @@ is_gateway_daemon_loaded() {
   fi
 
   local status_json=""
-  status_json="$("$claw" daemon status --json 2>/dev/null || true)"
+  # Unlike daemon status, gateway status reports service.loaded during pending migrations.
+  status_json="$("$claw" gateway status --json 2>/dev/null || true)"
   if [[ -z "$status_json" ]]; then
     return 1
   fi
 
-  printf '%s' "$status_json" | node -e '
+  # Managed installs must parse with their provisioned Node even when the system has none.
+  local node_bin="${PREFIX}/tools/node/bin/node"
+  if [[ ! -x "$node_bin" ]]; then
+    if command -v node >/dev/null 2>&1; then
+      node_bin="$(command -v node)"
+    else
+      # Approximate POSIX-safe fallback when neither managed nor system Node is available.
+      printf '%s\n' "$status_json" | grep -Eq '"loaded"[[:space:]]*:[[:space:]]*true'
+      return
+    fi
+  fi
+
+  printf '%s' "$status_json" | "$node_bin" -e '
 const fs = require("fs");
 const raw = fs.readFileSync(0, "utf8").trim();
 if (!raw) process.exit(1);


### PR DESCRIPTION
## What Problem This Solves

The Linux desktop companion (Tauri app in `apps/linux/`) did not deliver the "easy install" experience the macOS app has. Tested end-to-end as a real user in a clean Ubuntu 24.04 aarch64 VM (Lima, Xvfb + openbox, driven via xdotool), it failed on every release channel in a different way, and every failure ended at the same dishonest dead end:

- **Stable channel**: the CLI installed successfully, but the app then claimed "Installation did not finish" with circular "update via npm" advice. The real cause (stable `2026.7.1-2` predates `dashboard --json`) was discarded because a failed CLI command's empty stdout was parsed as JSON and mislabeled `InvalidJson`.
- **Beta channel**: `doctor` found real config/state problems, but the app threw away the CLI's stderr — the operator saw a generic error with no diagnosis and no path forward.
- **All channels**: the installer's structured JSON step events were dumped raw into the visible log, the failure screen hid the Reinstall control (retry-only dead end), the gateway service refresh was silently skipped on clean machines (no bare `node`, and `daemon status` dies during pending migrations), and a corepack signature failure (npm registry key rotation) hard-aborted dev-channel installs even though an npm fallback exists two lines below.

## Why This Change Was Made

Severity order in this repo is silent failure > crash > missing feature. Every one of these was a silent or lying failure on the default out-of-box path. The fixes make each failure surface truthful and actionable, and make the app self-heal where the CLI already knows how:

- `apps/linux/src-tauri/src/cli.rs`: failed CLI commands now return their stderr tail (last 12 non-empty lines, consecutive-duplicate deduped) as `CliError::CommandFailed` instead of being mislabeled as JSON parse failures. Unit-tested.
- `apps/linux/src-tauri/src/gateway.rs`: a CLI without `dashboard --json` support maps to one honest curated message ("choose Beta or Development, or wait for the next stable release") instead of circular npm-update advice.
- `apps/linux/src-tauri/src/main.rs`: run `doctor --fix --non-interactive` immediately after install, streaming its output into the install log, so the CLI repairs config/state before any Gateway readiness check consumes an outdated home. Post-install failures render as "OpenClaw is installed, but connecting to the Gateway failed: <real reason>".
- `apps/linux/src-tauri/src/installer.rs`: structured step events stay in the log pane; the prose failure tail keeps only human-readable diagnostics.
- `apps/linux/ui/main.js`: streamed install steps are humanized ("→ Node runtime 24.15.0…", "✓ OpenClaw CLI", "– Gateway service skipped (not-loaded)"), the failure screen shows the real error instead of a hardcoded lie, and Reinstall is always reachable from a connection failure (a broken managed CLI can only be replaced by reinstalling).
- `scripts/install-cli.sh`: service refresh detection uses `gateway status --json` with the bundled Node runtime (works during pending migrations and on machines with no system node), `corepack prepare` failure warns and falls back to npm instead of aborting, and the dev channel clones with `--filter=blob:none`.

## User Impact

A Linux operator who runs the companion app now either lands in the dashboard's Model Setup with zero terminal use, or sees exactly what failed and a working Reinstall path — never a false "Installation did not finish" over a successful install.

## Evidence

Three full live rounds in the clean VM, each an actual click-through as a user:

**Round A — Stable**: install succeeds, app now says honestly that the installed CLI can't serve the dashboard, with the humanized install log below (this capture predates the final curated-message polish; the wording now names the Beta/Development channels):

![Stable: honest installed-but-cannot-connect](https://github.com/user-attachments/assets/67e3b861-8be3-46fb-8944-2edd72d90008)

**Round B — Beta**: the CLI's real doctor diagnosis (pending state-DB migration + invalid config with its own fix advice) is surfaced verbatim instead of being discarded:

![Beta: real doctor diagnosis surfaced](https://github.com/user-attachments/assets/d4e558b9-961a-4080-b722-22a2a18f7b16)

**Round C/D — Development**: complete zero-terminal self-heal: install → `doctor --fix` repairs the beta-bricked home → systemd user service replaced and started → dashboard opens at Model Setup. `~/.openclaw/bin/openclaw` resolves to `2026.8.1 (082cdc8)`, service active:

![Dev: dashboard Model Setup after full self-heal](https://github.com/user-attachments/assets/df44feee-b33b-4c8a-a33c-1ce40b6b22cf)

Validation: `cargo build` clean, `cargo test` 10 passed / 0 failed, `cargo fmt --check` clean (all in the Linux VM against this exact tree); `bash -n scripts/install-cli.sh` and `node --check apps/linux/ui/main.js` clean; `apps/linux/ui/main.js` and `scripts/install-cli.sh` are excluded from oxfmt by repo ignore rules. Autoreview (uncommitted diff): clean, no actionable findings, "patch is correct (0.98)".

Related core context: the beta `doctor` migration failure itself (`device_bootstrap_tokens` missing `setup_id`) is already fixed on `main` and `release/2026.8.1` by #124282 — this PR only makes the companion surface and repair such failures instead of hiding them.
