### PR TITLE
fix(ios): report unavailable when network observation times out

### DIFF
--- a/apps/ios/Sources/Device/DeviceStatusService.swift
+++ b/apps/ios/Sources/Device/DeviceStatusService.swift
@@ -14,7 +14,7 @@ final class DeviceStatusService: DeviceStatusServicing {
         let battery = Self.batteryStatus(device: UIDevice.current)
         let thermal = self.thermalStatus()
         let storage = self.storageStatus()
-        let network = await self.networkStatus.currentStatus()
+        let network = try await self.networkStatus.currentStatus()
         let uptime = ProcessInfo.processInfo.systemUptime
 
         return OpenClawDeviceStatusPayload(

--- a/apps/ios/Sources/Device/NetworkStatusService.swift
+++ b/apps/ios/Sources/Device/NetworkStatusService.swift
@@ -3,8 +3,10 @@ import Network
 import OpenClawKit
 
 final class NetworkStatusService: @unchecked Sendable {
-    func currentStatus(timeoutMs: Int = 1500) async -> OpenClawNetworkStatusPayload {
-        await withCheckedContinuation { cont in
+    func currentStatus(timeoutMs: Int = 1500) async throws -> OpenClawNetworkStatusPayload {
+        guard timeoutMs > 0 else { throw URLError(.timedOut) }
+
+        return try await withCheckedThrowingContinuation { cont in
             let monitor = NWPathMonitor()
             let queue = DispatchQueue(label: "ai.openclawfoundation.app.network-status")
             let state = NetworkStatusState()
@@ -20,7 +22,7 @@ final class NetworkStatusService: @unchecked Sendable {
             queue.asyncAfter(deadline: .now() + .milliseconds(timeoutMs)) {
                 guard state.markCompleted() else { return }
                 monitor.cancel()
-                cont.resume(returning: Self.fallbackPayload())
+                cont.resume(throwing: URLError(.timedOut))
             }
         }
     }
@@ -44,14 +46,6 @@ final class NetworkStatusService: @unchecked Sendable {
             isExpensive: path.isExpensive,
             isConstrained: path.isConstrained,
             interfaces: interfaces)
-    }
-
-    private static func fallbackPayload() -> OpenClawNetworkStatusPayload {
-        OpenClawNetworkStatusPayload(
-            status: .unsatisfied,
-            isExpensive: false,
-            isConstrained: false,
-            interfaces: [.other])
     }
 }
 

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -1000,7 +1000,37 @@ private final class BatteryMonitoringDevice: UIDevice {
     }
 }
 
+@MainActor
+private final class TimingOutDeviceStatusService: DeviceStatusServicing {
+    func status() async throws -> OpenClawDeviceStatusPayload {
+        throw URLError(.timedOut)
+    }
+
+    func info() -> OpenClawDeviceInfoPayload {
+        DeviceStatusService().info()
+    }
+}
+
 @Suite(.serialized) struct NodeAppModelInvokeTests {
+    @Test func `network status timeout never invents offline network facts`() async {
+        await #expect(throws: URLError(.timedOut)) {
+            try await NetworkStatusService().currentStatus(timeoutMs: 0)
+        }
+    }
+
+    @Test @MainActor func `device status reports unavailable when its network observation times out`() async {
+        let appModel = NodeAppModel(deviceStatusService: TimingOutDeviceStatusService())
+        let request = BridgeInvokeRequest(
+            id: "device-status-network-timeout",
+            command: OpenClawDeviceCommand.status.rawValue,
+            paramsJSON: "{}")
+
+        let response = await appModel.handleInvoke(request)
+
+        #expect(response.ok == false)
+        #expect(response.error?.code == .unavailable)
+    }
+
     @Test @MainActor func `device status battery snapshot preserves monitoring ownership`() {
         for initial in [false, true] {
             let device = BatteryMonitoringDevice(monitoringEnabled: initial)
@@ -1010,7 +1040,7 @@ private final class BatteryMonitoringDevice: UIDevice {
             #expect(payload.level == 0.5)
             #expect(payload.state == .charging)
             #expect(!device.monitoringStatesDuringBatteryReads.isEmpty)
-            #expect(device.monitoringStatesDuringBatteryReads.allSatisfy { $0 })
+            #expect(!device.monitoringStatesDuringBatteryReads.contains(false))
             #expect(device.isBatteryMonitoringEnabled == initial)
         }
     }


### PR DESCRIPTION
## Summary

Fixes #127482.

iOS previously converted an `NWPathMonitor` observation timeout into a fabricated network payload claiming the device was offline, unmetered, and unconstrained. A timeout is not a network observation, and Apple's `NWPath.Status` contract does not define an unknown value.

- Make the network-status owner throw `URLError(.timedOut)` when no observation arrives, including deterministic handling of already-expired deadlines.
- Propagate that failure through the existing throwing `device.status` owner and existing `UNAVAILABLE` invoke contract instead of changing the public payload or protocol.
- Delete the fabricated fallback payload entirely. Production: +6/-12, net -6 lines; tests: +31/-1.

## Verification

- Failing before the fix on a real iPhone 17 Pro simulator: `NodeAppModelInvokeTests.network status timeout never invents offline network facts`.
- Passing after the fix: the complete `OpenClawTests/NodeAppModelInvokeTests` simulator suite, including the real network-status owner regression and the existing public invoke-boundary `UNAVAILABLE` response.
- Repository changed-files gate: `node scripts/check-changed.mjs -- apps/ios/Sources/Device/NetworkStatusService.swift apps/ios/Sources/Device/DeviceStatusService.swift apps/ios/Tests/NodeAppModelInvokeTests.swift`.
- Pinned SwiftFormat/SwiftLint checks and clean independent structured code review.
- Reviewed Apple's local Network framework `NWPath`, `NWPathMonitor`, and closed `NWPath.Status` interfaces directly; no public schema, protocol, or configuration changes.
