### PR TITLE
refactor(ui): reuse canonical UUID generation

### DIFF
--- a/ui/src/components/onboarding-memory-import.ts
+++ b/ui/src/components/onboarding-memory-import.ts
@@ -11,6 +11,7 @@ import type { ApplicationContext } from "../app/context.ts";
 import { hasOperatorAdminAccess } from "../app/operator-access.ts";
 import { t } from "../i18n/index.ts";
 import { formatUiError, formatUiExternalText } from "../lib/format-error.ts";
+import { generateUUID } from "../lib/uuid.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import "../styles/onboarding-memory-import.css";
@@ -25,15 +26,6 @@ type ProviderResult =
 
 function toErrorMessage(error: unknown): string {
   return formatUiError(error, t("onboarding.memoryImport.unknownError"));
-}
-
-function createIdempotencyKey(): string {
-  if (typeof globalThis.crypto.randomUUID === "function") {
-    return globalThis.crypto.randomUUID();
-  }
-  return [...globalThis.crypto.getRandomValues(new Uint32Array(4))]
-    .map((value) => value.toString(16).padStart(8, "0"))
-    .join("");
 }
 
 function plannedItems(provider: MemoryMigrationProviderPlan) {
@@ -244,7 +236,7 @@ class OnboardingMemoryImport extends OpenClawLightDomElement {
         const result = await client.request<MigrationsMemoryApplyResult>(
           "migrations.memory.apply",
           {
-            idempotencyKey: createIdempotencyKey(),
+            idempotencyKey: generateUUID(),
             agentId,
             providerId: provider.providerId,
             planFingerprint,

--- a/ui/src/pages/custodian/custodian-session-identity.ts
+++ b/ui/src/pages/custodian/custodian-session-identity.ts
@@ -1,4 +1,5 @@
 import type { ApplicationGateway } from "../../app/context.ts";
+import { generateUUID } from "../../lib/uuid.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 
 const CUSTODIAN_SESSION_STORAGE_KEY = "openclaw.custodian.session.v1";
@@ -8,13 +9,7 @@ function isStoredCustodianSessionId(value: string | null): value is string {
 }
 
 export function createCustodianSessionId(): string {
-  if (typeof crypto.randomUUID === "function") {
-    return `control-ui-onboarding-${crypto.randomUUID()}`;
-  }
-  const suffix = [...crypto.getRandomValues(new Uint32Array(4))]
-    .map((value) => value.toString(16).padStart(8, "0"))
-    .join("");
-  return `control-ui-onboarding-${suffix}`;
+  return `control-ui-onboarding-${generateUUID()}`;
 }
 
 export function persistCustodianSessionId(sessionId: string): void {

--- a/ui/src/pages/memory-import/memory-import-page.ts
+++ b/ui/src/pages/memory-import/memory-import-page.ts
@@ -15,6 +15,7 @@ import { t } from "../../i18n/index.ts";
 import { listSelectableAgents } from "../../lib/agents/display.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
+import { generateUUID } from "../../lib/uuid.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import {
@@ -39,15 +40,6 @@ type PendingMemoryImport = {
 
 function toErrorMessage(error: unknown): string {
   return formatUiError(error, "request failed");
-}
-
-function createIdempotencyKey(): string {
-  if (typeof globalThis.crypto.randomUUID === "function") {
-    return globalThis.crypto.randomUUID();
-  }
-  return [...globalThis.crypto.getRandomValues(new Uint32Array(4))]
-    .map((value) => value.toString(16).padStart(8, "0"))
-    .join("");
 }
 
 export class MemoryImportPage extends OpenClawLightDomElement {
@@ -275,7 +267,7 @@ export class MemoryImportPage extends OpenClawLightDomElement {
       planFingerprint,
       itemIds: [...itemIds],
       overwrite: this.replaceExisting,
-      idempotencyKey: createIdempotencyKey(),
+      idempotencyKey: generateUUID(),
       attempted: false,
     };
   }


### PR DESCRIPTION
## What Problem This Solves

The Control UI maintained three separate implementations for generating secure identifiers for memory imports and Ask OpenClaw companion sessions, despite already having a shared UUID generator used by other Gateway requests.

## Why This Change Was Made

Route onboarding memory imports, the memory-import settings page, and companion-session identity through the existing canonical Control UI UUID generator. This removes duplicate cryptographic fallback implementations while retaining existing request-idempotency ownership, stored session identifiers, and the companion session prefix.

## User Impact

No user-visible behavior changes. Memory-import retries continue using their existing idempotency key, companion sessions retain their existing prefix and stored identity, and environments without `crypto.randomUUID` continue using secure Web Crypto randomness.

## Evidence

- Production: +6/-27, net -21 across three existing Control UI files; no test, dependency, schema, generated-manifest, or changelog changes.
- Five focused owner-boundary suites passed: 74 tests covering canonical UUID generation, secure fallback, onboarding memory imports, memory-import retry idempotency, companion-session identity, and companion-session storage.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-cleanup3-lane2-vitest-cache node scripts/run-vitest.mjs --configLoader runner ui/src/lib/uuid.test.ts ui/src/components/onboarding-memory-import.test.ts ui/src/pages/memory-import/memory-import-page.test.ts ui/src/pages/custodian/custodian-page.test.ts ui/src/pages/custodian/custodian-session-store.test.ts`
- Targeted formatter, oxlint, stylelint, changed-lane classification, and `git diff --check` passed.
- Independent owner-boundary source review accepted; fresh structured autoreview reported no actionable findings.
- The migration Gateway schema accepts a nonempty identifier, the companion-session loader preserves existing stored identifiers, and the canonical UUID module is already present in the generated startup manifest.
