### PR TITLE
fix(agents): preserve valid CLI session bindings

### DIFF
--- a/docs/plugins/cli-backend-plugins.md
+++ b/docs/plugins/cli-backend-plugins.md
@@ -215,7 +215,22 @@ model-alias, session, image, and watchdog fields as the bundled
 | `imagePathScope`                                          | Where staged image files live before handoff: `temp` or `workspace`               |
 | `serialize`                                               | Keep same-backend runs ordered                                                    |
 | `reseedFromRawTranscriptWhenUncompacted`                  | Opt in to bounded raw-transcript reseed before compaction for safe session resets |
+| `freshSessionRecovery`                                    | Fresh recovery policy after a recoverable resumed-session failure                 |
 | `reliability.watchdog`                                    | No-output timeout tuning, separate for fresh vs resumed runs                      |
+
+`freshSessionRecovery` is a backend-owned compatibility contract:
+
+- Leave it undefined or set it to `"replace-binding"` to preserve the legacy
+  clear-and-reseed behavior. OpenClaw clears the persisted binding and retries
+  with a fresh session when the failure is eligible for recovery.
+- Set it to `"invalidated-only"` to suppress fresh replacement unless the
+  canonical invalidation predicate proves the old session is dead. Currently,
+  only `session_expired` does so.
+
+Choose the value from the CLI or SDK session contract, not from a provider id
+or broad error class. The bundled Anthropic backend uses `"invalidated-only"`;
+its Agent SDK contract does not treat non-expiration failures as proof that the
+conversation can no longer resume.
 
 Prefer the smallest static config that matches the CLI. Add plugin callbacks
 only for behavior that really belongs to the backend.

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -218,6 +218,7 @@ export function buildAnthropicCliBackend(
       sessionArgs: ["--session-id", "{sessionId}"],
       sessionMode: "always",
       reseedFromRawTranscriptWhenUncompacted: true,
+      freshSessionRecovery: "invalidated-only",
       sessionIdFields: [...CLAUDE_CLI_SESSION_ID_FIELDS],
       systemPromptFileArg: "--append-system-prompt-file",
       systemPromptMode: "append",

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -97,6 +97,7 @@ describe("anthropic provider replay hooks", () => {
     expect(backend.bundleMcp).toBe(true);
     expectFields(backend.config, {
       command: "claude",
+      freshSessionRecovery: "invalidated-only",
       modelArg: "--model",
       sessionArgs: ["--session-id", "{sessionId}"],
     });

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -56,6 +56,7 @@ import {
   requestHeartbeatMock,
   supervisorSpawnMock,
 } from "./cli-runner.test-support.js";
+import { runCliRecovery } from "./cli-runner/cli-run-recovery.js";
 import { executePreparedCliRun } from "./cli-runner/execute.js";
 import {
   resolveCliNoOutputTimeoutMs,
@@ -65,6 +66,7 @@ import { prepareCliRunContext } from "./cli-runner/prepare.js";
 import { hashCliReseedPrompt } from "./cli-runner/reseed-envelope.js";
 import * as sessionHistoryModule from "./cli-runner/session-history.js";
 import type { PreparedCliRunContext } from "./cli-runner/types.js";
+import { FailoverError } from "./failover-error.js";
 import { runAgentHarnessBeforeMessageWriteHook } from "./harness/hook-helpers.js";
 import { MAX_AGENT_HOOK_HISTORY_MESSAGES } from "./harness/hook-history.js";
 
@@ -2122,6 +2124,7 @@ describe("runCliAgent reliability", () => {
       });
       context.preparedBackend.backend = {
         ...context.preparedBackend.backend,
+        freshSessionRecovery: "invalidated-only",
         output: "jsonl",
         input: "stdin",
         jsonlDialect: "claude-stream-json",
@@ -2142,15 +2145,78 @@ describe("runCliAgent reliability", () => {
       ).rejects.toMatchObject({ reason: "format", code: "cli_synthetic_no_response" });
 
       expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
-      expect(clearBeforeRetry).toHaveBeenCalledWith({
-        provider: "claude-cli",
-        reason: "format",
-        sessionId: "retained-cli-session",
-      });
+      expect(clearBeforeRetry).not.toHaveBeenCalled();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it.each([
+    ["format", "cli_synthetic_no_response"],
+    ["timeout", "cli_no_output_timeout"],
+  ] as const)(
+    "keeps undefined Gemini recovery policy compatible after %s failover",
+    async (reason, code) => {
+      const context = buildPreparedContext({
+        provider: "google-gemini-cli",
+        sessionKey: `agent:main:gemini-${reason}`,
+        cliSessionId: "gemini-resumed-session",
+        openClawHistoryPrompt: CLI_RESEED_PROMPT,
+      });
+      context.preparedBackend.backend = {
+        command: "gemini",
+        args: ["--prompt", "{prompt}"],
+        resumeArgs: ["--resume", "{sessionId}", "--prompt", "{prompt}"],
+        output: "jsonl",
+        jsonlDialect: "gemini-stream-json",
+        input: "arg",
+        sessionMode: "existing",
+      };
+      context.backendResolved.config = context.preparedBackend.backend;
+      expect(context.preparedBackend.backend.freshSessionRecovery).toBeUndefined();
+
+      const executeAttempt = vi
+        .fn()
+        .mockRejectedValueOnce(
+          new FailoverError(`Gemini ${reason} failure`, {
+            reason,
+            code,
+            provider: "google-gemini-cli",
+            model: "gemini-3.1-pro-preview",
+          }),
+        )
+        .mockResolvedValueOnce({ sessionId: `gemini-fresh-${reason}` });
+      const clearBeforeRetry = vi.fn(async () => true);
+
+      const result = await runCliRecovery({
+        context: {
+          ...context,
+          params: {
+            ...context.params,
+            onBeforeFreshCliSessionRetry: clearBeforeRetry,
+          },
+        },
+        executeAttempt,
+        finishAttempt: async (attempt: { sessionId: string }) =>
+          ({
+            payloads: [{ text: "Gemini recovered" }],
+            meta: { cliSessionId: attempt.sessionId },
+          }) as never,
+        finishDeliveredFailure: async () => undefined,
+        onTerminalFailure: async () => {},
+      });
+
+      expect(executeAttempt).toHaveBeenCalledTimes(2);
+      expect(executeAttempt.mock.calls[0]?.[0]).toBe("gemini-resumed-session");
+      expect(executeAttempt.mock.calls[1]?.[0]).toBeUndefined();
+      expect(clearBeforeRetry).toHaveBeenCalledWith({
+        provider: "google-gemini-cli",
+        reason,
+        sessionId: "gemini-resumed-session",
+      });
+      expect(requireRecord(result.meta, "result meta").cliSessionId).toBe(`gemini-fresh-${reason}`);
+    },
+  );
 
   it.each(["timeout", "unknown", "context_overflow", "format"] as const)(
     "retries a fresh CLI session after recoverable %s failover without a failed agent_end",
@@ -4110,6 +4176,7 @@ describe("runCliAgent reliability", () => {
       openClawHistoryPrompt:
         "Continue this conversation using the OpenClaw transcript below.\n\nUser: recovered history\n\n<next_user_message>\nhi\n</next_user_message>",
     });
+    context.preparedBackend.backend.freshSessionRecovery = "invalidated-only";
     const clearBeforeRetry = vi.fn(async () => true);
 
     try {

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -2092,6 +2092,66 @@ describe("runCliAgent reliability", () => {
     expect(clearBeforeRetry).not.toHaveBeenCalled();
   });
 
+  it("does not start a fresh CLI attempt when format recovery retains the binding", async () => {
+    supervisorSpawnMock.mockClear();
+    supervisorSpawnMock.mockResolvedValueOnce(
+      makeManagedRun({
+        stdout: [
+          JSON.stringify({
+            type: "assistant",
+            message: {
+              model: "<synthetic>",
+              content: [{ type: "text", text: "No response requested." }],
+            },
+          }),
+          JSON.stringify({ type: "result", subtype: "success", result: "" }),
+        ].join("\n"),
+      }),
+    );
+    const clearBeforeRetry = vi.fn(async () => false);
+    const { dir, sessionFile } = createSessionFile({
+      history: [{ role: "user", content: "earlier context" }],
+    });
+
+    try {
+      const context = makeClaudePreparedContext({
+        sessionKey: "agent:main:subagent:retained-format",
+        runId: "run-retained-format",
+        cliSessionId: "retained-cli-session",
+        openClawHistoryPrompt: CLI_RESEED_PROMPT,
+      });
+      context.preparedBackend.backend = {
+        ...context.preparedBackend.backend,
+        output: "jsonl",
+        input: "stdin",
+        jsonlDialect: "claude-stream-json",
+      };
+      context.backendResolved.config = context.preparedBackend.backend;
+
+      await expect(
+        runPreparedCliAgent({
+          ...context,
+          params: {
+            ...context.params,
+            agentId: "main",
+            sessionFile,
+            workspaceDir: dir,
+            onBeforeFreshCliSessionRetry: clearBeforeRetry,
+          },
+        }),
+      ).rejects.toMatchObject({ reason: "format", code: "cli_synthetic_no_response" });
+
+      expect(supervisorSpawnMock).toHaveBeenCalledTimes(1);
+      expect(clearBeforeRetry).toHaveBeenCalledWith({
+        provider: "claude-cli",
+        reason: "format",
+        sessionId: "retained-cli-session",
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it.each(["timeout", "unknown", "context_overflow", "format"] as const)(
     "retries a fresh CLI session after recoverable %s failover without a failed agent_end",
     async (reason) => {

--- a/src/agents/cli-runner/cli-run-recovery.ts
+++ b/src/agents/cli-runner/cli-run-recovery.ts
@@ -1,4 +1,5 @@
 import { formatErrorMessage } from "../../infra/errors.js";
+import { isCliSessionInvalidatingFailoverReason } from "../cli-session.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent-runner.js";
 import { type FailoverError, isFailoverError } from "../failover-error.js";
 import { createCliFailoverError } from "./exit-error.js";
@@ -21,8 +22,17 @@ export function resolveCliSessionId(reusableCliSession: CliReusableSession): str
 function shouldRetryFreshCliSessionAfterFailover(params: {
   error: FailoverError;
   hasHistoryPrompt: boolean;
+  recoveryPolicy?: "replace-binding" | "invalidated-only";
 }): boolean {
   if (!params.hasHistoryPrompt) {
+    return false;
+  }
+  // Some CLIs can safely replace a resumable conversation after transport or
+  // format failures. Backends that cannot must positively prove invalidation.
+  if (
+    params.recoveryPolicy === "invalidated-only" &&
+    !isCliSessionInvalidatingFailoverReason(params.error.reason)
+  ) {
     return false;
   }
   switch (params.error.reason) {
@@ -163,6 +173,7 @@ export async function runCliRecovery<TAttempt>(params: {
         shouldRetryFreshCliSessionAfterFailover({
           error: recoveryError,
           hasHistoryPrompt: Boolean(context.openClawHistoryPrompt),
+          recoveryPolicy: context.preparedBackend.backend.freshSessionRecovery,
         }) &&
         retryableSessionId &&
         runParams.sessionKey

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -13,6 +13,7 @@ import {
   clearCliSession,
   getCliSessionBinding,
   hashCliSessionText,
+  isCliSessionInvalidatingFailoverReason,
   resolveCliSessionClearReason,
   resolveCliSessionReuse,
   setCliSessionBinding,
@@ -20,6 +21,7 @@ import {
   shouldClearFailedCliSessionBinding,
 } from "./cli-session.js";
 import { FailoverError } from "./failover-error.js";
+import { FAILOVER_REASONS } from "./failover/signal.js";
 
 describe("cli-session helpers", () => {
   it("persists binding metadata alongside legacy session ids", () => {
@@ -653,33 +655,14 @@ describe("cli-session helpers", () => {
     expect(shouldClearFailedCliSessionBinding({ error: abort })).toBe(false);
   });
 
-  it.each([["session_expired"], ["auth"], ["auth_permanent"]] as const)(
-    "clears binding for session-invalidating reason: %s",
-    (reason) => {
-      const error = new FailoverError("failover", { reason, provider: "claude-cli" });
-      expect(shouldClearFailedCliSessionBinding({ error, binding: { sessionId: "reused" } })).toBe(
-        true,
-      );
-    },
-  );
-
-  it.each([
-    ["format"],
-    ["timeout"],
-    ["empty_response"],
-    ["rate_limit"],
-    ["overloaded"],
-    ["billing"],
-    ["server_error"],
-    ["context_overflow"],
-    ["model_not_found"],
-    ["no_error_details"],
-    ["unclassified"],
-    ["unknown"],
-  ] as const)("preserves binding for non-session-invalidating reason: %s", (reason) => {
+  it.each(FAILOVER_REASONS)("only clears binding for a provider-expired session: %s", (reason) => {
     const error = new FailoverError("failover", { reason, provider: "claude-cli" });
+    const invalidatesSession = reason === "session_expired";
+
+    expect(FAILOVER_REASONS).toHaveLength(16);
+    expect(isCliSessionInvalidatingFailoverReason(reason)).toBe(invalidatesSession);
     expect(shouldClearFailedCliSessionBinding({ error, binding: { sessionId: "reused" } })).toBe(
-      false,
+      invalidatesSession,
     );
   });
 });

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -628,26 +628,20 @@ describe("cli-session helpers", () => {
   });
 
   it("shares failed reused-session cleanup policy across CLI entry points", () => {
-    const failover = new FailoverError("session expired", {
-      reason: "session_expired",
-      provider: "claude-cli",
-      model: "claude-opus-4-8",
-    });
     const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
 
     const binding = { sessionId: "reused" };
     const forkBinding = { sessionId: "fork-source", forkNextResume: true as const };
 
-    expect(shouldClearFailedCliSessionBinding({ error: failover, binding })).toBe(true);
-    expect(shouldClearFailedCliSessionBinding({ error: failover, binding: forkBinding })).toBe(
-      true,
-    );
-    expect(resolveCliSessionClearReason(failover)).toBe("session_expired");
     expect(shouldClearFailedCliSessionBinding({ error: abort, binding })).toBe(true);
     expect(shouldClearFailedCliSessionBinding({ error: abort, binding: forkBinding })).toBe(false);
     expect(
       shouldClearFailedCliSessionBinding({
-        error: failover,
+        error: new FailoverError("session expired", {
+          reason: "session_expired",
+          provider: "claude-cli",
+          model: "claude-opus-4-8",
+        }),
         binding,
         hasNewGeneratedMediaTask: true,
       }),
@@ -656,6 +650,36 @@ describe("cli-session helpers", () => {
     expect(
       shouldClearFailedCliSessionBinding({ error: new Error("provider failed"), binding }),
     ).toBe(false);
-    expect(shouldClearFailedCliSessionBinding({ error: failover })).toBe(false);
+    expect(shouldClearFailedCliSessionBinding({ error: abort })).toBe(false);
+  });
+
+  it.each([["session_expired"], ["auth"], ["auth_permanent"]] as const)(
+    "clears binding for session-invalidating reason: %s",
+    (reason) => {
+      const error = new FailoverError("failover", { reason, provider: "claude-cli" });
+      expect(shouldClearFailedCliSessionBinding({ error, binding: { sessionId: "reused" } })).toBe(
+        true,
+      );
+    },
+  );
+
+  it.each([
+    ["format"],
+    ["timeout"],
+    ["empty_response"],
+    ["rate_limit"],
+    ["overloaded"],
+    ["billing"],
+    ["server_error"],
+    ["context_overflow"],
+    ["model_not_found"],
+    ["no_error_details"],
+    ["unclassified"],
+    ["unknown"],
+  ] as const)("preserves binding for non-session-invalidating reason: %s", (reason) => {
+    const error = new FailoverError("failover", { reason, provider: "claude-cli" });
+    expect(shouldClearFailedCliSessionBinding({ error, binding: { sessionId: "reused" } })).toBe(
+      false,
+    );
   });
 });

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -19,12 +19,12 @@ export {
 
 const CLAUDE_CLI_BACKEND_ID = "claude-cli";
 
-/** Failover reasons that truly invalidate a CLI session on disk. */
-const SESSION_INVALIDATING_FAILOVER_REASONS: ReadonlySet<FailoverReason> = new Set([
-  "session_expired",
-  "auth",
-  "auth_permanent",
-]);
+/** Whether a failover proves the provider-side conversation can no longer be resumed. */
+export function isCliSessionInvalidatingFailoverReason(reason: FailoverReason): boolean {
+  // Auth identity changes are handled by the reuse fingerprint's auth epoch.
+  // Other execution failures say nothing about the persisted transcript.
+  return reason === "session_expired";
+}
 
 /** Hash CLI session-sensitive text so reuse checks can compare stable fingerprints. */
 export function hashCliSessionText(value: string | undefined): string | undefined {
@@ -134,7 +134,7 @@ export function shouldClearFailedCliSessionBinding(params: {
     return false;
   }
   if (isFailoverError(params.error)) {
-    return SESSION_INVALIDATING_FAILOVER_REASONS.has(params.error.reason);
+    return isCliSessionInvalidatingFailoverReason(params.error.reason);
   }
   // A pre-successor fork abort keeps its one-shot marker for the next turn.
   return params.binding?.forkNextResume !== true && readErrorName(params.error) === "AbortError";

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -10,6 +10,7 @@ import type { CliSessionBinding, SessionEntry } from "../config/sessions.js";
 import { normalizeCliSessionReseedReceipt } from "../config/sessions/cli-session-binding.js";
 import { readErrorName } from "../infra/errors.js";
 import { isFailoverError } from "./failover-error.js";
+import type { FailoverReason } from "./failover/signal.js";
 export {
   clearAllCliSessions,
   getCliSessionBinding,
@@ -17,6 +18,13 @@ export {
 } from "../config/sessions/cli-session-binding.js";
 
 const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+
+/** Failover reasons that truly invalidate a CLI session on disk. */
+const SESSION_INVALIDATING_FAILOVER_REASONS: ReadonlySet<FailoverReason> = new Set([
+  "session_expired",
+  "auth",
+  "auth_permanent",
+]);
 
 /** Hash CLI session-sensitive text so reuse checks can compare stable fingerprints. */
 export function hashCliSessionText(value: string | undefined): string | undefined {
@@ -126,7 +134,7 @@ export function shouldClearFailedCliSessionBinding(params: {
     return false;
   }
   if (isFailoverError(params.error)) {
-    return true;
+    return SESSION_INVALIDATING_FAILOVER_REASONS.has(params.error.reason);
   }
   // A pre-successor fork abort keeps its one-shot marker for the next turn.
   return params.binding?.forkNextResume !== true && readErrorName(params.error) === "AbortError";

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -1357,7 +1357,7 @@ describe("CLI attempt execution", () => {
     expect(firstRunCliAgentArg().onBeforeFreshCliSessionRetry).toBeUndefined();
   });
 
-  it.each(["auth", "billing", "rate_limit"] as const)(
+  it.each(["auth"] as const)(
     "clears reused Claude CLI session IDs after %s failover without retrying",
     async (reason) => {
       const sessionKey = `agent:main:direct:cli-${reason}`;
@@ -1389,6 +1389,44 @@ describe("CLI attempt execution", () => {
       expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
       expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
       expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    },
+  );
+
+  it.each(["billing", "rate_limit", "format"] as const)(
+    "preserves reused Claude CLI session IDs after %s failover without retrying",
+    async (reason) => {
+      const sessionKey = `agent:main:direct:cli-${reason}`;
+      const cliSessionId = `${reason}-poisoned-session`;
+      await writeClaudeCliAssistantTranscript(cliSessionId);
+      const sessionEntry = makeClaudeCliSessionEntry(`session-cli-${reason}`, cliSessionId);
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+      await writeSessionStoreSeed(sessionStore);
+      runCliAgentMock.mockRejectedValueOnce(
+        new FailoverError(`${reason} failed`, {
+          reason,
+          provider: "claude-cli",
+          model: "opus",
+        }),
+      );
+
+      await expect(
+        runClaudeCliAttempt({
+          sessionKey,
+          sessionEntry,
+          sessionStore,
+          body: `resume after ${reason}`,
+          runId: `run-cli-${reason}`,
+        }),
+      ).rejects.toMatchObject({ name: "FailoverError", reason });
+
+      expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+      expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeDefined();
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+        cliSessionId,
+      );
+      expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe(cliSessionId);
+      expect(sessionStore[sessionKey]?.claudeCliSessionId).toBe(cliSessionId);
     },
   );
 

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -973,7 +973,7 @@ describe("CLI attempt execution", () => {
     expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
   });
 
-  it("preserves a valid Claude CLI binding through a format fresh retry", async () => {
+  it("preserves and resumes a valid Claude CLI binding after format failover", async () => {
     const sessionKey = "agent:main:subagent:cli-format";
     const cliSessionId = "format-retry-session";
     await writeClaudeCliAssistantTranscript(cliSessionId);
@@ -996,7 +996,7 @@ describe("CLI attempt execution", () => {
           reason: "format",
           sessionId: cliSessionId,
         }),
-      ).resolves.toBe(true);
+      ).resolves.toBe(false);
 
       expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
         cliSessionId,
@@ -1004,19 +1004,38 @@ describe("CLI attempt execution", () => {
       expect(readSessionStore()[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
         cliSessionId,
       );
-      return makeCliResult("hello after format retry");
+      throw new FailoverError("Claude CLI returned an unusable result", {
+        reason: "format",
+        code: "cli_synthetic_no_response",
+        provider: "claude-cli",
+        model: "opus",
+      });
     });
+
+    await expect(
+      runClaudeCliAttempt({
+        sessionEntry,
+        sessionKey,
+        sessionStore,
+        body: "retry this malformed turn",
+        runId: "run-cli-format",
+      }),
+    ).rejects.toMatchObject({ name: "FailoverError", reason: "format" });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("hello after retained resume"));
 
     await runClaudeCliAttempt({
       sessionEntry,
       sessionKey,
       sessionStore,
-      body: "retry this malformed turn",
-      runId: "run-cli-format",
+      body: "continue on the next turn",
+      runId: "run-cli-format-resume",
     });
 
-    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
-    expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
+    expect(runCliAgentMock).toHaveBeenCalledTimes(2);
+    expect(firstRunCliAgentArg(1).cliSessionId).toBe(cliSessionId);
     expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
       cliSessionId,
     );

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -973,6 +973,58 @@ describe("CLI attempt execution", () => {
     expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
   });
 
+  it("preserves a valid Claude CLI binding through a format fresh retry", async () => {
+    const sessionKey = "agent:main:subagent:cli-format";
+    const cliSessionId = "format-retry-session";
+    await writeClaudeCliAssistantTranscript(cliSessionId);
+    const sessionEntry = makeClaudeCliSessionEntry("session-cli-format", cliSessionId);
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await writeSessionStoreSeed(sessionStore);
+
+    runCliAgentMock.mockImplementationOnce(async (args: unknown) => {
+      const retry = requireRecord(args, "run CLI agent argument").onBeforeFreshCliSessionRetry;
+      expect(retry).toBeTypeOf("function");
+      await expect(
+        (
+          retry as (params: {
+            provider: string;
+            reason: "format";
+            sessionId: string;
+          }) => Promise<boolean>
+        )({
+          provider: "claude-cli",
+          reason: "format",
+          sessionId: cliSessionId,
+        }),
+      ).resolves.toBe(true);
+
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+        cliSessionId,
+      );
+      expect(readSessionStore()[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+        cliSessionId,
+      );
+      return makeCliResult("hello after format retry");
+    });
+
+    await runClaudeCliAttempt({
+      sessionEntry,
+      sessionKey,
+      sessionStore,
+      body: "retry this malformed turn",
+      runId: "run-cli-format",
+    });
+
+    expect(runCliAgentMock).toHaveBeenCalledTimes(1);
+    expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+      cliSessionId,
+    );
+    expect(readSessionStore()[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+      cliSessionId,
+    );
+  });
+
   it("clears reused Claude CLI session IDs after AbortError without retrying", async () => {
     const sessionKey = "agent:main:direct:cli-abort";
     const cliSessionId = "abort-poisoned-session";
@@ -1134,7 +1186,7 @@ describe("CLI attempt execution", () => {
     );
   });
 
-  it("clears a persisted fork successor before transcript fallback", async () => {
+  it("preserves a persisted fork successor before a non-invalidating fresh retry", async () => {
     const sessionKey = "agent:main:direct:cli-fork-timeout";
     const cliSessionId = "timeout-parent-session";
     const forkedCliSessionId = "timeout-stalled-fork";
@@ -1175,9 +1227,13 @@ describe("CLI attempt execution", () => {
       runId: "run-cli-fork-timeout",
     });
 
-    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+      forkedCliSessionId,
+    );
     const persisted = readSessionStore();
-    expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
+    expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+      forkedCliSessionId,
+    );
   });
 
   it("clears a persisted fork successor when recovery fails after rebinding", async () => {
@@ -1357,8 +1413,8 @@ describe("CLI attempt execution", () => {
     expect(firstRunCliAgentArg().onBeforeFreshCliSessionRetry).toBeUndefined();
   });
 
-  it.each(["auth"] as const)(
-    "clears reused Claude CLI session IDs after %s failover without retrying",
+  it.each(["auth", "auth_permanent"] as const)(
+    "preserves reused Claude CLI session IDs after %s failover without retrying",
     async (reason) => {
       const sessionKey = `agent:main:direct:cli-${reason}`;
       const cliSessionId = `${reason}-poisoned-session`;
@@ -1386,13 +1442,22 @@ describe("CLI attempt execution", () => {
 
       expect(runCliAgentMock).toHaveBeenCalledTimes(1);
       expect(firstRunCliAgentArg().cliSessionId).toBe(cliSessionId);
-      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
-      expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBeUndefined();
-      expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+        cliSessionId,
+      );
+      expect(sessionStore[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe(cliSessionId);
+      expect(sessionStore[sessionKey]?.claudeCliSessionId).toBe(cliSessionId);
+
+      const persisted = readSessionStore();
+      expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
+        cliSessionId,
+      );
+      expect(persisted[sessionKey]?.cliSessionIds?.["claude-cli"]).toBe(cliSessionId);
+      expect(persisted[sessionKey]?.claudeCliSessionId).toBe(cliSessionId);
     },
   );
 
-  it.each(["billing", "rate_limit", "format"] as const)(
+  it.each(["billing", "rate_limit"] as const)(
     "preserves reused Claude CLI session IDs after %s failover without retrying",
     async (reason) => {
       const sessionKey = `agent:main:direct:cli-${reason}`;

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -981,23 +981,7 @@ describe("CLI attempt execution", () => {
     const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
     await writeSessionStoreSeed(sessionStore);
 
-    runCliAgentMock.mockImplementationOnce(async (args: unknown) => {
-      const retry = requireRecord(args, "run CLI agent argument").onBeforeFreshCliSessionRetry;
-      expect(retry).toBeTypeOf("function");
-      await expect(
-        (
-          retry as (params: {
-            provider: string;
-            reason: "format";
-            sessionId: string;
-          }) => Promise<boolean>
-        )({
-          provider: "claude-cli",
-          reason: "format",
-          sessionId: cliSessionId,
-        }),
-      ).resolves.toBe(false);
-
+    runCliAgentMock.mockImplementationOnce(async () => {
       expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
         cliSessionId,
       );
@@ -1205,7 +1189,7 @@ describe("CLI attempt execution", () => {
     );
   });
 
-  it("preserves a persisted fork successor before a non-invalidating fresh retry", async () => {
+  it("clears a persisted fork successor when fresh recovery is authorized", async () => {
     const sessionKey = "agent:main:direct:cli-fork-timeout";
     const cliSessionId = "timeout-parent-session";
     const forkedCliSessionId = "timeout-stalled-fork";
@@ -1224,17 +1208,19 @@ describe("CLI attempt execution", () => {
       expect(clearFork).toBeTypeOf("function");
       await (claimFork as () => Promise<boolean>)();
       await (persistFork as (sessionId: string) => Promise<void>)(forkedCliSessionId);
-      await (
-        clearFork as (params: {
-          provider: string;
-          reason: "timeout";
-          sessionId: string;
-        }) => Promise<boolean>
-      )({
-        provider: "claude-cli",
-        reason: "timeout",
-        sessionId: forkedCliSessionId,
-      });
+      await expect(
+        (
+          clearFork as (params: {
+            provider: string;
+            reason: "timeout";
+            sessionId: string;
+          }) => Promise<boolean>
+        )({
+          provider: "claude-cli",
+          reason: "timeout",
+          sessionId: forkedCliSessionId,
+        }),
+      ).resolves.toBe(true);
       return makeCliResult("hello after fork timeout");
     });
 
@@ -1246,13 +1232,9 @@ describe("CLI attempt execution", () => {
       runId: "run-cli-fork-timeout",
     });
 
-    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
-      forkedCliSessionId,
-    );
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
     const persisted = readSessionStore();
-    expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]?.sessionId).toBe(
-      forkedCliSessionId,
-    );
+    expect(persisted[sessionKey]?.cliSessionBindings?.["claude-cli"]).toBeUndefined();
   });
 
   it("clears a persisted fork successor when recovery fails after rebinding", async () => {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1081,7 +1081,9 @@ export function runAgentAttempt(params: {
                     }
 
                     if (!isCliSessionInvalidatingFailoverReason(retry.reason)) {
-                      return true;
+                      // A retained binding must be resumed by the next normal turn.
+                      // Authorizing fresh recovery here would replace it with a new conversation.
+                      return false;
                     }
 
                     log.warn(

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -22,6 +22,7 @@ import { messageToolOwnsVisibleReply } from "../../auto-reply/source-reply-deliv
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import {
+  loadSessionEntry,
   persistSessionTranscriptTurn,
   type SessionTranscriptRuntimeTarget,
 } from "../../config/sessions/session-accessor.js";
@@ -71,6 +72,7 @@ import { hasCliLiveSession } from "../cli-runner/cli-live-session-registry.js";
 import { resolveCliRuntimeToolsAllow } from "../cli-runner/tool-policy.js";
 import {
   getCliSessionBinding,
+  isCliSessionInvalidatingFailoverReason,
   resolveCliSessionClearReason,
   shouldClearFailedCliSessionBinding,
 } from "../cli-session.js";
@@ -1062,9 +1064,24 @@ export function runAgentAttempt(params: {
               ? {
                   onBeforeFreshCliSessionRetry: async (retry) => {
                     if (
-                      hasNewGeneratedMediaTaskForSessionKey(params.sessionKey, mediaTaskIdsBefore)
+                      hasNewGeneratedMediaTaskForSessionKey(
+                        params.sessionKey,
+                        mediaTaskIdsBefore,
+                      ) ||
+                      getCliSessionBinding(
+                        loadSessionEntry({
+                          sessionKey: mutableCliSessionStore.sessionKey,
+                          storePath: mutableCliSessionStore.storePath,
+                          readConsistency: "latest",
+                        }),
+                        cliExecutionProvider,
+                      )?.sessionId !== retry.sessionId
                     ) {
                       return false;
+                    }
+
+                    if (!isCliSessionInvalidatingFailoverReason(retry.reason)) {
+                      return true;
                     }
 
                     log.warn(

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -72,7 +72,6 @@ import { hasCliLiveSession } from "../cli-runner/cli-live-session-registry.js";
 import { resolveCliRuntimeToolsAllow } from "../cli-runner/tool-policy.js";
 import {
   getCliSessionBinding,
-  isCliSessionInvalidatingFailoverReason,
   resolveCliSessionClearReason,
   shouldClearFailedCliSessionBinding,
 } from "../cli-session.js";
@@ -1077,12 +1076,6 @@ export function runAgentAttempt(params: {
                         cliExecutionProvider,
                       )?.sessionId !== retry.sessionId
                     ) {
-                      return false;
-                    }
-
-                    if (!isCliSessionInvalidatingFailoverReason(retry.reason)) {
-                      // A retained binding must be resumed by the next normal turn.
-                      // Authorizing fresh recovery here would replace it with a new conversation.
                       return false;
                     }
 

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -62,6 +62,13 @@ export type CliBackendConfig = {
   serialize?: boolean;
   /** Opt in to bounded raw transcript reseed before compaction for safe session resets. */
   reseedFromRawTranscriptWhenUncompacted?: boolean;
+  /**
+   * Controls fresh recovery after a recoverable resumed-session failure.
+   *
+   * Undefined and `replace-binding` preserve the legacy clear-and-reseed behavior.
+   * `invalidated-only` retries fresh only when the failure proves the binding expired.
+   */
+  freshSessionRecovery?: "replace-binding" | "invalidated-only";
   /** Runtime reliability tuning for this backend's process lifecycle. */
   reliability?: {
     /** No-output watchdog tuning (fresh vs resumed runs). */


### PR DESCRIPTION
Fixes #128698

## What Problem This Solves

OpenClaw could discard a valid persisted CLI/Agent SDK conversation binding after a failure that did not prove the provider-side session was gone. The next turn then started without the prior conversation.

## Root Cause and Fix

- Only `FailoverError(reason === "session_expired")` proves a provider conversation binding is invalid.
- `CliBackendConfig.freshSessionRecovery` now owns fresh-recovery policy. Undefined or `replace-binding` preserves existing Gemini/external clear-and-reseed behavior; Anthropic opts into `invalidated-only`.
- The policy decision lives with the recoverable-failure predicate in `src/agents/cli-runner/cli-run-recovery.ts`.
- The command path retains the canonical latest-store/CAS guard, so an older retry cannot overwrite a concurrent rebind.
- Credential identity changes remain owned by the auth-profile/auth-epoch invalidation path.

## AbortError Audit

`AbortError` cleanup remains unchanged. It represents terminal local process cleanup, not a `FailoverError` identity decision. Existing reuse, fork-marker, and detached-media coverage still passes.

## Release Note

Fixed Claude Agent SDK-backed conversations losing their persisted resume binding after format, authentication, rate-limit, TLS, and other non-session-expiration failures, while preserving Gemini and external CLI backends' existing fresh-session recovery behavior.

## Evidence

Exact head: `c6a6599fff8ee1103f7af9e566fbd5e0a28dffe9`

- Direct AWS Crabbox run `run_253be58aff3c` succeeded on clean implementation head `48cccd4667309355cb01482aed9b6fa1150ebbd4`: 40/40 session invalidation tests, 90/90 recovery tests, 121/121 persisted command-path tests, 51/51 Anthropic descriptor tests, and 27/27 Google descriptor tests. Git status was clean before and after.
- The Crabbox dependency manifests resolved `@anthropic-ai/claude-agent-sdk` `0.3.232` and `@google/genai` `2.17.1`.
- Full-clone remote GWT/Testbox proof also passed the combined recovery/backend matrix (102/102), Anthropic + Google setup/descriptor coverage (85/85), targeted formatting, oxlint, `git diff --check`, plugin SDK surface, full core-test type graph, and build/runtime postbuild.
- The runtime implementation head `48cccd4667309355cb01482aed9b6fa1150ebbd4` completed hosted CI: https://github.com/openclaw/openclaw/actions/runs/32790806640
- The pre-rebase docs head `d0e5dc2eceb81c9bfcb22170f5be5fef65eb2b10` completed hosted CI: https://github.com/openclaw/openclaw/actions/runs/32797209366
- This docs-only follow-up documents the public `freshSessionRecovery` values and legacy default. Remote proof passed targeted formatting, MDX validation (779 files), internal-link audit (6,555 links, zero broken), `git diff --check`, and the docs-only changed gate.
- The rebased exact head is based on main `b840a3c84e2ce43708ca8810caec0a1896c167c1` with zero touched-file overlap. Remote Testbox proof passed 40/40 session, 90/90 recovery, 121/121 persisted command-path, and 51/51 Anthropic descriptor tests; plugin SDK surface, formatting, boundaries, dead-export scan, and core production typecheck also passed. The core-test type shard reached only the known shared-install baseline: missing `pako` declarations in `ui/vite.config.ts`.
- All 16 current failover reasons are covered, including `tls_certificate`; only `session_expired` clears the persisted binding.
- Claude `format` failure performs one attempt, retains the binding on disk, and the next normal turn resumes it. Claude `session_expired` clears and starts fresh. Gemini `format`/timeout retains its two-attempt clear-and-reseed contract. Concurrent rebind replacement is refused.

Direct `@anthropic-ai/claude-agent-sdk` 0.3.232 source/types confirm `Options.resume` supplies the session to resume and result messages carry `session_id`. The real SDK subprocess transport was exercised on implementation head `48cccd4667309355cb01482aed9b6fa1150ebbd4` with a deterministic representative Claude executable; the rebased exact head reran the focused recovery matrix above:

```json
{"sdkVersion":"0.3.232","exactHead":"48cccd4667309355cb01482aed9b6fa1150ebbd4","firstResult":"error_during_execution","firstSessionId":"11111111-1111-4111-8111-111111111111","secondResumeArg":"--resume=11111111-1111-4111-8111-111111111111","secondResult":"success","secondSessionId":"11111111-1111-4111-8111-111111111111","bindingRetained":true}
```

No live Anthropic credential was available in the sanitized proof environment. This is exact-head proof through the real SDK process transport and result/session contract, not a live API claim.

The shipped Codex app-server path is unaffected: it owns `thread/resume` in `codex-rs/app-server-protocol` and `codex-rs/app-server`, outside the generic `CliBackendConfig` flow.

## Size

Production: +41/-2 (net +39). Tests: +268/-29 (net +239). Total: +309/-31 (net +278) across nine files.

The positive production delta is the additive plugin ownership boundary and canonical recovery-policy contract.

## AI Assistance

- AI-assisted: Yes
- Confirmed understanding of the changes: Yes

Co-authored-by: SunnyShu <265248434+SunnyShu0925@users.noreply.github.com>

Co-authored-by: Vincent Koc <25068+vincentkoc@users.noreply.github.com>
