### PR TITLE
fix(agents): stop double-sanitizing openai-responses tool-call ids

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1779,7 +1779,7 @@ src/agents/custom-api-registry.ts	2
 src/agents/delegation-capability.ts	1
 src/agents/embedded-agent-helpers/bootstrap.ts	2
 src/agents/embedded-agent-helpers/images.ts	8
-src/agents/embedded-agent-helpers/openai.ts	21
+src/agents/embedded-agent-helpers/openai.ts	20
 src/agents/embedded-agent-helpers/turns.ts	23
 src/agents/embedded-agent-live-edit-diff.ts	3
 src/agents/embedded-agent-messaging-extraction.ts	1

--- a/src/agents/embedded-agent-helpers/openai.test.ts
+++ b/src/agents/embedded-agent-helpers/openai.test.ts
@@ -167,7 +167,7 @@ describe("normalizeOpenAIResponsesToolCallIds", () => {
       const expectedId = toolCallId(assistant);
 
       expect(toolResultId(rewritten)).toBe(expectedId);
-      expect((rewritten as Record<string, unknown>)[alias]).toBe(expectedId);
+      expect(rewritten).toMatchObject({ [alias]: expectedId });
     },
   );
 });

--- a/src/agents/embedded-agent-helpers/openai.test.ts
+++ b/src/agents/embedded-agent-helpers/openai.test.ts
@@ -152,4 +152,22 @@ describe("normalizeOpenAIResponsesToolCallIds", () => {
     expect(toolResultId(out[4])).toMatch(/^call_[A-Za-z0-9_-]+\|fc_[A-Za-z0-9_-]+$/);
     expect(toolCallId(out[3])).not.toBe(toolResultId(out[4]));
   });
+
+  it.each(["call_id", "callId", "tool_call_id", "tool_use_id", "toolUseId"])(
+    "backfills and normalizes the %s tool-result alias",
+    (alias) => {
+      const rawId = "functions.gateway:0|fc_tmp_gateway";
+      const { toolCallId: _toolCallId, ...result } = buildToolResult(rawId);
+      const messages = [
+        buildAssistantToolCall(rawId),
+        { ...result, [alias]: rawId } as AgentMessage,
+      ];
+
+      const [assistant, rewritten] = normalizeOpenAIResponsesToolCallIds(messages);
+      const expectedId = toolCallId(assistant);
+
+      expect(toolResultId(rewritten)).toBe(expectedId);
+      expect((rewritten as Record<string, unknown>)[alias]).toBe(expectedId);
+    },
+  );
 });

--- a/src/agents/embedded-agent-helpers/openai.ts
+++ b/src/agents/embedded-agent-helpers/openai.ts
@@ -5,6 +5,7 @@ import { replaceCompactionReplayOwnerContent } from "@openclaw/ai/transports";
 import { parseDateFirstTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { sha256HexPrefixCore } from "../../infra/crypto-digest.js";
 import type { AgentMessage } from "../runtime/index.js";
+import { rewriteToolResultIds } from "../tool-call-id.js";
 
 type OpenAIThinkingBlock = {
   type?: unknown;
@@ -236,34 +237,14 @@ export function normalizeOpenAIResponsesToolCallIds(messages: AgentMessage[]): A
     }
 
     if (role === "toolResult") {
-      const toolResult = msg as Extract<AgentMessage, { role: "toolResult" }> & {
-        toolUseId?: unknown;
-      };
-      let toolResultChanged = false;
-      const updates: Record<string, string> = {};
-
-      if (typeof toolResult.toolCallId === "string") {
-        const nextToolCallId = resolveId(toolResult.toolCallId);
-        if (nextToolCallId !== toolResult.toolCallId) {
-          updates.toolCallId = nextToolCallId;
-          toolResultChanged = true;
-        }
+      const next = rewriteToolResultIds({
+        message: msg as Extract<AgentMessage, { role: "toolResult" }>,
+        resolveId,
+      });
+      if (next !== msg) {
+        changed = true;
       }
-
-      if (typeof toolResult.toolUseId === "string") {
-        const nextToolUseId = resolveId(toolResult.toolUseId);
-        if (nextToolUseId !== toolResult.toolUseId) {
-          updates.toolUseId = nextToolUseId;
-          toolResultChanged = true;
-        }
-      }
-
-      if (!toolResultChanged) {
-        rewrittenMessages.push(msg);
-        continue;
-      }
-      changed = true;
-      rewrittenMessages.push({ ...toolResult, ...updates } as AgentMessage);
+      rewrittenMessages.push(next);
       continue;
     }
 

--- a/src/agents/embedded-agent-runner.sanitize-session-history.policy.test.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.policy.test.ts
@@ -66,6 +66,39 @@ describe("sanitizeSessionHistory e2e smoke", () => {
     expect(result).toEqual(mockMessages);
   });
 
+  it.each(["openai-responses", "openai-chatgpt-responses", "azure-openai-responses"])(
+    "preserves paired tool-call ids for an unowned %s provider",
+    async (modelApi) => {
+      const id = "call_gateway_0|fc_gateway_0";
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "thinking",
+              thinking: "reasoning",
+              thinkingSignature: { id: "rs_1", type: "reasoning" },
+            },
+            { type: "toolCall", id, name: "gateway", arguments: {} },
+          ],
+        },
+        { role: "toolResult", toolCallId: id, toolName: "gateway", content: [], isError: false },
+      ] as Parameters<typeof sanitizeSessionHistory>[0]["messages"];
+
+      const result = await sanitizeSessionHistory({
+        messages,
+        modelApi,
+        provider: "custom-compatible",
+        sessionManager: mockSessionManager,
+        sessionId: "test-session",
+      });
+
+      const assistant = result[0] as { content: Array<{ type: string; id?: string }> };
+      expect(assistant.content.find((block) => block.type === "toolCall")?.id).toBe(id);
+      expect((result[1] as { toolCallId: string }).toolCallId).toBe(id);
+    },
+  );
+
   it("downgrades openai reasoning blocks when the model snapshot changed", async () => {
     // Snapshot changes are the public safety boundary: reasoning that was valid
     // for one provider must be replayed as text-only when the model family moves.

--- a/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
@@ -778,14 +778,14 @@ describe("sanitizeSessionHistory", () => {
       "toolResult",
       "user",
     ]);
-    expect((result[2] as { toolCallId?: string }).toolCallId).toBe("call1");
+    expect((result[2] as { toolCallId?: string }).toolCallId).toBe("call_1");
     expect((result[2] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
       { type: "text", text: "aborted" },
     ]);
     expect(JSON.stringify(result)).not.toContain("missing tool result");
   });
 
-  it("keeps OpenAI Responses real tool results paired when strict id sanitization rewrites aliases", async () => {
+  it("keeps OpenAI Responses real tool results paired without rewriting valid ids", async () => {
     const messages = castAgentMessages([
       makeUserMessage("generate"),
       makeAssistantMessage(
@@ -822,7 +822,7 @@ describe("sanitizeSessionHistory", () => {
       "toolResult",
       "user",
     ]);
-    expect(toolCall?.id).toBe("callmockimagegenerate1");
+    expect(toolCall?.id).toBe("call_mock_image_generate_1");
     expect(toolResult.toolCallId).toBe(toolCall?.id);
     expect(toolResult.call_id).toBe(toolCall?.id);
     expect(toolResult.content).toEqual([
@@ -957,7 +957,7 @@ describe("sanitizeSessionHistory", () => {
     expect(
       result.some((message) => (message as { model?: string }).model === "delivery-mirror"),
     ).toBe(false);
-    expect((result[2] as { toolCallId?: string }).toolCallId).toBe("callmessage");
+    expect((result[2] as { toolCallId?: string }).toolCallId).toBe("call_message");
     expect((result[2] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
       { type: "text", text: "aborted" },
     ]);
@@ -1021,7 +1021,7 @@ describe("sanitizeSessionHistory", () => {
     ]);
     expect(
       result.slice(1, 4).map((message) => (message as { toolCallId?: string }).toolCallId),
-    ).toEqual(["calla", "callb", "callc"]);
+    ).toEqual(["call_a", "call_b", "call_c"]);
     for (const message of result.slice(1, 4)) {
       expect((message as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
         { type: "text", text: "aborted" },
@@ -1064,13 +1064,13 @@ describe("sanitizeSessionHistory", () => {
         (call) => ({ id: call.id, name: call.name }),
       ),
     ).toEqual([
-      { id: "call1", name: "read" },
-      { id: "call2", name: "exec" },
-      { id: "call3", name: "write" },
+      { id: "call_1", name: "read" },
+      { id: "call_2", name: "exec" },
+      { id: "call_3", name: "write" },
     ]);
     expect(
       result.slice(1, 4).map((message) => (message as { toolCallId?: string }).toolCallId),
-    ).toEqual(["call1", "call2", "call3"]);
+    ).toEqual(["call_1", "call_2", "call_3"]);
     expect((result[1] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
       { type: "text", text: "aborted" },
     ]);
@@ -1100,7 +1100,7 @@ describe("sanitizeSessionHistory", () => {
     });
 
     expect(result.map((message) => message.role)).toEqual(["assistant", "toolResult", "user"]);
-    expect((result[1] as { toolCallId?: string }).toolCallId).toBe("callazure");
+    expect((result[1] as { toolCallId?: string }).toolCallId).toBe("call_azure");
     expect((result[1] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
       { type: "text", text: "aborted" },
     ]);
@@ -1138,7 +1138,7 @@ describe("sanitizeSessionHistory", () => {
     const result = await sanitizeOpenAIHistory(messages);
 
     expect(result.map((message) => message.role)).toEqual(["assistant", "toolResult", "user"]);
-    expect((result[1] as { toolCallId?: string }).toolCallId).toBe("callkeep");
+    expect((result[1] as { toolCallId?: string }).toolCallId).toBe("call_keep");
     expect((result[1] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
       { type: "text", text: "first" },
     ]);

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -887,7 +887,7 @@ export async function sanitizeSessionHistory(params: {
       ? sanitizeToolUseResultPairingForModel(openAISafeToolCalls, false)
       : openAISafeToolCalls;
   const sanitizedToolIds =
-    policy.sanitizeToolCallIds && policy.toolCallIdMode
+    !isOpenAIResponsesApi && policy.sanitizeToolCallIds && policy.toolCallIdMode
       ? sanitizeToolCallIdsForCloudCodeAssist(pairedToolCalls, policy.toolCallIdMode, {
           preserveNativeAnthropicToolUseIds: policy.preserveNativeAnthropicToolUseIds,
           duplicateToolCallIdStyle: policy.duplicateToolCallIdStyle,

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -372,7 +372,8 @@ function rewriteAssistantToolCallIds(params: {
   return { ...params.message, content: next as typeof params.message.content };
 }
 
-function rewriteToolResultIds(params: {
+/** Keeps every persisted tool-result ID alias aligned with its canonical call. */
+export function rewriteToolResultIds(params: {
   message: Extract<AgentMessage, { role: "toolResult" }>;
   resolveId: (id: string) => string;
 }): Extract<AgentMessage, { role: "toolResult" }> {


### PR DESCRIPTION
## What Problem This Solves

`sanitizeSessionHistory` unconditionally ran a generic, alnum-only ("strict") tool-call-id sanitizer (`sanitizeToolCallIdsForCloudCodeAssist`) on **all** history, including openai-responses-shaped history that had already been correctly normalized a few lines earlier by `normalizeOpenAIResponsesToolCallIds`. For any provider on the `openai-responses`/`openai-chatgpt-responses`/`azure-openai-responses` API that reaches the unowned-provider replay-policy fallback (any provider without its own `buildReplayPolicy`, e.g. custom/self-hosted OpenAI-Responses-compatible endpoints, OpenRouter, etc. — the bundled `openai` plugin itself explicitly opts out via `sanitizeToolCallIds: false` for this API family), the second pass re-hashed an already-valid `call_*`/`fc_*` id into a shape the provider never returned (stripping the required `call_`/`fc_` prefix and, on ID collisions, appending a hash suffix).

This silently broke HTTP continuation (`previous_response_id` reuse, #122194) for any multi-round tool-calling turn: the continuation cache stores the raw response the provider returned, but the next round's replay sent the corrupted id, so the byte-for-byte comparison in `resolveResponsesContinuationRequest` always returned `history_changed` and the client fell back to resending full history every round.

## Why This Change Was Made

`normalizeOpenAIResponsesToolCallIds` already fully owns id-shape correctness for openai-responses-shaped history — including malformed/foreign ids from non-native providers (verified against existing coverage for Kimi/Moonshot ids routed through this API shape). The generic strict-alnum sanitizer is redundant for this API family and actively harmful, since it doesn't understand the `call_id|fc_id` pairing convention this API requires. `attempt-tool-call-replay-sanitization.ts`'s separate consumer of the same policy fields already excludes `isOpenAIResponsesApi` for exactly this reason — `replay-history.ts`'s consumer was the one inconsistent site.

The fix adds the same `!isOpenAIResponsesApi` guard, and teaches `normalizeOpenAIResponsesToolCallIds` to backfill `toolCallId` from legacy alias fields (`call_id`, `tool_call_id`, `callId`) when `toolCallId` itself is absent, since the removed pass also covered that alias-normalization responsibility for this shape.

## User Impact

HTTP continuation now actually works for unowned/custom openai-responses-compatible providers doing multi-round tool calling — previously every second-and-later round fell back to full-history resend, defeating the point of continuation and materially increasing latency/cost. This also removes a source of malformed tool-call ids being sent to real providers.

## Evidence

- Regression test added at `src/agents/embedded-agent-runner.sanitize-session-history.policy.test.ts` ("preserves an already-valid call_id|fc_id pair for an unowned openai-responses provider"): fails on pre-fix code (`call_29b14f4fbcd049c2b37bf0cdb10f7263|fc_29b14f4fbcd049c2b37bf0cdb10f7263` gets mangled to `call29b14f4fbcd049c2b37bf0cdb10f7263fc29`), passes post-fix.
- Full affected suite green post-fix: `embedded-agent-runner.sanitize-session-history*`, `embedded-agent-runner.openai-tool-id-preservation.test.ts`, `tool-call-id.test.ts`, `replay-history.test.ts`, `sanitize-session-history.tool-result-details.test.ts`, `embedded-agent-helpers/openai*`, `openai-responses-client.continuation.test.ts`, `openai-responses-continuation*` — 178 tests passing.
- 7 pre-existing tests in `embedded-agent-runner.sanitize-session-history.test.ts` that hard-coded the buggy stripped-id output (e.g. `call_azure` → `callazure`) as "expected" were updated to assert the correct, unmangled id — those tests only exercised the same unowned-fallback path this fix corrects, and none of the underlying scenarios (aborted-result repair, poisoned-replay repair, parallel-tool-result pairing) changed.
- Live-verified on a real deployment (custom OpenAI-Responses-compatible endpoint, multi-round tool-calling cron job): pre-fix, one job run made 62/67 continuation attempts hit `history_changed` over 13+ minutes (60+ rapid-retry model calls), correlating with the model derailing into a bogus `apply_patch` attempt against an unrelated config file outside its sandbox. Post-fix, the same job completed cleanly in 5 request/response round-trips (~2s each) in under 2 minutes.
- `oxfmt --check` clean on all changed files.
- Autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings, patch correct 0.98.

