### PR TITLE
fix(plugins): reserve .disabled marker in plugin id namespace

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -336,6 +336,9 @@ function shouldIgnoreScannedDirectory(dirName: string): boolean {
   if (normalized.includes(".backup-")) {
     return true;
   }
+  // Operator-disabled/backup copies carry the ".disabled" marker (often with a
+  // date suffix). Install-path validation reserves the token in plugin ids, so
+  // anything matching here is operator-managed, not a live install candidate.
   if (normalized.includes(".disabled")) {
     return true;
   }

--- a/src/plugins/install-paths.test.ts
+++ b/src/plugins/install-paths.test.ts
@@ -7,6 +7,7 @@ import {
   resolveDefaultPluginNpmDir,
   resolvePluginNpmGenerationProjectDir,
   resolvePluginNpmGenerationProjectDirPrefix,
+  validatePluginId,
 } from "./install-paths.js";
 import { resolvePluginInstallRoots, withPluginInstallRoots } from "./install-root-context.js";
 import {
@@ -115,5 +116,22 @@ describe("managed npm plugin install paths", () => {
     expect(path.basename(projectDir)).toMatch(
       new RegExp(`^${resolvePluginNpmGenerationProjectDirPrefix(packageName)}`, "u"),
     );
+  });
+});
+
+describe("validatePluginId", () => {
+  it("accepts ordinary unscoped and scoped ids", () => {
+    expect(validatePluginId("telegram")).toBeNull();
+    expect(validatePluginId("@openclaw/codex")).toBeNull();
+  });
+
+  it("rejects ids carrying the reserved disabled marker (#127391)", () => {
+    // Discovery and installed-plugin security roots suppress any path
+    // containing ".disabled" so operator-disabled/backup copies stay hidden;
+    // such ids must fail loudly at the install boundary instead of being
+    // installed and then silently invisible.
+    expect(validatePluginId("valid.disabled-name")).toMatch(/reserved disabled marker/u);
+    expect(validatePluginId("telegram.disabled.20260222")).toMatch(/reserved disabled marker/u);
+    expect(validatePluginId("@scope/name.disabled")).toMatch(/reserved disabled marker/u);
   });
 });

--- a/src/plugins/install-paths.ts
+++ b/src/plugins/install-paths.ts
@@ -44,6 +44,14 @@ export function validatePluginId(pluginId: string): string | null {
   if (segments.some((segment) => segment === "." || segment === "..")) {
     return "invalid plugin name: reserved path segment";
   }
+  // ".disabled" is the operator convention for disabled/backup plugin copies
+  // (e.g. "telegram.disabled.20260222"); discovery and installed-plugin
+  // security-root enumeration suppress any path containing it. Reserving the
+  // token here keeps that convention unambiguous: an install whose directory
+  // would be suppressed by the disable marker cannot be created silently.
+  if (trimmed.includes(".disabled")) {
+    return "invalid plugin name: reserved disabled marker";
+  }
   if (segments.length === 1) {
     if (trimmed.startsWith("@")) {
       return "invalid plugin name: scoped ids must use @scope/name format";

--- a/src/security/installed-plugin-dirs.ts
+++ b/src/security/installed-plugin-dirs.ts
@@ -28,6 +28,9 @@ function shouldIgnoreInstalledPluginDirName(name: string): boolean {
   if (normalized.includes(".backup-")) {
     return true;
   }
+  // Operator-disabled/backup copies carry the ".disabled" marker (often with a
+  // date suffix). Install-path validation reserves the token in plugin ids, so
+  // anything matching here is operator-managed, not a live install root.
   if (normalized.includes(".disabled")) {
     return true;
   }


### PR DESCRIPTION
Closes #127391

## What Problem This Solves

Plugin install-path validation accepted ordinary IDs containing `.disabled`, but automatic discovery (`shouldIgnoreScannedDirectory`) and installed-plugin security-root enumeration (`shouldIgnoreInstalledPluginDirName`) suppress any path containing that substring. A valid plugin could therefore be installed and then be silently invisible to auto-discovery while also being omitted from trust/code-safety scan roots.

## Why This Change Was Made

The `.disabled` token is the operator convention for disabled/backup copies (existing fixtures use date-suffixed names like `telegram.disabled.20260222`), so narrowing the discovery/security filters would resurrect operator-disabled backups as live candidates - the wrong side to move. The sound boundary is the install namespace: `validatePluginId` now reserves the marker, rejecting IDs containing `.disabled` with `invalid plugin name: reserved disabled marker`.

- New installs fail loudly at the owned validation boundary instead of succeeding and then going silently invisible.
- Operator-managed disabled/backup directories keep their existing suppression semantics in discovery and security roots, unchanged.
- All `validatePluginId` callers already treat rejection as fail-closed (install flows throw; index records filter; legacy declarations reject).
- Cross-reference comments added at both suppression sites pointing at the reservation.

## User Impact

- No more silently-invisible plugins: an ID colliding with the disable marker is rejected at install time with a clear message.
- Existing valid installs are unaffected (no shipped plugin uses the marker); operator disable/rename workflows behave exactly as before.
- Security audits keep skipping operator-disabled/backup roots.

## Evidence

Focused proof (Windows, Node 24):

```
node node_modules/vitest/vitest.mjs run src/plugins/install-paths.test.ts
     Tests  6 passed (6)  # 2 new + 4 pre-existing
```

New regressions: ordinary unscoped/scoped ids accepted; `valid.disabled-name`, `telegram.disabled.20260222`, and `@scope/name.disabled` all rejected with the reserved-marker message. Existing discovery/security suppression tests remain green (behavior unchanged).

Note on local run environment: two unrelated pre-existing tests in this file assert POSIX-style root paths and fail on a Windows host both before and after this change; Linux CI runs them green.

Lint: oxlint clean on touched files.
