### PR TITLE
fix(discord): keep forum attachments and receipts in their first thread

### DIFF
--- a/extensions/discord/src/outbound-payload.contract.test.ts
+++ b/extensions/discord/src/outbound-payload.contract.test.ts
@@ -105,6 +105,12 @@ describe("Discord forum outbound payload ownership", () => {
     const onDeliveryResult = vi.fn();
     const sendPayload = requireDiscordSendPayload();
     const voiceError = params.voiceError;
+    const sendDiscord: typeof sendMessageDiscord = async (target, text, options) =>
+      await sendMessageDiscord(target, text, {
+        ...options,
+        rest,
+        token: "discord-fixture-token",
+      });
     const run = () =>
       sendPayload({
         cfg: { channels: { discord: { token: "discord-fixture-token" } } },
@@ -121,12 +127,7 @@ describe("Discord forum outbound payload ownership", () => {
         mediaLocalRoots: mediaAccess.localRoots,
         mediaReadFile: readFile,
         deps: {
-          discord: async (target, text, options) =>
-            await sendMessageDiscord(target, text, {
-              ...options,
-              rest,
-              token: "discord-fixture-token",
-            }),
+          discord: sendDiscord,
           ...(voiceError
             ? {
                 discordVoice: async () => {

--- a/extensions/discord/src/outbound-payload.contract.test.ts
+++ b/extensions/discord/src/outbound-payload.contract.test.ts
@@ -1,13 +1,15 @@
 // Discord tests cover outbound payload.contract plugin behavior.
+import { ChannelType } from "discord-api-types/v10";
 import {
   installChannelOutboundPayloadContractSuite,
   primeChannelOutboundSendMock,
   type OutboundPayloadHarnessParams,
 } from "openclaw/plugin-sdk/channel-contract-testing";
 import { describe, expect, it, vi } from "vitest";
-import { DiscordError, RateLimitError } from "./internal/discord.js";
+import { DiscordError, RateLimitError, RequestClient } from "./internal/discord.js";
 import { discordOutbound } from "./outbound-adapter.js";
 import { recordDiscordMessageCreateAmbiguity } from "./retry.js";
+import { sendMessageDiscord } from "./send.outbound.js";
 
 type DiscordSendPayload = NonNullable<typeof discordOutbound.sendPayload>;
 
@@ -48,6 +50,204 @@ describe("Discord outbound payload contract", () => {
     channel: "discord",
     chunking: { mode: "split", longTextLength: 3000, maxChunkLength: 2000 },
     createHarness: createDiscordHarness,
+  });
+});
+
+describe("Discord forum outbound payload ownership", () => {
+  function createForumDelivery(params: {
+    channelType?: ChannelType;
+    channelData: Record<string, unknown>;
+    threadId?: string;
+    withProgress?: boolean;
+    voiceError?: Error;
+  }) {
+    const requests: string[] = [];
+    let threadCount = 0;
+    let mediaCount = 0;
+    const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(
+        typeof input === "string" ? input : input instanceof URL ? input : input.url,
+      );
+      const route = url.pathname.replace("/api/v10", "");
+      const method = init?.method ?? "GET";
+      requests.push(`${method} ${route}`);
+      let response: Record<string, unknown>;
+      if (method === "GET") {
+        response = {
+          type:
+            route === "/channels/forum1"
+              ? (params.channelType ?? ChannelType.GuildForum)
+              : ChannelType.PublicThread,
+        };
+      } else if (route === "/channels/forum1/threads") {
+        threadCount += 1;
+        const threadId = `thread${threadCount}`;
+        response = {
+          id: threadId,
+          message: { id: `starter${threadCount}`, channel_id: threadId },
+        };
+      } else {
+        mediaCount += 1;
+        response = { id: `media${mediaCount}`, channel_id: route.split("/")[2] };
+      }
+      return new Response(JSON.stringify(response), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const rest = new RequestClient("discord-fixture-token", { fetch, queueRequests: false });
+    const readFile = vi.fn(async () => Buffer.from("forum attachment"));
+    const mediaAccess = {
+      localRoots: [process.cwd()],
+      readFile,
+      workspaceDir: process.cwd(),
+    };
+    const onDeliveryResult = vi.fn();
+    const sendPayload = requireDiscordSendPayload();
+    const voiceError = params.voiceError;
+    const run = () =>
+      sendPayload({
+        cfg: { channels: { discord: { token: "discord-fixture-token" } } },
+        to: "channel:forum1",
+        text: "",
+        ...(params.threadId ? { threadId: params.threadId } : {}),
+        payload: {
+          text: "one forum conversation",
+          mediaUrls: ["./package.json", "./package.json"],
+          channelData: { discord: params.channelData },
+          ...(params.voiceError ? { audioAsVoice: true } : {}),
+        },
+        mediaAccess,
+        mediaLocalRoots: mediaAccess.localRoots,
+        mediaReadFile: readFile,
+        deps: {
+          discord: async (target, text, options) =>
+            await sendMessageDiscord(target, text, {
+              ...options,
+              rest,
+              token: "discord-fixture-token",
+            }),
+          ...(voiceError
+            ? {
+                discordVoice: async () => {
+                  throw voiceError;
+                },
+              }
+            : {}),
+        },
+        ...(params.withProgress === false ? {} : { onDeliveryResult }),
+      });
+    return { fetch, onDeliveryResult, requests, run };
+  }
+
+  it.each([
+    {
+      label: "named forum attachments",
+      channelData: { filename: "first.txt" },
+    },
+    {
+      label: "embedded forum attachments",
+      channelData: { embeds: [{ description: "forum embed" }] },
+    },
+    {
+      label: "classic text components downgraded to forum messages",
+      channelData: {
+        presentationComponents: {
+          text: "one forum conversation",
+          blocks: [{ type: "text", text: "classic component body" }],
+        },
+      },
+    },
+    {
+      label: "media-channel attachments without an external progress callback",
+      channelData: { filename: "first.txt" },
+      channelType: ChannelType.GuildMedia,
+      withProgress: false,
+    },
+  ])("keeps $label and their complete receipt in their first created thread", async (params) => {
+    const delivery = createForumDelivery(params);
+    const globalFetch = vi.spyOn(globalThis, "fetch").mockImplementation(delivery.fetch);
+    try {
+      const result = await delivery.run();
+
+      expect(delivery.requests.filter((request) => request.startsWith("POST"))).toEqual([
+        "POST /channels/forum1/threads",
+        "POST /channels/thread1/messages",
+        "POST /channels/thread1/messages",
+      ]);
+      expect(result).toMatchObject({
+        target: { kind: "channel", id: "thread1" },
+        receipt: {
+          threadId: "thread1",
+          platformMessageIds: ["starter1", "media1", "media2"],
+          primaryPlatformMessageId: "starter1",
+        },
+      });
+      if (params.withProgress !== false) {
+        expect(
+          delivery.onDeliveryResult.mock.calls.map(([progressResult]) => progressResult.messageId),
+        ).toEqual(["starter1", "media1", "media2"]);
+      }
+    } finally {
+      globalFetch.mockRestore();
+    }
+  });
+
+  it("keeps voice fallback text and remaining media together before reporting the voice error", async () => {
+    const voiceError = new Error("fixture encoder unavailable");
+    const delivery = createForumDelivery({ channelData: {}, voiceError });
+
+    await expect(delivery.run()).rejects.toBe(voiceError);
+    expect(delivery.requests.filter((request) => request.startsWith("POST"))).toEqual([
+      "POST /channels/forum1/threads",
+      "POST /channels/thread1/messages",
+    ]);
+    expect(delivery.onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual([
+      "starter1",
+      "media1",
+    ]);
+  });
+
+  it.each([
+    {
+      label: "ordinary channels",
+      channelType: ChannelType.GuildText,
+      route: "POST /channels/forum1/messages",
+    },
+    {
+      label: "explicit existing threads",
+      threadId: "existing-thread",
+      route: "POST /channels/existing-thread/messages",
+    },
+  ])("preserves direct attachment delivery for $label", async ({ route, ...params }) => {
+    const delivery = createForumDelivery({ channelData: { filename: "first.txt" }, ...params });
+
+    await delivery.run();
+
+    expect(delivery.requests.filter((request) => request.startsWith("POST"))).toEqual([
+      route,
+      route,
+    ]);
+  });
+
+  it("still rejects actual interactive components on a forum parent before creating a thread", async () => {
+    const delivery = createForumDelivery({
+      channelData: {
+        presentationComponents: {
+          text: "interactive message",
+          blocks: [{ type: "actions", buttons: [] }],
+        },
+      },
+    });
+    const globalFetch = vi.spyOn(globalThis, "fetch").mockImplementation(delivery.fetch);
+    try {
+      await expect(delivery.run()).rejects.toThrow(
+        "Discord components are not supported in forum-style channels",
+      );
+      expect(delivery.requests.filter((request) => request.startsWith("POST"))).toEqual([]);
+    } finally {
+      globalFetch.mockRestore();
+    }
   });
 });
 

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -34,16 +34,6 @@ type DiscordPayloadSendContext = Awaited<ReturnType<typeof createDiscordPayloadS
 
 const log = createSubsystemLogger("discord/outbound");
 
-function resolveDiscordDeliveryProgress(ctx: DiscordOutboundPayloadContext) {
-  return ctx.onDeliveryResult
-    ? async (result: Awaited<ReturnType<DiscordPayloadSendContext["send"]>>) => {
-        await ctx.onDeliveryResult?.(
-          attachChannelToResult("discord", toDiscordOutboundDeliveryResult(result)),
-        );
-      }
-    : undefined;
-}
-
 function createDiscordUnknownPayloadResult(target: string) {
   return {
     messageId: "",
@@ -106,6 +96,42 @@ export async function sendDiscordOutboundPayload(params: {
   });
   const mediaUrls = resolvePayloadMediaUrls(payload);
   const sendContext = await createDiscordPayloadSendContext(ctx);
+  const payloadContext = { ...ctx, payload };
+  const deliveredResults: DiscordSendResult[] = [];
+  let createdThreadId: string | undefined;
+  payloadContext.onDeliveryResult = async (result) => {
+    await ctx.onDeliveryResult?.(result);
+    const threadId = result.receipt?.threadId;
+    if (threadId && payloadContext.threadId == null) {
+      // A forum starter owns the thread used by every later payload delivery.
+      payloadContext.threadId = threadId;
+      sendContext.target = `channel:${threadId}`;
+      createdThreadId = threadId;
+    }
+    if (createdThreadId && result.target?.kind === "channel" && result.receipt) {
+      deliveredResults.push({
+        messageId: result.messageId,
+        channelId: result.target.id,
+        receipt: result.receipt,
+      });
+    }
+  };
+  const completeResult = <T extends { receipt?: DiscordSendResult["receipt"] }>(result: T): T =>
+    createdThreadId
+      ? {
+          ...result,
+          receipt: createDiscordSendReceiptFromResults({
+            results: deliveredResults,
+            threadId: createdThreadId,
+          }),
+        }
+      : result;
+  const completeDelivery = (result: DiscordSendResult) =>
+    attachChannelToResult("discord", toDiscordOutboundDeliveryResult(completeResult(result)));
+  const onDeliveryResult = async (result: DiscordSendResult) =>
+    await payloadContext.onDeliveryResult?.(
+      attachChannelToResult("discord", toDiscordOutboundDeliveryResult(result)),
+    );
 
   if (payload.audioAsVoice && mediaUrls.length > 0) {
     // Defer voice failure until independent remainder sends finish while preserving progress.
@@ -139,20 +165,20 @@ export async function sendDiscordOutboundPayload(params: {
         await sendContext.send(sendContext.target, fallbackText, {
           verbose: false,
           ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext, voiceReply),
-          onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+          onDeliveryResult,
         });
       }
       voiceFailure = { error: err };
     }
     if (!voiceFailure) {
-      await ctx.onDeliveryResult?.(
+      await payloadContext.onDeliveryResult?.(
         attachChannelToResult("discord", toDiscordOutboundDeliveryResult(lastResult)),
       );
       if (payload.text?.trim()) {
         lastResult = await sendContext.send(sendContext.target, payload.text, {
           verbose: false,
           ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
-          onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+          onDeliveryResult,
         });
       }
     }
@@ -161,7 +187,7 @@ export async function sendDiscordOutboundPayload(params: {
         lastResult = await sendContext.send(sendContext.target, "", {
           verbose: false,
           ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
-          onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+          onDeliveryResult,
         });
       } catch (err) {
         if (!voiceFailure) {
@@ -175,7 +201,7 @@ export async function sendDiscordOutboundPayload(params: {
     if (voiceFailure) {
       throw voiceFailure.error;
     }
-    return attachChannelToResult("discord", toDiscordOutboundDeliveryResult(lastResult));
+    return completeDelivery(lastResult);
   }
 
   const componentSpec = await resolveDiscordComponentSpec(payload);
@@ -205,7 +231,7 @@ export async function sendDiscordOutboundPayload(params: {
             embeds,
             filename,
             ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
-            onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+            onDeliveryResult,
           }),
         send: async ({ text, mediaUrl, isFirst }) =>
           await sendContext.send(sendContext.target, text, {
@@ -214,44 +240,17 @@ export async function sendDiscordOutboundPayload(params: {
             components: isFirst ? nativeComponents : undefined,
             embeds: isFirst ? embeds : undefined,
             filename: isFirst ? filename : undefined,
-            onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+            onDeliveryResult,
           }),
       });
-      return attachChannelToResult("discord", toDiscordOutboundDeliveryResult(result));
+      return completeDelivery(result);
     }
-    const payloadContext = { ...ctx, payload };
-    const deliveredResults: DiscordSendResult[] = [];
-    let createdThreadId: string | undefined;
-    payloadContext.onDeliveryResult = async (result) => {
-      await ctx.onDeliveryResult?.(result);
-      const threadId = result.receipt?.threadId;
-      if (threadId && payloadContext.threadId == null) {
-        // A forum parent creates its conversation on the first platform send.
-        payloadContext.threadId = threadId;
-        createdThreadId = threadId;
-      }
-      if (createdThreadId && result.target?.kind === "channel" && result.receipt) {
-        deliveredResults.push({
-          messageId: result.messageId,
-          channelId: result.target.id,
-          receipt: result.receipt,
-        });
-      }
-    };
     const result = await sendTextMediaPayload({
       channel: "discord",
       ctx: payloadContext,
       adapter: params.fallbackAdapter,
     });
-    return createdThreadId
-      ? {
-          ...result,
-          receipt: createDiscordSendReceiptFromResults({
-            results: deliveredResults,
-            threadId: createdThreadId,
-          }),
-        }
-      : result;
+    return completeResult(result);
   }
 
   const result = await sendPayloadMediaSequenceOrFallback({
@@ -261,22 +260,22 @@ export async function sendDiscordOutboundPayload(params: {
     sendNoMedia: async () => {
       return await sendDiscordComponentMessageLazy(sendContext.target, componentSpec, {
         ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
-        onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+        onDeliveryResult,
       });
     },
     send: async ({ text, mediaUrl, isFirst }) => {
       if (isFirst) {
         return await sendDiscordComponentMessageLazy(sendContext.target, componentSpec, {
           ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
-          onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+          onDeliveryResult,
         });
       }
       return await sendContext.send(sendContext.target, text, {
         verbose: false,
         ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
-        onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
+        onDeliveryResult,
       });
     },
   });
-  return attachChannelToResult("discord", toDiscordOutboundDeliveryResult(result));
+  return completeDelivery(result);
 }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users sending multiple attachments with filenames, embeds, or classic text/file components to a Discord forum or media channel would unexpectedly create separate threads for one message and silently lose the first thread's messages from the delivery receipt. A failed voice note followed by visible fallback text and another attachment likewise split the conversation across two threads.

## Why This Change Was Made

Discord forum and media parents create their conversation on the first send. Reuse the existing private Discord payload delivery-progress owner for every payload variant so the first authoritative thread receipt determines later attachment targets and the final receipt includes every starter and attachment message. Ordinary channels, explicit existing threads, callback ordering, voice failure reporting, and the documented rejection of actual interactive components on forum parents remain unchanged. No public API, configuration, authorization, or security behavior changes; production code decreases by one line.

## User Impact

Operators can send complete structured multi-attachment messages to Discord forum and media channels without creating duplicate threads, splitting their conversation, or losing platform message IDs needed for durable delivery. Voice-note failures still surface their original error while keeping visible fallback text and remaining attachments together.

## Evidence

Five checked-in regressions failed on the previous code and pass after the fix: native filenames, native embeds, classic component downgrades, media-channel delivery without an external progress callback, and definitive voice failure with a remaining attachment. Three additional controls preserve ordinary channels, explicit existing threads, and intentional interactive-component rejection.

Actual Discord outbound adapter, classic component owner, send owner, installed Discord API types, authorized local media loading, and real `RequestClient` against a deterministic Discord HTTP contract:

```text
before: POST /channels/forum1/threads
        POST /channels/thread1/messages
        POST /channels/forum1/threads
        POST /channels/thread2/messages
        receipt = [starter2, media2]

after:  POST /channels/forum1/threads
        POST /channels/thread1/messages
        POST /channels/thread1/messages
        receipt = [starter1, media1, media2]
```

Independent owner and sibling validation passed **304 tests across 10 suites**, covering Discord outbound payloads, durable forum batches, adapter/session routing, interactive ordering, components, voice, message requests, actual HTTP delivery, and shared payload sequencing. Both full-diff authenticated reviews and the independent code review reported no actionable findings.

Live Discord delivery was not run because this maintainer session has no authorized disposable bot account or isolated forum/media channel; sending the reproduction to a real workspace would create persistent, user-visible threads. The deterministic proof instead exercises the actual Discord send owner, actual `RequestClient`, installed upstream API routes, and real local attachment loader against a controlled Discord HTTP contract. ClawSweeper also ran the complete owner suite twice with **50/50 passing**; its proof harness reported partial only because Vitest's default reporter does not print the suite-name string that the harness expected.

```bash
node scripts/run-vitest.mjs \
  extensions/discord/src/outbound-payload.contract.test.ts \
  extensions/discord/src/outbound-adapter.test.ts \
  extensions/discord/src/outbound-adapter.interactive-order.test.ts \
  extensions/discord/src/outbound-session-route.test.ts \
  extensions/discord/src/durable-forum-batch.test.ts \
  extensions/discord/src/send.components.test.ts \
  extensions/discord/src/send.voice.test.ts \
  extensions/discord/src/send.message-request.test.ts \
  extensions/discord/src/send.sends-basic-channel-messages.test.ts \
  src/plugin-sdk/reply-payload.test.ts
```
