### PR TITLE
fix(ui): keep loading and panel motion within duration budget

### DIFF
--- a/ui/src/e2e/chat-panel-reflow.e2e.test.ts
+++ b/ui/src/e2e/chat-panel-reflow.e2e.test.ts
@@ -137,6 +137,12 @@ suite.define(() => {
       const response = await page.goto(`${suite.server.baseUrl}chat`);
       expect(response?.status()).toBe(200);
       await expect.poll(() => page.locator(".chat-group").count()).toBe(historyMessageCount);
+      expect(
+        await page.locator(".chat-main").evaluate((element) => {
+          const style = getComputedStyle(element);
+          return `${style.transitionProperty} ${style.transitionDuration}`;
+        }),
+      ).toBe("flex 0.18s");
       await page.locator(".chat-thread").evaluate((element) => {
         element.scrollTop = Math.max(0, element.scrollHeight / 2);
       });

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -1863,7 +1863,13 @@ describe("sessions view", () => {
     );
     await Promise.resolve();
 
-    expect(container.querySelectorAll(".session-skeleton-row").length).toBeGreaterThan(0);
+    const skeletonRows = Array.from(container.querySelectorAll(".session-skeleton-row"));
+    expect(skeletonRows).toHaveLength(4);
+    expect(
+      skeletonRows.map(
+        (row) => row.querySelector<HTMLElement>(".session-skeleton")?.style.animationDelay,
+      ),
+    ).toEqual(["0ms", "60ms", "120ms", "180ms"]);
     expect(container.querySelector(".data-table-empty-cell")).toBeNull();
     expect(container.querySelector(".sessions-heading-facts")).toBeNull();
   });

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -571,7 +571,7 @@ function renderSkeletonRows(columnCount: number) {
             : html`<td>
                 <span
                   class="session-skeleton ${columnIndex === 1 ? "session-skeleton--key" : ""}"
-                  style=${`animation-delay: ${rowIndex * 120}ms`}
+                  style=${`animation-delay: ${rowIndex * 60}ms`}
                 ></span>
               </td>`,
         )}

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -51,7 +51,7 @@
   flex-direction: column;
   overflow: hidden;
   /* Smooth transition when sidebar opens/closes */
-  transition: flex 250ms ease-out;
+  transition: flex 180ms ease-out;
   flex: 1 1 0;
 }
 


### PR DESCRIPTION
Closes #128669

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where users loading the Sessions page or opening a chat side panel would see decorative and structural motion exceed the Control UI duration budget. The fourth skeleton row waited 360ms to begin, while the chat transcript reflow transition lasted 250ms.

## Why This Change Was Made

The Sessions owner now staggers rows by 60ms, keeping all four rows inside a 180ms band. The chat layout owner caps the existing flex transition at 180ms. The new-session Start spinner remains at 2.25s because #126044 explicitly defines and tests that period.

This is phase one for the sidebar transition: it reduces unavoidable reflow without changing geometry. Named follow-up: move the side-panel transition to transform-only geometry so opening and closing it no longer reflows the transcript on every frame.

## User Impact

Sessions loading choreography completes sooner, and opening or closing chat side panels settles 70ms faster while preserving the same layout, content, and reduced-motion behavior.

## Evidence

### Reproduction

On `b431a2300bd05b0937cead1b4731340eb4233e41`:

- Sessions regression failed with `0ms, 120ms, 240ms, 360ms`; this branch passes with `0ms, 60ms, 120ms, 180ms`.
- Chat regression failed with computed `flex 0.25s`; this branch passes with `flex 0.18s`.

### Visual Proof

Recorded with Playwright `recordVideo` against isolated source-mode mock dev servers. Before uses current `origin/main` (`1bca825105e5d332939ac8966a8dba54f1412fc2`); after uses PR head (`089af7faf7dca8e5d39d19b430f95a7cfbcb4b89`). Every video was inspected through distributed-frame contact sheets plus its asserted-state screenshot.

**Sessions skeleton, before:** the player shows the real Sessions loading renderer and computed row delays `0s · 0.12s · 0.24s · 0.36s`.

https://github.com/user-attachments/assets/5457a4f0-f8ea-49a4-bdd8-1241ca999685

**Sessions skeleton, after:** the same mock state shows `0s · 0.06s · 0.12s · 0.18s`.

https://github.com/user-attachments/assets/ce76b5fd-c80c-4f1e-babc-e3ec4216d860

**Chat side panel, before:** the player shows opening, closing, and reopening Tasks with computed `.chat-main` transition `flex 0.25s`.

https://github.com/user-attachments/assets/b308c98f-4cad-481e-8d27-42f292dd2fde

**Chat side panel, after:** the same flow shows `flex 0.18s`; transcript content remains visible throughout.

https://github.com/user-attachments/assets/69734cc0-be2a-44bd-b95e-658856a6d1b5

### Validation

- `node scripts/run-vitest.mjs ui/src/pages/sessions/view.test.ts` - 52 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-panel-reflow.e2e.test.ts` - 1 passed.
- `node scripts/check-changed.mjs -- ui/src/e2e/chat-panel-reflow.e2e.test.ts ui/src/pages/sessions/view.test.ts ui/src/pages/sessions/view.ts ui/src/styles/chat/sidebar.css` - passed.
- `pnpm ui:build` - passed; 952 finalized Control UI sidecars verified.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` - clean, no accepted/actionable findings.
- `git diff --check` - passed.

Full `pnpm build` generated all bundles but its root postbuild could not resolve a newly added `@openclaw/ai/internal/runtime` export through this worktree's required root `node_modules` symlink. The export exists in this worktree's generated `packages/ai/dist`; the affected code is outside this PR. The surface-specific Control UI build is green.

### Architecture And Scope

- Owners: `ui/src/pages/sessions/view.ts` and `ui/src/styles/chat/sidebar.css`.
- Callers checked: Sessions route/list snapshot flow and chat side-panel layout projection.
- Siblings checked: generic skeleton, session pulse reduced-motion override, shell navigation transitions, mobile drawer behavior, and new-session spinner contract.
- Production LOC: +2/-2 (net 0). Tests: +13/-1.
