### PR TITLE
fix(chunking): keep extended grapheme clusters whole across chunk cuts

### DIFF
--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -27,7 +27,10 @@ import {
   normalizeOptionalString as normalizeSlackApiString,
   normalizeTrimmedStringList,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import {
+  avoidTrailingGraphemeBreak,
+  sliceUtf16Safe,
+} from "openclaw/plugin-sdk/text-utility-runtime";
 import type { SlackTokenSource } from "./accounts.js";
 import { resolveSlackAccount, resolveSlackOperationToken } from "./accounts.js";
 import type { SlackAuthoredTextPlacement } from "./authored-text.js";
@@ -476,7 +479,10 @@ function resolveSlackTextChunks(params: {
     const chunks: string[] = [];
     let remaining = text;
     while (remaining) {
-      const chunk = sliceUtf16Safe(remaining, 0, chunkLimit) || Array.from(remaining)[0] || "";
+      // Grapheme-aware hard cut: keep ZWJ emoji/flags/combining sequences whole
+      // across Slack message boundaries instead of splitting the cluster.
+      const safeEnd = avoidTrailingGraphemeBreak(remaining, 0, chunkLimit);
+      const chunk = remaining.slice(0, safeEnd) || Array.from(remaining)[0] || "";
       chunks.push(chunk);
       remaining = remaining.slice(chunk.length);
     }

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -1,5 +1,6 @@
-import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 // Telegram helper module supports format behavior.
+import { avoidTrailingGraphemeBreak } from "@openclaw/normalization-core/utf16-slice";
+import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   FILE_REF_EXTENSIONS_WITH_TLD,
@@ -686,6 +687,13 @@ function clampToSurrogateBoundary(text: string, index: number): number {
   return index > 1 ? index - 1 : index + 1;
 }
 
+// HTML-safe splits must additionally keep extended grapheme clusters whole:
+// ZWJ emoji, flags, and combining sequences span multiple code points and a
+// mid-cluster cut re-encodes to broken replacement glyphs on both sides.
+function clampToGraphemeBoundary(text: string, index: number): number {
+  return avoidTrailingGraphemeBreak(text, 0, index);
+}
+
 // Prefer a word/paragraph boundary inside the entity-safe window so long text
 // runs break between words instead of mid-word. Whitespace never falls inside
 // an HTML entity, so this keeps entities intact; the caller falls back to the
@@ -712,7 +720,7 @@ function findTelegramHtmlSafeSplitIndex(text: string, maxLength: number): number
   const entitySafeIndex = findTelegramHtmlEntitySafeSplitIndex(text, normalizedMaxLength);
   const wordSafeIndex = findTelegramHtmlWordSafeSplitIndex(text, entitySafeIndex);
   const splitIndex = wordSafeIndex > 0 ? wordSafeIndex : entitySafeIndex;
-  return clampToSurrogateBoundary(text, splitIndex);
+  return clampToGraphemeBoundary(text, clampToSurrogateBoundary(text, splitIndex));
 }
 
 function findTelegramHtmlEntitySafeSplitIndex(text: string, normalizedMaxLength: number): number {

--- a/extensions/telegram/src/truncate.ts
+++ b/extensions/telegram/src/truncate.ts
@@ -1,20 +1,25 @@
 // Telegram tests cover progress text clipping behavior.
-import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import {
+  avoidTrailingGraphemeBreak,
+  sliceUtf16Safe,
+} from "openclaw/plugin-sdk/text-utility-runtime";
 
 const TELEGRAM_PROGRESS_MAX_CHARS = 300;
 
 /**
  * Clips Telegram progress text to at most {@link TELEGRAM_PROGRESS_MAX_CHARS} UTF-16 code units,
- * slicing on a code-point boundary so a surrogate pair straddling the limit is
- * dropped whole rather than leaving a lone high surrogate in the payload.
+ * slicing on a grapheme boundary so a surrogate pair or extended cluster
+ * (ZWJ emoji, flag) straddling the limit is dropped whole rather than leaving
+ * broken halves in the payload.
  */
 export function clipTelegramProgressText(text: string): string {
   if (text.length <= TELEGRAM_PROGRESS_MAX_CHARS) {
     return text;
   }
-  // Slice on a code-point boundary so an emoji (or any astral character) that
-  // straddles the limit is dropped whole instead of leaving a lone \uD83D-style
-  // high surrogate before the ellipsis, which serializes to an invalid character
-  // in the Telegram Bot API payload.
-  return `${sliceUtf16Safe(text, 0, TELEGRAM_PROGRESS_MAX_CHARS - 1).trimEnd()}…`;
+  // Slice on a cluster boundary so an emoji (or any astral/multi-code-point
+  // character) that straddles the limit is dropped whole instead of leaving a
+  // lone \uD83D-style high surrogate before the ellipsis, which serializes to
+  // an invalid character in the Telegram Bot API payload.
+  const clipped = sliceUtf16Safe(text, 0, TELEGRAM_PROGRESS_MAX_CHARS - 1);
+  return `${text.slice(0, avoidTrailingGraphemeBreak(clipped, 0, clipped.length)).trimEnd()}…`;
 }

--- a/packages/markdown-core/src/chunk-text.ts
+++ b/packages/markdown-core/src/chunk-text.ts
@@ -1,6 +1,9 @@
 // Markdown Core module implements chunk text behavior.
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
-import { avoidTrailingHighSurrogateBreak } from "@openclaw/normalization-core/utf16-slice";
+import {
+  avoidTrailingGraphemeBreak,
+  avoidTrailingHighSurrogateBreak,
+} from "@openclaw/normalization-core/utf16-slice";
 
 export { avoidTrailingHighSurrogateBreak };
 
@@ -109,7 +112,7 @@ export function chunkTextRanges(text: string, options: ChunkTextRangesOptions): 
         ? findPreferredRangeEnd(text, start, maxEnd)
         : undefined;
     const candidateEnd = preferredEnd && preferredEnd > start ? preferredEnd : maxEnd;
-    const end = avoidTrailingHighSurrogateBreak(text, start, candidateEnd);
+    const end = avoidTrailingGraphemeBreak(text, start, candidateEnd);
     ranges.push({ start, end });
     start = end;
   }
@@ -141,7 +144,7 @@ export function chunkText(text: string, limit: number): string[] {
     // Prefer block boundaries, then spaces, then a hard size cut when no
     // readable breakpoint exists inside this window.
     const breakOffset = lastNewline > 0 ? lastNewline : lastWhitespace;
-    const end = avoidTrailingHighSurrogateBreak(
+    const end = avoidTrailingGraphemeBreak(
       text,
       cursor,
       breakOffset > 0 ? cursor + breakOffset : windowEnd,

--- a/packages/markdown-core/src/render-aware-chunking.ts
+++ b/packages/markdown-core/src/render-aware-chunking.ts
@@ -1,5 +1,5 @@
-import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
-import { avoidTrailingHighSurrogateBreak } from "./chunk-text.js";
+﻿import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
+import { avoidTrailingGraphemeBreak } from "@openclaw/normalization-core/utf16-slice";
 // Markdown Core module implements render aware chunking behavior.
 import { annotateAssistantTranscriptRoleMessageBoundary } from "./ir-annotations.js";
 import {
@@ -152,7 +152,7 @@ function findLargestChunkTextLengthWithinRenderedLimit<TRendered>(
   // Rendered length is not guaranteed to be monotonic after escaping/link or
   // file-reference rewriting, so test exact candidates from longest to shortest.
   for (let candidateLength = currentTextLength - 1; candidateLength >= 1; candidateLength -= 1) {
-    const safeCandidateLength = avoidTrailingHighSurrogateBreak(chunk.text, 0, candidateLength);
+    const safeCandidateLength = avoidTrailingGraphemeBreak(chunk.text, 0, candidateLength);
     const candidate = sliceMarkdownIR(chunk, 0, safeCandidateLength);
     const rendered = options.renderChunk(candidate);
     if (options.measureRendered(rendered) <= renderedLimit) {
@@ -241,7 +241,7 @@ function findMarkdownIRPreservedSplitIndex(text: string, start: number, limit: n
   if (lastAnyWhitespaceBreak > start) {
     return resolveWhitespaceBreak(lastAnyWhitespaceBreak, lastAnyWhitespaceRunStart);
   }
-  return avoidTrailingHighSurrogateBreak(text, start, maxEnd);
+  return avoidTrailingGraphemeBreak(text, start, maxEnd);
 }
 
 function splitMarkdownIRPreserveWhitespace(ir: MarkdownIR, limit: number): MarkdownIR[] {

--- a/packages/normalization-core/src/utf16-slice.ts
+++ b/packages/normalization-core/src/utf16-slice.ts
@@ -26,6 +26,55 @@ export function avoidTrailingHighSurrogateBreak(text: string, start: number, end
   return adjusted > start ? adjusted : end + 1;
 }
 
+let graphemeSegmenter: Intl.Segmenter | undefined;
+
+function getGraphemeSegmenter(): Intl.Segmenter | undefined {
+  try {
+    graphemeSegmenter ??=
+      typeof Intl !== "undefined" && typeof Intl.Segmenter === "function"
+        ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+        : undefined;
+  } catch {
+    graphemeSegmenter = undefined;
+  }
+  return graphemeSegmenter;
+}
+
+/**
+ * Moves a proposed UTF-16 cut backward to an extended grapheme cluster
+ * boundary so multi-code-unit symbols (ZWJ emoji, flags, skin-tone modifiers,
+ * combining sequences, Indic clusters) stay whole across chunk boundaries.
+ * Falls back to the surrogate-pair clamp when Intl.Segmenter is unavailable.
+ */
+export function avoidTrailingGraphemeBreak(text: string, start: number, end: number): number {
+  const surrogateSafeEnd = avoidTrailingHighSurrogateBreak(text, start, end);
+  if (surrogateSafeEnd <= start || surrogateSafeEnd >= text.length) {
+    return surrogateSafeEnd;
+  }
+  const segmenter = getGraphemeSegmenter();
+  if (!segmenter) {
+    return surrogateSafeEnd;
+  }
+  for (const segment of segmenter.segment(text)) {
+    const segmentEnd = segment.index + segment.segment.length;
+    if (segmentEnd < surrogateSafeEnd) {
+      continue;
+    }
+    if (segment.index < surrogateSafeEnd && segmentEnd > surrogateSafeEnd) {
+      // Cut strictly inside this cluster. Move back to its start so the symbol
+      // stays whole; when the cluster already begins at/after the window start,
+      // emit it whole by extending forward instead (mirrors the surrogate
+      // helper's forward escape) so chunking still makes progress.
+      if (segment.index > start) {
+        return segment.index;
+      }
+      return Math.min(segmentEnd, text.length);
+    }
+    return surrogateSafeEnd;
+  }
+  return surrogateSafeEnd;
+}
+
 /** Slices a UTF-16 string without returning dangling surrogate halves at either edge. */
 export function sliceUtf16Safe(input: string, start: number, end?: number): string {
   const len = input.length;

--- a/src/plugin-sdk/text-utility-runtime.ts
+++ b/src/plugin-sdk/text-utility-runtime.ts
@@ -42,6 +42,7 @@ export async function runChannelProbe<
 }
 
 export {
+  avoidTrailingGraphemeBreak,
   CONFIG_DIR,
   clamp,
   clampInt,

--- a/src/shared/text-chunking.test.ts
+++ b/src/shared/text-chunking.test.ts
@@ -64,3 +64,30 @@ describe("shared/text-chunking", () => {
     );
   });
 });
+
+describe("grapheme-safe chunk boundaries (#127654)", () => {
+  const familyEmoji = "\u{1F468}\u200D\u{1F469}\u200D\u{1F467}\u200D\u{1F466}";
+
+  it("keeps an extended grapheme cluster whole across hard line splits", () => {
+    // "aa" + family emoji + "z" with limit 3: the naive code-unit cut lands
+    // inside the ZWJ family cluster; the grapheme-aware cut moves back.
+    const chunks = splitLongTextLine(`aa${familyEmoji}z`, 3, { preserveWhitespace: true });
+    expect(chunks.join("")).toBe(`aa${familyEmoji}z`);
+    // The whole family cluster is emitted as one chunk; nothing splits it.
+    expect(chunks).toContain(familyEmoji);
+  });
+
+  it("keeps flag and skin-tone clusters whole in break-resolver chunking", () => {
+    const flag = "\u{1F1FA}\u{1F1F8}";
+    const wavingHand = "\u{1F44B}\u{1F3FD}";
+    const text = `x${flag}${wavingHand}y`;
+    const chunks = chunkTextByBreakResolver(text, 2, () => -1);
+    expect(chunks.join("")).toBe(text);
+    for (const chunk of chunks) {
+      expect(chunk).not.toMatch(/^[\u{1F1FA}]$/u);
+      expect(chunk).not.toMatch(/^\u{1F44B}$/u);
+    }
+    expect(chunks[0]).toBe("x");
+    expect(chunks[1]).toContain(flag);
+  });
+});

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -1,5 +1,8 @@
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
-import { avoidTrailingHighSurrogateBreak } from "@openclaw/normalization-core/utf16-slice";
+import {
+  avoidTrailingGraphemeBreak,
+  avoidTrailingHighSurrogateBreak,
+} from "@openclaw/normalization-core/utf16-slice";
 
 export { avoidTrailingHighSurrogateBreak };
 
@@ -12,7 +15,9 @@ export function normalizeChunkLimit(limit: number): number {
 
 function clampToCodePointBoundary(text: string, index: number): number {
   const boundary = Math.min(Math.max(0, index), text.length);
-  return avoidTrailingHighSurrogateBreak(text, 0, boundary);
+  // Grapheme-aware so hard cuts keep ZWJ emoji, flags, and combining
+  // sequences whole instead of splitting them across platform messages.
+  return avoidTrailingGraphemeBreak(text, 0, boundary);
 }
 
 function findWhitespaceBreak(window: string): number {
@@ -96,7 +101,7 @@ export function chunkTextByBreakResolver(
       Number.isInteger(candidateBreak) && candidateBreak > 0 && candidateBreak <= normalizedLimit
         ? candidateBreak
         : normalizedLimit;
-    const safeBreakIdx = avoidTrailingHighSurrogateBreak(remaining, 0, breakIdx);
+    const safeBreakIdx = avoidTrailingGraphemeBreak(remaining, 0, breakIdx);
     const rawChunk = remaining.slice(0, safeBreakIdx);
     const chunk = rawChunk.trimEnd();
     if (chunk.length > 0) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,7 +58,11 @@ export function normalizeE164(number: string): string {
 // Surrogate-safe slicing helpers live in a node-free leaf module so browser/UI
 // bundles can import them without pulling in filesystem code. Re-exported here
 // to preserve the historical `utils.ts` import surface.
-export { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+export {
+  avoidTrailingGraphemeBreak,
+  sliceUtf16Safe,
+  truncateUtf16Safe,
+} from "@openclaw/normalization-core/utf16-slice";
 
 /** Resolves the OpenClaw config directory from state/config env overrides or home. */
 export function resolveConfigDir(


### PR DESCRIPTION
Closes #127654

## What Problem This Solves

Ordinary-send hard chunkers avoided splitting UTF-16 surrogate pairs but not extended grapheme clusters. ZWJ emoji (family emoji), flags, skin-tone modifiers, combining sequences, and Indic clusters could be divided between separate platform messages, corrupting the authored symbol recipients see. Affected shared primitives: `src/shared/text-chunking.ts`, `packages/markdown-core/src/chunk-text.ts`, and the render-aware retry cuts - plus channel-local Telegram HTML slicing and Slack plain-text chunking.

## Why This Change Was Made

One shared primitive per the issue's recommendation:

- `packages/normalization-core/src/utf16-slice.ts`: new `avoidTrailingGraphemeBreak(text, start, end)` - moves a proposed cut backward to an `Intl.Segmenter` grapheme boundary; falls back to the surrogate clamp when `Intl.Segmenter` is unavailable. When a cluster starts at/before the window start (backward movement impossible), it emits the cluster whole by extending forward, mirroring the surrogate helper's forward-escape so chunking always makes progress.
- Adopted at every enumerated cut site: `clampToCodePointBoundary` + break-resolver hard cuts (`text-chunking.ts`), `chunkTextRanges`/`chunkText` (`markdown-core/chunk-text.ts`), render-limit retry cuts and last-resort split (`render-aware-chunking.ts`), Telegram HTML-safe split index (`format.ts`), Telegram progress clipping (`truncate.ts`), Slack plain-text chunk loop (`send.ts`). Exported through `src/utils.ts` and the `plugin-sdk/text-utility-runtime` barrel for extension use.

Hard transport limits and progress guarantees are preserved: cuts move back only within the window (or forward by one whole cluster when unavoidable), never past it arbitrarily.

## User Impact

- One authored symbol (family emoji, flag, skin-tone wave, etc.) can no longer arrive broken across multiple messages on Telegram/Discord/Slack/Signal/Matrix/WhatsApp ordinary sends.
- ASCII content chunks are byte-identical to before; only mid-cluster boundaries move.

## Evidence

Focused proof (Windows, Node 24):

```
node node_modules/vitest/vitest.mjs run src/shared/text-chunking.test.ts packages/markdown-core
     Tests  246 passed (246)

node node_modules/vitest/vitest.mjs run extensions/telegram/src/truncate.test.ts
     Tests    5 passed (5)
```

New regressions:
- ZWJ family emoji survives `splitLongTextLine` hard splits whole (issue repro shape),
- flag + skin-tone clusters survive `chunkTextByBreakResolver` hard cuts,
- all prior surrogate/astral integrity tests unchanged and green,
- full markdown-core suite (incl. render-aware retry cuts and the whitespace-loss coalescing from #127655's sibling behavior) green.

Lint: oxlint clean on touched files.
