### PR TITLE
refactor(parallel): share search request lifecycle

### DIFF
--- a/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.runtime.ts
@@ -1,20 +1,10 @@
 import {
   mergeScopedSearchConfig,
-  readCachedSearchPayload,
   resolveProviderWebSearchPluginConfig,
-  resolveSearchCacheTtlMs,
-  resolveSearchTimeoutSeconds,
   type SearchConfigRecord,
-  writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
 import { PARALLEL_MCP_SEARCH_URL, runParallelMcpSearch } from "./parallel-mcp-search.runtime.js";
-import {
-  buildParallelCacheKey,
-  buildParallelSearchPayload,
-  PARALLEL_FREE_SESSION_ID_MAX_LENGTH,
-  normalizeParallelSearchRequest,
-  stripParallelGeneratedSessionId,
-} from "./parallel-search-normalize.js";
+import { executeParallelSearchRequest } from "./parallel-search-normalize.js";
 
 export async function executeParallelFreeWebSearchProviderTool(
   ctx: { config?: Record<string, unknown>; searchConfig?: SearchConfigRecord },
@@ -28,48 +18,19 @@ export async function executeParallelFreeWebSearchProviderTool(
     resolveProviderWebSearchPluginConfig(ctx.config, "parallel-free"),
   ) as SearchConfigRecord | undefined;
 
-  const request = normalizeParallelSearchRequest(
-    args,
-    searchConfig?.maxResults,
-    PARALLEL_FREE_SESSION_ID_MAX_LENGTH,
-  );
-  if ("error" in request) {
-    return request.error;
-  }
-  const { objective, searchQueries, count, sessionId, clientModel } = request;
-  const cacheKey = buildParallelCacheKey({
-    endpoint: PARALLEL_MCP_SEARCH_URL,
-    objective,
-    searchQueries,
-    count,
-    sessionId,
-    clientModel,
-  });
-  const cached = readCachedSearchPayload(cacheKey);
-  if (cached) {
-    return cached;
-  }
-
-  const start = Date.now();
-  const response = await runParallelMcpSearch({
-    objective,
-    searchQueries,
-    maxResults: count,
-    sessionId,
-    modelName: clientModel,
-    timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
-    signal,
-  });
-  signal?.throwIfAborted();
-  const payload = buildParallelSearchPayload({
+  return executeParallelSearchRequest({
     provider: "parallel-free",
-    objective,
-    searchQueries,
-    response,
-    start,
+    endpoint: PARALLEL_MCP_SEARCH_URL,
+    args,
+    searchConfig,
+    signal,
+    search: ({ count, clientModel, ...request }, timeoutSeconds) =>
+      runParallelMcpSearch({
+        ...request,
+        maxResults: count,
+        modelName: clientModel,
+        timeoutSeconds,
+        signal,
+      }),
   });
-
-  const cachePayload = sessionId ? payload : stripParallelGeneratedSessionId(payload);
-  writeCachedSearchPayload(cacheKey, cachePayload, resolveSearchCacheTtlMs(searchConfig));
-  return payload;
 }

--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -6,11 +6,16 @@ import { resolveIntegerOption } from "openclaw/plugin-sdk/number-runtime";
 import {
   buildSearchCacheKey,
   DEFAULT_SEARCH_COUNT,
+  readCachedSearchPayload,
   readPositiveIntegerParam,
   readStringArrayParam,
   readStringParam,
+  resolveSearchCacheTtlMs,
+  resolveSearchTimeoutSeconds,
   resolveSiteName,
+  type SearchConfigRecord,
   wrapWebContent,
+  writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
 import {
   normalizeBoundedOptionalString,
@@ -53,19 +58,19 @@ export type ParallelSearchResponse = {
   usage?: unknown;
 };
 
+type NormalizedParallelSearchRequest = {
+  objective?: string;
+  searchQueries: string[];
+  count: number;
+  sessionId?: string;
+  clientModel?: string;
+};
+
 export function normalizeParallelSearchRequest(
   args: Record<string, unknown>,
   configuredCount: unknown,
   sessionIdMaxLength: number,
-):
-  | { error: ReturnType<typeof invalidSearchQueriesPayload> }
-  | {
-      objective?: string;
-      searchQueries: string[];
-      count: number;
-      sessionId?: string;
-      clientModel?: string;
-    } {
+): { error: ReturnType<typeof invalidSearchQueriesPayload> } | NormalizedParallelSearchRequest {
   const objective = normalizeParallelObjective(readStringParam(args, "objective"));
   const cliQuery = normalizeParallelObjective(readStringParam(args, "query"));
   let searchQueries = normalizeParallelSearchQueries(readStringArrayParam(args, "search_queries"));
@@ -82,6 +87,49 @@ export function normalizeParallelSearchRequest(
     sessionId: normalizeParallelSessionId(readStringParam(args, "session_id"), sessionIdMaxLength),
     clientModel: normalizeParallelClientModel(readStringParam(args, "client_model")),
   };
+}
+
+export async function executeParallelSearchRequest(params: {
+  provider: "parallel" | "parallel-free";
+  endpoint: string;
+  args: Record<string, unknown>;
+  searchConfig: SearchConfigRecord | undefined;
+  signal?: AbortSignal;
+  search: (
+    request: NormalizedParallelSearchRequest,
+    timeoutSeconds: number,
+  ) => Promise<ParallelSearchResponse>;
+}): Promise<Record<string, unknown>> {
+  const request = normalizeParallelSearchRequest(
+    params.args,
+    params.searchConfig?.maxResults,
+    params.provider === "parallel"
+      ? PARALLEL_SESSION_ID_MAX_LENGTH
+      : PARALLEL_FREE_SESSION_ID_MAX_LENGTH,
+  );
+  if ("error" in request) {
+    return request.error;
+  }
+  const cacheKey = buildParallelCacheKey({ endpoint: params.endpoint, ...request });
+  const cached = readCachedSearchPayload(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const start = Date.now();
+  const response = await params.search(request, resolveSearchTimeoutSeconds(params.searchConfig));
+  // A provider can finish after its caller aborts; never cache that stale result.
+  params.signal?.throwIfAborted();
+  const payload = buildParallelSearchPayload({
+    provider: params.provider,
+    objective: request.objective,
+    searchQueries: request.searchQueries,
+    response,
+    start,
+  });
+  const cachePayload = request.sessionId ? payload : stripParallelGeneratedSessionId(payload);
+  writeCachedSearchPayload(cacheKey, cachePayload, resolveSearchCacheTtlMs(params.searchConfig));
+  return payload;
 }
 
 export function resolveParallelSearchCount(

--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -34,7 +34,7 @@ const PARALLEL_MAX_SEARCH_QUERIES = 5;
 // Paid v1 REST accepts session ids up to 1000 chars, but the free Search MCP
 // `tools/list` schema caps session_id at 100. Each runtime passes its own limit
 // (and advertises it in the tool schema) so callers never send an out-of-contract id.
-export const PARALLEL_SESSION_ID_MAX_LENGTH = 1000;
+const PARALLEL_SESSION_ID_MAX_LENGTH = 1000;
 export const PARALLEL_FREE_SESSION_ID_MAX_LENGTH = 100;
 const PARALLEL_CLIENT_MODEL_MAX_LENGTH = 100;
 
@@ -66,7 +66,7 @@ type NormalizedParallelSearchRequest = {
   clientModel?: string;
 };
 
-export function normalizeParallelSearchRequest(
+function normalizeParallelSearchRequest(
   args: Record<string, unknown>,
   configuredCount: unknown,
   sessionIdMaxLength: number,
@@ -249,7 +249,7 @@ function mapParallelResults(response: ParallelSearchResponse): Record<string, un
   });
 }
 
-export function buildParallelSearchPayload(params: {
+function buildParallelSearchPayload(params: {
   provider: "parallel" | "parallel-free";
   objective?: string;
   searchQueries: readonly string[];
@@ -291,7 +291,7 @@ export function buildParallelSearchPayload(params: {
  * unrelated tasks would otherwise share that id; caller-supplied session ids are
  * part of the cache key, so a cache hit only ever returns the matching id.
  */
-export function stripParallelGeneratedSessionId(
+function stripParallelGeneratedSessionId(
   payload: Record<string, unknown>,
 ): Record<string, unknown> {
   if (!("sessionId" in payload)) {

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -7,31 +7,24 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import {
   mergeScopedSearchConfig,
-  readCachedSearchPayload,
   readConfiguredSecretString,
   readProviderEnvValue,
   resolveProviderWebSearchPluginConfig,
-  resolveSearchCacheTtlMs,
-  resolveSearchTimeoutSeconds,
   type SearchConfigRecord,
   withTrustedWebSearchEndpoint,
-  writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
 import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildParallelCacheKey,
-  buildParallelSearchPayload,
+  executeParallelSearchRequest,
   normalizeParallelClientModel,
   normalizeParallelObjective,
   normalizeParallelResults,
-  normalizeParallelSearchRequest,
   normalizeParallelSearchQueries,
   normalizeParallelSessionId,
-  PARALLEL_SESSION_ID_MAX_LENGTH,
   type ParallelSearchResponse,
   resolveParallelSearchCount,
-  stripParallelGeneratedSessionId,
 } from "./parallel-search-normalize.js";
 
 const PARALLEL_BASE_URL = "https://api.parallel.ai";
@@ -200,57 +193,22 @@ export async function executeParallelWebSearchProviderTool(
   }
   const endpoint = endpointResult.endpoint;
 
-  const request = normalizeParallelSearchRequest(
-    args,
-    searchConfig?.maxResults,
-    PARALLEL_SESSION_ID_MAX_LENGTH,
-  );
-  if ("error" in request) {
-    return request.error;
-  }
-  const { objective, searchQueries, count, sessionId, clientModel } = request;
-  // Always pass max_results so Parallel matches the openclaw web_search default
-  // of 5 instead of Parallel's own default of 10.
-  const cacheKey = buildParallelCacheKey({
-    endpoint,
-    objective,
-    searchQueries,
-    count,
-    sessionId,
-    clientModel,
-  });
-  const cached = readCachedSearchPayload(cacheKey);
-  if (cached) {
-    return cached;
-  }
-
-  const start = Date.now();
-  const response = await runParallelSearch({
-    apiKey,
-    endpoint,
-    objective,
-    searchQueries,
-    maxResults: count,
-    sessionId,
-    clientModel,
-    timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
-    signal,
-  });
-  signal?.throwIfAborted();
-  const payload = buildParallelSearchPayload({
+  return executeParallelSearchRequest({
     provider: "parallel",
-    objective,
-    searchQueries,
-    response,
-    start,
+    endpoint,
+    args,
+    searchConfig,
+    signal,
+    search: ({ count, ...request }, timeoutSeconds) =>
+      runParallelSearch({
+        ...request,
+        apiKey,
+        endpoint,
+        maxResults: count,
+        timeoutSeconds,
+        signal,
+      }),
   });
-
-  // Don't persist a Parallel-generated session id into the shared cache:
-  // identical queries from unrelated tasks would otherwise share that id.
-  // Caller-supplied session ids are already part of the cache key.
-  const cachePayload = sessionId ? payload : stripParallelGeneratedSessionId(payload);
-  writeCachedSearchPayload(cacheKey, cachePayload, resolveSearchCacheTtlMs(searchConfig));
-  return payload;
 }
 
 export const testing = {


### PR DESCRIPTION
## What Problem This Solves

Parallel's paid web search and its free MCP-backed search maintained duplicate request normalization, cache ownership, cancellation, and result-shaping flows. Future fixes to session isolation or canceled searches could drift between the two providers despite their shared result contract.

## Why This Change Was Made

Both provider-private runtimes now delegate their identical request/cache lifecycle to the existing Parallel normalization owner while keeping paid REST and free MCP transport, authentication, endpoint guards, response bounds, and provider-specific session limits in their existing owners. A single post-response cancellation fence prevents either transport from caching results after its caller has canceled.

## User Impact

No user-visible behavior, public plugin contract, configuration, provider selection, credentials, or security policy changes. Paid and free Parallel searches retain their existing session isolation, cache partitioning, timeout, streamed-response bounds, MCP handshake, and cancellation behavior.

## Evidence

- Production: +86/-119 (net -33) across three plugin-private files; no tests, configuration, baselines, or public exports changed.
- Focused paid REST, free MCP, and transport-boundary suite: 55/55 passed.
- Intentional fault injection: removing the shared post-response cancellation fence made the existing real free-MCP cancellation/cache-isolation test fail because a canceled provider result was returned; restoring the fence returned the complete suite to 55/55 passing.
- `node_modules/.bin/oxfmt --check extensions/parallel/src/parallel-search-normalize.ts extensions/parallel/src/parallel-web-search-provider.runtime.ts extensions/parallel/src/parallel-free-web-search-provider.runtime.ts`
- `node scripts/check-changed.mjs --dry-run -- extensions/parallel/src/parallel-search-normalize.ts extensions/parallel/src/parallel-web-search-provider.runtime.ts extensions/parallel/src/parallel-free-web-search-provider.runtime.ts`
- Two independent owner-boundary source reviews accepted the exact final diff; hosted exact-head checks and the repository-native Testbox prepare gate run before landing.
