### PR TITLE
fix(apple): surface rejected chat session settings

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+ModelControls.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+ModelControls.swift
@@ -85,6 +85,7 @@ extension OpenClawChatViewModel {
         guard clearsOverride ? baselineSessionLevel != nil : Self.normalizedVerboseLevel(baselineSessionLevel) != next
         else { return }
 
+        self.errorText = nil
         if self.acceptedVerboseLevelsByTarget[target] == nil {
             self.acceptedVerboseLevelsByTarget[target] = baselineSessionLevel.map(VerboseLevelState.value)
                 ?? VerboseLevelState.none
@@ -133,6 +134,7 @@ extension OpenClawChatViewModel {
                         self.acceptedVerboseLevelsByTarget[target]?.level,
                         sessionKey: state.key,
                         exactMatchOnly: state.exactMatchOnly)
+                    if !state.exactMatchOnly { self.errorText = error.localizedDescription }
                 }
             }
         }
@@ -177,6 +179,7 @@ extension OpenClawChatViewModel {
         let baselineEffectiveFastMode = self.currentSessionEntry()?.effectiveFastMode
         guard baselineFastMode != next else { return }
 
+        self.errorText = nil
         if self.acceptedFastModesByTarget[target] == nil {
             self.acceptedFastModesByTarget[target] = FastModeState(
                 override: baselineFastMode,
@@ -225,6 +228,7 @@ extension OpenClawChatViewModel {
                         effective: accepted?.effective,
                         sessionKey: state.key,
                         exactMatchOnly: state.exactMatchOnly)
+                    if !state.exactMatchOnly { self.errorText = error.localizedDescription }
                 }
             }
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Thinking.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Thinking.swift
@@ -25,6 +25,7 @@ extension OpenClawChatViewModel {
             guard next != preferredThinkingLevel || self.thinkingOverrideIsInherited else { return }
         }
 
+        self.errorText = nil
         let sessionKey = self.sessionKey
         let acceptedBaseline = Self.normalizedThinkingLevel(currentSessionEntry()?.thinkingLevel)
             ?? Self.normalizedThinkingLevel(thinkingLevel)
@@ -159,6 +160,7 @@ extension OpenClawChatViewModel {
                 self.updateCurrentSessionThinkingLevel(
                     self.acceptedThinkingOverrideClearedByTarget[target] == true ? nil : rollbackLevel,
                     sessionKey: sessionKey)
+                self.errorText = error.localizedDescription
             }
         }
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -2748,13 +2748,17 @@ struct ChatViewModelTests {
         viewModel.sessions = [running]
         let omitted = try JSONDecoder().decode(
             OpenClawSessionMessageEventPayload.self,
-            from: Data(#"{"sessionKey":"main","hasActiveRun":true,"messageId":"message-1","message":{"role":"assistant","content":[{"type":"text","text":"working"}],"timestamp":2}}"#.utf8))
+            from: Data(
+                #"{"sessionKey":"main","hasActiveRun":true,"messageId":"message-1","message":{"role":"assistant","content":[{"type":"text","text":"working"}],"timestamp":2}}"#
+                    .utf8))
         viewModel.handleTransportEvent(.sessionMessage(omitted))
         #expect(viewModel.currentSessionEntry()?.activeRunIds == ["run-stale"])
 
         let payload = try JSONDecoder().decode(
             OpenClawSessionMessageEventPayload.self,
-            from: Data(#"{"sessionKey":"main","hasActiveRun":true,"activeRunIds":null,"messageId":"message-2","message":{"role":"assistant","content":[{"type":"text","text":"still working"}],"timestamp":3}}"#.utf8))
+            from: Data(
+                #"{"sessionKey":"main","hasActiveRun":true,"activeRunIds":null,"messageId":"message-2","message":{"role":"assistant","content":[{"type":"text","text":"still working"}],"timestamp":3}}"#
+                    .utf8))
 
         viewModel.handleTransportEvent(.sessionMessage(payload))
 
@@ -10408,6 +10412,7 @@ struct ChatViewModelTests {
         #expect(await MainActor.run {
             vm.sessions.first(where: { $0.key == "main" })?.thinkingLevel
         } == "high")
+        #expect(await MainActor.run { vm.errorText } == nil)
     }
 
     @Test func `older pending thinking choice becomes preference fallback`() async throws {
@@ -10486,12 +10491,14 @@ struct ChatViewModelTests {
         try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
         await MainActor.run { vm.selectFastMode("off") }
         await vm.waitForPendingSessionSettings(in: "main")
+        #expect(await MainActor.run { vm.errorText } == "rejected")
         #expect(await MainActor.run { vm.fastModeSelectionID } == OpenClawChatViewModel.inheritedThinkingSelectionID)
         #expect(await MainActor.run { vm.sessions.first?.fastMode } == nil)
         #expect(await MainActor.run { vm.sessions.first?.effectiveFastMode } == .on)
 
         await MainActor.run { vm.selectVerboseLevel("full") }
         await vm.waitForPendingSessionSettings(in: "main")
+        #expect(await MainActor.run { vm.errorText } == "rejected")
         #expect(await MainActor.run { vm.verboseLevel } == OpenClawChatViewModel.inheritedThinkingSelectionID)
         #expect(await MainActor.run { vm.sessions.first?.verboseLevel } == nil)
     }
@@ -10763,6 +10770,7 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.preferredThinkingLevel } == "off")
         #expect(await MainActor.run { !vm.prefersExplicitThinkingLevel })
         #expect(await MainActor.run { callbackState.values } == ["medium", "off"])
+        #expect(await MainActor.run { vm.errorText } == "rejected")
     }
 
     @Test func `two failed queued thinking patches restore the confirmed level`() async throws {


### PR DESCRIPTION
## Summary

Addresses the silent-failure/accessibility portion of #126520. That issue must remain open for its separate request to change gateway authorization policy.

The shared Apple chat model already exposes rejected model-picker changes through its existing visible error banner, but thinking-level, verbosity, and fast-mode changes silently rolled back when the gateway rejected them. This was particularly difficult for VoiceOver users because the picker closed without an applied change or an explanation.

- Surface rejection errors through the existing shared chat error banner for all three session-setting controls.
- Clear a stale rejection when a fresh setting change begins.
- Keep failures from background/inactive sessions out of the currently displayed conversation.
- Preserve the existing `operator.admin` authorization boundary; no gateway permission, security, protocol, schema, or configuration changes.
- Production: +6/-0 across the three owner paths; tests: +10/-2 including existing baseline SwiftFormat cleanup.

## Verification

- Before the fix: three independent failing assertions reproduce silent thinking-level, verbosity, and fast-mode rejections; the inactive-session isolation test already passes.
- After the fix: all three rejection assertions and inactive-session isolation pass.
- Full shared Apple chat suite: 289 tests across two suites pass.
- Repository changed-files gate: all seven macOS/tooling Vitest shards pass (485 tests), Swift lint passes, and native schema validation passes.
- Independent structured code review: clean, with no P0/P1 findings.
- One pre-existing optimistic-message timing test failed only while the 485-test tooling lane was competing for resources; it passed immediately in isolation and the entire 289-test suite passed afterward.

## Native accessibility proof boundary

ClawSweeper's optional rank-up request for a redacted Apple-client rejection recording is skipped because this task has no paired physical iPhone/iPad with an enabled VoiceOver session and a bounded operator token available for capture. The changed path is instead proven by three real shared Apple view-model fail-before/pass-after regressions, inactive-session isolation, the inspected existing `ChatView` error-banner consumer, the full 289-test Apple chat suite, and exact-head hosted iOS/macOS/Android CI. No claim is made that VoiceOver announcement behavior was physically exercised.
