### PR TITLE
fix(ai): preserve root properties when flattening root-level anyOf tool schemas

### DIFF
--- a/packages/ai/src/providers/agent-tools-parameter-schema.ts
+++ b/packages/ai/src/providers/agent-tools-parameter-schema.ts
@@ -892,7 +892,15 @@ function normalizeToolParameterSchemaUncached(
     return applyProviderCleaning(inlinedSchema);
   }
   const variants = schemaRecord[flattenableVariantKey] as unknown[];
-  const mergedProperties: Record<string, unknown> = {};
+  // Seed mergedProperties with the root-declared properties so branch properties
+  // merge *into* them instead of replacing them. Otherwise a root `required`
+  // field that is not re-declared in any branch would be dropped from
+  // `properties` while staying `required`, producing an unsatisfiable schema
+  // when `additionalProperties` is false (#128743).
+  const rootProperties = isSchemaRecord(schemaRecord.properties)
+    ? { ...schemaRecord.properties }
+    : {};
+  const mergedProperties: Record<string, unknown> = rootProperties;
   const requiredCounts = new Map<string, number>();
   let objectVariants = 0;
 

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -913,4 +913,56 @@ describe("createBundleMcpToolRuntime", () => {
       }),
     ).toEqual({ parent: { page_id: "page-id" } });
   });
+
+  it("keeps root fields callable when an MCP input schema uses a root union (#128743)", async () => {
+    const inputSchema = {
+      type: "object",
+      title: "MessagesReplyInput",
+      additionalProperties: false,
+      required: ["thread_id"],
+      properties: {
+        thread_id: { type: "string", minLength: 1, maxLength: 128 },
+        body: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+        body_file: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+        task_id: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+        turn_grant_id: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+      },
+      anyOf: [
+        { required: ["body"], properties: { body: { type: "string" } } },
+        { required: ["body_file"], properties: { body_file: { type: "string" } } },
+      ],
+    };
+    const runtime = await materializeBundleMcpToolsForRun({
+      runtime: makeToolRuntime({
+        serverName: "aihub",
+        tools: [
+          {
+            serverName: "aihub",
+            safeServerName: "aihub",
+            toolName: "messages_reply",
+            inputSchema,
+            fallbackDescription: "Reply to a message",
+          },
+        ],
+      }),
+    });
+    const tool = expectDefined(runtime.tools[0], "runtime.tools[0] test invariant");
+
+    expect(() =>
+      validateToolArguments(tool, {
+        type: "toolCall",
+        id: "call-inline-body",
+        name: tool.name,
+        arguments: { thread_id: "thread-1", body: "hello" },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateToolArguments(tool, {
+        type: "toolCall",
+        id: "call-body-file",
+        name: tool.name,
+        arguments: { thread_id: "thread-1", body_file: "/tmp/body.md" },
+      }),
+    ).not.toThrow();
+  });
 });

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -958,45 +958,57 @@ describe("normalizeToolParameterSchema", () => {
     expect(count?.oneOf).toBeUndefined();
   });
 
-  // Regression for #128743: a root-level anyOf whose branches carry their own
+  // Regression for #128743: a root-level union whose branches carry their own
   // properties must not replace the root properties. Root `required` entries
   // (e.g. thread_id) must remain declared in `properties`, otherwise the schema
   // becomes unsatisfiable when `additionalProperties` is false.
-  it("preserves root properties when flattening a root-level anyOf (#128743)", () => {
-    const schema = {
-      type: "object",
-      title: "MessagesReplyInput",
-      additionalProperties: false,
-      required: ["thread_id"],
-      properties: {
-        thread_id: { type: "string", minLength: 1, maxLength: 128 },
-        body: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
-        body_file: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
-        task_id: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
-        turn_grant_id: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
-      },
-      anyOf: [
-        { required: ["body"], properties: { body: { type: "string" } } },
-        { required: ["body_file"], properties: { body_file: { type: "string" } } },
-      ],
-    } as Record<string, unknown>;
+  it.each(["anyOf", "oneOf"] as const)(
+    "preserves root properties and constraints when flattening root-level %s (#128743)",
+    (unionKey) => {
+      const schema = {
+        type: "object",
+        title: "MessagesReplyInput",
+        additionalProperties: false,
+        required: ["thread_id"],
+        properties: {
+          thread_id: { type: "string", minLength: 1, maxLength: 128 },
+          body: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+          body_file: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+          task_id: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+          turn_grant_id: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+        },
+        [unionKey]: [
+          { required: ["body"], properties: { body: { type: "string" } } },
+          { required: ["body_file"], properties: { body_file: { type: "string" } } },
+        ],
+      } as Record<string, unknown>;
 
-    const normalized = normalizeToolParameterSchema(schema) as Record<string, unknown>;
-    const properties = (normalized.properties as Record<string, unknown>) ?? {};
-    const required = (normalized.required as string[] | undefined) ?? [];
+      const normalized = normalizeToolParameterSchema(schema) as Record<string, unknown>;
+      const properties = (normalized.properties as Record<string, unknown>) ?? {};
+      const required = (normalized.required as string[] | undefined) ?? [];
 
-    // The root composition keyword is flattened for portability, but the root
-    // declared properties must survive the merge.
-    expect(Object.keys(properties)).toEqual(
-      expect.arrayContaining(["thread_id", "body", "body_file", "task_id", "turn_grant_id"]),
-    );
-    expect(normalized.additionalProperties).toBe(false);
-    // Every required field must be a declared property, otherwise the schema is
-    // unsatisfiable by construction (required + additionalProperties:false).
-    for (const field of required) {
-      expect(Object.hasOwn(properties, field)).toBe(true);
-    }
-  });
+      // The root composition keyword is flattened for portability, but the root
+      // declared properties must survive the merge.
+      expect(Object.keys(properties)).toEqual(
+        expect.arrayContaining(["thread_id", "body", "body_file", "task_id", "turn_grant_id"]),
+      );
+      expect(normalized.additionalProperties).toBe(false);
+      // Every required field must be a declared property, otherwise the schema is
+      // unsatisfiable by construction (required + additionalProperties:false).
+      for (const field of required) {
+        expect(Object.hasOwn(properties, field)).toBe(true);
+      }
+      expect(properties.thread_id).toEqual({ type: "string", minLength: 1, maxLength: 128 });
+      expect(properties.body).toEqual({
+        anyOf: [{ type: "string" }, { type: "null" }],
+        default: null,
+      });
+      expect(properties.body_file).toEqual({
+        anyOf: [{ type: "string" }, { type: "null" }],
+        default: null,
+      });
+    },
+  );
 });
 
 function makeTool(parameters: TSchema): AnyAgentTool {

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -957,6 +957,46 @@ describe("normalizeToolParameterSchema", () => {
     expect(parentId?.anyOf).toBeUndefined();
     expect(count?.oneOf).toBeUndefined();
   });
+
+  // Regression for #128743: a root-level anyOf whose branches carry their own
+  // properties must not replace the root properties. Root `required` entries
+  // (e.g. thread_id) must remain declared in `properties`, otherwise the schema
+  // becomes unsatisfiable when `additionalProperties` is false.
+  it("preserves root properties when flattening a root-level anyOf (#128743)", () => {
+    const schema = {
+      type: "object",
+      title: "MessagesReplyInput",
+      additionalProperties: false,
+      required: ["thread_id"],
+      properties: {
+        thread_id: { type: "string", minLength: 1, maxLength: 128 },
+        body: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+        body_file: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+        task_id: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+        turn_grant_id: { anyOf: [{ type: "string" }, { type: "null" }], default: null },
+      },
+      anyOf: [
+        { required: ["body"], properties: { body: { type: "string" } } },
+        { required: ["body_file"], properties: { body_file: { type: "string" } } },
+      ],
+    } as Record<string, unknown>;
+
+    const normalized = normalizeToolParameterSchema(schema) as Record<string, unknown>;
+    const properties = (normalized.properties as Record<string, unknown>) ?? {};
+    const required = (normalized.required as string[] | undefined) ?? [];
+
+    // The root composition keyword is flattened for portability, but the root
+    // declared properties must survive the merge.
+    expect(Object.keys(properties)).toEqual(
+      expect.arrayContaining(["thread_id", "body", "body_file", "task_id", "turn_grant_id"]),
+    );
+    expect(normalized.additionalProperties).toBe(false);
+    // Every required field must be a declared property, otherwise the schema is
+    // unsatisfiable by construction (required + additionalProperties:false).
+    for (const field of required) {
+      expect(Object.hasOwn(properties, field)).toBe(true);
+    }
+  });
 });
 
 function makeTool(parameters: TSchema): AnyAgentTool {


### PR DESCRIPTION
> **AI-assisted: yes**

## Summary

- **What problem does this PR solve?** When an MCP server publishes a tool whose `inputSchema` has a root-level `anyOf` (or `oneOf`) as a sibling of `properties`, OpenClaw's tool-parameter normaliser replaced the root `properties` with the unioned branch properties, dropped the composition keyword, but kept the root `required` and `additionalProperties: false`. A root `required` field that no branch re-declares (e.g. `thread_id`) then became simultaneously `required` and forbidden (absent from `properties` under `additionalProperties: false`) — an unsatisfiable schema, so the tool was silently uncallable for the whole session and every call was rejected locally before reaching the MCP server.
- **Why does this matter now?** Reported in #128743: five tools from `aihub-mcp-client` were silently broken session-long; the model exhausted the argument matrix before concluding the schema was contradictory.
- **What is the intended outcome?** Branch properties merge *into* the existing root `properties` instead of replacing them, so every root `required` entry stays declared in `properties` and the flattened schema remains satisfiable.
- **What is intentionally out of scope?** No change to provider-specific projection (Gemini/OpenAI/Anthropic cleaning), no change to validator selection, no preservation of the root composition keyword (portability flattening is kept).
- **What does success look like?** For the reported schema, the normalised output keeps all root properties (`thread_id`, `body`, `body_file`, `task_id`, `turn_grant_id`), keeps `required: ["thread_id"]` + `additionalProperties: false`, and every `required` field is present in `properties` (schema satisfiable).
- **What should reviewers focus on?** `packages/ai/src/providers/agent-tools-parameter-schema.ts` — the one-line seeding of `mergedProperties` from root `properties`; regression test `preserves root properties when flattening a root-level anyOf (#128743)` in `src/agents/agent-tools.schema.test.ts`.

## Linked context

- **Which issue does this close?** Closes #128743
- **Related issues or PRs:** None
- **Was this requested by a maintainer or labeled with a fix signal?** Issue carries `clawsweeper:queueable-fix`, `clawsweeper:fix-shape-clear`, `clawsweeper:source-repro`, `P1`; reporter's "Suggested handling" matches this approach ("merging branch properties into the existing root properties instead of replacing them").

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Root-level `anyOf` flattening dropped root `properties`, making the normalised schema unsatisfiable for any tool whose root `required` field is not re-declared in a branch.
- **Real environment tested:** Isolated worktree `aispace/worktrees/issue-128743` on branch `feat/issue-128743-mcp-anyof-schema-normalise` (Node v26.7.0); `normalizeToolParameterSchema` invoked directly on the verbatim schema from the issue.
- **Exact steps or command run after this patch:**
  ```bash
  # Regression test (covers the reported schema end-to-end through the normaliser)
  npx vitest run src/agents/agent-tools.schema.test.ts
  # Related anyOf/normaliser suites
  npx vitest run src/agents/schema/clean-for-xai.test.ts src/agents/tools/cron-tool.schema.test.ts packages/ai/src/providers/openai-tool-schema.test.ts packages/ai/src/providers/google-shared.convert.test.ts
  # Type checks
  pnpm tsgo:core
  node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.agents-root.json --builders 1
  ```
- **Evidence after fix:**
  ```json
  {"type":"object","title":"MessagesReplyInput","properties":{"thread_id":{"type":"string","minLength":1,"maxLength":128},"body":{"anyOf":[{"type":"string"},{"type":"null"}],"default":null},"body_file":{"anyOf":[{"type":"string"},{"type":"null"}],"default":null},"task_id":{"anyOf":[{"type":"string"},{"type":"null"}],"default":null},"turn_grant_id":{"anyOf":[{"type":"string"},{"type":"null"}],"default":null}},"required":["thread_id"],"additionalProperties":false}
  PROPERTIES_KEYS: ["thread_id","body","body_file","task_id","turn_grant_id"]
  REQUIRED: ["thread_id"]
  ADDITIONAL_PROPERTIES: false
  REQUIRED_MISSING_FROM_PROPERTIES: []
  SCHEMA_SATISFIABLE: true
  ```
- **Observed result after fix:** Normalised schema retains all five root properties; `thread_id` is both `required` and declared in `properties`; `additionalProperties: false` no longer forbids the required field; schema is satisfiable.
- **What was not tested:** No live MCP server round-trip in this environment (the failure is fully reproducible at the pure deterministic normaliser level using the verbatim published schema, so unit-level L2 proof is sufficient; a live `aihub-mcp-client` registration would exercise the same code path but requires external API credentials).
- **Before evidence (optional but encouraged):** Same input on `origin/main`: `PROPERTIES_KEYS: ["body","body_file"]`, `REQUIRED_MISSING_FROM_PROPERTIES: ["thread_id"]`, `SCHEMA_SATISFIABLE: false` — `thread_id` was required yet absent from `properties` under `additionalProperties: false`.

## Tests and validation

- **Which commands did you run?**
  ```bash
  npx vitest run src/agents/agent-tools.schema.test.ts                       # 136 passed
  npx vitest run src/agents/schema/clean-for-xai.test.ts src/agents/tools/cron-tool.schema.test.ts packages/ai/src/providers/openai-tool-schema.test.ts packages/ai/src/providers/google-shared.convert.test.ts  # 75 passed
  pnpm tsgo:core                                                            # production type check, pass
  node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.agents-root.json --builders 1  # test type check, pass
  ```
- **What regression coverage was added or updated?** `src/agents/agent-tools.schema.test.ts` → `normalizeToolParameterSchema > preserves root properties when flattening a root-level anyOf (#128743)`: feeds the verbatim issue schema, asserts all five root properties survive, `additionalProperties` stays `false`, and every `required` field is a declared property.
- **What failed before this fix, if known?** The new regression test failed on `origin/main`: `expected ['body','body_file'] to deeply equal ArrayContaining […, 'thread_id', …, 'task_id', 'turn_grant_id']`.
- **If no test was added, why not?** N/A — regression test added.

## Risk checklist

- **Did user-visible behavior change?** Yes — MCP tools publishing a root-level `anyOf`/`oneOf` alongside root `properties` now produce a satisfiable model-facing schema instead of an unsatisfiable one (the broken tools become callable).
- **Did config, environment, or migration behavior change?** No
- **Did security, auth, secrets, network, or tool execution behavior change?** No
- **What is the highest-risk area?** The root-level union flattening branch also serves Gemini/OpenAI portability; seeding root properties could, in principle, widen the declared properties for schemas that previously relied on root-property replacement. `mergePropertySchemas` keeps the existing (root) value when a branch re-declares a property without an enum, so root definitions are preserved, not widened.
- **How is that risk mitigated?** Narrow one-line change; all 136 existing normaliser tests + 75 related anyOf/provider-schema tests pass unchanged; the new test pins the satisfiability invariant.

## Current review state

- **What is the next action?** Maintainer review; CI.
- **What is still waiting on author, maintainer, CI, or external proof?** CI; maintainer verdict. Branch is based on a recent `main` commit (a few commits behind tip); no file overlap with tip changes — GitHub reports no conflict.
- **Which bot or reviewer comments were addressed?** None yet.
