### PR TITLE
fix(sqlite): stage read-only snapshots in private user cache

### DIFF
--- a/src/infra/sqlite-private-directory.test.ts
+++ b/src/infra/sqlite-private-directory.test.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnv } from "../test-utils/env.js";
 
 const childProcess = vi.hoisted(() => ({
   execFile: vi.fn(),
@@ -21,7 +23,9 @@ vi.mock("./windows-encoding.js", async (importOriginal) => {
 import {
   createPrivateSqliteDirectory,
   createPrivateSqliteTempDirectorySync,
+  resolvePrivateSqliteSnapshotStagingRoot,
 } from "./sqlite-private-directory.js";
+import * as tmpOpenClawDir from "./tmp-openclaw-dir.js";
 
 function errorCause(error: unknown): Error {
   expect(error).toBeInstanceOf(Error);
@@ -36,6 +40,62 @@ describe("private Windows SQLite directory diagnostics", () => {
     childProcess.execFile.mockReset();
     childProcess.execFileSync.mockReset();
   });
+
+  it.each([
+    {
+      label: "an absolute LOCALAPPDATA root",
+      xdgCacheHome: undefined,
+      localAppData: path.resolve("sqlite-local-app-data"),
+      expectedRoot: path.resolve("sqlite-local-app-data"),
+    },
+    {
+      label: "LOCALAPPDATA when XDG_CACHE_HOME is relative",
+      xdgCacheHome: "relative/cache",
+      localAppData: path.resolve("sqlite-local-app-data"),
+      expectedRoot: path.resolve("sqlite-local-app-data"),
+    },
+    {
+      label: "HOME/AppData/Local when LOCALAPPDATA is absent",
+      xdgCacheHome: undefined,
+      localAppData: undefined,
+      expectedRoot: path.join(path.resolve("sqlite-home"), "AppData", "Local"),
+    },
+    {
+      label: "HOME/AppData/Local when LOCALAPPDATA is relative",
+      xdgCacheHome: undefined,
+      localAppData: "relative/local-app-data",
+      expectedRoot: path.join(path.resolve("sqlite-home"), "AppData", "Local"),
+    },
+    {
+      label: "absolute XDG_CACHE_HOME ahead of LOCALAPPDATA",
+      xdgCacheHome: path.resolve("sqlite-xdg-cache"),
+      localAppData: path.resolve("sqlite-local-app-data"),
+      expectedRoot: path.resolve("sqlite-xdg-cache"),
+    },
+  ])(
+    "selects $label for the Windows snapshot cache",
+    ({ xdgCacheHome, localAppData, expectedRoot }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const resolveTempRoot = vi
+        .spyOn(tmpOpenClawDir, "resolvePreferredOpenClawTmpDir")
+        .mockImplementation((options) => options?.preferredDir ?? "");
+
+      withEnv(
+        {
+          HOME: path.resolve("sqlite-home"),
+          LOCALAPPDATA: localAppData,
+          XDG_CACHE_HOME: xdgCacheHome,
+        },
+        () => {
+          expect(resolvePrivateSqliteSnapshotStagingRoot()).toBe(
+            path.join(expectedRoot, "openclaw"),
+          );
+        },
+      );
+
+      expect(resolveTempRoot.mock.calls[0]?.[0]?.tmpdir?.()).toBe(expectedRoot);
+    },
+  );
 
   it("reports bounded async stderr without retaining the child-process error", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");

--- a/src/infra/sqlite-private-directory.ts
+++ b/src/infra/sqlite-private-directory.ts
@@ -209,12 +209,12 @@ function createPrivateSqliteDirectorySync(directoryPath: string): void {
 }
 
 export function resolvePrivateSqliteSnapshotStagingRoot(): string {
-  const configuredRoot = process.env.XDG_CACHE_HOME?.trim();
-  const defaultRoot = process.platform === "darwin" ? "Library/Caches" : ".cache";
+  const appData = process.platform === "win32" ? process.env.LOCALAPPDATA?.trim() : undefined;
+  const defaultRoot = process.platform === "win32" ? "AppData/Local" : ".cache";
+  const platformRoot = process.platform === "darwin" ? "Library/Caches" : defaultRoot;
   const cacheRoot =
-    configuredRoot && path.isAbsolute(configuredRoot)
-      ? configuredRoot
-      : path.join(resolveRequiredOsHomeDir(), defaultRoot);
+    [process.env.XDG_CACHE_HOME?.trim(), appData].find((root) => root && path.isAbsolute(root)) ??
+    path.join(resolveRequiredOsHomeDir(), platformRoot);
   return resolvePreferredOpenClawTmpDir({
     preferredDir: path.join(cacheRoot, "openclaw"),
     tmpdir: () => cacheRoot,

--- a/src/infra/sqlite-private-directory.ts
+++ b/src/infra/sqlite-private-directory.ts
@@ -4,7 +4,9 @@ import { randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolveRequiredOsHomeDir } from "./home-dir.js";
 import { resolveSystemBin } from "./resolve-system-bin.js";
+import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
 import { decodeWindowsOutputBuffer } from "./windows-encoding.js";
 import {
   buildEncodedPowerShellArgs,
@@ -204,6 +206,19 @@ function createPrivateSqliteDirectorySync(directoryPath: string): void {
   } catch (error) {
     throw privateDirectoryError(directoryPath, error);
   }
+}
+
+export function resolvePrivateSqliteSnapshotStagingRoot(): string {
+  const configuredRoot = process.env.XDG_CACHE_HOME?.trim();
+  const defaultRoot = process.platform === "darwin" ? "Library/Caches" : ".cache";
+  const cacheRoot =
+    configuredRoot && path.isAbsolute(configuredRoot)
+      ? configuredRoot
+      : path.join(resolveRequiredOsHomeDir(), defaultRoot);
+  return resolvePreferredOpenClawTmpDir({
+    preferredDir: path.join(cacheRoot, "openclaw"),
+    tmpdir: () => cacheRoot,
+  });
 }
 
 export async function createPrivateSqliteTempDirectory(

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -297,6 +297,39 @@ describe("prepareSqliteReadOnlyLocation", () => {
     },
   );
 
+  it("identifies nested Windows private-directory allocation failures without losing their cause", async () => {
+    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-windows-allocation-");
+    const databasePath = createTempDatabasePath();
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(databasePath);
+    database.exec("CREATE TABLE probe (value TEXT);");
+    database.close();
+    const stagingRoot = path.join(cacheRoot, "openclaw");
+    const directoryPath = path.join(stagingRoot, "openclaw-sqlite-readonly-stage");
+    const allocationError = Object.assign(new Error("PowerShell failed (code=EACCES)"), {
+      code: "EACCES",
+      path: directoryPath,
+    });
+    const windowsError = new Error(
+      `Unable to create private Windows SQLite directory: ${directoryPath}`,
+      { cause: allocationError },
+    );
+    vi.spyOn(fs.promises, "mkdtemp").mockRejectedValueOnce(windowsError);
+
+    await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+      const error = await prepareSqliteReadOnlyLocationInProcess(databasePath).catch(
+        (cause: unknown) => cause,
+      );
+      expect(error).toMatchObject({ cause: windowsError });
+      expect((error as Error).message).toContain(windowsError.message);
+      expect((error as Error).message).toContain(stagingRoot);
+      expect((error as Error).message).toContain("XDG_CACHE_HOME");
+      expect(((error as Error).cause as Error).cause).toBe(allocationError);
+    });
+
+    expect(fs.readdirSync(stagingRoot)).toEqual([]);
+  });
+
   it.each([
     { label: "SQLite source read", code: "ERR_SQLITE_ERROR", errcode: 266 },
     { label: "SQLite source locking", code: "ERR_SQLITE_ERROR", errcode: 5 },

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -227,6 +227,76 @@ describe("prepareSqliteReadOnlyLocation", () => {
     },
   );
 
+  it.each(
+    [
+      {
+        mode: "async backup",
+        prepare: prepareSqliteReadOnlyLocationInProcess,
+        empty: false,
+        sync: false,
+      },
+      {
+        mode: "async copy",
+        prepare: prepareSqliteReadOnlyLocationInProcess,
+        empty: true,
+        sync: false,
+      },
+      {
+        mode: "sync copy",
+        prepare: prepareSqliteReadOnlyLocationSyncInProcess,
+        empty: false,
+        sync: true,
+      },
+    ].flatMap((scenario) =>
+      ["ENOSPC", "EDQUOT", "EACCES", "EPERM", "EROFS"].map((code) =>
+        Object.assign({}, scenario, { code }),
+      ),
+    ),
+  )(
+    "identifies $mode private cache allocation failure $code before backup or copying",
+    async ({ code, empty, prepare, sync }) => {
+      const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-allocation-");
+      const databasePath = createTempDatabasePath();
+      const sqlite = requireNodeSqlite();
+      if (empty) {
+        fs.writeFileSync(databasePath, "");
+      } else {
+        const database = new sqlite.DatabaseSync(databasePath);
+        database.exec("CREATE TABLE probe (value TEXT);");
+        database.close();
+      }
+      const stagingRoot = path.join(cacheRoot, "openclaw");
+      const allocationError = Object.assign(new Error("snapshot directory allocation failed"), {
+        code,
+        path: path.join(stagingRoot, "openclaw-sqlite-readonly-stage"),
+      });
+      const backup = vi.spyOn(sqlite, "backup");
+      const write = vi.spyOn(fs, "writeSync");
+      if (sync) {
+        vi.spyOn(fs, "mkdtempSync").mockImplementationOnce(() => {
+          throw allocationError;
+        });
+      } else {
+        vi.spyOn(fs.promises, "mkdtemp").mockRejectedValueOnce(allocationError);
+      }
+
+      await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+        const error = await Promise.resolve()
+          .then(() => prepare(databasePath))
+          .catch((cause: unknown) => cause);
+        expect(error).toMatchObject({
+          cause: allocationError,
+          message: expect.stringContaining(stagingRoot),
+        });
+        expect((error as Error).message).toContain("XDG_CACHE_HOME");
+      });
+
+      expect(backup).not.toHaveBeenCalled();
+      expect(write).not.toHaveBeenCalled();
+      expect(fs.readdirSync(stagingRoot)).toEqual([]);
+    },
+  );
+
   it.each([
     { label: "SQLite source read", code: "ERR_SQLITE_ERROR", errcode: 266 },
     { label: "SQLite source locking", code: "ERR_SQLITE_ERROR", errcode: 5 },

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -202,52 +202,146 @@ describe("prepareSqliteReadOnlyLocation", () => {
     });
   });
 
-  it("retains the quota failure and identifies the exhausted snapshot cache", async () => {
-    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-full-");
+  it.each([13, 778, 1034, 1290])(
+    "retains SQLite destination write failure %i and identifies the snapshot cache",
+    async (errcode) => {
+      const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-full-");
+      const sqlite = requireNodeSqlite();
+      const databasePath = createTempDatabasePath();
+      const database = new sqlite.DatabaseSync(databasePath);
+      database.exec("CREATE TABLE probe (value TEXT);");
+      database.close();
+      const quotaError = Object.assign(new Error("disk I/O error"), {
+        code: "ERR_SQLITE_ERROR",
+        errcode,
+      });
+      vi.spyOn(sqlite, "backup").mockRejectedValueOnce(quotaError);
+
+      await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+        await expect(prepareSqliteReadOnlyLocationInProcess(databasePath)).rejects.toMatchObject({
+          cause: quotaError,
+          message: expect.stringContaining(`SQLite errcode=${errcode}`),
+        });
+      });
+      expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
+    },
+  );
+
+  it.each([
+    { label: "SQLite source read", code: "ERR_SQLITE_ERROR", errcode: 266 },
+    { label: "SQLite source locking", code: "ERR_SQLITE_ERROR", errcode: 5 },
+    { label: "filesystem source read", code: "EACCES", errcode: undefined },
+  ])("preserves $label failures without staging guidance", async ({ label, code, errcode }) => {
+    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-source-failure-");
     const sqlite = requireNodeSqlite();
     const databasePath = createTempDatabasePath();
     const database = new sqlite.DatabaseSync(databasePath);
     database.exec("CREATE TABLE probe (value TEXT);");
     database.close();
-    const quotaError = Object.assign(new Error("disk I/O error"), {
-      code: "ERR_SQLITE_ERROR",
-      errcode: 778,
+    const sourceError = Object.assign(new Error(label), {
+      code,
+      ...(errcode === undefined ? { path: databasePath } : { errcode }),
     });
-    vi.spyOn(sqlite, "backup").mockRejectedValueOnce(quotaError);
+    vi.spyOn(sqlite, "backup").mockRejectedValueOnce(sourceError);
+
+    await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+      await expect(prepareSqliteReadOnlyLocationInProcess(databasePath)).rejects.toBe(sourceError);
+    });
+    expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
+  });
+
+  it("identifies filesystem failures whose path belongs to the staging destination", async () => {
+    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-destination-path-");
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const database = new sqlite.DatabaseSync(databasePath);
+    database.exec("CREATE TABLE probe (value TEXT);");
+    database.close();
+    vi.spyOn(sqlite, "backup").mockImplementationOnce(async (_source, destination) => {
+      throw Object.assign(new Error("destination permission denied"), {
+        code: "EACCES",
+        path: String(destination),
+      });
+    });
 
     await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
       await expect(prepareSqliteReadOnlyLocationInProcess(databasePath)).rejects.toMatchObject({
-        cause: quotaError,
+        cause: { code: "EACCES", path: expect.stringContaining(cacheRoot) },
         message: expect.stringContaining(cacheRoot),
       });
     });
     expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
   });
 
-  it("keeps synchronous destination quota failures actionable without changing the source", async () => {
-    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-sync-full-");
+  it("preserves source corruption without reporting a snapshot staging quota failure", async () => {
+    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-corrupt-source-");
     const sqlite = requireNodeSqlite();
     const databasePath = createTempDatabasePath();
     const database = new sqlite.DatabaseSync(databasePath);
-    database.exec("CREATE TABLE probe (value TEXT);");
+    database.exec("CREATE TABLE probe (value TEXT); INSERT INTO probe VALUES ('corrupt');");
     database.close();
-    const before = readFamily(databasePath);
-    const quotaError = Object.assign(new Error("Disk quota exceeded"), { code: "EDQUOT" });
-    vi.spyOn(fs, "writeSync").mockImplementationOnce(() => {
-      throw quotaError;
-    });
+
+    const descriptor = fs.openSync(databasePath, "r+");
+    try {
+      fs.writeSync(descriptor, Buffer.from([0]), 0, 1, 100);
+    } finally {
+      fs.closeSync(descriptor);
+    }
+
+    const corruptSource = new sqlite.DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(() => corruptSource.prepare("PRAGMA quick_check;").get()).toThrow(
+        /database disk image is malformed/u,
+      );
+    } finally {
+      corruptSource.close();
+    }
 
     await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
-      expect(() => prepareSqliteReadOnlyLocationSyncInProcess(databasePath)).toThrowError(
-        expect.objectContaining({
-          cause: quotaError,
-          message: expect.stringContaining(cacheRoot),
-        }),
+      const inProcessError = await prepareSqliteReadOnlyLocationInProcess(databasePath).catch(
+        (error: unknown) => error,
       );
+      const workerError = await prepareSqliteReadOnlyLocation(databasePath).catch(
+        (error: unknown) => error,
+      );
+
+      expect(inProcessError).toMatchObject({
+        errcode: 11,
+        message: "database disk image is malformed",
+      });
+      expect(workerError).toBeInstanceOf(Error);
+      expect((workerError as Error).message).toContain("database disk image is malformed");
+      expect((workerError as Error).message).not.toMatch(/staging|quota|XDG_CACHE_HOME/u);
     });
-    expect(readFamily(databasePath)).toEqual(before);
-    expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
   });
+
+  it.each(["EDQUOT", "ENOSPC"])(
+    "keeps synchronous destination %s failures actionable without changing the source",
+    async (code) => {
+      const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-sync-full-");
+      const sqlite = requireNodeSqlite();
+      const databasePath = createTempDatabasePath();
+      const database = new sqlite.DatabaseSync(databasePath);
+      database.exec("CREATE TABLE probe (value TEXT);");
+      database.close();
+      const before = readFamily(databasePath);
+      const quotaError = Object.assign(new Error("Disk quota exceeded"), { code });
+      vi.spyOn(fs, "writeSync").mockImplementationOnce(() => {
+        throw quotaError;
+      });
+
+      await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+        expect(() => prepareSqliteReadOnlyLocationSyncInProcess(databasePath)).toThrowError(
+          expect.objectContaining({
+            cause: quotaError,
+            message: expect.stringContaining(cacheRoot),
+          }),
+        );
+      });
+      expect(readFamily(databasePath)).toEqual(before);
+      expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
+    },
+  );
 
   it("keeps a newly created cache root on the requested cache filesystem", async () => {
     const cacheRoot = path.join(tempDirs.make("openclaw-sqlite-snapshot-new-cache-"), "missing");

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -297,38 +297,47 @@ describe("prepareSqliteReadOnlyLocation", () => {
     },
   );
 
-  it("identifies nested Windows private-directory allocation failures without losing their cause", async () => {
-    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-windows-allocation-");
-    const databasePath = createTempDatabasePath();
-    const sqlite = requireNodeSqlite();
-    const database = new sqlite.DatabaseSync(databasePath);
-    database.exec("CREATE TABLE probe (value TEXT);");
-    database.close();
-    const stagingRoot = path.join(cacheRoot, "openclaw");
-    const directoryPath = path.join(stagingRoot, "openclaw-sqlite-readonly-stage");
-    const allocationError = Object.assign(new Error("PowerShell failed (code=EACCES)"), {
-      code: "EACCES",
-      path: directoryPath,
-    });
-    const windowsError = new Error(
-      `Unable to create private Windows SQLite directory: ${directoryPath}`,
-      { cause: allocationError },
-    );
-    vi.spyOn(fs.promises, "mkdtemp").mockRejectedValueOnce(windowsError);
-
-    await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
-      const error = await prepareSqliteReadOnlyLocationInProcess(databasePath).catch(
-        (cause: unknown) => cause,
+  it.each([
+    { mode: "async", prepare: prepareSqliteReadOnlyLocationInProcess, sync: false },
+    { mode: "sync", prepare: prepareSqliteReadOnlyLocationSyncInProcess, sync: true },
+  ])(
+    "identifies sanitized $mode Windows allocation failures without losing their causes",
+    async ({ prepare, sync }) => {
+      const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-windows-allocation-");
+      const databasePath = createTempDatabasePath();
+      const sqlite = requireNodeSqlite();
+      const database = new sqlite.DatabaseSync(databasePath);
+      database.exec("CREATE TABLE probe (value TEXT);");
+      database.close();
+      const stagingRoot = path.join(cacheRoot, "openclaw");
+      const directoryPath = path.join(stagingRoot, "openclaw-sqlite-readonly-stage");
+      const allocationError = new Error("PowerShell failed (status=1); stderr: Access is denied.");
+      const windowsError = new Error(
+        `Unable to create private Windows SQLite directory: ${directoryPath}`,
+        { cause: allocationError },
       );
-      expect(error).toMatchObject({ cause: windowsError });
-      expect((error as Error).message).toContain(windowsError.message);
-      expect((error as Error).message).toContain(stagingRoot);
-      expect((error as Error).message).toContain("XDG_CACHE_HOME");
-      expect(((error as Error).cause as Error).cause).toBe(allocationError);
-    });
+      if (sync) {
+        vi.spyOn(fs, "mkdtempSync").mockImplementationOnce(() => {
+          throw windowsError;
+        });
+      } else {
+        vi.spyOn(fs.promises, "mkdtemp").mockRejectedValueOnce(windowsError);
+      }
 
-    expect(fs.readdirSync(stagingRoot)).toEqual([]);
-  });
+      await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+        const error = await Promise.resolve()
+          .then(() => prepare(databasePath))
+          .catch((cause: unknown) => cause);
+        expect(error).toMatchObject({ cause: windowsError });
+        expect((error as Error).message).toContain(windowsError.message);
+        expect((error as Error).message).toContain(stagingRoot);
+        expect((error as Error).message).toContain("XDG_CACHE_HOME");
+        expect(((error as Error).cause as Error).cause).toBe(allocationError);
+      });
+
+      expect(fs.readdirSync(stagingRoot)).toEqual([]);
+    },
+  );
 
   it.each([
     { label: "SQLite source read", code: "ERR_SQLITE_ERROR", errcode: 266 },

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -2,9 +2,11 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
 import { Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import {
   prepareSqliteReadOnlyLocation,
@@ -143,6 +145,177 @@ describe("prepareSqliteReadOnlyLocation", () => {
   it("prepares a readable WAL snapshot through the sync public entry point", async () => {
     await expectPublicSnapshot(prepareSqliteReadOnlyLocationSync);
   });
+
+  it.each([
+    { mode: "async", prepare: prepareSqliteReadOnlyLocation },
+    { mode: "sync", prepare: prepareSqliteReadOnlyLocationSync },
+  ])("stages the $mode isolated worker snapshot in the private user cache", async ({ prepare }) => {
+    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-cache-");
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const database = new sqlite.DatabaseSync(databasePath);
+    database.exec("CREATE TABLE probe (value TEXT); INSERT INTO probe VALUES ('cached');");
+    database.close();
+
+    await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+      const prepared = await prepare(databasePath);
+      try {
+        expect(prepared.location.startsWith(`${cacheRoot}${path.sep}`)).toBe(true);
+        expect(fs.statSync(path.dirname(prepared.location)).mode & 0o777).toBe(0o700);
+        const snapshot = new sqlite.DatabaseSync(prepared.location, { readOnly: true });
+        expect(snapshot.prepare("SELECT value FROM probe").all()).toEqual([{ value: "cached" }]);
+        snapshot.close();
+      } finally {
+        expect(prepared.cleanup()).toBe(true);
+      }
+    });
+  });
+
+  it("avoids an exhausted OS temp root when a private cache can hold the snapshot", async () => {
+    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-quota-");
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const database = new sqlite.DatabaseSync(databasePath);
+    database.exec("CREATE TABLE probe (value TEXT); INSERT INTO probe VALUES ('survived');");
+    database.close();
+    const before = readFamily(databasePath);
+    const quotaError = Object.assign(new Error("disk I/O error"), {
+      code: "ERR_SQLITE_ERROR",
+      errcode: 778,
+    });
+    const backup = sqlite.backup.bind(sqlite);
+    vi.spyOn(sqlite, "backup").mockImplementation(async (source, destination, options) => {
+      if (!String(destination).startsWith(`${cacheRoot}${path.sep}`)) {
+        throw quotaError;
+      }
+      return await (options ? backup(source, destination, options) : backup(source, destination));
+    });
+
+    await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+      const prepared = await prepareSqliteReadOnlyLocationInProcess(databasePath);
+      try {
+        expect(prepared.location.startsWith(`${cacheRoot}${path.sep}`)).toBe(true);
+        expect(readFamily(databasePath)).toEqual(before);
+      } finally {
+        expect(prepared.cleanup()).toBe(true);
+      }
+    });
+  });
+
+  it("retains the quota failure and identifies the exhausted snapshot cache", async () => {
+    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-full-");
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const database = new sqlite.DatabaseSync(databasePath);
+    database.exec("CREATE TABLE probe (value TEXT);");
+    database.close();
+    const quotaError = Object.assign(new Error("disk I/O error"), {
+      code: "ERR_SQLITE_ERROR",
+      errcode: 778,
+    });
+    vi.spyOn(sqlite, "backup").mockRejectedValueOnce(quotaError);
+
+    await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+      await expect(prepareSqliteReadOnlyLocationInProcess(databasePath)).rejects.toMatchObject({
+        cause: quotaError,
+        message: expect.stringContaining(cacheRoot),
+      });
+    });
+    expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
+  });
+
+  it("keeps synchronous destination quota failures actionable without changing the source", async () => {
+    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-sync-full-");
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const database = new sqlite.DatabaseSync(databasePath);
+    database.exec("CREATE TABLE probe (value TEXT);");
+    database.close();
+    const before = readFamily(databasePath);
+    const quotaError = Object.assign(new Error("Disk quota exceeded"), { code: "EDQUOT" });
+    vi.spyOn(fs, "writeSync").mockImplementationOnce(() => {
+      throw quotaError;
+    });
+
+    await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+      expect(() => prepareSqliteReadOnlyLocationSyncInProcess(databasePath)).toThrowError(
+        expect.objectContaining({
+          cause: quotaError,
+          message: expect.stringContaining(cacheRoot),
+        }),
+      );
+    });
+    expect(readFamily(databasePath)).toEqual(before);
+    expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
+  });
+
+  it("keeps a newly created cache root on the requested cache filesystem", async () => {
+    const cacheRoot = path.join(tempDirs.make("openclaw-sqlite-snapshot-new-cache-"), "missing");
+    const sqlite = requireNodeSqlite();
+    const databasePath = createTempDatabasePath();
+    const database = new sqlite.DatabaseSync(databasePath);
+    database.exec("CREATE TABLE probe (value TEXT);");
+    database.close();
+
+    await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+      const prepared = await prepareSqliteReadOnlyLocation(databasePath);
+      try {
+        expect(prepared.location.startsWith(`${cacheRoot}${path.sep}`)).toBe(true);
+        expect(fs.statSync(path.dirname(prepared.location)).mode & 0o777).toBe(0o700);
+      } finally {
+        expect(prepared.cleanup()).toBe(true);
+      }
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "reports the real SQLite write errcode across the isolated worker boundary",
+    () => {
+      const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-worker-full-");
+      const sqlite = requireNodeSqlite();
+      const databasePath = createTempDatabasePath();
+      const database = new sqlite.DatabaseSync(databasePath);
+      database.exec(
+        "CREATE TABLE probe (payload BLOB); INSERT INTO probe VALUES (zeroblob(8192));",
+      );
+      database.close();
+      const moduleUrl = pathToFileURL(path.resolve("src/infra/sqlite-readonly-location.ts")).href;
+      const script = `
+        const { prepareSqliteReadOnlyLocation } = await import(${JSON.stringify(moduleUrl)});
+        try {
+          await prepareSqliteReadOnlyLocation(${JSON.stringify(databasePath)});
+          process.exitCode = 24;
+        } catch (error) {
+          console.log(JSON.stringify({ message: error.message }));
+        }
+      `;
+      const child = spawnSync(
+        "/bin/sh",
+        [
+          "-c",
+          'ulimit -f 1; exec "$@"',
+          "openclaw-sqlite-snapshot-quota",
+          process.execPath,
+          "--import",
+          "tsx",
+          "--input-type=module",
+          "-e",
+          script,
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: { ...process.env, XDG_CACHE_HOME: cacheRoot },
+        },
+      );
+
+      expect(child.status, child.stderr).toBe(0);
+      const reported = JSON.parse(child.stdout) as { message: string };
+      expect(reported.message).toContain(cacheRoot);
+      expect(reported.message).toMatch(/free.*space|quota/iu);
+      expect(reported.message).toContain("778");
+    },
+  );
 
   it("propagates async public entry point failures", async () => {
     const missingPath = path.join(tempDirs.make("openclaw-sqlite-readonly-missing-"), "missing.db");

--- a/src/infra/sqlite-readonly-location.test.ts
+++ b/src/infra/sqlite-readonly-location.test.ts
@@ -362,6 +362,31 @@ describe("prepareSqliteReadOnlyLocation", () => {
     expect(fs.readdirSync(path.join(cacheRoot, "openclaw"))).toEqual([]);
   });
 
+  it("preserves source failures inside the snapshot cache without staging guidance", async () => {
+    const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-cached-source-");
+    const stagingRoot = path.join(cacheRoot, "openclaw");
+    fs.mkdirSync(stagingRoot, { mode: 0o700 });
+    const databasePath = path.join(stagingRoot, "source.sqlite");
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(databasePath);
+    database.exec("CREATE TABLE probe (value TEXT);");
+    database.close();
+    const sourceError = Object.assign(new Error("source permission denied"), {
+      code: "EACCES",
+      path: databasePath,
+    });
+    vi.spyOn(sqlite, "backup").mockRejectedValueOnce(sourceError);
+
+    await withEnvAsync({ XDG_CACHE_HOME: cacheRoot }, async () => {
+      const error = await prepareSqliteReadOnlyLocationInProcess(databasePath).catch(
+        (cause: unknown) => cause,
+      );
+      expect(error).toBe(sourceError);
+      expect((error as Error).message).not.toMatch(/staging|quota|XDG_CACHE_HOME/u);
+    });
+    expect(fs.readdirSync(stagingRoot)).toEqual(["source.sqlite"]);
+  });
+
   it("identifies filesystem failures whose path belongs to the staging destination", async () => {
     const cacheRoot = tempDirs.make("openclaw-sqlite-snapshot-destination-path-");
     const sqlite = requireNodeSqlite();

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -2,6 +2,7 @@
 import { execFile, spawnSync } from "node:child_process";
 import fs, { type BigIntStats } from "node:fs";
 import path from "node:path";
+import { isErrno } from "./errno.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 import {
   openNodeSqliteDatabase,
@@ -49,14 +50,19 @@ type SqliteReadOnlyWorkerResult = { ok: true; location: string } | { ok: false; 
 
 class SqliteSourceChangedError extends Error {}
 
-function sqliteSnapshotStagingError(tempDir: string, cause: unknown): Error {
-  const message = cause instanceof Error ? cause.message : String(cause);
-  const errcode = cause instanceof Error && "errcode" in cause ? cause.errcode : undefined;
-  const sqliteCode = typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : "";
-  return new Error(
-    `${message}${sqliteCode}; snapshot staging root ${path.dirname(tempDir)}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`,
-    { cause },
-  );
+function sqliteSnapshotStagingError(tempDir: string, cause: unknown): unknown {
+  const error = isErrno(cause) ? cause : undefined;
+  const errcode = error && "errcode" in error ? error.errcode : undefined;
+  // SQLite FULL and IOERR_WRITE/FSYNC/DIR_FSYNC identify destination writes.
+  if (
+    !["ENOSPC", "EDQUOT"].includes(error?.code ?? "") &&
+    !(typeof errcode === "number" && [13, 778, 1034, 1290].includes(errcode)) &&
+    !`${error?.path ?? ""}${path.sep}`.startsWith(`${tempDir}${path.sep}`)
+  ) {
+    return cause;
+  }
+  const message = `${error?.message}${typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : ""}; snapshot staging root ${path.dirname(tempDir)}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`;
+  return new Error(message, { cause });
 }
 
 function statIfPresent(pathname: string): BigIntStats | undefined {
@@ -392,9 +398,7 @@ function createStableReadOnlyCopyInTempDirectory(
     return adoptPreparedLocation(snapshotPath);
   } catch (error) {
     removeTempDirectory(tempDir);
-    throw error instanceof SqliteSourceChangedError
-      ? error
-      : sqliteSnapshotStagingError(tempDir, error);
+    throw sqliteSnapshotStagingError(tempDir, error);
   }
 }
 
@@ -433,9 +437,7 @@ async function createOnlineReadOnlyBackup(
     if (process.platform !== "win32") {
       fs.chmodSync(tempDir, 0o700);
     }
-    const source = openNodeSqliteDatabase(pathname, {
-      readOnly: true,
-    });
+    const source = openNodeSqliteDatabase(pathname, { readOnly: true });
     try {
       source.exec("PRAGMA busy_timeout = 30000; PRAGMA trusted_schema = OFF; BEGIN;");
       source.prepare("PRAGMA schema_version;").get();

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -12,8 +12,8 @@ import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-wor
 import {
   createPrivateSqliteTempDirectory,
   createPrivateSqliteTempDirectorySync,
+  resolvePrivateSqliteSnapshotStagingRoot,
 } from "./sqlite-private-directory.js";
-import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
 
 const MAX_SNAPSHOT_ATTEMPTS = 10;
 const COPY_BUFFER_BYTES = 1024 * 1024;
@@ -48,6 +48,16 @@ type PreparedSqliteReadOnlyLocation = {
 type SqliteReadOnlyWorkerResult = { ok: true; location: string } | { ok: false; message: string };
 
 class SqliteSourceChangedError extends Error {}
+
+function sqliteSnapshotStagingError(tempDir: string, cause: unknown): Error {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  const errcode = cause instanceof Error && "errcode" in cause ? cause.errcode : undefined;
+  const sqliteCode = typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : "";
+  return new Error(
+    `${message}${sqliteCode}; snapshot staging root ${path.dirname(tempDir)}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`,
+    { cause },
+  );
+}
 
 function statIfPresent(pathname: string): BigIntStats | undefined {
   try {
@@ -382,7 +392,9 @@ function createStableReadOnlyCopyInTempDirectory(
     return adoptPreparedLocation(snapshotPath);
   } catch (error) {
     removeTempDirectory(tempDir);
-    throw error;
+    throw error instanceof SqliteSourceChangedError
+      ? error
+      : sqliteSnapshotStagingError(tempDir, error);
   }
 }
 
@@ -391,7 +403,7 @@ async function createStableReadOnlyCopy(
   journalMode: Exclude<SourceJournalMode, "unknown">,
 ): Promise<PreparedSqliteReadOnlyLocation> {
   const tempDir = await createPrivateSqliteTempDirectory(
-    resolvePreferredOpenClawTmpDir(),
+    resolvePrivateSqliteSnapshotStagingRoot(),
     `openclaw-sqlite-readonly-${process.pid}-`,
   );
   return createStableReadOnlyCopyInTempDirectory(pathname, journalMode, tempDir);
@@ -402,7 +414,7 @@ function createStableReadOnlyCopySync(
   journalMode: Exclude<SourceJournalMode, "unknown">,
 ): PreparedSqliteReadOnlyLocation {
   const tempDir = createPrivateSqliteTempDirectorySync(
-    resolvePreferredOpenClawTmpDir(),
+    resolvePrivateSqliteSnapshotStagingRoot(),
     `openclaw-sqlite-readonly-${process.pid}-`,
   );
   return createStableReadOnlyCopyInTempDirectory(pathname, journalMode, tempDir);
@@ -412,7 +424,7 @@ async function createOnlineReadOnlyBackup(
   pathname: string,
 ): Promise<PreparedSqliteReadOnlyLocation> {
   const tempDir = await createPrivateSqliteTempDirectory(
-    resolvePreferredOpenClawTmpDir(),
+    resolvePrivateSqliteSnapshotStagingRoot(),
     `openclaw-sqlite-readonly-${process.pid}-`,
   );
   const snapshotPath = path.join(tempDir, "database.sqlite");
@@ -449,7 +461,7 @@ async function createOnlineReadOnlyBackup(
     return adoptPreparedLocation(snapshotPath);
   } catch (error) {
     removeTempDirectory(tempDir);
-    throw error;
+    throw sqliteSnapshotStagingError(tempDir, error);
   }
 }
 

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -22,6 +22,7 @@ const SQLITE_HEADER_BYTES = 20;
 const SQLITE_READONLY_RESULT_CODE = 8;
 const SQLITE_RESULT_CODE_MASK = 0xff;
 const SQLITE_JOURNAL_MAGIC = Buffer.from([0xd9, 0xd5, 0x05, 0xf9, 0x20, 0xa1, 0x63, 0xd7]);
+const SQLITE_SNAPSHOT_STAGING_PREFIX = `openclaw-sqlite-readonly-${process.pid}-`;
 export const SQLITE_READONLY_CHILD_ARG = "--openclaw-sqlite-readonly-child";
 const SQLITE_READONLY_STDERR_TAIL_CHARS = 4_000;
 const pendingTempDirectoryCleanup = new Set<string>();
@@ -50,18 +51,18 @@ type SqliteReadOnlyWorkerResult = { ok: true; location: string } | { ok: false; 
 
 class SqliteSourceChangedError extends Error {}
 
-function sqliteSnapshotStagingError(tempDir: string, cause: unknown): unknown {
+function sqliteSnapshotStagingError(stagingRoot: string, cause: unknown): unknown {
   const error = isErrno(cause) ? cause : undefined;
   const errcode = error && "errcode" in error ? error.errcode : undefined;
   // SQLite FULL and IOERR_WRITE/FSYNC/DIR_FSYNC identify destination writes.
   if (
     !["ENOSPC", "EDQUOT"].includes(error?.code ?? "") &&
     !(typeof errcode === "number" && [13, 778, 1034, 1290].includes(errcode)) &&
-    !`${error?.path ?? ""}${path.sep}`.startsWith(`${tempDir}${path.sep}`)
+    !`${error?.path ?? ""}${path.sep}`.startsWith(`${stagingRoot}${path.sep}`)
   ) {
     return cause;
   }
-  const message = `${error?.message}${typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : ""}; snapshot staging root ${path.dirname(tempDir)}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`;
+  const message = `${error?.message}${typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : ""}; snapshot staging root ${stagingRoot}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`;
   return new Error(message, { cause });
 }
 
@@ -346,12 +347,15 @@ function recoverPrivateRollbackCopy(snapshotPath: string): void {
 function createStableReadOnlyCopyInTempDirectory(
   pathname: string,
   journalMode: Exclude<SourceJournalMode, "unknown">,
-  tempDir: string,
+  existingTempDir?: string,
 ): PreparedSqliteReadOnlyLocation {
-  const snapshotPath = path.join(tempDir, "database.sqlite");
-  const firstPath = path.join(tempDir, "first");
-  const secondPath = path.join(tempDir, "second");
+  let tempDir = existingTempDir;
+  const stagingRoot = tempDir ? path.dirname(tempDir) : resolvePrivateSqliteSnapshotStagingRoot();
   try {
+    tempDir ??= createPrivateSqliteTempDirectorySync(stagingRoot, SQLITE_SNAPSHOT_STAGING_PREFIX);
+    const snapshotPath = path.join(tempDir, "database.sqlite");
+    const firstPath = path.join(tempDir, "first");
+    const secondPath = path.join(tempDir, "second");
     if (process.platform !== "win32") {
       fs.chmodSync(tempDir, 0o700);
     }
@@ -397,8 +401,19 @@ function createStableReadOnlyCopyInTempDirectory(
     }
     return adoptPreparedLocation(snapshotPath);
   } catch (error) {
-    removeTempDirectory(tempDir);
-    throw sqliteSnapshotStagingError(tempDir, error);
+    if (tempDir) {
+      removeTempDirectory(tempDir);
+    }
+    throw sqliteSnapshotStagingError(stagingRoot, error);
+  }
+}
+
+async function createSqliteSnapshotStagingDirectory(): Promise<string> {
+  const stagingRoot = resolvePrivateSqliteSnapshotStagingRoot();
+  try {
+    return await createPrivateSqliteTempDirectory(stagingRoot, SQLITE_SNAPSHOT_STAGING_PREFIX);
+  } catch (error) {
+    throw sqliteSnapshotStagingError(stagingRoot, error);
   }
 }
 
@@ -406,31 +421,14 @@ async function createStableReadOnlyCopy(
   pathname: string,
   journalMode: Exclude<SourceJournalMode, "unknown">,
 ): Promise<PreparedSqliteReadOnlyLocation> {
-  const tempDir = await createPrivateSqliteTempDirectory(
-    resolvePrivateSqliteSnapshotStagingRoot(),
-    `openclaw-sqlite-readonly-${process.pid}-`,
-  );
-  return createStableReadOnlyCopyInTempDirectory(pathname, journalMode, tempDir);
-}
-
-function createStableReadOnlyCopySync(
-  pathname: string,
-  journalMode: Exclude<SourceJournalMode, "unknown">,
-): PreparedSqliteReadOnlyLocation {
-  const tempDir = createPrivateSqliteTempDirectorySync(
-    resolvePrivateSqliteSnapshotStagingRoot(),
-    `openclaw-sqlite-readonly-${process.pid}-`,
-  );
+  const tempDir = await createSqliteSnapshotStagingDirectory();
   return createStableReadOnlyCopyInTempDirectory(pathname, journalMode, tempDir);
 }
 
 async function createOnlineReadOnlyBackup(
   pathname: string,
 ): Promise<PreparedSqliteReadOnlyLocation> {
-  const tempDir = await createPrivateSqliteTempDirectory(
-    resolvePrivateSqliteSnapshotStagingRoot(),
-    `openclaw-sqlite-readonly-${process.pid}-`,
-  );
+  const tempDir = await createSqliteSnapshotStagingDirectory();
   const snapshotPath = path.join(tempDir, "database.sqlite");
   const sqlite = requireNodeSqlite();
   try {
@@ -463,7 +461,7 @@ async function createOnlineReadOnlyBackup(
     return adoptPreparedLocation(snapshotPath);
   } catch (error) {
     removeTempDirectory(tempDir);
-    throw sqliteSnapshotStagingError(tempDir, error);
+    throw sqliteSnapshotStagingError(path.dirname(tempDir), error);
   }
 }
 
@@ -577,7 +575,7 @@ export function prepareSqliteReadOnlyLocationSyncInProcess(
       continue;
     }
     try {
-      return createStableReadOnlyCopySync(canonicalPath, journalMode);
+      return createStableReadOnlyCopyInTempDirectory(canonicalPath, journalMode);
     } catch (error) {
       if (!(error instanceof SqliteSourceChangedError)) {
         throw error;

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -50,17 +50,17 @@ type SqliteReadOnlyWorkerResult = { ok: true; location: string } | { ok: false; 
 
 class SqliteSourceChangedError extends Error {}
 
-function sqliteSnapshotStagingError(stagingRoot: string, cause: unknown): unknown {
+function sqliteSnapshotStagingError(root: string, cause: unknown, destination = false): unknown {
   for (let depth = 0, error = cause; depth < 8 && error instanceof Error; depth += 1) {
-    const details: NodeJS.ErrnoException & { errcode?: unknown } = error;
-    const errcode = details.errcode;
+    const { code, errcode, path: errorPath }: NodeJS.ErrnoException & { errcode?: unknown } = error;
     // SQLite FULL and IOERR_WRITE/FSYNC/DIR_FSYNC identify destination writes.
     if (
-      ["ENOSPC", "EDQUOT"].includes(details.code ?? "") ||
+      destination ||
+      ["ENOSPC", "EDQUOT"].includes(code ?? "") ||
       (typeof errcode === "number" && [13, 778, 1034, 1290].includes(errcode)) ||
-      `${details.path ?? ""}${path.sep}`.startsWith(`${stagingRoot}${path.sep}`)
+      `${errorPath ?? ""}${path.sep}`.startsWith(`${root}${path.sep}`)
     ) {
-      const message = `${cause instanceof Error ? cause.message : String(cause)}${typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : ""}; snapshot staging root ${stagingRoot}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`;
+      const message = `${cause instanceof Error ? cause.message : String(cause)}${typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : ""}; snapshot staging root ${root}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`;
       return new Error(message, { cause });
     }
     error = error.cause;
@@ -406,7 +406,7 @@ function createStableReadOnlyCopyInTempDirectory(
     if (tempDir) {
       removeTempDirectory(tempDir);
     }
-    throw sqliteSnapshotStagingError(stagingRoot, error);
+    throw sqliteSnapshotStagingError(stagingRoot, error, !tempDir);
   }
 }
 
@@ -415,7 +415,7 @@ async function createSqliteSnapshotStagingDirectory(): Promise<string> {
   try {
     return await createPrivateSqliteTempDirectory(stagingRoot, SQLITE_SNAPSHOT_STAGING_PREFIX);
   } catch (error) {
-    throw sqliteSnapshotStagingError(stagingRoot, error);
+    throw sqliteSnapshotStagingError(stagingRoot, error, true);
   }
 }
 

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -2,7 +2,6 @@
 import { execFile, spawnSync } from "node:child_process";
 import fs, { type BigIntStats } from "node:fs";
 import path from "node:path";
-import { isErrno } from "./errno.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 import {
   openNodeSqliteDatabase,
@@ -52,18 +51,21 @@ type SqliteReadOnlyWorkerResult = { ok: true; location: string } | { ok: false; 
 class SqliteSourceChangedError extends Error {}
 
 function sqliteSnapshotStagingError(stagingRoot: string, cause: unknown): unknown {
-  const error = isErrno(cause) ? cause : undefined;
-  const errcode = error && "errcode" in error ? error.errcode : undefined;
-  // SQLite FULL and IOERR_WRITE/FSYNC/DIR_FSYNC identify destination writes.
-  if (
-    !["ENOSPC", "EDQUOT"].includes(error?.code ?? "") &&
-    !(typeof errcode === "number" && [13, 778, 1034, 1290].includes(errcode)) &&
-    !`${error?.path ?? ""}${path.sep}`.startsWith(`${stagingRoot}${path.sep}`)
-  ) {
-    return cause;
+  for (let depth = 0, error = cause; depth < 8 && error instanceof Error; depth += 1) {
+    const details: NodeJS.ErrnoException & { errcode?: unknown } = error;
+    const errcode = details.errcode;
+    // SQLite FULL and IOERR_WRITE/FSYNC/DIR_FSYNC identify destination writes.
+    if (
+      ["ENOSPC", "EDQUOT"].includes(details.code ?? "") ||
+      (typeof errcode === "number" && [13, 778, 1034, 1290].includes(errcode)) ||
+      `${details.path ?? ""}${path.sep}`.startsWith(`${stagingRoot}${path.sep}`)
+    ) {
+      const message = `${cause instanceof Error ? cause.message : String(cause)}${typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : ""}; snapshot staging root ${stagingRoot}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`;
+      return new Error(message, { cause });
+    }
+    error = error.cause;
   }
-  const message = `${error?.message}${typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : ""}; snapshot staging root ${stagingRoot}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`;
-  return new Error(message, { cause });
+  return cause;
 }
 
 function statIfPresent(pathname: string): BigIntStats | undefined {

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -50,17 +50,17 @@ type SqliteReadOnlyWorkerResult = { ok: true; location: string } | { ok: false; 
 
 class SqliteSourceChangedError extends Error {}
 
-function sqliteSnapshotStagingError(root: string, cause: unknown, destination = false): unknown {
+function sqliteSnapshotStagingError(tempDir: string, cause: unknown, allocation = false): unknown {
   for (let depth = 0, error = cause; depth < 8 && error instanceof Error; depth += 1) {
     const { code, errcode, path: errorPath }: NodeJS.ErrnoException & { errcode?: unknown } = error;
     // SQLite FULL and IOERR_WRITE/FSYNC/DIR_FSYNC identify destination writes.
     if (
-      destination ||
+      allocation ||
       ["ENOSPC", "EDQUOT"].includes(code ?? "") ||
       (typeof errcode === "number" && [13, 778, 1034, 1290].includes(errcode)) ||
-      `${errorPath ?? ""}${path.sep}`.startsWith(`${root}${path.sep}`)
+      `${errorPath ?? ""}${path.sep}`.startsWith(`${tempDir}${path.sep}`)
     ) {
-      const message = `${cause instanceof Error ? cause.message : String(cause)}${typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : ""}; snapshot staging root ${root}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`;
+      const message = `${cause instanceof Error ? cause.message : String(cause)}${typeof errcode === "number" ? ` (SQLite errcode=${errcode})` : ""}; snapshot staging root ${allocation ? tempDir : path.dirname(tempDir)}: free disk space/quota or set XDG_CACHE_HOME to a writable filesystem`;
       return new Error(message, { cause });
     }
     error = error.cause;
@@ -406,7 +406,7 @@ function createStableReadOnlyCopyInTempDirectory(
     if (tempDir) {
       removeTempDirectory(tempDir);
     }
-    throw sqliteSnapshotStagingError(stagingRoot, error, !tempDir);
+    throw sqliteSnapshotStagingError(tempDir ?? stagingRoot, error, !tempDir);
   }
 }
 
@@ -463,7 +463,7 @@ async function createOnlineReadOnlyBackup(
     return adoptPreparedLocation(snapshotPath);
   } catch (error) {
     removeTempDirectory(tempDir);
-    throw sqliteSnapshotStagingError(path.dirname(tempDir), error);
+    throw sqliteSnapshotStagingError(tempDir, error);
   }
 }
 

--- a/src/infra/tmp-openclaw-dir.test.ts
+++ b/src/infra/tmp-openclaw-dir.test.ts
@@ -160,6 +160,22 @@ describe("resolvePreferredOpenClawTmpDir", () => {
     expect(tmpdir).not.toHaveBeenCalled();
   });
 
+  it("honors a caller-selected secure root without changing the default temp policy", () => {
+    const preferredDir = "/var/cache/openclaw";
+    const lstatSync = vi.fn(() => secureDirStat());
+
+    expect(
+      resolvePreferredOpenClawTmpDir({
+        accessSync: vi.fn(),
+        getuid: () => 501,
+        lstatSync,
+        preferredDir,
+        tmpdir: () => "/var/cache",
+      }),
+    ).toBe(preferredDir);
+    expect(lstatSync).toHaveBeenCalledWith(preferredDir);
+  });
+
   it("prefers /tmp/openclaw when it does not exist but /tmp is writable", () => {
     const lstatSyncMock = missingThenSecureLstat();
 

--- a/src/infra/tmp-openclaw-dir.ts
+++ b/src/infra/tmp-openclaw-dir.ts
@@ -19,6 +19,7 @@ export type ResolvePreferredOpenClawTmpDirOptions = {
   lstatSync?: (path: string) => SecureDirStat;
   mkdirSync?: (path: string, opts: { recursive: boolean; mode?: number }) => void;
   platform?: NodeJS.Platform;
+  preferredDir?: string;
   tmpdir?: () => string;
   warn?: (message: string) => void;
 };
@@ -68,7 +69,7 @@ export function resolvePreferredOpenClawTmpDir(
 ): string {
   return loadResolveSecureTempRoot()({
     ...options,
-    preferredDir: DEFAULT_POSIX_TMP_ROOT,
+    preferredDir: options.preferredDir ?? DEFAULT_POSIX_TMP_ROOT,
     fallbackPrefix: "openclaw",
     warningPrefix: "[openclaw]",
     unsafeFallbackLabel: "OpenClaw temp dir",


### PR DESCRIPTION
## What Problem This Solves

Gateway startup prepares a consistent SQLite read-only snapshot before opening shared state for writes. That staging was hard-wired to the shared OpenClaw temp root under `/tmp`. On a host with tmpfs user quotas, the runtime user exhausted its quota while global `df` still showed ample free space. `node:sqlite.backup()` then failed with extended SQLite error 778 (`SQLITE_IOERR_WRITE`), and the Gateway could not start even though both databases and the state filesystem were healthy.

## Why This Change Was Made

Potentially multi-gigabyte SQLite snapshots now use one securely validated user-cache staging root: absolute `XDG_CACHE_HOME` when configured; otherwise `LOCALAPPDATA` (falling back to `HOME/AppData/Local`) on Windows, `HOME/Library/Caches` on macOS, or `HOME/.cache` on other POSIX systems. The ordinary OpenClaw temp policy remains unchanged for unrelated temp users.

WAL-aware online backup, incomplete-WAL private copy, rollback-journal recovery, child-process lock isolation, cleanup, and source identity checks retain their existing ownership. Only destination-side quota/write failures receive staging-root guidance and an extended SQLite code. Source corruption, read, and locking failures preserve their original diagnosis.

## User Impact

Unrelated exhaustion of a shared OS temp quota no longer silently bricks Gateway startup when the user's cache filesystem is healthy. If cache staging is also unavailable, the failure tells the operator which root failed and how to repair or redirect it.

Production changes are +62/-32 (net +30). Tests add 480 lines.

## Evidence

The regression reproduces the actual operating-system failure: a destination write rejected by quota produces SQLite errcode 778 while the source database remains valid. Focused coverage also exercises Gateway startup, worker isolation, WAL/rollback handling, secure cache-root selection, cleanup, and actionable failure reporting.

- 78 focused tests passed; one platform-specific case skipped in the final follow-up
- formatting, targeted lint, SQLite schema guard, diff-check, and fresh autoreview passed
- earlier branch proof completed a full build and real Gateway startup; exact-head hosted CI covers the final follow-up
- Windows cache-root precedence, sanitized Windows allocation errors, a source database under the cache root, source-corruption attribution, and pre-backup cache-allocation failures have dedicated regressions
- changed-file checks passed formatting, core/test type checks, lint, dead exports, cycles, database/schema, and boundary guards
- `git diff --check` passed
- fresh structured autoreview found no actionable issue
