### PR TITLE
fix(deps): repair Claude SDK lockfile snapshot

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,7 +473,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: 0.3.219
-        version: 0.3.219(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
+        version: 0.3.219(@anthropic-ai/sdk@0.117.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -2488,9 +2488,19 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.219':
+    resolution: {integrity: sha512-TQhGAlbMsOGXi03dwf4nD274Lc5BOJg4QFJTuXcQyhLhx0hUqzxCmtvpXt6S70K6yl1Zgc+2n5W/r1Dgt8G8iw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.232':
     resolution: {integrity: sha512-+/4PX+dwmQAjlOlooocwa3kClulZfMo133xQH3LYDlK7D5bzze16lwlDGPVAYGEarpvXg7G5JK8QjfWAJ2HYbg==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.219':
+    resolution: {integrity: sha512-zA/wHN+os4yqXASXJxvGGNSD1p7LZ6BMN71CCphoy5u+d6IpNOCtATnZwINEc2fGFHpv/QDci6jhywJ2O9Flbw==}
+    cpu: [x64]
     os: [darwin]
 
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.232':
@@ -2498,11 +2508,23 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.219':
+    resolution: {integrity: sha512-yiZo+UBCp42FAYqSakgVj/g6LfTH0AklWqIZNEHfVDPaofledXdSu0QJM5yScWNg0hVMaNRXPt0DmuS1oIWW6g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.232':
     resolution: {integrity: sha512-XkLcb9UT/l42Rtw7KBApzgxUe/kwoWJ9KCPcVEnYojzIvVR+AwBCl/QReNU5+6c72w48dYBMmLebI64gQbN0tg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.219':
+    resolution: {integrity: sha512-lizasky9Xj0ouYrz/Akst573Sm8NO3k/0iGCeCDBoQKLnONbVFwc7sHq9x426Pfcllgb4C2Xyc79/1iOALh/9g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.232':
     resolution: {integrity: sha512-wW2opwA5s7gLghjU6B2ADMAtoc7bAZMevUzi4g+1PXMJ8MGcPvbnx92EDYJrVDcZmAl1+fz19XyPsaShlisTzw==}
@@ -2510,11 +2532,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.219':
+    resolution: {integrity: sha512-IhfG57/XorWOQTB6BVdjEFPGH0LwOWO6HnAi+FNuCeiC+XRFl9QI9AKY43opS0gbvJWRobZO865tHX5j7Ou+ow==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.232':
     resolution: {integrity: sha512-L1x2ge9NpXMLTczmT44TKPQ88PHE+gsCakQMVEOa8rXFvfBoqvcpxM0DT8wrqYWUHhQEYR8NXxQTP9a1NVRj8Q==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.219':
+    resolution: {integrity: sha512-yzXhEsT5XcKa8Dc3sM4D1CQ92/6YGmsBbAhRAdw0PYNkG8x6wbHqfzYZS491Bdjry4tSWemNFtGPNkHiWVo3Hg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.232':
     resolution: {integrity: sha512-6Px1xDiwQyLkSxwRQ34/kPA8WMXQ2rHYGkwockND7+9yMw+ShI3AfLkyi9G7JtJHObWFT6B82eSHjDS/Fy+9hQ==}
@@ -2522,15 +2556,33 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.219':
+    resolution: {integrity: sha512-L/cAT27t3FGP4GlJ16WpXMtaeqDu9olpOlIaqqmjElQp5Lknd8alJ3NIY/SlRAtHDvm4WXug74wnfBOSlwppkg==}
+    cpu: [arm64]
+    os: [win32]
+
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.232':
     resolution: {integrity: sha512-fDiuwL5dm1elOy7fNp4Qmdor8so4R8npj2pUGQA1G/xKfJhaK236aTWezvZid3L/O7cRdFeN9IVofOAlWLQcsw==}
     cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.219':
+    resolution: {integrity: sha512-Fl8Rb9K64jbpC/omIF9y828LIvwRmm1zhZgO8zjalTpjZR/0C31Kl+5FwAS9KkXXUXwmdHSY+82e9dyvBrbIRw==}
+    cpu: [x64]
     os: [win32]
 
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.232':
     resolution: {integrity: sha512-Hc/9uy1BI9mqKVyB1b/zoUnm3MFgtVNzQY6p5zgaq9DaIjCKDpR4a4L1aDZM4lMqUcWFMZM+u7juOhh+m39NBQ==}
     cpu: [x64]
     os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.219':
+    resolution: {integrity: sha512-dJjzKxoyCQSEEEo9a0g3wBQprRMCpsqjmsNOZaGOWw+W+JHZsolDBhoYfoZ9BA8EdwgaJmbQUvhkAZjROUsBnQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': 0.117.1
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
 
   '@anthropic-ai/claude-agent-sdk@0.3.232':
     resolution: {integrity: sha512-8od7hJk9fZnF1/oYYiR9PvroGbZRQrpmNgKirjHNGoj5ur5YcAZLohI70XVUAUe3KvjB1msLxtkvmlAT9sqFAg==}
@@ -9358,29 +9410,68 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.219':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.219':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.232':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.219':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.219':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.232':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.219':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.219':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.232':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.219':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.232':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.219':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.232':
     optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.219(@anthropic-ai/sdk@0.117.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.117.1(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.30.0(supports-color@10.2.2)(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.219
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.219
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.219
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.219
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.219
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.219
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.219
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.219
 
   '@anthropic-ai/claude-agent-sdk@0.3.232(@anthropic-ai/sdk@0.117.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.30.0(supports-color@10.2.2)(zod@4.4.3))(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
Related: #128661

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where every frozen pnpm installation on the current main branch fails before tests can start, blocking main CI and pull requests based on main.

## Why This Change Was Made

PR #128131 added the Anthropic plugin's exact `@anthropic-ai/claude-agent-sdk@0.3.219` dependency. The later dependency refresh in #128414 replaced that version's package and platform snapshots with `0.3.232` without updating the plugin's importer, leaving a dangling lockfile reference. Regenerating the existing lockfile restores SDK `0.3.219` and its eight published platform packages, and resolves its peer against the already-configured `@anthropic-ai/sdk@0.117.1` override; manifests, version policy, patches, and unrelated lock entries remain unchanged.

## User Impact

Developers and CI can install the existing workspace dependencies reproducibly again. There is no runtime behavior or dependency-policy change.

## Evidence

- Broken main CI: https://github.com/openclaw/openclaw/actions/runs/32714925515
- Blocked PR #128661 CI: https://github.com/openclaw/openclaw/actions/runs/32715176911
- Before: `pnpm install --frozen-lockfile` fails with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` for the Anthropic plugin's Claude Agent SDK `0.3.219` importer.
- After: `pnpm install --frozen-lockfile` passes for all 170 workspace projects.
- `node scripts/check-changed.mjs -- pnpm-lock.yaml`
- Direct dependency pin guard: 620 declared specs across 176 tracked manifests; zero violations.
- npm package-lock guard: all 94 package locks validated.
- Package patch guard: no new pnpm patches; the existing two approved patches remain unchanged.
- Published package contract: `pnpm view @anthropic-ai/claude-agent-sdk@0.3.219 peerDependencies optionalDependencies --json` confirms `@anthropic-ai/sdk >=0.93.0` and the eight restored exact-version platform packages.
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted --max-priority P1` completed cleanly with no actionable findings.
- Scope: `pnpm-lock.yaml` only; generated lockfile `+92/-1`; production `+0/-0`, tests `+0/-0`.
