### PR TITLE
fix(slack): keep edited and deleted messages in their original threads

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1189,7 +1189,7 @@ extensions/slack/src/monitor/events/interactions.block-actions.ts	16
 extensions/slack/src/monitor/events/interactions.modal.ts	4
 extensions/slack/src/monitor/events/interactions.ts	7
 extensions/slack/src/monitor/events/members.ts	2
-extensions/slack/src/monitor/events/message-subtype-handlers.ts	6
+extensions/slack/src/monitor/events/message-subtype-handlers.ts	5
 extensions/slack/src/monitor/events/messages.ts	14
 extensions/slack/src/monitor/events/pins.ts	1
 extensions/slack/src/monitor/events/reactions.ts	2

--- a/extensions/slack/src/monitor/events/message-subtype-handlers.test.ts
+++ b/extensions/slack/src/monitor/events/message-subtype-handlers.test.ts
@@ -17,8 +17,6 @@ describe("resolveSlackMessageSubtypeHandler", () => {
     const handler = resolveSlackMessageSubtypeHandler(event);
     expect(handler?.eventKind).toBe("message_changed");
     expect(handler?.resolveSenderId(event)).toBe("U1");
-    expect(handler?.resolveChannelId(event)).toBe("D1");
-    expect(handler?.resolveChannelType(event)).toBeUndefined();
     expect(handler?.contextKey(event)).toBe("slack:message:changed:D1:123.456");
     expect(handler?.describe("DM with @user")).toContain("edited");
   });
@@ -36,8 +34,6 @@ describe("resolveSlackMessageSubtypeHandler", () => {
     const handler = resolveSlackMessageSubtypeHandler(event);
     expect(handler?.eventKind).toBe("message_deleted");
     expect(handler?.resolveSenderId(event)).toBe("U1");
-    expect(handler?.resolveChannelId(event)).toBe("C1");
-    expect(handler?.resolveChannelType(event)).toBeUndefined();
     expect(handler?.contextKey(event)).toBe("slack:message:deleted:C1:123.456");
     expect(handler?.describe("general")).toContain("deleted");
   });

--- a/extensions/slack/src/monitor/events/message-subtype-handlers.ts
+++ b/extensions/slack/src/monitor/events/message-subtype-handlers.ts
@@ -1,21 +1,31 @@
 // Slack plugin module implements message subtype handlers behavior.
+import { resolveSlackThreadContext } from "../../threading.js";
 import type { SlackMessageEvent } from "../../types.js";
 import type { SlackMessageChangedEvent, SlackMessageDeletedEvent } from "../types.js";
 
 type SupportedSubtype = "message_changed" | "message_deleted";
 
 type SlackMessageSubtypeHandler = {
-  subtype: SupportedSubtype;
   eventKind: SupportedSubtype;
   describe: (channelLabel: string) => string;
   contextKey: (event: SlackMessageEvent) => string;
   resolveSenderId: (event: SlackMessageEvent) => string | undefined;
-  resolveChannelId: (event: SlackMessageEvent) => string | undefined;
-  resolveChannelType: (event: SlackMessageEvent) => string | null | undefined;
+  resolveThreadTs: (event: SlackMessageEvent) => string | undefined;
 };
 
+function resolveNestedThreadTs(event: SlackMessageEvent): string | undefined {
+  const changed = event as SlackMessageChangedEvent;
+  const message = changed.message?.thread_ts ? changed.message : changed.previous_message;
+  if (!message) {
+    return undefined;
+  }
+  return resolveSlackThreadContext({
+    message: { type: "message", channel: event.channel, ...message },
+    replyToMode: "off",
+  }).replyToId;
+}
+
 const changedHandler: SlackMessageSubtypeHandler = {
-  subtype: "message_changed",
   eventKind: "message_changed",
   describe: (channelLabel) => `Slack message edited in ${channelLabel}.`,
   contextKey: (event) => {
@@ -34,12 +44,10 @@ const changedHandler: SlackMessageSubtypeHandler = {
       changed.previous_message?.bot_id
     );
   },
-  resolveChannelId: (event) => (event as SlackMessageChangedEvent).channel,
-  resolveChannelType: () => undefined,
+  resolveThreadTs: resolveNestedThreadTs,
 };
 
 const deletedHandler: SlackMessageSubtypeHandler = {
-  subtype: "message_deleted",
   eventKind: "message_deleted",
   describe: (channelLabel) => `Slack message deleted in ${channelLabel}.`,
   contextKey: (event) => {
@@ -52,8 +60,7 @@ const deletedHandler: SlackMessageSubtypeHandler = {
     const deleted = event as SlackMessageDeletedEvent;
     return deleted.previous_message?.user ?? deleted.previous_message?.bot_id;
   },
-  resolveChannelId: (event) => (event as SlackMessageDeletedEvent).channel,
-  resolveChannelType: () => undefined,
+  resolveThreadTs: resolveNestedThreadTs,
 };
 
 const SUBTYPE_HANDLER_REGISTRY: Record<SupportedSubtype, SlackMessageSubtypeHandler> = {

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -2,6 +2,7 @@
 import type { App } from "@slack/bolt";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createInboundSlackTestContext } from "../message-handler/prepare.test-helpers.js";
+import { createSlackSystemEventRouteResolver } from "../system-event-session.js";
 import {
   createSlackSystemEventTestHarness,
   type SlackSystemEventTestOverrides,
@@ -731,6 +732,155 @@ describe("registerSlackMessageEvents", () => {
       contextKey: "slack:message:changed:C1:123.456:Ev-message-change-1",
     });
   });
+
+  it.each([
+    { channelType: "channel", subtype: "message_changed", threadSession: true },
+    { channelType: "channel", subtype: "message_deleted", threadSession: true },
+    { channelType: "group", subtype: "message_changed", threadSession: true },
+    { channelType: "group", subtype: "message_deleted", threadSession: true },
+    { channelType: "mpim", subtype: "message_changed", threadSession: true },
+    { channelType: "mpim", subtype: "message_deleted", threadSession: true },
+    { channelType: "im", subtype: "message_changed", threadSession: false },
+    { channelType: "im", subtype: "message_deleted", threadSession: false },
+    { channelType: "channel", subtype: "message_changed", root: true, threadSession: false },
+    { channelType: "channel", subtype: "message_deleted", root: true, threadSession: false },
+    {
+      channelType: "channel",
+      subtype: "message_changed",
+      previousOnly: true,
+      threadSession: true,
+    },
+    {
+      channelType: "channel",
+      subtype: "message_changed",
+      root: true,
+      parentUserId: "U_PARENT",
+      threadSession: true,
+    },
+    {
+      channelType: "channel",
+      subtype: "message_deleted",
+      root: true,
+      parentUserId: "U_PARENT",
+      threadSession: true,
+    },
+    { channelType: "mpim", subtype: "message_changed", denied: true, threadSession: false },
+    { channelType: "mpim", subtype: "message_deleted", denied: true, threadSession: false },
+    {
+      channelType: "channel",
+      subtype: "message_changed",
+      enterprise: true,
+      threadSession: true,
+    },
+    {
+      channelType: "channel",
+      subtype: "message_deleted",
+      enterprise: true,
+      threadSession: true,
+    },
+  ] as const)(
+    "routes $channelType $subtype events to their actual conversation",
+    async ({ channelType, subtype, threadSession, ...scenario }) => {
+      const actualSystemEvents = await vi.importActual<
+        typeof import("openclaw/plugin-sdk/system-event-runtime")
+      >("openclaw/plugin-sdk/system-event-runtime");
+      actualSystemEvents.resetSystemEventsForTest();
+      messageQueueMock.mockImplementation(
+        (text: string, { sessionKey, ...options }: { sessionKey: string }) =>
+          actualSystemEvents.enqueueRoutedSystemEvent(
+            text,
+            { agentId: "main", sessionKey },
+            options,
+          ),
+      );
+
+      const senderId = "U123";
+      const denied = "denied" in scenario;
+      const enterprise = "enterprise" in scenario;
+      const harness = createSlackSystemEventTestHarness({
+        channelType,
+        ...(channelType === "mpim" ? { allowFrom: denied ? ["U_OTHER"] : [senderId] } : {}),
+      });
+      harness.ctx.cfg = { channels: { slack: { enabled: true } } };
+      harness.ctx.accountId = "default";
+      harness.ctx.channelsConfigKeys = [];
+      if (enterprise) {
+        harness.ctx.installationIdentity = {
+          kind: "enterprise",
+          apiAppId: "A_TEST",
+          enterpriseId: "E_TEST",
+        };
+      }
+      harness.ctx.resolveSlackSystemEventRoute = createSlackSystemEventRouteResolver({
+        cfg: harness.ctx.cfg,
+        accountId: harness.ctx.accountId,
+        getTeamId: () => harness.ctx.teamId,
+        mainKey: "agent:main:main",
+        threadInheritParent: false,
+        recallSlackChannelType: () => channelType,
+      });
+      registerSlackMessageEvents({ ctx: harness.ctx, handleSlackMessage: async () => {} });
+
+      const threadTs = "1712345678.123456";
+      const channelId = channelType === "im" ? "D123" : channelType === "mpim" ? "G123" : "C123";
+      const nestedMessage = {
+        ts: "root" in scenario ? threadTs : "1712345678.654321",
+        thread_ts: threadTs,
+        user: senderId,
+        ...("parentUserId" in scenario ? { parent_user_id: scenario.parentUserId } : {}),
+      };
+      const event = {
+        type: "message",
+        subtype,
+        channel: channelId,
+        channel_type: channelType,
+        previous_message: nestedMessage,
+        event_ts: "1712345679.000000",
+        ...(subtype === "message_changed"
+          ? {
+              message:
+                "previousOnly" in scenario
+                  ? { ts: nestedMessage.ts, user: senderId }
+                  : nestedMessage,
+            }
+          : { deleted_ts: nestedMessage.ts }),
+      };
+      const listenerClient = {} as App["client"];
+      await requireMessageHandler(harness.getHandler("message") as MessageHandler | null)({
+        event,
+        body: { api_app_id: "A_TEST", event_id: `Ev-${channelType}-${subtype}` },
+        ...(enterprise
+          ? {
+              context: { isEnterpriseInstall: true, enterpriseId: "E_TEST", teamId: "T_GRID" },
+              client: listenerClient,
+            }
+          : {}),
+      });
+
+      const eventScope = enterprise ? { teamId: "T_GRID", client: listenerClient } : undefined;
+      const parentSessionKey = harness.ctx.resolveSlackSystemEventRoute({
+        channelId,
+        channelType,
+        senderId,
+        eventScope,
+      }).sessionKey;
+      const threadSessionKey = harness.ctx.resolveSlackSystemEventRoute({
+        channelId,
+        channelType,
+        senderId,
+        threadTs,
+        eventScope,
+      }).sessionKey;
+
+      expect(actualSystemEvents.peekSystemEventEntries(parentSessionKey)).toHaveLength(
+        denied || threadSession ? 0 : 1,
+      );
+      expect(actualSystemEvents.peekSystemEventEntries(threadSessionKey)).toHaveLength(
+        threadSession ? 1 : 0,
+      );
+      actualSystemEvents.resetSystemEventsForTest();
+    },
+  );
 
   it("keeps bot edit and delete events on a remembered C-prefix mpDM session", async () => {
     const handlers: Record<string, MessageHandler> = {};

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -280,12 +280,11 @@ export function registerSlackMessageEvents(params: {
 
       const subtypeHandler = resolveSlackMessageSubtypeHandler(message);
       if (subtypeHandler) {
-        const channelId = subtypeHandler.resolveChannelId(message);
         const ingressContext = await authorizeAndResolveSlackSystemEventContext({
           ctx,
           senderId: subtypeHandler.resolveSenderId(message),
-          channelId,
-          channelType: subtypeHandler.resolveChannelType(message),
+          channelId: message.channel,
+          threadTs: subtypeHandler.resolveThreadTs(message),
           eventKind: subtypeHandler.eventKind,
           eventScope,
         });

--- a/extensions/slack/src/monitor/events/system-event-context.ts
+++ b/extensions/slack/src/monitor/events/system-event-context.ts
@@ -16,6 +16,7 @@ export async function authorizeAndResolveSlackSystemEventContext(params: {
   senderId?: string;
   channelId?: string;
   channelType?: string | null;
+  threadTs?: string;
   eventKind: string;
   eventScope?: SlackEventScope;
 }): Promise<SlackAuthorizedSystemEventContext | undefined> {
@@ -43,6 +44,7 @@ export async function authorizeAndResolveSlackSystemEventContext(params: {
     channelId,
     channelType: auth.channelType,
     senderId,
+    threadTs: auth.channelType === "im" ? undefined : params.threadTs,
     eventScope: params.eventScope,
   });
   return {

--- a/extensions/slack/src/monitor/types.ts
+++ b/extensions/slack/src/monitor/types.ts
@@ -86,12 +86,17 @@ export type SlackPinEvent = {
   event_ts?: string;
 };
 
+type SlackMessageSubtypeMessage = Pick<
+  SlackMessageEvent,
+  "ts" | "thread_ts" | "parent_user_id" | "user" | "bot_id"
+>;
+
 export type SlackMessageChangedEvent = {
   type: "message";
   subtype: "message_changed";
   channel?: string;
-  message?: { ts?: string; user?: string; bot_id?: string };
-  previous_message?: { ts?: string; user?: string; bot_id?: string };
+  message?: SlackMessageSubtypeMessage;
+  previous_message?: SlackMessageSubtypeMessage;
   event_ts?: string;
 };
 
@@ -100,6 +105,6 @@ export type SlackMessageDeletedEvent = {
   subtype: "message_deleted";
   channel?: string;
   deleted_ts?: string;
-  previous_message?: { ts?: string; user?: string; bot_id?: string };
+  previous_message?: SlackMessageSubtypeMessage;
   event_ts?: string;
 };


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users editing or deleting messages inside Slack threads would have those changes queued for the parent conversation instead of the actual thread. Another thread could consume the event first, while the intended conversation never learned that its message had changed.

## Why This Change Was Made

Slack includes the parent thread timestamp on the nested current or previous message. Preserve that existing provider fact through Slack's private subtype and system-event owners, reuse the existing genuine-reply classifier, and hand it to the existing thread-aware session router only after unchanged channel authorization. Ordinary direct-message threads and top-level thread roots retain their existing parent sessions; reactions, pins, public APIs, and security policy are unchanged. The repair also removes obsolete subtype-registry indirection and requires a net 13 production lines.

## User Impact

Slack users can edit or delete messages in public channels, private channels, group direct messages, and Enterprise workspaces without leaking those updates into another thread or losing them from the correct conversation. Existing ordinary direct-message behavior, sender allowlists, and unthreaded messages continue to work unchanged.

## Evidence

- Checked-in regression tests drive the actual registered Slack listener through unchanged authorization, the real thread-aware resolver, and the real system-event queue: **11 failures before the fix; all 17 scenarios pass afterward**.
- Cases include changed and deleted messages across channels, private channels, authorized group DMs, and Enterprise workspaces; ordinary DMs, genuine thread roots, parent-user replies, previous-message fallback, and denied senders are preserved.
- Full focused owner and sibling proof: **206 tests passing** across message events, subtype handling, reactions, pins, membership events, interactions, session routing, and thread classification.
- Independent verification: **84 additional focused tests passing**, plus **eight real event-to-queue scenarios passing** across channel, private-channel, group-DM, and ordinary-DM edits/deletions.
- Production and test type checks report **zero Slack diagnostics**; targeted typed lint, formatting, and full committed-branch review are clean.
