### PR TITLE
fix(acp): context usage stays at 0% after the first prompt

### DIFF
--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -607,7 +607,13 @@ export class AcpTranslatorPromptStream {
     const promptKey = this.pendingPromptKey(sessionId, pending.idempotencyKey);
     this.settlingPromptKeys.add(promptKey);
     try {
-      const sessionSnapshot = await this.sessionState.getSnapshot(pending.sessionKey);
+      let sessionSnapshot = await this.sessionState.getSnapshot(pending.sessionKey);
+      if (!sessionSnapshot.usage || sessionSnapshot.usage.used === 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 1000);
+        });
+        sessionSnapshot = await this.sessionState.getSnapshot(pending.sessionKey);
+      }
       try {
         await this.sessionState.sendSnapshotUpdate(
           {

--- a/src/acp/translator.session-snapshot.test.ts
+++ b/src/acp/translator.session-snapshot.test.ts
@@ -15,6 +15,75 @@ vi.mock("./commands.js", () => ({
 }));
 
 describe("acp session metadata and usage updates", () => {
+  it("retries a zero-token final snapshot before resolving the prompt", async () => {
+    vi.useFakeTimers();
+    try {
+      const sessionStore = createInMemorySessionStore();
+      const connection = createAcpConnection();
+      const sessionUpdate = connection["__sessionUpdateMock"];
+      let sessionsListCalls = 0;
+      const request = vi.fn(async (method: string) => {
+        if (method === "sessions.list") {
+          sessionsListCalls += 1;
+          return {
+            ts: Date.now(),
+            path: "/tmp/sessions.json",
+            count: 1,
+            defaults: {
+              modelProvider: null,
+              model: null,
+              contextTokens: null,
+            },
+            sessions: [
+              {
+                key: "usage-session",
+                displayName: "Usage session",
+                kind: "direct",
+                updatedAt: 1_710_000_123_000,
+                modelProvider: "openai",
+                model: "gpt-5.4",
+                totalTokens: sessionsListCalls >= 3 ? 1200 : 0,
+                totalTokensFresh: true,
+                contextTokens: 4000,
+              },
+            ],
+          };
+        }
+        if (method === "chat.send") {
+          return new Promise(() => {});
+        }
+        return { ok: true };
+      }) as GatewayClient["request"];
+      const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+        sessionStore,
+      });
+
+      await agent.loadSession(createLoadSessionRequest("usage-session"));
+      sessionUpdate.mockClear();
+
+      const promptPromise = agent.prompt(createPromptRequest("usage-session", "hello"));
+      const finalPromise = agent.handleGatewayEvent(createChatFinalEvent("usage-session"));
+      await vi.advanceTimersByTimeAsync(1000);
+      await finalPromise;
+      await promptPromise;
+
+      expect(sessionUpdate).toHaveBeenCalledWith({
+        sessionId: "usage-session",
+        update: {
+          sessionUpdate: "usage_update",
+          used: 1200,
+          size: 4000,
+          _meta: {
+            source: "gateway-session-store",
+            approximate: true,
+          },
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits a fresh usage snapshot after prompt completion when gateway totals are available", async () => {
     const sessionStore = createInMemorySessionStore();
     const connection = createAcpConnection();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a new ACP session would see context usage remain at 0% after the first prompt, even though the completed model call had consumed tokens. Reloading the session later showed the correct usage.

The incorrect value was delivered through the ACP `usage_update` event, so ACP clients had no fresh non-zero usage value to display after the first response.

## Why This Change Was Made

This was caused by a timing race between the final chat event and Gateway session usage persistence. The ACP bridge handled the final event and read the session snapshot before the Gateway had persisted the completed run's token usage. It therefore emitted an ACP `usage_update` with `used: 0`; the correct token count became available only afterward.

When the final snapshot has missing usage or `used: 0`, the bridge now waits one second and reads the Gateway session snapshot once more before emitting `usage_update` and resolving the prompt. The retry is bounded and does not affect snapshots that already contain non-zero usage.

## User Impact

ACP clients can display accurate context usage immediately after the first prompt instead of showing 0% until the session is reloaded.

## Evidence

Before the change, the first ACP `usage_update` for a live new session reported:

Focused validation:
- pnpm test src/acp/translator.session-snapshot.test.ts
- pnpm exec oxfmt --check src/acp/translator.prompt-stream.ts src/acp/translator.session-snapshot.test.ts
- pnpm exec oxlint src/acp/translator.prompt-stream.ts src/acp/translator.session-snapshot.test.ts

The regression test uses fake timers to reproduce the timing race: the first final snapshot reports zero usage, and the refreshed snapshot reports the persisted non-zero usage after the one-second retry.