### PR TITLE
perf(plugins): enforce load-once — default credential-source gate and containment registry reuse

### DIFF
--- a/src/infra/provider-usage.auth.normalizes-keys.test.ts
+++ b/src/infra/provider-usage.auth.normalizes-keys.test.ts
@@ -122,6 +122,7 @@ vi.mock("../agents/auth-profiles.js", () => {
   return {
     clearRuntimeAuthProfileStoreSnapshots: () => {},
     ensureAuthProfileStore: (agentDir?: string) => readStore(agentDir),
+    ensureAuthProfileStoreWithoutExternalProfiles: (agentDir?: string) => readStore(agentDir),
     hasAnyAuthProfileStoreSource: (agentDir?: string) =>
       Boolean(agentDir && nodeFs.existsSync(path.join(agentDir, "auth-profiles.json"))),
     dedupeProfileIds,

--- a/src/infra/provider-usage.auth.plugin.test.ts
+++ b/src/infra/provider-usage.auth.plugin.test.ts
@@ -70,6 +70,7 @@ vi.mock("../secrets/provider-env-vars.js", () => ({
     anthropic: ["ANTHROPIC_API_KEY"],
     minimax: ["MINIMAX_CODE_PLAN_KEY"],
     openai: ["OPENAI_API_KEY"],
+    zai: ["ZAI_API_KEY"],
   }),
   resolveProviderAuthLookupMaps: () => ({
     aliasMap: {},
@@ -77,6 +78,7 @@ vi.mock("../secrets/provider-env-vars.js", () => ({
       anthropic: ["ANTHROPIC_API_KEY"],
       minimax: ["MINIMAX_CODE_PLAN_KEY"],
       openai: ["OPENAI_API_KEY"],
+      zai: ["ZAI_API_KEY"],
     },
     authEvidenceMap: {},
   }),
@@ -139,16 +141,19 @@ describe("resolveProviderAuths plugin boundary", () => {
       token: "plugin-zai-token",
     });
 
-    await expect(
-      resolveProviderAuthsForTest({
-        providers: ["zai"],
-      }),
-    ).resolves.toEqual([
-      {
-        provider: "zai",
-        token: "plugin-zai-token",
-      },
-    ]);
+    await withTempHome(async (homeDir) => {
+      await expect(
+        resolveProviderAuthsForTest({
+          providers: ["zai"],
+          env: { HOME: homeDir, ZAI_API_KEY: "zai-env-key" },
+        }),
+      ).resolves.toEqual([
+        {
+          provider: "zai",
+          token: "plugin-zai-token",
+        },
+      ]);
+    });
     expect(ensureAuthProfileStoreMock).not.toHaveBeenCalled();
   });
 
@@ -156,11 +161,14 @@ describe("resolveProviderAuths plugin boundary", () => {
     const authError = new Error("plugin auth failed");
     resolveProviderUsageAuthWithPluginMock.mockRejectedValueOnce(authError);
 
-    await expect(
-      resolveProviderAuthsForTest({
-        providers: ["anthropic"],
-      }),
-    ).rejects.toBe(authError);
+    await withTempHome(async (homeDir) => {
+      await expect(
+        resolveProviderAuthsForTest({
+          providers: ["anthropic"],
+          env: { HOME: homeDir, ANTHROPIC_API_KEY: "sk-ant-env" },
+        }),
+      ).rejects.toBe(authError);
+    });
   });
 
   it("resolves SecretRef-backed profiles before provider credential classification", async () => {
@@ -174,6 +182,8 @@ describe("resolveProviderAuths plugin boundary", () => {
       },
     };
     ensureAuthProfileStoreMock.mockReturnValue(store as never);
+    hasAnyAuthProfileStoreSourceMock.mockReturnValue(true);
+    ensureAuthProfileStoreWithoutExternalProfilesMock.mockReturnValue(store as never);
     resolveAuthProfileOrderMock.mockReturnValue(["anthropic:admin"]);
     resolveApiKeyForProfileMock.mockResolvedValue({
       apiKey: "sk-ant-admin-secretref",
@@ -216,20 +226,23 @@ describe("resolveProviderAuths plugin boundary", () => {
   });
 
   it("does not synthesize Codex app-server auth for generic OpenAI usage", async () => {
-    await expect(
-      resolveProviderAuthsForTest({
-        providers: ["openai"],
-      }),
-    ).resolves.toEqual([]);
-    expect(providerCalls(resolveProviderUsageAuthWithPluginMock)).toEqual(["openai"]);
+    await withTempHome(async (homeDir) => {
+      await expect(
+        resolveProviderAuthsForTest({
+          providers: ["openai"],
+          env: { HOME: homeDir },
+        }),
+      ).resolves.toEqual([]);
+    });
+    // The credential-source gate keeps credential-less providers off plugin runtime entirely.
+    expect(resolveProviderUsageAuthWithPluginMock).not.toHaveBeenCalled();
   });
 
-  it("skips plugin usage auth when requested and no direct credential source exists", async () => {
+  it("skips plugin usage auth by default when no credential source exists", async () => {
     await withTempHome(async (homeDir) => {
       await expect(
         resolveProviderAuthsForTest({
           providers: ["zai"],
-          skipPluginAuthWithoutCredentialSource: true,
           env: { HOME: homeDir },
         }),
       ).resolves.toStrictEqual([]);
@@ -265,7 +278,6 @@ describe("resolveProviderAuths plugin boundary", () => {
       await expect(
         resolveProviderAuthsForTest({
           providers: ["anthropic", "zai"],
-          skipPluginAuthWithoutCredentialSource: true,
           env: { HOME: homeDir },
         }),
       ).resolves.toEqual([
@@ -307,7 +319,6 @@ describe("resolveProviderAuths plugin boundary", () => {
       await expect(
         resolveProviderAuthsForTest({
           providers: ["minimax"],
-          skipPluginAuthWithoutCredentialSource: true,
           env: { HOME: homeDir },
         }),
       ).resolves.toEqual([
@@ -332,7 +343,6 @@ describe("resolveProviderAuths plugin boundary", () => {
       await expect(
         resolveProviderAuthsForTest({
           providers: ["minimax"],
-          skipPluginAuthWithoutCredentialSource: true,
           env: {
             HOME: homeDir,
             MINIMAX_CODE_PLAN_KEY: "code-plan-key",
@@ -359,7 +369,6 @@ describe("resolveProviderAuths plugin boundary", () => {
       await expect(
         resolveProviderAuthsForTest({
           providers: ["openai"],
-          skipPluginAuthWithoutCredentialSource: true,
           env: {
             HOME: homeDir,
             OPENAI_API_KEY: "sk-admin-test",
@@ -385,7 +394,6 @@ describe("resolveProviderAuths plugin boundary", () => {
       await expect(
         resolveProviderAuthsForTest({
           providers: ["openai"],
-          skipPluginAuthWithoutCredentialSource: true,
           env: {
             HOME: homeDir,
             OPENAI_ADMIN_KEY: "sk-admin-test",
@@ -409,7 +417,6 @@ describe("resolveProviderAuths plugin boundary", () => {
       await expect(
         resolveProviderAuthsForTest({
           providers: ["anthropic"],
-          skipPluginAuthWithoutCredentialSource: true,
           env: { HOME: homeDir },
         }),
       ).resolves.toStrictEqual([]);
@@ -426,7 +433,6 @@ describe("resolveProviderAuths plugin boundary", () => {
       await expect(
         resolveProviderAuthsForTest({
           providers: ["anthropic", "zai"],
-          skipPluginAuthWithoutCredentialSource: true,
           env: {
             HOME: homeDir,
             ANTHROPIC_API_KEY: "sk-ant-api03-status-key", // pragma: allowlist secret

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -485,7 +485,6 @@ export async function resolveProviderAuths(params: {
   agentDir?: string;
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
-  skipPluginAuthWithoutCredentialSource?: boolean;
   onError?: (provider: UsageProviderId, error: unknown) => void;
 }): Promise<ProviderAuth[]> {
   if (params.auth) {
@@ -503,35 +502,19 @@ export async function resolveProviderAuths(params: {
     getStore: params.getStore,
     store: params.store,
   };
-  const hasAuthProfileStoreSource = params.skipPluginAuthWithoutCredentialSource
-    ? hasAnyAuthProfileStoreSource(params.agentDir)
-    : false;
+  // Credential-source gate (#69479): resolving plugin usage auth imports the
+  // provider plugin's runtime, so a provider with no config/env/profile-store
+  // credential source must be skipped before that import — otherwise every
+  // usage read cold-loads plugin runtime just to learn there is nothing to auth.
+  // A caller-prepared store is itself the source; only probe disk without one.
+  const hasAuthProfileStoreSource =
+    params.store !== undefined ||
+    params.getStore !== undefined ||
+    hasAnyAuthProfileStoreSource(params.agentDir);
   const auths: ProviderAuth[] = [];
 
   for (const provider of params.providers) {
     try {
-      if (!params.skipPluginAuthWithoutCredentialSource) {
-        const pluginAuth = await resolveProviderUsageAuthViaPlugin({
-          state: authProfileSourceState,
-          provider,
-        });
-        if (pluginAuth.auth) {
-          auths.push(pluginAuth.auth);
-          continue;
-        }
-        if (pluginAuth.handled) {
-          continue;
-        }
-        const fallbackAuth = await resolveProviderUsageAuthFallback({
-          state: authProfileSourceState,
-          provider,
-        });
-        if (fallbackAuth) {
-          auths.push(fallbackAuth);
-        }
-        continue;
-      }
-
       const directCredentialState = { ...stateBase, allowAuthProfileStore: false };
       const credentialProviderIds = resolveUsageCredentialProviderIds({
         state: directCredentialState,
@@ -562,6 +545,8 @@ export async function resolveProviderAuths(params: {
       const state: UsageAuthState = {
         ...stateBase,
         allowAuthProfileStore,
+        getStore: params.getStore,
+        store: params.store,
       };
       const hasPluginCredentialSource = hasDirectCredentialSource || allowAuthProfileStore;
 

--- a/src/infra/provider-usage.load.test.ts
+++ b/src/infra/provider-usage.load.test.ts
@@ -280,7 +280,9 @@ describe("provider-usage.load", () => {
     const summary = await loadProviderUsageSummary({
       providers: ["anthropic", "openai"],
       config: {},
-      env: {},
+      // Credential sources keep both providers past the plugin-auth gate so the
+      // sibling-isolation behavior under test is actually exercised.
+      env: { ANTHROPIC_API_KEY: "sk-ant-test", OPENAI_API_KEY: "sk-openai-test" },
     });
 
     expect(summary.providers).toEqual([

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -49,7 +49,6 @@ type UsageSummaryOptions = {
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   fetch?: typeof fetch;
-  skipPluginAuthWithoutCredentialSource?: boolean;
 };
 
 async function fetchProviderUsageSnapshot(params: {
@@ -149,7 +148,6 @@ export async function loadProviderUsageSummary(
               env,
               getStore: getAuthStore,
               store: opts.authStore,
-              skipPluginAuthWithoutCredentialSource: opts.skipPluginAuthWithoutCredentialSource,
               onError: (_provider, error) => {
                 authError = error;
               },

--- a/src/plugins/active-runtime-registry.test.ts
+++ b/src/plugins/active-runtime-registry.test.ts
@@ -155,6 +155,35 @@ describe("getLoadedRuntimePluginRegistry", () => {
     expect(listRuntimePluginIdsFromRegistry(bundleRegistry)).toContain("bundle");
   });
 
+  it("falls through to containment reuse when scoped load options miss the exact cache key", () => {
+    const registry = createRegistryWithPlugin("demo");
+    setActivePluginRegistry(registry, "gateway-root-key", "default", "/tmp/ws");
+
+    expect(
+      getLoadedRuntimePluginRegistry({
+        loadOptions: { workspaceDir: "/tmp/ws", onlyPluginIds: ["demo"] },
+        workspaceDir: "/tmp/ws",
+        requiredPluginIds: ["demo"],
+      }),
+    ).toBe(registry);
+  });
+
+  it("keeps exact-key semantics for unscoped load-option requests", () => {
+    setActivePluginRegistry(
+      createRegistryWithPlugin("demo"),
+      "gateway-root-key",
+      "default",
+      "/tmp/ws",
+    );
+
+    expect(
+      getLoadedRuntimePluginRegistry({
+        loadOptions: { workspaceDir: "/tmp/ws" },
+        workspaceDir: "/tmp/ws",
+      }),
+    ).toBeUndefined();
+  });
+
   it("does not reuse workspace-agnostic registries for workspace-specific requests", () => {
     setActivePluginRegistry(createRegistryWithPlugin("demo"), "demo");
 

--- a/src/plugins/active-runtime-registry.ts
+++ b/src/plugins/active-runtime-registry.ts
@@ -116,10 +116,18 @@ export function getLoadedRuntimePluginRegistry(
   );
   if (params.loadOptions && requiredPluginIds?.length !== 0) {
     const compatible = resolveCompatibleRuntimePluginRegistry(params.loadOptions);
-    if (!compatible || !registryContainsRuntimePluginIds(compatible, requiredPluginIds)) {
+    if (compatible && registryContainsRuntimePluginIds(compatible, requiredPluginIds)) {
+      return compatible;
+    }
+    // Exact cache-key reuse fails for every caller whose options differ from the
+    // composition root's load (scoped ids, derived config, no gateway bindings),
+    // which used to force a cold scoped load even when the active registry already
+    // holds the requested runtime plugins. An explicit id list proves what the
+    // caller needs, so fall through to the containment check below; unscoped
+    // requests keep exact-key semantics because no id list bounds their intent.
+    if (requiredPluginIds === undefined) {
       return undefined;
     }
-    return compatible;
   }
 
   const activeWorkspaceDir = getActivePluginRegistryWorkspaceDir();


### PR DESCRIPTION
## What Problem This Solves

A full audit of the "plugins load once (lazily) at startup, then stay process-stable" invariant found it structurally unenforced on two seams, with a live-measured consequence: on a fresh gateway, one `usage.status` RPC performed **9 plugin registry loads on the request path** (one 18.4s under load; RPC total 20.7s), because provider usage-auth resolution imported every usage-capable provider plugin's runtime just to ask it for credentials that don't exist. Stack-attributed repro: `usage.status` → `resolveProviderAuths` → `resolveProviderUsageAuthViaPlugin` → `resolveProviderRuntimePlugin` → scoped `loadOpenClawPlugins` per provider.

## Why This Change Was Made

Two root causes, each fixed at its owner:

1. **The credential-source gate was dead code.** PR #69479 (Apr 2026) introduced `skipPluginAuthWithoutCredentialSource` to keep status reads off plugin runtimes; PR #78456 (May 2026) refactored away the last caller, silently reverting that fix — and the gateway usage cache never had it. Instead of re-adding a caller-remembered opt-in flag (the exact rot pattern that killed it), this PR deletes the flag and makes the gate the only behavior in `resolveProviderAuths`: providers with no config/env/profile-store credential source never reach plugin runtime import. Behavior-safe by inspection of all ten `resolveUsageAuth` implementations (anthropic, openai, github-copilot, minimax, zai, deepseek, xiaomi, venice, openrouter, clawrouter): every one resolves credentials exclusively through store/config/env-backed context resolvers, so a source-less provider could only ever return null. The gated path now also threads the caller-prepared auth store through (previously dropped), so gateway refreshes reuse the prepared store instead of re-reading disk.

2. **Shared registry reuse required exact cache-key equality no runtime caller can satisfy.** `getLoadedRuntimePluginRegistry` with `loadOptions` reused the active registry only on an exact load-option cache-key match — but the gateway's composition-root load bakes in gateway-only options (core handlers, runtime bindings, startup plugin ids), so every scoped runtime consumer (tools, capability providers, web providers, provider hooks) missed and fell to a cold scoped load. The helper now falls through to the existing runtime-containment check (`registryContainsRuntimePluginIds`, workspace-guarded) when the caller names explicit plugin ids; unscoped requests keep exact-key semantics since no id list bounds their intent. This generalizes the fix pattern from #128551 into the shared owner so per-surface hand-rolled variants stop being necessary.

## User Impact

The Control UI usage/settings surface no longer stalls the gateway event loop for seconds on first read after a restart, and scoped plugin consumers across the gateway reuse the already-loaded registry instead of re-transforming plugin source. Operators with configured providers see identical auth/usage results; providers without any credential source now skip runtime import entirely (previously they imported runtime and still reported nothing).

## Evidence

Live before/after on an isolated dist gateway (25-RPC read sweep, debug loader logging, counting post-startup `[plugins] loaded` events):

| metric | before (main) | after |
| --- | --- | --- |
| post-startup registry loads (full sweep) | 10 | 2 (memory plugin lazy-once first-use, 6ms each — by design) |
| `usage.status` RPC | 20,726ms (9 loads, worst single load 18,448ms) | 55ms (0 loads) |
| second sweep loads | 0 | 0 |

- Both regression tests fail on pre-fix code: `active-runtime-registry.test.ts` "falls through to containment reuse..." (1 failed pre-fix) and the `provider-usage.auth.plugin.test.ts` gate-default tests (6 failed pre-fix).
- `pnpm check:changed` green; `pnpm build` clean (required for loader changes).
- `pnpm test:changed`: the wide local `vitest.gateway.config.ts` mega-shard dies with a silent `Worker exited unexpectedly` crash **identically on pristine `origin/main` (4e82e9256b9) with zero diff applied** (same command, same signature, no test ever reported) — a local-environment worker crash, not a regression from this change; hosted CI on main is green. Every other shard passes, and all targeted suites touching this change pass directly: `provider-usage*` (130), `usage.status-cache` + `models-auth-status` (98), `provider-runtime` + `capability-provider-runtime` (132), `status`/`status-runtime-shared` (80), `active-runtime-registry` (13).
- Gateway suites: `usage.status-cache`, `models-auth-status`, `provider-usage*` all green (98 + 130 tests).
- Codex autoreview: clean.
- Production LOC net −9 (flag + ungated branch deleted; helper +8 with invariant comments); tests +~45.
