### PR TITLE
fix: show context window switcher on new sessions

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -777,6 +777,18 @@ function buildModelProviderMocks(baseTime: number) {
     models: [
       { id: "claude-opus-4-8", name: "Claude Opus 4.8", provider: "anthropic", available: true },
       {
+        id: "claude-fable-5",
+        name: "Claude Fable 5",
+        provider: "anthropic",
+        available: true,
+        contextWindow: 1_000_000,
+        contextWindows: [
+          { id: "200k", label: "200K", contextWindow: 200_000 },
+          { id: "1m", label: "1M", contextWindow: 1_000_000 },
+        ],
+        contextWindowDefault: "1m",
+      },
+      {
         id: "claude-sonnet-4-6",
         name: "Claude Sonnet 4.6",
         provider: "anthropic",

--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -30,6 +30,68 @@ function catalogDiscoveryRequests(
 }
 
 suite.define(() => {
+  it("selects a context window before creating a session", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      agentModel: "openai/gpt-5.6-luna",
+      methodResponses: {
+        "sessions.create": { key: "agent:main:context-window", runStarted: true },
+      },
+      models: [
+        {
+          available: true,
+          id: "gpt-5.6-luna",
+          name: "GPT-5.6 Luna",
+          provider: "openai",
+        },
+        {
+          available: true,
+          id: "claude-fable-5",
+          name: "Claude Fable 5",
+          provider: "anthropic",
+          contextWindow: 1_000_000,
+          contextWindows: [
+            { id: "200k", label: "200K", contextWindow: 200_000 },
+            { id: "1m", label: "1M", contextWindow: 1_000_000 },
+          ],
+          contextWindowDefault: "1m",
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      const modelSelect = page.locator('[data-chat-model-select="true"]');
+      await modelSelect.click();
+      await page.locator('[data-chat-model-option="anthropic/claude-fable-5"]').click();
+      await modelSelect.click();
+
+      const contextWindowToggle = page.locator('[data-chat-context-window-toggle="200k"]');
+      await expect.poll(() => contextWindowToggle.isVisible()).toBe(true);
+      expect(await contextWindowToggle.getAttribute("aria-checked")).toBe("true");
+      await contextWindowToggle.click();
+      await expect
+        .poll(() => page.locator("[data-chat-model-context-badge]").textContent())
+        .toContain("200K");
+
+      await page.locator(".new-session-page__message").fill("use the smaller window");
+      await page.getByRole("button", { name: "Start session" }).click();
+      const create = await gateway.waitForRequest("sessions.create");
+      expect(create.params).toMatchObject({
+        message: "use the smaller window",
+        model: "anthropic/claude-fable-5",
+        contextWindow: "200k",
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
   it("shows metadata failure truthfully and recovers when the picker opens", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -25,6 +25,11 @@ import { renderChatModelPicker, type ChatModelCatalogState } from "./chat-model-
 
 export type { ChatModelCatalogState } from "./chat-model-picker.ts";
 
+type ChatContextWindowTarget = Pick<
+  SessionsListResult["defaults"],
+  "contextWindow" | "contextWindows" | "contextWindowDefault"
+>;
+
 type ChatModelControlsProps = {
   activeRunId: string | null;
   agentDefaultModel?: string;
@@ -46,6 +51,7 @@ type ChatModelControlsProps = {
   sessionKey: string;
   sessionsResult: SessionsListResult | null;
   stream: string | null;
+  contextWindowTarget?: ChatContextWindowTarget;
   thinkingDefaults?: SessionsListResult["defaults"];
   thinkingSession?: ChatThinkingTarget;
   onFastModeSelect?: (value: ChatFastModeSelectValue, sessionKey: string) => unknown;
@@ -370,7 +376,8 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
   // One owner supplies the whole tuple: mixing an override session's fields with
   // the defaults row can render the default model's options for a session whose
   // model declares none, then patch an invalid option id.
-  const contextWindowOwner = activeSession ?? props.sessionsResult?.defaults;
+  const contextWindowOwner =
+    props.contextWindowTarget ?? activeSession ?? props.sessionsResult?.defaults;
   const contextWindows = contextWindowOwner?.contextWindows ?? [];
   const selectedContextWindow =
     contextWindowOwner?.contextWindow ?? contextWindowOwner?.contextWindowDefault ?? "";

--- a/ui/src/pages/new-session/create-params.test.ts
+++ b/ui/src/pages/new-session/create-params.test.ts
@@ -86,12 +86,13 @@ describe("buildDraftSessionCreateParams", () => {
     ).toEqual({ agentId: "main", message: "", attachments });
   });
 
-  it("includes selected model and thinking overrides for a plain session", () => {
+  it("includes selected model, context-window, and thinking overrides for a plain session", () => {
     expect(
       buildDraftSessionCreateParams({
         agentId: "main",
         message: "use the selected model",
         model: "anthropic/claude-sonnet-4-6",
+        contextWindow: "200k",
         thinkingLevel: "high",
         worktree: false,
       }),
@@ -99,6 +100,7 @@ describe("buildDraftSessionCreateParams", () => {
       agentId: "main",
       message: "use the selected model",
       model: "anthropic/claude-sonnet-4-6",
+      contextWindow: "200k",
       thinkingLevel: "high",
     });
   });
@@ -109,6 +111,7 @@ describe("buildDraftSessionCreateParams", () => {
         agentId: "main",
         message: "start coding",
         model: "openai/gpt-5.5",
+        contextWindow: "200k",
         thinkingLevel: "medium",
         worktree: false,
         catalogId: "claude",

--- a/ui/src/pages/new-session/create-params.ts
+++ b/ui/src/pages/new-session/create-params.ts
@@ -29,6 +29,7 @@ export function buildDraftSessionCreateParams(draft: {
   agentId: string;
   message: string;
   model?: string;
+  contextWindow?: string;
   thinkingLevel?: string;
   visibility?: NewSessionVisibility;
   attachments?: unknown[];
@@ -46,6 +47,7 @@ export function buildDraftSessionCreateParams(draft: {
   const catalogId = normalizeOptionalString(draft.catalogId);
   const category = normalizeOptionalString(draft.category);
   const model = normalizeOptionalString(draft.model);
+  const contextWindow = normalizeOptionalString(draft.contextWindow);
   const thinkingLevel = normalizeOptionalString(draft.thinkingLevel);
   const projectId = normalizeOptionalString(draft.projectId);
   const customFolder = !projectId && cwd && cwd !== workspace ? cwd : undefined;
@@ -59,6 +61,7 @@ export function buildDraftSessionCreateParams(draft: {
     ...(catalogId ? { catalogId } : {}),
     ...(category ? { category } : {}),
     ...(!catalogId && model ? { model } : {}),
+    ...(!catalogId && contextWindow ? { contextWindow } : {}),
     ...(!catalogId && thinkingLevel ? { thinkingLevel } : {}),
     ...(projectId ? { projectId } : {}),
     ...(customFolder ? { cwd: customFolder } : {}),

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -218,6 +218,7 @@ export class DraftSubmissionFlow {
       agentId: this.place.agentId,
       message: options.message ?? "",
       model: this.place.modelControl.selected,
+      contextWindow: this.place.modelControl.contextWindow,
       thinkingLevel: this.place.modelControl.thinkingLevel,
       visibility: options.visibility ?? this.visibilityValue,
       attachments: options.attachments,

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -219,6 +219,54 @@ describe("new-session model runtime", () => {
     expect(control.thinkingLevel).toBe("high");
   });
 
+  it("selects a context window for the draft model", async () => {
+    const { context } = contextWith([
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+      {
+        id: "claude-fable-5",
+        name: "Claude Fable 5",
+        provider: "anthropic",
+        contextWindow: 1_000_000,
+        contextWindows: [
+          { id: "200k", label: "200K", contextWindow: 200_000 },
+          { id: "1m", label: "1M", contextWindow: 1_000_000 },
+        ],
+        contextWindowDefault: "1m",
+      },
+    ]);
+    const control = new NewSessionModelControl(() => undefined);
+    control.load(context, "main", true);
+
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector(
+          '[data-chat-model-option="anthropic/claude-fable-5"]',
+        ),
+      ).not.toBeNull(),
+    );
+    renderControl(control, context)
+      .querySelector<HTMLButtonElement>('[data-chat-model-option="anthropic/claude-fable-5"]')
+      ?.click();
+
+    const container = renderControl(control, context);
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '[data-chat-context-window-toggle="200k"]',
+    );
+    expect(toggle).toBeInstanceOf(HTMLButtonElement);
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
+    toggle?.click();
+
+    expect(control.contextWindow).toBe("200k");
+
+    renderControl(control, context)
+      .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.6-luna"]')
+      ?.click();
+    expect(control.contextWindow).toBe("");
+    expect(
+      renderControl(control, context).querySelector("[data-chat-context-window-toggle]"),
+    ).toBeNull();
+  });
+
   it("does not mark ordinary catalog loading as preference restoration", async () => {
     const { context, request } = contextWith([
       { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -121,6 +121,7 @@ export class NewSessionModelControl {
   private catalogTargetRequestId = 0;
   private catalogTargetDiscovery: CatalogTargetDiscoveryState = { status: "idle" };
   selected = "";
+  contextWindow = "";
   thinkingLevel = "";
 
   constructor(
@@ -336,6 +337,7 @@ export class NewSessionModelControl {
       this.agentId = "";
       this.metadataClient = undefined;
       this.selected = "";
+      this.contextWindow = "";
       this.thinkingLevel = "";
       this.updateMetadataState({
         catalog: [],
@@ -370,6 +372,7 @@ export class NewSessionModelControl {
       this.agentId = normalizedAgentId;
       this.metadataClient = undefined;
       this.selected = "";
+      this.contextWindow = "";
       this.thinkingLevel = "";
       this.metadataState = {
         catalog: [],
@@ -555,6 +558,9 @@ export class NewSessionModelControl {
       this.catalog,
     );
     const selectedTarget = resolveDraftModelTarget(this.selected, undefined, this.catalog);
+    const contextWindowTarget = selectedTarget?.entry ?? defaultTarget?.entry;
+    const contextWindowDefault = contextWindowTarget?.contextWindowDefault;
+    const selectedContextWindow = this.contextWindow || contextWindowDefault;
     const thinkingTarget = {
       model: selectedTarget?.model,
       modelProvider: selectedTarget?.provider ?? undefined,
@@ -587,6 +593,14 @@ export class NewSessionModelControl {
             ? "loading"
             : this.metadataState.status,
       },
+      contextWindowTarget:
+        contextWindowTarget?.contextWindows && selectedContextWindow
+          ? {
+              contextWindow: selectedContextWindow,
+              contextWindows: contextWindowTarget.contextWindows,
+              ...(contextWindowDefault ? { contextWindowDefault } : {}),
+            }
+          : undefined,
       modelOverrides: { [sessionKey]: this.selected },
       modelPickerTargetGroups: this.catalogTargetGroups(),
       modelSwitching: false,
@@ -602,6 +616,7 @@ export class NewSessionModelControl {
         this.restoringPreference = false;
         const selection = this.reconcileSelection(value, this.thinkingLevel, options);
         this.selected = selection.model;
+        this.contextWindow = "";
         this.thinkingLevel = selection.thinkingLevel;
         this.onSelectionChange({ model: this.selected, thinkingLevel: this.thinkingLevel });
       },
@@ -620,6 +635,12 @@ export class NewSessionModelControl {
         this.restoringPreference = false;
         this.thinkingLevel = value;
         this.onSelectionChange({ model: this.selected, thinkingLevel: this.thinkingLevel });
+      },
+      onContextWindowSelect: (value) => {
+        this.selectionGeneration += 1;
+        this.restoringPreference = false;
+        this.contextWindow = value;
+        this.notify();
       },
       onModelSetup: () => options.context?.navigate("model-setup"),
       onModelPickerOpen: () => this.refreshPickerCatalogs(),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting Claude Fable on `/new` could not see or change its context window before starting the session. The new-session composer incorrectly used the default session model's context metadata and then omitted the selected context window from `sessions.create`.

## Why This Change Was Made

The new-session draft now gives the shared model control the selected catalog model's complete context-window tuple and carries the chosen value into session creation. Existing sessions keep their canonical session-backed path; catalog presets continue to own their own model settings.

## User Impact

Users can select Claude Fable's 1M or 200K context window directly on `/new`, see the active value on the model badge, and start the session with that choice.

## Evidence

| Agent-browser flow | Proof | Result |
| --- | --- | --- |
| Select Claude Fable on `/new` | <img src="https://github.com/user-attachments/assets/fe52eedb-be09-4540-809f-f608494bc7ef" width="420" alt="Claude Fable selected with the 1M context-window switch visible"> | 1M default switch is visible |
| Switch the draft to 200K | <img src="https://github.com/user-attachments/assets/e7624077-c3f2-4df9-a9cb-2ab4d784d695" width="420" alt="Claude Fable selected with the context-window switch and model badge showing 200K"> | Toggle and model badge both show 200K |
| Start the session | <img src="https://github.com/user-attachments/assets/79b51d9f-c935-4d37-8d2e-990525b8ce23" width="420" alt="New-session composer ready to start with Claude Fable and a 200K badge"> | Ready state keeps 200K; submission navigates to `/chat/main/mock-created-1` with zero browser errors |

| Automated gate | Result |
| --- | --- |
| Focused new-session unit tests | 59 passed |
| New-session model-catalog E2E | 4 passed; asserts `sessions.create.contextWindow = "200k"` |
| UI + scripts tsgo; full test types | Passed |
| Targeted Oxfmt + Oxlint | Passed |
| Production Control UI build + performance budgets | Passed |
| Exact-head ClawSweeper review | Patch correct; 0 findings; security cleared; 0 rank-up moves |
| Generic Telegram default-turn smoke (non-channel-visible diff) | Real-user DM: sent message 14; 2 SUT typing events; `OPENCLAW_E2E_OK` reply message 2012; 1 mock provider request |

Production LOC: +32 net. The growth is the missing draft state, selected-model context owner tuple, and create-parameter plumbing; the existing shared switcher remains the sole rendering path.
