### PR TITLE
docs: align Linux host tuning with managed systemd policy [AI-assisted]

### DIFF
--- a/docs/install/raspberry-pi.md
+++ b/docs/install/raspberry-pi.md
@@ -154,7 +154,7 @@ echo 'gpu_mem=16' | sudo tee -a /boot/config.txt
 sudo systemctl disable bluetooth
 ```
 
-**systemd drop-in for stable restarts** -- If this Pi is mostly running OpenClaw, add a service drop-in:
+**systemd drop-in for host-specific startup tuning** -- The managed unit owns the generic restart policy (`Restart=always`, `RestartSec=5`). If this Pi is mostly running OpenClaw, add a service drop-in for host-specific startup settings only:
 
 ```bash
 systemctl --user edit openclaw-gateway.service
@@ -164,8 +164,6 @@ systemctl --user edit openclaw-gateway.service
 [Service]
 Environment=OPENCLAW_NO_RESPAWN=1
 Environment=NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache
-Restart=always
-RestartSec=2
 TimeoutStartSec=90
 ```
 

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -104,11 +104,12 @@ For VM hosts using `systemd`, consider:
 
 - Service env for a stable startup path: `OPENCLAW_NO_RESPAWN=1` and
   `NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache`
-- Explicit restart behavior: `Restart=always`, `RestartSec=2`, `TimeoutStartSec=90`
+- A longer startup timeout for slow hosts: `TimeoutStartSec=90`.
+- The managed unit owns the generic restart policy: `Restart=always`, `RestartSec=5`.
 - SSD-backed disks for state/cache paths to reduce random-I/O cold-start penalties.
 
 The standard `openclaw onboard --install-daemon` path installs a systemd user
-unit; edit it with:
+unit; customize only host-specific startup settings with:
 
 ```bash
 systemctl --user edit openclaw-gateway.service
@@ -118,16 +119,13 @@ systemctl --user edit openclaw-gateway.service
 [Service]
 Environment=OPENCLAW_NO_RESPAWN=1
 Environment=NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache
-Restart=always
-RestartSec=2
 TimeoutStartSec=90
 ```
 
 If you deliberately installed a system unit instead, edit it via
 `sudo systemctl edit openclaw-gateway.service`.
 
-How `Restart=` policies help automated recovery:
-[systemd can automate service recovery](https://www.redhat.com/en/blog/systemd-automate-recovery).
+For the canonical managed unit body and its restart policy, see the [Gateway runbook](/gateway).
 
 For Linux OOM behavior, child process victim selection, and `exit 137`
 diagnostics, see [Linux memory pressure and OOM kills](/platforms/linux#memory-pressure-and-oom-kills).


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators following the Raspberry Pi or Linux server tuning guides would override OpenClaw's managed systemd restart delay with `RestartSec=2`. The generated service, Doctor audit, Gateway runbook, and Linux platform guide consistently define the generic policy as `Restart=always` with `RestartSec=5`, so the tuning snippets created contradictory effective service configuration.

## Why This Change Was Made

The optional host-tuning drop-ins now contain only host-specific settings: the compile-cache environment, `OPENCLAW_NO_RESPAWN=1`, and a longer startup timeout for slower machines. Generic restart behavior remains owned by the managed systemd unit, avoiding duplicate policy and future drift. No Raspberry Pi-, VPS-, or team-specific exception was added to the service audit.

## User Impact

Raspberry Pi and Linux server operators can apply the documented performance tuning without making `openclaw doctor` report their effective restart delay as noncanonical. Existing installations are unchanged until an operator edits their drop-in.

## Evidence

- `node scripts/run-vitest.mjs src/daemon/systemd-unit.test.ts src/daemon/service-audit.test.ts` — 65 tests passed.
- `pnpm check:docs` — formatting, Markdown lint, MDX, glossary, links, and config examples passed.
- `pnpm docs:list` — passed.
- `git diff --check` — passed.
- Autoreview found no accepted or actionable findings.

AI-assisted: yes.
