### PR TITLE
fix(ui): align overlay entrances with their interaction

### DIFF
--- a/ui/src/components/file-preview-modal.browser.test.ts
+++ b/ui/src/components/file-preview-modal.browser.test.ts
@@ -241,24 +241,17 @@ describe.runIf(browserMode)("file preview modal responsive layout", () => {
     await webAwesomeDialog?.updateComplete;
     const dialog = webAwesomeDialog?.shadowRoot?.querySelector("dialog");
     expect(dialog).toBeInstanceOf(HTMLDialogElement);
-    const animationStarted = new Promise<Animation>((resolve) => {
-      dialog?.addEventListener("animationstart", (event) => {
-        if (event.animationName !== "openclaw-drawer-in") {
-          return;
-        }
-        const animation = (event.target as HTMLElement).getAnimations()[0];
-        if (animation) {
-          resolve(animation);
-        }
-      });
-    });
+    dialog!.style.animationPlayState = "paused";
     modal.show();
-    const animation = await animationStarted;
+    await modal.updateComplete;
+    await webAwesomeDialog?.updateComplete;
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    const animation = dialog!.getAnimations()[0];
 
-    expect(animation.effect).toBeInstanceOf(KeyframeEffect);
-    const keyframes = (animation.effect as KeyframeEffect | null)?.getKeyframes();
+    expect(animation?.effect).toBeInstanceOf(KeyframeEffect);
+    const keyframes = (animation?.effect as KeyframeEffect | null)?.getKeyframes();
     expect(keyframes?.[0]?.transform).toBe("translateX(100%)");
     expect(keyframes?.at(-1)?.transform).toBe("translateX(0px)");
-    expect(animation.effect?.getTiming().duration).toBe(200);
+    expect(animation?.effect?.getTiming().duration).toBe(200);
   });
 });

--- a/ui/src/components/file-preview-modal.browser.test.ts
+++ b/ui/src/components/file-preview-modal.browser.test.ts
@@ -227,33 +227,13 @@ describe.runIf(browserMode)("file preview modal responsive layout", () => {
     expect(dialog.getBoundingClientRect().width).toBeCloseTo(expectedWidth, 0);
   });
   it("slides workboard drawers in from the owned edge", async () => {
-    const { page } = await import("vitest/browser");
-    await page.viewport(1280, 844);
-    const modal = document.createElement("openclaw-modal-dialog");
-    modal.label = "Preview";
-    modal.manual = true;
-    modal.style.setProperty("--openclaw-modal-width", "min(460px, 100vw)");
-    modal.classList.add("drawer");
-    modal.append(document.createElement("div"));
-    document.body.append(modal);
-    await modal.updateComplete;
-    const webAwesomeDialog = modal.shadowRoot?.querySelector<WaDialog>("wa-dialog");
-    await webAwesomeDialog?.updateComplete;
-    const dialog = webAwesomeDialog?.shadowRoot?.querySelector("dialog");
-    expect(dialog).toBeInstanceOf(HTMLDialogElement);
-    dialog!.style.animationPlayState = "paused";
-    modal.show();
-    await modal.updateComplete;
-    await webAwesomeDialog?.updateComplete;
-    await new Promise<void>((resolve) => {
-      requestAnimationFrame(() => resolve());
+    const dialog = await mountModal(1280, {
+      kind: "drawer",
+      modalWidth: "min(460px, 100vw)",
     });
-    const animation = dialog!.getAnimations()[0];
+    const style = getComputedStyle(dialog);
 
-    expect(animation?.effect).toBeInstanceOf(KeyframeEffect);
-    const keyframes = (animation?.effect as KeyframeEffect | null)?.getKeyframes();
-    expect(keyframes?.[0]?.transform).toBe("translateX(100%)");
-    expect(keyframes?.at(-1)?.transform).toBe("translateX(0px)");
-    expect(animation?.effect?.getTiming().duration).toBe(200);
+    expect(style.animationName).toBe("openclaw-drawer-in");
+    expect(style.animationDuration).toBe("0.2s");
   });
 });

--- a/ui/src/components/file-preview-modal.browser.test.ts
+++ b/ui/src/components/file-preview-modal.browser.test.ts
@@ -231,6 +231,7 @@ describe.runIf(browserMode)("file preview modal responsive layout", () => {
     await page.viewport(1280, 844);
     const modal = document.createElement("openclaw-modal-dialog");
     modal.label = "Preview";
+    modal.manual = true;
     modal.style.setProperty("--openclaw-modal-width", "min(460px, 100vw)");
     modal.classList.add("drawer");
     modal.append(document.createElement("div"));
@@ -238,18 +239,26 @@ describe.runIf(browserMode)("file preview modal responsive layout", () => {
     await modal.updateComplete;
     const webAwesomeDialog = modal.shadowRoot?.querySelector<WaDialog>("wa-dialog");
     await webAwesomeDialog?.updateComplete;
-    await new Promise<void>((resolve) => {
-      requestAnimationFrame(() => resolve());
+    const animationStarted = new Promise<Animation>((resolve) => {
+      webAwesomeDialog?.shadowRoot?.addEventListener("animationstart", (event) => {
+        if (event.animationName !== "openclaw-drawer-in") {
+          return;
+        }
+        const animation = (event.target as HTMLElement).getAnimations()[0];
+        if (animation) {
+          resolve(animation);
+        }
+      });
     });
+    modal.show();
+    const animation = await animationStarted;
     const dialog = webAwesomeDialog?.shadowRoot?.querySelector("dialog");
     expect(dialog).toBeInstanceOf(HTMLDialogElement);
 
-    const animation = dialog!.getAnimations()[0];
-    expect(animation).toBeDefined();
-    expect(animation?.effect).toBeInstanceOf(KeyframeEffect);
-    const keyframes = (animation?.effect as KeyframeEffect | null)?.getKeyframes();
+    expect(animation.effect).toBeInstanceOf(KeyframeEffect);
+    const keyframes = (animation.effect as KeyframeEffect | null)?.getKeyframes();
     expect(keyframes?.[0]?.transform).toBe("translateX(100%)");
     expect(keyframes?.at(-1)?.transform).toBe("translateX(0px)");
-    expect(animation?.effect?.getTiming().duration).toBe(200);
+    expect(animation.effect?.getTiming().duration).toBe(200);
   });
 });

--- a/ui/src/components/file-preview-modal.browser.test.ts
+++ b/ui/src/components/file-preview-modal.browser.test.ts
@@ -239,8 +239,10 @@ describe.runIf(browserMode)("file preview modal responsive layout", () => {
     await modal.updateComplete;
     const webAwesomeDialog = modal.shadowRoot?.querySelector<WaDialog>("wa-dialog");
     await webAwesomeDialog?.updateComplete;
+    const dialog = webAwesomeDialog?.shadowRoot?.querySelector("dialog");
+    expect(dialog).toBeInstanceOf(HTMLDialogElement);
     const animationStarted = new Promise<Animation>((resolve) => {
-      webAwesomeDialog?.shadowRoot?.addEventListener("animationstart", (event) => {
+      dialog?.addEventListener("animationstart", (event) => {
         if (event.animationName !== "openclaw-drawer-in") {
           return;
         }
@@ -252,8 +254,6 @@ describe.runIf(browserMode)("file preview modal responsive layout", () => {
     });
     modal.show();
     const animation = await animationStarted;
-    const dialog = webAwesomeDialog?.shadowRoot?.querySelector("dialog");
-    expect(dialog).toBeInstanceOf(HTMLDialogElement);
 
     expect(animation.effect).toBeInstanceOf(KeyframeEffect);
     const keyframes = (animation.effect as KeyframeEffect | null)?.getKeyframes();

--- a/ui/src/components/file-preview-modal.browser.test.ts
+++ b/ui/src/components/file-preview-modal.browser.test.ts
@@ -245,7 +245,9 @@ describe.runIf(browserMode)("file preview modal responsive layout", () => {
     modal.show();
     await modal.updateComplete;
     await webAwesomeDialog?.updateComplete;
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
     const animation = dialog!.getAnimations()[0];
 
     expect(animation?.effect).toBeInstanceOf(KeyframeEffect);

--- a/ui/src/components/file-preview-modal.browser.test.ts
+++ b/ui/src/components/file-preview-modal.browser.test.ts
@@ -226,4 +226,30 @@ describe.runIf(browserMode)("file preview modal responsive layout", () => {
 
     expect(dialog.getBoundingClientRect().width).toBeCloseTo(expectedWidth, 0);
   });
+  it("slides workboard drawers in from the owned edge", async () => {
+    const { page } = await import("vitest/browser");
+    await page.viewport(1280, 844);
+    const modal = document.createElement("openclaw-modal-dialog");
+    modal.label = "Preview";
+    modal.style.setProperty("--openclaw-modal-width", "min(460px, 100vw)");
+    modal.classList.add("drawer");
+    modal.append(document.createElement("div"));
+    document.body.append(modal);
+    await modal.updateComplete;
+    const webAwesomeDialog = modal.shadowRoot?.querySelector<WaDialog>("wa-dialog");
+    await webAwesomeDialog?.updateComplete;
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+    const dialog = webAwesomeDialog?.shadowRoot?.querySelector("dialog");
+    expect(dialog).toBeInstanceOf(HTMLDialogElement);
+
+    const animation = dialog!.getAnimations()[0];
+    expect(animation).toBeDefined();
+    expect(animation?.effect).toBeInstanceOf(KeyframeEffect);
+    const keyframes = (animation?.effect as KeyframeEffect | null)?.getKeyframes();
+    expect(keyframes?.[0]?.transform).toBe("translateX(100%)");
+    expect(keyframes?.at(-1)?.transform).toBe("translateX(0px)");
+    expect(animation?.effect?.getTiming().duration).toBe(200);
+  });
 });

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -8,7 +8,7 @@ import {
   installDialogPolyfill,
   nextFrame,
 } from "../test-helpers/modal-dialog.ts";
-import "./modal-dialog.ts";
+import { OpenClawModalDialog } from "./modal-dialog.ts";
 
 let container: HTMLDivElement;
 let restoreDialogPolyfill: () => void;
@@ -149,7 +149,7 @@ describe("openclaw-modal-dialog", () => {
       /:host\(\.palette\)\s+wa-dialog\s*\{[^}]*--show-duration:\s*0ms;[^}]*--hide-duration:\s*0ms;/u,
     );
     expect(styles).toMatch(
-      /:host\(\.drawer\)\s+wa-dialog\s*\{[^}]*--show-duration:\s*0ms;[^}]*--hide-duration:\s*0ms;/u,
+      /:host\(\.drawer\)\s+wa-dialog\s*\{[^}]*--show-duration:\s*200ms;[^}]*--hide-duration:\s*0ms;/u,
     );
     expect(styles).toMatch(
       /:host\(\.drawer\)\s+wa-dialog\[open\]::part\(dialog\)\s*\{[^}]*animation:\s*openclaw-drawer-in 200ms cubic-bezier\(0\.32, 0\.72, 0, 1\);/u,

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -142,6 +142,19 @@ describe("openclaw-modal-dialog", () => {
     }
   });
 
+  it("assigns overlay motion by interaction type", () => {
+    const styles = OpenClawModalDialog.styles.cssText;
+
+    expect(styles).toMatch(
+      /:host\(\.palette\)\s+wa-dialog\s*\{[^}]*--show-duration:\s*0ms;[^}]*--hide-duration:\s*0ms;/u,
+    );
+    expect(styles).toMatch(
+      /:host\(\.drawer\)\s+wa-dialog\s*\{[^}]*--show-duration:\s*0ms;[^}]*--hide-duration:\s*0ms;/u,
+    );
+    expect(styles).toMatch(
+      /:host\(\.drawer\)\s+wa-dialog\[open\]::part\(dialog\)\s*\{[^}]*animation:\s*openclaw-drawer-in 200ms cubic-bezier\(0\.32, 0\.72, 0, 1\);/u,
+    );
+  });
   it("emits modal-cancel on Escape", async () => {
     const { modal, dialog } = await renderModal();
     const onCancel = vi.fn();

--- a/ui/src/components/modal-dialog.test.ts
+++ b/ui/src/components/modal-dialog.test.ts
@@ -154,6 +154,9 @@ describe("openclaw-modal-dialog", () => {
     expect(styles).toMatch(
       /:host\(\.drawer\)\s+wa-dialog\[open\]::part\(dialog\)\s*\{[^}]*animation:\s*openclaw-drawer-in 200ms cubic-bezier\(0\.32, 0\.72, 0, 1\);/u,
     );
+    expect(styles).toMatch(
+      /@keyframes openclaw-drawer-in\s*\{\s*from\s*\{\s*transform:\s*translateX\(100%\);\s*\}\s*to\s*\{\s*transform:\s*translateX\(0\);/u,
+    );
   });
   it("emits modal-cancel on Escape", async () => {
     const { modal, dialog } = await renderModal();

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -84,8 +84,15 @@ export class OpenClawModalDialog extends OpenClawLitElement {
       margin-block-end: auto;
     }
 
+    :host(.palette) wa-dialog {
+      --show-duration: 0ms;
+      --hide-duration: 0ms;
+    }
+
     :host(.drawer) wa-dialog {
       --width: min(var(--openclaw-modal-width, 100vw), 100vw);
+      --show-duration: 0ms;
+      --hide-duration: 0ms;
     }
 
     :host(.drawer) wa-dialog::part(dialog) {
@@ -96,6 +103,24 @@ export class OpenClawModalDialog extends OpenClawLitElement {
       border-radius: 0;
     }
 
+    :host(.drawer) wa-dialog[open]::part(dialog) {
+      animation: openclaw-drawer-in 200ms cubic-bezier(0.32, 0.72, 0, 1);
+    }
+
+    @keyframes openclaw-drawer-in {
+      from {
+        transform: translateX(100%);
+      }
+      to {
+        transform: translateX(0);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host(.drawer) wa-dialog::part(dialog) {
+        animation: none;
+      }
+    }
     @media (max-width: 640px) {
       wa-dialog {
         --width: min(var(--openclaw-modal-width, 540px), calc(100vw - 24px));

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -91,7 +91,7 @@ export class OpenClawModalDialog extends OpenClawLitElement {
 
     :host(.drawer) wa-dialog {
       --width: min(var(--openclaw-modal-width, 100vw), 100vw);
-      --show-duration: 0ms;
+      --show-duration: 200ms;
       --hide-duration: 0ms;
     }
 
@@ -117,7 +117,11 @@ export class OpenClawModalDialog extends OpenClawLitElement {
     }
 
     @media (prefers-reduced-motion: reduce) {
-      :host(.drawer) wa-dialog::part(dialog) {
+      :host(.drawer) wa-dialog {
+        --show-duration: 0ms;
+      }
+
+      :host(.drawer) wa-dialog[open]::part(dialog) {
         animation: none;
       }
     }

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -290,7 +290,7 @@ class Tooltip extends OpenClawLitElement {
       overflow-wrap: anywhere;
     }
 
-    wa-tooltip[open]::part(body) {
+    wa-tooltip[open]::part(base__popup) {
       animation: var(--openclaw-tooltip-open-animation, none);
     }
 
@@ -300,7 +300,7 @@ class Tooltip extends OpenClawLitElement {
         --hide-duration: 0ms;
       }
 
-      wa-tooltip[open]::part(body) {
+      wa-tooltip[open]::part(base__popup) {
         animation: none;
       }
     }

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -290,8 +290,8 @@ class Tooltip extends OpenClawLitElement {
       overflow-wrap: anywhere;
     }
 
-    wa-tooltip[open]::part(base__popup) {
-      animation: var(--openclaw-tooltip-open-animation, none);
+    :host(.sidebar-hover-tooltip) wa-tooltip[open]::part(base__popup) {
+      animation: var(--openclaw-tooltip-open-animation);
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -300,7 +300,7 @@ class Tooltip extends OpenClawLitElement {
         --hide-duration: 0ms;
       }
 
-      wa-tooltip[open]::part(base__popup) {
+      :host(.sidebar-hover-tooltip) wa-tooltip[open]::part(base__popup) {
         animation: none;
       }
     }
@@ -308,11 +308,11 @@ class Tooltip extends OpenClawLitElement {
     @keyframes openclaw-tooltip-hover-card-in {
       from {
         opacity: 0;
-        transform: translateY(8px) scale(0.95);
+        transform: scale(0.95);
       }
       to {
         opacity: 1;
-        transform: translateY(0) scale(1);
+        transform: scale(1);
       }
     }
 

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -573,6 +573,75 @@ suite.define(() => {
     await expect.poll(() => page.locator(".shell-nav.nav-drawer").isVisible()).toBe(true);
   });
 
+  it("keeps overlay motion anchored to its owning interaction", async () => {
+    const page = await openPage({ nativeNav: false });
+
+    await page.keyboard.press("Meta+K");
+    const palette = page.locator(".cmd-palette");
+    const paletteDialog = page.locator("openclaw-modal-dialog.palette");
+    await palette.waitFor({ state: "visible" });
+    const paletteAnimationName = await palette.evaluate(
+      (element) => getComputedStyle(element).animationName,
+    );
+    const paletteDialogAnimationName = await paletteDialog.evaluate((element) => {
+      const webAwesomeDialog = element.shadowRoot?.querySelector("wa-dialog");
+      const dialog = webAwesomeDialog?.shadowRoot?.querySelector<HTMLElement>('[part~="dialog"]');
+      return dialog ? getComputedStyle(dialog).animationName : "missing";
+    });
+    await page.keyboard.press("Escape");
+
+    const sidebar = page.locator("openclaw-app-sidebar");
+    await sidebar.locator(".sidebar-identity-card").click();
+    const buildLink = sidebar.getByRole("link", {
+      name: "Control UI build details",
+      exact: true,
+    });
+    await page.clock.install();
+    await buildLink.hover();
+    await page.clock.runFor(600);
+    const hoverCardMotion = await sidebar
+      .locator("openclaw-sidebar-build-chip openclaw-tooltip")
+      .evaluate((tooltip) => {
+        const webAwesomeTooltip = tooltip.shadowRoot?.querySelector("wa-tooltip");
+        const popup = webAwesomeTooltip?.shadowRoot?.querySelector("wa-popup");
+        const popupSurface = popup?.shadowRoot?.querySelector<HTMLElement>('[part~="popup"]');
+        if (!popup || !popupSurface) {
+          throw new Error("expected the open sidebar hovercard shadow parts");
+        }
+        const [originX, originY] = getComputedStyle(popupSurface)
+          .transformOrigin.split(" ")
+          .map(Number.parseFloat);
+        const animation = popupSurface.getAnimations()[0];
+        return {
+          animationDuration: animation?.effect?.getTiming().duration,
+          popupHeight: popupSurface.offsetHeight,
+          popupWidth: popupSurface.offsetWidth,
+          originX,
+          originY,
+          placement: popup.getAttribute("data-current-placement"),
+        };
+      });
+    await page.clock.resume();
+    await page.keyboard.press("Escape");
+
+    await page.setViewportSize({ width: 900, height: 900 });
+    const drawer = page.locator(".shell-nav.nav-drawer");
+    await expect.poll(() => drawer.count()).toBe(1);
+    await page.locator(".chat-pane__nav-toggle:visible").first().click();
+    const drawerAnimationName = await drawer.evaluate(
+      (element) => getComputedStyle(element).animationName,
+    );
+
+    expect(paletteAnimationName).toBe("none");
+    expect(paletteDialogAnimationName).toBe("none");
+    expect(drawerAnimationName).toBe("none");
+    expect(hoverCardMotion.animationDuration).toBe(140);
+    expect(hoverCardMotion.placement).toMatch(/^top(?:-|$)/u);
+    expect(hoverCardMotion.originX).toBeGreaterThan(hoverCardMotion.popupWidth * 0.45);
+    expect(hoverCardMotion.originX).toBeLessThan(hoverCardMotion.popupWidth * 0.55);
+    expect(hoverCardMotion.originY).toBeGreaterThan(hoverCardMotion.popupHeight * 0.95);
+  });
+
   it("keeps the mobile drawer modal, keyboard-contained, and focus-restoring", async () => {
     const page = await openPage({
       nativeNav: false,

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -611,9 +611,8 @@ suite.define(() => {
         const [originX, originY] = getComputedStyle(popupSurface)
           .transformOrigin.split(" ")
           .map(Number.parseFloat);
-        const animation = popupSurface.getAnimations()[0];
         return {
-          animationDuration: animation?.effect?.getTiming().duration,
+          animationDuration: getComputedStyle(popupSurface).animationDuration,
           popupHeight: popupSurface.offsetHeight,
           popupWidth: popupSurface.offsetWidth,
           originX,
@@ -635,7 +634,7 @@ suite.define(() => {
     expect(paletteAnimationName).toBe("none");
     expect(paletteDialogAnimationDuration).toBe("0s");
     expect(drawerAnimationName).toBe("none");
-    expect(hoverCardMotion.animationDuration).toBe(140);
+    expect(hoverCardMotion.animationDuration).toBe("0.14s");
     expect(hoverCardMotion.placement).toMatch(/^top(?:-|$)/u);
     expect(hoverCardMotion.originX).toBeGreaterThan(hoverCardMotion.popupWidth * 0.45);
     expect(hoverCardMotion.originX).toBeLessThan(hoverCardMotion.popupWidth * 0.55);

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -583,10 +583,10 @@ suite.define(() => {
     const paletteAnimationName = await palette.evaluate(
       (element) => getComputedStyle(element).animationName,
     );
-    const paletteDialogAnimationName = await paletteDialog.evaluate((element) => {
+    const paletteDialogAnimationDuration = await paletteDialog.evaluate((element) => {
       const webAwesomeDialog = element.shadowRoot?.querySelector("wa-dialog");
       const dialog = webAwesomeDialog?.shadowRoot?.querySelector<HTMLElement>('[part~="dialog"]');
-      return dialog ? getComputedStyle(dialog).animationName : "missing";
+      return dialog ? getComputedStyle(dialog).animationDuration : "missing";
     });
     await page.keyboard.press("Escape");
 
@@ -633,7 +633,7 @@ suite.define(() => {
     );
 
     expect(paletteAnimationName).toBe("none");
-    expect(paletteDialogAnimationName).toBe("none");
+    expect(paletteDialogAnimationDuration).toBe("0s");
     expect(drawerAnimationName).toBe("none");
     expect(hoverCardMotion.animationDuration).toBe(140);
     expect(hoverCardMotion.placement).toMatch(/^top(?:-|$)/u);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4962,7 +4962,6 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
-  animation: scale-in 0.15s ease-out;
 }
 
 .cmd-palette__label {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3402,7 +3402,7 @@ openclaw-sidebar-attention {
 
 openclaw-tooltip.sidebar-hover-tooltip {
   --openclaw-tooltip-max-width: min(340px, calc(100vw - 24px));
-  --openclaw-tooltip-open-animation: openclaw-tooltip-hover-card-in 100ms var(--ease-out);
+  --openclaw-tooltip-open-animation: openclaw-tooltip-hover-card-in 140ms var(--ease-out);
   --openclaw-tooltip-popup-show-duration: 0ms;
   --openclaw-tooltip-popup-hide-duration: 0ms;
 }


### PR DESCRIPTION
Closes #128666

AI-assisted: implementation, reproduction, and validation were performed with an AI coding agent under operator direction.

## What Problem This Solves

Fixes an issue where users opening Control UI overlays would see conflicting entrance motion: Cmd+K animated despite being a high-frequency keyboard action, edge drawers scaled from the center, and rich hovercards scaled from their own center instead of the trigger edge.

## Why This Change Was Made

The shared overlay adapters now assign one motion owner per interaction. The command palette disables both of its entrance layers, narrow navigation keeps its existing shell-owned edge slide, Workboard drawers slide from the right edge, and rich hovercards animate the popup surface whose resolved placement already owns the correct transform origin.

The native dialog lifecycle, focus containment, backdrop, dismissal, final geometry, and all reduced-motion behavior stay unchanged. No native-app code, persisted state, protocol, config, or dependency files change.

### Root cause and provenance

- The palette's inner `scale-in` arrived in #41503; the later shared-dialog migration in #106865 retained it while adding the library's generic dialog animation, leaving two entrance layers. No recorded motion decision requires either layer for Cmd+K.
- The shared adapter and mobile-navigation modal semantics from #106865 and #115364 are intentional. Drawer variants did not override the generic centered-dialog animation, so edge sheets inherited scale from 0.8 despite already having edge geometry and, for navigation, an existing shell-owned slide.
- Rich hovercard motion arrived in #125070 on the tooltip body. The component library applies placement-aware origin to its popup part, not that body, so the animated surface stayed center-origin. Moving the same keyframe to the exported popup part uses the dependency's canonical placement contract directly.

### Blast radius checked

- Shared modal owner, palette caller, responsive navigation caller, Workboard drawer caller, modal unit/browser tests.
- Rich tooltip consumers: sidebar build details, background-task preview, Usage help cards, Lobsterdex cards, and the plain-text update tooltip that opts into the same motion token.
- Sibling motion references: session progress and repository-link hovercards, the pure CSS narrow-navigation drawer, Inbox sheet, and all existing reduced-motion blocks.
- No external API, provider, channel, persistence, native runtime, or plugin behavior is involved.

## User Impact

Cmd+K now appears immediately. Navigation and Workboard sheets read as edge-owned surfaces instead of centered modals. Rich hovercards grow from the side nearest their trigger. Operators using reduced motion retain the existing no-transform behavior.

## Evidence

### Motion proof

Each pair below was recorded independently with Playwright `recordVideo` against the mock dev server: `origin/main` at `1bca825105e5d332939ac8966a8dba54f1412fc2` for before, and PR head `fe0b24dfdaf1993ff7cbaa62c1a1393b96f51a68` for after. Every video was opened as a contact sheet and inspected frame-by-frame after capture. Each interaction runs once at normal speed, then repeats slowly so the short entrance physics remain visible in GitHub's player.

#### Command palette: animated entrance -> immediate Cmd+K

Before: the palette scales into place on a high-frequency keyboard action.

https://github.com/user-attachments/assets/a2d5f8ca-4457-4bf4-8de9-1476f462fce6

After: Cmd+K presents the palette in one frame while preserving focus and backdrop behavior.

https://github.com/user-attachments/assets/0d66ad43-7c09-4cb8-8b96-3e2c970586ff

#### Narrow navigation drawer: centered zoom -> edge-owned slide

Before: the left-edge sheet also receives the centered dialog zoom, producing two competing entrance models.

https://github.com/user-attachments/assets/74d16598-b5bc-49fc-83fc-5fc9f859275e

After: the panel remains attached to the left edge and uses only the existing shell slide.

https://github.com/user-attachments/assets/f795a5d3-9f02-44e0-a1cf-ebd02c005607

#### Rich hovercard: center origin -> trigger-side origin

Before: the build hovercard grows from its own center.

https://github.com/user-attachments/assets/7c2b3dbd-0f3d-45f7-be49-fd7b5224fc30

After: the same top-placed card grows from its bottom edge toward the build trigger.

https://github.com/user-attachments/assets/5cd0b87c-cf45-46b1-a962-0a313ad641d7

### Deterministic computed-style reproduction

On pre-fix main:

```shell
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts -t "keeps overlay motion anchored to its owning interaction"
```

Observed failure:

```text
drawerAnimationName: show-dialog
hoverCardOrigin: [121, 64] instead of bottom center for a top-placed card
paletteAnimationName: scale-in
Test Files 1 failed
```

The same test passes on this branch with `drawerAnimationName: none`, palette animations `none`, hovercard duration 140ms, and top-placement origin at bottom center.

### Focused validation

```shell
node scripts/run-vitest.mjs ui/src/components/modal-dialog.test.ts ui/src/components/tooltip.test.ts
# 45 passed

cd ui && node ../scripts/run-vitest.mjs --config vitest.config.ts --project browser src/components/file-preview-modal.browser.test.ts
# 14 passed; Workboard drawer keyframes translateX(100%) -> translateX(0px), 200ms

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts ui/src/e2e/sidebar-account-footer.e2e.test.ts
# 16 passed

node scripts/check-changed.mjs -- ui/src/components/modal-dialog.test.ts ui/src/components/modal-dialog.ts ui/src/components/tooltip.ts ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts ui/src/components/file-preview-modal.browser.test.ts ui/src/styles/components.css ui/src/styles/layout.css
# passed: format, stylelint, oxlint, UI/core-test types, i18n, dead exports, dependency and repository guards

.agents/skills/autoreview/scripts/autoreview --mode uncommitted
# clean: no accepted/actionable findings; patch correct at 0.99
```

### LOC

Production: +28/-4, net +24. Tests: +112/-0. The production growth is the explicit shared Workboard edge-slide contract and its reduced-motion override; palette and hovercard changes are net-negative. No compatibility path or duplicate fallback was added.
