### PR TITLE
fix(matrix): show edited messages in replies and thread context

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -673,7 +673,7 @@ extensions/matrix/src/matrix/actions/devices.ts	1
 extensions/matrix/src/matrix/actions/messages.ts	8
 extensions/matrix/src/matrix/actions/polls.ts	1
 extensions/matrix/src/matrix/actions/reactions.ts	1
-extensions/matrix/src/matrix/actions/summary.ts	6
+extensions/matrix/src/matrix/actions/summary.ts	2
 extensions/matrix/src/matrix/actions/verification.ts	1
 extensions/matrix/src/matrix/client-bootstrap.ts	1
 extensions/matrix/src/matrix/client/config.ts	5

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -1,7 +1,10 @@
 // Matrix plugin module implements summary behavior.
 import { asNullableObjectRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isMatrixNotFoundError } from "../errors.js";
-import { resolveMatrixMessageAttachment } from "../media-text.js";
+import {
+  resolveBundledMatrixReplacementContent,
+  resolveMatrixMessageAttachment,
+} from "../media-text.js";
 import { fetchMatrixPollMessageSummary } from "../poll-summary.js";
 import type { MatrixClient } from "../sdk.js";
 import {
@@ -46,35 +49,6 @@ function parseMatrixRawEvent(value: unknown): MatrixRawEvent | null {
       : {}),
     ...(typeof event.state_key === "string" ? { state_key: event.state_key } : {}),
   };
-}
-
-function resolveBundledMatrixReplacementContent(
-  event: MatrixRawEvent,
-): RoomMessageEventContent | undefined {
-  const rawReplacement = event.unsigned?.["m.relations"]?.["m.replace"];
-  if (!rawReplacement || typeof rawReplacement !== "object" || event.state_key !== undefined) {
-    return undefined;
-  }
-  const replacement = rawReplacement as Partial<MatrixRawEvent>;
-  const content = replacement.content;
-  const relation = content?.["m.relates_to"];
-  const newContent = content?.["m.new_content"];
-  if (
-    replacement.sender !== event.sender ||
-    replacement.type !== event.type ||
-    replacement.state_key !== undefined ||
-    replacement.unsigned?.redacted_because ||
-    !relation ||
-    typeof relation !== "object" ||
-    (relation as { rel_type?: unknown }).rel_type !== "m.replace" ||
-    (relation as { event_id?: unknown }).event_id !== event.event_id ||
-    !newContent ||
-    typeof newContent !== "object" ||
-    Array.isArray(newContent)
-  ) {
-    return undefined;
-  }
-  return newContent as RoomMessageEventContent;
 }
 
 export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSummary {

--- a/extensions/matrix/src/matrix/media-text.ts
+++ b/extensions/matrix/src/matrix/media-text.ts
@@ -1,5 +1,9 @@
 // Matrix plugin module implements media text behavior.
 import path from "node:path";
+import {
+  asNullableObjectRecord,
+  asNullableRecord,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
   MatrixMessageAttachmentKind,
   MatrixMessageAttachmentSummary,
@@ -72,31 +76,26 @@ function resolveCaptionOrFilename(params: { body?: string; filename?: string }):
 
 export function resolveBundledMatrixReplacementContent(
   event: MatrixRawEvent,
-): RoomMessageEventContent | undefined {
-  const rawReplacement = event.unsigned?.["m.relations"]?.["m.replace"];
-  if (!rawReplacement || typeof rawReplacement !== "object" || event.state_key !== undefined) {
+): Partial<RoomMessageEventContent> | undefined {
+  const replacement = asNullableObjectRecord(event.unsigned?.["m.relations"]?.["m.replace"]);
+  if (!replacement || event.state_key !== undefined) {
     return undefined;
   }
-  const replacement = rawReplacement as Partial<MatrixRawEvent>;
-  const content = replacement.content;
-  const relation = content?.["m.relates_to"];
+  const content = asNullableObjectRecord(replacement.content);
+  const relation = asNullableObjectRecord(content?.["m.relates_to"]);
   const newContent = content?.["m.new_content"];
   if (
     replacement.sender !== event.sender ||
     replacement.type !== event.type ||
     replacement.state_key !== undefined ||
-    replacement.unsigned?.redacted_because ||
+    asNullableObjectRecord(replacement.unsigned)?.redacted_because ||
     !relation ||
-    typeof relation !== "object" ||
-    (relation as { rel_type?: unknown }).rel_type !== "m.replace" ||
-    (relation as { event_id?: unknown }).event_id !== event.event_id ||
-    !newContent ||
-    typeof newContent !== "object" ||
-    Array.isArray(newContent)
+    relation.rel_type !== "m.replace" ||
+    relation.event_id !== event.event_id
   ) {
     return undefined;
   }
-  return newContent as RoomMessageEventContent;
+  return asNullableRecord(newContent) ?? undefined;
 }
 
 type MatrixMessageContentInput = {

--- a/extensions/matrix/src/matrix/media-text.ts
+++ b/extensions/matrix/src/matrix/media-text.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import type {
   MatrixMessageAttachmentKind,
   MatrixMessageAttachmentSummary,
+  MatrixRawEvent,
+  RoomMessageEventContent,
 } from "./actions/types.js";
 
 const MATRIX_MEDIA_KINDS: Record<string, MatrixMessageAttachmentKind> = {
@@ -66,6 +68,35 @@ function resolveCaptionOrFilename(params: { body?: string; filename?: string }):
     return { filename: body };
   }
   return { caption: body };
+}
+
+export function resolveBundledMatrixReplacementContent(
+  event: MatrixRawEvent,
+): RoomMessageEventContent | undefined {
+  const rawReplacement = event.unsigned?.["m.relations"]?.["m.replace"];
+  if (!rawReplacement || typeof rawReplacement !== "object" || event.state_key !== undefined) {
+    return undefined;
+  }
+  const replacement = rawReplacement as Partial<MatrixRawEvent>;
+  const content = replacement.content;
+  const relation = content?.["m.relates_to"];
+  const newContent = content?.["m.new_content"];
+  if (
+    replacement.sender !== event.sender ||
+    replacement.type !== event.type ||
+    replacement.state_key !== undefined ||
+    replacement.unsigned?.redacted_because ||
+    !relation ||
+    typeof relation !== "object" ||
+    (relation as { rel_type?: unknown }).rel_type !== "m.replace" ||
+    (relation as { event_id?: unknown }).event_id !== event.event_id ||
+    !newContent ||
+    typeof newContent !== "object" ||
+    Array.isArray(newContent)
+  ) {
+    return undefined;
+  }
+  return newContent as RoomMessageEventContent;
 }
 
 type MatrixMessageContentInput = {

--- a/extensions/matrix/src/matrix/monitor/context-summary.ts
+++ b/extensions/matrix/src/matrix/monitor/context-summary.ts
@@ -3,7 +3,7 @@ import {
   normalizeOptionalString,
   readStringValue,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { formatMatrixMessageText } from "../media-text.js";
+import { formatMatrixMessageText, resolveBundledMatrixReplacementContent } from "../media-text.js";
 import {
   formatPollAsText,
   isPollStartType,
@@ -20,7 +20,13 @@ export function summarizeMatrixMessageContextEvent(event: MatrixRawEvent): strin
     }
   }
 
-  const content = event.content as { body?: unknown; filename?: unknown; msgtype?: unknown };
+  // Thread roots do not reject redacted originals before projection; never
+  // restore their content from a replacement bundled by the homeserver.
+  const content = (
+    event.unsigned?.redacted_because
+      ? event.content
+      : (resolveBundledMatrixReplacementContent(event) ?? event.content)
+  ) as { body?: unknown; filename?: unknown; msgtype?: unknown };
   return formatMatrixMessageText({
     body: readStringValue(content.body),
     filename: readStringValue(content.filename),

--- a/extensions/matrix/src/matrix/monitor/reply-context.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reply-context.test.ts
@@ -1,7 +1,12 @@
 // Matrix tests cover reply context plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import { createMatrixReplyContextResolver } from "./reply-context.js";
-import { createPollStartEvent } from "./test-events.js";
+import {
+  bundledReplacementContentCases,
+  createBundledReplacementEvent,
+  createPollStartEvent,
+  invalidBundledReplacementCases,
+} from "./test-events.js";
 import type { MatrixRawEvent } from "./types.js";
 
 async function resolveReplyBody(event: MatrixRawEvent): Promise<string | undefined> {
@@ -32,6 +37,32 @@ describe("matrix reply context", () => {
         },
       } as MatrixRawEvent),
     ).toBe("Some quoted message");
+  });
+
+  it.each(bundledReplacementContentCases)(
+    "uses the latest bundled $name when quoting an edited message",
+    async ({ options, expected }) => {
+      expect(await resolveReplyBody(createBundledReplacementEvent("$original", options))).toBe(
+        expected,
+      );
+    },
+  );
+
+  it.each(invalidBundledReplacementCases)(
+    "does not quote a bundled replacement from $name",
+    async ({ options }) => {
+      expect(await resolveReplyBody(createBundledReplacementEvent("$original", options))).toBe(
+        "original text",
+      );
+    },
+  );
+
+  it("does not revive a bundled replacement from a redacted original", async () => {
+    expect(
+      await resolveReplyBody(
+        createBundledReplacementEvent("$original", { content: {}, redacted: true }),
+      ),
+    ).toBeUndefined();
   });
 
   it("truncates long reply bodies", async () => {

--- a/extensions/matrix/src/matrix/monitor/test-events.ts
+++ b/extensions/matrix/src/matrix/monitor/test-events.ts
@@ -6,6 +6,8 @@ type BundledReplacementEventOptions = {
   replacementContent?: Record<string, unknown>;
   replacement?: Partial<MatrixRawEvent>;
   redacted?: boolean;
+  stateKey?: string;
+  objectBackedArrays?: boolean;
 };
 
 export function createBundledReplacementEvent(
@@ -21,7 +23,9 @@ export function createBundledReplacementEvent(
       msgtype: "m.text",
       body: "* edited text",
       "m.new_content": { msgtype: "m.text", body: "edited text" },
-      "m.relates_to": { rel_type: "m.replace", event_id: eventId },
+      "m.relates_to": options.objectBackedArrays
+        ? Object.assign([], { rel_type: "m.replace", event_id: eventId })
+        : { rel_type: "m.replace", event_id: eventId },
       ...options.replacementContent,
     },
     ...options.replacement,
@@ -33,9 +37,12 @@ export function createBundledReplacementEvent(
     type: "m.room.message",
     origin_server_ts: 100,
     content: options.content ?? { msgtype: "m.text", body: "original text" },
+    ...(options.stateKey === undefined ? {} : { state_key: options.stateKey }),
     unsigned: {
       ...(options.redacted ? { redacted_because: { event_id: "$redaction" } } : {}),
-      "m.relations": { "m.replace": replacement },
+      "m.relations": {
+        "m.replace": options.objectBackedArrays ? Object.assign([], replacement) : replacement,
+      },
     },
   };
 }
@@ -44,6 +51,11 @@ export const bundledReplacementContentCases = [
   {
     name: "text",
     options: {},
+    expected: "edited text",
+  },
+  {
+    name: "legacy object-backed relation arrays",
+    options: { objectBackedArrays: true },
     expected: "edited text",
   },
   {
@@ -84,9 +96,37 @@ export const invalidBundledReplacementCases = [
     options: { replacement: { type: "m.room.notice" } },
   },
   {
+    name: "a state-event original",
+    options: { stateKey: "" },
+  },
+  {
+    name: "a state-event replacement",
+    options: { replacement: { state_key: "" } },
+  },
+  {
+    name: "a malformed replacement relation",
+    options: { replacementContent: { "m.relates_to": undefined } },
+  },
+  {
+    name: "missing replacement content",
+    options: { replacement: { content: {} } },
+  },
+  {
+    name: "array replacement content",
+    options: { replacementContent: { "m.new_content": [] } },
+  },
+  {
     name: "a redacted replacement",
     options: {
       replacement: { unsigned: { redacted_because: { event_id: "$redaction" } } },
+    },
+  },
+  {
+    name: "an object-backed redacted replacement",
+    options: {
+      replacement: {
+        unsigned: Object.assign([], { redacted_because: { event_id: "$redaction" } }),
+      },
     },
   },
 ] satisfies Array<{ name: string; options: BundledReplacementEventOptions }>;

--- a/extensions/matrix/src/matrix/monitor/test-events.ts
+++ b/extensions/matrix/src/matrix/monitor/test-events.ts
@@ -1,6 +1,96 @@
 // Matrix plugin module implements test events behavior.
 import type { MatrixRawEvent } from "./types.js";
 
+type BundledReplacementEventOptions = {
+  content?: Record<string, unknown>;
+  replacementContent?: Record<string, unknown>;
+  replacement?: Partial<MatrixRawEvent>;
+  redacted?: boolean;
+};
+
+export function createBundledReplacementEvent(
+  eventId: string,
+  options: BundledReplacementEventOptions = {},
+): MatrixRawEvent {
+  const replacement: MatrixRawEvent = {
+    event_id: "$edit",
+    sender: "@alice:example.org",
+    type: "m.room.message",
+    origin_server_ts: 200,
+    content: {
+      msgtype: "m.text",
+      body: "* edited text",
+      "m.new_content": { msgtype: "m.text", body: "edited text" },
+      "m.relates_to": { rel_type: "m.replace", event_id: eventId },
+      ...options.replacementContent,
+    },
+    ...options.replacement,
+  };
+
+  return {
+    event_id: eventId,
+    sender: "@alice:example.org",
+    type: "m.room.message",
+    origin_server_ts: 100,
+    content: options.content ?? { msgtype: "m.text", body: "original text" },
+    unsigned: {
+      ...(options.redacted ? { redacted_because: { event_id: "$redaction" } } : {}),
+      "m.relations": { "m.replace": replacement },
+    },
+  };
+}
+
+export const bundledReplacementContentCases = [
+  {
+    name: "text",
+    options: {},
+    expected: "edited text",
+  },
+  {
+    name: "media caption",
+    options: {
+      content: { msgtype: "m.image", body: "before.jpg", filename: "before.jpg" },
+      replacementContent: {
+        "m.new_content": {
+          msgtype: "m.image",
+          body: "edited caption",
+          filename: "after.jpg",
+        },
+      },
+    },
+    expected: "edited caption\n\n[matrix image attachment]",
+  },
+] satisfies Array<{
+  name: string;
+  options: BundledReplacementEventOptions;
+  expected: string;
+}>;
+
+export const invalidBundledReplacementCases = [
+  {
+    name: "another sender",
+    options: { replacement: { sender: "@mallory:example.org" } },
+  },
+  {
+    name: "another target",
+    options: {
+      replacementContent: {
+        "m.relates_to": { rel_type: "m.replace", event_id: "$different" },
+      },
+    },
+  },
+  {
+    name: "another event type",
+    options: { replacement: { type: "m.room.notice" } },
+  },
+  {
+    name: "a redacted replacement",
+    options: {
+      replacement: { unsigned: { redacted_because: { event_id: "$redaction" } } },
+    },
+  },
+] satisfies Array<{ name: string; options: BundledReplacementEventOptions }>;
+
 export function createPollStartEvent(eventId: string): MatrixRawEvent {
   return {
     event_id: eventId,

--- a/extensions/matrix/src/matrix/monitor/thread-context.test.ts
+++ b/extensions/matrix/src/matrix/monitor/thread-context.test.ts
@@ -1,6 +1,11 @@
 // Matrix tests cover thread context plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import { createPollStartEvent } from "./test-events.js";
+import {
+  bundledReplacementContentCases,
+  createBundledReplacementEvent,
+  createPollStartEvent,
+  invalidBundledReplacementCases,
+} from "./test-events.js";
 import { createMatrixThreadContextResolver } from "./thread-context.js";
 import type { MatrixRawEvent } from "./types.js";
 
@@ -32,6 +37,32 @@ describe("matrix thread context", () => {
         },
       } as MatrixRawEvent),
     ).toBe("Thread starter body");
+  });
+
+  it.each(bundledReplacementContentCases)(
+    "uses the latest bundled $name when summarizing an edited thread root",
+    async ({ options, expected }) => {
+      expect(await resolveThreadSummary(createBundledReplacementEvent("$root", options))).toBe(
+        expected,
+      );
+    },
+  );
+
+  it.each(invalidBundledReplacementCases)(
+    "does not summarize a bundled thread-root replacement from $name",
+    async ({ options }) => {
+      expect(await resolveThreadSummary(createBundledReplacementEvent("$root", options))).toBe(
+        "original text",
+      );
+    },
+  );
+
+  it("does not revive a bundled replacement from a redacted thread root", async () => {
+    expect(
+      await resolveThreadSummary(
+        createBundledReplacementEvent("$root", { content: {}, redacted: true }),
+      ),
+    ).toBe("Matrix m.room.message event");
   });
 
   it("truncates long thread starter bodies on code-point boundaries", async () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Matrix users replying to an edited message or continuing an edited message's thread would receive responses based on the obsolete original text. Edited attachment captions were also silently omitted from quoted-message and thread-root context, even though Matrix history and pinned messages already displayed the latest edit correctly.

## Why This Change Was Made

Matrix homeservers return the latest edit as a bundled `m.replace` relation. Move the existing Matrix history validation into the already shared private message-presentation owner, so history, replies, and thread roots select the same authorized replacement. Replace four legacy type assertions with OpenClaw's existing typed record guards while preserving every sender, event-type, target, state-event, and replacement-redaction check, the original replacement object identity, object-backed array handling, and accessor evaluation order. Explicitly reject bundled replacements for redacted original events before applying them.

The upstream `matrix-js-sdk` event mapper cannot replace this existing validator: its bundled-edit path does not enforce the same sender, target, type, or replacement-redaction checks. This change does not modify the SDK adapter, encryption, authentication, configuration, public plugin APIs, or protected security-owned files. The small positive production-line delta is necessary for shared import wiring and the explicit original-redaction ownership invariant. The assertion-safety baseline only tightens the original history file from six legacy assertions to two; the shared presentation owner remains assertion-free.

## User Impact

Matrix reply quotes and thread-root context now show the same current edited text or attachment caption that users see in their Matrix client and existing OpenClaw history/pin actions. Invalid, forged, or redacted replacements remain invisible, and polls, original message relationships, and attachment markers keep their existing behavior.

## Evidence

- Regression tests first failed on unchanged `main`: four failures covered edited text and image captions through both actual Matrix reply and thread-root context owners; the other 27 owner and safety cases already passed.
- After the private owner repair, 127 tests passed across 10 focused suites covering reply/thread context, action summaries, history, pins, real handler thread-root media, room history, agent-visible message bodies, thread routing, SDK event conversion, and existing poll behavior:

  ```sh
  OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-matrix-edited-context-20260824 node scripts/run-vitest.mjs extensions/matrix/src/matrix/monitor/reply-context.test.ts extensions/matrix/src/matrix/monitor/thread-context.test.ts extensions/matrix/src/matrix/actions/summary.test.ts extensions/matrix/src/matrix/actions/messages.test.ts extensions/matrix/src/matrix/actions/pins.test.ts extensions/matrix/src/matrix/monitor/handler.thread-root-media.test.ts extensions/matrix/src/matrix/monitor/handler.group-history.test.ts extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts extensions/matrix/src/matrix/monitor/threads.test.ts extensions/matrix/src/matrix/sdk/event-helpers.test.ts -- --configLoader runner
  ```

- Both actual context owners reject cross-sender edits, edits targeting another event, mismatched event types, original or replacement state events, missing relations/content, malformed replacement arrays, redacted replacements, and redacted originals; valid edited text, image captions, and legacy object-backed relation arrays are accepted. An independent reviewer separately reran the history/reply/thread owner suites: 53 tests passed.
- Independently executed the original and assertion-free production validators against 13 valid and hostile event shapes: identical decisions, identical returned object identity, and identical getter/accessor ordering in every case. Inspected the direct pinned `matrix-js-sdk@41.9.0` mapper and event source before rejecting the unsafe mapper shortcut.
- The initial hosted CI run passed production types, test types, lint, extension-package boundaries, and security checks, but correctly caught the four relocated legacy assertions. Replacing those assertions and tightening the original baseline fixes the exact failing guard: `node --import tsx scripts/check-assertion-safety-ratchet.mts --base fb576e3518dff572a03f7f1f085cd7c936df2aad` passes with 4,274 files and 13,442 grandfathered assertions.
- Scoped formatting, focused extension lint, and `git diff --check` passed. Existing unrelated shared-dependency/type mismatches prevent the broad local extension typecheck; none of the six changed files reports a type diagnostic, and hosted clean-install CI is the authoritative full gate.
- A live Matrix homeserver run is unavailable in this isolated worktree because no disposable authenticated Matrix account or homeserver is configured; the regressions exercise the real production context owners with actual Matrix homeserver-shaped bundled events.
- AI-assisted; independent review and authenticated Codex review both reported no findings.
