### PR TITLE
fix(telegram): remove stale buttons after model selection

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback-actions.ts
+++ b/extensions/telegram/src/bot-handlers.callback-actions.ts
@@ -107,7 +107,7 @@ export function createTelegramCallbackMessageActions(params: {
     extra?: { parse_mode?: "HTML" | "Markdown" | "MarkdownV2" },
   ) => {
     const keyboard = buildInlineKeyboard(buttons);
-    const editParams = keyboard ? { reply_markup: keyboard, ...extra } : extra;
+    const editParams = { reply_markup: keyboard ?? { inline_keyboard: [] }, ...extra };
     try {
       await editCallbackMessage(text, editParams);
     } catch (editErr) {

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2858,6 +2858,7 @@ describe("createTelegramBot", () => {
       `${CHECK_MARK_EMOJI} Model changed to <b>openai/gpt-5.4</b>\n\nSession-only model selection. Runtime unchanged. Use /model openai/gpt-5.4 --runtime &lt;runtime&gt; -s to switch harnesses. The agent default in openclaw.json is unchanged. This chat keeps the model selection across /new and /reset; use /model default -s to clear the session model selection.`,
     );
     expect(requireRecord(editCall[3], "edit params").parse_mode).toBe("HTML");
+    expect(requireRecord(editCall[3], "edit params").reply_markup).toEqual({ inline_keyboard: [] });
 
     const entry = readOnlySessionEntry(storePath);
     expect(entry?.providerOverride).toBe("openai");

--- a/extensions/telegram/src/transport-payload.test.ts
+++ b/extensions/telegram/src/transport-payload.test.ts
@@ -367,6 +367,10 @@ describe("Telegram topic transport payloads", () => {
 
     try {
       await actions.editCallbackMessageWithButtons("Replacement", []);
+      expect(editMessage).toHaveBeenCalledWith(DIRECT_CHAT_ID, 41, "Replacement", {
+        business_connection_id: "business-media-1",
+        reply_markup: { inline_keyboard: [] },
+      });
     } finally {
       editMessage.mockRestore();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting a Telegram model would continue to see and be able to press the previous inline picker buttons after the selection had already completed. The same stale controls remained visible for terminal provider, unavailable-model, and model-selection failure outcomes.

## Why This Change Was Made

Telegram distinguishes an omitted keyboard, which preserves existing controls, from an explicitly empty keyboard, which removes them. The private callback-message owner now always translates the already-required empty button list into Telegram's existing empty-keyboard contract when editing terminal messages. This is a one-line, production-net-zero repair; active nonempty keyboards, HTML formatting, business connection identity, topic routing, fallback replacement-message payloads, authorization, and public APIs remain unchanged.

## User Impact

Completed Telegram model and provider picker messages now remove obsolete buttons immediately instead of presenting clickable controls that no longer match their final state. Business-message callbacks receive the same correction without changing their established deletion, replacement, or topic-routing behavior.

## Evidence

- Real model-selection regression before the fix: the existing Telegram bot integration test expected an empty keyboard but received no keyboard update; after the fix it passes while preserving HTML formatting.
- Real business-callback regression before the fix: the existing transport test received only its business connection identity instead of an explicit empty keyboard; after the fix it passes and still verifies the unchanged replacement-message request and direct-message topic.
- Full focused Telegram owner and sibling coverage: **571 passing tests across six suites**, including bot callbacks, model pickers, business transport, pagination, outbound delivery, and command keyboards.
- Both regression cases were independently rerun successfully; independent review and authenticated pre-commit and exact-commit reviews reported no actionable findings.
- Production delta: **one line replaced, zero net production lines**; regression coverage extends existing tests by five lines.
- Live Telegram/Desktop proof is infeasible for this isolated maintenance run because it would require access to an operator-owned live bot, credentials, and chat; the checked-in bot and real provider-transport request boundaries exercise the actual callback and serialized payload paths.
