### PR TITLE
fix(nodes): require matching launch and turn identity

### DIFF
--- a/src/node-host/invoke-worker-supervisor.test.ts
+++ b/src/node-host/invoke-worker-supervisor.test.ts
@@ -42,6 +42,11 @@ function launchInput() {
   return testWorkerLaunchInput(fixture.workspaceDir, "launch-1", "wait");
 }
 
+function mismatchedLaunchInput() {
+  const input = launchInput();
+  return { ...input, launchId: "other-launch" };
+}
+
 function fullReceipt(input = launchInput()): NodeWorkerLaunchReceipt {
   return {
     launchId: input.launchId,
@@ -741,6 +746,11 @@ describe("node-host worker supervisor commands", () => {
       name: "extra cancel identity field",
       command: NODE_WORKER_SUPERVISOR_CANCEL_COMMAND,
       raw: JSON.stringify({ ...cancelInput(fullReceipt()), extra: true }),
+    },
+    {
+      name: "mismatched launch and turn ids",
+      command: NODE_WORKER_SUPERVISOR_LAUNCH_COMMAND,
+      raw: JSON.stringify(mismatchedLaunchInput()),
     },
     {
       name: "extra launch field",

--- a/src/node-host/node-worker-supervisor-contract.ts
+++ b/src/node-host/node-worker-supervisor-contract.ts
@@ -12,6 +12,7 @@ import type { WorkerConnectionEndpoint } from "../worker/worker-connection-endpo
 import type { NodeWorkerLaunchReceipt } from "./node-worker-launch-store.js";
 
 export {
+  assertNodeWorkerLaunchIdentity,
   nodeWorkerPlanHash,
   parseNodeWorkerCancelInput,
   parseNodeWorkerLaunchInput,

--- a/src/node-host/node-worker-supervisor.container.test.ts
+++ b/src/node-host/node-worker-supervisor.container.test.ts
@@ -77,6 +77,22 @@ const journalState = (launchId) => {
   }
 };
 const record = (entry) => fs.appendFileSync(commandLog, JSON.stringify(entry) + "\n");
+const waitForRunningJournal = async (container) => {
+  let journal;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    journal = journalState(launchIdFor(container));
+    const persisted = journal?.container_json && JSON.parse(journal.container_json);
+    if (
+      journal?.state === "running" &&
+      persisted?.containerId === container.id &&
+      persisted?.engineTarget === expectedEngineTarget
+    ) {
+      return journal;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return journal;
+};
 const releaseAfterMarker = (marker, operation) => {
   const markerPath = path.join(engineRoot, marker);
   if (!fs.existsSync(markerPath)) {
@@ -131,7 +147,7 @@ if (command === "version") {
     let descriptor = "";
     for await (const chunk of process.stdin) descriptor += chunk;
     const container = readContainer(args.at(-1));
-    const journal = journalState(launchIdFor(container));
+    const journal = await waitForRunningJournal(container);
     record({ argv: args, journal });
     const persisted = journal?.container_json && JSON.parse(journal.container_json);
     if (

--- a/src/node-host/node-worker-supervisor.test-support.ts
+++ b/src/node-host/node-worker-supervisor.test-support.ts
@@ -147,7 +147,11 @@ if (mode === "connection-failure") {
 }
 `;
 
-export function testWorkerDescriptor(workspaceDir: string, prompt = "success"): WorkerLaunchPlan {
+export function testWorkerDescriptor(
+  workspaceDir: string,
+  prompt = "success",
+  turnId = "turn-1",
+): WorkerLaunchPlan {
   return {
     version: 4,
     admission: {
@@ -167,7 +171,7 @@ export function testWorkerDescriptor(workspaceDir: string, prompt = "success"): 
       operationalRunInstance: { instanceId: "instance-1", runId: "run-1" },
       agentRuntimeIdentityToken: "signed-runtime-token",
       runId: "run-1",
-      turnId: "turn-1",
+      turnId,
       prompt,
       suppressPromptTranscript: false,
       workspaceDir,
@@ -216,6 +220,6 @@ export function testWorkerLaunchInput(
     gatewayNamespace: "gateway-1",
     expectedBundleHash: TEST_BUNDLE_HASH,
     placementGeneration: 4,
-    descriptor: testWorkerDescriptor(workspaceDir, prompt),
+    descriptor: testWorkerDescriptor(workspaceDir, prompt, launchId),
   };
 }

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -219,6 +219,21 @@ describe("node worker supervisor", () => {
     await recovered.close();
   });
 
+  it("rejects a mismatched launch and turn identity before durable admission", async () => {
+    const { env, supervisor, workspaceDir } = fixture();
+    const input = launchInput(workspaceDir, "launch-id");
+    input.descriptor.assignment.turnId = "other-turn-id";
+
+    try {
+      await expect(supervisor.launch(input, TEST_WORKER_ENDPOINT)).rejects.toThrow(
+        "launchId must match descriptor assignment turnId",
+      );
+      expect(new NodeWorkerLaunchStore({ env }).get(input.launchId)).toBeUndefined();
+    } finally {
+      await supervisor.close();
+    }
+  });
+
   it("launches idempotently and persists only bounded non-secret facts", async () => {
     const { env, supervisor, workspaceDir } = fixture();
     const input = launchInput(workspaceDir, "success-launch");
@@ -243,7 +258,7 @@ describe("node worker supervisor", () => {
       supervisor.launch(
         {
           ...input,
-          descriptor: testWorkerDescriptor(workspaceDir, "different-plan"),
+          descriptor: testWorkerDescriptor(workspaceDir, "different-plan", input.launchId),
         },
         TEST_WORKER_ENDPOINT,
       ),

--- a/src/node-host/node-worker-supervisor.ts
+++ b/src/node-host/node-worker-supervisor.ts
@@ -39,6 +39,7 @@ import {
   type NodeWorkerProcessIdentity,
 } from "./node-worker-process-identity.js";
 import {
+  assertNodeWorkerLaunchIdentity,
   nodeWorkerPlanHash,
   type NodeWorkerLaunchInput,
   type NodeWorkerSupervisorIdentity,
@@ -144,9 +145,7 @@ class NodeWorkerSupervisor {
     }
     const plan = parseWorkerLaunchPlan(structuredClone(input.descriptor));
     const descriptor = completeWorkerLaunchDescriptor(plan, connectionEndpoint);
-    if (descriptor.admission.handshake.bundleHash !== input.expectedBundleHash) {
-      throw new Error("node worker descriptor bundle hash does not match the launch bundle");
-    }
+    assertNodeWorkerLaunchIdentity(input, descriptor);
     const planHash = nodeWorkerPlanHash(input);
     if (this.closed) {
       throw new Error("node worker supervisor is closed");

--- a/src/worker/node-supervisor-protocol.test.ts
+++ b/src/worker/node-supervisor-protocol.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { testWorkerDescriptor } from "../node-host/node-worker-supervisor.test-support.js";
 import {
   NODE_WORKER_CONNECTION_FAILURE_MESSAGE_TYPE,
   parseNodeWorkerConnectionFailureMessage,
+  parseNodeWorkerLaunchInput,
   parseNodeWorkerSupervisorReceipt,
   type NodeWorkerSupervisorIdentity,
 } from "./node-supervisor-protocol.js";
@@ -18,6 +20,24 @@ const identity: NodeWorkerSupervisorIdentity = {
   placementGeneration: 4,
   runId: "run-1",
 };
+
+describe("node worker supervisor launch request", () => {
+  it("rejects mismatched launch and turn ids", () => {
+    const descriptor = testWorkerDescriptor("/tmp/worker", "success", "turn-1");
+
+    expect(() =>
+      parseNodeWorkerLaunchInput(
+        JSON.stringify({
+          launchId: "other-launch",
+          gatewayNamespace: "gateway-1",
+          expectedBundleHash: descriptor.admission.handshake.bundleHash,
+          placementGeneration: 4,
+          descriptor,
+        }),
+      ),
+    ).toThrow("launchId must match descriptor assignment turnId");
+  });
+});
 
 describe("node worker supervisor wire receipt", () => {
   it("accepts only bounded worker connection diagnostics", () => {

--- a/src/worker/node-supervisor-protocol.ts
+++ b/src/worker/node-supervisor-protocol.ts
@@ -102,6 +102,18 @@ function decodeRequest(raw?: string | null): unknown {
   }
 }
 
+export function assertNodeWorkerLaunchIdentity(
+  input: Pick<NodeWorkerLaunchInput, "launchId" | "expectedBundleHash">,
+  descriptor: WorkerLaunchPlan,
+): void {
+  if (descriptor.assignment.turnId !== input.launchId) {
+    throw new Error("INVALID_REQUEST: launchId must match descriptor assignment turnId");
+  }
+  if (descriptor.admission.handshake.bundleHash !== input.expectedBundleHash) {
+    throw new Error("INVALID_REQUEST: descriptor bundle hash does not match expectedBundleHash");
+  }
+}
+
 export function parseNodeWorkerLaunchInput(raw?: string | null): NodeWorkerLaunchInput {
   const value = decodeRequest(raw);
   if (
@@ -132,9 +144,10 @@ export function parseNodeWorkerLaunchInput(raw?: string | null): NodeWorkerLaunc
   } catch {
     throw new Error("INVALID_REQUEST: invalid worker launch descriptor");
   }
-  if (descriptor.admission.handshake.bundleHash !== value.expectedBundleHash) {
-    throw new Error("INVALID_REQUEST: descriptor bundle hash does not match expectedBundleHash");
-  }
+  assertNodeWorkerLaunchIdentity(
+    { launchId, expectedBundleHash: value.expectedBundleHash },
+    descriptor,
+  );
   return {
     launchId,
     gatewayNamespace,


### PR DESCRIPTION
Closes #128707

## What Problem This Solves

Fixes an issue where the node-host worker launch boundary accepted an outer launch ID that differed from the worker descriptor’s turn ID. Durable supervisor ownership, status, cancellation, and audit correlation could therefore refer to a different operational identity than the worker itself.

## Why This Change Was Made

One shared protocol assertion now requires launch ID and descriptor turn ID equality while preserving the existing bundle-hash identity check. The private node command parser rejects malformed wire requests as `INVALID_REQUEST`, and the supervisor repeats the assertion for direct internal callers before initialization, capacity claim, durable recording, or process startup. Shared fixtures now generate realistic matching identities.

Production LOC: +19/-6 (net +13) | Tests/test support: +70/-5

The production growth establishes a node-owned identity boundary that was previously enforced only by the ordinary Gateway adapter; the receiver must not rely on every caller following that convention.

AI-assisted: yes. I reviewed the Gateway launch adapter, wire parser, node-host command path, supervisor durable claim, fixture construction, and cancellation/status identity and understand the change.

## User Impact

Malformed or stale node worker launch requests now fail before any worker or durable launch side effect. Normal Gateway-generated launches are unchanged because they already use the turn ID as the launch ID.

## Evidence

- Pre-fix protocol regression: the mismatched launch request parsed successfully.
- Pre-fix private-command regression: the request returned `ok: true` and called `supervisor.launch`.
- Pre-fix direct-supervisor regression: the supervisor returned a running durable receipt for mismatched IDs.
- Post-fix focused proof: 106 tests passed across protocol, private command, supervisor, container, and recovery surfaces.
- The first exact-head CI run exposed an unrelated loaded-runner flake in the container proof: its fake engine performed one immediate SQLite journal read and treated a transient miss as worker failure. The harness now polls for at most one second for the exact running/container identity before spawning, then retains the same fail-closed validation.
- Container proof stress: the formerly failing round-trip passed 10 consecutive bounded runs; the full focused owner suite passed afterward.
- Full changed-file gate: `node scripts/check-changed.mjs` passed.
- Fresh P0/P1 autoreviews: no accepted/actionable findings (0.96 identity repair, 0.98 test reliability fix).
- Coverage proves parser rejection, no supervisor invocation, direct defense before durable row creation, realistic matching fixtures, idempotent replay, container isolation, restart recovery, and scheduling-independent journal proof.
