### PR TITLE
fix(ui): shorten the composer prefill cue

### DIFF
--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -42,9 +42,15 @@ suite.define(() => {
     const { context, input, page } = await openCapabilitiesPrompt("no-preference");
 
     try {
-      await expect
-        .poll(() => input.evaluate((element) => getComputedStyle(element).animationName))
-        .toBe("chat-composer-prefill-attention");
+      expect(
+        await input.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return {
+            duration: style.animationDuration,
+            name: style.animationName,
+          };
+        }),
+      ).toEqual({ duration: "0.6s", name: "chat-composer-prefill-attention" });
       const highlightedBackground = await input.evaluate(
         (element) => getComputedStyle(element).backgroundColor,
       );

--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -27,39 +27,50 @@ suite.define(() => {
       .click();
 
     const textarea = page.locator(".agent-chat__composer-combobox > textarea");
-    await expect.poll(() => textarea.inputValue()).toBe("What can you do?");
-    await expect
-      .poll(() => textarea.evaluate((element) => element === document.activeElement))
-      .toBe(true);
     const input = textarea.locator("xpath=ancestor::*[contains(@class, 'agent-chat__input')][1]");
+    let cueStyle = { background: "", boxShadow: "", duration: "", name: "" };
     await expect
-      .poll(() => input.getAttribute("class"))
-      .toContain("agent-chat__input--prefill-attention");
-    return { context, input, page };
+      .poll(async () => {
+        const state = await textarea.evaluate((element) => {
+          const inputElement = element.closest<HTMLElement>(".agent-chat__input");
+          const style = inputElement ? getComputedStyle(inputElement) : null;
+          return {
+            active:
+              inputElement?.classList.contains("agent-chat__input--prefill-attention") ?? false,
+            background: style?.backgroundColor ?? "",
+            boxShadow: style?.boxShadow ?? "",
+            duration: style?.animationDuration ?? "",
+            focused: element === document.activeElement,
+            name: style?.animationName ?? "",
+            value: element.value,
+          };
+        });
+        cueStyle = {
+          background: state.background,
+          boxShadow: state.boxShadow,
+          duration: state.duration,
+          name: state.name,
+        };
+        return { active: state.active, focused: state.focused, value: state.value };
+      })
+      .toEqual({ active: true, focused: true, value: "What can you do?" });
+    return { context, cueStyle, input, page };
   }
 
   it("focuses and highlights the composer from the agent capabilities action", async () => {
-    const { context, input, page } = await openCapabilitiesPrompt("no-preference");
+    const { context, cueStyle, input, page } = await openCapabilitiesPrompt("no-preference");
 
     try {
-      expect(
-        await input.evaluate((element) => {
-          const style = getComputedStyle(element);
-          return {
-            duration: style.animationDuration,
-            name: style.animationName,
-          };
-        }),
-      ).toEqual({ duration: "0.6s", name: "chat-composer-prefill-attention" });
-      const highlightedBackground = await input.evaluate(
-        (element) => getComputedStyle(element).backgroundColor,
-      );
+      expect(cueStyle).toMatchObject({
+        duration: "0.6s",
+        name: "chat-composer-prefill-attention",
+      });
       await captureSidebarUiProof(page, "capabilities-composer-focus.png");
       await expect
         .poll(() => input.getAttribute("class"))
         .not.toContain("agent-chat__input--prefill-attention");
       expect(await input.evaluate((element) => getComputedStyle(element).backgroundColor)).not.toBe(
-        highlightedBackground,
+        cueStyle.background,
       );
     } finally {
       await suite.closeBrowserContext(context);
@@ -67,29 +78,17 @@ suite.define(() => {
   });
 
   it("keeps a static composer cue when reduced motion is requested", async () => {
-    const { context, input, page } = await openCapabilitiesPrompt("reduce");
+    const { context, cueStyle, input, page } = await openCapabilitiesPrompt("reduce");
 
     try {
-      await expect
-        .poll(() =>
-          input.evaluate((element) => {
-            const style = getComputedStyle(element);
-            return { animationName: style.animationName, boxShadow: style.boxShadow };
-          }),
-        )
-        .toEqual(expect.objectContaining({ animationName: "none" }));
-      await expect
-        .poll(() => input.evaluate((element) => getComputedStyle(element).boxShadow))
-        .not.toBe("none");
-      const highlightedBackground = await input.evaluate(
-        (element) => getComputedStyle(element).backgroundColor,
-      );
+      expect(cueStyle.name).toBe("none");
+      expect(cueStyle.boxShadow).not.toBe("none");
       await captureSidebarUiProof(page, "capabilities-composer-reduced-motion.png");
       await expect
         .poll(() => input.getAttribute("class"))
         .not.toContain("agent-chat__input--prefill-attention");
       expect(await input.evaluate((element) => getComputedStyle(element).backgroundColor)).not.toBe(
-        highlightedBackground,
+        cueStyle.background,
       );
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -57,7 +57,7 @@ describe("chat pane composer prefill attention", () => {
 
     expect(document.activeElement).toBe(textarea);
     expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
-    vi.advanceTimersByTime(1_200);
+    vi.advanceTimersByTime(600);
     expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(false);
     input.remove();
   });
@@ -67,12 +67,12 @@ describe("chat pane composer prefill attention", () => {
     const { input, lifecycle } = createComposerAttentionFixture();
 
     lifecycle.updated(new Map([["focusComposer", false]]));
-    vi.advanceTimersByTime(600);
+    vi.advanceTimersByTime(300);
     lifecycle.updated(new Map([["focusComposer", false]]));
-    vi.advanceTimersByTime(600);
+    vi.advanceTimersByTime(300);
 
     expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
-    vi.advanceTimersByTime(600);
+    vi.advanceTimersByTime(300);
     expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(false);
     input.remove();
   });

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -57,7 +57,9 @@ describe("chat pane composer prefill attention", () => {
 
     expect(document.activeElement).toBe(textarea);
     expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
-    vi.advanceTimersByTime(600);
+    vi.advanceTimersByTime(599);
+    expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
+    vi.advanceTimersByTime(1);
     expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(false);
     input.remove();
   });
@@ -69,10 +71,10 @@ describe("chat pane composer prefill attention", () => {
     lifecycle.updated(new Map([["focusComposer", false]]));
     vi.advanceTimersByTime(300);
     lifecycle.updated(new Map([["focusComposer", false]]));
-    vi.advanceTimersByTime(300);
+    vi.advanceTimersByTime(599);
 
     expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(true);
-    vi.advanceTimersByTime(300);
+    vi.advanceTimersByTime(1);
     expect(input.classList.contains("agent-chat__input--prefill-attention")).toBe(false);
     input.remove();
   });

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -80,7 +80,7 @@ import {
 } from "./session-message-cache.ts";
 import { closeSlot, openSlot, type SidebarSlotId } from "./sidebar-layout.ts";
 
-const COMPOSER_PREFILL_ATTENTION_DURATION_MS = 1_200;
+const COMPOSER_PREFILL_ATTENTION_DURATION_MS = 600;
 const COMPOSER_PREFILL_ATTENTION_CLASS = "agent-chat__input--prefill-attention";
 
 export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3278,12 +3278,12 @@ button.chat-pr__diff {
 }
 
 .agent-chat__input--prefill-attention {
-  animation: chat-composer-prefill-attention 1200ms ease-out;
+  animation: chat-composer-prefill-attention 600ms ease-out;
 }
 
 @keyframes chat-composer-prefill-attention {
   0%,
-  30% {
+  20% {
     background: color-mix(in srgb, var(--accent) 14%, var(--card));
     border-color: color-mix(in srgb, var(--accent) 88%, var(--border));
     box-shadow:


### PR DESCRIPTION
Closes #128675

## What Problem This Solves

Fixes an issue where users entering chat through a prefilled route action would see the strong composer attention cue remain active for 1.2 seconds. The cue correctly identifies where text landed, but its long hold makes a frequent composer handoff feel slower than necessary.

## Why This Change Was Made

The prefill lifecycle owner and its CSS animation now share a 600 ms deadline, with the strong keyframe hold reduced from 30% to 20%. The visual treatment, focus handoff, replay fencing, and static reduced-motion state remain unchanged.

This is the canonical owner-boundary fix: changing CSS alone would leave the class and reduced-motion state active for 1.2 seconds; changing only the timer would truncate a longer CSS animation. No fallback or downstream guard was added.

## User Impact

Prefilled composer text still receives an obvious focus cue, but the cue settles in half the time. Reduced-motion users receive the same static indication for the same bounded 600 ms lifecycle.

## Evidence

### Reproduction before the fix

At current `origin/main` (`1bca825105e5`), Playwright `recordVideo` measured `animationDuration: 1.2s` and observed the cue class clear after 1164 ms:

https://github.com/user-attachments/assets/d3d0fb89-c402-40b5-9fce-d96ef0191c38

The video was inspected frame by frame. It shows the agent-menu action, the prefilled composer with its halo, a live `ACTIVE` HUD, and the final `CLEARED` state. The HUD reports the browser's computed duration and observed class lifetime; it does not alter the product animation.

The pre-fix regression output was:

```text
chat-pane-lifecycle.test.ts:
expected prefill class false after 600 ms; received true

sidebar-interactions.e2e.test.ts:
expected animationDuration "0.6s"; received "1.2s"
```

The regression tests fail against the pre-fix code for those exact reasons. Before edits, the existing owner and E2E suites were green (`28/28` and `6/6`), establishing that this is a timing-contract change rather than an unrelated broken fixture.

Before, normal motion:

![Composer prefill cue before the timing fix](https://github.com/user-attachments/assets/48d66759-48ad-48a8-a8ed-fe808c924eac)

Before, reduced motion:

![Static reduced-motion composer cue before the timing fix](https://github.com/user-attachments/assets/11f1e4dd-6524-4adb-9dfd-673747bc12af)

### After the fix

- Chromium computed style: `animationName = chat-composer-prefill-attention`, `animationDuration = 0.6s`.
- Lifecycle test: cue clears at 600 ms and a retriggered cue cannot be cleared by the prior timer.
- Reduced motion: animation remains disabled while the static cue clears at the same 600 ms deadline.

At exact PR head `80865b5c53be`, Playwright `recordVideo` measured `animationDuration: 0.6s` and observed the cue class clear after 611 ms:

https://github.com/user-attachments/assets/838d3287-ddfd-4d0d-8007-8e1c931f8275

This video was also inspected frame by frame. It shows the same menu action, prefilled composer and halo, followed by `CLEARED` at roughly half the before duration.

After, normal motion:

![Composer prefill cue after the timing fix](https://github.com/user-attachments/assets/32db01bc-1386-457f-8e98-415cc3d8a348)

After, reduced motion:

![Static reduced-motion composer cue after the timing fix](https://github.com/user-attachments/assets/c87ff432-0a3d-4dc8-8774-ab3f764e9f71)

### Validation

```text
node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-lifecycle.test.ts
28 passed

OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-interactions.e2e.test.ts
6 passed

node scripts/run-tsgo-core-test-shards.mjs
passed

node scripts/run-tsgo.mjs -p tsconfig.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/ui.tsbuildinfo
passed

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/e2e/sidebar-interactions.e2e.test.ts ui/src/pages/chat/chat-pane-lifecycle.test.ts ui/src/pages/chat/chat-pane-lifecycle.ts
passed

node --import tsx scripts/run-stylelint.mts ui/src/e2e/sidebar-interactions.e2e.test.ts ui/src/pages/chat/chat-pane-lifecycle.test.ts ui/src/pages/chat/chat-pane-lifecycle.ts ui/src/styles/chat/layout.css
passed

.agents/skills/autoreview/scripts/autoreview --mode uncommitted
clean: no accepted/actionable findings
```

`check-changed` also passed conflict markers, ratchets, dependency guards, formatting, dead-export scans, i18n verification, and both typecheck lanes before reaching the same lint commands run directly above.

### Provenance and blast radius

The 1.2-second CSS duration and lifecycle timer were introduced together by #117279 on 2026-08-01. That change also added the correct focus handoff, replay behavior, cleanup, and reduced-motion state; this PR preserves those decisions and changes only their duration.

The producer is the one-shot route focus handoff consumed by the active chat pane. The cue class has one production owner in `ChatPaneLifecycle`; the CSS is shared by retained and split chat panes. New Session can trigger it only after navigating to the resulting chat pane. The attachment, microphone, send, session companion, Custodian, persistence, Gateway, provider, and native-app paths are unaffected.

### Expected stack conflict

The composer stack #124301 -> #127824 -> #127823 was checked at each base/head pair. It moves and redesigns the surrounding composer but preserves the prefill selector, `1200ms` duration, `30%` hold, and `1_200` timer byte-for-byte. This PR will likely conflict textually with #124301 in `ui/src/styles/chat/layout.css`; the semantic resolution is to retain this PR's `600ms` / `20%` values and lifecycle `600` timer when the stack is reconciled.

Production LOC: `+3/-3` (net 0) | Tests: `+13/-7`

AI-assisted: implementation, regression proof, and review were completed with an AI coding agent under operator direction.
