### PR TITLE
refactor(config): simplify plugin validation state

### DIFF
--- a/src/config/validation-plugin-config.ts
+++ b/src/config/validation-plugin-config.ts
@@ -136,7 +136,6 @@ function formatMissingOfficialExternalPluginWarning(
 export function validateExplicitPluginConfig(params: {
   raw: unknown;
   config: OpenClawConfig;
-  effectiveConfig: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   applyDefaults: boolean;
   registry: PluginManifestRegistry;
@@ -151,7 +150,6 @@ export function validateExplicitPluginConfig(params: {
   const {
     raw,
     config,
-    effectiveConfig,
     env,
     applyDefaults,
     registry,
@@ -365,7 +363,7 @@ export function validateExplicitPluginConfig(params: {
       id: pluginId,
       origin: record.origin,
       config: normalizedPlugins,
-      rootConfig: effectiveConfig,
+      rootConfig: config,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(record),
     });
     let enabled = activationState.activated;

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -241,9 +241,7 @@ function validateConfigObjectWithPluginsBase(
       : formatRawChannelConfigIssueMessage(message);
   };
 
-  let compatConfig: OpenClawConfig | null | undefined;
   let compatPluginIds: ReadonlySet<string> | null = null;
-  let compatPluginIdsResolved = false;
   let registryDiagnosticsPushed = false;
 
   const pushRegistryDiagnostics = (registry: PluginManifestRegistry): void => {
@@ -286,22 +284,16 @@ function validateConfigObjectWithPluginsBase(
   const ensureLoadedRegistryInfo = (): RegistryInfo => registryInfo ?? loadValidationRegistry();
 
   const ensureCompatPluginIds = (): ReadonlySet<string> => {
-    if (compatPluginIdsResolved) {
-      return compatPluginIds ?? new Set<string>();
+    if (compatPluginIds) {
+      return compatPluginIds;
     }
-    compatPluginIdsResolved = true;
     const allow = config.plugins?.allow;
     if (!Array.isArray(allow) || allow.length === 0) {
       compatPluginIds = new Set<string>();
       return compatPluginIds;
     }
     const { registry } = registryInfo ?? loadValidationRegistry();
-    const overriddenBundledPluginIds = new Set(
-      registry.diagnostics
-        .filter((diag) => diag.message.includes("duplicate plugin id detected"))
-        .map((diag) => diag.pluginId)
-        .filter((pluginId): pluginId is string => typeof pluginId === "string" && pluginId !== ""),
-    );
+    const overriddenBundledPluginIds = ensureOverriddenPluginIds();
     compatPluginIds = new Set(
       registry.plugins
         .filter(
@@ -315,17 +307,8 @@ function validateConfigObjectWithPluginsBase(
     return compatPluginIds;
   };
 
-  const ensureCompatConfig = (): OpenClawConfig => {
-    if (compatConfig !== undefined) {
-      return compatConfig ?? config;
-    }
-    compatConfig = config;
-    return config;
-  };
-
   const ensureRegistry = (): RegistryInfo => {
     const info = ensureLoadedRegistryInfo();
-    ensureCompatConfig();
     pushRegistryDiagnostics(info.registry);
     return info;
   };
@@ -349,7 +332,7 @@ function validateConfigObjectWithPluginsBase(
 
   const ensureNormalizedPlugins = (): ReturnType<typeof normalizePluginsConfig> => {
     const info = ensureRegistry();
-    info.normalizedPlugins ??= normalizePluginsConfig(ensureCompatConfig().plugins);
+    info.normalizedPlugins ??= normalizePluginsConfig(config.plugins);
     return info.normalizedPlugins;
   };
 
@@ -716,7 +699,6 @@ function validateConfigObjectWithPluginsBase(
     validateExplicitPluginConfig({
       raw,
       config,
-      effectiveConfig: ensureCompatConfig(),
       env: opts.env,
       applyDefaults: opts.applyDefaults,
       registry,


### PR DESCRIPTION
## What Problem This Solves

Configuration validation carried an extra compatibility-configuration cache and passed the same configuration object through two parameter names. It also tracked plugin compatibility readiness separately from its cached set and rebuilt duplicate-plugin diagnostics that were already cached by the validation owner.

## Why This Change Was Made

Use the existing configuration object directly, rely on the cached compatibility set itself, and reuse the canonical duplicate-plugin diagnostic set. Real bundled-plugin compatibility, plugin activation, doctor migrations, registry laziness, warning ordering, and public configuration contracts are unchanged.

## User Impact

No user-visible behavior change. Configuration validation is simpler, with 20 fewer production lines and no new configuration or plugin SDK surface.

## Evidence

- Focused plugin validation, bundled web-search compatibility, channel metadata, cold-import, doctor migration, and bundled-compatibility suites: **6 files, 167 tests passed**.
- Existing coverage preserves bundled allowlist compatibility, overridden-plugin warnings, missing-plugin diagnostics, activation defaults, registry load-once behavior, and cold imports.
- Targeted formatting, production lint, and `git diff --check` pass.
- Independent source review and structured code review found no actionable issues.
- Production diff: **+5/-25 (net -20)**. No test or generated files changed.

```text
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-cleanup2-config-validation-vitest-cache OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/config/config.plugin-validation.test.ts src/config/config.web-search-provider.test.ts src/config/validation.channel-metadata.test.ts src/config/validation.cold-imports.test.ts

Test Files  4 passed (4)
Tests       160 passed (160)

OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-cleanup2-config-validation-vitest-cache OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrate.validation.test.ts src/plugins/bundled-compat.test.ts

Test Files  2 passed (2)
Tests       7 passed (7)

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/config/validation.ts src/config/validation-plugin-config.ts
./node_modules/.bin/oxfmt --check src/config/validation.ts src/config/validation-plugin-config.ts
```
