### PR TITLE
fix(cli): normalize echoed binary tool outputs

### DIFF
--- a/src/agents/cli-output-echoed-binary.ts
+++ b/src/agents/cli-output-echoed-binary.ts
@@ -39,12 +39,19 @@ export function normalizeClaudeCliStreamJsonRecord(
       omittedRawChars += data.length;
       normalized = true;
     }
-    const file = node.file;
-    if (isRecord(file) && typeof file.base64 === "string") {
-      const base64 = file.base64;
-      delete file.base64;
-      file.omitted = true;
-      file.bytes = estimateBase64DecodedBytes(base64);
+    const directBase64Outputs = [
+      node.file,
+      ...(Array.isArray(node.images) ? node.images : []),
+      ...(Array.isArray(node.documents) ? node.documents : []),
+    ];
+    for (const output of directBase64Outputs) {
+      if (!isRecord(output) || typeof output.base64 !== "string") {
+        continue;
+      }
+      const base64 = output.base64;
+      delete output.base64;
+      output.omitted = true;
+      output.bytes = estimateBase64DecodedBytes(base64);
       omittedRawChars += base64.length;
       normalized = true;
     }

--- a/src/agents/cli-output-echoed-binary.ts
+++ b/src/agents/cli-output-echoed-binary.ts
@@ -1,0 +1,64 @@
+import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+/** Drops Claude's echoed binary bytes before they enter retained tool/transcript state. */
+export function normalizeClaudeCliStreamJsonRecord(
+  parsed: Record<string, unknown>,
+): { line: string; omittedRawChars: number } | undefined {
+  if (parsed.type !== "user" || !isRecord(parsed.message)) {
+    return undefined;
+  }
+  let normalized = false;
+  let omittedRawChars = 0;
+  // Claude echoes each payload twice, under `message` and under `tool_use_result`, so the
+  // whole record is walked. The walk is iterative to stay stack-safe on deep records.
+  const pending: unknown[] = [parsed];
+  while (pending.length > 0) {
+    const node = pending.pop();
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        pending.push(item);
+      }
+      continue;
+    }
+    if (!isRecord(node)) {
+      continue;
+    }
+    const source = node.source;
+    const data = isRecord(source) && source.type === "base64" ? source.data : undefined;
+    if (
+      typeof data === "string" &&
+      isRecord(source) &&
+      (node.type === "image" ||
+        (node.type === "document" && source.media_type === "application/pdf"))
+    ) {
+      const { data: _omitted, ...rest } = source;
+      node.source = rest;
+      node.omitted = true;
+      node.bytes = estimateBase64DecodedBytes(data);
+      omittedRawChars += data.length;
+      normalized = true;
+    }
+    const file = node.file;
+    if (isRecord(file) && typeof file.base64 === "string") {
+      const base64 = file.base64;
+      delete file.base64;
+      file.omitted = true;
+      file.bytes = estimateBase64DecodedBytes(base64);
+      omittedRawChars += base64.length;
+      normalized = true;
+    }
+    for (const value of Object.values(node)) {
+      pending.push(value);
+    }
+  }
+  if (!normalized) {
+    return undefined;
+  }
+  try {
+    // JSON.stringify recurses; a record too deep to re-serialize falls back to raw accounting.
+    return { line: JSON.stringify(parsed), omittedRawChars };
+  } catch {
+    return undefined;
+  }
+}

--- a/src/agents/cli-output-framing.test.ts
+++ b/src/agents/cli-output-framing.test.ts
@@ -1,3 +1,4 @@
+import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { describe, expect, it, vi } from "vitest";
 import type { CliToolResultDelta, CliToolUseStartDelta } from "./cli-output-contracts.js";
 import { createCliJsonlStreamingParser } from "./cli-output-stream.js";
@@ -270,6 +271,91 @@ describe("createCliJsonlStreamingParser framing", () => {
         bytes: 0,
       },
     ]);
+  });
+
+  it("omits the echoed tool_use_result payload MCP image tools duplicate alongside the message copy", () => {
+    const results: CliToolResultDelta[] = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+      onToolResult: (result) => results.push(result),
+    });
+    const data = "A".repeat(600_000);
+    const screenshotLine = (index: number) =>
+      `${JSON.stringify({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: `screenshot-${index}`,
+              content: [
+                { type: "text", text: "Cursor Position: (1, 2)" },
+                {
+                  type: "image",
+                  source: { type: "base64", media_type: "image/jpeg", data },
+                },
+              ],
+            },
+          ],
+        },
+        // Claude echoes the same payload a second time outside the message.
+        tool_use_result: [
+          { type: "text", text: "Cursor Position: (1, 2)" },
+          { type: "image", source: { type: "base64", media_type: "image/jpeg", data } },
+        ],
+      })}\n`;
+
+    for (let index = 0; index < 20; index += 1) {
+      parser.push(screenshotLine(index));
+    }
+
+    expect(parser.getErrorText()).toBeNull();
+    expect(results).toHaveLength(20);
+    expect(results[0]?.result).toEqual([
+      { type: "text", text: "Cursor Position: (1, 2)" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/jpeg" },
+        omitted: true,
+        bytes: estimateBase64DecodedBytes(data),
+      },
+    ]);
+  });
+
+  it("omits the base64 file payload Claude echoes for built-in image reads", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+    });
+    const base64 = "A".repeat(600_000);
+    const readLine = (index: number) =>
+      `${JSON.stringify({
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: `read-${index}`,
+              content: [
+                {
+                  type: "image",
+                  source: { type: "base64", media_type: "image/png", data: base64 },
+                },
+              ],
+            },
+          ],
+        },
+        tool_use_result: { type: "image", file: { base64, type: "image/png", originalSize: 1 } },
+      })}\n`;
+
+    for (let index = 0; index < 20; index += 1) {
+      parser.push(readLine(index));
+    }
+
+    expect(parser.getErrorText()).toBeNull();
   });
 
   it("still enforces raw Claude line and retained-text limits", () => {

--- a/src/agents/cli-output-framing.test.ts
+++ b/src/agents/cli-output-framing.test.ts
@@ -358,6 +358,26 @@ describe("createCliJsonlStreamingParser framing", () => {
     expect(parser.getErrorText()).toBeNull();
   });
 
+  it("normalizes a deeply nested record without exhausting the stack", () => {
+    const parser = createCliJsonlStreamingParser({
+      backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+      providerId: "claude-cli",
+      onAssistantDelta: () => {},
+    });
+    // Built as text: JSON.stringify is itself recursive and cannot serialize this.
+    const depth = 50_000;
+    const payload = JSON.stringify({
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "AAAA" },
+    });
+    const line = `{"type":"user","message":{"content":[]},"tool_use_result":${
+      '{"nested":'.repeat(depth) + payload + "}".repeat(depth)
+    }}`;
+
+    expect(() => parser.push(`${line}\n`)).not.toThrow();
+    expect(parser.getErrorText()).toBeNull();
+  });
+
   it("still enforces raw Claude line and retained-text limits", () => {
     const createParser = () =>
       createCliJsonlStreamingParser({

--- a/src/agents/cli-output-framing.test.ts
+++ b/src/agents/cli-output-framing.test.ts
@@ -358,6 +358,47 @@ describe("createCliJsonlStreamingParser framing", () => {
     expect(parser.getErrorText()).toBeNull();
   });
 
+  it.each([
+    {
+      name: "image",
+      field: "images",
+      metadata: { mediaType: "image/png" },
+    },
+    {
+      name: "document",
+      field: "documents",
+      metadata: {},
+    },
+  ] as const)(
+    "omits Agent SDK REPL $name output from retained accounting",
+    ({ field, metadata }) => {
+      const parser = createCliJsonlStreamingParser({
+        backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },
+        providerId: "claude-cli",
+        onAssistantDelta: () => {},
+      });
+      const base64 = "A".repeat(600_000);
+      const replLine = () =>
+        `${JSON.stringify({
+          type: "user",
+          message: { role: "user", content: [] },
+          tool_use_result: {
+            code: "return await Read({ file_path });",
+            result: {},
+            stdout: "",
+            stderr: "",
+            [field]: [{ base64, ...metadata }],
+          },
+        })}\n`;
+
+      for (let index = 0; index < 20; index += 1) {
+        parser.push(replLine());
+      }
+
+      expect(parser.getErrorText()).toBeNull();
+    },
+  );
+
   it("normalizes a deeply nested record without exhausting the stack", () => {
     const parser = createCliJsonlStreamingParser({
       backend: { command: "claude", output: "jsonl", jsonlDialect: "claude-stream-json" },

--- a/src/agents/cli-output-stream.ts
+++ b/src/agents/cli-output-stream.ts
@@ -102,6 +102,48 @@ function frameBoundedCliJsonlChunk(
   return true;
 }
 
+type EchoedBinaryStrip = { normalized: boolean; omittedRawChars: number };
+
+/** Strips every echoed base64 payload a parsed record carries, in place. */
+function stripEchoedBinaryPayloads(node: unknown, out: EchoedBinaryStrip) {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      stripEchoedBinaryPayloads(item, out);
+    }
+    return;
+  }
+  if (!isRecord(node)) {
+    return;
+  }
+  const source = node.source;
+  const data = isRecord(source) && source.type === "base64" ? source.data : undefined;
+  if (
+    typeof data === "string" &&
+    isRecord(source) &&
+    (node.type === "image" || (node.type === "document" && source.media_type === "application/pdf"))
+  ) {
+    const { data: _omitted, ...rest } = source;
+    node.source = rest;
+    node.omitted = true;
+    node.bytes = estimateBase64DecodedBytes(data);
+    out.omittedRawChars += data.length;
+    out.normalized = true;
+  }
+  // Claude echoes built-in image reads a second time as `tool_use_result.file.base64`.
+  const file = node.file;
+  if (isRecord(file) && typeof file.base64 === "string") {
+    const base64 = file.base64;
+    delete file.base64;
+    file.omitted = true;
+    file.bytes = estimateBase64DecodedBytes(base64);
+    out.omittedRawChars += base64.length;
+    out.normalized = true;
+  }
+  for (const value of Object.values(node)) {
+    stripEchoedBinaryPayloads(value, out);
+  }
+}
+
 /** Drops Claude's echoed binary bytes before they enter retained tool/transcript state. */
 function normalizeClaudeCliStreamJsonRecord(
   parsed: Record<string, unknown>,
@@ -109,35 +151,11 @@ function normalizeClaudeCliStreamJsonRecord(
   if (parsed.type !== "user" || !isRecord(parsed.message)) {
     return undefined;
   }
-  const content = Array.isArray(parsed.message.content) ? parsed.message.content : [];
-  let normalized = false;
-  let omittedRawChars = 0;
-  for (const result of content) {
-    if (!isRecord(result) || result.type !== "tool_result" || !Array.isArray(result.content)) {
-      continue;
-    }
-    for (const block of result.content) {
-      if (!isRecord(block) || !isRecord(block.source) || block.source.type !== "base64") {
-        continue;
-      }
-      if (
-        block.type !== "image" &&
-        !(block.type === "document" && block.source.media_type === "application/pdf")
-      ) {
-        continue;
-      }
-      const { data, ...source } = block.source;
-      if (typeof data !== "string") {
-        continue;
-      }
-      block.source = source;
-      block.omitted = true;
-      block.bytes = estimateBase64DecodedBytes(data);
-      omittedRawChars += data.length;
-      normalized = true;
-    }
-  }
-  return normalized ? { line: JSON.stringify(parsed), omittedRawChars } : undefined;
+  const stripped: EchoedBinaryStrip = { normalized: false, omittedRawChars: 0 };
+  stripEchoedBinaryPayloads(parsed, stripped);
+  return stripped.normalized
+    ? { line: JSON.stringify(parsed), omittedRawChars: stripped.omittedRawChars }
+    : undefined;
 }
 
 function streamJsonOutputLimitErrorText(kind: "raw" | "line" | "lines", limit: number): string {

--- a/src/agents/cli-output-stream.ts
+++ b/src/agents/cli-output-stream.ts
@@ -1,4 +1,3 @@
-import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -13,6 +12,7 @@ import type {
   CliStreamJsonOutputLimits,
   CliUsage,
 } from "./cli-output-contracts.js";
+import { normalizeClaudeCliStreamJsonRecord } from "./cli-output-echoed-binary.js";
 import type { CliEventProjectionState } from "./cli-output-events.js";
 import {
   createLeadingTaggedReasoningRouter,
@@ -100,62 +100,6 @@ function frameBoundedCliJsonlChunk(
     }
   }
   return true;
-}
-
-type EchoedBinaryStrip = { normalized: boolean; omittedRawChars: number };
-
-/** Strips every echoed base64 payload a parsed record carries, in place. */
-function stripEchoedBinaryPayloads(node: unknown, out: EchoedBinaryStrip) {
-  if (Array.isArray(node)) {
-    for (const item of node) {
-      stripEchoedBinaryPayloads(item, out);
-    }
-    return;
-  }
-  if (!isRecord(node)) {
-    return;
-  }
-  const source = node.source;
-  const data = isRecord(source) && source.type === "base64" ? source.data : undefined;
-  if (
-    typeof data === "string" &&
-    isRecord(source) &&
-    (node.type === "image" || (node.type === "document" && source.media_type === "application/pdf"))
-  ) {
-    const { data: _omitted, ...rest } = source;
-    node.source = rest;
-    node.omitted = true;
-    node.bytes = estimateBase64DecodedBytes(data);
-    out.omittedRawChars += data.length;
-    out.normalized = true;
-  }
-  // Claude echoes built-in image reads a second time as `tool_use_result.file.base64`.
-  const file = node.file;
-  if (isRecord(file) && typeof file.base64 === "string") {
-    const base64 = file.base64;
-    delete file.base64;
-    file.omitted = true;
-    file.bytes = estimateBase64DecodedBytes(base64);
-    out.omittedRawChars += base64.length;
-    out.normalized = true;
-  }
-  for (const value of Object.values(node)) {
-    stripEchoedBinaryPayloads(value, out);
-  }
-}
-
-/** Drops Claude's echoed binary bytes before they enter retained tool/transcript state. */
-function normalizeClaudeCliStreamJsonRecord(
-  parsed: Record<string, unknown>,
-): { line: string; omittedRawChars: number } | undefined {
-  if (parsed.type !== "user" || !isRecord(parsed.message)) {
-    return undefined;
-  }
-  const stripped: EchoedBinaryStrip = { normalized: false, omittedRawChars: 0 };
-  stripEchoedBinaryPayloads(parsed, stripped);
-  return stripped.normalized
-    ? { line: JSON.stringify(parsed), omittedRawChars: stripped.omittedRawChars }
-    : undefined;
 }
 
 function streamJsonOutputLimitErrorText(kind: "raw" | "line" | "lines", limit: number): string {


### PR DESCRIPTION
Normalize duplicated base64 echoes before Claude stream accounting, including MCP content blocks, built-in Read output, and Anthropic Agent SDK REPL images and documents. Keep one stack-safe parser-boundary normalization path while preserving projected tool metadata.

Closes #128697
