### PR TITLE
fix(google): support stable Gemini Embedding 2 request contracts

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -165,7 +165,7 @@ run the hybrid MMR pass.
 
 ## Multimodal memory
 
-With `gemini-embedding-2-preview`, you can index images and audio alongside
+With `gemini-embedding-2`, you can index images and audio alongside
 Markdown. This only applies to files under `memory.search.extraPaths`; default
 memory roots (`MEMORY.md`, `memory/*.md`) stay Markdown-only. Search queries
 remain text, but they match against visual and audio content. See

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -220,6 +220,13 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
     <Warning>
     Changing model or `outputDimensionality` changes the index identity. OpenClaw
     pauses vector search until you explicitly rebuild the memory index.
+
+    Upgrading an existing configuration that already uses `gemini-embedding-2`
+    can trigger the same pause even when you do not edit the configuration. This
+    release resolves the model's previously unknown default dimensionality to
+    3072 and includes that value in the index identity. Check the affected agent
+    with `openclaw memory status --index --agent <id>`, then rebuild when ready
+    with `openclaw memory index --force --agent <id>`.
     </Warning>
 
   </Accordion>

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -221,12 +221,15 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
     Changing model or `outputDimensionality` changes the index identity. OpenClaw
     pauses vector search until you explicitly rebuild the memory index.
 
-    Upgrading an existing configuration that already uses `gemini-embedding-2`
-    can trigger the same pause even when you do not edit the configuration. This
-    release resolves the model's previously unknown default dimensionality to
-    3072 and includes that value in the index identity. Check the affected agent
-    with `openclaw memory status --index --agent <id>`, then rebuild when ready
-    with `openclaw memory index --force --agent <id>`.
+    Upgrading any existing configuration that already uses
+    `gemini-embedding-2` can trigger the same pause even when you do not edit the
+    configuration. Before this release, the stable model's dimension was
+    omitted from index identity whether `outputDimensionality` was absent or
+    explicitly set. After upgrade, an absent setting resolves to 3072, while an
+    explicit 768, 1536, or 3072 setting becomes part of the identity. For either
+    path, check the affected agent with
+    `openclaw memory status --index --agent <id>`, then rebuild when ready with
+    `openclaw memory index --force --agent <id>`.
     </Warning>
 
   </Accordion>

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -211,8 +211,11 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
   <Accordion title="Gemini">
     | Key                    | Type     | Default                | Description                                |
     | ---------------------- | -------- | ---------------------- | ------------------------------------------- |
-    | `model`                | `string` | `gemini-embedding-001` | Also supports `gemini-embedding-2-preview` |
+    | `model`                | `string` | `gemini-embedding-001` | Also supports `gemini-embedding-2`         |
     | `outputDimensionality` | `number` | `3072`                 | For Embedding 2: 768, 1536, or 3072        |
+
+    The legacy `gemini-embedding-2-preview` identifier remains accepted during
+    migration to the stable model.
 
     <Warning>
     Changing model or `outputDimensionality` changes the index identity. OpenClaw
@@ -420,7 +423,7 @@ Index images and audio alongside Markdown using Gemini Embedding 2:
 | `multimodal.maxFileBytes` | `number`   | `10485760` | Max file size for indexing (10 MiB)    |
 
 <Note>
-Only applies to files in `extraPaths`. Default memory roots stay Markdown-only. Requires `gemini-embedding-2-preview`. `fallback` must be `"none"`.
+Only applies to files in `extraPaths`. Default memory roots stay Markdown-only. Requires `gemini-embedding-2` (the legacy preview identifier is also accepted). `fallback` must be `"none"`.
 </Note>
 
 Supported formats: `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`, `.heic`, `.heif` (images); `.mp3`, `.wav`, `.ogg`, `.opus`, `.m4a`, `.aac`, `.flac` (audio).

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -228,7 +228,7 @@ Use `provider: "openai-compatible"` for a generic OpenAI-compatible
     explicitly set. After upgrade, an absent setting resolves to 3072, while an
     explicit 768, 1536, or 3072 setting becomes part of the identity. For either
     path, check the affected agent with
-    `openclaw memory status --index --agent <id>`, then rebuild when ready with
+    `openclaw memory status --deep --agent <id>`, then rebuild when ready with
     `openclaw memory index --force --agent <id>`.
     </Warning>
 
@@ -436,7 +436,7 @@ Index images and audio alongside Markdown using Gemini Embedding 2:
 Only applies to files in `extraPaths`. Default memory roots stay Markdown-only. Requires `gemini-embedding-2` (the legacy preview identifier is also accepted). `fallback` must be `"none"`.
 </Note>
 
-Supported formats: `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`, `.heic`, `.heif` (images); `.mp3`, `.wav`, `.ogg`, `.opus`, `.m4a`, `.aac`, `.flac` (audio).
+Supported formats: `.jpg`, `.jpeg`, `.png` (images); `.mp3`, `.wav` (audio).
 
 ---
 

--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -80,6 +80,18 @@ function makeGeminiClient(
   };
 }
 
+function makeGeminiEmbedding2Client(
+  outputDimensionality: number,
+  baseUrl = "https://generativelanguage.googleapis.com/v1beta",
+): GeminiEmbeddingClient {
+  return {
+    ...makeGeminiClient(baseUrl),
+    model: "gemini-embedding-2",
+    modelPath: "models/gemini-embedding-2",
+    outputDimensionality,
+  };
+}
+
 type GeminiBatchRequest = Parameters<typeof runGeminiEmbeddingBatches>[0]["requests"][number];
 
 function batchRequest(customId: string, text: string): GeminiBatchRequest {
@@ -207,6 +219,22 @@ function makeOversizedResponse(status = 200): {
 }
 
 describe("Google embedding-batch bounded JSON reads", () => {
+  it("rejects async batch embeddings that do not match the requested dimensions", async () => {
+    stubBatchFetch((stage) => {
+      if (stage !== "download") {
+        return undefined;
+      }
+      return new Response(
+        JSON.stringify({ key: "r0", response: { embedding: { values: [1, 0, 0] } } }),
+        { status: 200 },
+      );
+    });
+
+    await expect(runBatch(singleRequest(), makeGeminiEmbedding2Client(768))).rejects.toThrow(
+      "gemini embeddings failed: expected 768 dimensions, received 3",
+    );
+  });
+
   it("stops before polling status after the batch timeout expires", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -9,7 +9,6 @@ import {
   formatBatchErrorDetail,
   normalizeBatchBaseUrl,
   readEmbeddingBatchJsonl,
-  sanitizeAndNormalizeEmbedding,
   withRemoteHttpResponse,
   type EmbeddingBatchExecutionParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
@@ -21,7 +20,11 @@ import {
   resolveProviderOperationTimeoutMs,
   waitProviderOperationPollInterval,
 } from "openclaw/plugin-sdk/provider-http";
-import type { GeminiEmbeddingClient, GeminiTextEmbeddingRequest } from "./embedding-provider.js";
+import {
+  sanitizeGeminiEmbedding,
+  type GeminiEmbeddingClient,
+  type GeminiTextEmbeddingRequest,
+} from "./embedding-provider.js";
 import { parseGeminiAuth } from "./gemini-auth.js";
 
 type GeminiBatchRequest = {
@@ -290,6 +293,7 @@ function applyGeminiBatchOutputLine(params: {
   remaining: Set<string>;
   errors: string[];
   byCustomId: Map<string, number[]>;
+  expectedDimensions?: number;
 }): void {
   const customId = params.line.key ?? params.line.custom_id ?? params.line.request_id;
   // Only the first response for a submitted id may mutate results.
@@ -301,8 +305,9 @@ function applyGeminiBatchOutputLine(params: {
     params.errors.push(`${customId}: ${error}`);
     return;
   }
-  const embedding = sanitizeAndNormalizeEmbedding(
+  const embedding = sanitizeGeminiEmbedding(
     params.line.embedding?.values ?? params.line.response?.embedding?.values ?? [],
+    params.expectedDimensions,
   );
   if (embedding.length === 0) {
     params.errors.push(`${customId}: empty embedding`);
@@ -338,6 +343,7 @@ async function fetchGeminiBatchOutput(params: {
             remaining: params.remaining,
             errors: params.errors,
             byCustomId: params.byCustomId,
+            expectedDimensions: params.gemini.outputDimensionality,
           });
           return params.errors.length === 0 && params.remaining.size > 0;
         },

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -55,6 +55,10 @@ function requireFirstFetchInput(fetchMock: ReturnType<typeof vi.fn>): RequestInf
   return call[0] as RequestInfo | URL;
 }
 
+function axisVector(length: number, index = 0, value = 1): number[] {
+  return Array.from({ length }, (_, offset) => (offset === index ? value : 0));
+}
+
 describe("Gemini embedding provider", () => {
   const providerBaseUrl = "https://provider.example.test/v1beta";
   const config = {
@@ -144,19 +148,22 @@ describe("Gemini embedding provider", () => {
   it.each(["models/", "gemini/", "google/"])(
     "normalizes the %s model prefix through the provider request",
     async (prefix) => {
-      const fetchMock = installFetchMock(() => ({ embedding: { values: [1, 0] } }));
+      const fetchMock = installFetchMock(() => ({
+        embedding: { values: axisVector(768) },
+      }));
       const { provider } = await createGeminiEmbeddingProvider({
         config: {} as never,
         provider: "gemini",
         remote: { apiKey: "placeholder" },
-        model: `${prefix}gemini-embedding-2-preview`,
+        model: `${prefix}gemini-embedding-2`,
+        outputDimensionality: 768,
         fallback: "none",
       });
 
       await provider.embedQuery("query");
 
       expect(requireFirstFetchInput(fetchMock)).toBe(
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent",
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent",
       );
     },
   );
@@ -167,7 +174,7 @@ describe("Gemini embedding provider", () => {
         config: {} as never,
         provider: "gemini",
         remote: { apiKey: "placeholder" },
-        model: "gemini-embedding-2-preview",
+        model: "gemini-embedding-2",
         outputDimensionality: 1024,
         fallback: "none",
       }),
@@ -180,17 +187,23 @@ describe("Gemini embedding provider", () => {
       return url.endsWith(":batchEmbedContents")
         ? {
             embeddings: Array.from({ length: 2 }, () => ({
-              values: [0, 0, 5],
+              values: axisVector(768, 2, 5),
             })),
           }
-        : { embedding: { values: [3, 4, 0] } };
+        : {
+            embedding: {
+              values: Array.from({ length: 768 }, (_, index) =>
+                index === 0 ? 3 : index === 1 ? 4 : 0,
+              ),
+            },
+          };
     });
 
     const { provider } = await createGeminiEmbeddingProvider({
       config: {} as never,
       provider: "gemini",
       remote: { apiKey: "test-key" },
-      model: "gemini-embedding-2-preview",
+      model: "gemini-embedding-2",
       outputDimensionality: 768,
       taskType: "SEMANTIC_SIMILARITY",
       fallback: "none",
@@ -198,7 +211,9 @@ describe("Gemini embedding provider", () => {
 
     await expect(provider.embedQuery("   ")).resolves.toStrictEqual([]);
     await expect(provider.embedBatch([])).resolves.toStrictEqual([]);
-    await expect(provider.embedQuery("test query")).resolves.toEqual([0.6, 0.8, 0]);
+    const queryEmbedding = await provider.embedQuery("test query");
+    expect(queryEmbedding).toHaveLength(768);
+    expect(queryEmbedding.slice(0, 3)).toEqual([0.6, 0.8, 0]);
 
     const structuredBatch = await provider.embedBatchInputs?.([
       {
@@ -216,13 +231,13 @@ describe("Gemini embedding provider", () => {
         ],
       },
     ]);
-    expect(structuredBatch).toEqual([
-      [0, 0, 1],
-      [0, 0, 1],
-    ]);
+    expect(structuredBatch).toHaveLength(2);
+    expect(structuredBatch?.[0]).toHaveLength(768);
+    expect(structuredBatch?.[0]?.slice(0, 4)).toEqual([0, 0, 1, 0]);
+    expect(structuredBatch?.[1]).toEqual(structuredBatch?.[0]);
 
     expect(requireFirstFetchInput(fetchMock)).toBe(
-      "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:embedContent",
     );
     expect(fetchJsonBody(fetchMock, 0)).toEqual({
       outputDimensionality: 768,
@@ -232,7 +247,7 @@ describe("Gemini embedding provider", () => {
     expect(fetchJsonBody(fetchMock, 1)).toEqual({
       requests: [
         {
-          model: "models/gemini-embedding-2-preview",
+          model: "models/gemini-embedding-2",
           content: {
             parts: [
               { text: "Image file: diagram.png" },
@@ -243,7 +258,7 @@ describe("Gemini embedding provider", () => {
           outputDimensionality: 768,
         },
         {
-          model: "models/gemini-embedding-2-preview",
+          model: "models/gemini-embedding-2",
           content: {
             parts: [
               { text: "Audio file: note.wav" },
@@ -302,6 +317,49 @@ describe("Gemini embedding provider", () => {
 
     await expect(provider.embedBatch(["one", "two"])).rejects.toThrow(
       "gemini embeddings failed: malformed JSON response",
+    );
+  });
+
+  it("keeps the preview identifier compatible during migration", async () => {
+    const fetchMock = installFetchMock(() => ({
+      embedding: { values: axisVector(768) },
+    }));
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-2-preview",
+      outputDimensionality: 768,
+      fallback: "none",
+    });
+
+    await expect(provider.embedQuery("test query")).resolves.toHaveLength(768);
+    expect(requireFirstFetchInput(fetchMock)).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent",
+    );
+  });
+
+  it("rejects Gemini 2 responses that drift from the requested dimensions", async () => {
+    installFetchMock((input) => {
+      const url = input instanceof URL ? input.href : typeof input === "string" ? input : input.url;
+      return url.endsWith(":batchEmbedContents")
+        ? { embeddings: [{ values: axisVector(3072) }] }
+        : { embedding: { values: axisVector(3072) } };
+    });
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-2",
+      outputDimensionality: 768,
+      fallback: "none",
+    });
+
+    await expect(provider.embedQuery("test query")).rejects.toThrow(
+      "gemini embeddings failed: expected 768 dimensions, received 3072",
+    );
+    await expect(provider.embedBatch(["test document"])).rejects.toThrow(
+      "gemini embeddings failed: expected 768 dimensions, received 3072",
     );
   });
 });

--- a/extensions/google/embedding-provider.test.ts
+++ b/extensions/google/embedding-provider.test.ts
@@ -241,8 +241,7 @@ describe("Gemini embedding provider", () => {
     );
     expect(fetchJsonBody(fetchMock, 0)).toEqual({
       outputDimensionality: 768,
-      taskType: "SEMANTIC_SIMILARITY",
-      content: { parts: [{ text: "test query" }] },
+      content: { parts: [{ text: "task: sentence similarity | query: test query" }] },
     });
     expect(fetchJsonBody(fetchMock, 1)).toEqual({
       requests: [
@@ -254,7 +253,6 @@ describe("Gemini embedding provider", () => {
               { inlineData: { mimeType: "image/png", data: "img" } },
             ],
           },
-          taskType: "SEMANTIC_SIMILARITY",
           outputDimensionality: 768,
         },
         {
@@ -265,7 +263,6 @@ describe("Gemini embedding provider", () => {
               { inlineData: { mimeType: "audio/wav", data: "aud" } },
             ],
           },
-          taskType: "SEMANTIC_SIMILARITY",
           outputDimensionality: 768,
         },
       ],
@@ -337,6 +334,76 @@ describe("Gemini embedding provider", () => {
     expect(requireFirstFetchInput(fetchMock)).toBe(
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent",
     );
+    expect(fetchJsonBody(fetchMock, 0)).toEqual({
+      content: { parts: [{ text: "test query" }] },
+      taskType: "RETRIEVAL_QUERY",
+      outputDimensionality: 768,
+    });
+  });
+
+  it("formats stable Gemini retrieval requests without unsupported task types", async () => {
+    const fetchMock = installFetchMock((input) => {
+      const url = input instanceof URL ? input.href : typeof input === "string" ? input : input.url;
+      return url.endsWith(":batchEmbedContents")
+        ? { embeddings: [{ values: axisVector(768) }] }
+        : { embedding: { values: axisVector(768) } };
+    });
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-2",
+      outputDimensionality: 768,
+      fallback: "none",
+    });
+
+    await provider.embedQuery("find this");
+    await provider.embedBatch(["remember this"]);
+
+    expect(fetchJsonBody(fetchMock, 0)).toEqual({
+      content: { parts: [{ text: "task: search result | query: find this" }] },
+      outputDimensionality: 768,
+    });
+    expect(fetchJsonBody(fetchMock, 1)).toEqual({
+      requests: [
+        {
+          content: { parts: [{ text: "title: none | text: remember this" }] },
+          model: "models/gemini-embedding-2",
+          outputDimensionality: 768,
+        },
+      ],
+    });
+  });
+
+  it.each([
+    ["QUESTION_ANSWERING", "question answering"],
+    ["FACT_VERIFICATION", "fact checking"],
+  ] as const)("keeps %s query and document instructions asymmetric", async (taskType, task) => {
+    const fetchMock = installFetchMock((input) => {
+      const url = input instanceof URL ? input.href : typeof input === "string" ? input : input.url;
+      return url.endsWith(":batchEmbedContents")
+        ? { embeddings: [{ values: axisVector(768) }] }
+        : { embedding: { values: axisVector(768) } };
+    });
+    const { provider } = await createGeminiEmbeddingProvider({
+      config: {} as never,
+      provider: "gemini",
+      remote: { apiKey: "test-key" },
+      model: "gemini-embedding-2",
+      outputDimensionality: 768,
+      taskType,
+      fallback: "none",
+    });
+
+    await provider.embedQuery("find this");
+    await provider.embedBatch(["remember this"]);
+
+    expect(fetchJsonBody(fetchMock, 0)).toMatchObject({
+      content: { parts: [{ text: `task: ${task} | query: find this` }] },
+    });
+    expect(fetchJsonBody(fetchMock, 1)).toMatchObject({
+      requests: [{ content: { parts: [{ text: "title: none | text: remember this" }] } }],
+    });
   });
 
   it("rejects Gemini 2 responses that drift from the requested dimensions", async () => {

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -56,6 +56,15 @@ const GEMINI_EMBEDDING_2_MODELS = new Set(["gemini-embedding-2", "gemini-embeddi
 
 const GEMINI_EMBEDDING_2_DEFAULT_DIMENSIONS = 3072;
 const GEMINI_EMBEDDING_2_VALID_DIMENSIONS = [768, 1536, 3072] as const;
+const GEMINI_EMBEDDING_2_TASK_PREFIXES: Record<GeminiTaskType, string> = {
+  RETRIEVAL_QUERY: "task: search result | query:",
+  RETRIEVAL_DOCUMENT: "title: none | text:",
+  SEMANTIC_SIMILARITY: "task: sentence similarity | query:",
+  CLASSIFICATION: "task: classification | query:",
+  CLUSTERING: "task: clustering | query:",
+  QUESTION_ANSWERING: "task: question answering | query:",
+  FACT_VERIFICATION: "task: fact checking | query:",
+};
 
 type GeminiTextPart = { text: string };
 type GeminiInlinePart = {
@@ -65,7 +74,7 @@ type GeminiPart = GeminiTextPart | GeminiInlinePart;
 type GeminiEmbeddingInputPart = NonNullable<EmbeddingInput["parts"]>[number];
 type GeminiEmbeddingRequest = {
   content: { parts: GeminiPart[] };
-  taskType: GeminiTaskType;
+  taskType?: GeminiTaskType;
   outputDimensionality?: number;
   model?: string;
 };
@@ -115,39 +124,38 @@ function readGeminiBatchEmbeddings(
   });
 }
 
-/** Builds the text-only Gemini embedding request shape used across direct and batch APIs. */
-function buildGeminiTextEmbeddingRequest(params: {
-  text: string;
-  taskType: GeminiTaskType;
-  outputDimensionality?: number;
-  modelPath?: string;
-}): GeminiTextEmbeddingRequest {
-  return buildGeminiEmbeddingRequest({
-    input: { text: params.text },
-    taskType: params.taskType,
-    outputDimensionality: params.outputDimensionality,
-    modelPath: params.modelPath,
-  });
-}
-
 export function buildGeminiEmbeddingRequest(params: {
   input: EmbeddingInput;
+  model: string;
+  role: "query" | "document";
   taskType: GeminiTaskType;
   outputDimensionality?: number;
   modelPath?: string;
 }): GeminiEmbeddingRequest {
-  const request: GeminiEmbeddingRequest = {
-    content: {
-      parts: params.input.parts?.map((part: GeminiEmbeddingInputPart) =>
-        part.type === "text"
-          ? ({ text: part.text } satisfies GeminiTextPart)
-          : ({
-              inlineData: { mimeType: part.mimeType, data: part.data },
-            } satisfies GeminiInlinePart),
-      ) ?? [{ text: params.input.text }],
-    },
-    taskType: params.taskType,
-  };
+  const parts = params.input.parts?.map((part: GeminiEmbeddingInputPart) =>
+    part.type === "text"
+      ? ({ text: part.text } satisfies GeminiTextPart)
+      : ({
+          inlineData: { mimeType: part.mimeType, data: part.data },
+        } satisfies GeminiInlinePart),
+  ) ?? [{ text: params.input.text }];
+  const isStableEmbedding2 = normalizeGeminiModel(params.model) === "gemini-embedding-2";
+  const request: GeminiEmbeddingRequest = { content: { parts } };
+  if (isStableEmbedding2 && parts.every((part) => "text" in part)) {
+    const first = parts[0];
+    if (first && "text" in first) {
+      const taskType =
+        params.role === "document" &&
+        (params.taskType === "RETRIEVAL_QUERY" ||
+          params.taskType === "QUESTION_ANSWERING" ||
+          params.taskType === "FACT_VERIFICATION")
+          ? "RETRIEVAL_DOCUMENT"
+          : params.taskType;
+      first.text = `${GEMINI_EMBEDDING_2_TASK_PREFIXES[taskType]} ${first.text}`;
+    }
+  } else if (!isStableEmbedding2) {
+    request.taskType = params.taskType;
+  }
   if (params.modelPath) {
     request.model = params.modelPath;
   }
@@ -307,8 +315,10 @@ export async function createGeminiEmbeddingProvider(
     const payload = await fetchGeminiEmbeddingPayload({
       client,
       endpoint: embedUrl,
-      body: buildGeminiTextEmbeddingRequest({
-        text,
+      body: buildGeminiEmbeddingRequest({
+        input: { text },
+        model: client.model,
+        role: "query",
         taskType: options.taskType ?? "RETRIEVAL_QUERY",
         outputDimensionality: isV2 ? outputDimensionality : undefined,
       }),
@@ -334,6 +344,8 @@ export async function createGeminiEmbeddingProvider(
         requests: inputs.map((input) =>
           buildGeminiEmbeddingRequest({
             input,
+            model: client.model,
+            role: "document",
             modelPath: client.modelPath,
             taskType: options.taskType ?? "RETRIEVAL_DOCUMENT",
             outputDimensionality: isV2 ? outputDimensionality : undefined,

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -44,17 +44,15 @@ export const DEFAULT_GEMINI_EMBEDDING_MODEL = "gemini-embedding-001";
 const DEFAULT_GOOGLE_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
 const GEMINI_MAX_INPUT_TOKENS: Record<string, number> = {
   "gemini-embedding-001": 2048,
+  "gemini-embedding-2": 8192,
   "gemini-embedding-2-preview": 8192,
 };
 
 type GeminiTaskType = NonNullable<MemoryEmbeddingProviderCreateOptions["taskType"]>;
 
-// --- gemini-embedding-2-preview support ---
+// --- Gemini Embedding 2 support ---
 
-const GEMINI_EMBEDDING_2_MODELS = new Set([
-  "gemini-embedding-2-preview",
-  // Add the GA model name here once released.
-]);
+const GEMINI_EMBEDDING_2_MODELS = new Set(["gemini-embedding-2", "gemini-embedding-2-preview"]);
 
 const GEMINI_EMBEDDING_2_DEFAULT_DIMENSIONS = 3072;
 const GEMINI_EMBEDDING_2_VALID_DIMENSIONS = [768, 1536, 3072] as const;
@@ -75,6 +73,10 @@ export type GeminiTextEmbeddingRequest = GeminiEmbeddingRequest;
 
 function malformedGeminiEmbeddingResponse(): Error {
   return new Error("gemini embeddings failed: malformed JSON response");
+}
+
+function unexpectedGeminiEmbeddingDimensions(expected: number, actual: number): Error {
+  return new Error(`gemini embeddings failed: expected ${expected} dimensions, received ${actual}`);
 }
 
 function readGeminiEmbeddingValues(value: unknown): number[] {
@@ -159,8 +161,8 @@ export function buildGeminiEmbeddingRequest(params: {
  * Returns true if the given model name is a gemini-embedding-2 variant that
  * supports `outputDimensionality` and extended task types.
  */
-function isGeminiEmbedding2Model(model: string): boolean {
-  return GEMINI_EMBEDDING_2_MODELS.has(model);
+export function isGeminiEmbedding2Model(model: string): boolean {
+  return GEMINI_EMBEDDING_2_MODELS.has(normalizeGeminiModel(model));
 }
 
 /**
@@ -202,6 +204,13 @@ function normalizeGeminiModel(model: string): string {
     return withoutPrefix.slice("google/".length);
   }
   return withoutPrefix;
+}
+
+function sanitizeGeminiEmbedding(values: number[], expectedDimensions?: number): number[] {
+  if (expectedDimensions != null && values.length !== expectedDimensions) {
+    throw unexpectedGeminiEmbeddingDimensions(expectedDimensions, values.length);
+  }
+  return sanitizeAndNormalizeEmbedding(values);
 }
 
 async function fetchGeminiEmbeddingPayload(params: {
@@ -305,7 +314,10 @@ export async function createGeminiEmbeddingProvider(
       }),
       signal: callOptions?.signal,
     });
-    return sanitizeAndNormalizeEmbedding(readGeminiSingleEmbedding(payload));
+    return sanitizeGeminiEmbedding(
+      readGeminiSingleEmbedding(payload),
+      isV2 ? outputDimensionality : undefined,
+    );
   };
 
   const embedBatchInputs = async (
@@ -331,7 +343,9 @@ export async function createGeminiEmbeddingProvider(
       signal: callOptions?.signal,
     });
     const embeddings = readGeminiBatchEmbeddings(payload, inputs.length);
-    return embeddings.map((values) => sanitizeAndNormalizeEmbedding(values));
+    return embeddings.map((values) =>
+      sanitizeGeminiEmbedding(values, isV2 ? outputDimensionality : undefined),
+    );
   };
 
   const embedBatch = async (

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -206,7 +206,7 @@ function normalizeGeminiModel(model: string): string {
   return withoutPrefix;
 }
 
-function sanitizeGeminiEmbedding(values: number[], expectedDimensions?: number): number[] {
+export function sanitizeGeminiEmbedding(values: number[], expectedDimensions?: number): number[] {
   if (expectedDimensions != null && values.length !== expectedDimensions) {
     throw unexpectedGeminiEmbeddingDimensions(expectedDimensions, values.length);
   }

--- a/extensions/google/memory-embedding-adapter.test.ts
+++ b/extensions/google/memory-embedding-adapter.test.ts
@@ -15,7 +15,6 @@ vi.mock("./embedding-provider.js", async (importOriginal) => {
   return {
     ...actual,
     createGeminiEmbeddingProvider: mocks.createGeminiEmbeddingProvider,
-    buildGeminiEmbeddingRequest: vi.fn(),
   };
 });
 
@@ -76,6 +75,35 @@ describe("Gemini memory embedding adapter", () => {
         model: "gemini-embedding-001",
       }),
     ).toBe(false);
+  });
+
+  it("formats stable Gemini asynchronous batch documents without a task type", async () => {
+    const result = await createAdapterWithHeaders({});
+
+    await result.runtime?.batchEmbed?.({
+      agentId: "main",
+      chunks: [{ text: "remember this" }],
+      wait: true,
+      concurrency: 1,
+      pollIntervalMs: 1000,
+      timeoutMs: 60_000,
+      debug: () => {},
+    });
+
+    expect(mocks.runGeminiEmbeddingBatches).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requests: [
+          {
+            custom_id: "0",
+            request: {
+              content: { parts: [{ text: "title: none | text: remember this" }] },
+              model: "models/gemini-embedding-2",
+              outputDimensionality: 768,
+            },
+          },
+        ],
+      }),
+    );
   });
 
   it("keeps durable identity stable across generated client-version changes", async () => {

--- a/extensions/google/memory-embedding-adapter.test.ts
+++ b/extensions/google/memory-embedding-adapter.test.ts
@@ -10,11 +10,14 @@ const mocks = vi.hoisted(() => ({
   runGeminiEmbeddingBatches: vi.fn(async () => new Map([["0", [1, 0]]])),
 }));
 
-vi.mock("./embedding-provider.js", () => ({
-  DEFAULT_GEMINI_EMBEDDING_MODEL: "gemini-embedding-001",
-  createGeminiEmbeddingProvider: mocks.createGeminiEmbeddingProvider,
-  buildGeminiEmbeddingRequest: vi.fn(),
-}));
+vi.mock("./embedding-provider.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./embedding-provider.js")>();
+  return {
+    ...actual,
+    createGeminiEmbeddingProvider: mocks.createGeminiEmbeddingProvider,
+    buildGeminiEmbeddingRequest: vi.fn(),
+  };
+});
 
 vi.mock("./embedding-batch.js", () => ({
   runGeminiEmbeddingBatches: mocks.runGeminiEmbeddingBatches,
@@ -24,15 +27,15 @@ import { geminiMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter
 
 const provider: MemoryEmbeddingProvider = {
   id: "gemini",
-  model: "gemini-embedding-2-preview",
+  model: "gemini-embedding-2",
   embedQuery: async () => [1, 0],
   embedBatch: async (texts) => texts.map(() => [1, 0]),
 };
 
 const clientBase = {
   baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-  model: "gemini-embedding-2-preview",
-  modelPath: "models/gemini-embedding-2-preview",
+  model: "gemini-embedding-2",
+  modelPath: "models/gemini-embedding-2",
   outputDimensionality: 768,
 };
 
@@ -44,7 +47,7 @@ async function createAdapterWithHeaders(headers: Record<string, string>) {
   return await geminiMemoryEmbeddingProviderAdapter.create({
     config: {} as never,
     provider: "gemini",
-    model: "gemini-embedding-2-preview",
+    model: "gemini-embedding-2",
     fallback: "none",
   });
 }
@@ -53,6 +56,26 @@ describe("Gemini memory embedding adapter", () => {
   beforeEach(() => {
     mocks.createGeminiEmbeddingProvider.mockReset();
     mocks.runGeminiEmbeddingBatches.mockClear();
+  });
+
+  it.each([
+    "gemini-embedding-2",
+    "gemini-embedding-2-preview",
+    "models/gemini-embedding-2",
+    "gemini/gemini-embedding-2",
+    "google/gemini-embedding-2",
+  ])("accepts multimodal memory for %s", (model) => {
+    expect(geminiMemoryEmbeddingProviderAdapter.supportsMultimodalEmbeddings?.({ model })).toBe(
+      true,
+    );
+  });
+
+  it("keeps legacy Gemini embeddings text-only", () => {
+    expect(
+      geminiMemoryEmbeddingProviderAdapter.supportsMultimodalEmbeddings?.({
+        model: "gemini-embedding-001",
+      }),
+    ).toBe(false);
   });
 
   it("keeps durable identity stable across generated client-version changes", async () => {

--- a/extensions/google/memory-embedding-adapter.ts
+++ b/extensions/google/memory-embedding-adapter.ts
@@ -11,15 +11,8 @@ import {
   buildGeminiEmbeddingRequest,
   createGeminiEmbeddingProvider,
   DEFAULT_GEMINI_EMBEDDING_MODEL,
+  isGeminiEmbedding2Model,
 } from "./embedding-provider.js";
-
-function supportsGeminiMultimodalEmbeddings(model: string): boolean {
-  const normalized = model
-    .trim()
-    .replace(/^models\//, "")
-    .replace(/^(gemini|google)\//, "");
-  return normalized === "gemini-embedding-2-preview";
-}
 
 export const geminiMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapter = {
   id: "gemini",
@@ -28,7 +21,7 @@ export const geminiMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapte
   authProviderId: "google",
   autoSelectPriority: 30,
   allowExplicitWhenConfiguredAuto: true,
-  supportsMultimodalEmbeddings: ({ model }) => supportsGeminiMultimodalEmbeddings(model),
+  supportsMultimodalEmbeddings: ({ model }) => isGeminiEmbedding2Model(model),
   shouldContinueAutoSelection: isMissingEmbeddingApiKeyError,
   create: async (options) => {
     const { provider, client } = await createGeminiEmbeddingProvider({

--- a/extensions/google/memory-embedding-adapter.ts
+++ b/extensions/google/memory-embedding-adapter.ts
@@ -58,6 +58,8 @@ export const geminiMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapte
               custom_id: String(index),
               request: buildGeminiEmbeddingRequest({
                 input: chunk.embeddingInput ?? { text: chunk.text },
+                model: client.model,
+                role: "document",
                 taskType: "RETRIEVAL_DOCUMENT",
                 modelPath: client.modelPath,
                 outputDimensionality: client.outputDimensionality,


### PR DESCRIPTION
## Summary

- Support Google's stable `gemini-embedding-2` model in the owning Google memory plugin while preserving `gemini-embedding-001` and the existing preview identifier.
- Honor Google's actual stable-model contract: omit unsupported `taskType`, apply documented task instructions for all seven existing task modes, and preserve asymmetric query/document instructions across direct, synchronous-batch, and asynchronous-batch requests.
- Keep multimodal content intact, validate returned dimensions before direct or batch vectors enter memory, and retain existing current-main destination-ownership and credential behavior.
- Document deliberate index rebuilds with non-mutating `memory status --deep` inspection, and correct Gemini-supported image/audio formats.

Closes #120662.
Supersedes #120665, preserving all four original contributor commits. Thank you @fr-meyer for the original implementation, tests, documentation, and authenticated provider proof.

## Why the additional repair is necessary

Google's [embedding documentation](https://ai.google.dev/gemini-api/docs/embeddings) explicitly states that the stable `gemini-embedding-2` model does not support `task_type`; task instructions belong in text-only content instead. The original PR sent the unsupported field on direct requests and both batch paths. The Google plugin now owns one canonical, model-aware request builder and removes its redundant text-only wrapper.

- Retrieval queries use `task: search result | query: ...`.
- Retrieval documents use `title: none | text: ...`.
- Explicit semantic similarity, classification, clustering, question answering, and fact verification use Google's documented task instructions.
- Question-answering and fact-verification document requests retain the required asymmetric document format.
- Existing preview and legacy-model request payloads remain unchanged; structured multimodal content is not rewritten.

Existing stable-model indexes already change identity because this fix starts resolving their previously omitted output dimensions. Operators therefore inspect first and explicitly rebuild rather than silently mixing incompatible vectors.

## Real-provider verification

Two authenticated requests against the live Google Gemini API verified the corrected stable-model contract without exposing credentials, changing configuration, or mutating a memory index:

```json
{
  "model": "gemini-embedding-2",
  "query": {
    "httpStatus": 200,
    "taskTypeSent": false,
    "instruction": "task: search result | query: ...",
    "requestedDimensions": 768,
    "receivedDimensions": 768,
    "finiteValues": true
  },
  "document": {
    "httpStatus": 200,
    "taskTypeSent": false,
    "instruction": "title: none | text: ...",
    "requestedDimensions": 768,
    "receivedDimensions": 768,
    "finiteValues": true
  },
  "configurationChanged": false,
  "memoryIndexChanged": false,
  "credentialsRedacted": true
}
```

The original contributor additionally verified an authenticated stable-model 768-dimensional request and an existing live memory search returning three results without mutating its index; see #120665.

## Focused regression coverage

- Stable direct query, synchronous document batch, and asynchronous document batch verify exact transmitted content and absence of `taskType`.
- Explicit question-answering and fact-verification overrides verify asymmetric query/document payloads.
- Existing semantic-similarity and multimodal cases preserve the correct content contract.
- Preview requests retain the existing `taskType` field.
- Direct, synchronous-batch, and asynchronous-batch vectors reject mismatched dimensions before caching or indexing.
- Current-main destination ownership, query-parameter handling, provider credentials, and owner headers remain intact after the contributor-commit rebase.
- Changed-file formatting and structured independent review passed; exact-head hosted CI will provide focused and full test execution.

Production delta: +78/-51 (net +27), justified by stable-model support, provider-required request semantics, and vector-dimension integrity. Test delta: +232/-28.
