### PR TITLE
fix(line): preserve full Flex action labels up to LINE's limit

### DIFF
--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -3,7 +3,6 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { messageAction, postbackAction, uriAction } from "./actions.js";
 import {
   createActionCard,
   createImageCard,
@@ -72,22 +71,13 @@ function parseActions(actionsStr: string | undefined): CardAction[] {
 
     const actionData = data || label;
 
-    if (actionData.startsWith("http://") || actionData.startsWith("https://")) {
-      results.push({
-        label,
-        action: uriAction(label, actionData),
-      });
-    } else if (actionData.includes("=")) {
-      results.push({
-        label,
-        action: postbackAction(label, actionData, label),
-      });
-    } else {
-      results.push({
-        label,
-        action: messageAction(label, actionData),
-      });
-    }
+    const action =
+      actionData.startsWith("http://") || actionData.startsWith("https://")
+        ? { type: "uri" as const, label, uri: actionData }
+        : actionData.includes("=")
+          ? { type: "postback" as const, label, data: actionData, displayText: label }
+          : { type: "message" as const, label, text: actionData };
+    results.push({ label, action });
   }
 
   return results;

--- a/extensions/line/src/channel.rich-messages.test.ts
+++ b/extensions/line/src/channel.rich-messages.test.ts
@@ -77,6 +77,65 @@ describe("LINE rich-message boundaries", () => {
     });
   });
 
+  it.each([
+    {
+      kind: "command",
+      action: { type: "command", command: "/status" },
+      expected: { type: "message", text: "/status" },
+    },
+    {
+      kind: "callback",
+      action: { type: "callback", value: "action=status" },
+      expected: { type: "postback", data: "action=status" },
+    },
+    {
+      kind: "url",
+      action: { type: "url", url: "https://example.com/status" },
+      expected: { type: "uri", uri: "https://example.com/status" },
+    },
+    {
+      kind: "web-app",
+      action: { type: "web-app", url: "https://example.com/app" },
+      expected: { type: "uri", uri: "https://example.com/app" },
+    },
+  ] as const)(
+    "preserves 40-character Flex $kind labels while quick replies stay bounded",
+    async ({ action, expected }) => {
+      const label = "x".repeat(40);
+      const result = await lineOutboundAdapter.renderPresentation?.({
+        payload: { text: "Choose one" },
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                { label, action },
+                { label: `${label}y`, action },
+              ],
+            },
+            {
+              type: "select",
+              options: [{ label, action: { type: "callback", value: "quick" } }],
+            },
+          ],
+        },
+        ctx: {} as never,
+      });
+      const line = result?.channelData?.line as {
+        flexMessage: { contents: { footer: { contents: Array<{ action: { label: string } }> } } };
+        quickReplyItems: unknown[];
+      };
+
+      expect(line.flexMessage.contents.footer.contents).toMatchObject([
+        { action: { ...expected, label } },
+        { action: { ...expected, label } },
+      ]);
+      expect(createLineQuickReply(line.quickReplyItems as never)).toMatchObject({
+        items: [{ action: { type: "postback", data: "quick", label: "x".repeat(20) } }],
+      });
+    },
+  );
+
   it("validates every typed LINE-specific rich-message shape", () => {
     const schema = resolveChannelDataSchema();
     const valid = [

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -100,6 +100,21 @@ async function runLineFlexCardCommand(
   return result.channelData.line.flexMessage;
 }
 
+function resolveLineFlexCardActions(message: {
+  contents: messagingApi.FlexContainer;
+}): messagingApi.Action[] {
+  if (message.contents.type !== "bubble") {
+    throw new Error("Expected LINE Flex action card to render a bubble");
+  }
+  const footer = expectDefined(message.contents.footer, "LINE flex-message footer");
+  return footer.contents.map((component) => {
+    if (component.type !== "button") {
+      throw new Error("Expected LINE Flex action card footer to contain buttons");
+    }
+    return component.action;
+  });
+}
+
 type LineProviderRequest = {
   path: string;
   authenticated: boolean;
@@ -531,13 +546,9 @@ describe("action label/data surrogate-safe truncation", () => {
     const message = await runLineFlexCardCommand(
       `action "Menu" "Body" --actions "${label}|${data},${label}y|${data}"`,
     );
-    const footer = message.contents.footer as {
-      contents: Array<{ action: { label: string } }>;
-    };
-
-    expect(footer.contents).toMatchObject([
-      { action: { ...expected, label } },
-      { action: { ...expected, label } },
+    expect(resolveLineFlexCardActions(message)).toMatchObject([
+      { ...expected, label },
+      { ...expected, label },
     ]);
   });
 
@@ -546,11 +557,13 @@ describe("action label/data surrogate-safe truncation", () => {
     const message = await runLineFlexCardCommand(
       `action "Menu" "Body" --actions "${label}|/status"`,
     );
-    const footer = message.contents.footer as { contents: Array<{ action: { label: string } }> };
-    const action = expectDefined(footer.contents[0], "LINE flex-message footer action").action;
+    const action = expectDefined(
+      resolveLineFlexCardActions(message)[0],
+      "LINE flex-message footer action",
+    );
 
     expect(action.label).toBe(label);
-    expect(loneHighSurrogate.test(action.label)).toBe(false);
+    expect(loneHighSurrogate.test(action.label ?? "")).toBe(false);
   });
 
   it("/card buttons retains the template-specific 20-character action label limit", async () => {
@@ -579,9 +592,7 @@ describe("action label/data surrogate-safe truncation", () => {
   it("/card action visibly disables an oversized URI at the Flex action owner", async () => {
     const uri = `https://example.test/${"u".repeat(1_000)}`;
     const message = await runLineFlexCardCommand(`action "Menu" "Body" --actions "Open|${uri}"`);
-    const footer = message.contents.footer as { contents: Array<{ action: unknown }> };
-
-    expect(footer.contents[0]?.action).toEqual({
+    expect(resolveLineFlexCardActions(message)[0]).toEqual({
       type: "message",
       label: "Unavailable",
       text: "Link unavailable: URL exceeds LINE's limit.",

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -514,6 +514,80 @@ describe("action label/data surrogate-safe truncation", () => {
     });
   });
 
+  it.each([
+    { kind: "message", data: "/status", expected: { type: "message", text: "/status" } },
+    {
+      kind: "postback",
+      data: "action=status",
+      expected: { type: "postback", data: "action=status" },
+    },
+    {
+      kind: "uri",
+      data: "https://example.test/status",
+      expected: { type: "uri", uri: "https://example.test/status" },
+    },
+  ])("/card action preserves 40-character $kind labels", async ({ data, expected }) => {
+    const label = "x".repeat(40);
+    const message = await runLineFlexCardCommand(
+      `action "Menu" "Body" --actions "${label}|${data},${label}y|${data}"`,
+    );
+    const footer = message.contents.footer as {
+      contents: Array<{ action: { label: string } }>;
+    };
+
+    expect(footer.contents).toMatchObject([
+      { action: { ...expected, label } },
+      { action: { ...expected, label } },
+    ]);
+  });
+
+  it("/card action preserves Unicode labels without splitting the 40-grapheme boundary", async () => {
+    const label = `${"x".repeat(39)}😀`;
+    const message = await runLineFlexCardCommand(
+      `action "Menu" "Body" --actions "${label}|/status"`,
+    );
+    const footer = message.contents.footer as { contents: Array<{ action: { label: string } }> };
+    const action = expectDefined(footer.contents[0], "LINE flex-message footer action").action;
+
+    expect(action.label).toBe(label);
+    expect(loneHighSurrogate.test(action.label)).toBe(false);
+  });
+
+  it("/card buttons retains the template-specific 20-character action label limit", async () => {
+    const label = "x".repeat(40);
+    const result = (await registerCommandWithHandler((command: unknown) => {
+      const { handler } = command as {
+        handler: (ctx: { args: string; channel: string }) => Promise<unknown>;
+      };
+      return handler({
+        channel: "line",
+        args: `buttons "Menu" "Body" --actions "${label}|/status"`,
+      });
+    })) as {
+      channelData: {
+        line: { templateMessage: Parameters<typeof buildTemplateMessageFromPayload>[0] };
+      };
+    };
+    const template = expectDefined(
+      buildTemplateMessageFromPayload(result.channelData.line.templateMessage),
+      "LINE buttons template message",
+    ).template as { actions: Array<{ label: string }> };
+
+    expect(template.actions).toMatchObject([{ type: "message", label: "x".repeat(20) }]);
+  });
+
+  it("/card action visibly disables an oversized URI at the Flex action owner", async () => {
+    const uri = `https://example.test/${"u".repeat(1_000)}`;
+    const message = await runLineFlexCardCommand(`action "Menu" "Body" --actions "Open|${uri}"`);
+    const footer = message.contents.footer as { contents: Array<{ action: unknown }> };
+
+    expect(footer.contents[0]?.action).toEqual({
+      type: "message",
+      label: "Unavailable",
+      text: "Link unavailable: URL exceeds LINE's limit.",
+    });
+  });
+
   it.each(lineFlexCardCommandScenarios)(
     "/card $kind preserves provider-valid Flex alternative text",
     async (scenario) => {

--- a/extensions/line/src/rich-messages.ts
+++ b/extensions/line/src/rich-messages.ts
@@ -16,7 +16,7 @@ import {
 import { Type } from "typebox";
 import { hasLineCredentials } from "./account-helpers.js";
 import { resolveLineAccount } from "./accounts.js";
-import { messageAction, postbackAction, uriAction, type Action } from "./actions.js";
+import { messageAction, postbackAction, type Action } from "./actions.js";
 import {
   createActionCard,
   createAgendaCard,
@@ -129,17 +129,18 @@ export const LINE_PRESENTATION_CAPABILITIES = {
 
 function toLineAction(button: MessagePresentationButton): Action | undefined {
   const normalized = resolveMessagePresentationButtonAction(button);
+  const { label } = button;
   if (normalized?.type === "command") {
-    return messageAction(button.label, normalized.command);
+    return { type: "message", label, text: normalized.command };
   }
   if (normalized?.type === "callback") {
-    return postbackAction(button.label, normalized.value, button.label);
+    return { type: "postback", label, data: normalized.value, displayText: label };
   }
   if (normalized?.type === "url") {
-    return uriAction(button.label, normalized.url);
+    return { type: "uri", label, uri: normalized.url };
   }
   if (normalized?.type === "web-app" && normalized.url) {
-    return uriAction(button.label, normalized.url);
+    return { type: "uri", label, uri: normalized.url };
   }
   return undefined;
 }


### PR DESCRIPTION
Related: #128711

## What Problem This Solves

LINE Flex buttons support 40-character labels, but portable presentations and `/card action` eagerly normalized their typed actions through generic 20-character constructors. Later Flex normalization could not restore the lost text, so distinct buttons became visually indistinguishable before delivery.

[LINE's official action-label specification](https://developers.line.biz/en/reference/messaging-api/nojs/#action-object-label-spec) assigns Flex buttons 40 characters, ordinary template actions and quick replies 20 characters, and image-carousel actions 12 characters.

## Why This Change Was Made

Construct the typed action at each existing LINE producer and defer validation to its existing destination owner. The canonical Flex builder retains its 40-character normalizer; templates, quick replies, and image carousels retain their existing 20/20/12-character normalizers. Callback data, URLs, postback display text, Unicode boundaries, provider push/reply validation, and visible unavailable-action behavior remain protected by the unchanged canonical validators.

The repair removes nine production lines overall and adds focused regression coverage. Original contribution by @edenfunf is preserved in the commit attribution.

## Evidence

On the untouched current-main baseline, the new focused tests reproduced eight failures across portable command, callback, URL, and web-app actions, `/card` message/postback/URI actions, and Unicode labels; 67 existing and sibling cases passed. On the repaired commit:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/line/src/channel.rich-messages.test.ts \
  extensions/line/src/message-cards.test.ts --reporter=dot --maxWorkers=1

Test Files  2 passed (2)
Tests      75 passed (75)
```

The real production channel adapter was also exercised through `renderPresentation -> sendPayload -> pushLineMessages -> sendLineProviderMessages`. Only the destination of each actual provider HTTPS request was redirected to a localhost LINE-provider server; synthetic credentials were used, and no live LINE API or client was contacted. Four decoded authenticated HTTP requests proved:

- Portable Flex action labels of 30 and 40 characters survive; 41-character labels become 40, including surrogate-safe Unicode.
- `/card action` message and postback labels preserve 30/40 characters and their original payloads.
- Quick replies and `/card buttons` templates remain bounded at 20 characters.
- Callback and URL destinations remain unchanged.
- Oversized callback data and URLs both become visible `Unavailable` actions before the provider request.

An isolated autoreview and a separate exact-commit read-only review reported no actionable findings. Production delta: +13/-22; regression tests: +133.
