### PR TITLE
refactor(tooling): remove test-only production helper exports

### DIFF
--- a/scripts/check-deadcode-unused-files.mts
+++ b/scripts/check-deadcode-unused-files.mts
@@ -3,13 +3,10 @@
 import { fileURLToPath } from "node:url";
 import {
   isLikelyRepoFilePath,
-  KNIP_MAX_BUFFER_BYTES,
   runKnip,
   type KnipRunResult,
   uniqueSorted,
 } from "./deadcode-knip-runner.mts";
-
-export { KNIP_MAX_BUFFER_BYTES };
 
 const KNIP_COMMON_ARGS = ["--no-progress", "--reporter", "compact", "--files", "--no-config-hints"];
 
@@ -51,14 +48,6 @@ export function parseKnipCompactUnusedFiles(output: string) {
   }
 
   return uniqueSorted(files);
-}
-
-/** Runs Knip and returns parsed unused-file results. */
-export async function runKnipUnusedFiles(params: NonNullable<Parameters<typeof runKnip>[1]> = {}) {
-  return await runKnip([...KNIP_SCANS[0].args, ...KNIP_COMMON_ARGS], {
-    ...params,
-    scanName: KNIP_SCANS[0].name,
-  });
 }
 
 /** Rejects every unused file reported by Knip. */

--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -240,17 +240,6 @@ function listFilesystemTestFiles(rootPath: string) {
   return files.toSorted((left, right) => left.localeCompare(right));
 }
 
-/** List tracked or filesystem-discovered test files for extension roots. */
-export function listTrackedTestFilesForRoots(roots: string[]) {
-  const files = [];
-  for (const root of roots) {
-    const rootPath = path.join(repoRoot, root);
-    const trackedFiles = listTrackedTestFiles(rootPath) ?? listFilesystemTestFiles(rootPath);
-    files.push(...trackedFiles);
-  }
-  return [...new Set(files)].toSorted((left, right) => left.localeCompare(right));
-}
-
 /** List working-tree test files for extension roots, including new untracked tests. */
 export function listExtensionTestFilesForRoots(roots: string[]) {
   const files = roots.flatMap((root) => listFilesystemTestFiles(path.join(repoRoot, root)));

--- a/scripts/test-report-utils.mts
+++ b/scripts/test-report-utils.mts
@@ -32,17 +32,6 @@ export function readJsonFile(filePath: fs.PathOrFileDescriptor) {
   return parsed;
 }
 
-/**
- * Reads a JSON file or returns the provided fallback on failure.
- */
-export function tryReadJsonFile(filePath: fs.PathOrFileDescriptor, fallback: unknown) {
-  try {
-    return readJsonFile(filePath);
-  } catch {
-    return fallback;
-  }
-}
-
 function validateVitestJsonReport(reportPath: fs.PathLike) {
   const displayPath = typeof reportPath === "string" ? reportPath : reportPath.toString();
   if (!fs.existsSync(reportPath)) {

--- a/test/scripts/check-deadcode-unused-files.test.ts
+++ b/test/scripts/check-deadcode-unused-files.test.ts
@@ -9,10 +9,9 @@ import { describe, expect, it } from "vitest";
 import {
   checkKnipUnusedFileScanResult,
   checkUnusedFiles,
-  KNIP_MAX_BUFFER_BYTES,
   parseKnipCompactUnusedFiles,
-  runKnipUnusedFiles,
 } from "../../scripts/check-deadcode-unused-files.mts";
+import { KNIP_MAX_BUFFER_BYTES, runKnip } from "../../scripts/deadcode-knip-runner.mts";
 import { killPidIfAlive } from "../../src/test-utils/process-tree.js";
 import {
   isProcessAlive,
@@ -21,6 +20,18 @@ import {
   waitForFile,
   waitForPidFile,
 } from "../helpers/process-wait.js";
+
+const KNIP_UNUSED_FILE_ARGS = [
+  "--config",
+  "config/knip.config.ts",
+  "--production",
+  "--no-progress",
+  "--reporter",
+  "compact",
+  "--files",
+  "--no-config-hints",
+];
+const KNIP_UNUSED_FILE_SCAN_NAME = "production unused-file scan";
 
 class FakeKnipProcess extends EventEmitter {
   readonly stderr = new EventEmitter();
@@ -150,7 +161,7 @@ Delete the files or model their real entrypoints in Knip.`,
     writeFileSync(pnpmExecPath, "console.log('pnpm');\n", "utf8");
 
     try {
-      const resultPromise = runKnipUnusedFiles({
+      const resultPromise = runKnip(KNIP_UNUSED_FILE_ARGS, {
         nodeExecPath: "/test-node",
         npmExecPath: pnpmExecPath,
         spawnCommand(command: string, args: string[], options: unknown) {
@@ -208,7 +219,7 @@ Delete the files or model their real entrypoints in Knip.`,
   it("falls back to bare pnpm when no managed pnpm runner is available", async () => {
     const calls: unknown[] = [];
 
-    const resultPromise = runKnipUnusedFiles({
+    const resultPromise = runKnip(KNIP_UNUSED_FILE_ARGS, {
       env: { PATH: "" },
       npmExecPath: "",
       platform: "linux",
@@ -266,10 +277,11 @@ Delete the files or model their real entrypoints in Knip.`,
       return originalKill(pid, signal as NodeJS.Signals);
     }) as typeof process.kill;
     try {
-      const result = await runKnipUnusedFiles({
+      const result = await runKnip(KNIP_UNUSED_FILE_ARGS, {
         heartbeatMs: 1,
         killGraceMs: 50,
         maxBufferBytes: KNIP_MAX_BUFFER_BYTES,
+        scanName: KNIP_UNUSED_FILE_SCAN_NAME,
         spawnCommand: () => child,
         timeoutMs: 5,
         writeStatus: (message: string) => statuses.push(message),
@@ -311,7 +323,7 @@ Delete the files or model their real entrypoints in Knip.`,
           "setInterval(() => {}, 1000);",
         ].join("");
 
-        const resultPromise = runKnipUnusedFiles({
+        const resultPromise = runKnip(KNIP_UNUSED_FILE_ARGS, {
           env: { ...process.env, OPENCLAW_TEST_CHILD_PID: childPidPath },
           killGraceMs: 50,
           spawnCommand(_command: string, _args: string[], options: unknown) {
@@ -345,7 +357,7 @@ Delete the files or model their real entrypoints in Knip.`,
       const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-knip-parent-signal-"));
       const childPidPath = path.join(root, "child.pid");
       const readyPath = path.join(root, "child.ready");
-      const scriptUrl = pathToFileURL(path.resolve("scripts/check-deadcode-unused-files.mts")).href;
+      const scriptUrl = pathToFileURL(path.resolve("scripts/deadcode-knip-runner.mts")).href;
       let childPid = 0;
       let runner: ReturnType<typeof spawn> | undefined;
 
@@ -365,8 +377,8 @@ Delete the files or model their real entrypoints in Knip.`,
         ].join("");
         const runnerScript = [
           "import { spawn } from 'node:child_process';",
-          `import { runKnipUnusedFiles } from ${JSON.stringify(scriptUrl)};`,
-          "await runKnipUnusedFiles({",
+          `import { runKnip } from ${JSON.stringify(scriptUrl)};`,
+          `await runKnip(${JSON.stringify(KNIP_UNUSED_FILE_ARGS)}, {`,
           "  spawnCommand(_command, _args, options) {",
           `    return spawn(process.execPath, ['-e', ${JSON.stringify(parentScript)}], options);`,
           "  },",
@@ -403,7 +415,7 @@ Delete the files or model their real entrypoints in Knip.`,
 
   it("keeps output delivered after process exit but before stdio close", async () => {
     const child = new FakeKnipProcess();
-    const resultPromise = runKnipUnusedFiles({
+    const resultPromise = runKnip(KNIP_UNUSED_FILE_ARGS, {
       spawnCommand: () => child,
       writeStatus: () => {},
     });
@@ -436,9 +448,10 @@ Delete the files or model their real entrypoints in Knip.`,
       return originalKill(pid, signal as NodeJS.Signals);
     }) as typeof process.kill;
     try {
-      const resultPromise = runKnipUnusedFiles({
+      const resultPromise = runKnip(KNIP_UNUSED_FILE_ARGS, {
         killGraceMs: 50,
         maxBufferBytes: 4,
+        scanName: KNIP_UNUSED_FILE_SCAN_NAME,
         spawnCommand: () => child,
         timeoutMs: 1000,
         writeStatus: () => {},
@@ -458,7 +471,7 @@ Delete the files or model their real entrypoints in Knip.`,
   });
 
   it("reports spawn errors", async () => {
-    const resultPromise = runKnipUnusedFiles({
+    const resultPromise = runKnip(KNIP_UNUSED_FILE_ARGS, {
       spawnCommand: () => {
         const child = new FakeKnipProcess();
         queueMicrotask(() =>

--- a/test/scripts/plugin-prerelease-telegram-shards.test.ts
+++ b/test/scripts/plugin-prerelease-telegram-shards.test.ts
@@ -7,7 +7,7 @@ import { parse } from "yaml";
 import {
   DEFAULT_EXTENSION_TEST_SHARD_COUNT,
   createExtensionTestShards,
-  listTrackedTestFilesForRoots,
+  listExtensionTestFilesForRoots,
   splitExtensionTestJobTargets,
 } from "../../scripts/lib/extension-test-plan.mts";
 import { createVitestRunSpecs } from "../../scripts/test-projects.test-support.mts";
@@ -137,7 +137,7 @@ describe("plugin prerelease Telegram extension shards", () => {
     const matrix = runPluginPrereleaseManifest();
     const genericRows = matrix.include.filter((row) => row.task === "extensions-batch");
     const telegramRows = matrix.include.filter((row) => row.task === "extension-file-shard");
-    const trackedTelegramTestFiles = listTrackedTestFilesForRoots(["extensions/telegram"]);
+    const allTelegramTestFiles = listExtensionTestFilesForRoots(["extensions/telegram"]);
     const runnableTelegramTestFiles = listTelegramRunnableTestFiles();
 
     expect(genericRows).toHaveLength(DEFAULT_EXTENSION_TEST_SHARD_COUNT);
@@ -173,7 +173,7 @@ describe("plugin prerelease Telegram extension shards", () => {
     expect(telegramPartitions.every((partition) => partition.length <= 10)).toBe(true);
     expect(Math.max(...telegramPartitions.map((partition) => partition.length))).toBe(10);
     expect(
-      trackedTelegramTestFiles.filter((file) => !runnableTelegramTestFiles.includes(file)).length,
+      allTelegramTestFiles.filter((file) => !runnableTelegramTestFiles.includes(file)).length,
     ).toBeGreaterThan(0);
 
     const tempDir = mkdtempSync(join(tmpdir(), "openclaw-plugin-prerelease-telegram-specs-"));

--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -17,7 +17,6 @@ import {
   createExtensionTestProcessTargetChunks,
   createExtensionTestShards,
   listExtensionTestFilesForRoots,
-  listTrackedTestFilesForRoots,
   resolveExtensionBatchPlan,
   resolveExtensionTestConfig,
   resolveExtensionTestPlan,
@@ -94,7 +93,7 @@ function findExtensionWithoutTests() {
 }
 
 function listExtensionTestFiles(extensionId: string): string[] {
-  return listTrackedTestFilesForRoots([bundledPluginRoot(extensionId)]);
+  return listExtensionTestFilesForRoots([bundledPluginRoot(extensionId)]);
 }
 
 function expectedMatrixTestProcessCount() {

--- a/test/scripts/test-report-utils.test.ts
+++ b/test/scripts/test-report-utils.test.ts
@@ -8,7 +8,6 @@ import {
   collectVitestAssertionDurations,
   collectVitestFileDurations,
   normalizeTrackedRepoPath,
-  tryReadJsonFile,
 } from "../../scripts/test-report-utils.mts";
 
 const { spawnSyncMock } = vi.hoisted(() => ({
@@ -88,25 +87,6 @@ describe("scripts/test-report-utils collectVitestAssertionDurations", () => {
         status: "passed",
       },
     ]);
-  });
-});
-
-describe("scripts/test-report-utils tryReadJsonFile", () => {
-  it("returns the fallback when the file is missing", () => {
-    const missingPath = path.join(os.tmpdir(), `openclaw-missing-${Date.now()}.json`);
-
-    expect(tryReadJsonFile(missingPath, { ok: true })).toEqual({ ok: true });
-  });
-
-  it("reads valid JSON files", () => {
-    const tempPath = path.join(os.tmpdir(), `openclaw-json-${Date.now()}.json`);
-    fs.writeFileSync(tempPath, JSON.stringify({ ok: true }));
-
-    try {
-      expect(tryReadJsonFile(tempPath, null)).toEqual({ ok: true });
-    } finally {
-      fs.unlinkSync(tempPath);
-    }
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Repository test and dead-code tooling carried three production entrypoints that existed only because implementation-coupled tests imported them. This duplicated the actual Knip subprocess owner and extension test-file inventory while retaining a JSON fallback that no real reporting flow called.

## Why This Change Was Made

Delete the unused report fallback, the unused-file scan's test-only Knip wrapper and redundant buffer-limit re-export, and the extension planner's test-only tracked-file facade. Retarget meaningful process-group, timeout, output, signal, extension, and Telegram prerelease coverage directly to the real production owners; retain the actual dual Knip scans, strict JSON reader, cached tracked Git inventory, and working-tree extension inventory.

Production: +0/-33. Tests: +29/-37. Only the two tests dedicated solely to the removed unused JSON fallback were deleted.

## User Impact

No public CLI, package, release, or test-runner behavior changes. Developers retain the same dead-code checks, extension test selection, process cleanup, and Telegram prerelease shards with fewer production-only-for-tests paths.

## Evidence

- Five existing focused suites passed 209 tests: reporting helpers, Knip unused-file scanning and subprocess cleanup, Knip unused-export sibling coverage, plugin extension planning, and the executable Telegram prerelease workflow manifest.
- Executed the actual `scripts/check-deadcode-unused-files.mts` CLI against a bounded external pnpm fixture, captured both child invocations, and asserted the exact pinned `knip@6.32.2` production/full-tree argument vectors and normal success output.
- Executed the actual `node scripts/test-extension.mts --help` entrypoint successfully.
- Existing retained subprocess tests cover 16 MiB output limits, heartbeats, timeouts, SIGTERM/SIGKILL escalation, descendant cleanup, parent signal forwarding, stderr/stdout ordering, and spawn errors directly at the canonical runner.
- Existing retained extension tests cover tracked Git inventory reuse, working-tree discovery, executable workflow manifest generation, runnable Telegram exclusions, process recycling, and the ten-file shard cap.
- Scoped formatter, targeted scripts lint, changed-check dry-run routing, independent source review, and clean automated review.
- Exact-head hosted CI and mandatory native Testbox preparation provide full clean-checkout validation because the shared local dependency tree belongs to a different checkout revision.
