### PR TITLE
fix(discord): super reactions disappear when ordinary reactions already exist

### DIFF
--- a/extensions/discord/src/monitor.test.ts
+++ b/extensions/discord/src/monitor.test.ts
@@ -1,9 +1,11 @@
 // Discord tests cover monitor plugin behavior.
+import { GatewayDispatchEvents } from "discord-api-types/v10";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { createRequireRecord, typedCases } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelType, type Guild } from "./internal/discord.js";
+import { mapGatewayDispatchData } from "./internal/gateway-dispatch.js";
 import {
   allowListMatches,
   type DiscordGuildEntryResolved,
@@ -1097,6 +1099,86 @@ describe("discord DM reaction handling", () => {
     expect(enqueueSystemEventSpy).toHaveBeenCalledOnce();
     const text = firstMockArg(enqueueSystemEventSpy, "enqueueSystemEvent");
     expect(text).toContain("Discord reaction removed: 👍 by user-42 on");
+  });
+
+  it.each([
+    {
+      action: "added",
+      event: GatewayDispatchEvents.MessageReactionAdd,
+      Listener: DiscordReactionListener,
+    },
+    {
+      action: "removed",
+      event: GatewayDispatchEvents.MessageReactionRemove,
+      Listener: DiscordReactionRemoveListener,
+    },
+  ])("preserves distinct normal and super reactions when $action", async (testCase) => {
+    channelRuntimeModule.resetSystemEventsForTest();
+    enqueueSystemEventSpy.mockImplementation((text: string, options: { sessionKey: string }) =>
+      channelRuntimeModule.enqueueSystemEvent(text, options),
+    );
+
+    try {
+      const fetchMessage = vi.fn(async () => ({
+        id: "msg-1",
+        channel_id: "channel-1",
+        author: { id: "bot-1", username: "bot", discriminator: "0" },
+      }));
+      const client = Object.assign(
+        makeReactionClient({ channelType: ChannelType.GuildText, channelName: "general" }),
+        { rest: { get: fetchMessage } },
+      );
+      const listener = new testCase.Listener(makeReactionListenerParams());
+      const gatewayEvent = {
+        user_id: "user-1",
+        channel_id: "channel-1",
+        message_id: "msg-1",
+        guild_id: "guild-123",
+        emoji: { id: null, name: "👍" },
+        ...(testCase.action === "added"
+          ? { member: { user: { id: "user-1", username: "actor", discriminator: "0" }, roles: [] } }
+          : {}),
+      };
+
+      for (const reaction of [
+        { burst: false, type: 0 },
+        { burst: true, type: 1 },
+        { burst: false, type: 0 },
+        { burst: true, type: 1 },
+      ]) {
+        await listener.handle(
+          mapGatewayDispatchData(client, testCase.event, {
+            ...gatewayEvent,
+            ...reaction,
+          }) as DiscordReactionEvent,
+          client,
+        );
+      }
+
+      const events = channelRuntimeModule.peekSystemEventEntries("discord:acc-1:dm:user-1");
+      const actor = testCase.action === "added" ? "actor" : "user-1";
+      expect(events.map(({ text, contextKey }) => ({ text, contextKey }))).toEqual([
+        {
+          text: `Discord reaction ${testCase.action}: 👍 by ${actor} on guild-123 #general msg msg-1 from bot`,
+          contextKey: `discord:reaction:${testCase.action}:msg-1:user-1:👍`,
+        },
+        {
+          text: `Discord super reaction ${testCase.action}: 👍 by ${actor} on guild-123 #general msg msg-1 from bot`,
+          contextKey: `discord:reaction:${testCase.action}:msg-1:user-1:👍:burst`,
+        },
+      ]);
+      expect(fetchMessage).toHaveBeenCalledTimes(4);
+      expect(fetchMessage).toHaveBeenCalledWith("/channels/channel-1/messages/msg-1");
+      expect(resolveAgentRouteMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          guildId: "guild-123",
+          peer: { kind: "channel", id: "channel-1" },
+        }),
+      );
+    } finally {
+      enqueueSystemEventSpy.mockReset();
+      channelRuntimeModule.resetSystemEventsForTest();
+    }
   });
 
   it("blocks DM reactions when dmPolicy is disabled", async () => {

--- a/extensions/discord/src/monitor/listeners.reactions.ts
+++ b/extensions/discord/src/monitor/listeners.reactions.ts
@@ -481,8 +481,8 @@ async function handleDiscordReactionEvent(
         : channelName
           ? `#${normalizeDiscordSlug(channelName)}`
           : `#${data.channel_id}`;
-      const baseText = `Discord reaction ${action}: ${emojiLabel} by ${actorLabel} on ${guildSlug} ${channelLabel} msg ${data.message_id}`;
-      const contextKey = `discord:reaction:${action}:${data.message_id}:${user.id}:${emojiLabel}`;
+      const baseText = `Discord ${data.burst ? "super " : ""}reaction ${action}: ${emojiLabel} by ${actorLabel} on ${guildSlug} ${channelLabel} msg ${data.message_id}`;
+      const contextKey = `discord:reaction:${action}:${data.message_id}:${user.id}:${emojiLabel}${data.burst ? ":burst" : ""}`;
       reactionBase = { baseText, contextKey };
       return reactionBase;
     };


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where Discord users adding or removing both an ordinary reaction and a super reaction with the same emoji would silently lose the second reaction notification before the agent could see it, including with the default `own` reaction-notification mode.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

Discord's reaction owner now carries the gateway's authoritative super-reaction fact into both its human/model-visible event text and its private deduplication identity. Ordinary reaction text and keys remain byte-for-byte unchanged, duplicate deliveries of either kind remain suppressed, and routing, authorization, public APIs, security decisions, and configuration are unchanged.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Agents now receive both ordinary and super reaction additions and removals, can tell which reaction was super, and retain the existing behavior for every ordinary Discord reaction.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

- Discord's published [reaction object and reaction types](https://docs.discord.com/developers/resources/message) expose independent ordinary/super user flags and counts, plus `NORMAL = 0` and `BURST = 1`; its [Reactions and Super Reactions FAQ](https://support.discord.com/hc/en-us/articles/12102061808663-Reactions-and-Super-Reactions-FAQ) documents independently viewing and removing the two kinds.
- Regression RED: the real Discord gateway mapper, real reaction-add/remove listeners, default `own` notification mode, actual message REST route, real routed system-event queue, and repeated gateway deliveries produced one queued event instead of the expected two for both add and remove.
- Regression GREEN: the same checked-in cases now queue exactly one ordinary event and one visibly distinct super event for both add and remove; replaying either kind does not create duplicates.
- Focused regression: `node scripts/run-vitest.mjs extensions/discord/src/monitor.test.ts -t 'preserves distinct normal and super reactions'` — 2 passed; both failed against pre-fix production.
- Independent gateway, Discord owner, Discord authorization, provider-registration, Slack-reaction sibling, and real system-event-queue suites — **183 passed** across six files; an additional independent zero-mock default-route probe confirms both normal/super events and exact duplicate suppression.
- Targeted typed lint, formatting, and two independent authenticated full-diff reviews passed. Production change: **2 additions, 2 removals; net zero lines**.
