### PR TITLE
feat(cli): add skills update dry-run

### DIFF
--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -40,11 +40,13 @@ openclaw skills install @owner/<slug> --agent <id>
 openclaw skills install @owner/<slug> --global
 openclaw skills update @owner/<slug>
 openclaw skills update @owner/<slug> --force
+openclaw skills update @owner/<slug> --dry-run
 openclaw skills update @owner/<slug> --force-install
 openclaw skills update @owner/<slug> --acknowledge-clawhub-risk
 openclaw skills update @owner/<slug> --acknowledge-install-policy-warning
 openclaw skills update @owner/<slug> --global
 openclaw skills update --all
+openclaw skills update --all --dry-run --json
 openclaw skills update --all --agent <id>
 openclaw skills update --all --global
 openclaw skills verify @owner/<slug>
@@ -76,7 +78,9 @@ openclaw skills workshop reject <proposal-id> --reason "Not reusable"
 openclaw skills workshop quarantine <proposal-id> --reason "Needs security review"
 ```
 
-`search`, `update`, and `verify` use ClawHub directly. `install @owner/<slug>`
+`search`, `update`, and `verify` use ClawHub directly. `update --dry-run`
+only reads tracked install metadata and ClawHub release metadata; it does not
+download archives or write the workspace. `install @owner/<slug>`
 installs a native ClawHub skill. `install skills-sh:<owner>/<repo>/<slug>` asks
 ClawHub to resolve an external listing to its exact synchronized GitHub commit;
 OpenClaw does not download from skills.sh. These entries are shown as

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -209,6 +209,7 @@ publish and sync.
 | Install from a Git repository      | `openclaw skills install git:owner/repo@ref`           |
 | Install a local skill directory    | `openclaw skills install ./path/to/skill --as my-tool` |
 | Install for all local agents       | `openclaw skills install @owner/<slug> --global`       |
+| Preview workspace skill updates    | `openclaw skills update --all --dry-run --json`        |
 | Update all workspace skills        | `openclaw skills update --all`                         |
 | Update a shared managed skill      | `openclaw skills update @owner/<slug> --global`        |
 | Update all shared managed skills   | `openclaw skills update --all --global`                |
@@ -226,7 +227,9 @@ publish and sync.
     Git and local installs expect `SKILL.md` at the source root. The slug comes
     from `SKILL.md` frontmatter `name` when valid, then falls back to the
     directory or repository name. Use `--as <slug>` to override.
-    `openclaw skills update` tracks ClawHub installs only — reinstall Git or
+    `openclaw skills update --dry-run` checks ClawHub-tracked installs without
+    downloading or writing. `openclaw skills update` tracks ClawHub installs only
+    — reinstall Git or
     local sources to refresh them.
 
   </Accordion>

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -113,6 +113,7 @@ const mocks = vi.hoisted(() => {
       (_configForTest: unknown, _agentId: string) => "/tmp/workspace",
     ),
     searchSkillsFromClawHubMock: vi.fn(),
+    checkSkillsFromClawHubMock: vi.fn(),
     installSkillFromClawHubMock: vi.fn(),
     installSkillFromSourceMock: vi.fn(),
     updateSkillsFromClawHubMock: vi.fn(),
@@ -141,6 +142,7 @@ const {
   resolveConfiguredAgentIdMock,
   resolveAgentWorkspaceDirMock,
   searchSkillsFromClawHubMock,
+  checkSkillsFromClawHubMock,
   installSkillFromClawHubMock,
   installSkillFromSourceMock,
   updateSkillsFromClawHubMock,
@@ -287,6 +289,7 @@ vi.mock("../agents/agent-scope.js", () => ({
 
 vi.mock("../skills/lifecycle/clawhub.js", () => ({
   searchSkillsFromClawHub: (...args: unknown[]) => mocks.searchSkillsFromClawHubMock(...args),
+  checkSkillsFromClawHub: (...args: unknown[]) => mocks.checkSkillsFromClawHubMock(...args),
   installSkillFromClawHub: (...args: unknown[]) => mocks.installSkillFromClawHubMock(...args),
   updateSkillsFromClawHub: (...args: unknown[]) => mocks.updateSkillsFromClawHubMock(...args),
   readTrackedClawHubSkillSlugs: (...args: unknown[]) =>
@@ -357,6 +360,7 @@ describe("skills cli commands", () => {
     resolveConfiguredAgentIdMock.mockReset();
     resolveAgentWorkspaceDirMock.mockReset();
     searchSkillsFromClawHubMock.mockReset();
+    checkSkillsFromClawHubMock.mockReset();
     installSkillFromClawHubMock.mockReset();
     installSkillFromSourceMock.mockReset();
     updateSkillsFromClawHubMock.mockReset();
@@ -377,6 +381,7 @@ describe("skills cli commands", () => {
     resolveConfiguredAgentIdMock.mockImplementation((_config, agentId: string) => agentId);
     resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
     searchSkillsFromClawHubMock.mockResolvedValue([]);
+    checkSkillsFromClawHubMock.mockResolvedValue([]);
     installSkillFromClawHubMock.mockResolvedValue({
       ok: false,
       error: "install disabled in test",
@@ -947,6 +952,47 @@ describe("skills cli commands", () => {
     await expect(runCommand(args)).rejects.toThrow("__exit__:1");
     expect(runtimeErrors).toContain("Use either --global or --agent, not both.");
     expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
+  });
+
+  it("previews all tracked ClawHub skill updates without writing", async () => {
+    readTrackedClawHubSkillSlugsMock.mockResolvedValue(["calendar"]);
+    checkSkillsFromClawHubMock.mockResolvedValue([
+      {
+        ok: true,
+        slug: "calendar",
+        previousVersion: "1.2.2",
+        version: "1.2.3",
+        changed: true,
+      },
+    ]);
+
+    await runCommand(["skills", "update", "--all", "--dry-run", "--json"]);
+
+    expect(checkSkillsFromClawHubMock).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace",
+      slug: undefined,
+    });
+    expect(updateSkillsFromClawHubMock).not.toHaveBeenCalled();
+    expect(JSON.parse(runtimeStdout[0] ?? "")).toEqual({
+      results: [
+        {
+          ok: true,
+          slug: "calendar",
+          previousVersion: "1.2.2",
+          version: "1.2.3",
+          changed: true,
+        },
+      ],
+    });
+  });
+
+  it("prints an empty JSON result when no tracked skills are available", async () => {
+    readTrackedClawHubSkillSlugsMock.mockResolvedValue([]);
+
+    await runCommand(["skills", "--json", "update", "--all", "--dry-run"]);
+
+    expect(checkSkillsFromClawHubMock).not.toHaveBeenCalled();
+    expect(JSON.parse(runtimeStdout[0] ?? "")).toEqual({ results: [] });
   });
 
   it("updates all tracked ClawHub skills", async () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -28,6 +28,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveSkillStatusEntry, type SkillStatusReport } from "../skills/discovery/status.js";
 import {
+  checkSkillsFromClawHub,
   installSkillFromClawHub,
   readVerifiedClawHubSkillSourceUrl,
   readTrackedClawHubSkillSlugs,
@@ -112,7 +113,11 @@ function formatClawHubSearchText(value: string): string {
   return sanitizeForLog(value.replace(/\s+/gu, " ")).trim();
 }
 
-function isClawHubSkillBlockedCliFailure(result: { code?: string; warning?: string }): boolean {
+function isClawHubSkillBlockedCliFailure(result: {
+  code?: string;
+  warning?: string;
+  error?: string;
+}): boolean {
   return (
     result.code === CLAWHUB_TRUST_ERROR_CODE.CLAWHUB_DOWNLOAD_BLOCKED &&
     typeof result.warning === "string" &&
@@ -775,6 +780,8 @@ export function registerSkillsCli(program: Command) {
     .argument("[skill-ref]", "Single ClawHub skill ref (@owner/slug)")
     .option("--all", "Update all tracked ClawHub skills", false)
     .option("--force", "Replace installed skills even when they have local changes", false)
+    .option("--dry-run", "Check for updates without downloading or writing", false)
+    .option("--json", "Output dry-run results as JSON", false)
     .option(
       "--force-install",
       "Install a pending GitHub-backed skill before ClawHub scan completes",
@@ -798,6 +805,8 @@ export function registerSkillsCli(program: Command) {
         opts: {
           all?: boolean;
           force?: boolean;
+          dryRun?: boolean;
+          json?: boolean;
           forceInstall?: boolean;
           acknowledgeClawhubRisk?: boolean;
           acknowledgeClawHubRisk?: boolean;
@@ -818,51 +827,75 @@ export function registerSkillsCli(program: Command) {
             defaultRuntime.exit(1);
             return;
           }
+          const jsonOutput = hasJsonOutput(opts);
+          if (jsonOutput && !opts.dryRun) {
+            defaultRuntime.error("--json requires --dry-run.");
+            defaultRuntime.exit(1);
+            return;
+          }
           const target = resolveClawHubTargetWorkspace(command, opts);
           if (!target) {
             return;
           }
           const tracked = await readTrackedClawHubSkillSlugs(target.workspaceDir);
           if (opts.all && tracked.length === 0) {
-            defaultRuntime.log("No tracked ClawHub skills to update.");
+            if (opts.dryRun && jsonOutput) {
+              defaultRuntime.writeJson({ results: [] });
+            } else {
+              defaultRuntime.log(
+                opts.dryRun
+                  ? "No tracked ClawHub skills to check."
+                  : "No tracked ClawHub skills to update.",
+              );
+            }
             return;
           }
-          const results = await updateSkillsFromClawHub({
-            workspaceDir: target.workspaceDir,
-            slug,
-            ...(opts.force ? { force: true } : {}),
-            ...(opts.forceInstall ? { forceInstall: true } : {}),
-            ...resolveInstallPolicyWarningAcknowledgementCliOptions({
-              acknowledgeInstallPolicyWarning: opts.acknowledgeInstallPolicyWarning,
-            }),
-            ...resolveSkillClawHubRiskOptions(
-              opts.acknowledgeClawhubRisk === true || opts.acknowledgeClawHubRisk === true,
-              "updating",
-            ),
-            logger: {
-              info: (message) => defaultRuntime.log(message),
-              warn: (message) => defaultRuntime.log(formatSkillWarning(message)),
-            },
-            config: target.config,
-          });
-          let failed = false;
-          for (const result of results) {
-            if (!result.ok) {
-              failed = true;
-              if (result.code === "force_required") {
-                defaultRuntime.error(`${result.error} Re-run with --force to update it anyway.`);
-              } else if (!isClawHubSkillBlockedCliFailure(result)) {
-                defaultRuntime.error(result.error);
+          const results = opts.dryRun
+            ? await checkSkillsFromClawHub({
+                workspaceDir: target.workspaceDir,
+                slug,
+              })
+            : await updateSkillsFromClawHub({
+                workspaceDir: target.workspaceDir,
+                slug,
+                ...(opts.force ? { force: true } : {}),
+                ...(opts.forceInstall ? { forceInstall: true } : {}),
+                ...resolveInstallPolicyWarningAcknowledgementCliOptions({
+                  acknowledgeInstallPolicyWarning: opts.acknowledgeInstallPolicyWarning,
+                }),
+                ...resolveSkillClawHubRiskOptions(
+                  opts.acknowledgeClawhubRisk === true || opts.acknowledgeClawHubRisk === true,
+                  "updating",
+                ),
+                logger: {
+                  info: (message) => defaultRuntime.log(message),
+                  warn: (message) => defaultRuntime.log(formatSkillWarning(message)),
+                },
+                config: target.config,
+              });
+          const failed = results.some((result) => !result.ok);
+          if (opts.dryRun && jsonOutput) {
+            defaultRuntime.writeJson({ results });
+          } else {
+            for (const result of results) {
+              if (!result.ok) {
+                if ("code" in result && result.code === "force_required") {
+                  defaultRuntime.error(`${result.error} Re-run with --force to update it anyway.`);
+                } else if (!isClawHubSkillBlockedCliFailure(result)) {
+                  defaultRuntime.error(result.error);
+                }
+                continue;
               }
-              continue;
+              if (result.changed) {
+                defaultRuntime.log(
+                  opts.dryRun
+                    ? `Update available ${result.slug}: ${result.previousVersion ?? "unknown"} -> ${result.version}`
+                    : `Updated ${result.slug}: ${result.previousVersion ?? "unknown"} -> ${result.version}`,
+                );
+                continue;
+              }
+              defaultRuntime.log(`${result.slug} already at ${result.version}`);
             }
-            if (result.changed) {
-              defaultRuntime.log(
-                `Updated ${result.slug}: ${result.previousVersion ?? "unknown"} -> ${result.version}`,
-              );
-              continue;
-            }
-            defaultRuntime.log(`${result.slug} already at ${result.version}`);
           }
           if (failed) {
             defaultRuntime.exit(1);

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -82,6 +82,7 @@ vi.mock("../../state/claw-package-adoption.js", () => ({
 const { ClawHubRequestError } = await import("../../infra/clawhub-client.js");
 
 const {
+  checkSkillsFromClawHub,
   installSkillFromClawHub,
   preflightSkillFromClawHub,
   readVerifiedClawHubSkillSourceUrl,
@@ -228,6 +229,33 @@ async function writeClawHubOriginFixture(params: {
 }
 
 describe("skills-clawhub", () => {
+  it("checks tracked skill versions without downloading or writing", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skills-check-");
+    await writeClawHubOriginFixture({
+      workspaceDir,
+      slug: "agentreceipt",
+      installedVersion: "0.9.0",
+    });
+
+    const results = await checkSkillsFromClawHub({ workspaceDir });
+
+    expect(results).toEqual([
+      {
+        ok: true,
+        slug: "agentreceipt",
+        previousVersion: "0.9.0",
+        version: "1.0.0",
+        changed: true,
+      },
+    ]);
+    expect(fetchClawHubSkillDetailMock).toHaveBeenCalledWith({
+      slug: "agentreceipt",
+      baseUrl: "https://private.example.com/clawhub",
+    });
+    expect(downloadClawHubSkillArchiveMock).not.toHaveBeenCalled();
+    expect(installPackageDirMock).not.toHaveBeenCalled();
+  });
+
   afterEach(async () => {
     await tempDirs.cleanup();
   });

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -96,6 +96,16 @@ type UpdateClawHubSkillResult =
       warning?: string;
     };
 
+export type ClawHubSkillUpdateCheckResult =
+  | {
+      ok: true;
+      slug: string;
+      previousVersion: string | null;
+      version: string;
+      changed: boolean;
+    }
+  | { ok: false; slug: string; error: string };
+
 type TrackedUpdateTarget =
   | {
       ok: true;
@@ -385,6 +395,53 @@ async function guardTrackedSkillLocalState(params: {
     return { ok: true, plan: local.plan };
   }
   return { ok: false, error: local.error };
+}
+
+export async function checkSkillsFromClawHub(params: {
+  workspaceDir: string;
+  slug?: string;
+  baseUrl?: string;
+}): Promise<ClawHubSkillUpdateCheckResult[]> {
+  const lock = await readClawHubSkillsLockfile(params.workspaceDir);
+  const slugs = params.slug
+    ? [
+        await resolveRequestedUpdateSlug({
+          workspaceDir: params.workspaceDir,
+          requestedSlug: params.slug,
+          lock,
+        }),
+      ]
+    : Object.keys(lock.skills).map((slug) => normalizeTrackedSkillSlug(slug));
+  const results: ClawHubSkillUpdateCheckResult[] = [];
+  for (const slug of slugs) {
+    const tracked = await resolveTrackedUpdateTarget({
+      workspaceDir: params.workspaceDir,
+      slug,
+      lock,
+      baseUrl: params.baseUrl,
+    });
+    if (!tracked.ok) {
+      results.push({ ok: false, slug: tracked.slug, error: tracked.error });
+      continue;
+    }
+    try {
+      const resolved = await resolveInstallVersion({
+        slug: tracked.slug,
+        ...(tracked.ownerHandle ? { ownerHandle: tracked.ownerHandle } : {}),
+        baseUrl: tracked.baseUrl,
+      });
+      results.push({
+        ok: true,
+        slug: tracked.slug,
+        previousVersion: tracked.previousVersion,
+        version: resolved.version,
+        changed: tracked.previousVersion !== resolved.version,
+      });
+    } catch (err) {
+      results.push({ ok: false, slug: tracked.slug, error: formatErrorMessage(err) });
+    }
+  }
+  return results;
 }
 
 export async function updateSkillsFromClawHub(params: {


### PR DESCRIPTION
## Summary

- Add `openclaw skills update --all --dry-run` to report tracked ClawHub updates without downloading or modifying skills.
- Add `--json` output for automation, including an empty `results` array when no tracked skills exist.
- Reuse the lifecycle's tracked-skill and release-metadata resolution instead of duplicating ClawHub discovery in scheduled scripts.
- Keep the existing mutating update path, including `--force`, unchanged.

## Linked context

Closes #128686

Was this requested by a maintainer or owner? No; this addresses the report-only update-check gap identified during operational diagnosis.

## Real behavior proof (required for external PRs)

Behavior addressed: A report-only command can discover available updates without entering the archive download or installation flow.

Real environment tested: Isolated OpenClaw checkout with a temporary state/workspace fixture and the live ClawHub metadata endpoint.

Exact steps or command run after this patch:

```bash
OPENCLAW_HOME=/tmp/openclaw-skills-dry-run-smoke2/home \
OPENCLAW_CONFIG=/tmp/openclaw-skills-dry-run-smoke2/openclaw.json \
OPENCLAW_STATE_DIR=/tmp/openclaw-skills-dry-run-smoke2/state \
pnpm openclaw skills update --all --dry-run --json
```

Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "results": [
    {
      "ok": true,
      "slug": "instagram-content-studio",
      "previousVersion": "0.0.0",
      "version": "1.0.2",
      "changed": true
    }
  ]
}
```

Observed result after fix: The command returned the available version from ClawHub. Lifecycle tests also verified that archive download and installation functions were not called.

What was not tested: Deployment through the lue-kube workflow, the production weekly job, and a real scheduled run were not tested; cluster operations remain read-only.

Proof limitations or environment constraints: The smoke used an isolated temporary workspace and did not mutate the cluster or a production skill installation.

## Tests and validation

- `node scripts/run-vitest.mjs src/skills/lifecycle/clawhub.test.ts src/cli/skills-cli.commands.test.ts --maxWorkers=1` — 112 lifecycle tests and 96 CLI tests passed.
- `pnpm tsgo:core` — passed.
- `node scripts/run-oxlint.mjs src/cli/skills-cli.ts src/cli/skills-cli.commands.test.ts src/skills/lifecycle/clawhub.ts src/skills/lifecycle/clawhub.test.ts` — passed.
- `oxfmt --check` on all six changed files — passed.
- `pnpm build` — passed.
- `pnpm check:changed` — blocked by the existing assertion-safety baseline in `src/logging/logger.ts` (`14 > 13`); this file is not changed by the PR.
- Autoreview — clean, with no accepted/actionable findings.

## Risk checklist

Did user-visible behavior change? Yes. This adds a new CLI mode; existing update behavior remains unchanged.

Did config, environment, or migration behavior change? No.

Did security, auth, secrets, network, or tool execution behavior change? No new trust or installation behavior is introduced. Dry-run reads release metadata but does not download archives or execute skill installation.

What is the highest-risk area? Accidentally turning a report-only scheduled check into a mutating update.

How is that risk mitigated? Dry-run uses a separate metadata-only lifecycle function, has explicit CLI coverage, and the real smoke test confirms the command completes without entering download/install code.

## Current review state

What is the next action? Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof? CI and maintainer confirmation; production deployment proof is intentionally out of scope for this PR.

Which bot or reviewer comments were addressed? The local autoreview completed cleanly with no actionable findings.

## AI assistance

This PR is AI-assisted. The author understands the implementation and its testing; the patch was reviewed locally with autoreview before submission.
