### PR TITLE
refactor(catalog): normalize provider routing fields once

### DIFF
--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -126,10 +126,6 @@ function normalizeModelCatalogInputs(value: unknown): ModelCatalogInput[] | unde
   return inputs.length > 0 ? inputs : undefined;
 }
 
-function normalizeStringOrNumber(value: unknown): string | number | undefined {
-  return normalizeOptionalString(value) ?? normalizeFiniteNumber(value);
-}
-
 function normalizePositiveInteger(value: unknown): number | undefined {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
 }
@@ -198,55 +194,37 @@ function normalizeOpenRouterPrice(value: unknown): ModelCatalogOpenRouterRouting
   if (!isRecord(value)) {
     return undefined;
   }
-  const maxPrice = {
-    ...(normalizeStringOrNumber(value.prompt) !== undefined
-      ? { prompt: normalizeStringOrNumber(value.prompt) }
-      : {}),
-    ...(normalizeStringOrNumber(value.completion) !== undefined
-      ? { completion: normalizeStringOrNumber(value.completion) }
-      : {}),
-    ...(normalizeStringOrNumber(value.image) !== undefined
-      ? { image: normalizeStringOrNumber(value.image) }
-      : {}),
-    ...(normalizeStringOrNumber(value.audio) !== undefined
-      ? { audio: normalizeStringOrNumber(value.audio) }
-      : {}),
-    ...(normalizeStringOrNumber(value.request) !== undefined
-      ? { request: normalizeStringOrNumber(value.request) }
-      : {}),
-  } satisfies NonNullable<ModelCatalogOpenRouterRouting["max_price"]>;
-  return Object.keys(maxPrice).length > 0 ? maxPrice : undefined;
-}
-
-function normalizeOpenRouterPercentileCutoffs(
-  value: unknown,
-):
-  | NonNullable<Exclude<ModelCatalogOpenRouterRouting["preferred_min_throughput"], number>>
-  | undefined {
-  if (!isRecord(value)) {
-    return undefined;
+  const maxPrice: NonNullable<ModelCatalogOpenRouterRouting["max_price"]> = {};
+  for (const field of ["prompt", "completion", "image", "audio", "request"] as const) {
+    const candidate = value[field];
+    const normalized = normalizeOptionalString(candidate) ?? normalizeFiniteNumber(candidate);
+    if (normalized !== undefined) {
+      maxPrice[field] = normalized;
+    }
   }
-  const normalized = {
-    ...(normalizeFiniteNumber(value.p50) !== undefined
-      ? { p50: normalizeFiniteNumber(value.p50) }
-      : {}),
-    ...(normalizeFiniteNumber(value.p75) !== undefined
-      ? { p75: normalizeFiniteNumber(value.p75) }
-      : {}),
-    ...(normalizeFiniteNumber(value.p90) !== undefined
-      ? { p90: normalizeFiniteNumber(value.p90) }
-      : {}),
-    ...(normalizeFiniteNumber(value.p99) !== undefined
-      ? { p99: normalizeFiniteNumber(value.p99) }
-      : {}),
-  };
-  return Object.keys(normalized).length > 0 ? normalized : undefined;
+  return Object.keys(maxPrice).length > 0 ? maxPrice : undefined;
 }
 
 function normalizeOpenRouterMetricPreference(
   value: unknown,
 ): ModelCatalogOpenRouterRouting["preferred_min_throughput"] {
-  return normalizeFiniteNumber(value) ?? normalizeOpenRouterPercentileCutoffs(value);
+  const numeric = normalizeFiniteNumber(value);
+  if (numeric !== undefined) {
+    return numeric;
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const normalized: NonNullable<
+    Exclude<ModelCatalogOpenRouterRouting["preferred_min_throughput"], number>
+  > = {};
+  for (const field of ["p50", "p75", "p90", "p99"] as const) {
+    const cutoff = normalizeFiniteNumber(value[field]);
+    if (cutoff !== undefined) {
+      normalized[field] = cutoff;
+    }
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
 function normalizeOpenRouterSort(value: unknown): ModelCatalogOpenRouterRouting["sort"] {
@@ -271,7 +249,7 @@ function normalizeOpenRouterRouting(value: unknown): ModelCatalogOpenRouterRouti
   if (!isRecord(value)) {
     return undefined;
   }
-  const routing = {
+  const routing: ModelCatalogOpenRouterRouting = {
     ...(typeof value.allow_fallbacks === "boolean"
       ? { allow_fallbacks: value.allow_fallbacks }
       : {}),
@@ -285,33 +263,27 @@ function normalizeOpenRouterRouting(value: unknown): ModelCatalogOpenRouterRouti
     ...(typeof value.enforce_distillable_text === "boolean"
       ? { enforce_distillable_text: value.enforce_distillable_text }
       : {}),
-    ...(normalizeOptionalTrimmedStringList(value.order)
-      ? { order: normalizeOptionalTrimmedStringList(value.order) }
-      : {}),
-    ...(normalizeOptionalTrimmedStringList(value.only)
-      ? { only: normalizeOptionalTrimmedStringList(value.only) }
-      : {}),
-    ...(normalizeOptionalTrimmedStringList(value.ignore)
-      ? { ignore: normalizeOptionalTrimmedStringList(value.ignore) }
-      : {}),
-    ...(normalizeOptionalTrimmedStringList(value.quantizations)
-      ? { quantizations: normalizeOptionalTrimmedStringList(value.quantizations) }
-      : {}),
-    ...(normalizeOpenRouterSort(value.sort) ? { sort: normalizeOpenRouterSort(value.sort) } : {}),
-    ...(normalizeOpenRouterPrice(value.max_price)
-      ? { max_price: normalizeOpenRouterPrice(value.max_price) }
-      : {}),
-    ...(normalizeOpenRouterMetricPreference(value.preferred_min_throughput) !== undefined
-      ? {
-          preferred_min_throughput: normalizeOpenRouterMetricPreference(
-            value.preferred_min_throughput,
-          ),
-        }
-      : {}),
-    ...(normalizeOpenRouterMetricPreference(value.preferred_max_latency) !== undefined
-      ? { preferred_max_latency: normalizeOpenRouterMetricPreference(value.preferred_max_latency) }
-      : {}),
-  } satisfies ModelCatalogOpenRouterRouting;
+  };
+  for (const field of ["order", "only", "ignore", "quantizations"] as const) {
+    const normalized = normalizeOptionalTrimmedStringList(value[field]);
+    if (normalized) {
+      routing[field] = normalized;
+    }
+  }
+  const sort = normalizeOpenRouterSort(value.sort);
+  if (sort) {
+    routing.sort = sort;
+  }
+  const maxPrice = normalizeOpenRouterPrice(value.max_price);
+  if (maxPrice) {
+    routing.max_price = maxPrice;
+  }
+  for (const field of ["preferred_min_throughput", "preferred_max_latency"] as const) {
+    const normalized = normalizeOpenRouterMetricPreference(value[field]);
+    if (normalized !== undefined) {
+      routing[field] = normalized;
+    }
+  }
   return Object.keys(routing).length > 0 ? routing : undefined;
 }
 
@@ -321,14 +293,13 @@ function normalizeVercelGatewayRouting(
   if (!isRecord(value)) {
     return undefined;
   }
-  const routing = {
-    ...(normalizeOptionalTrimmedStringList(value.only)
-      ? { only: normalizeOptionalTrimmedStringList(value.only) }
-      : {}),
-    ...(normalizeOptionalTrimmedStringList(value.order)
-      ? { order: normalizeOptionalTrimmedStringList(value.order) }
-      : {}),
-  } satisfies ModelCatalogVercelGatewayRouting;
+  const routing: ModelCatalogVercelGatewayRouting = {};
+  for (const field of ["only", "order"] as const) {
+    const normalized = normalizeOptionalTrimmedStringList(value[field]);
+    if (normalized) {
+      routing[field] = normalized;
+    }
+  }
   return Object.keys(routing).length > 0 ? routing : undefined;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Model catalog normalization repeatedly evaluated the same OpenRouter and Vercel routing inputs while processing provider manifests, provider-index previews, and runtime model rows. Each populated routing field could trigger duplicate normalization and duplicate accessor reads without changing the resulting catalog.

## Why This Change Was Made

The existing model-catalog owner now normalizes pricing fields, percentile cutoffs, provider lists, and throughput/latency preferences exactly once in their existing deterministic order. This reuses the owner's established ordered-field-loop pattern and removes two obsolete private helpers without changing exported APIs, provider routing contracts, configuration, or validation.

## User Impact

No user-visible behavior changes. OpenRouter and Vercel model routing retains the same ordered serialized output, provider ownership, accepted string and numeric values, invalid-value rejection, and empty-field handling while avoiding redundant work.

## Evidence

- Production: one model-catalog owner, +54/-83 lines (net -29); no test or configuration changes.
- Focused owner and production-caller proof: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-cleanup2-lane1-vitest-cache node scripts/run-vitest.mjs --configLoader runner packages/model-catalog-core/src/model-catalog-normalize.test.ts src/model-catalog/manifest-planner.test.ts src/model-catalog/provider-index/normalize.test.ts src/plugin-sdk/provider-catalog-shared.test.ts` — four files, 43 tests passed.
- Executable exported-boundary probe verified 24 tracked routing getters are normalized once, exact OpenRouter/Vercel output key order, numeric zero pricing/percentiles/latency, `false` flags, `null` sort partitions, trimmed arrays, and `NaN`/`Infinity` rejection.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json packages/model-catalog-core/src/model-catalog-normalize.ts` and `./node_modules/.bin/oxfmt --check packages/model-catalog-core/src/model-catalog-normalize.ts` passed; `git diff --check` passed.
- Independent source-aware review accepted; fresh structured Codex autoreview passed with no actionable findings.
- Full core changed-gate proof is delegated to exact-head hosted CI and the mandatory repository-native Testbox prepare flow because this isolated checkout links a known stale/mixed canonical dependency tree.
