### PR TITLE
fix(ui): keep Model Setup visible while checking AI access

### DIFF
--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -214,6 +214,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
 
   it("redirects before setup detection without loading the discarded workspace", async () => {
     const page = await createPage();
+    await page.emulateMedia({ colorScheme: "dark" });
     const workspaceModules = new Set([
       "/src/components/app-sidebar.ts",
       "/src/components/browser/browser-panel.ts",
@@ -237,6 +238,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
         "desktop.observe",
         "openclaw.chat",
         "openclaw.setup.detect",
+        "openclaw.setup.prepare.start",
         "terminal.open",
       ],
       terminalEnabled: true,
@@ -251,20 +253,91 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
       exact: true,
     });
     await loading.waitFor();
+    const loadingSections = page.locator('.model-setup__loading[role="status"][aria-busy="true"]');
+    await loadingSections.locator(".model-setup__loading-sections").waitFor();
+    expect(await loadingSections.locator(".settings-section").count()).toBe(5);
+    expect(await loadingSections.locator(".model-setup__loading-row").count()).toBe(6);
+    expect(await loadingSections.locator("button, input, wa-dropdown").count()).toBe(0);
+    await page.evaluate(() => document.fonts.ready);
+    const sectionTitles = [
+      "Selected model",
+      "Found on this Gateway",
+      "Run a model locally",
+      "Sign in with a provider",
+      "Connect with an API key or token",
+    ];
+    const loadingSectionTops = await Promise.all(
+      sectionTitles.map(
+        async (name) =>
+          (await page.locator(".model-setup__loading-sections h2").getByText(name).boundingBox())!
+            .y,
+      ),
+    );
     expect(await page.locator(".connect-splash").count()).toBe(0);
     expect([...requestedWorkspaceModules]).toEqual([]);
     await captureProof(page, "06-first-run-routed-before-detection");
+    await page.setViewportSize({ height: 844, width: 390 });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+        ),
+      )
+      .toBe(true);
+    await captureProof(page, "06b-first-run-routed-before-detection-mobile");
+    await page.setViewportSize(viewport);
 
     await gateway.resolveDeferred("openclaw.setup.detect", {
-      candidates: [],
-      manualProviders: [],
+      candidates: [
+        {
+          kind: "claude-cli",
+          brandId: "claude",
+          label: "Claude Code",
+          detail: "Signed in locally",
+          modelRef: "claude-cli/claude-opus-5",
+          recommended: false,
+          credentials: true,
+        },
+      ],
+      manualProviders: [{ id: "openai", brandId: "openai", label: "OpenAI" }],
+      authOptions: [
+        {
+          id: "openai-oauth",
+          brandId: "openai",
+          label: "OpenAI",
+          kind: "oauth",
+          featured: true,
+        },
+      ],
+      prepareOptions: [
+        { id: "ollama", brandId: "ollama", label: "Ollama" },
+        { id: "lmstudio", brandId: "lmstudio", label: "LM Studio" },
+      ],
+      configuredModel: "openai/gpt-5.6-sol",
       setupComplete: false,
       workspace: "/tmp/openclaw-e2e",
     });
     await loading.waitFor({ state: "detached" });
     await page.getByRole("heading", { name: "Connect a verified AI model" }).waitFor();
+    const readySectionTops = await Promise.all(
+      sectionTitles.map(
+        async (name) => (await page.getByRole("heading", { name }).boundingBox())!.y,
+      ),
+    );
+    expect(
+      Math.max(...readySectionTops.map((top, index) => Math.abs(top - loadingSectionTops[index]!))),
+    ).toBeLessThanOrEqual(13);
     expect([...requestedWorkspaceModules]).toEqual([]);
     await captureProof(page, "07-first-run-model-setup-ready");
+    await page.setViewportSize({ height: 844, width: 390 });
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+        ),
+      )
+      .toBe(true);
+    await captureProof(page, "07b-first-run-model-setup-ready-mobile");
   });
 
   it("falls back to the login gate when stored credentials are rejected", async () => {

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -255,12 +255,11 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     await loading.waitFor();
     const loadingSections = page.locator('.model-setup__loading[role="status"][aria-busy="true"]');
     await loadingSections.locator(".model-setup__loading-sections").waitFor();
-    expect(await loadingSections.locator(".settings-section").count()).toBe(5);
-    expect(await loadingSections.locator(".model-setup__loading-row").count()).toBe(6);
+    expect(await loadingSections.locator(".settings-section").count()).toBe(4);
+    expect(await loadingSections.locator(".model-setup__loading-row").count()).toBe(5);
     expect(await loadingSections.locator("button, input, wa-dropdown").count()).toBe(0);
     await page.evaluate(() => document.fonts.ready);
     const sectionTitles = [
-      "Selected model",
       "Found on this Gateway",
       "Run a model locally",
       "Sign in with a provider",
@@ -313,7 +312,6 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
         { id: "ollama", brandId: "ollama", label: "Ollama" },
         { id: "lmstudio", brandId: "lmstudio", label: "LM Studio" },
       ],
-      configuredModel: "openai/gpt-5.6-sol",
       setupComplete: false,
       workspace: "/tmp/openclaw-e2e",
     });

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -10,6 +10,7 @@ import type {
 } from "../../api/types.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
+import { readSessionDefaults } from "../../app/gateway-store.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
@@ -647,6 +648,9 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         canAdmin &&
         !gatewayTooOld &&
         isGatewayMethodAdvertised(snapshot, "openclaw.setup.prepare.start") === true,
+      modelConfigured: snapshot.hello
+        ? readSessionDefaults(snapshot.hello)?.modelConfigured === true
+        : false,
       gatewayTooOld,
       refreshWarning: this.setupRefreshWarning,
       actionsDisabled: this.actionsDisabled(),

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -85,6 +85,7 @@ type ModelSetupViewProps = {
   canAdmin: boolean;
   canVerify: boolean;
   canPrepare: boolean;
+  modelConfigured?: boolean;
   gatewayTooOld: boolean;
   refreshWarning: string | null;
   actionsDisabled: boolean;
@@ -613,7 +614,7 @@ function renderLoadingSection(params: {
   `;
 }
 
-function renderLoading() {
+function renderLoading(modelConfigured: boolean) {
   return html`
     <div
       class="model-setup__loading"
@@ -622,14 +623,17 @@ function renderLoading() {
       aria-label=${t("modelSetup.loading")}
     >
       <div class="model-setup__loading-sections" aria-hidden="true">
-        ${renderLoadingSection({
-          title: t("modelSetup.verify.title"),
-          className: "model-setup__loading-section--selected",
-          status: t("modelSetup.loading"),
-        })}
+        ${modelConfigured
+          ? renderLoadingSection({
+              title: t("modelSetup.verify.title"),
+              className: "model-setup__loading-section--selected",
+              status: t("modelSetup.loading"),
+            })
+          : nothing}
         ${renderLoadingSection({
           title: t("modelSetup.candidates.title"),
           className: "model-setup__loading-section--candidates",
+          status: modelConfigured ? undefined : t("modelSetup.loading"),
         })}
         ${renderLoadingSection({
           title: t("modelSetup.prepare.title"),
@@ -659,7 +663,7 @@ export function renderModelSetup(props: ModelSetupViewProps): TemplateResult {
       ${t("modelSetup.access.gatewayTooOld")}
     </div>`;
   } else if (props.page.phase === "loading") {
-    body = renderLoading();
+    body = renderLoading(props.modelConfigured === true);
   } else if (props.page.phase === "detect-error") {
     body = html`
       <div class="callout danger" role="alert">${props.page.message}</div>

--- a/ui/src/pages/model-setup/view.ts
+++ b/ui/src/pages/model-setup/view.ts
@@ -581,6 +581,71 @@ function renderReady(props: ModelSetupViewProps, result: SystemAgentSetupDetectR
   `;
 }
 
+function renderLoadingSection(params: {
+  title: string;
+  rows?: number;
+  intro?: string;
+  className?: string;
+  status?: string;
+}) {
+  return html`
+    <section class=${`settings-section ${params.className ?? ""}`.trim()}>
+      <div class="settings-section__header"><h2>${params.title}</h2></div>
+      ${params.intro ? html`<p class="muted">${params.intro}</p>` : nothing}
+      <div class="model-setup__rows">
+        ${Array.from(
+          { length: params.rows ?? 1 },
+          (_, index) => html`
+            <div class="model-setup__row model-setup__loading-row">
+              <span class="model-setup__loading-icon skeleton"></span>
+              <span class="model-setup__loading-copy">
+                ${index === 0 && params.status
+                  ? html`<span class="model-setup__loading-status">${params.status}</span>`
+                  : html`<span class="skeleton skeleton-line skeleton-line--medium"></span>`}
+                <span class="skeleton skeleton-line skeleton-line--long"></span>
+              </span>
+              <span class="model-setup__loading-action skeleton"></span>
+            </div>
+          `,
+        )}
+      </div>
+    </section>
+  `;
+}
+
+function renderLoading() {
+  return html`
+    <div
+      class="model-setup__loading"
+      role="status"
+      aria-busy="true"
+      aria-label=${t("modelSetup.loading")}
+    >
+      <div class="model-setup__loading-sections" aria-hidden="true">
+        ${renderLoadingSection({
+          title: t("modelSetup.verify.title"),
+          className: "model-setup__loading-section--selected",
+          status: t("modelSetup.loading"),
+        })}
+        ${renderLoadingSection({
+          title: t("modelSetup.candidates.title"),
+          className: "model-setup__loading-section--candidates",
+        })}
+        ${renderLoadingSection({
+          title: t("modelSetup.prepare.title"),
+          intro: t("modelSetup.prepare.intro"),
+          rows: 2,
+        })}
+        ${renderLoadingSection({
+          title: t("modelSetup.signIn.title"),
+          className: "model-setup__loading-section--sign-in",
+        })}
+        ${renderLoadingSection({ title: t("modelSetup.manual.title") })}
+      </div>
+    </div>
+  `;
+}
+
 export function renderModelSetup(props: ModelSetupViewProps): TemplateResult {
   let body: unknown;
   if (props.page.phase === "ready") {
@@ -594,7 +659,7 @@ export function renderModelSetup(props: ModelSetupViewProps): TemplateResult {
       ${t("modelSetup.access.gatewayTooOld")}
     </div>`;
   } else if (props.page.phase === "loading") {
-    body = html`<div class="model-setup__loading" role="status">${t("modelSetup.loading")}</div>`;
+    body = renderLoading();
   } else if (props.page.phase === "detect-error") {
     body = html`
       <div class="callout danger" role="alert">${props.page.message}</div>

--- a/ui/src/styles/model-setup.css
+++ b/ui/src/styles/model-setup.css
@@ -27,6 +27,56 @@
   gap: 10px;
 }
 
+.model-setup__loading-sections {
+  display: grid;
+  gap: 18px;
+}
+
+.model-setup__loading-row {
+  min-height: 72px;
+}
+
+.model-setup__loading-section--selected .model-setup__loading-row {
+  min-height: 73px;
+}
+
+.model-setup__loading-section--candidates .model-setup__loading-row {
+  min-height: 79px;
+}
+
+.model-setup__loading-section--sign-in .model-setup__loading-row {
+  min-height: 68px;
+}
+
+.model-setup__loading-sections .settings-section > p {
+  margin: 0 0 12px;
+}
+
+.model-setup__loading-icon {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+}
+
+.model-setup__loading-copy {
+  display: grid;
+  flex: 1;
+  gap: 8px;
+}
+
+.model-setup__loading-status {
+  height: 14px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 14px;
+}
+
+.model-setup__loading-action {
+  width: 96px;
+  height: 36px;
+  flex: none;
+}
+
 .model-setup__row {
   display: flex;
   align-items: center;
@@ -471,6 +521,11 @@
   .model-setup__row {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .model-setup__loading-icon,
+  .model-setup__loading-action {
+    align-self: flex-start;
   }
 
   .model-setup__row > .btn {


### PR DESCRIPTION
Closes #128623

## What Problem This Solves

Fixes an issue where users opening Model Setup would see almost the entire page disappear while the Gateway checked available AI access. The detailed scan has a documented 40-second budget, so the default first-run path could look empty or stalled before all setup choices appeared at once.

Deterministic reproduction on pre-fix `main` (`628b7a2f91a`):

```shell
CHOKIDAR_USEPOLLING=1 OPENCLAW_UI_E2E_ARTIFACT_DIR=.artifacts/control-ui-e2e/model-setup-before node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/initial-connect-splash.e2e.test.ts -t "redirects before setup detection without loading the discarded workspace"
```

The mocked Gateway advertises `openclaw.setup.detect` but defers its response. Before the response resolves, the browser reaches `/settings/model-setup?firstRun=1` and renders only `Checking this Gateway for available AI access…` below the intro. Resolving that same request inserts the complete setup page.

## Why This Change Was Made

Model Setup now renders its known five-section structure immediately and reserves result-dependent copy and CTAs with the Control UI's existing shared skeleton primitive. The current loading sentence remains visible and is exposed as one `role=status`/`aria-busy` announcement; placeholder structure is hidden from assistive technology and contains no interactive controls.

The fix stays in the Model Setup presentation owner. It does not change `openclaw.setup.detect`, timeout policy, provider detection, activation, route state, persistence, or backend timing. The separate `gw-setup-latency` lane owns detection and activation latency.

Historical intent is preserved:

- #108868 introduced the explicit pending phase and one-line loading presentation.
- #116086 established the current provider-first Model Setup structure while retaining that loading branch.
- #128135 deliberately routes first-run operators to Model Setup before detailed detection resolves, confirming that detection belongs to this page rather than blocking navigation.

No Peter/Vincent decision requires the empty loading presentation. The repair follows the shared shimmer primitive in `ui/src/styles/base.css` and the settings-page loading precedent in Usage.

## User Impact

Operators now see where the configured model, detected access, local model options, provider sign-in, and manual credentials will appear as soon as Model Setup opens. The transition to real results keeps the five section headings within 13 px in the representative desktop flow, has no horizontal overflow on a 390 px viewport, and avoids extra spinners or controls that cannot yet work.

## Evidence

### Desktop dark

| Before | After |
| --- | --- |
| ![Model Setup empty while detection is pending](https://github.com/user-attachments/assets/bf7d17ce-b533-49ef-99ea-e411394bc6b0) | ![Model Setup skeleton while detection is pending](https://github.com/user-attachments/assets/faea8eea-e5ca-4cc1-80d4-d21e3bb40598) |

### Mobile dark

| Before | After |
| --- | --- |
| ![Mobile Model Setup empty while detection is pending](https://github.com/user-attachments/assets/e0b804c0-04ee-4c52-9df3-0786be9b17cb) | ![Mobile Model Setup skeleton while detection is pending](https://github.com/user-attachments/assets/6e42c3ff-28cc-4c3b-999b-6eb8a8b4b15b) |

All four frames were captured from the mocked Gateway flow and inspected after capture.

Validation:

- Regression test: the added pending-structure assertions fail on pre-fix code because `.model-setup__loading-sections` never renders, then pass after the fix.
- `node scripts/run-vitest.mjs ui/src/pages/model-setup/view.test.ts` — 41 passed.
- `CHOKIDAR_USEPOLLING=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/initial-connect-splash.e2e.test.ts` — 7 passed.
- `node scripts/check-changed.mjs -- ui/src/pages/model-setup/view.ts ui/src/styles/model-setup.css ui/src/e2e/initial-connect-splash.e2e.test.ts` — passed formatting, i18n, core-test/UI typechecks, lint, dead exports, and repository guards.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings; TruffleHog clean.

Blast radius checked: route loader, page state/task lifecycle, RPC timeout, first-run redirect, configured-model rendering, provider/auth/manual/local setup sections, responsive styles, shared skeleton/reduced-motion policy, adjacent Model Setup tests, and the mocked Gateway browser boundary. Sibling loading surfaces were reviewed; the router mascot is for unresolved lazy modules and Usage is the closest settings-page structural skeleton.

Production LOC: +121/-1. Test LOC: +75/-2. The production growth is the required Model Setup-shaped loading capability; no parallel state, RPC, fallback, or backend path was added.
