### PR TITLE
fix(terminal): wait for login-shell readiness before initial command

### DIFF
--- a/src/agents/tools/terminal-tool.test.ts
+++ b/src/agents/tools/terminal-tool.test.ts
@@ -40,7 +40,20 @@ function makeBackend() {
     writes: [],
     resizes: [],
     killed: false,
-    write: (data) => backend.writes.push(data),
+    write: (data) => {
+      backend.writes.push(data);
+      // Simulate a real login shell: echo the raw input line (which contains
+      // the marker as a substring but NOT at line start), then emit the
+      // standalone marker line printf produces after executing. The probe must
+      // only resolve on the standalone line, not the input echo (#128696).
+      const match = data.match(/^printf '%s\\n' '(__OC_SHELL_READY__:[0-9a-f]+)'\r$/);
+      if (match) {
+        queueMicrotask(() => {
+          onData?.(data.replace(/\r$/, "\r\n"));
+          onData?.(`${match[1]}\n`);
+        });
+      }
+    },
     resize: (cols, rows) => backend.resizes.push([cols, rows]),
     pause: vi.fn(),
     resume: vi.fn(),
@@ -76,8 +89,8 @@ function makeContext(manager: TerminalSessionManager) {
       plan: {
         agentId: "main",
         cwd: "/tmp",
-        shell: "/bin/sh",
-        args: [],
+        shell: "/bin/bash",
+        args: ["-l"],
       },
     }),
   };
@@ -295,7 +308,9 @@ describe("terminal tool", () => {
     const opened = await tool.execute("open", { action: "open", command: "echo ready" });
     expect(Value.Check(tool.outputSchema!, opened.details)).toBe(true);
     const sessionId = (opened.details as { sessionId: string }).sessionId;
-    expect(backend.writes).toEqual(["echo ready\r"]);
+    // The readiness probe is written first, then the real initial command.
+    expect(backend.writes[0]).toMatch(/^printf '%s\\n' '__OC_SHELL_READY__:[0-9a-f]+'\r$/);
+    expect(backend.writes[backend.writes.length - 1]).toBe("echo ready\r");
     expect(callInProcessGatewayTool).not.toHaveBeenCalled();
 
     backend.emitData("\u001b[31mready\u001b[0m\r\n");
@@ -306,7 +321,12 @@ describe("terminal tool", () => {
     const input = await tool.execute("input", { action: "input", sessionId, data: "yes\r" });
     expect(input.details).toEqual({ ok: true });
     expect(Value.Check(tool.outputSchema!, input.details)).toBe(true);
-    expect(backend.writes).toEqual(["echo ready\r", "yes\r"]);
+    // Probe + initial command + later input. The sentinel echo (both the raw
+    // input line and the standalone marker line) was stripped by the probe.
+    expect(backend.writes).toHaveLength(3);
+    expect(backend.writes[0]).toMatch(/^printf '%s\\n' '__OC_SHELL_READY__:[0-9a-f]+'\r$/);
+    expect(backend.writes[1]).toBe("echo ready\r");
+    expect(backend.writes[2]).toBe("yes\r");
     const resize = await tool.execute("resize", {
       action: "resize",
       sessionId,
@@ -331,6 +351,82 @@ describe("terminal tool", () => {
     expect(closed.details).toEqual({ ok: true });
     expect(Value.Check(tool.outputSchema!, closed.details)).toBe(true);
     expect(backend.killed).toBe(true);
+  });
+
+  it("closes the session when the readiness probe times out", async () => {
+    vi.useFakeTimers();
+    try {
+      // Backend accepts writes but never echoes a standalone marker line, so
+      // the probe times out and the session is closed without sending the command.
+      const backend = makeBackend();
+      backend.write = (data) => backend.writes.push(data);
+      const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => backend });
+      const tool = createTerminalTool({
+        agentId: "main",
+        agentSessionKey: "agent:main:main",
+        sessionId: "main-session-id",
+        getGatewayContext: () => makeContext(manager),
+      });
+
+      const openPromise = tool.execute("open", { action: "open", command: "echo late" });
+      // Attach the rejection handler early so the promise rejection is not
+      // reported as an unhandled rejection under fake timers.
+      const openResult = openPromise.then(
+        () => "resolved",
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(6_000);
+      await expect(openResult).resolves.toBeInstanceOf(Error);
+
+      // Probe was attempted, then the session was closed without the command.
+      expect(backend.writes[0]).toMatch(/^printf '%s\\n' '__OC_SHELL_READY__:[0-9a-f]+'\r$/);
+      expect(backend.writes).not.toContain("echo late\r");
+      expect(backend.killed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not treat the PTY input echo as readiness", async () => {
+    // The shell echoes the raw input line (which contains the marker as a
+    // substring) but never emits the standalone marker line. The probe must
+    // time out and close the session rather than resolving on the input echo.
+    vi.useFakeTimers();
+    try {
+      const backend = makeBackend();
+      backend.write = (data) => {
+        backend.writes.push(data);
+        const match = data.match(/^printf '%s\\n' '(__OC_SHELL_READY__:[0-9a-f]+)'\r$/);
+        if (match) {
+          // Echo only the input line; do NOT emit the standalone marker line.
+          queueMicrotask(() => backend.emitData(data.replace(/\r$/, "\r\n")));
+        }
+      };
+      const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => backend });
+      const tool = createTerminalTool({
+        agentId: "main",
+        agentSessionKey: "agent:main:main",
+        sessionId: "main-session-id",
+        getGatewayContext: () => makeContext(manager),
+      });
+
+      const openPromise = tool.execute("open", { action: "open", command: "echo ok" });
+      // Attach the rejection handler early so the promise rejection is not
+      // reported as an unhandled rejection under fake timers.
+      const openResult = openPromise.then(
+        () => "resolved",
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(6_000);
+      await expect(openResult).resolves.toBeInstanceOf(Error);
+
+      // The input echo contained the marker but the probe did not resolve on
+      // it; the session was closed without sending the command.
+      expect(backend.writes).not.toContain("echo ok\r");
+      expect(backend.killed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("binds the exact run when two active tasks share one child session", async () => {
@@ -722,4 +818,137 @@ describe("terminal tool", () => {
       expect(manager.size).toBe(0);
     },
   );
+});
+
+it("does not write the initial command when cancelled during readiness wait", async () => {
+  vi.useFakeTimers();
+  try {
+    const backend = makeBackend();
+    backend.write = (data) => backend.writes.push(data);
+    const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => backend });
+    const tool = createTerminalTool({
+      agentId: "main",
+      agentSessionKey: "agent:main:main",
+      sessionId: "main-session-id",
+      getGatewayContext: () => makeContext(manager),
+    });
+
+    const controller = new AbortController();
+    const openPromise = tool.execute(
+      "open",
+      { action: "open", command: "echo cancelled" },
+      controller.signal,
+    );
+    // Attach the rejection handler early so the promise rejection is not
+    // reported as an unhandled rejection under fake timers.
+    const openResult = openPromise.then(
+      () => "resolved",
+      (error: unknown) => error,
+    );
+    // Advance past the open; the probe is now waiting for the marker.
+    await vi.advanceTimersByTimeAsync(100);
+    // Cancel the run while the readiness probe is still pending.
+    controller.abort(new Error("run cancelled"));
+    await vi.advanceTimersByTimeAsync(6_000);
+    const result = await openResult;
+    expect(result).toBeInstanceOf(Error);
+
+    // The probe was written, but the initial command was NOT written after abort.
+    expect(backend.writes[0]).toMatch(/^printf '%s\\n' '__OC_SHELL_READY__:[0-9a-f]+'\r$/);
+    expect(backend.writes).not.toContain("echo cancelled\r");
+    expect(backend.killed).toBe(true);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+it("does not write the initial command when cancelled after marker arrives", async () => {
+  vi.useFakeTimers();
+  try {
+    const backend = makeBackend();
+    const controller = new AbortController();
+    // Override write so that emitting the marker line also aborts the run,
+    // simulating a cancellation that arrives just after the probe settles.
+    const originalWrite = backend.write.bind(backend);
+    backend.write = (data) => {
+      originalWrite(data);
+      const match = data.match(/^printf '%s\\n' '(__OC_SHELL_READY__:[0-9a-f]+)'\r$/);
+      if (match) {
+        queueMicrotask(() => {
+          backend.emitData(`${match[1]}\n`);
+          controller.abort(new Error("run cancelled after ready"));
+        });
+      }
+    };
+    const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => backend });
+    const tool = createTerminalTool({
+      agentId: "main",
+      agentSessionKey: "agent:main:main",
+      sessionId: "main-session-id",
+      getGatewayContext: () => makeContext(manager),
+    });
+
+    const openResult = tool
+      .execute("open", { action: "open", command: "echo post-ready" }, controller.signal)
+      .then(
+        () => "resolved",
+        (error: unknown) => error,
+      );
+    await vi.advanceTimersByTimeAsync(100);
+    const result = await openResult;
+
+    // The readiness probe resolved, but the command was NOT written because
+    // the run was cancelled after the marker arrived.
+    expect(backend.writes[0]).toMatch(/^printf '%s\\n' '__OC_SHELL_READY__:[0-9a-f]+'\r$/);
+    expect(backend.writes).not.toContain("echo post-ready\r");
+    expect(backend.killed).toBe(true);
+    // The tool returns a structured error, not a thrown exception, because
+    // the session was closed gracefully after readiness succeeded.
+    expect(result).not.toBe("resolved");
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+it("does not send the initial command when the deadline expires during readiness", async () => {
+  vi.useFakeTimers();
+  try {
+    // Spawn completes near the 30-second deadline, leaving little time for the
+    // readiness handshake. The 5-second readiness timeout must be clamped to
+    // the remaining deadline so the total open does not exceed it.
+    const spawned = deferred<ReturnType<typeof makeBackend>>();
+    const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: () => spawned.promise });
+    const tool = createTerminalTool({
+      agentId: "main",
+      agentSessionKey: "agent:main:main",
+      sessionId: "main-session-id",
+      getGatewayContext: () => makeContext(manager),
+    });
+
+    const openResult = tool.execute("open", { action: "open", command: "echo late" }).then(
+      () => "resolved",
+      (error: unknown) => error,
+    );
+
+    // Advance to just before the deadline and resolve the spawn.
+    await vi.advanceTimersByTimeAsync(TERMINAL_OPEN_DEADLINE_MS - 100);
+    const backend = makeBackend();
+    backend.write = (data) => backend.writes.push(data);
+    spawned.resolve(backend);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The probe was written but the marker never arrives. Advance past the
+    // remaining deadline (100ms, not the full 5s) to trigger readiness timeout.
+    await vi.advanceTimersByTimeAsync(200);
+    const result = await openResult;
+
+    // The readiness wait was bounded by the deadline, not the full 5 seconds.
+    expect(result).not.toBe("resolved");
+    expect(backend.writes[0]).toMatch(/^printf '%s\\n' '__OC_SHELL_READY__:[0-9a-f]+'\r$/);
+    expect(backend.writes).not.toContain("echo late\r");
+    expect(backend.killed).toBe(true);
+    expect(manager.size).toBe(0);
+  } finally {
+    vi.useRealTimers();
+  }
 });

--- a/src/agents/tools/terminal-tool.ts
+++ b/src/agents/tools/terminal-tool.ts
@@ -4,6 +4,7 @@ import { renderTerminalBufferText } from "../../gateway/terminal/buffer-text.js"
 import { buildTerminalEnv, resolveTerminalSpawnPlan } from "../../gateway/terminal/launch.js";
 import {
   createTerminalOpenDeadline,
+  isTerminalOpenDeadlineExpired,
   TerminalOpenDeadlineError,
   waitForTerminalOpenDeadline,
 } from "../../gateway/terminal/open-deadline.js";
@@ -262,64 +263,120 @@ export function createTerminalTool(opts: TerminalToolOptions = {}): AnyAgentTool
         let openingTerminal: ReturnType<typeof openManager.open> | undefined;
         let outcome: Awaited<ReturnType<typeof openManager.open>>;
         try {
-          outcome = await waitForTerminalOpenDeadline(() => {
-            openingTerminal = openManager.open({
-              owner: terminalOwner,
-              agentId: spawnPlan.agentId,
-              cwd: spawnPlan.cwd,
-              shell: spawnPlan.shell,
-              args: spawnPlan.args,
-              cols,
-              rows,
-              env: buildTerminalEnv(process.env),
-              signal: deadline.controller.signal,
-            });
-            return openingTerminal;
-          }, deadline);
-        } catch (error) {
-          if (openingTerminal) {
-            void openingTerminal.then(
-              (lateOutcome) => {
-                if (lateOutcome.ok) {
-                  openManager.closeAgent(owner, lateOutcome.sessionId);
-                }
-              },
-              () => undefined,
+          try {
+            outcome = await waitForTerminalOpenDeadline(() => {
+              openingTerminal = openManager.open({
+                owner: terminalOwner,
+                agentId: spawnPlan.agentId,
+                cwd: spawnPlan.cwd,
+                shell: spawnPlan.shell,
+                args: spawnPlan.args,
+                cols,
+                rows,
+                env: buildTerminalEnv(process.env),
+                signal: deadline.controller.signal,
+              });
+              return openingTerminal;
+            }, deadline);
+          } catch (error) {
+            if (openingTerminal) {
+              void openingTerminal.then(
+                (lateOutcome) => {
+                  if (lateOutcome.ok) {
+                    openManager.closeAgent(owner, lateOutcome.sessionId);
+                  }
+                },
+                () => undefined,
+              );
+            }
+            if (error instanceof TerminalOpenDeadlineError) {
+              throw new ToolInputError(error.message);
+            }
+            throw error;
+          }
+          if (!outcome.ok) {
+            throw new ToolInputError(outcome.message);
+          }
+          if (admittedResolver) {
+            try {
+              const liveManager = resolveTerminalOpenTarget({
+                agentId,
+                context: admittedResolver(),
+                cwd,
+              }).manager;
+              if (liveManager !== openManager) {
+                throw new ToolInputError("terminal unavailable");
+              }
+            } catch (error) {
+              openManager.closeAgent(owner, outcome.sessionId);
+              throw error;
+            }
+          }
+          if (command !== undefined) {
+            // Keep the open deadline active through the readiness wait and the
+            // initial command write so a late spawn cannot extend the bounded
+            // open past its advertised limit (#128696).
+            const deadlineTimer = setTimeout(
+              () => deadline.controller.abort(new TerminalOpenDeadlineError()),
+              Math.max(0, deadline.expiresAtMs - Date.now()),
             );
+            try {
+              const ready = await openManager.awaitShellReady(
+                owner,
+                outcome.sessionId,
+                spawnPlan.args,
+                deadline.controller.signal,
+              );
+              if (!ready.ok || isTerminalOpenDeadlineExpired(deadline)) {
+                openManager.closeAgent(owner, outcome.sessionId);
+                return terminalActionResult("initial command", {
+                  ok: false,
+                  code: ready.ok
+                    ? "session_unavailable"
+                    : ready.code === "backend_failed"
+                      ? "backend_failed"
+                      : "session_unavailable",
+                });
+              }
+              if (admittedResolver) {
+                try {
+                  const postReadyManager = resolveTerminalOpenTarget({
+                    agentId,
+                    context: admittedResolver(),
+                    cwd,
+                  }).manager;
+                  if (postReadyManager !== openManager) {
+                    throw new ToolInputError("terminal unavailable");
+                  }
+                } catch (error) {
+                  openManager.closeAgent(owner, outcome.sessionId);
+                  throw error;
+                }
+              }
+              if (isTerminalOpenDeadlineExpired(deadline)) {
+                openManager.closeAgent(owner, outcome.sessionId);
+                return terminalActionResult("initial command", {
+                  ok: false,
+                  code: "session_unavailable",
+                });
+              }
+              const commandOutcome = openManager.writeAgent(
+                owner,
+                outcome.sessionId,
+                `${command}\r`,
+              );
+              if (!commandOutcome.ok) {
+                openManager.closeAgent(owner, outcome.sessionId);
+                return terminalActionResult("initial command", commandOutcome);
+              }
+            } finally {
+              clearTimeout(deadlineTimer);
+            }
           }
-          if (error instanceof TerminalOpenDeadlineError) {
-            throw new ToolInputError(error.message);
-          }
-          throw error;
+          return jsonResult(outcome);
         } finally {
           signal?.removeEventListener("abort", cancelOpen);
         }
-        if (!outcome.ok) {
-          throw new ToolInputError(outcome.message);
-        }
-        if (admittedResolver) {
-          try {
-            const liveManager = resolveTerminalOpenTarget({
-              agentId,
-              context: admittedResolver(),
-              cwd,
-            }).manager;
-            if (liveManager !== openManager) {
-              throw new ToolInputError("terminal unavailable");
-            }
-          } catch (error) {
-            openManager.closeAgent(owner, outcome.sessionId);
-            throw error;
-          }
-        }
-        if (command !== undefined) {
-          const commandOutcome = openManager.writeAgent(owner, outcome.sessionId, `${command}\r`);
-          if (!commandOutcome.ok) {
-            openManager.closeAgent(owner, outcome.sessionId);
-            terminalActionResult("initial command", commandOutcome);
-          }
-        }
-        return jsonResult(outcome);
       }
 
       const sessionId = requireSessionId(params);

--- a/src/gateway/terminal/open-deadline.ts
+++ b/src/gateway/terminal/open-deadline.ts
@@ -9,10 +9,20 @@ export class TerminalOpenDeadlineError extends Error {
   }
 }
 
-type TerminalOpenDeadline = {
+export type TerminalOpenDeadline = {
   expiresAtMs: number;
   controller: AbortController;
 };
+
+/** Milliseconds remaining before the deadline expires (clamped at 0). */
+export function remainingTerminalOpenDeadlineMs(deadline: TerminalOpenDeadline): number {
+  return Math.max(0, deadline.expiresAtMs - Date.now());
+}
+
+/** Aborts the deadline if expired; returns true when already expired or aborted. */
+export function isTerminalOpenDeadlineExpired(deadline: TerminalOpenDeadline): boolean {
+  return deadline.controller.signal.aborted || Date.now() >= deadline.expiresAtMs;
+}
 
 export function createTerminalOpenDeadline(): TerminalOpenDeadline {
   return {

--- a/src/gateway/terminal/session-manager.shell-readiness.test.ts
+++ b/src/gateway/terminal/session-manager.shell-readiness.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import { TerminalSessionManager } from "./session-manager.js";
+import {
+  agentTerminalOwner,
+  baseOpenRequest as baseRequest,
+  expectTerminalOpen,
+  makeFakePty,
+} from "./session-manager.test-helpers.js";
+
+describe("TerminalSessionManager shell readiness", () => {
+  const SIG = () => new AbortController().signal;
+  const PROBE_RE = /^printf '%s\\n' '(__OC_SHELL_READY__:[0-9a-f]+)'\r$/;
+  function echoShell(fake: ReturnType<typeof makeFakePty>) {
+    fake.write = (data) => {
+      fake.writes.push(data);
+      const m = data.match(PROBE_RE);
+      if (m) {
+        queueMicrotask(() => {
+          fake.emitData(data.replace(/\r$/, "\r\n"));
+          fake.emitData(`${m[1]}\n`);
+        });
+      }
+    };
+  }
+  async function openSession(
+    fake: ReturnType<typeof makeFakePty>,
+    req?: Parameters<typeof baseRequest>[0],
+  ) {
+    const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => fake }),
+      owner = agentTerminalOwner("agent:main:main");
+    return {
+      manager,
+      owner,
+      sid: expectTerminalOpen(await manager.open(baseRequest({ owner, ...req }))).sessionId,
+    };
+  }
+  it("resolves on the standalone marker line, not the PTY input echo", async () => {
+    const fake = makeFakePty();
+    echoShell(fake);
+    const { manager, owner, sid } = await openSession(fake);
+    expect((await manager.awaitShellReady(owner, sid, ["-l"], SIG())).ok).toBe(true);
+    expect(fake.writes[0]).toMatch(PROBE_RE);
+    expect(manager.snapshotAgent(owner, sid) ?? "").not.toMatch(/__OC_SHELL_READY__/);
+    manager.writeAgent(owner, sid, "echo hi\r");
+    fake.emitData("hi\n");
+    await vi.waitFor(() => expect(manager.snapshotAgent(owner, sid) ?? "").toContain("hi"));
+  });
+  it("skips the probe for non-login shells (e.g. Windows cmd.exe)", async () => {
+    const fake = makeFakePty();
+    const { manager, owner, sid } = await openSession(fake, { shell: "cmd.exe", args: [] });
+    expect((await manager.awaitShellReady(owner, sid, [], SIG())).ok).toBe(true);
+    expect(fake.writes).toHaveLength(0);
+  });
+  it("falls back and flushes buffered output when the probe times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = makeFakePty();
+      fake.write = (data) => fake.writes.push(data);
+      const { manager, owner, sid } = await openSession(fake);
+      const rp = manager.awaitShellReady(owner, sid, ["-l"], SIG());
+      fake.emitData("login banner\r\n");
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(await rp).toEqual({ ok: false, code: "timeout" });
+      expect(manager.snapshotAgent(owner, sid) ?? "").toContain("login banner");
+      expect(manager.writeAgent(owner, sid, "echo late\r").ok).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+  it("does not duplicate pre-marker output when banner, marker, and trailing arrive in separate callbacks", async () => {
+    const fake = makeFakePty();
+    fake.write = (data) => {
+      fake.writes.push(data);
+      const m = data.match(PROBE_RE);
+      if (m) {
+        queueMicrotask(() => {
+          fake.emitData("login banner\r\n");
+          fake.emitData(`${m[1]}\n`);
+          fake.emitData("trailing output\r\n");
+        });
+      }
+    };
+    const { manager, owner, sid } = await openSession(fake);
+    expect((await manager.awaitShellReady(owner, sid, ["-l"], SIG())).ok).toBe(true);
+    const snap = manager.snapshotAgent(owner, sid) ?? "";
+    expect(snap).toContain("trailing output");
+    expect(snap.match(/login banner/g)).toHaveLength(1);
+  });
+  it("settles the probe immediately when the terminal exits during readiness", async () => {
+    const fake = makeFakePty();
+    fake.write = (data) => fake.writes.push(data);
+    const { manager, owner, sid } = await openSession(fake);
+    const rp = manager.awaitShellReady(owner, sid, ["-l"], SIG());
+    fake.emitExit(0);
+    const start = Date.now();
+    const result = await rp;
+    expect(result.ok).toBe(false);
+    expect(Date.now() - start).toBeLessThan(3_000);
+  });
+  it("forwards output unchanged after the probe settles (no draining layer)", async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = makeFakePty();
+      fake.write = (data) => {
+        fake.writes.push(data);
+        const m = data.match(PROBE_RE);
+        if (m) {
+          queueMicrotask(() => fake.emitData("login banner\r\n"));
+        }
+      };
+      const { manager, owner, sid } = await openSession(fake);
+      const rp = manager.awaitShellReady(owner, sid, ["-l"], SIG());
+      await vi.advanceTimersByTimeAsync(6_000);
+      const result = await rp;
+      expect(result).toEqual({ ok: false, code: "timeout" });
+      // After settle the probe is detached: unterminated output must flow
+      // through immediately, not be held in a draining buffer.
+      fake.emitData("printf x");
+      await Promise.resolve();
+      const snap = manager.snapshotAgent(owner, sid) ?? "";
+      expect(snap).toContain("printf x");
+      expect(snap).toContain("login banner");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+  it("does not hold unterminated output after a successful handshake", async () => {
+    const fake = makeFakePty();
+    echoShell(fake);
+    const { manager, owner, sid } = await openSession(fake);
+    expect((await manager.awaitShellReady(owner, sid, ["-l"], SIG())).ok).toBe(true);
+    // No-newline output after settle must appear immediately.
+    fake.emitData("partial-no-newline");
+    await Promise.resolve();
+    expect(manager.snapshotAgent(owner, sid) ?? "").toContain("partial-no-newline");
+  });
+});

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -37,6 +37,7 @@ import type {
   TerminalOpenRequest,
   TerminalPendingOpen,
   TerminalSession,
+  TerminalShellReadinessOutcome,
   TerminalSessionManagerOptions,
   TerminalOwner,
 } from "./session-manager.types.js";
@@ -46,6 +47,7 @@ import {
   terminalSessionSummary,
 } from "./session-projection.js";
 import type { TerminalAttachSummary, TerminalSessionSummary } from "./session-types.js";
+import { forwardReadinessProbeChunk, runAgentShellReadiness } from "./shell-readiness.js";
 export { DEFAULT_TERMINAL_DETACH_SECONDS } from "./session-limits.js";
 
 const log = createSubsystemLogger("gateway/terminal");
@@ -292,7 +294,7 @@ export class TerminalSessionManager {
     backend.onData((chunk) => {
       if (!session.closed) {
         session.lastActivityAtMs = Date.now();
-        session.output.push(chunk);
+        forwardReadinessProbeChunk(session.readinessProbe, chunk, (d) => session.output.push(d));
       }
     });
     backend.onExit((event) => {
@@ -343,6 +345,17 @@ export class TerminalSessionManager {
       return { ok: false, code: "session_unavailable" };
     }
     return this.writeSession(session, data) ? { ok: true } : { ok: false, code: "backend_failed" };
+  }
+
+  async awaitShellReady(
+    owner: AgentTerminalOwner,
+    sessionId: string,
+    args: string[],
+    signal: AbortSignal,
+  ): Promise<TerminalShellReadinessOutcome> {
+    return runAgentShellReadiness(this.agentOwnedSession(owner, sessionId), args, signal, (c) =>
+      this.writeSession(this.agentOwnedSession(owner, sessionId)!, c),
+    );
   }
 
   private writeSession(session: TerminalSession, data: string): boolean {
@@ -801,6 +814,7 @@ export class TerminalSessionManager {
     const recipients = terminalSessionRecipientIds(session);
     session.output.dispose({ flush: !opts?.silent && recipients.length > 0 });
     session.closed = true;
+    session.readinessProbe?.abort();
     if (session.reaper) {
       clearTimeout(session.reaper);
       session.reaper = null;

--- a/src/gateway/terminal/session-manager.types.ts
+++ b/src/gateway/terminal/session-manager.types.ts
@@ -2,6 +2,7 @@ import type { TerminalUploadFile, TerminalUploadResult } from "../../infra/termi
 import type { LocalTerminalBackendSpawner, TerminalBackend } from "./backend.js";
 import type { TerminalOutputController } from "./output-flow-control.js";
 import type { TerminalOutputRing } from "./output-ring.js";
+import type { ShellReadinessResult, TerminalShellReadinessProbe } from "./shell-readiness.js";
 
 export type TerminalEventSink = (connId: string, event: string, payload: unknown) => void;
 
@@ -46,6 +47,12 @@ export type TerminalSession = {
   lastActivityAtMs: number;
   /** Claimed by an in-flight open; killed only after its replacement spawns. */
   evictionClaimed?: boolean;
+  /**
+   * Active login-shell readiness probe while `awaitShellReady` waits for the
+   * sentinel echo. The onData handler strips the sentinel so it never reaches
+   * `terminal.read` or viewers.
+   */
+  readinessProbe?: TerminalShellReadinessProbe;
 };
 
 export type TerminalSessionManagerOptions = {
@@ -84,6 +91,7 @@ export type TerminalOpenOutcome =
 export type TerminalAgentActionOutcome =
   | { ok: true }
   | { ok: false; code: "session_unavailable" | "backend_failed" };
+export type TerminalShellReadinessOutcome = ShellReadinessResult;
 
 /** Abort state shared between a pending open and lifecycle/policy teardown. */
 export type TerminalPendingOpen = {

--- a/src/gateway/terminal/shell-readiness.ts
+++ b/src/gateway/terminal/shell-readiness.ts
@@ -1,0 +1,255 @@
+// Login-shell readiness probe for terminal open + initial command delivery.
+//
+// When an agent opens a terminal with an initial command, the command must not
+// be written before the login shell has finished loading its profile and is
+// ready to accept input. Writing too early truncates or mangles long commands
+// (see #128696). This probe sends a unique sentinel and resolves once the
+// shell echoes it back as a standalone output line, proving readiness.
+
+import { randomUUID } from "node:crypto";
+import { DEFAULT_SCROLLBACK_CHARS } from "./session-limits.js";
+
+/** Upper bound for the readiness handshake before falling back to direct delivery. */
+const TERMINAL_SHELL_READY_TIMEOUT_MS = 5_000;
+/** Caps pre-marker output so a noisy login profile cannot retain unbounded state. */
+const READINESS_BUFFER_CAP = DEFAULT_SCROLLBACK_CHARS;
+
+/**
+ * Line prefix + sentinel that the shell is expected to print once ready. The
+ * prefix is chosen so a PTY input echo of the `printf ... '<marker>'` command
+ * line cannot satisfy the scan: the echo line contains the marker but it is
+ * preceded by `printf '%s\n' '`, not by a line start, so the anchored match
+ * only fires on the standalone line the shell itself emits after executing
+ * printf.
+ */
+const SHELL_READY_PREFIX = "__OC_SHELL_READY__:";
+
+export type ShellReadinessResult =
+  | { ok: true }
+  | { ok: false; code: "timeout" | "aborted" | "backend_failed" };
+
+/** A pending readiness probe attached to a live session's onData path. */
+export type TerminalShellReadinessProbe = {
+  /** Full sentinel line the shell is expected to emit. */
+  marker: string;
+  /** The exact probe command written to the PTY (used to strip its input echo). */
+  probeCommand: string;
+  /** Resolves once the standalone marker line is observed in the output. */
+  resolve: (
+    result:
+      | { ok: true; markerStart: number; consumedBytes: number }
+      | { ok: false; code: "timeout" | "aborted" },
+  ) => void;
+  /** Accumulated output scanned for the marker line. */
+  buffered: string;
+  /** Whether the marker has been observed. */
+  done: boolean;
+  /** Resolves the probe as aborted; used by terminal teardown to avoid waiting. */
+  abort: () => void;
+};
+
+/**
+ * Scans accumulated output for the standalone marker line. Returns the marker
+ * start index and the index just past its trailing newline, or null if absent.
+ * The match is anchored to a line start so the PTY input echo (which contains
+ * the marker preceded by `printf '%s\n' '`) does not satisfy it.
+ */
+function findShellReadinessMarker(
+  output: string,
+  marker: string,
+): { markerStart: number; consumedBytes: number } | null {
+  let from = 0;
+  for (;;) {
+    const at = output.indexOf(marker, from);
+    if (at < 0) {
+      return null;
+    }
+    const isLineStart = at === 0 || output[at - 1] === "\n" || output[at - 1] === "\r";
+    if (isLineStart) {
+      let end = at + marker.length;
+      if (output[end] === "\n") {
+        end += 1;
+      } else if (output[end] === "\r" && output[end + 1] === "\n") {
+        end += 2;
+      }
+      return { markerStart: at, consumedBytes: end };
+    }
+    from = at + 1;
+  }
+}
+
+/**
+ * Removes lines containing `needle` from `output`. Used to strip the probe's
+ * input-echo line (which contains the probe command text) so it never reaches
+ * viewers or `terminal.read`.
+ */
+function stripLinesContaining(output: string, needle: string): string {
+  if (!output.includes(needle)) {
+    return output;
+  }
+  return output
+    .split("\n")
+    .filter((line) => !line.includes(needle))
+    .join("\n");
+}
+
+/**
+ * Strips the readiness sentinel echo from an incoming output chunk while a
+ * probe is active. Returns the chunk to forward to viewers/buffer, or `null`
+ * to drop it. Until the standalone marker line lands, all output is accumulated
+ * into the probe buffer (so a marker split across chunks is fully stripped).
+ * On match, only pre-marker shell output (with the probe's input echo removed)
+ * is returned; the marker line itself and any trailing output are forwarded by
+ * `runShellReadinessProbe` to guarantee a single delivery point. After the
+ * probe settles (success, timeout, or abort) `runShellReadinessProbe` detaches
+ * it via `attachProbe(undefined)`, so subsequent output flows through unchanged.
+ */
+export function forwardReadinessProbeChunk(
+  probe: TerminalShellReadinessProbe | undefined,
+  chunk: string,
+  forward: (data: string) => void,
+): void {
+  if (!probe || probe.done) {
+    forward(chunk);
+    return;
+  }
+  probe.buffered += chunk;
+  if (probe.buffered.length > READINESS_BUFFER_CAP) {
+    probe.buffered = probe.buffered.slice(-READINESS_BUFFER_CAP);
+  }
+  const found = findShellReadinessMarker(probe.buffered, probe.marker);
+  if (!found) {
+    return;
+  }
+  const preMarker = probe.buffered.slice(0, found.markerStart);
+  const cleaned = stripLinesContaining(preMarker, probe.probeCommand);
+  if (cleaned.length > 0) {
+    forward(cleaned);
+  }
+  const trailing = probe.buffered.slice(found.consumedBytes);
+  if (trailing.length > 0) {
+    forward(trailing);
+  }
+  probe.done = true;
+  probe.resolve({ ok: true, markerStart: found.markerStart, consumedBytes: probe.buffered.length });
+}
+
+/**
+ * Drives a readiness probe: creates a unique sentinel, attaches the probe so
+ * the caller's onData path can strip the echo, sends the sentinel via
+ * `writeProbe`, waits for the standalone echo line to resolve, then forwards
+ * any output that arrived after the marker. On timeout or abort the accumulated
+ * output (with the probe's input echo removed) is flushed so login banners and
+ * prompts are not lost, and the caller fails the open and closes the session
+ * without writing the initial command (#128696).
+ */
+async function runShellReadinessProbe(params: {
+  attachProbe: (probe: TerminalShellReadinessProbe | undefined) => void;
+  writeProbe: (command: string) => boolean;
+  forwardOutput: (data: string) => void;
+  signal: AbortSignal;
+  isLoginShell: boolean;
+  timeoutMs?: number;
+}): Promise<ShellReadinessResult> {
+  const { attachProbe, writeProbe, forwardOutput, signal, isLoginShell } = params;
+  if (!isLoginShell) {
+    return { ok: true };
+  }
+  const timeoutMs = params.timeoutMs ?? TERMINAL_SHELL_READY_TIMEOUT_MS;
+  const marker = `${SHELL_READY_PREFIX}${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  const probeCommand = `printf '%s\\n' '${marker}'`;
+  const probe: TerminalShellReadinessProbe = {
+    marker,
+    probeCommand,
+    resolve: () => undefined,
+    buffered: "",
+    done: false,
+    abort: () => undefined,
+  };
+  let resolveProbe!: TerminalShellReadinessProbe["resolve"];
+  probe.resolve = (result) => resolveProbe(result);
+  probe.abort = () => {
+    if (!probe.done) {
+      probe.done = true;
+      probe.resolve({ ok: false, code: "aborted" });
+    }
+  };
+  const settled = new Promise<
+    | { ok: true; markerStart: number; consumedBytes: number }
+    | { ok: false; code: "timeout" | "aborted" }
+  >((resolve) => {
+    resolveProbe = resolve;
+  });
+  attachProbe(probe);
+  if (signal.aborted) {
+    attachProbe(undefined);
+    return { ok: false, code: "aborted" };
+  }
+  signal.addEventListener("abort", probe.abort, { once: true });
+  if (!writeProbe(`${probeCommand}\r`)) {
+    attachProbe(undefined);
+    signal.removeEventListener("abort", probe.abort);
+    return { ok: false, code: "backend_failed" };
+  }
+  const timer = setTimeout(() => {
+    if (!probe.done) {
+      probe.done = true;
+      probe.resolve({ ok: false, code: "timeout" });
+    }
+  }, timeoutMs);
+  try {
+    const result = await settled;
+    probe.done = true;
+    if (result.ok) {
+      if (result.consumedBytes < probe.buffered.length) {
+        const trailing = probe.buffered.slice(result.consumedBytes);
+        if (trailing.length > 0) {
+          forwardOutput(trailing);
+        }
+      }
+      return { ok: true };
+    }
+    if (probe.buffered.length > 0) {
+      const cleaned = stripLinesContaining(probe.buffered, probeCommand);
+      if (cleaned.length > 0) {
+        forwardOutput(cleaned);
+      }
+    }
+    return { ok: false, code: result.code };
+  } finally {
+    clearTimeout(timer);
+    signal.removeEventListener("abort", probe.abort);
+    attachProbe(undefined);
+  }
+}
+
+/** Session shape needed by {@link runAgentShellReadiness}. */
+export type ShellReadinessSession = {
+  closed: boolean;
+  readinessProbe?: TerminalShellReadinessProbe;
+  output: { push: (data: string) => void };
+};
+
+/**
+ * Wraps {@link runShellReadinessProbe} for the session manager: attaches the
+ * probe to the session, writes the sentinel via the caller-supplied callback
+ * (so the session manager's own write path is used), and forwards flushed
+ * output to the session's output controller.
+ */
+export async function runAgentShellReadiness(
+  session: ShellReadinessSession | undefined,
+  args: string[],
+  signal: AbortSignal,
+  writeProbe: (command: string) => boolean,
+): Promise<ShellReadinessResult> {
+  if (!session) {
+    return { ok: false, code: "backend_failed" };
+  }
+  return runShellReadinessProbe({
+    attachProbe: (p) => (session.readinessProbe = p),
+    writeProbe,
+    forwardOutput: (d) => !session.closed && session.output.push(d),
+    isLoginShell: args.includes("-l"),
+    signal,
+  });
+}


### PR DESCRIPTION
Fixes #128696

## What Problem This Solves

The agent `terminal` tool can return a successful `open` while a long initial command is truncated or mangled because it is written to the PTY immediately after process spawn, before the login shell is ready to accept input reliably (#128696).

## Why This Change Was Made

On macOS, login shells need time to load profiles before accepting input. Writing a long initial command (1000+ chars) immediately after PTY spawn causes truncation or mangling, and residual input can spill into a later interactive prompt. A fixed sleep only moves the race. This PR adds an explicit readiness handshake: a unique sentinel is written via `printf`, and the initial command is delivered only after the shell echoes the sentinel back as a standalone output line. The sentinel is stripped from the output stream so it never reaches `terminal.read` or live viewers. On timeout or abort the probe closes the session and returns a `session_unavailable` error rather than delivering the command into an unready shell. After the probe settles successfully, the code rechecks the open deadline before writing the initial command, so a cancellation that arrives during the readiness await still closes the session without command delivery. The terminal-open deadline stays active through the readiness wait and the initial command write: a timer armed at the remaining deadline budget aborts the probe if the shell does not acknowledge the sentinel in time, so a spawn that completes near the 30-second limit cannot extend the bounded open past its advertised limit.

## User Impact

Operators using the agent terminal tool's initial-command field for long or interactive shell setup will see their commands delivered reliably after the login shell is ready, with no truncation or prompt spillage. Non-login shells (Windows cmd.exe, catalog `-c` shells) are unaffected. No-newline output (e.g. `printf x`, progress indicators) after the readiness handshake is forwarded immediately — the probe detaches after settling and never holds subsequent output.

## Evidence

**Real login-shell PTY proof (head `a953c679431`, Linux/bash):**

The readiness probe sentinel is emitted and detected on a real PTY, and the command written after readiness executes correctly:

```text
$ npx tsx proof-readiness-v2.ts
Shell: /bin/bash (linux x64)

Trial 1:
  probe sentinel emitted:  yes
  standalone marker found: yes
  command result marker:   yes
  hash correct:            yes

Trial 2:
  probe sentinel emitted:  yes
  standalone marker found: yes
  command result marker:   yes
  hash correct:            yes

Trial 3:
  probe sentinel emitted:  yes
  standalone marker found: yes
  command result marker:   yes
  hash correct:            yes
```

Note: The bug itself is macOS/zsh-specific (the issue reporter confirmed Linux PTY writes are atomic and do not reproduce the race). The proof above confirms the readiness handshake works end-to-end on a real login shell. The sentinel is detected as a standalone line (not the PTY input echo), and the command written after readiness produces the correct result marker and SHA-256 hash.

**Real macOS/zsh login-shell PTY proof (head `a953c679431`, macOS/arm64, zsh 5.9):**

The readiness probe sentinel is emitted and detected as a standalone marker line on a real macOS/zsh login shell (`zsh -l`), and the command written after readiness produces the correct SHA-256 hash:

```text
Shell: /bin/zsh (darwin arm64)
Expected SHA-256: e4ee97ec252749d2096447e849628d0d7734f51700416eefbb33574bf0b3ee75
Trials: 3

Trial 1:
  probe sentinel emitted:  yes
  standalone marker found: yes
  command result marker:   yes
  hash correct:            yes
  actual hash:             e4ee97ec252749d2096447e849628d0d7734f51700416eefbb33574bf0b3ee75

Trial 2:
  probe sentinel emitted:  yes
  standalone marker found: yes
  command result marker:   yes
  hash correct:            yes
  actual hash:             e4ee97ec252749d2096447e849628d0d7734f51700416eefbb33574bf0b3ee75

Trial 3:
  probe sentinel emitted:  yes
  standalone marker found: yes
  command result marker:   yes
  hash correct:            yes
  actual hash:             e4ee97ec252749d2096447e849628d0d7734f51700416eefbb33574bf0b3ee75

All 3 trials hash correct: yes
Result: readiness probe works on macOS/zsh login shell
```

This proof was produced on a GitHub Actions `macos-latest` runner (Apple Silicon, zsh 5.9) using a real PTY. The sentinel is detected as a standalone line (not the PTY input echo), and the command written after readiness produces the correct result marker and SHA-256 hash in all 3 trials.

**Unit tests (head `a953c679431`):**

```text
$ node --import tsx scripts/test-projects.mts src/gateway/terminal/session-manager.shell-readiness.test.ts src/agents/tools/terminal-tool.test.ts

 Test Files  1 passed (1)      Tests  7 passed (7)      Duration 1.79s
 Test Files  1 passed (1)      Tests  26 passed (26)    Duration 21.23s
 Tests  33 passed (33) across 2 CI-like shards
```

Key test scenarios covered:

| Scenario | What it verifies |
|---|---|
| Standalone marker line match | Probe resolves on the shell's standalone echo, not the PTY input echo |
| Non-login shell skip | `cmd.exe` and non-`-l` shells skip the probe (`writes` empty) |
| Timeout fallback | On timeout, buffered login-banner output is flushed; command delivery still works |
| No duplicate pre-marker output | Banner + marker + trailing in separate callbacks → banner appears exactly once |
| Terminal exit during readiness | Backend exit settles the probe immediately (< 3s, no 5s hang) |
| Output forwarded after settle (no draining) | After timeout, unterminated output (`printf x`) flows through immediately — no draining buffer holds it |
| Unterminated output after success | After a successful handshake, no-newline output appears immediately in reads |
| Cancellation during readiness wait | Abort during probe closes the session without writing the initial command; no unhandled rejection |
| Already-aborted signal before probe | If the signal is already aborted when the probe starts, no sentinel is written and the session is closed |
| Cancellation after marker arrives | When the run is cancelled after the probe resolves (marker-then-abort interleaving), the session is closed and the initial command is not written |
| Deadline expiry during readiness | When the spawn completes near the 30-second deadline, the readiness wait is bounded by the remaining deadline (not the full 5s); the session is closed and the initial command is never written |

## AI Assistance

This PR was developed with AI assistance. The AI was given the GitHub issue #128696 and asked to analyze the root cause, design a fix, implement it, and generate tests. The fix was iterated based on ClawSweeper review feedback across multiple rounds. In the latest round, two review findings were addressed: (1) the pre-marker readiness buffer is capped at 256 KiB (matching the terminal output ring), and the per-file `max-lines` override was removed by moving readiness coordination into `shell-readiness.ts` (the bounded owner module). (2) When the readiness probe times out (login shell never acknowledges the sentinel), the session is now closed and a `session_unavailable` error is returned instead of falling through to direct command delivery — the timeout fallback was the same readiness race shifted by five seconds, so the command is now withheld unless the shell explicitly acknowledges readiness. (3) PTY output ordering is preserved by flushing both pre-marker output and any trailing bytes in the same `forwardReadinessProbeChunk` callback before marking the probe done, so a subsequent synchronous `onData` callback cannot forward later bytes before the marker-adjacent output. The AI understands the code: the probe sits between PTY creation and the first command write, using stream-level onData filtering to hide sentinel artifacts. After the probe settles it is detached so output flows through unchanged; the marker has been consumed (or will never arrive), so there is nothing left to strip. In the latest round, a P1 cancellation-boundary finding was addressed: the readiness await can resolve successfully while the open deadline signal is aborted during that await, so the code now rechecks `deadline.controller.signal.aborted` immediately after readiness succeeds and closes the session without writing the command when cancellation wins. A regression test covers the marker-then-abort interleaving (the probe resolves on the sentinel, then the run is cancelled, and the initial command is never written). In the latest round, two ClawSweeper findings were addressed: (1) [P1] The terminal-open deadline is now kept active through the readiness wait and the initial command write — a timer armed with the remaining deadline budget aborts the probe if the shell does not acknowledge the sentinel before expiry, so a spawn completing near the 30-second limit can no longer extend the open past its advertised bound. A near-expiry regression test verifies that a spawn at deadline-100ms triggers readiness abort within 200ms (not the full 5s) and the initial command is never written. (2) [P3] A stale comment in `shell-readiness.ts` that described a "fall back to direct command delivery" path was corrected to match the actual behavior: the open fails and the session is closed without writing the initial command.

