### PR TITLE
test(ui): split settings node suite by concern

### DIFF
--- a/src/node-host/node-worker-supervisor.container.test.ts
+++ b/src/node-host/node-worker-supervisor.container.test.ts
@@ -55,7 +55,16 @@ const args = process.argv.slice(2);
 const command = args[0];
 const statePath = (id) => path.join(engineRoot, id + ".container.json");
 const load = (id) => JSON.parse(fs.readFileSync(statePath(id), "utf8"));
-const save = (container) => fs.writeFileSync(statePath(container.id), JSON.stringify(container));
+// Sibling shim invocations (rm/inspect/wait) read this state while another
+// writes it. A truncating write exposes a zero-length window, so a reader
+// parses partial JSON and the shim exits 1; rename is atomic, so readers
+// always see either the previous or the next complete state.
+const save = (container) => {
+  const target = statePath(container.id);
+  const pending = target + "." + process.pid + ".pending";
+  fs.writeFileSync(pending, JSON.stringify(container));
+  fs.renameSync(pending, target);
+};
 const launchIdFor = (container) =>
   Buffer.from(container.labels["openclaw.node-worker.launch"], "base64url").toString("utf8");
 const journalState = (launchId) => {

--- a/ui/src/app/settings.layout.node.test.ts
+++ b/ui/src/app/settings.layout.node.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment node
+// Chat split, workspace dock, board, and sidebar layout persistence. Split from
+// settings.node.test.ts to keep each file under the lint size budget.
+import { describe, expect, it } from "vitest";
+import { openSlot } from "../pages/chat/sidebar-layout.ts";
+import {
+  expectedGatewayUrl,
+  installSettingsStorageLifecycle,
+  setTestLocation,
+} from "../test-helpers/settings-node.ts";
+import { loadSettings, saveSettings } from "./settings.ts";
+
+describe("settings layout persistence", () => {
+  installSettingsStorageLifecycle();
+
+  it("persists and parses a chat split layout", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+    const settings = loadSettings();
+    const chatSplitLayout = {
+      columns: [
+        { id: "c1", panes: [{ id: "p1", sessionKey: "main" }], paneWeights: [1] },
+        { id: "c2", panes: [{ id: "p2", sessionKey: "agent:main:work" }], paneWeights: [1] },
+      ],
+      columnWeights: [0.4, 0.6],
+      activePaneId: "p2",
+    };
+
+    saveSettings({ ...settings, chatSplitLayout });
+
+    expect(loadSettings().chatSplitLayout).toEqual(chatSplitLayout);
+  });
+
+  it("omits an invalid stored chat split layout", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+    const gwUrl = expectedGatewayUrl("");
+    localStorage.setItem(
+      `openclaw.control.settings.v1:${gwUrl}`,
+      JSON.stringify({ gatewayUrl: gwUrl, chatSplitLayout: { columns: "invalid" } }),
+    );
+
+    expect(loadSettings().chatSplitLayout).toBeUndefined();
+  });
+
+  it("preserves an opted-in bottom workspace dock", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    saveSettings({ ...loadSettings(), chatWorkspaceDock: "bottom" });
+
+    expect(loadSettings().chatWorkspaceDock).toBe("bottom");
+  });
+
+  it("persists dashboard tab and dock state per session", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+    const settings = loadSettings();
+    const boardSessionViews = {
+      "agent:main:main": {
+        activeTabId: "research",
+        reopenDockByTab: { research: "left" as const },
+      },
+    };
+
+    saveSettings({ ...settings, boardSessionViews });
+
+    expect(loadSettings().boardSessionViews).toEqual(boardSessionViews);
+  });
+
+  it("silently drops legacy local face while preserving per-device tab state", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+    const gwUrl = expectedGatewayUrl("");
+    localStorage.setItem(
+      `openclaw.control.settings.v1:${gwUrl}`,
+      JSON.stringify({
+        gatewayUrl: gwUrl,
+        boardSessionViews: {
+          "agent:main:main": { face: "grid", activeTabId: "research" },
+        },
+      }),
+    );
+
+    expect(loadSettings().boardSessionViews).toEqual({
+      "agent:main:main": { activeTabId: "research" },
+    });
+  });
+
+  it("persists normalized sidebar layouts per session", () => {
+    setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
+    const settings = loadSettings();
+    const sidebarSessionLayouts = {
+      "agent:main:main": openSlot({ columns: [] }, "discussion"),
+    };
+
+    saveSettings({ ...settings, sidebarSessionLayouts });
+
+    // Deep-partial match: loading also fills dock/expanded defaults, which the
+    // corrupt-layout test below pins down.
+    expect(loadSettings().sidebarSessionLayouts).toMatchObject(sidebarSessionLayouts);
+  });
+
+  it("normalizes corrupt stored sidebar layouts to empty columns", () => {
+    setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
+    const gwUrl = expectedGatewayUrl("");
+    localStorage.setItem(
+      `openclaw.control.settings.v1:${gwUrl}`,
+      JSON.stringify({
+        gatewayUrl: gwUrl,
+        sidebarSessionLayouts: { "agent:main:main": { columns: "invalid" } },
+      }),
+    );
+
+    expect(loadSettings().sidebarSessionLayouts).toEqual({
+      "agent:main:main": { columns: [], open: false, expanded: false },
+    });
+  });
+});

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -1,71 +1,23 @@
 // @vitest-environment node
+// Gateway URL derivation, tab-local token handling, and per-gateway session
+// scoping. Preference and layout persistence live in the dotted sibling files
+// that keep each of them under the lint size budget.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { openSlot } from "../pages/chat/sidebar-layout.ts";
-import { createImportedCustomThemeFixture } from "../test-helpers/custom-theme.ts";
+import {
+  expectedGatewayUrl,
+  installSettingsStorageLifecycle,
+  makeUiSettings,
+  setControlUiBasePath,
+  setTestLocation,
+} from "../test-helpers/settings-node.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import {
-  loadLocalUserIdentity,
   loadSettings,
-  normalizeChatMessageMaxWidth,
   persistSessionToken,
   resolvePageGatewaySettings,
   saveSettings,
-  type UiSettings,
 } from "./settings.ts";
 import { resolveApplicationStartupSettings } from "./startup-settings.ts";
-
-function setTestLocation(params: { protocol: string; host: string; pathname: string }) {
-  vi.stubGlobal("location", {
-    protocol: params.protocol,
-    host: params.host,
-    hostname: params.host.replace(/:\d+$/, ""),
-    pathname: params.pathname,
-  } as Location);
-}
-
-function setControlUiBasePath(value: string | undefined) {
-  type TestWindow = Window & typeof globalThis & { [key: string]: unknown };
-  if (typeof window === "undefined") {
-    vi.stubGlobal(
-      "window",
-      value == null
-        ? ({} as TestWindow)
-        : ({ __OPENCLAW_CONTROL_UI_BASE_PATH__: value } as unknown as TestWindow),
-    );
-    return;
-  }
-  if (value == null) {
-    delete (window as TestWindow)["__OPENCLAW_CONTROL_UI_BASE_PATH__"];
-    return;
-  }
-  Object.defineProperty(window, "__OPENCLAW_CONTROL_UI_BASE_PATH__", {
-    value,
-    writable: true,
-    configurable: true,
-  });
-}
-
-function expectedGatewayUrl(basePath: string): string {
-  const proto = location.protocol === "https:" ? "wss" : "ws";
-  return `${proto}://${location.host}${basePath}`;
-}
-
-function makeSettings(gatewayUrl: string, overrides: Partial<UiSettings> = {}): UiSettings {
-  return {
-    gatewayUrl,
-    token: "",
-    sessionKey: "main",
-    lastActiveSessionKey: "main",
-    theme: "claw",
-    themeMode: "system",
-    chatShowThinking: true,
-    chatShowToolCalls: true,
-    navCollapsed: false,
-    navWidth: 258,
-    sidebarEntries: [],
-    ...overrides,
-  };
-}
 
 describe("resolveApplicationStartupSettings", () => {
   beforeEach(() => {
@@ -77,7 +29,7 @@ describe("resolveApplicationStartupSettings", () => {
   });
 
   it("strips fragment bootstrap tokens without persisting them", () => {
-    const startup = resolveApplicationStartupSettings(makeSettings("wss://gateway.example"), {
+    const startup = resolveApplicationStartupSettings(makeUiSettings("wss://gateway.example"), {
       pathname: "/",
       search: "",
       hash: "#gatewayUrl=wss%3A%2F%2Fgateway.example&bootstrapToken=boot-123&bootstrapProfile=owner",
@@ -92,7 +44,7 @@ describe("resolveApplicationStartupSettings", () => {
   });
 
   it("carries fragment bootstrap tokens with changed gateway URLs", () => {
-    const startup = resolveApplicationStartupSettings(makeSettings("wss://gateway-a.example"), {
+    const startup = resolveApplicationStartupSettings(makeUiSettings("wss://gateway-a.example"), {
       pathname: "/dash",
       search: "",
       hash: "#gatewayUrl=wss%3A%2F%2Fgateway-b.example&bootstrapToken=boot-456",
@@ -107,25 +59,7 @@ describe("resolveApplicationStartupSettings", () => {
 });
 
 describe("loadSettings default gateway URL derivation", () => {
-  beforeEach(() => {
-    vi.stubGlobal("localStorage", createStorageMock());
-    vi.stubGlobal("sessionStorage", createStorageMock());
-    vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
-    localStorage.clear();
-    sessionStorage.clear();
-    setControlUiBasePath(undefined);
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-    vi.stubGlobal("localStorage", createStorageMock());
-    vi.stubGlobal("sessionStorage", createStorageMock());
-    vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
-    setTestLocation({ protocol: "https:", host: "gateway.example", pathname: "/" });
-    saveSettings(loadSettings());
-    setControlUiBasePath(undefined);
-    vi.unstubAllGlobals();
-  });
+  installSettingsStorageLifecycle();
 
   it("keeps IPv6 dev-page default gateway hosts dialable", () => {
     setTestLocation({ protocol: "http:", host: "[::1]:5173", pathname: "/" });
@@ -163,7 +97,7 @@ describe("loadSettings default gateway URL derivation", () => {
       pathname: "/openclaw/approve/exec%3A1",
     });
     setControlUiBasePath("/openclaw");
-    const remote = makeSettings("wss://remote.example:8443", {
+    const remote = makeUiSettings("wss://remote.example:8443", {
       sessionKey: "agent:remote:main",
       lastActiveSessionKey: "agent:remote:main",
     });
@@ -180,16 +114,6 @@ describe("loadSettings default gateway URL derivation", () => {
     expect([...Array(localStorage.length)].map((_, index) => localStorage.key(index))).toEqual(
       before,
     );
-  });
-
-  it("defaults the chat send shortcut to enter", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    expect(loadSettings().chatSendShortcut).toBe("enter");
   });
 
   it("infers base path from nested pathname when configured base path is not set", () => {
@@ -379,318 +303,6 @@ describe("loadSettings default gateway URL derivation", () => {
     expect(sessionStorage.length).toBe(1);
   });
 
-  it("persists pinned agents and drops malformed or duplicate entries", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    saveSettings({
-      gatewayUrl: gwUrl,
-      token: "",
-      sessionKey: "main",
-      lastActiveSessionKey: "main",
-      theme: "claw",
-      themeMode: "system",
-      chatShowThinking: true,
-      chatShowToolCalls: true,
-      navCollapsed: false,
-      navWidth: 258,
-      sidebarEntries: [],
-      pinnedAgentIds: ["main", "research"],
-    });
-    expect(loadSettings().pinnedAgentIds).toEqual(["main", "research"]);
-
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    const persisted = JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<
-      string,
-      unknown
-    >;
-    persisted.pinnedAgentIds = ["main", "main", 7, "  ", " research "];
-    localStorage.setItem(scopedKey, JSON.stringify(persisted));
-    expect(loadSettings().pinnedAgentIds).toEqual(["main", "research"]);
-  });
-
-  it("normalizes persisted text scale to the nearest supported stop", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    localStorage.setItem(
-      `openclaw.control.settings.v1:${gwUrl}`,
-      JSON.stringify({
-        gatewayUrl: gwUrl,
-        textScale: 123,
-      }),
-    );
-
-    expect(loadSettings().textScale).toBe(125);
-  });
-
-  it("keeps the last written settings in memory when persistence fails", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const setItem = vi.spyOn(localStorage, "setItem").mockImplementation(() => {
-      throw new DOMException("blocked", "SecurityError");
-    });
-    saveSettings({
-      ...loadSettings(),
-      realtimeTalkInputDeviceId: "usb-mic",
-      realtimeTalkVideoDeviceId: "desk-camera",
-    });
-
-    // Same-tab reads (e.g. a talk session launched from chat) must observe
-    // the selection even though localStorage rejected the write.
-    expect(loadSettings().realtimeTalkInputDeviceId).toBe("usb-mic");
-    expect(loadSettings().realtimeTalkVideoDeviceId).toBe("desk-camera");
-
-    setItem.mockRestore();
-    saveSettings({
-      ...loadSettings(),
-      realtimeTalkInputDeviceId: undefined,
-      realtimeTalkVideoDeviceId: undefined,
-    });
-    expect(loadSettings().realtimeTalkInputDeviceId).toBeUndefined();
-    expect(loadSettings().realtimeTalkVideoDeviceId).toBeUndefined();
-  });
-
-  it("persists only the non-default chat send shortcut", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    saveSettings({ ...loadSettings(), chatSendShortcut: "modifier-enter" });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").chatSendShortcut).toBe(
-      "modifier-enter",
-    );
-    expect(loadSettings().chatSendShortcut).toBe("modifier-enter");
-
-    saveSettings({ ...loadSettings(), chatSendShortcut: "enter" });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
-      "chatSendShortcut",
-    );
-
-    localStorage.setItem(
-      scopedKey,
-      JSON.stringify({ gatewayUrl: gwUrl, chatSendShortcut: "unsupported" }),
-    );
-    expect(loadSettings().chatSendShortcut).toBe("enter");
-  });
-
-  it("persists only explicit chat follow-up overrides", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    expect(loadSettings().chatFollowUpMode).toBeUndefined();
-    saveSettings({ ...loadSettings(), chatFollowUpMode: "queue" });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").chatFollowUpMode).toBe("queue");
-    expect(loadSettings().chatFollowUpMode).toBe("queue");
-
-    saveSettings({ ...loadSettings(), chatFollowUpMode: "steer" });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").chatFollowUpMode).toBe("steer");
-    expect(loadSettings().chatFollowUpMode).toBe("steer");
-
-    saveSettings({ ...loadSettings(), chatFollowUpMode: undefined });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
-      "chatFollowUpMode",
-    );
-    localStorage.setItem(
-      scopedKey,
-      JSON.stringify({ gatewayUrl: gwUrl, chatFollowUpMode: "interrupt" }),
-    );
-    expect(loadSettings().chatFollowUpMode).toBeUndefined();
-  });
-
-  it("persists only the non-default catalog open target", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    expect(loadSettings().catalogOpenTarget).toBe("viewer");
-    saveSettings({ ...loadSettings(), catalogOpenTarget: "terminal" });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").catalogOpenTarget).toBe("terminal");
-    expect(loadSettings().catalogOpenTarget).toBe("terminal");
-
-    saveSettings({ ...loadSettings(), catalogOpenTarget: "viewer" });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
-      "catalogOpenTarget",
-    );
-    localStorage.setItem(
-      scopedKey,
-      JSON.stringify({ gatewayUrl: gwUrl, catalogOpenTarget: "shell" }),
-    );
-    expect(loadSettings().catalogOpenTarget).toBe("viewer");
-  });
-
-  it("defaults live sidebar activity on and persists only an explicit opt-out", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    expect(loadSettings().sidebarLiveActivity).toBe(true);
-
-    saveSettings({ ...loadSettings(), sidebarLiveActivity: false });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").sidebarLiveActivity).toBe(false);
-    expect(loadSettings().sidebarLiveActivity).toBe(false);
-
-    saveSettings({ ...loadSettings(), sidebarLiveActivity: true });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
-      "sidebarLiveActivity",
-    );
-  });
-
-  it("defaults advanced settings off and persists only an explicit opt-in", () => {
-    setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-
-    expect(loadSettings().showAdvancedSettings).toBe(false);
-    saveSettings({ ...loadSettings(), showAdvancedSettings: true });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").showAdvancedSettings).toBe(true);
-    expect(loadSettings().showAdvancedSettings).toBe(true);
-
-    saveSettings({ ...loadSettings(), showAdvancedSettings: false });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
-      "showAdvancedSettings",
-    );
-  });
-
-  it("normalizes and persists browser-local chat message width", () => {
-    setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-
-    expect(normalizeChatMessageMaxWidth("  min(1280px,   82%)  ")).toBe("min(1280px, 82%)");
-    expect(normalizeChatMessageMaxWidth("960px; color: red")).toBeUndefined();
-
-    saveSettings({ ...loadSettings(), chatMessageMaxWidth: "  min(1280px,   82%)  " });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").chatMessageMaxWidth).toBe(
-      "min(1280px, 82%)",
-    );
-    expect(loadSettings().chatMessageMaxWidth).toBe("min(1280px, 82%)");
-
-    saveSettings({ ...loadSettings(), chatMessageMaxWidth: undefined });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
-      "chatMessageMaxWidth",
-    );
-  });
-
-  it("persists only a normalized realtime Talk microphone id", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    saveSettings({ ...loadSettings(), realtimeTalkInputDeviceId: " usb-mic " });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").realtimeTalkInputDeviceId).toBe(
-      "usb-mic",
-    );
-    expect(loadSettings().realtimeTalkInputDeviceId).toBe("usb-mic");
-
-    saveSettings({ ...loadSettings(), realtimeTalkInputDeviceId: "" });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
-      "realtimeTalkInputDeviceId",
-    );
-  });
-
-  it("persists only a normalized realtime Talk camera id", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    saveSettings({ ...loadSettings(), realtimeTalkVideoDeviceId: " back-camera " });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").realtimeTalkVideoDeviceId).toBe(
-      "back-camera",
-    );
-    expect(loadSettings().realtimeTalkVideoDeviceId).toBe("back-camera");
-
-    saveSettings({ ...loadSettings(), realtimeTalkVideoDeviceId: "" });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
-      "realtimeTalkVideoDeviceId",
-    );
-  });
-
-  it("defaults composer hold-to-record on and persists only the opt-out", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    expect(loadSettings().composerHoldToRecord).toBe(true);
-
-    saveSettings({ ...loadSettings(), composerHoldToRecord: false });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").composerHoldToRecord).toBe(false);
-    expect(loadSettings().composerHoldToRecord).toBe(false);
-
-    saveSettings({ ...loadSettings(), composerHoldToRecord: true });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
-      "composerHoldToRecord",
-    );
-    expect(loadSettings().composerHoldToRecord).toBe(true);
-  });
-
-  it("normalizes and persists the device-local talk camera preference", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    expect(loadSettings().talkCameraAutoEnable).toBeUndefined();
-
-    saveSettings({ ...loadSettings(), talkCameraAutoEnable: true });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").talkCameraAutoEnable).toBe(true);
-    expect(loadSettings().talkCameraAutoEnable).toBe(true);
-
-    saveSettings({ ...loadSettings(), talkCameraAutoEnable: false });
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").talkCameraAutoEnable).toBe(false);
-    expect(loadSettings().talkCameraAutoEnable).toBe(false);
-
-    localStorage.setItem(
-      scopedKey,
-      JSON.stringify({ gatewayUrl: gwUrl, talkCameraAutoEnable: "true" }),
-    );
-    expect(loadSettings().talkCameraAutoEnable).toBeUndefined();
-  });
-
   it("clears the current-tab token when saving an empty token", () => {
     setTestLocation({
       protocol: "https:",
@@ -728,263 +340,6 @@ describe("loadSettings default gateway URL derivation", () => {
 
     expect(loadSettings().token).toBe("");
     expect(sessionStorage.length).toBe(0);
-  });
-
-  it("persists themeMode and navWidth alongside the selected theme", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    saveSettings({
-      gatewayUrl: gwUrl,
-      token: "",
-      sessionKey: "main",
-      lastActiveSessionKey: "main",
-      theme: "dash",
-      themeMode: "light",
-      chatShowThinking: true,
-      chatShowToolCalls: true,
-      navCollapsed: false,
-      navWidth: 320,
-      sidebarEntries: [],
-    });
-
-    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    const persisted = JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<
-      string,
-      unknown
-    >;
-    expect(persisted.theme).toBe("dash");
-    expect(persisted.themeMode).toBe("light");
-    expect(persisted.navWidth).toBe(320);
-  });
-
-  it("omits the inherited text scale and removes an authored override on reset", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-    const defaults = loadSettings();
-    const scopedKey = `openclaw.control.settings.v1:${defaults.gatewayUrl}`;
-    expect(defaults.textScale).toBeUndefined();
-
-    saveSettings({ ...defaults, textScale: 125 });
-    expect(
-      JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<string, unknown>,
-    ).toMatchObject({ textScale: 125 });
-
-    saveSettings({ ...loadSettings(), textScale: undefined });
-    const reset = JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<string, unknown>;
-    expect(Object.hasOwn(reset, "textScale")).toBe(false);
-  });
-
-  it("treats the legacy always-persisted default text scale as inherited", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-    const gatewayUrl = expectedGatewayUrl("");
-    const scopedKey = `openclaw.control.settings.v1:${gatewayUrl}`;
-    localStorage.setItem(scopedKey, JSON.stringify({ gatewayUrl, textScale: 100 }));
-
-    expect(loadSettings().textScale).toBeUndefined();
-    saveSettings(loadSettings());
-    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty("textScale");
-  });
-
-  it("persists and parses a chat split layout", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-    const settings = loadSettings();
-    const chatSplitLayout = {
-      columns: [
-        { id: "c1", panes: [{ id: "p1", sessionKey: "main" }], paneWeights: [1] },
-        { id: "c2", panes: [{ id: "p2", sessionKey: "agent:main:work" }], paneWeights: [1] },
-      ],
-      columnWeights: [0.4, 0.6],
-      activePaneId: "p2",
-    };
-
-    saveSettings({ ...settings, chatSplitLayout });
-
-    expect(loadSettings().chatSplitLayout).toEqual(chatSplitLayout);
-  });
-
-  it("preserves an opted-in bottom workspace dock", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    saveSettings({ ...loadSettings(), chatWorkspaceDock: "bottom" });
-
-    expect(loadSettings().chatWorkspaceDock).toBe("bottom");
-  });
-
-  it("persists dashboard tab and dock state per session", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-    const settings = loadSettings();
-    const boardSessionViews = {
-      "agent:main:main": {
-        activeTabId: "research",
-        reopenDockByTab: { research: "left" as const },
-      },
-    };
-
-    saveSettings({ ...settings, boardSessionViews });
-
-    expect(loadSettings().boardSessionViews).toEqual(boardSessionViews);
-  });
-
-  it("silently drops legacy local face while preserving per-device tab state", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-    const gwUrl = expectedGatewayUrl("");
-    localStorage.setItem(
-      `openclaw.control.settings.v1:${gwUrl}`,
-      JSON.stringify({
-        gatewayUrl: gwUrl,
-        boardSessionViews: {
-          "agent:main:main": { face: "grid", activeTabId: "research" },
-        },
-      }),
-    );
-
-    expect(loadSettings().boardSessionViews).toEqual({
-      "agent:main:main": { activeTabId: "research" },
-    });
-  });
-
-  it("persists normalized sidebar layouts per session", () => {
-    setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
-    const settings = loadSettings();
-    const sidebarSessionLayouts = {
-      "agent:main:main": openSlot({ columns: [] }, "discussion"),
-    };
-
-    saveSettings({ ...settings, sidebarSessionLayouts });
-
-    // Deep-partial match: loading also fills dock/expanded defaults, which the
-    // corrupt-layout test below pins down.
-    expect(loadSettings().sidebarSessionLayouts).toMatchObject(sidebarSessionLayouts);
-  });
-
-  it("normalizes corrupt stored sidebar layouts to empty columns", () => {
-    setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
-    const gwUrl = expectedGatewayUrl("");
-    localStorage.setItem(
-      `openclaw.control.settings.v1:${gwUrl}`,
-      JSON.stringify({
-        gatewayUrl: gwUrl,
-        sidebarSessionLayouts: { "agent:main:main": { columns: "invalid" } },
-      }),
-    );
-
-    expect(loadSettings().sidebarSessionLayouts).toEqual({
-      "agent:main:main": { columns: [], open: false, expanded: false },
-    });
-  });
-
-  it("omits an invalid stored chat split layout", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-    const gwUrl = expectedGatewayUrl("");
-    localStorage.setItem(
-      `openclaw.control.settings.v1:${gwUrl}`,
-      JSON.stringify({ gatewayUrl: gwUrl, chatSplitLayout: { columns: "invalid" } }),
-    );
-
-    expect(loadSettings().chatSplitLayout).toBeUndefined();
-  });
-
-  it("persists the browser-local custom theme payload when present", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    const customTheme = createImportedCustomThemeFixture();
-    saveSettings({
-      gatewayUrl: gwUrl,
-      token: "",
-      sessionKey: "main",
-      lastActiveSessionKey: "main",
-      theme: "custom",
-      themeMode: "system",
-      chatShowThinking: true,
-      chatShowToolCalls: true,
-      navCollapsed: false,
-      navWidth: 258,
-      sidebarEntries: [],
-      customTheme,
-    });
-
-    const settings = loadSettings();
-    expect(settings.theme).toBe("custom");
-    expect(settings.customTheme?.label).toBe("Light Green");
-    expect(settings.customTheme?.themeId).toBe("cmlhfpjhw000004l4f4ax3m7z");
-  });
-
-  it("falls back to claw when persisted custom theme data is invalid", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-
-    const gwUrl = expectedGatewayUrl("");
-    localStorage.setItem(
-      `openclaw.control.settings.v1:${gwUrl}`,
-      JSON.stringify({
-        gatewayUrl: gwUrl,
-        theme: "custom",
-        themeMode: "dark",
-        chatShowThinking: true,
-        chatShowToolCalls: true,
-        navCollapsed: false,
-        navWidth: 258,
-        sidebarEntries: [],
-        customTheme: {
-          sourceUrl: "https://tweakcn.com/themes/broken",
-          themeId: "broken",
-          label: "Broken",
-          importedAt: "2026-04-22T00:00:00.000Z",
-          light: {},
-          dark: {},
-        },
-        sessionsByGateway: {
-          [gwUrl]: {
-            sessionKey: "main",
-            lastActiveSessionKey: "main",
-          },
-        },
-      }),
-    );
-
-    const settings = loadSettings();
-    expect(settings.theme).toBe("claw");
-    expect(settings.themeMode).toBe("dark");
   });
 
   it("scopes persisted session selection per gateway", () => {
@@ -1077,7 +432,7 @@ describe("loadSettings default gateway URL derivation", () => {
   it("does not let a saved sibling base path override the current page gateway", () => {
     setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-a/" });
     setControlUiBasePath("/gateway-a");
-    saveSettings(makeSettings(expectedGatewayUrl("/gateway-a")));
+    saveSettings(makeUiSettings(expectedGatewayUrl("/gateway-a")));
 
     setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-b/" });
     setControlUiBasePath("/gateway-b");
@@ -1089,11 +444,11 @@ describe("loadSettings default gateway URL derivation", () => {
   it("keeps custom gateway selections isolated per Control UI base path", () => {
     setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-a/" });
     setControlUiBasePath("/gateway-a");
-    saveSettings(makeSettings("wss://remote-a.example.com", { sessionKey: "agent:a:main" }));
+    saveSettings(makeUiSettings("wss://remote-a.example.com", { sessionKey: "agent:a:main" }));
 
     setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-b/" });
     setControlUiBasePath("/gateway-b");
-    saveSettings(makeSettings("wss://remote-b.example.com", { sessionKey: "agent:b:main" }));
+    saveSettings(makeUiSettings("wss://remote-b.example.com", { sessionKey: "agent:b:main" }));
 
     setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-a/" });
     setControlUiBasePath("/gateway-a");
@@ -1107,42 +462,6 @@ describe("loadSettings default gateway URL derivation", () => {
     expect(loadSettings()).toMatchObject({
       gatewayUrl: "wss://remote-b.example.com",
       sessionKey: "agent:b:main",
-    });
-  });
-
-  it("loads local user identity separately from gateway settings", () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-    localStorage.setItem(
-      "openclaw.control.user.v1",
-      JSON.stringify({ name: "Buns", avatar: "🦞" }),
-    );
-
-    expect(loadLocalUserIdentity()).toEqual({
-      name: "Buns",
-      avatar: "🦞",
-    });
-    expect(JSON.parse(localStorage.getItem("openclaw.control.user.v1") ?? "{}")).toEqual({
-      name: "Buns",
-      avatar: "🦞",
-    });
-  });
-
-  it("normalizes invalid local user identity values on load", () => {
-    localStorage.setItem(
-      "openclaw.control.user.v1",
-      JSON.stringify({
-        name: "  ",
-        avatar: "https://example.com/avatar.png",
-      }),
-    );
-
-    expect(loadLocalUserIdentity()).toEqual({
-      name: null,
-      avatar: null,
     });
   });
 });

--- a/ui/src/app/settings.preferences.node.test.ts
+++ b/ui/src/app/settings.preferences.node.test.ts
@@ -1,0 +1,517 @@
+// @vitest-environment node
+// Browser-local preference persistence: chat, talk, theme, text scale, and the
+// local user identity. Split from settings.node.test.ts to keep each file under
+// the lint size budget.
+import { describe, expect, it, vi } from "vitest";
+import { createImportedCustomThemeFixture } from "../test-helpers/custom-theme.ts";
+import {
+  expectedGatewayUrl,
+  installSettingsStorageLifecycle,
+  setTestLocation,
+} from "../test-helpers/settings-node.ts";
+import {
+  loadLocalUserIdentity,
+  loadSettings,
+  normalizeChatMessageMaxWidth,
+  saveSettings,
+} from "./settings.ts";
+
+describe("settings preference persistence", () => {
+  installSettingsStorageLifecycle();
+
+  it("defaults the chat send shortcut to enter", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    expect(loadSettings().chatSendShortcut).toBe("enter");
+  });
+
+  it("persists only the non-default chat send shortcut", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    saveSettings({ ...loadSettings(), chatSendShortcut: "modifier-enter" });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").chatSendShortcut).toBe(
+      "modifier-enter",
+    );
+    expect(loadSettings().chatSendShortcut).toBe("modifier-enter");
+
+    saveSettings({ ...loadSettings(), chatSendShortcut: "enter" });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "chatSendShortcut",
+    );
+
+    localStorage.setItem(
+      scopedKey,
+      JSON.stringify({ gatewayUrl: gwUrl, chatSendShortcut: "unsupported" }),
+    );
+    expect(loadSettings().chatSendShortcut).toBe("enter");
+  });
+
+  it("persists only explicit chat follow-up overrides", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    expect(loadSettings().chatFollowUpMode).toBeUndefined();
+    saveSettings({ ...loadSettings(), chatFollowUpMode: "queue" });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").chatFollowUpMode).toBe("queue");
+    expect(loadSettings().chatFollowUpMode).toBe("queue");
+
+    saveSettings({ ...loadSettings(), chatFollowUpMode: "steer" });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").chatFollowUpMode).toBe("steer");
+    expect(loadSettings().chatFollowUpMode).toBe("steer");
+
+    saveSettings({ ...loadSettings(), chatFollowUpMode: undefined });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "chatFollowUpMode",
+    );
+    localStorage.setItem(
+      scopedKey,
+      JSON.stringify({ gatewayUrl: gwUrl, chatFollowUpMode: "interrupt" }),
+    );
+    expect(loadSettings().chatFollowUpMode).toBeUndefined();
+  });
+
+  it("persists only the non-default catalog open target", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    expect(loadSettings().catalogOpenTarget).toBe("viewer");
+    saveSettings({ ...loadSettings(), catalogOpenTarget: "terminal" });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").catalogOpenTarget).toBe("terminal");
+    expect(loadSettings().catalogOpenTarget).toBe("terminal");
+
+    saveSettings({ ...loadSettings(), catalogOpenTarget: "viewer" });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "catalogOpenTarget",
+    );
+    localStorage.setItem(
+      scopedKey,
+      JSON.stringify({ gatewayUrl: gwUrl, catalogOpenTarget: "shell" }),
+    );
+    expect(loadSettings().catalogOpenTarget).toBe("viewer");
+  });
+
+  it("persists pinned agents and drops malformed or duplicate entries", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    saveSettings({
+      gatewayUrl: gwUrl,
+      token: "",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "claw",
+      themeMode: "system",
+      chatShowThinking: true,
+      chatShowToolCalls: true,
+      navCollapsed: false,
+      navWidth: 258,
+      sidebarEntries: [],
+      pinnedAgentIds: ["main", "research"],
+    });
+    expect(loadSettings().pinnedAgentIds).toEqual(["main", "research"]);
+
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    const persisted = JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    persisted.pinnedAgentIds = ["main", "main", 7, "  ", " research "];
+    localStorage.setItem(scopedKey, JSON.stringify(persisted));
+    expect(loadSettings().pinnedAgentIds).toEqual(["main", "research"]);
+  });
+
+  it("defaults live sidebar activity on and persists only an explicit opt-out", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    expect(loadSettings().sidebarLiveActivity).toBe(true);
+
+    saveSettings({ ...loadSettings(), sidebarLiveActivity: false });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").sidebarLiveActivity).toBe(false);
+    expect(loadSettings().sidebarLiveActivity).toBe(false);
+
+    saveSettings({ ...loadSettings(), sidebarLiveActivity: true });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "sidebarLiveActivity",
+    );
+  });
+
+  it("defaults advanced settings off and persists only an explicit opt-in", () => {
+    setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+
+    expect(loadSettings().showAdvancedSettings).toBe(false);
+    saveSettings({ ...loadSettings(), showAdvancedSettings: true });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").showAdvancedSettings).toBe(true);
+    expect(loadSettings().showAdvancedSettings).toBe(true);
+
+    saveSettings({ ...loadSettings(), showAdvancedSettings: false });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "showAdvancedSettings",
+    );
+  });
+
+  it("normalizes and persists browser-local chat message width", () => {
+    setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+
+    expect(normalizeChatMessageMaxWidth("  min(1280px,   82%)  ")).toBe("min(1280px, 82%)");
+    expect(normalizeChatMessageMaxWidth("960px; color: red")).toBeUndefined();
+
+    saveSettings({ ...loadSettings(), chatMessageMaxWidth: "  min(1280px,   82%)  " });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").chatMessageMaxWidth).toBe(
+      "min(1280px, 82%)",
+    );
+    expect(loadSettings().chatMessageMaxWidth).toBe("min(1280px, 82%)");
+
+    saveSettings({ ...loadSettings(), chatMessageMaxWidth: undefined });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "chatMessageMaxWidth",
+    );
+  });
+
+  it("keeps the last written settings in memory when persistence fails", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const setItem = vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    saveSettings({
+      ...loadSettings(),
+      realtimeTalkInputDeviceId: "usb-mic",
+      realtimeTalkVideoDeviceId: "desk-camera",
+    });
+
+    // Same-tab reads (e.g. a talk session launched from chat) must observe
+    // the selection even though localStorage rejected the write.
+    expect(loadSettings().realtimeTalkInputDeviceId).toBe("usb-mic");
+    expect(loadSettings().realtimeTalkVideoDeviceId).toBe("desk-camera");
+
+    setItem.mockRestore();
+    saveSettings({
+      ...loadSettings(),
+      realtimeTalkInputDeviceId: undefined,
+      realtimeTalkVideoDeviceId: undefined,
+    });
+    expect(loadSettings().realtimeTalkInputDeviceId).toBeUndefined();
+    expect(loadSettings().realtimeTalkVideoDeviceId).toBeUndefined();
+  });
+
+  it("persists only a normalized realtime Talk microphone id", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    saveSettings({ ...loadSettings(), realtimeTalkInputDeviceId: " usb-mic " });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").realtimeTalkInputDeviceId).toBe(
+      "usb-mic",
+    );
+    expect(loadSettings().realtimeTalkInputDeviceId).toBe("usb-mic");
+
+    saveSettings({ ...loadSettings(), realtimeTalkInputDeviceId: "" });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "realtimeTalkInputDeviceId",
+    );
+  });
+
+  it("persists only a normalized realtime Talk camera id", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    saveSettings({ ...loadSettings(), realtimeTalkVideoDeviceId: " back-camera " });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").realtimeTalkVideoDeviceId).toBe(
+      "back-camera",
+    );
+    expect(loadSettings().realtimeTalkVideoDeviceId).toBe("back-camera");
+
+    saveSettings({ ...loadSettings(), realtimeTalkVideoDeviceId: "" });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "realtimeTalkVideoDeviceId",
+    );
+  });
+
+  it("defaults composer hold-to-record on and persists only the opt-out", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    expect(loadSettings().composerHoldToRecord).toBe(true);
+
+    saveSettings({ ...loadSettings(), composerHoldToRecord: false });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").composerHoldToRecord).toBe(false);
+    expect(loadSettings().composerHoldToRecord).toBe(false);
+
+    saveSettings({ ...loadSettings(), composerHoldToRecord: true });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "composerHoldToRecord",
+    );
+    expect(loadSettings().composerHoldToRecord).toBe(true);
+  });
+
+  it("normalizes and persists the device-local talk camera preference", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    expect(loadSettings().talkCameraAutoEnable).toBeUndefined();
+
+    saveSettings({ ...loadSettings(), talkCameraAutoEnable: true });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").talkCameraAutoEnable).toBe(true);
+    expect(loadSettings().talkCameraAutoEnable).toBe(true);
+
+    saveSettings({ ...loadSettings(), talkCameraAutoEnable: false });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").talkCameraAutoEnable).toBe(false);
+    expect(loadSettings().talkCameraAutoEnable).toBe(false);
+
+    localStorage.setItem(
+      scopedKey,
+      JSON.stringify({ gatewayUrl: gwUrl, talkCameraAutoEnable: "true" }),
+    );
+    expect(loadSettings().talkCameraAutoEnable).toBeUndefined();
+  });
+
+  it("persists themeMode and navWidth alongside the selected theme", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    saveSettings({
+      gatewayUrl: gwUrl,
+      token: "",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "dash",
+      themeMode: "light",
+      chatShowThinking: true,
+      chatShowToolCalls: true,
+      navCollapsed: false,
+      navWidth: 320,
+      sidebarEntries: [],
+    });
+
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    const persisted = JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(persisted.theme).toBe("dash");
+    expect(persisted.themeMode).toBe("light");
+    expect(persisted.navWidth).toBe(320);
+  });
+
+  it("normalizes persisted text scale to the nearest supported stop", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    localStorage.setItem(
+      `openclaw.control.settings.v1:${gwUrl}`,
+      JSON.stringify({
+        gatewayUrl: gwUrl,
+        textScale: 123,
+      }),
+    );
+
+    expect(loadSettings().textScale).toBe(125);
+  });
+
+  it("omits the inherited text scale and removes an authored override on reset", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+    const defaults = loadSettings();
+    const scopedKey = `openclaw.control.settings.v1:${defaults.gatewayUrl}`;
+    expect(defaults.textScale).toBeUndefined();
+
+    saveSettings({ ...defaults, textScale: 125 });
+    expect(
+      JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<string, unknown>,
+    ).toMatchObject({ textScale: 125 });
+
+    saveSettings({ ...loadSettings(), textScale: undefined });
+    const reset = JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<string, unknown>;
+    expect(Object.hasOwn(reset, "textScale")).toBe(false);
+  });
+
+  it("treats the legacy always-persisted default text scale as inherited", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+    const gatewayUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gatewayUrl}`;
+    localStorage.setItem(scopedKey, JSON.stringify({ gatewayUrl, textScale: 100 }));
+
+    expect(loadSettings().textScale).toBeUndefined();
+    saveSettings(loadSettings());
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty("textScale");
+  });
+
+  it("persists the browser-local custom theme payload when present", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    const customTheme = createImportedCustomThemeFixture();
+    saveSettings({
+      gatewayUrl: gwUrl,
+      token: "",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "custom",
+      themeMode: "system",
+      chatShowThinking: true,
+      chatShowToolCalls: true,
+      navCollapsed: false,
+      navWidth: 258,
+      sidebarEntries: [],
+      customTheme,
+    });
+
+    const settings = loadSettings();
+    expect(settings.theme).toBe("custom");
+    expect(settings.customTheme?.label).toBe("Light Green");
+    expect(settings.customTheme?.themeId).toBe("cmlhfpjhw000004l4f4ax3m7z");
+  });
+
+  it("falls back to claw when persisted custom theme data is invalid", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    localStorage.setItem(
+      `openclaw.control.settings.v1:${gwUrl}`,
+      JSON.stringify({
+        gatewayUrl: gwUrl,
+        theme: "custom",
+        themeMode: "dark",
+        chatShowThinking: true,
+        chatShowToolCalls: true,
+        navCollapsed: false,
+        navWidth: 258,
+        sidebarEntries: [],
+        customTheme: {
+          sourceUrl: "https://tweakcn.com/themes/broken",
+          themeId: "broken",
+          label: "Broken",
+          importedAt: "2026-04-22T00:00:00.000Z",
+          light: {},
+          dark: {},
+        },
+        sessionsByGateway: {
+          [gwUrl]: {
+            sessionKey: "main",
+            lastActiveSessionKey: "main",
+          },
+        },
+      }),
+    );
+
+    const settings = loadSettings();
+    expect(settings.theme).toBe("claw");
+    expect(settings.themeMode).toBe("dark");
+  });
+
+  it("loads local user identity separately from gateway settings", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+    localStorage.setItem(
+      "openclaw.control.user.v1",
+      JSON.stringify({ name: "Buns", avatar: "🦞" }),
+    );
+
+    expect(loadLocalUserIdentity()).toEqual({
+      name: "Buns",
+      avatar: "🦞",
+    });
+    expect(JSON.parse(localStorage.getItem("openclaw.control.user.v1") ?? "{}")).toEqual({
+      name: "Buns",
+      avatar: "🦞",
+    });
+  });
+
+  it("normalizes invalid local user identity values on load", () => {
+    localStorage.setItem(
+      "openclaw.control.user.v1",
+      JSON.stringify({
+        name: "  ",
+        avatar: "https://example.com/avatar.png",
+      }),
+    );
+
+    expect(loadLocalUserIdentity()).toEqual({
+      name: null,
+      avatar: null,
+    });
+  });
+});

--- a/ui/src/app/settings.sidebar-prefs.node.test.ts
+++ b/ui/src/app/settings.sidebar-prefs.node.test.ts
@@ -1,66 +1,24 @@
 // @vitest-environment node
-// Sidebar zone and session-section persistence split from settings.node.test.ts
-// to keep both files under the lint size budget.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createStorageMock } from "../test-helpers/storage.ts";
-import { loadSettings, saveSettings, type UiSettings } from "./settings.ts";
-
-function setTestLocation(params: { protocol: string; host: string; pathname: string }) {
-  vi.stubGlobal("location", {
-    protocol: params.protocol,
-    host: params.host,
-    hostname: params.host.replace(/:\d+$/, ""),
-    pathname: params.pathname,
-  } as Location);
-}
-
-function expectedGatewayUrl(basePath: string): string {
-  const proto = location.protocol === "https:" ? "wss" : "ws";
-  return `${proto}://${location.host}${basePath}`;
-}
-
-function makeSettings(gatewayUrl: string, overrides: Partial<UiSettings> = {}): UiSettings {
-  return {
-    gatewayUrl,
-    token: "",
-    sessionKey: "main",
-    lastActiveSessionKey: "main",
-    theme: "claw",
-    themeMode: "system",
-    chatShowThinking: true,
-    chatShowToolCalls: true,
-    navCollapsed: false,
-    navWidth: 258,
-    sidebarEntries: [],
-    ...overrides,
-  };
-}
+// Sidebar zone and session-section persistence split from the settings suites
+// to keep each file under the lint size budget.
+import { describe, expect, it } from "vitest";
+import {
+  expectedGatewayUrl,
+  installSettingsStorageLifecycle,
+  makeUiSettings,
+  setTestLocation,
+} from "../test-helpers/settings-node.ts";
+import { loadSettings, saveSettings } from "./settings.ts";
 
 describe("sidebar preference persistence", () => {
-  beforeEach(() => {
-    vi.stubGlobal("localStorage", createStorageMock());
-    vi.stubGlobal("sessionStorage", createStorageMock());
-    vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
-    localStorage.clear();
-    sessionStorage.clear();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-    vi.stubGlobal("localStorage", createStorageMock());
-    vi.stubGlobal("sessionStorage", createStorageMock());
-    vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
-    setTestLocation({ protocol: "https:", host: "gateway.example", pathname: "/" });
-    saveSettings(loadSettings());
-    vi.unstubAllGlobals();
-  });
+  installSettingsStorageLifecycle();
 
   it("persists sidebar width without leaking tab-local visibility across reloads", () => {
     setTestLocation({ protocol: "https:", host: "gateway.example:8443", pathname: "/" });
     const gatewayUrl = expectedGatewayUrl("");
     const scopedKey = `openclaw.control.settings.v1:${gatewayUrl}`;
 
-    saveSettings(makeSettings(gatewayUrl, { navCollapsed: true, navWidth: 320 }));
+    saveSettings(makeUiSettings(gatewayUrl, { navCollapsed: true, navWidth: 320 }));
 
     const persisted = JSON.parse(localStorage.getItem(scopedKey) ?? "{}") as Record<
       string,
@@ -83,7 +41,7 @@ describe("sidebar preference persistence", () => {
 
     const gwUrl = expectedGatewayUrl("");
     saveSettings(
-      makeSettings(gwUrl, {
+      makeUiSettings(gwUrl, {
         sidebarEntries: ["route:tasks", "route:cron"],
         textScale: 100,
       }),
@@ -114,7 +72,7 @@ describe("sidebar preference persistence", () => {
     });
     const gwUrl = expectedGatewayUrl("");
     const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
-    const legacy = makeSettings(gwUrl) as unknown as Record<string, unknown>;
+    const legacy = makeUiSettings(gwUrl) as unknown as Record<string, unknown>;
     delete legacy.sidebarEntries;
     legacy.sidebarPinnedRoutes = ["workboard", "usage", "tasks", "usage", "worktrees", 7];
     localStorage.setItem(scopedKey, JSON.stringify(legacy));

--- a/ui/src/test-helpers/settings-node.ts
+++ b/ui/src/test-helpers/settings-node.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, vi } from "vitest";
+import { loadSettings, saveSettings, type UiSettings } from "../app/settings.ts";
+import { createStorageMock } from "./storage.ts";
+
+/** Points the node-environment settings suites at a synthetic Control UI page URL. */
+export function setTestLocation(params: { protocol: string; host: string; pathname: string }) {
+  vi.stubGlobal("location", {
+    protocol: params.protocol,
+    host: params.host,
+    hostname: params.host.replace(/:\d+$/, ""),
+    pathname: params.pathname,
+  } as Location);
+}
+
+export function setControlUiBasePath(value: string | undefined) {
+  type TestWindow = Window & typeof globalThis & { [key: string]: unknown };
+  if (typeof window === "undefined") {
+    vi.stubGlobal(
+      "window",
+      value == null
+        ? ({} as TestWindow)
+        : ({ __OPENCLAW_CONTROL_UI_BASE_PATH__: value } as unknown as TestWindow),
+    );
+    return;
+  }
+  if (value == null) {
+    delete (window as TestWindow)["__OPENCLAW_CONTROL_UI_BASE_PATH__"];
+    return;
+  }
+  Object.defineProperty(window, "__OPENCLAW_CONTROL_UI_BASE_PATH__", {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
+export function expectedGatewayUrl(basePath: string): string {
+  const proto = location.protocol === "https:" ? "wss" : "ws";
+  return `${proto}://${location.host}${basePath}`;
+}
+
+export function makeUiSettings(
+  gatewayUrl: string,
+  overrides: Partial<UiSettings> = {},
+): UiSettings {
+  return {
+    gatewayUrl,
+    token: "",
+    sessionKey: "main",
+    lastActiveSessionKey: "main",
+    theme: "claw",
+    themeMode: "system",
+    chatShowThinking: true,
+    chatShowToolCalls: true,
+    navCollapsed: false,
+    navWidth: 258,
+    sidebarEntries: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Gives each settings suite owned storage globals and drains the module-level
+ * in-memory settings cache afterwards: without the trailing save/load pass a
+ * leaked selection from one file would surface as another file's default.
+ */
+export function installSettingsStorageLifecycle(): void {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
+    localStorage.clear();
+    sessionStorage.clear();
+    setControlUiBasePath(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
+    setTestLocation({ protocol: "https:", host: "gateway.example", pathname: "/" });
+    saveSettings(loadSettings());
+    setControlUiBasePath(undefined);
+    vi.unstubAllGlobals();
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

`ui/src/app/settings.node.test.ts` sat at 999 oxlint-counted lines against its
1000-line `max-lines` cap. Any contributor adding a single counted line to it
failed the `check-lint-core-*` CI shard — and because the cap is evaluated on
the merge ref, two branches that each add a few lines can both pass locally and
fail only after merge. #128474 hit exactly that failure mode on
`ui/src/app/bootstrap.test.ts`; this file was the next one queued up to do it.

## Why This Change Was Made

The file had one 42-test `describe` still titled "loadSettings default gateway
URL derivation" that had long since grown past gateway URLs into every
preference and layout key the settings module persists. Rather than cut it at
an arbitrary line number, it is split along the surfaces under test:

- `settings.node.test.ts` keeps gateway URL derivation, tab-local token
  handling, and per-gateway/per-base-path session scoping (16 tests).
- `settings.preferences.node.test.ts` takes browser-local preference
  persistence: chat shortcut/follow-up/catalog target, sidebar live activity,
  advanced toggle, message width, realtime Talk devices, theme, text scale,
  pinned agents, and local user identity (21 tests).
- `settings.layout.node.test.ts` takes chat split, workspace dock, board
  session views, and sidebar session layouts (7 tests).

Keeping the base filename follows the precedent set by the earlier
`settings.sidebar-prefs.node.test.ts` split rather than renaming every sibling.
The location/base-path/settings-fixture helpers and the storage lifecycle hooks
are genuinely shared by four files now, so they move into
`ui/src/test-helpers/settings-node.ts` in the style of the existing
`installBrowserHistoryIsolation`; `settings.sidebar-prefs.node.test.ts` drops
its copy-pasted duplicates of the same helpers (-56/+14).

Tests were moved, never duplicated or rewritten, and no `max-lines` suppression
or `config/max-lines-baseline.txt` entry was added.

## User Impact

No runtime or user-visible change — test-file organization only. For
contributors, the settings suites now have 557 to 890 counted lines of headroom
instead of 1, so ordinary test additions stop tripping the core lint shard.

## Evidence

Test names and counts are identical before and after — verified by diffing the
sorted `it()` titles from `HEAD` against the new files (44 titles, byte-identical),
plus the 3 in `settings.sidebar-prefs.node.test.ts`:

```
before: Test Files 2 passed (2) | Tests 47 passed (47)
after:  Test Files 4 passed (4) | Tests 47 passed (47)
```

Counted lines vs the 1000-line test cap, measured with the rule's own counter
(a throwaway `max-lines: 1` oxlint config), not an approximation:

| File | Before | After |
| --- | ---: | ---: |
| `settings.node.test.ts` | 999 | 409 |
| `settings.preferences.node.test.ts` | — | 443 |
| `settings.layout.node.test.ts` | — | 110 |
| `settings.sidebar-prefs.node.test.ts` | 111 | 73 |

Validation run locally on this branch:

- `node --import tsx scripts/run-oxlint-shards.mts --only=core --split-core --core-stripe=5/5 --threads=1` — clean
- `node scripts/check-changed.mjs` — exit 0 (format, package patch guard, knip, i18n catalog, tsgo core tests + UI, full core lint)
- `node_modules/.bin/oxfmt` over all touched files
- autoreview (Codex, `gpt-5.6-sol`, high) — clean, no accepted findings

### Also in this PR: a CI flake fixed rather than waited out

`checks-node-compact-large-3` failed twice on this branch, in two *different*
tests of `src/node-host/node-worker-supervisor.container.test.ts` — unrelated to
the UI split, which touches no `src/**` code. The second failure named the cause
outright: `SyntaxError: Unexpected end of JSON input` from the fake engine's
`load()` while the supervisor ran `docker rm --force`.

The test shim saved container state with a truncating `fs.writeFileSync` while
sibling shim invocations (`rm`, `inspect`, `wait`, `ps`) read the same path, so a
reader could hit the zero-length window and exit 1. It now writes a `.pending`
sibling and renames over the target; rename is atomic, so readers always observe
a complete previous or next state. The `ps` handler filters on the
`.container.json` suffix, so pending files are ignored.

A concurrent write/read probe over the old pattern produced **2014 partial reads
in 212900**; the same probe over write-then-rename produced **0 in 203468**. The
end-to-end failure does not reproduce on macOS even under 96-way CPU contention
— the truncation window is far narrower there than on the loaded Linux shard —
so the CI stack trace plus the mechanism probe are the evidence, not a local red
test.

### Nearby, not touched

These are the next merge-ref landmines of the same kind: `ui/src/components/app-sidebar-session-navigation.ts` is at 695/700
and `ui/src/app/app-shell-view.ts` at 681/700. Both are production files, so
splitting them is an ownership decision rather than a mechanical move; not
touched here.
