### PR TITLE
fix(channels): restore setup for fleets without a default owner

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -45,8 +45,10 @@ For `add`, `login`, `logout`, `remove`, and `resolve`, or `capabilities --channe
 use `--agent <id>` to select the workspace used for channel plugin discovery.
 The option works before or after the subcommand; a subcommand value takes precedence.
 Without it, discovery uses the configured System Agent or the existing sole/legacy owner.
-An explicit fleet with no such owner requires `--agent`. Selecting a workspace
-does not create account routing bindings; guided setup asks about routing separately.
+In an interactive guided `channels add`, an explicit fleet with no such owner
+prompts for the setup owner before workspace-scoped discovery; flag-driven or
+non-interactive setup still requires `--agent`. Selecting a workspace does not
+create account routing bindings; guided setup asks about routing separately.
 
 `add`, `login`, `logout`, and `remove` also take `--account <id>`. Omitting it selects the
 default account. A blank value is rejected instead of falling back to the default, as with

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -13,6 +13,7 @@ import type { PluginPackageChannelCliOption } from "../plugins/manifest.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { WizardSession } from "../wizard/session.js";
 import {
   ensureChannelSetupPluginInstalled,
   loadChannelSetupPluginRegistrySnapshotForChannel,
@@ -855,6 +856,108 @@ describe("channelsAddCommand", () => {
         bindings: [
           {
             agentId: "helper",
+            match: { channel: "lifecycle-chat", accountId: "ops" },
+          },
+        ],
+      });
+    },
+  );
+
+  it("rejects an unconfigured agent returned by the hosted wizard", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        entries: {
+          main: { workspace: "/tmp/openclaw-main-workspace" },
+          helper: { workspace: "/tmp/openclaw-helper-workspace" },
+        },
+      },
+      channels: {},
+    };
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      sourceConfig: config,
+      config,
+    });
+    const session = new WizardSession(async (prompter) => {
+      await runChannelsSetupWizard({ channel: "lifecycle-chat" }, runtime, prompter);
+    });
+
+    const selection = await session.next();
+    expect(selection).toMatchObject({
+      step: { type: "select", message: "Set up channels for agent" },
+    });
+    if (selection.done) {
+      throw new Error("Expected agent selection step");
+    }
+    try {
+      await session.answer(selection.step.id, "missing");
+      expect(await session.next()).toMatchObject({
+        done: true,
+        status: "error",
+        error: expect.stringContaining('Unknown agent id "missing"'),
+      });
+      expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
+      expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    } finally {
+      session.cancel();
+      await session.whenSettled();
+    }
+  });
+
+  it.each(["CLI", "hosted"] as const)(
+    "uses the configured setup owner and preserves binding choice in the %s wizard",
+    async (surface) => {
+      const config: OpenClawConfig = {
+        agents: {
+          ownership: "explicit",
+          defaults: { systemAgent: { agentId: "helper" } },
+          entries: {
+            main: { workspace: "/tmp/openclaw-main-workspace" },
+            helper: { workspace: "/tmp/openclaw-helper-workspace" },
+          },
+        },
+        channels: {},
+      };
+      configMocks.readConfigFileSnapshot.mockResolvedValue({
+        ...baseConfigSnapshot,
+        sourceConfig: config,
+        config,
+      });
+      channelWizardMocks.prompter.select.mockResolvedValueOnce("main");
+      channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
+        const options = requireRecord(args[3], "setup options");
+        const onSelection = options.onSelection as ((selection: string[]) => void) | undefined;
+        const onAccountId = options.onAccountId as
+          | ((channel: string, accountId: string) => void)
+          | undefined;
+        onSelection?.(["lifecycle-chat"]);
+        onAccountId?.("lifecycle-chat", "ops");
+        return args[0] as OpenClawConfig;
+      });
+
+      if (surface === "CLI") {
+        await channelsAddCommand({ channel: "lifecycle-chat" }, runtime, { hasFlags: false });
+      } else {
+        await runChannelsSetupWizard(
+          { channel: "lifecycle-chat" },
+          runtime,
+          channelWizardMocks.prompter,
+        );
+      }
+
+      expect(channelWizardMocks.prompter.select).toHaveBeenCalledOnce();
+      expect(channelWizardMocks.prompter.select).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Send lifecycle-chat/ops messages to agent",
+          initialValue: "helper",
+        }),
+      );
+      expect(setupOptions().workspaceDir).toBe("/tmp/openclaw-helper-workspace");
+      expect(writtenConfig()).toMatchObject({
+        bindings: [
+          {
+            agentId: "main",
             match: { channel: "lifecycle-chat", accountId: "ops" },
           },
         ],

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -59,6 +59,12 @@ const terminalMocks = vi.hoisted(() => ({
   isTerminalInteractive: vi.fn(() => true),
 }));
 
+const policyMocks = vi.hoisted(() => ({
+  readCurrentConfigForPolicyCheck: vi.fn<() => OpenClawConfig>(() => ({})),
+}));
+
+vi.mock("../config/io.runtime.js", () => policyMocks);
+
 const channelWizardMocks = vi.hoisted(() => {
   const prompter = {
     intro: vi.fn(async () => undefined),
@@ -476,6 +482,7 @@ describe("channelsAddCommand", () => {
   });
 
   beforeEach(async () => {
+    policyMocks.readCurrentConfigForPolicyCheck.mockReset().mockReturnValue({});
     resetPluginRuntimeStateForTest();
     configFiles.clear();
     configMocks.readConfigFileSnapshot.mockClear();
@@ -851,7 +858,8 @@ describe("channelsAddCommand", () => {
       });
       channelWizardMocks.prompter.select
         .mockResolvedValueOnce({ agentId: "helper" })
-        .mockResolvedValueOnce("helper");
+        .mockResolvedValueOnce("main");
+      policyMocks.readCurrentConfigForPolicyCheck.mockReturnValue(config);
       channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
         const options = requireRecord(args[3], "setup options");
         const onSelection = options.onSelection as ((selection: string[]) => void) | undefined;
@@ -885,7 +893,7 @@ describe("channelsAddCommand", () => {
       expect(writtenConfig()).toMatchObject({
         bindings: [
           {
-            agentId: "helper",
+            agentId: "main",
             match: { channel: "lifecycle-chat", accountId: "ops" },
           },
         ],
@@ -893,7 +901,14 @@ describe("channelsAddCommand", () => {
     },
   );
 
-  it("rejects an unconfigured agent returned by the hosted wizard", async () => {
+  it.each([
+    { answer: { agentId: "missing" }, error: 'Unknown agent id "missing"' },
+    { answer: { agentId: "" }, error: 'Unknown agent id ""' },
+    { answer: { agentId: "   " }, error: 'Unknown agent id "   "' },
+    { answer: null, error: "Invalid channel setup owner selection" },
+    { answer: {}, error: "Invalid channel setup owner selection" },
+    { answer: { agentId: 17 }, error: "Invalid channel setup owner selection" },
+  ])("rejects invalid hosted owner $answer before setup", async ({ answer, error }) => {
     const config: OpenClawConfig = {
       agents: {
         ownership: "explicit",
@@ -909,6 +924,7 @@ describe("channelsAddCommand", () => {
       sourceConfig: config,
       config,
     });
+    policyMocks.readCurrentConfigForPolicyCheck.mockReturnValue(config);
     const session = new WizardSession(async (prompter) => {
       await runChannelsSetupWizard({ channel: "lifecycle-chat" }, runtime, prompter);
     });
@@ -921,11 +937,51 @@ describe("channelsAddCommand", () => {
       throw new Error("Expected agent selection step");
     }
     try {
-      await session.answer(selection.step.id, { agentId: "missing" });
+      await session.answer(selection.step.id, answer);
       expect(await session.next()).toMatchObject({
         done: true,
         status: "error",
-        error: expect.stringContaining('Unknown agent id "missing"'),
+        error: expect.stringContaining(error),
+      });
+      expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
+      expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    } finally {
+      session.cancel();
+      await session.whenSettled();
+    }
+  });
+
+  it("rejects an owner removed while the hosted selection is pending", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        entries: {
+          main: { workspace: "/tmp/openclaw-main-workspace" },
+          helper: { workspace: "/tmp/openclaw-helper-workspace" },
+        },
+      },
+    };
+    configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(config));
+    policyMocks.readCurrentConfigForPolicyCheck.mockReturnValue(config);
+    const session = new WizardSession(async (prompter) => {
+      await runChannelsSetupWizard({ channel: "lifecycle-chat" }, runtime, prompter);
+    });
+    try {
+      const selection = await session.next();
+      if (selection.done || !selection.step) {
+        throw new Error("Expected owner selection step");
+      }
+      policyMocks.readCurrentConfigForPolicyCheck.mockReturnValue({
+        agents: {
+          ownership: "explicit",
+          entries: { main: { workspace: "/tmp/openclaw-main-workspace" } },
+        },
+      });
+      await session.answer(selection.step.id, { agentId: "helper" });
+      expect(await session.next()).toMatchObject({
+        done: true,
+        status: "error",
+        error: expect.stringContaining('Unknown agent id "helper"'),
       });
       expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
       expect(configMocks.writeConfigFile).not.toHaveBeenCalled();

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -887,7 +887,7 @@ describe("channelsAddCommand", () => {
     expect(selection).toMatchObject({
       step: { type: "select", message: "Set up channels for agent" },
     });
-    if (selection.done) {
+    if (selection.done || !selection.step) {
       throw new Error("Expected agent selection step");
     }
     try {

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -802,6 +802,66 @@ describe("channelsAddCommand", () => {
     },
   );
 
+  it.each(["CLI", "hosted"] as const)(
+    "selects and carries an explicit multi-agent channel owner in the %s wizard",
+    async (surface) => {
+      const config: OpenClawConfig = {
+        agents: {
+          ownership: "explicit",
+          entries: {
+            main: { workspace: "/tmp/openclaw-main-workspace" },
+            helper: { workspace: "/tmp/openclaw-helper-workspace" },
+          },
+        },
+        channels: {},
+      };
+      configMocks.readConfigFileSnapshot.mockResolvedValue({
+        ...baseConfigSnapshot,
+        sourceConfig: config,
+        config,
+      });
+      channelWizardMocks.prompter.select.mockResolvedValue("helper");
+      channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
+        const options = requireRecord(args[3], "setup options");
+        const onSelection = options.onSelection as ((selection: string[]) => void) | undefined;
+        const onAccountId = options.onAccountId as
+          | ((channel: string, accountId: string) => void)
+          | undefined;
+        onSelection?.(["lifecycle-chat"]);
+        onAccountId?.("lifecycle-chat", "ops");
+        return args[0] as OpenClawConfig;
+      });
+
+      if (surface === "CLI") {
+        await channelsAddCommand({ channel: "lifecycle-chat" }, runtime, { hasFlags: false });
+      } else {
+        await runChannelsSetupWizard(
+          { channel: "lifecycle-chat" },
+          runtime,
+          channelWizardMocks.prompter,
+        );
+      }
+
+      expect(channelWizardMocks.prompter.select).toHaveBeenCalledTimes(2);
+      expect(channelWizardMocks.prompter.select.mock.calls[0]?.[0]).toEqual({
+        message: "Set up channels for agent",
+        options: [
+          { value: "main", label: "main" },
+          { value: "helper", label: "helper" },
+        ],
+      });
+      expect(setupOptions().workspaceDir).toBe("/tmp/openclaw-helper-workspace");
+      expect(writtenConfig()).toMatchObject({
+        bindings: [
+          {
+            agentId: "helper",
+            match: { channel: "lifecycle-chat", accountId: "ops" },
+          },
+        ],
+      });
+    },
+  );
+
   it.each([
     {
       channel: "single-env-chat",

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -649,7 +649,7 @@ describe("channelsAddCommand", () => {
 
       expect(setupOptions().workspaceDir).toBe("/tmp/ops-workspace");
       expect(channelWizardMocks.prompter.select).toHaveBeenCalledWith(
-        expect.objectContaining({ initialValue: systemAgentId }),
+        expect.objectContaining({ initialValue: "ops" }),
       );
       expect(writtenConfig().bindings).toEqual([
         {

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -673,6 +673,32 @@ describe("channelsAddCommand", () => {
     expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
   });
 
+  it("keeps no-TTY guidance for an explicit ownerless agent fleet", async () => {
+    terminalMocks.isTerminalInteractive.mockReturnValue(false);
+    const config: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        entries: {
+          main: { workspace: "/tmp/openclaw-main-workspace" },
+          helper: { workspace: "/tmp/openclaw-helper-workspace" },
+        },
+      },
+    };
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      sourceConfig: config,
+      config,
+    });
+
+    await channelsAddCommand({ channel: "telegram" }, runtime, { hasFlags: false });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("channels add --channel <id> --use-env"),
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(channelWizardMocks.setupChannels).not.toHaveBeenCalled();
+  });
+
   it.each(
     [true, false].flatMap((interactive) => [
       { label: "empty", channel: "", expectedChannel: "", interactive },
@@ -693,7 +719,9 @@ describe("channelsAddCommand", () => {
       await channelsAddCommand({ channel }, runtime, { hasFlags: false });
 
       expect(runtime.error).toHaveBeenCalledWith(
-        `Unknown channel "${expectedChannel}". Run \`openclaw channels list --all\` to see configured and installable channels.`,
+        interactive
+          ? `Unknown channel "${expectedChannel}". Run \`openclaw channels list --all\` to see configured and installable channels.`
+          : expect.stringContaining("channels add --channel <id> --use-env"),
       );
       expect(runtime.exit).toHaveBeenCalledWith(1);
       expect(runtime.log).not.toHaveBeenCalled();

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -849,7 +849,9 @@ describe("channelsAddCommand", () => {
         sourceConfig: config,
         config,
       });
-      channelWizardMocks.prompter.select.mockResolvedValue("helper");
+      channelWizardMocks.prompter.select
+        .mockResolvedValueOnce({ agentId: "helper" })
+        .mockResolvedValueOnce("helper");
       channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
         const options = requireRecord(args[3], "setup options");
         const onSelection = options.onSelection as ((selection: string[]) => void) | undefined;
@@ -875,8 +877,8 @@ describe("channelsAddCommand", () => {
       expect(channelWizardMocks.prompter.select.mock.calls[0]?.[0]).toEqual({
         message: "Set up channels for agent",
         options: [
-          { value: "main", label: "main" },
-          { value: "helper", label: "helper" },
+          { value: { agentId: "main" }, label: "main" },
+          { value: { agentId: "helper" }, label: "helper" },
         ],
       });
       expect(setupOptions().workspaceDir).toBe("/tmp/openclaw-helper-workspace");
@@ -919,7 +921,7 @@ describe("channelsAddCommand", () => {
       throw new Error("Expected agent selection step");
     }
     try {
-      await session.answer(selection.step.id, "missing");
+      await session.answer(selection.step.id, { agentId: "missing" });
       expect(await session.next()).toMatchObject({
         done: true,
         status: "error",

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -28,6 +28,8 @@ type InitialWizardChannelTarget =
   | { kind: "resolved"; channel: ChannelChoice }
   | { kind: "unresolved"; message: string };
 
+type ChannelSetupAgentChoice = { agentId: string };
+
 function unresolvedInitialWizardChannelTarget(channel: string): InitialWizardChannelTarget {
   return { kind: "unresolved", message: formatUnknownChannelMessage({ channel }) };
 }
@@ -44,11 +46,11 @@ export async function selectChannelSetupAgentId(
       throw error;
     }
   }
-  const selectedAgentId = await prompter.select({
+  const selectedAgent = await prompter.select<ChannelSetupAgentChoice>({
     message: "Set up channels for agent",
-    options: listAgentIds(cfg).map((agentId) => ({ value: agentId, label: agentId })),
+    options: listAgentIds(cfg).map((agentId) => ({ value: { agentId }, label: agentId })),
   });
-  return resolveConfiguredAgentId(cfg, selectedAgentId);
+  return resolveConfiguredAgentId(cfg, selectedAgent.agentId);
 }
 
 /** Resolve omitted, matched, and unmatched channel targets without collapsing caller intent. */

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -3,6 +3,7 @@
 // prompter driving the Control UI / native clients).
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import {
+  listAgentIds,
   resolveConfiguredAgentId,
   tryResolveAgentOperationAgentId,
 } from "../../agents/agent-scope-config.js";
@@ -27,6 +28,21 @@ type InitialWizardChannelTarget =
 
 function unresolvedInitialWizardChannelTarget(channel: string): InitialWizardChannelTarget {
   return { kind: "unresolved", message: formatUnknownChannelMessage({ channel }) };
+}
+
+/** Select a setup owner before workspace-scoped channel discovery. */
+export async function selectChannelSetupAgentId(
+  cfg: OpenClawConfig,
+  prompter: WizardPrompter,
+): Promise<string> {
+  const agentIds = listAgentIds(cfg);
+  if (agentIds.length <= 1) {
+    return resolveChannelSetupOwner(cfg).agentId;
+  }
+  return await prompter.select({
+    message: "Set up channels for agent",
+    options: agentIds.map((agentId) => ({ value: agentId, label: agentId })),
+  });
 }
 
 /** Resolve omitted, matched, and unmatched channel targets without collapsing caller intent. */
@@ -288,7 +304,9 @@ export async function runChannelsSetupWizard(
     );
   }
   const cfg = snapshot.sourceConfig;
-  const target = await resolveInitialWizardChannelTarget(opts.channel, cfg);
+  const agentId = await selectChannelSetupAgentId(cfg, prompter);
+  const workspaceDir = resolveChannelSetupOwner(cfg, agentId).workspaceDir;
+  const target = await resolveInitialWizardChannelTarget(opts.channel, cfg, workspaceDir);
   if (target.kind === "unresolved") {
     throw new Error(target.message);
   }
@@ -296,6 +314,7 @@ export async function runChannelsSetupWizard(
     writeSnapshot,
     runtime,
     prompter,
+    workspaceDir,
     ...(target.kind === "resolved" ? { initialChannel: target.channel } : {}),
     deferDeviceLinkToClient: true,
     ...(opts.onConfigured ? { onConfigured: opts.onConfigured } : {}),

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -3,8 +3,10 @@
 // prompter driving the Control UI / native clients).
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import {
+  AgentSelectionRequiredError,
   listAgentIds,
   resolveConfiguredAgentId,
+  resolveAgentOperationAgentId,
   tryResolveAgentOperationAgentId,
 } from "../../agents/agent-scope-config.js";
 import { getLoadedChannelPlugin } from "../../channels/plugins/index.js";
@@ -35,14 +37,18 @@ export async function selectChannelSetupAgentId(
   cfg: OpenClawConfig,
   prompter: WizardPrompter,
 ): Promise<string> {
-  const agentIds = listAgentIds(cfg);
-  if (agentIds.length <= 1) {
-    return resolveChannelSetupOwner(cfg).agentId;
+  try {
+    return resolveAgentOperationAgentId(cfg);
+  } catch (error) {
+    if (!(error instanceof AgentSelectionRequiredError)) {
+      throw error;
+    }
   }
-  return await prompter.select({
+  const selectedAgentId = await prompter.select({
     message: "Set up channels for agent",
-    options: agentIds.map((agentId) => ({ value: agentId, label: agentId })),
+    options: listAgentIds(cfg).map((agentId) => ({ value: agentId, label: agentId })),
   });
+  return resolveConfiguredAgentId(cfg, selectedAgentId);
 }
 
 /** Resolve omitted, matched, and unmatched channel targets without collapsing caller intent. */
@@ -83,6 +89,7 @@ export async function resolveInitialWizardChannelTarget(
 
 type ChannelsAddWizardFlowParams = {
   writeSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>;
+  agentId?: string;
   workspaceDir?: string;
   runtime: RuntimeEnv;
   prompter: WizardPrompter;
@@ -238,7 +245,7 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
             value: agent.id,
             label: agent.isDefault ? `${agent.id} (default)` : agent.id,
           })),
-          initialValue: defaultAgentId,
+          initialValue: params.agentId ?? defaultAgentId,
         });
         const bindingResult = applyAgentBindings(nextConfig, [
           {
@@ -312,6 +319,7 @@ export async function runChannelsSetupWizard(
   }
   await runChannelsAddWizardFlow({
     writeSnapshot,
+    agentId,
     runtime,
     prompter,
     workspaceDir,

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -1,18 +1,19 @@
 // Guided channel-setup wizard flow shared by `openclaw channels add` (clack
 // prompter) and the gateway `wizard.start {flow:"channels"}` RPC (session
 // prompter driving the Control UI / native clients).
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import {
   AgentSelectionRequiredError,
   listAgentIds,
   resolveConfiguredAgentId,
-  resolveAgentOperationAgentId,
   tryResolveAgentOperationAgentId,
 } from "../../agents/agent-scope-config.js";
 import { getLoadedChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelSetupPlugin } from "../../channels/plugins/setup-wizard-types.js";
 import { formatUnknownChannelMessage } from "../../cli/error-format.js";
 import { readConfigFileSnapshotForWrite, type OpenClawConfig } from "../../config/config.js";
+import { readCurrentConfigForPolicyCheck } from "../../config/io.runtime.js";
 import { commitConfigWithPendingPluginInstalls } from "../../plugins/install-record-commit.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../../plugins/registry-refresh.js";
 import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
@@ -35,22 +36,34 @@ function unresolvedInitialWizardChannelTarget(channel: string): InitialWizardCha
 }
 
 /** Select a setup owner before workspace-scoped channel discovery. */
-export async function selectChannelSetupAgentId(
-  cfg: OpenClawConfig,
+export async function selectChannelSetupOwner(
+  writeSnapshot: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>,
   prompter: WizardPrompter,
-): Promise<string> {
+  requestedAgentId?: string,
+): Promise<ReturnType<typeof resolveChannelSetupOwner>> {
+  const cfg = writeSnapshot.snapshot.sourceConfig;
   try {
-    return resolveAgentOperationAgentId(cfg);
+    return resolveChannelSetupOwner(cfg, requestedAgentId);
   } catch (error) {
     if (!(error instanceof AgentSelectionRequiredError)) {
       throw error;
     }
   }
-  const selectedAgent = await prompter.select<ChannelSetupAgentChoice>({
+  const selectedAgent: unknown = await prompter.select<ChannelSetupAgentChoice>({
     message: "Set up channels for agent",
     options: listAgentIds(cfg).map((agentId) => ({ value: { agentId }, label: agentId })),
   });
-  return resolveConfiguredAgentId(cfg, selectedAgent.agentId);
+  if (!isRecord(selectedAgent) || typeof selectedAgent.agentId !== "string") {
+    throw new Error("Invalid channel setup owner selection");
+  }
+  writeSnapshot.writeOptions.assertConfigPathForWrite?.();
+  // The roster can change while the prompt waits; retain the original snapshot for the commit fence.
+  const currentConfig = readCurrentConfigForPolicyCheck({
+    configPath: writeSnapshot.snapshot.path,
+    env: process.env,
+  });
+  const agentId = resolveConfiguredAgentId(currentConfig, selectedAgent.agentId);
+  return resolveChannelSetupOwner(currentConfig, agentId);
 }
 
 /** Resolve omitted, matched, and unmatched channel targets without collapsing caller intent. */
@@ -313,8 +326,7 @@ export async function runChannelsSetupWizard(
     );
   }
   const cfg = snapshot.sourceConfig;
-  const agentId = await selectChannelSetupAgentId(cfg, prompter);
-  const workspaceDir = resolveChannelSetupOwner(cfg, agentId).workspaceDir;
+  const { agentId, workspaceDir } = await selectChannelSetupOwner(writeSnapshot, prompter);
   const target = await resolveInitialWizardChannelTarget(opts.channel, cfg, workspaceDir);
   if (target.kind === "unresolved") {
     throw new Error(target.message);

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -147,8 +147,7 @@ async function channelsAddCommandImpl(
       resolveInitialWizardChannelTarget,
       runChannelsAddWizardFlow,
       selectChannelSetupAgentId,
-    } =
-      await import("./add-wizard.js");
+    } = await import("./add-wizard.js");
     const prompter = createClackPrompter();
     if (!isTerminalInteractive()) {
       runtime.error(

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -143,11 +143,8 @@ async function channelsAddCommandImpl(
 
   const useWizard = shouldUseWizard(params);
   if (useWizard) {
-    const {
-      resolveInitialWizardChannelTarget,
-      runChannelsAddWizardFlow,
-      selectChannelSetupAgentId,
-    } = await import("./add-wizard.js");
+    const { resolveInitialWizardChannelTarget, runChannelsAddWizardFlow, selectChannelSetupOwner } =
+      await import("./add-wizard.js");
     const prompter = createClackPrompter();
     if (!isTerminalInteractive()) {
       runtime.error(
@@ -156,11 +153,11 @@ async function channelsAddCommandImpl(
       runtime.exit(1);
       return;
     }
-    const agentId =
-      opts.agent === undefined
-        ? await selectChannelSetupAgentId(cfg, prompter)
-        : resolveChannelSetupOwner(cfg, opts.agent).agentId;
-    const workspaceDir = resolveChannelSetupOwner(cfg, agentId).workspaceDir;
+    const { agentId, workspaceDir } = await selectChannelSetupOwner(
+      writeSnapshot,
+      prompter,
+      opts.agent,
+    );
     const target = await resolveInitialWizardChannelTarget(opts.channel, cfg, workspaceDir);
     if (target.kind === "unresolved") {
       runtime.error(target.message);
@@ -172,7 +169,7 @@ async function channelsAddCommandImpl(
       agentId,
       runtime,
       prompter,
-      ...(workspaceDir ? { workspaceDir } : {}),
+      workspaceDir,
       ...(target.kind === "resolved" ? { initialChannel: target.channel } : {}),
       ...(params?.beforePersistentEffect
         ? { beforePersistentEffect: params.beforePersistentEffect }

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -143,16 +143,13 @@ async function channelsAddCommandImpl(
 
   const useWizard = shouldUseWizard(params);
   if (useWizard) {
-    const { resolveInitialWizardChannelTarget, runChannelsAddWizardFlow } =
+    const {
+      resolveInitialWizardChannelTarget,
+      runChannelsAddWizardFlow,
+      selectChannelSetupAgentId,
+    } =
       await import("./add-wizard.js");
-    const workspaceDir =
-      opts.agent === undefined ? undefined : resolveChannelSetupOwner(cfg, opts.agent).workspaceDir;
-    const target = await resolveInitialWizardChannelTarget(opts.channel, cfg, workspaceDir);
-    if (target.kind === "unresolved") {
-      runtime.error(target.message);
-      runtime.exit(1);
-      return;
-    }
+    const prompter = createClackPrompter();
     if (!isTerminalInteractive()) {
       runtime.error(
         "Interactive channel setup requires a TTY. Use `openclaw channels add --channel <id> --use-env` or pass the channel's credential flags for non-interactive setup.",
@@ -160,10 +157,20 @@ async function channelsAddCommandImpl(
       runtime.exit(1);
       return;
     }
+    const workspaceDir =
+      opts.agent === undefined
+        ? resolveChannelSetupOwner(cfg, await selectChannelSetupAgentId(cfg, prompter)).workspaceDir
+        : resolveChannelSetupOwner(cfg, opts.agent).workspaceDir;
+    const target = await resolveInitialWizardChannelTarget(opts.channel, cfg, workspaceDir);
+    if (target.kind === "unresolved") {
+      runtime.error(target.message);
+      runtime.exit(1);
+      return;
+    }
     await runChannelsAddWizardFlow({
       writeSnapshot,
       runtime,
-      prompter: createClackPrompter(),
+      prompter,
       ...(workspaceDir ? { workspaceDir } : {}),
       ...(target.kind === "resolved" ? { initialChannel: target.channel } : {}),
       ...(params?.beforePersistentEffect

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -157,10 +157,11 @@ async function channelsAddCommandImpl(
       runtime.exit(1);
       return;
     }
-    const workspaceDir =
+    const agentId =
       opts.agent === undefined
-        ? resolveChannelSetupOwner(cfg, await selectChannelSetupAgentId(cfg, prompter)).workspaceDir
-        : resolveChannelSetupOwner(cfg, opts.agent).workspaceDir;
+        ? await selectChannelSetupAgentId(cfg, prompter)
+        : resolveChannelSetupOwner(cfg, opts.agent).agentId;
+    const workspaceDir = resolveChannelSetupOwner(cfg, agentId).workspaceDir;
     const target = await resolveInitialWizardChannelTarget(opts.channel, cfg, workspaceDir);
     if (target.kind === "unresolved") {
       runtime.error(target.message);
@@ -169,6 +170,7 @@ async function channelsAddCommandImpl(
     }
     await runChannelsAddWizardFlow({
       writeSnapshot,
+      agentId,
       runtime,
       prompter,
       ...(workspaceDir ? { workspaceDir } : {}),

--- a/ui/src/pages/channels/wizard-controller.test.ts
+++ b/ui/src/pages/channels/wizard-controller.test.ts
@@ -78,6 +78,67 @@ describe("ChannelWizardController", () => {
     });
   });
 
+  it("does not treat a colliding owner selection as the channel presentation", async () => {
+    let nextCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "wizard.start") {
+        return {
+          sessionId: "s-owner-collision",
+          done: false,
+          status: "running",
+          step: {
+            id: "step-owner",
+            type: "select" as const,
+            message: "Set up channels for agent",
+            options: [
+              { value: { agentId: "telegram" }, label: "telegram" },
+              { value: { agentId: "helper" }, label: "helper" },
+            ],
+          },
+        };
+      }
+      if (method !== "wizard.next") {
+        throw new Error(`unexpected ${method}`);
+      }
+      nextCount += 1;
+      if (nextCount === 1) {
+        return {
+          done: false,
+          status: "running",
+          step: {
+            id: "step-channel",
+            type: "select" as const,
+            message: "Select channels",
+            options: [{ value: "discord", label: "Discord" }],
+          },
+        };
+      }
+      return {
+        done: true,
+        status: "done",
+        channels: ["discord"],
+        accounts: [{ channel: "discord", accountId: "default" }],
+      };
+    });
+    const controller = new ChannelWizardController(
+      () => ({ request: request as never }),
+      vi.fn(),
+      (value) => value === "telegram" || value === "discord",
+      () => "Setup expired. Close and restart setup.",
+    );
+
+    await controller.start(null);
+    await controller.answer({ agentId: "telegram" });
+    await controller.answer("discord");
+
+    expect(controller.state).toEqual({
+      phase: "done",
+      channel: "discord",
+      channels: ["discord"],
+      accounts: [{ channel: "discord", accountId: "default" }],
+    });
+  });
+
   it("advances gateway-owned progress without inventing user answers", async () => {
     let resolveProgress: ((value: unknown) => void) | undefined;
     let nextCount = 0;


### PR DESCRIPTION
Related: #128637 (channel setup only; the issue remains open).

## What Problem This Solves

Fixes an issue where users setting up a channel would receive an agent-selection error before they could choose an agent when an explicitly owned fleet had several agents and no default setup owner. The failure affected both `openclaw channels add` and hosted channel setup.

## Why This Change Was Made

Both setup entrypoints select a configured owner before workspace-dependent setup. Existing explicit and configured owners keep their precedence. A prompted selection is checked against the current roster before discovery, while the original config write fence remains intact.

The setup workspace and later message-routing destination remain separate choices. Structured owner answers also prevent an agent name from being mistaken for a channel selection in the Control UI.

## User Impact

Users can complete channel configuration in an explicit fleet and route its messages to another configured agent. Invalid or removed owner selections stop before setup. Existing plugin consent, cancellation, and concurrent config-write protection remain in place.

## Evidence

- Pinned main failed before owner selection through both the real terminal command and the real hosted wizard.
- The candidate completed both flows with the normally installed Nextcloud Talk plugin and saved a routing destination different from the setup owner.
- A real pending-selection case reproduced acceptance of a removed owner on the incoming branch. The added regression failed there and passed with the current-roster check.
- 223 focused command, UI-controller, discovery, plugin-install, setup, and wizard-session checks passed. Changed-file formatting/lint and both existing ratchets passed.
- Independent acceptance passed explicit, System, sole, and legacy owner controls; reversed setup/routing choices; malformed and removed owner rejection with same-Gateway recovery; cancellation; concurrent-write rejection; and complete noninteractive flag-driven setup.
- The actual Control UI flow completed Nextcloud Talk setup after choosing an agent named like another channel. Its finalized recording and screenshots were inspected.
- These runs validate configuration with synthetic inputs. They do not claim live Nextcloud message delivery.

Original implementation by @Leon-SK668; maintainer repair and verification are AI-assisted.
