### PR TITLE
fix(slack): keep partial preview stable across reasoning turns

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -91,7 +91,7 @@ export function createSlackProgressRuntime(runtimeParams: {
         warn: logVerbose,
       })
     : undefined;
-  let hasStreamedMessage = false;
+  let hasStreamedAnswer = false;
   const isProgressMode = slackStreaming.mode === "progress";
   const useNativeProgressStreaming = useStreaming && slackStreaming.mode === "progress";
   const progressDraftActive = Boolean(draftStream) || useNativeProgressStreaming;
@@ -360,7 +360,6 @@ export function createSlackProgressRuntime(runtimeParams: {
             }
           : previewText,
       );
-      hasStreamedMessage = true;
       if (options?.flush) {
         await draftStream.flush();
       }
@@ -483,7 +482,6 @@ export function createSlackProgressRuntime(runtimeParams: {
     });
     if (text) {
       draftStream.update(text);
-      hasStreamedMessage = true;
     }
     return false;
   };
@@ -531,7 +529,7 @@ export function createSlackProgressRuntime(runtimeParams: {
         return false;
       }
       draftStream?.update(next.rendered);
-      hasStreamedMessage = true;
+      hasStreamedAnswer = true;
       return false;
     }
 
@@ -542,7 +540,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     previewToolProgressSuppressed = true;
     progressDraft.suppress();
     draftStream?.update(trimmed);
-    hasStreamedMessage = true;
+    hasStreamedAnswer = true;
     return false;
   };
   const pushReasoningProgress = async (payload?: {
@@ -577,7 +575,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     });
   };
   const resetDraftDeliveryState = () => {
-    hasStreamedMessage = false;
+    hasStreamedAnswer = false;
     appendRenderedText = "";
     appendSourceText = "";
   };
@@ -623,7 +621,7 @@ export function createSlackProgressRuntime(runtimeParams: {
             await beginNewProgressTurn();
             return;
           }
-          if (hasStreamedMessage) {
+          if (hasStreamedAnswer) {
             draftStream?.forceNewMessage();
           }
           resetDraftDeliveryState();

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -4403,6 +4403,36 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(draftStream.update).toHaveBeenLastCalledWith("• Reading the Slack handler");
   });
 
+  it("keeps one partial preview across reasoning and tool boundaries", async () => {
+    const draftStream = createDraftStreamStub();
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedSlackStreamingMode = "partial";
+    mockedSlackDraftMode = "replace";
+    mockedDispatchSequence = [];
+    mockedReplyOptionEvents = [
+      { kind: "reasoning", text: "Checking the first path" },
+      { kind: "reasoning_end" },
+      { kind: "item", progressText: "tool one" },
+      { kind: "assistant_start" },
+      { kind: "reasoning", text: "Checking the second path" },
+      { kind: "reasoning_end" },
+      { kind: "item", progressText: "tool two" },
+      { kind: "assistant_start" },
+      { kind: "partial", text: "final answer" },
+    ];
+
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        accountConfig: {
+          streaming: { mode: "partial", progress: { label: false } },
+        },
+      }),
+    );
+
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(draftStream.update).toHaveBeenLastCalledWith("final answer");
+  });
+
   it("keeps preamble headlines and tool progress when commentary is disabled", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);


### PR DESCRIPTION
Closes #119041

## What Problem This Solves

Fixes an issue where Slack users receiving a streamed answer with multiple reasoning and tool phases could see each phase rotate into a separate message before the final answer arrived.

## Why This Change Was Made

Tracks whether assistant answer text, rather than progress or reasoning text, has entered the partial preview before rotating at a draft boundary. Progress remains visible in the existing draft, while an interrupted answer still rotates through the established path.

The closed predecessor #119067 targeted the same symptom before current Slack streaming refactors. This change was rebuilt and proven against current `main`. Open #119763 touches the same dispatcher for queued-thread status rearming but does not change preview boundary or answer-text ownership.

## User Impact

Slack partial streaming now keeps reasoning, tool progress, and the eventual answer in one preview message. Genuine assistant-answer boundaries retain their existing rotation and cleanup behavior.

## Evidence

Exact base: `b42748ffc643219c2d3fa492f2ba751e8fc4f04b`

Exact head: `55dc8c0ac396860fd9435012dfb9d0143d47c699`

Production LOC: `+5/-7` (net `-2`). Test LOC: `+30/-0`.

Parent-red reproduction on the base SHA:

```text
OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_VITEST_NO_OUTPUT_HEARTBEAT_MS=30000 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-slack.config.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts -t "keeps one partial preview across reasoning and tool boundaries" --maxWorkers=1

AssertionError: expected forceNewMessage to not be called, but it was called 4 times
Test Files  1 failed (1)
Tests       1 failed | 153 skipped (154)
```

The identical command on the head SHA:

```text
Test Files  1 passed (1)
Tests       1 passed | 153 skipped (154)
```

Focused sibling verification covered progress completion, reasoning visibility, interrupted-answer rotation and cleanup, queued-followup rotation, and the new multi-reasoning regression:

```text
Test Files  1 passed (1)
Tests       6 passed | 148 skipped (154)
```

Formatting and patch checks:

```text
oxfmt --check extensions/slack/src/monitor/message-handler/dispatch-progress.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
All matched files use the correct format.

git diff --check
(clean)
```

Public mock-Gateway-to-Slack transport proof: [Actions run 32718029926](https://github.com/Alix-007/openclaw/actions/runs/32718029926). Artifact `9516745867` (`openclaw-slack-preview-55dc8c0ac396860fd9435012dfb9d0143d47c699`), digest `sha256:58f26f66c6f1639127d745b601e2f53d535595516ac2a6c2a184e7e50dd44b3a`.

The artifact verdict is `pass` and records:

- immutable source, build stamp, and runtime post-build stamp all at `55dc8c0ac396860fd9435012dfb9d0143d47c699`;
- a Crabline-generated, HMAC-signed Slack Events API message accepted by the exact Gateway `/slack/events` endpoint (`200` from ingress and Gateway);
- mock Responses rounds `0,1,2`, with rounds 1 and 2 each starting with exactly one Slack preview, response timestamp `1700000000.000101`;
- the final marker delivered by `chat.update` to the same request/response timestamp `1700000000.000101`, proving reasoning and tool boundaries did not rotate the preview;
- a redacted method/round/timestamp/marker trace for every Slack API request; and
- cleanup of the Gateway, provider, Slack server, ingress relay, API proxy, and temporary data.

The recorded transport closeout occurs after that successful final update: Crabline accepts a terminal `chat.postMessage` at `1700000000.000102`, then reports its unsupported `chat.delete` for the prior preview at `1700000000.000101`. Both events remain visible in the artifact. They are outside the reasoning-boundary identity window asserted by this PR.

AI assistance: implementation and test authoring were AI-assisted. The parent-red reproduction and focused tests above were run locally against the stated SHAs. The public proof ran the immutable head in GitHub Actions.

Limitations: the proof uses a mock Responses provider and a loopback Slack transport, not external Slack credentials. Crabline does not implement `chat.update`, so the proof proxy owns only that endpoint; authentication, user lookup, post, and delete requests are forwarded unchanged to Crabline. The verdict is scoped to the changed reasoning/tool preview-identity invariant and does not claim full live-workspace behavior.
