### PR TITLE
fix(ollama): support adaptive thinking level for Ollama models

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -1021,7 +1021,9 @@ For full setup and behavior, see [Ollama Web Search](/tools/ollama-search).
     OpenClaw forwards thinking as Ollama expects it: top-level `think`, not
     `options.think`. Auto-discovered models whose `/api/show` reports a
     `thinking` capability expose `/think low`, `/think medium`, `/think high`,
-    and `/think max`; non-thinking models expose only `/think off`.
+    `/think adaptive`, and `/think max`; non-thinking models expose only
+    `/think off`. The `/think adaptive` level is an OpenClaw-only tier that
+    maps to Ollama's native high effort (`think: "high"`).
 
     ```bash
     openclaw agent --model ollama/gemma4 --thinking off

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -2564,7 +2564,14 @@ describe("ollama plugin", () => {
         reasoning: true,
       }),
     ).toEqual({
-      levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
+      levels: [
+        { id: "off" },
+        { id: "low" },
+        { id: "medium" },
+        { id: "high" },
+        { id: "adaptive" },
+        { id: "max" },
+      ],
       defaultLevel: "off",
     });
   });

--- a/extensions/ollama/provider-policy-api.test.ts
+++ b/extensions/ollama/provider-policy-api.test.ts
@@ -25,6 +25,17 @@ function createModel(id: string, name: string): ModelDefinitionConfig {
   };
 }
 
+// Reasoning-capable Ollama models expose the same native effort tiers, including
+// the OpenClaw-only `adaptive` tier mapped to Ollama high effort.
+const OLLAMA_FULL_REASONING_LEVELS = [
+  { id: "off" },
+  { id: "low" },
+  { id: "medium" },
+  { id: "high" },
+  { id: "adaptive" },
+  { id: "max" },
+] as const;
+
 describe("ollama provider policy public artifact", () => {
   it("injects defaults so implicit discovery can run before validation", () => {
     expect(
@@ -110,7 +121,7 @@ describe("ollama provider policy public artifact", () => {
     expect(
       resolveThinkingProfile({ provider: "ollama", modelId: "qwen3:32b", reasoning: true }),
     ).toEqual({
-      levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
+      levels: [...OLLAMA_FULL_REASONING_LEVELS],
       defaultLevel: "off",
     });
     expect(
@@ -125,11 +136,7 @@ describe("ollama provider policy public artifact", () => {
     "exposes full native effort for cloud model %s when lightweight projections omit metadata",
     (modelId) => {
       expect(resolveThinkingProfile({ provider: "ollama-cloud", modelId }).levels).toEqual([
-        { id: "off" },
-        { id: "low" },
-        { id: "medium" },
-        { id: "high" },
-        { id: "max" },
+        ...OLLAMA_FULL_REASONING_LEVELS,
       ]);
     },
   );

--- a/extensions/ollama/provider-policy-api.ts
+++ b/extensions/ollama/provider-policy-api.ts
@@ -13,7 +13,14 @@ import { supportsOllamaCloudFullThinkingEffort } from "./src/model-reasoning.js"
 type OllamaProviderConfigDraft = Partial<ModelProviderConfig>;
 
 const OLLAMA_REASONING_THINKING_PROFILE = {
-  levels: [{ id: "off" }, { id: "low" }, { id: "medium" }, { id: "high" }, { id: "max" }],
+  levels: [
+    { id: "off" },
+    { id: "low" },
+    { id: "medium" },
+    { id: "high" },
+    { id: "adaptive" },
+    { id: "max" },
+  ],
   defaultLevel: "off",
 } satisfies ProviderThinkingProfile;
 

--- a/extensions/ollama/stream-compat.live.test.ts
+++ b/extensions/ollama/stream-compat.live.test.ts
@@ -1,0 +1,36 @@
+import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
+import { describe, expect, it } from "vitest";
+
+const ollamaApiKey = process.env.OLLAMA_API_KEY?.trim() ?? "";
+const LIVE =
+  isLiveTestEnabled(["OPENCLAW_LIVE_TEST", "OLLAMA_LIVE_TEST"]) && ollamaApiKey.length > 0;
+const describeLive = LIVE ? describe : describe.skip;
+
+// Live proof for the `adaptive` thinking tier added in #128757:
+// 1. the OpenClaw-only `adaptive` tier maps to native Ollama high effort, and
+// 2. a real Ollama Cloud thinking-capable model accepts the mapped `think: "high"` payload.
+describeLive("ollama adaptive thinking (live proof)", () => {
+  it("maps the OpenClaw-only adaptive tier to native Ollama high effort", async () => {
+    const { resolveOllamaThinkParamValue } = await import("./src/stream-compat.js");
+    expect(resolveOllamaThinkParamValue({ think: "adaptive" }, true)).toBe("high");
+  });
+
+  it("ollama-cloud gpt-oss:20b accepts the adaptive-mapped think:high payload", async () => {
+    const res = await fetch("https://ollama.com/api/chat", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${ollamaApiKey}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-oss:20b",
+        messages: [{ role: "user", content: "Reply with exactly the word: hi" }],
+        think: "high",
+        stream: false,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { message?: { content?: string } };
+    expect(data.message?.content?.toLowerCase().includes("hi")).toBe(true);
+  }, 60_000);
+});

--- a/src/acp/translator.presentation.ts
+++ b/src/acp/translator.presentation.ts
@@ -41,6 +41,7 @@ export type GatewaySessionPresentationRow = Pick<
   | "derivedTitle"
   | "updatedAt"
   | "thinkingLevel"
+  | "thinkingDefault"
   | "fastMode"
   | "effectiveFastMode"
   | "modelProvider"
@@ -141,7 +142,13 @@ export function buildSessionPresentation(params: {
   const availableLevelIds: string[] = row.thinkingLevels?.map((level) => level.id) ?? [
     ...BASE_THINKING_LEVELS,
   ];
-  const currentModeId = normalizeOptionalString(row.thinkingLevel) || "adaptive";
+  // Prefer the gateway's recorded thinking level; if absent, honor the
+  // configured thinking default so ACP sessions reflect user-configured
+  // defaults instead of being forced to "adaptive".
+  const currentModeId =
+    normalizeOptionalString(row.thinkingLevel) ||
+    normalizeOptionalString(row.thinkingDefault) ||
+    "adaptive";
   const currentFastMode = normalizeFastMode(row.effectiveFastMode ?? row.fastMode) ?? false;
   if (!availableLevelIds.includes(currentModeId)) {
     availableLevelIds.push(currentModeId);

--- a/src/acp/translator.session-setup.test.ts
+++ b/src/acp/translator.session-setup.test.ts
@@ -99,6 +99,91 @@ describe("acp session UX bridge behavior", () => {
     expectConfigOption(result.configOptions, "elevated_level", { currentValue: "off" });
   });
 
+  it("honors configured thinkingDefault when gateway session has no explicit thinkingLevel", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "agent:main:thinking-default",
+              displayName: "Thinking Default",
+              kind: "direct",
+              updatedAt: 1_710_000_000_000,
+              thinkingDefault: "off",
+              modelProvider: "openai",
+              model: "gpt-5.4",
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+      sessionStore,
+    });
+
+    const result = await agent.loadSession(createLoadSessionRequest("agent:main:thinking-default"));
+
+    // thinkingLevel is absent on the row, so thinkingDefault should be used.
+    expect(result.modes?.currentModeId).toBe("off");
+    expectConfigOption(result.configOptions, "thought_level", {
+      currentValue: "off",
+    });
+  });
+
+  it("prefers explicit thinkingLevel over thinkingDefault", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          ts: Date.now(),
+          path: "/tmp/sessions.json",
+          count: 1,
+          defaults: {
+            modelProvider: null,
+            model: null,
+            contextTokens: null,
+          },
+          sessions: [
+            {
+              key: "agent:main:explicit-thinking",
+              displayName: "Explicit Thinking",
+              kind: "direct",
+              updatedAt: 1_710_000_000_000,
+              thinkingLevel: "high",
+              thinkingDefault: "off",
+              modelProvider: "openai",
+              model: "gpt-5.4",
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+      sessionStore,
+    });
+
+    const result = await agent.loadSession(
+      createLoadSessionRequest("agent:main:explicit-thinking"),
+    );
+
+    // thinkingLevel takes precedence over thinkingDefault.
+    expect(result.modes?.currentModeId).toBe("high");
+    expectConfigOption(result.configOptions, "thought_level", {
+      currentValue: "high",
+    });
+  });
+
   it("replays user text, assistant text, and hidden assistant thinking on loadSession", async () => {
     const sessionStore = createInMemorySessionStore();
     const connection = createAcpConnection();

--- a/src/acp/translator.session-state.ts
+++ b/src/acp/translator.session-state.ts
@@ -234,6 +234,7 @@ export class AcpTranslatorSessionState {
       derivedTitle: session.derivedTitle,
       updatedAt: session.updatedAt,
       thinkingLevel: session.thinkingLevel,
+      thinkingDefault: session.thinkingDefault,
       thinkingLevels: session.thinkingLevels,
       modelProvider: session.modelProvider,
       model: session.model,


### PR DESCRIPTION
## What Problem This Solves

Ollama reasoning-capable models expose native effort tiers, but OpenClaw did not
advertise the `adaptive` thinking tier for Ollama, and ACP session presentation
forced the current thinking mode to `"adaptive"` even when the operator had
configured a different `thinkingDefault`. This PR adds the `adaptive` tier
(mapped to Ollama's native `think: "high"`) and makes ACP honor the configured
`thinkingDefault` when no explicit `thinkingLevel` is set.

## Why This Change Was Made

This revision replaces the earlier `/acp spawn` changes on this branch, which
did not compile (referenced an undeclared loop variable in `shared.ts` and a
non-existent `AcpConfig.defaultModel` field in `lifecycle.ts`) and overlapped the
already-merged bridge `thinkingDefault` handling in #128169. Per steipete's
CHANGES_REQUESTED and ClawSweeper `needs proof`, the scope is narrowed to one
coherent defect:

- Advertise the OpenClaw-only `adaptive` thinking level in Ollama's reasoning
  profile (maps to native `think: "high"` via `normalizeOllamaThinkValue`).
- ACP session presentation falls back to the configured `thinkingDefault` when
  no explicit `thinkingLevel` is present, instead of forcing `"adaptive"`.
- The unsupported `Fixes #128145` claim is dropped: #128169 already fixed the
  bridge `thinkingDefault` wiring, so this PR no longer duplicates it.

## User Impact

- `/think adaptive` (and the ACP thinking control) is now available for Ollama
  reasoning models; it forwards `think: "high"` to Ollama.
- ACP clients show the operator-configured thinking default as the current mode
  when a session has no explicit thinking level, rather than always `"adaptive"`.

## Evidence

### Unit tests (P1) — green locally

- `extensions/ollama/index.test.ts`: reasoning-capable Ollama profile exposes
  `adaptive` in its levels.
- `extensions/ollama/provider-policy-api.test.ts`: native effort tiers include
  `adaptive` (duplicated fixture consolidated into one const).
- `src/acp/translator.session-setup.test.ts` (new): "honors configured
  thinkingDefault when gateway session has no explicit thinkingLevel" and
  "prefers explicit thinkingLevel over thinkingDefault" both pass.
- Full affected suites: 122 ollama tests + 8 acp translator tests pass; core
  prod `tsgo` passes; `oxlint` clean on changed files.

### Live proof (P2) — green

- `resolveOllamaThinkParamValue({ think: "adaptive" }, true) === "high"` (real
  extension function).
- Real Ollama Cloud call: `POST https://ollama.com/api/chat` for `gpt-oss:20b`
  with `think: "high"` returned HTTP 200 and the model echoed the prompt.
  (Local `pnpm test:live` could not stage live auth profiles because the
  operator agent DB is at a stale schema version 17 and migrating requires
  stopping the gateway; the committed `extensions/ollama/stream-compat.live.test.ts`
  runs this proof in CI where the DB is current.)

## Verification

- `pnpm test extensions/ollama/provider-policy-api.test.ts extensions/ollama/index.test.ts src/acp/translator.session-setup.test.ts` — all pass.
- `extensions/ollama/stream-compat.live.test.ts` — committed live proof (gated on
  `OPENCLAW_LIVE_TEST`), runs in CI.

## Related

- #128169 (Fixes #128145, merged) owns the bridge `thinkingDefault` handling this
  PR no longer duplicates.
