### PR TITLE
refactor(telegram): unify interactive keyboard rendering

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1279,7 +1279,7 @@ extensions/telegram/src/bot/body-helpers.ts	1
 extensions/telegram/src/bot/delivery.replies.ts	1
 extensions/telegram/src/bot/delivery.resolve-media.ts	1
 extensions/telegram/src/bot/helpers.ts	2
-extensions/telegram/src/button-types.ts	2
+extensions/telegram/src/button-types.ts	1
 extensions/telegram/src/callback-query-answer-state.ts	1
 extensions/telegram/src/channel-actions.ts	1
 extensions/telegram/src/channel.ts	1

--- a/extensions/telegram/src/button-types.test.ts
+++ b/extensions/telegram/src/button-types.test.ts
@@ -53,6 +53,55 @@ describe("buildTelegramInteractiveButtons callback limits", () => {
   });
 });
 
+describe("resolveTelegramInlineButtons precedence", () => {
+  it("returns explicit buttons without reading lower-priority payloads", () => {
+    const buttons = [[{ text: "Explicit", callback_data: "explicit" }]];
+    const params = {
+      buttons,
+      get interactive(): never {
+        throw new Error("unexpected interactive normalization");
+      },
+      get presentation(): never {
+        throw new Error("unexpected presentation normalization");
+      },
+    };
+
+    expect(resolveTelegramInlineButtons(params)).toBe(buttons);
+  });
+
+  it.each([
+    {
+      description: "the legacy payload contains only text",
+      interactive: { blocks: [{ type: "text", text: "Legacy heading" }] },
+      expectedDropped: [],
+    },
+    {
+      description: "every legacy callback exceeds the Telegram byte limit",
+      interactive: {
+        blocks: [{ type: "buttons", buttons: [{ label: "Oversized", value: "x".repeat(65) }] }],
+      },
+      expectedDropped: [
+        { label: "Oversized", reason: "callback_data_too_long", callbackDataBytes: 65 },
+      ],
+    },
+  ])("falls back to presentation buttons when $description", ({ interactive, expectedDropped }) => {
+    const dropped: Array<{ label: string; reason: string; callbackDataBytes?: number }> = [];
+
+    expect(
+      resolveTelegramInlineButtons(
+        {
+          interactive,
+          presentation: {
+            blocks: [{ type: "buttons", buttons: [{ label: "Fallback", value: "fallback" }] }],
+          },
+        },
+        { onDroppedControl: (control) => dropped.push(control) },
+      ),
+    ).toEqual([[{ text: "Fallback", callback_data: "fallback", style: undefined }]]);
+    expect(dropped).toEqual(expectedDropped);
+  });
+});
+
 describe("buildTelegramPresentationButtons", () => {
   it("builds inline buttons from presentation blocks", () => {
     expect(

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -1,13 +1,12 @@
 // Telegram plugin module implements button types behavior.
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import {
-  reduceLegacyInteractiveReply,
+  legacyInteractiveReplyToPresentation,
   isMessagePresentationInteractiveBlock,
   normalizeMessagePresentation,
   normalizeLegacyInteractiveReply,
   renderMessagePresentationFallbackText,
   resolveMessagePresentationButtonAction,
-  type LegacyInteractiveReply,
   type MessagePresentation,
   type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
@@ -228,38 +227,6 @@ function chunkInteractiveButtons(
   }
 }
 
-/**
- * @deprecated Use buildTelegramPresentationButtons with MessagePresentation.
- */
-function buildTelegramInteractiveButtons(
-  interactive?: LegacyInteractiveReply,
-  options?: TelegramButtonBuildOptions,
-): TelegramInlineButtons | undefined {
-  const rows = reduceLegacyInteractiveReply(
-    interactive,
-    [] as TelegramInlineButton[][],
-    (state, block) => {
-      if (block.type === "buttons") {
-        chunkInteractiveButtons(block.buttons, state, options);
-        return state;
-      }
-      if (block.type === "select") {
-        chunkInteractiveButtons(
-          block.options.map((option) => ({
-            label: option.label,
-            action: option.action,
-            value: option.value,
-          })),
-          state,
-          options,
-        );
-      }
-      return state;
-    },
-  );
-  return rows.length > 0 ? rows : undefined;
-}
-
 /** Convert portable presentation controls to Telegram inline keyboard rows. */
 export function buildTelegramPresentationButtons(
   presentation?: MessagePresentation,
@@ -296,9 +263,16 @@ export function resolveTelegramInlineButtons(
   },
   options?: TelegramButtonBuildOptions,
 ): TelegramInlineButtons | undefined {
+  if (params.buttons) {
+    return params.buttons;
+  }
+
+  const interactive = normalizeLegacyInteractiveReply(params.interactive);
   return (
-    params.buttons ??
-    buildTelegramInteractiveButtons(normalizeLegacyInteractiveReply(params.interactive), options) ??
+    buildTelegramPresentationButtons(
+      interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined,
+      options,
+    ) ??
     buildTelegramPresentationButtons(normalizeMessagePresentation(params.presentation), options)
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Telegram maintained two separate inline-keyboard renderers for legacy interactive replies and modern message presentations. Both repeated the same button/select conversion and row chunking, leaving callback, approval, and fallback behavior vulnerable to drift.

## Why This Change Was Made

Delete the obsolete plugin-private legacy renderer and reuse the existing Plugin SDK legacy-to-presentation bridge together with Telegram's canonical presentation renderer. Explicit keyboards still retain exact reference identity and short-circuit before lower-priority payloads are inspected. Legacy payloads are normalized once; text-only or entirely discarded legacy controls still fall back to usable presentation buttons, including existing dropped-control notifications.

The canonical renderer remains the sole owner of three-button row ordering, callback byte limits, typed approval/command/question authorization boundaries, opaque callback envelopes, and direct-chat Web App gating. No public API, configuration, SDK export, or security behavior changes.

Production: +10/-36, net -26 lines. Tests: +49 lines for explicit lazy identity and table-driven text-only/oversized-control fallback regressions.

## User Impact

Telegram inline keyboards keep their existing visible behavior while a duplicate private rendering path is removed. Existing approval, question, callback, select, Web App, and delivery behavior remains unchanged.

## Evidence

- The new preservation regressions were added and run against untouched production code first: 33 Telegram button tests passed, proving the expected existing behavior before refactoring.
- After the cleanup, ten focused suites passed: 607 tests covering button rendering, inline-button policy, interactive fallback, approval handlers, actions, outbound presentation/Web App handling, and real mocked Telegram delivery/send keyboard payloads.
- Focused command: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-cleanup2-lane6-vitest-cache node scripts/run-vitest.mjs --configLoader runner extensions/telegram/src/button-types.test.ts extensions/telegram/src/inline-buttons.test.ts extensions/telegram/src/interactive-fallback.test.ts extensions/telegram/src/approval-handler.runtime.test.ts extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/outbound-adapter.test.ts extensions/telegram/src/outbound-adapter.presentation.test.ts extensions/telegram/src/outbound-adapter.web-app.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/send.test.ts`.
- Targeted formatter check, `git diff --check`, and exact changed-lane dry-run all pass; two independent source reviews found no issues and structured autoreview reports the patch correct.
- Full local changed checks cannot run against this campaign's stale shared dependency install: even the direct two-file lint wrapper triggers unrelated existing Google provider enum, `markdown-it` type, and TUI declaration-generation failures before examining Telegram. Exact-head hosted CI and mandatory repository-native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run` provide the authoritative clean-environment full gate.
- No authenticated live Telegram API was used; real Telegram Bot API request payloads were verified through the existing mocked delivery/send boundaries.
