### PR TITLE
fix(agent-core): restore drained steer/follow-up to its source queue on abort

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1127,6 +1127,111 @@ describe("agentLoop tool termination", () => {
     expect(skippedEnd).not.toHaveProperty("errorKind");
   });
 
+  it("restores drained steering in order when turn_end aborts before injection", async () => {
+    const firstReleased = createDeferred();
+    const firstStarted = createDeferred();
+    const secondExecute = vi.fn(async () => ({ content: [], details: {} }));
+    const requestMessages: Message[][] = [];
+    const agent = new Agent({
+      initialState: {
+        model,
+        tools: [
+          {
+            ...makeTool("first", []),
+            execute: async () => {
+              firstStarted.resolve();
+              await firstReleased.promise;
+              return { content: [{ type: "text", text: "first result" }], details: {} };
+            },
+          },
+          { ...makeTool("second", []), execute: secondExecute },
+        ],
+      },
+      streamFn: createTurnSequenceStream(
+        [
+          [
+            { type: "toolCall", id: "call-first", name: "first", arguments: {} },
+            { type: "toolCall", id: "call-second", name: "second", arguments: {} },
+          ],
+          [{ type: "text", text: "handled steering" }],
+        ],
+        requestMessages,
+      ),
+      steeringMode: "all",
+      toolExecution: "sequential",
+    });
+    agent.subscribe((event) => {
+      if (event.type === "turn_end" && event.toolResults.length > 0) {
+        agent.abort();
+      }
+    });
+    const firstSteer = { role: "user" as const, content: "first steer", timestamp: 2 };
+    const secondSteer = { role: "user" as const, content: "second steer", timestamp: 3 };
+
+    const run = agent.prompt("start");
+    await firstStarted.promise;
+    agent.steer(firstSteer);
+    agent.steer(secondSteer);
+    firstReleased.resolve();
+    await run;
+
+    expect(secondExecute).not.toHaveBeenCalled();
+    expect(agent.state.messages).not.toContain(firstSteer);
+    expect(agent.state.messages).not.toContain(secondSteer);
+    expect(agent.hasQueuedMessages()).toBe(true);
+
+    await agent.prompt("again");
+
+    expect(requestMessages).toHaveLength(2);
+    expect(requestMessages[1]?.slice(-2)).toEqual([firstSteer, secondSteer]);
+    expect(agent.hasQueuedMessages()).toBe(false);
+  });
+
+  it("restores drained follow-ups to their deferred queue in order", async () => {
+    const requestMessages: Message[][] = [];
+    const agent = new Agent({
+      initialState: {
+        model,
+        messages: [makeAssistantMessage([{ type: "text", text: "ready" }])],
+      },
+      streamFn: createTurnSequenceStream(
+        [
+          [{ type: "text", text: "new prompt response" }],
+          [{ type: "text", text: "follow-up response" }],
+        ],
+        requestMessages,
+      ),
+      followUpMode: "all",
+    });
+    const firstFollowUp = { role: "user" as const, content: "first follow-up", timestamp: 2 };
+    const secondFollowUp = { role: "user" as const, content: "second follow-up", timestamp: 3 };
+    agent.followUp(firstFollowUp);
+    agent.followUp(secondFollowUp);
+    let abortBeforeInjection = true;
+    agent.subscribe((event) => {
+      if (event.type !== "agent_start" || !abortBeforeInjection) {
+        return;
+      }
+      abortBeforeInjection = false;
+      const error = new Error("abort before queued prompt injection");
+      agent.abort(error);
+      throw error;
+    });
+
+    await agent.continue();
+
+    expect(requestMessages).toHaveLength(0);
+    expect(agent.hasQueuedMessages()).toBe(true);
+
+    await agent.prompt("again");
+
+    expect(requestMessages).toHaveLength(2);
+    expect(requestMessages[0]).not.toContain(firstFollowUp);
+    expect(requestMessages[0]).not.toContain(secondFollowUp);
+    expect(requestMessages[1]?.slice(-2)).toEqual([firstFollowUp, secondFollowUp]);
+    expect(agent.hasQueuedMessages()).toBe(false);
+  });
+
   it("uses a private synchronous steer at the scheduler without invoking the public fallback", async () => {
     const steer = { role: "user" as const, content: "redirect", timestamp: 2 };
     let steerReady = false;

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -164,6 +164,9 @@ export interface AgentOptions {
 
 class PendingMessageQueue {
   private messages: AgentMessage[] = [];
+  // Drained messages stay owned here until message_end commits them.
+  // A failed run restores them ahead of messages accepted later.
+  private inFlight: AgentMessage[] = [];
   public mode: QueueMode;
 
   constructor(mode: QueueMode) {
@@ -179,23 +182,27 @@ class PendingMessageQueue {
   }
 
   drain(): AgentMessage[] {
-    if (this.mode === "all") {
-      const drained = this.messages.slice();
-      this.messages = [];
-      return drained;
-    }
+    const count = this.mode === "all" ? this.messages.length : 1;
+    const drained = this.messages.splice(0, count);
+    this.inFlight.push(...drained);
+    return drained;
+  }
 
-    // one-at-a-time preserves later queued messages for subsequent loop turns.
-    const first = this.messages[0];
-    if (!first) {
-      return [];
+  commit(message: AgentMessage): void {
+    const index = this.inFlight.indexOf(message);
+    if (index >= 0) {
+      this.inFlight.splice(index, 1);
     }
-    this.messages = this.messages.slice(1);
-    return [first];
+  }
+
+  restore(): void {
+    this.messages = [...this.inFlight, ...this.messages];
+    this.inFlight = [];
   }
 
   clear(): void {
     this.messages = [];
+    this.inFlight = [];
   }
 }
 
@@ -391,8 +398,7 @@ export class Agent {
     this.mutableState.pendingToolCalls = new Set<string>();
     this.mutableState.errorMessage = undefined;
     this.toolLoopRecoveryState.criticalToolLoopSeen = false;
-    this.clearFollowUpQueue();
-    this.clearSteeringQueue();
+    this.clearAllQueues();
   }
 
   /** Start a new prompt from text, a single message, or a batch of messages. */
@@ -587,6 +593,8 @@ export class Agent {
   }
 
   private finishRun(): void {
+    this.steeringQueue.restore();
+    this.followUpQueue.restore();
     this.mutableState.isStreaming = false;
     this.mutableState.streamingMessage = undefined;
     this.mutableState.pendingToolCalls = new Set<string>();
@@ -619,6 +627,8 @@ export class Agent {
       case "message_end":
         this.mutableState.streamingMessage = undefined;
         this.mutableState.messages.push(event.message);
+        this.steeringQueue.commit(event.message);
+        this.followUpQueue.commit(event.message);
         break;
 
       case "tool_execution_start": {


### PR DESCRIPTION
Closes #128008

## What Problem This Solves

An accepted steering or follow-up message could disappear when the Agent drained it from its queue and the run then aborted before transcript injection. The message was no longer queued, never reached the provider, and could remain visible as a ghost pending entry.

## Why This Change Was Made

`Agent` owns both queues, so each queue now keeps drained messages in its own in-flight state until `message_end` commits them to the transcript. When a run settles with an uncommitted message, the same queue restores it ahead of messages accepted later.

This keeps steering and follow-up scheduling separate by construction. It also replaces the earlier loop-level source flag and optional public callback with one private queue lifecycle. The maintainer rewrite keeps the behavior and credit from @SunnyShu0925's PR and the original reproduction from @yetval.

## User Impact

- Steering accepted during a sequential tool batch survives an abort and reaches the next provider request in order.
- Follow-ups survive the same pre-injection abort window and remain deferred until the agent would otherwise stop.
- No configuration or public Agent Loop API changes.

## Evidence

The live proof used the real `Agent`, real steering and follow-up queues, real sequential tool execution, a real awaited `turn_end` abort, and the built-in OpenAI Responses HTTP transport against a loopback provider that recorded each request.

| Revision | Steering after abort | Follow-up after abort |
| --- | --- | --- |
| Main `1dba34be9be1249c0e35badcb5ec887ce5d71c72` | Queue empty; neither ordered marker reached request 2 | Queue empty; neither ordered marker reached the later request |
| Head `685501499843f4f6be7d8c66d92f038824091640` | Queue retained; both markers reached request 2 in order | Queue retained; both markers stayed out of request 2 and reached request 3 in order |

The skipped sequential tail tool ran zero times on both revisions.

Focused validation:

- `node scripts/run-vitest.mjs packages/agent-core/src` — 206 tests passed.
- `node scripts/run-vitest.mjs src/agents/sessions/agent-session-loop-correctness.test.ts src/agents/sessions/agent-session-loop-next-turn.test.ts` — 40 tests passed.
- Repository formatter — passed for both changed files.
- Core lint — 0 warnings and 0 errors.
- Core production type check — passed.
- `git diff --check` — passed.
- Exact-head [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/33157665572) — passed.
- Exact-head local ClawSweeper — patch correct, security clear, no findings, owner decisions, or Rank-up moves.

The two new regressions fail on pre-fix production code at the queue-retention assertion and pass with this repair.

## AI Assistance

- AI-assisted: Yes
- Confirmed understanding: Yes. Drained messages remain owned by their source queue, transcript commit removes them from in-flight state, and run settlement restores only messages that never committed.
