### PR TITLE
fix(startup): preserve preloaded resolver hooks

### DIFF
--- a/src/daemon/gateway-heap.ts
+++ b/src/daemon/gateway-heap.ts
@@ -1,5 +1,6 @@
 /** Adaptive Node heap policy for the managed Gateway service. */
 import os from "node:os";
+import { parseNodeOptionsEnvVar } from "../infra/node-options.js";
 
 const MEBIBYTE_BYTES = 1024 * 1024;
 const GATEWAY_HEAP_FLOOR_MIB = 2048;
@@ -65,50 +66,11 @@ function resolveGatewayHeapLimit(params: GatewayHeapMemoryInputs = {}): GatewayH
   };
 }
 
-function parseNodeOptionsTokens(nodeOptions: string): string[] | null {
-  // Match Node's NODE_OPTIONS splitter: space delimiters, double quotes, and
-  // backslash escapes only inside quotes. Other shell quoting does not apply.
-  const tokens: string[] = [];
-  let token = "";
-  let inQuotes = false;
-  let tokenStarted = false;
-  for (let index = 0; index < nodeOptions.length; index += 1) {
-    let char = nodeOptions[index];
-    if (char === "\\" && inQuotes) {
-      index += 1;
-      if (index >= nodeOptions.length) {
-        return null;
-      }
-      char = nodeOptions[index];
-    } else if (char === " " && !inQuotes) {
-      if (tokenStarted) {
-        tokens.push(token);
-        token = "";
-        tokenStarted = false;
-      }
-      continue;
-    } else if (char === '"') {
-      inQuotes = !inQuotes;
-      tokenStarted = true;
-      continue;
-    }
-    token += char;
-    tokenStarted = true;
-  }
-  if (inQuotes) {
-    return null;
-  }
-  if (tokenStarted) {
-    tokens.push(token);
-  }
-  return tokens;
-}
-
 function parseMaxOldSpaceSizeMiB(nodeOptions: string | undefined): number | null {
   if (!nodeOptions) {
     return null;
   }
-  const tokens = parseNodeOptionsTokens(nodeOptions);
+  const tokens = parseNodeOptionsEnvVar(nodeOptions);
   if (!tokens) {
     return null;
   }

--- a/src/entry.esm-resolve-fast-path.test.ts
+++ b/src/entry.esm-resolve-fast-path.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../test/helpers/temp-dir.js";
 import { installDistEsmResolveFastPath } from "./entry.esm-resolve-fast-path.js";
 
 type ResolveHook = (
@@ -8,6 +13,7 @@ type ResolveHook = (
 ) => { url: string; format?: string | null; shortCircuit?: boolean };
 
 const DIST_ROOT = "file:///opt/openclaw/dist/";
+const DIST_ENTRY_PATH = path.resolve("dist/entry.js");
 
 function installCapturedHook(entryFileUrl: string): ResolveHook {
   let hook: ResolveHook | undefined;
@@ -16,6 +22,8 @@ function installCapturedHook(entryFileUrl: string): ResolveHook {
       hook = options.resolve as ResolveHook;
       return { deregister: () => {} };
     },
+    execArgv: [],
+    nodeOptions: undefined,
   });
   expect(installed).toBe(true);
   if (!hook) {
@@ -97,8 +105,9 @@ describe("installDistEsmResolveFastPath gating", () => {
       return { deregister: () => {} };
     };
     const root = "file:///opt/openclaw-idempotent/dist/";
-    expect(installDistEsmResolveFastPath(`${root}entry.js`, { registerHooks })).toBe(true);
-    expect(installDistEsmResolveFastPath(`${root}index.js`, { registerHooks })).toBe(true);
+    const deps = { registerHooks, execArgv: [], nodeOptions: undefined };
+    expect(installDistEsmResolveFastPath(`${root}entry.js`, deps)).toBe(true);
+    expect(installDistEsmResolveFastPath(`${root}index.js`, deps)).toBe(true);
     expect(registered).toBe(1);
   });
 
@@ -115,7 +124,181 @@ describe("installDistEsmResolveFastPath gating", () => {
     expect(
       installDistEsmResolveFastPath("file:///opt/openclaw-two/dist/entry.js", {
         registerHooks: undefined,
+        execArgv: [],
+        nodeOptions: undefined,
       }),
     ).toBe(false);
+  });
+
+  it.each([
+    { name: "CLI --import", execArgv: ["--import", "./hook.mjs"], nodeOptions: undefined },
+    { name: "CLI --import=", execArgv: ["--import=./hook.mjs"], nodeOptions: undefined },
+    { name: "CLI --require", execArgv: ["--require", "./hook.cjs"], nodeOptions: undefined },
+    { name: "CLI --require=", execArgv: ["--require=./hook.cjs"], nodeOptions: undefined },
+    { name: "CLI -r", execArgv: ["-r", "./hook.cjs"], nodeOptions: undefined },
+    { name: "CLI --loader", execArgv: ["--loader", "./hook.mjs"], nodeOptions: undefined },
+    { name: "CLI --loader=", execArgv: ["--loader=./hook.mjs"], nodeOptions: undefined },
+    {
+      name: "CLI --experimental-loader",
+      execArgv: ["--experimental-loader", "./hook.mjs"],
+      nodeOptions: undefined,
+    },
+    {
+      name: "CLI --experimental-loader=",
+      execArgv: ["--experimental-loader=./hook.mjs"],
+      nodeOptions: undefined,
+    },
+    {
+      name: "CLI --experimental_loader",
+      execArgv: ["--experimental_loader", "./hook.mjs"],
+      nodeOptions: undefined,
+    },
+    {
+      name: "CLI --experimental_loader=",
+      execArgv: ["--experimental_loader=./hook.mjs"],
+      nodeOptions: undefined,
+    },
+    {
+      name: "CLI --experimental-config-file",
+      execArgv: ["--experimental-config-file"],
+      nodeOptions: undefined,
+    },
+    {
+      name: "CLI --experimental-config-file=",
+      execArgv: ["--experimental-config-file=./node.config.json"],
+      nodeOptions: undefined,
+    },
+    {
+      name: "CLI --experimental-default-config-file",
+      execArgv: ["--experimental-default-config-file"],
+      nodeOptions: undefined,
+    },
+    { name: "NODE_OPTIONS --import", execArgv: [], nodeOptions: "--import ./hook.mjs" },
+    {
+      name: "NODE_OPTIONS quoted --import token",
+      execArgv: [],
+      nodeOptions: '"--import" ./hook.mjs',
+    },
+    {
+      name: "NODE_OPTIONS quoted --require value",
+      execArgv: [],
+      nodeOptions: '--enable-source-maps --require "./my hook.cjs"',
+    },
+    { name: "NODE_OPTIONS --loader", execArgv: [], nodeOptions: "--loader ./hook.mjs" },
+    {
+      name: "NODE_OPTIONS --experimental-loader=",
+      execArgv: [],
+      nodeOptions: "--experimental-loader=./hook.mjs",
+    },
+    {
+      name: "NODE_OPTIONS --experimental_loader",
+      execArgv: [],
+      nodeOptions: "--experimental_loader ./hook.mjs",
+    },
+  ])(
+    "declines when a resolver hook may be configured through $name",
+    ({ execArgv, nodeOptions }) => {
+      let registered = 0;
+      const installed = installDistEsmResolveFastPath(
+        `file:///opt/openclaw-preload-${registered}-${execArgv.length}/dist/entry.js`,
+        {
+          registerHooks: () => {
+            registered += 1;
+            return { deregister: () => {} };
+          },
+          execArgv,
+          nodeOptions,
+        },
+      );
+
+      expect(installed).toBe(false);
+      expect(registered).toBe(0);
+    },
+  );
+});
+
+describe.skipIf(!fs.existsSync(DIST_ENTRY_PATH))("built dist resolver hook chaining", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it.each([
+    {
+      name: "synchronous preload",
+      nodeOption: "--import",
+      source: `import { registerHooks } from "node:module";
+registerHooks({ resolve: recordRuntimeGuard });`,
+    },
+    {
+      name: "asynchronous loader",
+      nodeOption: "--loader",
+      source:
+        "export async function resolve(specifier, context, nextResolve) { return recordRuntimeGuard(specifier, context, nextResolve); }",
+    },
+    {
+      name: "quoted NODE_OPTIONS synchronous preload",
+      nodeOption: "--import",
+      nodeOptions: true,
+      source: `import { registerHooks } from "node:module";
+registerHooks({ resolve: recordRuntimeGuard });`,
+    },
+    {
+      name: "underscore asynchronous loader",
+      nodeOption: "--experimental_loader",
+      source:
+        "export async function resolve(specifier, context, nextResolve) { return recordRuntimeGuard(specifier, context, nextResolve); }",
+    },
+    {
+      name: "configuration-file synchronous preload",
+      nodeConfig: true,
+      nodeOption: "--experimental-config-file",
+      source: `import { registerHooks } from "node:module";
+registerHooks({ resolve: recordRuntimeGuard });`,
+    },
+  ])("preserves $name resolver hooks", ({ nodeConfig, nodeOption, nodeOptions, source }) => {
+    const root = tempDirs.make("openclaw-dist-resolver-hook-");
+    const hookPath = path.join(root, "resolver-hook.mjs");
+    const markerPath = path.join(root, "resolver-hook.log");
+    fs.writeFileSync(
+      hookPath,
+      `import { appendFileSync } from "node:fs";
+function recordRuntimeGuard(specifier, context, nextResolve) {
+  if (/^\\.\\/runtime-guard-[^/]+\\.js$/.test(specifier)) {
+    appendFileSync(process.env.OPENCLAW_TEST_RESOLVER_HOOK_MARKER, specifier + "\\n");
+  }
+  return nextResolve(specifier, context);
+}
+${source}
+`,
+    );
+    const hookUrl = pathToFileURL(hookPath).href;
+    const configPath = path.join(root, "node.config.json");
+    if (nodeConfig) {
+      fs.writeFileSync(configPath, JSON.stringify({ nodeOptions: { import: [hookUrl] } }));
+    }
+    const nodeArgs = nodeConfig
+      ? [`${nodeOption}=${configPath}`, DIST_ENTRY_PATH, "--version"]
+      : nodeOptions
+        ? [DIST_ENTRY_PATH, "--version"]
+        : [nodeOption, hookUrl, DIST_ENTRY_PATH, "--version"];
+
+    const result = spawnSync(process.execPath, nodeArgs, {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: root,
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        NODE_ENV: undefined,
+        NODE_OPTIONS: nodeOptions ? `"${nodeOption}" ${hookUrl}` : undefined,
+        OPENCLAW_NO_RESPAWN: "1",
+        OPENCLAW_TEST_RESOLVER_HOOK_MARKER: markerPath,
+        VITEST: undefined,
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    const resolvedRuntimeGuards = fs.readFileSync(markerPath, "utf8").trim().split("\n");
+    expect(resolvedRuntimeGuards.length).toBeGreaterThan(0);
+    expect(resolvedRuntimeGuards).toEqual(
+      resolvedRuntimeGuards.filter((specifier) => /^\.\/runtime-guard-[^/]+\.js$/.test(specifier)),
+    );
   });
 });

--- a/src/entry.esm-resolve-fast-path.test.ts
+++ b/src/entry.esm-resolve-fast-path.test.ts
@@ -14,6 +14,7 @@ type ResolveHook = (
 
 const DIST_ROOT = "file:///opt/openclaw/dist/";
 const DIST_ENTRY_PATH = path.resolve("dist/entry.js");
+const DIST_INDEX_PATH = path.resolve("dist/index.js");
 
 function installCapturedHook(entryFileUrl: string): ResolveHook {
   let hook: ResolveHook | undefined;
@@ -105,7 +106,11 @@ describe("installDistEsmResolveFastPath gating", () => {
       return { deregister: () => {} };
     };
     const root = "file:///opt/openclaw-idempotent/dist/";
-    const deps = { registerHooks, execArgv: [], nodeOptions: undefined };
+    const deps = {
+      registerHooks,
+      execArgv: ["--trace-warnings"],
+      nodeOptions: "--max-old-space-size=4096",
+    };
     expect(installDistEsmResolveFastPath(`${root}entry.js`, deps)).toBe(true);
     expect(installDistEsmResolveFastPath(`${root}index.js`, deps)).toBe(true);
     expect(registered).toBe(1);
@@ -131,174 +136,152 @@ describe("installDistEsmResolveFastPath gating", () => {
   });
 
   it.each([
-    { name: "CLI --import", execArgv: ["--import", "./hook.mjs"], nodeOptions: undefined },
-    { name: "CLI --import=", execArgv: ["--import=./hook.mjs"], nodeOptions: undefined },
-    { name: "CLI --require", execArgv: ["--require", "./hook.cjs"], nodeOptions: undefined },
-    { name: "CLI --require=", execArgv: ["--require=./hook.cjs"], nodeOptions: undefined },
-    { name: "CLI -r", execArgv: ["-r", "./hook.cjs"], nodeOptions: undefined },
-    { name: "CLI --loader", execArgv: ["--loader", "./hook.mjs"], nodeOptions: undefined },
-    { name: "CLI --loader=", execArgv: ["--loader=./hook.mjs"], nodeOptions: undefined },
-    {
-      name: "CLI --experimental-loader",
-      execArgv: ["--experimental-loader", "./hook.mjs"],
-      nodeOptions: undefined,
-    },
-    {
-      name: "CLI --experimental-loader=",
-      execArgv: ["--experimental-loader=./hook.mjs"],
-      nodeOptions: undefined,
-    },
-    {
-      name: "CLI --experimental_loader",
-      execArgv: ["--experimental_loader", "./hook.mjs"],
-      nodeOptions: undefined,
-    },
-    {
-      name: "CLI --experimental_loader=",
-      execArgv: ["--experimental_loader=./hook.mjs"],
-      nodeOptions: undefined,
-    },
-    {
-      name: "CLI --experimental-config-file",
-      execArgv: ["--experimental-config-file"],
-      nodeOptions: undefined,
-    },
-    {
-      name: "CLI --experimental-config-file=",
-      execArgv: ["--experimental-config-file=./node.config.json"],
-      nodeOptions: undefined,
-    },
-    {
-      name: "CLI --experimental-default-config-file",
-      execArgv: ["--experimental-default-config-file"],
-      nodeOptions: undefined,
-    },
-    { name: "NODE_OPTIONS --import", execArgv: [], nodeOptions: "--import ./hook.mjs" },
-    {
-      name: "NODE_OPTIONS quoted --import token",
-      execArgv: [],
-      nodeOptions: '"--import" ./hook.mjs',
-    },
-    {
-      name: "NODE_OPTIONS quoted --require value",
-      execArgv: [],
-      nodeOptions: '--enable-source-maps --require "./my hook.cjs"',
-    },
-    { name: "NODE_OPTIONS --loader", execArgv: [], nodeOptions: "--loader ./hook.mjs" },
-    {
-      name: "NODE_OPTIONS --experimental-loader=",
-      execArgv: [],
-      nodeOptions: "--experimental-loader=./hook.mjs",
-    },
-    {
-      name: "NODE_OPTIONS --experimental_loader",
-      execArgv: [],
-      nodeOptions: "--experimental_loader ./hook.mjs",
-    },
-  ])(
-    "declines when a resolver hook may be configured through $name",
-    ({ execArgv, nodeOptions }) => {
-      let registered = 0;
-      const installed = installDistEsmResolveFastPath(
-        `file:///opt/openclaw-preload-${registered}-${execArgv.length}/dist/entry.js`,
-        {
-          registerHooks: () => {
-            registered += 1;
-            return { deregister: () => {} };
-          },
-          execArgv,
-          nodeOptions,
+    ["--import", ["--import", "./hook.mjs"]],
+    ["--require", ["--require=./hook.cjs"]],
+    ["-r", ["-r", "./hook.cjs"]],
+    ["--loader", ["--loader=./hook.mjs"]],
+    ["--experimental-loader", ["--experimental_loader", "./hook.mjs"]],
+    ["--experimental-config-file", ["--experimental_config_file=./node.config.json"]],
+    ["--experimental-default-config-file", ["--experimental_default_config_file"]],
+  ])("declines when execArgv contains %s", (_name, execArgv) => {
+    let registered = 0;
+    const installed = installDistEsmResolveFastPath(
+      `file:///opt/openclaw-preload-${execArgv[0]}/dist/entry.js`,
+      {
+        registerHooks: () => {
+          registered += 1;
+          return { deregister: () => {} };
         },
-      );
+        execArgv,
+        nodeOptions: undefined,
+      },
+    );
 
-      expect(installed).toBe(false);
+    expect(installed).toBe(false);
+    expect(registered).toBe(0);
+  });
+
+  it.each([
+    '--im"port" "./hook.mjs"',
+    '"--im\\port" "./hook.mjs"',
+    "--experimental_loader ./hook.mjs",
+    "--experimental_config_file=./node.config.json",
+  ])("declines for parsed NODE_OPTIONS %j", (nodeOptions) => {
+    let registered = 0;
+    const installed = installDistEsmResolveFastPath(
+      `file:///opt/openclaw-node-options-${registered}-${nodeOptions.length}/dist/entry.js`,
+      {
+        registerHooks: () => {
+          registered += 1;
+          return { deregister: () => {} };
+        },
+        execArgv: [],
+        nodeOptions,
+      },
+    );
+
+    expect(installed).toBe(false);
+    expect(registered).toBe(0);
+  });
+
+  it.each(['"--import ./hook.mjs', '"--import ./hook.mjs\\'])(
+    "declines for malformed NODE_OPTIONS %j",
+    (nodeOptions) => {
+      let registered = 0;
+      expect(
+        installDistEsmResolveFastPath(
+          `file:///opt/openclaw-malformed-${nodeOptions.length}/dist/entry.js`,
+          {
+            registerHooks: () => {
+              registered += 1;
+              return { deregister: () => {} };
+            },
+            execArgv: [],
+            nodeOptions,
+          },
+        ),
+      ).toBe(false);
       expect(registered).toBe(0);
     },
   );
 });
 
-describe.skipIf(!fs.existsSync(DIST_ENTRY_PATH))("built dist resolver hook chaining", () => {
-  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+describe.skipIf(!fs.existsSync(DIST_ENTRY_PATH) || !fs.existsSync(DIST_INDEX_PATH))(
+  "built dist resolver hook chaining",
+  () => {
+    const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-  it.each([
-    {
-      name: "synchronous preload",
-      nodeOption: "--import",
-      source: `import { registerHooks } from "node:module";
-registerHooks({ resolve: recordRuntimeGuard });`,
-    },
-    {
-      name: "asynchronous loader",
-      nodeOption: "--loader",
-      source:
-        "export async function resolve(specifier, context, nextResolve) { return recordRuntimeGuard(specifier, context, nextResolve); }",
-    },
-    {
-      name: "quoted NODE_OPTIONS synchronous preload",
-      nodeOption: "--import",
-      nodeOptions: true,
-      source: `import { registerHooks } from "node:module";
-registerHooks({ resolve: recordRuntimeGuard });`,
-    },
-    {
-      name: "underscore asynchronous loader",
-      nodeOption: "--experimental_loader",
-      source:
-        "export async function resolve(specifier, context, nextResolve) { return recordRuntimeGuard(specifier, context, nextResolve); }",
-    },
-    {
-      name: "configuration-file synchronous preload",
-      nodeConfig: true,
-      nodeOption: "--experimental-config-file",
-      source: `import { registerHooks } from "node:module";
-registerHooks({ resolve: recordRuntimeGuard });`,
-    },
-  ])("preserves $name resolver hooks", ({ nodeConfig, nodeOption, nodeOptions, source }) => {
-    const root = tempDirs.make("openclaw-dist-resolver-hook-");
-    const hookPath = path.join(root, "resolver-hook.mjs");
-    const markerPath = path.join(root, "resolver-hook.log");
-    fs.writeFileSync(
-      hookPath,
-      `import { appendFileSync } from "node:fs";
-function recordRuntimeGuard(specifier, context, nextResolve) {
-  if (/^\\.\\/runtime-guard-[^/]+\\.js$/.test(specifier)) {
+    it.each([
+      {
+        name: "synchronous preload",
+        entryPath: DIST_ENTRY_PATH,
+        nodeOption: "--import",
+        argv: ["--version"],
+        targetPrefix: "./runtime-guard-",
+        registerSource: "registerHooks({ resolve: recordTarget });",
+      },
+      {
+        name: "asynchronous loader",
+        entryPath: DIST_INDEX_PATH,
+        nodeOption: "--loader",
+        argv: ["--help"],
+        targetPrefix: "./runtime-",
+        registerSource:
+          "export async function resolve(specifier, context, nextResolve) { return recordTarget(specifier, context, nextResolve); }",
+      },
+      {
+        name: "split-quoted NODE_OPTIONS preload",
+        entryPath: DIST_ENTRY_PATH,
+        nodeOption: "--import",
+        nodeOptions: true,
+        argv: ["--version"],
+        targetPrefix: "./runtime-guard-",
+        registerSource: "registerHooks({ resolve: recordTarget });",
+      },
+    ])(
+      "preserves $name resolver hooks",
+      ({ entryPath, nodeOption, nodeOptions, argv, targetPrefix, registerSource }) => {
+        const root = tempDirs.make("openclaw-dist-resolver-hook-");
+        const hookPath = path.join(root, "resolver-hook.mjs");
+        const markerPath = path.join(root, "resolver-hook.log");
+        fs.writeFileSync(
+          hookPath,
+          `import { appendFileSync } from "node:fs";
+import { registerHooks } from "node:module";
+function recordTarget(specifier, context, nextResolve) {
+  if (specifier.startsWith(${JSON.stringify(targetPrefix)}) && specifier.endsWith(".js")) {
     appendFileSync(process.env.OPENCLAW_TEST_RESOLVER_HOOK_MARKER, specifier + "\\n");
   }
   return nextResolve(specifier, context);
 }
-${source}
+${registerSource}
 `,
-    );
-    const hookUrl = pathToFileURL(hookPath).href;
-    const configPath = path.join(root, "node.config.json");
-    if (nodeConfig) {
-      fs.writeFileSync(configPath, JSON.stringify({ nodeOptions: { import: [hookUrl] } }));
-    }
-    const nodeArgs = nodeConfig
-      ? [`${nodeOption}=${configPath}`, DIST_ENTRY_PATH, "--version"]
-      : nodeOptions
-        ? [DIST_ENTRY_PATH, "--version"]
-        : [nodeOption, hookUrl, DIST_ENTRY_PATH, "--version"];
+        );
+        const hookUrl = pathToFileURL(hookPath).href;
+        const nodeArgs = nodeOptions
+          ? [entryPath, ...argv]
+          : [nodeOption, hookUrl, entryPath, ...argv];
 
-    const result = spawnSync(process.execPath, nodeArgs, {
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        HOME: root,
-        NODE_DISABLE_COMPILE_CACHE: "1",
-        NODE_ENV: undefined,
-        NODE_OPTIONS: nodeOptions ? `"${nodeOption}" ${hookUrl}` : undefined,
-        OPENCLAW_NO_RESPAWN: "1",
-        OPENCLAW_TEST_RESOLVER_HOOK_MARKER: markerPath,
-        VITEST: undefined,
+        const result = spawnSync(process.execPath, nodeArgs, {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            HOME: root,
+            NODE_DISABLE_COMPILE_CACHE: "1",
+            NODE_ENV: undefined,
+            NODE_OPTIONS: nodeOptions ? `--im"port" "${hookUrl}"` : undefined,
+            OPENCLAW_NO_RESPAWN: "1",
+            OPENCLAW_TEST_RESOLVER_HOOK_MARKER: markerPath,
+            VITEST: undefined,
+          },
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(fs.existsSync(markerPath), result.stderr).toBe(true);
+        const resolvedTargets = fs.readFileSync(markerPath, "utf8").trim().split("\n");
+        expect(resolvedTargets.length).toBeGreaterThan(0);
+        expect(resolvedTargets.every((specifier) => specifier.startsWith(targetPrefix))).toBe(true);
       },
-    });
-
-    expect(result.status, result.stderr).toBe(0);
-    const resolvedRuntimeGuards = fs.readFileSync(markerPath, "utf8").trim().split("\n");
-    expect(resolvedRuntimeGuards.length).toBeGreaterThan(0);
-    expect(resolvedRuntimeGuards).toEqual(
-      resolvedRuntimeGuards.filter((specifier) => /^\.\/runtime-guard-[^/]+\.js$/.test(specifier)),
     );
-  });
-});
+  },
+);

--- a/src/entry.esm-resolve-fast-path.ts
+++ b/src/entry.esm-resolve-fast-path.ts
@@ -12,6 +12,7 @@
  * byte-identical to Node's default resolution.
  */
 import Module from "node:module";
+import process from "node:process";
 
 type SyncResolveResult = { url: string; format?: string | null; shortCircuit?: boolean };
 type SyncResolveContext = { parentURL?: string; conditions?: readonly string[] };
@@ -28,6 +29,36 @@ const moduleWithHooks = Module as typeof Module & {
 };
 
 const installedDistRootUrls = new Set<string>();
+const NODE_OPTIONS_RESOLVER_HOOK_PATTERN =
+  /(?:^|[\s"])(?:--import|--require|-r|--loader|--experimental[-_]loader)(?:=|[\s"]|$)/u;
+
+function hasNodeResolverHookOption(params: {
+  execArgv: readonly string[];
+  nodeOptions: string | undefined;
+}): boolean {
+  if (
+    params.execArgv.some(
+      (arg) =>
+        arg === "--import" ||
+        arg.startsWith("--import=") ||
+        arg === "--require" ||
+        arg.startsWith("--require=") ||
+        arg === "-r" ||
+        arg === "--loader" ||
+        arg.startsWith("--loader=") ||
+        arg === "--experimental-loader" ||
+        arg.startsWith("--experimental-loader=") ||
+        arg === "--experimental_loader" ||
+        arg.startsWith("--experimental_loader=") ||
+        arg === "--experimental-config-file" ||
+        arg.startsWith("--experimental-config-file=") ||
+        arg === "--experimental-default-config-file",
+    )
+  ) {
+    return true;
+  }
+  return NODE_OPTIONS_RESOLVER_HOOK_PATTERN.test(params.nodeOptions ?? "");
+}
 
 /**
  * Resolves a dist-internal relative ESM specifier to its final file URL, or
@@ -73,7 +104,11 @@ function resolveDistEsmFastPathUrl(params: {
  */
 export function installDistEsmResolveFastPath(
   entryFileUrl: string,
-  deps: { registerHooks?: RegisterModuleHooks | undefined } = {},
+  deps: {
+    registerHooks?: RegisterModuleHooks | undefined;
+    execArgv?: readonly string[];
+    nodeOptions?: string | undefined;
+  } = {},
 ): boolean {
   const registerHooks =
     "registerHooks" in deps ? deps.registerHooks : moduleWithHooks.registerHooks;
@@ -82,6 +117,12 @@ export function installDistEsmResolveFastPath(
   }
   const distRootUrl = new URL("./", entryFileUrl).href;
   if (!distRootUrl.endsWith("/dist/")) {
+    return false;
+  }
+  const nodeOptions = "nodeOptions" in deps ? deps.nodeOptions : process.env.NODE_OPTIONS;
+  // Preloads and loaders can register resolver hooks before OpenClaw starts.
+  // Our later short circuit would otherwise bypass that user-owned chain.
+  if (hasNodeResolverHookOption({ execArgv: deps.execArgv ?? process.execArgv, nodeOptions })) {
     return false;
   }
   if (installedDistRootUrls.has(distRootUrl)) {

--- a/src/entry.esm-resolve-fast-path.ts
+++ b/src/entry.esm-resolve-fast-path.ts
@@ -13,51 +13,36 @@
  */
 import Module from "node:module";
 import process from "node:process";
+import { parseNodeOptionsEnvVar } from "./infra/node-options.js";
 
-type SyncResolveResult = { url: string; format?: string | null; shortCircuit?: boolean };
-type SyncResolveContext = { parentURL?: string; conditions?: readonly string[] };
-type SyncResolveHook = (
-  specifier: string,
-  context: SyncResolveContext,
-  nextResolve: (specifier: string, context?: SyncResolveContext) => SyncResolveResult,
-) => SyncResolveResult;
-type RegisterModuleHooks = (options: { resolve?: SyncResolveHook }) => { deregister: () => void };
-
-// SAFETY: Module.registerHooks ships in every supported Node runtime but is missing from the bundled type declarations; the optional member keeps callers probing before use (Bun lacks it).
-const moduleWithHooks = Module as typeof Module & {
-  registerHooks?: RegisterModuleHooks;
-};
+// Bun lacks registerHooks, so keep the runtime probe despite supported Node types.
+const moduleWithHooks: { registerHooks?: typeof Module.registerHooks } = Module;
 
 const installedDistRootUrls = new Set<string>();
-const NODE_OPTIONS_RESOLVER_HOOK_PATTERN =
-  /(?:^|[\s"])(?:--import|--require|-r|--loader|--experimental[-_]loader)(?:=|[\s"]|$)/u;
+const NODE_RESOLVER_HOOK_OPTIONS = new Set([
+  "--import",
+  "--require",
+  "-r",
+  "--loader",
+  "--experimental-loader",
+  "--experimental-config-file",
+  "--experimental-default-config-file",
+]);
 
-function hasNodeResolverHookOption(params: {
-  execArgv: readonly string[];
-  nodeOptions: string | undefined;
-}): boolean {
-  if (
-    params.execArgv.some(
-      (arg) =>
-        arg === "--import" ||
-        arg.startsWith("--import=") ||
-        arg === "--require" ||
-        arg.startsWith("--require=") ||
-        arg === "-r" ||
-        arg === "--loader" ||
-        arg.startsWith("--loader=") ||
-        arg === "--experimental-loader" ||
-        arg.startsWith("--experimental-loader=") ||
-        arg === "--experimental_loader" ||
-        arg.startsWith("--experimental_loader=") ||
-        arg === "--experimental-config-file" ||
-        arg.startsWith("--experimental-config-file=") ||
-        arg === "--experimental-default-config-file",
+const normalizeNodeOptionName = (token: string) =>
+  (token.split("=", 1)[0] ?? "").replaceAll("_", "-");
+
+function hasNodeResolverHookOption(
+  execArgv: readonly string[],
+  nodeOptions: string | undefined,
+): boolean {
+  const envOptions = parseNodeOptionsEnvVar(nodeOptions);
+  return (
+    envOptions === null ||
+    [...execArgv, ...envOptions].some((token) =>
+      NODE_RESOLVER_HOOK_OPTIONS.has(normalizeNodeOptionName(token)),
     )
-  ) {
-    return true;
-  }
-  return NODE_OPTIONS_RESOLVER_HOOK_PATTERN.test(params.nodeOptions ?? "");
+  );
 }
 
 /**
@@ -105,7 +90,7 @@ function resolveDistEsmFastPathUrl(params: {
 export function installDistEsmResolveFastPath(
   entryFileUrl: string,
   deps: {
-    registerHooks?: RegisterModuleHooks | undefined;
+    registerHooks?: typeof Module.registerHooks | undefined;
     execArgv?: readonly string[];
     nodeOptions?: string | undefined;
   } = {},
@@ -120,9 +105,8 @@ export function installDistEsmResolveFastPath(
     return false;
   }
   const nodeOptions = "nodeOptions" in deps ? deps.nodeOptions : process.env.NODE_OPTIONS;
-  // Preloads and loaders can register resolver hooks before OpenClaw starts.
-  // Our later short circuit would otherwise bypass that user-owned chain.
-  if (hasNodeResolverHookOption({ execArgv: deps.execArgv ?? process.execArgv, nodeOptions })) {
+  // A later short circuit would bypass preload and loader hooks registered before startup.
+  if (hasNodeResolverHookOption(deps.execArgv ?? process.execArgv, nodeOptions)) {
     return false;
   }
   if (installedDistRootUrls.has(distRootUrl)) {

--- a/src/infra/node-options.test.ts
+++ b/src/infra/node-options.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseNodeOptionsEnvVar } from "./node-options.js";
+
+describe("parseNodeOptionsEnvVar", () => {
+  it.each([
+    { input: undefined, expected: [] },
+    { input: "", expected: [] },
+    {
+      input: '--im"port" "file:///tmp/my hook.mjs"',
+      expected: ["--import", "file:///tmp/my hook.mjs"],
+    },
+    {
+      input: '"--im\\port" "file:///tmp/my hook.mjs"',
+      expected: ["--import", "file:///tmp/my hook.mjs"],
+    },
+    {
+      input: "--experimental_loader ./hook.mjs",
+      expected: ["--experimental_loader", "./hook.mjs"],
+    },
+    {
+      input: "'--import' ./hook.mjs\twith-tab",
+      expected: ["'--import'", "./hook.mjs\twith-tab"],
+    },
+    {
+      input: '--require "" ./hook.cjs',
+      expected: ["--require", "./hook.cjs"],
+    },
+  ])("matches Node tokenization for $input", ({ input, expected }) => {
+    expect(parseNodeOptionsEnvVar(input)).toEqual(expected);
+  });
+
+  it.each(['"--import ./hook.mjs', '"--import ./hook.mjs\\'])(
+    "rejects malformed input %j",
+    (input) => {
+      expect(parseNodeOptionsEnvVar(input)).toBeNull();
+    },
+  );
+});

--- a/src/infra/node-options.ts
+++ b/src/infra/node-options.ts
@@ -1,0 +1,38 @@
+// Matches Node's NODE_OPTIONS grammar: literal-space delimiters, double quotes,
+// and backslash escapes only inside quotes.
+export function parseNodeOptionsEnvVar(value: string | undefined): string[] | null {
+  const tokens: string[] = [];
+  let token = "";
+  let inQuotes = false;
+  const nodeOptions = value ?? "";
+
+  for (let index = 0; index < nodeOptions.length; index += 1) {
+    let char = nodeOptions.charAt(index);
+    if (char === "\\" && inQuotes) {
+      index += 1;
+      if (index >= nodeOptions.length) {
+        return null;
+      }
+      char = nodeOptions.charAt(index);
+    } else if (char === " " && !inQuotes) {
+      if (token.length > 0) {
+        tokens.push(token);
+        token = "";
+      }
+      continue;
+    } else if (char === '"') {
+      inQuotes = !inQuotes;
+      continue;
+    }
+
+    token += char;
+  }
+
+  if (inQuotes) {
+    return null;
+  }
+  if (token.length > 0) {
+    tokens.push(token);
+  }
+  return tokens;
+}


### PR DESCRIPTION
Related: #128541

## What Problem This Solves

Fixes an issue where operators launching OpenClaw with a Node preload, loader,
or effective config file could silently lose resolver-hook observations during
built CLI startup.

## Why This Change Was Made

The dist resolver fast path registers a later LIFO hook with `shortCircuit:
true`, so it must not install when an earlier hook may own the resolver chain.
The fix parses `NODE_OPTIONS` with Node's actual literal-space, double-quote,
and in-quote backslash grammar, shares that parser with gateway heap selection,
and conservatively declines the fast path for resolver-affecting options or
malformed input. Normal launches keep the optimization.

## User Impact

Preloads and loaders continue observing OpenClaw's built runtime imports.
Launches without resolver-affecting Node options retain the existing startup
fast path.

## Evidence

- Red on current main `b55ae89f230`: built `dist/entry.js` exited 0, but the
  preload marker was absent for direct `--import` and valid split-quoted
  `NODE_OPTIONS`.
- Green on exact head `11c9ef3f529`: both launches recorded
  `./runtime-guard-Cx9Cuq24.js`; `dist/index.js --help` with `--loader` recorded
  `./runtime-C4YU4VDg.js`.
- Shared parser matrix: 9 passed.
- Gateway heap tests: 11 passed.
- Entry resolver fast-path tests: 23 passed, including built sync preload,
  async loader, and split-quoted `NODE_OPTIONS`.
- `node --import tsx scripts/build-all.mts cliStartup`, `pnpm tsgo`,
  `node scripts/check-changed.mjs`, native `scripts/pr review-tests`, and
  `git diff --check` passed.
- Fresh branch autoreview reported no accepted or actionable findings (0.99).
- Judged production delta: net +25 across exactly three production files.

## AI Disclosure

This pull request was prepared with AI assistance.
