### PR TITLE
fix(ui): keep restart-resumed tool activity together

### DIFF
--- a/ui/src/e2e/chat-agent-run-transcript.e2e.test.ts
+++ b/ui/src/e2e/chat-agent-run-transcript.e2e.test.ts
@@ -25,6 +25,76 @@ function transcriptMessage(
 }
 
 suite.define(() => {
+  it("keeps restart-recovered live tool batches in one transcript row", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1200 } });
+    const page = await context.newPage();
+    const runId = "run-restart-recovery";
+    const toolResult = (id: string, seq: number, name: string) => ({
+      ...transcriptMessage(
+        "toolResult",
+        [{ type: "text", text: `${name} completed` }],
+        runId,
+        id,
+        seq,
+      ),
+      toolCallId: id,
+      toolName: name,
+    });
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          ...transcriptMessage(
+            "user",
+            "[System] Continue the interrupted turn.",
+            `${runId}:user`,
+            "restart-recovery",
+            1,
+          ),
+          provenance: {
+            kind: "internal_system",
+            sourceSessionKey: "main",
+            sourceTool: "main_session_restart_recovery",
+          },
+        },
+        toolResult("process-1", 2, "process"),
+        toolResult("process-2", 3, "process"),
+        transcriptMessage("assistant", "Checking the next batch.", runId, "gap-1", 4),
+        toolResult("exec-1", 5, "exec"),
+        toolResult("exec-2", 6, "exec"),
+        transcriptMessage("assistant", "Checking the final batch.", runId, "gap-2", 7),
+        toolResult("process-3", 8, "process"),
+        toolResult("process-4", 9, "process"),
+      ],
+      inFlightRun: { runId, text: "" },
+      sessionInfo: {
+        activeRunIds: [runId],
+        hasActiveRun: true,
+        key: "main",
+      },
+    });
+
+    await page.goto(`${suite.server.baseUrl}chat`);
+    const summaries = page.locator(".chat-activity-group__summary");
+    await expect.poll(() => summaries.count()).toBe(3);
+    const rowKeys = await summaries.evaluateAll((elements) =>
+      elements.map(
+        (element) => element.closest<HTMLElement>(".chat-virtual-row")?.dataset.virtualRowKey,
+      ),
+    );
+
+    expect(rowKeys[0]).toMatch(/^agent-run:/u);
+    expect(rowKeys).toEqual([rowKeys[0], rowKeys[0], rowKeys[0]]);
+    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    if (artifactDir) {
+      await fs.mkdir(artifactDir, { recursive: true });
+      await page.locator(".chat-thread-inner").screenshot({
+        path: path.join(artifactDir, "restart-recovery-run-frame.png"),
+      });
+    }
+
+    await context.close();
+  });
+
   it("renders each run as one linear response with actions only on its terminal text", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1200 } });
     const page = await context.newPage();

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -103,6 +103,7 @@ export type ChatItem =
       icon?: keyof typeof toolIcons;
       label?: string;
       startsTurn?: true;
+      boundaryId?: string;
       tone?: "danger";
     }
   | {

--- a/ui/src/pages/chat/chat-agent-run-grouping.test.ts
+++ b/ui/src/pages/chat/chat-agent-run-grouping.test.ts
@@ -132,6 +132,34 @@ describe("coalesceAgentRunFrames", () => {
     expect(history.key).toBe(live.key);
   });
 
+  it("keeps a restart-recovered tool-only run in one stable frame", () => {
+    const runId = "run-recovered";
+    const boundaryId = `send:${runId}`;
+    const recoveryNotice = {
+      kind: "notice" as const,
+      key: "notice:restart-recovery",
+      text: "Turn interrupted by a gateway restart.",
+      timestamp: 1,
+      startsTurn: true as const,
+      boundaryId,
+    };
+    const first = group("tool", "recovered-tool-1", runId);
+    const second = group("tool", "recovered-tool-2", runId);
+    const historyActivity: ActivityRunRenderItem = {
+      kind: "activity-run",
+      key: "activity:recovered-tools",
+      groups: [first, second],
+    };
+
+    const live = requireFrame(coalesceAgentRunFrames([recoveryNotice, first, second])[1]);
+    const history = requireFrame(coalesceAgentRunFrames([recoveryNotice, historyActivity])[1]);
+
+    expect(live.parts).toEqual([first, second]);
+    expect(history.parts).toEqual([historyActivity]);
+    expect(live.boundaryId).toBe(boundaryId);
+    expect(history.key).toBe(live.key);
+  });
+
   it("remounts a large live stream after steer without destabilizing ordinary frames", () => {
     const runId = "run-steered";
     const boundaryId = "send:steer-run";

--- a/ui/src/pages/chat/chat-agent-run-grouping.ts
+++ b/ui/src/pages/chat/chat-agent-run-grouping.ts
@@ -231,8 +231,8 @@ export function coalesceAgentRunFrames(
     if (!isAgentRunFramePart(item)) {
       flush();
       result.push(item);
-      boundaryId = undefined;
-      segmentId = item.key;
+      boundaryId = item.kind === "notice" && item.startsTurn ? item.boundaryId : undefined;
+      segmentId = boundaryId ? undefined : item.key;
       continue;
     }
     const candidate = item;

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -52,6 +52,7 @@ import {
   transcriptPositionTimestamp,
   turnHasMatchingAssistant,
   type TurnInsertionBounds,
+  userTurnSendIdentity,
 } from "./chat-thread-items.ts";
 import {
   findCurrentTurnBounds,
@@ -192,6 +193,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
         ? t(noticeKind.summaryKey)
         : extractTextCached(msg)?.replace(/^\[System\] /u, "");
       if (text?.trim()) {
+        const boundaryId = userTurnSendIdentity(msg);
         items.push({
           kind: "notice",
           key: itemKey,
@@ -200,6 +202,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
           startsTurn: true,
           text,
           timestamp: normalized.timestamp,
+          ...(boundaryId ? { boundaryId } : {}),
         });
       }
       continue;

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1829,6 +1829,7 @@ describe("buildCachedChatItems", () => {
       userMessage("before", 999),
       userMessage("[System] Continue the interrupted turn.", 1000, {
         provenance: { kind: "internal_system", sourceTool: "main_session_restart_recovery" },
+        __openclaw: { id: "restart-recovery", idempotencyKey: "run-recovered:user" },
       }),
       userMessage("[System] Gateway restarted during update 2026.8.2 -> 2026.8.3.", 1001, {
         provenance: { kind: "internal_system", sourceTool: "restart-sentinel" },
@@ -1853,6 +1854,7 @@ describe("buildCachedChatItems", () => {
       label: "System · restart recovery",
       text: "Turn interrupted by a gateway restart — asked the agent to resume and finish the response.",
       timestamp: 1000,
+      boundaryId: "send:run-recovered",
     });
     // Summary-less kinds keep the producer's informative text under the label.
     expect(items[2]).toMatchObject({


### PR DESCRIPTION
Related: #126278
Related: #128298
Related: #128645

AI-assisted: yes (Codex)

## What Problem This Solves

Fixes an issue where Control UI users would see large gaps between tool activity batches when an agent turn resumed after a gateway restart. The resumed work appeared as several separate transcript rows even though every batch belonged to the same run.

## Why This Change Was Made

Restart recovery replaces its internal user message with a system notice. That projection discarded the turn boundary identity added by the persisted recovery message, so subsequent tool-only activity had no stable frame boundary. This change carries that existing identity through the notice and lets the normal agent-run grouping path reuse it; ordinary notices remain hard boundaries.

## User Impact

Restart-resumed tool activity now stays in one continuous response frame. The normal spacing between genuinely separate turns remains unchanged.

## Evidence

- Reproduced with the affected Falc0n session: all 174 post-restart assistant/tool rows shared run ID `19257331-3da3-43e7-9611-97db7adbf322`, but the pre-fix UI projection emitted a recovery notice, a detached tool row, and a separate status frame.
- Replayed the exact 498-row history through the patched projection: recovery notice and resumed activity now share `send:19257331-3da3-43e7-9611-97db7adbf322` and produce one resumed frame.
- Regression-first proof: the new grouping test failed before the production change with `expected an agent run frame`.
- Focused grouped tests: 197 unit tests and 3 Control UI browser tests passed.
- Browser regression drives three tool batches separated by commentary and proves all three activity summaries share one `agent-run` virtual row.
- Static gates passed: Oxfmt, Oxlint, `pnpm tsgo:ui`, and `pnpm check:test-types`.
- Performance audit: no new transcript scan, render pass, or asymptotic change; only one existing identity parse for internal system notices.
- Before/after captures were inspected locally: the reported Falc0n view showed five detached activity rows with large turn gaps; the patched browser fixture shows all three tool batches inside one compact response row.
- ClawSweeper exact-head review passed with zero correctness findings, security concerns, maintainer decisions, or rank-up moves.
- Full GitHub CI passed. One unrelated `src/commands/**` shard initially stalled twice at the runner's five-minute no-output timeout (`exit 143`), then passed unchanged on rerun.
- The auxiliary Telegram default-turn probe could not acquire the shared QA credential (`POOL_EXHAUSTED`). This change has no channel-visible behavior; direct Control UI browser coverage is included above.
