### PR TITLE
fix(tui): keep foreign session resets from clearing active chats

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1815,6 +1815,67 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
   });
 
+  it.each([
+    { name: "another agent's fixed-store session", agentId: "main" },
+    { name: "an ownerless default-agent alias", agentId: undefined },
+  ])("ignores a reset for $name colliding with the selected session", ({ agentId }) => {
+    const pendingSubmit = acceptedSubmit("run-pending");
+    const { state, loadHistory, setActivityStatus, handleSessionsChangedEvent } =
+      createHandlersHarness({
+        state: {
+          agentDefaultId: "main",
+          currentAgentId: "work",
+          currentSessionKey: "agent:work:support",
+          currentSessionId: "session-work",
+          activeChatRunId: "run-work",
+          activityStatus: "streaming",
+          pendingSubmit,
+          sessionInfo: { updatedAt: 100 },
+        },
+      });
+
+    handleSessionsChangedEvent({
+      sessionKey: "support",
+      ...(agentId ? { agentId } : {}),
+      reason: "reset",
+      sessionId: "session-main-new",
+      updatedAt: 200,
+      activeRunIds: [],
+    });
+
+    expect(state.activeChatRunId).toBe("run-work");
+    expect(state.pendingSubmit).toBe(pendingSubmit);
+    expect(state.currentSessionId).toBe("session-work");
+    expect(state.sessionInfo.updatedAt).toBe(100);
+    expect(state.activityStatus).toBe("streaming");
+    expect(loadHistory).not.toHaveBeenCalled();
+    expect(setActivityStatus).not.toHaveBeenCalledWith("idle");
+  });
+
+  it("accepts a reset for the selected non-default agent's owned session alias", () => {
+    const { state, loadHistory, handleSessionsChangedEvent } = createHandlersHarness({
+      state: {
+        agentDefaultId: "main",
+        currentAgentId: "work",
+        currentSessionKey: "agent:work:support",
+        currentSessionId: "session-work-old",
+        activeChatRunId: "run-work",
+        activityStatus: "streaming",
+      },
+    });
+
+    handleSessionsChangedEvent({
+      sessionKey: "support",
+      agentId: "work",
+      reason: "reset",
+      sessionId: "session-work-new",
+    });
+
+    expect(state.activeChatRunId).toBeNull();
+    expect(state.currentSessionId).toBe("session-work-new");
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
+
   it("ignores selected-global sessions.changed reset events from other agents", () => {
     const { state, loadHistory, setActivityStatus, handleSessionsChangedEvent } =
       createHandlersHarness({

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -399,7 +399,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as SessionChangedEvent;
     syncSessionKey();
-    if (!matchesSelectedTuiSession(state, evt)) {
+    if (!matchesSelectedTuiSession(state, evt, { requireAliasOwnership: true })) {
       return;
     }
 
@@ -408,11 +408,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         typeof evt.sessionId !== "string" ||
         !state.currentSessionId ||
         evt.sessionId === state.currentSessionId;
-      if (
-        !matchesSelectedTuiSession(state, evt, { requireAliasOwnership: true }) ||
-        !matchesCurrentSessionId ||
-        !isIdentityOnlyTuiSessionInvalidation(evt)
-      ) {
+      if (!matchesCurrentSessionId || !isIdentityOnlyTuiSessionInvalidation(evt)) {
         return;
       }
       // Legacy atomic batches expose no replayable message identity. Refresh


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where terminal users working in a non-default agent's active conversation could lose its live response, pending prompt, and session identity when another agent reset a colliding bare session name. Configured fixed-store owners legitimately retain bare keys such as `support`, while another agent can independently own `agent:work:support`.

## Why This Change Was Made

Apply the existing canonical TUI owner-aware session matcher once, at the `sessions.changed` ingress boundary, before reset, new-session, completion, or transcript invalidation can mutate selected-session state. Remove the now-redundant nested ownership check. Default-agent legacy aliases, correctly owned non-default aliases, canonical agent keys, global sessions, and the separately owned `session.message` boundary retain their existing behavior.

Production LOC: +2/-6 (net -4). Tests: +61/-0.

## User Impact

A second agent's session reset can no longer silently erase or interrupt the terminal conversation currently being used. Valid resets for the selected agent continue to clear and reload that conversation, and legacy default-agent sessions keep working.

## Evidence

- Before the repair, both new regression cases failed at the real TUI event-owner boundary because the selected agent's active run became `null`: one case supplied the configured fixed-store owner's explicit agent identity, and the other covered an ownerless default-agent alias.
- After the repair, all 214 event-owner, canonical session-matcher, and run-coordinator tests passed:

  `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-tui-foreign-session-reset-cache node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts src/tui/tui-session-events.test.ts src/tui/tui-session-run-coordinator.test.ts --configLoader runner`

- Two real interactive terminal scenarios passed: overlapping typed input survived `/reset` and was delivered exactly once, and a remembered global session restored while preserving editable input:

  `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-tui-foreign-session-reset-pty-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner src/tui/tui-reset-transition-pty.e2e.test.ts src/tui/tui-session-identity-pty.e2e.test.ts -t 'preserves overlapping input while /reset|restores a remembered global session'`

- Targeted formatting and lint passed. Independent maintainer review and structured Codex autoreview reported no actionable findings.
- The terminal scenarios execute the real TUI in a PTY against its fixture backend; Gateway fixed-store ownership and broadcast contracts were also verified directly in the producer source and existing Gateway RPC coverage. They are not represented as live Gateway proof.
