### PR TITLE
fix(ui): preserve agent prompts when the default session is already open

### DIFF
--- a/ui/src/pages/chat/chat-page-retained-sessions.test.ts
+++ b/ui/src/pages/chat/chat-page-retained-sessions.test.ts
@@ -13,9 +13,11 @@ import type { ApplicationContext } from "../../app/context.ts";
 import { SESSION_NAVIGATION_INTENT_EVENT } from "../../lib/sessions/navigation-handoff.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { ChatPage } from "./chat-page.ts";
+import { routeDraft } from "./route-draft.ts";
 
 type RenderedPane = HTMLElement & {
   active: boolean;
+  draft?: string;
   focusComposer: boolean;
   onFaceChange?: (paneId: string, sessionKey: string, face: "chat" | "dashboard") => void;
   onPaneSessionChange?: (
@@ -139,6 +141,72 @@ describe("chat page retained sessions", () => {
         .toSorted(),
     ).toEqual(["agent:main:a", "agent:main:c", "agent:main:d"]);
     expect(paneB?.isConnected).toBe(false);
+  });
+
+  it.each([
+    { retainedSessionKey: "main", routeSessionKey: "agent:main:main" },
+    { retainedSessionKey: "agent:main:main", routeSessionKey: "main" },
+  ])(
+    "delivers a one-shot route draft and composer focus across the $retainedSessionKey alias",
+    async ({ retainedSessionKey, routeSessionKey }) => {
+      const { navigation, page, paneFor } = await mountRetainedPage(retainedSessionKey);
+      const pane = expectDefined(paneFor(retainedSessionKey), "retained main chat pane");
+      const receivedDrafts: Array<string | undefined> = [];
+      const focusRequests: boolean[] = [];
+
+      Object.defineProperties(pane, {
+        draft: {
+          configurable: true,
+          get: () => receivedDrafts.at(-1),
+          set: (value: string | undefined) => receivedDrafts.push(value),
+        },
+        focusComposer: {
+          configurable: true,
+          get: () => focusRequests.at(-1) ?? false,
+          set: (value: boolean) => focusRequests.push(value),
+        },
+      });
+
+      page.data = {
+        sessionKey: routeSessionKey,
+        draft: "What can you do?",
+        focusComposer: true,
+      };
+      await page.updateComplete;
+      await Promise.resolve();
+      await page.updateComplete;
+
+      expect(paneFor(retainedSessionKey)).toBe(pane);
+      expect(receivedDrafts.filter((draft) => draft !== undefined)).toEqual(["What can you do?"]);
+      expect(focusRequests).toContain(true);
+      expect(navigation.replace).toHaveBeenCalledOnce();
+
+      page.data = { sessionKey: routeSessionKey };
+      await page.updateComplete;
+    },
+  );
+
+  it.each([
+    { routeSessionKey: "agent:main:main", paneSessionKey: "" },
+    { routeSessionKey: "agent:main:main", paneSessionKey: "global" },
+    { routeSessionKey: "agent:main:main", paneSessionKey: "agent:research:main" },
+    {
+      routeSessionKey: "agent:ops:matrix:channel:!Room:Example.Org",
+      paneSessionKey: "agent:ops:matrix:channel:!room:example.org",
+    },
+    {
+      routeSessionKey: "agent:ops:signal:group:AbC123=",
+      paneSessionKey: "agent:ops:signal:group:abc123=",
+    },
+  ])("never sends a route draft to a different session", ({ routeSessionKey, paneSessionKey }) => {
+    expect(
+      routeDraft({ sessionKey: routeSessionKey, draft: "private draft" }, null, paneSessionKey),
+    ).toBeUndefined();
+  });
+
+  it("never replays a consumed route draft through an equivalent main alias", () => {
+    const data = { sessionKey: "agent:main:main", draft: "already delivered" };
+    expect(routeDraft(data, data, "main")).toBeUndefined();
   });
 
   it("hands route-owned focus to the final page across pane replacement", async () => {

--- a/ui/src/pages/chat/route-draft.ts
+++ b/ui/src/pages/chat/route-draft.ts
@@ -1,5 +1,6 @@
 import type { RouteLocation } from "@openclaw/uirouter";
 import { SESSION_COMPOSER_FOCUS_PARAM } from "../../lib/sessions/route-navigation.ts";
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 
 type RouteDraftHint = { draft?: string; focusComposer?: boolean };
 type RouteDraftData = { sessionKey: string; draft?: string };
@@ -47,5 +48,7 @@ export function routeDraft(
   consumed: RouteDraftData | null,
   sessionKey = data?.sessionKey,
 ): string | undefined {
-  return !data || sessionKey !== data.sessionKey || consumed === data ? undefined : data.draft;
+  return !data || !areUiSessionKeysEquivalent(sessionKey, data.sessionKey) || consumed === data
+    ? undefined
+    : data.draft;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users asking what an agent can do would see an empty, unfocused composer when the default chat session was already open under its other supported session-key spelling. The requested prompt was silently consumed and could not be recovered.

## Why This Change Was Made

Retained chat panes already recognize `main` and `agent:main:main` as the same default session, but their one-shot draft owner still compared those keys literally. Reuse the existing canonical UI session-key equivalence at that owner so the visible retained pane receives both its draft and composer focus exactly once. Distinct agents, global sessions, blank keys, and case-sensitive Matrix/Signal identities remain isolated.

## User Impact

The existing **Ask what this agent can do** action reliably fills and focuses the composer even when an existing default-session pane uses the equivalent spelling. Other route-owned composer drafts, including command-palette prompts, benefit from the same canonical owner repair without new settings or public API changes.

## Evidence

**Before:** the retained default-session composer remains empty and unfocused after the action.

![Before: default-session composer is empty after asking what the agent can do](https://github.com/user-attachments/assets/9bd916e8-28c6-4840-ae97-fff97175ecc7)

**After:** the same retained composer contains the requested prompt and is focused.

![After: default-session composer contains the requested prompt and is focused](https://github.com/user-attachments/assets/09d63dfb-2392-41cf-a6d8-a7dc08d09d6d)

Both screenshots use isolated Chromium, the real production composer, and exclusively synthetic non-sensitive fixtures.

The existing real Lit `ChatPage` suite reproduces both default-session alias directions against the original code and proves a single delivered draft, focus request, route cleanup, and retained DOM-pane identity after the fix. Separate cases reject cross-agent/global/blank keys and preserve opaque Matrix/Signal casing and consumed-draft identity.

Owner and independent runs each passed **405 tests across 6 suites** covering the actual chat page, retained sessions, canonical session identities, navigation, sidebar actions, and command-palette ingress. Targeted typed lint, formatting, i18n verification, and both repository safety ratchets pass. Production growth is **3 lines**, comprising the existing canonical-helper import and its formatted owner comparison.
