### PR TITLE
fix(codex): restore GitHub tools in Codex sessions

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -11,6 +11,7 @@ import {
   wrapToolWithBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { readMemoryArtifactProvenance } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { createAgentHarnessHostCapabilitiesForTest } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { dynamicToolBuildState } from "./dynamic-tool-build-state.js";
 import {
@@ -749,6 +750,58 @@ describe("Codex app-server dynamic tool build", () => {
       (receivedOptions?.webFetchHostnameAllowlistRef as { value?: string[] } | undefined)?.value,
     ).toBeUndefined();
   });
+
+  it.each([
+    {
+      name: "publication capability is unavailable",
+      githubPublicationAvailable: undefined,
+      profile: "coding",
+      expectedTools: [],
+    },
+    {
+      name: "publication is unavailable for a prepared session",
+      githubPublicationAvailable: false,
+      profile: "coding",
+      expectedTools: ["github_identity_status"],
+    },
+    {
+      name: "publication is available for a prepared session",
+      githubPublicationAvailable: true,
+      profile: "coding",
+      expectedTools: ["github_identity_status", "github_publish"],
+    },
+    {
+      name: "the active profile excludes coding tools",
+      githubPublicationAvailable: true,
+      profile: "messaging",
+      expectedTools: [],
+    },
+  ] as const)(
+    "exposes prepared GitHub tools when $name",
+    async ({ githubPublicationAvailable, profile, expectedTools }) => {
+      const workspaceDir = path.join(tempDir, "workspace");
+      const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+      params.disableTools = false;
+      params.githubPublicationAvailable = githubPublicationAvailable;
+      params.config = { tools: { profile } };
+      params.runtimePlan = createCodexRuntimePlanFixture();
+      const { hostCapabilities: _hostCapabilities, ...attempt } = params;
+      const host = await createAgentHarnessHostCapabilitiesForTest({ attempt, pluginId: "codex" });
+      params.hostCapabilities = host.capabilities;
+
+      try {
+        const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+          sandbox: null as never,
+        });
+
+        expect(tools.map((tool) => tool.name).filter((name) => name.startsWith("github_"))).toEqual(
+          expectedTools,
+        );
+      } finally {
+        host.close();
+      }
+    },
+  );
 
   it("forwards client caps alongside channel authority context", async () => {
     // Regression: capability-gated tools (requiredClientCaps) vanished on the

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -345,6 +345,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
               resolvedWorkspace: input.resolvedWorkspace,
             }),
       config: params.config,
+      githubPublicationAvailable: params.githubPublicationAvailable,
       authProfileStore: params.toolAuthProfileStore ?? params.authProfileStore,
       abortSignal: input.runAbortController.signal,
       emitBeforeToolCallDiagnostics: false,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents using the Codex runtime could not inspect or use their prepared GitHub identity because the runtime omitted both `github_identity_status` and `github_publish` from the host tool surface.

A fresh RoboClaw run on Team reproduced the problem: its managed `roboclaw-bot` OAuth identity verified successfully in Settings, but the agent reported that the identity-status tool was unavailable.

## Why This Change Was Made

The Gateway already prepares one bounded `githubPublicationAvailable` fact for the admitted run. This change carries that fact through the Codex host-tool construction boundary, matching the embedded runtime instead of rediscovering identity or workspace state.

The existing semantics remain intact: an unprepared run exposes neither GitHub tool, a prepared but non-publishable run exposes status only, and a publishable run exposes status plus publication. Normal tool-profile policy still applies.

## User Impact

RoboClaw and other Codex-runtime agents can verify their effective managed GitHub account. Sessions with an eligible reconciled workspace can also request Gateway-owned GitHub publication, while cloud workers remain credential-free.

## Evidence

- Pre-fix focused regression: 2 failed and 2 passed because the Codex path omitted the prepared GitHub tools.
- Post-fix focused regression: 4 passed.
- Full `extensions/codex/src/app-server/dynamic-tool-build.test.ts`: 91 passed.
- Changed checks for the two touched files: passed.
- `pnpm build`: passed. Two pre-existing Control UI ineffective-dynamic-import warnings remain unrelated.
- Structured autoreview at P1 breadth: clean, 0.98 confidence.
- Production LOC: +1/-0. Tests: +53/-0.

AI-assisted; the implementation and proof were reviewed by the maintainer.
