### PR TITLE
fix(usage): preserve Claude CLI usage credentials

### DIFF
--- a/src/infra/provider-usage.auth.plugin.test.ts
+++ b/src/infra/provider-usage.auth.plugin.test.ts
@@ -44,6 +44,12 @@ vi.mock("../plugins/manifest-contract-eligibility.js", () => ({
   loadManifestMetadataSnapshot: () => ({
     plugins: [
       {
+        id: "anthropic",
+        origin: "bundled",
+        providers: ["anthropic"],
+        syntheticAuthRefs: ["claude-cli"],
+      },
+      {
         id: "minimax",
         origin: "bundled",
         providers: ["minimax", "minimax-portal"],
@@ -291,6 +297,73 @@ describe("resolveProviderAuths plugin boundary", () => {
     expect(resolveProviderUsageAuthWithPluginMock).toHaveBeenCalledTimes(1);
     expect(providerCalls(resolveProviderUsageAuthWithPluginMock)).toEqual(["anthropic"]);
     expect(ensureAuthProfileStoreMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps usage auth when an owned synthetic auth ref has OAuth credentials", async () => {
+    const store = {
+      profiles: {
+        "claude-cli:default": {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "claude-cli-access",
+          refresh: "claude-cli-refresh",
+          expires: Date.now() + 3_600_000,
+          subscriptionType: "max",
+          rateLimitTier: "default_max_20x",
+        },
+      },
+    };
+    hasAnyAuthProfileStoreSourceMock.mockReturnValue(true);
+    ensureAuthProfileStoreWithoutExternalProfilesMock.mockReturnValue(store as never);
+    ensureAuthProfileStoreMock.mockReturnValue(store as never);
+    resolveAuthProfileOrderMock.mockImplementation((params: unknown) => {
+      const provider =
+        params && typeof params === "object" && "provider" in params
+          ? (params as { provider?: unknown }).provider
+          : undefined;
+      return provider === "claude-cli" ? ["claude-cli:default"] : [];
+    });
+    resolveApiKeyForProfileMock.mockResolvedValue({
+      apiKey: "claude-cli-access",
+      provider: "claude-cli",
+    });
+    resolveProviderUsageAuthWithPluginMock.mockImplementationOnce(async (rawParams) => {
+      const params = rawParams as {
+        context: {
+          resolveOAuthToken: (options?: { provider?: string }) => Promise<{
+            token: string;
+            subscriptionType?: string;
+            rateLimitTier?: string;
+          } | null>;
+        };
+      };
+      return (
+        (await params.context.resolveOAuthToken()) ??
+        (await params.context.resolveOAuthToken({ provider: "claude-cli" }))
+      );
+    });
+
+    await expect(
+      resolveProviderAuthsForTest({
+        providers: ["anthropic"],
+        agentDir: "/tmp/openclaw-agent",
+        env: {},
+      }),
+    ).resolves.toEqual([
+      {
+        provider: "anthropic",
+        token: "claude-cli-access",
+        subscriptionType: "max",
+        rateLimitTier: "default_max_20x",
+      },
+    ]);
+    expect(providerCalls(resolveProviderUsageAuthWithPluginMock)).toEqual(["anthropic"]);
+    expect(resolveApiKeyForProfileMock).toHaveBeenCalledWith({
+      cfg: {},
+      store,
+      profileId: "claude-cli:default",
+      agentDir: "/tmp/openclaw-agent",
+    });
   });
 
   it("keeps plugin usage auth when an owned alias provider has auth-profile credentials", async () => {

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -283,7 +283,11 @@ function resolveUsageCredentialProviderIds(params: {
       if (!isUsageProviderManifestEligible({ plugin, state: params.state })) {
         continue;
       }
-      for (const providerId of pluginProviderIds) {
+      const credentialProviderIds = normalizeProviderIds([
+        ...pluginProviderIds,
+        ...(plugin.syntheticAuthRefs ?? []),
+      ]);
+      for (const providerId of credentialProviderIds) {
         providerIds.add(providerId);
       }
     }


### PR DESCRIPTION
Related: #128639

## What Problem This Solves

The provider-usage credential-source gate only considered a usage plugin's declared provider IDs. Anthropic owns `anthropic` usage, but its existing Claude Code subscription fallback reads the synthetic `claude-cli` OAuth profile. A Claude CLI-only setup was therefore rejected before the Anthropic usage hook could run, making subscription usage disappear from status surfaces.

## Why This Change Was Made

Once a manifest has matched the requested usage provider and passed the existing eligibility policy, include that owner's declared `syntheticAuthRefs` in the credential-source candidates. This keeps the repair generic at the manifest/auth-discovery boundary while limiting the extra candidates to the already-selected usage owner; it adds no provider special case, config surface, or network fallback.

## User Impact

Users authenticated only through Claude Code CLI can see their Anthropic subscription usage again in `/status`, `openclaw status --usage`, model auth status, and the Control UI. Other providers still skip plugin runtime loading when no declared credential source exists.

## Evidence

- RED on current `main`: the new OAuth-only `claude-cli` profile regression was the sole failure in `src/infra/provider-usage.auth.plugin.test.ts` (12 passed, 1 failed); the Anthropic usage hook was never admitted and the result was `[]`.
- GREEN on this head: `node scripts/run-vitest.mjs src/infra/provider-usage.auth.plugin.test.ts` (13/13).
- Caller and sibling coverage: Node 24 grouped proof across the owner gate, Anthropic usage hook, usage loaders, Gateway models-auth-status, and usage cache (3 shards, 134/134).
- Focused `run-oxlint --openclaw-focused-config`: 0 warnings, 0 errors; `oxfmt` and `git diff --check` passed.
- Fresh autoreview: no findings, patch correct, confidence 0.98.
- The committed test exercises the production credential-source gate and plugin auth context with a future-expiry synthetic OAuth profile. It does not claim a live Anthropic API call. A broader actual bundled-plugin loader harness remained in cold plugin load for 330 seconds and was stopped; no temporary harness files remain.
- Full type-aware lint was blocked before the touched files by the unrelated plugin-SDK boundary declaration build timing out after 300 seconds. Testbox/Crabbox is not provisioned on this host.
- Current upstream has a separate frozen-lockfile regression from #128414; canonical dependency-only repair #128671 should land before treating install-stage CI failures on this PR as source failures.
