### PR TITLE
fix(deps): restore frozen installs for Anthropic SDK

### DIFF
--- a/extensions/anthropic/package.json
+++ b/extensions/anthropic/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw Anthropic provider, Claude CLI, and native session catalog plugin",
   "type": "module",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.219"
+    "@anthropic-ai/claude-agent-sdk": "0.3.232"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,8 +472,8 @@ importers:
   extensions/anthropic:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.219
-        version: 0.3.219(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
+        specifier: 0.3.232
+        version: 0.3.232(@anthropic-ai/sdk@0.117.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*


### PR DESCRIPTION
Related: #128414
Related: #128131

## What Problem This Solves

Fixes an issue where clean installs and CI hydration failed with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` after #128414 refreshed the resolved Anthropic Agent SDK graph to `0.3.232` while the plugin manifest and lockfile importer added by #128131 still requested `0.3.219`.

## Why This Change Was Made

Align the Anthropic plugin's exact SDK pin and importer with the already-resolved `0.3.232` graph. This is intentionally limited to the manifest/importer mismatch; it adds no new resolved packages or workflow changes. AI-assisted.

## User Impact

Developers and CI can run frozen pnpm installs from a clean checkout again. Anthropic runtime behavior and dependency ownership remain unchanged.

## Evidence

- Baseline reproduction on `main` (`a9fdb68496d636461d11e8be29323de55636e337`): Blacksmith Testbox hydration failed with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` for the stale `0.3.219` importer: https://github.com/openclaw/openclaw/actions/runs/32716399797
- Fixed head `61cb1fd2224abea05b0061fde59936c3d052697e`: branch Testbox hydration completed the repository frozen install, and an explicit `pnpm install --frozen-lockfile --ignore-scripts` passed with installed SDK readback `0.3.232`: https://github.com/openclaw/openclaw/actions/runs/32716575433
- Anthropic Agent SDK runtime: 31 tests passed.
- Plugin runtime dependency contract: 439 tests passed.
- Package manifest contract: the Anthropic assertion confirming `@anthropic-ai/claude-agent-sdk` stays plugin-local passed. The aggregate sparse-checkout run also reported eight unrelated empty suites for plugins omitted by the GWT profile.
- Docker plugin selection: 3 tests passed; direct selection and required-bundled checks both include `anthropic`.
- Dependency change report: 2 dependency files changed; 0 packages added, removed, or version-changed in the resolved graph.
- Direct dependency pin guard: 620 declared dependency specs checked, 0 violations.
- `git diff --check` passed.
- Autoreview: clean, 0.99 confidence.
