### PR TITLE
fix(android): fence canceled voice-note permission callbacks

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/VoiceNoteRecorderController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/VoiceNoteRecorderController.kt
@@ -77,17 +77,29 @@ internal class VoiceNoteRecorderController(
   private var elapsedJob: Job? = null
   private var ownsMic = false
 
+  // Permission callbacks can outlive cancellation; only the current owner may start capture.
+  private var pendingStart: Any? = null
+
   suspend fun start(id: String = UUID.randomUUID().toString()): Boolean {
-    synchronized(lock) {
-      if (_state.value !is VoiceNoteRecorderState.Idle && _state.value !is VoiceNoteRecorderState.Failure) return false
-    }
-    if (!requestPermission()) {
-      fail("Microphone permission is required to record a voice note.")
-      return false
-    }
+    val operation =
+      synchronized(lock) {
+        if (pendingStart != null) return false
+        if (_state.value !is VoiceNoteRecorderState.Idle && _state.value !is VoiceNoteRecorderState.Failure) return false
+        Any().also { pendingStart = it }
+      }
+    val permitted =
+      try {
+        requestPermission()
+      } catch (error: Throwable) {
+        synchronized(lock) { if (pendingStart === operation) pendingStart = null }
+        throw error
+      }
 
     return synchronized(lock) {
-      if (_state.value !is VoiceNoteRecorderState.Idle && _state.value !is VoiceNoteRecorderState.Failure) {
+      if (pendingStart !== operation) return@synchronized false
+      pendingStart = null
+      if (!permitted) {
+        failLocked("Microphone permission is required to record a voice note.")
         return@synchronized false
       }
       if (!acquireMic()) {
@@ -180,6 +192,7 @@ internal class VoiceNoteRecorderController(
 
   fun cancel() {
     synchronized(lock) {
+      pendingStart = null
       elapsedJob?.cancel()
       elapsedJob = null
       if (_state.value is VoiceNoteRecorderState.Recording) {
@@ -225,10 +238,6 @@ internal class VoiceNoteRecorderController(
           delay(100L)
         }
       }
-  }
-
-  private fun fail(message: String) {
-    synchronized(lock) { failLocked(message) }
   }
 
   private fun failLocked(message: String) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/VoiceNoteRecorderControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/VoiceNoteRecorderControllerTest.kt
@@ -1,6 +1,8 @@
 package ai.openclaw.app.chat
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -295,6 +297,222 @@ class VoiceNoteRecorderControllerTest {
         VoiceNoteRecorderState.Failure("Microphone permission is required to record a voice note."),
         controller.state.value,
       )
+      directory.deleteRecursively()
+    }
+
+  @Test
+  fun cancelledPermissionGrantCannotStartRecording() =
+    runTest {
+      val directory = Files.createTempDirectory("voice-note-test").toFile()
+      val engine = FakeEngine()
+      val permission = CompletableDeferred<Boolean>()
+      var microphoneAcquisitions = 0
+      val controller =
+        controller(
+          directory,
+          engine,
+          requestPermission = { permission.await() },
+          acquireMic = {
+            microphoneAcquisitions += 1
+            true
+          },
+        )
+      val result = async { controller.start() }
+      runCurrent()
+
+      controller.cancel()
+      permission.complete(true)
+      runCurrent()
+
+      assertFalse(result.await())
+      assertEquals(0, microphoneAcquisitions)
+      assertEquals(0, engine.startCount)
+      assertEquals(VoiceNoteRecorderState.Idle, controller.state.value)
+      assertTrue(directory.listFiles().orEmpty().isEmpty())
+      directory.deleteRecursively()
+    }
+
+  @Test
+  fun cancelledPermissionDenialCannotReplaceIdleState() =
+    runTest {
+      val directory = Files.createTempDirectory("voice-note-test").toFile()
+      val engine = FakeEngine()
+      val permission = CompletableDeferred<Boolean>()
+      val controller = controller(directory, engine, requestPermission = { permission.await() })
+      val result = async { controller.start() }
+      runCurrent()
+
+      controller.cancel()
+      permission.complete(false)
+      runCurrent()
+
+      assertFalse(result.await())
+      assertEquals(VoiceNoteRecorderState.Idle, controller.state.value)
+      assertEquals(0, engine.startCount)
+      directory.deleteRecursively()
+    }
+
+  @Test
+  fun cancelledPermissionGrantCannotTakeOverRestartedRecording() =
+    runTest {
+      val directory = Files.createTempDirectory("voice-note-test").toFile()
+      val engine = FakeEngine()
+      val firstPermission = CompletableDeferred<Boolean>()
+      val secondPermission = CompletableDeferred<Boolean>()
+      var permissionRequests = 0
+      val controller =
+        controller(
+          directory,
+          engine,
+          requestPermission = {
+            permissionRequests += 1
+            if (permissionRequests == 1) firstPermission.await() else secondPermission.await()
+          },
+        )
+      val cancelledAttempt = async { controller.start("cancelled") }
+      runCurrent()
+      controller.cancel()
+      val replacementAttempt = async { controller.start("replacement") }
+      runCurrent()
+
+      firstPermission.complete(true)
+      runCurrent()
+
+      assertFalse(cancelledAttempt.await())
+      assertEquals(0, engine.startCount)
+
+      secondPermission.complete(true)
+      runCurrent()
+
+      assertTrue(replacementAttempt.await())
+      assertEquals(1, engine.startCount)
+      assertEquals("voice-note-replacement.m4a", requireNotNull(engine.outputFile).name)
+      controller.cancel()
+      directory.deleteRecursively()
+    }
+
+  @Test
+  fun cancelledPermissionDenialCannotReplaceRestartedRecording() =
+    runTest {
+      val directory = Files.createTempDirectory("voice-note-test").toFile()
+      val engine = FakeEngine()
+      val firstPermission = CompletableDeferred<Boolean>()
+      val secondPermission = CompletableDeferred<Boolean>()
+      var permissionRequests = 0
+      val controller =
+        controller(
+          directory,
+          engine,
+          requestPermission = {
+            permissionRequests += 1
+            if (permissionRequests == 1) firstPermission.await() else secondPermission.await()
+          },
+        )
+      val cancelledAttempt = async { controller.start("cancelled") }
+      runCurrent()
+      controller.cancel()
+      val replacementAttempt = async { controller.start("replacement") }
+      runCurrent()
+
+      firstPermission.complete(false)
+      runCurrent()
+
+      assertFalse(cancelledAttempt.await())
+      assertEquals(VoiceNoteRecorderState.Idle, controller.state.value)
+
+      secondPermission.complete(true)
+      runCurrent()
+
+      assertTrue(replacementAttempt.await())
+      assertEquals(1, engine.startCount)
+      controller.cancel()
+      directory.deleteRecursively()
+    }
+
+  @Test
+  fun overlappingStartCannotReplacePendingPermissionOwner() =
+    runTest {
+      val directory = Files.createTempDirectory("voice-note-test").toFile()
+      val engine = FakeEngine()
+      val permission = CompletableDeferred<Boolean>()
+      var permissionRequests = 0
+      val controller =
+        controller(
+          directory,
+          engine,
+          requestPermission = {
+            permissionRequests += 1
+            if (permissionRequests == 1) permission.await() else true
+          },
+        )
+      val originalAttempt = async { controller.start("original") }
+      runCurrent()
+      val overlappingAttempt = async { controller.start("overlapping") }
+      runCurrent()
+
+      assertFalse(overlappingAttempt.await())
+      assertEquals(1, permissionRequests)
+      assertEquals(0, engine.startCount)
+
+      permission.complete(true)
+      runCurrent()
+
+      assertTrue(originalAttempt.await())
+      assertEquals("voice-note-original.m4a", requireNotNull(engine.outputFile).name)
+      controller.cancel()
+      directory.deleteRecursively()
+    }
+
+  @Test
+  fun cancelledPermissionCoroutineReleasesPendingRecordingOwner() =
+    runTest {
+      val directory = Files.createTempDirectory("voice-note-test").toFile()
+      val engine = FakeEngine()
+      val permission = CompletableDeferred<Boolean>()
+      var permissionRequests = 0
+      val controller =
+        controller(
+          directory,
+          engine,
+          requestPermission = {
+            permissionRequests += 1
+            if (permissionRequests == 1) permission.await() else true
+          },
+        )
+      val cancelledAttempt = async { controller.start("cancelled") }
+      runCurrent()
+
+      cancelledAttempt.cancel()
+      cancelledAttempt.join()
+
+      assertTrue(controller.start("replacement"))
+      assertEquals(1, engine.startCount)
+      assertEquals("voice-note-replacement.m4a", requireNotNull(engine.outputFile).name)
+      controller.cancel()
+      directory.deleteRecursively()
+    }
+
+  @Test
+  fun failedPermissionRequestReleasesPendingRecordingOwner() =
+    runTest {
+      val directory = Files.createTempDirectory("voice-note-test").toFile()
+      val engine = FakeEngine()
+      var permissionRequests = 0
+      val controller =
+        controller(
+          directory,
+          engine,
+          requestPermission = {
+            permissionRequests += 1
+            if (permissionRequests == 1) error("permission host failed") else true
+          },
+        )
+
+      assertTrue(runCatching { controller.start("failed") }.isFailure)
+      assertTrue(controller.start("replacement"))
+      assertEquals(1, engine.startCount)
+      assertEquals("voice-note-replacement.m4a", requireNotNull(engine.outputFile).name)
+      controller.cancel()
       directory.deleteRecursively()
     }
 


### PR DESCRIPTION
## What Problem This Solves

An Android voice-note request could begin using the microphone after its owning chat recording had already been canceled. `VoiceNoteRecorderController.start()` remained idle while awaiting the real Android microphone-permission callback, so a later grant was incorrectly treated as permission to start a stale recording. A late denial could also overwrite the canceled idle state, and overlapping requests could take over another pending recording.

`VoiceNoteComposer` calls this same recorder-owner cancellation method when its session owner changes, the Activity stops, or the composition is disposed. The platform proof below invokes that production owner method directly while a genuine system permission response is pending; it does not claim to have navigated sessions or backgrounded the Activity during the device run.

## Why This Change Was Made

Claim one private recording-start owner before requesting permission, reject overlapping claims, retire that owner on cancellation, and revalidate the exact owner under the existing controller lock before handling either a grant or a denial. Permission-request exceptions and coroutine cancellation release only their own claim. This mirrors the existing Android dictation owner invariant without adding a public state, changing permission behavior, touching database schemas, or introducing a fallback.

## User Impact

A canceled voice-note attempt can no longer start recording, acquire the shared microphone, suppress voice wake, create a temporary audio file, or replace the current chat's recorder state after a late Android permission response. Ordinary recordings and visible permission-denial errors continue to work.

## Evidence

- Before the repair, four focused regressions failed on current main: canceled late grant, canceled late denial, canceled request overtaking a replacement recording, and overlapping pending starts.
- After the repair, **32 focused Android tests passed**: all 20 `VoiceNoteRecorderControllerTest` cases and all 12 sibling `ChatDictationControllerTest` cases. New coverage also proves cancellation/exception cleanup and stale denial during a replacement request.
- All four hosted Android formatting tasks passed locally: `:app:ktlintCheck`, `:benchmark:ktlintCheck`, `:wear:ktlintCheck`, and `:wear-shared:ktlintCheck`.
- A real Android API 36 emulator ran the production `MainActivity`, process-owned `PermissionRequester`, Android system `RECORD_AUDIO` dialog and actual Allow callback, `VoiceNoteRecorderController`, shared `NodeRuntime` microphone lease, `AndroidVoiceNoteRecordingEngine`, platform `MediaRecorder`, real M4A cache file, and `AudioManager` recording-state query. The production recorder-owner `cancel()` was invoked directly while the real permission callback was pending; no permission result, microphone, or recording engine was mocked.
- Unfixed current-main APK: `started=true state=Recording acquisitions=1 files=1 activeRecordings=1` after the canceled request received the actual Android Allow response.
- Repaired APK with the same system dialog, cancellation ordering, and actual Allow response: `started=false state=Idle acquisitions=0 files=0 activeRecordings=0`.
- Both real-device instrumentation runs completed `OK (1 test)`. Independent source review, dependency/API review, platform-proof review, and automated review reported no actionable findings.
- Production delta: **+21/-12 (net +9)**, required for the missing asynchronous recorder-ownership boundary; tests add 218 lines. No generated files, temporary platform-proof fixture, or changelog are included.

### Real Android microphone-permission dialog

![Actual Android microphone permission dialog in OpenClaw Chat](https://github.com/user-attachments/assets/ece7152f-4e17-4130-8d0b-b8a659509f8a)
