### PR TITLE
fix(macos): user accent from Control UI is clobbered by config snapshots and never live-updates the chat window

### DIFF
--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
@@ -69,13 +69,14 @@ extension ChannelsStore {
         }
     }
 
-    func loadConfig(force: Bool = true) async {
+    func loadConfig(force: Bool = true, refresh: Bool = false) async {
         let sourceKey = self.currentConfigCacheSourceKey()
         self.resetConfigCacheIfSourceChanged(sourceKey)
-        if !force, self.configLoaded {
+        if !force, !refresh, self.configLoaded {
             return
         }
-        guard !self.queueConfigReloadIfLoading(sourceKey: sourceKey, force: force) else { return }
+        guard !self.queueConfigReloadIfLoading(sourceKey: sourceKey, force: force, refresh: refresh)
+        else { return }
         self.configLoading = true
         self.configLoadingSourceKey = sourceKey
         defer {
@@ -98,9 +99,9 @@ extension ChannelsStore {
                 self.configStatus = error.localizedDescription
             }
 
-            guard self.configForceReloadPending else { break }
-            self.configForceReloadPending = false
-            requestForce = true
+            guard self.configReloadPending != .none else { break }
+            requestForce = self.configReloadPending == .force
+            self.configReloadPending = .none
             requestSourceKey = self.currentConfigCacheSourceKey()
             self.resetConfigCacheIfSourceChanged(requestSourceKey)
         }
@@ -253,10 +254,12 @@ extension ChannelsStore {
         self.configSourceKey = sourceKey
     }
 
-    func queueConfigReloadIfLoading(sourceKey: String, force: Bool) -> Bool {
+    func queueConfigReloadIfLoading(sourceKey: String, force: Bool, refresh: Bool = false) -> Bool {
         guard self.configLoading else { return false }
         if force || self.configLoadingSourceKey != sourceKey {
-            self.configForceReloadPending = true
+            self.configReloadPending = .force
+        } else if refresh, self.configReloadPending == .none {
+            self.configReloadPending = .refresh
         }
         return true
     }

--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
@@ -172,8 +172,17 @@ extension ChannelsStore {
 
     private func applyUIConfig(_ snap: ConfigSnapshot) {
         let ui = snap.config?["ui"]?.dictionaryValue
-        let rawSeam = ui?["seamColor"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        AppStateStore.shared.seamColorHex = rawSeam.isEmpty ? nil : rawSeam
+        AppStateStore.shared.seamColorHex = Self.uiAccent(
+            userAccent: ui?["prefs"]?.dictionaryValue?["accent"]?.stringValue,
+            seamColor: ui?["seamColor"]?.stringValue)
+    }
+
+    /// User accent wins over the operator seam color, mirroring the gateway's
+    /// talk.config precedence (ui.prefs.accent -> ui.seamColor -> theme default).
+    static func uiAccent(userAccent: String?, seamColor: String?) -> String? {
+        [userAccent, seamColor]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty }
     }
 
     func channelConfigSchema(for channelId: String) -> ConfigSchemaNode? {

--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import OpenClawProtocol
 
 func whatsappLoginWaitRequestTimeoutMs(
@@ -25,6 +26,9 @@ extension ChannelsStore {
         self.startCount += 1
         guard self.startCount == 1 else { return }
         guard self.pollTask == nil else { return }
+        GatewayPushSubscription.restartTask(task: &self.gatewayPushTask) { [weak self] push in
+            self?.handleGatewayPush(push)
+        }
         self.pollTask = Task.detached { [weak self] in
             guard let self else { return }
             await self.refresh(probe: false)
@@ -44,6 +48,23 @@ extension ChannelsStore {
         guard self.startCount == 0 else { return }
         self.pollTask?.cancel()
         self.pollTask = nil
+        self.gatewayPushTask?.cancel()
+        self.gatewayPushTask = nil
+    }
+
+    static func gatewayPushRequestsConfigRefresh(_ push: GatewayPush) -> Bool {
+        switch push {
+        case let .event(event):
+            event.event == "config.changed"
+        case .snapshot, .seqGap:
+            true
+        }
+    }
+
+    private func handleGatewayPush(_ push: GatewayPush) {
+        guard Self.gatewayPushRequestsConfigRefresh(push) else { return }
+        // Change events contain only a hash; refetch without overwriting a dirty local draft.
+        Task { await self.loadConfig(force: false, refresh: true) }
     }
 
     func refresh(probe: Bool) async {

--- a/apps/macos/Sources/OpenClaw/ChannelsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore.swift
@@ -300,7 +300,10 @@ final class ChannelsStore {
     var configSchemaReloadPending = false
     var configLoading = false
     var configLoadingSourceKey: String?
-    var configForceReloadPending = false
+    /// Coalesced re-load request while a config fetch is in flight: `refresh`
+    /// refetches without overwriting a dirty local draft; `force` overwrites it.
+    enum ConfigReloadRequest { case none, refresh, force }
+    var configReloadPending: ConfigReloadRequest = .none
     var configDraft: [String: Any] = [:]
     var configDirty = false
 
@@ -308,6 +311,7 @@ final class ChannelsStore {
     let isPreview: Bool
     var startCount = 0
     var pollTask: Task<Void, Never>?
+    var gatewayPushTask: Task<Void, Never>?
     var configRoot: [String: Any] = [:]
     var configLoaded = false
     var configSourceKey: String?

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -869,20 +869,17 @@ private struct MacChatSurface: View {
     @AppStorage(OpenClawChatWindowShell.assistantToolActivityDefaultsKey, store: AppDefaults.standard)
     private var showsToolActivity = WebChatTracePreferences.displayOptions().contains(.toolActivity)
 
-    private let userAccent: Color?
     private let usesPrimaryAppRuntime: Bool
     private let speech: OpenClawChatSpeechController
     private let voiceNoteRecorder: OpenClawVoiceNoteRecorder
 
     init(
         viewModel: OpenClawChatViewModel,
-        userAccent: Color?,
         usesPrimaryAppRuntime: Bool,
         speech: OpenClawChatSpeechController,
         voiceNoteRecorder: OpenClawVoiceNoteRecorder)
     {
         _viewModel = State(initialValue: viewModel)
-        self.userAccent = userAccent
         self.usesPrimaryAppRuntime = usesPrimaryAppRuntime
         self.speech = speech
         self.voiceNoteRecorder = voiceNoteRecorder
@@ -891,7 +888,7 @@ private struct MacChatSurface: View {
     var body: some View {
         OpenClawChatWindowShell(
             viewModel: self.viewModel,
-            userAccent: self.userAccent,
+            userAccent: ColorHexSupport.color(fromHex: self.appState.seamColorHex),
             displayOptions: self.displayOptions,
             emptyAssistantIntro: Self.emptyAssistantIntro,
             emptyAssistantPrompts: Self.emptyAssistantPrompts,
@@ -1164,12 +1161,10 @@ final class WebChatSwiftUIWindowController: NSObject, NSWindowDelegate {
                 }
             }
         }
-        let accent = Self.color(fromHex: AppStateStore.shared.seamColorHex)
         // Full window: native split-view shell with sessions sidebar and
         // toolbar pickers bridged into the NSToolbar.
         let hosting = NSHostingController(rootView: MacChatSurface(
             viewModel: vm,
-            userAccent: accent,
             usesPrimaryAppRuntime: usesPrimaryAppRuntime,
             speech: speech,
             voiceNoteRecorder: voiceNoteRecorder))
@@ -1301,10 +1296,6 @@ final class WebChatSwiftUIWindowController: NSObject, NSWindowDelegate {
             let frame = WindowPlacement.centeredFrame(size: WebChatSwiftUILayout.windowSize)
             window.setFrame(frame, display: false)
         }
-    }
-
-    private static func color(fromHex raw: String?) -> Color? {
-        ColorHexSupport.color(fromHex: raw)
     }
 
     #if DEBUG

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
@@ -100,7 +100,7 @@ struct ChannelsSettingsSmokeTests {
                 now: Date(timeInterval: 1.5, since: startedAt)) == nil)
     }
 
-    @Test func `cached config loads return without clearing dirty draft`() async {
+    @Test func `cached config loads return without clearing dirty draft`() {
         let store = makeChannelsStore(channels: [:])
         store.configSchema = ConfigSchemaNode(raw: ["type": "object"])
         store.configSchemaSourceKey = "source-a"
@@ -194,14 +194,21 @@ struct ChannelsSettingsSmokeTests {
         store.configLoadingSourceKey = "source-a"
 
         #expect(store.queueConfigReloadIfLoading(sourceKey: "source-a", force: false) == true)
-        #expect(store.configForceReloadPending == false)
+        #expect(store.configReloadPending == .none)
+
+        #expect(store.queueConfigReloadIfLoading(sourceKey: "source-a", force: false, refresh: true) == true)
+        #expect(store.configReloadPending == .refresh)
 
         #expect(store.queueConfigReloadIfLoading(sourceKey: "source-a", force: true) == true)
-        #expect(store.configForceReloadPending == true)
+        #expect(store.configReloadPending == .force)
 
-        store.configForceReloadPending = false
+        // Force is sticky: a queued refresh must not downgrade a pending force reload.
+        #expect(store.queueConfigReloadIfLoading(sourceKey: "source-a", force: false, refresh: true) == true)
+        #expect(store.configReloadPending == .force)
+
+        store.configReloadPending = .none
         #expect(store.queueConfigReloadIfLoading(sourceKey: "source-b", force: false) == true)
-        #expect(store.configForceReloadPending == true)
+        #expect(store.configReloadPending == .force)
     }
 
     @Test func `schema reload queues behind background load after source changes`() {

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsStoreUIConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsStoreUIConfigTests.swift
@@ -1,0 +1,46 @@
+import OpenClawProtocol
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct ChannelsStoreUIConfigTests {
+    @Test func `user accent overrides the operator seam color`() {
+        #expect(ChannelsStore.uiAccent(userAccent: " #112233 ", seamColor: "#445566") == "#112233")
+    }
+
+    @Test func `empty user accent falls back to the operator seam color`() {
+        #expect(ChannelsStore.uiAccent(userAccent: "", seamColor: " #445566 ") == "#445566")
+        #expect(ChannelsStore.uiAccent(userAccent: " \n\t ", seamColor: "#445566") == "#445566")
+    }
+
+    @Test func `missing accents use the theme default`() {
+        #expect(ChannelsStore.uiAccent(userAccent: nil, seamColor: nil) == nil)
+        #expect(ChannelsStore.uiAccent(userAccent: "  ", seamColor: " \n ") == nil)
+    }
+
+    @Test func `config snapshots preserve the Control UI user accent`() {
+        let previousAccent = AppStateStore.shared.seamColorHex
+        defer { AppStateStore.shared.seamColorHex = previousAccent }
+
+        let store = ChannelsStore(isPreview: true)
+        store.configSourceKey = "gateway"
+        let snapshot = ConfigSnapshot(
+            path: nil,
+            exists: true,
+            raw: nil,
+            hash: nil,
+            parsed: nil,
+            valid: true,
+            config: [
+                "ui": AnyCodable([
+                    "prefs": ["accent": " #112233 "],
+                    "seamColor": "#445566",
+                ]),
+            ],
+            issues: nil)
+
+        store.applyConfigSnapshot(snapshot, sourceKey: "gateway", force: true)
+
+        #expect(AppStateStore.shared.seamColorHex == "#112233")
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsStoreUIConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsStoreUIConfigTests.swift
@@ -1,3 +1,4 @@
+import OpenClawKit
 import OpenClawProtocol
 import Testing
 @testable import OpenClaw
@@ -42,5 +43,27 @@ struct ChannelsStoreUIConfigTests {
         store.applyConfigSnapshot(snapshot, sourceKey: "gateway", force: true)
 
         #expect(AppStateStore.shared.seamColorHex == "#112233")
+    }
+
+    @Test func `gateway pushes refresh config only when its snapshot may be stale`() {
+        let hello = HelloOk(
+            type: "hello-ok",
+            _protocol: 3,
+            server: [:],
+            features: [:],
+            snapshot: Snapshot(
+                presence: [],
+                health: [:],
+                stateversion: StateVersion(presence: 0, health: 0),
+                uptimems: 0),
+            auth: [:],
+            policy: [:])
+
+        #expect(ChannelsStore.gatewayPushRequestsConfigRefresh(
+            .event(EventFrame(type: "event", event: "config.changed"))))
+        #expect(ChannelsStore.gatewayPushRequestsConfigRefresh(.snapshot(hello)))
+        #expect(ChannelsStore.gatewayPushRequestsConfigRefresh(.seqGap(expected: 1, received: 3)))
+        #expect(!ChannelsStore.gatewayPushRequestsConfigRefresh(
+            .event(EventFrame(type: "event", event: "presence"))))
     }
 }

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -547,7 +547,10 @@ See [Plugins](/tools/plugin).
 }
 ```
 
-- `seamColor`: accent color for native app UI chrome (Talk Mode bubble tint, etc.).
+- `seamColor`: operator accent color for native app UI chrome (Talk Mode bubble
+  tint, etc.). The Control UI user accent (`ui.prefs.accent`) takes precedence in
+  `talk.config` payloads and the macOS app's config snapshot. If neither is set,
+  the theme default applies.
 - `assistant`: Control UI identity override. Falls back to active agent identity.
 - `prefs`: cross-device operator preferences. This is the canonical home so agents can
   change them through the approval gate and every Control UI client stays in


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS app users who set a Control UI user accent (`ui.prefs.accent`, landed in #128432/#128577) would see the native app chrome fall back to the operator `ui.seamColor` — or a stale color — depending on which gateway payload arrived last, and where accent changes never reached a running app at all. Three defects:

- `ChannelsStore.applyUIConfig` read raw `ui.seamColor` from the `config.get` snapshot and overwrote `AppStateStore.seamColorHex`, clobbering the user accent that `TalkModeRuntime.applyTalkConfig` had set from the `talk.config` payload (which already applies the precedence server-side).
- The native chat window read `AppStateStore.seamColorHex` once at window construction, so accent changes never live-updated the window's `userAccent`.
- No macOS consumer existed for the gateway's hash-only `config.changed` broadcast, so `ChannelsStore`'s config snapshot was loaded once at startup and a Control UI accent change (or any config change) never refreshed shared state while the app ran (flagged by ClawSweeper's review; addressed in the second commit).

## Why This Change Was Made

The accent precedence contract (user accent → operator `ui.seamColor` → theme default) must hold on every path that feeds native-app chrome, and a Control UI edit must end in a visible outcome in the running app. The snapshot path now resolves `ui.prefs.accent ?? ui.seamColor` through a testable helper (`ChannelsStore.uiAccent`) mirroring `src/gateway/server-methods/talk.ts`. The chat window derives its accent inside `MacChatSurface.body` from the `@Observable` `AppStateStore` (deleting the one-shot `userAccent` init plumbing), so any accent change recolors open windows. `ChannelsStore` now subscribes to gateway pushes (same idiom as `InstancesStore`) and re-fetches `config.get` on `config.changed`, reconnect snapshots, and sequence gaps; the refresh applies non-force so an in-progress local settings draft wins, and the in-flight reload queue's pending flag became a closed level (`none`/`refresh`/`force`) so refreshes arriving mid-load are coalesced instead of dropped and a requeued refresh cannot clobber a dirty draft.

## User Impact

User accent set in the Control UI now sticks in the macOS app regardless of payload arrival order, propagates to a running app without restart, and recolors open native chat windows live. Docs (`docs/gateway/configuration-reference.md`) document the precedence for native-app chrome.

## Evidence

- `ChannelsStoreUIConfigTests` (5 tests): precedence, whitespace fallback, both-absent → nil, a real-`ConfigSnapshot` regression through `applyConfigSnapshot` (fails pre-fix: returned operator seam `#445566` instead of user accent `#112233`), and gateway-push refresh classification (`config.changed`/snapshot/seqGap refresh; unrelated events don't).
- `ChannelsSettingsSmokeTests` (8 tests) extended: reload queue coalesces a refresh during an in-flight load, force stays sticky over refresh, and non-force snapshots leave dirty drafts intact.
- `swift build` green; both suites pass; repo SwiftFormat macOS lane clean (0/26).
- Codex autoreview per commit: both clean ("patch is correct", 0.99 / 0.98).
- Production LOC: +49/−21 | Tests: +81/−5. Growth is the new event-consumer capability (gateway push subscription + closed reload-request level); the precedence/window fixes themselves are net negative.
- ClawSweeper rank-up moves: (1) consume gateway config-change notifications — done in commit 2; (2) live before/after capture of a Control UI edit recoloring an open native chat — skipped this PR: it needs a signed app bundle plus a live gateway rig; the event→refresh→observation chain is covered end-to-end by the unit seams above (push classification, non-force apply, observable store read in `body`).
