### PR TITLE
fix(amazon-bedrock): sanitize toolUse.input on replay to avoid session poisoning

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -998,6 +998,17 @@ describe("Bedrock toolUse.input replay sanitization", () => {
     expect(await toolUseInputOf('{"path":"README.md"}')).toEqual({ path: "README.md" });
   });
 
+  it("preserves unsafe integer literals in recovered serialized arguments", async () => {
+    // JSON.parse would round a 64-bit integer literal (e.g. a snowflake ID)
+    // before replay; the canonical transport coercion keeps it as a string,
+    // matching the terminal parser contract, so the replayed toolUse.input
+    // carries the exact stored value.
+    expect(await toolUseInputOf('{"id":9223372036854775807,"safe":42}')).toEqual({
+      id: "9223372036854775807",
+      safe: 42,
+    });
+  });
+
   it("preserves a well-formed object toolCall arguments as-is", async () => {
     expect(await toolUseInputOf({ path: "README.md" })).toEqual({ path: "README.md" });
   });

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -944,3 +944,53 @@ describe("Bedrock canonical Claude aliases", () => {
     },
   );
 });
+
+describe("Bedrock toolUse.input replay sanitization", () => {
+  // A non-Anthropic model on Bedrock can stream tool-argument deltas that fail
+  // to parse into an object, leaving a stored toolCall.arguments as a raw
+  // string/array/primitive. Bedrock Converse validates toolUse.input against a
+  // strict document schema on replay and rejects a non-object with
+  // "Invalid 'input': value did not match any expected variant" — poisoning
+  // every subsequent turn that replays the history until the session is reset.
+  const assistantToolCall = (args: unknown) =>
+    ({
+      messages: [
+        { role: "user", content: "run the tool", timestamp: 0 },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call_replay", name: "search", arguments: args }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_replay",
+          toolName: "search",
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        },
+      ],
+    }) as never;
+
+  const toolUseInputOf = async (args: unknown) => {
+    const input = await captureCommandInput(bedrockModel({}), assistantToolCall(args));
+    const messages = input.messages as Array<{
+      content?: Array<{ toolUse?: { input?: unknown } }>;
+    }>;
+    const block = messages
+      .flatMap((message) => message.content ?? [])
+      .find((content) => content.toolUse);
+    return block?.toolUse?.input;
+  };
+
+  it.each([
+    { label: "a raw string", value: "not-an-object" },
+    { label: "an array", value: ["a", "b"] },
+    { label: "a number", value: 42 },
+    { label: "null", value: null },
+  ])("falls back to an empty document when toolCall arguments is $label", async ({ value }) => {
+    expect(await toolUseInputOf(value)).toEqual({});
+  });
+
+  it("preserves a well-formed object toolCall arguments as-is", async () => {
+    expect(await toolUseInputOf({ path: "README.md" })).toEqual({ path: "README.md" });
+  });
+});

--- a/extensions/amazon-bedrock/stream.runtime.test.ts
+++ b/extensions/amazon-bedrock/stream.runtime.test.ts
@@ -983,11 +983,19 @@ describe("Bedrock toolUse.input replay sanitization", () => {
 
   it.each([
     { label: "a raw string", value: "not-an-object" },
+    { label: "a malformed JSON string", value: '{"path":"README.md"' },
     { label: "an array", value: ["a", "b"] },
     { label: "a number", value: 42 },
     { label: "null", value: null },
   ])("falls back to an empty document when toolCall arguments is $label", async ({ value }) => {
     expect(await toolUseInputOf(value)).toEqual({});
+  });
+
+  it("recovers a serialized JSON-object string as the parsed arguments", async () => {
+    // A non-Anthropic model can leave stored arguments as a serialized JSON
+    // object string; the canonical transport coercion parses it back into the
+    // object Bedrock Converse accepts, rather than dropping a valid payload.
+    expect(await toolUseInputOf('{"path":"README.md"}')).toEqual({ path: "README.md" });
   });
 
   it("preserves a well-formed object toolCall arguments as-is", async () => {

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -1008,7 +1008,16 @@ function convertMessages(
               break;
             case "toolCall":
               contentBlocks.push({
-                toolUse: { toolUseId: c.id, name: c.name, input: c.arguments as DocumentType },
+                toolUse: {
+                  toolUseId: c.id,
+                  name: c.name,
+                  // Bedrock Converse rejects a non-object toolUse.input on replay
+                  // with "Invalid 'input': value did not match any expected variant";
+                  // a non-Anthropic model can leave stored arguments as a raw
+                  // string/array/primitive. Fall back to an empty document rather
+                  // than replaying malformed input that poisons every later turn.
+                  input: isRecord(c.arguments) ? (c.arguments as DocumentType) : {},
+                },
               });
               break;
             case "thinking": {

--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -71,6 +71,7 @@ import {
   notifyLlmRequestActivity,
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import {
+  coerceTransportToolCallArguments,
   describeToolResultMediaPlaceholder,
   finalizeTerminalToolCallArguments,
   notifyProviderHttpMetadata,
@@ -1011,12 +1012,11 @@ function convertMessages(
                 toolUse: {
                   toolUseId: c.id,
                   name: c.name,
-                  // Bedrock Converse rejects a non-object toolUse.input on replay
-                  // with "Invalid 'input': value did not match any expected variant";
-                  // a non-Anthropic model can leave stored arguments as a raw
-                  // string/array/primitive. Fall back to an empty document rather
-                  // than replaying malformed input that poisons every later turn.
-                  input: isRecord(c.arguments) ? (c.arguments as DocumentType) : {},
+                  // Canonical transport coercion shared with sibling provider replay
+                  // (e.g. Anthropic): preserves object args, parses serialized
+                  // JSON-string args, and empties malformed/scalar values Bedrock
+                  // rejects on replay ("Invalid 'input': value did not match any expected variant").
+                  input: coerceTransportToolCallArguments(c.arguments) as DocumentType,
                 },
               });
               break;

--- a/packages/ai/src/transports/transport-stream-shared.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseTerminalToolCallArguments } from "./transport-stream-shared.js";
+import {
+  coerceTransportToolCallArguments,
+  parseTerminalToolCallArguments,
+} from "./transport-stream-shared.js";
 
 const MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE =
   "Provider completed tool call with malformed JSON arguments";
@@ -24,6 +27,25 @@ describe("parseTerminalToolCallArguments", () => {
       }
       expect(thrown).toMatchObject({ message: MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE });
       expect(String(thrown)).not.toContain("do-not-echo");
+    },
+  );
+});
+
+describe("coerceTransportToolCallArguments", () => {
+  it("preserves unsafe integer literals in recovered serialized arguments", () => {
+    // Raw JSON.parse rounds integer literals above Number.MAX_SAFE_INTEGER
+    // (e.g. 64-bit snowflake IDs) before provider replay; the recovered
+    // arguments must match the terminal parser's string-preservation contract.
+    expect(coerceTransportToolCallArguments('{"id":9223372036854775807,"safe":42}')).toEqual({
+      id: "9223372036854775807",
+      safe: 42,
+    });
+  });
+
+  it.each(["not-an-object", '{"path":"README.md"', "[]", "null", "", 42, null, ["a"]])(
+    "falls back to an empty document for non-object input %#",
+    (value) => {
+      expect(coerceTransportToolCallArguments(value)).toEqual({});
     },
   );
 });

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -58,12 +58,10 @@ export function coerceTransportToolCallArguments(argumentsValue: unknown): Recor
     return argumentsRecord;
   }
   if (typeof argumentsValue === "string") {
-    try {
-      return asNonArrayRecord(JSON.parse(argumentsValue));
-    } catch {
-      // Preserve malformed strings in stored history, but send object-shaped payloads to
-      // providers that require structured tool-call arguments.
-    }
+    // Same unsafe-integer contract as parseTerminalToolCallArguments below:
+    // raw JSON.parse rounds 64-bit literals before provider replay, silently
+    // changing stored tool arguments. Malformed strings fall through to {}.
+    return asNonArrayRecord(parseJsonObjectPreservingUnsafeIntegers(argumentsValue));
   }
   return {};
 }


### PR DESCRIPTION
## What Problem This Solves

Closes #125873.

A stored tool call whose `arguments` ended up in a non-object shape (raw string, array, primitive) was replayed to Bedrock Converse unchanged. Bedrock validates `toolUse.input` against a strict document schema on replay and rejects a non-object with `Invalid 'input': value did not match any expected variant`. Once that tool call lands in transcript history, **every subsequent turn that replays the history fails identically** — surfacing the raw provider validation error to the end user instead of a normal reply, until the session is reset. The configured model-fallback chain was not engaged for this error class (`providerRuntimeFailureKind: "unclassified"`), so the error reached the end user directly (in the reporter's case, in a Slack channel).

This is the same conversation-poisoning class and the same code path as #21873, which covered the sibling `toolUse.name` field and was closed by stale-bot without being merged. `toolUse.input` never received equivalent treatment.

## Why This Change Was Made

`convertMessages()` in `extensions/amazon-bedrock/stream.runtime.ts` built the outbound `toolUse` block with a bare type assertion:

```ts
case "toolCall":
    contentBlocks.push({
        toolUse: { toolUseId: c.id, name: c.name, input: c.arguments as DocumentType },
    });
    break;
```

`as DocumentType` is a pure type assertion with zero runtime validation. A non-Anthropic model on Bedrock (the reporter's case: `us.openai.gpt-5.6-luna`) can stream tool-argument deltas that fail to parse into an object, leaving the stored `c.arguments` as a raw string/array/primitive; that malformed value was then replayed verbatim.

The fix uses `coerceTransportToolCallArguments` — the **canonical transport coercion** exported from `openclaw/plugin-sdk/provider-transport-runtime` — at the outbound `toolUse.input` site. This is the same helper sibling provider replay already uses for outbound tool-argument coercion:
- Anthropic: `packages/ai/src/transports/anthropic-transport-stream.ts:503` — `input: coerceTransportToolCallArguments(block.arguments)`.
- Google: `extensions/google/transport-stream.ts:330,681` and `packages/ai/src/providers/google-shared.ts:266`.

The helper preserves object arguments, parses a serialized JSON-object string (a recoverable legacy value a non-Anthropic model may store) back into the object Bedrock accepts, and falls back to an empty document only for malformed or scalar values. An earlier revision used a local `isRecord(c.arguments) ? ... : {}` guard; the review correctly flagged that as duplicating the existing canonical policy *and* silently dropping recoverable serialized-object strings to `{}` — losing valid tool context that the canonical helper recovers. The canonical helper resolves both: no duplicated policy, and a serialized `{"path":"README.md"}` is parsed back to `{path:"README.md"}` instead of being emptied.

**No model scoping.** An empty `input` document is a valid Bedrock document for every model, so scoping to non-Anthropic models would add branching for no benefit. `supportsThinkingSignature()` branches reasoning *content* (genuinely model-family-specific); input-document validity is not.

**Scope kept to `.input`.** The sibling `.name` field (#21873) has its own validation contract and is a separate, stale-bot-closed concern; it is not folded in here.

## User Impact

Operators running non-Anthropic models on Bedrock no longer have a session permanently poisoned by a tool call whose arguments streamed in a shape Bedrock rejects. The malformed `input` is normalized — an object is preserved, a serialized JSON-object string is recovered, a malformed/scalar value becomes an empty document — instead of failing every later turn. Sessions with well-formed tool arguments are unchanged.

## Evidence

**Root cause line:** `extensions/amazon-bedrock/stream.runtime.ts` — the original `input: c.arguments as DocumentType` (pure assertion, no validation), now `input: coerceTransportToolCallArguments(c.arguments) as DocumentType`.

**Regression** (`node scripts/run-vitest.mjs extensions/amazon-bedrock/stream.runtime.test.ts -t "toolUse.input replay sanitization"`):

- Against the original `as DocumentType` line, all replay cases passed the malformed value through verbatim (the bug: non-object `input` replayed as-is).
- Against the local `isRecord` guard (prior revision): four malformed shapes (raw string, malformed JSON string, array, number, null) correctly fell back to `{}`, the valid object was preserved, **but** a serialized JSON-object string `'{"path":"README.md"}'` failed — `expected {} to deeply equal { path: "README.md" }` — the guard dropped a recoverable payload.
- Against the canonical helper (this revision): **7/7 pass** — the four malformed/scalar shapes fall back to `{}`, the valid object is preserved, and the serialized JSON-object string is recovered as `{ path: "README.md" }`.

**Full suite**: `node scripts/run-vitest.mjs extensions/amazon-bedrock` — **229/229 pass (11 files)**, no regression. `oxfmt` clean; `oxlint` clean; `tsgo:extensions` clean (exit 0).

**Real behavior (source-level proof)** — the outbound conversion owner, before and after:

```text
// original: non-object arguments replayed verbatim -> Bedrock rejects -> session poisoned
convertMessages(..., { type: "toolCall", arguments: "not-an-object" })   // toolUse.input === "not-an-object"
convertMessages(..., { type: "toolCall", arguments: null })              // toolUse.input === null

// canonical helper: malformed/scalar -> empty document Bedrock accepts
convertMessages(..., { type: "toolCall", arguments: "not-an-object" })   // toolUse.input === {}
convertMessages(..., { type: "toolCall", arguments: null })              // toolUse.input === {}

// canonical helper: serialized JSON-object string -> parsed back to the object (recoverable)
convertMessages(..., { type: "toolCall", arguments: '{"path":"README.md"}' })  // toolUse.input === { path: "README.md" }

// valid object passes through unchanged
convertMessages(..., { type: "toolCall", arguments: { path: "README.md" } })   // toolUse.input === { path: "README.md" }
```

The regression tests exercise the real `convertMessages` outbound path via `captureCommandInput` (spies `BedrockRuntimeClient.prototype.send` and asserts the `toolUse.input` field of the captured `ConverseStreamCommand`), covering the exact replay path the issue reports. The helper (`coerceTransportToolCallArguments`) is the same one Anthropic and Google replay use for the identical outbound coercion, so its behavior is already exercised by sibling-provider tests.

**Independent real-setup verification (after review)** — @shojikumaru (human + AI agent, 2026-09-02) ran an isolated Docker verification at this exact head (`e5afa3f4`): `node scripts/run-vitest.mjs extensions/amazon-bedrock/stream.runtime.test.ts` → **49/49 green**. Overlaying only this PR's test file onto the merge-base (`a435cf68`) with the same command → **6 failed | 43 passed**, reproducing the pre-fix behavior (`AssertionError: expected '{"path":"README.md"}' to deeply equal { path: 'README.md' }` at `stream.runtime.test.ts:998`). That is an independent before/after A/B on the real outbound conversion path (isolated checkout, `--network=none`, no secrets in env), not a mock-only claim.

**Proof gap**: no live Bedrock provider is attached, so a redacted after-fix Bedrock provider trace is not attached. The regression harness exercises the real outbound `convertMessages` path (mocked client + real conversion code), and the coercion helper is shared with sibling-provider replay. The error class (`Invalid 'input': value did not match any expected variant`) is a top-level document-shape rejection, which the canonical coercion resolves at the object-shape boundary; nested non-JSON values are handled by SDK JSON marshaling and surface a different error.

## reviewMetrics

- Production: +10/−1 in `stream.runtime.ts` — one `coerceTransportToolCallArguments` import added to the existing `openclaw/plugin-sdk/provider-transport-runtime` barrel (already imported for `finalizeTerminalToolCallArguments`), the guard line (`input: coerceTransportToolCallArguments(c.arguments) as DocumentType`) reshaping the original `input: c.arguments as DocumentType` in place (net-zero logic: a `as DocumentType` cast remains, now on the helper's runtime-guaranteed record), and a 4-line invariant comment documenting why canonical coercion is used and what it protects against. Why it matters: stops a silent session-poisoning failure — any non-Anthropic-model tool call with a non-object `arguments` permanently broke the session. Zero new helpers: reuses the exported canonical coercion shared with sibling provider replay rather than duplicating a local guard.
- Tests: +58/−0 in `stream.runtime.test.ts` — seven regression cases (raw string, malformed JSON string, array, number, null, a valid-object control, and a serialized JSON-object string recovery) via the existing `captureCommandInput` harness; the five malformed/scalar cases fall back to `{}`, the valid object is preserved, and the serialized-object string is recovered — all fail against the prior `isRecord` revision (the serialized-object case) or the original `as DocumentType` line, and pass against the canonical helper.

## risks

- **Positive production delta** (+9 net): one import and a 4-line invariant comment; the guard logic is delegated to the canonical helper, so no local coercion policy is duplicated. The growth is the required invariant comment (documenting why canonical coercion, not a local guard, is used — without it a future change would re-introduce a local `isRecord` guard and re-drop recoverable serialized-object strings) plus the import. The canonical helper cannot be expressed more simply inline without re-duplicating the parse-record/empty-fallback policy the helper already owns.
- **No new config or path**: one guard line on the existing `case "toolCall"` using a helper already exported from a barrel the module already imports, and already used by sibling provider replay.

## bestSolution

Using `coerceTransportToolCallArguments` at the one outbound owner (`convertMessages` `case "toolCall"`) is the canonical fix. Sibling provider replay (Anthropic `anthropic-transport-stream.ts:503`, Google) already uses this exact helper for the identical outbound `tool-arguments` coercion; Bedrock was the one consumer missing it. The helper preserves object arguments, recovers a serialized JSON-object string (a legacy value a non-Anthropic model may store), and empties only malformed/scalar values — strictly better than a local `isRecord` guard, which silently lost recoverable payloads. No model-scoping is required because a non-object `input` is invalid for every Bedrock model, and the empty-document fallback is universally accepted.
