### PR TITLE
fix(llama-cpp): preserve managed local embedding batch capacity

### DIFF
--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -20,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   discoverServer: vi.fn(),
   ensureModel: vi.fn(),
+  ensureChat: vi.fn(),
   prepareServer: vi.fn(),
   inspectRuntime: vi.fn(),
   genericCreate: vi.fn(),
@@ -33,6 +34,7 @@ vi.mock("openclaw/plugin-sdk/embedding-providers", async (importOriginal) => ({
 vi.mock("./src/managed-server.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./src/managed-server.js")>()),
   ensureLlamaCppModel: mocks.ensureModel,
+  ensureManagedLlamaServerForChat: mocks.ensureChat,
   prepareManagedLlamaServer: mocks.prepareServer,
   inspectLlamaServerRuntime: mocks.inspectRuntime,
 }));
@@ -60,6 +62,7 @@ beforeEach(() => {
   previousPluginRegistry = getActivePluginRegistry();
   mocks.discoverServer.mockReset();
   mocks.ensureModel.mockResolvedValue("/models/model.gguf");
+  mocks.ensureChat.mockResolvedValue(undefined);
   mocks.prepareServer.mockResolvedValue({});
   mocks.inspectRuntime.mockResolvedValue({
     engine: "llama.cpp",
@@ -281,15 +284,61 @@ describe("llama.cpp provider plugin", () => {
     );
     expect(mocks.prepareServer).toHaveBeenCalledWith(
       expect.objectContaining({
-        chatModelPath: undefined,
         embeddingModelPath: "/models/model.gguf",
       }),
+    );
+    expect(mocks.prepareServer).not.toHaveBeenCalledWith(
+      expect.objectContaining({ chatModelPath: expect.anything() }),
     );
     expect(result.runtime?.cacheKeyData).toEqual({
       provider: "local",
       model: "/models/custom-embedding.gguf",
     });
   });
+
+  it.each([
+    ["uses an active custom local model", { enabled: true, provider: "local" }],
+    ["uses another memory provider", { enabled: true, provider: "openai" }],
+    ["has memory search disabled", { enabled: false, provider: "local" }],
+  ] as const)(
+    "keeps chat preparation independent from embedding config when memory %s",
+    async (_label, searchConfig) => {
+      const staleEmbeddingSource = "hf:retired-org/removed-embedding-model-GGUF/embedding.gguf";
+      const configured = configuredOptions();
+      const providerConfig = configured.config.models.providers[LLAMA_CPP_PROVIDER_ID];
+      const config = {
+        ...configured.config,
+        memory: {
+          search: {
+            ...searchConfig,
+            local: { modelPath: staleEmbeddingSource },
+          },
+        },
+      };
+      const provider = registerTextProvider();
+      const selectedModel = expectDefined(providerConfig.models[0], "managed chat model");
+      const inner = vi.fn(() => ({}) as never);
+      const wrapped = provider.wrapStreamFn?.({
+        config,
+        provider: LLAMA_CPP_PROVIDER_ID,
+        modelId: selectedModel.id,
+        model: {
+          ...selectedModel,
+          provider: LLAMA_CPP_PROVIDER_ID,
+          baseUrl: providerConfig.baseUrl,
+        },
+        streamFn: inner,
+      } as never);
+
+      await wrapped?.({} as never, { messages: [] } as never, {});
+
+      expect(mocks.ensureChat).toHaveBeenCalledWith({
+        provider: providerConfig,
+        model: expect.objectContaining({ id: selectedModel.id }),
+      });
+      expect(inner).toHaveBeenCalledOnce();
+    },
+  );
 
   it("keeps registered text setup chat-capable when local memory is enabled", async () => {
     const provider = registerTextProvider();
@@ -340,11 +389,15 @@ describe("llama.cpp provider plugin", () => {
 
   it("preserves default local index identity across old and managed cache paths", () => {
     const modelCacheDir = path.join(os.tmpdir(), "managed-llama-models");
+    const options = configuredOptions();
+    Object.assign(options.config.models.providers[LLAMA_CPP_PROVIDER_ID], {
+      params: { modelCacheDir },
+    });
     const identity = llamaCppEmbeddingProviderAdapter.resolveIndexIdentity?.({
-      config: {},
-      provider: "local",
-      model: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
-      local: { modelPath: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL, modelCacheDir },
+      ...options,
+      local: {
+        modelPath: path.join(modelCacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
+      },
     });
 
     expect(identity).toMatchObject({

--- a/extensions/llama-cpp/src/embedding-provider.ts
+++ b/extensions/llama-cpp/src/embedding-provider.ts
@@ -11,11 +11,9 @@ import {
   DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID,
-  DEFAULT_LLAMA_CPP_MODEL_ID,
   LLAMA_CPP_PROVIDER_ID,
   resolveLegacyLlamaCppModelCacheDir,
   resolveLlamaCppModelCacheDir,
-  resolveLlamaCppModelSource,
 } from "./defaults.js";
 import { selectLlamaServerAsset } from "./llama-server-install.js";
 import { resolveManagedLlamaCppProviderConfig } from "./managed-provider-config.js";
@@ -31,6 +29,11 @@ type LlamaCppLocalOptions = {
   modelCacheDir?: string;
 };
 
+type LlamaCppEmbeddingModel = {
+  source: string;
+  isDefault: boolean;
+};
+
 const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
 const preparedEmbeddingServers = new Map<string, Promise<void>>();
 
@@ -42,6 +45,14 @@ type LlamaCppModelIdentity = {
 
 function readLocalOptions(options: { local?: unknown }): LlamaCppLocalOptions {
   return (options.local as LlamaCppLocalOptions | undefined) ?? {};
+}
+
+function readIdentityLocalOptions(options: EmbeddingProviderCreateOptions): LlamaCppLocalOptions {
+  const local = readLocalOptions(options);
+  const provider = options.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+  return provider?.localService
+    ? { ...local, modelCacheDir: resolveLlamaCppModelCacheDir(provider) }
+    : local;
 }
 
 function createCacheKeyData(model: string, dimensions?: number): Record<string, unknown> {
@@ -98,6 +109,16 @@ function resolveModelIdentity(
   };
 }
 
+function resolveLlamaCppEmbeddingModel(localValue?: unknown): LlamaCppEmbeddingModel {
+  const local = readLocalOptions({ local: localValue });
+  const source = normalizeOptionalString(local.modelPath) ?? DEFAULT_LLAMA_CPP_EMBEDDING_MODEL;
+  const identity = resolveModelIdentity(local, source);
+  return {
+    source,
+    isDefault: identity.model === DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
+  };
+}
+
 function resolveConfiguredProvider(options: EmbeddingProviderCreateOptions): ModelProviderConfig {
   return resolveManagedLlamaCppProviderConfig(options.config);
 }
@@ -113,46 +134,21 @@ function resolveProviderPort(provider: ModelProviderConfig): number {
 async function prepareEmbeddingServer(
   options: EmbeddingProviderCreateOptions,
   embeddingSource: string,
+  embeddingModelIsDefault: boolean,
 ): Promise<void> {
   const provider = resolveConfiguredProvider(options);
-  const configuredPrimary = options.config.agents?.defaults?.model;
-  const primaryRef =
-    typeof configuredPrimary === "string" ? configuredPrimary : configuredPrimary?.primary;
-  const primaryId = primaryRef?.startsWith(`${LLAMA_CPP_PROVIDER_ID}/`)
-    ? primaryRef.slice(LLAMA_CPP_PROVIDER_ID.length + 1)
-    : undefined;
-  const chatModel =
-    provider.models.find((model) => model.id === primaryId) ??
-    provider.models.find((model) => model.id !== DEFAULT_LLAMA_CPP_MODEL_ID) ??
-    provider.models[0];
   const cacheDir = resolveLlamaCppModelCacheDir(provider);
-  const key = JSON.stringify([provider.baseUrl, chatModel?.id ?? null, embeddingSource, cacheDir]);
+  const key = JSON.stringify([provider.baseUrl, embeddingSource, cacheDir]);
   const pending =
     preparedEmbeddingServers.get(key) ??
     (async () => {
-      const [chatModelPath, embeddingModelPath] = await Promise.all([
-        chatModel
-          ? ensureLlamaCppModel({
-              source: resolveLlamaCppModelSource(chatModel),
-              cacheDir,
-              download: false,
-            })
-          : Promise.resolve(undefined),
-        ensureLlamaCppModel({
-          source: embeddingSource,
-          cacheDir,
-          download: true,
-        }),
-      ]);
-      const configuredContext = chatModel?.params?.contextSize;
+      const embeddingModelPath = await ensureLlamaCppModel({
+        source: embeddingSource,
+        cacheDir,
+        download: true,
+      });
       await prepareManagedLlamaServer({
-        ...(chatModel ? { chatModelId: chatModel.id } : {}),
-        chatModelPath,
-        contextSize:
-          typeof configuredContext === "number" && configuredContext > 0
-            ? Math.floor(configuredContext)
-            : chatModel?.contextTokens,
-        maxTokens: chatModel?.maxTokens,
+        embeddingModelIsDefault,
         embeddingModelPath,
         port: resolveProviderPort(provider),
       });
@@ -217,14 +213,15 @@ export const llamaCppEmbeddingProviderAdapter: EmbeddingProviderAdapter = {
   formatSetupError: (error) =>
     `Managed local embeddings are unavailable. Run \`openclaw configure\`, choose llama.cpp, and retry. ${error instanceof Error ? error.message : String(error)}`,
   resolveIndexIdentity: (options) => {
-    const local = readLocalOptions(options);
+    const local = readIdentityLocalOptions(options);
     const modelPath = normalizeOptionalString(local.modelPath) ?? DEFAULT_LLAMA_CPP_EMBEDDING_MODEL;
     return resolveModelIdentity(local, modelPath, options.dimensions);
   },
   create: async (options) => {
-    const local = readLocalOptions(options);
-    const modelPath = normalizeOptionalString(local.modelPath) ?? DEFAULT_LLAMA_CPP_EMBEDDING_MODEL;
-    await prepareEmbeddingServer(options, modelPath);
+    const local = readIdentityLocalOptions(options);
+    const embeddingModel = resolveLlamaCppEmbeddingModel(local);
+    const identity = resolveModelIdentity(local, embeddingModel.source, options.dimensions);
+    await prepareEmbeddingServer(options, embeddingModel.source, embeddingModel.isDefault);
     const genericAdapter = getEmbeddingProvider("openai-compatible", options.config);
     if (!genericAdapter) {
       throw new Error("OpenAI-compatible embedding transport is unavailable.");
@@ -238,7 +235,6 @@ export const llamaCppEmbeddingProviderAdapter: EmbeddingProviderAdapter = {
     if (!result.provider) {
       return result;
     }
-    const identity = resolveModelIdentity(local, modelPath, options.dimensions);
     return {
       provider: wrapProvider({
         provider: result.provider,

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -18,6 +18,7 @@ vi.mock("./llama-server-install.js", async (importOriginal) => ({
 import { selectLlamaServerAsset } from "./llama-server-install.js";
 import {
   ensureLlamaCppModel,
+  ensureManagedLlamaServerForChat,
   inspectLlamaServerRuntime,
   prepareManagedLlamaServer,
 } from "./managed-server.js";
@@ -106,7 +107,7 @@ describe("managed llama-server", () => {
     );
   });
 
-  it("writes separate chat and embedding presets without unwired capabilities", async () => {
+  it("writes a 2048-token physical batch in the combined preset", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "llama-server-preset-"));
     const presetPath = path.join(tempRoot, "models.ini");
     const asset = selectLlamaServerAsset("darwin", "arm64");
@@ -126,13 +127,14 @@ describe("managed llama-server", () => {
         chatModelPath: "/models/chat.gguf",
         contextSize: 8192,
         maxTokens: 2048,
+        embeddingModelIsDefault: true,
         embeddingModelPath: "/models/embedding.gguf",
         port: 19_432,
       });
       const preset = await fs.readFile(presetPath, "utf8");
       expect(preset).toContain("[chat-model]\nmodel = /models/chat.gguf\nctx-size = 8192");
       expect(preset).toContain(
-        "[embeddinggemma-300m-qat-q8_0]\nmodel = /models/embedding.gguf\nembedding = true",
+        "[embeddinggemma-300m-qat-q8_0]\nmodel = /models/embedding.gguf\nubatch-size = 2048\nembedding = true",
       );
       expect(preset).not.toMatch(/mmproj|draft/iu);
     } finally {
@@ -140,7 +142,7 @@ describe("managed llama-server", () => {
     }
   });
 
-  it("writes an embedding-only preset without requiring a chat model", async () => {
+  it("preserves the llama.cpp physical batch default for a custom embedding model", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "llama-server-embedding-only-"));
     const presetPath = path.join(tempRoot, "models.ini");
     const asset = selectLlamaServerAsset("darwin", "arm64");
@@ -164,6 +166,58 @@ describe("managed llama-server", () => {
         "version = 1\n\n[embeddinggemma-300m-qat-q8_0]\nmodel = /models/custom-embedding.gguf\nembedding = true\n",
       );
       expect(preset).not.toContain("jinja");
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a custom embedding model when chat prepares the shared restart preset", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "llama-server-chat-preset-"));
+    const presetPath = path.join(tempRoot, "models.ini");
+    const chatModelPath = path.join(tempRoot, "chat.gguf");
+    const embeddingModelPath = path.join(tempRoot, "custom-embedding.gguf");
+    const asset = selectLlamaServerAsset("darwin", "arm64");
+    installMocks.ensureLlamaServerInstalled.mockResolvedValue({
+      command: path.join(tempRoot, "llama-server"),
+      asset,
+    });
+    installMocks.resolveManagedLlamaServerPaths.mockReturnValue({
+      installDir: tempRoot,
+      command: path.join(tempRoot, "llama-server"),
+      presetPath,
+    });
+
+    try {
+      await Promise.all([
+        fs.writeFile(chatModelPath, "GGUF"),
+        fs.writeFile(embeddingModelPath, "GGUF"),
+      ]);
+      await Promise.all([
+        prepareManagedLlamaServer({
+          embeddingModelPath,
+          port: 19_434,
+        }),
+        ensureManagedLlamaServerForChat({
+          provider: {
+            baseUrl: "http://127.0.0.1:19434/v1",
+            localService: { command: path.join(tempRoot, "llama-server"), args: [] },
+            models: [],
+            params: { modelCacheDir: tempRoot },
+          },
+          model: {
+            id: "chat-model",
+            params: { modelPath: chatModelPath, contextSize: 8192 },
+            maxTokens: 2048,
+          },
+        }),
+      ]);
+
+      const preset = await fs.readFile(presetPath, "utf8");
+      expect(preset).toContain(`[chat-model]\nmodel = ${chatModelPath}\nctx-size = 8192`);
+      expect(preset).toContain(
+        `[embeddinggemma-300m-qat-q8_0]\nmodel = ${embeddingModelPath}\nembedding = true`,
+      );
+      expect(preset).not.toContain("ubatch-size");
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -70,6 +70,11 @@ export type LlamaServerRuntimeFacts = {
 
 const modelPromises = new Map<string, Promise<string>>();
 const chatPreparationPromises = new Map<string, Promise<void>>();
+// Chat and embedding share one restart preset. Serialize read-modify-write updates so neither
+// path can discard the other model stanza during concurrent preparation.
+const presetWritePromises = new Map<string, Promise<void>>();
+// Pooled embeddings must fit one input in one physical batch. Match llama.cpp's EmbeddingGemma preset.
+const LLAMA_CPP_EMBEDDING_UBATCH_SIZE = 2048;
 
 function parseHuggingFaceSource(source: string): {
   user: string;
@@ -300,43 +305,69 @@ function assertIniValue(value: string, label: string): string {
   return value;
 }
 
-function renderLlamaServerPreset(params: {
-  chatModelId?: string;
-  chatModelPath?: string;
+function renderChatModelSection(params: {
+  id: string;
+  modelPath: string;
   contextSize?: number;
   maxTokens?: number;
-  embeddingModelId: string;
-  embeddingModelPath: string;
 }): string {
-  const embeddingId = assertIniValue(params.embeddingModelId, "llama.cpp embedding model id");
-  if (embeddingId.includes("]")) {
+  const id = assertIniValue(params.id, "llama.cpp model id");
+  if (id.includes("]")) {
     throw new Error("llama.cpp model ids cannot contain ]");
   }
-  const lines = ["version = 1", ""];
-  if (params.chatModelId || params.chatModelPath) {
-    if (!params.chatModelId || !params.chatModelPath) {
-      throw new Error("llama.cpp chat model id and path must be provided together");
-    }
-    const chatId = assertIniValue(params.chatModelId, "llama.cpp model id");
-    if (chatId.includes("]")) {
-      throw new Error("llama.cpp model ids cannot contain ]");
-    }
-    lines.push(
-      `[${chatId}]`,
-      `model = ${assertIniValue(params.chatModelPath, "llama.cpp model path")}`,
-      `ctx-size = ${params.contextSize ?? DEFAULT_LLAMA_CPP_CONTEXT_SIZE}`,
-      `n-predict = ${params.maxTokens ?? 2048}`,
-      "jinja = true",
-      "",
-    );
-  }
-  lines.push(
-    `[${embeddingId}]`,
-    `model = ${assertIniValue(params.embeddingModelPath, "llama.cpp embedding model path")}`,
+  return [
+    `[${id}]`,
+    `model = ${assertIniValue(params.modelPath, "llama.cpp model path")}`,
+    `ctx-size = ${params.contextSize ?? DEFAULT_LLAMA_CPP_CONTEXT_SIZE}`,
+    `n-predict = ${params.maxTokens ?? 2048}`,
+    "jinja = true",
+  ].join("\n");
+}
+
+function renderEmbeddingModelSection(params: { isDefault?: boolean; modelPath: string }): string {
+  return [
+    `[${DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID}]`,
+    `model = ${assertIniValue(params.modelPath, "llama.cpp embedding model path")}`,
+    ...(params.isDefault ? [`ubatch-size = ${LLAMA_CPP_EMBEDDING_UBATCH_SIZE}`] : []),
     "embedding = true",
+  ].join("\n");
+}
+
+function readModelSection(contents: string | undefined, id: string): string | undefined {
+  if (!contents) {
+    return undefined;
+  }
+  const lines = contents.split(/\r?\n/u);
+  const start = lines.indexOf(`[${id}]`);
+  if (start < 0) {
+    return undefined;
+  }
+  let end = start + 1;
+  while (end < lines.length && !/^\[[^\]]+\]$/u.test(lines[end] ?? "")) {
+    end += 1;
+  }
+  return lines.slice(start, end).join("\n").trimEnd();
+}
+
+function readChatModelSection(contents: string | undefined): string | undefined {
+  const id = contents
+    ?.split(/\r?\n/u)
+    .map((line) => /^\[([^\]]+)\]$/u.exec(line)?.[1])
+    .find((candidate) => candidate && candidate !== DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID);
+  return id ? readModelSection(contents, id) : undefined;
+}
+
+function renderLlamaServerPreset(params: {
+  chatSection?: string;
+  embeddingSection: string;
+}): string {
+  return [
+    "version = 1",
     "",
-  );
-  return lines.join("\n");
+    ...(params.chatSection ? [params.chatSection, ""] : []),
+    params.embeddingSection,
+    "",
+  ].join("\n");
 }
 
 async function writePreset(presetPath: string, contents: string): Promise<void> {
@@ -344,6 +375,68 @@ async function writePreset(presetPath: string, contents: string): Promise<void> 
   const temporary = `${presetPath}.tmp-${randomUUID()}`;
   await fsp.writeFile(temporary, contents, { mode: 0o600 });
   await fsp.rename(temporary, presetPath);
+}
+
+async function updatePreset(
+  presetPath: string,
+  params: {
+    chatModelId?: string;
+    chatModelPath?: string;
+    contextSize?: number;
+    maxTokens?: number;
+    embeddingModelIsDefault?: boolean;
+    embeddingModelPath?: string;
+    defaultEmbeddingModelPath?: string;
+  },
+): Promise<void> {
+  const previous = presetWritePromises.get(presetPath) ?? Promise.resolve();
+  const pending = previous
+    .catch(() => undefined)
+    .then(async () => {
+      const existing = await fsp.readFile(presetPath, "utf8").catch((error: unknown) => {
+        if (asOptionalRecord(error)?.code === "ENOENT") {
+          return undefined;
+        }
+        throw error;
+      });
+      if (params.chatModelId || params.chatModelPath) {
+        if (!params.chatModelId || !params.chatModelPath) {
+          throw new Error("llama.cpp chat model id and path must be provided together");
+        }
+      }
+      const chatSection = params.chatModelPath
+        ? renderChatModelSection({
+            id: params.chatModelId ?? DEFAULT_LLAMA_CPP_MODEL_ID,
+            modelPath: params.chatModelPath,
+            contextSize: params.contextSize,
+            maxTokens: params.maxTokens,
+          })
+        : readChatModelSection(existing);
+      const embeddingSection = params.embeddingModelPath
+        ? renderEmbeddingModelSection({
+            isDefault: params.embeddingModelIsDefault,
+            modelPath: params.embeddingModelPath,
+          })
+        : (readModelSection(existing, DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID) ??
+          (params.defaultEmbeddingModelPath
+            ? renderEmbeddingModelSection({
+                isDefault: true,
+                modelPath: params.defaultEmbeddingModelPath,
+              })
+            : undefined));
+      if (!embeddingSection) {
+        throw new Error("llama.cpp embedding model path is required for a new managed preset");
+      }
+      await writePreset(presetPath, renderLlamaServerPreset({ chatSection, embeddingSection }));
+    });
+  presetWritePromises.set(presetPath, pending);
+  try {
+    await pending;
+  } finally {
+    if (presetWritePromises.get(presetPath) === pending) {
+      presetWritePromises.delete(presetPath);
+    }
+  }
 }
 
 async function findAvailableLlamaServerPort(preferred = LLAMA_CPP_DEFAULT_PORT): Promise<number> {
@@ -370,26 +463,26 @@ export async function prepareManagedLlamaServer(params: {
   chatModelPath?: string;
   contextSize?: number;
   maxTokens?: number;
-  embeddingModelPath: string;
+  embeddingModelIsDefault?: boolean;
+  embeddingModelPath?: string;
+  defaultEmbeddingModelPath?: string;
   port?: number;
 }): Promise<ManagedLlamaServer> {
   const { command, asset } = await ensureLlamaServerInstalled();
   const { presetPath } = resolveManagedLlamaServerPaths(asset);
-  await writePreset(
-    presetPath,
-    renderLlamaServerPreset({
-      ...(params.chatModelPath
-        ? {
-            chatModelId: params.chatModelId ?? DEFAULT_LLAMA_CPP_MODEL_ID,
-            chatModelPath: params.chatModelPath,
-          }
-        : {}),
-      contextSize: params.contextSize,
-      maxTokens: params.maxTokens,
-      embeddingModelId: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID,
-      embeddingModelPath: params.embeddingModelPath,
-    }),
-  );
+  await updatePreset(presetPath, {
+    ...(params.chatModelPath
+      ? {
+          chatModelId: params.chatModelId ?? DEFAULT_LLAMA_CPP_MODEL_ID,
+          chatModelPath: params.chatModelPath,
+        }
+      : {}),
+    contextSize: params.contextSize,
+    maxTokens: params.maxTokens,
+    embeddingModelIsDefault: params.embeddingModelIsDefault,
+    embeddingModelPath: params.embeddingModelPath,
+    defaultEmbeddingModelPath: params.defaultEmbeddingModelPath,
+  });
   const port = params.port ?? (await findAvailableLlamaServerPort());
   const rootUrl = `http://127.0.0.1:${port}`;
   return {
@@ -469,7 +562,7 @@ export async function ensureManagedLlamaServerForChat(params: {
             ? Math.floor(configuredContext)
             : params.model.contextTokens,
         maxTokens: params.model.maxTokens,
-        embeddingModelPath: path.join(cacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
+        defaultEmbeddingModelPath: path.join(cacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
         port: Number.isInteger(port) && port > 0 ? port : undefined,
       });
     })();

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -252,6 +252,7 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
       chatModelPath,
       contextSize,
       maxTokens: selected.model.maxTokens,
+      embeddingModelIsDefault: true,
       embeddingModelPath,
       port: readConfiguredPort(managedExisting),
     });


### PR DESCRIPTION
Closes #127283

Supersedes #127288. Thanks @cantoblanco for the original report and complete contributor fix; the original Git author is Alex <alex@example.com>.

## What Problem This Solves

Managed local llama.cpp embeddings fail with HTTP 500 when a pooled input exceeds the server's default 512-token physical micro-batch. Memory indexing then remains dirty and semantic search becomes unavailable, even though the default EmbeddingGemma model supports the input.

## Why This Change Was Made

- Set `ubatch-size = 2048` only for the managed default EmbeddingGemma preset, matching the currently pinned upstream llama.cpp `b10453` contract. Custom embedding models retain their existing physical-batch behavior.
- Give chat and embedding preparation independent ownership of their stanzas in the shared `models.ini`. Serialized, atomic read/merge/write updates preserve custom embeddings across concurrent preparation, chat restarts, fallback activation, and process restarts.
- Resolve managed default-model aliases against the provider's actual cache directory and prevent unrelated chat startup from validating or downloading stale embedding configuration.
- Keep the change inside the llama.cpp plugin: no public configuration, SDK, schema, context-limit, or other provider changes.

The production delta is +90 lines because shared preset ownership, atomic concurrency, and custom-model compatibility are real invariants; earlier smaller versions each failed those invariants. Tests grow by +107 lines.

## Evidence

### Exact current pinned upstream contract

Verified against llama.cpp `b10453`, commit `3cb7ffb1a1f612d5e4a46244ae5a3c77ad934a70`:

- `common/common.h:443-444`: logical batch defaults to 2048; physical micro-batch defaults to 512.
- `common/arg.cpp:4464-4477`: upstream's own EmbeddingGemma preset sets both physical and logical batches to 2048.
- `tools/server/server-context.cpp:3090-3097`: unsplittable pooled inputs exceeding the physical micro-batch produce the exact reported error.

### Real current-pin server reproduction

The official macOS `b10453` server artifact was verified against SHA-256 `f1531b1c520f8b473d83352c5eec2f4f43bd0a54f9ca1366a6f202211cfbc098`. An existing local Nomic GGUF was used to exercise the shared llama.cpp engine invariant without downloading a model or changing user configuration; EmbeddingGemma's exact model-specific 2048 contract was independently confirmed in the upstream source above.

With the same server, existing Nomic model, isolated loopback endpoint, and input `"memory ".repeat(531)` (531 tokenizer tokens; 533 server tokens including special tokens):

```text
Default physical micro-batch 512:
HTTP 500: input (533 tokens) is too large to process. increase the physical batch size (current batch size: 512)

Physical micro-batch 2048:
HTTP 200: 768 finite embedding dimensions; 335 ms
```

### Review and regression coverage

- Two independent source-aware reviews approved the exact five-file current-main patch and shared-preset concurrency behavior.
- Focused tests cover default versus custom embedding presets, custom cache aliases, concurrent chat/embedding preparation, and chat independence from disabled/non-local/stale embedding settings.
- Trusted formatter check passes on all five changed files; exact-head hosted CI is the authoritative final verification.

## Contributor Credit

This replacement preserves the original contributor commit author `Alex <alex@example.com>` and credits issue/PR opener @cantoblanco. The organization-owned branch avoids rewriting or force-pushing a contributor-owned fork while refreshing the fix onto current `main` and the current `b10453` server pin.
