### PR TITLE
fix(android): gateway accent color is fetched but never applied to the app theme

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -590,7 +590,7 @@ class MainViewModel private constructor(
   val healthLogsRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.healthLogsRefreshing }
   val healthLogsErrorText: StateFlow<String?> = runtimeState(initial = null) { it.healthLogsErrorText }
   val pendingGatewayTrust: StateFlow<NodeRuntime.GatewayTrustPrompt?> = runtimeState(initial = null) { it.pendingGatewayTrust }
-  val seamColorArgb: StateFlow<Long> = runtimeState(initial = 0xFF0EA5E9) { it.seamColorArgb }
+  val gatewayAccentArgb: StateFlow<Long?> = runtimeState(initial = null) { it.gatewayAccentArgb }
   val mainSessionKey: StateFlow<String> = runtimeState(initial = "main") { it.mainSessionKey }
 
   val cameraHud: StateFlow<CameraHudState?> = runtimeState(initial = null) { it.cameraHud }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -72,7 +72,6 @@ import ai.openclaw.app.node.CameraCaptureManager
 import ai.openclaw.app.node.CameraHandler
 import ai.openclaw.app.node.ConnectionManager
 import ai.openclaw.app.node.ContactsHandler
-import ai.openclaw.app.node.DEFAULT_SEAM_COLOR_ARGB
 import ai.openclaw.app.node.DebugHandler
 import ai.openclaw.app.node.DeviceHandler
 import ai.openclaw.app.node.DeviceNotificationListenerService
@@ -91,8 +90,8 @@ import ai.openclaw.app.node.TalkHandler
 import ai.openclaw.app.node.asObjectOrNull
 import ai.openclaw.app.node.asStringOrNull
 import ai.openclaw.app.node.invokeErrorFromThrowable
-import ai.openclaw.app.node.parseHexColorArgb
 import ai.openclaw.app.node.readAndroidPermissionSnapshot
+import ai.openclaw.app.node.resolveGatewayAccentArgb
 import ai.openclaw.app.systemagent.SystemAgentChatController
 import ai.openclaw.app.systemagent.SystemAgentChatState
 import ai.openclaw.app.systemagent.SystemAgentGatewayAccess
@@ -1185,8 +1184,8 @@ class NodeRuntime private constructor(
   private val _gatewayUpdateAvailable = MutableStateFlow<GatewayUpdateAvailableSummary?>(null)
   val gatewayUpdateAvailable: StateFlow<GatewayUpdateAvailableSummary?> = _gatewayUpdateAvailable.asStateFlow()
 
-  private val _seamColorArgb = MutableStateFlow(DEFAULT_SEAM_COLOR_ARGB)
-  val seamColorArgb: StateFlow<Long> = _seamColorArgb.asStateFlow()
+  private val _gatewayAccentArgb = MutableStateFlow<Long?>(null)
+  val gatewayAccentArgb: StateFlow<Long?> = _gatewayAccentArgb.asStateFlow()
   private val _modelCatalog = MutableStateFlow<List<GatewayModelSummary>>(emptyList())
   val modelCatalog: StateFlow<List<GatewayModelSummary>> = _modelCatalog.asStateFlow()
   private val _providerModelCatalog = MutableStateFlow<List<GatewayModelSummary>>(emptyList())
@@ -1407,7 +1406,7 @@ class NodeRuntime private constructor(
         // Pairing capabilities require positive hello advertisement; an unknown catalog grants none.
         _devicePairingCapabilities.value =
           selectGatewayDevicePairingCapabilities(hello.methods.orEmpty(), operatorScopes)
-        _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
+        _gatewayAccentArgb.value = null
         val mainSessionKey =
           prepareMainSessionKey(resolveAgentIdFromMainSessionKey(hello.mainSessionKey))
         // Create/adopt before history refresh; this keeps the first connected read on the
@@ -1676,7 +1675,7 @@ class NodeRuntime private constructor(
     replaceGatewayMethods(null)
     _operatorScopes.value = emptyList()
     _devicePairingCapabilities.value = GatewayDevicePairingCapabilities()
-    _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
+    _gatewayAccentArgb.value = null
     _gatewayAgents.value = emptyList()
     selectedChatAgentId = null
     _modelCatalog.value = emptyList()
@@ -5532,11 +5531,9 @@ class NodeRuntime private constructor(
       val res = requestGatewayData(gatewayScope, "config.get", "{}")
       val root = json.parseToJsonElement(res).asObjectOrNull()
       val config = root?.get("config").asObjectOrNull()
-      val ui = config?.get("ui").asObjectOrNull()
-      val raw = ui?.get("seamColor").asStringOrNull()?.trim()
-      val parsed = parseHexColorArgb(raw)
+      val parsed = resolveGatewayAccentArgb(config)
       publishGatewayData(gatewayScope) {
-        _seamColorArgb.value = parsed ?: DEFAULT_SEAM_COLOR_ARGB
+        _gatewayAccentArgb.value = parsed
       }
     } catch (_: Throwable) {
       // ignore

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1425,6 +1425,7 @@ class NodeRuntime private constructor(
         wearProxyBridge()?.publishConnection(connected = true, status = "Connected")
         scope.launch {
           subscribeOperatorSessionEvents()
+          refreshBrandingFromGateway()
           refreshWakeWordsFromGateway()
           refreshExecApprovalsFromGateway()
           if (voiceReplySpeakerLazy.isInitialized()) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/NodeUtils.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/NodeUtils.kt
@@ -77,12 +77,17 @@ fun parseHexColorArgb(raw: String?): Long? {
 
 fun resolveGatewayAccentArgb(config: JsonObject?): Long? {
   val ui = config?.get("ui").asObjectOrNull()
-  val prefs = ui?.get("prefs").asObjectOrNull()
-  // Match Control UI precedence: a present string user accent wins, even when invalid.
-  val accent =
-    readJsonPrimitive(prefs, "accent")?.takeIf { it.isString }?.contentOrNull
-      ?: readJsonPrimitive(ui, "seamColor")?.takeIf { it.isString }?.contentOrNull
-  return parseHexColorArgb(accent)
+  // Control UI precedence (gateway talk.config): a present user accent wins over the
+  // operator seam color even when it is not a usable hex string; only an absent or
+  // JSON-null accent falls through, matching the gateway's `??` selection.
+  val chosen =
+    ui
+      ?.get("prefs")
+      .asObjectOrNull()
+      ?.get("accent")
+      ?.takeIf { it !is JsonNull }
+      ?: ui?.get("seamColor")
+  return parseHexColorArgb((chosen as? JsonPrimitive)?.takeIf { it.isString }?.contentOrNull)
 }
 
 /** Converts gateway invocation throwables into protocol code/message pairs. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/NodeUtils.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/NodeUtils.kt
@@ -8,9 +8,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 
-/** Default canvas seam color used when gateway/user params omit a hex color. */
-const val DEFAULT_SEAM_COLOR_ARGB: Long = 0xFF4F7A9A
-
 fun JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject
 
 /** Parses invoke params into a JSON object, returning null for absent/malformed input. */
@@ -76,6 +73,16 @@ fun parseHexColorArgb(raw: String?): Long? {
   if (hex.length != 6) return null
   val rgb = hex.toLongOrNull(16) ?: return null
   return 0xFF000000L or rgb
+}
+
+fun resolveGatewayAccentArgb(config: JsonObject?): Long? {
+  val ui = config?.get("ui").asObjectOrNull()
+  val prefs = ui?.get("prefs").asObjectOrNull()
+  // Match Control UI precedence: a present string user accent wins, even when invalid.
+  val accent =
+    readJsonPrimitive(prefs, "accent")?.takeIf { it.isString }?.contentOrNull
+      ?: readJsonPrimitive(ui, "seamColor")?.takeIf { it.isString }?.contentOrNull
+  return parseHexColorArgb(accent)
 }
 
 /** Converts gateway invocation throwables into protocol code/message pairs. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -410,8 +410,9 @@ fun OnboardingFlow(
   modifier: Modifier = Modifier,
 ) {
   val appearanceThemeMode by viewModel.appearanceThemeMode.collectAsState()
+  val gatewayAccentArgb by viewModel.gatewayAccentArgb.collectAsState()
   val onboardingDark = appearanceThemeMode.isDark(systemDark = isSystemInDarkTheme())
-  ClawDesignTheme(dark = onboardingDark) {
+  ClawDesignTheme(dark = onboardingDark, accentArgb = gatewayAccentArgb) {
     val context = LocalContext.current
     val gatewayConnectionDisplay by viewModel.gatewayConnectionDisplay.collectAsState()
     val statusText = gatewayConnectionDisplay.statusText

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -161,9 +161,10 @@ fun ShellScreen(
   modifier: Modifier = Modifier,
 ) {
   val appearanceThemeMode by viewModel.appearanceThemeMode.collectAsState()
+  val gatewayAccentArgb by viewModel.gatewayAccentArgb.collectAsState()
   val shellDark = appearanceThemeMode.isDark(systemDark = isSystemInDarkTheme())
   OpenClawSystemBarAppearance(lightAppearance = !shellDark)
-  ClawDesignTheme(dark = shellDark) {
+  ClawDesignTheme(dark = shellDark, accentArgb = gatewayAccentArgb) {
     val nav = rememberSaveable(saver = ShellNavigation.Saver) { ShellNavigation() }
     var commandOpen by rememberSaveable { mutableStateOf(false) }
     var conversationScreenWasActive by rememberSaveable { mutableStateOf(false) }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawTheme.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawTheme.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -156,6 +158,19 @@ private val ClawLightColors =
     codeBorder = Color(0xFFD7DDE7),
   )
 
+internal fun clawColorsForTheme(
+  dark: Boolean,
+  accentArgb: Long?,
+): ClawColors {
+  val base = if (dark) ClawDarkColors else ClawLightColors
+  val accent = accentArgb?.let(::Color) ?: return base
+  return base.copy(
+    accent = accent,
+    accentSoft = accent.copy(alpha = if (dark) 0.25f else 0.08f).compositeOver(base.canvas),
+    accentBorder = lerp(accent, Color.Black, 0.12f),
+  )
+}
+
 private val LocalClawColors = staticCompositionLocalOf { ClawDarkColors }
 private val LocalClawSpacing = staticCompositionLocalOf { ClawSpacing() }
 private val LocalClawRadii = staticCompositionLocalOf { ClawRadii() }
@@ -192,9 +207,10 @@ internal object ClawTheme {
 @Composable
 internal fun ClawDesignTheme(
   dark: Boolean = true,
+  accentArgb: Long? = null,
   content: @Composable () -> Unit,
 ) {
-  val colors = if (dark) ClawDarkColors else ClawLightColors
+  val colors = clawColorsForTheme(dark = dark, accentArgb = accentArgb)
   val typography = clawTypography(clawFontFamily)
 
   CompositionLocalProvider(

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/NodeUtilsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/NodeUtilsTest.kt
@@ -62,4 +62,24 @@ class NodeUtilsTest {
       assertEquals(source, expected, parseJsonBooleanFlag(params, "includeAudio"))
     }
   }
+
+  @Test
+  fun resolveGatewayAccentArgb_honorsUserPrecedenceAndHexFormats() {
+    val cases =
+      linkedMapOf(
+        """{"ui":{"prefs":{"accent":"#123456"},"seamColor":"#ABCDEF"}}""" to 0xFF123456L,
+        """{"ui":{"seamColor":"ABCDEF"}}""" to 0xFFABCDEFL,
+        """{"ui":{"prefs":{"accent":"invalid"},"seamColor":"#ABCDEF"}}""" to null,
+        """{"ui":{"prefs":{"accent":123},"seamColor":"#ABCDEF"}}""" to 0xFFABCDEFL,
+        """{"ui":{"prefs":{"accent":null},"seamColor":"#ABCDEF"}}""" to 0xFFABCDEFL,
+        """{"ui":{}}""" to null,
+        """{}""" to null,
+      )
+
+    for ((source, expected) in cases) {
+      val config = json.parseToJsonElement(source) as JsonObject
+      assertEquals(source, expected, resolveGatewayAccentArgb(config))
+    }
+    assertNull(resolveGatewayAccentArgb(null))
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/NodeUtilsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/NodeUtilsTest.kt
@@ -70,7 +70,7 @@ class NodeUtilsTest {
         """{"ui":{"prefs":{"accent":"#123456"},"seamColor":"#ABCDEF"}}""" to 0xFF123456L,
         """{"ui":{"seamColor":"ABCDEF"}}""" to 0xFFABCDEFL,
         """{"ui":{"prefs":{"accent":"invalid"},"seamColor":"#ABCDEF"}}""" to null,
-        """{"ui":{"prefs":{"accent":123},"seamColor":"#ABCDEF"}}""" to 0xFFABCDEFL,
+        """{"ui":{"prefs":{"accent":123},"seamColor":"#ABCDEF"}}""" to null,
         """{"ui":{"prefs":{"accent":null},"seamColor":"#ABCDEF"}}""" to 0xFFABCDEFL,
         """{"ui":{}}""" to null,
         """{}""" to null,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawColorsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawColorsTest.kt
@@ -1,0 +1,51 @@
+package ai.openclaw.app.ui.design
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.lerp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class ClawColorsTest {
+  @Test
+  fun nullAccentPreservesHardcodedDarkAndLightPalettes() {
+    val expectedAccents =
+      mapOf(
+        true to Triple(Color(0xFF6EA8FF), Color(0xFF1A2A44), Color(0xFF5B93E8)),
+        false to Triple(Color(0xFF1B5ACB), Color(0xFFEAF2FF), Color(0xFF174CA9)),
+      )
+
+    for ((dark, expected) in expectedAccents) {
+      val colors = clawColorsForTheme(dark = dark, accentArgb = null)
+
+      assertEquals(expected.first, colors.accent)
+      assertEquals(expected.second, colors.accentSoft)
+      assertEquals(expected.third, colors.accentBorder)
+      assertSame(colors, clawColorsForTheme(dark = dark, accentArgb = null))
+    }
+  }
+
+  @Test
+  fun gatewayAccentOverridesOnlyAccentTokensForBothPalettes() {
+    val accent = Color(0xFFE84B35)
+
+    for (dark in listOf(true, false)) {
+      val base = clawColorsForTheme(dark = dark, accentArgb = null)
+      val colors = clawColorsForTheme(dark = dark, accentArgb = 0xFFE84B35L)
+
+      assertEquals(accent, colors.accent)
+      assertEquals(accent.copy(alpha = if (dark) 0.25f else 0.08f).compositeOver(base.canvas), colors.accentSoft)
+      assertEquals(lerp(accent, Color.Black, 0.12f), colors.accentBorder)
+      assertNotEquals(accent, colors.accentSoft)
+      assertNotEquals(accent, colors.accentBorder)
+      assertNotEquals(base.accentSoft, colors.accentSoft)
+      assertNotEquals(base.accentBorder, colors.accentBorder)
+      assertEquals(
+        base.copy(accent = colors.accent, accentSoft = colors.accentSoft, accentBorder = colors.accentBorder),
+        colors,
+      )
+    }
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where setting a gateway accent color (the Control UI user accent or the operator `ui.seamColor`) had no effect in the Android app. The app fetched the color from the gateway on every connect and then silently dropped it: the value landed in a StateFlow with zero Compose consumers, so the app always rendered its hardcoded blue accent.

## Why This Change Was Made

The fetch side already existed (`refreshBrandingFromGateway` reads `config.get`), so the missing piece was precedence and consumption:

- Accent resolution now follows the landed Control UI contract from #128432/#128577: `ui.prefs.accent ?? ui.seamColor` (a present user accent wins, matching `src/gateway/server-methods/talk.ts`), extracted into a pure, tested `resolveGatewayAccentArgb` helper.
- `ClawDesignTheme` accepts the accent and overrides only the three Claw accent tokens: `accent` directly, `accentSoft` composited over the canvas (0.25 alpha dark / 0.08 light, matching the ratios of the existing hardcoded pairs), `accentBorder` as a 12% lerp toward black. The outer Material You dynamic color scheme is deliberately untouched — system chrome stays platform-native.
- The flow is now `StateFlow<Long?>` with `null` meaning "no gateway accent", which dissolves a latent default mismatch (`DEFAULT_SEAM_COLOR_ARGB = 0xFF4F7A9A` in NodeUtils vs `0xFF0EA5E9` in MainViewModel): both magic defaults are deleted and the hardcoded ClawDark/ClawLight palettes remain the canonical no-accent state.

## User Impact

Android operators who set a user accent in the Control UI (or an operator seam color) now see it applied across the app shell and onboarding. With no accent configured, nothing changes.

## Evidence

- Production LOC: +39/−17 (net +22, all accent derivation + wiring) | Tests: +91/−0.
- `resolveGatewayAccentArgb` precedence table test (accent wins; seamColor fallback; present-but-invalid accent does not fall through, per the `??` contract; non-string/null/absent cases; `#RRGGBB` and bare hex) and `ClawColorsTest` (null accent returns the exact hardcoded dark/light palettes; override touches only the three accent tokens). Both new tests fail on pre-fix code.
- `pnpm android:format`, `pnpm android:lint`, and the full `:app:testPlayDebugUnitTest` lane: 2,136 tests, 0 failures.
- Codex autoreview (gpt-5.6-sol, high) on the exact diff: clean, no actionable findings.
- UI screenshot proof: not captured — this session has no Android device/emulator rig; the change is covered by the palette-derivation unit tests above.
