### PR TITLE
fix(gateway): keep cloud-managed nodes out of device placement

### DIFF
--- a/src/gateway/server-methods/environments.node-ownership.test.ts
+++ b/src/gateway/server-methods/environments.node-ownership.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { listNodePairing } from "../../infra/device-pairing-node.js";
+import { listDevicePairing } from "../../infra/device-pairing.js";
+import {
+  collectNodeRunnerIssuesByNodeId,
+  collectNodeWorkerBundleStatusByNodeId,
+  collectNodeWorkerCapacityByNodeId,
+  isNodeRunnerSessionHost,
+} from "../node-registry-private.js";
+import type {
+  WorkerEnvironmentServiceContract,
+  WorkerEnvironmentServiceRecord,
+} from "../worker-environments/service-contract.js";
+import { environmentsHandlers } from "./environments.js";
+
+vi.mock("../../infra/device-pairing.js", () => ({
+  listDevicePairing: vi.fn(),
+  resolveNodePairingState: vi.fn(),
+}));
+
+vi.mock("../../infra/device-pairing-node.js", () => ({
+  listNodePairing: vi.fn(),
+}));
+
+vi.mock("../node-registry-private.js", () => ({
+  collectNodeRunnerIssuesByNodeId: vi.fn(() => new Map()),
+  collectNodeWorkerBundleStatusByNodeId: vi.fn(() => new Map()),
+  collectNodeWorkerCapacityByNodeId: vi.fn(() => new Map()),
+  isNodeRunnerSessionHost: vi.fn(() => false),
+}));
+
+type TestWorkerService = Pick<WorkerEnvironmentServiceContract, "get" | "list">;
+
+const CONNECTED_NODE = {
+  nodeId: "node-live",
+  connId: "conn-live",
+  displayName: "Live Node",
+  platform: "linux",
+  caps: [],
+  commands: ["system.run"],
+  connectedAtMs: 123,
+};
+
+function workerRecord(
+  overrides: Partial<WorkerEnvironmentServiceRecord> = {},
+): WorkerEnvironmentServiceRecord {
+  return {
+    environmentId: "worker-1",
+    providerId: "static-ssh",
+    leaseId: "lease-1",
+    sharedHost: false,
+    state: "ready",
+    ownerEpoch: 1,
+    createdAtMs: 1_000,
+    idleSinceAtMs: null,
+    attachedSessionIds: [],
+    desktopAvailable: false,
+    desktopApps: [],
+    tunnelStatus: "stopped",
+    ...overrides,
+  };
+}
+
+function workerService(overrides: Partial<TestWorkerService> = {}): TestWorkerService {
+  return {
+    list: vi.fn(() => []),
+    get: vi.fn(() => undefined),
+    ...overrides,
+  };
+}
+
+async function callEnvironmentMethod(
+  method: "environments.list" | "environments.status",
+  params: unknown,
+  service: TestWorkerService,
+) {
+  const respond = vi.fn();
+  await environmentsHandlers[method]?.({
+    params: params as Record<string, unknown>,
+    respond,
+    context: {
+      logGateway: { warn: vi.fn() },
+      nodeRegistry: {
+        listConnectedForPairingStates: () => [CONNECTED_NODE],
+      },
+      workerEnvironmentService: service,
+      getRuntimeConfig: () => ({}),
+    },
+  } as never);
+  const call = respond.mock.calls.at(0);
+  if (!call) {
+    throw new Error("expected environments handler to respond");
+  }
+  return call;
+}
+
+beforeEach(() => {
+  vi.mocked(isNodeRunnerSessionHost).mockReturnValue(false);
+  vi.mocked(collectNodeRunnerIssuesByNodeId).mockReturnValue(new Map());
+  vi.mocked(collectNodeWorkerCapacityByNodeId).mockReturnValue(new Map());
+  vi.mocked(collectNodeWorkerBundleStatusByNodeId).mockReturnValue(new Map());
+  vi.mocked(listDevicePairing).mockResolvedValue({ paired: [] } as never);
+  vi.mocked(listNodePairing).mockResolvedValue({ paired: [] } as never);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("environment node ownership", () => {
+  it.each([
+    {
+      name: "requested worker without a node binding",
+      state: "requested",
+      status: "starting",
+      visible: true,
+      providerId: "static-ssh",
+      nodeDeviceId: undefined,
+    },
+    {
+      name: "ready cloud worker",
+      state: "ready",
+      status: "available",
+      visible: false,
+      providerId: "static-ssh",
+      nodeDeviceId: "node-live",
+    },
+    {
+      name: "draining cloud worker",
+      state: "draining",
+      status: "stopping",
+      visible: false,
+      providerId: "static-ssh",
+      nodeDeviceId: "node-live",
+    },
+    {
+      name: "destroyed cloud worker",
+      state: "destroyed",
+      status: "unavailable",
+      visible: true,
+      providerId: "static-ssh",
+      nodeDeviceId: "node-live",
+    },
+    {
+      name: "failed cloud worker retaining its node binding",
+      state: "failed",
+      status: "error",
+      visible: false,
+      providerId: "static-ssh",
+      nodeDeviceId: "node-live",
+    },
+    {
+      name: "failed cloud worker after enrollment retirement",
+      state: "failed",
+      status: "error",
+      visible: true,
+      providerId: "static-ssh",
+      nodeDeviceId: undefined,
+    },
+    {
+      name: "orphaned cloud worker",
+      state: "orphaned",
+      status: "error",
+      visible: false,
+      providerId: "static-ssh",
+      nodeDeviceId: "node-live",
+    },
+    {
+      name: "paired-device provider worker",
+      state: "ready",
+      status: "available",
+      visible: true,
+      providerId: "device",
+      nodeDeviceId: "node-live",
+    },
+  ] as const)("projects $name without losing pairing ownership", async (scenario) => {
+    const error =
+      scenario.state === "orphaned" ? "provider no longer recognizes the lease" : undefined;
+    const service = workerService({
+      list: vi.fn(() => [
+        workerRecord({
+          state: scenario.state,
+          providerId: scenario.providerId,
+          nodeDeviceId: scenario.nodeDeviceId,
+          ...(error ? { error } : {}),
+        }),
+      ]),
+    });
+
+    const [ok, payload] = await callEnvironmentMethod("environments.list", {}, service);
+    const environments = (payload as { environments: Array<Record<string, unknown>> }).environments;
+
+    expect(ok).toBe(true);
+    expect(environments.some((entry) => entry.id === "node:node-live")).toBe(scenario.visible);
+    expect(environments.find((entry) => entry.id === "worker-1")).toMatchObject({
+      type: "worker",
+      status: scenario.status,
+      worker: {
+        providerId: scenario.providerId,
+        state: scenario.state,
+        ...(error ? { error } : {}),
+      },
+    });
+  });
+
+  it("fails closed and redacts worker inventory read failures", async () => {
+    const secret = "private SecretRef and database path";
+    const listFailure = workerService({
+      list: vi.fn(() => {
+        throw new Error(secret);
+      }),
+    });
+    const statusFailure = workerService({
+      get: vi.fn(() => {
+        throw new Error(secret);
+      }),
+    });
+
+    const listResult = await callEnvironmentMethod("environments.list", {}, listFailure);
+    const nodeStatusResult = await callEnvironmentMethod(
+      "environments.status",
+      { environmentId: "node:node-live" },
+      listFailure,
+    );
+    const workerStatusResult = await callEnvironmentMethod(
+      "environments.status",
+      { environmentId: "worker-missing" },
+      statusFailure,
+    );
+
+    const inventoryFailure = {
+      code: ErrorCodes.UNAVAILABLE,
+      message: "Error: environment inventory unavailable",
+    };
+    expect(listResult).toEqual([false, undefined, inventoryFailure]);
+    expect(nodeStatusResult).toEqual([false, undefined, inventoryFailure]);
+    expect(workerStatusResult[2]).toEqual({
+      code: ErrorCodes.UNAVAILABLE,
+      message: "environment status unavailable",
+    });
+    expect(JSON.stringify([listResult, nodeStatusResult, workerStatusResult])).not.toContain(
+      secret,
+    );
+  });
+});

--- a/src/gateway/server-methods/environments.test.ts
+++ b/src/gateway/server-methods/environments.test.ts
@@ -13,7 +13,10 @@ import {
   collectNodeWorkerCapacityByNodeId,
   isNodeRunnerSessionHost,
 } from "../node-registry-private.js";
-import type { WorkerEnvironmentServiceRecord } from "../worker-environments/service-contract.js";
+import type {
+  WorkerEnvironmentServiceContract,
+  WorkerEnvironmentServiceRecord,
+} from "../worker-environments/service-contract.js";
 import type { WorkerEnvironmentRecord } from "../worker-environments/store.js";
 import { environmentsHandlers, summarizeWorkerEnvironment } from "./environments.js";
 
@@ -35,36 +38,9 @@ vi.mock("../node-registry-private.js", () => ({
 
 const NOW = 10_000;
 
-type TestWorkerRecord = WorkerEnvironmentRecord &
-  Pick<
-    WorkerEnvironmentServiceRecord,
-    "desktopAvailable" | "desktopApps" | "tunnelStatus" | "error"
-  >;
+type TestWorkerRecord = WorkerEnvironmentRecord & WorkerEnvironmentServiceRecord;
 
-type TestWorkerService = {
-  list: () => TestWorkerRecord[];
-  get: (environmentId: string) => TestWorkerRecord | undefined;
-  supportsExecutionMode: (profileId: string, mode: "worker-turn" | "remote-exec") => boolean;
-  listMachineOptions: (
-    profileId: string,
-  ) => Promise<
-    Array<{ id: string; label: string; description?: string; default?: boolean }> | undefined
-  >;
-  create: (profileId: string, idempotencyKey: string) => Promise<TestWorkerRecord>;
-  destroy: (environmentId: string) => Promise<TestWorkerRecord>;
-  destroyUnattached: (environmentId: string) => Promise<TestWorkerRecord>;
-  observeDesktop: (request: { environmentId: string; control: boolean }) => Promise<{
-    transport: "rfb";
-    wsPath: string;
-    expiresAtMs: number;
-    control: boolean;
-    vncPassword?: string;
-  }>;
-  launchDesktopApp: (request: {
-    environmentId: string;
-    app: "browser" | "terminal";
-  }) => Promise<{ app: "browser" | "terminal"; status: "ready" }>;
-};
+type TestWorkerService = Omit<WorkerEnvironmentServiceContract, "startTunnel" | "stopTunnel">;
 
 function mockContext(
   workerEnvironmentService?: TestWorkerService,
@@ -494,6 +470,7 @@ describe("environment gateway methods", () => {
     expect(worker).not.toHaveProperty("sshEndpoint");
     expect(worker?.worker).not.toHaveProperty("sshEndpoint");
     expect(worker?.worker).not.toHaveProperty("keyRef");
+    expect(service.list).toHaveBeenCalledOnce();
   });
 
   it("adds known provider capabilities to configured profile summaries", async () => {
@@ -549,17 +526,6 @@ describe("environment gateway methods", () => {
         (profile) => profile.id === "zeta",
       ),
     ).not.toHaveProperty("executionMode");
-  });
-
-  it.each([
-    ["requested", "starting"],
-    ["ready", "available"],
-    ["draining", "stopping"],
-    ["destroyed", "unavailable"],
-    ["failed", "error"],
-    ["orphaned", "error"],
-  ] as const)("maps worker state %s to %s", (state, status) => {
-    expect(summarizeWorkerEnvironment(workerRecord({ state }), NOW).status).toBe(status);
   });
 
   it("projects trust from recorded worker isolation without guessing unknown leases", () => {
@@ -653,49 +619,6 @@ describe("environment gateway methods", () => {
       code: ErrorCodes.INVALID_REQUEST,
       message: "unknown environmentId",
     });
-  });
-
-  it("preserves gateway listing and hides durable-store details when worker reads fail", async () => {
-    const secret = "private SecretRef and database path";
-    const listFailure = workerService({
-      list: vi.fn(() => {
-        throw new Error(secret);
-      }),
-    });
-    const statusFailure = workerService({
-      get: vi.fn(() => {
-        throw new Error(secret);
-      }),
-    });
-
-    const listResult = await callEnvironmentMethod(
-      "environments.list",
-      {},
-      {
-        service: listFailure,
-      },
-    );
-    const statusResult = await callEnvironmentMethod(
-      "environments.status",
-      { environmentId: "worker-missing" },
-      { service: statusFailure },
-    );
-
-    expect(listResult[0]).toBe(true);
-    const listed = (listResult[1] as { environments: Array<{ id: string; type: string }> })
-      .environments;
-    // Gateway/node inventory survives a damaged worker store; worker rows are omitted.
-    expect(listed.map((entry) => entry.id)).toEqual([
-      "gateway",
-      "node:node-live",
-      "node:node-offline",
-    ]);
-    expect(listed.every((entry) => entry.type !== "worker")).toBe(true);
-    expect(statusResult[2]).toEqual({
-      code: ErrorCodes.UNAVAILABLE,
-      message: "environment status unavailable",
-    });
-    expect(JSON.stringify([listResult, statusResult])).not.toContain(secret);
   });
 
   it("keeps worker creation unavailable until a provider profile is configured", async () => {

--- a/src/gateway/server-methods/environments.ts
+++ b/src/gateway/server-methods/environments.ts
@@ -148,15 +148,16 @@ export function summarizeWorkerEnvironment(
 }
 export async function listGatewayEnvironments(
   context: GatewayRequestContext,
+  workers = listWorkerEnvironments(context),
 ): Promise<EnvironmentSummary[]> {
   const [devices, nodes] = await Promise.all([listDevicePairing(), listNodePairing()]);
+  // Orphaned or failed rows that retain a node binding still own its pairing role.
+  // Only destroyed proves enrollment retirement; teardown-failed rows clear nodeDeviceId.
   const managedCloudNodeIds = new Set(
-    listWorkerEnvironments(context).flatMap((environment) =>
+    workers.flatMap((environment) =>
       environment.providerId !== "device" &&
       environment.nodeDeviceId &&
-      environment.state !== "destroyed" &&
-      environment.state !== "failed" &&
-      environment.state !== "orphaned"
+      environment.state !== "destroyed"
         ? [environment.nodeDeviceId]
         : [],
     ),
@@ -219,8 +220,7 @@ function listWorkerEnvironments(context: GatewayRequestContext): WorkerEnvironme
   try {
     return context.workerEnvironmentService?.list() ?? [];
   } catch {
-    // A damaged worker store must not regress the pre-existing gateway/node inventory.
-    return [];
+    throw new Error("environment inventory unavailable");
   }
 }
 export function listWorkerProfiles(context: GatewayRequestContext) {
@@ -469,8 +469,8 @@ export const environmentsHandlers: GatewayRequestHandlers = {
       return rejectInvalid(respond, "environments.list", validateEnvironmentsListParams);
     }
     await respondUnavailableOnThrow(respond, async () => {
-      const environments = await listGatewayEnvironments(context);
       const workers = listWorkerEnvironments(context);
+      const environments = await listGatewayEnvironments(context, workers);
       const summarizedAtMs = Date.now();
       environments.push(
         ...workers.map((record) => summarizeWorkerEnvironment(record, summarizedAtMs)),


### PR DESCRIPTION
Closes #128769

## What Problem This Solves

Fixes an issue where cloud-managed node hosts could reappear as ordinary paired-device destinations when their worker owner became orphaned, failed while retaining a durable node binding, or could not be read from the worker store.

## Why This Change Was Made

Environment discovery now gathers one worker inventory snapshot and uses that exact snapshot for both node ownership classification and worker projection. A non-device worker that still retains `nodeDeviceId` remains the infrastructure owner unless its state is `destroyed`, which is the lifecycle point after enrollment retirement succeeds. Canonical failed teardown already clears the binding; failed rows that still retain it remain fenced.

Worker inventory read failures now fail the environment request closed with a generic redacted unavailable result instead of silently treating every cloud node as an ordinary device. Device-provider workers remain ordinary paired devices by design.

Production LOC: +7/-7 (net 0) | Tests: +252/-85 (net +167)

AI-assisted: yes. I reviewed worker enrollment retirement, provider teardown terminal states, worker inventory projection, node catalog construction, automatic device selection, status/list error handling, and the duplicate inventory-read path and understand the change.

## User Impact

Operators no longer see or automatically select infrastructure-owned cloud nodes through the ordinary paired-device path while ownership is unresolved. If the ownership store cannot be read, discovery returns a visible redacted failure instead of a misleading partial inventory.

## Evidence

- Pre-fix regressions: orphaned cloud nodes remained visible as ordinary node environments; failed rows retaining `nodeDeviceId` were treated as released; worker inventory failures returned a successful partial gateway/node inventory; `environments.list` read worker ownership twice.
- Post-fix focused proof: 4 files, 86 tests passed across environment ownership/list/status and automatic/explicit session dispatch surfaces.
- Full changed-file gate: `node scripts/check-changed.mjs` passed after rebase, including core/test typechecking, lint, formatting, import-cycle, pairing, database-first, and architecture guards.
- State matrix proves requested/unbound, ready, draining, destroyed, failed-bound, failed-retired, orphaned, and device-provider behavior.
- Failure proof verifies both list and node status fail `UNAVAILABLE`, underlying store details stay redacted, and worker-specific status failures retain their existing redacted response.
- Fresh P0/P1 autoreview: no accepted/actionable findings (0.96).
- Live Gateway proof not run for the store-corruption branch because deterministically injecting a worker inventory read failure into a running Gateway would require replacing the owning store. The handler regression exercises the shipped request path and automatic dispatch consumes the same `listGatewayEnvironments` owner; the campaign's final current-main live matrix will cover normal node/cloud discovery.
