### PR TITLE
fix(chat): show native commentary progress

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.update-commentary.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update-commentary.test.ts
@@ -109,7 +109,13 @@ describe("handleMessageUpdate commentary phase", () => {
       | undefined;
     expect(commentaryEvent?.stream).toBe("assistant");
     expect(commentaryEvent?.data?.phase).toBe("commentary");
-    expect(commentaryEvent?.data?.delta).toBe("Working...");
+    expect(commentaryEvent?.data).toMatchObject({
+      text: "Working...",
+      delta: "",
+      replace: true,
+      phase: "commentary",
+      itemId: "item_commentary",
+    });
     expect(ctx.state.deltaBuffer).toBe("Working...");
     expect(ctx.state.blockBuffer).toBe("");
 

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update-stream-items.test.ts
@@ -263,7 +263,13 @@ describe("handleMessageUpdate text signatures", () => {
       // phase; reply lanes still exclude it (covered below).
       {
         stream: "assistant",
-        data: { delta: "Hello", phase: "commentary", itemId: "item-commentary" },
+        data: {
+          text: "Hello",
+          delta: "",
+          replace: true,
+          phase: "commentary",
+          itemId: "item-commentary",
+        },
       },
       {
         stream: "assistant",
@@ -335,11 +341,23 @@ describe("handleMessageUpdate text signatures", () => {
     expect(onAgentEvent.mock.calls.map(([event]) => event)).toMatchObject([
       {
         stream: "assistant",
-        data: { delta: "Work", phase: "commentary", itemId: "item-commentary" },
+        data: {
+          text: "Work",
+          delta: "",
+          replace: true,
+          phase: "commentary",
+          itemId: "item-commentary",
+        },
       },
       {
         stream: "assistant",
-        data: { delta: "ing...", phase: "commentary", itemId: "item-commentary" },
+        data: {
+          text: "Working...",
+          delta: "",
+          replace: true,
+          phase: "commentary",
+          itemId: "item-commentary",
+        },
       },
     ]);
     expect(context.state.deltaBuffer).toBe("Working...");
@@ -386,11 +404,23 @@ describe("handleMessageUpdate text signatures", () => {
     expect(onAgentEvent.mock.calls.map(([event]) => event)).toMatchObject([
       {
         stream: "assistant",
-        data: { delta: "Working", phase: "commentary", itemId: "item-1" },
+        data: {
+          text: "Working",
+          delta: "",
+          replace: true,
+          phase: "commentary",
+          itemId: "item-1",
+        },
       },
       {
         stream: "assistant",
-        data: { delta: " now", phase: "commentary", itemId: "item-1" },
+        data: {
+          text: "Working now",
+          delta: "",
+          replace: true,
+          phase: "commentary",
+          itemId: "item-1",
+        },
       },
     ]);
     expect(context.state.lastAssistantStreamItemId).toBe("item-1");

--- a/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.update.ts
@@ -254,13 +254,11 @@ export function handleMessageUpdate(
       ctx.state.deltaBuffer += chunk;
       ctx.state.deltaBufferIsCommentary = true;
     }
-    const commentaryText =
-      !chunk && (!isResponsesCommentary || !hadResponsesCommentaryText)
-        ? coerceChatContentText(extractAssistantCommentaryText(streamAssistant))
-        : undefined;
-    const commentaryData = chunk
-      ? buildAssistantStreamData({ delta: chunk, phase: "commentary", itemId: deliveryItemId })
-      : commentaryText
+    const commentaryText = isResponsesCommentary
+      ? ctx.state.deltaBuffer
+      : coerceChatContentText(extractAssistantCommentaryText(streamAssistant));
+    const commentaryData =
+      commentaryText && (chunk || !hadResponsesCommentaryText)
         ? buildAssistantStreamData({
             text: commentaryText,
             replace: true,

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -60,6 +60,7 @@ type AssistantStreamData = {
   replace?: true;
   mediaUrls?: string[];
   phase?: AssistantPhase;
+  itemId?: string;
 };
 
 /** Deferred assistant stream event plus whether it should emit partial replies. */

--- a/src/agents/embedded-agent-subscribe.reply-delivery.ts
+++ b/src/agents/embedded-agent-subscribe.reply-delivery.ts
@@ -23,6 +23,7 @@ type ReplyDeliveryParams = {
 
 export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams) {
   const assistantTexts = state.assistantTexts;
+  const lastEmittedCommentaryByItem = new Map<string, string>();
   const pendingBlockReplyTasks = new Set<Promise<void>>();
   const pendingPartialReplyTasks = new Set<Promise<void>>();
   const shouldAllowSilentTurnText = (text: string | undefined) =>
@@ -31,21 +32,40 @@ export function createReplyDelivery({ params, state, log }: ReplyDeliveryParams)
     delivery: EmbeddedAgentSubscribeContext["state"]["deferredAssistantEvents"][number],
   ) => {
     const { data } = delivery;
-    emitAgentEvent({
-      runId: params.runId,
-      stream: "assistant",
-      data,
-    });
-    if (params.onAgentEvent) {
-      runBestEffortCallback({
-        label: "assistant agent event",
-        log,
-        callback: () =>
-          params.onAgentEvent?.({
-            stream: "assistant",
-            data,
-          }),
-      });
+    const itemId = typeof data.itemId === "string" ? data.itemId : "";
+    const progressText =
+      data.phase === "commentary" && typeof data.text === "string"
+        ? data.text.replace(/\s+/g, " ").trim()
+        : "";
+    const event = progressText
+      ? {
+          stream: "item" as const,
+          data: {
+            kind: "preamble",
+            title: "Preamble",
+            phase: "update",
+            progressText,
+            ...(itemId ? { itemId } : {}),
+          },
+        }
+      : data.phase === "commentary"
+        ? undefined
+        : { stream: "assistant" as const, data };
+    if (
+      event &&
+      (event.stream !== "item" || lastEmittedCommentaryByItem.get(itemId) !== progressText)
+    ) {
+      if (event.stream === "item") {
+        lastEmittedCommentaryByItem.set(itemId, progressText);
+      }
+      emitAgentEvent({ runId: params.runId, ...event });
+      if (params.onAgentEvent) {
+        runBestEffortCallback({
+          label: "assistant agent event",
+          log,
+          callback: () => params.onAgentEvent?.(event),
+        });
+      }
     }
     if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
       try {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.reasoning-delivery.test.ts
@@ -150,6 +150,75 @@ type AssistantMessageWithPhase = AssistantMessage & {
 };
 
 describe("subscribeEmbeddedAgentSession", () => {
+  it("projects commentary deltas into one cumulative keyed preamble", async () => {
+    const onAgentEvent = vi.fn();
+    const onBlockReply = vi.fn();
+    const onPartialReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onAgentEvent,
+      onBlockReply,
+      onPartialReply,
+    });
+    const commentaryMessage = {
+      role: "assistant",
+      api: "openai-responses",
+      content: [
+        {
+          type: "text",
+          text: "Checking files",
+          textSignature: JSON.stringify({ v: 1, id: "item-commentary", phase: "commentary" }),
+        },
+      ],
+    } as AssistantMessage;
+
+    emit({ type: "message_start", message: commentaryMessage });
+    emit({
+      type: "message_update",
+      message: commentaryMessage,
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "Checking ",
+        partial: commentaryMessage,
+      },
+    });
+    emit({
+      type: "message_update",
+      message: commentaryMessage,
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "files",
+        partial: commentaryMessage,
+      },
+    });
+    await subscription.waitForPendingEvents();
+
+    expect(onAgentEvent.mock.calls.map(([event]) => event)).toMatchObject([
+      {
+        stream: "item",
+        data: {
+          kind: "preamble",
+          itemId: "item-commentary",
+          phase: "update",
+          progressText: "Checking",
+        },
+      },
+      {
+        stream: "item",
+        data: {
+          kind: "preamble",
+          itemId: "item-commentary",
+          phase: "update",
+          progressText: "Checking files",
+        },
+      },
+    ]);
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onPartialReply).not.toHaveBeenCalled();
+  });
+
   it("suppresses commentary-phase assistant messages before tool use", () => {
     const onBlockReply = vi.fn();
     const onPartialReply = vi.fn();

--- a/src/agents/tools/embedded-gateway-stub.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.test.ts
@@ -239,6 +239,7 @@ describe("embedded gateway stub", () => {
     });
 
     expect(runtime.projectRecentChatDisplayMessages).toHaveBeenCalledWith(rawMessages, {
+      includeCommentaryFallbacks: true,
       maxChars: 100_000,
       maxMessages: 200,
     });
@@ -306,6 +307,7 @@ describe("embedded gateway stub", () => {
     });
 
     expect(runtime.projectRecentChatDisplayMessages).toHaveBeenCalledWith(rawMessages, {
+      includeCommentaryFallbacks: true,
       maxChars: 100_000,
       maxMessages: 1,
     });
@@ -366,6 +368,7 @@ describe("embedded gateway stub", () => {
       },
     );
     expect(runtime.projectChatDisplayMessages).toHaveBeenCalledWith(rawMessages.slice(0, 2), {
+      includeCommentaryFallbacks: true,
       maxChars: 100_000,
     });
     expect(result).toMatchObject({
@@ -403,6 +406,7 @@ describe("embedded gateway stub", () => {
     });
 
     expect(runtime.projectChatDisplayMessages).toHaveBeenCalledWith([rawMessages[1]], {
+      includeCommentaryFallbacks: true,
       maxChars: 100_000,
     });
     expect(result.messages).toEqual([projectedMessages[1]]);
@@ -438,6 +442,7 @@ describe("embedded gateway stub", () => {
 
     expect(runtime.dropPreSessionStartAnnouncePairs).toHaveBeenCalledWith(rawMessages, 1234);
     expect(runtime.projectChatDisplayMessages).toHaveBeenCalledWith(filteredMessages, {
+      includeCommentaryFallbacks: true,
       maxChars: 100_000,
     });
     expect(result.messages).toEqual(filteredMessages);
@@ -501,6 +506,7 @@ describe("embedded gateway stub", () => {
       },
     );
     expect(runtime.projectRecentChatDisplayMessages).toHaveBeenCalledWith(rawMessages, {
+      includeCommentaryFallbacks: true,
       maxChars: 100_000,
       maxMessages: 2,
     });
@@ -555,6 +561,7 @@ describe("embedded gateway stub", () => {
     });
 
     expect(runtime.projectRecentChatDisplayMessages).toHaveBeenCalledWith(rawMessages, {
+      includeCommentaryFallbacks: true,
       maxChars: 100_000,
       maxMessages: 2,
     });

--- a/src/agents/tools/embedded-gateway-stub.ts
+++ b/src/agents/tools/embedded-gateway-stub.ts
@@ -65,10 +65,13 @@ interface EmbeddedGatewayRuntime {
     messages: unknown[],
     sessionStartedAt: number | undefined,
   ) => unknown[];
-  projectChatDisplayMessages: (msgs: unknown[], opts?: { maxChars?: number }) => unknown[];
+  projectChatDisplayMessages: (
+    msgs: unknown[],
+    opts?: { includeCommentaryFallbacks?: boolean; maxChars?: number },
+  ) => unknown[];
   projectRecentChatDisplayMessages: (
     msgs: unknown[],
-    opts?: { maxChars?: number; maxMessages?: number },
+    opts?: { includeCommentaryFallbacks?: boolean; maxChars?: number; maxMessages?: number },
   ) => unknown[];
   capArrayByJsonBytes: (items: unknown[], maxBytes: number) => { items: unknown[] };
   listSessionsFromStoreAsync: (opts: {
@@ -428,15 +431,20 @@ async function handleChatHistory(params: Record<string, unknown>): Promise<{
   const projected =
     params.offset === undefined
       ? rt.projectRecentChatDisplayMessages(recencyFilteredMessages, {
+          includeCommentaryFallbacks: true,
           maxChars: effectiveMaxChars,
           maxMessages: max,
         })
       : offset === 0
         ? rt.projectRecentChatDisplayMessages(recencyFilteredMessages, {
+            includeCommentaryFallbacks: true,
             maxChars: effectiveMaxChars,
             maxMessages: max,
           })
-        : rt.projectChatDisplayMessages(recencyFilteredMessages, { maxChars: effectiveMaxChars });
+        : rt.projectChatDisplayMessages(recencyFilteredMessages, {
+            includeCommentaryFallbacks: true,
+            maxChars: effectiveMaxChars,
+          });
   const windowed =
     params.offset === undefined || offset === 0
       ? projected

--- a/src/auto-reply/reply/agent-runner-event-handler.ts
+++ b/src/auto-reply/reply/agent-runner-event-handler.ts
@@ -41,8 +41,6 @@ export function createAgentRunEventHandler(params: {
   onCompactionCompleted: () => number;
   messageToolDeliveryState: MessageToolDeliveryState;
 }): NonNullable<RunEmbeddedAgentParams["onAgentEvent"]> {
-  const commentaryTextByItem = new Map<string, string>();
-  const lastEmittedCommentaryByItem = new Map<string, string>();
   const shouldSuppressProgressAfterMessageToolDelivery = () =>
     params.sourceRepliesAreToolOnly &&
     params.messageToolDeliveryState.completed &&
@@ -151,33 +149,6 @@ export function createAgentRunEventHandler(params: {
       params.messageToolDeliveryState.completed = true;
     }
 
-    if (
-      evt.stream === "assistant" &&
-      readStringValue(evt.data.phase) === "commentary" &&
-      !shouldSuppressProgressAfterMessageToolDelivery()
-    ) {
-      const commentaryItemId = readStringValue(evt.data.itemId) ?? "";
-      const snapshotText = readStringValue(evt.data.text);
-      const deltaText = readStringValue(evt.data.delta);
-      const accumulated =
-        evt.data.replace === true && snapshotText
-          ? snapshotText
-          : deltaText
-            ? `${commentaryTextByItem.get(commentaryItemId) ?? ""}${deltaText}`
-            : (snapshotText ?? "");
-      commentaryTextByItem.set(commentaryItemId, accumulated);
-      const commentaryText = accumulated.replace(/\s+/g, " ").trim();
-      if (commentaryText && lastEmittedCommentaryByItem.get(commentaryItemId) !== commentaryText) {
-        lastEmittedCommentaryByItem.set(commentaryItemId, commentaryText);
-        await params.turn.opts?.onItemEvent?.({
-          itemId: commentaryItemId || undefined,
-          kind: "preamble",
-          title: "Preamble",
-          phase: "update",
-          progressText: commentaryText,
-        });
-      }
-    }
     if (
       evt.stream === "item" &&
       !hideItemFromChannelProgress &&

--- a/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
@@ -71,11 +71,12 @@ describe("executeAgentTurn: message tool progress", () => {
         },
       });
       await params.onAgentEvent?.({
-        stream: "assistant",
+        stream: "item",
         data: {
-          phase: "commentary",
+          kind: "preamble",
+          phase: "update",
           itemId: "commentary-1",
-          text: "This must stay suppressed.",
+          progressText: "This must stay suppressed.",
         },
       });
       releaseItemEvent?.();

--- a/src/auto-reply/reply/agent-runner-execution-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-progress.test.ts
@@ -78,7 +78,10 @@ describe("executeAgentTurn: lifecycle progress", () => {
       ).toBe(0);
 
       for (const event of [
-        { stream: "assistant", data: { phase: "commentary", text: "Working" } },
+        {
+          stream: "item",
+          data: { kind: "preamble", phase: "update", progressText: "Working" },
+        },
         { stream: "tool", data: { phase: "start", name: "read", toolCallId: "call-1" } },
         {
           stream: "tool",

--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -30,6 +30,7 @@ import type {
 } from "./current-user-profile-display.js";
 
 type ChatDisplayProjectionOptions = {
+  includeCommentaryFallbacks?: boolean;
   maxChars?: number;
   resolveCurrentUserProfileDisplay?: CurrentUserProfileDisplayResolver;
   stripEnvelope?: boolean;
@@ -314,7 +315,11 @@ export function projectChatDisplayMessagesWithState(
   const projectedErrors = projectEmptyAssistantErrorMessages(repairedStreamErrors.messages);
   const filtered = filterVisibleProjectedHistoryMessages(
     projectSessionsSendInterSessionMessages(
-      toProjectedMessages(sanitizeChatHistoryMessages(projectedErrors, Number.MAX_SAFE_INTEGER)),
+      toProjectedMessages(
+        sanitizeChatHistoryMessages(projectedErrors, Number.MAX_SAFE_INTEGER, {
+          includeCommentaryFallbacks: options?.includeCommentaryFallbacks,
+        }),
+      ),
     ),
     options?.turnBoundaryPending,
   );

--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -298,6 +298,7 @@ function projectAssistantCommentaryFallbacks(message: unknown, maxChars: number)
   ) {
     return [];
   }
+  const transcriptMeta = readRecord(entry["__openclaw"]);
   return entry.content.flatMap((block) => {
     const content = readRecord(block);
     if (!content) {
@@ -315,6 +316,16 @@ function projectAssistantCommentaryFallbacks(message: unknown, maxChars: number)
       return [];
     }
     const projected = truncateChatHistoryText(text, maxChars);
+    const projectedMeta = projected.truncated
+      ? {
+          ...transcriptMeta,
+          truncated: true,
+          reason:
+            typeof transcriptMeta?.reason === "string" ? transcriptMeta.reason : "display-cap",
+        }
+      : transcriptMeta
+        ? { ...transcriptMeta }
+        : undefined;
     return [
       {
         role: "assistant",
@@ -325,7 +336,7 @@ function projectAssistantCommentaryFallbacks(message: unknown, maxChars: number)
           source: "segment",
           itemId,
         },
-        ...(projected.truncated ? { __openclaw: { truncated: true, reason: "display-cap" } } : {}),
+        ...(projectedMeta ? { __openclaw: projectedMeta } : {}),
       },
     ];
   });

--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -659,6 +659,7 @@ export function shouldDropAssistantHistoryMessage(message: unknown): boolean {
 export function sanitizeChatHistoryMessages(
   messages: unknown[],
   maxChars: number = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+  opts?: { includeCommentaryFallbacks?: boolean },
 ): unknown[] {
   if (messages.length === 0) {
     return messages;
@@ -666,10 +667,12 @@ export function sanitizeChatHistoryMessages(
   let changed = false;
   const next: unknown[] = [];
   for (const message of messages) {
-    for (const commentary of projectAssistantCommentaryFallbacks(message, maxChars)) {
-      const projected = sanitizeChatHistoryMessage(commentary, maxChars);
-      next.push(projected.message);
-      changed = true;
+    if (opts?.includeCommentaryFallbacks === true) {
+      for (const commentary of projectAssistantCommentaryFallbacks(message, maxChars)) {
+        const projected = sanitizeChatHistoryMessage(commentary, maxChars);
+        next.push(projected.message);
+        changed = true;
+      }
     }
     if (shouldDropAssistantHistoryMessage(message)) {
       changed = true;

--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -261,9 +261,12 @@ function projectAssistantMixedToolContent(
     if (!block || typeof block !== "object") {
       continue;
     }
-    const entry = block as { type?: unknown; text?: unknown };
+    const entry = block as { type?: unknown; text?: unknown; textSignature?: unknown };
     if (!isAssistantTextContentType(entry.type)) {
       projectedContent.push(block);
+      continue;
+    }
+    if (parseAssistantTextSignature(entry)?.phase === "commentary") {
       continue;
     }
     if (typeof entry.text !== "string" || !entry.text.trim()) {
@@ -279,6 +282,53 @@ function projectAssistantMixedToolContent(
   // Mixed messages supply both the visible bubble and its reasoning/tool trace.
   // Keep structured siblings or a history reload loses activity shown while live.
   return hasVisibleText ? { content: projectedContent, changed: true } : null;
+}
+
+function projectAssistantCommentaryFallbacks(message: unknown, maxChars: number): unknown[] {
+  if (!message || typeof message !== "object") {
+    return [];
+  }
+  const entry = readRecord(message);
+  if (
+    !entry ||
+    entry.role !== "assistant" ||
+    !Array.isArray(entry.content) ||
+    entry.stopReason === "error" ||
+    typeof entry.errorMessage === "string"
+  ) {
+    return [];
+  }
+  return entry.content.flatMap((block) => {
+    const content = readRecord(block);
+    if (!content) {
+      return [];
+    }
+    const signature = parseAssistantTextSignature(content);
+    const text = typeof content.text === "string" ? content.text : "";
+    const itemId = signature?.id?.trim();
+    if (
+      !isAssistantTextContentType(content.type) ||
+      signature?.phase !== "commentary" ||
+      !itemId ||
+      !text.trim()
+    ) {
+      return [];
+    }
+    const projected = truncateChatHistoryText(text, maxChars);
+    return [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: projected.text }],
+        ...(typeof entry.timestamp === "number" ? { timestamp: entry.timestamp } : {}),
+        openclawStreamFallback: {
+          replacementText: projected.text,
+          source: "segment",
+          itemId,
+        },
+        ...(projected.truncated ? { __openclaw: { truncated: true, reason: "display-cap" } } : {}),
+      },
+    ];
+  });
 }
 
 function sanitizeCost(raw: unknown): Record<string, number> | undefined {
@@ -616,6 +666,11 @@ export function sanitizeChatHistoryMessages(
   let changed = false;
   const next: unknown[] = [];
   for (const message of messages) {
+    for (const commentary of projectAssistantCommentaryFallbacks(message, maxChars)) {
+      const projected = sanitizeChatHistoryMessage(commentary, maxChars);
+      next.push(projected.message);
+      changed = true;
+    }
     if (shouldDropAssistantHistoryMessage(message)) {
       changed = true;
       continue;

--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -459,6 +459,7 @@ export async function readChatHistoryPage(params: {
     const projected = isTailPage
       ? (incrementalTail?.projected ?? [])
       : projectChatDisplayMessages(recencyFilteredMessages, {
+          includeCommentaryFallbacks: true,
           maxChars: effectiveMaxChars,
           resolveCurrentUserProfileDisplay,
           turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
@@ -552,6 +553,7 @@ export async function readChatHistoryPage(params: {
       typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,
     );
     const displayMessages = projectChatDisplayMessages(mergedMessages, {
+      includeCommentaryFallbacks: true,
       maxChars: effectiveMaxChars,
       resolveCurrentUserProfileDisplay,
     });
@@ -571,6 +573,7 @@ export async function readChatHistoryPage(params: {
   // local messages; the filter is single-pass complete, so no second pass is needed.
   const recencyFilteredMessages = cliHistory.messages;
   const displayMessages = projectRecentChatDisplayMessages(recencyFilteredMessages, {
+    includeCommentaryFallbacks: true,
     maxChars: effectiveMaxChars,
     maxMessages: max,
     resolveCurrentUserProfileDisplay,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1027,7 +1027,7 @@ describe("sanitizeChatHistoryMessages", () => {
     ]);
   });
 
-  it("drops commentary-only assistant entries when phase exists only in textSignature", () => {
+  it("projects keyed commentary entries into durable preamble rows", () => {
     const result = sanitizeChatHistoryMessages([
       userHistoryMessage("hello", { timestamp: 1 }),
       {
@@ -1046,7 +1046,93 @@ describe("sanitizeChatHistoryMessages", () => {
 
     expect(result).toEqual([
       userHistoryMessage("hello", { timestamp: 1 }),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "thinking like caveman" }],
+        timestamp: 2,
+        openclawStreamFallback: {
+          replacementText: "thinking like caveman",
+          source: "segment",
+          itemId: "msg_commentary",
+        },
+      },
       assistantHistoryMessage("real reply", { timestamp: 3 }),
+    ]);
+  });
+
+  it("uses one capped text value for commentary content and fallback metadata", () => {
+    const fullText = "A long commentary message that must be capped";
+    const [fallback] = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: fullText,
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "msg_commentary",
+                phase: "commentary",
+              }),
+            },
+          ],
+          timestamp: 2,
+        },
+      ],
+      12,
+    ) as Array<{
+      content: Array<{ text: string }>;
+      openclawStreamFallback: { replacementText: string };
+    }>;
+
+    expect(fallback?.openclawStreamFallback.replacementText).toBe(fallback?.content[0]?.text);
+    expect(fallback?.openclawStreamFallback.replacementText).not.toBe(fullText);
+  });
+
+  it("splits commentary from final text and tool history", () => {
+    const toolCall = {
+      type: "toolCall",
+      id: "call-1",
+      name: "read",
+      arguments: { path: "README.md" },
+    };
+    const result = sanitizeChatHistoryMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Checking the file",
+            textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+          },
+          toolCall,
+          {
+            type: "text",
+            text: "Done.",
+            textSignature: JSON.stringify({ v: 1, id: "msg_final", phase: "final_answer" }),
+          },
+        ],
+        timestamp: 2,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Checking the file" }],
+        timestamp: 2,
+        openclawStreamFallback: {
+          replacementText: "Checking the file",
+          source: "segment",
+          itemId: "msg_commentary",
+        },
+      },
+      {
+        role: "assistant",
+        content: [toolCall, { type: "text", text: "Done." }],
+        timestamp: 2,
+      },
     ]);
   });
 });
@@ -1787,24 +1873,35 @@ describe("projectRecentChatDisplayMessages", () => {
       },
     ]);
 
-    expect(result[1]).toEqual({
-      role: "assistant",
-      content: [
-        { type: "thinking", thinking: "private reasoning" },
-        { type: "text", text: "I will clean that up now." },
-        {
-          type: "toolCall",
-          id: "call-read",
-          name: "read",
-          arguments: { path: "AGENTS.md" },
+    expect(result.slice(1, 3)).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I will clean that up now." }],
+        timestamp: 2,
+        openclawStreamFallback: {
+          replacementText: "I will clean that up now.",
+          source: "segment",
+          itemId: "msg-progress",
         },
-      ],
-      timestamp: 2,
-      __openclaw: { seq: 2 },
-    });
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "private reasoning" },
+          {
+            type: "toolCall",
+            id: "call-read",
+            name: "read",
+            arguments: { path: "AGENTS.md" },
+          },
+        ],
+        timestamp: 2,
+        __openclaw: { seq: 2 },
+      },
+    ]);
   });
 
-  it("keeps pure commentary assistant messages hidden", () => {
+  it("projects pure keyed commentary as a durable preamble", () => {
     const result = projectRecentChatDisplayMessages([
       userHistoryMessage("status", { timestamp: 1 }),
       {
@@ -1824,7 +1921,19 @@ describe("projectRecentChatDisplayMessages", () => {
       },
     ]);
 
-    expect(result).toEqual([userHistoryMessage("status", { timestamp: 1 })]);
+    expect(result).toEqual([
+      userHistoryMessage("status", { timestamp: 1 }),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Working..." }],
+        timestamp: 2,
+        openclawStreamFallback: {
+          replacementText: "Working...",
+          source: "segment",
+          itemId: "msg-commentary",
+        },
+      },
+    ]);
   });
 
   it("drops duplicate ACP gateway-injected assistant replies from chat history", () => {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1890,6 +1890,7 @@ describe("projectRecentChatDisplayMessages", () => {
         role: "assistant",
         content: [{ type: "text", text: "I will clean that up now." }],
         timestamp: 2,
+        __openclaw: { seq: 2 },
         openclawStreamFallback: {
           replacementText: "I will clean that up now.",
           source: "segment",

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1028,21 +1028,25 @@ describe("sanitizeChatHistoryMessages", () => {
   });
 
   it("projects keyed commentary entries into durable preamble rows", () => {
-    const result = sanitizeChatHistoryMessages([
-      userHistoryMessage("hello", { timestamp: 1 }),
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "thinking like caveman",
-            textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
-          },
-        ],
-        timestamp: 2,
-      },
-      assistantHistoryMessage("real reply", { timestamp: 3 }),
-    ]);
+    const result = sanitizeChatHistoryMessages(
+      [
+        userHistoryMessage("hello", { timestamp: 1 }),
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "thinking like caveman",
+              textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+            },
+          ],
+          timestamp: 2,
+        },
+        assistantHistoryMessage("real reply", { timestamp: 3 }),
+      ],
+      undefined,
+      { includeCommentaryFallbacks: true },
+    );
 
     expect(result).toEqual([
       userHistoryMessage("hello", { timestamp: 1 }),
@@ -1081,6 +1085,7 @@ describe("sanitizeChatHistoryMessages", () => {
         },
       ],
       12,
+      { includeCommentaryFallbacks: true },
     ) as Array<{
       content: Array<{ text: string }>;
       openclawStreamFallback: { replacementText: string };
@@ -1097,25 +1102,29 @@ describe("sanitizeChatHistoryMessages", () => {
       name: "read",
       arguments: { path: "README.md" },
     };
-    const result = sanitizeChatHistoryMessages([
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "Checking the file",
-            textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
-          },
-          toolCall,
-          {
-            type: "text",
-            text: "Done.",
-            textSignature: JSON.stringify({ v: 1, id: "msg_final", phase: "final_answer" }),
-          },
-        ],
-        timestamp: 2,
-      },
-    ]);
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Checking the file",
+              textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+            },
+            toolCall,
+            {
+              type: "text",
+              text: "Done.",
+              textSignature: JSON.stringify({ v: 1, id: "msg_final", phase: "final_answer" }),
+            },
+          ],
+          timestamp: 2,
+        },
+      ],
+      undefined,
+      { includeCommentaryFallbacks: true },
+    );
 
     expect(result).toEqual([
       {
@@ -1839,39 +1848,42 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("preserves structured trace alongside visible assistant progress text", () => {
-    const result = projectRecentChatDisplayMessages([
-      userHistoryMessage("fix it", { timestamp: 1 }),
-      {
-        role: "assistant",
-        content: [
-          { type: "thinking", thinking: "private reasoning" },
-          {
-            type: "text",
-            text: "I will clean that up now.",
-            textSignature: JSON.stringify({
-              v: 1,
-              id: "msg-progress",
-              phase: "commentary",
-            }),
-          },
-          {
-            type: "toolCall",
-            id: "call-read",
-            name: "read",
-            arguments: { path: "AGENTS.md" },
-          },
-        ],
-        timestamp: 2,
-        __openclaw: { seq: 2 },
-      },
-      {
-        role: "toolResult",
-        toolCallId: "call-read",
-        toolName: "read",
-        content: [{ type: "text", text: "file contents" }],
-        timestamp: 3,
-      },
-    ]);
+    const result = projectRecentChatDisplayMessages(
+      [
+        userHistoryMessage("fix it", { timestamp: 1 }),
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "private reasoning" },
+            {
+              type: "text",
+              text: "I will clean that up now.",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "msg-progress",
+                phase: "commentary",
+              }),
+            },
+            {
+              type: "toolCall",
+              id: "call-read",
+              name: "read",
+              arguments: { path: "AGENTS.md" },
+            },
+          ],
+          timestamp: 2,
+          __openclaw: { seq: 2 },
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-read",
+          toolName: "read",
+          content: [{ type: "text", text: "file contents" }],
+          timestamp: 3,
+        },
+      ],
+      { includeCommentaryFallbacks: true },
+    );
 
     expect(result.slice(1, 3)).toEqual([
       {
@@ -1902,24 +1914,27 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("projects pure keyed commentary as a durable preamble", () => {
-    const result = projectRecentChatDisplayMessages([
-      userHistoryMessage("status", { timestamp: 1 }),
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "Working...",
-            textSignature: JSON.stringify({
-              v: 1,
-              id: "msg-commentary",
-              phase: "commentary",
-            }),
-          },
-        ],
-        timestamp: 2,
-      },
-    ]);
+    const result = projectRecentChatDisplayMessages(
+      [
+        userHistoryMessage("status", { timestamp: 1 }),
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Working...",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "msg-commentary",
+                phase: "commentary",
+              }),
+            },
+          ],
+          timestamp: 2,
+        },
+      ],
+      { includeCommentaryFallbacks: true },
+    );
 
     expect(result).toEqual([
       userHistoryMessage("status", { timestamp: 1 }),

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -6336,15 +6336,23 @@ describe("gateway server chat", () => {
       ]);
 
       const messages = await fetchHistoryMessages(ws);
-      const assistantMessage = messages[1] as {
+      const assistantMessage = messages[2] as {
         role?: string;
         content?: Array<{ type?: string; text?: string }>;
         timestamp?: number;
       };
       expect(assistantMessage.role).toBe("assistant");
+      expect(messages[1]).toMatchObject({
+        role: "assistant",
+        content: [{ type: "text", text: "I will clean that up now." }],
+        openclawStreamFallback: {
+          replacementText: "I will clean that up now.",
+          source: "segment",
+          itemId: "msg-progress",
+        },
+      });
       expect(assistantMessage.content).toEqual([
         { type: "thinking", thinking: "private reasoning" },
-        { type: "text", text: "I will clean that up now." },
         {
           type: "toolCall",
           id: "call-read",

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -384,6 +384,50 @@ describe("SessionHistorySseState", () => {
     expect(oldest.nextCursor).toBeUndefined();
   });
 
+  test("keeps commentary fallback rows reachable across cursor pages and SSE state", () => {
+    const rawMessages = [
+      userTextMessage("check the workspace", 1),
+      {
+        role: "assistant" as const,
+        content: [
+          {
+            type: "text" as const,
+            text: "Checking the workspace before answering.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "msg_commentary",
+              phase: "commentary",
+            }),
+          },
+        ],
+        __openclaw: { seq: 2 },
+      },
+      assistantTextMessage("Done.", 3),
+    ];
+
+    const newest = buildSessionHistorySnapshot({ rawMessages, limit: 1 }).history;
+    expect(newest.nextCursor).toBe("3");
+
+    const middle = newState(rawMessages, { limit: 1, cursor: newest.nextCursor }).snapshot();
+    expect(middle.hasMore).toBe(true);
+    expect(middle.nextCursor).toBe("2");
+    expect(middle.messages).toMatchObject([
+      {
+        content: [{ text: "Checking the workspace before answering." }],
+        openclawStreamFallback: { itemId: "msg_commentary" },
+        __openclaw: { seq: 2 },
+      },
+    ]);
+
+    const oldest = buildSessionHistorySnapshot({
+      rawMessages,
+      limit: 1,
+      cursor: middle.nextCursor,
+    }).history;
+    expect(oldest.messages).toEqual([userTextMessage("check the workspace", 1)]);
+    expect(oldest.hasMore).toBe(false);
+  });
+
   test("does not coerce partial cursor values", () => {
     const snapshot = buildSessionHistorySnapshot({
       rawMessages: [assistantTextMessage("first", 1), assistantTextMessage("second", 2)],

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -184,6 +184,7 @@ export function buildSessionHistorySnapshot(params: {
   totalRawMessages?: number;
 }): SessionHistorySnapshot {
   const projected = projectChatDisplayMessagesWithState(params.rawMessages, {
+    includeCommentaryFallbacks: true,
     maxChars: params.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
     resolveCurrentUserProfileDisplay,
   });
@@ -320,6 +321,7 @@ export class SessionHistorySseState {
     });
     const hadPendingTurnBoundary = this.turnBoundaryPending;
     const nextProjection = projectChatDisplayMessagesWithState([nextMessage], {
+      includeCommentaryFallbacks: true,
       maxChars: this.maxChars,
       turnBoundaryPending: hadPendingTurnBoundary,
       streamErrorFallbackPending: this.streamErrorFallbackPending,
@@ -337,6 +339,7 @@ export class SessionHistorySseState {
     // emitting a misleading single SSE item.
     const projectedMessages = toSessionHistoryMessages(
       projectChatDisplayMessages([...this.sentHistory.messages, nextMessage], {
+        includeCommentaryFallbacks: true,
         maxChars: this.maxChars,
         resolveCurrentUserProfileDisplay,
       }),

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -1449,13 +1449,22 @@ describe("session history HTTP endpoints", () => {
         sessionKey?: string;
         messages?: Array<{
           content?: Array<{ text?: string }>;
+          openclawStreamFallback?: { itemId?: string; replacementText?: string; source?: string };
           __openclaw?: { id?: string; seq?: number };
         }>;
       };
       expect(body.sessionKey).toBe("agent:main:main");
-      expect(body.messages).toHaveLength(1);
-      expect(body.messages?.[0]?.content?.[0]?.text).toBe("Done.");
-      expectOpenClawMetadata(body.messages?.[0]?.["__openclaw"], {
+      expect(body.messages).toHaveLength(2);
+      expect(body.messages?.[0]).toMatchObject({
+        content: [{ type: "text", text: "internal reasoning" }],
+        openclawStreamFallback: {
+          itemId: "item_commentary",
+          replacementText: "internal reasoning",
+          source: "segment",
+        },
+      });
+      expect(body.messages?.[1]?.content?.[0]?.text).toBe("Done.");
+      expectOpenClawMetadata(body.messages?.[1]?.["__openclaw"], {
         id: visibleMessageId,
         seq: 2,
       });


### PR DESCRIPTION
## Problem

Native phased commentary was emitted as assistant events, while Control UI progress consumes keyed preamble items. Tool calls appeared, but commentary around them disappeared live and after history reload.

## Root cause

Commentary had consumer-specific representations instead of one presentation contract. Gateway history also removed commentary before the UI could reconcile it. The first history fallback implementation then omitted transcript sequence metadata, which could strand older cursor pages.

## Fix

- Normalize native commentary once into cumulative keyed preamble items at embedded reply delivery.
- Route channels and Control UI through the existing item path; remove the channel-only adapter.
- Project keyed commentary into bounded chat-history fallbacks while preserving source transcript metadata and structured trace.
- Keep exact phased transcript content for model replay and prompt-context consumers.

This exposes explicit provider commentary/preambles, not hidden chain-of-thought.

## Proof

Exact head: `68ce4369635f7b19d1e250b526ab5171bf2c97b3`

- owner regression without the metadata fix: `hasMore: true`, `nextCursor: undefined`
- same regression with the fix: cursor `2`; older page reachable
- `pnpm check:changed`
- production tsgo + `pnpm check:test-types`
- 499 Gateway tests
- 4 cron prompt-context tests
- 25 auto-reply tests
- 41 embedded-agent tests
- 21 embedded-Gateway tests
- 4 Control UI E2E tests; exact-head [before/after screenshots](https://github.com/openclaw/openclaw/pull/128793#issuecomment-5399042361)
- `$distill`: one normalized metadata representation; no extra compatibility path
- `$greybeard`: bounded linear projection scan; no new I/O or repeated transcript scan

Production LOC: +134/-56, net +78. Growth owns the missing generic live/history presentation contract and transcript identity; the channel-only adapter was removed. Tests: +374/-72.

## Exact-head review

ClawSweeper local review: PASS — patch correct; 0 findings; 0 security concerns; no maintainer decision; 0 Rank-up moves.

## Telegram proof

Final exact-head real-user DM used the deterministic two-turn OpenAI commentary fixture with progress commentary enabled.

- 2 provider requests
- 4 typing events
- temporary progress showed `Working`, `Checking the workspace before answering.`, and `Exec blocked`
- persistent final contained `OPENCLAW_E2E_DRAFTPROOF`
- temporary progress was deleted after final delivery; no intermediate Telegram edit was observed

This exercises the changed embedded commentary normalization and generic item-delivery path. Commentary is user-visible before the final answer; no temporary draft remains.

Overlap checked: #102182 and #117951 touch nearby Gateway owners but address assistant terminal gating and media payloads, not commentary projection.
