### PR TITLE
fix(gateway): keep patch-created sessions visible to their creator

### DIFF
--- a/src/gateway/server-methods/sessions-mutations.owner.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.owner.test.ts
@@ -9,6 +9,7 @@ import { ensureProfileForEmail } from "../../state/user-profiles.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { dispatchGatewayMethodInProcess } from "../server-plugins.js";
 import {
+  createSessionListEntryFilter,
   resolveSessionMutationAuthorization,
   resolveSessionSharingRole,
   resolveSessionSharingTarget,
@@ -84,6 +85,69 @@ async function invoke(params: {
   }
   return { authorization, requestContext, responses };
 }
+
+describe("sessions.patch", () => {
+  it("keeps a newly created session visible to its identified non-admin creator", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const profileId = ensureProfileForEmail("patch-creator@example.test").id;
+      const sessionKey = "agent:main:patch-created";
+      const requestClient = client(profileId);
+      const cfg: OpenClawConfig = {
+        gateway: {
+          roles: {
+            default: "member",
+            definitions: {
+              member: {
+                sessions: { others: "none" },
+                agents: "*",
+                scopes: ["operator.write"],
+              },
+            },
+          },
+        },
+      };
+      const requestContext = context(cfg);
+      const patch = async (pinned: boolean) => {
+        const request = { key: sessionKey, pinned };
+        const authorization = resolveSessionMutationAuthorization({
+          client: requestClient,
+          method: "sessions.patch",
+          requestParams: request,
+          context: requestContext,
+        });
+        expect(authorization.error).toBeNull();
+        const respond = vi.fn();
+        await sessionMutationHandlers["sessions.patch"]?.({
+          params: request,
+          client: requestClient,
+          context: requestContext,
+          sessionMutationAuthorization: authorization.authorization,
+          respond,
+        } as never);
+        expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+      };
+
+      await patch(true);
+      const entry = loadSessionEntry({ agentId: "main", env: state.env, sessionKey });
+      expect(entry).toMatchObject({
+        createdVia: "operator",
+        createdActor: { type: "human", id: profileId },
+        createdAt: expect.any(Number),
+      });
+      if (!entry) {
+        throw new Error("expected patch-created session entry");
+      }
+      expect(
+        createSessionListEntryFilter({ client: requestClient, cfg })?.(sessionKey, entry),
+      ).toBe(true);
+
+      await patch(false);
+      expect(
+        loadSessionEntry({ agentId: "main", env: state.env, sessionKey })?.pinnedAt,
+      ).toBeUndefined();
+    });
+  });
+});
 
 describe("sessions.assignOwner", () => {
   it("records the trusted in-process agent tool caller as the assigning agent", async () => {

--- a/src/gateway/server-methods/sessions-patch-engine.ts
+++ b/src/gateway/server-methods/sessions-patch-engine.ts
@@ -35,6 +35,7 @@ import {
 import { projectSessionsPatchEntry } from "../sessions-patch.js";
 import { gatewayClientSessionCreator } from "./gateway-client-identity.js";
 import { emitSessionsChanged } from "./session-change-event.js";
+import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
 import {
   prepareSessionPatchArchive,
   type SessionPatchArchivePreparation,
@@ -132,6 +133,7 @@ async function executeSessionPatchMutations(params: {
 }): Promise<MutationCoreResult> {
   const { client } = params;
   const cfg = params.context.getRuntimeConfig();
+  const creation = resolveOperatorSessionCreation(client);
   const archiveActor = gatewayClientSessionCreator(client);
   const callerScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
   const callerCanManageCron = client === null || callerScopes.includes(ADMIN_SCOPE);
@@ -432,6 +434,7 @@ async function executeSessionPatchMutations(params: {
                         }
                         const projected = await projectSessionsPatchEntry({
                           cfg,
+                          creation,
                           existingEntry,
                           isLabelInUse: (label) => labelOwners.isLabelInUse(label, candidateKeys),
                           storeKey: primaryKey,

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -40,6 +40,10 @@ import type {
   InternalSessionEntry as SessionEntry,
   SessionToolOverrides,
 } from "../config/sessions.js";
+import {
+  buildSessionCreationStamp,
+  type SessionCreatedVia,
+} from "../config/sessions/session-entry-provenance.js";
 import { projectCanonicalSessionEntryShape } from "../config/sessions/store-entry-shape.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeExecTarget } from "../infra/exec-approvals.js";
@@ -167,6 +171,7 @@ function normalizeSessionToolOverrides(
 /** Project a validated gateway session patch for one session entry. */
 export async function projectSessionsPatchEntry(params: {
   cfg: OpenClawConfig;
+  creation?: { via: SessionCreatedVia; actor?: SessionCreatedActor };
   existingEntry?: SessionEntry;
   isLabelInUse: (label: string) => boolean;
   storeKey: string;
@@ -178,7 +183,7 @@ export async function projectSessionsPatchEntry(params: {
   /** Exact harness owner authorized to project its new reserved session row. */
   authorizedAgentHarnessId?: string;
 }): Promise<{ ok: true; entry: SessionEntry } | { ok: false; error: ErrorShape }> {
-  const { cfg, storeKey, patch } = params;
+  const { cfg, storeKey, patch, creation } = params;
   const authorizedHarnessCreation =
     params.existingEntry === undefined &&
     isAgentHarnessSessionKeyOwnedBy(storeKey, params.authorizedAgentHarnessId);
@@ -245,20 +250,16 @@ export async function projectSessionsPatchEntry(params: {
     return loadedModelCatalog;
   };
 
-  const existing = params.existingEntry
-    ? projectCanonicalSessionEntryShape({ ...params.existingEntry })
-    : undefined;
+  const existing =
+    params.existingEntry && projectCanonicalSessionEntryShape({ ...params.existingEntry });
   // Existing entries without session ids are placeholder aliases; assigning an id makes them real.
-  const next: SessionEntry = existing?.sessionId
-    ? {
-        ...existing,
-        updatedAt: Math.max(existing.updatedAt ?? 0, now),
-      }
-    : {
-        ...existing,
-        sessionId: randomUUID(),
-        updatedAt: Math.max(existing?.updatedAt ?? 0, now),
-      };
+  const next: SessionEntry = {
+    ...existing,
+    sessionId: existing?.sessionId || randomUUID(),
+    updatedAt: Math.max(existing?.updatedAt ?? 0, now),
+    // Stamp only genuinely new rows; existing placeholder aliases must not be restamped.
+    ...(creation && params.existingEntry === undefined ? buildSessionCreationStamp(creation) : {}),
+  };
   if (existing && !existing.sessionId) {
     delete next.label;
     delete next.category;


### PR DESCRIPTION
Related: #128548

## What Problem This Solves

Fixes an issue where operators who created a session through `sessions.patch` immediately lost access to their own session on gateways that hide other users' sessions. Subsequent reads and writes incorrectly failed with `Session ... was not found`, including when `gateway.roles` sets `sessions.others="none"`.

## Why This Change Was Made

Carry the authenticated operator's existing session-creation provenance through the patch mutation owner and stamp it only when `sessions.patch` genuinely creates a new session row. This matches `sessions.create` semantics while preserving the original provenance of existing rows and placeholder aliases.

## User Impact

Operators can immediately see, read, and update sessions they create through `sessions.patch` when session visibility is restricted. Existing sessions keep their original creation provenance.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-mutations.owner.test.ts src/gateway/sessions-patch.test.ts`: 92 tests passed across both focused suites.
- The new gateway owner-boundary regression was verified to fail before the production fix and now passes while checking creator provenance, visibility, and a subsequent patch.
- `node scripts/check-changed.mjs -- src/gateway/sessions-patch.ts src/gateway/server-methods/sessions-patch-engine.ts src/gateway/server-methods/sessions-mutations.owner.test.ts`: passed.
- Fresh Codex autoreview: clean, with no accepted or actionable findings.
- AI-assisted change. Validation exercises the real in-process gateway mutation handler; no separate Control UI recording was captured.
- Exact-head pull-request CI passed for `1441a462b97c799a11fdffd2d6d4a0642c19207e`: https://github.com/openclaw/openclaw/actions/runs/32743692221.
- ClawSweeper independently reran `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-mutations.owner.test.ts`: 4 tests passed, with no actionable correctness or security findings.
- ClawSweeper merge-risk follow-up: retain the necessary +4 production lines because the mutation owner must resolve the authenticated creation identity and pass it to the existing canonical projection; no clearer net-neutral owner-boundary repair exists.
- ClawSweeper stored-state follow-up: no schema or migration change applies. The fix writes existing canonical creation fields only for genuinely new rows and never rewrites existing rows or placeholder aliases.
- ClawSweeper next-step follow-up: exact-head CI is green and the PR is proceeding through the repository-native maintainer review, preparation, and merge gates; no separate repair lane is needed.
