### PR TITLE
fix(workers): reject conflicting placement identity

### DIFF
--- a/src/gateway/worker-environments/worker-turn-admission.ts
+++ b/src/gateway/worker-environments/worker-turn-admission.ts
@@ -118,22 +118,16 @@ export async function waitForTurnOperation<T>(params: {
   });
 }
 
-function resolvePlacementIdentityField(params: {
-  field: string;
-  supplied: string | undefined;
-  persisted: string | undefined;
-}): string {
-  if (!params.persisted) {
-    return required(params.supplied, params.field);
+function resolvePlacementIdentityField(
+  supplied: string | undefined,
+  persisted: string | undefined,
+  field: string,
+): string {
+  const resolved = supplied === undefined && persisted ? persisted : required(supplied, field);
+  if (persisted && resolved !== persisted) {
+    throw new Error(`Worker turn ${field} does not match its placement`);
   }
-  if (params.supplied === undefined) {
-    return params.persisted;
-  }
-  const supplied = required(params.supplied, params.field);
-  if (supplied !== params.persisted) {
-    throw new Error(`Worker turn ${params.field} does not match its placement`);
-  }
-  return params.persisted;
+  return resolved;
 }
 
 export function resolvePlacementIdentity(
@@ -142,16 +136,12 @@ export function resolvePlacementIdentity(
 ) {
   return {
     sessionId: claim.sessionId,
-    agentId: resolvePlacementIdentityField({
-      field: "agent id",
-      supplied: claim.agentId,
-      persisted: placement?.agentId,
-    }),
-    sessionKey: resolvePlacementIdentityField({
-      field: "session key",
-      supplied: claim.sessionKey,
-      persisted: placement?.sessionKey,
-    }),
+    agentId: resolvePlacementIdentityField(claim.agentId, placement?.agentId, "agent id"),
+    sessionKey: resolvePlacementIdentityField(
+      claim.sessionKey,
+      placement?.sessionKey,
+      "session key",
+    ),
   };
 }
 

--- a/src/gateway/worker-environments/worker-turn-admission.ts
+++ b/src/gateway/worker-environments/worker-turn-admission.ts
@@ -118,14 +118,40 @@ export async function waitForTurnOperation<T>(params: {
   });
 }
 
+function resolvePlacementIdentityField(params: {
+  field: string;
+  supplied: string | undefined;
+  persisted: string | undefined;
+}): string {
+  if (!params.persisted) {
+    return required(params.supplied, params.field);
+  }
+  if (params.supplied === undefined) {
+    return params.persisted;
+  }
+  const supplied = required(params.supplied, params.field);
+  if (supplied !== params.persisted) {
+    throw new Error(`Worker turn ${params.field} does not match its placement`);
+  }
+  return params.persisted;
+}
+
 export function resolvePlacementIdentity(
   claim: LocalTurnPlacementClaim,
   placement: WorkerSessionPlacementRecord | undefined,
 ) {
   return {
     sessionId: claim.sessionId,
-    agentId: placement?.agentId ?? required(claim.agentId, "agent id"),
-    sessionKey: placement?.sessionKey ?? required(claim.sessionKey, "session key"),
+    agentId: resolvePlacementIdentityField({
+      field: "agent id",
+      supplied: claim.agentId,
+      persisted: placement?.agentId,
+    }),
+    sessionKey: resolvePlacementIdentityField({
+      field: "session key",
+      supplied: claim.sessionKey,
+      persisted: placement?.sessionKey,
+    }),
   };
 }
 

--- a/src/gateway/worker-environments/worker-turn-launcher-reclaimed-placement.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-reclaimed-placement.test.ts
@@ -48,6 +48,33 @@ describe("worker turn launcher reclaimed placement", () => {
   beforeEach(setupWorkerTurnLauncherTest);
   afterEach(cleanupWorkerTurnLauncherTest);
 
+  it.each([
+    ["agent id", { agentId: "other", sessionKey: SESSION_KEY }],
+    ["session key", { agentId: "main", sessionKey: "agent:main:other" }],
+    ["blank agent id", { agentId: " ", sessionKey: SESSION_KEY }],
+    ["blank session key", { agentId: "main", sessionKey: " " }],
+  ])("rejects a conflicting supplied %s before redispatch", async (_label, identity) => {
+    seedReclaimedPlacement();
+    const redispatchReclaimed = vi.fn(async () => {
+      throw new Error("redispatch should not run");
+    });
+    const provider = createWorkerSessionTurnPlacementProvider({
+      environments: unusedEnvironments(),
+      placements,
+      redispatchReclaimed,
+    });
+
+    await expect(
+      provider.executeTurn(
+        { sessionId: SESSION_ID, ...identity, runId: `run-reclaimed-conflict-${_label}` },
+        turn(`run-reclaimed-conflict-${_label}`),
+        vi.fn(),
+      ),
+    ).rejects.toThrow(/Worker turn (agent id|session key) (?:is required|does not match)/u);
+    expect(redispatchReclaimed).not.toHaveBeenCalled();
+    expect(placements.get(SESSION_ID)).toMatchObject({ state: "reclaimed", turnClaim: null });
+  });
+
   it("redispatches a reclaimed placement before launching the worker turn", async () => {
     const reclaimed = seedReclaimedPlacement();
     const runId = "run-reclaimed-worker";

--- a/src/gateway/worker-environments/worker-turn-launcher.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test.ts
@@ -24,6 +24,7 @@ import {
   cleanupWorkerTurnLauncherTest,
   createWorkerSessionTurnPlacementProvider,
   placements,
+  root,
   seedActivePlacement,
   sessionTarget,
   setupWorkerTurnLauncherTest,
@@ -132,6 +133,61 @@ describe("worker turn launcher local placement", () => {
 
     expect(runLocal).toHaveBeenCalledOnce();
     expect(placements.list()).toEqual([]);
+  });
+
+  it.each([
+    ["agent id", { agentId: "other", sessionKey: SESSION_KEY }],
+    ["session key", { agentId: "main", sessionKey: "agent:main:other" }],
+    ["blank agent id", { agentId: " ", sessionKey: SESSION_KEY }],
+    ["blank session key", { agentId: "main", sessionKey: " " }],
+  ])(
+    "rejects a conflicting supplied placement %s before workspace access",
+    async (_label, identity) => {
+      seedActivePlacement();
+      const resolveWorkspacePath = vi.fn(async () => root);
+      const runLocal = vi.fn(async () => ({ meta: { durationMs: 1 } }));
+      const provider = createWorkerSessionTurnPlacementProvider({
+        environments: unusedEnvironments(),
+        placements,
+        resolveWorkspacePath,
+      });
+
+      await expect(
+        provider.executeTurn(
+          { sessionId: SESSION_ID, ...identity, runId: `run-conflict-${_label}` },
+          turn(`run-conflict-${_label}`),
+          runLocal,
+        ),
+      ).rejects.toThrow(/Worker turn (agent id|session key) (?:is required|does not match)/u);
+      expect(resolveWorkspacePath).not.toHaveBeenCalled();
+      expect(runLocal).not.toHaveBeenCalled();
+      expect(placements.get(SESSION_ID)?.turnClaim).toBeNull();
+    },
+  );
+
+  it("inherits omitted placement identity before workspace access", async () => {
+    seedActivePlacement();
+    const resolveWorkspacePath = vi.fn(async () => {
+      throw new Error("workspace reached");
+    });
+    const provider = createWorkerSessionTurnPlacementProvider({
+      environments: unusedEnvironments(),
+      placements,
+      resolveWorkspacePath,
+    });
+
+    await expect(
+      provider.executeTurn(
+        { sessionId: SESSION_ID, runId: "run-inherited-identity" },
+        turn("run-inherited-identity"),
+        vi.fn(),
+      ),
+    ).rejects.toThrow("workspace reached");
+    expect(resolveWorkspacePath).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      agentId: "main",
+      sessionKey: SESSION_KEY,
+    });
   });
 
   it("holds a local placement claim around CLI execution", async () => {

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -503,17 +503,21 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
       if (!current || current.state === "local") {
         return await executeLocalTurn({ claim, placements: options.placements, runLocal });
       }
+      let identity = resolvePlacementIdentity(claim, current);
       let routablePlacement = current;
       if (routablePlacement.state === "reclaimed") {
         emitAgentRunStatusEvent({
           runId: claim.runId,
           phase: "provisioning_environment",
-          ...(claim.sessionKey ? { sessionKey: claim.sessionKey } : {}),
-          ...(claim.agentId ? { agentId: claim.agentId } : {}),
+          sessionKey: identity.sessionKey,
+          agentId: identity.agentId,
         });
         routablePlacement = await options.redispatchReclaimed(routablePlacement);
+        identity = resolvePlacementIdentity(
+          { ...claim, agentId: identity.agentId, sessionKey: identity.sessionKey },
+          routablePlacement,
+        );
       }
-      const identity = resolvePlacementIdentity(claim, routablePlacement);
       if (
         routablePlacement.state === "draining" &&
         options.placements


### PR DESCRIPTION
Closes #128662

## What Problem This Solves

Fixes an issue where a worker turn carrying the correct session ID but a conflicting or blank agent ID/session key could continue admission under the placement’s persisted identity. Active placements silently discarded the supplied conflict, and reclaimed placements could begin provisioning before any rejection.

## Why This Change Was Made

The common placement identity resolver now inherits only omitted fields. Any supplied field is normalized, required to be non-empty, and compared with the durable placement before workspace resolution, claim acquisition, worker handoff, or reclaimed-placement redispatch. A redispatched active placement is compared again with the resolved canonical identity before admission continues.

Production LOC: +25/-5 (net +20) | Tests: +83/-0

The production growth establishes one shared identity validation boundary used by local, CLI, cron, embedded, active, and reclaimed worker admission; downstream durable-store checks cannot catch a conflict after the supplied value has already been replaced or provisioning has started.

AI-assisted: yes. I reviewed the common admission resolver, active/reclaimed launcher paths, durable claim checks, workspace/provisioning ordering, and regression coverage and understand the change.

## User Impact

Stale or mismatched worker-turn requests now fail immediately instead of proceeding or provisioning under another persisted placement identity. Existing callers that omit optional identity fields continue inheriting canonical placement values.

## Evidence

- Pre-fix active regressions: all four conflicting/blank cases passed admission and failed later at attached-environment validation, proving the supplied conflict was discarded.
- Pre-fix reclaimed regressions: all four cases invoked redispatch and failed with the fixture’s `redispatch should not run` error.
- Post-fix focused proof: all 41 active/reclaimed worker-turn launcher tests passed.
- Full changed-file gate: `node scripts/check-changed.mjs` passed.
- ClawSweeper’s P1 was accepted and fixed: current reclaimed identity is validated before the provisioning status event or redispatch, and the active replacement is revalidated afterward.
- Fresh final P0/P1 autoreview: no accepted/actionable findings (0.94).
- Coverage asserts conflicting agent ID, conflicting session key, blank agent ID, blank session key, omission inheritance, no workspace access, no local execution, no redispatch, and no durable turn claim on rejection.

The unrelated pnpm 11.22 red-main incident observed during this PR was fixed canonically by #128671; this branch contains no dependency changes.
