### PR TITLE
fix(ui): distinguish pending and failed empty states

### DIFF
--- a/ui/src/components/panel-refresh-status.test.ts
+++ b/ui/src/components/panel-refresh-status.test.ts
@@ -40,4 +40,19 @@ describe("panel refresh status", () => {
       stale: false,
     });
   });
+
+  it("disables retry when the owner cannot refresh", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderPanelRefreshStatus({
+        status: failPanelRefresh(createPanelRefreshStatus(), "request failed"),
+        onRetry: vi.fn(),
+        retryDisabled: true,
+      }),
+      container,
+    );
+
+    expect(container.querySelector<HTMLButtonElement>("button")?.disabled).toBe(true);
+  });
 });

--- a/ui/src/components/panel-refresh-status.ts
+++ b/ui/src/components/panel-refresh-status.ts
@@ -38,6 +38,7 @@ export function renderPanelRefreshStatus(params: {
   status: PanelRefreshStatus;
   errorMessage?: string;
   onRetry: () => void;
+  retryDisabled?: boolean;
   className?: string;
 }): TemplateResult | typeof nothing {
   const { status } = params;
@@ -60,7 +61,9 @@ export function renderPanelRefreshStatus(params: {
         <span>${error}</span>
         ${status.stale ? html`<br /><strong>${t("common.staleData")}</strong>` : nothing}
       </span>
-      <button class="btn btn--sm" @click=${params.onRetry}>${t("common.retry")}</button>
+      <button class="btn btn--sm" ?disabled=${params.retryDisabled} @click=${params.onRetry}>
+        ${t("common.retry")}
+      </button>
     </div>
   `;
 }

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -379,12 +379,17 @@ describe("custodian page", () => {
     ]);
   });
 
-  it("continues to the welcome when the bounded history request times out", async () => {
+  it("continues to the welcome and retries when the bounded history request times out", async () => {
+    let historyCalls = 0;
     const request = vi.fn(
       async (method: string, _params?: unknown, options?: { timeoutMs?: number }) => {
         if (method === "openclaw.chat.history") {
           expect(options).toEqual({ timeoutMs: 15_000 });
-          throw new Error("history request timed out");
+          historyCalls += 1;
+          if (historyCalls === 1) {
+            throw new Error("history request timed out");
+          }
+          return { turns: [{ role: "assistant", text: "Recovered history.", at: 1 }] };
         }
         return {
           sessionId: "engine-session-after-history-timeout",
@@ -397,9 +402,16 @@ describe("custodian page", () => {
     const { page } = await mountPage(context);
 
     await waitForFast(() => expect(page.textContent).toContain("Welcome without history."));
+    const historyAlert = Array.from(page.querySelectorAll<HTMLElement>('[role="alert"]')).find(
+      (alert) => alert.textContent?.includes("history request timed out"),
+    );
+    expect(historyAlert).toBeDefined();
+    historyAlert?.querySelector<HTMLButtonElement>("button")?.click();
+    await waitForFast(() => expect(page.textContent).toContain("Recovered history."));
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "openclaw.chat.history",
       "openclaw.chat",
+      "openclaw.chat.history",
     ]);
   });
 

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -379,42 +379,6 @@ describe("custodian page", () => {
     ]);
   });
 
-  it("continues to the welcome and retries when the bounded history request times out", async () => {
-    let historyCalls = 0;
-    const request = vi.fn(
-      async (method: string, _params?: unknown, options?: { timeoutMs?: number }) => {
-        if (method === "openclaw.chat.history") {
-          expect(options).toEqual({ timeoutMs: 15_000 });
-          historyCalls += 1;
-          if (historyCalls === 1) {
-            throw new Error("history request timed out");
-          }
-          return { turns: [{ role: "assistant", text: "Recovered history.", at: 1 }] };
-        }
-        return {
-          sessionId: "engine-session-after-history-timeout",
-          reply: "Welcome without history.",
-          action: "none",
-        };
-      },
-    );
-    const { context } = createContext(request, ["openclaw.chat", "openclaw.chat.history"]);
-    const { page } = await mountPage(context);
-
-    await waitForFast(() => expect(page.textContent).toContain("Welcome without history."));
-    const historyAlert = Array.from(page.querySelectorAll<HTMLElement>('[role="alert"]')).find(
-      (alert) => alert.textContent?.includes("history request timed out"),
-    );
-    expect(historyAlert).toBeDefined();
-    historyAlert?.querySelector<HTMLButtonElement>("button")?.click();
-    await waitForFast(() => expect(page.textContent).toContain("Recovered history."));
-    expect(request.mock.calls.map(([method]) => method)).toEqual([
-      "openclaw.chat.history",
-      "openclaw.chat",
-      "openclaw.chat.history",
-    ]);
-  });
-
   it("refreshes durable rows for a same-ownership client replacement", async () => {
     let historyCalls = 0;
     const request = vi.fn(async (method: string, _params?: unknown) => {
@@ -530,9 +494,13 @@ describe("custodian page", () => {
     const { page } = await mountPage(context);
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
-    const input = page.querySelector<HTMLInputElement>(
-      '.agent-chat__composer-combobox input[type="password"]',
-    )!;
+    const input = await waitForFast(() => {
+      const candidate = page.querySelector<HTMLInputElement>(
+        '.agent-chat__composer-combobox input[type="password"]',
+      );
+      expect(candidate).not.toBeNull();
+      return candidate!;
+    });
     input.value = "test-token-placeholder";
     input.dispatchEvent(new InputEvent("input", { bubbles: true }));
     await page.updateComplete;
@@ -709,9 +677,13 @@ describe("custodian page", () => {
     const { page } = await mountPage(context);
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
 
-    const input = page.querySelector<HTMLInputElement>(
-      '.agent-chat__composer-combobox input[type="password"]',
-    )!;
+    const input = await waitForFast(() => {
+      const candidate = page.querySelector<HTMLInputElement>(
+        '.agent-chat__composer-combobox input[type="password"]',
+      );
+      expect(candidate).not.toBeNull();
+      return candidate!;
+    });
     input.value = "test-token-placeholder";
     input.dispatchEvent(new InputEvent("input", { bubbles: true }));
     await page.updateComplete;

--- a/ui/src/pages/custodian/custodian-session-store.test.ts
+++ b/ui/src/pages/custodian/custodian-session-store.test.ts
@@ -217,9 +217,8 @@ describe("CustodianSessionStore", () => {
     expect(store.messages[0]?.question?.id).toBe("repair");
   });
 
-  it("keeps the newest transcript when concurrent refreshes resolve out of order", async () => {
-    const older = deferred<{ turns: Array<{ role: "assistant"; text: string; at: number }> }>();
-    const newer = deferred<{ turns: Array<{ role: "assistant"; text: string; at: number }> }>();
+  it("coalesces concurrent transcript refreshes", async () => {
+    const pending = deferred<{ turns: Array<{ role: "assistant"; text: string; at: number }> }>();
     let historyCall = 0;
     const request = vi.fn((method: string, params: { sessionId?: string }) => {
       if (method === "openclaw.chat.history") {
@@ -227,7 +226,7 @@ describe("CustodianSessionStore", () => {
         if (historyCall === 1) {
           return Promise.resolve({ turns: [] });
         }
-        return historyCall === 2 ? older.promise : newer.promise;
+        return pending.promise;
       }
       return Promise.resolve({ sessionId: params.sessionId, reply: "Ready.", action: "none" });
     });
@@ -236,14 +235,47 @@ describe("CustodianSessionStore", () => {
     store.connect(context, "caretaker");
     await waitForFast(() => expect(store.sending).toBe(false));
 
-    const olderRefresh = store.refreshTranscriptIfIdle();
-    const newerRefresh = store.refreshTranscriptIfIdle();
-    newer.resolve({ turns: [{ role: "assistant", text: "Newest history", at: 2 }] });
-    await newerRefresh;
-    older.resolve({ turns: [{ role: "assistant", text: "Older history", at: 1 }] });
-    await olderRefresh;
+    const firstRefresh = store.refreshTranscriptIfIdle();
+    const secondRefresh = store.refreshTranscriptIfIdle();
+    expect(historyCall).toBe(2);
+    pending.resolve({ turns: [{ role: "assistant", text: "Fresh history", at: 2 }] });
+    await Promise.all([firstRefresh, secondRefresh]);
 
-    expect(store.messages.map((message) => message.text)).toEqual(["Newest history"]);
+    expect(store.messages.map((message) => message.text)).toEqual(["Fresh history"]);
+  });
+
+  it("keeps a transcript failure visible when a user turn invalidates its retry", async () => {
+    const retry = deferred<{ turns: Array<{ role: "assistant"; text: string; at: number }> }>();
+    const reply = deferred<{ sessionId: string; reply: string; action: "none" }>();
+    let historyCall = 0;
+    const request = vi.fn((method: string, params: { sessionId?: string; message?: string }) => {
+      if (method === "openclaw.chat.history") {
+        historyCall += 1;
+        if (historyCall === 1) {
+          return Promise.reject(new Error("history unavailable"));
+        }
+        return retry.promise;
+      }
+      if (params.message) {
+        return reply.promise;
+      }
+      return Promise.resolve({ sessionId: params.sessionId, reply: "Ready.", action: "none" });
+    });
+    const { context } = createContext(request, ["openclaw.chat", "openclaw.chat.history"]);
+    const store = new CustodianSessionStore();
+    store.connect(context, "caretaker");
+    await waitForFast(() => expect(store.sending).toBe(false));
+    expect(store.transcript.status.error).toContain("history unavailable");
+
+    const refresh = store.refreshTranscriptIfIdle();
+    const send = store.send("Continue");
+    retry.resolve({ turns: [{ role: "assistant", text: "Stale history", at: 2 }] });
+    await refresh;
+
+    expect(store.transcript.status.error).toContain("history unavailable");
+    expect(store.messages.some((message) => message.text === "Stale history")).toBe(false);
+    reply.resolve({ sessionId: "session-after-send", reply: "Continued.", action: "none" });
+    await send;
   });
 
   it("refreshes durable history after reconnect and clears the abandoned outcome", async () => {

--- a/ui/src/pages/custodian/custodian-session-store.test.ts
+++ b/ui/src/pages/custodian/custodian-session-store.test.ts
@@ -9,6 +9,14 @@ import { createContext } from "./custodian-page.test-harness.ts";
 import { CustodianSessionStore } from "./custodian-session-store.ts";
 import { custodianErrorMessage } from "./transcript.ts";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("CustodianSessionStore", () => {
   beforeEach(() => {
     installSafeLocalStorageForTesting(window).clear();
@@ -207,6 +215,35 @@ describe("CustodianSessionStore", () => {
       request.mock.calls.filter(([method]) => method === "openclaw.chat.history"),
     ).toHaveLength(historyCallCount);
     expect(store.messages[0]?.question?.id).toBe("repair");
+  });
+
+  it("keeps the newest transcript when concurrent refreshes resolve out of order", async () => {
+    const older = deferred<{ turns: Array<{ role: "assistant"; text: string; at: number }> }>();
+    const newer = deferred<{ turns: Array<{ role: "assistant"; text: string; at: number }> }>();
+    let historyCall = 0;
+    const request = vi.fn((method: string, params: { sessionId?: string }) => {
+      if (method === "openclaw.chat.history") {
+        historyCall += 1;
+        if (historyCall === 1) {
+          return Promise.resolve({ turns: [] });
+        }
+        return historyCall === 2 ? older.promise : newer.promise;
+      }
+      return Promise.resolve({ sessionId: params.sessionId, reply: "Ready.", action: "none" });
+    });
+    const { context } = createContext(request, ["openclaw.chat", "openclaw.chat.history"]);
+    const store = new CustodianSessionStore();
+    store.connect(context, "caretaker");
+    await waitForFast(() => expect(store.sending).toBe(false));
+
+    const olderRefresh = store.refreshTranscriptIfIdle();
+    const newerRefresh = store.refreshTranscriptIfIdle();
+    newer.resolve({ turns: [{ role: "assistant", text: "Newest history", at: 2 }] });
+    await newerRefresh;
+    older.resolve({ turns: [{ role: "assistant", text: "Older history", at: 1 }] });
+    await olderRefresh;
+
+    expect(store.messages.map((message) => message.text)).toEqual(["Newest history"]);
   });
 
   it("refreshes durable history after reconnect and clears the abandoned outcome", async () => {

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -35,8 +35,8 @@ import { parseCustodianQuestion, type CustodianStructuredQuestion } from "./stru
 import {
   createCustodianTranscriptMessages,
   custodianErrorMessage,
+  CustodianTranscriptLoader,
   hasUnresolvedCustodianQuestion,
-  readCustodianTranscript,
   retireCustodianQuestions,
   type CustodianMessage,
 } from "./transcript.ts";
@@ -58,6 +58,7 @@ export class CustodianSessionStore {
   wizardSecretVisible = false;
   questionReplyUncertain = false;
   error: string | null = null;
+  transcript = new CustodianTranscriptLoader();
   setupIssue: CustodianSetupIssue | null = null;
   dismissedQuestions = new Set<string>();
   answeredQuestions = new Set<string>();
@@ -601,13 +602,17 @@ export class CustodianSessionStore {
     ) {
       return false;
     }
-    const turns = await readCustodianTranscript(client);
-    if (turns === null || epoch !== this.requestEpoch || client !== this.activeClient) {
+    const result = await this.transcript.read(client);
+    if (epoch !== this.requestEpoch || client !== this.activeClient) {
       return false;
     }
-    const transcript = createCustodianTranscriptMessages(turns, this.nextMessageId);
-    this.messages = transcript.messages;
-    this.nextMessageId = transcript.nextMessageId;
+    this.transcript.finish(result);
+    if (!result.ok) {
+      this.emit();
+      return false;
+    }
+    const transcript = createCustodianTranscriptMessages(result.turns, this.nextMessageId);
+    [this.messages, this.nextMessageId] = [transcript.messages, transcript.nextMessageId];
     this.earlierBoundaryAfterId = this.messages.at(-1)?.id ?? null;
     this.emit();
     return true;
@@ -619,10 +624,10 @@ export class CustodianSessionStore {
     this.answeredQuestions = new Set();
     this.retryParams = null;
     this.error = null;
+    this.transcript.reset();
     this.setupIssue = null;
     this.input = "";
-    this.wizardValue = undefined;
-    this.wizardSecretVisible = false;
+    [this.wizardValue, this.wizardSecretVisible] = [undefined, false];
     this.sensitive = this.wizardInputPending = this.questionReplyUncertain = false;
     this.earlierBoundaryAfterId = null;
   }

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -4,7 +4,6 @@ import {
   type SystemAgentChatResult,
 } from "@openclaw/gateway-protocol";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { WizardStep } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import { canCallGatewayMethod, isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
@@ -31,9 +30,9 @@ import {
   isCustodianSessionInvalidatedError,
   type CustodianSessionVariant,
 } from "./session-lifecycle.ts";
-import { parseCustodianQuestion, type CustodianStructuredQuestion } from "./structured-question.ts";
+import { parseCustodianQuestion } from "./structured-question.ts";
 import {
-  createCustodianTranscriptMessages,
+  createCustodianAssistantMessage,
   custodianErrorMessage,
   CustodianTranscriptLoader,
   hasUnresolvedCustodianQuestion,
@@ -58,7 +57,7 @@ export class CustodianSessionStore {
   wizardSecretVisible = false;
   questionReplyUncertain = false;
   error: string | null = null;
-  transcript = new CustodianTranscriptLoader();
+  transcript = new CustodianTranscriptLoader(() => this.emit());
   setupIssue: CustodianSetupIssue | null = null;
   dismissedQuestions = new Set<string>();
   answeredQuestions = new Set<string>();
@@ -80,7 +79,6 @@ export class CustodianSessionStore {
   // refresh and on any fresh mint.
   private rejoinBarrierPending = this.restoredIdentity.restored;
   private requestEpoch = 0;
-  private transcriptGeneration = 0;
   private requestAbort: AbortController | null = null;
   private nextMessageId = 1;
   private retryParams: SystemAgentChatParams | null = null;
@@ -171,8 +169,7 @@ export class CustodianSessionStore {
 
   async refreshTranscriptIfIdle(): Promise<void> {
     const client = this.activeClient;
-    // hasUnresolvedQuestion() also covers a pending wizard step.
-    if (!client || !this.sessionStarted || this.sending || this.hasUnresolvedQuestion()) {
+    if (!client || !this.canRefreshTranscript()) {
       return;
     }
     const refreshed = await this.refreshTranscriptHistory(client, this.requestEpoch);
@@ -180,6 +177,12 @@ export class CustodianSessionStore {
       this.abandonedTurnOutcomeUnknown = false;
       this.emit();
     }
+  }
+
+  canRefreshTranscript(): boolean {
+    // hasUnresolvedQuestion() also covers a pending wizard step.
+    const blocked = this.sending || this.hasUnresolvedQuestion() || this.transcript.refreshing;
+    return this.activeClient !== null && this.sessionStarted && this.chatAvailable && !blocked;
   }
 
   canRetry(): boolean {
@@ -381,11 +384,16 @@ export class CustodianSessionStore {
   private revokeNavigationAuthority(): void {
     this.requestAbort?.abort();
     this.requestAbort = null;
-    this.requestEpoch += 1;
+    this.advanceRequestEpoch();
     this.sending = false;
     this.questionReplyUncertain = false;
     this.retryParams = null;
     this.error = null;
+  }
+
+  private advanceRequestEpoch(): number {
+    this.transcript.invalidate();
+    return ++this.requestEpoch;
   }
 
   openModelSetup(): void {
@@ -490,7 +498,7 @@ export class CustodianSessionStore {
     const requestWasPending = this.sending && this.retryParams !== null;
     const pendingParams = requestWasPending ? this.retryParams : null;
     this.activeClient = client;
-    this.requestEpoch += 1;
+    this.advanceRequestEpoch();
     this.sending = false;
     this.chatAvailable = false;
     if (variantChanged || ownershipChanged) {
@@ -578,7 +586,7 @@ export class CustodianSessionStore {
     params: SystemAgentChatParams,
     loadTranscript = true,
   ): Promise<void> {
-    const epoch = ++this.requestEpoch;
+    const epoch = this.advanceRequestEpoch();
     this.sending = true;
     this.error = null;
     this.retryParams = params;
@@ -603,22 +611,16 @@ export class CustodianSessionStore {
     ) {
       return false;
     }
-    const generation = ++this.transcriptGeneration;
-    const result = await this.transcript.read(client);
-    // The request epoch fences session changes; this generation fences same-session Retry overlap.
-    if (
-      epoch !== this.requestEpoch ||
-      client !== this.activeClient ||
-      generation !== this.transcriptGeneration
-    ) {
+    const isCurrent = () => epoch === this.requestEpoch && client === this.activeClient;
+    const transcript = await this.transcript.loadMessages(
+      client,
+      epoch,
+      this.nextMessageId,
+      isCurrent,
+    );
+    if (!transcript) {
       return false;
     }
-    this.transcript.finish(result);
-    if (!result.ok) {
-      this.emit();
-      return false;
-    }
-    const transcript = createCustodianTranscriptMessages(result.turns, this.nextMessageId);
     [this.messages, this.nextMessageId] = [transcript.messages, transcript.nextMessageId];
     this.earlierBoundaryAfterId = this.messages.at(-1)?.id ?? null;
     this.emit();
@@ -639,24 +641,6 @@ export class CustodianSessionStore {
     this.earlierBoundaryAfterId = null;
   }
 
-  private appendAssistant(
-    reply: string,
-    question: CustodianStructuredQuestion | null,
-    step: WizardStep | null,
-  ): void {
-    this.messages = [
-      ...this.messages,
-      {
-        id: this.nextMessageId++,
-        role: "assistant",
-        text: reply,
-        at: Date.now(),
-        question,
-        step,
-      },
-    ];
-  }
-
   private async requestReply(
     client: GatewayBrowserClient,
     params: SystemAgentChatParams,
@@ -675,7 +659,7 @@ export class CustodianSessionStore {
     this.requestAbort?.abort();
     const requestAbort = new AbortController();
     this.requestAbort = requestAbort;
-    const epoch = ++this.requestEpoch;
+    const epoch = this.advanceRequestEpoch();
     let delivery: eventNudgeState.CustodianSendDelivery = "unsent";
     this.sending = true;
     this.error = null;
@@ -717,7 +701,13 @@ export class CustodianSessionStore {
       this.wizardSecretVisible = false;
       const silentReply = SILENT_REPLY_PATTERN.test(result.reply);
       if (!silentReply || question || step) {
-        this.appendAssistant(silentReply ? "" : result.reply, question, step);
+        const message = createCustodianAssistantMessage(
+          this.nextMessageId++,
+          silentReply ? "" : result.reply,
+          question,
+          step,
+        );
+        this.messages = [...this.messages, message];
       }
       if (result.action === "open-agent") {
         const handoff = await performCustodianAgentHandoff({

--- a/ui/src/pages/custodian/custodian-session-store.ts
+++ b/ui/src/pages/custodian/custodian-session-store.ts
@@ -80,6 +80,7 @@ export class CustodianSessionStore {
   // refresh and on any fresh mint.
   private rejoinBarrierPending = this.restoredIdentity.restored;
   private requestEpoch = 0;
+  private transcriptGeneration = 0;
   private requestAbort: AbortController | null = null;
   private nextMessageId = 1;
   private retryParams: SystemAgentChatParams | null = null;
@@ -602,8 +603,14 @@ export class CustodianSessionStore {
     ) {
       return false;
     }
+    const generation = ++this.transcriptGeneration;
     const result = await this.transcript.read(client);
-    if (epoch !== this.requestEpoch || client !== this.activeClient) {
+    // The request epoch fences session changes; this generation fences same-session Retry overlap.
+    if (
+      epoch !== this.requestEpoch ||
+      client !== this.activeClient ||
+      generation !== this.transcriptGeneration
+    ) {
       return false;
     }
     this.transcript.finish(result);

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -13,6 +13,7 @@ import {
   handleMarkdownTableInteraction,
   releaseMarkdownTables,
 } from "../../components/markdown-tables.ts";
+import { renderPanelRefreshStatus } from "../../components/panel-refresh-status.ts";
 import "../../components/openclaw-mascot.ts";
 import { t } from "../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -265,6 +266,11 @@ class CustodianSurface extends OpenClawLightDomElement {
                 <span>${t("custodian.connectionChanged")}</span>
               </div>`
             : nothing}
+          ${renderPanelRefreshStatus({
+            status: store.transcript.status,
+            onRetry: () => void store.refreshTranscriptIfIdle(),
+            className: "custodian__transcript-status",
+          })}
           ${store.error &&
           !(store.abandonedTurnOutcomeUnknown && store.error === t("custodian.connectionChanged"))
             ? html`<div class="custodian__error" role="alert">

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -269,6 +269,7 @@ class CustodianSurface extends OpenClawLightDomElement {
           ${renderPanelRefreshStatus({
             status: store.transcript.status,
             onRetry: () => void store.refreshTranscriptIfIdle(),
+            retryDisabled: !store.canRefreshTranscript(),
             className: "custodian__transcript-status",
           })}
           ${store.error &&

--- a/ui/src/pages/custodian/custodian-transcript-status.test.ts
+++ b/ui/src/pages/custodian/custodian-transcript-status.test.ts
@@ -1,0 +1,104 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { createContext, mountPage } from "./custodian-page.test-harness.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("custodian transcript status", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("continues to the welcome and retries when the bounded history request times out", async () => {
+    let historyCalls = 0;
+    const request = vi.fn(
+      async (method: string, _params?: unknown, options?: { timeoutMs?: number }) => {
+        if (method === "openclaw.chat.history") {
+          expect(options).toEqual({ timeoutMs: 15_000 });
+          historyCalls += 1;
+          if (historyCalls === 1) {
+            throw new Error("history request timed out");
+          }
+          return { turns: [{ role: "assistant", text: "Recovered history.", at: 1 }] };
+        }
+        return {
+          sessionId: "engine-session-after-history-timeout",
+          reply: "Welcome without history.",
+          action: "none",
+        };
+      },
+    );
+    const { context } = createContext(request, ["openclaw.chat", "openclaw.chat.history"]);
+    const { page } = await mountPage(context);
+
+    await waitForFast(() => expect(page.textContent).toContain("Welcome without history."));
+    const historyAlert = Array.from(page.querySelectorAll<HTMLElement>('[role="alert"]')).find(
+      (alert) => alert.textContent?.includes("history request timed out"),
+    );
+    expect(historyAlert).toBeDefined();
+    historyAlert?.querySelector<HTMLButtonElement>("button")?.click();
+    await waitForFast(() => expect(page.textContent).toContain("Recovered history."));
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "openclaw.chat.history",
+      "openclaw.chat",
+      "openclaw.chat.history",
+    ]);
+  });
+
+  it("disables retry until the welcome and active wizard settle", async () => {
+    const welcome = deferred<{
+      sessionId: string;
+      reply: string;
+      action: "none";
+      wizardInputPending: true;
+      step: { id: string; type: "text"; message: string };
+    }>();
+    const request = vi.fn((method: string) => {
+      if (method === "openclaw.chat.history") {
+        return Promise.reject(new Error("history unavailable"));
+      }
+      return welcome.promise;
+    });
+    const { context } = createContext(request, ["openclaw.chat", "openclaw.chat.history"]);
+    const { page } = await mountPage(context);
+
+    const retry = await waitForFast(() => {
+      const button = page.querySelector<HTMLButtonElement>(".custodian__transcript-status button");
+      expect(button).not.toBeNull();
+      return button!;
+    });
+    expect(retry.disabled).toBe(true);
+
+    welcome.resolve({
+      sessionId: "wizard-session",
+      reply: "Choose one.",
+      action: "none",
+      wizardInputPending: true,
+      step: { id: "choice", type: "text", message: "Continue?" },
+    });
+    await waitForFast(() => expect(page.querySelector(".custodian__wizard-step")).not.toBeNull());
+
+    expect(
+      page.querySelector<HTMLButtonElement>(".custodian__transcript-status button")?.disabled,
+    ).toBe(true);
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "openclaw.chat.history",
+      "openclaw.chat",
+    ]);
+  });
+});

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -5,6 +5,13 @@ import type {
 import { html, nothing } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { WizardStep } from "../../api/types.ts";
+import {
+  beginPanelRefresh,
+  completePanelRefresh,
+  createPanelRefreshStatus,
+  failPanelRefresh,
+  type PanelRefreshStatus,
+} from "../../components/panel-refresh-status.ts";
 import { renderWizardStepControls } from "../../components/wizard-step-controls.ts";
 import { t } from "../../i18n/index.ts";
 import type { MessageGroup } from "../../lib/chat/chat-types.ts";
@@ -73,21 +80,37 @@ function toCustodianMessageGroup(message: CustodianMessage): MessageGroup {
   };
 }
 
-export async function readCustodianTranscript(
-  client: GatewayBrowserClient,
-): Promise<SystemAgentChatHistoryResult["turns"] | null> {
-  try {
-    return (
-      await client.request<SystemAgentChatHistoryResult>(
+export class CustodianTranscriptLoader {
+  status: PanelRefreshStatus = createPanelRefreshStatus();
+
+  begin(): void {
+    this.status = beginPanelRefresh(this.status);
+  }
+
+  reset(): void {
+    this.status = createPanelRefreshStatus();
+  }
+
+  async read(
+    client: GatewayBrowserClient,
+  ): Promise<
+    { ok: true; turns: SystemAgentChatHistoryResult["turns"] } | { ok: false; error: string }
+  > {
+    this.begin();
+    try {
+      const result = await client.request<SystemAgentChatHistoryResult>(
         "openclaw.chat.history",
         {},
-        {
-          timeoutMs: CUSTODIAN_TRANSCRIPT_TIMEOUT_MS,
-        },
-      )
-    ).turns;
-  } catch {
-    return null;
+        { timeoutMs: CUSTODIAN_TRANSCRIPT_TIMEOUT_MS },
+      );
+      return { ok: true, turns: result.turns };
+    } catch (error) {
+      return { ok: false, error: custodianErrorMessage(error) };
+    }
+  }
+
+  finish(result: { ok: true } | { ok: false; error: string }): void {
+    this.status = result.ok ? completePanelRefresh() : failPanelRefresh(this.status, result.error);
   }
 }
 

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -32,6 +32,15 @@ export type CustodianMessage = {
   step: WizardStep | null;
 };
 
+export function createCustodianAssistantMessage(
+  id: number,
+  text: string,
+  question: CustodianStructuredQuestion | null,
+  step: WizardStep | null,
+): CustodianMessage {
+  return { id, role: "assistant", text, at: Date.now(), question, step };
+}
+
 export function hasUnresolvedCustodianQuestion(
   messages: readonly CustodianMessage[],
   dismissedQuestions: ReadonlySet<string>,
@@ -80,37 +89,92 @@ function toCustodianMessageGroup(message: CustodianMessage): MessageGroup {
   };
 }
 
+type CustodianTranscriptResult =
+  | { ok: true; turns: SystemAgentChatHistoryResult["turns"] }
+  | { ok: false; error: string };
+
+async function readCustodianTranscript(
+  client: GatewayBrowserClient,
+): Promise<CustodianTranscriptResult> {
+  try {
+    const result = await client.request<SystemAgentChatHistoryResult>(
+      "openclaw.chat.history",
+      {},
+      { timeoutMs: CUSTODIAN_TRANSCRIPT_TIMEOUT_MS },
+    );
+    return { ok: true, turns: result.turns };
+  } catch (error) {
+    return { ok: false, error: custodianErrorMessage(error) };
+  }
+}
+
 export class CustodianTranscriptLoader {
   status: PanelRefreshStatus = createPanelRefreshStatus();
+  private generation = 0;
+  private inFlight: {
+    client: GatewayBrowserClient;
+    epoch: number;
+    promise: Promise<CustodianTranscriptResult>;
+  } | null = null;
 
-  begin(): void {
-    this.status = beginPanelRefresh(this.status);
+  constructor(private readonly onStatusChange: () => void) {}
+
+  get refreshing(): boolean {
+    return this.inFlight !== null;
+  }
+
+  invalidate(): void {
+    this.generation += 1;
+    this.inFlight = null;
   }
 
   reset(): void {
+    this.invalidate();
     this.status = createPanelRefreshStatus();
   }
 
   async read(
     client: GatewayBrowserClient,
-  ): Promise<
-    { ok: true; turns: SystemAgentChatHistoryResult["turns"] } | { ok: false; error: string }
-  > {
-    this.begin();
+    epoch: number,
+    isCurrent: () => boolean,
+  ): Promise<CustodianTranscriptResult | null> {
+    const current = this.inFlight;
+    if (current && current.client === client && current.epoch === epoch) {
+      await current.promise;
+      return null;
+    }
+    const generation = ++this.generation;
+    this.status = beginPanelRefresh(this.status, { clearError: false });
+    const promise = readCustodianTranscript(client);
+    this.inFlight = { client, epoch, promise };
+    this.onStatusChange();
     try {
-      const result = await client.request<SystemAgentChatHistoryResult>(
-        "openclaw.chat.history",
-        {},
-        { timeoutMs: CUSTODIAN_TRANSCRIPT_TIMEOUT_MS },
-      );
-      return { ok: true, turns: result.turns };
-    } catch (error) {
-      return { ok: false, error: custodianErrorMessage(error) };
+      const result = await promise;
+      if (!isCurrent() || generation !== this.generation) {
+        return null;
+      }
+      this.status = result.ok
+        ? completePanelRefresh()
+        : failPanelRefresh(this.status, result.error);
+      return result;
+    } finally {
+      if (this.inFlight?.promise === promise) {
+        this.inFlight = null;
+        this.onStatusChange();
+      }
     }
   }
 
-  finish(result: { ok: true } | { ok: false; error: string }): void {
-    this.status = result.ok ? completePanelRefresh() : failPanelRefresh(this.status, result.error);
+  async loadMessages(
+    client: GatewayBrowserClient,
+    epoch: number,
+    firstMessageId: number,
+    isCurrent: () => boolean,
+  ): Promise<{ messages: CustodianMessage[]; nextMessageId: number } | null> {
+    const result = await this.read(client, epoch, isCurrent);
+    return result?.ok && isCurrent()
+      ? createCustodianTranscriptMessages(result.turns, firstMessageId)
+      : null;
   }
 }
 
@@ -122,7 +186,7 @@ export class CustodianTranscriptLoader {
  */
 const SERVER_SENSITIVE_MASK = "<redacted secret>";
 
-export function createCustodianTranscriptMessages(
+function createCustodianTranscriptMessages(
   turns: readonly SystemAgentChatHistoryTurn[],
   firstMessageId: number,
 ): { messages: CustodianMessage[]; nextMessageId: number } {

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -259,6 +259,7 @@ class LogsPage extends OpenClawLightDomElement {
   override render() {
     const body = renderLogs({
       loading: this.logsTask.status === TaskStatus.PENDING && !this.logsTaskQuiet,
+      refreshDisabled: !this.gateway.connected || this.logsTask.status === TaskStatus.PENDING,
       status: this.logsStatus,
       file: this.logsFile,
       entries: this.logsEntries,

--- a/ui/src/pages/logs/view.test.ts
+++ b/ui/src/pages/logs/view.test.ts
@@ -86,6 +86,15 @@ afterEach(async () => {
 });
 
 describe("renderLogs", () => {
+  it("does not claim the log is empty before the initial load completes", () => {
+    const container = document.createElement("div");
+
+    render(renderLogs(createProps({ loading: true, entries: [] })), container);
+
+    expect(container.textContent).not.toContain("No log entries.");
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+  });
+
   it("renders the subtitle under the section header", () => {
     const container = document.createElement("div");
 

--- a/ui/src/pages/logs/view.test.ts
+++ b/ui/src/pages/logs/view.test.ts
@@ -95,6 +95,15 @@ describe("renderLogs", () => {
     expect(container.querySelector('[role="status"]')).not.toBeNull();
   });
 
+  it("does not show loading when no initial request is pending", () => {
+    const container = document.createElement("div");
+
+    render(renderLogs(createProps({ loading: false, entries: [] })), container);
+
+    expect(container.textContent).not.toContain("No log entries.");
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
   it("renders the subtitle under the section header", () => {
     const container = document.createElement("div");
 

--- a/ui/src/pages/logs/view.test.ts
+++ b/ui/src/pages/logs/view.test.ts
@@ -24,6 +24,7 @@ function createLevelFilters(overrides: Partial<Record<LogLevel, boolean>> = {}) 
 function createProps(overrides: Partial<LogsProps> = {}): LogsProps {
   return {
     loading: false,
+    refreshDisabled: false,
     status: { error: null, hasLoaded: false, stale: false },
     file: null,
     entries: [
@@ -102,6 +103,27 @@ describe("renderLogs", () => {
 
     expect(container.textContent).not.toContain("No log entries.");
     expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it("disables refresh actions while the gateway cannot accept them", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderLogs(
+        createProps({
+          refreshDisabled: true,
+          status: { error: "logs unavailable", hasLoaded: false, stale: false },
+        }),
+      ),
+      container,
+    );
+
+    expect(
+      container.querySelector<HTMLButtonElement>(".settings-section__actions .btn")?.disabled,
+    ).toBe(true);
+    expect(
+      container.querySelector<HTMLButtonElement>(".logs-refresh-status button")?.disabled,
+    ).toBe(true);
   });
 
   it("renders the subtitle under the section header", () => {

--- a/ui/src/pages/logs/view.ts
+++ b/ui/src/pages/logs/view.ts
@@ -5,6 +5,7 @@ import {
   renderPanelRefreshStatus,
   type PanelRefreshStatus,
 } from "../../components/panel-refresh-status.ts";
+import { renderPanelState } from "../../components/panel-state.ts";
 import {
   renderSettingsEmpty,
   renderSettingsRow,
@@ -67,6 +68,22 @@ export function renderLogs(props: LogsProps) {
   });
   const exportFileLabel: ExportFileLabel = needle || levelFiltered ? "filtered" : "visible";
   const exportDisplayLabel = t(`gatewayLogs.exportLabels.${exportFileLabel}`);
+  const streamContent = !props.status.hasLoaded
+    ? props.status.error
+      ? nothing
+      : renderPanelState({ kind: "loading" })
+    : filtered.length === 0
+      ? renderSettingsEmpty(t("gatewayLogs.empty"))
+      : filtered.map(
+          (entry) => html`
+            <div class="log-row">
+              <div class="log-time mono">${formatLogTime(entry.time)}</div>
+              <div class="log-level ${entry.level ?? ""}">${entry.level ?? ""}</div>
+              <div class="log-subsystem mono">${entry.subsystem ?? ""}</div>
+              <div class="log-message mono">${entry.message ?? entry.raw}</div>
+            </div>
+          `,
+        );
 
   // The stream fills the remaining viewport height; the settings-page column
   // wrapper is intentionally skipped so the fill-height flex chain
@@ -143,20 +160,7 @@ export function renderLogs(props: LogsProps) {
             </div>
           `
         : nothing}
-      <div class="log-stream" @scroll=${props.onScroll}>
-        ${filtered.length === 0
-          ? renderSettingsEmpty(t("gatewayLogs.empty"))
-          : filtered.map(
-              (entry) => html`
-                <div class="log-row">
-                  <div class="log-time mono">${formatLogTime(entry.time)}</div>
-                  <div class="log-level ${entry.level ?? ""}">${entry.level ?? ""}</div>
-                  <div class="log-subsystem mono">${entry.subsystem ?? ""}</div>
-                  <div class="log-message mono">${entry.message ?? entry.raw}</div>
-                </div>
-              `,
-            )}
-      </div>
+      <div class="log-stream" @scroll=${props.onScroll}>${streamContent}</div>
     </div>
   `;
 }

--- a/ui/src/pages/logs/view.ts
+++ b/ui/src/pages/logs/view.ts
@@ -1,11 +1,11 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 // Control UI view renders logs screen content.
 import { html, nothing } from "lit";
+import { renderLoadingState } from "../../components/loading-state.ts";
 import {
   renderPanelRefreshStatus,
   type PanelRefreshStatus,
 } from "../../components/panel-refresh-status.ts";
-import { renderPanelState } from "../../components/panel-state.ts";
 import {
   renderSettingsEmpty,
   renderSettingsRow,
@@ -21,6 +21,7 @@ type ExportFileLabel = "filtered" | "visible";
 
 type LogsProps = {
   loading: boolean;
+  refreshDisabled: boolean;
   status: PanelRefreshStatus;
   file: string | null;
   entries: LogEntry[];
@@ -70,7 +71,7 @@ export function renderLogs(props: LogsProps) {
   const exportDisplayLabel = t(`gatewayLogs.exportLabels.${exportFileLabel}`);
   const streamContent = !props.status.hasLoaded
     ? props.loading
-      ? renderPanelState({ kind: "loading" })
+      ? renderLoadingState()
       : nothing
     : filtered.length === 0
       ? renderSettingsEmpty(t("gatewayLogs.empty"))
@@ -92,7 +93,7 @@ export function renderLogs(props: LogsProps) {
     <div class="settings-section__header">
       <h2 class="settings-section__heading">${t("gatewayLogs.title")}</h2>
       <div class="settings-section__actions">
-        <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
+        <button class="btn" ?disabled=${props.refreshDisabled} @click=${props.onRefresh}>
           ${props.loading ? t("common.loading") : t("common.refresh")}
         </button>
         <button
@@ -112,6 +113,7 @@ export function renderLogs(props: LogsProps) {
     ${renderPanelRefreshStatus({
       status: props.status,
       onRetry: props.onRefresh,
+      retryDisabled: props.refreshDisabled,
       className: "logs-refresh-status",
     })}
     <div class="settings-group logs-card">

--- a/ui/src/pages/logs/view.ts
+++ b/ui/src/pages/logs/view.ts
@@ -69,9 +69,9 @@ export function renderLogs(props: LogsProps) {
   const exportFileLabel: ExportFileLabel = needle || levelFiltered ? "filtered" : "visible";
   const exportDisplayLabel = t(`gatewayLogs.exportLabels.${exportFileLabel}`);
   const streamContent = !props.status.hasLoaded
-    ? props.status.error
-      ? nothing
-      : renderPanelState({ kind: "loading" })
+    ? props.loading
+      ? renderPanelState({ kind: "loading" })
+      : nothing
     : filtered.length === 0
       ? renderSettingsEmpty(t("gatewayLogs.empty"))
       : filtered.map(


### PR DESCRIPTION
Closes #128667
Closes #128668

## What Problem This Solves

Fixes two cases where the Control UI presented missing data as an authoritative empty result:

- Logs displayed “No log entries.” while the initial `logs.tail` request was still pending.
- Custodian discarded `openclaw.chat.history` failures, continued to the normal welcome, and gave operators no indication that durable conversation history was unavailable.

Pre-fix reproductions:

```shell
node scripts/run-vitest.mjs ui/src/pages/logs/view.test.ts -t 'does not claim the log is empty before the initial load completes'
node scripts/run-vitest.mjs ui/src/pages/custodian/custodian-transcript-status.test.ts -t 'continues to the welcome and retries when the bounded history request times out'
```

Both tests fail before the fix. Logs receives `loading: true`, `hasLoaded: false`, and `entries: []`, but renders “No log entries.” Custodian rejects the history RPC, renders the welcome, and has no history-owned alert or Retry control.

## Why This Change Was Made

The fix is rebased directly onto `main` and uses its existing loading and `PanelRefreshStatus` primitives.

Logs derives initial loading from the actual `TaskStatus.PENDING` fact and reserves the empty state for a completed load. Custodian's transcript loader owns the bounded RPC, refresh status, single-flight request, and generation invalidation; the session store supplies the current request-epoch/client predicate before any result may replace rows or status. Retry remains visible but disabled while chat is sending, a wizard/question is unresolved, the Gateway is unavailable, or a transcript refresh is already in flight.

No Gateway protocol, persistence, timeout, polling, fallback, or compatibility behavior changed. A successful `{ turns: [] }` remains the only authoritative empty-history response.

Historical decisions preserved:

- #111440 introduced bounded durable transcript loading and required transient history failure not to block Custodian chat.
- #115720 established that settled Custodian startup failures remain visible rather than presenting an apparently empty surface.
- #108689 established owner-local `PanelRefreshStatus`, stale-data retention, and targeted Retry.

Blast radius checked: initial Logs load, unloaded idle/disconnected state, quiet polling, loaded-row refresh, filtered-empty results, read-scope failures, Custodian cold startup, retained transcript refresh, concurrent Retry, user-turn invalidation, reconnect/client replacement, rejoin barrier refresh, missing history method, stale request epochs, wizard/question idle gates, and successful empty history.

## User Impact

Operators opening Logs see loading until the first request settles; “No log entries.” now means the Gateway successfully returned no lines. Refresh controls are disabled when disconnected or while a request is pending.

Custodian continues to welcome and accept input when durable history fails, but now reports the history failure with an actionable Retry. Previously loaded transcript rows remain visible and are marked stale until a successful retry replaces them.

## Evidence

Regression proof before the fix:

```text
Logs: expected pending output not to contain 'No log entries.'; assertion failed.
Custodian: expected a history timeout alert to be defined; received undefined.
```

Validation on head `1438b0eafbf44cac4bc1ff821176f79f1fb08071`:

- `node scripts/run-vitest.mjs ui/src/components/panel-refresh-status.test.ts ui/src/pages/logs/view.test.ts ui/src/pages/logs/logs-page.test.ts ui/src/pages/custodian/custodian-page.test.ts ui/src/pages/custodian/custodian-session-store.test.ts ui/src/pages/custodian/custodian-transcript-status.test.ts` — 70 passed.
- `node scripts/check-changed.mjs -- <11 changed UI files>` — passed, including formatting, i18n verification, dead exports, core-test/UI typechecks, lint, and style checks.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking high --max-priority P1` — clean; no accepted/actionable findings, confidence 0.89; TruffleHog clean.

The mocked-browser deferred-response controller could not preserve the deferred history RPC across the reconnect required by this scenario, so no screenshot/video is claimed. Deterministic page/store boundary tests exercise the rendered failure/Retry states, pending Logs projection, request count, and stale-response fencing.

Production LOC: +172/-66 (net +106). Tests: +242/-30 (net +212). Production growth adds an explicit transcript read result, owner-scoped status/single-flight lifecycle, and actionable refresh-state wiring; it replaces the prior silent-null and overlapping-request paths rather than adding a compatibility path.
