### PR TITLE
fix(codex): keep /codex model scoped to the native binding

### DIFF
--- a/extensions/codex/src/command-handler-actions.ts
+++ b/extensions/codex/src/command-handler-actions.ts
@@ -352,10 +352,10 @@ export async function setConversationModel(
         ? (currentSession.modelOverride ?? currentSession.model)
         : undefined;
     const binding = await deps.bindingStore.read(target.identity);
-    // The native binding owns the selection once it exists (set by /codex
-    // model or a completed Codex turn); the outer session model is only a
-    // fallback before any Codex-specific binding has been established.
-    const activeModel = binding?.model ?? selectedModel;
+    // Direct sessions report their desired selection; bound conversations
+    // must never mistake an ambient outer-session model for native ownership.
+    const activeModel =
+      target.identity.kind === "conversation" ? binding?.model : (selectedModel ?? binding?.model);
     return activeModel
       ? `Codex model: ${formatCodexDisplayText(activeModel)}`
       : "Usage: /codex model <model>";

--- a/extensions/codex/src/command-handler-actions.ts
+++ b/extensions/codex/src/command-handler-actions.ts
@@ -352,7 +352,10 @@ export async function setConversationModel(
         ? (currentSession.modelOverride ?? currentSession.model)
         : undefined;
     const binding = await deps.bindingStore.read(target.identity);
-    const activeModel = selectedModel ?? binding?.model;
+    // The native binding owns the selection once it exists (set by /codex
+    // model or a completed Codex turn); the outer session model is only a
+    // fallback before any Codex-specific binding has been established.
+    const activeModel = binding?.model ?? selectedModel;
     return activeModel
       ? `Codex model: ${formatCodexDisplayText(activeModel)}`
       : "Usage: /codex model <model>";

--- a/extensions/codex/src/command-handler-actions.ts
+++ b/extensions/codex/src/command-handler-actions.ts
@@ -364,15 +364,6 @@ export async function setConversationModel(
     model: normalized,
     agentDir: target.agentDir,
     config: ctx.config,
-    ...(ctx.sessionId && ctx.sessionKey
-      ? {
-          session: {
-            agentId: target.agentId,
-            sessionId: ctx.sessionId,
-            sessionKey: ctx.sessionKey,
-          },
-        }
-      : {}),
   });
 }
 

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -1433,7 +1433,7 @@ describe("codex command", () => {
 
     await expect(
       handleCodexCommand(createSandboxedContext("model", sessionFile), { deps: createDeps() }),
-    ).resolves.toEqual({ text: "Codex model: codex-execution-model" });
+    ).resolves.toEqual({ text: "Codex model: gpt-5.6-sol" });
     await expect(
       handleCodexCommand(createSandboxedContext("fast status", sessionFile), {
         deps: createDeps(),
@@ -6109,9 +6109,27 @@ describe("codex command", () => {
     });
   });
 
-  it("does not forward an outer session identity when setting the model on a bound conversation", async () => {
-    const setCodexConversationModel = vi.fn(async () => "Codex model set to gpt-5.5.");
-    const deps = createDeps({ setCodexConversationModel });
+  it("updates a bound conversation without changing its ambient outer session", async () => {
+    const sessionKey = "agent:main:session-1";
+    const storePath = resolveStorePath(undefined, { agentId: "main" });
+    await upsertSessionEntry({
+      agentId: "main",
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        providerOverride: "anthropic",
+        modelOverride: "claude-sonnet-4-6",
+        agentRuntimeOverride: "claude-cli",
+        authProfileOverride: "anthropic:personal",
+        authProfileOverrideSource: "user",
+      },
+    });
+    await writeTestBinding(
+      { kind: "conversation", bindingId: "binding-data-1" },
+      { threadId: "thread-conversation", cwd: "/repo", model: "gpt-5.4", modelProvider: "openai" },
+    );
     const getCurrentConversationBinding = async () => ({
       bindingId: "binding-1",
       pluginId: "codex",
@@ -6131,20 +6149,26 @@ describe("codex command", () => {
     await expect(
       handleCodexCommand(
         createContext("model gpt-5.5", undefined, {
-          sessionKey: "agent:main:session-1",
+          sessionKey,
           getCurrentConversationBinding,
         }),
-        { deps },
+        { deps: createDeps() },
       ),
     ).resolves.toEqual({ text: "Codex model set to gpt-5.5." });
 
-    expect(setCodexConversationModel).toHaveBeenCalledWith({
-      identity: { kind: "conversation", bindingId: "binding-data-1" },
-      bindingStore: testCodexAppServerBindingStore,
-      pluginConfig: undefined,
+    await expect(
+      testCodexAppServerBindingStore.read({ kind: "conversation", bindingId: "binding-data-1" }),
+    ).resolves.toMatchObject({
+      threadId: "thread-conversation",
       model: "gpt-5.5",
-      agentDir: expect.any(String),
-      config: {},
+      modelProvider: "openai",
+    });
+    expect(getSessionEntry({ storePath, sessionKey })).toMatchObject({
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-6",
+      agentRuntimeOverride: "claude-cli",
+      authProfileOverride: "anthropic:personal",
+      authProfileOverrideSource: "user",
     });
   });
 
@@ -6325,7 +6349,7 @@ describe("codex command", () => {
     expect(setCodexConversationPermissions).toHaveBeenCalledOnce();
   });
 
-  it("reports the bound model, not a diverged outer session override", async () => {
+  it("reports the desired direct-session model before its stale native binding reloads", async () => {
     const sessionKey = "agent:main:diverged-model";
     const storePath = resolveStorePath(undefined, { agentId: "main" });
     await upsertSessionEntry({
@@ -6350,7 +6374,56 @@ describe("codex command", () => {
           deps: createDeps(),
         },
       ),
-    ).resolves.toEqual({ text: "Codex model: bound-model" });
+    ).resolves.toEqual({ text: "Codex model: outer-override-model" });
+  });
+
+  it.each([
+    { boundModel: "bound-model", expected: "Codex model: bound-model" },
+    { boundModel: undefined, expected: "Usage: /codex model <model>" },
+  ])("keeps conversation model status independent from its ambient session", async (testCase) => {
+    const sessionKey = "agent:main:conversation-model";
+    await upsertSessionEntry({
+      agentId: "main",
+      storePath: resolveStorePath(undefined, { agentId: "main" }),
+      sessionKey,
+      entry: {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        modelOverride: "outer-override-model",
+      },
+    });
+    await writeTestBinding(
+      { kind: "conversation", bindingId: "binding-data-1" },
+      {
+        threadId: "thread-conversation",
+        cwd: "/repo",
+        ...(testCase.boundModel ? { model: testCase.boundModel } : {}),
+      },
+    );
+
+    const result = await handleCodexCommand(
+      createContext("model", undefined, {
+        sessionKey,
+        getCurrentConversationBinding: async () => ({
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: "/plugin",
+          channel: "test",
+          accountId: "default",
+          conversationId: "conversation",
+          boundAt: 1,
+          data: {
+            kind: "codex-app-server-session",
+            version: 2,
+            bindingId: "binding-data-1",
+            workspaceDir: tempDir,
+          },
+        }),
+      }),
+      { deps: createDeps() },
+    );
+
+    expect(result).toEqual({ text: testCase.expected });
   });
 
   it("escapes current bound model status before chat display", async () => {

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -6109,6 +6109,45 @@ describe("codex command", () => {
     });
   });
 
+  it("does not forward an outer session identity when setting the model on a bound conversation", async () => {
+    const setCodexConversationModel = vi.fn(async () => "Codex model set to gpt-5.5.");
+    const deps = createDeps({ setCodexConversationModel });
+    const getCurrentConversationBinding = async () => ({
+      bindingId: "binding-1",
+      pluginId: "codex",
+      pluginRoot: "/plugin",
+      channel: "test",
+      accountId: "default",
+      conversationId: "conversation",
+      boundAt: 1,
+      data: {
+        kind: "codex-app-server-session" as const,
+        version: 2 as const,
+        bindingId: "binding-data-1",
+        workspaceDir: "/repo",
+      },
+    });
+
+    await expect(
+      handleCodexCommand(
+        createContext("model gpt-5.5", undefined, {
+          sessionKey: "agent:main:session-1",
+          getCurrentConversationBinding,
+        }),
+        { deps },
+      ),
+    ).resolves.toEqual({ text: "Codex model set to gpt-5.5." });
+
+    expect(setCodexConversationModel).toHaveBeenCalledWith({
+      identity: { kind: "conversation", bindingId: "binding-data-1" },
+      bindingStore: testCodexAppServerBindingStore,
+      pluginConfig: undefined,
+      model: "gpt-5.5",
+      agentDir: expect.any(String),
+      config: {},
+    });
+  });
+
   it.each([
     {
       name: "rejects owner yolo without admin scope",

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -1433,7 +1433,7 @@ describe("codex command", () => {
 
     await expect(
       handleCodexCommand(createSandboxedContext("model", sessionFile), { deps: createDeps() }),
-    ).resolves.toEqual({ text: "Codex model: gpt-5.6-sol" });
+    ).resolves.toEqual({ text: "Codex model: codex-execution-model" });
     await expect(
       handleCodexCommand(createSandboxedContext("fast status", sessionFile), {
         deps: createDeps(),
@@ -6323,6 +6323,34 @@ describe("codex command", () => {
 
     expect(setCodexConversationFastMode).toHaveBeenCalledOnce();
     expect(setCodexConversationPermissions).toHaveBeenCalledOnce();
+  });
+
+  it("reports the bound model, not a diverged outer session override", async () => {
+    const sessionKey = "agent:main:diverged-model";
+    const storePath = resolveStorePath(undefined, { agentId: "main" });
+    await upsertSessionEntry({
+      agentId: "main",
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "session-1",
+        updatedAt: Date.now(),
+        modelOverride: "outer-override-model",
+      },
+    });
+    await writeTestBinding(
+      { kind: "session", agentId: "main", sessionId: "session-1", sessionKey },
+      { threadId: "thread-diverged", cwd: "/repo", model: "bound-model" },
+    );
+
+    await expect(
+      handleCodexCommand(
+        createContext("model", undefined, { sessionId: "session-1", sessionKey }),
+        {
+          deps: createDeps(),
+        },
+      ),
+    ).resolves.toEqual({ text: "Codex model: bound-model" });
   });
 
   it("escapes current bound model status before chat display", async () => {

--- a/extensions/codex/src/conversation-control.test.ts
+++ b/extensions/codex/src/conversation-control.test.ts
@@ -420,7 +420,7 @@ describe("codex conversation controls", () => {
     expect(sharedClientMocks.getSharedCodexAppServerClient).not.toHaveBeenCalled();
   });
 
-  it("updates the native binding without mutating the outer session model override", async () => {
+  it("persists direct-session model selection without overwriting the active native binding", async () => {
     const sessionKey = "agent:main:model-session";
     const sessionId = "session-model-authority";
     const identity = { kind: "session" as const, agentId: "main", sessionId, sessionKey };
@@ -455,19 +455,20 @@ describe("codex conversation controls", () => {
     ).resolves.toBe("Codex model set to gpt-5.5.");
 
     expect(getSessionEntry({ storePath, sessionKey })).toMatchObject({
+      providerOverride: "openai",
+      modelOverride: "gpt-5.5",
       authProfileOverride: "openai:personal",
       authProfileOverrideSource: "user",
+      liveModelSwitchPending: true,
     });
-    expect(getSessionEntry({ storePath, sessionKey })?.modelOverride).toBeUndefined();
-    expect(getSessionEntry({ storePath, sessionKey })?.liveModelSwitchPending).toBeUndefined();
     await expect(testCodexAppServerBindingStore.read(identity)).resolves.toMatchObject({
       threadId: "thread-model-authority",
-      model: "gpt-5.5",
+      model: "gpt-5.4",
     });
     expect(sharedClientMocks.getSharedCodexAppServerClient).not.toHaveBeenCalled();
   });
 
-  it("switches provider on the native binding without touching the outer session auth override", async () => {
+  it("clears incompatible direct-session auth when the selected provider changes", async () => {
     const sessionKey = "agent:main:model-provider-switch";
     const sessionId = "session-provider-switch";
     const identity = { kind: "session" as const, agentId: "main", sessionId, sessionKey };
@@ -503,14 +504,15 @@ describe("codex conversation controls", () => {
 
     await expect(testCodexAppServerBindingStore.read(identity)).resolves.toMatchObject({
       threadId: "thread-provider-switch",
-      model: "gpt-5.5",
-      modelProvider: "openai",
+      model: "local-model",
+      modelProvider: "lmstudio",
     });
     expect(getSessionEntry({ storePath, sessionKey })).toMatchObject({
-      authProfileOverride: "lmstudio:work",
-      authProfileOverrideSource: "user",
+      providerOverride: "openai",
+      modelOverride: "gpt-5.5",
+      liveModelSwitchPending: true,
     });
-    expect(getSessionEntry({ storePath, sessionKey })?.modelOverride).toBeUndefined();
+    expect(getSessionEntry({ storePath, sessionKey })?.authProfileOverride).toBeUndefined();
   });
 
   it("escapes requested model names before chat display", async () => {

--- a/extensions/codex/src/conversation-control.test.ts
+++ b/extensions/codex/src/conversation-control.test.ts
@@ -420,7 +420,7 @@ describe("codex conversation controls", () => {
     expect(sharedClientMocks.getSharedCodexAppServerClient).not.toHaveBeenCalled();
   });
 
-  it("persists ordinary model selection on SessionEntry without overwriting native ownership", async () => {
+  it("updates the native binding without mutating the outer session model override", async () => {
     const sessionKey = "agent:main:model-session";
     const sessionId = "session-model-authority";
     const identity = { kind: "session" as const, agentId: "main", sessionId, sessionKey };
@@ -455,20 +455,19 @@ describe("codex conversation controls", () => {
     ).resolves.toBe("Codex model set to gpt-5.5.");
 
     expect(getSessionEntry({ storePath, sessionKey })).toMatchObject({
-      providerOverride: "openai",
-      modelOverride: "gpt-5.5",
       authProfileOverride: "openai:personal",
       authProfileOverrideSource: "user",
-      liveModelSwitchPending: true,
     });
+    expect(getSessionEntry({ storePath, sessionKey })?.modelOverride).toBeUndefined();
+    expect(getSessionEntry({ storePath, sessionKey })?.liveModelSwitchPending).toBeUndefined();
     await expect(testCodexAppServerBindingStore.read(identity)).resolves.toMatchObject({
       threadId: "thread-model-authority",
-      model: "gpt-5.4",
+      model: "gpt-5.5",
     });
     expect(sharedClientMocks.getSharedCodexAppServerClient).not.toHaveBeenCalled();
   });
 
-  it("drops an incompatible pinned auth profile when selecting another provider", async () => {
+  it("switches provider on the native binding without touching the outer session auth override", async () => {
     const sessionKey = "agent:main:model-provider-switch";
     const sessionId = "session-provider-switch";
     const identity = { kind: "session" as const, agentId: "main", sessionId, sessionKey };
@@ -502,12 +501,16 @@ describe("codex conversation controls", () => {
       }),
     ).resolves.toBe("Codex model set to gpt-5.5.");
 
-    expect(getSessionEntry({ storePath, sessionKey })).toMatchObject({
-      providerOverride: "openai",
-      modelOverride: "gpt-5.5",
-      liveModelSwitchPending: true,
+    await expect(testCodexAppServerBindingStore.read(identity)).resolves.toMatchObject({
+      threadId: "thread-provider-switch",
+      model: "gpt-5.5",
+      modelProvider: "openai",
     });
-    expect(getSessionEntry({ storePath, sessionKey })?.authProfileOverride).toBeUndefined();
+    expect(getSessionEntry({ storePath, sessionKey })).toMatchObject({
+      authProfileOverride: "lmstudio:work",
+      authProfileOverrideSource: "user",
+    });
+    expect(getSessionEntry({ storePath, sessionKey })?.modelOverride).toBeUndefined();
   });
 
   it("escapes requested model names before chat display", async () => {

--- a/extensions/codex/src/conversation-control.ts
+++ b/extensions/codex/src/conversation-control.ts
@@ -1,5 +1,9 @@
 // Codex plugin module implements conversation control behavior.
-import { ModelSelectionLockedError } from "openclaw/plugin-sdk/model-session-runtime";
+import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  applyModelOverrideWithAuthProfileCompatibility,
+  ModelSelectionLockedError,
+} from "openclaw/plugin-sdk/model-session-runtime";
 import {
   getSessionEntry,
   patchSessionEntry,
@@ -213,16 +217,50 @@ export async function setCodexConversationModel(params: {
   });
   const nextModel = modelSelection.model;
   const modelChanged = nextModel !== binding.model || nextModelProvider !== binding.modelProvider;
-  // The native binding is the sole owner of this selection; the outer
-  // OpenClaw session model override is a separate contract that only /model
-  // may change, so it must stay untouched here regardless of identity kind.
-  await patchThreadBinding(params.bindingStore, params.identity, binding.threadId, {
-    model: nextModel,
-    modelProvider: nextModelProvider,
-    ...(modelChanged && binding.contextEngine?.projection
+  const projectionPatch =
+    modelChanged && binding.contextEngine?.projection
       ? { contextEngine: { ...binding.contextEngine, projection: undefined } }
-      : {}),
-  });
+      : {};
+  if (params.identity.kind === "session" && params.identity.sessionKey) {
+    const identity = params.identity;
+    // SessionEntry owns the desired model; retain the loaded binding until
+    // lifecycle reconciliation can rotate its native generation safely.
+    const updated = await patchSessionEntry({
+      agentId: identity.agentId,
+      storePath: resolveStorePath(params.config?.session?.store, { agentId: identity.agentId }),
+      sessionKey: identity.sessionKey,
+      requireWriteSuccess: true,
+      replaceEntry: true,
+      update: (entry) => {
+        if (entry.sessionId !== identity.sessionId) {
+          throw new Error("Codex session changed while applying the model selection.");
+        }
+        applyModelOverrideWithAuthProfileCompatibility({
+          cfg: params.config ?? {},
+          agentDir: params.agentDir ?? resolveAgentDir(params.config ?? {}, identity.agentId),
+          entry,
+          currentProvider: binding.modelProvider ?? "openai",
+          selection: { provider: nextModelProvider ?? "openai", model: nextModel },
+          markLiveSwitchPending: true,
+        });
+        return entry;
+      },
+    });
+    if (!updated) {
+      throw new Error("Codex session changed while applying the model selection.");
+    }
+    if (modelChanged && binding.contextEngine?.projection) {
+      await patchThreadBinding(params.bindingStore, identity, binding.threadId, projectionPatch);
+    }
+  } else {
+    // Conversation bindings and ephemeral sessions own native selection;
+    // ambient outer-session metadata must never redirect their runtime.
+    await patchThreadBinding(params.bindingStore, params.identity, binding.threadId, {
+      model: nextModel,
+      modelProvider: nextModelProvider,
+      ...projectionPatch,
+    });
+  }
   return `Codex model set to ${formatCodexDisplayText(nextModel)}.`;
 }
 

--- a/extensions/codex/src/conversation-control.ts
+++ b/extensions/codex/src/conversation-control.ts
@@ -221,8 +221,8 @@ export async function setCodexConversationModel(params: {
     modelChanged && binding.contextEngine?.projection
       ? { contextEngine: { ...binding.contextEngine, projection: undefined } }
       : {};
-  if (params.identity.kind === "session" && params.identity.sessionKey) {
-    const identity = params.identity;
+  const identity = params.identity;
+  if (identity.kind === "session" && identity.sessionKey) {
     // SessionEntry owns the desired model; retain the loaded binding until
     // lifecycle reconciliation can rotate its native generation safely.
     const updated = await patchSessionEntry({

--- a/extensions/codex/src/conversation-control.ts
+++ b/extensions/codex/src/conversation-control.ts
@@ -1,9 +1,5 @@
-import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 // Codex plugin module implements conversation control behavior.
-import {
-  applyModelOverrideWithAuthProfileCompatibility,
-  ModelSelectionLockedError,
-} from "openclaw/plugin-sdk/model-session-runtime";
+import { ModelSelectionLockedError } from "openclaw/plugin-sdk/model-session-runtime";
 import {
   getSessionEntry,
   patchSessionEntry,
@@ -187,7 +183,6 @@ export async function setCodexConversationModel(params: {
   pluginConfig?: unknown;
   agentDir?: string;
   config?: CodexAppServerBindingLookup["config"];
-  session?: { agentId: string; sessionId: string; sessionKey: string };
 }): Promise<string> {
   const model = params.model.trim();
   if (!model) {
@@ -218,66 +213,16 @@ export async function setCodexConversationModel(params: {
   });
   const nextModel = modelSelection.model;
   const modelChanged = nextModel !== binding.model || nextModelProvider !== binding.modelProvider;
-  const session =
-    params.session ??
-    (params.identity.kind === "session" && params.identity.sessionKey
-      ? {
-          agentId: params.identity.agentId,
-          sessionId: params.identity.sessionId,
-          sessionKey: params.identity.sessionKey,
-        }
-      : undefined);
-  if (session) {
-    const updated = await patchSessionEntry({
-      agentId: session.agentId,
-      storePath: resolveStorePath(params.config?.session?.store, { agentId: session.agentId }),
-      sessionKey: session.sessionKey,
-      requireWriteSuccess: true,
-      // Model override helpers delete stale credentials and model metadata;
-      // replacing the snapshot is required because partial patches merge fields.
-      replaceEntry: true,
-      update: (entry) => {
-        if (entry.sessionId !== session.sessionId) {
-          throw new Error("Codex session changed while applying the model selection.");
-        }
-        applyModelOverrideWithAuthProfileCompatibility({
-          cfg: params.config ?? {},
-          agentDir: params.agentDir ?? resolveAgentDir(params.config ?? {}, session.agentId),
-          entry,
-          currentProvider: binding.modelProvider ?? "openai",
-          selection: { provider: nextModelProvider ?? "openai", model: nextModel },
-          markLiveSwitchPending: true,
-        });
-        return entry;
-      },
-    });
-    if (!updated) {
-      throw new Error("Codex session changed while applying the model selection.");
-    }
-    // SessionEntry owns desired selection; the native binding remains the
-    // currently loaded model so generation transitions still rotate safely.
-    if (params.identity.kind === "conversation") {
-      await patchThreadBinding(params.bindingStore, params.identity, binding.threadId, {
-        model: nextModel,
-        modelProvider: nextModelProvider,
-        ...(modelChanged && binding.contextEngine?.projection
-          ? { contextEngine: { ...binding.contextEngine, projection: undefined } }
-          : {}),
-      });
-    } else if (modelChanged && binding.contextEngine?.projection) {
-      await patchThreadBinding(params.bindingStore, params.identity, binding.threadId, {
-        contextEngine: { ...binding.contextEngine, projection: undefined },
-      });
-    }
-  } else {
-    await patchThreadBinding(params.bindingStore, params.identity, binding.threadId, {
-      model: nextModel,
-      modelProvider: nextModelProvider,
-      ...(modelChanged && binding.contextEngine?.projection
-        ? { contextEngine: { ...binding.contextEngine, projection: undefined } }
-        : {}),
-    });
-  }
+  // The native binding is the sole owner of this selection; the outer
+  // OpenClaw session model override is a separate contract that only /model
+  // may change, so it must stay untouched here regardless of identity kind.
+  await patchThreadBinding(params.bindingStore, params.identity, binding.threadId, {
+    model: nextModel,
+    modelProvider: nextModelProvider,
+    ...(modelChanged && binding.contextEngine?.projection
+      ? { contextEngine: { ...binding.contextEngine, projection: undefined } }
+      : {}),
+  });
   return `Codex model set to ${formatCodexDisplayText(nextModel)}.`;
 }
 


### PR DESCRIPTION
Fixes #128718
Fixes #128976

Thanks @chelsealong for the original report, contributor implementation, and regression coverage.

## Problem and root cause

`/codex model` incorrectly treated whichever outer session happened to be present in the command context as the owner of a conversation-bound Codex model. In a `/codex bind` conversation, that ambient session can belong to a different provider, runtime, or authentication profile, so the command silently rewrote unrelated ordinary-session routing.

The original binding-only patch fixed that leak but introduced #128976 for direct Codex sessions: their canonical desired model is the persistent `SessionEntry`, while the native binding describes the model actually loaded into the existing app-server thread. Updating only the binding lost the desired selection on the next turn and bypassed live-switch signaling, auth-profile reconciliation, and generation-safe thread lifecycle handling.

## Architectural repair

Choose the owner exclusively from the authoritative target identity:

- A persistent session identity updates its `SessionEntry` desired model, preserves `liveModelSwitchPending` and auth compatibility, and leaves the actual native binding unchanged until the existing lifecycle safely reconciles it.
- A bound conversation or ephemeral session identity updates only its native binding. Ambient outer-session provider, model, runtime, and auth state remain untouched.
- Bare `/codex model` reports the same authoritative owner. A conversation without a native model never falls back to an unrelated ambient session.

No new persistence, compatibility markers, lifecycle branches, or protocol surfaces are added. Production code is net negative: +23/-46; regression coverage is +147/-2.

## Real native app-server proof

Executed against the actual installed Codex app server with an isolated temporary `CODEX_HOME`, file-only credential storage, all provider/GitHub credentials removed, and no operator gateway or home-directory state. This proves the real native protocol accepts a different model for a later turn in the same thread:

```json
{
  "nativeAppServer": true,
  "isolatedHome": true,
  "credentials": "removed",
  "initialized": true,
  "threadStartRequestedModel": "gpt-5.6-sol",
  "threadStartReportedModel": "gpt-5.6-sol",
  "turnStartRequestedModel": "gpt-5.6-terra",
  "turnStartAccepted": true
}
```

The real OpenClaw command integration additionally dispatches `/codex model` against a bound conversation with a deliberately divergent outer provider/runtime/auth profile and verifies the native binding changes while every ambient outer-session field remains unchanged. Direct-session regressions verify desired-model persistence, stale native binding retention, live-switch signaling, compatible auth preservation, and incompatible auth cleanup.

## Direct upstream contract inspection

Personally inspected the sibling `openai/codex` source before changing or approving behavior:

- `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:197-199`: a `turn/start` model override applies to that turn and subsequent turns.
- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:335-361`: `thread/resume` carries thread-scoped model/provider overrides.
- `codex-rs/app-server/src/request_processors/thread_processor.rs:4133-4181`: loaded threads with subscribers retain their current configuration; resume overrides are ignored until ownership is released. This is why prematurely overwriting the active binding would break OpenClaw's existing lifecycle reconciliation.
- `extensions/codex/src/app-server/thread-lifecycle.binding.test.ts:2091-2169`: existing coverage protects same-generation resume and generation-changing thread rotation.

## Verification

```text
node scripts/run-vitest.mjs extensions/codex/src/conversation-control.test.ts extensions/codex/src/commands.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
Test Files: 3 passed; Tests: 316 passed

node scripts/run-vitest.mjs extensions/codex/src/conversation-control.test.ts extensions/codex/src/commands.test.ts
Test Files: 2 passed; Tests: 204 passed

node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit
PASS

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --noEmit
PASS

node scripts/run-tsgo.mjs -p extensions/codex/tsconfig.json --noEmit --incremental --tsBuildInfoFile extensions/codex/dist/.boundary-tsc.tsbuildinfo
PASS after canonical plugin-SDK boundary artifact preparation

git diff --check
PASS

Fresh independent autoreview
PASS; no actionable findings
```

The first rewritten head exposed one control-flow narrowing error in CI; the final corrective commit hoists the checked identity before its session-key guard, and all three formerly failing type/package-boundary checks now pass locally.
