### PR TITLE
fix(diagnostics-otel): preserve message duration ranges

### DIFF
--- a/extensions/diagnostics-otel/src/service-metrics.ts
+++ b/extensions/diagnostics-otel/src/service-metrics.ts
@@ -101,6 +101,7 @@ export function createDiagnosticsMetrics(
   const messageDurationHistogram = createHistogram("openclaw.message.duration_ms", {
     unit: "ms",
     description: "Message processing duration",
+    advice: { explicitBucketBoundaries: AGENT_DURATION_MS_BUCKETS },
   });
   const messageDeliveryStartedCounter = createCounter("openclaw.message.delivery.started", {
     unit: "1",

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -4330,6 +4330,18 @@ describe("diagnostics-otel service", () => {
     }
   });
 
+  test("uses agent-duration buckets for full message processing", async () => {
+    await startOtelService({ metrics: true });
+
+    const runBoundaries = histogramCreateOptions("openclaw.run.duration_ms")?.advice
+      ?.explicitBucketBoundaries;
+    const messageOptions = histogramCreateOptions("openclaw.message.duration_ms");
+
+    expect(messageOptions?.unit).toBe("ms");
+    expect(messageOptions?.advice?.explicitBucketBoundaries).toEqual(runBoundaries);
+    expect(messageOptions?.advice?.explicitBucketBoundaries).toContain(3_600_000);
+  });
+
   test.each([
     ["bounds agent identifiers on model usage metric attributes", "Bearer sk-test-secret-value"],
     [


### PR DESCRIPTION
Related: #127382

## What Problem This Solves

Fixes an issue where operators querying `openclaw.message.duration_ms` could not distinguish normal long-running message processing because every value above the OpenTelemetry SDK's 10-second finite ceiling collapsed into the overflow bucket.

## Why This Change Was Made

The message lifecycle includes the agent run, so the metric now reuses the existing agent-duration boundaries through one hour at the histogram's owner boundary. This is intentionally separate from #127382, which covers model-call timing and process-memory histograms.

## User Impact

Operators can use message-processing P50/P95/P99 values above 10 seconds instead of seeing all long-running messages clamped to the same finite boundary. Runtime message handling is unchanged.

## Evidence

- Axiom production window `2026-08-21T18:12:41Z..2026-08-24T15:04:14Z`: collaborator averages were 46.9s and 91.2s while P50/P95/P99 all reported the 10s finite ceiling.
- Red proof before the fix: the focused regression received `undefined` for the message histogram's explicit boundaries while the run histogram exposed the expected range.
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts`: 192 passed.
- Final exact-branch focused proof: `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts -t 'uses agent-duration buckets for full message processing'`: 1 passed.
- `git diff --check origin/main...HEAD`: passed.
- `oxfmt --check` on both changed files: passed.
- Autoreview: clean, no accepted/actionable findings, overall 0.99.
- Local `check-changed` passed all policy lanes before extension typecheck encountered unrelated stale shared dependency errors. Clean Blacksmith Testbox `tbx_01m0t6b36hd2krsze9az9nbp6v` did not reach the command because checkout sync timed out; hosted exact-head CI is required for the clean dependency gate.

AI-assisted: yes. I understand the change and verified the metric lifecycle and OpenTelemetry aggregation contract. No transcript is attached.
