### PR TITLE
improve: serialize Telegram Mantis proofs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -29,10 +29,13 @@ paths:
       - 'constant expression "false" in condition'
       # actionlint's built-in runner label allowlist lags Blacksmith additions.
       - 'label "blacksmith-16vcpu-[^"]+" is unknown\.'
+  # GitHub Actions supports concurrency.queue, but actionlint does not yet model it.
   .github/workflows/qa-live-transports-convex.yml:
     ignore:
       - 'unexpected key "queue" for "concurrency" section'
-  # GitHub Actions supports concurrency.queue, but actionlint does not yet model it.
+  .github/workflows/mantis-telegram-desktop-proof.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'
   .github/workflows/docker-release.yml:
     ignore:
       - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -26,6 +26,11 @@ on:
         default: workflow_dispatch
         type: string
 
+concurrency:
+  group: mantis-telegram-visible-proof
+  cancel-in-progress: false
+  queue: max
+
 permissions:
   actions: read
   contents: read

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -452,6 +452,11 @@ cancel adopted children.
 
 ## Live and E2E shards
 
+The native Telegram Mantis proof workflow uses a lossless workflow-level
+concurrency queue. Only one proof allocates a runner at a time; up to 100
+additional requests wait without consuming their proof timeout or contending
+for the shared Telegram user.
+
 The release live/E2E child keeps broad native `pnpm test:live` coverage, but it runs it as named shards through `scripts/test-live-shard.mjs` instead of one serial job:
 
 - `native-live-src-agents` and `native-live-src-agents-zai-coding`

--- a/docs/concepts/mantis.md
+++ b/docs/concepts/mantis.md
@@ -392,8 +392,10 @@ reacts with 👀 when it accepts the request, then posts the active run link in
 its evidence comment and replaces that same comment with the result. ClawSweeper's
 `mantis: telegram-visible-proof` label starts the proof automatically for
 branches in `openclaw/openclaw`; fork PRs still require an explicit maintainer
-comment. Manual runs first inspect the diff and stop before desktop setup when
-there is no Telegram-visible behavior to test.
+comment. Proof requests queue serially because they share one Telegram user;
+queued runs do not allocate a runner or start their proof timeout. Manual runs
+first inspect the diff and stop before desktop setup when there is no
+Telegram-visible behavior to test.
 
 The other scenario workflows remain available through manual Actions dispatch.
 

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -12,7 +12,10 @@ type Step = {
   env?: Record<string, string>;
   with?: Record<string, unknown>;
 };
-type Workflow = { jobs?: Record<string, { steps?: Step[] }> };
+type Workflow = {
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean; queue?: string };
+  jobs?: Record<string, { steps?: Step[] }>;
+};
 
 function workflow() {
   return parse(readFileSync(WORKFLOW, "utf8")) as Workflow;
@@ -23,6 +26,14 @@ function proofSteps() {
 }
 
 describe("Mantis Telegram proof workflow", () => {
+  it("queues every proof behind the shared Telegram user", () => {
+    expect(workflow().concurrency).toEqual({
+      group: "mantis-telegram-visible-proof",
+      "cancel-in-progress": false,
+      queue: "max",
+    });
+  });
+
   it("gives one Codex run unrestricted scenario ownership", () => {
     const prompt = readFileSync(PROMPT, "utf8");
     const agent = readFileSync("scripts/mantis/telegram-visible-run-agent.sh", "utf8");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where concurrent Mantis requests each allocated a runner and contended for the single shared Telegram QA user. In the 10-run trial, one proof spent about 79 minutes waiting and then hit its 100-minute job timeout.

## Why This Change Was Made

Use the native GitHub Actions lossless concurrency queue for the whole Telegram Mantis workflow. One proof runs at a time; up to 100 requests wait outside a runner with no custom dispatcher, queue state, or Mantis scenario restrictions.

## User Impact

Maintainers can request multiple Mantis proofs together. GitHub queues them serially instead of burning runners and proof timeouts while they fight over one Telegram user.

No OpenClaw runtime behavior changes.

## Evidence

- Exact-head real Telegram DM: sent `Please answer with OPENCLAW_E2E_BASIC only.` as the leased QA user; sent message `2200961024`; observed two SUT typing events and one SUT message `OPENCLAW_E2E_BASIC` at 4.965 seconds; one mock-provider request. Recorded timeline and logs preserved locally.
- `node scripts/run-vitest.mjs test/scripts/mantis-telegram-desktop-proof-workflow.test.ts` — 7 tests passed.
- `node --import tsx scripts/check-workflows.mts` — actionlint, Zizmor, and composite-action interpolation checks passed.
- `node scripts/docs-list.js` — passed.
- `pnpm exec oxfmt --check` on all five changed files — passed.
- Exact-head local ClawSweeper: patch correct; zero findings; security clear; no maintainer decision; zero rank-up moves.
- Production runtime LOC: +0. Workflow/tooling/docs: +18/-3. Test: +12/-1.
- `pnpm tsgo` and `pnpm check:test-types` were attempted using the initially available shared dependency tree; both stopped in untouched Google, Markdown, and TUI surfaces because that tree did not match current `main`. Exact-head hosted type checks passed with locked dependencies.

Direct Codex contract check: `../codex/codex-rs/exec/src/lib.rs` terminal shutdown path and `../codex/codex-rs/exec/src/event_processor_with_human_output.rs` final-output path. Workflow-level pending requests never start Codex, so this changes no Codex cancellation or shutdown semantics.