### PR TITLE
fix(codex): restore after hook for intercepted patches

### DIFF
--- a/extensions/codex/src/app-server/event-projector-after-tool-call.ts
+++ b/extensions/codex/src/app-server/event-projector-after-tool-call.ts
@@ -1,0 +1,123 @@
+import {
+  runAgentHarnessAfterToolCallHook,
+  type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
+import {
+  itemName,
+  itemStatus,
+  shouldSynthesizeToolProgressForItem,
+} from "./event-projector-items.js";
+import type { CodexAppServerEventProjectorOptions } from "./event-projector-options.js";
+import {
+  isNativePostToolUseRelayItem,
+  itemToolArgs,
+  itemToolError,
+  itemToolResult,
+} from "./event-projector-tool-items.js";
+import type { CodexToolProgressProjection } from "./event-projector-tool-progress.js";
+import type { CodexThreadItem } from "./protocol.js";
+
+export class CodexAfterToolCallProjection {
+  private readonly observedItemIds = new Set<string>();
+  private readonly pendingFileChanges = new Map<string, CodexThreadItem>();
+
+  constructor(
+    private readonly params: EmbeddedRunAttemptParams,
+    private readonly progress: CodexToolProgressProjection,
+    private readonly options: CodexAppServerEventProjectorOptions = {},
+  ) {}
+
+  emit(item: CodexThreadItem): void {
+    if (
+      item.type === "fileChange" &&
+      this.options.nativePostToolUseRelayEnabled &&
+      !this.observedItemIds.has(item.id)
+    ) {
+      const coverage =
+        this.options.resolveNativeFileChangeAfterToolCallCoverage?.(item.id) ?? "pending";
+
+      if (coverage === "native_apply_patch") {
+        this.observedItemIds.add(item.id);
+        return;
+      }
+
+      if (coverage === "pending") {
+        this.pendingFileChanges.set(item.id, item);
+        return;
+      }
+    }
+
+    this.emitNow(item);
+  }
+
+  settlePendingFileChanges(options?: { finalize?: boolean }): void {
+    for (const [itemId, item] of this.pendingFileChanges) {
+      const coverage =
+        this.options.resolveNativeFileChangeAfterToolCallCoverage?.(itemId) ?? "pending";
+
+      if (coverage === "native_apply_patch") {
+        this.observedItemIds.add(itemId);
+        this.pendingFileChanges.delete(itemId);
+        continue;
+      }
+
+      if (coverage === "intercepted" || options?.finalize === true) {
+        this.pendingFileChanges.delete(itemId);
+        this.emitNow(item);
+      }
+    }
+  }
+
+  private emitNow(item: CodexThreadItem): void {
+    if (!this.shouldEmit(item)) {
+      return;
+    }
+
+    const name = itemName(item);
+    const status = itemStatus(item);
+    if (!name || status === "running") {
+      return;
+    }
+
+    this.observedItemIds.add(item.id);
+    const result = itemToolResult(item).result;
+    const error =
+      this.progress.approvalTimeoutExplanation(item.id, status) ??
+      itemToolError(item, status, this.progress.outputTextByItem);
+    const startedAt = resolveStartedAtFromDurationMs(item.durationMs);
+    const hookParams = {
+      toolName: name,
+      toolCallId: item.id,
+      runId: this.params.runId,
+      agentId: this.params.agentId,
+      sessionId: this.params.sessionId,
+      sessionKey: this.params.sessionKey,
+      startArgs: itemToolArgs(item) ?? {},
+      ...(result !== undefined ? { result } : {}),
+      ...(error ? { error } : {}),
+      ...(startedAt !== undefined ? { startedAt } : {}),
+    };
+
+    setImmediate(() => {
+      void runAgentHarnessAfterToolCallHook(hookParams);
+    });
+  }
+
+  private shouldEmit(item: CodexThreadItem): boolean {
+    if (!shouldSynthesizeToolProgressForItem(item) || this.observedItemIds.has(item.id)) {
+      return false;
+    }
+    if (!this.options.nativePostToolUseRelayEnabled || item.type === "fileChange") {
+      return true;
+    }
+    return !isNativePostToolUseRelayItem(item);
+  }
+}
+
+function resolveStartedAtFromDurationMs(durationMs: unknown): number | undefined {
+  if (typeof durationMs !== "number" || !Number.isFinite(durationMs)) {
+    return undefined;
+  }
+  return asDateTimestampMs(Date.now() - Math.max(0, durationMs));
+}

--- a/extensions/codex/src/app-server/event-projector-options.ts
+++ b/extensions/codex/src/app-server/event-projector-options.ts
@@ -9,6 +9,9 @@ export type CodexAsyncDeliverySettlement = "settled" | "retry";
 export type CodexAppServerEventProjectorOptions = {
   initialContextTokens?: number;
   nativePostToolUseRelayEnabled?: boolean;
+  resolveNativeFileChangeAfterToolCallCoverage?: (
+    toolUseId: string,
+  ) => "native_apply_patch" | "intercepted" | "pending";
   asyncUserMessageAllowed?: boolean;
   onAsyncDelivery?: (delivery: {
     itemId: string;

--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -1,26 +1,23 @@
 import path from "node:path";
 import {
   embeddedAgentLog,
-  runAgentHarnessAfterToolCallHook,
   type AgentMessage,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { Usage } from "openclaw/plugin-sdk/llm";
-import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
+import { CodexAfterToolCallProjection } from "./event-projector-after-tool-call.js";
 import {
   isMutatingNativeToolItem,
   isNonSuccessItemStatus,
   itemName,
   itemStatus,
   shouldRecordNativeToolTranscript,
-  shouldSynthesizeToolProgressForItem,
 } from "./event-projector-items.js";
+import type { CodexAppServerEventProjectorOptions } from "./event-projector-options.js";
 import {
-  isNativePostToolUseRelayItem,
   itemMeta,
   itemOutputText,
   itemToolArgs,
-  itemToolError,
   itemToolResult,
   itemTranscriptResultText,
 } from "./event-projector-tool-items.js";
@@ -44,7 +41,6 @@ import {
 } from "./protocol.js";
 import { readCodexMirroredSessionHistoryMessages } from "./session-history.js";
 import { sanitizeCodexToolArguments } from "./tool-progress-normalization.js";
-import type { CodexTrajectoryRecorder } from "./trajectory.js";
 import type { CodexTranscriptCheckpointEntry } from "./transcript-checkpoint.js";
 import { attachCodexMirrorIdentity } from "./upstream-prompt-provenance.js";
 
@@ -145,8 +141,7 @@ export class CodexToolTranscriptProjection {
   private readonly trajectoryResultIds = new Set<string>();
   private readonly trajectoryNamesById = new Map<string, string>();
   private readonly trajectoryItemsById = new Map<string, CodexThreadItem>();
-  private readonly afterToolCallObservedItemIds = new Set<string>();
-  private readonly pendingFileChangeAfterToolCallObservations = new Map<string, CodexThreadItem>();
+  private readonly afterToolCall: CodexAfterToolCallProjection;
   private readonly nativeMcpAppResultDetails = new Map<string, unknown>();
   private readonly nativeMcpAppResultDetailsAttempted = new Set<string>();
   private readonly approvalReviewsByCallId = new Map<string, ToolApprovalReviewState>();
@@ -160,16 +155,12 @@ export class CodexToolTranscriptProjection {
     private readonly turnId: string,
     private readonly progress: CodexToolProgressProjection,
     private readonly nextTranscriptTimestamp: () => number,
-    private readonly options: {
-      nativePostToolUseRelayEnabled?: boolean;
-      resolveNativeFileChangeAfterToolCallCoverage?: (
-        toolUseId: string,
-      ) => "native_apply_patch" | "intercepted" | "pending";
-      prepareNativeMcpAppResultDetails?: (item: CodexThreadItem) => Promise<unknown>;
-      trajectoryRecorder?: CodexTrajectoryRecorder | null;
+    private readonly options: CodexAppServerEventProjectorOptions & {
       checkpointMessage?: (entry: CodexTranscriptCheckpointEntry) => void;
     } = {},
-  ) {}
+  ) {
+    this.afterToolCall = new CodexAfterToolCallProjection(params, progress, options);
+  }
 
   get transcriptMessages(): readonly AgentMessage[] {
     return this.messages;
@@ -503,83 +494,11 @@ export class CodexToolTranscriptProjection {
   }
 
   emitAfterToolCallObservation(item: CodexThreadItem): void {
-    if (
-      item.type === "fileChange" &&
-      this.options.nativePostToolUseRelayEnabled &&
-      !this.afterToolCallObservedItemIds.has(item.id)
-    ) {
-      const coverage =
-        this.options.resolveNativeFileChangeAfterToolCallCoverage?.(item.id) ?? "pending";
-
-      if (coverage === "native_apply_patch") {
-        this.afterToolCallObservedItemIds.add(item.id);
-        return;
-      }
-
-      if (coverage === "pending") {
-        this.pendingFileChangeAfterToolCallObservations.set(item.id, item);
-        return;
-      }
-    }
-
-    this.emitAfterToolCallObservationNow(item);
+    this.afterToolCall.emit(item);
   }
 
   settlePendingFileChangeAfterToolCallObservations(options?: { finalize?: boolean }): void {
-    for (const [itemId, item] of this.pendingFileChangeAfterToolCallObservations) {
-      const coverage =
-        this.options.resolveNativeFileChangeAfterToolCallCoverage?.(itemId) ?? "pending";
-
-      if (coverage === "native_apply_patch") {
-        this.afterToolCallObservedItemIds.add(itemId);
-        this.pendingFileChangeAfterToolCallObservations.delete(itemId);
-        continue;
-      }
-
-      if (coverage === "intercepted" || options?.finalize === true) {
-        this.pendingFileChangeAfterToolCallObservations.delete(itemId);
-        this.emitAfterToolCallObservationNow(item);
-      }
-    }
-  }
-
-  private emitAfterToolCallObservationNow(item: CodexThreadItem): void {
-    if (!this.shouldEmitAfterToolCallObservation(item)) {
-      return;
-    }
-
-    const name = itemName(item);
-    const status = itemStatus(item);
-
-    if (!name || status === "running") {
-      return;
-    }
-
-    this.afterToolCallObservedItemIds.add(item.id);
-
-    const result = itemToolResult(item).result;
-    const error =
-      this.progress.approvalTimeoutExplanation(item.id, status) ??
-      itemToolError(item, status, this.progress.outputTextByItem);
-
-    const startedAt = resolveStartedAtFromDurationMs(item.durationMs);
-
-    const hookParams = {
-      toolName: name,
-      toolCallId: item.id,
-      runId: this.params.runId,
-      agentId: this.params.agentId,
-      sessionId: this.params.sessionId,
-      sessionKey: this.params.sessionKey,
-      startArgs: itemToolArgs(item) ?? {},
-      ...(result !== undefined ? { result } : {}),
-      ...(error ? { error } : {}),
-      ...(startedAt !== undefined ? { startedAt } : {}),
-    };
-
-    setImmediate(() => {
-      void runAgentHarnessAfterToolCallHook(hookParams);
-    });
+    this.afterToolCall.settlePendingFileChanges(options);
   }
 
   synthesizeMissingToolResults(params: {
@@ -713,24 +632,6 @@ export class CodexToolTranscriptProjection {
     });
   }
 
-  private shouldEmitAfterToolCallObservation(item: CodexThreadItem): boolean {
-    if (
-      !shouldSynthesizeToolProgressForItem(item) ||
-      this.afterToolCallObservedItemIds.has(item.id)
-    ) {
-      return false;
-    }
-    if (!this.options.nativePostToolUseRelayEnabled) {
-      return true;
-    }
-
-    if (item.type === "fileChange") {
-      return true;
-    }
-
-    return !isNativePostToolUseRelayItem(item);
-  }
-
   private createToolCallMessage(params: ToolTranscriptCallInput): AgentMessage {
     const args = normalizeToolTranscriptArguments(params.arguments);
     const attribution = resolveCodexLocalRuntimeAttribution(this.params);
@@ -785,11 +686,4 @@ function formatMissingToolResultError(params: { id: string; name: string }): str
 
 function toolResultStatusText(params: ToolTranscriptResultInput): string {
   return params.isError ? `${params.name} failed` : `${params.name} completed`;
-}
-
-function resolveStartedAtFromDurationMs(durationMs: unknown): number | undefined {
-  if (typeof durationMs !== "number" || !Number.isFinite(durationMs)) {
-    return undefined;
-  }
-  return asDateTimestampMs(Date.now() - Math.max(0, durationMs));
 }

--- a/extensions/codex/src/app-server/event-projector-tool-transcript.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-transcript.ts
@@ -146,6 +146,7 @@ export class CodexToolTranscriptProjection {
   private readonly trajectoryNamesById = new Map<string, string>();
   private readonly trajectoryItemsById = new Map<string, CodexThreadItem>();
   private readonly afterToolCallObservedItemIds = new Set<string>();
+  private readonly pendingFileChangeAfterToolCallObservations = new Map<string, CodexThreadItem>();
   private readonly nativeMcpAppResultDetails = new Map<string, unknown>();
   private readonly nativeMcpAppResultDetailsAttempted = new Set<string>();
   private readonly approvalReviewsByCallId = new Map<string, ToolApprovalReviewState>();
@@ -161,6 +162,9 @@ export class CodexToolTranscriptProjection {
     private readonly nextTranscriptTimestamp: () => number,
     private readonly options: {
       nativePostToolUseRelayEnabled?: boolean;
+      resolveNativeFileChangeAfterToolCallCoverage?: (
+        toolUseId: string,
+      ) => "native_apply_patch" | "intercepted" | "pending";
       prepareNativeMcpAppResultDetails?: (item: CodexThreadItem) => Promise<unknown>;
       trajectoryRecorder?: CodexTrajectoryRecorder | null;
       checkpointMessage?: (entry: CodexTranscriptCheckpointEntry) => void;
@@ -499,20 +503,67 @@ export class CodexToolTranscriptProjection {
   }
 
   emitAfterToolCallObservation(item: CodexThreadItem): void {
+    if (
+      item.type === "fileChange" &&
+      this.options.nativePostToolUseRelayEnabled &&
+      !this.afterToolCallObservedItemIds.has(item.id)
+    ) {
+      const coverage =
+        this.options.resolveNativeFileChangeAfterToolCallCoverage?.(item.id) ?? "pending";
+
+      if (coverage === "native_apply_patch") {
+        this.afterToolCallObservedItemIds.add(item.id);
+        return;
+      }
+
+      if (coverage === "pending") {
+        this.pendingFileChangeAfterToolCallObservations.set(item.id, item);
+        return;
+      }
+    }
+
+    this.emitAfterToolCallObservationNow(item);
+  }
+
+  settlePendingFileChangeAfterToolCallObservations(options?: { finalize?: boolean }): void {
+    for (const [itemId, item] of this.pendingFileChangeAfterToolCallObservations) {
+      const coverage =
+        this.options.resolveNativeFileChangeAfterToolCallCoverage?.(itemId) ?? "pending";
+
+      if (coverage === "native_apply_patch") {
+        this.afterToolCallObservedItemIds.add(itemId);
+        this.pendingFileChangeAfterToolCallObservations.delete(itemId);
+        continue;
+      }
+
+      if (coverage === "intercepted" || options?.finalize === true) {
+        this.pendingFileChangeAfterToolCallObservations.delete(itemId);
+        this.emitAfterToolCallObservationNow(item);
+      }
+    }
+  }
+
+  private emitAfterToolCallObservationNow(item: CodexThreadItem): void {
     if (!this.shouldEmitAfterToolCallObservation(item)) {
       return;
     }
+
     const name = itemName(item);
     const status = itemStatus(item);
+
     if (!name || status === "running") {
       return;
     }
+
     this.afterToolCallObservedItemIds.add(item.id);
+
     const result = itemToolResult(item).result;
     const error =
       this.progress.approvalTimeoutExplanation(item.id, status) ??
       itemToolError(item, status, this.progress.outputTextByItem);
+
     const startedAt = resolveStartedAtFromDurationMs(item.durationMs);
+
     const hookParams = {
       toolName: name,
       toolCallId: item.id,
@@ -525,6 +576,7 @@ export class CodexToolTranscriptProjection {
       ...(error ? { error } : {}),
       ...(startedAt !== undefined ? { startedAt } : {}),
     };
+
     setImmediate(() => {
       void runAgentHarnessAfterToolCallHook(hookParams);
     });
@@ -668,7 +720,15 @@ export class CodexToolTranscriptProjection {
     ) {
       return false;
     }
-    return !(this.options.nativePostToolUseRelayEnabled && isNativePostToolUseRelayItem(item));
+    if (!this.options.nativePostToolUseRelayEnabled) {
+      return true;
+    }
+
+    if (item.type === "fileChange") {
+      return true;
+    }
+
+    return !isNativePostToolUseRelayItem(item);
   }
 
   private createToolCallMessage(params: ToolTranscriptCallInput): AgentMessage {

--- a/extensions/codex/src/app-server/event-projector.native-hooks.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-hooks.test.ts
@@ -180,6 +180,199 @@ describe("CodexAppServerEventProjector native tool hook projection", () => {
     });
   });
 
+  it("waits for native apply_patch PostToolUse before suppressing direct FileChange AFTER", async () => {
+    const afterToolCall = vi.fn();
+    let coverage: "native_apply_patch" | "intercepted" | "pending" = "pending";
+
+    const resolveNativeFileChangeAfterToolCallCoverage = vi.fn(() => coverage);
+
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "after_tool_call",
+          handler: afterToolCall,
+        },
+      ]),
+    );
+
+    const projector = await createProjector(
+      {
+        ...(await createParams()),
+        sessionKey: "agent:main:session-1",
+      },
+      {
+        nativePostToolUseRelayEnabled: true,
+        resolveNativeFileChangeAfterToolCallCoverage,
+      },
+    );
+
+    const changes = [
+      {
+        path: "direct.txt",
+        kind: { type: "add" },
+      },
+    ];
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "fileChange",
+          id: "patch-direct",
+          changes,
+          status: "completed",
+        },
+      }),
+    );
+
+    expect(afterToolCall).not.toHaveBeenCalled();
+
+    coverage = "native_apply_patch";
+
+    await projector.handleNotification(
+      forCurrentTurn("hook/completed", {
+        run: {
+          id: "hook-direct",
+          eventName: "postToolUse",
+          handlerType: "command",
+          executionMode: "sync",
+          scope: "turn",
+          source: "project",
+          sourcePath: "/repo/.codex/hooks.json",
+          status: "completed",
+          statusMessage: null,
+          durationMs: 1,
+          entries: [],
+        },
+      }),
+    );
+
+    expect(resolveNativeFileChangeAfterToolCallCoverage).toHaveBeenCalledWith("patch-direct");
+
+    expect(afterToolCall).not.toHaveBeenCalled();
+  });
+
+  it("synthesizes apply_patch AFTER immediately for an intercepted FileChange", async () => {
+    const afterToolCall = vi.fn();
+
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "after_tool_call",
+          handler: afterToolCall,
+        },
+      ]),
+    );
+
+    const projector = await createProjector(
+      {
+        ...(await createParams()),
+        sessionKey: "agent:main:session-1",
+      },
+      {
+        nativePostToolUseRelayEnabled: true,
+        resolveNativeFileChangeAfterToolCallCoverage: () => "intercepted",
+      },
+    );
+
+    const changes = [
+      {
+        path: "intercepted.txt",
+        kind: { type: "add" },
+      },
+    ];
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "fileChange",
+          id: "patch-intercepted",
+          changes,
+          status: "completed",
+        },
+      }),
+    );
+
+    await vi.waitFor(() => expect(afterToolCall).toHaveBeenCalledTimes(1));
+
+    const event = requireRecord(
+      mockCallArg(afterToolCall, 0, 0, "after_tool_call event"),
+      "after_tool_call event",
+    );
+
+    expect(event.toolName).toBe("apply_patch");
+    expect(event.toolCallId).toBe("patch-intercepted");
+    expect(event.params).toEqual({ changes });
+    expect(event.result).toEqual({
+      status: "completed",
+      changes,
+    });
+  });
+
+  it("falls back to one synthetic FileChange AFTER at turn completion", async () => {
+    const afterToolCall = vi.fn();
+
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "after_tool_call",
+          handler: afterToolCall,
+        },
+      ]),
+    );
+
+    const projector = await createProjector(
+      {
+        ...(await createParams()),
+        sessionKey: "agent:main:session-1",
+      },
+      {
+        nativePostToolUseRelayEnabled: true,
+        resolveNativeFileChangeAfterToolCallCoverage: () => "pending",
+      },
+    );
+
+    const changes = [
+      {
+        path: "fallback.txt",
+        kind: { type: "add" },
+      },
+    ];
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "fileChange",
+          id: "patch-fallback",
+          changes,
+          status: "completed",
+        },
+      }),
+    );
+
+    expect(afterToolCall).not.toHaveBeenCalled();
+
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [],
+          error: null,
+        },
+      }),
+    );
+
+    await vi.waitFor(() => expect(afterToolCall).toHaveBeenCalledTimes(1));
+
+    const event = requireRecord(
+      mockCallArg(afterToolCall, 0, 0, "after_tool_call event"),
+      "after_tool_call event",
+    );
+
+    expect(event.toolName).toBe("apply_patch");
+    expect(event.toolCallId).toBe("patch-fallback");
+  });
+
   it("uses Codex web search action metadata when the top-level query is empty", async () => {
     const afterToolCall = vi.fn();
     initializeGlobalHookRunner(

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -130,11 +130,7 @@ export class CodexAppServerEventProjector {
       this.toolProgressProjection,
       this.transcriptCheckpoint.nextTimestamp,
       {
-        nativePostToolUseRelayEnabled: options.nativePostToolUseRelayEnabled,
-        resolveNativeFileChangeAfterToolCallCoverage:
-          options.resolveNativeFileChangeAfterToolCallCoverage,
-        prepareNativeMcpAppResultDetails: options.prepareNativeMcpAppResultDetails,
-        trajectoryRecorder: options.trajectoryRecorder,
+        ...options,
         checkpointMessage: this.transcriptCheckpoint.enqueue,
       },
     );

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -49,7 +49,6 @@ import type { CodexApprovalKind } from "./plugin-approval-roundtrip.js";
 import { readCodexTurn } from "./protocol-validators.js";
 import {
   isJsonObject,
-  type CodexDynamicToolCallOutputContentItem,
   type CodexServerNotification,
   type CodexThreadItem,
   type CodexTurn,
@@ -62,6 +61,10 @@ import { createCodexUsageLimitPromptError } from "./usage-limit-error.js";
 
 export { shouldEmitTranscriptToolProgress } from "./event-projector-tool-progress.js";
 
+type DynamicToolResultParams = Parameters<
+  CodexToolProgressProjection["recordDynamicToolResult"]
+>[0] &
+  Parameters<CodexToolTranscriptProjection["recordDynamicToolResult"]>[0];
 export class CodexAppServerEventProjector {
   readonly transcriptCheckpoint: CodexTranscriptCheckpoint;
   private readonly asyncDeliveryProjection: CodexAsyncDeliveryProjection;
@@ -441,17 +444,7 @@ export class CodexAppServerEventProjector {
     }
   }
 
-  recordDynamicToolResult(params: {
-    callId: string;
-    tool: string;
-    asyncStarted?: boolean;
-    terminalResolution?: ReturnType<NonNullable<EmbeddedRunAttemptParams["observeToolTerminal"]>>;
-    success: boolean;
-    terminalType?: "blocked" | "completed" | "error";
-    sideEffectEvidence?: boolean;
-    contentItems: CodexDynamicToolCallOutputContentItem[];
-    details?: unknown;
-  }): void {
+  recordDynamicToolResult(params: DynamicToolResultParams): void {
     this.toolProgressProjection.recordDynamicToolResult(params);
     const source = this.options.resolveDynamicToolResultContentSource?.(params.tool);
     this.toolTranscriptProjection.recordDynamicToolResult(params, source);

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -348,9 +348,7 @@ export class CodexAppServerEventProjector {
         break;
       case "turn/completed":
         await this.handleTurnCompleted(params);
-        this.toolTranscriptProjection.settlePendingFileChangeAfterToolCallObservations({
-          finalize: true,
-        });
+        this.finalizePendingFileChangeAfterToolCallObservations();
         break;
       case "rawResponse/completed":
         this.responseCompletions.record(params);
@@ -391,6 +389,12 @@ export class CodexAppServerEventProjector {
         this.diagnostics.warnUnknownEvent(notification, params);
         break;
     }
+  }
+
+  finalizePendingFileChangeAfterToolCallObservations(): void {
+    this.toolTranscriptProjection.settlePendingFileChangeAfterToolCallObservations({
+      finalize: true,
+    });
   }
 
   buildResult(

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -131,6 +131,8 @@ export class CodexAppServerEventProjector {
       this.transcriptCheckpoint.nextTimestamp,
       {
         nativePostToolUseRelayEnabled: options.nativePostToolUseRelayEnabled,
+        resolveNativeFileChangeAfterToolCallCoverage:
+          options.resolveNativeFileChangeAfterToolCallCoverage,
         prepareNativeMcpAppResultDetails: options.prepareNativeMcpAppResultDetails,
         trajectoryRecorder: options.trajectoryRecorder,
         checkpointMessage: this.transcriptCheckpoint.enqueue,
@@ -321,6 +323,9 @@ export class CodexAppServerEventProjector {
       case "hook/started":
       case "hook/completed":
         this.eventProjection.handleHook(notification.method, params);
+        if (notification.method === "hook/completed") {
+          this.toolTranscriptProjection.settlePendingFileChangeAfterToolCallObservations();
+        }
         break;
       case "thread/tokenUsage/updated":
         projectCodexThreadUsageUpdate(
@@ -344,6 +349,9 @@ export class CodexAppServerEventProjector {
         break;
       case "turn/completed":
         await this.handleTurnCompleted(params);
+        this.toolTranscriptProjection.settlePendingFileChangeAfterToolCallObservations({
+          finalize: true,
+        });
         break;
       case "rawResponse/completed":
         this.responseCompletions.record(params);

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -7,6 +7,7 @@ import {
   resolveAttemptFsWorkspaceOnly,
   setActiveEmbeddedRun,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { hasNativeHookRelayInvocationForBundledRuntime } from "openclaw/plugin-sdk/native-hook-relay-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-local-roots";
 import { hasPromptImageInput } from "openclaw/plugin-sdk/session-transcript-runtime";
 import {
@@ -81,6 +82,13 @@ export async function activateCodexAttemptTurn(
     attempt: dynamicToolParams,
   });
   const streamState = { eventEmitted: false, needsTerminalSnapshot: false };
+  const nativeHookRelay = resourceState.nativeHookRelay;
+  const nativePreToolUseRelayEnabled =
+    nativeHookRelay?.allowedEvents.includes("pre_tool_use") === true &&
+    nativeHookRelay.shouldRelayEvent("pre_tool_use");
+  const nativePostToolUseRelayEnabled =
+    nativeHookRelay?.allowedEvents.includes("post_tool_use") === true &&
+    nativeHookRelay.shouldRelayEvent("post_tool_use");
   emitExecutionPhaseOnce("turn_accepted", { phase: "turn_accepted" });
   userInputBridgeRef.current = createCodexUserInputBridge({
     paramsForRun: params,
@@ -109,10 +117,50 @@ export async function activateCodexAttemptTurn(
     activeTurnId,
     {
       initialContextTokens: connection.mutable.startupContextTokens,
-      nativePostToolUseRelayEnabled:
-        resourceState.nativeHookRelay?.allowedEvents.includes("post_tool_use") === true &&
-        resourceState.nativeHookRelay.shouldRelayEvent("post_tool_use"),
-      asyncUserMessageAllowed:
+      nativePostToolUseRelayEnabled,
+      ...(nativePostToolUseRelayEnabled && nativeHookRelay
+        ? {
+            resolveNativeFileChangeAfterToolCallCoverage: (toolUseId: string) => {
+              if (
+                hasNativeHookRelayInvocationForBundledRuntime({
+                  relayId: nativeHookRelay.relayId,
+                  event: "post_tool_use",
+                  toolUseId,
+                  toolName: "apply_patch",
+                })
+              ) {
+                return "native_apply_patch" as const;
+              }
+
+              if (!nativePreToolUseRelayEnabled) {
+                return "pending" as const;
+              }
+
+              if (
+                hasNativeHookRelayInvocationForBundledRuntime({
+                  relayId: nativeHookRelay.relayId,
+                  event: "pre_tool_use",
+                  toolUseId,
+                  toolName: "apply_patch",
+                })
+              ) {
+                return "pending" as const;
+              }
+
+              if (
+                hasNativeHookRelayInvocationForBundledRuntime({
+                  relayId: nativeHookRelay.relayId,
+                  event: "pre_tool_use",
+                  toolUseId,
+                })
+              ) {
+                return "intercepted" as const;
+              }
+
+              return "pending" as const;
+            },
+          }
+        : {}),      asyncUserMessageAllowed:
         params.disableTools !== true &&
         (params.toolsAllow === undefined ||
           toolBridge.availableTools.some((tool) => tool.name === "message")),

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -4,10 +4,10 @@ import {
   detectAndLoadAgentHarnessPromptImages,
   embeddedAgentLog,
   formatErrorMessage,
+  hasNativeHookRelayInvocation,
   resolveAttemptFsWorkspaceOnly,
   setActiveEmbeddedRun,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { hasNativeHookRelayInvocationForBundledRuntime } from "openclaw/plugin-sdk/native-hook-relay-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-local-roots";
 import { hasPromptImageInput } from "openclaw/plugin-sdk/session-transcript-runtime";
 import {
@@ -122,7 +122,7 @@ export async function activateCodexAttemptTurn(
         ? {
             resolveNativeFileChangeAfterToolCallCoverage: (toolUseId: string) => {
               if (
-                hasNativeHookRelayInvocationForBundledRuntime({
+                hasNativeHookRelayInvocation({
                   relayId: nativeHookRelay.relayId,
                   event: "post_tool_use",
                   toolUseId,
@@ -137,7 +137,7 @@ export async function activateCodexAttemptTurn(
               }
 
               if (
-                hasNativeHookRelayInvocationForBundledRuntime({
+                hasNativeHookRelayInvocation({
                   relayId: nativeHookRelay.relayId,
                   event: "pre_tool_use",
                   toolUseId,
@@ -148,7 +148,7 @@ export async function activateCodexAttemptTurn(
               }
 
               if (
-                hasNativeHookRelayInvocationForBundledRuntime({
+                hasNativeHookRelayInvocation({
                   relayId: nativeHookRelay.relayId,
                   event: "pre_tool_use",
                   toolUseId,

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -160,7 +160,8 @@ export async function activateCodexAttemptTurn(
               return "pending" as const;
             },
           }
-        : {}),      asyncUserMessageAllowed:
+        : {}),
+      asyncUserMessageAllowed:
         params.disableTools !== true &&
         (params.toolsAllow === undefined ||
           toolBridge.availableTools.some((tool) => tool.name === "message")),

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -115,6 +115,7 @@ export async function finalizeCodexAttempt(
     abortListener[Symbol.dispose]();
     clearTimeout(abortGraceTimer);
   }
+  activeProjector.finalizePendingFileChangeAfterToolCallObservations();
   const hasQuiescentCompletedAssistant =
     activeProjector.hasCompletedTerminalAssistantText() &&
     state.activeAppServerTurnRequests === 0 &&

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay-filechange.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay-filechange.test.ts
@@ -1,0 +1,239 @@
+import path from "node:path";
+import { invokeNativeHookRelay } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { initializeGlobalHookRunner } from "openclaw/plugin-sdk/hook-runtime";
+import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createParams,
+  createStartedThreadHarness,
+  extractRelayIdFromThreadRequest,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+} from "./run-attempt-test-harness.js";
+
+setupRunAttemptTestHooks();
+
+type ObservedAfterToolCall = {
+  params?: unknown;
+  result?: unknown;
+  toolCallId?: string;
+  toolName?: string;
+};
+
+function afterToolCallsFor(
+  afterToolCall: ReturnType<typeof vi.fn>,
+  toolName: string,
+): ObservedAfterToolCall[] {
+  return afterToolCall.mock.calls
+    .map((call) => call[0] as ObservedAfterToolCall)
+    .filter((event) => event?.toolName === toolName);
+}
+
+async function notifyFileChange(
+  harness: ReturnType<typeof createStartedThreadHarness>,
+  params: {
+    id: string;
+    path: string;
+  },
+): Promise<void> {
+  await harness.notify({
+    method: "item/completed",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      item: {
+        type: "fileChange",
+        id: params.id,
+        changes: [
+          {
+            path: params.path,
+            kind: { type: "add" },
+          },
+        ],
+        status: "completed",
+      },
+    },
+  });
+}
+
+async function notifyPostToolUseCompleted(
+  harness: ReturnType<typeof createStartedThreadHarness>,
+  id: string,
+): Promise<void> {
+  await harness.notify({
+    method: "hook/completed",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      run: {
+        id,
+        eventName: "postToolUse",
+        handlerType: "command",
+        executionMode: "sync",
+        scope: "turn",
+        source: "project",
+        sourcePath: "/repo/.codex/hooks.json",
+        status: "completed",
+        statusMessage: null,
+        durationMs: 1,
+        entries: [],
+      },
+    },
+  });
+}
+
+describe("runCodexAppServerAttempt FileChange relay ownership", () => {
+  it("uses retained native relay records to emit exactly one apply_patch AFTER per path", async () => {
+    const beforeToolCall = vi.fn(() => undefined);
+    const afterToolCall = vi.fn(async () => undefined);
+
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_tool_call",
+          handler: beforeToolCall,
+        },
+        {
+          hookName: "after_tool_call",
+          handler: afterToolCall,
+        },
+      ]),
+    );
+
+    const sessionFile = path.join(tempDir, "file-change-relay-ownership.jsonl");
+    const workspaceDir = path.join(tempDir, "file-change-relay-ownership-workspace");
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use", "post_tool_use"],
+      },
+    });
+
+    await harness.waitForMethod("turn/start");
+
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+
+    const directPatch = "*** Begin Patch\n*** Add File: direct.txt\n+direct\n*** End Patch\n";
+
+    await invokeNativeHookRelay({
+      provider: "codex",
+      relayId,
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "apply_patch",
+        tool_use_id: "patch-direct",
+        tool_input: { command: directPatch },
+      },
+    });
+
+    await notifyFileChange(harness, {
+      id: "patch-direct",
+      path: "direct.txt",
+    });
+
+    expect(afterToolCallsFor(afterToolCall, "apply_patch")).toHaveLength(0);
+
+    await invokeNativeHookRelay({
+      provider: "codex",
+      relayId,
+      event: "post_tool_use",
+      rawPayload: {
+        hook_event_name: "PostToolUse",
+        tool_name: "apply_patch",
+        tool_use_id: "patch-direct",
+        tool_input: { command: directPatch },
+        tool_response: "Done!",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(afterToolCallsFor(afterToolCall, "apply_patch")).toHaveLength(1);
+    });
+
+    await notifyPostToolUseCompleted(harness, "hook-direct-post");
+
+    expect(afterToolCallsFor(afterToolCall, "apply_patch")).toHaveLength(1);
+
+    const interceptedPatch =
+      "apply_patch <<'PATCH'\n*** Begin Patch\n*** Add File: intercepted.txt\n+intercepted\n*** End Patch\nPATCH\n";
+
+    await invokeNativeHookRelay({
+      provider: "codex",
+      relayId,
+      event: "pre_tool_use",
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_use_id: "patch-intercepted",
+        tool_input: { cmd: interceptedPatch },
+      },
+    });
+
+    await notifyFileChange(harness, {
+      id: "patch-intercepted",
+      path: "intercepted.txt",
+    });
+
+    await vi.waitFor(() => {
+      expect(afterToolCallsFor(afterToolCall, "apply_patch")).toHaveLength(2);
+    });
+
+    await invokeNativeHookRelay({
+      provider: "codex",
+      relayId,
+      event: "post_tool_use",
+      rawPayload: {
+        hook_event_name: "PostToolUse",
+        tool_name: "Bash",
+        tool_use_id: "patch-intercepted",
+        tool_input: { cmd: interceptedPatch },
+        tool_response: { output: "Done!", exit_code: 0 },
+      },
+    });
+
+    await notifyPostToolUseCompleted(harness, "hook-intercepted-post");
+
+    await harness.completeTurn({
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+    await run;
+
+    const applyPatchEvents = afterToolCallsFor(afterToolCall, "apply_patch");
+    const directEvents = applyPatchEvents.filter((event) => event.toolCallId === "patch-direct");
+    const interceptedEvents = applyPatchEvents.filter(
+      (event) => event.toolCallId === "patch-intercepted",
+    );
+
+    expect(directEvents).toHaveLength(1);
+    expect(interceptedEvents).toHaveLength(1);
+    expect(interceptedEvents[0]?.params).toEqual({
+      changes: [
+        {
+          path: "intercepted.txt",
+          kind: { type: "add" },
+        },
+      ],
+    });
+    expect(interceptedEvents[0]?.result).toEqual({
+      status: "completed",
+      changes: [
+        {
+          path: "intercepted.txt",
+          kind: { type: "add" },
+        },
+      ],
+    });
+
+    const execEvents = afterToolCallsFor(afterToolCall, "exec").filter(
+      (event) => event.toolCallId === "patch-intercepted",
+    );
+    expect(execEvents).toHaveLength(1);
+    expect(beforeToolCall).toHaveBeenCalled();
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay-filechange.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay-filechange.test.ts
@@ -236,4 +236,100 @@ describe("runCodexAppServerAttempt FileChange relay ownership", () => {
     expect(execEvents).toHaveLength(1);
     expect(beforeToolCall).toHaveBeenCalled();
   });
+
+  it("finalizes a pending intercepted fileChange when the client closes before turn completion", async () => {
+    const afterToolCall = vi.fn(async () => undefined);
+
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "after_tool_call",
+          handler: afterToolCall,
+        },
+      ]),
+    );
+
+    const sessionFile = path.join(tempDir, "file-change-client-close.jsonl");
+    const workspaceDir = path.join(tempDir, "file-change-client-close-workspace");
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      nativeHookRelay: {
+        enabled: true,
+        events: ["pre_tool_use", "post_tool_use"],
+      },
+    });
+
+    await harness.waitForMethod("turn/start");
+
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+
+    const interceptedPatch =
+      "apply_patch <<'PATCH'\n*** Begin Patch\n*** Add File: client-close.txt\n+client-close\n*** End Patch\nPATCH\n";
+
+    await invokeNativeHookRelay({
+      provider: "codex",
+      relayId,
+      event: "post_tool_use",
+      rawPayload: {
+        hook_event_name: "PostToolUse",
+        tool_name: "Bash",
+        tool_use_id: "patch-client-close",
+        tool_input: {
+          cmd: interceptedPatch,
+        },
+        tool_response: {
+          output: "Done!",
+          exit_code: 0,
+        },
+      },
+    });
+
+    await notifyFileChange(harness, {
+      id: "patch-client-close",
+      path: "client-close.txt",
+    });
+
+    expect(afterToolCallsFor(afterToolCall, "apply_patch")).toHaveLength(0);
+
+    harness.close(
+      new Error('codex app-server exited: code=137 signal=SIGKILL stderr="worker exhausted"'),
+    );
+
+    const result = await run;
+
+    await vi.waitFor(() => {
+      expect(afterToolCallsFor(afterToolCall, "apply_patch")).toHaveLength(1);
+    });
+
+    expect(result.codexAppServerFailure?.kind).toBe("client_closed_before_turn_completed");
+
+    const applyPatchEvent = afterToolCallsFor(afterToolCall, "apply_patch")[0];
+
+    expect(applyPatchEvent?.toolCallId).toBe("patch-client-close");
+
+    expect(applyPatchEvent?.params).toEqual({
+      changes: [
+        {
+          path: "client-close.txt",
+          kind: {
+            type: "add",
+          },
+        },
+      ],
+    });
+
+    expect(applyPatchEvent?.result).toEqual({
+      status: "completed",
+      changes: [
+        {
+          path: "client-close.txt",
+          kind: {
+            type: "add",
+          },
+        },
+      ],
+    });
+  });
 });

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -236,6 +236,49 @@ async function importDuplicateNativeHookRelayModuleForTests(): Promise<NativeHoo
 }
 
 describe("native hook relay registry", () => {
+  it("filters recorded invocations by normalized tool name", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-filter",
+      runId: "run-filter",
+      allowedEvents: ["post_tool_use"],
+      ttlMs: 10_000,
+    });
+
+    await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "post_tool_use",
+      rawPayload: {
+        hook_event_name: "PostToolUse",
+        tool_name: "Write",
+        tool_use_id: "file-change-1",
+        tool_input: {
+          command: "*** Begin Patch\n*** End Patch\n",
+        },
+        tool_response: "Done!",
+      },
+    });
+
+    expect(
+      hasNativeHookRelayInvocation({
+        relayId: relay.relayId,
+        event: "post_tool_use",
+        toolUseId: "file-change-1",
+        toolName: "apply_patch",
+      }),
+    ).toBe(true);
+
+    expect(
+      hasNativeHookRelayInvocation({
+        relayId: relay.relayId,
+        event: "post_tool_use",
+        toolUseId: "file-change-1",
+        toolName: "exec",
+      }),
+    ).toBe(false);
+  });
+
   it("registers a short-lived relay and builds hidden CLI commands", () => {
     const relay = registerNativeHookRelay({
       provider: "codex",

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -595,16 +595,21 @@ export function hasNativeHookRelayInvocation(params: {
   relayId: string;
   event: NativeHookRelayEvent;
   toolUseId?: string;
+  toolName?: string;
 }): boolean {
   const toolUseId = params.toolUseId?.trim();
   if (!toolUseId) {
     return false;
   }
+  const toolName = params.toolName?.trim();
+  const normalizedToolName = toolName ? normalizeNativeHookToolName(toolName) : undefined;
   return invocations.some(
     (invocation) =>
       invocation.relayId === params.relayId &&
       invocation.event === params.event &&
-      invocation.toolUseId === toolUseId,
+      invocation.toolUseId === toolUseId &&
+      (normalizedToolName === undefined ||
+        normalizeNativeHookToolName(invocation.toolName) === normalizedToolName),
   );
 }
 

--- a/src/plugin-sdk/native-hook-relay-runtime.ts
+++ b/src/plugin-sdk/native-hook-relay-runtime.ts
@@ -1,7 +1,6 @@
 import type { RegisterNativeHookRelayParams } from "../agents/harness/native-hook-relay-types.js";
 // Private retained native-hook relay capability for bundled runtime owners.
 import {
-  hasNativeHookRelayInvocation,
   registerRetainedNativeHookRelay,
   type NativeHookRelayRetention,
 } from "../agents/harness/native-hook-relay.js";
@@ -9,13 +8,6 @@ import {
 export type RetainedNativeHookRelayParams = RegisterNativeHookRelayParams & {
   retention: NativeHookRelayRetention;
 };
-
-/** Reads native relay invocation ownership for bundled runtime consumers. */
-export function hasNativeHookRelayInvocationForBundledRuntime(
-  params: Parameters<typeof hasNativeHookRelayInvocation>[0],
-): boolean {
-  return hasNativeHookRelayInvocation(params);
-}
 
 /** Registers a bundled-only relay that may retain host policy for direct children. */
 export function registerRetainedNativeHookRelayForBundledRuntime(

--- a/src/plugin-sdk/native-hook-relay-runtime.ts
+++ b/src/plugin-sdk/native-hook-relay-runtime.ts
@@ -1,6 +1,7 @@
 import type { RegisterNativeHookRelayParams } from "../agents/harness/native-hook-relay-types.js";
 // Private retained native-hook relay capability for bundled runtime owners.
 import {
+  hasNativeHookRelayInvocation,
   registerRetainedNativeHookRelay,
   type NativeHookRelayRetention,
 } from "../agents/harness/native-hook-relay.js";
@@ -8,6 +9,13 @@ import {
 export type RetainedNativeHookRelayParams = RegisterNativeHookRelayParams & {
   retention: NativeHookRelayRetention;
 };
+
+/** Reads native relay invocation ownership for bundled runtime consumers. */
+export function hasNativeHookRelayInvocationForBundledRuntime(
+  params: Parameters<typeof hasNativeHookRelayInvocation>[0],
+): boolean {
+  return hasNativeHookRelayInvocation(params);
+}
 
 /** Registers a bundled-only relay that may retain host policy for direct children. */
 export function registerRetainedNativeHookRelayForBundledRuntime(

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -15,6 +15,7 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts",
       "extensions/codex/src/app-server/run-attempt.hooks.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts",
+      "extensions/codex/src/app-server/run-attempt.native-hook-relay-filechange.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay-retention.test.ts",
       "extensions/codex/src/app-server/run-attempt.notification-burst.test.ts",
       "extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts",


### PR DESCRIPTION
AI-assisted: yes. The implementation and tests were developed with AI coding assistance; I reviewed the change, understand the ownership/classification logic, and verified the behavior described below.

## What Problem This Solves

Codex file edits can arrive as `fileChange` items from two native-hook ownership paths:

- a direct native `apply_patch`, where Codex owns the `apply_patch` PreToolUse/PostToolUse lifecycle; or
- an intercepted patch issued through an outer exec/Bash tool, where the resulting `fileChange` is owned by that outer invocation and there is no native `apply_patch` PostToolUse to deliver `after_tool_call`.

The reliable correlation point is the canonical native-hook relay invocation ID plus normalized tool name.

Without that distinction, intercepted patches can miss their `apply_patch` `after_tool_call`; synthesizing blindly would instead duplicate the direct native patch path.

## Why This Change Was Made

Each terminal `fileChange` is classified from retained native-hook relay records for the same canonical tool-use ID:

- native `apply_patch` PostToolUse already observed → **native_apply_patch**: suppress synthetic AFTER;
- same-ID PreToolUse belongs to another normalized tool such as exec/Bash → **intercepted**: synthesize exactly one `apply_patch` AFTER;
- ownership is not settled yet → **pending**: retain the file change and re-evaluate on hook completion / turn completion before deciding.

Pending ownership is re-settled on `hook/completed`; normal `turn/completed` forces final settlement, and shared attempt finalization now performs the same forced settlement when the client closes or a terminal timeout wins before `turn/completed`. Existing non-file-change native suppression remains unchanged.

## User Impact

Codex hook consumers receive the missing `apply_patch` `after_tool_call` for intercepted patches without receiving a duplicate completion hook for direct native `apply_patch` calls.

## Evidence

Exact tested PR head: `1cfa04bc19c9523238614bb6cac1b365b3db4971`

Checked-in runtime: `@openai/codex` **0.150.1**

### Exact-head CI

GitHub Actions were triggered for `1cfa04bc19c9523238614bb6cac1b365b3db4971` after the current-main rebase and format-only conflict cleanup. Seven workflows are already green; the main CI workflow is still running.

GitHub currently reports the PR mergeable. Current upstream `main` has moved beyond the rebased base, but the only watched-file movement since the validated base is an unrelated Vitest shard registration change; no production ownership/relay seam or pinned Codex/toolchain contract changed.

### Focused regression coverage

Fresh disposable Linux validation on the exact current head passed:

- `run-attempt.native-hook-relay-filechange.test.ts`: **2/2**
- `run-attempt.turn-watches.test.ts`: **98/98**
- `run-attempt-thread-cleanup.test.ts`: **14/14**
- `run-attempt.steering-media.test.ts`: **14/14**
- `run-attempt.channel-tool-progress.test.ts`: **2/2**
- `event-projector.native-hooks.test.ts`: **8/8**
- Vitest project ownership audit: **23/23**
- `src/agents/harness/native-hook-relay.test.ts`: **119/119**
- narrow oxlint on all 11 PR files: **0 warnings / 0 errors**
- extension type check: **passed**
- full extension/scripts lint family: **0 warnings / 0 errors**
- full repository format check: **passed**
- `git diff --check`: **passed**

The attempt-boundary regression does not inject the final ownership classification. It records native relay events through the production attempt wiring and drives both direct and intercepted `fileChange` paths through the production resolver.

### Codex 0.150.1 upstream ownership contract

The version-specific ownership premise was checked against exact upstream Codex **0.150.1** release source (`rust-v0.150.1`, commit `90854393966b21e9ebfd21b122334eb09a20c93d`):

- direct `apply_patch` uses `apply_patch` PreToolUse/PostToolUse and the same invocation `call_id` / `tool_use_id`;
- intercepted `exec_command` passes the outer `context.call_id` into `intercept_apply_patch`, while native hook ownership remains outer Bash/exec.

Immutable upstream source references for maintainer verification:

- direct `apply_patch` PreToolUse/PostToolUse and `tool_use_id = invocation.call_id`: https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/tools/handlers/apply_patch.rs#L466-L497
- intercepted `exec_command` passes its outer `context.call_id` into `intercept_apply_patch`: https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs#L323-L334
- intercepted exec native PreToolUse ownership remains Bash: https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs#L423-L463
- `fileChange` start/completion IDs are the same `ctx.call_id`: https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/tools/events.rs#L238-L243 and https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/tools/events.rs#L602-L615

### Real Codex 0.150.1 runtime proof

A disposable Linux proof was run from an exact `git archive` of `1cfa04bc19c9523238614bb6cac1b365b3db4971`, with fresh frozen-lockfile dependencies and the OpenClaw native-hook CLI build completed before starting native hooks. The installed binary reported `codex-cli 0.150.1`.

To minimize constrained Codex usage without weakening the runtime contract, the proof used `gpt-5.6-luna` with low reasoning and exactly two real model calls.

**Direct native apply_patch**
- Codex server: `0.150.1`
- model: `gpt-5.6-luna`
- native BEFORE tool names: `["apply_patch"]`
- AFTER tool names: `["apply_patch"]`
- `apply_patch` BEFORE count: **1**
- outer exec/Bash BEFORE count: **0**
- `apply_patch` AFTER count: **1**
- ownership ID matches emitted AFTER: **true**
- file contents verified: **true**

**Intercepted exec-owned patch**
- Codex server: `0.150.1`
- model: `gpt-5.6-luna`
- native BEFORE tool names: `["exec"]`
- AFTER tool names: `["apply_patch"]`
- native `apply_patch` BEFORE count: **0**
- outer exec/Bash BEFORE count: **1**
- `apply_patch` AFTER count: **1**
- ownership ID matches emitted AFTER: **true**
- file contents verified: **true**

The real-binary Vitest proof passed **1/1**. Private local paths and raw tool-use identifiers are intentionally omitted.

### Rebased-head validation

The five-commit PR stack was rebased onto `8e4eb78fa20b12a700cb60507fd15442b4c1c018`. The rebase preserved the current-main active-turn image steering, native background-terminal cleanup, bounded terminal settlement, and the PR ownership classifier/final settlement behavior.

The only rebase-created formatting defect was a missing newline before `asyncUserMessageAllowed` in `run-attempt-active-turn.ts`. It was corrected by the repository formatter in the format-only commit at current head `1cfa04bc19c9523238614bb6cac1b365b3db4971`, then the full disposable validation and exact-head real Codex proof above were run against that final head.

ClawSweeper's current-head review reports **Findings: None**. Its remaining block is a maintainer proof-capture/override decision because its own reviewer environment cannot directly inspect the required sibling Codex source checkout; it is not requesting another contributor code change.

## Scope

Current PR diff is 11 files:

- `extensions/codex/src/app-server/event-projector-after-tool-call.ts`
- `extensions/codex/src/app-server/event-projector-options.ts`
- `extensions/codex/src/app-server/event-projector-tool-transcript.ts`
- `extensions/codex/src/app-server/event-projector.native-hooks.test.ts`
- `extensions/codex/src/app-server/event-projector.ts`
- `extensions/codex/src/app-server/run-attempt-active-turn.ts`
- `extensions/codex/src/app-server/run-attempt.native-hook-relay-filechange.test.ts`
- `extensions/codex/src/app-server/run-attempt-finalize.ts`
- `src/agents/harness/native-hook-relay.test.ts`
- `src/agents/harness/native-hook-relay.ts`
- `test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts`

`src/plugin-sdk/native-hook-relay-runtime.ts` has no net PR diff on the current head.
