### PR TITLE
fix(telegram): preserve delivered rich fallback reply chunks

### DIFF
--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -100,7 +100,8 @@ export async function sendTelegramText(
     silent: opts?.silent,
   });
   const fallbackText = opts?.plainText ?? text;
-  const acceptProviderMessage = async (message: Message) => {
+  let firstDeliveredMessageId: number | undefined;
+  const acceptProviderMessage = async (message: Message, plainText: string) => {
     if (opts?.thread?.id !== undefined) {
       await reportTelegramProviderDelivery({
         message,
@@ -109,9 +110,13 @@ export async function sendTelegramText(
         successfulSendThread: opts.thread,
       });
     }
-    return message.message_id;
+    const messageId = message.message_id;
+    firstDeliveredMessageId ??= messageId;
+    runtime.log?.(`telegram text delivery ok chat=${chatId} message=${messageId}`);
+    await opts?.onAcceptedMessage?.(messageId, plainText);
+    return message;
   };
-  const pages = planTelegramTextDeliveryPages({
+  const page = planTelegramTextDeliveryPages({
     text,
     maxChars: text.length || 1,
     tableMode: opts?.tableMode,
@@ -120,8 +125,7 @@ export async function sendTelegramText(
     degradationReasons: opts?.richDegradationReasons,
     skipEntityDetection: opts?.linkPreview === false,
     ...(opts?.textMode === "html" ? { textMode: "html" as const } : {}),
-  });
-  const page = pages[0];
+  })[0];
   if (!page || (!page.richMessage && !page.htmlText?.trim() && !fallbackText.trim())) {
     throw new Error("telegram text delivery failed: empty formatted text and empty plain fallback");
   }
@@ -141,10 +145,9 @@ export async function sendTelegramText(
       operation?: string;
     },
   ) => {
-    const requestParams =
-      params.fallback && params.fallback.index > 0 ? withoutReply(baseParams) : baseParams;
+    const requestParams = params.fallback?.index ? withoutReply(baseParams) : baseParams;
     const isFinalFallback = !params.fallback || params.fallback.index === params.fallback.count - 1;
-    return await sendTelegramWithThreadFallback({
+    const message = await sendTelegramWithThreadFallback({
       operation: params.operation ?? "sendMessage",
       runtime,
       requestParams,
@@ -157,8 +160,9 @@ export async function sendTelegramText(
           ...effectiveParams,
         }),
     });
+    return params.fallback ? await acceptProviderMessage(message, messageText) : message;
   };
-  const delivered = await deliverTelegramTextPage({
+  const [accepted] = await deliverTelegramTextPage({
     page,
     context: page.richMessage ? "sendRichMessage" : "sendMessage",
     warn: (message) => runtime.log?.(message),
@@ -186,12 +190,8 @@ export async function sendTelegramText(
         }),
     },
   });
-  let firstDeliveredMessageId: number | undefined;
-  for (const accepted of delivered) {
-    const messageId = await acceptProviderMessage(accepted.result);
-    firstDeliveredMessageId ??= messageId;
-    runtime.log?.(`telegram text delivery ok chat=${chatId} message=${messageId}`);
-    await opts?.onAcceptedMessage?.(messageId, accepted.page.plainText);
+  if (firstDeliveredMessageId === undefined && accepted) {
+    await acceptProviderMessage(accepted.result, accepted.page.plainText);
   }
   return firstDeliveredMessageId!;
 }

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -2280,6 +2280,155 @@ describe("deliverReplies", () => {
     expect(mockCallArg(sendMessage, 0, 2)).not.toHaveProperty("parse_mode");
   });
 
+  it("preserves accepted rich plain-fallback chunks when a later chunk is rejected", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ message_id: 41, chat: { id: "123" } })
+      .mockRejectedValueOnce(createChunkRejection("second fallback rejected"));
+    const bot = createBot({ sendMessage });
+    Object.assign(bot.api.raw, {
+      sendRichMessage: vi.fn().mockRejectedValue(createRichEntityInvalidError("URL")),
+    });
+    const observer = vi.fn();
+    const promptContextSequence = createObservedPromptContextSequence(observer);
+    const cfg = { session: { store: "/tmp/telegram-rich-fallback-partial.json" } } as const;
+
+    let observed: unknown;
+    try {
+      await deliverWith({
+        replies: [{ text: "A".repeat(4500) }],
+        cfg,
+        runtime,
+        bot,
+        richMessages: true,
+        textLimit: 32_768,
+        promptContextSequence,
+      });
+    } catch (error) {
+      observed = error;
+    }
+    await promptContextSequence.fail();
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    if (!isChannelPartialDeliveryError(observed)) {
+      throw observed;
+    }
+    expect(observed.deliveryResult.messageIds).toEqual(["41"]);
+    expect(observed.deliveryResult.visibleReplySent).toBe(true);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(observer).toHaveBeenCalledWith({ messageId: 41, text: "A".repeat(4000) });
+    expect(recordSentMessage).toHaveBeenCalledWith("123", 41, cfg);
+  });
+
+  it("reports each rich plain-fallback acceptance before attempting the next chunk", async () => {
+    const runtime = createRuntime();
+    const acceptedMessageIds: number[] = [];
+    const sendMessage = vi.fn(async (_chatId: string, _text: string) => {
+      if (acceptedMessageIds.length === 0) {
+        return { message_id: 51, message_thread_id: 42, chat: { id: "123" } };
+      }
+      expect(acceptedMessageIds).toEqual([51]);
+      return { message_id: 52, message_thread_id: 42, chat: { id: "123" } };
+    });
+    const bot = createBot({ sendMessage });
+    Object.assign(bot.api.raw, {
+      sendRichMessage: vi.fn().mockRejectedValue(createRichEntityInvalidError("URL")),
+    });
+    const replyMarkup = { inline_keyboard: [[{ text: "Allow", callback_data: "allow" }]] };
+
+    const messageId = await sendTelegramText(bot, "123", "A".repeat(4500), runtime, {
+      richMessages: true,
+      replyToMessageId: 17,
+      replyMarkup,
+      thread: { id: 42, scope: "forum" },
+      onAcceptedMessage: (acceptedId) => {
+        acceptedMessageIds.push(acceptedId);
+      },
+    });
+
+    expect(messageId).toBe(51);
+    expect(acceptedMessageIds).toEqual([51, 52]);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(mockCallArg(sendMessage, 0, 2)).toEqual(
+      expect.objectContaining({ message_thread_id: 42, reply_to_message_id: 17 }),
+    );
+    expect(mockCallArg(sendMessage, 0, 2)).not.toHaveProperty("reply_markup");
+    expect(mockCallArg(sendMessage, 1, 2)).toEqual(
+      expect.objectContaining({ message_thread_id: 42, reply_markup: replyMarkup }),
+    );
+    expect(mockCallArg(sendMessage, 1, 2)).not.toHaveProperty("reply_to_message_id");
+  });
+
+  it("stops rich plain fallback as soon as an accepted chunk lands in the wrong topic", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        message_id: 61,
+        message_thread_id: 43,
+        chat: { id: "123", type: "supergroup" },
+      })
+      .mockResolvedValueOnce({
+        message_id: 62,
+        message_thread_id: 42,
+        chat: { id: "123", type: "supergroup" },
+      });
+    const bot = createBot({ sendMessage });
+    Object.assign(bot.api.raw, {
+      sendRichMessage: vi.fn().mockRejectedValue(createRichEntityInvalidError("URL")),
+    });
+
+    let observed: unknown;
+    try {
+      await sendTelegramText(bot, "123", "A".repeat(4500), runtime, {
+        richMessages: true,
+        thread: { id: 42, scope: "forum" },
+      });
+    } catch (error) {
+      observed = error;
+    }
+
+    expect(isChannelPartialDeliveryError(observed)).toBe(true);
+    expect(sendMessage).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      kind: "rich",
+      text: "Rich reply",
+      error: "RICH_MESSAGE_URL_INVALID",
+      options: { richMessages: true },
+    },
+    {
+      kind: "HTML",
+      text: "<b>HTML reply</b>",
+      error: "can't parse entities",
+      options: { textMode: "html" as const },
+    },
+  ])(
+    "does not plain-fallback after accepted $kind bookkeeping fails",
+    async ({ kind, text, error, options }) => {
+      const sendMessage = vi.fn().mockResolvedValue({ message_id: 71, chat: { id: "123" } });
+      const bot = createBot({ sendMessage });
+      const sendRichMessage = vi.fn().mockResolvedValue({ message_id: 72, chat: { id: "123" } });
+      Object.assign(bot.api.raw, { sendRichMessage });
+      const bookkeepingFailure = new Error(error);
+
+      await expect(
+        sendTelegramText(bot, "123", text, createRuntime(), {
+          ...options,
+          onAcceptedMessage: () => {
+            throw bookkeepingFailure;
+          },
+        }),
+      ).rejects.toBe(bookkeepingFailure);
+
+      expect(sendRichMessage).toHaveBeenCalledTimes(kind === "rich" ? 1 : 0);
+      expect(sendMessage).toHaveBeenCalledTimes(kind === "rich" ? 0 : 1);
+    },
+  );
+
   it("does not plain-fallback after Telegram accepts a rich message in the wrong topic", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receiving a long Telegram reply would see its first plain-text fallback chunk even though OpenClaw reported that nothing was delivered when Telegram rejected a later chunk. A fallback chunk accepted in the wrong forum topic could also be followed by another send before the existing topic-validation owner observed the mismatch.

## Why This Change Was Made

The private Telegram reply sender now records each accepted multi-chunk plain fallback immediately at its existing provider-acceptance boundary, before attempting the next chunk. Ordinary rich, HTML, and single-message acceptance stays outside the formatted-send fallback decision, so a later bookkeeping error cannot be mistaken for a provider rejection and send a duplicate reply. This preserves the existing public result, durable sender and edit paths, partial-delivery receipts, topic validation, single-use replies, and final-chunk inline keyboards without adding production lines.

## User Impact

Previously accepted Telegram reply chunks remain visible to OpenClaw's delivery accounting and prompt context when a later fallback chunk fails. Incorrect-topic delivery stops immediately, and accepted rich or HTML replies are never duplicated because unrelated bookkeeping happens to contain a formatting-style error.

## Evidence

- Five new authentic owner-boundary regressions failed before their respective repairs: accepted-first/later-rejected partial delivery, per-chunk callback order, immediate forum-topic validation, and rich/HTML post-acceptance duplicate-send prevention.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot/delivery.test.ts`: **118 passed**, including the freshly committed revision and a separate independent run.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/chunk-delivery.test.ts extensions/telegram/src/send-caption-editing.test.ts extensions/telegram/src/bot-native-command-dispatch.delivery.test.ts extensions/telegram/src/bot-message-dispatch.delivery-basics.test.ts extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts extensions/telegram/src/bot-message-dispatch.draft-finalization.test.ts`: **446 passed** across lifecycle, durable delivery, chunk tracking, editing, native commands, topics, and draft finalization.
- Exact-file type-aware lint, formatting, conflict checks, maximum-lines ratchet, and assertion-safety ratchet passed. Broad workspace extension type programs additionally report existing unrelated ACPX dependency-shape mismatches; neither touched Telegram file reports a type diagnostic.
- Pinned grammY's `sendMessage` contract confirms a successful call returns the accepted message and limits text to 4,096 characters; OpenClaw's existing 4,000-character fallback chunks remain unchanged.
- Production delta: **15 lines added, 15 removed**; tests: **149 lines added**.
- Live Telegram verification would require sending intentionally duplicated/wrong-topic messages through an operator-owned live chat, which is not authorized; the tests instead exercise the actual production sender and lifecycle with provider-accurate accepted messages and rejected requests.
