### PR TITLE
fix(scripts): ignore superseded target dispatch checks

### DIFF
--- a/scripts/watch-pr-ci.mts
+++ b/scripts/watch-pr-ci.mts
@@ -32,6 +32,7 @@ const RollupCheckSchema = z.object({
       workflowRun: optionalNullable(
         z.object({
           databaseId: optionalNumber,
+          event: optionalString,
           workflow: optional(z.object({ databaseId: optionalNumber })),
         }),
       ),
@@ -66,7 +67,7 @@ const RollupResponseSchema = z.object({
     repository: z.object({ pullRequest: RollupPageSchema.nullish() }).nullish(),
   }),
 });
-const RunListItemSchema = z.object({ id: z.number(), created_at: z.string() });
+const RunListItemSchema = z.object({ id: z.number(), workflow_id: optionalNumber });
 const RunListSchema = z
   .object({ workflow_runs: validArray(RunListItemSchema) })
   .transform((response) => response.workflow_runs)
@@ -89,7 +90,7 @@ const FAILURE_CONCLUSIONS = new Set([
   "STALE",
   "TIMED_OUT",
 ]);
-const ROLLUP_QUERY = `query($owner:String!,$name:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$pr){state mergeable headRefOid statusCheckRollup{state contexts(first:100,after:$cursor){totalCount pageInfo{hasNextPage endCursor} nodes{kind:__typename ... on CheckRun{name status conclusion databaseId checkSuite{workflowRun{databaseId workflow{databaseId}}}} ... on StatusContext{context state}}}}}}}`;
+const ROLLUP_QUERY = `query($owner:String!,$name:String!,$pr:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$pr){state mergeable headRefOid statusCheckRollup{state contexts(first:100,after:$cursor){totalCount pageInfo{hasNextPage endCursor} nodes{kind:__typename ... on CheckRun{name status conclusion databaseId checkSuite{workflowRun{databaseId event workflow{databaseId}}}} ... on StatusContext{context state}}}}}}}`;
 const GH_READ_OPTIONS = {
   stdio: ["ignore", "pipe", "pipe"],
   timeout: 60_000,
@@ -192,7 +193,7 @@ function checkRunIdentity(check: RollupCheck) {
 const newerJob = (a: JobIdentity, b: JobIdentity) =>
   a.runId !== b.runId ? a.runId > b.runId : a.checkId > b.checkId;
 
-export function classifyRollup(rollup: RollupPayload | null | undefined) {
+export function classifyRollup(rollup: RollupPayload | null | undefined, runs: RunListItem[] = []) {
   const rawNodes = rollup?.contexts?.nodes ?? [];
   const hiddenContextCount = Math.max(
     0,
@@ -221,8 +222,8 @@ export function classifyRollup(rollup: RollupPayload | null | undefined) {
   let supersededCount = 0;
   // Re-triggers leave every prior run's check runs on the SHA forever and GitHub's aggregate
   // counts them. A check is superseded when a newer same-workflow check shares its name
-  // (GitHub's latest-name-wins semantics), or when it was cancelled and its workflow has a
-  // newer run (draft->ready cancels the old run before the replacement posts check runs).
+  // (GitHub's latest-name-wins semantics), or when its cancelled workflow has a newer run.
+  // Actions run metadata also proves target-run supersession before a newer run posts jobs.
   // Older-run checks with unique names stay visible so distinct invocations are not dropped.
   const nodes = rawNodes.filter((check) => {
     const identity = checkRunIdentity(check);
@@ -236,8 +237,13 @@ export function classifyRollup(rollup: RollupPayload | null | undefined) {
         return false;
       }
     }
-    const newestRun = newestRunByWorkflow.get(identity.workflowId);
-    if (check.conclusion === "CANCELLED" && newestRun !== undefined && newestRun > identity.runId) {
+    const newestRun = newestRunByWorkflow.get(identity.workflowId) ?? identity.runId;
+    if (
+      check.conclusion === "CANCELLED" &&
+      (newestRun > identity.runId ||
+        (check.checkSuite?.workflowRun?.event === "pull_request_target" &&
+          runs.some((run) => run.workflow_id === identity.workflowId && run.id > identity.runId)))
+    ) {
       supersededCount += 1;
       return false;
     }
@@ -309,6 +315,13 @@ const findRun = (repo: string, sha: string, after?: number) =>
   selectRunAfter(
     RunListSchema.parse(execGhJson(buildFindRunArgs(repo, sha), GH_READ_OPTIONS)),
     after,
+  );
+const findTargetRuns = (repo: string, sha: string) =>
+  RunListSchema.parse(
+    execGhJson(
+      ["api", `repos/${repo}/actions/runs?event=pull_request_target&head_sha=${sha}&per_page=100`],
+      GH_READ_OPTIONS,
+    ),
   );
 const readRun = (repo: string, runId: number) =>
   RunStatusSchema.parse(
@@ -541,7 +554,18 @@ async function main(argv = process.argv.slice(2)) {
         if (blocked !== null) {
           return blocked;
         }
-        const result = classifyRollup(pr.statusCheckRollup);
+        let result = classifyRollup(pr.statusCheckRollup);
+        if (
+          result.verdict === "FAILING" &&
+          pr.statusCheckRollup?.contexts?.nodes?.some(
+            (check) =>
+              check.conclusion === "CANCELLED" &&
+              check.checkSuite?.workflowRun?.event === "pull_request_target" &&
+              checkRunIdentity(check),
+          )
+        ) {
+          result = classifyRollup(pr.statusCheckRollup, findTargetRuns(args.repo, args.headSha));
+        }
         lastState = pr.statusCheckRollup?.state ?? "NONE";
         lastPending = result.pendingCount;
         console.log(

--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -320,6 +320,78 @@ describe("watch-pr-ci", () => {
     ).toEqual({ verdict: "PENDING", pendingCount: 2, failingNames: [], supersededCount: 1 });
   });
 
+  it.each<{
+    label: string;
+    name?: string;
+    conclusion?: string;
+    event?: string | null;
+    workflowId?: number | null;
+    newerRunId?: number;
+    newerWorkflowId?: number | null;
+    ciStatus?: string;
+    verdict?: string;
+  }>([
+    { label: "pending CI", ciStatus: "IN_PROGRESS", verdict: "PENDING" },
+    { label: "successful CI with a different check name", name: "target guard", verdict: "GREEN" },
+    { label: "latest target cancellation", newerRunId: 100 },
+    { label: "real target failure", conclusion: "FAILURE" },
+    { label: "another event's cancellation", event: "pull_request" },
+    { label: "another workflow", newerWorkflowId: 20 },
+    { label: "unknown event", event: null },
+    { label: "unknown visible workflow identity", workflowId: null },
+    { label: "unknown replacement workflow identity", newerWorkflowId: null },
+  ])(
+    "uses newer same-workflow target-run identity without hiding $label",
+    ({
+      name = "dispatch",
+      conclusion = "CANCELLED",
+      event = "pull_request_target",
+      workflowId = 10,
+      newerRunId = 200,
+      newerWorkflowId = 10,
+      ciStatus = "COMPLETED",
+      verdict = "FAILING",
+    }) => {
+      expect(
+        classifyRollup(
+          {
+            state: "FAILURE",
+            contexts: {
+              nodes: [
+                {
+                  kind: "CheckRun",
+                  name,
+                  status: "COMPLETED",
+                  conclusion,
+                  checkSuite: {
+                    workflowRun: {
+                      databaseId: 100,
+                      event: event ?? undefined,
+                      workflow: { databaseId: workflowId ?? undefined },
+                    },
+                  },
+                },
+                {
+                  kind: "CheckRun",
+                  name: "CI",
+                  status: ciStatus,
+                  conclusion: ciStatus === "COMPLETED" ? "SUCCESS" : null,
+                  checkSuite: { workflowRun: { databaseId: 200, workflow: { databaseId: 20 } } },
+                },
+              ],
+            },
+          },
+          [{ id: newerRunId, workflow_id: newerWorkflowId ?? undefined }],
+        ),
+      ).toEqual({
+        verdict,
+        pendingCount: ciStatus === "IN_PROGRESS" ? 1 : 0,
+        failingNames: verdict === "FAILING" ? [name] : [],
+        supersededCount: verdict === "FAILING" ? 0 : 1,
+      });
+    },
+  );
+
   it("keeps only the newest same-run check attempt while its replacement is pending", () => {
     expect(
       classifyRollup({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maintainers waiting for pull-request CI can see a false terminal failure after GitHub cancels an older target-dispatch run even though the actual pull-request checks have succeeded.

Read-only reproduction: #128464 at head `765c6728c0db3f5c9e19910725b4d7431789e854` retained seven cancelled, already-superseded target checks in its failing aggregate rollup.

## Why This Change Was Made

GitHub's check rollup can retain cancelled jobs from an older `pull_request_target` run while omitting its newer same-workflow replacement when that replacement created no jobs. The watcher therefore could not prove supersession from rollup-visible checks alone. When this precise ambiguous failure occurs, resolve bounded Actions runs for the exact PR head and ignore an old cancellation only when its event, workflow identity, and strictly newer run ID prove replacement; preserve genuine failures, current cancellations, other workflows/events, unknown identities, and pending pull-request CI.

## User Impact

Maintainers and automated landing flows can wait for the real required CI verdict without being blocked by obsolete target-dispatch cancellations. Actual failing or pending checks remain actionable. No OpenClaw runtime, channel, configuration, or changelog behavior changes.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/watch-pr-ci.test.ts`: 38 tests passed, including table-driven coverage for pending CI, successful differently named checks, real failures, latest cancellations, event/workflow mismatches, and unknown identities.
- `node scripts/check-changed.mjs -- scripts/watch-pr-ci.mts test/scripts/watch-pr-ci.test.ts`: changed-file format, type, lint, and applicable guard checks passed.
- `node scripts/watch-pr-ci.mjs 128464 765c6728c0db3f5c9e19910725b4d7431789e854`: live, read-only GitHub reproduction reports `STATUS state=FAILURE pending=0 superseded=7`, then `GREEN`.
- Fresh Codex autoreview of the final dirty diff: clean, with no actionable findings. AI-assisted; no agent transcript included.
- Tooling LOC: `+32/-8` (net `+24`); tests: `+72/-0`. The tooling growth is required for the bounded exact-head Actions lookup because no-job replacement runs are absent from GitHub's rollup; no existing rollup-only refactor can recover an unreported run identity.
- Proof gaps: no product UI/channel or live-provider proof applies to this maintainer-only watcher; the relevant GitHub Actions behavior was exercised live against the existing PR without modifying it.
