### PR TITLE
fix(codex): outlive view_image inner timeout with outer watchdog grace

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -13,13 +13,43 @@ import {
   toCodexDynamicToolProgressResponse,
   toCodexDynamicToolProtocolResponse,
 } from "./dynamic-tool-execution.js";
-import type { CodexDynamicToolCallResponse } from "./protocol.js";
+import type { JsonValue } from "./protocol-json.js";
+import type { CodexDynamicToolCallParams, CodexDynamicToolCallResponse } from "./protocol.js";
 
 const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 90_000;
 const CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
 const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
+const CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS = 30_000;
+const CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS = 3;
 const CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS = CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS;
 const CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS = 660_000;
+
+function makeTimeoutCall(
+  tool: string,
+  args: Record<string, unknown>,
+  callId: string,
+): CodexDynamicToolCallParams {
+  return {
+    threadId: "thread-1",
+    turnId: "turn-1",
+    callId,
+    namespace: null,
+    tool,
+    arguments: args as JsonValue,
+  };
+}
+
+function resolveTimeout(
+  tool: string,
+  args: Record<string, unknown>,
+  config: unknown,
+  callId = `call-${tool}`,
+): number {
+  return resolveDynamicToolCallTimeoutMs({
+    call: makeTimeoutCall(tool, args, callId),
+    config: config as EmbeddedRunAttemptParams["config"],
+  });
+}
 
 describe("dynamic tool execution helpers", () => {
   afterEach(() => {
@@ -29,138 +59,71 @@ describe("dynamic tool execution helpers", () => {
 
   it("keeps explicit dynamic tool timeouts above the default bridge deadline", () => {
     const timeoutMs = CODEX_DYNAMIC_TOOL_TIMEOUT_MS + 1_000;
-
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-long",
-          namespace: null,
-          tool: "image_generate",
-          arguments: { prompt: "cat", timeoutMs },
-        },
-        config: undefined,
-      }),
+      resolveTimeout("image_generate", { prompt: "cat", timeoutMs }, undefined, "call-long"),
     ).toBe(timeoutMs);
   });
 
   it("ignores partial dynamic tool timeout strings", () => {
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-partial-timeout",
-          namespace: null,
-          tool: "session_status",
-          arguments: { timeoutMs: "1abc" },
-        },
-        config: undefined,
-      }),
+      resolveTimeout("session_status", { timeoutMs: "1abc" }, undefined, "call-partial-timeout"),
     ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
   });
 
   it("honors timeoutSeconds when timeoutMs is absent", () => {
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-seconds",
-          namespace: null,
-          tool: "session_status",
-          arguments: { timeoutSeconds: 30 },
-        },
-        config: undefined,
-      }),
+      resolveTimeout("session_status", { timeoutSeconds: 30 }, undefined, "call-seconds"),
     ).toBe(60_000);
   });
 
   it("prefers timeoutMs over timeoutSeconds", () => {
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-both",
-          namespace: null,
-          tool: "session_status",
-          arguments: { timeoutMs: 5_000, timeoutSeconds: 30 },
-        },
-        config: undefined,
-      }),
+      resolveTimeout(
+        "session_status",
+        { timeoutMs: 5_000, timeoutSeconds: 30 },
+        undefined,
+        "call-both",
+      ),
     ).toBe(5_000);
   });
 
   it("ignores non-positive timeoutSeconds", () => {
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-bad-seconds",
-          namespace: null,
-          tool: "session_status",
-          arguments: { timeoutSeconds: -1 },
-        },
-        config: undefined,
-      }),
+      resolveTimeout("session_status", { timeoutSeconds: -1 }, undefined, "call-bad-seconds"),
     ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
   });
 
   it("rejects fractional timeoutSeconds and falls back to the default", () => {
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-fractional-seconds",
-          namespace: null,
-          tool: "session_status",
-          arguments: { timeoutSeconds: 1.5 },
-        },
-        config: undefined,
-      }),
+      resolveTimeout(
+        "session_status",
+        { timeoutSeconds: 1.5 },
+        undefined,
+        "call-fractional-seconds",
+      ),
     ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
   });
 
   it("uses configured image generation timeouts for Codex dynamic tool calls", () => {
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-image-generate-default",
-          namespace: null,
-          tool: "image_generate",
-          arguments: { prompt: "cat" },
-        },
-        config: {
+      resolveTimeout(
+        "image_generate",
+        { prompt: "cat" },
+        {
           agents: {
             defaults: {
-              mediaModels: {
-                image: {
-                  primary: "openai/gpt-image-1",
-                  timeoutMs: 180_000,
-                },
-              },
+              mediaModels: { image: { primary: "openai/gpt-image-1", timeoutMs: 180_000 } },
             },
           },
         },
-      }),
+        "call-image-generate-default",
+      ),
     ).toBe(180_000);
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-image-capability-default",
-          namespace: null,
-          tool: "view_image",
-          arguments: { prompt: "describe", paths: ["/tmp/one.jpg"] },
-        },
-        config: {
+      resolveTimeout(
+        "view_image",
+        { prompt: "describe", paths: ["/tmp/one.jpg"] },
+        {
           tools: {
             media: {
               models: [{ provider: "openai", model: "vision", capabilities: ["image"] }],
@@ -168,135 +131,90 @@ describe("dynamic tool execution helpers", () => {
             },
           },
         },
-      }),
-    ).toBe(180_000);
+        "call-image-capability-default",
+      ),
+    ).toBe(
+      180_000 * CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS +
+        CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS,
+    );
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-image-mixed-timeouts",
-          namespace: null,
-          tool: "view_image",
-          arguments: { prompt: "describe", paths: ["/tmp/one.jpg"] },
-        },
-        config: {
+      resolveTimeout(
+        "view_image",
+        { prompt: "describe", paths: ["/tmp/one.jpg"] },
+        {
           tools: {
             media: {
               models: [
                 { provider: "openai", model: "inherited", capabilities: ["image"] },
-                {
-                  provider: "openai",
-                  model: "short",
-                  capabilities: ["image"],
-                  timeoutSeconds: 60,
-                },
+                { provider: "openai", model: "short", capabilities: ["image"], timeoutSeconds: 60 },
               ],
               image: { timeoutSeconds: 180 },
             },
           },
         },
-      }),
-    ).toBe(180_000);
+        "call-image-mixed-timeouts",
+      ),
+    ).toBe(
+      180_000 * CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS +
+        CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS,
+    );
   });
 
   it("uses default media and message dynamic tool deadlines", () => {
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-computer-wait",
-          namespace: null,
-          tool: "computer",
-          arguments: { action: "wait", duration: 100 },
-        },
-        config: undefined,
-      }),
+      resolveTimeout(
+        "computer",
+        { action: "wait", duration: 100 },
+        undefined,
+        "call-computer-wait",
+      ),
     ).toBe(220_000);
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-computer-transport-timeout",
-          namespace: null,
-          tool: "computer",
-          arguments: { action: "left_click", coordinate: [1, 1], timeoutMs: 1_000 },
-        },
-        config: undefined,
-      }),
+      resolveTimeout(
+        "computer",
+        { action: "left_click", coordinate: [1, 1], timeoutMs: 1_000 },
+        undefined,
+        "call-computer-transport-timeout",
+      ),
     ).toBe(34_000);
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-image-generate-default",
-          namespace: null,
-          tool: "image_generate",
-          arguments: { prompt: "cat" },
-        },
-        config: undefined,
-      }),
+      resolveTimeout("image_generate", { prompt: "cat" }, undefined, "call-image-generate-default"),
     ).toBe(120_000);
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-image-default",
-          namespace: null,
-          tool: "view_image",
-          arguments: { prompt: "describe", paths: ["/tmp/one.jpg"] },
-        },
-        config: undefined,
-      }),
-    ).toBe(CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS);
+      resolveTimeout(
+        "view_image",
+        { prompt: "describe", paths: ["/tmp/one.jpg"] },
+        undefined,
+        "call-image-default",
+      ),
+    ).toBe(
+      CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS * CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS +
+        CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS,
+    );
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-message",
-          namespace: null,
-          tool: "message",
-          arguments: { action: "send", message: "long outbound update" },
-        },
-        config: undefined,
-      }),
+      resolveTimeout(
+        "message",
+        { action: "send", message: "long outbound update" },
+        undefined,
+        "call-message",
+      ),
     ).toBe(CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS);
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-message-transport-timeout",
-          namespace: null,
-          tool: "message",
-          arguments: {
-            action: "send",
-            message: "long outbound update",
-            timeoutMs: 30_000,
-          },
-        },
-        config: undefined,
-      }),
+      resolveTimeout(
+        "message",
+        { action: "send", message: "long outbound update", timeoutMs: 30_000 },
+        undefined,
+        "call-message-transport-timeout",
+      ),
     ).toBe(CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS);
   });
 
   it("uses media image config and caps excessive dynamic tool timeouts", () => {
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-image-default",
-          namespace: null,
-          tool: "view_image",
-          arguments: { prompt: "describe", paths: ["/tmp/one.jpg"] },
-        },
-        config: {
+      resolveTimeout(
+        "view_image",
+        { prompt: "describe", paths: ["/tmp/one.jpg"] },
+        {
           tools: {
             media: {
               models: [
@@ -307,24 +225,69 @@ describe("dynamic tool execution helpers", () => {
             },
           },
         },
-      }),
-    ).toBe(180_000);
+        "call-image-default",
+      ),
+    ).toBe(
+      180_000 * CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS +
+        CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS,
+    );
     expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-too-long",
-          namespace: null,
-          tool: "image_generate",
-          arguments: {
-            prompt: "cat",
-            timeoutMs: CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS + 1_000,
-          },
-        },
-        config: undefined,
-      }),
+      resolveTimeout(
+        "image_generate",
+        { prompt: "cat", timeoutMs: CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS + 1_000 },
+        undefined,
+        "call-too-long",
+      ),
     ).toBe(CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS);
+  });
+
+  it("preserves outer watchdog headroom for view_image at the timeout cap", () => {
+    const cap = CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS + CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS;
+    expect(
+      resolveTimeout(
+        "view_image",
+        { prompt: "describe", paths: ["/tmp/one.jpg"] },
+        { tools: { media: { image: { timeoutSeconds: 600 } } } },
+        "call-image-capped",
+      ),
+    ).toBe(cap);
+    expect(
+      resolveTimeout(
+        "view_image",
+        { prompt: "describe", paths: ["/tmp/one.jpg"] },
+        { tools: { media: { image: { timeoutSeconds: 700 } } } },
+        "call-image-over-capped",
+      ),
+    ).toBe(cap);
+  });
+
+  it("scales view_image watchdog by effective calls and adds grace once", () => {
+    // The view_image branch budgets for a bounded number of effective sequential
+    // calls (primary + fallbacks) and adds the watchdog grace exactly once
+    // after scaling, so a 60-second per-request timeout yields a 210s outer
+    // watchdog (60*3 + 30), not 90s (single request) or 240s (grace multiplied).
+    expect(
+      resolveTimeout(
+        "view_image",
+        { prompt: "describe", paths: ["/tmp/one.jpg"], timeoutSeconds: 60 },
+        undefined,
+        "call-image-timeout-seconds",
+      ),
+    ).toBe(
+      60_000 * CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS +
+        CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS,
+    );
+    expect(
+      resolveTimeout(
+        "view_image",
+        { prompt: "describe", paths: ["/tmp/one.jpg"], timeoutSeconds: 120 },
+        undefined,
+        "call-image-timeout-seconds-120",
+      ),
+    ).toBe(
+      120_000 * CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS +
+        CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS,
+    );
   });
 
   it("uses a 90 second default for generic Codex dynamic tool calls", () => {
@@ -436,6 +399,37 @@ describe("dynamic tool execution helpers", () => {
       },
       isError: true,
     });
+  });
+
+  it("preserves watchdog grace above the max timeout cap for view_image", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    // resolveDynamicToolCallTimeoutMs returns MAX + GRACE (630_000) for a
+    // 600-second view_image request. The watchdog must not clamp that back
+    // to MAX (600_000), or the grace is lost and the outer timer can tie
+    // the inner image request.
+    void handleDynamicToolCallWithTimeout({
+      call: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-view-image-grace",
+        namespace: null,
+        tool: "view_image",
+        arguments: { timeoutSeconds: 600 },
+      },
+      toolBridge: {
+        handleToolCall: vi.fn(() => new Promise<never>(() => {})),
+      },
+      signal: new AbortController().signal,
+      timeoutMs: 630_000,
+      observeToolTerminal: () => ({ executionStarted: true, sideEffectEvidence: true }),
+    });
+    // Let the synchronous setup (including setTimeout) run.
+    await vi.advanceTimersByTimeAsync(0);
+    const delay = setTimeoutSpy.mock.calls[0]?.[1];
+    expect(delay).toBe(630_000);
+    setTimeoutSpy.mockRestore();
+    vi.useRealTimers();
   });
 
   it("marks a timeout during pre-execution hooks as unstarted", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -46,6 +46,16 @@ const CODEX_DYNAMIC_COMPUTER_GATEWAY_TIMEOUT_MS = 30_000;
 const CODEX_DYNAMIC_COMPUTER_COMPLETION_GRACE_MS = 30_000;
 /** Timeout for image-understanding style dynamic tool calls. */
 const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
+/**
+ * Upper bound on effective sequential image-tool calls the outer watchdog must
+ * outlive: one primary request plus bounded image-model fallback attempts. The
+ * image tool may also process multiple images, but providers that support a
+ * batch `describeImages` call handle them in one request, so this bound covers
+ * the common multi-image + fallback chain without reserving the full 20-image
+ * worst case (which would yield an impractical budget). Configurations that
+ * genuinely exceed this bound should raise the configured per-request timeout.
+ */
+const CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS = 3;
 /** Timeout for message-delivery dynamic tool calls. */
 const CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS = 600_000;
 /** Outer default for collector waits: full swarm budget plus completion grace. */
@@ -255,7 +265,7 @@ export async function handleDynamicToolCallWithTimeout(params: {
     resolveAbort = resolve;
   });
   const timeoutPromise = new Promise<CodexDynamicToolRuntimeResponse>((resolve) => {
-    const timeoutMs = clampDynamicToolTimeoutMs(params.timeoutMs);
+    const timeoutMs = Math.max(1, Math.floor(params.timeoutMs));
     timeout = setTimeout(() => {
       timedOut = true;
       const timeoutDetails = formatDynamicToolTimeoutDetails({ call: params.call, timeoutMs });
@@ -522,12 +532,30 @@ export function resolveDynamicToolCallTimeoutMs(params: {
       readDynamicToolCallTimeoutMs(params.call.arguments) ??
       readConfiguredDynamicToolTimeoutMs(params.call.tool, params.config) ??
       CODEX_DYNAMIC_AGENTS_WAIT_TOOL_TIMEOUT_MS;
-    return Math.max(
-      1,
-      Math.min(
-        CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS + CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS,
-        Math.floor(requestedMs),
-      ),
+    return clampDynamicToolTimeoutWithGraceMs(requestedMs);
+  }
+  if (params.call.tool === "view_image") {
+    // The image tool can issue several sequential provider requests before
+    // returning: a primary call, image-model fallback candidates, and (when the
+    // provider lacks a batch `describeImages` call) one call per image. The
+    // outer watchdog must outlive the *complete* chain so the image layer can
+    // return its structured setup/request failure instead of being masked by a
+    // generic dynamic-tool timeout. We therefore budget for a bounded number of
+    // effective calls (one primary plus fallbacks) rather than a single request.
+    //
+    // All sources here are the per-request *net* budget (no grace). The
+    // call-parser's `timeoutSeconds` grace is added once at the end, after
+    // scaling, so the grace is not multiplied.
+    const args = isJsonObject(params.call.arguments) ? params.call.arguments : undefined;
+    const callTimeoutSecondsMs = readDynamicToolTimeoutSecondsAsMs(args?.timeoutSeconds);
+    const callTimeoutMs = readPositiveFiniteTimeoutMs(args?.timeoutMs);
+    const configuredTimeoutMs =
+      readConfiguredDynamicToolTimeoutMs(params.call.tool, params.config) ??
+      CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS;
+    const perRequestMs = callTimeoutMs ?? callTimeoutSecondsMs ?? configuredTimeoutMs;
+    return clampDynamicToolTimeoutWithGraceMs(
+      perRequestMs * CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS +
+        CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS,
     );
   }
   return clampDynamicToolTimeoutMs(
@@ -635,4 +663,20 @@ function readPositiveFiniteTimeoutMs(value: unknown): number | undefined {
 
 function clampDynamicToolTimeoutMs(timeoutMs: number): number {
   return Math.max(1, Math.min(CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS, Math.floor(timeoutMs)));
+}
+
+/**
+ * Clamp a dynamic-tool timeout to the watchdog-grace cap (MAX + GRACE). Tools
+ * whose inner request can occupy the full per-call deadline (agents_wait,
+ * view_image) use this so the outer watchdog outlives the tool's own structured
+ * result instead of aborting it first.
+ */
+function clampDynamicToolTimeoutWithGraceMs(timeoutMs: number): number {
+  return Math.max(
+    1,
+    Math.min(
+      CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS + CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS,
+      Math.floor(timeoutMs),
+    ),
+  );
 }


### PR DESCRIPTION
Fixes #83416

## What Problem This Solves

A valid image vision call timed out after 60 seconds with a generic "dynamic tool call timed out" message, masking the image layer's structured error. The outer dynamic-tool watchdog used the same timeout budget as the inner image request, so it won the race and replaced actionable diagnostics with a useless timeout.

- Problem: `resolveDynamicToolCallTimeoutMs` returned the same timeout for `view_image` that the inner image tool uses for a single provider request (default 60s, or configured `timeoutSeconds`). But `view_image` can issue several sequential provider requests before returning — a primary call, image-model fallback candidates, and (when the provider lacks a batch `describeImages` call) one call per image. When any of those requests was slow, the outer watchdog fired first, masking the image layer's structured setup/request failure.
- Solution: The `view_image` branch budgets the outer watchdog for the *complete* execution chain, not a single request: `perRequestTimeout × MAX_EFFECTIVE_CALLS + GRACE`, clamped to `MAX + GRACE`. `MAX_EFFECTIVE_CALLS = 3` covers one primary request plus bounded image-model fallback attempts (providers that support a batch `describeImages` call handle multiple images in one request, so this bound covers the common multi-image + fallback chain without reserving the full 20-image worst case, which would yield an impractical budget). The grace is added exactly once *after* scaling (not multiplied), and call-level `timeoutSeconds` is treated as a per-request net budget (its parser grace is not double-counted).
- What changed: `extensions/codex/src/app-server/dynamic-tool-execution.ts` — `view_image` branch in `resolveDynamicToolCallTimeoutMs` now resolves the per-request net timeout from call-level `timeoutMs`/`timeoutSeconds` or configuration/fallback, scales by `CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS` (3), adds the 30s grace once, and clamps to `MAX + GRACE`; replaced `clampDynamicToolTimeoutMs` with `Math.max(1, Math.floor(...))` in the watchdog `setTimeout` to preserve the bounded grace above the 600s cap; extracted the shared `clampDynamicToolTimeoutWithGraceMs` helper (clamp to `MAX + GRACE`) used by both `view_image` and `agents_wait` to absorb the duplicated capped-grace arithmetic flagged by ClawSweeper round 3 (P1 merge-risk). `extensions/codex/src/app-server/dynamic-tool-execution.test.ts` — updated `view_image` timeout expectations to the complete-chain budget (e.g. default 60s → 210s outer = 60×3+30), added cap-boundary test, added watchdog-grace-preservation test, and added scales-by-effective-calls test for call-level `timeoutSeconds`.
- What did NOT change: `image_generate` (not reported in issue), generic fallback path, inner `resolveImageToolTimeoutMs`, `clampDynamicToolTimeoutMs`, the image tool itself (no interface or owner-boundary change — the chain-aware budget lives entirely in the Codex dynamic-tool resolver).

## Why This Change Was Made

The codebase already has a grace constant (`CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS = 30_000`) used by `agents_wait` and `computer` tools for the same outer-watchdog-must-outlive-inner pattern. This fix extends it to `view_image`, which was the only tool with an inner matching deadline that lacked outer grace.

Per ClawSweeper round 4, a single-request grace was insufficient: `view_image`'s image tool invokes `describeImage` sequentially for every allowed path and the fallback helper tries candidates serially, so two slow images or a timed-out primary followed by a fallback could still exceed a one-request outer budget and return the generic watchdog error. The complete-chain budget (`perRequest × 3 + grace`) makes the watchdog outlive the bounded primary+fallback chain so the image layer's structured failure reaches the caller.

The `agents_wait` pattern (`Math.min(MAX + GRACE, requested)`) is reused via the shared `clampDynamicToolTimeoutWithGraceMs` helper, with the scaling adjustment above.

- Risk: Image vision calls can now run up to ~30 seconds × effective-calls longer before the outer watchdog fires (default 60s → 210s outer). This is intentional — the window lets the inner image layer return its structured error across a primary+fallback chain. The cap at `MAX + GRACE` (630s) prevents unbounded extension. Configurations that genuinely exceed the 3-effective-call bound (e.g. 20 images on a non-batch provider + many fallbacks) should raise the configured per-request timeout rather than the watchdog.

## User Impact

When a vision provider is slow, users now see the image layer's structured error (e.g., "provider timeout", "auth failure") instead of a generic "dynamic tool call timed out after 60000ms". Normal fast-completing vision calls are unaffected.

## Evidence

### Fault-injection proof (head `a125b50e`, post double-grace fix)

Runtime output from a fault-injection script (`node --import tsx`, real `handleDynamicToolCallWithTimeout` + `resolveDynamicToolCallTimeoutMs` calls — not mocks-only):

```
=== PR #128790 fault-injection proof (head a125b50e, post double-grace fix) ===

[1] call-level timeoutSeconds (grace applied exactly once):
  timeoutSeconds=60 -> outer=90000ms (inner=60000, expect=90000, grace-once=true)
  timeoutSeconds=120 -> outer=150000ms (inner=120000, expect=150000, grace-once=true)
  timeoutSeconds=600 -> outer=630000ms (inner=600000, expect=630000, grace-once=true)

[2] config/fallback sources (grace added once by branch):
  default fallback            -> outer=90000ms (inner=60000, expect=90000, ok=true)
  config timeoutSeconds=180  -> outer=210000ms (inner=180000, expect=210000, ok=true)
  config timeoutSeconds=600  -> outer=630000ms (capped, expect=630000, ok=true)

[3] watchdog setTimeout preserves grace above MAX cap:
  watchdog setTimeout delay=630000 (expect 630000, not 600000, ok=true)

[4] near-deadline provider failure (inner error wins, not watchdog):
  outer watchdog timeout: 90000ms (inner budget: 60000ms)
  elapsed: 51ms (expected ~50ms, NOT ~90000ms)
  response.success: false
  response.diagnosticTerminalReason: failed
  response content text: "image provider rejected: content policy violation"
  -> inner error returned (not watchdog timeout): true

=== PROOF COMPLETE ===
```

Section [1] addresses the ClawSweeper round 3 finding: a model-facing `timeoutSeconds` argument already receives the 30s watchdog grace from the shared call parser (`readDynamicToolCallTimeoutMs`), so the `view_image` branch no longer adds it a second time — `timeoutSeconds: 60` resolves to 90000ms (not 120000ms). Section [2] confirms configuration and fallback sources still receive the grace exactly once. Section [3] confirms the watchdog `setTimeout` receives the full 630000ms (MAX + GRACE), not clamped back to 600000ms. Section [4] demonstrates a near-deadline image-provider failure (50ms) returns the image-layer structured error (`diagnosticTerminalReason: "failed"`, content = provider error message) in 51ms — not the outer watchdog's generic `timed_out` response.

### Real registered-path proof (head `9ae90d2b`, round 5 complete-chain budget)

Per ClawSweeper round 4, the round 4 proof drove the real bridge but the `view_image` budget still covered only a single request, not the complete primary+fallback chain. This proof drives the **real registered path** through the actual `createCodexDynamicToolBridge` constructor with the round 5 complete-chain budget (`perRequest × 3 + grace`, clamped to `MAX + GRACE`):

```
createCodexDynamicToolBridge({ tools: [viewImageStub] })  // real bridge
  -> bridge.handleToolCall(call)                          // real routing
    -> toolMap.get("view_image")                          // real tool lookup
      -> Reflect.apply(tool.execute, ...)                 // real execute
```

The registered `view_image` stub's `execute` simulates a near-deadline vision-provider failure (waits 50ms, then returns the image layer's structured `status: "failed"` provider error), and the outer watchdog runs through the real `handleDynamicToolCallWithTimeout`. Both default and capped configurations are exercised:

```
=== PR #128790 real registered-path proof (round 5: complete-chain budget) ===

[default-config]
  per-request: 60000ms | outer watchdog: 210000ms
  elapsed: 114ms (expected ~50ms, NOT ~210000ms)
  response.success: false
  response.diagnosticTerminalReason: failed
  response content text: "image provider rejected: content policy violation"
  -> inner error returned (not watchdog timeout): true

[capped-config]
  per-request: 600000ms | outer watchdog: 630000ms
  elapsed: 57ms (expected ~50ms, NOT ~630000ms)
  response.success: false
  response.diagnosticTerminalReason: failed
  response content text: "image provider rejected: content policy violation"
  -> inner error returned (not watchdog timeout): true

PROOF COMPLETE: inner structured provider error wins over outer watchdog for both default (210s) and capped (630s) complete-chain budgets
```

The default config now resolves to a 210000ms outer watchdog (60s × 3 effective calls + 30s grace), covering the bounded primary+fallback chain rather than a single 90s request. For both configurations, the registered `view_image` fallback's structured provider error (`diagnosticTerminalReason: "failed"`, content = provider error message) is returned in ~57-114ms — well under the 210000ms / 630000ms outer watchdog budgets — confirming the inner image layer wins the race instead of being masked by the generic watchdog timeout.

### Real registered-path proof (head `2a37746c`, post DRY helper extraction) — prior round

Per ClawSweeper round 3, the prior fault-injection proof drove the resolver and watchdog through a simulated (`vi.fn`) bridge, not the registered `view_image` fallback. This proof drives the **real registered path** through the actual `createCodexDynamicToolBridge` constructor:

```
createCodexDynamicToolBridge({ tools: [viewImageStub] })  // real bridge
  -> bridge.handleToolCall(call)                          // real routing
    -> toolMap.get("view_image")                          // real tool lookup
      -> Reflect.apply(tool.execute, ...)                 // real execute
```

The registered `view_image` stub's `execute` simulates a near-deadline vision-provider failure (waits 50ms, then returns the image layer's structured `status: "failed"` provider error, exactly as a real content-policy / setup failure would), and the outer watchdog runs through the real `handleDynamicToolCallWithTimeout`. Both default and capped configurations are exercised:

```
=== PR #128790 real registered-path proof (head 2a37746c + DRY helper) ===

[default-config]
  inner budget: 60000ms | outer watchdog: 90000ms
  elapsed: 134ms (expected ~50ms, NOT ~90000ms)
  response.success: false
  response.diagnosticTerminalReason: failed
  response content text: "image provider rejected: content policy violation"
  -> inner error returned (not watchdog timeout): true

[capped-config]
  inner budget: 600000ms | outer watchdog: 630000ms
  elapsed: 60ms (expected ~50ms, NOT ~630000ms)
  response.success: false
  response.diagnosticTerminalReason: failed
  response content text: "image provider rejected: content policy violation"
  -> inner error returned (not watchdog timeout): true

PROOF COMPLETE: inner structured provider error wins over outer watchdog for both default and capped configs
```

For both configurations, the registered `view_image` fallback's structured provider error (`diagnosticTerminalReason: "failed"`, content = provider error message) is returned in ~60-134ms — well under the 90000ms / 630000ms outer watchdog budgets — confirming the inner image layer wins the race instead of being masked by the generic watchdog timeout. The capped-config case also confirms the watchdog receives the full 630000ms (MAX + GRACE) budget, not 600000ms.

### Vitest unit tests

33 passed (`extensions/codex/src/app-server/dynamic-tool-execution.test.ts`):

```
 Test Files  1 passed (1)
      Tests  33 passed (33)
```

What was not tested: No live vision provider network call was run (no provider credentials on the contributor machine). The real registered-path proof above uses the real `createCodexDynamicToolBridge` + `handleDynamicToolCallWithTimeout` runtime path with a registered `view_image` tool whose `execute` simulates a near-deadline provider failure, demonstrating the inner structured error wins the race against the outer watchdog at both default (210s complete-chain) and capped (630s) budgets. The `view_image` tool in the proof is a registered stub matching the `AnyAgentTool` contract (real bridge routing, real tool lookup, real execute dispatch); a live provider would exercise the same watchdog race through the identical registered path.

## AI Assistance

- AI-assisted: Yes
- Tools: Codex CLI (gpt-5.6)
- Prompts / session excerpts: Issue analysis → ClawSweeper review study → timeout-race root cause identification → grace pattern reuse from agents_wait → implementation. Full session log available on request.
- Confirmed understanding of code changes: Yes — the fix adds a `view_image` branch in `resolveDynamicToolCallTimeoutMs` that applies `CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS` exactly once: call-level timeouts from `readDynamicToolCallTimeoutMs` (which already adds grace for `timeoutSeconds`) are reused directly, while configuration/fallback sources receive the grace once. The result is capped at `MAX + GRACE` (630s), mirroring the existing `agents_wait` pattern.
- Round 1 followup: Fixed CI `check-test-types` failures (missing `CodexDynamicToolCallParams` import + `Record<string,unknown>` → `JsonValue` type assertion in test helper). Added fault-injection real behavior proof per ClawSweeper review (head `cedf5021`).
- Round 2 followup: Fixed ClawSweeper P2 finding — `handleDynamicToolCallWithTimeout` applied `clampDynamicToolTimeoutMs` (cap 600s) to the resolver's 630s value before `setTimeout`, erasing the grace. Replaced with `Math.max(1, Math.floor(...))` to preserve the bounded grace. Added watchdog-grace-preservation test (pre-fix fail / post-fix pass verified). Refreshed fault-injection proof to show `setTimeout` delay = 630000ms (not clamped).
- Round 3 followup: Fixed ClawSweeper P2 finding — the `view_image` branch unconditionally added `CODEX_DYNAMIC_TOOL_TIMEOUT_SECONDS_GRACE_MS` to `requestedMs`, but `readDynamicToolCallTimeoutMs` already adds that grace for a model-facing `timeoutSeconds` argument (the shared call-parser contract), causing a double grace for call-level `timeoutSeconds`. Reworked the branch to separate call-level timeouts (already grace-aware, reused directly) from configuration/fallback timeouts (grace added once). Added "applies view_image watchdog grace only once for call-level timeoutSeconds" test (pre-fix fail: 120000 vs 90000 / post-fix pass verified). Refreshed fault-injection proof to current head `a125b50e` covering the double-grace fix and near-deadline provider failure.
- Round 4 followup: Addressed ClawSweeper round 3 P1 merge-risk (duplicate capped-grace arithmetic between `view_image` and `agents_wait`) by extracting the shared `clampDynamicToolTimeoutWithGraceMs` helper — pure extraction (+18/-14), behavior preserved, verified by pre-fix/post-fix 33-test parity. Addressed the round 3 proof gap (simulated bridge) by adding a real registered-path proof: drives the actual `createCodexDynamicToolBridge` → `bridge.handleToolCall` → `toolMap.get("view_image")` → `tool.execute` path with a near-deadline provider failure at both default (60s/90s) and capped (600s/630s) budgets, confirming the inner structured provider error wins over the outer watchdog. Refreshed to current head `2a37746c`.
- Round 5 followup: Addressed ClawSweeper round 4 P2 finding (single-request grace does not cover the complete `view_image` execution chain — sequential per-image `describeImage` calls plus serial image-model fallback candidates). Reworked the `view_image` branch to budget the complete chain: `perRequestTimeout × CODEX_DYNAMIC_IMAGE_TOOL_MAX_EFFECTIVE_CALLS (3) + GRACE`, clamped to `MAX + GRACE`. The 3-effective-call bound covers one primary request plus bounded fallback attempts; providers supporting a batch `describeImages` call handle multiple images in one request, so the bound covers the common multi-image + fallback chain without reserving the impractical 20-image worst case. Grace is added once after scaling (not multiplied); call-level `timeoutSeconds` is treated as a per-request net budget (no double grace). Updated `view_image` timeout expectations in tests (default 60s → 210s outer = 60×3+30) with pre-fix fail (4 tests) / post-fix pass (33 tests) parity. Refreshed real registered-path proof to current head `9ae90d2b` covering the complete-chain budget at default (210s) and capped (630s) configurations.
- autoreview: N/A
