### PR TITLE
fix(discord): a failing slash command leaves the user watching a spinner that never resolves

### DIFF
--- a/extensions/discord/src/internal/interaction-dispatch.test.ts
+++ b/extensions/discord/src/internal/interaction-dispatch.test.ts
@@ -295,6 +295,53 @@ describe("dispatchInteraction", () => {
     expect(patch).not.toHaveBeenCalled();
   });
 
+  it("does not overwrite a follow-up that was still in flight when the handler threw", async () => {
+    // The handler starts a follow-up without awaiting it, then throws. Read
+    // outside the response queue, hasSentFollowUp is still false at that moment,
+    // because it is only set once the follow-up REST call resolves. The edit
+    // re-reads it inside the queue, after the follow-up has settled.
+    let releaseFollowUp: (() => void) | undefined;
+    // The first post is the deferred callback and must resolve, or the handler
+    // never runs. Only the follow-up that follows it is held open.
+    let posts = 0;
+    const post = vi.fn(async () => {
+      posts += 1;
+      if (posts === 1) {
+        return undefined;
+      }
+      return await new Promise<undefined>((resolve) => {
+        releaseFollowUp = () => resolve(undefined);
+      });
+    });
+    const patch = vi.fn(async () => undefined);
+    const run = vi.fn((interaction: CommandInteraction) => {
+      void interaction.followUp("progress").catch(() => undefined);
+      return Promise.reject(new Error("failed with a follow-up in flight"));
+    });
+    class RacingFollowUpCommand extends Command {
+      override name = "boom";
+      override description = "Throws with a follow-up in flight";
+      override defer = true;
+      run = run as unknown as Command["run"];
+    }
+    const client = createInternalTestClient([new RacingFollowUpCommand()]);
+    attachRestMock(client, { post, patch });
+
+    const handled = client.handleInteraction(
+      createInternalInteractionPayload({
+        id: "interaction1",
+        token: "token1",
+        data: { id: "command1", name: "boom", type: 1 },
+      }),
+    );
+    await vi.waitFor(() => expect(releaseFollowUp).toBeDefined());
+    releaseFollowUp?.();
+
+    await expect(handled).rejects.toThrow("failed with a follow-up in flight");
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(patch).not.toHaveBeenCalled();
+  });
+
   it("dispatches the focused option autocomplete handler", async () => {
     const optionAutocomplete = vi.fn(async (interaction: AutocompleteInteraction) => {
       await interaction.respond([{ name: "alpha", value: "alpha" }]);

--- a/extensions/discord/src/internal/interaction-dispatch.test.ts
+++ b/extensions/discord/src/internal/interaction-dispatch.test.ts
@@ -88,17 +88,27 @@ describe("dispatchInteraction", () => {
       expect.objectContaining({
         body: expect.objectContaining({
           content: expect.stringContaining("failed"),
+          allowed_mentions: { parse: [] },
+        }),
+      }),
+    );
+    // The exception text must not reach the channel; it carries the agent dir.
+    expect(patch).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        body: expect.objectContaining({
+          content: expect.stringContaining("prepared model catalog"),
         }),
       }),
     );
   });
 
-  it("suppresses mention parsing in the failure notice", async () => {
-    // The detail is an arbitrary exception message. Sent as a bare string it
-    // would be mention-parsed by Discord, so a handler throwing text containing
-    // @everyone would ping the channel.
+  it("keeps handler exception text out of the channel", async () => {
+    // An interaction response is visible to the whole channel, and the notice
+    // used to interpolate the exception message. That both disclosed internal
+    // detail and let Discord mention-parse whatever the handler threw.
     const run = vi.fn(async () => {
-      throw new Error("@everyone broke the catalog");
+      throw new Error("@everyone broke the catalog at /Users/someone/.openclaw");
     });
     class MentionThrowingCommand extends Command {
       override name = "boom";
@@ -121,13 +131,18 @@ describe("dispatchInteraction", () => {
       ),
     ).rejects.toThrow("@everyone broke the catalog");
 
+    for (const leak of ["@everyone", "/Users/someone/.openclaw"]) {
+      expect(patch).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          body: expect.objectContaining({ content: expect.stringContaining(leak) }),
+        }),
+      );
+    }
     expect(patch).toHaveBeenCalledWith(
       "/webhooks/app1/token1/messages/%40original",
       expect.objectContaining({
-        body: expect.objectContaining({
-          content: expect.stringContaining("@everyone"),
-          allowed_mentions: { parse: [] },
-        }),
+        body: expect.objectContaining({ allowed_mentions: { parse: [] } }),
       }),
     );
   });

--- a/extensions/discord/src/internal/interaction-dispatch.test.ts
+++ b/extensions/discord/src/internal/interaction-dispatch.test.ts
@@ -1,6 +1,7 @@
 // Discord tests cover interaction dispatch plugin behavior.
 import {
   ApplicationCommandOptionType,
+  ComponentType,
   InteractionResponseType,
   InteractionType,
 } from "discord-api-types/v10";
@@ -9,6 +10,7 @@ import { Command, CommandWithSubcommands } from "./commands.js";
 import type { AutocompleteInteraction, CommandInteraction } from "./interactions.js";
 import {
   attachRestMock,
+  createInternalComponentInteractionPayload,
   createInternalInteractionPayload,
   createInternalTestClient,
 } from "./test-builders.test-support.js";
@@ -48,6 +50,234 @@ describe("dispatchInteraction", () => {
       body: { content: "done" },
     });
     expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a visible failure when a deferred command handler throws", async () => {
+    // Regression: a throwing handler used to leave the deferred interaction
+    // pending forever, so Discord showed a spinner that never resolved and the
+    // only trace was a Gateway log line. See openclaw#77716.
+    const run = vi.fn(async () => {
+      throw new Error("prepared model catalog owner config was replaced during the read");
+    });
+    class ThrowingDeferredCommand extends Command {
+      override name = "boom";
+      override description = "Throwing command";
+      override defer = true;
+      run = run;
+    }
+    const client = createInternalTestClient([new ThrowingDeferredCommand()]);
+    const post = vi.fn(async () => undefined);
+    const patch = vi.fn(async () => undefined);
+    attachRestMock(client, { post, patch });
+
+    await expect(
+      client.handleInteraction(
+        createInternalInteractionPayload({
+          id: "interaction1",
+          token: "token1",
+          data: { id: "command1", name: "boom", type: 1 },
+        }),
+      ),
+    ).rejects.toThrow("prepared model catalog owner config was replaced");
+
+    expect(run).toHaveBeenCalledTimes(1);
+    // The deferred response must be resolved with a visible message rather than
+    // left hanging; the caller still sees the rejection so it is logged.
+    expect(patch).toHaveBeenCalledWith(
+      "/webhooks/app1/token1/messages/%40original",
+      expect.objectContaining({
+        body: expect.objectContaining({
+          content: expect.stringContaining("failed"),
+        }),
+      }),
+    );
+  });
+
+  it("suppresses mention parsing in the failure notice", async () => {
+    // The detail is an arbitrary exception message. Sent as a bare string it
+    // would be mention-parsed by Discord, so a handler throwing text containing
+    // @everyone would ping the channel.
+    const run = vi.fn(async () => {
+      throw new Error("@everyone broke the catalog");
+    });
+    class MentionThrowingCommand extends Command {
+      override name = "boom";
+      override description = "Throws a mention";
+      override defer = true;
+      run = run;
+    }
+    const client = createInternalTestClient([new MentionThrowingCommand()]);
+    const post = vi.fn(async () => undefined);
+    const patch = vi.fn(async () => undefined);
+    attachRestMock(client, { post, patch });
+
+    await expect(
+      client.handleInteraction(
+        createInternalInteractionPayload({
+          id: "interaction1",
+          token: "token1",
+          data: { id: "command1", name: "boom", type: 1 },
+        }),
+      ),
+    ).rejects.toThrow("@everyone broke the catalog");
+
+    expect(patch).toHaveBeenCalledWith(
+      "/webhooks/app1/token1/messages/%40original",
+      expect.objectContaining({
+        body: expect.objectContaining({
+          content: expect.stringContaining("@everyone"),
+          allowed_mentions: { parse: [] },
+        }),
+      }),
+    );
+  });
+
+  it("does not add a failure follow-up when the handler already replied", async () => {
+    // nextReplyAction() maps `replied` to a follow-up, so an unconditional
+    // report would post a second, contradictory message next to the reply the
+    // user already received.
+    const run = vi.fn(async (interaction: CommandInteraction) => {
+      await interaction.reply("partial result");
+      throw new Error("failed after replying");
+    });
+    class RepliesThenThrowsCommand extends Command {
+      override name = "boom";
+      override description = "Replies then throws";
+      override defer = true;
+      run = run;
+    }
+    const client = createInternalTestClient([new RepliesThenThrowsCommand()]);
+    // Typed parameters so mock.calls is indexable: the absence assertions below
+    // read the request path, which a zero-arity vi.fn() cannot express.
+    const post = vi.fn(async (_path: string, _data?: unknown, _query?: unknown) => undefined);
+    const patch = vi.fn(async () => undefined);
+    attachRestMock(client, { post, patch });
+
+    await expect(
+      client.handleInteraction(
+        createInternalInteractionPayload({
+          id: "interaction1",
+          token: "token1",
+          data: { id: "command1", name: "boom", type: 1 },
+        }),
+      ),
+    ).rejects.toThrow("failed after replying");
+
+    // Exactly the handler's own two requests: the deferred callback and the
+    // edit carrying its reply. Counting them is what makes this an absence
+    // assertion -- matching on argument shape silently passes when the follow-up
+    // is issued with a different arity.
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post.mock.calls[0]?.[0]).toBe("/interactions/interaction1/token1/callback");
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith("/webhooks/app1/token1/messages/%40original", {
+      body: { content: "partial result" },
+    });
+    // A follow-up would POST to the webhook route; nothing may go there.
+    expect(post.mock.calls.some(([path]) => path === "/webhooks/app1/token1")).toBe(false);
+  });
+
+  it("does not touch the original response when a component acknowledgement fails", async () => {
+    // A component acknowledgement is a DeferredMessageUpdate: Discord leaves no
+    // spinner, and the interaction's original response IS the message the button
+    // is attached to. Editing it would overwrite the message the user is still
+    // reading -- destroying live content to report a failure.
+    const run = vi.fn(async () => {
+      throw new Error("approval resolution exploded");
+    });
+    const client = createInternalTestClient([]);
+    client.componentHandler.register({
+      customId: "component1",
+      type: ComponentType.Button,
+      defer: true,
+      ephemeral: false,
+      run,
+      customIdParser: (id: string) => ({ data: { id } }),
+    } as never);
+    const post = vi.fn(async () => undefined);
+    const patch = vi.fn(async () => undefined);
+    attachRestMock(client, { post, patch });
+
+    await expect(
+      client.handleInteraction(
+        createInternalComponentInteractionPayload({
+          id: "interaction1",
+          token: "token1",
+        }),
+      ),
+    ).rejects.toThrow("approval resolution exploded");
+
+    expect(run).toHaveBeenCalledTimes(1);
+    // The acknowledgement callback is the handler's own. Nothing may edit the
+    // component's message afterwards.
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("does not issue a second callback when nothing was acknowledged", async () => {
+    // Response state advances only after a REST success, so an unacknowledged
+    // interaction cannot be distinguished from one whose acknowledgement reached
+    // Discord but whose response was lost. Replying here would start a fresh
+    // rate-limit budget and risk "already acknowledged"; Discord already shows
+    // its own "application did not respond" notice.
+    const run = vi.fn(async () => {
+      throw new Error("exploded before deferring");
+    });
+    class ImmediateThrowCommand extends Command {
+      override name = "boom";
+      override description = "Throws immediately";
+      override defer = false;
+      run = run;
+    }
+    const client = createInternalTestClient([new ImmediateThrowCommand()]);
+    const post = vi.fn(async () => undefined);
+    const patch = vi.fn(async () => undefined);
+    attachRestMock(client, { post, patch });
+
+    await expect(
+      client.handleInteraction(
+        createInternalInteractionPayload({
+          id: "interaction1",
+          token: "token1",
+          data: { id: "command1", name: "boom", type: 1 },
+        }),
+      ),
+    ).rejects.toThrow("exploded before deferring");
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(post).not.toHaveBeenCalled();
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite output a deferred handler already sent as a follow-up", async () => {
+    // followUp() puts a visible message in front of the user without advancing
+    // responseState. Discord may have consumed the deferred placeholder to
+    // deliver it, so editing the original response could overwrite that output.
+    const run = vi.fn(async (interaction: CommandInteraction) => {
+      await interaction.followUp("progress");
+      throw new Error("failed after follow-up");
+    });
+    class FollowUpThenThrowsCommand extends Command {
+      override name = "boom";
+      override description = "Follows up then throws";
+      override defer = true;
+      run = run;
+    }
+    const client = createInternalTestClient([new FollowUpThenThrowsCommand()]);
+    const post = vi.fn(async () => undefined);
+    const patch = vi.fn(async () => undefined);
+    attachRestMock(client, { post, patch });
+
+    await expect(
+      client.handleInteraction(
+        createInternalInteractionPayload({
+          id: "interaction1",
+          token: "token1",
+          data: { id: "command1", name: "boom", type: 1 },
+        }),
+      ),
+    ).rejects.toThrow("failed after follow-up");
+
+    expect(patch).not.toHaveBeenCalled();
   });
 
   it("dispatches the focused option autocomplete handler", async () => {

--- a/extensions/discord/src/internal/interaction-dispatch.ts
+++ b/extensions/discord/src/internal/interaction-dispatch.ts
@@ -71,7 +71,7 @@ export async function dispatchInteraction(
   } catch (error) {
     // A handler that throws after deferring leaves Discord showing a spinner
     // forever, so surface the failure before rethrowing for the caller's log.
-    await reportInteractionFailure(interaction, error);
+    await reportInteractionFailure(interaction);
     throw error;
   }
 }
@@ -127,7 +127,13 @@ async function dispatchAcknowledgeableInteraction(
   }
 }
 
-const INTERACTION_FAILURE_DETAIL_LIMIT = 300;
+/**
+ * Fixed text. The thrown error is deliberately not echoed here: an interaction
+ * response is visible to the whole channel, and handler exceptions routinely
+ * carry absolute paths, config keys, and provider responses. The rethrow keeps
+ * the detail in the Gateway log where operators already look for it.
+ */
+const INTERACTION_FAILURE_NOTICE = "Command failed. Check the Gateway logs for details.";
 
 type FailureReportableInteraction = {
   responseState: InteractionResponseState;
@@ -156,10 +162,7 @@ type FailureReportableInteraction = {
  * - `replied`         the user has seen a message, and nextReplyAction() would
  *                     turn this into a contradictory follow-up beside it.
  */
-async function reportInteractionFailure(
-  interaction: FailureReportableInteraction,
-  error: unknown,
-): Promise<void> {
+async function reportInteractionFailure(interaction: FailureReportableInteraction): Promise<void> {
   if (interaction.responseState !== "deferred") {
     return;
   }
@@ -171,16 +174,11 @@ async function reportInteractionFailure(
     return;
   }
   try {
-    const detail = error instanceof Error ? error.message : String(error);
-    const trimmed =
-      detail.length > INTERACTION_FAILURE_DETAIL_LIMIT
-        ? `${detail.slice(0, INTERACTION_FAILURE_DETAIL_LIMIT)}…`
-        : detail;
-    // The detail is an arbitrary exception message. Sending it as a bare string
-    // would let Discord parse mentions inside it, so a handler that throws text
-    // containing @everyone or a role mention would ping the channel.
+    // allowed_mentions stays pinned even though the notice is a constant, so a
+    // later change to this text cannot silently gain the ability to ping a
+    // channel through Discord's default mention parsing.
     await interaction.reply({
-      content: `Command failed: ${trimmed || "unknown error"}`,
+      content: INTERACTION_FAILURE_NOTICE,
       allowed_mentions: { parse: [] },
     });
   } catch {

--- a/extensions/discord/src/internal/interaction-dispatch.ts
+++ b/extensions/discord/src/internal/interaction-dispatch.ts
@@ -5,6 +5,7 @@ import {
   deferCommandInteractionIfNeeded,
   resolveFocusedCommandOptionAutocompleteHandler,
 } from "./commands.js";
+import type { InteractionResponseState } from "./interaction-response.js";
 import {
   AutocompleteInteraction,
   BaseComponentInteraction,
@@ -65,6 +66,21 @@ export async function dispatchInteraction(
     }
     return;
   }
+  try {
+    await dispatchAcknowledgeableInteraction(client, rawData, interaction);
+  } catch (error) {
+    // A handler that throws after deferring leaves Discord showing a spinner
+    // forever, so surface the failure before rethrowing for the caller's log.
+    await reportInteractionFailure(interaction, error);
+    throw error;
+  }
+}
+
+async function dispatchAcknowledgeableInteraction(
+  client: DispatchClient,
+  rawData: APIInteraction,
+  interaction: ReturnType<typeof createInteraction>,
+): Promise<void> {
   if (rawData.type === InteractionType.ApplicationCommand) {
     const command = client.commands.find((entry) => entry.name === readInteractionName(rawData));
     if (command) {
@@ -108,6 +124,67 @@ export async function dispatchInteraction(
     if (modal) {
       await modal.run(interaction as ModalInteraction, modal.customIdParser(customId).data);
     }
+  }
+}
+
+const INTERACTION_FAILURE_DETAIL_LIMIT = 300;
+
+type FailureReportableInteraction = {
+  responseState: InteractionResponseState;
+  hasSentFollowUp: boolean;
+  reply(payload: { content: string; allowed_mentions: { parse: [] } }): Promise<unknown>;
+};
+
+/**
+ * Best-effort user-visible notice for a failed interaction. Never throws: a
+ * reporting failure must not mask the original error.
+ *
+ * Deliberately narrow. It reports only for `deferred`, where a spinner is known
+ * to exist and the original response is a placeholder this dispatch created:
+ *
+ * - `deferred`        the deferring callback succeeded (state advances only
+ *                     after a REST success), so editing the original response
+ *                     resolves a spinner that would otherwise hang forever.
+ * - `deferred-update` a component acknowledgement. Discord leaves no spinner,
+ *                     and the original response is the message the component is
+ *                     attached to, so editing it would overwrite content the
+ *                     user is still reading.
+ * - `unacknowledged`  nothing is known to have reached Discord. A second
+ *                     initial callback risks "already acknowledged" if the
+ *                     first one landed after all, and Discord already shows its
+ *                     own "did not respond" notice.
+ * - `replied`         the user has seen a message, and nextReplyAction() would
+ *                     turn this into a contradictory follow-up beside it.
+ */
+async function reportInteractionFailure(
+  interaction: FailureReportableInteraction,
+  error: unknown,
+): Promise<void> {
+  if (interaction.responseState !== "deferred") {
+    return;
+  }
+  // A follow-up has already put output in front of the user. Discord may have
+  // consumed the deferred placeholder to deliver it, so editing the original
+  // response here risks overwriting that output. Leaving the placeholder alone
+  // is the safer failure: the user has something to see either way.
+  if (interaction.hasSentFollowUp) {
+    return;
+  }
+  try {
+    const detail = error instanceof Error ? error.message : String(error);
+    const trimmed =
+      detail.length > INTERACTION_FAILURE_DETAIL_LIMIT
+        ? `${detail.slice(0, INTERACTION_FAILURE_DETAIL_LIMIT)}…`
+        : detail;
+    // The detail is an arbitrary exception message. Sending it as a bare string
+    // would let Discord parse mentions inside it, so a handler that throws text
+    // containing @everyone or a role mention would ping the channel.
+    await interaction.reply({
+      content: `Command failed: ${trimmed || "unknown error"}`,
+      allowed_mentions: { parse: [] },
+    });
+  } catch {
+    // Ignored: the caller rethrows and logs the original failure.
   }
 }
 

--- a/extensions/discord/src/internal/interaction-dispatch.ts
+++ b/extensions/discord/src/internal/interaction-dispatch.ts
@@ -138,7 +138,10 @@ const INTERACTION_FAILURE_NOTICE = "Command failed. Check the Gateway logs for d
 type FailureReportableInteraction = {
   responseState: InteractionResponseState;
   hasSentFollowUp: boolean;
-  reply(payload: { content: string; allowed_mentions: { parse: [] } }): Promise<unknown>;
+  editDeferredPlaceholderIfUnanswered(payload: {
+    content: string;
+    allowed_mentions: { parse: [] };
+  }): Promise<boolean>;
 };
 
 /**
@@ -174,10 +177,14 @@ async function reportInteractionFailure(interaction: FailureReportableInteractio
     return;
   }
   try {
+    // The checks above are a fast path read outside the response queue. The edit
+    // re-reads both inside it, so a follow-up still in flight when the handler
+    // threw settles first and this cannot overwrite output it delivered.
+    //
     // allowed_mentions stays pinned even though the notice is a constant, so a
     // later change to this text cannot silently gain the ability to ping a
     // channel through Discord's default mention parsing.
-    await interaction.reply({
+    await interaction.editDeferredPlaceholderIfUnanswered({
       content: INTERACTION_FAILURE_NOTICE,
       allowed_mentions: { parse: [] },
     });

--- a/extensions/discord/src/internal/interactions.ts
+++ b/extensions/discord/src/internal/interactions.ts
@@ -218,6 +218,27 @@ class BaseInteraction {
     return await this.enqueueResponse(() => this.performReplyEdit(payload));
   }
 
+  /**
+   * Edits the deferred placeholder only if this interaction is still an
+   * unanswered spinner when the queue reaches this operation.
+   *
+   * Both conditions are re-read inside the queue. A follow-up that was still in
+   * flight when the caller decided to report will have settled — and recorded
+   * itself in `sentFollowUp` — by the time this runs, so the decision cannot be
+   * made against state that is about to change.
+   *
+   * Resolves true when the edit was sent.
+   */
+  async editDeferredPlaceholderIfUnanswered(payload: MessagePayload): Promise<boolean> {
+    return await this.enqueueResponse(async () => {
+      if (this.responseState !== "deferred" || this.sentFollowUp) {
+        return false;
+      }
+      await this.performReplyEdit(payload);
+      return true;
+    });
+  }
+
   private async performReplyEdit(payload: MessagePayload): Promise<unknown> {
     const body = serializePayload(payload);
     const query = needsComponentsV2Query(body) ? { with_components: true } : undefined;

--- a/extensions/discord/src/internal/interactions.ts
+++ b/extensions/discord/src/internal/interactions.ts
@@ -121,6 +121,7 @@ class BaseInteraction {
   message: Message | null = null;
   private readonly response = new InteractionResponseController();
   private pendingResponse: Promise<void> = Promise.resolve();
+  private sentFollowUp = false;
 
   constructor(
     public client: InteractionClient,
@@ -147,6 +148,15 @@ class BaseInteraction {
 
   set responseState(nextState: InteractionResponseState) {
     this.response.state = nextState;
+  }
+
+  /**
+   * True once a follow-up message has been delivered. Follow-ups are visible to
+   * the user but never advance `responseState`, so this is the only record that
+   * the interaction has already produced output.
+   */
+  get hasSentFollowUp(): boolean {
+    return this.sentFollowUp;
   }
 
   private enqueueResponse<T>(operation: () => Promise<T>): Promise<T> {
@@ -266,13 +276,15 @@ class BaseInteraction {
 
   private async performFollowUp(payload: MessagePayload): Promise<unknown> {
     const body = serializePayload(payload);
-    return await createWebhookMessage(
+    const result = await createWebhookMessage(
       this.client.rest,
       this.client.options.clientId,
       this.token,
       { body },
       needsComponentsV2Query(body) ? { with_components: true } : undefined,
     );
+    this.sentFollowUp = true;
+    return result;
   }
 }
 


### PR DESCRIPTION
Related: #128515

AI-assisted: implemented by Claude (Sonnet 4.6 and Opus 5), adversarially reviewed by Codex.

## What Problem This Solves

Fixes an issue where a Discord slash command whose handler throws after deferring would leave the
user looking at a spinner that never resolves. The command appears to still be running. It is not.
The only trace is one line in the Gateway log, so from the channel there is nothing to distinguish a
permanently failed command from a slow one, and re-running it produces the same silent hang.

The trigger that surfaced this was #128515 — `/models` throwing `PreparedModelCatalogConfigReplacedError`
after an unrelated config edit — but the gap is general: `dispatchInteraction` had no error handling
at all, so any throwing handler behaves this way.

Prior art: #77716 reported the same symptom and was closed as not planned after being attributed to
event-loop saturation. This report has a deterministic trigger and a focused regression test, so the
hang is reproducible rather than load-dependent.

## Why This Change Was Made

`dispatchInteraction` now wraps non-autocomplete dispatch, resolves the deferred placeholder with a
visible notice, and rethrows so the caller still logs the original failure.

The reporting is deliberately narrow, and getting that boundary right was most of the work. It fires
only when the response state is `deferred` and no follow-up has been sent — the single state where a
spinner is known to exist and the original response is a placeholder this dispatch created. Every
other state is excluded for a concrete reason:

- `deferred-update` is a component acknowledgement. Discord leaves no spinner, and the original
  response is the message the component is attached to, so editing it would overwrite live content
  the user is still reading. An earlier revision of this change reported here and would have
  destroyed an in-flight approval prompt.
- `unacknowledged` means nothing is known to have reached Discord. A second initial callback risks
  "already acknowledged" if the first one landed after all, and Discord already shows its own "did
  not respond" notice.
- `replied` means the user has already seen a message; `nextReplyAction()` would turn the notice
  into a contradictory follow-up beside it.
- A sent follow-up means output is already in front of the user, and Discord may have consumed the
  placeholder to deliver it.

An earlier revision inferred from the handler's error whether the interaction webhook would accept a
write (`instanceof RateLimitError`). That was wrong in both directions — too broad, because a 429 on
an unrelated route suppressed a report the webhook could have delivered, and too narrow, because
`native-command-reply.ts` wraps rate-limit errors in a partial-delivery error that `instanceof`
misses. The inference is gone; the decision now rests only on response state, which advances only
after a REST success.

The notice is fixed text and does not include the exception message. An interaction response is
visible to the whole channel, and handler exceptions in this codebase routinely carry absolute
paths, config keys, and provider responses. Withholding the text also removes the mention-injection
source by construction rather than escaping it, though `allowed_mentions.parse` stays pinned empty
so a later change to the wording cannot silently regain the ability to ping a channel.

The follow-up check happens **inside** the response queue. `hasSentFollowUp` is only set once the
follow-up REST call resolves, so a fire-and-forget follow-up still in flight when the handler threw
would otherwise let the reporter decide against state that was about to change. The dispatcher keeps
a cheap read outside the queue as a fast path, and `editDeferredPlaceholderIfUnanswered` re-reads
both the response state and follow-up delivery inside it, after any in-flight follow-up has settled
and recorded itself.

**Known limitation, not addressed here.** The report is awaited before rethrowing, which delays the
caller's log; under a saturated per-interaction queue that wait can in principle approach the
15-minute interaction token lifetime. That is a pre-existing shape in this file and is called out
rather than changed, to keep this to one concern.

## User Impact

A Discord command that fails now says so in the channel instead of spinning forever. Operators can
tell a failed command from a slow one and know to check the Gateway log, and the log keeps the full
error exactly as before. No change to successful commands, to autocomplete, to component
interactions, or to any command that already replied.

## Evidence

**The regression test fails on stock and passes patched.** Reverting only the two source files —
`interaction-dispatch.ts` and `interactions.ts`, with the test file left in place:

```
 × reports a visible failure when a deferred command handler throws
 × keeps handler exception text out of the channel
 Test Files  1 failed (1)
      Tests  2 failed | 7 passed (9)
```

With the source restored:

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

The other seven tests assert **absence** — that no write reaches Discord for `deferred-update`,
`unacknowledged`, `replied`, or after a follow-up. They pass vacuously on stock, which is correct:
they exist to stop this change from reporting where it must not, and each was verified by mutation.

**The disclosure guard was verified red.** Changing the notice to `"Command failed at
/Users/someone/.openclaw"` fails the test that exists to catch it:

```
 × keeps handler exception text out of the channel
 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
```

**The in-queue re-check is mutation-tested.** Removing the guard from inside the queued operation
fails the test that holds a follow-up's REST call open across the throw:

```
 × does not overwrite a follow-up that was still in flight when the handler threw
 Test Files  1 failed (1)
      Tests  1 failed | 9 passed (10)
```

**Full Discord lane** (before the in-queue re-check, on the prior base):

```
 Test Files  227 passed (227)
      Tests  2895 passed (2895)
```

`node scripts/check-changed.mjs` exits 0 on the current head, which includes the typecheck of the
extension tests.

⚠️ On the current base the full 230-file Discord lane aborts locally with vitest `Worker exited
unexpectedly` before running any test. That reproduces with this branch's changes stashed, so it is
not introduced here; CI runs the lane independently.

**Live reproduction of the silent failure.** On a host running **stock current `main`** with a live
Discord channel, a `/models` slash command whose handler throws after deferring produced exactly one
artifact — a log line — and nothing at all in the channel:

```
2026-08-24T11:55:54.913Z ERROR [discord/monitor]
discord interaction handler failed: PreparedModelCatalogConfigReplacedError:
prepared model catalog owner config was replaced during the read
(<statedir>/agents/main/agent)
```

The subsystem is the point: `discord/monitor` is the detached listener that logs a rejected handler
promise. That is the whole of the current handling. The invoking user saw a spinner that never
resolved, and re-invoking produced the same silence.

Worth noting for scope: an ordinary Discord *message* reading `/models` answered normally in 2.4 s
against the same build. Only the slash command hangs, because only it enters `dispatchInteraction`.

**After the fix, on the same host and the same trigger.** The branch at `8583182067f` was built and
deployed to that Gateway (`INTERACTION_FAILURE_NOTICE` confirmed present in the built `dist`), the
Gateway restarted, a prepared owner published by an ordinary turn, and the same no-op config edit
applied. The same `/models` slash command then produced **both** of these, where before it produced
only the first:

```
2026-08-24T13:09:12.525Z ERROR [discord/monitor]
discord interaction handler failed: PreparedModelCatalogConfigReplacedError:
prepared model catalog owner config was replaced during the read
(<statedir>/agents/main/agent)
```

and, in the channel, a resolved response reading **"Command failed. Check the Gateway logs for
details."** in place of the spinner.

The underlying error is unchanged and still reaches the log — this PR does not fix the fault, it
stops the fault being invisible. #128515 is the fault itself.

**What this does not establish.** The channel text was read by the invoking user; the log line is a
direct capture. Slash-command invocations and their interaction responses are not returned by
`GET /channels/{id}/messages`, so the notice cannot be scraped by another bot — which is itself part
of why this failure mode went unnoticed. The unit tests cover the dispatch decision against a mocked
REST client, so the mechanical claim is that the dispatcher writes the placeholder edit in exactly
one response state and no other.
