### PR TITLE
fix(android): normalize optional motion date ranges

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/MotionHandler.kt
@@ -388,8 +388,8 @@ class MotionHandler private constructor(
     // one live classification sample for now.
     val limit = ((params["limit"] as? JsonPrimitive)?.content?.toIntOrNull() ?: 200).coerceIn(1, 1000)
     return MotionActivityRequest(
-      startISO = (params["startISO"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
-      endISO = (params["endISO"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
+      startISO = parseJsonString(params, "startISO")?.trim()?.ifEmpty { null },
+      endISO = parseJsonString(params, "endISO")?.trim()?.ifEmpty { null },
       limit = limit,
     )
   }
@@ -405,8 +405,8 @@ class MotionHandler private constructor(
         null
       } ?: return null
     return MotionPedometerRequest(
-      startISO = (params["startISO"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
-      endISO = (params["endISO"] as? JsonPrimitive)?.content?.trim()?.ifEmpty { null },
+      startISO = parseJsonString(params, "startISO")?.trim()?.ifEmpty { null },
+      endISO = parseJsonString(params, "endISO")?.trim()?.ifEmpty { null },
     )
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/MotionHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/MotionHandlerTest.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -71,6 +72,57 @@ class MotionHandlerTest : NodeHandlerRobolectricTest() {
           .getValue("confidence")
           .jsonPrimitive.content,
       )
+    }
+
+  @Test
+  fun handleMotionActivity_treatsJsonNullRangeAsAbsent() =
+    runTest {
+      val dataSource = FakeMotionDataSource(hasPermission = true)
+      val handler = MotionHandler.forTesting(appContext(), dataSource)
+
+      val result = handler.handleMotionActivity("""{"startISO":null,"endISO":null,"limit":null}""")
+
+      assertTrue(result.ok)
+      assertNull(dataSource.lastActivityRequest?.startISO)
+      assertNull(dataSource.lastActivityRequest?.endISO)
+      assertEquals(200, dataSource.lastActivityRequest?.limit)
+    }
+
+  @Test
+  fun handleMotionPedometer_treatsJsonNullRangeAsAbsent() =
+    runTest {
+      val dataSource = FakeMotionDataSource(hasPermission = true)
+      val handler = MotionHandler.forTesting(appContext(), dataSource)
+
+      val result = handler.handleMotionPedometer("""{"startISO":null,"endISO":null}""")
+
+      assertTrue(result.ok)
+      assertNull(dataSource.lastPedometerRequest?.startISO)
+      assertNull(dataSource.lastPedometerRequest?.endISO)
+      val payload = Json.parseToJsonElement(result.payloadJson ?: error("missing payload")).jsonObject
+      assertEquals(
+        1234,
+        payload
+          .getValue("steps")
+          .jsonPrimitive.content
+          .toInt(),
+      )
+    }
+
+  @Test
+  fun motionRangeRequests_preserveLiteralNullStringsAndLimitBounds() =
+    runTest {
+      val dataSource = FakeMotionDataSource(hasPermission = true)
+      val handler = MotionHandler.forTesting(appContext(), dataSource)
+
+      assertTrue(handler.handleMotionActivity("""{"startISO":" null ","endISO":"null","limit":2000}""").ok)
+      assertEquals("null", dataSource.lastActivityRequest?.startISO)
+      assertEquals("null", dataSource.lastActivityRequest?.endISO)
+      assertEquals(1000, dataSource.lastActivityRequest?.limit)
+
+      assertTrue(handler.handleMotionPedometer("""{"startISO":"null","endISO":" null "}""").ok)
+      assertEquals("null", dataSource.lastPedometerRequest?.startISO)
+      assertEquals("null", dataSource.lastPedometerRequest?.endISO)
     }
 
   @Test
@@ -161,6 +213,9 @@ private class FakeMotionDataSource(
   private val activityError: Throwable? = null,
   private val pedometerError: Throwable? = null,
 ) : MotionDataSource {
+  var lastActivityRequest: MotionActivityRequest? = null
+  var lastPedometerRequest: MotionPedometerRequest? = null
+
   override fun isActivityAvailable(context: Context): Boolean = activityAvailable
 
   override fun isPedometerAvailable(context: Context): Boolean = pedometerAvailable
@@ -171,6 +226,7 @@ private class FakeMotionDataSource(
     context: Context,
     request: MotionActivityRequest,
   ): MotionActivityRecord {
+    lastActivityRequest = request
     activityError?.let { throw it }
     return activityRecord
   }
@@ -179,6 +235,7 @@ private class FakeMotionDataSource(
     context: Context,
     request: MotionPedometerRequest,
   ): PedometerRecord {
+    lastPedometerRequest = request
     pedometerError?.let { throw it }
     return pedometerRecord
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes Android `motion.activity` and `motion.pedometer` requests incorrectly rejecting explicit JSON `null` date bounds as unsupported historical date ranges.

## Why This Change Was Made

`kotlinx.serialization.json.JsonNull` is a `JsonPrimitive` whose `content` is the literal string `"null"`. Both Android motion request parsers read `startISO` and `endISO` through that property, so omitted bounds encoded explicitly as JSON null became nonempty historical range requests before the platform sensors could run.

Use the existing `NodeUtils.parseJsonString` owner helper for all four nullable date fields. Its `contentOrNull` contract maps only JSON null to Kotlin null while preserving actual JSON strings, numeric/boolean primitive coercion, trimming, existing activity limits, permissions, cancellation, and sensor behavior. This completes the same Android null-normalization owner invariant fixed for calendar/contact writes in #125527.

## User Impact

Android motion activity requests with nullable date bounds can sample the actual accelerometer instead of returning a false `MOTION_RANGE_UNAVAILABLE` error. Pedometer requests similarly reach the real step-counter capability and return either its normal reading or its truthful hardware-unavailable error instead of a false `PEDOMETER_RANGE_UNAVAILABLE`. Actual nonempty historical ranges, including the real JSON string `"null"`, remain rejected.

## Evidence

- Fail-first Android owner proof on the exact current-main baseline: `MotionHandlerTest` ran 9 tests with exactly 2 failures, one for each explicit-null motion/pedometer request; 7 existing permission, cancellation, literal-string, and range controls passed.
- Fixed Android owner proof: all 9 `MotionHandlerTest` cases pass, including captured null activity/pedometer bounds, the normal 1,234-step pedometer payload through the existing injected source, default limit 200, bounded limit 1,000, and literal JSON string `"null"` preservation.
- Full hosted-equivalent Kotlin lint succeeded for all four Android modules: `:app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck`.
- Actual API 36 platform proof on the same foreground production debug APK and granted `ACTIVITY_RECOGNITION`: the exact frozen-main runner executed 3 real-device tests and failed the 2 null activity/pedometer paths with their incorrect historical-range errors; the identical fixed runner completed in 1.375 seconds with `OK (3 tests)`. The fixed app sampled 20 actual Goldfish accelerometer events and returned a classified motion payload, returned the truthful missing-step-hardware error for null pedometer bounds, and preserved historical-range rejection of actual JSON string `"null"` on both commands.
- Hardware limitation disclosed: the Android emulator exposes a real Goldfish accelerometer but no `TYPE_STEP_COUNTER` or `TYPE_STEP_DETECTOR`; real pedometer step-count success is impossible without physical hardware. The platform test must instead verify the truthful `PEDOMETER_UNAVAILABLE` result after null normalization, while the owner regression verifies the successful pedometer payload through its existing production data-source boundary.
- Production: +4/-4 (net zero). Tests: +57/-0. No new helpers, dependencies, configuration, permissions, schema, protocol, or changelog changes.
- Fresh authenticated structured code review: no accepted/actionable findings; independent owner, dependency-contract, and platform-proof reviews completed.
