### PR TITLE
fix(slack): honor HTTP setup credentials

### DIFF
--- a/extensions/slack/src/channel-actions-setup-status.contract.test.ts
+++ b/extensions/slack/src/channel-actions-setup-status.contract.test.ts
@@ -5,9 +5,12 @@ import {
   installChannelStatusContractSuite,
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { moveSingleAccountChannelSectionToDefaultAccount } from "openclaw/plugin-sdk/setup";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { slackPlugin } from "../api.js";
+import { SlackConfigSchema } from "../config-api.js";
 import { slackSetupPlugin } from "../setup-plugin-api.js";
+import { inspectSlackAccount } from "./account-inspect.js";
 
 const slackDefaultActions = [
   "send",
@@ -64,6 +67,95 @@ describe("slack actions contract", () => {
 });
 
 describe("slack setup contract", () => {
+  it("keeps a shared HTTP signing secret at the channel root during account promotion", () => {
+    const cfg = {
+      channels: {
+        slack: {
+          enabled: true,
+          mode: "http",
+          botToken: "xoxb-default",
+          signingSecret: "shared-signing-secret",
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = moveSingleAccountChannelSectionToDefaultAccount({
+      cfg,
+      channelKey: "slack",
+      setupSurface: slackSetupPlugin.setupContract,
+    });
+
+    expect(next.channels?.slack?.signingSecret).toBe("shared-signing-secret");
+    expect(next.channels?.slack).not.toHaveProperty("botToken");
+    expect(next.channels?.slack?.accounts?.default).toMatchObject({
+      botToken: "xoxb-default",
+    });
+    expect(inspectSlackAccount({ cfg: next, accountId: "default" })).toMatchObject({
+      configured: true,
+      signingSecret: "shared-signing-secret",
+    });
+    expect(SlackConfigSchema.safeParse(next.channels?.slack).success).toBe(true);
+  });
+
+  it.each([
+    {
+      name: "an HTTP account with its own signing secret",
+      account: {
+        mode: "http" as const,
+        botToken: "xoxb-target",
+        signingSecret: "target-signing-secret",
+      },
+    },
+    {
+      name: "a Socket Mode account",
+      account: { mode: "socket" as const, botToken: "xoxb-target", appToken: "xapp-target" },
+    },
+    {
+      name: "a relay account",
+      account: {
+        mode: "relay" as const,
+        botToken: "xoxb-target",
+        relay: {
+          url: "https://relay.example.test",
+          authToken: "relay-auth-token",
+          gatewayId: "relay-gateway",
+        },
+      },
+    },
+  ])("preserves sibling HTTP credentials when promoting $name", ({ account }) => {
+    const cfg = {
+      channels: {
+        slack: {
+          enabled: true,
+          mode: "http",
+          signingSecret: "shared-signing-secret",
+          accounts: {
+            default: account,
+            bot: { mode: "http", botToken: "xoxb-sibling" },
+            user: { mode: "http", postAs: "user", userToken: "xoxp-sibling" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const next = moveSingleAccountChannelSectionToDefaultAccount({
+      cfg,
+      channelKey: "slack",
+      setupSurface: slackSetupPlugin.setupContract,
+    });
+
+    expect(next.channels?.slack?.signingSecret).toBe("shared-signing-secret");
+    expect(SlackConfigSchema.safeParse(next.channels?.slack).success).toBe(true);
+    expect(inspectSlackAccount({ cfg: next, accountId: "bot" })).toMatchObject({
+      configured: true,
+      signingSecret: "shared-signing-secret",
+    });
+    expect(inspectSlackAccount({ cfg: next, accountId: "user" })).toMatchObject({
+      configured: true,
+      signingSecret: "shared-signing-secret",
+    });
+  });
+
   it("recognizes HTTP bot accounts at the setup plugin boundary without an app token", () => {
     const cfg = {
       channels: {
@@ -262,7 +354,28 @@ describe("slack setup contract", () => {
           "Slack user identity setup does not support --use-env; configure userToken and the transport credential explicitly.",
       },
       {
-        name: "explicit bot identity keeps the bot and app token setup contract",
+        name: "HTTP bot identity stores the bot token and signing secret",
+        cfg: {} as OpenClawConfig,
+        input: {
+          identity: "bot",
+          mode: "http",
+          botToken: "test-bot-token",
+          signingSecret: "test-signing-secret",
+        },
+        expectedAccountId: "default",
+        assertPatchedConfig: (cfg) => {
+          expect(cfg.channels?.slack).toMatchObject({
+            enabled: true,
+            postAs: "bot",
+            mode: "http",
+            botToken: "test-bot-token",
+            signingSecret: "test-signing-secret",
+          });
+          expect(cfg.channels?.slack?.appToken).toBeUndefined();
+        },
+      },
+      {
+        name: "HTTP bot identity rejects an app token without a signing secret",
         cfg: {} as OpenClawConfig,
         input: {
           identity: "bot",
@@ -271,15 +384,8 @@ describe("slack setup contract", () => {
           appToken: "test-app-token",
         },
         expectedAccountId: "default",
-        assertPatchedConfig: (cfg) => {
-          expect(cfg.channels?.slack).toMatchObject({
-            enabled: true,
-            postAs: "bot",
-            botToken: "test-bot-token",
-            appToken: "test-app-token",
-          });
-          expect(cfg.channels?.slack?.mode).toBeUndefined();
-        },
+        expectedValidation:
+          "Slack HTTP mode requires --bot-token and --signing-secret (or --use-env).",
       },
     ],
   });

--- a/extensions/slack/src/setup-core.ts
+++ b/extensions/slack/src/setup-core.ts
@@ -163,14 +163,10 @@ function hasSlackSetupCredentials(params: {
   identity: "bot" | "user";
   mode: "socket" | "http" | "relay";
 }): boolean {
-  if (params.identity !== "user") {
-    const { input } = params;
-    return Boolean(input.botToken && input.appToken);
-  }
-  if (params.mode === "http") {
-    return Boolean(params.input.userToken && params.input.signingSecret);
-  }
-  return params.mode === "socket" && Boolean(params.input.userToken && params.input.appToken);
+  const identityToken = params.identity === "user" ? params.input.userToken : params.input.botToken;
+  const transportCredential =
+    params.mode === "http" ? params.input.signingSecret : params.input.appToken;
+  return Boolean(identityToken && transportCredential);
 }
 
 const slackSetupAdapterBase = createPatchedAccountSetupAdapter({
@@ -214,13 +210,15 @@ const slackSetupAdapterBase = createPatchedAccountSetupAdapter({
         ? "Slack user identity requires --user-token and --signing-secret."
         : "Slack user identity requires --user-token and --app-token.";
     }
-    return "Slack requires --bot-token and --app-token (or --use-env).";
+    return mode === "http"
+      ? "Slack HTTP mode requires --bot-token and --signing-secret (or --use-env)."
+      : "Slack requires --bot-token and --app-token (or --use-env).";
   },
   buildPatch: (input) => {
     const setupInput = input as SlackSetupInput;
     return {
       ...(setupInput.identity ? { postAs: setupInput.identity } : {}),
-      ...(setupInput.identity === "user" && setupInput.mode ? { mode: setupInput.mode } : {}),
+      ...(setupInput.mode ? { mode: setupInput.mode } : {}),
       ...(setupInput.botToken ? { botToken: setupInput.botToken } : {}),
       ...(setupInput.appToken ? { appToken: setupInput.appToken } : {}),
       ...(setupInput.userToken ? { userToken: setupInput.userToken } : {}),
@@ -379,12 +377,17 @@ export function createSlackSetupWizardBase(handlers: {
     envShortcut: {
       prompt: t("wizard.slack.envPrompt"),
       preferredEnvVar: "SLACK_BOT_TOKEN",
-      isAvailable: ({ cfg, accountId }) =>
-        accountId === DEFAULT_ACCOUNT_ID &&
-        (inspectSlackAccount({ cfg, accountId }).config.postAs ?? "bot") === "bot" &&
-        Boolean(process.env.SLACK_BOT_TOKEN?.trim()) &&
-        Boolean(process.env.SLACK_APP_TOKEN?.trim()) &&
-        !inspectSlackAccount({ cfg, accountId }).configured,
+      isAvailable: ({ cfg, accountId }) => {
+        const account = inspectSlackAccount({ cfg, accountId });
+        return (
+          accountId === DEFAULT_ACCOUNT_ID &&
+          (account.config.postAs ?? "bot") === "bot" &&
+          (account.config.mode ?? "socket") === "socket" &&
+          Boolean(process.env.SLACK_BOT_TOKEN?.trim()) &&
+          Boolean(process.env.SLACK_APP_TOKEN?.trim()) &&
+          !account.configured
+        );
+      },
       apply: ({ cfg, accountId }) => enableSlackAccount(cfg, accountId),
     },
     credentials: [
@@ -417,10 +420,7 @@ export function createSlackSetupWizardBase(handlers: {
         inputPrompt: t("wizard.slack.appTokenInput"),
         shouldPrompt: ({ cfg, accountId }) => {
           const account = inspectSlackAccount({ cfg, accountId });
-          return (
-            (account.config.postAs ?? "bot") === "bot" ||
-            (account.config.mode ?? "socket") === "socket"
-          );
+          return (account.config.mode ?? "socket") === "socket";
         },
       }),
       createSlackTokenCredential({
@@ -431,7 +431,7 @@ export function createSlackSetupWizardBase(handlers: {
         inputPrompt: "Enter Slack signing secret",
         shouldPrompt: ({ cfg, accountId }) => {
           const account = inspectSlackAccount({ cfg, accountId });
-          return account.config.postAs === "user" && account.config.mode === "http";
+          return account.config.mode === "http";
         },
       }),
     ],

--- a/extensions/slack/src/setup-surface.test.ts
+++ b/extensions/slack/src/setup-surface.test.ts
@@ -252,6 +252,86 @@ describe("slackSetupWizard.prepare", () => {
     expect(result.cfg.channels?.slack?.appToken).toBeUndefined();
   });
 
+  it("collects a signing secret instead of an app token for HTTP bot identity", async () => {
+    vi.stubEnv("SLACK_BOT_TOKEN", "");
+    vi.stubEnv("SLACK_APP_TOKEN", "");
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["bot"],
+      textValues: ["test-bot-token", "test-signing-secret"],
+    });
+    const configure = createSetupWizardAdapter({
+      plugin: {
+        id: "slack",
+        meta: { label: "Slack" },
+        config: {
+          listAccountIds: () => ["default"],
+          defaultAccountId: () => "default",
+        },
+        setupContract: slackSetupContract,
+      } as never,
+      wizard: credentialOnlySlackSetupWizard,
+    }).configure;
+
+    const result = await runSetupWizardConfigure({
+      configure,
+      cfg: { channels: { slack: { mode: "http" } } } as OpenClawConfig,
+      prompter: queued.prompter,
+      options: { secretInputMode: "plaintext" as const },
+    });
+
+    expect(result.cfg.channels?.slack).toMatchObject({
+      enabled: true,
+      mode: "http",
+      botToken: "test-bot-token",
+      signingSecret: "test-signing-secret",
+    });
+    expect(result.cfg.channels?.slack?.appToken).toBeUndefined();
+    expect(
+      queued.text.mock.calls.map(([params]) => (params as { message: string }).message),
+    ).toEqual(["Enter Slack bot token (xoxb-...)", "Enter Slack signing secret"]);
+  });
+
+  it("does not use the Socket Mode environment shortcut for HTTP bot setup", async () => {
+    vi.stubEnv("SLACK_BOT_TOKEN", "xoxb-env-test");
+    vi.stubEnv("SLACK_APP_TOKEN", "xapp-env-test");
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["bot"],
+      confirmValues: [true],
+      textValues: ["test-signing-secret"],
+    });
+    const configure = createSetupWizardAdapter({
+      plugin: {
+        id: "slack",
+        meta: { label: "Slack" },
+        config: {
+          listAccountIds: () => ["default"],
+          defaultAccountId: () => "default",
+        },
+        setupContract: slackSetupContract,
+      } as never,
+      wizard: credentialOnlySlackSetupWizard,
+    }).configure;
+
+    const result = await runSetupWizardConfigure({
+      configure,
+      cfg: { channels: { slack: { mode: "http" } } } as OpenClawConfig,
+      prompter: queued.prompter,
+      options: { secretInputMode: "plaintext" as const },
+    });
+
+    expect(result.cfg.channels?.slack).toMatchObject({
+      enabled: true,
+      mode: "http",
+      signingSecret: "test-signing-secret",
+    });
+    expect(result.cfg.channels?.slack?.botToken).toBeUndefined();
+    expect(result.cfg.channels?.slack?.appToken).toBeUndefined();
+    expect(queued.confirm).toHaveBeenCalledTimes(1);
+    expect(
+      queued.text.mock.calls.map(([params]) => (params as { message: string }).message),
+    ).toEqual(["Enter Slack signing secret"]);
+  });
+
   it("continues user setup after preserving a user-token SecretRef", async () => {
     const queued = createQueuedWizardPrompter({
       selectValues: ["user"],


### PR DESCRIPTION
## What Problem This Solves

Slack bot setup treated every transport like Socket Mode: it required an app token, accepted that token for HTTP mode, and omitted the explicit bot transport mode from persisted configuration. The guided wizard likewise prompted HTTP bot setups for an app token instead of the signing secret required by the HTTP receiver.

Follow-up to #128322.

## Why This Change Was Made

The Slack setup owner now selects credentials independently by identity and transport: bot versus user chooses the identity token, while Socket Mode versus HTTP chooses the app token or signing secret. Explicit modes are persisted for both identities, and the guided wizard follows the same transport rule. The Socket Mode environment shortcut only applies when the account's effective mode is `socket`, so stale Socket Mode credentials cannot silently skip HTTP signing-secret setup.

Account promotion intentionally leaves an existing shared `channels.slack.signingSecret` at the channel root. Slack's existing configuration schema and account-resolution contract explicitly allow multiple HTTP accounts to inherit that credential. Moving it into a single promoted account would delete the shared value and break sibling HTTP bot/user accounts; a newly configured HTTP account can still provide its own account-scoped signing secret. No new configuration surface, compatibility shim, or dependency is introduced.

This matches the existing Slack Bolt receiver contracts: HTTP uses `HTTPReceiver` with its signing secret and enabled request-signature verification, while Socket Mode uses `SocketModeReceiver` with its app token.

## User Impact

Operators can configure Slack HTTP bots with `botToken + signingSecret`; setup no longer asks for or accepts an app token as the HTTP transport credential, and the saved account remains in HTTP mode. Adding a named account preserves the root signing secret inherited by existing HTTP accounts while allowing the new account to own a separate signing secret. Existing Socket Mode setup and environment shortcuts continue to work.

## Evidence

- Regressions were reproduced on current `main`: HTTP bot setup rejected a valid bot-token/signing-secret pair, accepted an app token without a signing secret, omitted the HTTP signing-secret prompt, and incorrectly applied stale Socket Mode environment credentials.
- The corrected commit preserves the contributor's author credit and changes production code by exactly **+21/-21 lines**.
- `node scripts/run-vitest.mjs extensions/slack/src/channel-actions-setup-status.contract.test.ts extensions/slack/src/setup-surface.test.ts --reporter=dot`: **43/43 tests passed**.
- Account-promotion regressions cover an existing HTTP account with its own signing secret, a Socket Mode account, and a fully configured relay account; each retains the shared root secret, keeps existing HTTP bot and user accounts configured, and passes the production Slack configuration schema.
- A production Slack plugin + real Slack wizard + generic channel setup adapter + real `writeConfigFile`/`loadConfig` filesystem roundtrip passed both scenarios:
  - Fresh HTTP setup with stale Socket Mode environment credentials prompts only for the bot token and signing secret; readback preserves `mode=http`, both HTTP credentials, and no app token.
  - Named-account promotion retains the shared root signing secret; existing `default`, HTTP bot, and HTTP user accounts remain configured; the new named account persists its own signing secret; configuration schema validation passes.
- Slack Bolt **5.0.0** receiver source and types were inspected directly: HTTP requires `signingSecret` and verifies request signatures by default; Socket Mode requires `appToken`.
- Fresh automated review and a separate independent exact-commit review both passed after specifically challenging shared-root credential lifetime, account promotion, HTTP/socket/relay sibling behavior, and security boundaries.
- The isolated Testbox validation attempt hit an infrastructure synchronization timeout. Local repository checks passed formatting, plugin boundaries, doctor contract tests, dependency guards, and all dead-export scans; the broad extension typecheck encountered pre-existing unrelated stale shared-checkout dependencies, so exact-head hosted CI is the authoritative full dependency/typecheck gate.

No live Slack API call is required: this change only repairs local setup credential selection, account ownership, and configuration persistence; receiver authentication and external API behavior are unchanged.
