### PR TITLE
fix(gateway): skip worker bootstrap when teardown is pending

### DIFF
--- a/src/gateway/worker-environments/provider-lifecycle.ts
+++ b/src/gateway/worker-environments/provider-lifecycle.ts
@@ -283,34 +283,29 @@ export function createWorkerProviderLifecycle(options: WorkerProviderLifecycleOp
       leaseId: lease.leaseId,
       sharedHost: lease.sharedHost === true,
       desktop: lease.desktop ?? null,
+      ...(lease.node
+        ? { nodeDeviceId: lease.node.deviceId, sshEndpoint: null }
+        : { nodeDeviceId: null, sshEndpoint: lease.ssh }),
     };
     const leaseModeError = resolveWorkerLeaseModeError(provider, lease);
     if (leaseModeError) {
-      const leasePatch = {
-        ...patch,
-        ...(lease.node
-          ? { nodeDeviceId: lease.node.deviceId, sshEndpoint: null }
-          : { nodeDeviceId: null, sshEndpoint: lease.ssh }),
-      };
       return await failBootstrap(
         record,
         lease.leaseId,
         provider,
         leaseModeError,
         "invalid_profile",
-        leasePatch,
+        patch,
       );
+    }
+    if (record.destroyRequestedAtMs !== null) {
+      // Replay must recover its exact lease, but teardown intent forbids transport bootstrap.
+      return move(record, "draining", patch);
     }
     if (lease.node) {
       return await finishNodeProvisioning(record, lease, provider, patch);
     }
-    const bootstrapping = move(record, "bootstrapping", {
-      ...patch,
-      sshEndpoint: lease.ssh,
-    });
-    if (record.destroyRequestedAtMs !== null) {
-      return bootstrapping;
-    }
+    const bootstrapping = move(record, "bootstrapping", patch);
     let installation = preparedInstallation;
     if (!installation) {
       try {

--- a/src/gateway/worker-environments/provider-provisioning-node.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning-node.test.ts
@@ -76,6 +76,113 @@ describe("node worker provider provisioning", () => {
     );
   });
 
+  it("destroys a replayed node lease without installing or admitting its worker", async () => {
+    const leaseId = "cloud-lease-destroy-replay";
+    const deviceId = "cloud-device-destroy-replay";
+    const operationIds: string[] = [];
+    const ensureNodeWorkerBundle = vi.fn(async () => structuredClone(support.BOOTSTRAP_RECEIPT));
+    const generateWorkerCredential = vi.fn(() => support.CREDENTIAL);
+    const retireNodeEnrollment = vi.fn(async () => {});
+    const destroy = vi.fn(async () => {});
+    const transitions = vi.spyOn(support.testState.store, "transition");
+    const prepareNodeEnrollment = vi.fn(async (record) => {
+      const enrolled = support.testState.store.ensureNodeEnrollment(record.environmentId);
+      if (!enrolled.nodeSetupId) {
+        throw new Error("expected persisted cloud enrollment ownership");
+      }
+      return {
+        mode: "connect" as const,
+        setupCode: "setup-code",
+        setupId: enrolled.nodeSetupId,
+        openclawVersion: "2026.8.1",
+        packageSpecs: ["openclaw@2026.8.1"],
+        displayName: "Cloud worker destroy replay",
+        waitForDeviceId: async () => deviceId,
+      };
+    });
+    const workerService = support.createService(
+      support.createProvider({
+        supportedExecutionModes: ["worker-turn"],
+        provisionBeforeInstallation: true,
+        requiresNodeEnrollment: true,
+        provision: async (_profile, operationId, options) => {
+          operationIds.push(operationId);
+          if (operationIds.length === 1) {
+            await options?.beginNodeEnrollment?.();
+            throw new Error("provider response was lost after node allocation");
+          }
+          return {
+            leaseId,
+            node: { deviceId },
+            sharedHost: false,
+            desktop: support.DESKTOP,
+          };
+        },
+        destroy,
+      }),
+      {
+        prepareNodeEnrollment,
+        retireNodeEnrollment,
+        ensureNodeWorkerBundle,
+        generateWorkerCredential,
+      },
+    );
+
+    await expect(
+      workerService.create("development", "request-node-destroy-replay"),
+    ).rejects.toMatchObject({ code: "provider_failure" });
+    const provisioning = support.testState.store.list()[0]!;
+    expect(provisioning).toMatchObject({
+      state: "provisioning",
+      leaseId: null,
+      nodeSetupId: expect.any(String),
+    });
+
+    await expect(workerService.destroy(provisioning.environmentId)).resolves.toMatchObject({
+      state: "destroyed",
+      leaseId,
+      nodeDeviceId: deviceId,
+      sharedHost: false,
+      desktop: support.DESKTOP,
+    });
+
+    expect(operationIds).toEqual([
+      provisioning.provisionOperationId,
+      provisioning.provisionOperationId,
+    ]);
+    expect(ensureNodeWorkerBundle).not.toHaveBeenCalled();
+    expect(support.testState.prepareInstallation).not.toHaveBeenCalled();
+    expect(support.testState.bootstrapWorker).not.toHaveBeenCalled();
+    expect(generateWorkerCredential).not.toHaveBeenCalled();
+    expect(support.testState.store.getCredential(provisioning.environmentId)).toBeUndefined();
+    expect(transitions).not.toHaveBeenCalledWith(expect.objectContaining({ to: "ready" }));
+    expect(destroy).toHaveBeenCalledExactlyOnceWith({ leaseId, profile: { region: "test" } });
+    expect(retireNodeEnrollment).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        state: "destroying",
+        leaseId,
+        nodeSetupId: provisioning.nodeSetupId,
+        nodeDeviceId: deviceId,
+        sharedHost: false,
+        desktop: support.DESKTOP,
+        bootstrapReceipt: null,
+        ownerEpoch: 0,
+      }),
+    );
+    expect(support.testState.store.get(provisioning.environmentId)).toMatchObject({
+      state: "destroyed",
+      bootstrapReceipt: null,
+      ownerEpoch: 0,
+    });
+    expect(
+      workerService.takeMintedCredential({
+        environmentId: provisioning.environmentId,
+        ownerEpoch: 0,
+        sessionId: null,
+      }),
+    ).toBeUndefined();
+  });
+
   it("keeps paired-device roles when a node lease has no cloud enrollment owner", async () => {
     const retireNodeEnrollment = vi.fn(async () => {});
     const workerService = support.createService(


### PR DESCRIPTION
Closes #128744

## What Problem This Solves

Fixes an issue where operators destroying a node-backed cloud worker after an indeterminate provisioning result would trigger worker bundle installation and credential creation immediately before the environment was torn down.

## Why This Change Was Made

Provision replay still uses the original operation ID to recover the exact allocated lease, but the provider lifecycle now records the recovered transport facts and checks durable destroy intent once before either node or SSH bootstrap. Destroy-requested environments transition directly from provisioning to draining, then use the existing canonical provider teardown and node-enrollment retirement flow.

This removes the transport-specific ordering gap rather than adding a separate node cleanup path.

Production LOC: +9/-14 (net -5) | Tests: +107

AI-assisted: yes. I reviewed the provider-operation serialization, persisted lease adoption, node enrollment ownership, credential commit, state transition, and provider teardown paths and understand the change.

## User Impact

Cloud-worker teardown no longer performs unnecessary remote bundle installation or creates an admission credential after destruction is already authoritative. Replay-safe lease recovery, provider destruction, and owned node-enrollment retirement remain intact.

## Evidence

- Pre-fix regression: the destroy replay called `ensureNodeWorkerBundle("cloud-device-destroy-replay")` once despite persisted teardown intent.
- Post-fix owner suite: 7 files, 86 tests passed across node admission, provisioning replay, shutdown replay, bootstrap, and reconciliation.
- Full changed-file gate: `node scripts/check-changed.mjs` passed, including core/test typechecking, lint, formatting, import-cycle, database-first, and architecture guards.
- Regression coverage proves the original provision operation ID is reused; recovered lease/node/shared-host/desktop facts survive; bundle installation, SSH installation preparation, worker bootstrap, ready transition, bootstrap receipt, and credential generation/storage/staging do not occur; provider destruction and enrollment retirement each run exactly once; final state is destroyed.
- Live provider proof not run: the defect requires deterministic injection of a lost response after allocation but before lease persistence. A normal provider run cannot establish that ordering; the service-boundary regression injects the exact failure while exercising the real SQLite store and lifecycle owner.
- Fresh P0/P1 autoreview: no accepted/actionable findings.
