### PR TITLE
fix(ui): preserve new composer state across reconnects

### DIFF
--- a/ui/src/pages/chat/chat-history.test.ts
+++ b/ui/src/pages/chat/chat-history.test.ts
@@ -340,15 +340,17 @@ describe("rewindChatHistory", () => {
     expect(state.handleChatDraftChange).not.toHaveBeenCalled();
   });
 
-  it("does not overwrite composer state after a same-client reconnect", async () => {
+  it("reconciles committed rewind history without overwriting a replacement draft", async () => {
     let resolveRewind!: (result: { editorText?: string }) => void;
     const rewind = new Promise<{ editorText?: string }>((resolve) => {
       resolveRewind = resolve;
     });
-    const state = createState({ messages: [] }) as TestState & {
+    const canonical = { role: "assistant", content: "canonical history after rewind" };
+    const state = createState({ messages: [canonical] }) as TestState & {
       handleChatDraftChange: ReturnType<typeof vi.fn>;
       sessions: { rewind: ReturnType<typeof vi.fn> };
     };
+    state.chatMessages = [{ role: "assistant", content: "stale replacement history" }];
     state.handleChatDraftChange = vi.fn((next: string) => {
       state.chatMessage = next;
     });
@@ -373,6 +375,7 @@ describe("rewindChatHistory", () => {
     expect(state.chatAttachments).toEqual([
       { id: "new", mimeType: "image/jpeg", dataUrl: "data:image/jpeg;base64,bmV3" },
     ]);
+    expect(state.chatMessages).toEqual([canonical]);
     expect(state.handleChatDraftChange).not.toHaveBeenCalled();
     expect(result).toBeNull();
   });
@@ -525,17 +528,19 @@ describe("switchChatHistoryBranch", () => {
     expect(state.chatMessages).toEqual([selected]);
   });
 
-  it("does not apply a branch switch after a same-client reconnect", async () => {
+  it("reconciles a committed branch switch after a same-client reconnect", async () => {
     let resolveSwitch!: () => void;
     const switched = new Promise<object>((resolve) => {
       resolveSwitch = () => resolve({});
     });
-    const state = createState({ messages: [] }) as TestState & {
+    const selected = { role: "assistant", content: "selected branch after reconnect" };
+    const state = createState({ messages: [selected] }) as TestState & {
       sessions: {
         listBranches: ReturnType<typeof vi.fn>;
         switchBranch: ReturnType<typeof vi.fn>;
       };
     };
+    state.chatMessages = [{ role: "assistant", content: "stale branch after reconnect" }];
     state.sessions = {
       listBranches: vi.fn().mockResolvedValue([]),
       switchBranch: vi.fn(() => switched),
@@ -550,7 +555,8 @@ describe("switchChatHistoryBranch", () => {
     resolveSwitch();
 
     await expect(pending).resolves.toBe(false);
-    expect(state.sessions.listBranches).not.toHaveBeenCalled();
+    expect(state.chatMessages).toEqual([selected]);
+    expect(state.sessions.listBranches).toHaveBeenCalledWith(state.sessionKey, expect.any(Object));
   });
 });
 

--- a/ui/src/pages/chat/chat-history.test.ts
+++ b/ui/src/pages/chat/chat-history.test.ts
@@ -339,6 +339,43 @@ describe("rewindChatHistory", () => {
     expect(result).toBeNull();
     expect(state.handleChatDraftChange).not.toHaveBeenCalled();
   });
+
+  it("does not overwrite composer state after a same-client reconnect", async () => {
+    let resolveRewind!: (result: { editorText?: string }) => void;
+    const rewind = new Promise<{ editorText?: string }>((resolve) => {
+      resolveRewind = resolve;
+    });
+    const state = createState({ messages: [] }) as TestState & {
+      handleChatDraftChange: ReturnType<typeof vi.fn>;
+      sessions: { rewind: ReturnType<typeof vi.fn> };
+    };
+    state.handleChatDraftChange = vi.fn((next: string) => {
+      state.chatMessage = next;
+    });
+    state.sessions = {
+      rewind: vi.fn(() => rewind),
+      setModelOverride: vi.fn(),
+    };
+
+    const pending = rewindChatHistory(state as never, "user-entry");
+    state.connected = false;
+    state.connectionEpoch += 1;
+    state.connected = true;
+    state.connectionEpoch += 1;
+    state.chatMessage = "new connection draft";
+    state.chatAttachments = [
+      { id: "new", mimeType: "image/jpeg", dataUrl: "data:image/jpeg;base64,bmV3" },
+    ];
+    resolveRewind({ editorText: "stale rewind draft" });
+
+    const result = await pending;
+    expect(state.chatMessage).toBe("new connection draft");
+    expect(state.chatAttachments).toEqual([
+      { id: "new", mimeType: "image/jpeg", dataUrl: "data:image/jpeg;base64,bmV3" },
+    ]);
+    expect(state.handleChatDraftChange).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
 });
 
 describe("switchChatHistoryBranch", () => {
@@ -486,6 +523,34 @@ describe("switchChatHistoryBranch", () => {
 
     expect(request).toHaveBeenCalledTimes(2);
     expect(state.chatMessages).toEqual([selected]);
+  });
+
+  it("does not apply a branch switch after a same-client reconnect", async () => {
+    let resolveSwitch!: () => void;
+    const switched = new Promise<object>((resolve) => {
+      resolveSwitch = () => resolve({});
+    });
+    const state = createState({ messages: [] }) as TestState & {
+      sessions: {
+        listBranches: ReturnType<typeof vi.fn>;
+        switchBranch: ReturnType<typeof vi.fn>;
+      };
+    };
+    state.sessions = {
+      listBranches: vi.fn().mockResolvedValue([]),
+      switchBranch: vi.fn(() => switched),
+      setModelOverride: vi.fn(),
+    };
+
+    const pending = switchChatHistoryBranch(state as never, "stale-leaf");
+    state.connected = false;
+    state.connectionEpoch += 1;
+    state.connected = true;
+    state.connectionEpoch += 1;
+    resolveSwitch();
+
+    await expect(pending).resolves.toBe(false);
+    expect(state.sessions.listBranches).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -46,6 +46,7 @@ import {
   sleep,
 } from "./chat-history-retry.ts";
 import type { ChatRunStartupPhase } from "./chat-run-startup.ts";
+import { captureChatConnectionOwner } from "./chat-send-queue-state.ts";
 import type { ChatState } from "./chat-state-contract.ts";
 import { persistChatComposerState } from "./composer-persistence.ts";
 import {
@@ -1372,8 +1373,14 @@ export async function rewindChatHistory(
   }
   const sessionKey = state.sessionKey;
   const agentParams = scopedAgentParamsForSession(state, sessionKey);
+  const connectionIsCurrent = captureChatConnectionOwner(state);
+  const viewIsCurrent = () =>
+    connectionIsCurrent() && visibleSessionMatches(state, sessionKey, agentParams.agentId);
   try {
     const result = await state.sessions.rewind(sessionKey, entryId, agentParams);
+    if (!connectionIsCurrent()) {
+      return null;
+    }
     const editorText = result.editorText ?? "";
     if (state.chatMessagesBySession) {
       clearChatMessagesFromCache(state.chatMessagesBySession, state, {
@@ -1385,12 +1392,12 @@ export async function rewindChatHistory(
       agentId: agentParams.agentId,
       draft: editorText,
     });
-    if (!visibleSessionMatches(state, sessionKey, agentParams.agentId)) {
+    if (!viewIsCurrent()) {
       return null;
     }
     resetChatHistoryProjection(state, agentParams.agentId);
     await Promise.all([loadChatHistory(state), loadChatBranches(state)]);
-    if (!visibleSessionMatches(state, sessionKey, agentParams.agentId)) {
+    if (!viewIsCurrent()) {
       return null;
     }
     // Restored images intentionally stay in this tab's memory; persisted composer drafts remain
@@ -1402,8 +1409,10 @@ export async function rewindChatHistory(
     state.handleChatDraftChange(editorText);
     return result;
   } catch (error) {
-    setChatError(state, formatUiError(error));
-    scheduleChatScroll(state);
+    if (viewIsCurrent()) {
+      setChatError(state, formatUiError(error));
+      scheduleChatScroll(state);
+    }
     return null;
   }
 }
@@ -1417,23 +1426,31 @@ export async function switchChatHistoryBranch(
   }
   const sessionKey = state.sessionKey;
   const agentParams = scopedAgentParamsForSession(state, sessionKey);
+  const connectionIsCurrent = captureChatConnectionOwner(state);
+  const viewIsCurrent = () =>
+    connectionIsCurrent() && visibleSessionMatches(state, sessionKey, agentParams.agentId);
   try {
     await state.sessions.switchBranch(sessionKey, leafEntryId, agentParams);
+    if (!connectionIsCurrent()) {
+      return false;
+    }
     if (state.chatMessagesBySession) {
       clearChatMessagesFromCache(state.chatMessagesBySession, state, {
         sessionKey,
         agentId: agentParams.agentId,
       });
     }
-    if (!visibleSessionMatches(state, sessionKey, agentParams.agentId)) {
+    if (!viewIsCurrent()) {
       return false;
     }
     resetChatHistoryProjection(state, agentParams.agentId);
     await Promise.all([loadChatHistory(state), loadChatBranches(state)]);
-    return visibleSessionMatches(state, sessionKey, agentParams.agentId);
+    return viewIsCurrent();
   } catch (error) {
-    setChatError(state, formatUiError(error));
-    scheduleChatScroll(state);
+    if (viewIsCurrent()) {
+      setChatError(state, formatUiError(error));
+      scheduleChatScroll(state);
+    }
     return false;
   }
 }

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -1376,13 +1376,10 @@ export async function rewindChatHistory(
   const connectionEpoch = state.connectionEpoch;
   const connectionIsCurrent = () =>
     state.connected && state.client === client && state.connectionEpoch === connectionEpoch;
-  const viewIsCurrent = () =>
-    connectionIsCurrent() && visibleSessionMatches(state, sessionKey, agentParams.agentId);
+  const viewMatches = () => visibleSessionMatches(state, sessionKey, agentParams.agentId);
+  const viewIsCurrent = () => connectionIsCurrent() && viewMatches();
   try {
     const result = await state.sessions.rewind(sessionKey, entryId, agentParams);
-    if (!connectionIsCurrent()) {
-      return null;
-    }
     const editorText = result.editorText ?? "";
     if (state.chatMessagesBySession) {
       clearChatMessagesFromCache(state.chatMessagesBySession, state, {
@@ -1390,11 +1387,13 @@ export async function rewindChatHistory(
         agentId: agentParams.agentId,
       });
     }
-    persistChatComposerState(state, sessionKey, {
-      agentId: agentParams.agentId,
-      draft: editorText,
-    });
-    if (!viewIsCurrent()) {
+    if (connectionIsCurrent()) {
+      persistChatComposerState(state, sessionKey, {
+        agentId: agentParams.agentId,
+        draft: editorText,
+      });
+    }
+    if (!viewMatches()) {
       return null;
     }
     resetChatHistoryProjection(state, agentParams.agentId);
@@ -1432,20 +1431,17 @@ export async function switchChatHistoryBranch(
   const connectionEpoch = state.connectionEpoch;
   const connectionIsCurrent = () =>
     state.connected && state.client === client && state.connectionEpoch === connectionEpoch;
-  const viewIsCurrent = () =>
-    connectionIsCurrent() && visibleSessionMatches(state, sessionKey, agentParams.agentId);
+  const viewMatches = () => visibleSessionMatches(state, sessionKey, agentParams.agentId);
+  const viewIsCurrent = () => connectionIsCurrent() && viewMatches();
   try {
     await state.sessions.switchBranch(sessionKey, leafEntryId, agentParams);
-    if (!connectionIsCurrent()) {
-      return false;
-    }
     if (state.chatMessagesBySession) {
       clearChatMessagesFromCache(state.chatMessagesBySession, state, {
         sessionKey,
         agentId: agentParams.agentId,
       });
     }
-    if (!viewIsCurrent()) {
+    if (!viewMatches()) {
       return false;
     }
     resetChatHistoryProjection(state, agentParams.agentId);

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -46,7 +46,6 @@ import {
   sleep,
 } from "./chat-history-retry.ts";
 import type { ChatRunStartupPhase } from "./chat-run-startup.ts";
-import { captureChatConnectionOwner } from "./chat-send-queue-state.ts";
 import type { ChatState } from "./chat-state-contract.ts";
 import { persistChatComposerState } from "./composer-persistence.ts";
 import {
@@ -1373,7 +1372,10 @@ export async function rewindChatHistory(
   }
   const sessionKey = state.sessionKey;
   const agentParams = scopedAgentParamsForSession(state, sessionKey);
-  const connectionIsCurrent = captureChatConnectionOwner(state);
+  const client = state.client;
+  const connectionEpoch = state.connectionEpoch;
+  const connectionIsCurrent = () =>
+    state.connected && state.client === client && state.connectionEpoch === connectionEpoch;
   const viewIsCurrent = () =>
     connectionIsCurrent() && visibleSessionMatches(state, sessionKey, agentParams.agentId);
   try {
@@ -1426,7 +1428,10 @@ export async function switchChatHistoryBranch(
   }
   const sessionKey = state.sessionKey;
   const agentParams = scopedAgentParamsForSession(state, sessionKey);
-  const connectionIsCurrent = captureChatConnectionOwner(state);
+  const client = state.client;
+  const connectionEpoch = state.connectionEpoch;
+  const connectionIsCurrent = () =>
+    state.connected && state.client === client && state.connectionEpoch === connectionEpoch;
   const viewIsCurrent = () =>
     connectionIsCurrent() && visibleSessionMatches(state, sessionKey, agentParams.agentId);
   try {

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -516,7 +516,10 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
         draft: editorText,
       });
     } catch (error) {
-      if (!this.isConnectionScopeCurrent(scope)) {
+      if (
+        !this.isConnectionScopeCurrent(scope) ||
+        !visibleSessionMatches(state, sourceKey, agentParams.agentId)
+      ) {
         return;
       }
       state.lastError = formatUiError(error);

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -488,16 +488,20 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
   }
 
   protected async forkFromMessage(entryId: string): Promise<void> {
-    const state = this.state;
-    if (!state) {
+    const scope = this.captureConnectionScope();
+    if (!scope) {
       return;
     }
+    const state = scope.state;
     const sourceKey = state.sessionKey;
     const agentParams = scopedAgentParamsForSession(state, sourceKey);
     try {
       const result = await state.sessions.forkAtMessage(sourceKey, entryId, agentParams);
       const editorText = result.editorText ?? "";
-      if (this.state !== state || !visibleSessionMatches(state, sourceKey, agentParams.agentId)) {
+      if (
+        !this.isConnectionScopeCurrent(scope) ||
+        !visibleSessionMatches(state, sourceKey, agentParams.agentId)
+      ) {
         return;
       }
       if (this.onPaneSessionChange?.(this.paneId, result.sessionKey) === false) {
@@ -512,6 +516,9 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
         draft: editorText,
       });
     } catch (error) {
+      if (!this.isConnectionScopeCurrent(scope)) {
+        return;
+      }
       state.lastError = formatUiError(error);
       state.chatError = state.lastError;
       state.requestUpdate?.();

--- a/ui/src/pages/chat/chat-pane.message-cut.test.ts
+++ b/ui/src/pages/chat/chat-pane.message-cut.test.ts
@@ -132,4 +132,24 @@ describe("chat pane message cuts", () => {
     expect(state.sessionKey).toBe("global");
     expect(state.assistantAgentId).toBe("work");
   });
+
+  it("does not navigate to a fork that finishes after a same-client reconnect", async () => {
+    const forked = createDeferred<{ sessionKey: string; editorText?: string }>();
+    const sessions = {
+      forkAtMessage: vi.fn(() => forked.promise),
+    } as unknown as SessionCapability;
+    const client = {} as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions });
+    const navigate = vi.fn();
+    pane.onPaneSessionChange = navigate;
+
+    const pending = pane.forkFromMessage("user-entry");
+    pane.connectionGeneration += 1;
+    state.connectionEpoch = pane.connectionGeneration;
+    forked.resolve({ sessionKey: "agent:main:forked", editorText: "stale draft" });
+
+    await pending;
+    expect(navigate).not.toHaveBeenCalled();
+    expect(consumePaneSessionHandoff(pane.context, pane.paneId, "agent:main:forked")).toBeNull();
+  });
 });

--- a/ui/src/pages/chat/chat-pane.message-cut.test.ts
+++ b/ui/src/pages/chat/chat-pane.message-cut.test.ts
@@ -152,4 +152,24 @@ describe("chat pane message cuts", () => {
     expect(navigate).not.toHaveBeenCalled();
     expect(consumePaneSessionHandoff(pane.context, pane.paneId, "agent:main:forked")).toBeNull();
   });
+
+  it("does not paint a stale fork error after the selected session changes", async () => {
+    let rejectFork!: (error: Error) => void;
+    const forked = new Promise<never>((_resolve, reject) => {
+      rejectFork = reject;
+    });
+    const sessions = {
+      forkAtMessage: vi.fn(() => forked),
+    } as unknown as SessionCapability;
+    const client = {} as GatewayBrowserClient;
+    const { pane, state } = createTestChatPane({ client, sessions });
+
+    const pending = pane.forkFromMessage("user-entry");
+    state.sessionKey = "agent:main:replacement";
+    rejectFork(new Error("stale fork failed"));
+
+    await pending;
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #128617

## Summary

Prevents delayed rewind, branch-switch, and fork work from a retired Control UI
connection from publishing into the replacement chat pane.

The fix preserves both sides of the contract: a Gateway mutation that already
committed still refreshes canonical history after reconnect, but its retired UI
result cannot overwrite the replacement draft, attachments, navigation, or
error state.

## Root cause

A same-client reconnect can retain the browser client and selected session while
advancing the logical connection epoch. The message-cut paths checked session
identity, but did not consistently prove that the initiating connection still
owned the visible pane after awaiting the Gateway mutation.

Returning early on any connection change is also incorrect because rewind or
branch selection may already be durable on the server. The UI must reconcile
that committed state without applying connection-local editor results.

## Fix

- Rewind and branch switch capture the initiating client, connection epoch,
  session, and agent scope.
- Successful committed mutations invalidate the source cache and reload
  canonical history when that session remains visible.
- Only the initiating connection may restore returned drafts or attachments,
  report errors, or claim successful UI ownership.
- Fork success and failure use the existing pane connection scope plus the
  captured source-session predicate.

## Verification

- Exact head: `d7019c80dbcfe8112eeb28eb08b744ba0222a498`
- Exact-head Testbox: 28 history tests and 4 message-cut tests passed.
- Exact-head browser scenario passed on current main and the candidate.
- Independent P1 autoreview: no actionable findings, 0.94 confidence.
- Blacksmith: zero import cycles and production UI build passed.
- Startup JS: `340,881 B` gzip, 20 B below the refreshed baseline and 532 B
  below the enforced maximum.

## Visual evidence

| Current main | Candidate |
| --- | --- |
| ![Current main after canonical rewind history loaded but the retired result overwrote the replacement draft](https://github.com/user-attachments/assets/0621770e-0ec2-4229-9969-0cbdc7f4a95c) | ![Candidate after canonical rewind history loaded while the replacement draft remained unchanged](https://github.com/user-attachments/assets/98e113f3-11bd-495c-b9e5-ffbbd68d1cef) |

### Synchronized reconnect recording

https://github.com/user-attachments/assets/046af3d6-1a02-4085-9922-c57458d5f428

Both sides confirm Rewind, hold the Gateway response, advance connection epoch
`1 -> 2 -> 3`, enter `new connection draft`, and resolve the retired result.
Both load canonical committed history; current main changes the draft to
`stale rewind draft`, while the candidate keeps `new connection draft`.

## Scope

Production: +43/-15 (net +28). Tests: +111/-0.

No protocol, persistence, SQLite, configuration, compatibility, or fallback
surface is added.
