### PR TITLE
fix(browser): keep inspection state independent of error wording

### DIFF
--- a/extensions/browser/src/browser-node-proxy.test.ts
+++ b/extensions/browser/src/browser-node-proxy.test.ts
@@ -50,6 +50,7 @@ vi.mock("./browser-tool.runtime.js", () => runtimeMocks);
 vi.mock("./browser-proxy-upload.js", () => uploadMocks);
 
 import { createBrowserNodeProxyRequest } from "./browser-node-proxy.js";
+import { BrowserServiceError } from "./browser/client-fetch.js";
 
 function createSessionProxy() {
   return createBrowserNodeProxyRequest({
@@ -84,6 +85,38 @@ beforeEach(() => {
 });
 
 describe("Browser node proxy nested watchdogs", () => {
+  it.each([
+    {
+      code: "ACT_EVALUATE_DISABLED",
+      expected: { code: "ACT_EVALUATE_DISABLED", unrecognizedCode: undefined },
+    },
+    {
+      code: "ACT_FUTURE_CODE",
+      expected: { code: undefined, unrecognizedCode: true },
+    },
+  ])("preserves the bounded action-code state for $code", async ({ code, expected }) => {
+    runtimeMocks.callGatewayTool.mockResolvedValueOnce({
+      payload: {
+        error: {
+          status: 403,
+          body: { error: "evaluation disabled", code },
+        },
+      },
+    } as unknown as BrowserNodeResponse);
+
+    const error = await createSessionProxy()({ method: "POST", path: "/act" }).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(BrowserServiceError);
+    expect(error).toMatchObject({
+      name: "BrowserServiceError",
+      message: "evaluation disabled",
+      status: 403,
+      ...expected,
+    });
+  });
+
   it("keeps a requested action inside separate node and Gateway watchdogs", async () => {
     const signal = new AbortController().signal;
 

--- a/extensions/browser/src/browser-node-proxy.ts
+++ b/extensions/browser/src/browser-node-proxy.ts
@@ -213,7 +213,7 @@ export function createBrowserNodeProxyRequest(params: {
       const failure = parseBrowserProxyFailure(proxy);
       if (failure) {
         const { status, body } = failure.error;
-        throw new BrowserServiceError(body.error, "reason" in body ? body : undefined, status);
+        throw new BrowserServiceError(body.error, body, status);
       }
       if (!("result" in proxy)) {
         throw new Error("Browser proxy returned a failure without an error payload.");

--- a/extensions/browser/src/browser-proxy-envelope.test.ts
+++ b/extensions/browser/src/browser-proxy-envelope.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { createBrowserProxyFailure, parseBrowserProxyFailure } from "./browser-proxy-envelope.js";
+
+describe("browser proxy error envelope", () => {
+  it("preserves validated action error codes and drops unknown metadata", () => {
+    const failure = createBrowserProxyFailure(403, {
+      error: "evaluation disabled",
+      code: "ACT_EVALUATE_DISABLED",
+      untrusted: "drop me",
+    });
+
+    expect(parseBrowserProxyFailure(failure)).toEqual({
+      error: {
+        status: 403,
+        body: { error: "evaluation disabled", code: "ACT_EVALUATE_DISABLED" },
+      },
+    });
+  });
+});

--- a/extensions/browser/src/browser-proxy-envelope.test.ts
+++ b/extensions/browser/src/browser-proxy-envelope.test.ts
@@ -16,4 +16,18 @@ describe("browser proxy error envelope", () => {
       },
     });
   });
+
+  it("preserves unknown action-code presence without forwarding its value", () => {
+    const failure = createBrowserProxyFailure(403, {
+      error: "evaluation disabled",
+      code: "ACT_FUTURE_CODE",
+    });
+
+    expect(parseBrowserProxyFailure(failure)).toEqual({
+      error: {
+        status: 403,
+        body: { error: "evaluation disabled", unrecognizedCode: true },
+      },
+    });
+  });
 });

--- a/extensions/browser/src/browser-proxy-envelope.ts
+++ b/extensions/browser/src/browser-proxy-envelope.ts
@@ -3,7 +3,11 @@ import type { ResolvedBrowserProfile } from "./browser/config.js";
 /**
  * Browser node-proxy response envelope shared by the node host and Gateway.
  */
-import { parseBrowserErrorPayload, type BrowserNoDisplayErrorMetadata } from "./browser/errors.js";
+import {
+  parseBrowserErrorPayload,
+  type BrowserActErrorCode,
+  type BrowserNoDisplayErrorMetadata,
+} from "./browser/errors.js";
 
 /** Additive opt-in for structured browser route errors over node.invoke. */
 export const BROWSER_PROXY_ERROR_ENVELOPE = "browser-v1" as const;
@@ -105,8 +109,8 @@ export function visitBrowserProxyFilePaths(
 }
 
 type BrowserProxyErrorBody =
-  | { error: string }
-  | ({ error: string } & BrowserNoDisplayErrorMetadata);
+  | { error: string; code?: BrowserActErrorCode }
+  | ({ error: string; code?: BrowserActErrorCode } & BrowserNoDisplayErrorMetadata);
 
 export type BrowserProxySuccess = {
   result: unknown;

--- a/extensions/browser/src/browser-proxy-envelope.ts
+++ b/extensions/browser/src/browser-proxy-envelope.ts
@@ -3,11 +3,7 @@ import type { ResolvedBrowserProfile } from "./browser/config.js";
 /**
  * Browser node-proxy response envelope shared by the node host and Gateway.
  */
-import {
-  parseBrowserErrorPayload,
-  type BrowserActErrorCode,
-  type BrowserNoDisplayErrorMetadata,
-} from "./browser/errors.js";
+import { parseBrowserErrorPayload, type BrowserErrorPayload } from "./browser/errors.js";
 
 /** Additive opt-in for structured browser route errors over node.invoke. */
 export const BROWSER_PROXY_ERROR_ENVELOPE = "browser-v1" as const;
@@ -108,9 +104,7 @@ export function visitBrowserProxyFilePaths(
   }
 }
 
-type BrowserProxyErrorBody =
-  | { error: string; code?: BrowserActErrorCode }
-  | ({ error: string; code?: BrowserActErrorCode } & BrowserNoDisplayErrorMetadata);
+type BrowserProxyErrorBody = BrowserErrorPayload;
 
 export type BrowserProxySuccess = {
   result: unknown;

--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -156,6 +156,12 @@ describe("fetchHttpJson error body boundary", () => {
         return;
       }
 
+      if (req.url === "/evaluate-disabled") {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "evaluation disabled", code: "ACT_EVALUATE_DISABLED" }));
+        return;
+      }
+
       res.writeHead(500, { "Content-Type": "text/plain" });
       let written = 0;
       let closed = false;
@@ -272,6 +278,19 @@ describe("fetchHttpJson error body boundary", () => {
         headlessSource: "config",
         displayPresent: false,
       },
+    });
+  });
+
+  it("preserves validated browser action error codes over HTTP", async () => {
+    const error = await fetchBrowserJson(`${baseUrl}/evaluate-disabled`).catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toMatchObject({
+      name: "BrowserServiceError",
+      message: "evaluation disabled",
+      code: "ACT_EVALUATE_DISABLED",
+      status: 403,
     });
   });
 });

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -25,6 +25,7 @@ import { resolveBrowserConfig, resolveProfile } from "./config.js";
 import { resolveBrowserControlAuth } from "./control-auth.js";
 import {
   parseBrowserErrorPayload,
+  type BrowserActErrorCode,
   type BrowserNoDisplayErrorMetadata,
   type BrowserNoDisplayErrorDetails,
 } from "./errors.js";
@@ -34,13 +35,23 @@ import { resolveBrowserRateLimitMessage } from "./rate-limit-message.js";
 // but returned an error response). Must NOT be wrapped with "Can't reach ..." messaging.
 export class BrowserServiceError extends Error {
   readonly status?: number;
+  readonly code?: BrowserActErrorCode;
   readonly reason?: BrowserNoDisplayErrorMetadata["reason"];
   readonly details?: BrowserNoDisplayErrorDetails;
 
-  constructor(message: string, metadata?: BrowserNoDisplayErrorMetadata, status?: number) {
+  constructor(
+    message: string,
+    metadata?: {
+      code?: BrowserActErrorCode;
+      reason?: BrowserNoDisplayErrorMetadata["reason"];
+      details?: BrowserNoDisplayErrorDetails;
+    },
+    status?: number,
+  ) {
     super(message);
     this.name = "BrowserServiceError";
     this.status = status;
+    this.code = metadata?.code;
     this.reason = metadata?.reason;
     this.details = metadata?.details;
   }
@@ -56,7 +67,7 @@ function browserServiceErrorFromPayload(
   const modelHint = resolveBrowserServiceModelHint(message, status);
   return new BrowserServiceError(
     modelHint ? appendBrowserToolModelHint(message, modelHint) : message,
-    parsed && "reason" in parsed ? parsed : undefined,
+    parsed ?? undefined,
     status,
   );
 }

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -26,6 +26,7 @@ import { resolveBrowserControlAuth } from "./control-auth.js";
 import {
   parseBrowserErrorPayload,
   type BrowserActErrorCode,
+  type BrowserErrorPayload,
   type BrowserNoDisplayErrorMetadata,
   type BrowserNoDisplayErrorDetails,
 } from "./errors.js";
@@ -36,22 +37,16 @@ import { resolveBrowserRateLimitMessage } from "./rate-limit-message.js";
 export class BrowserServiceError extends Error {
   readonly status?: number;
   readonly code?: BrowserActErrorCode;
+  readonly unrecognizedCode?: true;
   readonly reason?: BrowserNoDisplayErrorMetadata["reason"];
   readonly details?: BrowserNoDisplayErrorDetails;
 
-  constructor(
-    message: string,
-    metadata?: {
-      code?: BrowserActErrorCode;
-      reason?: BrowserNoDisplayErrorMetadata["reason"];
-      details?: BrowserNoDisplayErrorDetails;
-    },
-    status?: number,
-  ) {
+  constructor(message: string, metadata?: BrowserErrorPayload, status?: number) {
     super(message);
     this.name = "BrowserServiceError";
     this.status = status;
     this.code = metadata?.code;
+    this.unrecognizedCode = metadata?.unrecognizedCode;
     this.reason = metadata?.reason;
     this.details = metadata?.details;
   }

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -47,8 +47,8 @@ export class BrowserServiceError extends Error {
     this.status = status;
     this.code = metadata?.code;
     this.unrecognizedCode = metadata?.unrecognizedCode;
-    this.reason = metadata?.reason;
-    this.details = metadata?.details;
+    this.reason = metadata && "reason" in metadata ? metadata.reason : undefined;
+    this.details = metadata && "details" in metadata ? metadata.details : undefined;
   }
 }
 

--- a/extensions/browser/src/browser/errors.test.ts
+++ b/extensions/browser/src/browser/errors.test.ts
@@ -1,12 +1,31 @@
 // Browser tests cover errors plugin behavior.
 import { describe, expect, it } from "vitest";
 import {
+  BROWSER_ACT_ERROR_CODES,
   BROWSER_ERROR_REASONS,
   BrowserProfileUnavailableError,
   BrowserTabNotFoundError,
   parseBrowserErrorPayload,
   toBrowserErrorResponse,
 } from "./errors.js";
+
+describe("browser action errors", () => {
+  it("preserves known codes and drops unknown route metadata", () => {
+    expect(
+      parseBrowserErrorPayload({
+        error: "evaluation disabled",
+        code: BROWSER_ACT_ERROR_CODES.evaluateDisabled,
+        untrusted: "drop me",
+      }),
+    ).toEqual({
+      error: "evaluation disabled",
+      code: BROWSER_ACT_ERROR_CODES.evaluateDisabled,
+    });
+    expect(parseBrowserErrorPayload({ error: "failure", code: "UNTRUSTED_CODE" })).toEqual({
+      error: "failure",
+    });
+  });
+});
 
 describe("BrowserTabNotFoundError", () => {
   it("teaches agents that bare numbers are not stable tab targets", () => {

--- a/extensions/browser/src/browser/errors.test.ts
+++ b/extensions/browser/src/browser/errors.test.ts
@@ -23,6 +23,7 @@ describe("browser action errors", () => {
     });
     expect(parseBrowserErrorPayload({ error: "failure", code: "UNTRUSTED_CODE" })).toEqual({
       error: "failure",
+      unrecognizedCode: true,
     });
   });
 });

--- a/extensions/browser/src/browser/errors.ts
+++ b/extensions/browser/src/browser/errors.ts
@@ -14,6 +14,27 @@ export const BROWSER_ERROR_REASONS = {
   noDisplayForHeadedProfile: "no_display_for_headed_profile",
 } as const;
 
+/** Stable machine-readable codes returned by browser action routes. */
+export const BROWSER_ACT_ERROR_CODES = {
+  kindRequired: "ACT_KIND_REQUIRED",
+  invalidRequest: "ACT_INVALID_REQUEST",
+  selectorUnsupported: "ACT_SELECTOR_UNSUPPORTED",
+  evaluateDisabled: "ACT_EVALUATE_DISABLED",
+  unsupportedForExistingSession: "ACT_EXISTING_SESSION_UNSUPPORTED",
+  targetIdMismatch: "ACT_TARGET_ID_MISMATCH",
+} as const;
+
+export type BrowserActErrorCode =
+  (typeof BROWSER_ACT_ERROR_CODES)[keyof typeof BROWSER_ACT_ERROR_CODES];
+
+const BROWSER_ACT_ERROR_CODE_VALUES: ReadonlySet<string> = new Set(
+  Object.values(BROWSER_ACT_ERROR_CODES),
+);
+
+function isBrowserActErrorCode(value: unknown): value is BrowserActErrorCode {
+  return typeof value === "string" && BROWSER_ACT_ERROR_CODE_VALUES.has(value);
+}
+
 const NO_DISPLAY_HEADLESS_SOURCES = ["request", "env", "profile", "config", "default"] as const;
 
 export type BrowserNoDisplayErrorDetails = {
@@ -30,7 +51,10 @@ export type BrowserNoDisplayErrorMetadata = {
 
 type WithNoDisplayMetadata<T> = T | (T & BrowserNoDisplayErrorMetadata);
 export type BrowserErrorResponse = WithNoDisplayMetadata<{ status: number; message: string }>;
-type BrowserErrorPayload = WithNoDisplayMetadata<{ error: string }>;
+type BrowserErrorPayload = WithNoDisplayMetadata<{
+  error: string;
+  code?: BrowserActErrorCode;
+}>;
 
 /** Base browser error carrying an HTTP status code. */
 export class BrowserError extends Error {
@@ -186,11 +210,12 @@ export function parseBrowserErrorPayload(value: unknown): BrowserErrorPayload | 
   if (typeof body.error !== "string" || body.error.length === 0) {
     return null;
   }
+  const code = isBrowserActErrorCode(body.code) ? body.code : undefined;
   if (body.reason === BROWSER_ERROR_REASONS.noDisplayForHeadedProfile) {
     const details = parseNoDisplayDetails(body.details);
     if (details) {
-      return { error: body.error, reason: body.reason, details };
+      return { error: body.error, ...(code ? { code } : {}), reason: body.reason, details };
     }
   }
-  return { error: body.error };
+  return { error: body.error, ...(code ? { code } : {}) };
 }

--- a/extensions/browser/src/browser/errors.ts
+++ b/extensions/browser/src/browser/errors.ts
@@ -51,9 +51,10 @@ export type BrowserNoDisplayErrorMetadata = {
 
 type WithNoDisplayMetadata<T> = T | (T & BrowserNoDisplayErrorMetadata);
 export type BrowserErrorResponse = WithNoDisplayMetadata<{ status: number; message: string }>;
-type BrowserErrorPayload = WithNoDisplayMetadata<{
+export type BrowserErrorPayload = WithNoDisplayMetadata<{
   error: string;
   code?: BrowserActErrorCode;
+  unrecognizedCode?: true;
 }>;
 
 /** Base browser error carrying an HTTP status code. */
@@ -211,11 +212,14 @@ export function parseBrowserErrorPayload(value: unknown): BrowserErrorPayload | 
     return null;
   }
   const code = isBrowserActErrorCode(body.code) ? body.code : undefined;
+  const unrecognizedCode =
+    body.unrecognizedCode === true || (body.code !== undefined && !code) ? true : undefined;
+  const actionCode = code ? { code } : unrecognizedCode ? { unrecognizedCode } : {};
   if (body.reason === BROWSER_ERROR_REASONS.noDisplayForHeadedProfile) {
     const details = parseNoDisplayDetails(body.details);
     if (details) {
-      return { error: body.error, ...(code ? { code } : {}), reason: body.reason, details };
+      return { error: body.error, ...actionCode, reason: body.reason, details };
     }
   }
-  return { error: body.error, ...(code ? { code } : {}) };
+  return { error: body.error, ...actionCode };
 }

--- a/extensions/browser/src/browser/errors.ts
+++ b/extensions/browser/src/browser/errors.ts
@@ -214,7 +214,11 @@ export function parseBrowserErrorPayload(value: unknown): BrowserErrorPayload | 
   const code = isBrowserActErrorCode(body.code) ? body.code : undefined;
   const unrecognizedCode =
     body.unrecognizedCode === true || (body.code !== undefined && !code) ? true : undefined;
-  const actionCode = code ? { code } : unrecognizedCode ? { unrecognizedCode } : {};
+  const actionCode: { code?: BrowserActErrorCode; unrecognizedCode?: true } = code
+    ? { code }
+    : unrecognizedCode
+      ? { unrecognizedCode: true }
+      : {};
   if (body.reason === BROWSER_ERROR_REASONS.noDisplayForHeadedProfile) {
     const details = parseNoDisplayDetails(body.details);
     if (details) {

--- a/extensions/browser/src/browser/routes/agent.act.errors.ts
+++ b/extensions/browser/src/browser/routes/agent.act.errors.ts
@@ -1,3 +1,4 @@
+import { BROWSER_ACT_ERROR_CODES, type BrowserActErrorCode } from "../errors.js";
 /**
  * Shared browser action error codes and messages.
  *
@@ -6,23 +7,13 @@
  */
 import type { BrowserResponse } from "./types.js";
 
-/** Stable machine-readable codes returned by browser action routes. */
-export const ACT_ERROR_CODES = {
-  kindRequired: "ACT_KIND_REQUIRED",
-  invalidRequest: "ACT_INVALID_REQUEST",
-  selectorUnsupported: "ACT_SELECTOR_UNSUPPORTED",
-  evaluateDisabled: "ACT_EVALUATE_DISABLED",
-  unsupportedForExistingSession: "ACT_EXISTING_SESSION_UNSUPPORTED",
-  targetIdMismatch: "ACT_TARGET_ID_MISMATCH",
-} as const;
-
-type ActErrorCode = (typeof ACT_ERROR_CODES)[keyof typeof ACT_ERROR_CODES];
+export const ACT_ERROR_CODES = BROWSER_ACT_ERROR_CODES;
 
 /** Send a browser action JSON error with a stable action error code. */
 export function jsonActError(
   res: BrowserResponse,
   status: number,
-  code: ActErrorCode,
+  code: BrowserActErrorCode,
   message: string,
 ) {
   res.status(status).json({ error: message, code });

--- a/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
+++ b/extensions/browser/src/gateway/browser-request.profile-from-body.test.ts
@@ -543,6 +543,30 @@ describe("browser.request profile selection", () => {
     });
   });
 
+  it.each([
+    {
+      name: "recognized action code",
+      body: { error: "evaluation disabled", code: "ACT_EVALUATE_DISABLED" },
+      details: { error: "evaluation disabled", code: "ACT_EVALUATE_DISABLED" },
+    },
+    {
+      name: "unrecognized action code",
+      body: { error: "evaluation disabled", code: "ACT_FUTURE_CODE" },
+      details: { error: "evaluation disabled", unrecognizedCode: true },
+    },
+  ])("preserves bounded $name state through the node proxy", async ({ body, details }) => {
+    const { respond } = await runBrowserRequest(
+      { method: "POST", path: "/act" },
+      { ok: true, payload: { error: { status: 403, body } } },
+    );
+
+    expect(firstRespondCall(respond)[2]).toEqual({
+      code: "INVALID_REQUEST",
+      message: "evaluation disabled",
+      details,
+    });
+  });
+
   it("returns UNAVAILABLE for an incomplete node file envelope", async () => {
     const { respond } = await runBrowserRequest(
       { method: "POST", path: "/screenshot" },

--- a/ui/src/components/browser/browser-client.ts
+++ b/ui/src/components/browser/browser-client.ts
@@ -7,7 +7,7 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import { buildAssistantMediaUrl } from "../../app/assistant-media.ts";
 import { t } from "../../i18n/index.ts";
 
@@ -215,7 +215,9 @@ async function evaluateInBrowser<T>(
 
 /** True when the failure is the config-gated `browser.evaluateEnabled=false` rejection. */
 export function isBrowserEvaluateDisabledError(err: unknown): boolean {
-  return err instanceof Error && err.message.includes("evaluateEnabled=false");
+  return (
+    err instanceof GatewayRequestError && asRecord(err.details)?.code === "ACT_EVALUATE_DISABLED"
+  );
 }
 
 export async function scrollBrowserBy(

--- a/ui/src/components/browser/browser-client.ts
+++ b/ui/src/components/browser/browser-client.ts
@@ -215,9 +215,13 @@ async function evaluateInBrowser<T>(
 
 /** True when the failure is the config-gated `browser.evaluateEnabled=false` rejection. */
 export function isBrowserEvaluateDisabledError(err: unknown): boolean {
-  return (
-    err instanceof GatewayRequestError && asRecord(err.details)?.code === "ACT_EVALUATE_DISABLED"
-  );
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const code = err instanceof GatewayRequestError ? asRecord(err.details)?.code : undefined;
+  return code === undefined
+    ? err.message.includes("evaluateEnabled=false")
+    : code === "ACT_EVALUATE_DISABLED";
 }
 
 export async function scrollBrowserBy(

--- a/ui/src/components/browser/browser-client.ts
+++ b/ui/src/components/browser/browser-client.ts
@@ -218,8 +218,10 @@ export function isBrowserEvaluateDisabledError(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false;
   }
-  const code = err instanceof GatewayRequestError ? asRecord(err.details)?.code : undefined;
-  return code === undefined
+  const details = err instanceof GatewayRequestError ? asRecord(err.details) : null;
+  const code = details?.code;
+  const hasStructuredCode = code !== undefined || details?.unrecognizedCode === true;
+  return !hasStructuredCode
     ? err.message.includes("evaluateEnabled=false")
     : code === "ACT_EVALUATE_DISABLED";
 }

--- a/ui/src/components/browser/browser-panel-controller-input.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.test.ts
@@ -1,6 +1,7 @@
 import { nothing, render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import {
   createBrowserClient,
   createBrowserPanelTestController,
@@ -618,7 +619,11 @@ describe("BrowserPanelController capture and input ownership", () => {
 
   it("preserves the localized disabled-evaluation inspection outcome", async () => {
     const { client } = createBrowserClient(async () => {
-      throw new Error("browser evaluateEnabled=false");
+      throw new GatewayRequestError({
+        code: "INVALID_REQUEST",
+        message: "evaluation disabled",
+        details: { code: "ACT_EVALUATE_DISABLED" },
+      });
     });
     const controller = createBrowserPanelTestController(client, "tab-a");
     controller.setMode("inspect");

--- a/ui/src/components/browser/browser-panel-controller-input.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.test.ts
@@ -636,6 +636,12 @@ describe("BrowserPanelController capture and input ownership", () => {
       details: { code: "ACT_UNKNOWN" },
       expected: false,
     },
+    {
+      name: "sanitized unknown action code with matching prose",
+      message: "act:evaluate is disabled by config (browser.evaluateEnabled=false).",
+      details: { unrecognizedCode: true },
+      expected: false,
+    },
   ])(
     "classifies $name without reinterpreting structured errors",
     async ({ message, details, expected }) => {

--- a/ui/src/components/browser/browser-panel-controller-input.test.ts
+++ b/ui/src/components/browser/browser-panel-controller-input.test.ts
@@ -617,25 +617,47 @@ describe("BrowserPanelController capture and input ownership", () => {
     ).toBe(false);
   });
 
-  it("preserves the localized disabled-evaluation inspection outcome", async () => {
-    const { client } = createBrowserClient(async () => {
-      throw new GatewayRequestError({
-        code: "INVALID_REQUEST",
-        message: "evaluation disabled",
-        details: { code: "ACT_EVALUATE_DISABLED" },
+  it.each([
+    {
+      name: "structured action code",
+      message: "evaluation disabled",
+      details: { code: "ACT_EVALUATE_DISABLED" },
+      expected: true,
+    },
+    {
+      name: "legacy Browser node message without an action code",
+      message: "403: act:evaluate is disabled by config (browser.evaluateEnabled=false).",
+      details: { nodeError: { message: "legacy Browser node" } },
+      expected: true,
+    },
+    {
+      name: "unknown action code with matching prose",
+      message: "act:evaluate is disabled by config (browser.evaluateEnabled=false).",
+      details: { code: "ACT_UNKNOWN" },
+      expected: false,
+    },
+  ])(
+    "classifies $name without reinterpreting structured errors",
+    async ({ message, details, expected }) => {
+      const { client } = createBrowserClient(async () => {
+        throw new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message,
+          details,
+        });
       });
-    });
-    const controller = createBrowserPanelTestController(client, "tab-a");
-    controller.setMode("inspect");
+      const controller = createBrowserPanelTestController(client, "tab-a");
+      controller.setMode("inspect");
 
-    controller.handleOverlayPointerMove(createPointer(10, 20));
-    await flushBrowserResponses();
+      controller.handleOverlayPointerMove(createPointer(10, 20));
+      await flushBrowserResponses();
 
-    expect(controller.evaluateUnavailable).toBe(true);
-    expect(controller.mode).toBe("interact");
-    expect(controller.errorText).toBeTruthy();
-    expect(controller.errorText).not.toContain("Browser request failed");
-  });
+      expect(controller.evaluateUnavailable).toBe(expected);
+      expect(controller.mode).toBe(expected ? "interact" : "inspect");
+      expect(controller.errorText).toBeTruthy();
+      expect(controller.errorText?.includes("Browser request failed")).toBe(!expected);
+    },
+  );
 
   it("keeps the newest inspected element when pointer responses finish out of order", async () => {
     vi.useFakeTimers({ now: 1_000 });


### PR DESCRIPTION
Closes #128624

## What Problem This Solves

Fixes an issue where operators using the Control UI Browser panel could get the wrong inspection availability state when Browser error wording changed or the Browser request was routed through a node. The Browser route already emitted `ACT_EVALUATE_DISABLED`, but intermediate Browser boundaries dropped that fact and the UI matched human-readable prose instead.

## Why This Change Was Made

The Browser plugin now owns one closed `ACT_*` code set and preserves validated codes through direct HTTP and node-proxy error envelopes. Gateway `browser.request` already carries the route body in additive error `details`, so the Control UI can consume `details.code` without a Gateway protocol field change or version bump.

Unknown metadata remains discarded at both Browser boundaries. The patch does not remove shipped Gateway text fallbacks: PRs #111013 and #120505 deliberately retained compatibility with older string-only gateways. Unknown-method and audit-cursor cases also remain unchanged because they still require new additive Gateway detail codes.

Blast radius checked:

- Producer: Browser `/act` route and all six stable `ACT_*` codes.
- Local transport: Browser HTTP client and `BrowserServiceError`.
- Remote transport: node-host Browser proxy sanitization, Gateway `browser.request`, and `GatewayRequestError.details`.
- Consumer: Control UI Browser panel inspection/evaluate state.
- Siblings: no-display Browser metadata remains validated and preserved; unknown metadata/codes remain dropped.
- Native/TUI/channel runtimes do not consume this Control UI Browser-panel predicate.

## User Impact

Browser inspection now becomes unavailable from the machine-readable Browser fact, independent of human error wording and whether Browser execution is local or node-proxied. Operators keep the localized unavailable state instead of a generic request failure.

## Evidence

Pre-fix deterministic reproduction on `main` at `082cdc88661`:

```sh
node --import tsx --input-type=module -e 'const { createBrowserProxyFailure, parseBrowserProxyFailure } = await import("./extensions/browser/src/browser-proxy-envelope.ts"); const input = { error: "evaluation disabled", code: "ACT_EVALUATE_DISABLED" }; const output = parseBrowserProxyFailure(createBrowserProxyFailure(403, input)); console.log(JSON.stringify({ input, output }, null, 2)); if (output?.error.body.code !== input.code) process.exitCode = 1;'
```

Observed pre-fix: exit 1; `{ error: "evaluation disabled", code: "ACT_EVALUATE_DISABLED" }` became `{ error: "evaluation disabled" }`.

Regression proof against pre-fix source:

```sh
node scripts/run-vitest.mjs extensions/browser/src/browser/errors.test.ts extensions/browser/src/browser-proxy-envelope.test.ts extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts ui/src/components/browser/browser-panel-controller-input.test.ts
```

Observed pre-fix: 4 new tests failed for the intended reason: code absent from the parser, proxy envelope, HTTP `BrowserServiceError`, and Control UI state classification.

Observed fixed head:

- Same focused command: 33 tests passed across UI and Browser plugin shards.
- Rebased final head `b8c0bc20114c7e954816b9b13f1d6702b046b40f`: 123 focused Browser/UI boundary tests passed, plus 2/2 isolated mocked-Gateway Control UI flows for structured-code and legacy no-code responses.
- Fresh full-branch autoreview against current `origin/main` with `gpt-5.6-sol`, high reasoning, and P1 scope returned clean with no accepted/actionable findings.
- Production LOC: +62/-26, net +36. The growth is the closed Browser code vocabulary and bounded code-state preservation in both supported Browser transports; duplicated payload shapes were consolidated. Tests: +175/-13.
- `check-changed` passed formatting, guards, plugin boundaries, dead-code scans, and i18n before local typecheck hit the host's stale shared dependency tree (`@types/pako` missing). Exact-head hosted CI is the clean typecheck authority.
- Exact-head visual proof: https://github.com/openclaw/openclaw/pull/128625#issuecomment-5436120678

No visual layout or copy changed, so screenshot evidence is not applicable. The observable state transition is covered at the real Control UI controller boundary with a `GatewayRequestError` whose message intentionally does not contain `evaluateEnabled=false`.
