### PR TITLE
fix(tui): restore session setting reset directives

### DIFF
--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -105,12 +105,12 @@ Core:
 - `/gateway-status` (alias `/gwstatus`; shows Gateway connection status directly)
 - `/agent <id>` (or `/agents`)
 - `/session <key>` (or `/sessions`)
-- `/model <provider/model>` (or `/models`)
+- `/model <provider/model|default>` (or `/models`; `default` clears the session override)
 
 Session controls:
 
-- `/think <off|minimal|low|medium|high>` (higher tiers may add levels like `xhigh`/`max` depending on the model)
-- `/fast <status|auto|on|off>`
+- `/think <off|minimal|low|medium|high|default>` (higher tiers may add levels like `xhigh`/`max` depending on the model; `default` clears the session override)
+- `/fast <status|auto|on|off|default>` (`default` clears the session override)
 - `/verbose <on|full|off>`
 - `/trace <on|off>`
 - `/reasoning <on|off|stream>`

--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -56,6 +56,14 @@ describe("getSlashCommands", () => {
     ]);
   });
 
+  it.each(["think", "fast"])("offers /%s default to clear the session override", (name) => {
+    const command = getSlashCommands().find((candidate) => candidate.name === name);
+
+    expect(command?.getArgumentCompletions?.("default")).toEqual([
+      { value: "default", label: "default" },
+    ]);
+  });
+
   it.each([{}, { local: true }])("exposes usage cost in completion and help", (options) => {
     const commands = getSlashCommands(options);
     const usage = commands.find((command) => command.name === "usage");
@@ -132,6 +140,7 @@ describe("getSlashCommands", () => {
     expect(completions).toEqual([
       { value: "off", label: "off" },
       { value: "adaptive", label: "adaptive" },
+      { value: "default", label: "default" },
     ]);
   });
 
@@ -202,11 +211,19 @@ describe("helpText", () => {
     },
   );
 
+  it("documents default reset values for model, thinking, and fast mode", () => {
+    const output = helpText();
+
+    expect(output).toContain("/model <provider/model|default>");
+    expect(output).toMatch(/\/think <[^>]+\|default>/u);
+    expect(output).toContain("/fast <status|auto|on|off|default>");
+  });
+
   it("includes slash command help for aliases", () => {
     const output = helpText();
     expect(output).toContain("/elevated <on|off|ask|full>");
     expect(output).toContain("/elev <on|off|ask|full>");
-    expect(output).toContain("/fast <status|auto|on|off>");
+    expect(output).toContain("/fast <status|auto|on|off|default>");
     expect(output).toContain("/gateway-status");
     expect(output).toContain("/gwstatus");
     expect(output).toContain("/openclaw [request]");

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -17,7 +17,7 @@ import type { OpenClawConfig } from "../config/types.js";
 
 const VERBOSE_LEVELS = ["on", "off", "full"] satisfies VerboseLevel[];
 const TRACE_LEVELS = ["on", "off"];
-const FAST_LEVELS = ["status", "auto", "on", "off"];
+const FAST_LEVELS = ["status", "auto", "on", "off", "default"];
 const REASONING_LEVELS = ["on", "off", "stream"] satisfies ReasoningLevel[];
 const ELEVATED_LEVELS = ["on", "off", "ask", "full"];
 const ACTIVATION_LEVELS = ["mention", "always"];
@@ -113,10 +113,10 @@ const TUI_COMMAND_ROWS = [
   ],
   ["session", "Switch session (or open picker)", "/session <key> (or /sessions)"],
   ["sessions", "Open session picker"],
-  ["model", "Set model (or open picker)", "/model <provider/model> (or /models)"],
+  ["model", "Set model (or open picker)", "/model <provider/model|default> (or /models)"],
   ["models", "Open model picker"],
-  ["think", "Set thinking level", "/think <{thinkingLevels}>", "thinking"],
-  ["fast", "Set fast mode auto/on/off", "/fast <status|auto|on|off>", FAST_LEVELS],
+  ["think", "Set thinking level", "/think <{thinkingLevels}|default>", "thinking"],
+  ["fast", "Set fast mode auto/on/off", "/fast <status|auto|on|off|default>", FAST_LEVELS],
   [
     "verbose",
     `Set verbose ${VERBOSE_LEVELS.join("/")}`,
@@ -258,7 +258,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     }
     const completions =
       command.completions === "thinking"
-        ? createLevelCompletion(thinkLevels)
+        ? createLevelCompletion([...thinkLevels, "default"])
         : command.completions
           ? createLevelCompletion([...command.completions])
           : undefined;

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -2061,6 +2061,56 @@ describe("tui command handlers", () => {
     expect(harness.addSystem).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { mode: "gateway", local: false, command: "/think default", field: "thinkingLevel" },
+    { mode: "gateway", local: false, command: "/fast default", field: "fastMode" },
+    { mode: "gateway", local: false, command: "/model default", field: "model" },
+    { mode: "embedded", local: true, command: "/think default", field: "thinkingLevel" },
+    { mode: "embedded", local: true, command: "/fast default", field: "fastMode" },
+    { mode: "embedded", local: true, command: "/model default", field: "model" },
+    { mode: "gateway", local: false, command: "/think inherit", field: "thinkingLevel" },
+    { mode: "embedded", local: true, command: "/fast reset", field: "fastMode" },
+    { mode: "gateway", local: false, command: "/model DEFAULT", field: "model" },
+  ])(
+    "clears the $field session override for $command in $mode mode",
+    async ({ local, command, field }) => {
+      const { handleCommand, patchSession, refreshSessionInfo } = createHarness({
+        opts: { local },
+      });
+
+      await handleCommand(command);
+
+      expect(patchSession).toHaveBeenCalledWith({
+        key: "agent:main:main",
+        [field]: null,
+      });
+      expect(refreshSessionInfo).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("does not treat non-default model names as session reset aliases", async () => {
+    const { handleCommand, patchSession } = createHarness();
+
+    await handleCommand("/model reset");
+
+    expect(patchSession).toHaveBeenCalledWith({
+      key: "agent:main:main",
+      model: "reset",
+    });
+  });
+
+  it.each(["", "invalid"])(
+    "rejects unsupported elevated mode %j without patching",
+    async (mode) => {
+      const { handleCommand, patchSession, addSystem } = createHarness();
+
+      await handleCommand(`/elevated ${mode}`);
+
+      expect(patchSession).not.toHaveBeenCalled();
+      expect(addSystem).toHaveBeenCalledWith("usage: /elevated <on|off|ask|full>");
+    },
+  );
+
   it("uses the effective runtime for the no-arg /think usage", async () => {
     const codex = createHarness({
       sessionInfo: {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -596,7 +596,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         await openModelSelector();
       } else {
         await applySessionSetting(
-          { model: args },
+          { model: /^default$/i.test(args) ? null : args },
           (result) => {
             const resolvedModel = result.resolved?.model;
             const resolvedProvider = result.resolved?.modelProvider;
@@ -623,10 +623,11 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             undefined,
             state.sessionInfo.agentRuntime?.id,
           );
-        chatLog.addSystem(`usage: /think <${levels}>`);
+        chatLog.addSystem(`usage: /think <${levels}|default>`);
         return;
       }
-      await applySessionSetting({ thinkingLevel: args }, `thinking set to ${args}`, "think failed");
+      const thinkingLevel = isSessionDefaultDirectiveValue(args) ? null : args;
+      await applySessionSetting({ thinkingLevel }, `thinking set to ${args}`, "think failed");
     },
     verbose: async (args) => {
       if (!args) {
@@ -659,15 +660,13 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         chatLog.addSystem(`fast mode: ${formatTuiFastMode(state.sessionInfo.fastMode)}`);
         return;
       }
-      if (args !== "auto" && args !== "on" && args !== "off") {
-        chatLog.addSystem("usage: /fast <status|auto|on|off>");
+      const reset = isSessionDefaultDirectiveValue(args);
+      if (!reset && !["auto", "on", "off"].includes(args)) {
+        chatLog.addSystem("usage: /fast <status|auto|on|off|default>");
         return;
       }
-      await applySessionSetting(
-        { fastMode: args === "auto" ? "auto" : args === "on" },
-        `fast mode set to ${args}`,
-        "fast failed",
-      );
+      const fastMode = reset ? null : args === "auto" ? args : args === "on";
+      await applySessionSetting({ fastMode }, `fast mode set to ${args}`, "fast failed");
     },
     reasoning: async (args) => {
       if (!args) {
@@ -730,10 +729,6 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       await applySessionSetting({ responseUsage: next }, `usage footer: ${next}`, "usage failed");
     },
     elevated: async (args) => {
-      if (!args) {
-        chatLog.addSystem("usage: /elevated <on|off|ask|full>");
-        return;
-      }
       if (!["on", "off", "ask", "full"].includes(args)) {
         chatLog.addSystem("usage: /elevated <on|off|ask|full>");
         return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users trying to clear a TUI session's thinking level, fast mode, or model override with the documented `/think default`, `/fast default`, or `/model default` commands instead received an invalid-thinking error, an unsupported-command usage message, or a model-not-allowed error. The same command contract and broken TUI paths are present in stable `v2026.7.1`, and both Gateway-backed and local embedded sessions were affected.

## Why This Change Was Made

The TUI bypasses the shared slash-command executor for these session settings and therefore sent literal reset words to the Gateway session-patch contract, whose canonical reset representation is `null`. Normalize thinking and fast-mode resets with the existing shared directive owner, preserve the model owner's stricter case-insensitive `default`-only contract, and expose the existing capability consistently through completion, `/help`, and the TUI guide. Consolidating duplicated neighboring session-setting validation keeps the production diff net-negative.

## User Impact

Operators can restore inherited thinking, fast-mode, and model defaults directly from either TUI mode without changing unrelated session preferences or leaving the terminal. Existing thinking/fast reset aliases keep their shared semantics; model names such as `reset` are not misclassified as aliases.

## Evidence

- Stable contract: `v2026.7.1:docs/tools/slash-commands.md` documents all three default-reset commands; the matching stable TUI source still forwards literal thinking/model values and rejects fast-mode reset.
- Regression-first RED: 12 targeted failures covered both TUI modes, canonical completion/help, thinking/fast aliases, case-insensitive model `default`, and the strict non-alias model boundary.
- Full owner and sibling proof: 243 passing tests across TUI command handlers, command metadata, editor input, autocomplete, and local shell ownership.
- Existing real Gateway session-patch owner proof: three focused tests confirm `thinkingLevel: null`, `fastMode: null`, and `model: null` remove persisted overrides.
- Real terminal proof: the actual TUI loop in a PTY received each typed command, displayed success, and emitted precisely:

```json
{"terminal":"real PTY","thinkingPatch":{"key":"agent:main:main","thinkingLevel":null},"fastPatch":{"key":"agent:main:main","fastMode":null},"modelPatch":{"key":"agent:main:main","model":null},"visibleSuccessNotices":true}
```

- Type-aware lint passed for all four changed TypeScript files; final diff and formatting are clean.
- Independent source review and fresh structured P0/P1 Codex review reported no actionable findings.
- Production: `+14/-19` (net `-5`); regression tests: `+68/-1` (net `+67`); documentation: `+3/-3`.
- Exact reviewed head: `333bde6849ab03e433dfed040033cc1c4db0cebc`; hosted CI will attach when the draft is marked ready.

Related: #117285.
