### PR TITLE
perf(sessions): avoid database maintenance during reads

### DIFF
--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -403,7 +403,7 @@ export function openSessionEntryReadView(
         clone: false,
         sessionKey,
       })?.entry,
-    entries: () => listSessionEntryRows({ ...scope, clone: false }),
+    entries: () => listSessionEntriesReadOnly({ ...scope, clone: false }),
   };
 }
 

--- a/src/config/sessions/session-accessor.readonly.test.ts
+++ b/src/config/sessions/session-accessor.readonly.test.ts
@@ -19,6 +19,10 @@ import {
   hasSessionEntriesByStatusReadOnly,
   listSessionEntriesCore,
   listSessionEntriesReadOnly,
+  openSessionEntryReadView,
+  readSessionTranscriptTitleProbeBatch,
+  readSessionTranscriptWatermark,
+  readSessionTranscriptWatermarkBatch,
   readSessionIdentityEvidenceBatch,
   resolveTranscriptSessionKeyBySessionId,
   upsertSessionEntryCore,
@@ -62,6 +66,8 @@ describe("session accessor readonly listing", () => {
     closeOpenClawAgentDatabasesForTest();
 
     expect(listSessionEntriesReadOnly(listScope)).toEqual(writableEntries);
+    expect(openSessionEntryReadView(listScope).entries()).toEqual(writableEntries);
+    expect(isOpenClawAgentDatabaseOpen(resolveOpenClawAgentSqlitePath(listScope))).toBe(false);
   });
 
   it("returns an empty list without creating or registering a missing agent database", () => {
@@ -72,8 +78,32 @@ describe("session accessor readonly listing", () => {
     clearRegisteredAgentDatabases(env);
 
     expect(listSessionEntriesReadOnly({ agentId, env })).toEqual([]);
+    expect(openSessionEntryReadView({ agentId, env }).entries()).toEqual([]);
     expect(fs.existsSync(databasePath)).toBe(false);
     expect(countRegisteredAgentDatabases(env)).toBe(0);
+  });
+
+  it("surfaces missing canonical transcript tables through single and batched reads", async () => {
+    const stateDir = makeTempDir(tempDirs, "openclaw-session-readonly-missing-transcript-table-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const scope = {
+      agentId: "worker-1",
+      env,
+      sessionId: "session-1",
+      sessionKey: "agent:worker-1:main",
+    };
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+    openOpenClawAgentDatabase({ agentId: scope.agentId, env }).db.exec(
+      "DROP TABLE transcript_events;",
+    );
+
+    for (const read of [
+      () => readSessionTranscriptWatermark(scope),
+      () => readSessionTranscriptWatermarkBatch([scope]),
+      () => readSessionTranscriptTitleProbeBatch([scope]),
+    ]) {
+      expect(read).toThrow(/no such table: transcript_events/);
+    }
   });
 
   it("probes lifecycle status without creating or registering a missing database", () => {

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -11,10 +11,12 @@ import {
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
 import { runQueuedStoreWrite } from "../../shared/store-writer-queue.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   resolveIncognitoOpenClawAgentSqlitePath,
   resolveOpenClawAgentSqlitePath,
+  type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
 import { formatSqliteSessionFileMarker } from "./legacy-sqlite-marker.js";
@@ -84,6 +86,7 @@ export type SessionSqliteTargetResolutionCache = Map<
 >;
 
 const SQLITE_SESSION_SLOW_WRITE_MS = 1_000;
+const SQLITE_TRANSCRIPT_READ_QUERY_CHUNK_SIZE = 400;
 
 export function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
   return getNodeSqliteKysely<SessionSqliteDatabase>(database);
@@ -329,6 +332,54 @@ export function resolveSqliteTranscriptReadScope(
     ...resolveSqliteReadScope(scope, targetCache),
     sessionId: scope.sessionId,
   };
+}
+
+/** Borrow one store at a time so bounded registry eviction cannot invalidate a batched read. */
+export function readSqliteTranscriptStoreBatches<T>(
+  scopes: readonly SessionTranscriptReadScope[],
+  readChunk: (
+    database: Pick<OpenClawAgentDatabase, "db" | "path">,
+    sessionIds: readonly string[],
+  ) => Map<string, T>,
+): Array<T | undefined> {
+  const results: Array<T | undefined> = Array.from({ length: scopes.length });
+  const groups = new Map<
+    string,
+    { indexes: Map<string, number[]>; options: OpenClawAgentDatabaseOptions }
+  >();
+  const targetCache: SessionSqliteTargetResolutionCache = new Map();
+  for (const [index, scope] of scopes.entries()) {
+    const resolved = resolveSqliteTranscriptReadScope(scope, targetCache);
+    const options = toDatabaseOptions(resolved);
+    const databasePath = resolveOpenClawAgentSqlitePath(options);
+    const group = groups.get(databasePath) ?? { indexes: new Map(), options };
+    const indexes = group.indexes.get(resolved.sessionId) ?? [];
+    indexes.push(index);
+    group.indexes.set(resolved.sessionId, indexes);
+    groups.set(databasePath, group);
+  }
+  for (const group of groups.values()) {
+    withOpenClawAgentDatabaseReadOnly(
+      (database) => {
+        const sessionIds = [...group.indexes.keys()];
+        for (
+          let offset = 0;
+          offset < sessionIds.length;
+          offset += SQLITE_TRANSCRIPT_READ_QUERY_CHUNK_SIZE
+        ) {
+          const chunk = sessionIds.slice(offset, offset + SQLITE_TRANSCRIPT_READ_QUERY_CHUNK_SIZE);
+          for (const [sessionId, value] of readChunk(database, chunk)) {
+            for (const index of group.indexes.get(sessionId) ?? []) {
+              results[index] = value;
+            }
+          }
+        }
+      },
+      group.options,
+      { throwOnMissingTable: true },
+    );
+  }
+  return results;
 }
 
 export function toDatabaseOptions(

--- a/src/config/sessions/session-accessor.sqlite-title-probes.ts
+++ b/src/config/sessions/session-accessor.sqlite-title-probes.ts
@@ -2,19 +2,12 @@ import { sql } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
-import {
-  openOpenClawAgentDatabase,
-  type OpenClawAgentDatabase,
-} from "../../state/openclaw-agent-db.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type {
   SessionTranscriptReadScope,
   TranscriptEvent,
 } from "./session-accessor.sqlite-contract.js";
-import {
-  resolveSqliteTranscriptReadScope,
-  toDatabaseOptions,
-  type SessionSqliteTargetResolutionCache,
-} from "./session-accessor.sqlite-scope.js";
+import { readSqliteTranscriptStoreBatches } from "./session-accessor.sqlite-scope.js";
 
 type TitleProbeDatabase = Pick<
   OpenClawAgentKyselyDatabase,
@@ -34,9 +27,8 @@ export type SessionTranscriptTitleProbe = {
 };
 
 const SESSION_TITLE_PROBE_MESSAGES = 20;
-const SESSION_TITLE_PROBE_QUERY_CHUNK_SIZE = 400;
 
-function getTitleProbeKysely(database: OpenClawAgentDatabase) {
+function getTitleProbeKysely(database: Pick<OpenClawAgentDatabase, "db">) {
   return getNodeSqliteKysely<TitleProbeDatabase>(database.db);
 }
 
@@ -57,7 +49,7 @@ function sqliteTranscriptBoundaryEventType() {
 }
 
 function readTitleProbeChunk(
-  database: OpenClawAgentDatabase,
+  database: Pick<OpenClawAgentDatabase, "db" | "path">,
   sessionIds: readonly string[],
 ): Map<string, SessionTranscriptTitleProbe> {
   const db = getTitleProbeKysely(database);
@@ -174,37 +166,5 @@ function readTitleProbeChunk(
 export function readSessionTranscriptTitleProbeBatch(
   scopes: readonly SessionTranscriptReadScope[],
 ): Array<SessionTranscriptTitleProbe | undefined> {
-  const results: Array<SessionTranscriptTitleProbe | undefined> = Array.from({
-    length: scopes.length,
-  });
-  const groups = new Map<
-    string,
-    { database: OpenClawAgentDatabase; items: Array<{ index: number; sessionId: string }> }
-  >();
-  const targetCache: SessionSqliteTargetResolutionCache = new Map();
-  for (const [index, scope] of scopes.entries()) {
-    const resolved = resolveSqliteTranscriptReadScope(scope, targetCache);
-    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    const group = groups.get(database.path) ?? { database, items: [] };
-    group.items.push({ index, sessionId: resolved.sessionId });
-    groups.set(database.path, group);
-  }
-  for (const group of groups.values()) {
-    const sessionIds = [...new Set(group.items.map((item) => item.sessionId))];
-    const probes = new Map<string, SessionTranscriptTitleProbe>();
-    for (
-      let offset = 0;
-      offset < sessionIds.length;
-      offset += SESSION_TITLE_PROBE_QUERY_CHUNK_SIZE
-    ) {
-      const chunk = sessionIds.slice(offset, offset + SESSION_TITLE_PROBE_QUERY_CHUNK_SIZE);
-      for (const [sessionId, probe] of readTitleProbeChunk(group.database, chunk)) {
-        probes.set(sessionId, probe);
-      }
-    }
-    for (const item of group.items) {
-      results[item.index] = probes.get(item.sessionId);
-    }
-  }
-  return results;
+  return readSqliteTranscriptStoreBatches(scopes, readTitleProbeChunk);
 }

--- a/src/config/sessions/session-accessor.sqlite-transcript-watermark.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-watermark.ts
@@ -7,16 +7,14 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
-import {
-  openOpenClawAgentDatabase,
-  type OpenClawAgentDatabase,
-} from "../../state/openclaw-agent-db.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { SessionTranscriptReadScope } from "./session-accessor.sqlite-contract.js";
 import {
+  readSqliteTranscriptStoreBatches,
   resolveSqliteTranscriptReadScope,
   toDatabaseOptions,
-  type SessionSqliteTargetResolutionCache,
 } from "./session-accessor.sqlite-scope.js";
 
 type WatermarkDatabase = Pick<
@@ -29,34 +27,38 @@ export type SessionTranscriptWatermark = {
   maxSeq: number | null;
 };
 
-const SESSION_TRANSCRIPT_WATERMARK_QUERY_CHUNK_SIZE = 400;
-
 /** Reads the append and rewrite tokens that validate transcript-derived caches. */
 export function readSessionTranscriptWatermark(
   scope: SessionTranscriptReadScope,
 ): SessionTranscriptWatermark {
   const resolved = resolveSqliteTranscriptReadScope(scope);
-  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-  const db = getNodeSqliteKysely<WatermarkDatabase>(database.db);
-  const maxSeq = executeSqliteQueryTakeFirstSync(
-    database.db,
-    db
-      .selectFrom("transcript_events")
-      .select((eb) => eb.fn.max<number>("seq").as("max_seq"))
-      .where("session_id", "=", resolved.sessionId),
-  )?.max_seq;
-  const generation = executeSqliteQueryTakeFirstSync(
-    database.db,
-    db
-      .selectFrom("transcript_rewrite_watermarks")
-      .select("generation")
-      .where("session_id", "=", resolved.sessionId),
-  )?.generation;
-  return { generation: generation ?? null, maxSeq: maxSeq ?? null };
+  const result = withOpenClawAgentDatabaseReadOnly(
+    (database) => {
+      const db = getNodeSqliteKysely<WatermarkDatabase>(database.db);
+      const maxSeq = executeSqliteQueryTakeFirstSync(
+        database.db,
+        db
+          .selectFrom("transcript_events")
+          .select((eb) => eb.fn.max<number>("seq").as("max_seq"))
+          .where("session_id", "=", resolved.sessionId),
+      )?.max_seq;
+      const generation = executeSqliteQueryTakeFirstSync(
+        database.db,
+        db
+          .selectFrom("transcript_rewrite_watermarks")
+          .select("generation")
+          .where("session_id", "=", resolved.sessionId),
+      )?.generation;
+      return { generation: generation ?? null, maxSeq: maxSeq ?? null };
+    },
+    toDatabaseOptions(resolved),
+    { throwOnMissingTable: true },
+  );
+  return result.found ? result.value : { generation: null, maxSeq: null };
 }
 
 function readSessionTranscriptWatermarkChunk(
-  database: OpenClawAgentDatabase,
+  database: Pick<OpenClawAgentDatabase, "db">,
   sessionIds: readonly string[],
 ): Map<string, SessionTranscriptWatermark> {
   const db = getNodeSqliteKysely<WatermarkDatabase>(database.db);
@@ -95,46 +97,7 @@ function readSessionTranscriptWatermarkChunk(
 export function readSessionTranscriptWatermarkBatch(
   scopes: readonly SessionTranscriptReadScope[],
 ): SessionTranscriptWatermark[] {
-  const results: Array<SessionTranscriptWatermark | undefined> = Array.from({
-    length: scopes.length,
-  });
-  const groups = new Map<
-    string,
-    { database: OpenClawAgentDatabase; items: Array<{ index: number; sessionId: string }> }
-  >();
-  const targetCache: SessionSqliteTargetResolutionCache = new Map();
-  for (const [index, scope] of scopes.entries()) {
-    const resolved = resolveSqliteTranscriptReadScope(scope, targetCache);
-    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-    const group = groups.get(database.path) ?? { database, items: [] };
-    group.items.push({ index, sessionId: resolved.sessionId });
-    groups.set(database.path, group);
-  }
-  for (const group of groups.values()) {
-    const sessionIds = [...new Set(group.items.map((item) => item.sessionId))];
-    const watermarks = new Map<string, SessionTranscriptWatermark>();
-    for (
-      let offset = 0;
-      offset < sessionIds.length;
-      offset += SESSION_TRANSCRIPT_WATERMARK_QUERY_CHUNK_SIZE
-    ) {
-      const chunk = sessionIds.slice(
-        offset,
-        offset + SESSION_TRANSCRIPT_WATERMARK_QUERY_CHUNK_SIZE,
-      );
-      for (const [sessionId, watermark] of readSessionTranscriptWatermarkChunk(
-        group.database,
-        chunk,
-      )) {
-        watermarks.set(sessionId, watermark);
-      }
-    }
-    for (const item of group.items) {
-      results[item.index] = watermarks.get(item.sessionId) ?? {
-        generation: null,
-        maxSeq: null,
-      };
-    }
-  }
-  return results.map((result) => result ?? { generation: null, maxSeq: null });
+  return readSqliteTranscriptStoreBatches(scopes, readSessionTranscriptWatermarkChunk).map(
+    (result) => result ?? { generation: null, maxSeq: null },
+  );
 }

--- a/src/config/sessions/session-sharing-store.test.ts
+++ b/src/config/sessions/session-sharing-store.test.ts
@@ -1,7 +1,10 @@
+import fs from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   closeOpenClawAgentDatabasesForTest,
+  isOpenClawAgentDatabaseOpen,
   openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
 } from "../../state/openclaw-agent-db.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import {
@@ -20,6 +23,34 @@ import {
 afterEach(() => closeOpenClawAgentDatabasesForTest());
 
 describe("session sharing store", () => {
+  it("reads existing and missing memberships without opening or creating writable databases", async () => {
+    await withTestDir({ prefix: "openclaw-session-sharing-readonly-" }, async (dir) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+      const scope = { agentId: "main", env, sessionKey: "agent:main:main" };
+      const missingScope = { agentId: "missing", env, sessionKey: "agent:missing:main" };
+      await upsertSessionEntryCore(scope, { sessionId: "session-main", updatedAt: 1 });
+      addSessionMember(scope, { identityId: "guest", addedBy: "owner", addedAt: 2 });
+      const databasePath = resolveOpenClawAgentSqlitePath({ agentId: scope.agentId, env });
+      const missingPath = resolveOpenClawAgentSqlitePath({ agentId: missingScope.agentId, env });
+      closeOpenClawAgentDatabasesForTest();
+
+      expect(listSessionMembers(scope)).toEqual([
+        { identityId: "guest", addedBy: "owner", addedAt: 2 },
+      ]);
+      expect(listSessionMembershipKeys(scope, [scope.sessionKey], "guest")).toEqual(
+        new Set([scope.sessionKey]),
+      );
+      expect(isSessionMember(scope, "guest")).toBe(true);
+      expect(isOpenClawAgentDatabaseOpen(databasePath)).toBe(false);
+      expect(listSessionMembers(missingScope)).toEqual([]);
+      expect(listSessionMembershipKeys(missingScope, [missingScope.sessionKey], "guest")).toEqual(
+        new Set(),
+      );
+      expect(isSessionMember(missingScope, "guest")).toBe(false);
+      expect(fs.existsSync(missingPath)).toBe(false);
+    });
+  });
+
   it("keeps deterministic membership rows", async () => {
     await withTestDir({ prefix: "openclaw-session-sharing-" }, async (dir) => {
       const env = { ...process.env, OPENCLAW_STATE_DIR: dir };

--- a/src/config/sessions/session-sharing-store.ts
+++ b/src/config/sessions/session-sharing-store.ts
@@ -3,9 +3,9 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
-  openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
   type OpenClawAgentDatabaseOptions,
@@ -27,25 +27,37 @@ function resolveDatabaseOptions(scope: SessionAccessScope): OpenClawAgentDatabas
   return toDatabaseOptions(resolveSqliteScope(scope));
 }
 
-function getSessionMemberKysely(database: OpenClawAgentDatabase) {
+function getSessionMemberKysely(database: Pick<OpenClawAgentDatabase, "db">) {
   return getNodeSqliteKysely<SessionMemberDatabase>(database.db);
 }
 
+function readSessionMembers<T>(
+  scope: SessionAccessScope,
+  fallback: T,
+  operation: (database: Pick<OpenClawAgentDatabase, "db">) => T,
+): T {
+  const result = withOpenClawAgentDatabaseReadOnly(operation, resolveDatabaseOptions(scope), {
+    throwOnMissingTable: true,
+  });
+  return result.found ? result.value : fallback;
+}
+
 export function listSessionMembers(scope: SessionAccessScope): SessionMember[] {
-  const database = openOpenClawAgentDatabase(resolveDatabaseOptions(scope));
-  const db = getSessionMemberKysely(database);
-  return executeSqliteQuerySync(
-    database.db,
-    db
-      .selectFrom("session_members")
-      .select(["identity_id", "added_by", "added_at"])
-      .where("session_key", "=", resolveSqliteScope(scope).sessionKey)
-      .orderBy("identity_id"),
-  ).rows.map((row) => ({
-    identityId: row.identity_id,
-    addedBy: row.added_by,
-    addedAt: row.added_at,
-  }));
+  return readSessionMembers(scope, [], (database) => {
+    const db = getSessionMemberKysely(database);
+    return executeSqliteQuerySync(
+      database.db,
+      db
+        .selectFrom("session_members")
+        .select(["identity_id", "added_by", "added_at"])
+        .where("session_key", "=", resolveSqliteScope(scope).sessionKey)
+        .orderBy("identity_id"),
+    ).rows.map((row) => ({
+      identityId: row.identity_id,
+      addedBy: row.added_by,
+      addedAt: row.added_at,
+    }));
+  });
 }
 
 export function listSessionMembershipKeys(
@@ -58,28 +70,32 @@ export function listSessionMembershipKeys(
   if (!normalizedIdentityId || normalizedSessionKeys.length === 0) {
     return new Set();
   }
-  const database = openOpenClawAgentDatabase(resolveDatabaseOptions(scope));
-  const db = getSessionMemberKysely(database);
-  const memberships = new Set<string>();
-  for (
-    let offset = 0;
-    offset < normalizedSessionKeys.length;
-    offset += SESSION_MEMBERSHIP_QUERY_CHUNK_SIZE
-  ) {
-    const chunk = normalizedSessionKeys.slice(offset, offset + SESSION_MEMBERSHIP_QUERY_CHUNK_SIZE);
-    const rows = executeSqliteQuerySync(
-      database.db,
-      db
-        .selectFrom("session_members")
-        .select("session_key")
-        .where("identity_id", "=", normalizedIdentityId)
-        .where("session_key", "in", chunk),
-    ).rows;
-    for (const row of rows) {
-      memberships.add(row.session_key);
+  return readSessionMembers(scope, new Set<string>(), (database) => {
+    const db = getSessionMemberKysely(database);
+    const memberships = new Set<string>();
+    for (
+      let offset = 0;
+      offset < normalizedSessionKeys.length;
+      offset += SESSION_MEMBERSHIP_QUERY_CHUNK_SIZE
+    ) {
+      const chunk = normalizedSessionKeys.slice(
+        offset,
+        offset + SESSION_MEMBERSHIP_QUERY_CHUNK_SIZE,
+      );
+      const rows = executeSqliteQuerySync(
+        database.db,
+        db
+          .selectFrom("session_members")
+          .select("session_key")
+          .where("identity_id", "=", normalizedIdentityId)
+          .where("session_key", "in", chunk),
+      ).rows;
+      for (const row of rows) {
+        memberships.add(row.session_key);
+      }
     }
-  }
-  return memberships;
+    return memberships;
+  });
 }
 
 export function isSessionMember(scope: SessionAccessScope, identityId: string): boolean {
@@ -87,18 +103,19 @@ export function isSessionMember(scope: SessionAccessScope, identityId: string): 
   if (!normalizedIdentityId) {
     return false;
   }
-  const database = openOpenClawAgentDatabase(resolveDatabaseOptions(scope));
-  const db = getSessionMemberKysely(database);
-  return Boolean(
-    executeSqliteQueryTakeFirstSync(
-      database.db,
-      db
-        .selectFrom("session_members")
-        .select("identity_id")
-        .where("session_key", "=", resolveSqliteScope(scope).sessionKey)
-        .where("identity_id", "=", normalizedIdentityId),
-    ),
-  );
+  return readSessionMembers(scope, false, (database) => {
+    const db = getSessionMemberKysely(database);
+    return Boolean(
+      executeSqliteQueryTakeFirstSync(
+        database.db,
+        db
+          .selectFrom("session_members")
+          .select("identity_id")
+          .where("session_key", "=", resolveSqliteScope(scope).sessionKey)
+          .where("identity_id", "=", normalizedIdentityId),
+      ),
+    );
+  });
 }
 
 // Membership is bound to a live session entry, never a transcript placeholder.

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -7,7 +7,9 @@ import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   closeOpenClawAgentDatabasesForTest,
+  isOpenClawAgentDatabaseOpen,
   openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import type { TranscriptEvent } from "./session-accessor.js";
@@ -107,6 +109,23 @@ function agentKysely() {
 }
 
 describe("searchSessionTranscripts", () => {
+  it("searches a populated closed database without reopening a writer", async () => {
+    await appendUserMessage("session-1", "agent:main:main", "readonly search needle");
+    const databasePath = resolveOpenClawAgentSqlitePath({ agentId: "main", env: env() });
+    closeOpenClawAgentDatabasesForTest();
+
+    expect(search("needle").hits).toHaveLength(1);
+    expect(isOpenClawAgentDatabaseOpen(databasePath)).toBe(false);
+  });
+
+  it("returns empty results without creating a missing database", () => {
+    const databasePath = resolveOpenClawAgentSqlitePath({ agentId: "main", env: env() });
+
+    expect(search("missing")).toEqual({ hits: [], indexing: false, truncated: false });
+    expect(fs.existsSync(databasePath)).toBe(false);
+    expect(isOpenClawAgentDatabaseOpen(databasePath)).toBe(false);
+  });
+
   it("indexes appended messages synchronously and returns bounded hits", async () => {
     await appendUserMessage("session-1", "agent:main:main", "the deployment failed on friday");
     await appendAssistantMessage("session-1", "agent:main:main", "the deployment fix is rolling");

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -2,7 +2,7 @@
 // inside the accessor's write transactions (session-transcript-index.ts);
 // this module owns the query path and schedules the shared reconcile owner
 // when doctor imports or out-of-band writes leave derived rows behind.
-import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
@@ -65,26 +65,27 @@ export function searchSessionTranscripts(params: {
     ...(params.env ? { env: params.env } : {}),
     ...(databasePath ? { path: databasePath } : {}),
   };
-  const database = openOpenClawAgentDatabase(databaseOptions);
-  const dirtySessions = listSessionsNeedingTranscriptIndexReconcile(database.db);
-  if (dirtySessions.length > 0) {
-    startSessionTranscriptIndexReconcile(databaseOptions);
-  }
-  const indexing =
-    dirtySessions.length > 0 || isSessionTranscriptIndexReconcileRunning(databaseOptions);
-  const limit = Math.min(Math.max(1, params.limit ?? 10), SEARCH_LIMIT_MAX);
-  const sessionKeys = params.sessionKeys ?? [];
-  const whereSession =
-    sessionKeys.length > 0
-      ? ` AND session_windows.session_key IN (${sessionKeys.map(() => "?").join(", ")})`
-      : "";
-  // MATCH, snippet(), and bm25() are FTS5 primitives without a Kysely
-  // representation. session_key lives on the window row so key renames
-  // never leave stale keys inside the index. Sessions flagged needs_rebuild
-  // are excluded: their rows may still hold rewound-away branch text that
-  // sessions_history no longer exposes, so they stay hidden until reconcile
-  // rebuilds them (indexing=true tells the caller to retry).
-  const statement = database.db.prepare(/* sqlite-allow-raw: FTS5 MATCH/snippet/bm25 */ `
+  const result = withOpenClawAgentDatabaseReadOnly(
+    (database) => {
+      const dirtySessions = listSessionsNeedingTranscriptIndexReconcile(database.db);
+      if (dirtySessions.length > 0) {
+        startSessionTranscriptIndexReconcile(databaseOptions);
+      }
+      const indexing =
+        dirtySessions.length > 0 || isSessionTranscriptIndexReconcileRunning(databaseOptions);
+      const limit = Math.min(Math.max(1, params.limit ?? 10), SEARCH_LIMIT_MAX);
+      const sessionKeys = params.sessionKeys ?? [];
+      const whereSession =
+        sessionKeys.length > 0
+          ? ` AND session_windows.session_key IN (${sessionKeys.map(() => "?").join(", ")})`
+          : "";
+      // MATCH, snippet(), and bm25() are FTS5 primitives without a Kysely
+      // representation. session_key lives on the window row so key renames
+      // never leave stale keys inside the index. Sessions flagged needs_rebuild
+      // are excluded: their rows may still hold rewound-away branch text that
+      // sessions_history no longer exposes, so they stay hidden until reconcile
+      // rebuilds them (indexing=true tells the caller to retry).
+      const statement = database.db.prepare(/* sqlite-allow-raw: FTS5 MATCH/snippet/bm25 */ `
     SELECT session_windows.session_key AS session_key, session_transcript_fts.session_id AS session_id,
       message_id, role, timestamp,
       snippet(session_transcript_fts, 0, '', '', ' … ', 48) AS snippet,
@@ -97,43 +98,48 @@ export function searchSessionTranscripts(params: {
       )
     ORDER BY rank ASC, timestamp DESC, message_id ASC
     LIMIT ?
-  `);
-  const values = [toFtsQuery(query), ...sessionKeys, limit + 1];
-  const rows = statement.all(...values) as Array<{
-    message_id: unknown;
-    rank: unknown;
-    role: unknown;
-    session_id: unknown;
-    session_key: unknown;
-    snippet: unknown;
-    timestamp: unknown;
-  }>;
-  const hits = rows.flatMap((row): SessionTranscriptSearchHit[] => {
-    if (
-      typeof row.session_key !== "string" ||
-      typeof row.session_id !== "string" ||
-      typeof row.message_id !== "string" ||
-      (row.role !== "user" && row.role !== "assistant") ||
-      typeof row.snippet !== "string"
-    ) {
-      return [];
-    }
-    const timestamp = typeof row.timestamp === "number" ? row.timestamp : Number(row.timestamp);
-    const rank = typeof row.rank === "number" ? row.rank : Number(row.rank);
-    return [
-      {
-        sessionKey: row.session_key,
-        sessionId: row.session_id,
-        messageId: row.message_id,
-        role: row.role,
-        timestamp: Number.isFinite(timestamp) ? timestamp : 0,
-        snippet:
-          row.snippet.length > SEARCH_SNIPPET_MAX_CHARS
-            ? `${truncateUtf16Safe(row.snippet, SEARCH_SNIPPET_MAX_CHARS)}…`
-            : row.snippet,
-        score: Number.isFinite(rank) ? -rank : 0,
-      },
-    ];
-  });
-  return { hits: hits.slice(0, limit), indexing, truncated: hits.length > limit };
+    `);
+      const values = [toFtsQuery(query), ...sessionKeys, limit + 1];
+      const rows = statement.all(...values) as Array<{
+        message_id: unknown;
+        rank: unknown;
+        role: unknown;
+        session_id: unknown;
+        session_key: unknown;
+        snippet: unknown;
+        timestamp: unknown;
+      }>;
+      const hits = rows.flatMap((row): SessionTranscriptSearchHit[] => {
+        if (
+          typeof row.session_key !== "string" ||
+          typeof row.session_id !== "string" ||
+          typeof row.message_id !== "string" ||
+          (row.role !== "user" && row.role !== "assistant") ||
+          typeof row.snippet !== "string"
+        ) {
+          return [];
+        }
+        const timestamp = typeof row.timestamp === "number" ? row.timestamp : Number(row.timestamp);
+        const rank = typeof row.rank === "number" ? row.rank : Number(row.rank);
+        return [
+          {
+            sessionKey: row.session_key,
+            sessionId: row.session_id,
+            messageId: row.message_id,
+            role: row.role,
+            timestamp: Number.isFinite(timestamp) ? timestamp : 0,
+            snippet:
+              row.snippet.length > SEARCH_SNIPPET_MAX_CHARS
+                ? `${truncateUtf16Safe(row.snippet, SEARCH_SNIPPET_MAX_CHARS)}…`
+                : row.snippet,
+            score: Number.isFinite(rank) ? -rank : 0,
+          },
+        ];
+      });
+      return { hits: hits.slice(0, limit), indexing, truncated: hits.length > limit };
+    },
+    databaseOptions,
+    { throwOnMissingTable: true },
+  );
+  return result.found ? result.value : { hits: [], indexing: false, truncated: false };
 }

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -637,7 +637,7 @@ test("session reads find a retired store only reachable through its deterministi
   expect(await listAgentIdsViaRpc()).toEqual(["main"]);
 });
 
-test("session reads still open stores for the default and configured agents", async () => {
+test("session reads do not provision missing stores for default or configured agents", async () => {
   await setAgentsConfig({ list: [{ id: "main", default: true }, { id: "work" }] });
   for (const agentId of ["main", "work"]) {
     const result = await directSessionReq<{ session: unknown }>("sessions.describe", {
@@ -651,12 +651,14 @@ test("session reads still open stores for the default and configured agents", as
           env: { OPENCLAW_STATE_DIR: requireStateDir() },
         }),
       ),
-    ).toBe(true);
+    ).toBe(false);
   }
 
   expect(
     listOpenClawRegisteredAgentDatabases({
       env: { OPENCLAW_STATE_DIR: requireStateDir() },
-    }).map((entry) => entry.agentId),
-  ).toEqual(expect.arrayContaining(["main", "work"]));
+    })
+      .map((entry) => entry.agentId)
+      .filter((agentId) => agentId === "main" || agentId === "work"),
+  ).toEqual([]);
 });

--- a/src/gateway/server.sessions.list-store-materialization.test.ts
+++ b/src/gateway/server.sessions.list-store-materialization.test.ts
@@ -10,7 +10,10 @@ import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import * as agentDatabaseRegistry from "../state/openclaw-agent-db-registry.js";
-import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import {
+  OPENCLAW_AGENT_DB_OPEN_HANDLE_CAP,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
 import { scheduleGatewayHandlerPrewarm } from "./server-startup-handler-prewarm.js";
 import type { SessionsListResult } from "./session-utils.types.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
@@ -95,6 +98,77 @@ test("sessions.list reuses prepared store targets for sharing", async () => {
     expect(discoverySpy.mock.calls.filter((call) => call[1] === "main")).toHaveLength(0);
   } finally {
     discoverySpy.mockRestore();
+  }
+});
+
+test("sessions.list keeps cold and warm transcript title batches valid beyond the database handle cap", async () => {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!stateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required for gateway session tests");
+  }
+  const agentIds = Array.from(
+    { length: OPENCLAW_AGENT_DB_OPEN_HANDLE_CAP + 1 },
+    (_, index) => `batch-agent-${index}`,
+  );
+  const storeTemplate = path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json");
+  testState.sessionConfig = { store: storeTemplate };
+  testState.agentsConfig = {
+    list: agentIds.map((id, index) => ({ id, default: index === 0 })),
+  };
+
+  for (const [index, agentId] of agentIds.entries()) {
+    const sessionId = `session-${agentId}`;
+    const sessionKey = `agent:${agentId}:main`;
+    const storePath = storeTemplate.replace("{agentId}", agentId);
+    await writeSessionStore({
+      agentId,
+      entries: {
+        [sessionKey]: sessionStoreEntry(sessionId, { updatedAt: 1_781_000_000_000 - index }),
+      },
+      storePath,
+    });
+    await seedSessionTranscript({
+      agentId,
+      messages: [
+        { role: "user", content: `Title ${agentId}` },
+        { role: "assistant", content: `Reply ${agentId}` },
+      ],
+      sessionId,
+      sessionKey,
+      storePath,
+    });
+  }
+
+  const watermarkBatchSpy = vi.spyOn(sessionAccessor, "readSessionTranscriptWatermarkBatch");
+  try {
+    for (const phase of ["cold", "warm"]) {
+      const result = await directSessionReq<SessionsListResult>("sessions.list", {
+        includeDerivedTitles: true,
+        includeLastMessage: true,
+        ...(phase === "warm" ? { limit: 100 } : {}),
+      });
+
+      expect(result.ok, `${phase} transcript title batch`).toBe(true);
+      expect(result.payload?.sessions, `${phase} transcript title batch`).toHaveLength(
+        agentIds.length,
+      );
+      expect(
+        result.payload?.sessions.every(
+          (session) =>
+            session.derivedTitle?.startsWith("Title ") &&
+            session.lastMessagePreview?.startsWith("Reply "),
+        ),
+        `${phase} transcript title batch`,
+      ).toBe(true);
+      if (phase === "warm") {
+        expect(
+          watermarkBatchSpy.mock.calls.some(([scopes]) => scopes.length === agentIds.length),
+        ).toBe(true);
+      }
+      watermarkBatchSpy.mockClear();
+    }
+  } finally {
+    watermarkBatchSpy.mockRestore();
   }
 });
 

--- a/src/gateway/session-group-mutation-targets.test.ts
+++ b/src/gateway/session-group-mutation-targets.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import { performance } from "node:perf_hooks";
+import { expect, test, vi } from "vitest";
+import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import * as sqliteWal from "../infra/sqlite-wal.js";
+import * as agentDatabaseLeases from "../state/openclaw-agent-db-lease.js";
+import * as agentDatabaseSchema from "../state/openclaw-agent-db-schema.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  listOpenClawAgentDatabasesForTest,
+  OPENCLAW_AGENT_DB_OPEN_HANDLE_CAP,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { setStateDirEnv, withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { resolveSessionGroupMutationTargetsByName } from "./session-sharing-target-input.js";
+
+test("discovers groups across more than the handle cap without writable database maintenance", async () => {
+  await withStateDirEnv("openclaw-session-group-readonly-", async ({ stateDir }) => {
+    setStateDirEnv(fs.realpathSync(stateDir));
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const agentIds = Array.from(
+      { length: OPENCLAW_AGENT_DB_OPEN_HANDLE_CAP + 1 },
+      (_, index) => `group-reader-${index}`,
+    );
+    const config = {
+      agents: {
+        list: agentIds.map((id, index) => ({ id, ...(index === 0 ? { default: true } : {}) })),
+      },
+    } satisfies OpenClawConfig;
+
+    for (const [index, agentId] of agentIds.entries()) {
+      await upsertSessionEntryCore(
+        { agentId, sessionKey: `agent:${agentId}:main` },
+        { category: "Shared work", sessionId: `group-session-${index}`, updatedAt: index + 1 },
+      );
+    }
+    closeOpenClawAgentDatabasesForTest();
+
+    const integritySpy = vi.spyOn(
+      agentDatabaseSchema,
+      "assertAgentDatabaseIntegrityBeforeMutation",
+    );
+    const claimSpy = vi.spyOn(agentDatabaseLeases, "claimOpenClawAgentDatabaseLease");
+    const releaseSpy = vi.spyOn(agentDatabaseLeases, "releaseOpenClawAgentDatabaseLease");
+    const walSpy = vi.spyOn(sqliteWal, "configureSqliteConnectionPragmas");
+
+    try {
+      let targets: ReturnType<typeof resolveSessionGroupMutationTargetsByName> | undefined;
+      const startedAt = performance.now();
+      try {
+        targets = resolveSessionGroupMutationTargetsByName(config);
+      } finally {
+        console.info(
+          JSON.stringify({
+            probe: "session-group-readonly-many-agents",
+            agents: agentIds.length,
+            elapsedMs: Math.round((performance.now() - startedAt) * 100) / 100,
+            integrityScans: integritySpy.mock.calls.length,
+            agentWalConfigurations: walSpy.mock.calls.filter(([, options]) =>
+              options?.databaseLabel?.startsWith("openclaw-agent:"),
+            ).length,
+            leaseClaims: claimSpy.mock.calls.length,
+            leaseReleases: releaseSpy.mock.calls.length,
+            openWriterHandles: listOpenClawAgentDatabasesForTest().length,
+            groupMembers: targets?.get("Shared work")?.length ?? 0,
+          }),
+        );
+      }
+
+      expect(targets?.get("Shared work")).toEqual(
+        agentIds.map((agentId) => ({ agentId, sessionKey: `agent:${agentId}:main` })),
+      );
+      expect(integritySpy.mock.calls.length).toBe(0);
+      expect(claimSpy.mock.calls.length).toBe(0);
+      expect(releaseSpy.mock.calls.length).toBe(0);
+      expect(
+        walSpy.mock.calls.filter(([, options]) =>
+          options?.databaseLabel?.startsWith("openclaw-agent:"),
+        ),
+      ).toEqual([]);
+      expect(listOpenClawAgentDatabasesForTest()).toEqual([]);
+    } finally {
+      integritySpy.mockRestore();
+      claimSpy.mockRestore();
+      releaseSpy.mockRestore();
+      walSpy.mockRestore();
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+    }
+  });
+});

--- a/src/gateway/session-sharing-target-input.ts
+++ b/src/gateway/session-sharing-target-input.ts
@@ -1,6 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions.js";
-import { listSessionEntriesCore } from "../config/sessions/session-accessor.js";
+import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { isIncognitoSessionKey } from "../shared/incognito-session-key.js";
@@ -13,7 +13,7 @@ export function resolveSessionGroupMutationTargetsByName(
 ): Map<string, SessionMutationTarget[]> {
   const targetsByName = new Map<string, SessionMutationTarget[]>();
   for (const storeTarget of resolveAllAgentSessionStoreTargetsSync(cfg)) {
-    for (const { sessionKey, entry } of listSessionEntriesCore({
+    for (const { sessionKey, entry } of listSessionEntriesReadOnly({
       agentId: storeTarget.agentId,
       storePath: storeTarget.storePath,
     })) {

--- a/src/gateway/session-transcript-readers.test.ts
+++ b/src/gateway/session-transcript-readers.test.ts
@@ -741,18 +741,24 @@ describe("session transcript reader facade", () => {
     }
     const prepareSpy = vi.spyOn(DatabaseSync.prototype, "prepare");
     try {
-      expect(sessionAccessor.readSessionTranscriptTitleProbeBatch(scopes)).toHaveLength(30);
-      const titleSchemaReads = prepareSpy.mock.calls.filter(([sql]) =>
-        sql.toLowerCase().includes("pragma user_version"),
-      );
-      expect(titleSchemaReads).toHaveLength(1);
+      for (const readBatch of [
+        sessionAccessor.readSessionTranscriptTitleProbeBatch,
+        sessionAccessor.readSessionTranscriptWatermarkBatch,
+      ]) {
+        prepareSpy.mockClear();
+        expect(readBatch(scopes.slice(0, 1))).toHaveLength(1);
+        const singleSessionSchemaReads = prepareSpy.mock.calls.filter(([sql]) =>
+          sql.toLowerCase().includes("pragma user_version"),
+        ).length;
 
-      prepareSpy.mockClear();
-      expect(sessionAccessor.readSessionTranscriptWatermarkBatch(scopes)).toHaveLength(30);
-      const watermarkSchemaReads = prepareSpy.mock.calls.filter(([sql]) =>
-        sql.toLowerCase().includes("pragma user_version"),
-      );
-      expect(watermarkSchemaReads).toHaveLength(1);
+        prepareSpy.mockClear();
+        expect(readBatch(scopes)).toHaveLength(scopes.length);
+        const batchSchemaReads = prepareSpy.mock.calls.filter(([sql]) =>
+          sql.toLowerCase().includes("pragma user_version"),
+        ).length;
+        expect(batchSchemaReads).toBe(singleSessionSchemaReads);
+        expect(batchSchemaReads).toBeGreaterThan(0);
+      }
     } finally {
       prepareSpy.mockRestore();
     }

--- a/src/state/openclaw-agent-db-readonly.ts
+++ b/src/state/openclaw-agent-db-readonly.ts
@@ -59,6 +59,7 @@ function findOpenAgentDatabase(
 export function withOpenClawAgentDatabaseReadOnly<T>(
   operation: (database: OpenClawAgentReadOnlyDatabase) => T,
   options: OpenClawAgentDatabaseOptions,
+  behavior: { throwOnMissingTable?: boolean } = {},
 ): OpenClawAgentDatabaseReadOnlyResult<T> {
   const agentId = normalizeAgentId(options.agentId);
   const pathname = resolveOpenClawAgentSqlitePath({ ...options, agentId });
@@ -82,7 +83,7 @@ export function withOpenClawAgentDatabaseReadOnly<T>(
     try {
       return { found: true, value: operation(opened) };
     } catch (error) {
-      if (isMissingTableError(error)) {
+      if (isMissingTableError(error) && !behavior.throwOnMissingTable) {
         return { found: false, reason: "table-missing" };
       }
       throw error;
@@ -104,7 +105,7 @@ export function withOpenClawAgentDatabaseReadOnly<T>(
     try {
       return { found: true, value: operation({ agentId, db, path: pathname }) };
     } catch (error) {
-      if (isMissingTableError(error)) {
+      if (isMissingTableError(error) && !behavior.throwOnMissingTable) {
         return { found: false, reason: "table-missing" };
       }
       throw error;


### PR DESCRIPTION
Related: #77373

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users listing sessions, looking up session groups or sharing membership, or searching transcripts would incur database writer initialization and maintenance for ordinary reads. Installations with many agents could experience multi-second read latency, unnecessary SQLite lease and WAL activity, or failed `sessions.list` requests after the bounded writer-handle registry evicted handles still referenced by batched title and watermark reads.

## Why This Change Was Made

Builds on the session/database ownership work in #113862 by moving entry read views, group discovery, sharing membership, transcript search, title probes, and transcript watermarks onto the canonical read-only database owner. Batched transcript reads now resolve store identities first and borrow one store at a time, so active handles cannot be invalidated by registry eviction. Missing databases remain absent; database creation, writes, integrity checks, WAL setup, leases, and transcript-index reconciliation remain with their explicit mutation or reconcile owners. Existing migration-required and missing-canonical-table errors remain explicit. The current-main shared-state SQLite schema remains v10 and the per-agent SQLite schema remains v17; this PR changes neither schema. This is a focused read-path performance and correctness repair; it does not claim to fully resolve #116877.

Rebased without conflicts onto `1473333f46d1b89e2bf1342d9ac5919d2c628d0c`, as requested by the durable ClawSweeper review. Current `main` moved group-target discovery into `src/gateway/session-sharing-target-input.ts` as part of its operator-role authorization changes, so the read-only invariant and regression target that canonical owner; the obsolete group-target module stays deleted. Newer gateway preview/history behavior, active-session maintenance, and progress-card artifact cleanup remain intact.

## User Impact

Read-only session and group operations stay fast as the number of agents grows, no longer create missing agent stores, and preserve correct session titles, previews, sharing membership, and transcript search results. Default cold and warm `sessions.list` requests now succeed even when the store count exceeds `OPENCLAW_AGENT_DB_OPEN_HANDLE_CAP`, instead of potentially failing with `ERR_INVALID_STATE`.

## Evidence

- Synthetic 65-agent read-only group operation: **3,192 ms before → 123 ms after**.
- Before: **65 integrity scans**, **65 WAL initializations/checkpoints**, **130 lease writes**, and retained writer handles. After: **zero** scans, WAL initializations/checkpoints, lease writes, and retained writer handles.
- Regression coverage exercises cold and warm default `sessions.list` with `OPENCLAW_AGENT_DB_OPEN_HANDLE_CAP + 1` stores and verifies successful responses with correct derived titles and last-message previews.
- Refreshed-head focused owner and sibling proof: **198 tests passed** across **13 files** and **three Vitest shards**, including readonly session access, sharing membership, transcript search, gateway session reads, list materialization, group targets, transcript readers, sharing policy/handlers, read caching, archive/delete lifecycle, and database-handle eviction.
- Exact local command: `node scripts/run-vitest.mjs src/config/sessions/session-accessor.readonly.test.ts src/config/sessions/session-sharing-store.test.ts src/config/sessions/session-transcript-search.test.ts src/gateway/server-methods/sessions-read.test.ts src/gateway/server.sessions.list-store-materialization.test.ts src/gateway/session-group-mutation-targets.test.ts src/gateway/session-transcript-readers.test.ts src/gateway/session-sharing.test.ts src/gateway/server-methods/sessions-sharing.test.ts src/gateway/server-methods/sessions-read-cache.test.ts src/gateway/server.sessions.archive-lifecycle.test.ts src/gateway/server.sessions.delete-lifecycle.test.ts src/state/openclaw-agent-db.cache-eviction.test.ts`.
- Actual `node scripts/check-changed.mjs -- <all 15 changed files>`: **core and coreTests passed**, including production and test typechecks, formatting, lint, dependency cycles, architecture boundaries, database-first checks, and the native schema guard.
- Shared-state SQLite remains **v10** and per-agent SQLite remains **v17**, matching the refreshed current-main base; the PR changes no schema, protocol, migration, or persistent-store contract.
- Fresh Codex autoreview against the exact rebased base: **no P0–P2 findings**.
- The prior ClawSweeper live verifier displayed **7/7 passing tests**; its reported failure was only a 30-second terminal-output observation timeout, not a test failure. The required current-main refresh and expanded owner-boundary rerun are complete.
- Production: **+224/-226 (net -2)**. Tests: **+273/-17 (net +256)**. Tooling/generated files: **0**.
- **AI-assisted:** Yes.
