### PR TITLE
fix: block NO_REPLY on open runtime resume contracts

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -256,6 +256,10 @@ export async function runEmbeddedAttemptPromptPhase(input: {
       },
       ...input.context,
     });
+    // Runtime-only resume with an open contract must not accept exact NO_REPLY.
+    attempt.blockRuntimeResumeSilentReply =
+      promptContext.promptSubmission.runtimeOnly === true &&
+      promptContext.promptSubmission.resumeContract?.open === true;
     const { hookMessagesForCurrentPrompt, promptForModel, systemPromptForHook } = promptContext;
     input.lifecycle.setPrePromptMessageCount(promptContext.prePromptMessageCount);
     input.lifecycle.setCurrentUserTimestampOverride(promptContext.currentUserTimestampOverride);

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -28,6 +28,7 @@ import {
 } from "./attempt-prompt-support.js";
 import { removeTrailingMidTurnPrecheckAssistantError } from "./attempt-transcript-helpers.js";
 import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
+import { shouldBlockSilentReplyOnRuntimeResume } from "./runtime-resume-contract.js";
 
 type PromptAssemblyInput = Parameters<typeof prepareEmbeddedAttemptPromptAssembly>[0];
 type PromptAssemblyResult = Awaited<ReturnType<typeof prepareEmbeddedAttemptPromptAssembly>>;
@@ -257,9 +258,10 @@ export async function runEmbeddedAttemptPromptPhase(input: {
       ...input.context,
     });
     // Runtime-only resume with an open contract must not accept exact NO_REPLY.
-    attempt.blockRuntimeResumeSilentReply =
-      promptContext.promptSubmission.runtimeOnly === true &&
-      promptContext.promptSubmission.resumeContract?.open === true;
+    attempt.blockRuntimeResumeSilentReply = shouldBlockSilentReplyOnRuntimeResume({
+      runtimeOnly: promptContext.promptSubmission.runtimeOnly,
+      resumeContract: promptContext.promptSubmission.resumeContract,
+    });
     const { hookMessagesForCurrentPrompt, promptForModel, systemPromptForHook } = promptContext;
     input.lifecycle.setPrePromptMessageCount(promptContext.prePromptMessageCount);
     input.lifecycle.setCurrentUserTimestampOverride(promptContext.currentUserTimestampOverride);

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -370,6 +370,7 @@ export function completeEmbeddedAttemptResult(
   const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
     allowEmptyAssistantReplyAsSilent: attempt.allowEmptyAssistantReplyAsSilent,
     terminalReplyExpectation: attempt.terminalReplyExpectation,
+    blockRuntimeResumeSilentReply: attempt.blockRuntimeResumeSilentReply,
     payloadCount: 0,
     aborted: terminal.aborted,
     timedOut: terminal.timedOut,

--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -370,7 +370,6 @@ export function completeEmbeddedAttemptResult(
   const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
     allowEmptyAssistantReplyAsSilent: attempt.allowEmptyAssistantReplyAsSilent,
     terminalReplyExpectation: attempt.terminalReplyExpectation,
-    blockRuntimeResumeSilentReply: attempt.blockRuntimeResumeSilentReply,
     payloadCount: 0,
     aborted: terminal.aborted,
     timedOut: terminal.timedOut,
@@ -392,6 +391,7 @@ export function completeEmbeddedAttemptResult(
       toolMetas: toolMetasNormalized,
       replayMetadata,
       terminal: state.terminal,
+      blockRuntimeResumeSilentReply: attempt.blockRuntimeResumeSilentReply,
     },
   });
   const result: EmbeddedRunAttemptWithReceiptEvidence = {
@@ -433,6 +433,7 @@ export function completeEmbeddedAttemptResult(
     clientToolCalls,
     yieldDetected: state.yieldDetected || undefined,
     yieldAcknowledgment: state.yieldAcknowledgment,
+    blockRuntimeResumeSilentReply: attempt.blockRuntimeResumeSilentReply,
   };
   return finalizeEmbeddedAttempt({
     result,

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-classification.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-classification.ts
@@ -38,7 +38,10 @@ export type IncompleteTurnAttempt = Pick<
   | "terminal"
   | "toolMetas"
 > &
-  Partial<Pick<EmbeddedRunAttemptResult, "acceptedSessionSpawns">>;
+  Partial<Pick<EmbeddedRunAttemptResult, "acceptedSessionSpawns">> & {
+    /** Set on runtime-only resume turns with an open resume contract. */
+    blockRuntimeResumeSilentReply?: boolean;
+  };
 
 export function hasPositiveOutputTokenUsage(message: AgentMessage | null): boolean {
   if (!message || typeof message !== "object") {

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -116,7 +116,10 @@ export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): boolean {
-  if (params.blockRuntimeResumeSilentReply === true) {
+  if (
+    params.blockRuntimeResumeSilentReply === true ||
+    params.attempt.blockRuntimeResumeSilentReply === true
+  ) {
     return false;
   }
   // "optional" is the run consumer's declaration that no user-facing reply is

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -109,11 +109,16 @@ export function shouldTreatEmptyAssistantReplyAsSilent(params: {
   allowEmptyAssistantReplyAsSilent?: boolean;
   onlyExplicitSilentReply?: boolean;
   terminalReplyExpectation?: "required" | "optional";
+  /** When true, exact NO_REPLY / empty finals are never intentional silence. */
+  blockRuntimeResumeSilentReply?: boolean;
   payloadCount: number;
   aborted: boolean;
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): boolean {
+  if (params.blockRuntimeResumeSilentReply === true) {
+    return false;
+  }
   // "optional" is the run consumer's declaration that no user-facing reply is
   // owed (e.g. cron without a delivery route). Silence after side-effecting
   // tools is intentional there; retry is replay-unsafe, so erroring would mark

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
@@ -22,6 +22,7 @@ import {
   joinAssistantTexts,
   type IncompleteTurnAttempt,
 } from "./incomplete-turn-classification.js";
+import { RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT } from "./runtime-resume-contract.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
 type SilentToolResultAttempt = Pick<
@@ -57,6 +58,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   timedOut: boolean;
   hadPotentialSideEffects?: boolean;
   hasIntentionalTerminalCompletion?: boolean;
+  blockRuntimeResumeSilentReply?: boolean;
   terminalAuthFailure?: TerminalAuthFailureContext;
   attempt: IncompleteTurnAttempt;
 }): string | null {
@@ -96,6 +98,9 @@ export function resolveIncompleteTurnPayloadText(params: {
   }
 
   if (hasOnlySilentAssistantReply(params.attempt.assistantTexts)) {
+    if (params.blockRuntimeResumeSilentReply === true) {
+      return RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT;
+    }
     return null;
   }
 

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
@@ -22,7 +22,10 @@ import {
   joinAssistantTexts,
   type IncompleteTurnAttempt,
 } from "./incomplete-turn-classification.js";
-import { RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT } from "./runtime-resume-contract.js";
+import {
+  isBlockedRuntimeResumeSilentReply,
+  RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT,
+} from "./runtime-resume-contract.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
 type SilentToolResultAttempt = Pick<
@@ -97,10 +100,18 @@ export function resolveIncompleteTurnPayloadText(params: {
     return null;
   }
 
+  if (
+    isBlockedRuntimeResumeSilentReply({
+      blockRuntimeResumeSilentReply:
+        params.blockRuntimeResumeSilentReply === true ||
+        params.attempt.blockRuntimeResumeSilentReply === true,
+      assistantTexts: params.attempt.assistantTexts,
+    })
+  ) {
+    return RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT;
+  }
+
   if (hasOnlySilentAssistantReply(params.attempt.assistantTexts)) {
-    if (params.blockRuntimeResumeSilentReply === true) {
-      return RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT;
-    }
     return null;
   }
 

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -402,6 +402,11 @@ export type RunEmbeddedAgentParams = {
    */
   allowEmptyAssistantReplyAsSilent?: boolean;
   /**
+   * Runtime-only resume turns with an open resume contract must not accept
+   * exact NO_REPLY / empty finals as intentional silence.
+   */
+  blockRuntimeResumeSilentReply?: boolean;
+  /**
    * Whether this run still owes a visible reply after settled non-reporting tools.
    * Exact configured silence and committed delivery remain terminal outcomes.
    */

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.ts
@@ -11,6 +11,11 @@ import {
   OPENCLAW_RUNTIME_EVENT_HEADER,
 } from "../../internal-runtime-context.js";
 import type { CurrentInboundPromptContext } from "./params.js";
+import {
+  extractRuntimeResumeContract,
+  formatRuntimeResumeSystemAppendix,
+  type RuntimeResumeContract,
+} from "./runtime-resume-contract.js";
 
 const OPENCLAW_RUNTIME_EVENT_USER_PROMPT = "Continue the OpenClaw runtime event.";
 
@@ -20,6 +25,8 @@ type RuntimeContextPromptParts = {
   runtimeContext?: string;
   runtimeOnly?: boolean;
   runtimeSystemContext?: string;
+  /** Present on runtime-only turns when an unfinished user task is still owed. */
+  resumeContract?: RuntimeResumeContract;
 };
 
 /** Hidden custom transcript message that carries runtime context into model conversion. */
@@ -199,23 +206,27 @@ export function resolveRuntimeContextPromptParts(params: {
       .filter((value): value is string => Boolean(value?.trim()))
       .join("\n\n") || (!prompt.trim() ? extracted.text.trim() : undefined);
   if (!prompt.trim()) {
-    return runtimeContext
-      ? {
-          prompt: OPENCLAW_RUNTIME_EVENT_USER_PROMPT,
-          ...(modelPromptText.trim() && modelPromptText !== OPENCLAW_RUNTIME_EVENT_USER_PROMPT
-            ? { modelPrompt: modelPromptText }
-            : {}),
-          runtimeContext,
-          runtimeOnly: true,
-          runtimeSystemContext: buildRuntimeContextMessageContent({
-            runtimeContext,
-            kind: "runtime-event",
-          }),
-        }
-      : {
-          prompt: "",
-          ...(modelPromptText ? { modelPrompt: modelPromptText } : {}),
-        };
+    if (!runtimeContext) {
+      return {
+        prompt: "",
+        ...(modelPromptText ? { modelPrompt: modelPromptText } : {}),
+      };
+    }
+    const resumeContract = extractRuntimeResumeContract(runtimeContext);
+    return {
+      prompt: OPENCLAW_RUNTIME_EVENT_USER_PROMPT,
+      ...(modelPromptText.trim() && modelPromptText !== OPENCLAW_RUNTIME_EVENT_USER_PROMPT
+        ? { modelPrompt: modelPromptText }
+        : {}),
+      runtimeContext,
+      runtimeOnly: true,
+      runtimeSystemContext: buildRuntimeContextMessageContent({
+        runtimeContext,
+        kind: "runtime-event",
+        resumeContract,
+      }),
+      ...(resumeContract.open ? { resumeContract } : {}),
+    };
   }
 
   // When hooks added pre-prompt context, modelPromptText still contains the
@@ -247,15 +258,21 @@ export function resolveRuntimeContextPromptParts(params: {
 function buildRuntimeContextMessageContent(params: {
   runtimeContext: string;
   kind: "next-turn" | "runtime-event";
+  resumeContract?: RuntimeResumeContract;
 }): string {
   // Wrap the runtime context body in delimited internal-context markers so
   // stripInternalRuntimeContext can fully remove the block when it leaks
   // into user-visible surfaces (e.g. Feishu streaming cards, #92589).
+  const resumeAppendix =
+    params.kind === "runtime-event" && params.resumeContract
+      ? formatRuntimeResumeSystemAppendix(params.resumeContract)
+      : "";
   return [
     params.kind === "runtime-event"
       ? OPENCLAW_RUNTIME_EVENT_HEADER
       : OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER,
     OPENCLAW_RUNTIME_CONTEXT_NOTICE,
+    ...(resumeAppendix ? ["", resumeAppendix] : []),
     "",
     INTERNAL_RUNTIME_CONTEXT_BEGIN,
     params.runtimeContext,

--- a/src/agents/embedded-agent-runner/run/runtime-resume-contract.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-resume-contract.test.ts
@@ -5,7 +5,6 @@ import { resolveRuntimeContextPromptParts } from "./runtime-context-prompt.js";
 import {
   extractRuntimeResumeContract,
   isBlockedRuntimeResumeSilentReply,
-  RUNTIME_RESUME_CONTINUATION_DIRECTIVE,
   RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT,
   shouldBlockSilentReplyOnRuntimeResume,
 } from "./runtime-resume-contract.js";
@@ -49,7 +48,7 @@ describe("runtime resume contract", () => {
     expect(parts.runtimeOnly).toBe(true);
     expect(parts.prompt).toBe("Continue the OpenClaw runtime event.");
     expect(parts.resumeContract?.open).toBe(true);
-    expect(parts.runtimeSystemContext).toContain(RUNTIME_RESUME_CONTINUATION_DIRECTIVE);
+    expect(parts.runtimeSystemContext).toContain("Runtime resume directive:");
     expect(parts.runtimeSystemContext).toContain('"open": true');
     expect(parts.runtimeSystemContext).toContain("Structured resume contract");
   });
@@ -61,7 +60,7 @@ describe("runtime resume contract", () => {
     });
     expect(parts.runtimeOnly).toBe(true);
     expect(parts.resumeContract).toBeUndefined();
-    expect(parts.runtimeSystemContext).not.toContain(RUNTIME_RESUME_CONTINUATION_DIRECTIVE);
+    expect(parts.runtimeSystemContext).not.toContain("Runtime resume directive:");
   });
 
   it("blocks exact NO_REPLY while a runtime resume contract is open", () => {
@@ -77,13 +76,13 @@ describe("runtime resume contract", () => {
       shouldTreatEmptyAssistantReplyAsSilent({
         allowEmptyAssistantReplyAsSilent: true,
         terminalReplyExpectation: "optional",
-        blockRuntimeResumeSilentReply: true,
         payloadCount: 0,
         aborted: false,
         timedOut: false,
         attempt: {
           assistantTexts: ["NO_REPLY"],
           replayMetadata: { hadPotentialSideEffects: false },
+          blockRuntimeResumeSilentReply: true,
         } as never,
       }),
     ).toBe(false);
@@ -93,10 +92,10 @@ describe("runtime resume contract", () => {
         aborted: false,
         externalAbort: false,
         timedOut: false,
-        blockRuntimeResumeSilentReply: true,
         attempt: {
           assistantTexts: ["NO_REPLY"],
           replayMetadata: { hadPotentialSideEffects: false },
+          blockRuntimeResumeSilentReply: true,
         } as never,
       }),
     ).toBe(RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT);
@@ -107,7 +106,6 @@ describe("runtime resume contract", () => {
       shouldTreatEmptyAssistantReplyAsSilent({
         allowEmptyAssistantReplyAsSilent: true,
         terminalReplyExpectation: "optional",
-        blockRuntimeResumeSilentReply: false,
         payloadCount: 0,
         aborted: false,
         timedOut: false,
@@ -123,7 +121,6 @@ describe("runtime resume contract", () => {
         aborted: false,
         externalAbort: false,
         timedOut: false,
-        blockRuntimeResumeSilentReply: false,
         attempt: {
           assistantTexts: ["NO_REPLY"],
           replayMetadata: { hadPotentialSideEffects: false },
@@ -139,32 +136,33 @@ describe("runtime resume contract", () => {
  */
 describe("runtime false-closure canary transcript", () => {
   it("keeps the task active across compaction → memory checkpoint → NO_REPLY attempt", () => {
+    const finalAssistant = {
+      role: "assistant" as const,
+      text: "NO_REPLY",
+    };
     const transcript = [
       {
-        role: "user",
+        role: "user" as const,
         text: "Build the approved PDF and Excel packet. Do it.",
       },
       {
-        role: "assistant",
+        role: "assistant" as const,
         text: "Starting the packet…",
       },
       {
-        role: "runtime",
+        role: "runtime" as const,
         kind: "compaction",
         syntheticPrompt: "Continue the OpenClaw runtime event.",
         context: INCIDENT_RUNTIME_CONTEXT,
       },
       {
-        role: "assistant",
+        role: "assistant" as const,
         tool: "memory_append",
         result: "ok",
         note: "checkpoint only — packet not started",
       },
-      {
-        role: "assistant",
-        text: "NO_REPLY",
-      },
-    ] as const;
+      finalAssistant,
+    ];
 
     const resumeTurn = transcript.find((entry) => entry.role === "runtime");
     expect(resumeTurn).toBeTruthy();
@@ -175,13 +173,12 @@ describe("runtime false-closure canary transcript", () => {
     expect(parts.runtimeOnly).toBe(true);
     expect(parts.resumeContract?.open).toBe(true);
 
-    const final = transcript[transcript.length - 1];
-    expect(final.text).toBe("NO_REPLY");
+    expect(finalAssistant.text).toBe("NO_REPLY");
     expect(
       isBlockedRuntimeResumeSilentReply({
         runtimeOnly: true,
         resumeContract: parts.resumeContract,
-        assistantTexts: [final.text ?? ""],
+        assistantTexts: [finalAssistant.text],
       }),
     ).toBe(true);
 
@@ -190,10 +187,10 @@ describe("runtime false-closure canary transcript", () => {
       aborted: false,
       externalAbort: false,
       timedOut: false,
-      blockRuntimeResumeSilentReply: true,
       attempt: {
         assistantTexts: ["NO_REPLY"],
         replayMetadata: { hadPotentialSideEffects: true },
+        blockRuntimeResumeSilentReply: true,
       } as never,
     });
     expect(blockedText).toBe(RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT);

--- a/src/agents/embedded-agent-runner/run/runtime-resume-contract.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-resume-contract.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import { shouldTreatEmptyAssistantReplyAsSilent } from "./incomplete-turn-recovery.js";
+import { resolveIncompleteTurnPayloadText } from "./incomplete-turn-resolution.js";
+import { resolveRuntimeContextPromptParts } from "./runtime-context-prompt.js";
+import {
+  extractRuntimeResumeContract,
+  isBlockedRuntimeResumeSilentReply,
+  RUNTIME_RESUME_CONTINUATION_DIRECTIVE,
+  RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT,
+  shouldBlockSilentReplyOnRuntimeResume,
+} from "./runtime-resume-contract.js";
+
+const INCIDENT_RUNTIME_CONTEXT = [
+  "Compaction interrupted an approved artifact build.",
+  "Session: agent:k3rnel:discord:channel:1540412387503509635",
+  "User approved with: Do it.",
+  "CLCR: open",
+  "Outline approved, packet not started.",
+  "Next turn must build the PDF and Excel deliverables.",
+  "Memory checkpoint is not completion.",
+].join("\n");
+
+describe("runtime resume contract", () => {
+  it("opens a resume contract from the false-closure incident markers", () => {
+    const contract = extractRuntimeResumeContract(INCIDENT_RUNTIME_CONTEXT);
+    expect(contract.open).toBe(true);
+    expect(contract.signals).toEqual(
+      expect.arrayContaining(["clcr-open", "packet-not-started", "next-turn-must-build"]),
+    );
+    expect(contract.deliverables.join(" ").toLowerCase()).toMatch(/pdf|excel/);
+    expect(contract.completionGate).toMatch(/deliverable|blocker/i);
+  });
+
+  it("stays closed for ordinary runtime events with no pending user task", () => {
+    const contract = extractRuntimeResumeContract(
+      "Heartbeat poll. No pending user task. Status only.",
+    );
+    expect(contract.open).toBe(false);
+    expect(
+      shouldBlockSilentReplyOnRuntimeResume({ runtimeOnly: true, resumeContract: contract }),
+    ).toBe(false);
+  });
+
+  it("injects continuation directive + structured contract into runtime-only system context", () => {
+    const parts = resolveRuntimeContextPromptParts({
+      effectivePrompt: INCIDENT_RUNTIME_CONTEXT,
+      transcriptPrompt: "",
+    });
+    expect(parts.runtimeOnly).toBe(true);
+    expect(parts.prompt).toBe("Continue the OpenClaw runtime event.");
+    expect(parts.resumeContract?.open).toBe(true);
+    expect(parts.runtimeSystemContext).toContain(RUNTIME_RESUME_CONTINUATION_DIRECTIVE);
+    expect(parts.runtimeSystemContext).toContain('"open": true');
+    expect(parts.runtimeSystemContext).toContain("Structured resume contract");
+  });
+
+  it("does not mark ordinary runtime events with an open resume contract", () => {
+    const parts = resolveRuntimeContextPromptParts({
+      effectivePrompt: "internal housekeeping event",
+      transcriptPrompt: "",
+    });
+    expect(parts.runtimeOnly).toBe(true);
+    expect(parts.resumeContract).toBeUndefined();
+    expect(parts.runtimeSystemContext).not.toContain(RUNTIME_RESUME_CONTINUATION_DIRECTIVE);
+  });
+
+  it("blocks exact NO_REPLY while a runtime resume contract is open", () => {
+    const contract = extractRuntimeResumeContract(INCIDENT_RUNTIME_CONTEXT);
+    expect(
+      isBlockedRuntimeResumeSilentReply({
+        runtimeOnly: true,
+        resumeContract: contract,
+        assistantTexts: ["NO_REPLY"],
+      }),
+    ).toBe(true);
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "optional",
+        blockRuntimeResumeSilentReply: true,
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: {
+          assistantTexts: ["NO_REPLY"],
+          replayMetadata: { hadPotentialSideEffects: false },
+        } as never,
+      }),
+    ).toBe(false);
+    expect(
+      resolveIncompleteTurnPayloadText({
+        payloadCount: 0,
+        aborted: false,
+        externalAbort: false,
+        timedOut: false,
+        blockRuntimeResumeSilentReply: true,
+        attempt: {
+          assistantTexts: ["NO_REPLY"],
+          replayMetadata: { hadPotentialSideEffects: false },
+        } as never,
+      }),
+    ).toBe(RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT);
+  });
+
+  it("still allows intentional NO_REPLY when no resume contract is open", () => {
+    expect(
+      shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: true,
+        terminalReplyExpectation: "optional",
+        blockRuntimeResumeSilentReply: false,
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: {
+          assistantTexts: ["NO_REPLY"],
+          replayMetadata: { hadPotentialSideEffects: false },
+        } as never,
+      }),
+    ).toBe(true);
+    expect(
+      resolveIncompleteTurnPayloadText({
+        payloadCount: 0,
+        aborted: false,
+        externalAbort: false,
+        timedOut: false,
+        blockRuntimeResumeSilentReply: false,
+        attempt: {
+          assistantTexts: ["NO_REPLY"],
+          replayMetadata: { hadPotentialSideEffects: false },
+        } as never,
+      }),
+    ).toBeNull();
+  });
+});
+
+/**
+ * Canary transcript shape for the 2026-08-24 false-closure incident.
+ * Not a live gateway session — proves the contract machine for CI/canary review.
+ */
+describe("runtime false-closure canary transcript", () => {
+  it("keeps the task active across compaction → memory checkpoint → NO_REPLY attempt", () => {
+    const transcript = [
+      {
+        role: "user",
+        text: "Build the approved PDF and Excel packet. Do it.",
+      },
+      {
+        role: "assistant",
+        text: "Starting the packet…",
+      },
+      {
+        role: "runtime",
+        kind: "compaction",
+        syntheticPrompt: "Continue the OpenClaw runtime event.",
+        context: INCIDENT_RUNTIME_CONTEXT,
+      },
+      {
+        role: "assistant",
+        tool: "memory_append",
+        result: "ok",
+        note: "checkpoint only — packet not started",
+      },
+      {
+        role: "assistant",
+        text: "NO_REPLY",
+      },
+    ] as const;
+
+    const resumeTurn = transcript.find((entry) => entry.role === "runtime");
+    expect(resumeTurn).toBeTruthy();
+    const parts = resolveRuntimeContextPromptParts({
+      effectivePrompt: INCIDENT_RUNTIME_CONTEXT,
+      transcriptPrompt: "",
+    });
+    expect(parts.runtimeOnly).toBe(true);
+    expect(parts.resumeContract?.open).toBe(true);
+
+    const final = transcript[transcript.length - 1];
+    expect(final.text).toBe("NO_REPLY");
+    expect(
+      isBlockedRuntimeResumeSilentReply({
+        runtimeOnly: true,
+        resumeContract: parts.resumeContract,
+        assistantTexts: [final.text ?? ""],
+      }),
+    ).toBe(true);
+
+    const blockedText = resolveIncompleteTurnPayloadText({
+      payloadCount: 0,
+      aborted: false,
+      externalAbort: false,
+      timedOut: false,
+      blockRuntimeResumeSilentReply: true,
+      attempt: {
+        assistantTexts: ["NO_REPLY"],
+        replayMetadata: { hadPotentialSideEffects: true },
+      } as never,
+    });
+    expect(blockedText).toBe(RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT);
+    // Task remains active: silent path is rejected and a visible continuation is required.
+    expect(blockedText).not.toBeNull();
+    expect(parts.runtimeSystemContext).toContain("Checkpoint-only work");
+  });
+});

--- a/src/agents/embedded-agent-runner/run/runtime-resume-contract.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-resume-contract.ts
@@ -1,0 +1,184 @@
+/**
+ * Structured resume contract for runtime-only continuation turns.
+ *
+ * Compaction and other runtime events can resume with an empty transcript
+ * prompt ("Continue the OpenClaw runtime event."). When an interrupted user
+ * task is still open, exact NO_REPLY must not close the turn.
+ */
+import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
+
+export type RuntimeResumeContract = {
+  /** True when an unfinished user-facing task is still owed. */
+  open: boolean;
+  originatingSessionHint?: string;
+  requestedOutcome?: string;
+  completionGate?: string;
+  deliverables: string[];
+  blockerState?: string;
+  /** Matched heuristic markers (for tests/debug). */
+  signals: string[];
+};
+
+export const RUNTIME_RESUME_CONTINUATION_DIRECTIVE = [
+  "Runtime resume directive:",
+  "- Resume the interrupted user task from the runtime context below.",
+  "- Checkpoint-only work (memory writes, status notes) is not completion.",
+  "- Do not return exact NO_REPLY or an empty final while the resume contract is open.",
+  "- Either execute the completion gate / produce deliverables, or state a concrete blocker.",
+].join("\n");
+
+export const RUNTIME_RESUME_SILENT_REPLY_BLOCKED_TEXT =
+  "⚠️ Runtime resume contract is still open. Exact NO_REPLY is not allowed until the requested deliverable is produced or a concrete blocker is reported.";
+
+const OPEN_SIGNAL_PATTERNS: Array<{ id: string; re: RegExp }> = [
+  { id: "clcr-open", re: /\bCLCR\s*:\s*open\b/i },
+  { id: "packet-not-started", re: /\bpacket\s+not\s+started\b/i },
+  { id: "next-turn-must-build", re: /\bnext\s+turn\s+must\s+build\b/i },
+  { id: "must-build", re: /\bmust\s+build\b/i },
+  { id: "outline-approved-unbuilt", re: /\boutline\s+approved\b/i },
+  {
+    id: "deliverable-pending",
+    re: /\bdeliverable[s]?\s+(?:still\s+)?(?:pending|unbuilt|missing)\b/i,
+  },
+  { id: "unbuilt", re: /\bunbuilt\b/i },
+  { id: "do-it-approval", re: /\bdo\s+it\.?\b/i },
+  { id: "approved-build", re: /\bapproved\b.{0,80}\b(?:build|pdf|excel|xlsx|artifact)\b/i },
+  { id: "completion-gate-open", re: /\bcompletion\s+gate\b.{0,40}\bopen\b/i },
+  { id: "task-incomplete", re: /\b(?:task|work)\s+(?:still\s+)?(?:incomplete|unfinished|open)\b/i },
+];
+
+const CLOSED_SIGNAL_PATTERNS: Array<{ id: string; re: RegExp }> = [
+  { id: "clcr-closed", re: /\bCLCR\s*:\s*(?:closed|done|complete)\b/i },
+  {
+    id: "task-complete",
+    re: /\b(?:task|deliverable[s]?)\s+(?:complete|completed|delivered|done)\b/i,
+  },
+  { id: "no-pending-task", re: /\bno\s+pending\s+(?:user\s+)?task\b/i },
+];
+
+const SESSION_HINT_RE = /(?:session(?:Key|Id)?|session\s+file)\s*[:=]\s*([^\s,;`"'<>]+)/i;
+const OUTCOME_RE =
+  /(?:requested\s+outcome|objective|user\s+asked|approved)\s*[:=-]?\s*([^\n]{8,200})/i;
+const COMPLETION_GATE_RE =
+  /(?:completion\s+gate|done\s+when|success\s+criteria)\s*[:=-]?\s*([^\n]{8,200})/i;
+const BLOCKER_RE = /(?:blocker|blocked\s+on|waiting\s+on)\s*[:=-]?\s*([^\n]{8,200})/i;
+const DELIVERABLE_RE = /\b((?:pdf|excel|xlsx|docx|csv|artifact|report|packet)[^\n,;]{0,80})/gi;
+
+function uniqueNonEmpty(values: Array<string | undefined>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/** Derive a resume contract from free-form runtime context prose. */
+export function extractRuntimeResumeContract(
+  runtimeContext: string | undefined | null,
+): RuntimeResumeContract {
+  const text = runtimeContext?.trim() ?? "";
+  if (!text) {
+    return { open: false, deliverables: [], signals: [] };
+  }
+
+  const signals: string[] = [];
+  for (const pattern of OPEN_SIGNAL_PATTERNS) {
+    if (pattern.re.test(text)) {
+      signals.push(pattern.id);
+    }
+  }
+  const closedSignals: string[] = [];
+  for (const pattern of CLOSED_SIGNAL_PATTERNS) {
+    if (pattern.re.test(text)) {
+      closedSignals.push(pattern.id);
+    }
+  }
+
+  const deliverables = uniqueNonEmpty(
+    Array.from(text.matchAll(DELIVERABLE_RE), (match) => match[1]?.trim()),
+  ).slice(0, 8);
+
+  const originatingSessionHint = text.match(SESSION_HINT_RE)?.[1]?.trim();
+  const requestedOutcome = text.match(OUTCOME_RE)?.[1]?.trim();
+  const completionGate = text.match(COMPLETION_GATE_RE)?.[1]?.trim();
+  const blockerState = text.match(BLOCKER_RE)?.[1]?.trim();
+
+  // Explicit closed markers win when no open markers remain strong.
+  const open =
+    signals.length > 0 &&
+    !(closedSignals.includes("clcr-closed") || closedSignals.includes("no-pending-task"));
+
+  return {
+    open,
+    ...(originatingSessionHint ? { originatingSessionHint } : {}),
+    ...(requestedOutcome ? { requestedOutcome } : {}),
+    ...(completionGate
+      ? { completionGate }
+      : open
+        ? {
+            completionGate:
+              "Produce the approved deliverable(s) or report a concrete blocker. Memory checkpoint alone is insufficient.",
+          }
+        : {}),
+    deliverables,
+    ...(blockerState ? { blockerState } : {}),
+    signals: [...signals, ...closedSignals.map((id) => `closed:${id}`)],
+  };
+}
+
+/** Appended to runtime-event system context when a resume contract is open. */
+export function formatRuntimeResumeSystemAppendix(contract: RuntimeResumeContract): string {
+  if (!contract.open) {
+    return "";
+  }
+  const payload = {
+    open: true,
+    originatingSessionHint: contract.originatingSessionHint,
+    requestedOutcome: contract.requestedOutcome,
+    completionGate: contract.completionGate,
+    deliverables: contract.deliverables,
+    blockerState: contract.blockerState,
+    signals: contract.signals,
+  };
+  return [
+    RUNTIME_RESUME_CONTINUATION_DIRECTIVE,
+    "",
+    "Structured resume contract (authoritative):",
+    "```json",
+    JSON.stringify(payload, null, 2),
+    "```",
+  ].join("\n");
+}
+
+/** Runtime-only turns with an open resume contract must not accept exact silence. */
+export function shouldBlockSilentReplyOnRuntimeResume(params: {
+  runtimeOnly?: boolean;
+  resumeContract?: RuntimeResumeContract | null;
+}): boolean {
+  return params.runtimeOnly === true && params.resumeContract?.open === true;
+}
+
+export function isBlockedRuntimeResumeSilentReply(params: {
+  runtimeOnly?: boolean;
+  resumeContract?: RuntimeResumeContract | null;
+  assistantTexts?: readonly string[];
+}): boolean {
+  if (!shouldBlockSilentReplyOnRuntimeResume(params)) {
+    return false;
+  }
+  const texts = (params.assistantTexts ?? []).map((text) => text.trim()).filter(Boolean);
+  if (texts.length === 0) {
+    return true;
+  }
+  return texts.every((text) => isSilentReplyPayloadText(text, SILENT_REPLY_TOKEN));
+}

--- a/src/agents/embedded-agent-runner/run/runtime-resume-contract.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-resume-contract.ts
@@ -19,7 +19,7 @@ export type RuntimeResumeContract = {
   signals: string[];
 };
 
-export const RUNTIME_RESUME_CONTINUATION_DIRECTIVE = [
+const RUNTIME_RESUME_CONTINUATION_DIRECTIVE = [
   "Runtime resume directive:",
   "- Resume the interrupted user task from the runtime context below.",
   "- Checkpoint-only work (memory writes, status notes) is not completion.",
@@ -164,13 +164,18 @@ export function formatRuntimeResumeSystemAppendix(contract: RuntimeResumeContrac
 export function shouldBlockSilentReplyOnRuntimeResume(params: {
   runtimeOnly?: boolean;
   resumeContract?: RuntimeResumeContract | null;
+  blockRuntimeResumeSilentReply?: boolean;
 }): boolean {
+  if (params.blockRuntimeResumeSilentReply === true) {
+    return true;
+  }
   return params.runtimeOnly === true && params.resumeContract?.open === true;
 }
 
 export function isBlockedRuntimeResumeSilentReply(params: {
   runtimeOnly?: boolean;
   resumeContract?: RuntimeResumeContract | null;
+  blockRuntimeResumeSilentReply?: boolean;
   assistantTexts?: readonly string[];
 }): boolean {
   if (!shouldBlockSilentReplyOnRuntimeResume(params)) {

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -151,7 +151,6 @@ export function resolveSettledTurnFinalizationRequest(input: {
     allowEmptyAssistantReplyAsSilent: input.runParams.allowEmptyAssistantReplyAsSilent,
     terminalReplyExpectation: input.runParams.terminalReplyExpectation,
     onlyExplicitSilentReply: false,
-    blockRuntimeResumeSilentReply: input.runParams.blockRuntimeResumeSilentReply,
     payloadCount,
     aborted: terminalAborted,
     timedOut: terminalTimedOut,
@@ -264,7 +263,6 @@ export async function resolveEmbeddedRunTerminal(input: {
     allowEmptyAssistantReplyAsSilent: runParams.allowEmptyAssistantReplyAsSilent,
     terminalReplyExpectation: runParams.terminalReplyExpectation,
     onlyExplicitSilentReply: settledTurnFinalizationAttempted,
-    blockRuntimeResumeSilentReply: runParams.blockRuntimeResumeSilentReply,
     payloadCount,
     aborted: terminalAborted,
     timedOut: terminalTimedOut,
@@ -358,7 +356,6 @@ export async function resolveEmbeddedRunTerminal(input: {
           timedOut: terminalTimedOut,
           hadPotentialSideEffects: input.replayState.hadPotentialSideEffects,
           hasIntentionalTerminalCompletion: intentionalTerminalCompletion,
-          blockRuntimeResumeSilentReply: runParams.blockRuntimeResumeSilentReply,
           terminalAuthFailure: input,
           attempt,
         });

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -151,6 +151,7 @@ export function resolveSettledTurnFinalizationRequest(input: {
     allowEmptyAssistantReplyAsSilent: input.runParams.allowEmptyAssistantReplyAsSilent,
     terminalReplyExpectation: input.runParams.terminalReplyExpectation,
     onlyExplicitSilentReply: false,
+    blockRuntimeResumeSilentReply: input.runParams.blockRuntimeResumeSilentReply,
     payloadCount,
     aborted: terminalAborted,
     timedOut: terminalTimedOut,
@@ -263,6 +264,7 @@ export async function resolveEmbeddedRunTerminal(input: {
     allowEmptyAssistantReplyAsSilent: runParams.allowEmptyAssistantReplyAsSilent,
     terminalReplyExpectation: runParams.terminalReplyExpectation,
     onlyExplicitSilentReply: settledTurnFinalizationAttempted,
+    blockRuntimeResumeSilentReply: runParams.blockRuntimeResumeSilentReply,
     payloadCount,
     aborted: terminalAborted,
     timedOut: terminalTimedOut,
@@ -356,6 +358,7 @@ export async function resolveEmbeddedRunTerminal(input: {
           timedOut: terminalTimedOut,
           hadPotentialSideEffects: input.replayState.hadPotentialSideEffects,
           hasIntentionalTerminalCompletion: intentionalTerminalCompletion,
+          blockRuntimeResumeSilentReply: runParams.blockRuntimeResumeSilentReply,
           terminalAuthFailure: input,
           attempt,
         });

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -341,6 +341,11 @@ export type EmbeddedRunAttemptResult = {
   /** Explicit user-facing waiting status supplied to sessions_yield. */
   yieldAcknowledgment?: string;
   /**
+   * Runtime-only resume with an open resume contract must not accept exact
+   * NO_REPLY / empty finals as intentional silence.
+   */
+  blockRuntimeResumeSilentReply?: boolean;
+  /**
    * True when code mode owned this attempt's model tool surface. Absent means
    * the harness did not report engagement (treated as not engaged), which is
    * how config-enabled code mode stays visible as a no-op on harness routes.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users waiting on an approved, unfinished deliverable (for example a Discord-approved PDF/Excel build) could lose the turn after compaction: the runtime resumed with the synthetic prompt `Continue the OpenClaw runtime event.`, the agent could write a memory checkpoint, return exact `NO_REPLY`, and the platform treated that silence as intentional even though the user task was still open.

Affected workflow: embedded agent runtime-only resume after compaction / internal runtime events while a user-facing artifact task is still owed.

## Why This Change Was Made

Runtime-only turns already inject free-form runtime context, but they did not carry a structured resume contract or a final guard against silent closure. This change extracts an open/closed resume contract from that context, injects a continuation directive plus JSON contract into runtime-event system context, and rejects exact `NO_REPLY` / empty finals while the contract is open. Ordinary runtime events with no pending user task remain allowed to stay silent.

Non-goals: no Discord routing changes; compaction memory flush stays enabled; not every runtime event becomes user-visible.

## User Impact

Operators and users should no longer see approved unfinished artifact work disappear into silent `NO_REPLY` after a runtime resume. The turn stays active until the completion gate is met or a concrete blocker is reported. Heartbeats and other no-pending-task runtime events remain quiet when appropriate.

## Evidence

Local focused tests on commit `fe6d30e19dc6c27b0af07bd86e62617476b0746e`:

```text
pnpm test   src/agents/embedded-agent-runner/run/runtime-resume-contract.test.ts   src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts

Test Files  2 passed (2)
     Tests  35 passed (35)
```

Covered behaviors:
- Incident markers (`CLCR: open`, packet not started, must build, approved artifact) open a resume contract.
- Runtime-only system context includes the continuation directive and structured JSON contract.
- Exact `NO_REPLY` is blocked while the contract is open (`shouldTreatEmptyAssistantReplyAsSilent` false; incomplete-turn path emits blocked-resume text).
- Ordinary runtime events with no pending user task still allow intentional `NO_REPLY`.
- Synthetic canary transcript walks compaction → memory checkpoint → NO_REPLY and asserts the task stays active.

What was not tested here:
- Live Discord unfinished-artifact session on a production gateway.
- Mini host package upgrade to this SHA (explicitly held; live remains `2026.7.1-2`).

## Summary

Source remediation for runtime false-closure. Full product close still needs merge, shipped package/gateway on this SHA, and a live compaction-during-unfinished-artifact canary.