### PR TITLE
refactor(firecrawl): reuse canonical provider runtime helpers

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -13,6 +13,7 @@ import {
   withStrictWebToolsEndpoint,
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-fetch";
+import { resolveSiteName } from "openclaw/plugin-sdk/provider-web-search";
 import { normalizeSecretInput } from "openclaw/plugin-sdk/secret-input";
 import {
   truncateSanitizedExternalContent,
@@ -70,14 +71,6 @@ type FirecrawlSearchItem = {
   published?: string;
   siteName?: string;
 };
-
-async function readFirecrawlJsonResponse(
-  response: Response,
-  label: string,
-  opts?: { maxBytes?: number },
-): Promise<Record<string, unknown>> {
-  return await readProviderJsonObjectResponse(response, label, opts);
-}
 
 type FirecrawlSearchParams = {
   cfg?: OpenClawConfig;
@@ -274,15 +267,6 @@ async function postFirecrawlJson<T>(
   return result;
 }
 
-function resolveSiteName(urlRaw: string): string | undefined {
-  try {
-    const host = new URL(urlRaw).hostname.replace(/^www\./, "");
-    return host || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 function normalizeFirecrawlResultUrl(value: unknown): string | undefined {
   if (typeof value !== "string" || value.length > FIRECRAWL_RESULT_URL_MAX_CHARS) {
     return undefined;
@@ -388,7 +372,7 @@ function resolveSearchItems(payload: Record<string, unknown>): FirecrawlSearchIt
       description,
       content,
       published,
-      siteName: resolveSiteName(url),
+      siteName: resolveSiteName(url)?.replace(/^www\./, ""),
     });
   }
   return items;
@@ -534,7 +518,10 @@ export async function runFirecrawlSearch(
       ...(params.signal ? { signal: params.signal } : {}),
     },
     async (response) => {
-      const payloadValue = await readFirecrawlJsonResponse(response, "Firecrawl Search API error");
+      const payloadValue = await readProviderJsonObjectResponse(
+        response,
+        "Firecrawl Search API error",
+      );
       if (payloadValue.success === false) {
         const error =
           typeof payloadValue.error === "string"
@@ -697,16 +684,16 @@ export async function runFirecrawlScrape(
       },
     },
     async (response) => {
-      const payloadLocal = await readFirecrawlJsonResponse(response, "Firecrawl fetch failed", {
+      const data = await readProviderJsonObjectResponse(response, "Firecrawl fetch failed", {
         // Scrape can legitimately return page bodies before maxChars truncates parsed output.
         maxBytes: FIRECRAWL_SCRAPE_RESPONSE_MAX_BYTES,
       });
-      if (payloadLocal.success === false) {
+      if (data.success === false) {
         const detail =
-          typeof payloadLocal.error === "string"
-            ? payloadLocal.error
-            : typeof payloadLocal.message === "string"
-              ? payloadLocal.message
+          typeof data.error === "string"
+            ? data.error
+            : typeof data.message === "string"
+              ? data.message
               : response.statusText;
         throw new Error(
           `Firecrawl fetch failed (${response.status}): ${wrapWebContent(
@@ -715,7 +702,7 @@ export async function runFirecrawlScrape(
           )}`.trim(),
         );
       }
-      return payloadLocal;
+      return data;
     },
   );
   return parseFirecrawlScrapePayload({
@@ -730,7 +717,6 @@ export const testing = {
   assertFirecrawlScrapeTargetAllowed,
   parseFirecrawlScrapePayload,
   postFirecrawlJson,
-  readFirecrawlJsonResponse,
   resolveEndpoint,
   resolveSearchItems,
 };

--- a/extensions/firecrawl/src/firecrawl-fetch-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-fetch-provider.ts
@@ -1,4 +1,5 @@
 // Firecrawl provider module implements model/runtime integration.
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import {
   enablePluginInConfig,
@@ -6,14 +7,7 @@ import {
 } from "openclaw/plugin-sdk/provider-web-fetch-contract";
 import { FIRECRAWL_WEB_FETCH_PROVIDER_SHARED } from "./firecrawl-fetch-provider-shared.js";
 
-type FirecrawlClientModule = typeof import("./firecrawl-client.js");
-
-let firecrawlClientModulePromise: Promise<FirecrawlClientModule> | undefined;
-
-function loadFirecrawlClientModule(): Promise<FirecrawlClientModule> {
-  firecrawlClientModulePromise ??= import("./firecrawl-client.js");
-  return firecrawlClientModulePromise;
-}
+const loadFirecrawlClientModule = createLazyRuntimeModule(() => import("./firecrawl-client.js"));
 
 export function createFirecrawlWebFetchProvider(): WebFetchProviderPlugin {
   return {

--- a/extensions/firecrawl/src/firecrawl-free-search-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-free-search-provider.ts
@@ -1,17 +1,11 @@
 // Firecrawl provider module implements model/runtime integration.
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
 import { buildFirecrawlFreeWebSearchProviderBase } from "../web-search-shared.js";
 import { GenericFirecrawlSearchSchema } from "./firecrawl-search-provider.js";
 
-type FirecrawlClientModule = typeof import("./firecrawl-client.js");
-
-let firecrawlClientModulePromise: Promise<FirecrawlClientModule> | undefined;
-
-function loadFirecrawlClientModule(): Promise<FirecrawlClientModule> {
-  firecrawlClientModulePromise ??= import("./firecrawl-client.js");
-  return firecrawlClientModulePromise;
-}
+const loadFirecrawlClientModule = createLazyRuntimeModule(() => import("./firecrawl-client.js"));
 
 export function createFirecrawlFreeWebSearchProvider(): WebSearchProviderPlugin {
   return {

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -1548,12 +1548,13 @@ describe("firecrawl tools", () => {
       headers: { "content-type": "application/json" },
     });
     const jsonSpy = vi.spyOn(streamed.response, "json").mockRejectedValue(new Error("unbounded"));
+    global.fetch = vi.fn(async () => streamed.response) as typeof fetch;
 
     await expect(
-      firecrawlClientTesting.readFirecrawlJsonResponse(
-        streamed.response,
-        "Firecrawl Search API error",
-      ),
+      runActualFirecrawlSearch({
+        query: "openclaw bounded search response",
+        access: "keyless",
+      }),
     ).rejects.toThrow("Firecrawl Search API error: JSON response exceeds 16777216 bytes");
 
     expect(streamed.getReadCount()).toBeLessThan(32);


### PR DESCRIPTION
## What Problem This Solves

Firecrawl's provider plugin maintained duplicate private implementations of lazy runtime loading, bounded provider JSON parsing, and result-hostname parsing. Its oversized-response regression also depended on a test-only parser seam instead of exercising the real protected search request.

## Why This Change Was Made

Reuse the existing canonical Plugin SDK helpers already used by sibling providers and remove the redundant Firecrawl-private adapters. Preserve cached failed imports, exact provider error labels, the default 16 MiB search limit versus explicit 64 MiB scrape limit, stream cancellation, trusted endpoints, authentication, caller cancellation, and Firecrawl's established `www.` stripping. Move the existing oversized-response regression to the actual guarded search HTTP boundary.

## User Impact

No user-visible behavior changes. Firecrawl search, keyless search, and web fetch retain the same provider contracts with less duplicate code and stronger security-boundary regression coverage.

## Evidence

- Production: +17/-43 (net **-26** lines); existing tests: +5/-4 (net +1 line).
- Focused existing provider and canonical parser suites: **143/143 tests passed** across three files.
- Deliberately increased the search response cap from 16 MiB to 64 MiB; the rewritten real-boundary regression failed with the expected missing-overflow error. Restored the canonical cap and reran all 143 tests successfully.
- Existing assertions retain early streaming-reader cancellation, bounded read count, no unbounded `response.json()`, exact malformed/error labels, scrape's 64 MiB cap, caller abort identity, SSRF policy, auth headers, and `www.` normalization.
- Focused formatter check and `git diff --check` passed; final automated review reported no actionable findings.
- No plugin public exports, config/manifest, provider models, or `CHANGELOG.md` changed.

```text
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-cleanup2-lane5-vitest-cache node scripts/run-vitest.mjs --configLoader runner extensions/firecrawl/src/firecrawl-tools.test.ts extensions/firecrawl/src/firecrawl-client.test.ts src/agents/provider-http-errors.test.ts

Test Files  3 passed (3)
Tests       143 passed (143)
```
