### PR TITLE
fix(ui): show chat before startup metadata finishes

### DIFF
--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -891,10 +891,18 @@ export const agentsHandlers: GatewayRequestHandlers = {
     }
 
     const cfg = context.getRuntimeConfig();
-    const modelCatalog = await readPreparedServerMethodModelCatalog(context);
+    const modelCatalogByAgentId = new Map(
+      await Promise.all(
+        listAgentIds(cfg).map(
+          async (agentId) =>
+            [agentId, await readPreparedServerMethodModelCatalog(context, { agentId })] as const,
+        ),
+      ),
+    );
     respond(
       true,
-      listAgentsForGateway(cfg, modelCatalog, {
+      listAgentsForGateway(cfg, undefined, {
+        modelCatalogByAgentId,
         includeSystem: hasGatewayClientCap(client?.connect.caps, GATEWAY_CLIENT_CAPS.AGENT_KIND),
       }),
       undefined,

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -1,11 +1,6 @@
 // Read-side chat handlers own history projection, startup metadata, and message lookup.
 import {
-  GATEWAY_CLIENT_CAPS,
-  hasGatewayClientCap,
-} from "../../../packages/gateway-protocol/src/client-info.js";
-import {
   ErrorCodes,
-  type AgentsListResult,
   errorShape,
   validateChatHistoryParams,
   validateChatMetadataParams,
@@ -37,7 +32,6 @@ import {
   getSessionDefaults,
   loadGatewaySessionEntryReadOnly,
   loadGatewaySessionRow,
-  listAgentsForGateway,
   resolveSessionModelRef,
 } from "../session-utils.js";
 import { prepareSessionWorkspaceIcon } from "../workspace-icon-http.js";
@@ -56,9 +50,7 @@ import {
   readChatHistoryPage,
   readChatHistoryMessageSeq,
 } from "./chat-history-pages.js";
-import type { ChatMetadataResult } from "./chat-metadata-runtime.js";
 import { resolveRequestedChatAgentId, validateChatSelectedAgent } from "./chat-origin-routing.js";
-import type { ChatStartupProjectionResult } from "./chat-startup-projection-contract.js";
 import { normalizeOptionalChatText as normalizeOptionalText } from "./chat-text-normalization.js";
 import {
   loadOptionalServerMethodModelCatalogSnapshot,
@@ -165,14 +157,9 @@ async function handleChatHistoryRequest({
   params,
   respond,
   context,
-  client,
   method,
-  includeAgentsList,
-  includeMetadata,
 }: GatewayRequestHandlerOptions & {
   method: ChatHistoryMethod;
-  includeAgentsList?: boolean;
-  includeMetadata?: boolean;
 }) {
   if (!assertValidParams(params, validateChatHistoryParams, method, respond)) {
     return;
@@ -314,58 +301,28 @@ async function handleChatHistoryRequest({
           return load;
         })()
       : Promise.resolve(undefined);
-  const startupProjectionsPromise =
-    method === "chat.startup"
-      ? (() => {
-          const includeSystem = hasGatewayClientCap(
-            client?.connect.caps,
-            GATEWAY_CLIENT_CAPS.AGENT_KIND,
+  const readStartupProjection = () =>
+    measureDiagnosticsTimelineSpan(
+      `gateway.${method}.startup_projection`,
+      async () => {
+        try {
+          return await context.readChatStartupProjection?.({
+            agentId: sessionAgentId,
+            sessionEntry: entry,
+          });
+        } catch (error) {
+          context.logGateway.debug(
+            `chat.startup continuing without prepared startup projection: ${formatErrorMessage(error)}`,
           );
-          return measureDiagnosticsTimelineSpan(
-            `gateway.${method}.startup_projections`,
-            async () => {
-              const projection = context.readChatStartupProjection
-                ? await context
-                    .readChatStartupProjection({
-                      agentId: sessionAgentId,
-                      sessionEntry: entry,
-                      includeSystem,
-                    })
-                    .catch((error: unknown) => {
-                      context.logGateway.debug(
-                        `chat.startup continuing without prepared startup projection: ${formatErrorMessage(error)}`,
-                      );
-                      return undefined;
-                    })
-                : undefined;
-              const metadata = includeMetadata
-                ? (projection?.metadata ??
-                  (await context
-                    .readChatMetadata({
-                      agentId: sessionAgentId,
-                      sessionEntry: entry,
-                    })
-                    .catch((error: unknown) => {
-                      context.logGateway.debug(
-                        `chat.startup continuing without metadata: ${formatErrorMessage(error)}`,
-                      );
-                      return undefined;
-                    })))
-                : undefined;
-              const agentsList = includeAgentsList
-                ? (projection?.agentsList ??
-                  listAgentsForGateway(cfg, undefined, { includeSystem }))
-                : undefined;
-              return { agentsList, projection, metadata };
-            },
-            {
-              config: cfg,
-              phase: method,
-              attributes: { agentId: sessionAgentId, includeSystem },
-            },
-          );
-        })()
-      : Promise.resolve(undefined);
+          return undefined;
+        }
+      },
+      { config: cfg, phase: method, attributes: { agentId: sessionAgentId } },
+    );
+  const startupProjectionPromise =
+    method === "chat.startup" && entry?.authProfileOverride?.trim()
+      ? readStartupProjection()
+      : undefined;
   const sessionId = requestedSessionId ?? entry?.sessionId;
   const historyEntry =
     requestedSessionId && requestedSessionId !== entry?.sessionId ? undefined : entry;
@@ -466,10 +423,11 @@ async function handleChatHistoryRequest({
   const catalogOwnedBySessionAgent = modelCatalogSnapshot?.agentId === sessionAgentId;
   const modelCatalog = catalogOwnedBySessionAgent ? modelCatalogSnapshot.entries : undefined;
   const compatibilityOwnerAgentId = tryResolveSessionCompatibilityOwnerAgentId(cfg, sessionKey);
-  const startupProjections = await startupProjectionsPromise;
-  const startupProjection: ChatStartupProjectionResult | undefined = startupProjections?.projection;
-  const startupMetadata: ChatMetadataResult | undefined = startupProjections?.metadata;
-  const startupAgentsList: AgentsListResult | undefined = startupProjections?.agentsList;
+  const startupProjection =
+    method === "chat.startup"
+      ? await (startupProjectionPromise ?? readStartupProjection())
+      : undefined;
+  const startupMetadata = startupProjection?.metadata;
   const sessionModelCatalog = startupProjection?.sessionModelCatalog ?? modelCatalog;
   const defaultModelCatalog = startupProjection?.defaultModelCatalog ?? modelCatalog;
   const sessionInfo = measureDiagnosticsTimelineSpanSync(
@@ -588,7 +546,6 @@ async function handleChatHistoryRequest({
       messages: delta.messages,
       deltaCursor: delta.deltaCursor,
       sessionInfo,
-      ...(includeAgentsList && startupAgentsList ? { agentsList: startupAgentsList } : {}),
       ...(startupMetadata ? { metadata: startupMetadata } : {}),
     });
     return;
@@ -612,7 +569,6 @@ async function handleChatHistoryRequest({
     toolOverrides: entry?.toolOverrides,
     verboseLevel,
     ...(boundedInFlightRun ? { inFlightRun: boundedInFlightRun } : {}),
-    ...(includeAgentsList && startupAgentsList ? { agentsList: startupAgentsList } : {}),
     ...(startupMetadata ? { metadata: startupMetadata } : {}),
   };
   respond(true, payload);
@@ -623,12 +579,7 @@ export const chatHistoryHandlers: GatewayRequestHandlers = {
     await handleChatHistoryRequest({ ...opts, method: "chat.history" });
   },
   "chat.startup": async (opts) => {
-    await handleChatHistoryRequest({
-      ...opts,
-      method: "chat.startup",
-      includeAgentsList: true,
-      includeMetadata: true,
-    });
+    await handleChatHistoryRequest({ ...opts, method: "chat.startup" });
   },
   "chat.metadata": handleChatMetadataRequest,
 };

--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs/promises";
 import { describe, expect, test, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import {
@@ -10,7 +9,6 @@ import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { setPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { createGatewayChatMetadataRuntime } from "./chat-metadata-runtime.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -226,21 +224,15 @@ describe("gateway chat metadata runtime", () => {
     harness.getSkillsVersion.mockClear();
     harness.getPluginRegistryVersion.mockClear();
 
-    const first = await harness.runtime.readStartup({
-      agentId: "main",
-      includeSystem: false,
-    });
-    const second = await harness.runtime.readStartup({
-      agentId: "main",
-      includeSystem: false,
-    });
+    const first = await harness.runtime.readStartup({ agentId: "main" });
+    const second = await harness.runtime.readStartup({ agentId: "main" });
 
-    expect(second.agentsList).toBe(first.agentsList);
-    expect(first.sessionModelCatalog).toEqual([
+    expect(first?.sessionModelCatalog).toEqual([
       expect.objectContaining({ id: "first", provider: "test" }),
     ]);
-    expect(first.defaultModelCatalog).toBe(first.sessionModelCatalog);
-    expect(first.metadata.models).toEqual(first.sessionModelCatalog);
+    expect(second).toEqual(first);
+    expect(first?.defaultModelCatalog).toBe(first?.sessionModelCatalog);
+    expect(first?.metadata.models).toEqual(first?.sessionModelCatalog);
     expect(harness.buildProjection).toHaveBeenCalledTimes(1);
     expect(harness.getPreparedOwner).not.toHaveBeenCalled();
     expect(harness.getPreparedAuthStore).not.toHaveBeenCalled();
@@ -262,16 +254,14 @@ describe("gateway chat metadata runtime", () => {
     });
     await harness.runtime.refresh();
 
-    const readNeutralStartup = async () =>
-      await harness.runtime.readStartup({
-        agentId: defaultAgentId,
-        includeSystem: false,
-      });
+    const readNeutralStartup = () => harness.runtime.readStartup({ agentId: defaultAgentId });
     const first = await readNeutralStartup();
     const second = await readNeutralStartup();
 
-    expect(first.agentsList.agents).toHaveLength(agentIds.length);
-    expect(second.agentsList).toBe(first.agentsList);
+    expect(first?.sessionModelCatalog).toEqual([
+      expect.objectContaining({ id: "first", provider: "test" }),
+    ]);
+    expect(second).toEqual(first);
     expect(harness.buildProjection).toHaveBeenCalledTimes(agentIds.length);
 
     await harness.runtime.readStartup({
@@ -280,14 +270,13 @@ describe("gateway chat metadata runtime", () => {
         authProfileOverride: "test:session",
         authProfileOverrideSource: "user",
       },
-      includeSystem: false,
     });
     await readNeutralStartup();
 
     expect(harness.buildProjection).toHaveBeenCalledTimes(agentIds.length + 1);
   });
 
-  test("caches a session auth projection separately from the neutral roster", async () => {
+  test("caches a session auth projection separately from the neutral projection", async () => {
     const harness = createHarness();
     await harness.runtime.refresh();
 
@@ -298,12 +287,10 @@ describe("gateway chat metadata runtime", () => {
     const first = await harness.runtime.readStartup({
       agentId: "main",
       sessionEntry,
-      includeSystem: false,
     });
     const second = await harness.runtime.readStartup({
       agentId: "main",
       sessionEntry,
-      includeSystem: false,
     });
 
     expect(second).toEqual(first);
@@ -337,7 +324,6 @@ describe("gateway chat metadata runtime", () => {
     await harness.runtime.readStartup({
       agentId: "main",
       sessionEntry,
-      includeSystem: false,
     });
 
     const projectionParams = harness.buildProjection.mock.calls.at(-1)?.[0];
@@ -355,31 +341,6 @@ describe("gateway chat metadata runtime", () => {
     } else {
       expect(projectionParams).not.toHaveProperty("lockedProfileId");
     }
-  });
-
-  test("keeps disk-only roster rows without projecting them", async () => {
-    await withOpenClawTestState(
-      {
-        layout: "state-only",
-        scenario: "minimal",
-        agentEnv: "main",
-      },
-      async (state) => {
-        await fs.mkdir(state.statePath("agents", "dormant", "agent"), { recursive: true });
-        const harness = createHarness({});
-
-        await harness.runtime.refresh();
-        harness.getPreparedOwner.mockClear();
-        const startup = await harness.runtime.readStartup({
-          agentId: "main",
-          includeSystem: false,
-        });
-
-        expect(startup.agentsList.agents.map((agent) => agent.id)).toEqual(["main", "dormant"]);
-        expect(harness.getPreparedOwner).not.toHaveBeenCalled();
-        expect(harness.buildProjection).toHaveBeenCalledTimes(1);
-      },
-    );
   });
 
   test("reuses the prepared generation for an equivalent config replacement", async () => {
@@ -570,13 +531,21 @@ describe("gateway chat metadata runtime", () => {
     expect(harness.buildProjection).toHaveBeenCalledTimes(4);
   });
 
-  test("waits for an invalidated generation to be replaced before serving reads", async () => {
+  test("waits for replacement only for canonical metadata and session auth projections", async () => {
     const harness = createHarness();
     await harness.runtime.refresh();
 
     harness.runtime.invalidate();
     const read = harness.runtime.read({ agentId: "main" });
+    const overriddenStartup = harness.runtime.readStartup({
+      agentId: "main",
+      sessionEntry: {
+        authProfileOverride: "test:session",
+        authProfileOverrideSource: "user",
+      },
+    });
     let settled = false;
+    let overriddenSettled = false;
     void read.then(
       () => {
         settled = true;
@@ -585,8 +554,18 @@ describe("gateway chat metadata runtime", () => {
         settled = true;
       },
     );
+    void overriddenStartup.then(
+      () => {
+        overriddenSettled = true;
+      },
+      () => {
+        overriddenSettled = true;
+      },
+    );
+    await expect(harness.runtime.readStartup({ agentId: "main" })).resolves.toBeUndefined();
     await Promise.resolve();
     expect(settled).toBe(false);
+    expect(overriddenSettled).toBe(false);
 
     const nextConfig = {
       agents: { list: [{ id: "main", default: true }] },
@@ -599,6 +578,13 @@ describe("gateway chat metadata runtime", () => {
     await expect(read).resolves.toMatchObject({
       models: [expect.objectContaining({ id: "replacement" })],
       swarmEnabled: true,
+    });
+    await expect(overriddenStartup).resolves.toMatchObject({
+      metadata: {
+        models: [expect.objectContaining({ id: "replacement" })],
+        swarmEnabled: true,
+      },
+      sessionModelCatalog: [expect.objectContaining({ id: "replacement" })],
     });
   });
 

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -20,7 +20,6 @@ import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { getActivePluginRegistryVersion } from "../../plugins/runtime.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { getSkillsSnapshotVersion } from "../../skills/runtime/refresh-state.js";
-import { listAgentsForGateway } from "../session-utils.js";
 import type {
   ChatMetadataReadParams,
   ChatMetadataResult,
@@ -31,8 +30,6 @@ import type {
   ChatStartupProjectionResult,
 } from "./chat-startup-projection-contract.js";
 import type { GatewayRequestContext } from "./types.js";
-
-export type { ChatMetadataResult } from "./chat-metadata-contract.js";
 
 type PreparedAgentFacts = {
   agentId: string;
@@ -65,7 +62,6 @@ type PreparedMetadataGeneration = {
   agentsById: Map<string, PreparedAgentMetadata>;
   neutralProjectionByAgentId: Map<string, Promise<PreparedAgentProjection>>;
   sessionProjectionByKey: Map<string, Promise<PreparedAgentProjection>>;
-  agentsListByKey: Map<string, ChatStartupProjectionResult["agentsList"]>;
 };
 
 type MetadataReplacement = {
@@ -271,7 +267,9 @@ export function createGatewayChatMetadataRuntime(params: {
   fail: (error: unknown) => void;
   refresh: () => Promise<void>;
   read: (params: ChatMetadataReadParams) => Promise<ChatMetadataResult>;
-  readStartup: (params: ChatStartupProjectionReadParams) => Promise<ChatStartupProjectionResult>;
+  readStartup: (
+    params: ChatStartupProjectionReadParams,
+  ) => Promise<ChatStartupProjectionResult | undefined>;
 } {
   const deps: ChatMetadataRuntimeDeps = {
     getConfig: params.getConfig,
@@ -368,7 +366,6 @@ export function createGatewayChatMetadataRuntime(params: {
       agentsById: new Map(agents.map((agent) => [agent.agentId, agent])),
       neutralProjectionByAgentId: new Map(),
       sessionProjectionByKey: new Map(),
-      agentsListByKey: new Map(),
     };
     if (epoch !== invalidationEpoch) {
       return false;
@@ -538,57 +535,41 @@ export function createGatewayChatMetadataRuntime(params: {
 
   const readStartup = async (
     readParams: ChatStartupProjectionReadParams,
-  ): Promise<ChatStartupProjectionResult> =>
-    await readCurrent(async (generation) => {
-      const sessionAgentId = normalizeAgentId(readParams.agentId);
-      const sessionAgent = generation.agentsById.get(sessionAgentId);
-      if (!sessionAgent) {
+  ): Promise<ChatStartupProjectionResult | undefined> => {
+    const projectStartup = async (
+      generation: PreparedMetadataGeneration,
+    ): Promise<ChatStartupProjectionResult> => {
+      const agentId = normalizeAgentId(readParams.agentId);
+      const agent = generation.agentsById.get(agentId);
+      if (!agent) {
         throw new ChatMetadataSnapshotUnavailableError(
-          `prepared chat startup projection is unavailable for agent "${sessionAgentId}"`,
+          `prepared chat startup projection is unavailable for agent "${agentId}"`,
         );
       }
-      const defaultAgentId = sessionAgentId;
-      const profileNeutralProjections = await Promise.all(
-        [...generation.agentsById.values()].map(
-          async (agent) => [agent.agentId, await projectAgent(generation, agent)] as const,
-        ),
-      );
-      const projectionByAgentId = new Map(profileNeutralProjections);
-      const sessionProjection = await projectAgent(
-        generation,
-        sessionAgent,
-        readParams.sessionEntry,
-      );
-      const defaultProjection = projectionByAgentId.get(defaultAgentId);
-      if (!defaultProjection) {
-        throw new ChatMetadataSnapshotUnavailableError(
-          `prepared chat startup projection is unavailable for default agent "${defaultAgentId}"`,
-        );
-      }
-      const agentsListKey = readParams.includeSystem ? "include-system" : "agents-only";
-      let agentsList = generation.agentsListByKey.get(agentsListKey);
-      if (!agentsList) {
-        const modelCatalogByAgentId = new Map(
-          profileNeutralProjections.map(([agentId, projection]) => [
-            agentId,
-            projection.modelCatalog,
-          ]),
-        );
-        // Disk-only legacy roster rows remain visible, but inherit the default prepared catalog.
-        // Only configured agents own auth/plugin projections in the lifecycle generation.
-        agentsList = listAgentsForGateway(generation.facts.config, defaultProjection.modelCatalog, {
-          modelCatalogByAgentId,
-          includeSystem: readParams.includeSystem,
-        });
-        generation.agentsListByKey.set(agentsListKey, agentsList);
-      }
+      const neutralProjection = await projectAgent(generation, agent);
+      const sessionProjection = await projectAgent(generation, agent, readParams.sessionEntry);
       return {
         metadata: sessionProjection.metadata,
         sessionModelCatalog: sessionProjection.modelCatalog,
-        defaultModelCatalog: defaultProjection.modelCatalog,
-        agentsList,
+        defaultModelCatalog: neutralProjection.modelCatalog,
       };
-    });
+    };
+    if (resolveSessionProfiles(readParams.sessionEntry).preferredProfileId) {
+      return readCurrent(projectStartup);
+    }
+    const generation = current;
+    // Neutral startup metadata is optional: never enter the lifecycle replacement gate.
+    if (!generation || replacement || pending || generation.epoch !== invalidationEpoch) {
+      return undefined;
+    }
+    const projection = await projectStartup(generation);
+    return current === generation &&
+      generation.epoch === invalidationEpoch &&
+      !replacement &&
+      !pending
+      ? projection
+      : undefined;
+  };
 
   const invalidate = () => {
     invalidationEpoch += 1;

--- a/src/gateway/server-methods/chat-startup-projection-contract.ts
+++ b/src/gateway/server-methods/chat-startup-projection-contract.ts
@@ -1,16 +1,13 @@
-import type { AgentsListResult } from "../../../packages/gateway-protocol/src/index.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { ChatMetadataResult, ChatMetadataSessionEntry } from "./chat-metadata-contract.js";
 
 export type ChatStartupProjectionReadParams = {
   agentId: string;
   sessionEntry?: ChatMetadataSessionEntry;
-  includeSystem: boolean;
 };
 
 export type ChatStartupProjectionResult = {
   metadata: ChatMetadataResult;
   sessionModelCatalog: ModelCatalogEntry[];
   defaultModelCatalog: ModelCatalogEntry[];
-  agentsList: AgentsListResult;
 };

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -95,9 +95,28 @@ async function setAgentsConfig(agentsConfig: Record<string, unknown> | undefined
 
 test("agents.list includes system rows only when negotiated", async () => {
   fs.mkdirSync(path.join(requireStateDir(), "agents", "openclaw"), { recursive: true });
+  testState.agentConfig = { model: { primary: "local/shared-reasoner" } };
+  const readPreparedGatewayModelCatalog = vi.fn(async () => [
+    {
+      id: "shared-reasoner",
+      name: "Shared Reasoner",
+      provider: "local",
+      reasoning: false,
+    },
+  ]);
 
-  expect(await listAgentIdsViaRpc()).toEqual(["main"]);
-  expect(await listAgentIdsViaRpc(true)).toEqual(["main", "openclaw"]);
+  expect(await listAgentIdsViaRpc(false, { readPreparedGatewayModelCatalog })).toEqual(["main"]);
+  const result = await listAgentsViaRpc(true, { readPreparedGatewayModelCatalog });
+  expect(result.agents.map((agent) => agent.id)).toEqual(["main", "openclaw"]);
+  expect(
+    result.agents
+      .find((agent) => agent.id === "openclaw")
+      ?.thinkingLevels?.map((level) => level.id),
+  ).toEqual(["off"]);
+  expect(readPreparedGatewayModelCatalog.mock.calls).toEqual([
+    [{ agentId: "main" }],
+    [{ agentId: "main" }],
+  ]);
 });
 
 test("agents.list reads published model facts without starting provider discovery", async () => {
@@ -111,7 +130,7 @@ test("agents.list reads published model facts without starting provider discover
     }),
   ).resolves.toEqual(["main"]);
 
-  expect(readPreparedGatewayModelCatalog).toHaveBeenCalledWith(undefined);
+  expect(readPreparedGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "main" });
   expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
 });
 
@@ -126,8 +145,55 @@ test("agents.list returns the roster when optional prepared model facts are unav
     "research",
   ]);
 
-  expect(readPreparedGatewayModelCatalog).toHaveBeenCalledOnce();
+  expect(readPreparedGatewayModelCatalog.mock.calls).toEqual([
+    [{ agentId: "ops" }],
+    [{ agentId: "research" }],
+  ]);
 });
+
+test.each([
+  { unavailableAgentId: undefined },
+  { unavailableAgentId: "work" },
+  { unavailableAgentId: "main" },
+])(
+  "agents.list keeps prepared thinking metadata scoped to each roster agent ($unavailableAgentId unavailable)",
+  async ({ unavailableAgentId }) => {
+    testState.agentConfig = { model: { primary: "local/shared-reasoner" } };
+    await setAgentsConfig({
+      ownership: "explicit",
+      entries: { main: {}, work: {} },
+    });
+    const readPreparedGatewayModelCatalog = vi.fn(async (options?: { agentId?: string }) => {
+      if (!options?.agentId || options.agentId === unavailableAgentId) {
+        return undefined;
+      }
+      return [
+        {
+          id: "shared-reasoner",
+          name: "Shared Reasoner",
+          provider: "local",
+          reasoning: options.agentId === "work",
+        },
+      ];
+    });
+
+    const result = await listAgentsViaRpc(false, { readPreparedGatewayModelCatalog });
+    const main = result.agents.find((agent) => agent.id === "main");
+    const work = result.agents.find((agent) => agent.id === "work");
+
+    const mainLevels = main?.thinkingLevels?.map((level) => level.id);
+    if (unavailableAgentId === "main") {
+      expect(mainLevels).toContain("high");
+    } else {
+      expect(mainLevels).toEqual(["off"]);
+    }
+    expect(work?.thinkingLevels?.map((level) => level.id)).toContain("high");
+    expect(readPreparedGatewayModelCatalog.mock.calls).toEqual([
+      [{ agentId: "main" }],
+      [{ agentId: "work" }],
+    ]);
+  },
+);
 
 test("agents.list includes durable provenance only for matching roster rows", async () => {
   await setAgentsConfig({ ownership: "explicit", entries: { ops: {}, research: {} } });

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -281,7 +281,7 @@ type GatewayKernelContext = {
   readChatMetadata: (params: ChatMetadataReadParams) => Promise<ChatMetadataResult>;
   readChatStartupProjection?: (
     params: ChatStartupProjectionReadParams,
-  ) => Promise<ChatStartupProjectionResult>;
+  ) => Promise<ChatStartupProjectionResult | undefined>;
   getHealthCache: () => HealthSummary | null;
   logHealth: { error: (message: string) => void };
   logGateway: SubsystemLogger;

--- a/src/gateway/server.chat-history-cursor.test.ts
+++ b/src/gateway/server.chat-history-cursor.test.ts
@@ -483,7 +483,11 @@ describe("chat.history cursor catch-up", () => {
 
   test("chat.startup returns startup projections with a delta", async () => {
     const { context, storePath } = await createCursorSession();
-    context.readChatMetadata = async () => ({}) as never;
+    context.readChatStartupProjection = async () => ({
+      metadata: { swarmEnabled: false },
+      sessionModelCatalog: [],
+      defaultModelCatalog: [],
+    });
     const page = await callChat<{ deltaCursor?: string }>(context, "chat.startup");
     await appendTranscriptMessage(currentScope(storePath), {
       eventId: "startup-append",
@@ -491,7 +495,6 @@ describe("chat.history cursor catch-up", () => {
       message: { role: "assistant", content: "startup delta", timestamp: 2 },
     });
     const delta = await callChat<{
-      agentsList?: unknown;
       kind?: string;
       messages?: unknown[];
       metadata?: unknown;
@@ -503,9 +506,9 @@ describe("chat.history cursor catch-up", () => {
         kind: "delta",
         messages: [expect.any(Object)],
         sessionInfo: expect.any(Object),
-        agentsList: expect.any(Object),
         metadata: expect.any(Object),
       },
     });
+    expect(delta.payload).not.toHaveProperty("agentsList");
   });
 });

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -53,6 +53,7 @@ import {
   createTextTranscriptEvent,
 } from "./server-chat.agent-events.test-helpers.js";
 import { getMaxChatHistoryMessagesBytes } from "./server-constants.js";
+import { createGatewayChatMetadataRuntime } from "./server-methods/chat-metadata-runtime.js";
 import type {
   GatewayRequestContext,
   GatewayRequestHandlerOptions,
@@ -1322,7 +1323,7 @@ describe("gateway server chat", () => {
     });
   });
 
-  test("chat.startup returns chat history with the initial agents list and provenance", async () => {
+  test("chat.startup returns warm metadata while agents.list owns roster provenance", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await writeGatewayConfig({
         agents: {
@@ -1361,18 +1362,10 @@ describe("gateway server chat", () => {
       await writeMainSessionTranscript([
         createTextTranscriptEvent("user", "startup hydrate", { timestamp: updatedAt }),
       ]);
+      const preparedMetadata = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+      expect(preparedMetadata.ok).toBe(true);
 
       const startup = await rpcReq<{
-        agentsList?: {
-          agents?: Array<{
-            id?: string;
-            createdVia?: string;
-            creatorAgentId?: string | null;
-            createdAt?: number;
-          }>;
-          defaultId?: string | null;
-          mainKey?: string | null;
-        };
         metadata?: {
           commands?: Array<{ name?: string; textAliases?: string[] }>;
           models?: Array<{ id?: string; provider?: string }>;
@@ -1380,14 +1373,24 @@ describe("gateway server chat", () => {
         messages?: unknown[];
         sessionInfo?: { key?: string; sessionId?: string };
       }>(ws, "chat.startup", makeMainSessionParams());
+      const agents = await rpcReq<{
+        agents?: Array<{
+          id?: string;
+          createdVia?: string;
+          creatorAgentId?: string | null;
+          createdAt?: number;
+        }>;
+        defaultId?: string | null;
+        mainKey?: string | null;
+      }>(ws, "agents.list", {});
 
       expect(startup.ok).toBe(true);
-      expect(startup.payload?.agentsList?.defaultId).toBe("main");
-      expect(startup.payload?.agentsList?.mainKey).toBe("main");
-      expect(startup.payload?.agentsList?.agents?.map((agent) => agent.id)).toContain("main");
-      expect(
-        startup.payload?.agentsList?.agents?.find((agent) => agent.id === "research"),
-      ).toMatchObject({
+      expect(startup.payload).not.toHaveProperty("agentsList");
+      expect(agents.ok).toBe(true);
+      expect(agents.payload?.defaultId).toBe("main");
+      expect(agents.payload?.mainKey).toBe("main");
+      expect(agents.payload?.agents?.map((agent) => agent.id)).toContain("main");
+      expect(agents.payload?.agents?.find((agent) => agent.id === "research")).toMatchObject({
         createdVia: "agent",
         creatorAgentId: "main",
         createdAt: 42,
@@ -1492,14 +1495,59 @@ describe("gateway server chat", () => {
       expect(responses[0]?.ok).toBe(true);
       const payload = responses[0]?.payload as
         | {
-            agentsList?: { agents?: Array<{ id?: string }> };
             metadata?: unknown;
             sessionInfo?: { sessionId?: string };
           }
         | undefined;
       expect(payload?.sessionInfo?.sessionId).toBe("sess-main");
-      expect(payload?.agentsList?.agents?.map((agent) => agent.id)).toContain("main");
       expect(payload?.metadata).toBeUndefined();
+    } finally {
+      testState.sessionStorePath = undefined;
+    }
+  });
+
+  test("chat.startup returns a profile-neutral transcript while metadata replacement is pending", async () => {
+    openDirectChatSession();
+    try {
+      await writeStoredMainSession();
+      await writeMainSessionTranscript([
+        createTextTranscriptEvent("user", "paint without metadata"),
+      ]);
+      const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
+      const context = createDirectChatContext({ getRuntimeConfig: () => ({}) });
+      const metadataRuntime = createGatewayChatMetadataRuntime({
+        getConfig: () => ({}),
+        getContext: () => context,
+        log: context.logGateway,
+      });
+      context.readChatStartupProjection = metadataRuntime.readStartup;
+      metadataRuntime.invalidate();
+
+      const startup = callDirectChat("chat.startup", {
+        id: "startup-neutral-pending-metadata",
+        params: makeMainSessionParams(),
+        respond: captureChatResponse(responses),
+        context,
+      });
+
+      try {
+        await vi.waitFor(() => expect(responses).toHaveLength(1), FAST_WAIT_OPTS);
+        expect(responses[0]).toMatchObject({
+          ok: true,
+          payload: {
+            messages: [
+              expect.objectContaining({
+                role: "user",
+                content: [{ type: "text", text: "paint without metadata" }],
+              }),
+            ],
+          },
+        });
+        expect(responses[0]?.payload).not.toHaveProperty("metadata");
+      } finally {
+        metadataRuntime.fail(new Error("test metadata replacement stopped"));
+        await startup;
+      }
     } finally {
       testState.sessionStorePath = undefined;
     }
@@ -1722,7 +1770,6 @@ describe("gateway server chat", () => {
           const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
           const { buildModelsListResult, createGatewayAgentModelCatalogProjector } =
             await import("./server-methods/models-list-result.js");
-          const { listAgentsForGateway } = await import("./session-utils.js");
           const projectionByKey = new Map<
             string,
             Promise<{
@@ -1793,10 +1840,9 @@ describe("gateway server chat", () => {
                 ...catalogSnapshot,
               }),
             getRuntimeConfig: () => persistedConfig,
-            readChatStartupProjection: vi.fn(async ({ agentId, sessionEntry, includeSystem }) => {
-              const [mainProjection, workProjection, sessionProjection] = await Promise.all([
-                projectAgent(context, "main"),
-                projectAgent(context, "work"),
+            readChatStartupProjection: vi.fn(async ({ agentId, sessionEntry }) => {
+              const [neutralProjection, sessionProjection] = await Promise.all([
+                projectAgent(context, agentId),
                 projectAgent(context, agentId, sessionEntry),
               ]);
               preparedThinkingPolicy.fallback = sessionProjection.modelCatalog.some(
@@ -1807,14 +1853,7 @@ describe("gateway server chat", () => {
               return {
                 metadata: sessionProjection.metadata,
                 sessionModelCatalog: sessionProjection.modelCatalog,
-                defaultModelCatalog: mainProjection.modelCatalog,
-                agentsList: listAgentsForGateway(persistedConfig, mainProjection.modelCatalog, {
-                  modelCatalogByAgentId: new Map([
-                    ["main", mainProjection.modelCatalog],
-                    ["work", workProjection.modelCatalog],
-                  ]),
-                  includeSystem,
-                }),
+                defaultModelCatalog: neutralProjection.modelCatalog,
               };
             }),
           });
@@ -1846,9 +1885,6 @@ describe("gateway server chat", () => {
                 metadata?: { models?: unknown[] };
                 sessionInfo?: { thinkingLevels?: Array<{ id?: string }> };
                 defaults?: { thinkingLevels?: Array<{ id?: string }> };
-                agentsList?: {
-                  agents?: Array<{ id?: string; thinkingLevels?: Array<{ id?: string }> }>;
-                };
               }
             | undefined;
           expect(payload?.metadata?.models).toEqual([
@@ -1869,10 +1905,6 @@ describe("gateway server chat", () => {
           ]);
           expect(payload?.sessionInfo?.thinkingLevels?.map((level) => level.id)).toEqual(["off"]);
           expect(payload?.defaults?.thinkingLevels?.map((level) => level.id)).toEqual(["off"]);
-          const mainAgent = payload?.agentsList?.agents?.find((agent) => agent.id === "main");
-          const workAgent = payload?.agentsList?.agents?.find((agent) => agent.id === "work");
-          expect(mainAgent?.thinkingLevels?.map((level) => level.id)).toEqual(["off"]);
-          expect(workAgent?.thinkingLevels?.map((level) => level.id)).toContain("high");
           const serialized = JSON.stringify(responses[0]?.payload);
           expect(serialized).not.toContain("private-route-token");
           expect(serialized).not.toContain("platform-api-key");
@@ -1949,6 +1981,8 @@ describe("gateway server chat", () => {
         },
       });
       await connectOk(ws);
+      const preparedMetadata = await rpcReq(ws, "chat.metadata", { agentId: "main" });
+      expect(preparedMetadata.ok).toBe(true);
 
       const startup = await rpcReq<{
         metadata?: { models?: Array<{ id?: string; provider?: string }> };
@@ -2014,7 +2048,7 @@ describe("gateway server chat", () => {
       } as unknown as OpenClawConfig;
       await writeGatewayConfig(config);
       const responses: Array<{ ok: boolean; payload?: unknown; error?: unknown }> = [];
-      const readChatMetadata = vi.fn(async () => ({
+      const metadata = {
         models: [
           {
             id: "MiniMax-M2.7-highspeed",
@@ -2023,6 +2057,11 @@ describe("gateway server chat", () => {
           },
         ],
         swarmEnabled: false,
+      };
+      const readChatStartupProjection = vi.fn(async () => ({
+        metadata,
+        sessionModelCatalog: metadata.models,
+        defaultModelCatalog: metadata.models,
       }));
       const context = createDirectChatContext({
         loadGatewayModelCatalogSnapshot: vi
@@ -2053,7 +2092,7 @@ describe("gateway server chat", () => {
             };
           }),
         getRuntimeConfig: () => config,
-        readChatMetadata,
+        readChatStartupProjection,
       });
       await callDirectChat("chat.startup", {
         id: "startup-agent-scoped-metadata",
@@ -2063,12 +2102,13 @@ describe("gateway server chat", () => {
       });
 
       expect(context.loadGatewayModelCatalogSnapshot).not.toHaveBeenCalled();
-      expect(readChatMetadata).toHaveBeenCalledWith(
+      expect(readChatStartupProjection).toHaveBeenCalledWith(
         expect.objectContaining({
           agentId: "work",
           sessionEntry: expect.objectContaining({ sessionId: "sess-work" }),
         }),
       );
+      expect(context.readChatMetadata).not.toHaveBeenCalled();
       expect(responses).toHaveLength(1);
       expect(responses[0]?.ok).toBe(true);
       const payload = responses[0]?.payload as

--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -304,7 +304,7 @@ export function listAgentsForGateway(
   cfg: OpenClawConfig,
   modelCatalog?: ModelCatalogEntry[],
   options?: {
-    modelCatalogByAgentId?: ReadonlyMap<string, ModelCatalogEntry[]>;
+    modelCatalogByAgentId?: ReadonlyMap<string, ModelCatalogEntry[] | undefined>;
     includeSystem?: boolean;
   },
 ): {
@@ -357,7 +357,9 @@ export function listAgentsForGateway(
         acpRuntime: false,
       }),
     );
-    const agentModelCatalog = options?.modelCatalogByAgentId?.get(id) ?? modelCatalog;
+    const agentModelCatalog = options?.modelCatalogByAgentId?.has(id)
+      ? options.modelCatalogByAgentId.get(id)
+      : (modelCatalog ?? options?.modelCatalogByAgentId?.get(basic.defaultId));
     const thinkingProfile = resolveGatewayModelThinkingProfile({
       cfg,
       agentId: id,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -3845,17 +3845,30 @@ describe("gateway session utils", () => {
         defaults: {
           model: { primary: "local/custom-reasoner" },
         },
-        list: [{ id: "main", default: true }],
+        list: [{ id: "main", default: true }, { id: "work" }, { id: "missing" }],
       },
     } as OpenClawConfig;
+    const catalogEntry = {
+      provider: "local",
+      id: "custom-reasoner",
+      name: "Custom Reasoner",
+    };
+    const disabledCatalog = [{ ...catalogEntry, reasoning: false }];
+    const enabledCatalog = [{ ...catalogEntry, reasoning: true }];
 
-    const result = listAgentsForGateway(cfg, [
-      { provider: "local", id: "custom-reasoner", name: "Custom Reasoner", reasoning: true },
-    ]);
-    const agent = result.agents.find((row) => row.id === "main");
+    const result = listAgentsForGateway(cfg, disabledCatalog, {
+      modelCatalogByAgentId: new Map([
+        ["main", disabledCatalog],
+        ["work", enabledCatalog],
+        ["missing", undefined],
+      ]),
+    });
+    const agentsById = new Map(result.agents.map((agent) => [agent.id, agent]));
 
-    expect(agent?.thinkingDefault).toBe("medium");
-    expect(agent?.thinkingLevels?.map((level) => level.id)).toContain("medium");
+    expect(agentsById.get("main")?.thinkingLevels?.map((level) => level.id)).toEqual(["off"]);
+    expect(agentsById.get("work")?.thinkingDefault).toBe("medium");
+    expect(agentsById.get("work")?.thinkingLevels?.map((level) => level.id)).toContain("medium");
+    expect(agentsById.get("missing")?.thinkingLevels?.map((level) => level.id)).toContain("high");
   });
 
   describe("listAgentsForGateway resolved model projection", () => {

--- a/ui/src/app/agent-selection.test.ts
+++ b/ui/src/app/agent-selection.test.ts
@@ -50,10 +50,22 @@ function createRoster() {
 describe("agent selection", () => {
   it("keeps page scope separate from the concrete chat agent", () => {
     const harness = createGateway();
-    const selection = createAgentSelectionCapability(harness.gateway, createRoster().roster);
+    const roster = createRoster();
+    const selection = createAgentSelectionCapability(harness.gateway, roster.roster);
 
     expect(selection.state).toEqual({ selectedId: "main", scopeId: "main" });
     selection.setScope(null);
+    expect(selection.state).toEqual({ selectedId: "main", scopeId: null });
+
+    roster.publish({
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [
+        { id: "main", kind: "agent" },
+        { id: "writer", kind: "agent" },
+      ],
+    });
     expect(selection.state).toEqual({ selectedId: "main", scopeId: null });
 
     selection.set("Writer");

--- a/ui/src/app/agent-selection.ts
+++ b/ui/src/app/agent-selection.ts
@@ -114,7 +114,10 @@ export function createAgentSelectionCapability(
       followsGatewayDefault = true;
     }
     if (followsGatewayDefault && assistantAgentId) {
-      publish({ selectedId: assistantAgentId, scopeId: assistantAgentId });
+      publish({
+        selectedId: assistantAgentId,
+        scopeId: state.selectedId === assistantAgentId ? state.scopeId : assistantAgentId,
+      });
     } else {
       publish(state);
     }

--- a/ui/src/app/app-shell-gateway.ts
+++ b/ui/src/app/app-shell-gateway.ts
@@ -1,7 +1,6 @@
 import type { UiCommandParams } from "@openclaw/gateway-protocol";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../api/gateway.ts";
 import type { GatewayAgentRow } from "../api/types.ts";
-import { isSessionRouteId } from "../app-route-paths.ts";
 import type { RouteId } from "../app-routes.ts";
 import type { SidebarWorkboardRuntime } from "../components/app-sidebar-workboard.ts";
 import {
@@ -308,7 +307,7 @@ export class ShellGatewayOwner {
       return;
     }
     const routeId = this.host.routeState.routeId;
-    if (!agents || !routeId || isSessionRouteId(routeId) || agents.state.agentsList) {
+    if (!agents || !routeId || agents.state.agentsList) {
       return;
     }
     if (this.host.agentsListClient === snapshot.client && this.host.agentsListSource === agents) {

--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -68,7 +68,7 @@ const multiAgentRoster = [
 ];
 
 suite.define(() => {
-  it("keeps a newer in-flight roster ahead of delayed chat startup", async () => {
+  it("preserves an in-flight canonical roster refresh while chat startup is delayed", async () => {
     await suite.withPage(
       { locale: "en-US", serviceWorkers: "block", viewport: { height: 900, width: 1440 } },
       async ({ page }) => {
@@ -79,16 +79,11 @@ suite.define(() => {
 
         await page.goto(`${suite.server.baseUrl}chat`);
         await gateway.waitForRequest("chat.startup");
+        await gateway.waitForRequest("agents.list");
         await gateway.deferNext("agents.list");
         await gateway.emitGatewayEvent("config.changed", { path: "agents.entries" });
-        await gateway.waitForRequest("agents.list");
+        await gateway.waitForRequest("agents.list", { after: 1 });
         await gateway.resolveDeferred("chat.startup", {
-          agentsList: {
-            defaultId: "main",
-            mainKey: "main",
-            scope: "agent",
-            agents: [{ id: "main", name: "Stale Main" }],
-          },
           messages: [],
           metadata: { models: [] },
           sessionId: "control-ui-e2e-session",
@@ -111,7 +106,7 @@ suite.define(() => {
     );
   });
 
-  it("keeps a refreshed roster ahead of delayed chat startup", async () => {
+  it("keeps a refreshed canonical roster while chat startup remains delayed", async () => {
     if (captureUiProof) {
       await mkdir(proofDir, { recursive: true });
     }
@@ -143,20 +138,15 @@ suite.define(() => {
 
         await page.goto(`${suite.server.baseUrl}chat`);
         await gateway.waitForRequest("chat.startup");
-        await gateway.emitGatewayEvent("config.changed", { path: "agents.entries" });
         await gateway.waitForRequest("agents.list");
+        await gateway.emitGatewayEvent("config.changed", { path: "agents.entries" });
+        await gateway.waitForRequest("agents.list", { after: 1 });
 
         const sidebar = page.locator("openclaw-app-sidebar");
         const agentName = sidebar.locator(".sidebar-agent-card__name");
         await expect.poll(async () => (await agentName.textContent())?.trim()).toBe("Research");
 
         await gateway.resolveDeferred("chat.startup", {
-          agentsList: {
-            defaultId: "main",
-            mainKey: "main",
-            scope: "agent",
-            agents: [{ id: "main", name: "Stale Main" }],
-          },
           messages: [],
           metadata: { models: [] },
           sessionId: "control-ui-e2e-session",

--- a/ui/src/e2e/chat-flow.session-start.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.session-start.e2e.test.ts
@@ -40,6 +40,7 @@ suite.define(() => {
     });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
+      agentModel: "openai/startup-model",
       defaultAgentId: "ops",
       deferredMethods: ["chat.startup"],
       historyMessages: [],
@@ -57,7 +58,7 @@ suite.define(() => {
     try {
       await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
-      expect(await gateway.getRequests("agents.list")).toHaveLength(0);
+      expect(await gateway.getRequests("agents.list")).toHaveLength(1);
       // chat.startup owns the initial metadata load; the old parallel
       // chat.metadata request was only a synchronization point for this test.
       expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
@@ -70,18 +71,6 @@ suite.define(() => {
       expect(await gateway.getRequests("chat.send")).toHaveLength(0);
 
       await gateway.resolveDeferred("chat.startup", {
-        agentsList: {
-          agents: [
-            {
-              id: "ops",
-              model: { primary: "openai/startup-model" },
-              name: "OpenClaw",
-            },
-          ],
-          defaultId: "ops",
-          mainKey: "main",
-          scope: "agent",
-        },
         messages: [],
         metadata: {
           commands: [
@@ -161,7 +150,77 @@ suite.define(() => {
         metadata: (await gateway.getRequests("chat.metadata")).length,
         models: (await gateway.getRequests("models.list")).length,
       }).toEqual({ commands: 0, metadata: 0, models: 0 });
-      expect(await gateway.getRequests("agents.list")).toHaveLength(0);
+      expect(await gateway.getRequests("agents.list")).toHaveLength(1);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("paints startup history while canonical roster and metadata requests remain pending", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      agentModel: "openai/hydrated-model",
+      deferredMethods: ["agents.list", "chat.metadata"],
+      methodResponses: {
+        "chat.startup": {
+          messages: [
+            {
+              content: [
+                { text: "Transcript paints while optional startup data loads", type: "text" },
+              ],
+              role: "assistant",
+            },
+          ],
+          sessionId: "control-ui-e2e-session",
+          thinkingLevel: null,
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await gateway.waitForRequest("agents.list");
+      await gateway.waitForRequest("chat.metadata");
+      await page
+        .locator(".chat-thread-inner")
+        .getByText("Transcript paints while optional startup data loads", { exact: true })
+        .waitFor({ timeout: 10_000 });
+      expect(await gateway.getRequests("agents.list")).toHaveLength(1);
+
+      await gateway.resolveDeferred("agents.list", {
+        agents: [{ id: "main", model: { primary: "openai/hydrated-model" }, name: "OpenClaw" }],
+        defaultId: "main",
+        mainKey: "main",
+        scope: "agent",
+      });
+      await gateway.resolveDeferred("chat.metadata", {
+        commands: [],
+        models: [
+          {
+            available: true,
+            id: "hydrated-model",
+            name: "Hydrated Model",
+            provider: "openai",
+          },
+        ],
+      });
+      await expect
+        .poll(() =>
+          page.locator("openclaw-chat-pane").evaluate((pane) => {
+            const state = (
+              pane as HTMLElement & { state?: { chatModelCatalog?: Array<{ id?: string }> } }
+            ).state;
+            return state?.chatModelCatalog?.map((model) => model.id);
+          }),
+        )
+        .toEqual(["hydrated-model"]);
+      expect(await gateway.getRequests("agents.list")).toHaveLength(1);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -244,11 +244,12 @@ suite.define(() => {
         await expect.poll(() => endpoint.inputValue()).toBe("external-api");
 
         const setRequestsBeforeRetry = (await gateway.getRequests("config.set")).length;
+        const retriedSetRequest = gateway.waitForRequest("config.set", {
+          after: setRequestsBeforeRetry,
+        });
         await endpoint.fill("form-api");
-        await expect
-          .poll(async () => (await gateway.getRequests("config.set")).length)
-          .toBe(setRequestsBeforeRetry + 1);
-        const retriedSetParams = mutationParams((await gateway.getRequests("config.set")).at(-1)!);
+        const retriedSetParams = mutationParams(await retriedSetRequest);
+        expect(await gateway.getRequests("config.set")).toHaveLength(setRequestsBeforeRetry + 1);
         expect(retriedSetParams.baseHash).toBe("snapshot-3");
         expect(JSON.parse(String(retriedSetParams.raw))).toMatchObject({
           laboratory: { endpoint: "form-api", retryBudget: 4 },
@@ -272,11 +273,12 @@ suite.define(() => {
         await capture(page, "02-raw-draft.png");
 
         const setRequestsBeforeRawSave = (await gateway.getRequests("config.set")).length;
+        const rawSetRequest = gateway.waitForRequest("config.set", {
+          after: setRequestsBeforeRawSave,
+        });
         await rawSave.click();
-        await expect
-          .poll(async () => (await gateway.getRequests("config.set")).length)
-          .toBe(setRequestsBeforeRawSave + 1);
-        const rawSetParams = mutationParams((await gateway.getRequests("config.set")).at(-1)!);
+        const rawSetParams = mutationParams(await rawSetRequest);
+        expect(await gateway.getRequests("config.set")).toHaveLength(setRequestsBeforeRawSave + 1);
         expect(rawSetParams.baseHash).toBe("mock-config-hash-1");
         expect(rawSetParams.raw).toBe(rawDraft);
         await expect

--- a/ui/src/lib/agents/index.test.ts
+++ b/ui/src/lib/agents/index.test.ts
@@ -136,57 +136,37 @@ function createSaveState(): {
 }
 
 describe("createAgentCapability lifecycle", () => {
-  it("keeps an adopted startup roster ahead of an older list request", async () => {
-    const pending = deferred<unknown>();
-    const request = vi.fn<TestRequest>().mockReturnValue(pending.promise);
+  it("reuses the current roster while preserving forced refresh and reconnect ownership", async () => {
+    const first = { defaultId: "main", agents: [{ id: "main" }] };
+    const replacement = { defaultId: "research", agents: [{ id: "research" }] };
+    const reconnected = { defaultId: "writer", agents: [{ id: "writer" }] };
+    const pendingRefresh = deferred<unknown>();
+    const request = vi
+      .fn<TestRequest>()
+      .mockResolvedValueOnce(first)
+      .mockReturnValueOnce(pendingRefresh.promise)
+      .mockResolvedValueOnce(reconnected);
     const client = { request } as unknown as GatewayBrowserClient;
     const harness = createGatewayHarness(client);
     const agents = createAgentCapability(harness.gateway);
 
-    const staleLoad = agents.refreshList();
-    const adopted = {
-      defaultId: "research",
-      mainKey: "main",
-      scope: "per-sender" as const,
-      agents: [{ id: "main" }, { id: "research" }],
-    };
-    agents.adoptList(adopted, client, agents.state.listRevision);
+    await expect(agents.ensureList()).resolves.toEqual(first);
+    await expect(agents.ensureList()).resolves.toEqual(first);
+    expect(request).toHaveBeenCalledTimes(1);
 
-    expect(agents.state.agentsList).toEqual(adopted);
-    expect(agents.state.agentsLoading).toBe(false);
+    const refresh = agents.refreshList();
+    const sharedRefresh = agents.ensureList();
+    expect(request).toHaveBeenCalledTimes(2);
+    pendingRefresh.resolve(replacement);
+    await expect(Promise.all([refresh, sharedRefresh])).resolves.toEqual([
+      replacement,
+      replacement,
+    ]);
 
-    pending.resolve({ defaultId: "main", agents: [{ id: "main" }] });
-    await staleLoad;
-    expect(agents.state.agentsList).toEqual(adopted);
-    agents.dispose();
-  });
-
-  it("rejects startup adoption after a newer list request begins", async () => {
-    const pending = deferred<unknown>();
-    const request = vi.fn<TestRequest>().mockReturnValue(pending.promise);
-    const client = { request } as unknown as GatewayBrowserClient;
-    const harness = createGatewayHarness(client);
-    const agents = createAgentCapability(harness.gateway);
-    const startupRevision = agents.state.listRevision;
-
-    const currentLoad = agents.refreshList();
-    expect(
-      agents.adoptList(
-        { defaultId: "stale", mainKey: "main", scope: "per-sender", agents: [{ id: "stale" }] },
-        client,
-        startupRevision,
-      ),
-    ).toBe(false);
-
-    const current = {
-      defaultId: "research",
-      mainKey: "main",
-      scope: "per-sender" as const,
-      agents: [{ id: "research" }],
-    };
-    pending.resolve(current);
-    await currentLoad;
-    expect(agents.state.agentsList).toEqual(current);
+    harness.publish(false);
+    harness.publish(true);
+    await expect(agents.ensureList()).resolves.toEqual(reconnected);
+    expect(request).toHaveBeenCalledTimes(3);
     agents.dispose();
   });
 

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -74,7 +74,6 @@ type AgentFilesStatus = {
 type AgentCapabilityState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
-  listRevision: number;
   agentsLoading: boolean;
   agentsError: string | null;
   agentsList: AgentsListResult | null;
@@ -82,11 +81,6 @@ type AgentCapabilityState = {
 
 export type AgentCapability = {
   readonly state: AgentCapabilityState;
-  adoptList: (
-    result: AgentsListResult,
-    client: GatewayBrowserClient,
-    expectedRevision?: number,
-  ) => boolean;
   ensureList: () => Promise<AgentsListResult | null>;
   refreshList: () => Promise<AgentsListResult | null>;
   files: (agentId: string | null | undefined) => AgentFilesStatus;
@@ -244,7 +238,6 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
   const state: AgentCapabilityState = {
     client: gateway.snapshot.client,
     connected: gateway.snapshot.phase === "connected",
-    listRevision: 0,
     agentsLoading: false,
     agentsError: null,
     agentsList: null,
@@ -254,11 +247,12 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
   const fileRequestOwners = new Map<string, symbol>();
   const listeners = new Set<(state: AgentCapabilityState) => void>();
   let disposed = false;
+  let listRevision = 0;
   let agentsRequest: Promise<AgentsListResult | null> | null = null;
 
   const retireAgentsRequest = () => {
     agentsRequest = null;
-    state.listRevision += 1;
+    listRevision += 1;
     state.agentsLoading = false;
   };
 
@@ -288,13 +282,16 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
     if (agentsRequest && !force) {
       return agentsRequest;
     }
-    const revision = ++state.listRevision;
+    if (state.agentsList && !force) {
+      return state.agentsList;
+    }
+    const revision = ++listRevision;
     state.agentsLoading = true;
     state.agentsError = null;
     publish();
     const request = loadAgentsList(scope.client)
       .then((result) => {
-        const current = lifecycle.isCurrent(scope) && state.listRevision === revision;
+        const current = lifecycle.isCurrent(scope) && listRevision === revision;
         if (current) {
           state.agentsList = result;
           state.agentsError = null;
@@ -302,7 +299,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
         return current ? result : null;
       })
       .catch((err: unknown) => {
-        if (lifecycle.isCurrent(scope) && state.listRevision === revision) {
+        if (lifecycle.isCurrent(scope) && listRevision === revision) {
           state.agentsError = isMissingOperatorReadScopeError(err)
             ? formatMissingOperatorReadScopeMessage("agent list")
             : formatUiError(err);
@@ -310,7 +307,7 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
         return null;
       })
       .finally(() => {
-        const currentRequest = state.listRevision === revision;
+        const currentRequest = listRevision === revision;
         if (currentRequest) {
           agentsRequest = null;
         }
@@ -398,17 +395,6 @@ export function createAgentCapability(gateway: AgentGateway): AgentCapability {
   return {
     get state() {
       return state;
-    },
-    adoptList(result, client, expectedRevision = state.listRevision) {
-      if (state.client !== client || !state.connected || state.listRevision !== expectedRevision) {
-        return false;
-      }
-      // Startup adoption retires older direct loads so late completions cannot overwrite it.
-      retireAgentsRequest();
-      state.agentsList = result;
-      state.agentsError = null;
-      publish();
-      return true;
     },
     ensureList: () => loadList(false),
     refreshList: () => loadList(true),

--- a/ui/src/lib/sessions/index-list.test.ts
+++ b/ui/src/lib/sessions/index-list.test.ts
@@ -154,6 +154,70 @@ describe("session list requests", () => {
     sessions.dispose();
   });
 
+  it("coalesces concurrent managed-list demand while preserving later forced refreshes", async () => {
+    let resolveRequest!: (result: SessionsListResult) => void;
+    const pendingResult = new Promise<SessionsListResult>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const request = vi
+      .fn()
+      .mockImplementationOnce(async () => pendingResult)
+      .mockResolvedValue(listResult(["agent:main:refreshed"]));
+    const { sessions } = sessionHarness(request);
+    const query = { agentId: "main", archivedFilter: "all" as const, limit: 50 };
+    const unsubscribe = sessions.subscribeList(query, () => undefined);
+
+    try {
+      const first = sessions.refreshList(query);
+      const duplicate = sessions.refreshList(query);
+      expect(duplicate).toBe(first);
+      expect(request).toHaveBeenCalledOnce();
+
+      resolveRequest(listResult(["agent:main:initial"]));
+      await Promise.all([first, duplicate]);
+      expect(request).toHaveBeenCalledOnce();
+
+      await sessions.refreshList({ ...query, force: true });
+      expect(request).toHaveBeenCalledTimes(2);
+      expect(sessions.listSnapshot(query).result?.sessions[0]?.key).toBe("agent:main:refreshed");
+    } finally {
+      resolveRequest(listResult());
+      unsubscribe();
+      sessions.dispose();
+    }
+  });
+
+  it("retains an in-flight managed query while its route subscriber is replaced", async () => {
+    let resolveRequest!: (result: SessionsListResult) => void;
+    const pendingResult = new Promise<SessionsListResult>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const request = vi.fn(async () => pendingResult);
+    const { sessions } = sessionHarness(request);
+    const query = { agentId: "main", archivedFilter: "all" as const, limit: 50 };
+    let unsubscribe = sessions.subscribeList(query, () => undefined);
+
+    try {
+      const first = sessions.refreshList(query);
+      unsubscribe();
+      unsubscribe = sessions.subscribeList(query, () => undefined);
+
+      expect(sessions.listSnapshot(query).loading).toBe(true);
+      const replacement = sessions.refreshList(query);
+      expect(replacement).toBe(first);
+      expect(request).toHaveBeenCalledOnce();
+
+      resolveRequest(listResult(["agent:main:retained"]));
+      await Promise.all([first, replacement]);
+      expect(sessions.listSnapshot(query).result?.sessions[0]?.key).toBe("agent:main:retained");
+      expect(request).toHaveBeenCalledOnce();
+    } finally {
+      resolveRequest(listResult());
+      unsubscribe();
+      sessions.dispose();
+    }
+  });
+
   it("keeps dashboard and sidebar queries distinct without inventing a dashboard agent", async () => {
     const request = vi.fn(async (_method: string, params?: ListParams) =>
       listResult([

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -38,6 +38,7 @@ type SessionRosterRefreshHost = {
 type ManagedSessionListRefresh = {
   append: boolean;
   offset?: number;
+  invalidated?: true;
 };
 
 type ManagedSessionListQuery = Readonly<Record<string, unknown>> & { readonly limit: number };
@@ -119,7 +120,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       listeners: new Set(),
       coordinator: createSessionEventRefreshCoordinator({
         active: pageActive,
-        refresh: () => refreshManagedList(entry, { append: false }),
+        refresh: () => refreshManagedList(entry, { append: false, invalidated: true }),
       }),
       pending: null,
       queued: null,
@@ -137,7 +138,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       return Promise.resolve();
     }
     if (entry.pending) {
-      if (!refresh.append) {
+      if (refresh.invalidated) {
         entry.queued = refresh;
       }
       return entry.pending;
@@ -471,9 +472,20 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       entry.listeners.add(listener);
       return () => {
         entry.listeners.delete(listener);
-        if (entry.listeners.size === 0 && managedLists.get(entry.key) === entry) {
-          entry.coordinator.dispose();
-          managedLists.delete(entry.key);
+        if (entry.listeners.size > 0 || managedLists.get(entry.key) !== entry) {
+          return;
+        }
+        const release = () => {
+          if (entry.listeners.size === 0 && managedLists.get(entry.key) === entry) {
+            entry.coordinator.dispose();
+            managedLists.delete(entry.key);
+          }
+        };
+        // Route replacement may briefly remove every subscriber while this query still owns a request.
+        if (entry.pending) {
+          void entry.pending.finally(release);
+        } else {
+          release();
         }
       };
     },

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -2735,55 +2735,21 @@ describe("loadChatHistory filtering", () => {
     expect(state.chatMessagesBySession?.has("agent:main:main")).toBe(false);
   });
 
-  it("rejects a stale startup roster before mutating chat-local selection", async () => {
+  it("loads startup history without taking ownership of the agent roster", async () => {
     const currentRoster = {
       agents: [{ id: "research", name: "Research" }],
       defaultId: "research",
       mainKey: "main",
       scope: "per-sender" as const,
     };
-    const onAgentsList = vi.fn(() => false);
-    const { state } = createResolvedHistoryState(
-      {
-        agentsList: {
-          agents: [{ id: "main", name: "Stale Main" }],
-          defaultId: "main",
-          mainKey: "main",
-          scope: "per-sender",
-        },
-        messages: [],
-      },
-      {
-        agentsError: "keep newer roster status",
-        agentsList: currentRoster,
-        agentsSelectedId: "research",
-        onAgentsList,
-      },
-    );
-
-    await loadChatHistory(state, { startup: true });
-
-    expect(onAgentsList).toHaveBeenCalledOnce();
-    expect(state.agentsError).toBe("keep newer roster status");
-    expect(state.agentsList).toBe(currentRoster);
-    expect(state.agentsSelectedId).toBe("research");
-  });
-
-  it("loads startup history with agents in one request", async () => {
-    const onAgentsList = vi.fn(() => true);
     const { request, state } = createResolvedHistoryState(
       {
         messages: [{ role: "assistant", content: [{ type: "text", text: "ready" }] }],
-        agentsList: {
-          agents: [{ id: "ops", name: "Ops" }],
-          defaultId: "ops",
-          mainKey: "main",
-          scope: "agent",
-        },
       },
       {
         agentsError: "previous agents.list failure",
-        onAgentsList,
+        agentsList: currentRoster,
+        agentsSelectedId: "research",
         sessionKey: "global",
       },
     );
@@ -2791,16 +2757,16 @@ describe("loadChatHistory filtering", () => {
     await loadChatHistory(state, { startup: true });
 
     expect(request).toHaveBeenCalledWith("chat.startup", {
+      agentId: "research",
       sessionKey: "global",
       limit: 100,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "ready" }] },
     ]);
-    expect(state.agentsError).toBeNull();
-    expect(state.agentsList?.defaultId).toBe("ops");
-    expect(state.agentsSelectedId).toBe("ops");
-    expect(onAgentsList).toHaveBeenCalledOnce();
+    expect(state.agentsError).toBe("previous agents.list failure");
+    expect(state.agentsList).toBe(currentRoster);
+    expect(state.agentsSelectedId).toBe("research");
   });
 
   it.each([

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -290,7 +290,6 @@ export type ChatHistoryResult = {
   verboseLevel?: string;
   defaults?: GatewaySessionsDefaults;
   sessionInfo?: GatewaySessionRow;
-  agentsList?: AgentsListResult;
   metadata?: ChatMetadataResult;
   inFlightRun?: {
     runId: string;
@@ -313,7 +312,6 @@ type ChatHistoryDeltaResult = {
   messages: unknown[];
   deltaCursor: string;
   sessionInfo: GatewaySessionRow;
-  agentsList?: AgentsListResult;
   metadata?: ChatMetadataResult;
 };
 
@@ -1455,9 +1453,6 @@ export function applyChatAgentsList(
   if (!agentsList || state.client !== client || !state.connected) {
     return;
   }
-  if (state.onAgentsList && !state.onAgentsList(agentsList, client)) {
-    return;
-  }
   state.agentsList = agentsList;
   state.agentsError = null;
   const selectedId =
@@ -1565,7 +1560,6 @@ async function loadChatHistoryUncached(
       for (const payload of response.messages) {
         applySessionMessagePayload(state, payload, runActive, { kind: "history-delta" });
       }
-      applyChatAgentsList(state, response.agentsList, client);
       if (Object.hasOwn(response.sessionInfo, "activeLeafEntryId")) {
         state.chatDisplayedLeafEntryId = response.sessionInfo.activeLeafEntryId?.trim() || null;
       }
@@ -1586,7 +1580,6 @@ async function loadChatHistoryUncached(
         messages: state.chatMessages,
         deltaCursor: response.deltaCursor,
         sessionInfo: response.sessionInfo,
-        ...(response.agentsList ? { agentsList: response.agentsList } : {}),
         ...(response.metadata ? { metadata: response.metadata } : {}),
         sourceCanonicalListRevision: response.sourceCanonicalListRevision,
       };
@@ -1608,7 +1601,6 @@ async function loadChatHistoryUncached(
     const messages = Array.isArray(res.messages) ? res.messages : [];
     const nextPagination = resolveChatHistoryPagination(res);
     const nextSessionId = resolveChatHistorySessionId(res);
-    applyChatAgentsList(state, res.agentsList, client);
     const visibleMessages = visibleChatHistoryMessages(messages);
     const previousTerminalMessages = reconcileAuthoritativeTerminalHistory({
       host: state,

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -407,27 +407,16 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       const startupClient = snapshot.client;
       const startupGeneration = this.connectionGeneration;
       const startupSessionKey = state.sessionKey;
-      const agentsListBeforeStartup = this.context.agents.state.agentsList;
-      const rosterRevisionBeforeStartup = this.context.agents.state.listRevision;
       const clientIsCurrent = () =>
         this.connectionGeneration === startupGeneration &&
         this.connectedClient === startupClient &&
         state.client === startupClient &&
         state.connected;
-      state.onAgentsList = (agentsList, client) => {
-        const ownsRoster =
-          clientIsCurrent() &&
-          this.context.agents.adoptList(agentsList, client, rosterRevisionBeforeStartup);
-        return ownsRoster;
-      };
       const finishStartup = async () => {
         if (!clientIsCurrent()) {
           return;
         }
-        let agentsList = this.context.agents.state.agentsList;
-        if (agentsList === agentsListBeforeStartup) {
-          agentsList = await this.context.agents.ensureList();
-        }
+        const agentsList = await this.context.agents.ensureList();
         if (!clientIsCurrent()) {
           return;
         }
@@ -457,9 +446,6 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       });
       this.deferSessionHydrationUntilTranscript(startupSessionKey, historyRefresh);
       void historyRefresh.finally(() => {
-        if (clientIsCurrent()) {
-          state.onAgentsList = undefined;
-        }
         void finishStartup();
       });
       void refreshChatModelAuthStatus(state).finally(() => state.requestUpdate?.());

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -464,6 +464,42 @@ describe("refreshChat", () => {
     expect(host.request).not.toHaveBeenCalledWith("commands.list", expect.anything());
   });
 
+  it("commits startup history before immediately hydrating missing metadata", async () => {
+    const metadata = createDeferred<unknown>();
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "Transcript paints before metadata" }],
+    };
+    const host = makeChatHost({
+      hello: gatewayHelloForMethods(["chat.metadata", "chat.startup"], []),
+      requestHandlers: {
+        "chat.startup": async () => ({ messages: [message] }),
+        "chat.metadata": () => metadata.promise,
+      },
+    });
+
+    await expect(
+      refreshPageChat(asChatPageHost(host), {
+        awaitHistory: true,
+        deferBranches: true,
+        startup: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(host.chatMessages).toEqual([message]);
+    expect(host.request).toHaveBeenCalledWith("chat.metadata", { agentId: "main" });
+    expect(asChatPageHost(host).chatModelsLoading).toBe(true);
+
+    const model = {
+      available: true,
+      id: "hydrated-model",
+      name: "Hydrated Model",
+      provider: "openai",
+    };
+    metadata.resolve({ commands: [], models: [model] });
+    await waitForFast(() => expect(host.chatModelCatalog).toEqual([model]));
+  });
+
   it("renders cached models while startup metadata refreshes", async () => {
     const startup = createDeferred<unknown>();
     const host = makeChatHost({

--- a/ui/src/pages/chat/chat-state-contract.ts
+++ b/ui/src/pages/chat/chat-state-contract.ts
@@ -48,7 +48,6 @@ export type ChatState = {
   lastLocalTerminalReconcile?: LocalTerminalReconcile | null;
   chatReplyTarget?: unknown;
   agentsError?: string | null;
-  onAgentsList?: (agentsList: AgentsListResult, client: GatewayBrowserClient) => boolean;
   resetChatInputHistoryNavigation?: () => void;
   assistantAgentId?: string | null;
   agentsList?: ChatAgentsListSnapshot | null;

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -1378,7 +1378,7 @@ describe("ChatStateController render lifecycle", () => {
     return {
       agents: {
         state: { agentsList: null },
-        adoptList: vi.fn(),
+        ensureList: vi.fn(async () => null),
       },
       agentSelection: { state: { selectedId: "main" } },
       basePath: "",
@@ -2277,7 +2277,7 @@ describe("image lightbox lifecycle", () => {
     const context = {
       agents: {
         state: { agentsList: null },
-        adoptList: vi.fn(),
+        ensureList: vi.fn(async () => null),
       },
       agentSelection: { state: { selectedId: "main" } },
       basePath: "",
@@ -2338,7 +2338,7 @@ describe("loadPageAssistantIdentity", () => {
     }));
     const client = { request } as unknown as GatewayBrowserClient;
     const context = {
-      agents: { state: { agentsList: null }, adoptList: vi.fn() },
+      agents: { state: { agentsList: null }, ensureList: vi.fn(async () => null) },
       agentSelection: { state: { selectedId: "main" } },
       basePath: "",
       config: {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1317,12 +1317,6 @@ function installControlUiMockGateway(
     if (method === "agents.list") {
       return applyAgentsList(value);
     }
-    if (method === "chat.startup" && hasOwn(value, "agentsList")) {
-      return {
-        ...value,
-        agentsList: applyAgentsList(value.agentsList),
-      };
-    }
     return value;
   }
 
@@ -1793,21 +1787,6 @@ function installControlUiMockGateway(
         };
       case "chat.startup":
         return {
-          agentsList: {
-            agents: [
-              {
-                id: scenario.defaultAgentId,
-                identity: { name: scenario.assistantName },
-                ...(scenario.agentModel ? { model: { primary: scenario.agentModel } } : {}),
-                name: scenario.assistantName,
-                ...(scenario.workspace ? { workspace: scenario.workspace } : {}),
-                workspaceGit: scenario.workspaceGit,
-              },
-            ],
-            defaultId: scenario.defaultAgentId,
-            mainKey: "main",
-            scope: "agent",
-          },
           messages: scenario.historyMessages,
           metadata: {
             models: scenario.models,


### PR DESCRIPTION
Related: #114693

## What Problem This Solves

Fixes an issue where users opening or refreshing a chat could remain behind the loading skeleton even after the transcript was available, because optional model metadata and the agent roster still had to finish first.

A live team-session baseline showed `chat.startup` taking 1.53–3.68s and the transcript becoming visible 4.26–7.59s after navigation. The startup response also owned agent-roster data that already has a canonical `agents.list` owner.

## Why This Change Was Made

Chat startup now keeps transcript/session state on the critical path while treating neutral model metadata as optional prepared data. Sessions with an explicit auth-profile override still wait for their authoritative session-specific projection so model context and thinking controls remain correct.

Agent-roster hydration moves back to `agents.list`, which now preserves per-agent model/thinking projections and reuses one successful roster per connection. The obsolete bundled-roster/adoption path and startup all-agent projection are removed.

The short session-URL resolution waterfall and the independently reproduced Control UI asset-preparation 503 are separate owner boundaries and are intentionally not hidden in this patch.

## User Impact

For ordinary sessions, chat history can render as soon as it is available even while optional model controls and agent metadata continue hydrating. Users no longer stare at a transcript skeleton because unrelated startup metadata is refreshing.

Auth-profile-overridden sessions retain their existing authoritative behavior. Agent switchers also retain agent-specific thinking capabilities rather than inheriting one shared catalog.

Production LOC: +105/-189 (net -84). Tests/test support: +454/-258 (net +196).

## Evidence

- Real isolated Gateway built from this branch, loopback-only state, five browser reloads:
  - four warm `chat.startup` runs: 286–384ms; one cold outlier: 1.15s
  - server `history_page`: 0.30–0.92ms
  - server neutral `startup_projection`: 0.09–0.17ms
  - one `agents.list` and one message subscription per empty dev session
- Deterministic browser proof holds `agents.list` and `chat.metadata` unresolved while the transcript appears and the loading skeleton disappears.
- Focused Vitest: 363 Gateway tests, 468 Control UI unit tests, 7 Chromium E2E tests.
- `node scripts/check-changed.mjs`
- `pnpm build`
- `git diff --check`
- Exact-head CI also exposed two pre-existing Control UI E2E ownership races. This PR now waits on the exact config-save request rather than a short count poll, preserves explicit all-agent scope across roster publication, and coalesces identical managed session-list demand. The failing files and exact shards pass repeatedly after the repairs.
- Fresh structured autoreview after each final behavior change: no accepted/actionable findings.
- AI-assisted implementation; maintainer reviewed the architecture, diff, tests, and live behavior directly.
