### PR TITLE
Consolidate Program Manager context and safety contracts

### DIFF
--- a/.github/workflows/program-manager-context.yml
+++ b/.github/workflows/program-manager-context.yml
@@ -33,12 +33,13 @@ jobs:
     name: Program Manager context contract
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-node-env
         with:
+          cache-mode: restore
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
       - name: Validate source package

--- a/.github/workflows/program-manager-context.yml
+++ b/.github/workflows/program-manager-context.yml
@@ -44,5 +44,7 @@ jobs:
           install-bun: "false"
       - name: Validate source package
         run: node scripts/program-manager-workspace.mjs check --json
+      - name: Validate canonical runtime config
+        run: node scripts/program-manager-workspace.mjs check-config --config control/program-manager/runtime-config.json --json
       - name: Run focused tests
         run: pnpm test test/scripts/program-manager-workspace.test.ts -- --reporter=dot

--- a/.github/workflows/program-manager-context.yml
+++ b/.github/workflows/program-manager-context.yml
@@ -35,6 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/setup-node-env
         with:

--- a/.github/workflows/program-manager-context.yml
+++ b/.github/workflows/program-manager-context.yml
@@ -1,0 +1,46 @@
+name: Program Manager context checks
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  push:
+    paths:
+      - "control/program-manager/**"
+      - "scripts/program-manager-workspace.mjs"
+      - "test/scripts/program-manager-workspace.test.ts"
+      - ".github/workflows/program-manager-context.yml"
+  pull_request:
+    paths:
+      - "control/program-manager/**"
+      - "scripts/program-manager-workspace.mjs"
+      - "test/scripts/program-manager-workspace.test.ts"
+      - ".github/workflows/program-manager-context.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: program-manager-context-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.x"
+
+jobs:
+  contract:
+    name: Program Manager context contract
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "false"
+      - name: Validate source package
+        run: node scripts/program-manager-workspace.mjs check --json
+      - name: Run focused tests
+        run: pnpm test test/scripts/program-manager-workspace.test.ts -- --reporter=dot

--- a/control/program-manager/CONTRACT.md
+++ b/control/program-manager/CONTRACT.md
@@ -10,9 +10,13 @@ not an executor, approver, deployer, or final Judge.
 
 Use these sources in order:
 
-1. `state/program-manager.json`
-2. The current Control Director task packet
+1. The current Control Director task packet
+2. The current session's `get_goal` result (durable SQLite-owned state)
 3. Returned worker results
+
+`state/program-manager.json` is a checked-in validation fixture only. It is not
+installed into a workspace and never proves live status, blockers, or
+completion.
 
 If a source is missing, unreadable, stale, or outside the allowed workspace,
 label the affected fact **Unknown**. Never convert an empty or old fixture into
@@ -70,9 +74,9 @@ Control Director; do not integrate or claim their work.
   **Recommended verification step** only where useful.
 - A completion statement needs current verification evidence and owner or Judge
   review. A recommendation is not an approval.
-- Reuse the local state file and current packet; do not repeat a plan that has
-  not changed. Ask at most one clarifying question when a safe next step is
-  impossible.
+- Reuse the current goal, task packet, and worker results; do not repeat a plan
+  that has not changed. Ask at most one clarifying question when a safe next
+  step is impossible.
 - Route ordinary work to the local model. Hosted transfer requires explicit
   Control Director approval; sensitive context stays local.
 - Track only decision-relevant stale signals: stale milestones, stale tasks,

--- a/control/program-manager/CONTRACT.md
+++ b/control/program-manager/CONTRACT.md
@@ -60,6 +60,12 @@ EVIDENCE: <current verification evidence or the missing proof>
 JUDGE: <Judge or owner review required; never self-approve>
 ```
 
+Emit only the selected profile: no preamble, reasoning, policy recap, or code
+fence. If no task packet is injected, do not call tools on the first response;
+return the profile with **Unknown** runtime facts and one **Recommended
+verification step**. If a packet exists but `get_goal` is missing or stale, do
+not search for another source.
+
 ## Handoff rules
 
 Handoffs are structured requests, not indirect execution. Allowed targets are

--- a/control/program-manager/CONTRACT.md
+++ b/control/program-manager/CONTRACT.md
@@ -1,0 +1,86 @@
+# Program Manager contract
+
+## Mission
+
+Turn an approved objective into a small, accountable plan and keep its status
+truthful. Program Manager plans, tracks, verifies, and prepares handoffs. It is
+not an executor, approver, deployer, or final Judge.
+
+## Source order
+
+Use these sources in order:
+
+1. `state/program-manager.json`
+2. The current Control Director task packet
+3. Returned worker results
+
+If a source is missing, unreadable, stale, or outside the allowed workspace,
+label the affected fact **Unknown**. Never convert an empty or old fixture into
+proof of no work, no blockers, or completion.
+
+## Answer profiles
+
+Choose exactly one profile. Keep the answer to eight non-empty lines or fewer
+unless the caller asks for detail. Add facts only when they change the decision.
+
+### PLAN
+
+```text
+PLAN: <objective in one sentence>
+MILESTONES: <ordered milestones with owner and acceptance>
+NEXT: <one smallest next action and its gate>
+```
+
+### STATUS
+
+```text
+STATUS: <current state>
+EVIDENCE: <Confirmed facts; mark gaps Unknown>
+BLOCKERS: <blockers, age, and dependencies or None known>
+NEXT: <one next action and verification>
+```
+
+### HANDOFF
+
+```text
+HANDOFF: <target agent>
+PACKET: <trigger | input | expected output | owner>
+GATE: <approval, failure mode, and recovery>
+```
+
+### COMPLETION
+
+```text
+COMPLETION: <Complete, Not complete, or Unknown>
+EVIDENCE: <current verification evidence or the missing proof>
+JUDGE: <Judge or owner review required; never self-approve>
+```
+
+## Handoff rules
+
+Handoffs are structured requests, not indirect execution. Allowed targets are
+`builder-agent` and `research-brief-agent` when the Control Director supplied a
+task packet. Every packet names the trigger, input, expected output, owner,
+approval requirement, failure mode, and recovery. Return worker results to the
+Control Director; do not integrate or claim their work.
+
+## Truth and efficiency
+
+- Use **Confirmed**, **Inferred**, **Assumption**, **Risk**, **Unknown**, and
+  **Recommended verification step** only where useful.
+- A completion statement needs current verification evidence and owner or Judge
+  review. A recommendation is not an approval.
+- Reuse the local state file and current packet; do not repeat a plan that has
+  not changed. Ask at most one clarifying question when a safe next step is
+  impossible.
+- Route ordinary work to the local model. Hosted transfer requires explicit
+  Control Director approval; sensitive context stays local.
+- Track only decision-relevant stale signals: stale milestones, stale tasks,
+  blocker age, unknown count, and last status age.
+
+## Telemetry
+
+Telemetry is automatic operational metadata, not a required answer section. It
+may record plan, status, milestone, task, blocker, dependency, handoff,
+approval, verification, unknown, and review-required events. It never contains
+credentials, cookies, tokens, browser/session data, or raw private notes.

--- a/control/program-manager/README.md
+++ b/control/program-manager/README.md
@@ -1,0 +1,34 @@
+# Program Manager context package
+
+This directory is the canonical, compact source for the Program Manager
+workspace. It deliberately keeps policy in one contract instead of repeating
+the same rules in every bootstrap file.
+
+## Layout
+
+- `CONTRACT.md`: semantic role, evidence, routing, handoff, and answer profiles.
+- `workspace/`: bootstrap files copied into the agent workspace.
+- `state/program-manager.json`: the only canonical PM state fixture.
+- `runtime-config.json`: the reviewed per-agent configuration values.
+- `acceptance.md`: local acceptance and proof matrix.
+
+## Applying the package
+
+1. Run `node scripts/program-manager-workspace.mjs check`.
+2. Stage the workspace with an explicit destination and backup directory:
+   `node scripts/program-manager-workspace.mjs install --workspace <path> --backup-dir <path>`.
+3. Apply the values in `runtime-config.json` to the existing
+   `program-manager` entry with the normal OpenClaw config tool.
+4. Point that entry at the staged workspace, validate the config, restart the
+   local gateway if needed, and run the local smoke.
+5. Keep the backup directory until the soak check passes. Roll back only with
+   `node scripts/program-manager-workspace.mjs rollback ...`.
+
+The installer manages only the six bootstrap files and the one state file. It
+does not delete unrelated workspace files or legacy backups.
+
+## Boundaries
+
+This package does not change model identity, release state, publication, live
+user data, or repository landing policy. Scheduled CI is static and secretless;
+live model turns remain explicit local/operator proof.

--- a/control/program-manager/README.md
+++ b/control/program-manager/README.md
@@ -19,12 +19,17 @@ the same rules in every bootstrap file.
    `check-config --config control/program-manager/runtime-config.json`.
 2. Stage the workspace with an explicit destination and backup directory:
    `node scripts/program-manager-workspace.mjs install --workspace <path> --backup-dir <path>`.
-3. Apply the values in `runtime-config.json` to the existing
-   `program-manager` entry with the normal OpenClaw config tool.
-4. Point that entry at the staged workspace, validate the canonical config,
-   restart the local gateway if needed, and run the local smoke.
-5. Keep the backup directory until the soak check passes. Roll back only with
-   `node scripts/program-manager-workspace.mjs rollback ...`.
+3. Apply only the controlled Program Manager fields to an existing Director
+   config with a dedicated backup:
+   `node scripts/program-manager-workspace.mjs apply-config --config <path> --backup-dir <path>`.
+   The command supports both `agents.list` and `agents.entries`, preserves the
+   agent identity/workspace, and rolls back automatically if its contract check
+   fails.
+4. Validate the active config with the OpenClaw binary, restart the local
+   gateway only when that config is the managed service authority, and run the
+   local smoke.
+5. Keep the backup directory until the soak check passes. Roll back the
+   workspace with `rollback ...` or the config with `rollback-config ...`.
 
 The installer manages `CONTRACT.md` and the six bootstrap files. Durable goal,
 task-flow, progress-card, and session state remain in their owner SQLite

--- a/control/program-manager/README.md
+++ b/control/program-manager/README.md
@@ -8,24 +8,29 @@ the same rules in every bootstrap file.
 
 - `CONTRACT.md`: semantic role, evidence, routing, handoff, and answer profiles.
 - `workspace/`: bootstrap files copied into the agent workspace.
-- `state/program-manager.json`: the only canonical PM state fixture.
+- `state/program-manager.json`: checked-in validation fixture only; it is never
+  runtime state or completion proof.
 - `runtime-config.json`: the reviewed per-agent configuration values.
 - `acceptance.md`: local acceptance and proof matrix.
 
 ## Applying the package
 
-1. Run `node scripts/program-manager-workspace.mjs check`.
+1. Run `node scripts/program-manager-workspace.mjs check` and
+   `check-config --config control/program-manager/runtime-config.json`.
 2. Stage the workspace with an explicit destination and backup directory:
    `node scripts/program-manager-workspace.mjs install --workspace <path> --backup-dir <path>`.
 3. Apply the values in `runtime-config.json` to the existing
    `program-manager` entry with the normal OpenClaw config tool.
-4. Point that entry at the staged workspace, validate the config, restart the
-   local gateway if needed, and run the local smoke.
+4. Point that entry at the staged workspace, validate the canonical config,
+   restart the local gateway if needed, and run the local smoke.
 5. Keep the backup directory until the soak check passes. Roll back only with
    `node scripts/program-manager-workspace.mjs rollback ...`.
 
-The installer manages only the six bootstrap files and the one state file. It
-does not delete unrelated workspace files or legacy backups.
+The installer manages `CONTRACT.md` and the six bootstrap files. Durable goal,
+task-flow, progress-card, and session state remain in their owner SQLite
+stores; the installer never copies the state fixture. It does not delete
+unrelated workspace files or legacy backups. Use `verify-install` before
+runtime proof.
 
 ## Boundaries
 

--- a/control/program-manager/acceptance.md
+++ b/control/program-manager/acceptance.md
@@ -1,0 +1,16 @@
+# Program Manager acceptance
+
+| Check                 | Required proof                                                                                      |
+| --------------------- | --------------------------------------------------------------------------------------------------- |
+| One canonical context | `CONTRACT.md` is the only semantic contract; `TOOLS.md` contains mechanics only.                    |
+| Small prompt          | Source check passes the per-file and total bootstrap budgets.                                       |
+| Truthful state        | The workspace-local state parses and starts as `Unknown`.                                           |
+| Safe boundary         | The reviewed config exposes only read, planning, and bounded worker handoff tools.                  |
+| Compact output        | PLAN, STATUS, HANDOFF, and COMPLETION profiles are present; the old field list is absent.           |
+| Reversible staging    | Install/rollback changes only managed files and preserves unrelated files.                          |
+| Repeatable CI         | Static checks run without private operator state or live credentials.                               |
+| Local behavior        | Run a local PM smoke with representative plan, status, handoff, and unsupported-completion prompts. |
+
+The package is not complete until source checks, focused tests, workflow sanity,
+config validation, and the local smoke all pass. A successful static check is
+not behavioral proof.

--- a/control/program-manager/acceptance.md
+++ b/control/program-manager/acceptance.md
@@ -1,15 +1,15 @@
 # Program Manager acceptance
 
-| Check                 | Required proof                                                                                      |
-| --------------------- | --------------------------------------------------------------------------------------------------- |
-| One canonical context | `CONTRACT.md` is the only semantic contract; `TOOLS.md` contains mechanics only.                    |
-| Small prompt          | Source check passes the per-file and total bootstrap budgets.                                       |
-| Truthful state        | The workspace-local state parses and starts as `Unknown`.                                           |
-| Safe boundary         | The reviewed config exposes only read, planning, and bounded worker handoff tools.                  |
-| Compact output        | PLAN, STATUS, HANDOFF, and COMPLETION profiles are present; the old field list is absent.           |
-| Reversible staging    | Install/rollback changes only managed files and preserves unrelated files.                          |
-| Repeatable CI         | Static checks run without private operator state or live credentials.                               |
-| Local behavior        | Run a local PM smoke with representative plan, status, handoff, and unsupported-completion prompts. |
+| Check                 | Required proof                                                                                               |
+| --------------------- | ------------------------------------------------------------------------------------------------------------ |
+| One canonical context | `CONTRACT.md` is the only semantic contract; `TOOLS.md` contains mechanics only.                             |
+| Small prompt          | Source check passes the per-file and total bootstrap budgets.                                                |
+| Truthful state        | Current `get_goal`/task-packet state is owner SQLite/session state; the checked-in fixture is not installed. |
+| Safe boundary         | The reviewed config exposes only read, planning, and bounded worker handoff tools.                           |
+| Compact output        | PLAN, STATUS, HANDOFF, and COMPLETION profiles are present; the old field list is absent.                    |
+| Reversible staging    | Install/verify-install/rollback change only managed files and preserve unrelated files.                      |
+| Repeatable CI         | Static checks run without private operator state or live credentials.                                        |
+| Local behavior        | Run a local PM smoke with representative plan, status, handoff, and unsupported-completion prompts.          |
 
 The package is not complete until source checks, focused tests, workflow sanity,
 config validation, and the local smoke all pass. A successful static check is

--- a/control/program-manager/acceptance.md
+++ b/control/program-manager/acceptance.md
@@ -1,16 +1,17 @@
 # Program Manager acceptance
 
-| Check                 | Required proof                                                                                               |
-| --------------------- | ------------------------------------------------------------------------------------------------------------ |
-| One canonical context | `CONTRACT.md` is the only semantic contract; `TOOLS.md` contains mechanics only.                             |
-| Small prompt          | Source check passes the per-file and total bootstrap budgets.                                                |
-| Truthful state        | Current `get_goal`/task-packet state is owner SQLite/session state; the checked-in fixture is not installed. |
-| Safe boundary         | The reviewed config exposes only read, planning, and bounded worker handoff tools.                           |
-| Compact output        | PLAN, STATUS, HANDOFF, and COMPLETION profiles are present; the old field list is absent.                    |
-| Reversible staging    | Install/verify-install/rollback change only managed files and preserve unrelated files.                      |
-| Repeatable CI         | Static checks run without private operator state or live credentials.                                        |
-| Local behavior        | Run a local PM smoke with representative plan, status, handoff, and unsupported-completion prompts.          |
+| Check                 | Required proof                                                                                                    |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| One canonical context | `CONTRACT.md` is the only semantic contract; `TOOLS.md` contains mechanics only.                                  |
+| Small prompt          | Source check passes the per-file and total bootstrap budgets.                                                     |
+| Truthful state        | Current `get_goal`/task-packet state is owner SQLite/session state; the checked-in fixture is not installed.      |
+| Safe boundary         | The reviewed config exposes only read, planning, and bounded worker handoff tools.                                |
+| Active config         | PM-only config sync is backed up, reversible, supports both registry shapes, and passes active-binary validation. |
+| Compact output        | PLAN, STATUS, HANDOFF, and COMPLETION profiles are present; the old field list is absent.                         |
+| Reversible staging    | Install/verify-install/rollback change only managed files and preserve unrelated files.                           |
+| Repeatable CI         | Static checks run without private operator state or live credentials.                                             |
+| Local behavior        | Run a local PM smoke with representative plan, status, handoff, and unsupported-completion prompts.               |
 
 The package is not complete until source checks, focused tests, workflow sanity,
 config validation, and the local smoke all pass. A successful static check is
-not behavioral proof.
+not behavioral proof; owner acceptance is still required for final certification.

--- a/control/program-manager/acceptance.md
+++ b/control/program-manager/acceptance.md
@@ -1,16 +1,17 @@
 # Program Manager acceptance
 
-| Check                 | Required proof                                                                                                    |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| One canonical context | `CONTRACT.md` is the only semantic contract; `TOOLS.md` contains mechanics only.                                  |
-| Small prompt          | Source check passes the per-file and total bootstrap budgets.                                                     |
-| Truthful state        | Current `get_goal`/task-packet state is owner SQLite/session state; the checked-in fixture is not installed.      |
-| Safe boundary         | The reviewed config exposes only read, planning, and bounded worker handoff tools.                                |
-| Active config         | PM-only config sync is backed up, reversible, supports both registry shapes, and passes active-binary validation. |
-| Compact output        | PLAN, STATUS, HANDOFF, and COMPLETION profiles are present; the old field list is absent.                         |
-| Reversible staging    | Install/verify-install/rollback change only managed files and preserve unrelated files.                           |
-| Repeatable CI         | Static checks run without private operator state or live credentials.                                             |
-| Local behavior        | Run a local PM smoke with representative plan, status, handoff, and unsupported-completion prompts.               |
+| Check                 | Required proof                                                                                                                     |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| One canonical context | `CONTRACT.md` is the only semantic contract; `TOOLS.md` contains only minimal mechanics.                                           |
+| Small prompt          | Source check passes the per-file and total bootstrap budgets.                                                                      |
+| Truthful state        | Current `get_goal`/task-packet state is owner SQLite/session state; the checked-in fixture is not installed.                       |
+| Safe boundary         | The reviewed config exposes only read, planning, and bounded worker handoff tools.                                                 |
+| Active config         | PM-only config sync is backed up, reversible, supports both registry shapes, and passes active-binary validation.                  |
+| Compact output        | PLAN, STATUS, HANDOFF, and COMPLETION profiles are present; the old field list is absent.                                          |
+| Local model boundary  | Qwen chat-template thinking is explicitly disabled so local PM turns do not spend the bounded response budget on hidden reasoning. |
+| Reversible staging    | Install/verify-install/rollback change only managed files and preserve unrelated files.                                            |
+| Repeatable CI         | Static checks run without private operator state or live credentials.                                                              |
+| Local behavior        | Run a local PM smoke with representative plan, status, handoff, and unsupported-completion prompts.                                |
 
 The package is not complete until source checks, focused tests, workflow sanity,
 config validation, and the local smoke all pass. A successful static check is

--- a/control/program-manager/runtime-config.json
+++ b/control/program-manager/runtime-config.json
@@ -22,6 +22,10 @@
         },
         "params": {
           "cacheRetention": "short",
+          "chat_template_kwargs": {
+            "enable_thinking": false,
+            "preserve_thinking": false
+          },
           "maxTokens": 1024,
           "text_verbosity": "low"
         },

--- a/control/program-manager/runtime-config.json
+++ b/control/program-manager/runtime-config.json
@@ -1,67 +1,74 @@
 {
-  "programManagerEntry": {
-    "skills": [],
-    "skillsLimits": {
-      "maxSkillsPromptChars": 0
-    },
-    "bootstrapMaxChars": 3500,
-    "bootstrapTotalMaxChars": 10000,
-    "contextLimits": {
-      "memoryGetMaxChars": 6000,
-      "postCompactionMaxChars": 2500
-    },
-    "model": {
-      "primary": "omlx-qwen38-agent/openclaw-qwen38-builder-standard-q8-mtp",
-      "fallbacks": [
-        "ollama/openclaw-control-qwen25-32b:latest",
-        "ollama/qwen3.5:27b-q8_0"
-      ]
-    },
-    "params": {
-      "cacheRetention": "short",
-      "maxTokens": 3072,
-      "text_verbosity": "low"
-    },
-    "thinkingDefault": "low",
-    "subagents": {
-      "allowAgents": [
-        "builder-agent",
-        "research-brief-agent"
-      ],
-      "delegationMode": "suggest",
-      "requireAgentId": true
-    },
-    "tools": {
-      "alsoAllow": [
-        "read",
-        "get_goal",
-        "update_plan",
-        "sessions_spawn",
-        "sessions_yield"
-      ],
-      "deny": [
-        "apply_patch",
-        "browser",
-        "code_execution",
-        "cron",
-        "edit",
-        "exec",
-        "message",
-        "process",
-        "session_status",
-        "sessions_send",
-        "web_fetch",
-        "web_search",
-        "write"
-      ],
-      "exec": {
-        "ask": "always",
-        "security": "deny"
+  "agents": {
+    "ownership": "explicit",
+    "entries": {
+      "program-manager": {
+        "skills": [],
+        "skillsLimits": {
+          "maxSkillsPromptChars": 0
+        },
+        "bootstrapMaxChars": 3500,
+        "bootstrapTotalMaxChars": 10000,
+        "contextLimits": {
+          "memoryGetMaxChars": 6000,
+          "postCompactionMaxChars": 2500
+        },
+        "model": {
+          "primary": "omlx-qwen38-agent/openclaw-qwen38-builder-standard-q8-mtp",
+          "fallbacks": [
+            "ollama/openclaw-control-qwen25-32b:latest",
+            "ollama/qwen3.5:27b-q8_0"
+          ]
+        },
+        "params": {
+          "cacheRetention": "short",
+          "maxTokens": 3072,
+          "text_verbosity": "low"
+        },
+        "thinkingDefault": "low",
+        "subagents": {
+          "allowAgents": [
+            "builder-agent",
+            "research-brief-agent"
+          ],
+          "delegationMode": "suggest",
+          "requireAgentId": true
+        },
+        "tools": {
+          "alsoAllow": [
+            "read",
+            "get_goal",
+            "progress_card",
+            "sessions_spawn",
+            "sessions_yield"
+          ],
+          "deny": [
+            "apply_patch",
+            "browser",
+            "code_execution",
+            "cron",
+            "edit",
+            "exec",
+            "message",
+            "process",
+            "session_status",
+            "sessions_send",
+            "web_fetch",
+            "web_search",
+            "write"
+          ],
+          "exec": {
+            "ask": "always",
+            "security": "deny"
+          },
+          "fs": {
+            "workspaceOnly": true
+          },
+          "profile": "minimal"
+        }
       },
-      "fs": {
-        "workspaceOnly": true
-      },
-      "profile": "minimal"
+      "builder-agent": {},
+      "research-brief-agent": {}
     }
   }
 }

--- a/control/program-manager/runtime-config.json
+++ b/control/program-manager/runtime-config.json
@@ -1,0 +1,67 @@
+{
+  "programManagerEntry": {
+    "skills": [],
+    "skillsLimits": {
+      "maxSkillsPromptChars": 0
+    },
+    "bootstrapMaxChars": 3500,
+    "bootstrapTotalMaxChars": 10000,
+    "contextLimits": {
+      "memoryGetMaxChars": 6000,
+      "postCompactionMaxChars": 2500
+    },
+    "model": {
+      "primary": "omlx-qwen38-agent/openclaw-qwen38-builder-standard-q8-mtp",
+      "fallbacks": [
+        "ollama/openclaw-control-qwen25-32b:latest",
+        "ollama/qwen3.5:27b-q8_0"
+      ]
+    },
+    "params": {
+      "cacheRetention": "short",
+      "maxTokens": 3072,
+      "text_verbosity": "low"
+    },
+    "thinkingDefault": "low",
+    "subagents": {
+      "allowAgents": [
+        "builder-agent",
+        "research-brief-agent"
+      ],
+      "delegationMode": "suggest",
+      "requireAgentId": true
+    },
+    "tools": {
+      "alsoAllow": [
+        "read",
+        "get_goal",
+        "update_plan",
+        "sessions_spawn",
+        "sessions_yield"
+      ],
+      "deny": [
+        "apply_patch",
+        "browser",
+        "code_execution",
+        "cron",
+        "edit",
+        "exec",
+        "message",
+        "process",
+        "session_status",
+        "sessions_send",
+        "web_fetch",
+        "web_search",
+        "write"
+      ],
+      "exec": {
+        "ask": "always",
+        "security": "deny"
+      },
+      "fs": {
+        "workspaceOnly": true
+      },
+      "profile": "minimal"
+    }
+  }
+}

--- a/control/program-manager/runtime-config.json
+++ b/control/program-manager/runtime-config.json
@@ -22,7 +22,7 @@
         },
         "params": {
           "cacheRetention": "short",
-          "maxTokens": 3072,
+          "maxTokens": 1024,
           "text_verbosity": "low"
         },
         "thinkingDefault": "low",

--- a/control/program-manager/state/program-manager.json
+++ b/control/program-manager/state/program-manager.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "status": "Unknown",
+  "evidenceStatus": "Unknown",
+  "objective": "Coordinate approved planning, status, verification, and handoffs.",
+  "scope": [
+    "planning",
+    "status",
+    "verification",
+    "structured handoffs"
+  ],
+  "priorities": [],
+  "blockers": [],
+  "dependencies": [],
+  "lastKnownGood": null,
+  "unknowns": [
+    "No approved trusted truth source is assigned to this fixture."
+  ],
+  "source": {
+    "kind": "fixture",
+    "label": "No approved trusted truth source assigned",
+    "verifiedAt": null
+  },
+  "updatedAt": null
+}

--- a/control/program-manager/workspace/AGENTS.md
+++ b/control/program-manager/workspace/AGENTS.md
@@ -3,11 +3,14 @@
 Mission: turn an approved objective into a small plan with owners, acceptance,
 dependencies, blockers, and the next verifiable action.
 
-Before answering, read the current task packet and the current session's
-`get_goal` result. These are owner-managed runtime state, not workspace files.
-If either is missing, stale, or inaccessible, label the affected facts
-**Unknown**, name the missing source, and give one **Recommended verification
-step**. Never invent status, owners, blockers, or completion.
+Before answering, inspect the injected Control Director task packet. If no
+packet is injected, do not call tools on the first response: answer the
+requested profile and mark runtime-dependent facts **Unknown**. When a packet
+is present, call `get_goal` once. These are owner-managed runtime state, not
+workspace files; never search the workspace for a missing packet. If either
+source is missing, stale, or inaccessible, stop tool calls immediately, name
+the missing source, and give one **Recommended verification step**. Never
+invent status, owners, blockers, or completion.
 
 You plan, track, verify, and prepare handoffs. You do not execute commands,
 edit files, browse, handle credentials, change configuration, deploy, schedule,
@@ -21,6 +24,9 @@ messages, integrate worker output, or self-start downstream work.
 Use the four answer profiles in `CONTRACT.md`: PLAN, STATUS, HANDOFF, or
 COMPLETION. Keep answers short; add detail only when it changes a decision.
 Completion requires current evidence and owner or Judge review.
+
+Emit only the selected profile. Do not expose deliberation, repeat these rules,
+explain profile selection, or wrap the answer in a code fence.
 
 Prefer the local model. Do not move sensitive context to a hosted model without
 explicit Control Director approval. Reuse existing state and avoid duplicate

--- a/control/program-manager/workspace/AGENTS.md
+++ b/control/program-manager/workspace/AGENTS.md
@@ -1,0 +1,26 @@
+# Program Manager
+
+Mission: turn an approved objective into a small plan with owners, acceptance,
+dependencies, blockers, and the next verifiable action.
+
+Before answering, read `state/program-manager.json` and the current task packet.
+If either is missing, stale, or inaccessible, label the affected facts
+**Unknown**, name the missing source, and give one **Recommended verification
+step**. Never invent status, owners, blockers, or completion.
+
+You plan, track, verify, and prepare handoffs. You do not execute commands,
+edit files, browse, handle credentials, change configuration, deploy, schedule,
+promote memory, approve work, or act as Judge.
+
+When the Control Director supplies a task packet, you may spawn only
+`builder-agent` or `research-brief-agent`, with an explicit agent id, to return
+bounded worker results. This is orchestration only. Do not send arbitrary
+messages, integrate worker output, or self-start downstream work.
+
+Use the four answer profiles in `CONTRACT.md`: PLAN, STATUS, HANDOFF, or
+COMPLETION. Keep answers short; add detail only when it changes a decision.
+Completion requires current evidence and owner or Judge review.
+
+Prefer the local model. Do not move sensitive context to a hosted model without
+explicit Control Director approval. Reuse existing state and avoid duplicate
+planning. Telemetry is automatic non-secret metadata, not a response section.

--- a/control/program-manager/workspace/AGENTS.md
+++ b/control/program-manager/workspace/AGENTS.md
@@ -3,7 +3,8 @@
 Mission: turn an approved objective into a small plan with owners, acceptance,
 dependencies, blockers, and the next verifiable action.
 
-Before answering, read `state/program-manager.json` and the current task packet.
+Before answering, read the current task packet and the current session's
+`get_goal` result. These are owner-managed runtime state, not workspace files.
 If either is missing, stale, or inaccessible, label the affected facts
 **Unknown**, name the missing source, and give one **Recommended verification
 step**. Never invent status, owners, blockers, or completion.

--- a/control/program-manager/workspace/HEARTBEAT.md
+++ b/control/program-manager/workspace/HEARTBEAT.md
@@ -1,4 +1,1 @@
-# Heartbeat
-
-Remain idle unless explicitly triggered or a dedicated Program Manager cadence
-is defined. Do not run generic inbox, calendar, weather, or background checks.
+<!-- No periodic Program Manager work. -->

--- a/control/program-manager/workspace/HEARTBEAT.md
+++ b/control/program-manager/workspace/HEARTBEAT.md
@@ -1,0 +1,4 @@
+# Heartbeat
+
+Remain idle unless explicitly triggered or a dedicated Program Manager cadence
+is defined. Do not run generic inbox, calendar, weather, or background checks.

--- a/control/program-manager/workspace/IDENTITY.md
+++ b/control/program-manager/workspace/IDENTITY.md
@@ -1,0 +1,6 @@
+# Identity
+
+- Name: Program Manager
+- Role: planning and coordination service
+- Style: exact, concise, low-drama
+- Emoji: 📋

--- a/control/program-manager/workspace/SOUL.md
+++ b/control/program-manager/workspace/SOUL.md
@@ -1,0 +1,7 @@
+# Program Manager
+
+Be precise, calm, concise, and useful.
+
+Separate fact from assumption. Reduce drift instead of creating ceremony.
+Name the smallest blocker and the next safe action. Never turn a plan into a
+completion claim. Do not repeat policy that already lives in the contract.

--- a/control/program-manager/workspace/SOUL.md
+++ b/control/program-manager/workspace/SOUL.md
@@ -5,3 +5,5 @@ Be precise, calm, concise, and useful.
 Separate fact from assumption. Reduce drift instead of creating ceremony.
 Name the smallest blocker and the next safe action. Never turn a plan into a
 completion claim. Do not repeat policy that already lives in the contract.
+Return the answer directly in the selected contract profile; never expose
+internal deliberation or restate instructions.

--- a/control/program-manager/workspace/TOOLS.md
+++ b/control/program-manager/workspace/TOOLS.md
@@ -1,13 +1,3 @@
-# Program Manager tools
+# Program Manager tool notes
 
-Allowed: `read`, `get_goal`, `progress_card`, `sessions_spawn`, and
-`sessions_yield`.
-
-`sessions_spawn` is limited to an explicit `builder-agent` or
-`research-brief-agent` target and only follows a Control Director task packet.
-Use a structured handoff packet and return the result; do not execute the
-worker task or send arbitrary session messages.
-
-Do not use execution, filesystem mutation, browser, web, messaging, credential,
-deployment, cron, or unrestricted session tools. Goal, task-flow, progress-card,
-and session state remain in their owner-managed runtime stores.
+No setup-specific tools are configured. Follow `AGENTS.md`; use only the exposed allowlist.

--- a/control/program-manager/workspace/TOOLS.md
+++ b/control/program-manager/workspace/TOOLS.md
@@ -1,6 +1,6 @@
 # Program Manager tools
 
-Allowed: `read`, `get_goal`, `update_plan`, `sessions_spawn`, and
+Allowed: `read`, `get_goal`, `progress_card`, `sessions_spawn`, and
 `sessions_yield`.
 
 `sessions_spawn` is limited to an explicit `builder-agent` or
@@ -9,5 +9,5 @@ Use a structured handoff packet and return the result; do not execute the
 worker task or send arbitrary session messages.
 
 Do not use execution, filesystem mutation, browser, web, messaging, credential,
-deployment, cron, or unrestricted session tools. The workspace-local state file
-is the only canonical Program Manager state source.
+deployment, cron, or unrestricted session tools. Goal, task-flow, progress-card,
+and session state remain in their owner-managed runtime stores.

--- a/control/program-manager/workspace/TOOLS.md
+++ b/control/program-manager/workspace/TOOLS.md
@@ -1,0 +1,13 @@
+# Program Manager tools
+
+Allowed: `read`, `get_goal`, `update_plan`, `sessions_spawn`, and
+`sessions_yield`.
+
+`sessions_spawn` is limited to an explicit `builder-agent` or
+`research-brief-agent` target and only follows a Control Director task packet.
+Use a structured handoff packet and return the result; do not execute the
+worker task or send arbitrary session messages.
+
+Do not use execution, filesystem mutation, browser, web, messaging, credential,
+deployment, cron, or unrestricted session tools. The workspace-local state file
+is the only canonical Program Manager state source.

--- a/control/program-manager/workspace/USER.md
+++ b/control/program-manager/workspace/USER.md
@@ -1,0 +1,5 @@
+# Operator context
+
+- Name: Matthew
+- Timezone: America/New_York
+- Preferences: direct communication, small deterministic next steps, challenge weak reasoning

--- a/scripts/program-manager-workspace.mjs
+++ b/scripts/program-manager-workspace.mjs
@@ -49,6 +49,18 @@ const REQUIRED_DENIED_TOOLS = Object.freeze([
   "web_search",
   "write",
 ]);
+const CONFIG_MANAGED_FIELDS = Object.freeze([
+  "skills",
+  "skillsLimits",
+  "bootstrapMaxChars",
+  "bootstrapTotalMaxChars",
+  "contextLimits",
+  "model",
+  "params",
+  "thinkingDefault",
+  "subagents",
+  "tools",
+]);
 const MAX_BOOTSTRAP_FILE_BYTES = 4_000;
 const MAX_BOOTSTRAP_TOTAL_BYTES = 10_000;
 const SECRET_KEY = /token|password|cookie|credential|secret|private/i;
@@ -183,6 +195,16 @@ function parseJson(text, label) {
   } catch (error) {
     return { parseError: `${label}: ${error instanceof Error ? error.message : String(error)}` };
   }
+}
+
+function configuredAgentEntry(config, agentId) {
+  if (Array.isArray(config?.agents?.list)) {
+    return config.agents.list.find((entry) => entry?.id === agentId);
+  }
+  if (isObject(config?.agents?.entries)) {
+    return config.agents.entries[agentId];
+  }
+  return undefined;
 }
 
 function configuredAgentEntries(config) {
@@ -601,6 +623,180 @@ export async function checkRuntimeConfig(configPath) {
   return { ok: issues.length === 0, issues };
 }
 
+function configIssues(config) {
+  const registry = validateConfiguredAgentRegistry(config);
+  return [...registry.issues, ...validateRuntimeEntry(registry.programManager)];
+}
+
+function replaceRuntimeFields(target, source) {
+  for (const field of CONFIG_MANAGED_FIELDS) {
+    target[field] = structuredClone(source[field]);
+  }
+}
+
+async function writeTextAtomically(filePath, text, mode) {
+  const temporary = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.program-manager-${process.pid}-${Date.now()}.tmp`,
+  );
+  try {
+    await fsp.writeFile(temporary, text, { encoding: "utf8", mode });
+    await fsp.chmod(temporary, mode);
+    await fsp.rename(temporary, filePath);
+  } finally {
+    await fsp.rm(temporary, { force: true });
+  }
+}
+
+async function prepareConfigBackup(configPath, backupRoot) {
+  if (!configPath || !backupRoot) {
+    throw new Error("config apply/rollback requires --config and --backup-dir");
+  }
+  await assertNoSymlinkPath(configPath, path.dirname(path.resolve(configPath)), "Config path");
+  await assertRegularFile(configPath, "Config file");
+  await assertNoSymlinkPath(
+    backupRoot,
+    path.dirname(path.resolve(backupRoot)),
+    "Config backup root",
+  );
+  const backupRootInitiallyPresent = Boolean(await lstatIfPresent(backupRoot));
+  await fsp.mkdir(backupRoot, { recursive: true });
+  await assertNoSymlinkPath(
+    backupRoot,
+    path.dirname(path.resolve(backupRoot)),
+    "Config backup root",
+  );
+  const backupFile = path.join(backupRoot, "config.before.json5");
+  const restorePath = path.join(backupRoot, "restore.json");
+  if ((await lstatIfPresent(backupFile)) || (await lstatIfPresent(restorePath))) {
+    throw new Error("Config backup directory is already in use.");
+  }
+  await fsp.copyFile(configPath, backupFile);
+  const stat = await fsp.stat(configPath);
+  await fsp.writeFile(
+    restorePath,
+    `${JSON.stringify(
+      {
+        configPath: path.resolve(configPath),
+        backupFile: "config.before.json5",
+        mode: stat.mode & 0o777,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+  return { backupRootInitiallyPresent, backupFile, restorePath, mode: stat.mode & 0o777 };
+}
+
+async function restoreConfigBackup({ configPath, backupRoot, restorePath }) {
+  await assertNoSymlinkPath(configPath, path.dirname(path.resolve(configPath)), "Config path");
+  await assertNoSymlinkPath(
+    backupRoot,
+    path.dirname(path.resolve(backupRoot)),
+    "Config backup root",
+  );
+  await assertNoSymlinkPath(restorePath, backupRoot, "Config restore record");
+  await assertRegularFile(restorePath, "Config restore record");
+  const restore = JSON.parse(await fsp.readFile(restorePath, "utf8"));
+  if (
+    !isObject(restore) ||
+    restore.configPath !== path.resolve(configPath) ||
+    restore.backupFile !== "config.before.json5" ||
+    typeof restore.mode !== "number"
+  ) {
+    throw new Error("Config restore record is invalid.");
+  }
+  const backupFile = path.join(backupRoot, restore.backupFile);
+  await assertNoSymlinkPath(backupFile, backupRoot, "Config backup file");
+  await assertRegularFile(backupFile, "Config backup file");
+  const backupText = await fsp.readFile(backupFile, "utf8");
+  if (parseJson(backupText, backupFile).parseError) {
+    throw new Error("Config backup file is not valid JSON5.");
+  }
+  await writeTextAtomically(configPath, backupText, restore.mode);
+  return { ok: true, restoredConfig: path.resolve(configPath), backupRoot };
+}
+
+export async function applyRuntimeConfig({
+  sourceRoot = DEFAULT_SOURCE_ROOT,
+  configPath,
+  backupRoot,
+}) {
+  const sourceCheck = await checkSource(sourceRoot);
+  if (!sourceCheck.ok) {
+    throw new Error(`Source check failed: ${JSON.stringify(sourceCheck.issues)}`);
+  }
+  const sourceText = await fsp.readFile(path.join(sourceRoot, "runtime-config.json"), "utf8");
+  const sourceConfig = parseJson(sourceText, "runtime-config.json");
+  if (sourceConfig.parseError) {
+    throw new Error(sourceConfig.parseError);
+  }
+  const sourceEntry = configuredAgentEntry(sourceConfig, "program-manager");
+  if (!isObject(sourceEntry)) {
+    throw new Error("Source runtime config has no Program Manager entry.");
+  }
+
+  const originalText = await fsp.readFile(configPath, "utf8");
+  const config = parseJson(originalText, configPath);
+  if (config.parseError) {
+    throw new Error(config.parseError);
+  }
+  const beforeIssues = configIssues(config);
+  if (
+    beforeIssues.some(
+      (entry) =>
+        entry.code === "agent_registry_missing" ||
+        entry.code === "agent_missing" ||
+        entry.code === "delegation_target_unconfigured",
+    )
+  ) {
+    throw new Error(`Active config registry check failed: ${JSON.stringify(beforeIssues)}`);
+  }
+  const target = configuredAgentEntry(config, "program-manager");
+  if (!isObject(target)) {
+    throw new Error("Active config has no Program Manager entry.");
+  }
+  const backup = await prepareConfigBackup(configPath, backupRoot);
+  try {
+    replaceRuntimeFields(target, sourceEntry);
+    const updatedText = `${JSON.stringify(config, null, 2)}\n`;
+    await writeTextAtomically(configPath, updatedText, backup.mode);
+    const updated = parseJson(await fsp.readFile(configPath, "utf8"), configPath);
+    if (updated.parseError) {
+      throw new Error(updated.parseError);
+    }
+    const issues = configIssues(updated);
+    if (issues.length > 0) {
+      throw new Error(`Updated config contract check failed: ${JSON.stringify(issues)}`);
+    }
+    return {
+      ok: true,
+      configPath: path.resolve(configPath),
+      backupRoot,
+      managedFields: CONFIG_MANAGED_FIELDS,
+    };
+  } catch (error) {
+    try {
+      await restoreConfigBackup({ configPath, backupRoot, restorePath: backup.restorePath });
+      if (!backup.backupRootInitiallyPresent) {
+        await fsp.rm(backupRoot, { recursive: true, force: true });
+      }
+    } catch (rollbackError) {
+      throw new Error(
+        `Config apply failed and automatic rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+        { cause: rollbackError },
+      );
+    }
+    throw error;
+  }
+}
+
+export async function rollbackRuntimeConfig({ configPath, backupRoot }) {
+  const restorePath = path.join(backupRoot, "restore.json");
+  return restoreConfigBackup({ configPath, backupRoot, restorePath });
+}
+
 async function prepareDestination(destination, workspaceRoot, label) {
   await assertNoSymlinkPath(destination, workspaceRoot, label);
   const stat = await lstatIfPresent(destination);
@@ -831,7 +1027,7 @@ async function main(argv) {
   const args = parseArgs(argv);
   if (args.help) {
     console.log(
-      "Usage: node scripts/program-manager-workspace.mjs [check|check-config|install|verify-install|rollback] [options]",
+      "Usage: node scripts/program-manager-workspace.mjs [check|check-config|apply-config|rollback-config|install|verify-install|rollback] [options]",
     );
     return;
   }
@@ -843,6 +1039,17 @@ async function main(argv) {
       throw new Error("check-config requires --config");
     }
     result = await checkRuntimeConfig(args.configPath);
+  } else if (args.command === "apply-config") {
+    result = await applyRuntimeConfig({
+      sourceRoot: args.sourceRoot,
+      configPath: args.configPath,
+      backupRoot: args.backupRoot,
+    });
+  } else if (args.command === "rollback-config") {
+    result = await rollbackRuntimeConfig({
+      configPath: args.configPath,
+      backupRoot: args.backupRoot,
+    });
   } else if (args.command === "install") {
     result = await installWorkspace({
       sourceRoot: args.sourceRoot,

--- a/scripts/program-manager-workspace.mjs
+++ b/scripts/program-manager-workspace.mjs
@@ -398,14 +398,14 @@ export function validateRuntimeEntry(value) {
     );
   }
   if (
-    value.params?.maxTokens !== 3072 ||
+    value.params?.maxTokens !== 1024 ||
     value.params?.text_verbosity !== "low" ||
     value.params?.cacheRetention !== "short"
   ) {
     issues.push(
       issue(
         "model_budget_changed",
-        "Model parameters must keep the bounded low-verbosity profile.",
+        "Model parameters must keep the 1024-token bounded low-verbosity profile.",
       ),
     );
   }

--- a/scripts/program-manager-workspace.mjs
+++ b/scripts/program-manager-workspace.mjs
@@ -1,21 +1,27 @@
 #!/usr/bin/env node
 
+import { execFile as execFileCallback } from "node:child_process";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import JSON5 from "json5";
+
+const execFile = promisify(execFileCallback);
+const canonicalValidationCache = new Map();
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 export const DEFAULT_SOURCE_ROOT = path.resolve(SCRIPT_DIR, "..", "control", "program-manager");
 
 export const MANAGED_FILES = Object.freeze([
+  "CONTRACT.md",
   "workspace/AGENTS.md",
   "workspace/TOOLS.md",
   "workspace/SOUL.md",
   "workspace/IDENTITY.md",
   "workspace/USER.md",
   "workspace/HEARTBEAT.md",
-  "state/program-manager.json",
 ]);
 
 const BOOTSTRAP_FILES = Object.freeze(
@@ -23,10 +29,10 @@ const BOOTSTRAP_FILES = Object.freeze(
 );
 const ALLOWED_TOOLS = Object.freeze([
   "get_goal",
+  "progress_card",
   "read",
   "sessions_spawn",
   "sessions_yield",
-  "update_plan",
 ]);
 const REQUIRED_DENIED_TOOLS = Object.freeze([
   "apply_patch",
@@ -95,15 +101,56 @@ async function readFileIfPresent(filePath) {
   }
 }
 
-async function fileExists(filePath) {
+async function lstatIfPresent(filePath) {
   try {
-    const stat = await fsp.stat(filePath);
-    return stat.isFile();
+    return await fsp.lstat(filePath);
   } catch (error) {
     if (error?.code === "ENOENT") {
-      return false;
+      return null;
     }
     throw error;
+  }
+}
+
+async function fileExists(filePath) {
+  const stat = await lstatIfPresent(filePath);
+  return Boolean(stat?.isFile());
+}
+
+async function assertNoSymlinkPath(targetPath, boundaryRoot, label) {
+  const target = path.resolve(targetPath);
+  const boundary = path.resolve(boundaryRoot);
+  const relative = path.relative(boundary, target);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${label} escapes its allowed root.`);
+  }
+  const paths = [];
+  let cursor = target;
+  while (true) {
+    paths.push(cursor);
+    if (cursor === boundary || cursor === path.dirname(cursor)) {
+      break;
+    }
+    cursor = path.dirname(cursor);
+  }
+  for (const candidate of paths.toReversed()) {
+    const stat = await lstatIfPresent(candidate);
+    if (stat?.isSymbolicLink()) {
+      throw new Error(`${label} contains a symlinked path: ${candidate}`);
+    }
+  }
+}
+
+async function assertRegularFile(filePath, label) {
+  const stat = await lstatIfPresent(filePath);
+  if (!stat) {
+    throw new Error(`${label} is missing.`);
+  }
+  if (stat.isSymbolicLink()) {
+    throw new Error(`${label} must not be a symlink.`);
+  }
+  if (!stat.isFile()) {
+    throw new Error(`${label} must be a regular file.`);
   }
 }
 
@@ -132,9 +179,121 @@ function workspaceRelativePath(relativePath) {
 
 function parseJson(text, label) {
   try {
-    return JSON.parse(text);
+    return JSON5.parse(text);
   } catch (error) {
     return { parseError: `${label}: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+function configuredAgentEntries(config) {
+  if (Array.isArray(config?.agents?.list)) {
+    return config.agents.list.filter((entry) => isObject(entry) && typeof entry.id === "string");
+  }
+  if (isObject(config?.agents?.entries)) {
+    return Object.entries(config.agents.entries).map(([id, entry]) =>
+      Object.assign({}, isObject(entry) ? entry : {}, { id }),
+    );
+  }
+  return [];
+}
+
+function validateConfiguredAgentRegistry(config) {
+  const entries = configuredAgentEntries(config);
+  const issues = [];
+  if (entries.length === 0) {
+    issues.push(
+      issue("agent_registry_missing", "Config must define agents.list or agents.entries."),
+    );
+  }
+  const ids = new Set(entries.map((entry) => entry.id));
+  const programManager = entries.find((entry) => entry.id === "program-manager");
+  if (!programManager) {
+    issues.push(issue("agent_missing", "Configured Program Manager entry was not found."));
+  }
+  for (const target of ["builder-agent", "research-brief-agent"]) {
+    if (!ids.has(target)) {
+      issues.push(
+        issue(
+          "delegation_target_unconfigured",
+          `Configured delegation target is missing from the agent registry: ${target}.`,
+          { agentId: target },
+        ),
+      );
+    }
+  }
+  return { entries, programManager, issues };
+}
+
+async function validateCanonicalConfig(configPath) {
+  const stat = await lstatIfPresent(configPath);
+  const cacheKey = stat
+    ? `${path.resolve(configPath)}:${stat.size}:${stat.mtimeNs ?? stat.mtimeMs}`
+    : `${path.resolve(configPath)}:missing`;
+  const cached = canonicalValidationCache.get(cacheKey);
+  if (cached) {
+    return [...cached];
+  }
+  const validationScript = [
+    'import fs from "node:fs/promises";',
+    'import { parseConfigJson5 } from "./src/config/config.ts";',
+    'import { validateConfigObjectRawWithPlugins } from "./src/config/validation.ts";',
+    'const source = await fs.readFile(process.argv[1], "utf8");',
+    "const parsed = parseConfigJson5(source);",
+    'if (!parsed.ok) { console.log(JSON.stringify({ valid: false, issues: [{ path: "<root>", message: "Config parsing failed." }] })); process.exitCode = 1; }',
+    'else { const result = validateConfigObjectRawWithPlugins(parsed.parsed, { pluginValidation: "core-only", semanticValidation: "strict" }); console.log(JSON.stringify({ valid: result.ok, issues: result.ok ? [] : result.issues })); if (!result.ok) process.exitCode = 1; }',
+  ].join(" ");
+  try {
+    const { stdout } = await execFile(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", validationScript, "--", configPath],
+      {
+        cwd: path.resolve(SCRIPT_DIR, ".."),
+        env: { ...process.env, OPENCLAW_CONFIG_PATH: configPath },
+        maxBuffer: 512 * 1024,
+      },
+    );
+    const result = JSON.parse(stdout);
+    if (result?.valid === true && result?.ok !== false) {
+      canonicalValidationCache.set(cacheKey, []);
+      return [];
+    }
+    const reportedIssues = Array.isArray(result?.issues) ? result.issues : [];
+    if (reportedIssues.length === 0) {
+      const issues = [
+        issue("config_schema_invalid", "Canonical OpenClaw config validation failed."),
+      ];
+      canonicalValidationCache.set(cacheKey, issues);
+      return [...issues];
+    }
+    const issues = reportedIssues.map((entry) =>
+      issue("config_schema_invalid", "Canonical OpenClaw config validation failed.", {
+        path: typeof entry?.path === "string" ? entry.path : "<unknown>",
+      }),
+    );
+    canonicalValidationCache.set(cacheKey, issues);
+    return [...issues];
+  } catch (error) {
+    const stdout = typeof error?.stdout === "string" ? error.stdout : "";
+    try {
+      const result = JSON.parse(stdout);
+      const reportedIssues = Array.isArray(result?.issues) ? result.issues : [];
+      if (reportedIssues.length > 0) {
+        const issues = reportedIssues.map((entry) =>
+          issue("config_schema_invalid", "Canonical OpenClaw config validation failed.", {
+            path: typeof entry?.path === "string" ? entry.path : "<unknown>",
+          }),
+        );
+        canonicalValidationCache.set(cacheKey, issues);
+        return [...issues];
+      }
+    } catch {
+      // Fall through to a stable, non-sensitive error below.
+    }
+    const issues = [
+      issue("config_validation_failed", "Canonical OpenClaw config validation could not run."),
+    ];
+    canonicalValidationCache.set(cacheKey, issues);
+    return [...issues];
   }
 }
 
@@ -211,9 +370,7 @@ export function validateState(value) {
 export function validateRuntimeEntry(value) {
   const issues = [];
   if (!isObject(value)) {
-    return [
-      issue("runtime_entry_invalid", "runtime-config.json must contain programManagerEntry."),
-    ];
+    return [issue("runtime_entry_invalid", "Program Manager config entry must be an object.")];
   }
   if (!Array.isArray(value.skills) || value.skills.length !== 0) {
     issues.push(issue("skills_not_empty", "Program Manager skills must be explicitly empty."));
@@ -250,6 +407,17 @@ export function validateRuntimeEntry(value) {
         "model_budget_changed",
         "Model parameters must keep the bounded low-verbosity profile.",
       ),
+    );
+  }
+  if (typeof value.model?.primary !== "string" || value.model.primary.length === 0) {
+    issues.push(issue("model_primary_missing", "Program Manager must define a primary model ref."));
+  }
+  if (
+    !Array.isArray(value.model?.fallbacks) ||
+    value.model.fallbacks.some((modelRef) => typeof modelRef !== "string" || modelRef.length === 0)
+  ) {
+    issues.push(
+      issue("model_fallbacks_invalid", "Program Manager model fallbacks must be non-empty refs."),
     );
   }
   if (value.thinkingDefault !== "low") {
@@ -353,8 +521,11 @@ export async function checkSource(sourceRoot = DEFAULT_SOURCE_ROOT) {
       }),
     );
   }
-  const stateText = await readFileIfPresent(path.join(sourceRoot, "state/program-manager.json"));
-  if (stateText !== null) {
+  const statePath = path.join(sourceRoot, "state/program-manager.json");
+  const stateText = await readFileIfPresent(statePath);
+  if (stateText === null) {
+    issues.push(issue("state_fixture_missing", "Program Manager state fixture is missing."));
+  } else {
     const parsed = parseJson(stateText, "state/program-manager.json");
     if (parsed.parseError) {
       issues.push(issue("state_invalid_json", parsed.parseError));
@@ -362,14 +533,17 @@ export async function checkSource(sourceRoot = DEFAULT_SOURCE_ROOT) {
       issues.push(...validateState(parsed));
     }
   }
-  const runtimeText = await readFileIfPresent(path.join(sourceRoot, "runtime-config.json"));
-  if (runtimeText !== null) {
-    const parsed = parseJson(runtimeText, "runtime-config.json");
-    if (parsed.parseError) {
-      issues.push(issue("runtime_invalid_json", parsed.parseError));
-    } else {
-      issues.push(...validateRuntimeEntry(parsed.programManagerEntry));
-    }
+  const runtimePath = path.join(sourceRoot, "runtime-config.json");
+  try {
+    const runtimeResult = await checkRuntimeConfig(runtimePath);
+    issues.push(...runtimeResult.issues);
+  } catch (error) {
+    issues.push(
+      issue(
+        "runtime_config_unreadable",
+        `Unable to read runtime-config.json: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+    );
   }
   const contract = await readFileIfPresent(path.join(sourceRoot, "CONTRACT.md"));
   if (contract !== null) {
@@ -404,29 +578,127 @@ export async function checkSource(sourceRoot = DEFAULT_SOURCE_ROOT) {
 }
 
 export async function checkRuntimeConfig(configPath) {
-  const text = await fsp.readFile(configPath, "utf8");
+  let text;
+  try {
+    text = await fsp.readFile(configPath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return { ok: false, issues: [issue("config_missing", "Runtime config file is missing.")] };
+    }
+    throw error;
+  }
   const config = parseJson(text, configPath);
   if (config.parseError) {
     return { ok: false, issues: [issue("config_invalid_json", config.parseError)] };
   }
-  if (isObject(config.programManagerEntry)) {
-    const result = validateRuntimeEntry(config.programManagerEntry);
-    return { ok: result.length === 0, issues: result };
+  const canonicalIssues = await validateCanonicalConfig(configPath);
+  if (canonicalIssues.length > 0) {
+    return { ok: false, issues: canonicalIssues };
   }
-  const entries = Array.isArray(config.agents?.list)
-    ? config.agents.list
-    : isObject(config.agents?.entries)
-      ? Object.entries(config.agents.entries).map(([id, entry]) => Object.assign({ id }, entry))
-      : [];
-  const entry = entries.find((candidate) => candidate?.id === "program-manager");
-  if (!entry) {
-    return {
-      ok: false,
-      issues: [issue("agent_missing", "Configured Program Manager entry was not found.")],
-    };
+  const registry = validateConfiguredAgentRegistry(config);
+  const result = validateRuntimeEntry(registry.programManager);
+  const issues = [...registry.issues, ...result];
+  return { ok: issues.length === 0, issues };
+}
+
+async function prepareDestination(destination, workspaceRoot, label) {
+  await assertNoSymlinkPath(destination, workspaceRoot, label);
+  const stat = await lstatIfPresent(destination);
+  if (stat?.isSymbolicLink()) {
+    throw new Error(`${label} must not be a symlink.`);
   }
-  const result = validateRuntimeEntry(entry);
-  return { ok: result.length === 0, issues: result };
+  if (stat && !stat.isFile()) {
+    throw new Error(`${label} must be a regular file.`);
+  }
+  return Boolean(stat);
+}
+
+async function restoreWorkspaceEntries({ workspaceRoot, backupRoot, files }) {
+  const allowed = new Set(MANAGED_FILES.map(workspaceRelativePath));
+  for (const entry of files.toReversed()) {
+    if (
+      !isObject(entry) ||
+      typeof entry.relativePath !== "string" ||
+      !allowed.has(entry.relativePath)
+    ) {
+      throw new Error("Backup restore record contains an unexpected managed path.");
+    }
+    const destination = destinationFor(workspaceRoot, entry.relativePath);
+    await prepareDestination(
+      destination,
+      workspaceRoot,
+      `Workspace destination ${entry.relativePath}`,
+    );
+    if (entry.existed === true) {
+      const backup = path.join(backupRoot, "files", entry.relativePath);
+      await assertNoSymlinkPath(backup, backupRoot, `Backup file ${entry.relativePath}`);
+      await assertRegularFile(backup, `Backup file ${entry.relativePath}`);
+      await fsp.mkdir(path.dirname(destination), { recursive: true });
+      await fsp.copyFile(backup, destination);
+    } else if (entry.existed === false) {
+      if (await fileExists(destination)) {
+        await fsp.unlink(destination);
+      }
+    } else {
+      throw new Error("Backup restore record contains an invalid existed flag.");
+    }
+  }
+}
+
+export async function verifyInstalledWorkspace({
+  sourceRoot = DEFAULT_SOURCE_ROOT,
+  workspaceRoot,
+}) {
+  if (!workspaceRoot) {
+    throw new Error("verify-install requires --workspace");
+  }
+  const issues = [];
+  for (const relativePath of MANAGED_FILES) {
+    const destinationRelativePath = workspaceRelativePath(relativePath);
+    const destination = destinationFor(workspaceRoot, destinationRelativePath);
+    try {
+      await prepareDestination(
+        destination,
+        workspaceRoot,
+        `Workspace destination ${destinationRelativePath}`,
+      );
+    } catch (error) {
+      issues.push(
+        issue(
+          "installed_destination_invalid",
+          error instanceof Error ? error.message : String(error),
+          {
+            file: destinationRelativePath,
+          },
+        ),
+      );
+      continue;
+    }
+    const sourceText = await readFileIfPresent(path.join(sourceRoot, relativePath));
+    const destinationText = await readFileIfPresent(destination);
+    if (sourceText === null || destinationText === null) {
+      issues.push(
+        issue(
+          "installed_file_missing",
+          `Installed managed file is missing: ${destinationRelativePath}.`,
+          {
+            file: destinationRelativePath,
+          },
+        ),
+      );
+    } else if (sourceText !== destinationText) {
+      issues.push(
+        issue(
+          "installed_file_mismatch",
+          `Installed managed file differs from source: ${destinationRelativePath}.`,
+          {
+            file: destinationRelativePath,
+          },
+        ),
+      );
+    }
+  }
+  return { ok: issues.length === 0, issues, managedFiles: MANAGED_FILES.length };
 }
 
 export async function installWorkspace({
@@ -441,50 +713,74 @@ export async function installWorkspace({
   if (!sourceCheck.ok) {
     throw new Error(`Source check failed: ${JSON.stringify(sourceCheck.issues)}`);
   }
-  if (await fileExists(path.join(backupRoot, "restore.json"))) {
+  await assertNoSymlinkPath(backupRoot, path.dirname(path.resolve(backupRoot)), "Backup root");
+  const restorePath = path.join(backupRoot, "restore.json");
+  const existingRestore = await lstatIfPresent(restorePath);
+  if (existingRestore) {
     throw new Error("Backup directory is already in use.");
   }
+  const backupRootInitiallyPresent = Boolean(await lstatIfPresent(backupRoot));
   await fsp.mkdir(path.join(backupRoot, "files"), { recursive: true });
+  await assertNoSymlinkPath(path.join(backupRoot, "files"), backupRoot, "Backup files root");
   const restore = { files: [] };
-  for (const relativePath of MANAGED_FILES) {
-    const destinationRelativePath = workspaceRelativePath(relativePath);
-    const destination = destinationFor(workspaceRoot, destinationRelativePath);
-    const source = path.join(sourceRoot, relativePath);
-    const existed = await fileExists(destination);
-    restore.files.push({ relativePath: destinationRelativePath, existed });
-    if (existed) {
-      const backup = path.join(backupRoot, "files", destinationRelativePath);
-      await fsp.mkdir(path.dirname(backup), { recursive: true });
-      await fsp.copyFile(destination, backup);
+  try {
+    for (const relativePath of MANAGED_FILES) {
+      const destinationRelativePath = workspaceRelativePath(relativePath);
+      const destination = destinationFor(workspaceRoot, destinationRelativePath);
+      const source = path.join(sourceRoot, relativePath);
+      await assertRegularFile(source, `Source file ${relativePath}`);
+      const existed = await prepareDestination(
+        destination,
+        workspaceRoot,
+        `Workspace destination ${destinationRelativePath}`,
+      );
+      if (existed) {
+        const backup = path.join(backupRoot, "files", destinationRelativePath);
+        await assertNoSymlinkPath(backup, backupRoot, `Backup file ${destinationRelativePath}`);
+        await fsp.mkdir(path.dirname(backup), { recursive: true });
+        await fsp.copyFile(destination, backup);
+      }
+      restore.files.push({ relativePath: destinationRelativePath, existed });
+      await fsp.mkdir(path.dirname(destination), { recursive: true });
+      await fsp.copyFile(source, destination);
     }
-    await fsp.mkdir(path.dirname(destination), { recursive: true });
-    await fsp.copyFile(source, destination);
+
+    const verification = await verifyInstalledWorkspace({ sourceRoot, workspaceRoot });
+    if (!verification.ok) {
+      throw new Error(`Install verification failed: ${JSON.stringify(verification.issues)}`);
+    }
+    await fsp.writeFile(restorePath, `${JSON.stringify(restore, null, 2)}\n`, "utf8");
+    return { ok: true, managedFiles: MANAGED_FILES.length, backupRoot };
+  } catch (error) {
+    try {
+      await restoreWorkspaceEntries({ workspaceRoot, backupRoot, files: restore.files });
+      if (!backupRootInitiallyPresent) {
+        await fsp.rm(backupRoot, { recursive: true, force: true });
+      }
+    } catch (rollbackError) {
+      throw new Error(
+        `Install failed and automatic rollback failed: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
+        { cause: rollbackError },
+      );
+    }
+    throw error;
   }
-  await fsp.writeFile(
-    path.join(backupRoot, "restore.json"),
-    `${JSON.stringify(restore, null, 2)}\n`,
-    "utf8",
-  );
-  return { ok: true, managedFiles: MANAGED_FILES.length, backupRoot };
 }
 
 export async function rollbackWorkspace({ workspaceRoot, backupRoot }) {
   if (!workspaceRoot || !backupRoot) {
     throw new Error("rollback requires --workspace and --backup-dir");
   }
-  const restoreText = await fsp.readFile(path.join(backupRoot, "restore.json"), "utf8");
+  await assertNoSymlinkPath(backupRoot, path.dirname(path.resolve(backupRoot)), "Backup root");
+  const restorePath = path.join(backupRoot, "restore.json");
+  await assertNoSymlinkPath(restorePath, backupRoot, "Restore record");
+  await assertRegularFile(restorePath, "Restore record");
+  const restoreText = await fsp.readFile(restorePath, "utf8");
   const restore = JSON.parse(restoreText);
   if (!Array.isArray(restore.files)) {
     throw new Error("Backup restore record is invalid.");
   }
-  for (const entry of restore.files) {
-    const destination = destinationFor(workspaceRoot, entry.relativePath);
-    if (entry.existed) {
-      await fsp.copyFile(path.join(backupRoot, "files", entry.relativePath), destination);
-    } else if (await fileExists(destination)) {
-      await fsp.unlink(destination);
-    }
-  }
+  await restoreWorkspaceEntries({ workspaceRoot, backupRoot, files: restore.files });
   return { ok: true, restoredFiles: restore.files.length };
 }
 
@@ -535,7 +831,7 @@ async function main(argv) {
   const args = parseArgs(argv);
   if (args.help) {
     console.log(
-      "Usage: node scripts/program-manager-workspace.mjs [check|check-config|install|rollback] [options]",
+      "Usage: node scripts/program-manager-workspace.mjs [check|check-config|install|verify-install|rollback] [options]",
     );
     return;
   }
@@ -552,6 +848,11 @@ async function main(argv) {
       sourceRoot: args.sourceRoot,
       workspaceRoot: args.workspaceRoot,
       backupRoot: args.backupRoot,
+    });
+  } else if (args.command === "verify-install") {
+    result = await verifyInstalledWorkspace({
+      sourceRoot: args.sourceRoot,
+      workspaceRoot: args.workspaceRoot,
     });
   } else if (args.command === "rollback") {
     result = await rollbackWorkspace({

--- a/scripts/program-manager-workspace.mjs
+++ b/scripts/program-manager-workspace.mjs
@@ -1,0 +1,577 @@
+#!/usr/bin/env node
+
+import fsp from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+export const DEFAULT_SOURCE_ROOT = path.resolve(SCRIPT_DIR, "..", "control", "program-manager");
+
+export const MANAGED_FILES = Object.freeze([
+  "workspace/AGENTS.md",
+  "workspace/TOOLS.md",
+  "workspace/SOUL.md",
+  "workspace/IDENTITY.md",
+  "workspace/USER.md",
+  "workspace/HEARTBEAT.md",
+  "state/program-manager.json",
+]);
+
+const BOOTSTRAP_FILES = Object.freeze(
+  MANAGED_FILES.filter((entry) => entry.startsWith("workspace/")),
+);
+const ALLOWED_TOOLS = Object.freeze([
+  "get_goal",
+  "read",
+  "sessions_spawn",
+  "sessions_yield",
+  "update_plan",
+]);
+const REQUIRED_DENIED_TOOLS = Object.freeze([
+  "apply_patch",
+  "browser",
+  "code_execution",
+  "cron",
+  "edit",
+  "exec",
+  "message",
+  "process",
+  "session_status",
+  "sessions_send",
+  "web_fetch",
+  "web_search",
+  "write",
+]);
+const MAX_BOOTSTRAP_FILE_BYTES = 4_000;
+const MAX_BOOTSTRAP_TOTAL_BYTES = 10_000;
+const SECRET_KEY = /token|password|cookie|credential|secret|private/i;
+
+function issue(code, message, details = {}) {
+  return { code, message, ...details };
+}
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function sorted(values) {
+  return values.toSorted((left, right) => left.localeCompare(right));
+}
+
+function findSecretKey(value, currentPath = []) {
+  if (Array.isArray(value)) {
+    for (const [index, entry] of value.entries()) {
+      const found = findSecretKey(entry, [...currentPath, String(index)]);
+      if (found) {
+        return found;
+      }
+    }
+    return null;
+  }
+  if (!isObject(value)) {
+    return null;
+  }
+  for (const [key, entry] of Object.entries(value)) {
+    if (SECRET_KEY.test(key)) {
+      return [...currentPath, key].join(".");
+    }
+    const found = findSecretKey(entry, [...currentPath, key]);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+async function readFileIfPresent(filePath) {
+  try {
+    return await fsp.readFile(filePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function fileExists(filePath) {
+  try {
+    const stat = await fsp.stat(filePath);
+    return stat.isFile();
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function assertSafeRelativePath(relativePath) {
+  const normalized = path.normalize(relativePath);
+  if (normalized.startsWith("..") || path.isAbsolute(normalized)) {
+    throw new Error(`Unsafe managed path: ${relativePath}`);
+  }
+}
+
+function destinationFor(workspaceRoot, relativePath) {
+  assertSafeRelativePath(relativePath);
+  const destination = path.resolve(workspaceRoot, relativePath);
+  const relative = path.relative(path.resolve(workspaceRoot), destination);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Managed path escapes workspace: ${relativePath}`);
+  }
+  return destination;
+}
+
+function workspaceRelativePath(relativePath) {
+  return relativePath.startsWith("workspace/")
+    ? relativePath.slice("workspace/".length)
+    : relativePath;
+}
+
+function parseJson(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return { parseError: `${label}: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+export function validateState(value) {
+  const issues = [];
+  if (!isObject(value)) {
+    return [issue("state_not_object", "Program Manager state must be a JSON object.")];
+  }
+  const required = [
+    "schemaVersion",
+    "status",
+    "evidenceStatus",
+    "objective",
+    "scope",
+    "priorities",
+    "blockers",
+    "dependencies",
+    "lastKnownGood",
+    "unknowns",
+    "source",
+    "updatedAt",
+  ];
+  for (const key of required) {
+    if (!Object.hasOwn(value, key)) {
+      issues.push(issue("state_field_missing", `State is missing ${key}.`, { field: key }));
+    }
+  }
+  if (value.schemaVersion !== 1) {
+    issues.push(issue("state_schema_unsupported", "State schemaVersion must be 1."));
+  }
+  if (!["Unknown", "Planning", "Blocked", "Complete"].includes(value.status)) {
+    issues.push(issue("state_status_invalid", "State status is not a supported value."));
+  }
+  if (!["Unknown", "Confirmed"].includes(value.evidenceStatus)) {
+    issues.push(
+      issue("state_evidence_invalid", "State evidenceStatus must be Unknown or Confirmed."),
+    );
+  }
+  if (
+    !Array.isArray(value.scope) ||
+    !Array.isArray(value.priorities) ||
+    !Array.isArray(value.blockers) ||
+    !Array.isArray(value.dependencies) ||
+    !Array.isArray(value.unknowns)
+  ) {
+    issues.push(
+      issue(
+        "state_lists_invalid",
+        "State scope, priorities, blockers, dependencies, and unknowns must be arrays.",
+      ),
+    );
+  }
+  if (
+    !isObject(value.source) ||
+    typeof value.source.kind !== "string" ||
+    typeof value.source.label !== "string"
+  ) {
+    issues.push(issue("state_source_invalid", "State source must include kind and label."));
+  }
+  if (value.evidenceStatus === "Confirmed" && typeof value.source?.verifiedAt !== "string") {
+    issues.push(
+      issue("state_confirmation_without_time", "Confirmed state requires source.verifiedAt."),
+    );
+  }
+  const secretPath = findSecretKey(value);
+  if (secretPath) {
+    issues.push(
+      issue("state_secret_like_key", `State contains a disallowed sensitive key at ${secretPath}.`),
+    );
+  }
+  return issues;
+}
+
+export function validateRuntimeEntry(value) {
+  const issues = [];
+  if (!isObject(value)) {
+    return [
+      issue("runtime_entry_invalid", "runtime-config.json must contain programManagerEntry."),
+    ];
+  }
+  if (!Array.isArray(value.skills) || value.skills.length !== 0) {
+    issues.push(issue("skills_not_empty", "Program Manager skills must be explicitly empty."));
+  }
+  if (value.skillsLimits?.maxSkillsPromptChars !== 0) {
+    issues.push(issue("skills_budget_missing", "Program Manager maxSkillsPromptChars must be 0."));
+  }
+  if (value.bootstrapMaxChars !== 3500 || value.bootstrapTotalMaxChars !== 10000) {
+    issues.push(
+      issue(
+        "bootstrap_budget_changed",
+        "Bootstrap budgets must remain 3500 per file and 10000 total.",
+      ),
+    );
+  }
+  if (
+    value.contextLimits?.memoryGetMaxChars !== 6000 ||
+    value.contextLimits?.postCompactionMaxChars !== 2500
+  ) {
+    issues.push(
+      issue(
+        "context_budget_changed",
+        "Context budgets must remain 6000 memory chars and 2500 post-compaction chars.",
+      ),
+    );
+  }
+  if (
+    value.params?.maxTokens !== 3072 ||
+    value.params?.text_verbosity !== "low" ||
+    value.params?.cacheRetention !== "short"
+  ) {
+    issues.push(
+      issue(
+        "model_budget_changed",
+        "Model parameters must keep the bounded low-verbosity profile.",
+      ),
+    );
+  }
+  if (value.thinkingDefault !== "low") {
+    issues.push(issue("thinking_default_changed", "thinkingDefault must be low."));
+  }
+  const configuredAllowed = sorted(value.tools?.alsoAllow ?? []);
+  if (JSON.stringify(configuredAllowed) !== JSON.stringify(sorted(ALLOWED_TOOLS))) {
+    issues.push(
+      issue(
+        "tool_allowlist_changed",
+        "Program Manager allowed tools must match the bounded allowlist.",
+      ),
+    );
+  }
+  const denied = new Set(value.tools?.deny ?? []);
+  for (const tool of REQUIRED_DENIED_TOOLS) {
+    if (!denied.has(tool)) {
+      issues.push(issue("tool_deny_missing", `Program Manager must deny ${tool}.`, { tool }));
+    }
+  }
+  if (value.tools?.exec?.security !== "deny" || value.tools?.exec?.ask !== "always") {
+    issues.push(
+      issue("execution_policy_changed", "Execution must remain denied and approval-gated."),
+    );
+  }
+  if (value.tools?.fs?.workspaceOnly !== true || value.tools?.profile !== "minimal") {
+    issues.push(
+      issue(
+        "filesystem_policy_changed",
+        "Program Manager must use the minimal workspace-only profile.",
+      ),
+    );
+  }
+  if (value.subagents?.delegationMode !== "suggest" || value.subagents?.requireAgentId !== true) {
+    issues.push(
+      issue(
+        "delegation_policy_changed",
+        "Delegation must be suggest-only and require an explicit target.",
+      ),
+    );
+  }
+  if (
+    JSON.stringify(sorted(value.subagents?.allowAgents ?? [])) !==
+    JSON.stringify(["builder-agent", "research-brief-agent"])
+  ) {
+    issues.push(
+      issue(
+        "delegation_targets_changed",
+        "Delegation targets must remain the two approved worker agents.",
+      ),
+    );
+  }
+  return issues;
+}
+
+export async function checkSource(sourceRoot = DEFAULT_SOURCE_ROOT) {
+  const issues = [];
+  let totalBootstrapBytes = 0;
+  let largestBootstrapBytes = 0;
+  for (const relativePath of MANAGED_FILES) {
+    const filePath = path.join(sourceRoot, relativePath);
+    if (!(await fileExists(filePath))) {
+      issues.push(
+        issue("managed_file_missing", `Managed file is missing: ${relativePath}.`, {
+          file: relativePath,
+        }),
+      );
+    }
+  }
+  for (const relativePath of BOOTSTRAP_FILES) {
+    const filePath = path.join(sourceRoot, relativePath);
+    const text = await readFileIfPresent(filePath);
+    if (text === null) {
+      continue;
+    }
+    const bytes = Buffer.byteLength(text, "utf8");
+    totalBootstrapBytes += bytes;
+    largestBootstrapBytes = Math.max(largestBootstrapBytes, bytes);
+    if (bytes > MAX_BOOTSTRAP_FILE_BYTES) {
+      issues.push(
+        issue("bootstrap_file_too_large", `${relativePath} exceeds its context budget.`, {
+          file: relativePath,
+          bytes,
+        }),
+      );
+    }
+    if (text.includes("control/state/") || text.includes("PROGRAM_MANAGER_STATUS")) {
+      issues.push(
+        issue(
+          "external_state_reference",
+          `${relativePath} references a retired external state surface.`,
+          { file: relativePath },
+        ),
+      );
+    }
+  }
+  if (totalBootstrapBytes > MAX_BOOTSTRAP_TOTAL_BYTES) {
+    issues.push(
+      issue("bootstrap_total_too_large", "Bootstrap files exceed the total context budget.", {
+        bytes: totalBootstrapBytes,
+      }),
+    );
+  }
+  const stateText = await readFileIfPresent(path.join(sourceRoot, "state/program-manager.json"));
+  if (stateText !== null) {
+    const parsed = parseJson(stateText, "state/program-manager.json");
+    if (parsed.parseError) {
+      issues.push(issue("state_invalid_json", parsed.parseError));
+    } else {
+      issues.push(...validateState(parsed));
+    }
+  }
+  const runtimeText = await readFileIfPresent(path.join(sourceRoot, "runtime-config.json"));
+  if (runtimeText !== null) {
+    const parsed = parseJson(runtimeText, "runtime-config.json");
+    if (parsed.parseError) {
+      issues.push(issue("runtime_invalid_json", parsed.parseError));
+    } else {
+      issues.push(...validateRuntimeEntry(parsed.programManagerEntry));
+    }
+  }
+  const contract = await readFileIfPresent(path.join(sourceRoot, "CONTRACT.md"));
+  if (contract !== null) {
+    for (const term of ["PLAN", "STATUS", "HANDOFF", "COMPLETION", "Unknown", "local model"]) {
+      if (!contract.includes(term)) {
+        issues.push(issue("contract_term_missing", `CONTRACT.md is missing ${term}.`, { term }));
+      }
+    }
+  }
+  const tools = await readFileIfPresent(path.join(sourceRoot, "workspace/TOOLS.md"));
+  if (
+    tools?.includes("Required output") ||
+    tools?.includes("Milestones") ||
+    tools?.includes("Acceptance Criteria")
+  ) {
+    issues.push(
+      issue("tool_policy_duplication", "TOOLS.md must not repeat semantic output policy."),
+    );
+  }
+  return {
+    ok: issues.length === 0,
+    issues,
+    metrics: {
+      managedFiles: MANAGED_FILES.length,
+      bootstrapFiles: BOOTSTRAP_FILES.length,
+      totalBootstrapBytes,
+      largestBootstrapBytes,
+      maxBootstrapFileBytes: MAX_BOOTSTRAP_FILE_BYTES,
+      maxBootstrapTotalBytes: MAX_BOOTSTRAP_TOTAL_BYTES,
+    },
+  };
+}
+
+export async function checkRuntimeConfig(configPath) {
+  const text = await fsp.readFile(configPath, "utf8");
+  const config = parseJson(text, configPath);
+  if (config.parseError) {
+    return { ok: false, issues: [issue("config_invalid_json", config.parseError)] };
+  }
+  if (isObject(config.programManagerEntry)) {
+    const result = validateRuntimeEntry(config.programManagerEntry);
+    return { ok: result.length === 0, issues: result };
+  }
+  const entries = Array.isArray(config.agents?.list)
+    ? config.agents.list
+    : isObject(config.agents?.entries)
+      ? Object.entries(config.agents.entries).map(([id, entry]) => Object.assign({ id }, entry))
+      : [];
+  const entry = entries.find((candidate) => candidate?.id === "program-manager");
+  if (!entry) {
+    return {
+      ok: false,
+      issues: [issue("agent_missing", "Configured Program Manager entry was not found.")],
+    };
+  }
+  const result = validateRuntimeEntry(entry);
+  return { ok: result.length === 0, issues: result };
+}
+
+export async function installWorkspace({
+  sourceRoot = DEFAULT_SOURCE_ROOT,
+  workspaceRoot,
+  backupRoot,
+}) {
+  if (!workspaceRoot || !backupRoot) {
+    throw new Error("install requires --workspace and --backup-dir");
+  }
+  const sourceCheck = await checkSource(sourceRoot);
+  if (!sourceCheck.ok) {
+    throw new Error(`Source check failed: ${JSON.stringify(sourceCheck.issues)}`);
+  }
+  if (await fileExists(path.join(backupRoot, "restore.json"))) {
+    throw new Error("Backup directory is already in use.");
+  }
+  await fsp.mkdir(path.join(backupRoot, "files"), { recursive: true });
+  const restore = { files: [] };
+  for (const relativePath of MANAGED_FILES) {
+    const destinationRelativePath = workspaceRelativePath(relativePath);
+    const destination = destinationFor(workspaceRoot, destinationRelativePath);
+    const source = path.join(sourceRoot, relativePath);
+    const existed = await fileExists(destination);
+    restore.files.push({ relativePath: destinationRelativePath, existed });
+    if (existed) {
+      const backup = path.join(backupRoot, "files", destinationRelativePath);
+      await fsp.mkdir(path.dirname(backup), { recursive: true });
+      await fsp.copyFile(destination, backup);
+    }
+    await fsp.mkdir(path.dirname(destination), { recursive: true });
+    await fsp.copyFile(source, destination);
+  }
+  await fsp.writeFile(
+    path.join(backupRoot, "restore.json"),
+    `${JSON.stringify(restore, null, 2)}\n`,
+    "utf8",
+  );
+  return { ok: true, managedFiles: MANAGED_FILES.length, backupRoot };
+}
+
+export async function rollbackWorkspace({ workspaceRoot, backupRoot }) {
+  if (!workspaceRoot || !backupRoot) {
+    throw new Error("rollback requires --workspace and --backup-dir");
+  }
+  const restoreText = await fsp.readFile(path.join(backupRoot, "restore.json"), "utf8");
+  const restore = JSON.parse(restoreText);
+  if (!Array.isArray(restore.files)) {
+    throw new Error("Backup restore record is invalid.");
+  }
+  for (const entry of restore.files) {
+    const destination = destinationFor(workspaceRoot, entry.relativePath);
+    if (entry.existed) {
+      await fsp.copyFile(path.join(backupRoot, "files", entry.relativePath), destination);
+    } else if (await fileExists(destination)) {
+      await fsp.unlink(destination);
+    }
+  }
+  return { ok: true, restoredFiles: restore.files.length };
+}
+
+function parseArgs(argv) {
+  const args = { command: "check", sourceRoot: DEFAULT_SOURCE_ROOT, json: false };
+  let index = 0;
+  if (argv[0] && !argv[0].startsWith("-")) {
+    args.command = argv[index++];
+  }
+  while (index < argv.length) {
+    const arg = argv[index++];
+    if (arg === "--source") {
+      args.sourceRoot = argv[index++];
+    } else if (arg === "--workspace") {
+      args.workspaceRoot = argv[index++];
+    } else if (arg === "--backup-dir") {
+      args.backupRoot = argv[index++];
+    } else if (arg === "--config") {
+      args.configPath = argv[index++];
+    } else if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function printResult(result, json) {
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  console.log(`Program Manager workspace: ${result.ok ? "passed" : "failed"}`);
+  if (result.metrics) {
+    console.log(
+      `Bootstrap bytes: ${result.metrics.totalBootstrapBytes}/${result.metrics.maxBootstrapTotalBytes}`,
+    );
+  }
+  for (const entry of result.issues ?? []) {
+    console.log(`- ${entry.code}: ${entry.message}`);
+  }
+}
+
+async function main(argv) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log(
+      "Usage: node scripts/program-manager-workspace.mjs [check|check-config|install|rollback] [options]",
+    );
+    return;
+  }
+  let result;
+  if (args.command === "check") {
+    result = await checkSource(args.sourceRoot);
+  } else if (args.command === "check-config") {
+    if (!args.configPath) {
+      throw new Error("check-config requires --config");
+    }
+    result = await checkRuntimeConfig(args.configPath);
+  } else if (args.command === "install") {
+    result = await installWorkspace({
+      sourceRoot: args.sourceRoot,
+      workspaceRoot: args.workspaceRoot,
+      backupRoot: args.backupRoot,
+    });
+  } else if (args.command === "rollback") {
+    result = await rollbackWorkspace({
+      workspaceRoot: args.workspaceRoot,
+      backupRoot: args.backupRoot,
+    });
+  } else {
+    throw new Error(`Unknown command: ${args.command}`);
+  }
+  printResult(result, args.json);
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+function handleMainError(error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2)).catch(handleMainError);
+}

--- a/scripts/program-manager-workspace.mjs
+++ b/scripts/program-manager-workspace.mjs
@@ -422,12 +422,14 @@ export function validateRuntimeEntry(value) {
   if (
     value.params?.maxTokens !== 1024 ||
     value.params?.text_verbosity !== "low" ||
-    value.params?.cacheRetention !== "short"
+    value.params?.cacheRetention !== "short" ||
+    value.params?.chat_template_kwargs?.enable_thinking !== false ||
+    value.params?.chat_template_kwargs?.preserve_thinking !== false
   ) {
     issues.push(
       issue(
         "model_budget_changed",
-        "Model parameters must keep the 1024-token bounded low-verbosity profile.",
+        "Model parameters must keep the bounded low-verbosity, thinking-off profile.",
       ),
     );
   }

--- a/test/scripts/program-manager-workspace.test.ts
+++ b/test/scripts/program-manager-workspace.test.ts
@@ -1,0 +1,80 @@
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  checkRuntimeConfig,
+  checkSource,
+  installWorkspace,
+  rollbackWorkspace,
+} from "../../scripts/program-manager-workspace.mjs";
+
+const repoRoot = process.cwd();
+const sourceRoot = path.join(repoRoot, "control", "program-manager");
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("Program Manager context package", () => {
+  it("passes the compact source contract and budget", async () => {
+    const result = await checkSource(sourceRoot);
+    expect(result.ok).toBe(true);
+    expect(result.metrics.totalBootstrapBytes).toBeLessThanOrEqual(10_000);
+    expect(result.metrics.largestBootstrapBytes).toBeLessThanOrEqual(4_000);
+  });
+
+  it("keeps the initial state explicitly unknown", async () => {
+    const state = JSON.parse(
+      await readFile(path.join(sourceRoot, "state/program-manager.json"), "utf8"),
+    );
+    expect(state.status).toBe("Unknown");
+    expect(state.evidenceStatus).toBe("Unknown");
+    expect(state.source.verifiedAt).toBeNull();
+    expect(state.lastKnownGood).toBeNull();
+  });
+
+  it("validates the reviewed runtime entry", async () => {
+    const result = await checkRuntimeConfig(path.join(sourceRoot, "runtime-config.json"));
+    expect(result).toEqual({ ok: true, issues: [] });
+  });
+
+  it("installs and rolls back only managed files", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openclaw-pm-context-test-"));
+    temporaryRoots.push(root);
+    const workspaceRoot = path.join(root, "workspace");
+    const backupRoot = path.join(root, "backup");
+    await mkdir(workspaceRoot, { recursive: true });
+    await writeFile(path.join(workspaceRoot, "unrelated.txt"), "keep me\n", "utf8");
+    await writeFile(path.join(workspaceRoot, "AGENTS.md"), "old context\n", "utf8");
+
+    await installWorkspace({ sourceRoot, workspaceRoot, backupRoot });
+    expect(await readFile(path.join(workspaceRoot, "AGENTS.md"), "utf8")).toContain(
+      "# Program Manager",
+    );
+    expect(await readFile(path.join(workspaceRoot, "unrelated.txt"), "utf8")).toBe("keep me\n");
+
+    await rollbackWorkspace({ workspaceRoot, backupRoot });
+    expect(await readFile(path.join(workspaceRoot, "AGENTS.md"), "utf8")).toBe("old context\n");
+    await expect(
+      readFile(path.join(workspaceRoot, "state/program-manager.json"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(path.join(workspaceRoot, "unrelated.txt"), "utf8")).toBe("keep me\n");
+  });
+
+  it("fails closed when state contains a sensitive field", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openclaw-pm-context-invalid-"));
+    temporaryRoots.push(root);
+    await cp(sourceRoot, root, { recursive: true });
+    const statePath = path.join(root, "state/program-manager.json");
+    const state = JSON.parse(await readFile(statePath, "utf8"));
+    state.secret = "not allowed";
+    await writeFile(statePath, `${JSON.stringify(state)}\n`, "utf8");
+    const result = await checkSource(root);
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((entry) => entry.code)).toContain("state_secret_like_key");
+  });
+});

--- a/test/scripts/program-manager-workspace.test.ts
+++ b/test/scripts/program-manager-workspace.test.ts
@@ -37,6 +37,16 @@ describe("Program Manager context package", () => {
     expect(result).toEqual({ ok: true, issues: [] });
   });
 
+  it("keeps runtime replies bounded and missing-state handling terminal", async () => {
+    const agents = JSON.parse(await readFile(path.join(sourceRoot, "runtime-config.json"), "utf8"))
+      .agents.entries;
+    expect(agents["program-manager"].params.maxTokens).toBe(1024);
+    const instructions = await readFile(path.join(sourceRoot, "workspace/AGENTS.md"), "utf8");
+    expect(instructions).toContain("stop tool calls immediately");
+    expect(instructions).toContain("never search the workspace for a missing packet");
+    expect(instructions).toContain("do not call tools on the first response");
+  });
+
   it("installs and rolls back only managed files", async () => {
     const root = temporaryRoots.make("openclaw-pm-context-test-");
     const workspaceRoot = path.join(root, "workspace");

--- a/test/scripts/program-manager-workspace.test.ts
+++ b/test/scripts/program-manager-workspace.test.ts
@@ -1,5 +1,4 @@
-import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -8,16 +7,11 @@ import {
   installWorkspace,
   rollbackWorkspace,
 } from "../../scripts/program-manager-workspace.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const repoRoot = process.cwd();
 const sourceRoot = path.join(repoRoot, "control", "program-manager");
-const temporaryRoots: string[] = [];
-
-afterEach(async () => {
-  await Promise.all(
-    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
-  );
-});
+const temporaryRoots = useAutoCleanupTempDirTracker(afterEach);
 
 describe("Program Manager context package", () => {
   it("passes the compact source contract and budget", async () => {
@@ -43,8 +37,7 @@ describe("Program Manager context package", () => {
   });
 
   it("installs and rolls back only managed files", async () => {
-    const root = await mkdtemp(path.join(os.tmpdir(), "openclaw-pm-context-test-"));
-    temporaryRoots.push(root);
+    const root = temporaryRoots.make("openclaw-pm-context-test-");
     const workspaceRoot = path.join(root, "workspace");
     const backupRoot = path.join(root, "backup");
     await mkdir(workspaceRoot, { recursive: true });
@@ -66,8 +59,7 @@ describe("Program Manager context package", () => {
   });
 
   it("fails closed when state contains a sensitive field", async () => {
-    const root = await mkdtemp(path.join(os.tmpdir(), "openclaw-pm-context-invalid-"));
-    temporaryRoots.push(root);
+    const root = temporaryRoots.make("openclaw-pm-context-invalid-");
     await cp(sourceRoot, root, { recursive: true });
     const statePath = path.join(root, "state/program-manager.json");
     const state = JSON.parse(await readFile(statePath, "utf8"));

--- a/test/scripts/program-manager-workspace.test.ts
+++ b/test/scripts/program-manager-workspace.test.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { cp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -6,6 +6,7 @@ import {
   checkSource,
   installWorkspace,
   rollbackWorkspace,
+  verifyInstalledWorkspace,
 } from "../../scripts/program-manager-workspace.mjs";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
@@ -48,14 +49,49 @@ describe("Program Manager context package", () => {
     expect(await readFile(path.join(workspaceRoot, "AGENTS.md"), "utf8")).toContain(
       "# Program Manager",
     );
+    expect(await readFile(path.join(workspaceRoot, "CONTRACT.md"), "utf8")).toContain(
+      "# Program Manager contract",
+    );
     expect(await readFile(path.join(workspaceRoot, "unrelated.txt"), "utf8")).toBe("keep me\n");
+    expect(await verifyInstalledWorkspace({ sourceRoot, workspaceRoot })).toEqual({
+      ok: true,
+      issues: [],
+      managedFiles: 7,
+    });
 
     await rollbackWorkspace({ workspaceRoot, backupRoot });
     expect(await readFile(path.join(workspaceRoot, "AGENTS.md"), "utf8")).toBe("old context\n");
-    await expect(
-      readFile(path.join(workspaceRoot, "state/program-manager.json"), "utf8"),
-    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(path.join(workspaceRoot, "CONTRACT.md"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
     expect(await readFile(path.join(workspaceRoot, "unrelated.txt"), "utf8")).toBe("keep me\n");
+  });
+
+  it("rejects symlinked managed destinations before copying", async () => {
+    const root = temporaryRoots.make("openclaw-pm-context-symlink-");
+    const workspaceRoot = path.join(root, "workspace");
+    const backupRoot = path.join(root, "backup");
+    const outside = path.join(root, "outside.txt");
+    await mkdir(workspaceRoot, { recursive: true });
+    await writeFile(outside, "must remain unchanged\n", "utf8");
+    await symlink(outside, path.join(workspaceRoot, "AGENTS.md"));
+
+    await expect(installWorkspace({ sourceRoot, workspaceRoot, backupRoot })).rejects.toThrow(
+      /symlink/i,
+    );
+    expect(await readFile(outside, "utf8")).toBe("must remain unchanged\n");
+  });
+
+  it("requires delegation targets to exist in the configured agent registry", async () => {
+    const root = temporaryRoots.make("openclaw-pm-context-registry-");
+    const configPath = path.join(root, "runtime-config.json");
+    const config = JSON.parse(await readFile(path.join(sourceRoot, "runtime-config.json"), "utf8"));
+    delete config.agents.entries["research-brief-agent"];
+    await writeFile(configPath, `${JSON.stringify(config)}\n`, "utf8");
+
+    const result = await checkRuntimeConfig(configPath);
+    expect(result.ok).toBe(false);
+    expect(result.issues.map((entry) => entry.code)).toContain("delegation_target_unconfigured");
   });
 
   it("fails closed when state contains a sensitive field", async () => {

--- a/test/scripts/program-manager-workspace.test.ts
+++ b/test/scripts/program-manager-workspace.test.ts
@@ -2,9 +2,11 @@ import { cp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  applyRuntimeConfig,
   checkRuntimeConfig,
   checkSource,
   installWorkspace,
+  rollbackRuntimeConfig,
   rollbackWorkspace,
   verifyInstalledWorkspace,
 } from "../../scripts/program-manager-workspace.mjs";
@@ -13,6 +15,15 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const repoRoot = process.cwd();
 const sourceRoot = path.join(repoRoot, "control", "program-manager");
 const temporaryRoots = useAutoCleanupTempDirTracker(afterEach);
+type TestAgentEntry = {
+  id?: string;
+  name?: string;
+  role?: string;
+  workspace?: string;
+  params?: { maxTokens?: number; text_verbosity?: string };
+  tools?: { alsoAllow?: string[]; deny?: string[] };
+  subagents?: { allowAgents?: string[]; delegationMode?: string; requireAgentId?: boolean };
+};
 
 describe("Program Manager context package", () => {
   it("passes the compact source contract and budget", async () => {
@@ -45,6 +56,68 @@ describe("Program Manager context package", () => {
     expect(instructions).toContain("stop tool calls immediately");
     expect(instructions).toContain("never search the workspace for a missing packet");
     expect(instructions).toContain("do not call tools on the first response");
+  });
+
+  it("synchronizes only the active Program Manager contract and restores it exactly", async () => {
+    const root = temporaryRoots.make("openclaw-pm-config-sync-");
+    const configPath = path.join(root, "director.json");
+    const backupRoot = path.join(root, "backup");
+    const sourceConfig = JSON.parse(
+      await readFile(path.join(sourceRoot, "runtime-config.json"), "utf8"),
+    ) as { agents: { entries: Record<string, TestAgentEntry> } };
+    const list: TestAgentEntry[] = Object.entries(sourceConfig.agents.entries).map(
+      ([id, entry]) => ({
+        id,
+        ...entry,
+      }),
+    );
+    const programManagerIndex = list.findIndex((entry) => entry.id === "program-manager");
+    list[programManagerIndex] = {
+      ...list[programManagerIndex],
+      name: "Program Manager",
+      role: "program_manager",
+      workspace: "/tmp/program-manager",
+      params: { maxTokens: 3072, text_verbosity: "low" },
+      tools: {
+        alsoAllow: ["memory_search", "sessions_list"],
+        deny: ["exec", "write"],
+      },
+      subagents: {
+        allowAgents: ["builder-agent", "qa-test-agent"],
+        delegationMode: "prefer",
+        requireAgentId: true,
+      },
+    };
+    const beforeText = `${JSON.stringify({ agents: { list } }, null, 2)}\n`;
+    await writeFile(configPath, beforeText, "utf8");
+
+    await applyRuntimeConfig({ sourceRoot, configPath, backupRoot });
+    const applied = JSON.parse(await readFile(configPath, "utf8")) as {
+      agents: { list: TestAgentEntry[] };
+    };
+    const programManager = applied.agents.list.find((entry) => entry.id === "program-manager");
+    if (
+      !programManager ||
+      !programManager.params ||
+      !programManager.tools?.alsoAllow ||
+      !programManager.subagents?.allowAgents
+    ) {
+      throw new Error("Applied Program Manager entry is incomplete.");
+    }
+    expect(programManager.params.maxTokens).toBe(1024);
+    expect(programManager.tools.alsoAllow.toSorted()).toEqual([
+      "get_goal",
+      "progress_card",
+      "read",
+      "sessions_spawn",
+      "sessions_yield",
+    ]);
+    expect(programManager.subagents.allowAgents).toEqual(["builder-agent", "research-brief-agent"]);
+    expect(programManager.role).toBe("program_manager");
+    expect(programManager.workspace).toBe("/tmp/program-manager");
+
+    await rollbackRuntimeConfig({ configPath, backupRoot });
+    expect(await readFile(configPath, "utf8")).toBe(beforeText);
   });
 
   it("installs and rolls back only managed files", async () => {

--- a/test/scripts/program-manager-workspace.test.ts
+++ b/test/scripts/program-manager-workspace.test.ts
@@ -20,7 +20,12 @@ type TestAgentEntry = {
   name?: string;
   role?: string;
   workspace?: string;
-  params?: { maxTokens?: number; text_verbosity?: string };
+  params?: {
+    cacheRetention?: string;
+    chat_template_kwargs?: { enable_thinking?: boolean; preserve_thinking?: boolean };
+    maxTokens?: number;
+    text_verbosity?: string;
+  };
   tools?: { alsoAllow?: string[]; deny?: string[] };
   subagents?: { allowAgents?: string[]; delegationMode?: string; requireAgentId?: boolean };
 };
@@ -52,6 +57,10 @@ describe("Program Manager context package", () => {
     const agents = JSON.parse(await readFile(path.join(sourceRoot, "runtime-config.json"), "utf8"))
       .agents.entries;
     expect(agents["program-manager"].params.maxTokens).toBe(1024);
+    expect(agents["program-manager"].params.chat_template_kwargs).toEqual({
+      enable_thinking: false,
+      preserve_thinking: false,
+    });
     const instructions = await readFile(path.join(sourceRoot, "workspace/AGENTS.md"), "utf8");
     expect(instructions).toContain("stop tool calls immediately");
     expect(instructions).toContain("never search the workspace for a missing packet");
@@ -105,6 +114,10 @@ describe("Program Manager context package", () => {
       throw new Error("Applied Program Manager entry is incomplete.");
     }
     expect(programManager.params.maxTokens).toBe(1024);
+    expect(programManager.params.chat_template_kwargs).toEqual({
+      enable_thinking: false,
+      preserve_thinking: false,
+    });
     expect(programManager.tools.alsoAllow.toSorted()).toEqual([
       "get_goal",
       "progress_card",


### PR DESCRIPTION
## What Problem This Solves

The Program Manager had contract guidance, workspace instructions, runtime settings, and state validation spread across separate surfaces. That increased prompt/context cost and made it easier for the role to overclaim completion, loop on missing state, or cross its planning and handoff boundary.

## Summary

- Consolidates the Program Manager contract, compact bootstrap files, runtime limits, and state fixture rules into one fail-closed package.
- Keeps the checked-in state JSON as validation-only; live status must come from the current task packet, `get_goal`, and returned worker evidence.
- Enforces an exact read/planning/bounded-handoff tool policy with only `builder-agent` and `research-brief-agent` as delegation targets.
- Adds a no-packet terminal path, bounded low-verbosity output, explicit Qwen thinking-off parameters, and no-deliberation/no-policy-recap response rules.
- Adds reversible workspace install/rollback plus PM-only Director-config apply/rollback for both `agents.list` and `agents.entries`, preserving agent identity and unrelated config.
- Keeps bootstrap context compact by replacing generic TOOLS/HEARTBEAT prose with minimal role-specific files.

## Verification

- Source package check passed: 2,677 bootstrap bytes within the 10,000-byte budget.
- Canonical source runtime-config validation passed.
- Focused tests passed: 9/9.
- Workflow sanity passed previously; current hosted checks are running for the latest pushed head.
- `env OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed` passed: typecheck, lint, import-cycle check (0 runtime value cycles), formatting, guards, and selected lanes.
- Governed workspace install/verify passed; the active Program Manager workspace now has compact TOOLS/HEARTBEAT files and unrelated workspace files were preserved.
- Active Director config synchronization is backed up and reversible. The governed managed runtime validated the active config successfully; only existing duplicate-plugin and readonly health-state warnings were reported.
- Managed Gateway loopback health returned HTTP 200 with `{"ok":true,"status":"live"}`.
- Active Program Manager smoke completed through the managed local OMLX provider: bounded PLAN output, missing-packet truthfulness, one `get_goal` call only, no forbidden tool calls, stop finish reason, and no secret output.
- The OMLX payload contained `chat_template_kwargs.enable_thinking=false` and `preserve_thinking=false`; the final response completed without hidden-reasoning budget exhaustion.
- Configuration and workspace backups remain available for rollback.

## Known Boundaries

- The active managed runtime is an older curator-managed release, so its governed launcher is authoritative for active-config validation; the source checkout's newer schema validator is not used against that older active config.
- Pre-existing duplicate-plugin warnings and state-database permission warnings were not changed because they are outside this PM package and could affect unrelated runtime state.
- Matthew must personally review and accept the final live behavior evidence before this role can be certified 100% complete.

## Scope and Safety

No merge, release, publication, spend, live-user-data mutation, or secret exposure. The latest verified commit is pushed to the existing branch; no SHA/promotion work was performed.
