### PR TITLE
refactor(build): reuse canonical direct-run entrypoint guard

### DIFF
--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -6,10 +6,10 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { pathToFileURL } from "node:url";
 import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import prettyMilliseconds from "pretty-ms";
 import { resolveBuildIdentityEnvironment } from "./lib/build-identity.mts";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import {
   listPluginSdkDistArtifacts,
   listPluginSdkDeclarationOutputs,
@@ -1083,15 +1083,7 @@ export function runBuildAllSteps(
   return { exitCode, timings };
 }
 
-function isMainModule() {
-  const argv1 = process.argv[1];
-  if (!argv1) {
-    return false;
-  }
-  return import.meta.url === pathToFileURL(argv1).href;
-}
-
-if (isMainModule()) {
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   let args;
   try {
     args = parseBuildAllArgs(process.argv.slice(2));

--- a/scripts/check-cli-bootstrap-imports.mts
+++ b/scripts/check-cli-bootstrap-imports.mts
@@ -4,12 +4,12 @@
 import fs from "node:fs";
 import module from "node:module";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { parse, type Node as AcornNode } from "acorn";
 import {
   WORKER_BUNDLE_ENTRY_PATH,
   WORKER_BUNDLE_RSYNC_RECEIVER_PATH,
 } from "../src/shared/worker-bundle-hash.js";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 
 const DEFAULT_ENTRYPOINTS = ["dist/entry.js", "dist/cli/run-main.js"];
 const WORKER_DEPLOY_ENTRYPOINTS = [
@@ -41,10 +41,6 @@ type CliBootstrapCheckParams = {
   fs?: typeof fs;
   logger?: { error(message: string): void };
 };
-
-function isMainModule() {
-  return process.argv[1] ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url) : false;
-}
 
 function isBuiltinSpecifier(specifier: string) {
   return specifier.startsWith("node:") || module.isBuiltin(specifier);
@@ -449,7 +445,7 @@ export function checkCliBootstrapExternalImports(params: CliBootstrapCheckParams
   throw new Error("CLI bootstrap static graph imports external packages.");
 }
 
-if (isMainModule()) {
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   try {
     checkCliBootstrapExternalImports();
     console.log("CLI bootstrap import guard passed.");

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -12,10 +12,10 @@ import {
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { isPathInside } from "@openclaw/fs-safe/path";
 import { decodeMountInfoPath } from "../packages/normalization-core/src/mountinfo-path.ts";
 import { BUNDLED_PLUGIN_PATH_PREFIX } from "./lib/bundled-plugin-paths.mjs";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import {
   inspectManagedProcessGroup,
   terminateManagedChild,
@@ -1714,15 +1714,7 @@ export async function runTsdownBuildInvocation(
   });
 }
 
-function isMainModule() {
-  const argv1 = process.argv[1];
-  if (!argv1) {
-    return false;
-  }
-  return import.meta.url === pathToFileURL(argv1).href;
-}
-
-if (isMainModule()) {
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   const args = parseTsdownBuildArgs(process.argv.slice(2));
   if (args.help) {
     console.log(tsdownBuildUsage());

--- a/scripts/write-build-info.ts
+++ b/scripts/write-build-info.ts
@@ -2,8 +2,9 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { normalizeControlUiBuildInfo } from "../ui/src/build-info-normalizers.ts";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 
 const defaultRootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const FULL_GIT_COMMIT_RE = /^[0-9a-f]{40}$/iu;
@@ -139,12 +140,7 @@ export function writeBuildInfo(options: ResolveBuildInfoOptions = {}): string {
   return outputPath;
 }
 
-function isMainModule(): boolean {
-  const argv1 = process.argv[1];
-  return Boolean(argv1 && import.meta.url === pathToFileURL(argv1).href);
-}
-
-if (isMainModule()) {
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   try {
     writeBuildInfo();
   } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

The four source-build entrypoints each carry their own copy of the script direct-execution check, so build tooling can disagree about imported modules, encoded paths, or case-insensitive Windows paths.

## Why This Change Was Made

Use the existing dependency-free `scripts/lib/direct-run.mjs` owner directly from the build orchestrator, tsdown wrapper, CLI bootstrap guard, and build-info writer. Delete all four private entrypoint helpers and their now-unused URL imports while preserving the existing package scripts, CLI exit behavior, source-checkout import closure, and build metadata root resolution.

Production: +9/-33, net -24. Tests: +0/-0.

## User Impact

No product or public CLI behavior changes. Source builds keep the same commands and outputs while sharing the repository's already-tested Windows-aware entrypoint policy.

## Evidence

- Existing build-owner and canonical-entrypoint coverage: 5 suites, 261 tests passed (`test/scripts/build-all.test.ts`, `test/scripts/tsdown-build.test.ts`, `test/scripts/check-cli-bootstrap-imports.test.ts`, `test/scripts/write-build-info.test.ts`, and `test/scripts/direct-run-entrypoints.test.ts`).
- Executed both real build wrappers with `--help`; both returned zero without starting a build.
- Imported all four production modules in one Node process and confirmed none executes its CLI entrypoint when imported.
- Independently exercised absent argv, encoded POSIX filenames, and case-insensitive Windows paths through the existing canonical helper.
- Scoped formatter, targeted scripts lint, changed-check dry-run classification, independent source review, and final automated review.
- Full local changed-gate validation is deferred to exact-head hosted CI and native Testbox preparation because the shared workspace dependencies do not match the frozen source checkout.
