### PR TITLE
fix(tasks): reconcile terminal subagent cancellation

### DIFF
--- a/src/plugins/runtime/runtime-tasks.test.ts
+++ b/src/plugins/runtime/runtime-tasks.test.ts
@@ -191,6 +191,51 @@ describe("runtime tasks", () => {
     expect(task.status).toBe("cancelled");
   });
 
+  it("reconciles a terminal task whose native subagent run is still active", async () => {
+    const runtimeTasks = createRuntimeTasks({
+      managedTaskFlow: createRuntimeTaskFlow(),
+    });
+    const taskRuns = runtimeTasks.runs.bindSession({
+      sessionKey: "agent:main:main",
+    });
+    const task = createTaskRecord({
+      runtime: "subagent",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:restart-split",
+      runId: "runtime-task-restart-split",
+      task: "Finish after restart",
+      status: "succeeded",
+      lastEventAt: 30,
+      terminalSummary: "Completed before restart.",
+    });
+    if (!task) {
+      throw new Error("expected terminal subagent task to be created");
+    }
+    runtimeTaskMocks.killSubagentRunAdminMock.mockResolvedValue({
+      found: true,
+      killed: true,
+    });
+
+    const result = await taskRuns.cancel({
+      taskId: task.taskId,
+      cfg: {} as never,
+    });
+
+    expect(runtimeTaskMocks.killSubagentRunAdminMock).toHaveBeenCalledWith({
+      cfg: {},
+      sessionKey: "agent:main:subagent:restart-split",
+    });
+    expect(result).toMatchObject({
+      found: true,
+      cancelled: false,
+      task: {
+        id: task.taskId,
+        status: "succeeded",
+      },
+    });
+  });
+
   it("routes runtime task cancellation through the detached task runtime seam", async () => {
     const runtimeTasks = createRuntimeTasks({
       managedTaskFlow: createRuntimeTaskFlow(),

--- a/src/tasks/task-registry-cancel.ts
+++ b/src/tasks/task-registry-cancel.ts
@@ -53,13 +53,12 @@ export async function cancelTaskById(params: {
     task.runtime === "subagent" &&
     task.status === "cancelled" &&
     task.error === SUBAGENT_KILL_TASK_ERROR;
+  const childSessionKey = task.childSessionKey?.trim();
+  const canReconcileTerminalSubagentRun = task.runtime === "subagent" && Boolean(childSessionKey);
   if (
     !isProvisionalSubagentKill &&
-    (task.status === "succeeded" ||
-      task.status === "failed" ||
-      task.status === "timed_out" ||
-      task.status === "lost" ||
-      task.status === "cancelled")
+    isTerminalTaskStatus(task.status) &&
+    !canReconcileTerminalSubagentRun
   ) {
     return {
       found: true,
@@ -68,7 +67,6 @@ export async function cancelTaskById(params: {
       task: cloneTaskRecord(task),
     };
   }
-  const childSessionKey = task.childSessionKey?.trim();
   try {
     ensureTaskCancellationReady(task);
     // A direct kill is only a provisional terminal projection. Re-read the


### PR DESCRIPTION
## What problem this solves

A caller using the public plugin task runtime can own a subagent task whose durable task row is already terminal while the native subagent run is still active after restart recovery. `tasks.runs.cancel(...)` currently returns `Task is already terminal.` before it reaches the subagent lifecycle owner, so the native run is never finalized and a yielded requester can remain stuck waiting.

## Root cause

`cancelTaskById` treats the task registry's terminal projection as proof that no runtime-specific reconciliation remains. The subagent registry is a separate durable lifecycle owner, so those two projections can temporarily disagree across restart recovery.

## Fix

- Keep terminal cancellation unchanged for every other runtime.
- For a terminal subagent task with a child session key, continue through the existing subagent cancellation path. That path re-reads the native outcome and preserves the task's existing terminal status, so this reconciles the child without rewriting a successful task as cancelled.
- Add coverage through the public `PluginRuntime.tasks.runs.cancel(...)` boundary.

Production delta is net -2 lines. No config, schema, or public type changes.

## Alternatives considered

- An external plugin importing `task-registry-control.runtime.js` can call the native finalizer directly, but that crosses a private host boundary and is not a supported contract.
- Plugin-owned session deletion is not equivalent and cannot delete ordinary built-in subagent sessions.
- A second plugin-specific recovery state machine would duplicate OpenClaw's lifecycle owner.

The existing public task cancellation operation is the smallest correct owner boundary.

## Evidence

Pre-fix reproduction:

- `pnpm test src/plugins/runtime/runtime-tasks.test.ts`
- Failed because `killSubagentRunAdmin` had 0 calls for a terminal subagent task.

After the fix, on the exact 2026.8.1-beta.2 source and again after rebasing onto current `main`:

- `pnpm test src/plugins/runtime/runtime-tasks.test.ts src/tasks/task-executor.test.ts`
- 2 test files passed; 31 tests passed.
- Built a complete local OpenClaw Docker image successfully from the patched exact 2026.8.1-beta.2 source.
- `git diff --check`
- `pnpm exec oxfmt` on both changed files.

## Negative boundaries

- Does not change terminal task status precedence.
- Does not make session deletion available to plugins.
- Does not expose a new admin API.
- Does not change cancellation for ACP, cron, CLI, or background exec tasks.