### PR TITLE
fix(install): stop npm postinstall from schema-migrating operator state

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -823,6 +823,10 @@ export async function runPluginRegistryPostinstallMigration(params = {}) {
   const env = params.env ?? process.env;
   const pathExists = params.existsSync ?? existsSync;
 
+  if (env?.[DISABLE_POSTINSTALL_ENV]?.trim()) {
+    return { status: "skipped", reason: "disabled" };
+  }
+
   // Registry migration belongs to installed-package upgrades. Source checkouts
   // can contain stale dist from a different build and must not touch operator state.
   if (isSourceCheckoutRoot({ packageRoot, existsSync: pathExists })) {
@@ -844,6 +848,9 @@ export async function runPluginRegistryPostinstallMigration(params = {}) {
     const result = await migrationModule.migratePluginRegistryForInstall({
       env,
       packageRoot,
+      // Package install must never one-way-migrate an existing operator state DB;
+      // that belongs to the binary actually running or an explicit `doctor --fix`.
+      skipIfStateSchemaOutdated: true,
     });
     if (result.migrated) {
       log.log(

--- a/src/commands/doctor/shared/plugin-registry-migration.test.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 // Plugin registry migration tests cover doctor repair of persisted plugin registry state.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -139,7 +140,44 @@ function insertStalePersistedIndexRow(stateDir: string, installRecordsJson = "{}
   );
 }
 
+function createOutdatedStateDatabase(stateDir: string, userVersion: number): string {
+  const filePath = resolveInstalledPluginIndexStorePath({ stateDir });
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const db = new DatabaseSync(filePath);
+  db.exec(`PRAGMA user_version = ${userVersion};`);
+  db.close();
+  return filePath;
+}
+
 describe("plugin registry install migration", () => {
+  it("skips instead of upgrading an older on-disk state schema when asked to", async () => {
+    const stateDir = makeTempDir();
+    const filePath = createOutdatedStateDatabase(stateDir, 5);
+    const readConfig = vi.fn(async () => ({}));
+
+    const result = await migratePluginRegistryForInstall({
+      stateDir,
+      readConfig,
+      skipIfStateSchemaOutdated: true,
+      env: hermeticEnv(),
+    });
+
+    expectRecordFields(requireRecord(result, "migration result"), {
+      status: "skip-outdated-schema",
+      migrated: false,
+    });
+    expectRecordFields(requireRecord(result.preflight, "migration preflight"), {
+      action: "skip-outdated-schema",
+      filePath,
+    });
+    expect(readConfig).not.toHaveBeenCalled();
+
+    const db = new DatabaseSync(filePath, { readOnly: true });
+    const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
+    db.close();
+    expect(row.user_version).toBe(5);
+  });
+
   it("short-circuits when a current registry file already exists", async () => {
     const stateDir = makeTempDir();
     const filePath = resolveInstalledPluginIndexStorePath({ stateDir });

--- a/src/commands/doctor/shared/plugin-registry-migration.test.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.test.ts
@@ -17,7 +17,11 @@ import {
   cleanupTrackedTempDirs,
   makeTrackedTempDir,
 } from "../../../plugins/test-helpers/fs-fixtures.js";
-import { runOpenClawStateWriteTransaction } from "../../../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../../../state/openclaw-state-db.js";
 import { migratePluginRegistryForInstall } from "./plugin-registry-migration.js";
 const tempDirs: string[] = [];
 
@@ -140,12 +144,25 @@ function insertStalePersistedIndexRow(stateDir: string, installRecordsJson = "{}
   );
 }
 
+// A bare stamped-version file never reaches the ownership/table checks that
+// gate the real v5-to-v9 upgrade path, so build a full canonical database
+// first and mark it down to the older version instead — same downgrade
+// fixture precedent as src/state/openclaw-state-db.test.ts.
 function createOutdatedStateDatabase(stateDir: string, userVersion: number): string {
   const filePath = resolveInstalledPluginIndexStorePath({ stateDir });
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  const db = new DatabaseSync(filePath);
-  db.exec(`PRAGMA user_version = ${userVersion};`);
-  db.close();
+  const opened = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
+  opened.db
+    .prepare(
+      `INSERT INTO state_leases (
+        scope, lease_key, owner, expires_at, heartbeat_at, payload_json, created_at, updated_at
+      ) VALUES ('test', 'preinstall-marker', 'postinstall-test', 100, 50, '{}', 1, 2)`,
+    )
+    .run();
+  opened.db.exec(`
+    PRAGMA user_version = ${userVersion};
+    UPDATE schema_meta SET schema_version = ${userVersion} WHERE meta_key = 'primary';
+  `);
+  closeOpenClawStateDatabaseForTest();
   return filePath;
 }
 
@@ -173,9 +190,17 @@ describe("plugin registry install migration", () => {
     expect(readConfig).not.toHaveBeenCalled();
 
     const db = new DatabaseSync(filePath, { readOnly: true });
-    const row = db.prepare("PRAGMA user_version").get() as { user_version: number };
-    db.close();
-    expect(row.user_version).toBe(5);
+    try {
+      expect(db.prepare("PRAGMA user_version").get()).toEqual({ user_version: 5 });
+      expect(
+        db.prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'").get(),
+      ).toEqual({ schema_version: 5 });
+      expect(
+        db.prepare("SELECT owner FROM state_leases WHERE lease_key = 'preinstall-marker'").get(),
+      ).toEqual({ owner: "postinstall-test" });
+    } finally {
+      db.close();
+    }
   });
 
   it("short-circuits when a current registry file already exists", async () => {

--- a/src/commands/doctor/shared/plugin-registry-migration.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.ts
@@ -11,8 +11,10 @@ import {
   setPluginInstallRecordMapEntry,
 } from "../../../config/plugin-install-record-map.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { readSqliteUserVersion } from "../../../infra/sqlite-user-version.js";
 import { inspectPersistedInstalledPluginIndexInstallRecordsSync } from "../../../plugins/installed-plugin-index-record-state.js";
 import { loadInstalledPluginIndexInstallRecords } from "../../../plugins/installed-plugin-index-records.js";
+import { resolveInstalledPluginIndexStateDatabaseOptions } from "../../../plugins/installed-plugin-index-store-path.js";
 import {
   readPersistedInstalledPluginIndexSync,
   resolveInstalledPluginIndexStorePath,
@@ -27,6 +29,8 @@ import {
 } from "../../../plugins/installed-plugin-index.js";
 import { loadPluginManifestRegistryForInstalledIndex } from "../../../plugins/manifest-registry-installed.js";
 import type { PluginManifestRecord } from "../../../plugins/manifest-registry.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../../state/openclaw-state-db-contract.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../../../state/openclaw-state-db-readonly.js";
 
 const DOCTOR_PLUGIN_ID_ALIASES: Readonly<Record<string, readonly string[]>> = {
   openai: ["openai-codex"],
@@ -42,13 +46,20 @@ type PluginRegistryInstallMigrationPreflight =
       current: InstalledPluginIndex;
     }
   | {
+      // A write here would open the shared state DB writable, which upgrades its schema.
+      // A caller that must not one-way-migrate operator state (package install) sets
+      // skipIfStateSchemaOutdated and gets this instead of "migrate"/"initialize".
+      action: "skip-outdated-schema";
+      filePath: string;
+    }
+  | {
       action: "initialize" | "migrate";
       filePath: string;
     };
 
 type PluginRegistryInstallMigrationResult =
   | {
-      status: "skip-existing" | "dry-run";
+      status: "skip-existing" | "skip-outdated-schema" | "dry-run";
       migrated: false;
       preflight: PluginRegistryInstallMigrationPreflight;
     }
@@ -76,13 +87,26 @@ export type PluginRegistryInstallMigrationParams = LoadInstalledPluginIndexParam
     dryRun?: boolean;
     existsSync?: (path: string) => boolean;
     readConfig?: () => Promise<OpenClawConfig> | OpenClawConfig;
+    /** Refuse to write (and thereby schema-upgrade) an existing older state DB. */
+    skipIfStateSchemaOutdated?: boolean;
   };
+
+function isPersistedStateSchemaOutdated(params: PluginRegistryInstallMigrationParams): boolean {
+  const onDiskVersion = withExistingOpenClawStateDatabaseReadOnly(
+    ({ db }) => readSqliteUserVersion(db),
+    resolveInstalledPluginIndexStateDatabaseOptions(params),
+  );
+  return onDiskVersion !== undefined && onDiskVersion < OPENCLAW_STATE_SCHEMA_VERSION;
+}
 
 /** Decide whether plugin install registry migration should run for this environment. */
 export function preflightPluginRegistryInstallMigration(
   params: PluginRegistryInstallMigrationParams = {},
 ): PluginRegistryInstallMigrationPreflight {
   const filePath = resolveInstalledPluginIndexStorePath(params);
+  if (params.skipIfStateSchemaOutdated && isPersistedStateSchemaOutdated(params)) {
+    return { action: "skip-outdated-schema", filePath };
+  }
   const persistedState = inspectPersistedInstalledPluginIndexInstallRecordsSync(params);
   if (persistedState.status === "invalid") {
     throw new InvalidPluginInstallRecordStateError(invalidPersistedInstallRecordMessage(filePath));
@@ -304,6 +328,9 @@ export async function migratePluginRegistryForInstall(
   const preflight = preflightPluginRegistryInstallMigration(params);
   if (preflight.action === "skip-existing") {
     return { status: "skip-existing", migrated: false, preflight };
+  }
+  if (preflight.action === "skip-outdated-schema") {
+    return { status: "skip-outdated-schema", migrated: false, preflight };
   }
   if (params.dryRun) {
     return { status: "dry-run", migrated: false, preflight };

--- a/src/commands/doctor/shared/plugin-registry-migration.ts
+++ b/src/commands/doctor/shared/plugin-registry-migration.ts
@@ -30,7 +30,7 @@ import {
 import { loadPluginManifestRegistryForInstalledIndex } from "../../../plugins/manifest-registry-installed.js";
 import type { PluginManifestRecord } from "../../../plugins/manifest-registry.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../../state/openclaw-state-db-contract.js";
-import { withExistingOpenClawStateDatabaseReadOnly } from "../../../state/openclaw-state-db-readonly.js";
+import { withExistingOpenClawStateDatabaseArtifactPreservingReadOnly } from "../../../state/openclaw-state-db-readonly.js";
 
 const DOCTOR_PLUGIN_ID_ALIASES: Readonly<Record<string, readonly string[]>> = {
   openai: ["openai-codex"],
@@ -92,7 +92,10 @@ export type PluginRegistryInstallMigrationParams = LoadInstalledPluginIndexParam
   };
 
 function isPersistedStateSchemaOutdated(params: PluginRegistryInstallMigrationParams): boolean {
-  const onDiskVersion = withExistingOpenClawStateDatabaseReadOnly(
+  // Package postinstall can run beside a live WAL-mode gateway; the artifact-
+  // preserving reader inspects a private snapshot so this check never creates
+  // or updates the on-disk database's journal/WAL/SHM sidecars.
+  const onDiskVersion = withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(
     ({ db }) => readSqliteUserVersion(db),
     resolveInstalledPluginIndexStateDatabaseOptions(params),
   );

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -464,10 +464,29 @@ describe("bundled plugin postinstall", () => {
     expect(migratePluginRegistryForInstall).toHaveBeenCalledWith({
       env: { OPENCLAW_HOME: "/tmp/home" },
       packageRoot,
+      skipIfStateSchemaOutdated: true,
     });
     expect(log.log).toHaveBeenCalledWith(
       "[postinstall] migrated plugin registry: 1 plugin(s) indexed",
     );
+  });
+
+  it("honors the postinstall disable env var for registry migration", async () => {
+    const importModule = vi.fn();
+
+    await expect(
+      runPluginRegistryPostinstallMigration({
+        packageRoot: "/pkg",
+        existsSync: vi.fn(() => true),
+        importModule,
+        env: { OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL: "1" },
+        log: { log: vi.fn(), warn: vi.fn() },
+      }),
+    ).resolves.toEqual({
+      status: "skipped",
+      reason: "disabled",
+    });
+    expect(importModule).not.toHaveBeenCalled();
   });
 
   it("does not migrate operator plugin state from a source checkout", async () => {


### PR DESCRIPTION
## What Problem This Solves

Closes #128782.

A bare `npm install openclaw@<version>` into a local prefix — binary
never executed — one-way-migrates `~/.openclaw/state/openclaw.sqlite`
from whatever schema version it's on up to the new package's target
version (e.g. v5 → v9). An older gateway that is still running on its
open handles then crash-loops on its next restart with
`SqliteSchemaVersionError`, and there is no rollback short of
restoring the state DB from a backup. The documented opt-out
(`OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL=1`) does not stop it
either, because it isn't checked on this call path.

## Why This Change Was Made

`scripts/postinstall-bundled-plugins.mjs` calls
`migratePluginRegistryForInstall` unconditionally after install so the
plugin registry is pre-indexed. That function opens the shared state
DB **writable** to persist the index, and the normal writable-open
path (`ensureSchema`) upgrades any older on-disk schema in the same
transaction — so a plugin-registry indexing convenience silently
performs a one-way operator-state migration as a side effect of
`npm install`.

Root cause: install-time code has no business opening an existing,
older operator state DB for writing at all. The schema migration
belongs to the binary that actually runs, or to an explicit
`openclaw doctor --fix`, both of which already own this contract
(`doctor-plugin-registry.ts` already calls the same migration function
for `--fix`, and is unaffected by this change since it never sets the
new option).

Fix, in the owning module (`src/commands/doctor/shared/plugin-registry-migration.ts`):

- `preflightPluginRegistryInstallMigration` gains a
  `skipIfStateSchemaOutdated` option. When set, it reads the on-disk
  state DB's `PRAGMA user_version` **read-only** (the same read path
  already used elsewhere in this file, safe under a live WAL-mode
  gateway) and returns a new `"skip-outdated-schema"` preflight action
  instead of `"initialize"`/`"migrate"` when that version is older
  than the current build's target schema version. No table/row read
  or write happens in that case.
- `migratePluginRegistryForInstall` returns
  `{ status: "skip-outdated-schema", migrated: false }` for that
  action without touching config or the registry.
- `scripts/postinstall-bundled-plugins.mjs` now passes
  `skipIfStateSchemaOutdated: true` on its call, and also honors
  `OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL` for this call (it
  previously only gated the sibling bundled-plugin postinstall step).

A brand-new install (no prior state DB) or a reinstall where the
on-disk schema already matches the current build is unaffected — only
an *existing, older* on-disk schema now gets left alone at install
time.

## User Impact

`npm install`/`npm install -g openclaw@<version>` no longer touches an
existing operator's state DB schema. Users can pre-flight a new
version into a separate npm prefix (as the reporter was doing) without
risking their live gateway's database. The schema migration still
happens exactly when it always has for a real upgrade: the first time
the new binary actually opens the DB, or when the operator explicitly
runs `openclaw doctor --fix`.

## Evidence

Regression test added and confirmed to fail without the fix (verified
by reverting only the two production files with `git checkout HEAD~1 --
<file>` and rerunning):

```
$ node scripts/run-vitest.mjs src/commands/doctor/shared/plugin-registry-migration.test.ts
...
 ❯ plugin registry install migration > skips instead of upgrading an older on-disk state schema when asked to
Error: OpenClaw state database .../state/openclaw.sqlite has schema role missing; expected global.
 ❯ assertOpenClawStateDatabaseOwner src/state/openclaw-state-db-maintenance.ts:96:11
 ❯ ensureSchema src/state/openclaw-state-db.ts:396:5
Tests  1 failed | 13 passed (14)
```

(without the fix, preflight proceeds straight to a writable open and
attempts the schema upgrade on the outdated on-disk DB — exactly the
reported mechanism)

```
$ node scripts/run-vitest.mjs test/scripts/postinstall-bundled-plugins.test.ts
...
 ❯ bundled plugin postinstall > honors the postinstall disable env var for registry migration
AssertionError: expected { status: 'skipped', reason: 'disabled' }
  Received: { status: 'skipped', reason: 'source-checkout' }
Tests  2 failed | 36 passed (38)
```

With the fix restored, both suites are green:

```
$ node scripts/run-vitest.mjs src/commands/doctor/shared/plugin-registry-migration.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)

$ node scripts/run-vitest.mjs test/scripts/postinstall-bundled-plugins.test.ts
 Test Files  1 passed (1)
      Tests  38 passed (38)
```

The new test uses a real on-disk SQLite file (`node:sqlite`
`DatabaseSync`) with `PRAGMA user_version` rolled back, calls the real
(unmocked) `migratePluginRegistryForInstall`, and re-opens the file
afterward to assert `PRAGMA user_version` is still the outdated value
— i.e. the decoy-DB scenario from the issue, exercised at the unit
level against the actual production code path rather than a full
`npm install` of a packed tarball.

Doctor's own callers, which do **not** set the new option and must
keep migrating explicitly on `--fix`, remain green and unmodified:

```
$ node scripts/run-vitest.mjs src/commands/doctor-plugin-registry.test.ts src/commands/doctor-plugin-registry.retirement.test.ts src/commands/doctor-plugin-registry-generation-repair.test.ts
 Test Files  3 passed (3)
      Tests  19 passed (19)
```

Full changed-surface checks (scoped via
`node scripts/check-changed.mjs -- <changed files>`), run individually
after the shared `check:max-lines-ratchet` and `check:assertion-safety`
baseline checks failed for reasons unrelated to this diff (confirmed
identical on unmodified `origin/main`, in `src/logging/logger.ts` and
several pre-existing baseline entries this PR never touches):

- `pnpm format:check` — clean
- `pnpm tsgo:core` — clean
- `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.commands.json --builders 1` (the shard containing the touched test) — clean
- `pnpm tsgo:test:root` — clean
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ...` / `...oxlint.scripts.json ...` — clean
- `pnpm check:import-cycles`, `check:coercion-helpers`, `check:database-first-legacy-stores`, `check:runtime-sidecar-loaders`, `check:doctor-deprecation-registry`, `check:wrapper-shadowing`, `node --import tsx scripts/check-deadcode-exports.mts` — all clean

## Proof gaps

- No full `npm pack` + `npm install` of a packed tarball against a copied
  real legacy-schema database in this sandboxed session (no network
  egress for a real package publish/install round-trip, and building a
  bit-identical legacy schema fixture was out of scope for the size of
  this fix). The unit-level regression test above exercises the same
  production function with a real SQLite file and is the closest
  available proxy; a maintainer with a real pre-v9 backup can confirm
  with the exact repro from the issue.
- Autoreview could not be run in this sandboxed session: no `codex`
  binary is available, and the `claude` engine subprocess has no
  separate login/credentials here (`Not logged in · Please run
  /login`). Manual review against the repo's Repair Doctrine and
  Architecture rules (SQLite/database-first, doctor-owns-migration,
  narrow-option, no schema-version bump) is reflected in the design
  above; a maintainer or CI-side reviewer should still run the
  project's normal review gate before merge.

AI-assisted: this change (implementation, tests, and this description)
was produced by an autonomous coding agent from the linked issue.
