### PR TITLE
fix(macos): allow cold ChatGPT Codex probes

### DIFF
--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -476,13 +476,13 @@ describe("detectInferenceBackends", () => {
 
   it("checks login status with the Codex executable discovered in a macOS app", async () => {
     const command = "/Applications/ChatGPT.app/Contents/Resources/codex";
-    const probed: Array<{ command: string; args: string[] }> = [];
+    const probed: Array<{ command: string; args: string[]; timeoutMs?: number }> = [];
     const candidates = await detectInferenceBackends({
       env: { HOME: "/Users/tester" },
       platform: "darwin",
       deps: {
-        probeLocalCommand: async (probedCommand, args = ["--version"]) => {
-          probed.push({ command: probedCommand, args });
+        probeLocalCommand: async (probedCommand, args = ["--version"], opts = {}) => {
+          probed.push({ command: probedCommand, args, timeoutMs: opts.timeoutMs });
           return {
             command: probedCommand,
             found: probedCommand === command,
@@ -494,7 +494,42 @@ describe("detectInferenceBackends", () => {
 
     expect(candidates).toMatchObject([{ kind: "codex-cli", detail: "installed" }]);
     expect(candidates[0]?.credentials).toBeUndefined();
-    expect(probed).toContainEqual({ command, args: ["login", "status"] });
+    expect(probed).toContainEqual({ command, args: ["--version"], timeoutMs: 3_000 });
+    expect(probed).toContainEqual({ command, args: ["login", "status"], timeoutMs: 3_000 });
+  });
+
+  it("allows a cold ChatGPT app probe more time than generic CLI discovery", async () => {
+    const command = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const candidates = await detectInferenceBackends({
+      env: { HOME: "/Users/tester" },
+      platform: "darwin",
+      deps: {
+        probeLocalCommand: async (probedCommand, args = ["--version"], opts = {}) => {
+          if (probedCommand !== command) {
+            return { command: probedCommand, found: false };
+          }
+          if (args[0] === "login") {
+            return { command: probedCommand, found: true, version: "Logged in using ChatGPT" };
+          }
+          return opts.timeoutMs === 3_000
+            ? { command: probedCommand, found: true, version: "codex-cli 0.149.0" }
+            : {
+                command: probedCommand,
+                found: true,
+                timedOut: true,
+                error: "timed out after 1500ms",
+              };
+        },
+      },
+    });
+
+    expect(candidates).toMatchObject([
+      {
+        kind: "codex-cli",
+        credentials: true,
+        detail: "logged in · ChatGPT subscription",
+      },
+    ]);
   });
 
   it.each([

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -171,6 +171,7 @@ function randomizeClaudeCodexTie(
 
 // ChatGPT.app is the current desktop owner; keep Codex stable/beta as fallbacks.
 const CODEX_MACOS_APP_NAMES = ["ChatGPT.app", "Codex.app", "Codex Beta.app"] as const;
+const CODEX_MACOS_APP_PROBE_TIMEOUT_MS = 3_000;
 
 async function probeCodexCommand(params: {
   probe: typeof probeLocalCommand;
@@ -189,7 +190,12 @@ async function probeCodexCommand(params: {
     ]),
   );
   for (const executable of appExecutables) {
-    const appProbe = await params.probe(executable);
+    // ChatGPT.app's signed Codex binary can spend most of the generic 1.5s
+    // probe budget in macOS cold-start validation. Keep the broader probe
+    // contract tight while giving known desktop-app binaries enough headroom.
+    const appProbe = await params.probe(executable, ["--version"], {
+      timeoutMs: CODEX_MACOS_APP_PROBE_TIMEOUT_MS,
+    });
     if (appProbe.found) {
       return appProbe;
     }


### PR DESCRIPTION
## What Problem This Solves

On macOS, onboarding can miss an authenticated ChatGPT/Codex installation on its first pass. The signed Codex binary inside `ChatGPT.app` can spend most of the generic 1.5-second command-probe budget in cold-start validation, so the initial probe times out even though an immediate retry succeeds.

## Why This Change Was Made

Known ChatGPT/Codex application-bundle binaries now receive a 3-second `--version` probe budget. Generic PATH discovery, Claude, Gemini, and non-macOS probes keep the existing timeout. The discovered executable continues through the existing `codex login status` classifier.

## User Impact

macOS onboarding detects an already-installed ChatGPT/Codex subscription more reliably on the first pass. Only known application-bundle paths can wait longer; ordinary CLI discovery and other platforms are unchanged.

## Evidence

- Regression test added before the production change: `src/commands/onboard-inference.test.ts` failed 2 tests and passed 31 against current `main`; after the fix it passes all 33 tests.
- `node scripts/check-changed.mjs -- src/commands/onboard-inference.ts src/commands/onboard-inference.test.ts` completed all runnable guards. Core/test typechecking was unavailable because this RooClaw sparse checkout excludes tracked `packages` and `ui` inputs.
- Focused oxfmt, oxlint, and diff checks passed.
- Direct Codex contract inspection at `openai/codex@4d7e3e90d9781514f9b3b99c95169a2386868ad9`: `codex-rs/cli/src/main.rs:95-105` confirms Clap owns `--version`; `main.rs:510-514,1394-1407` defines and routes `login status`; `codex-rs/cli/src/login.rs:439-485` confirms the ChatGPT/logged-out/error status outputs and exit behavior consumed here.
- Exact-head Base-VM cold-start proof used app commit `703aca2086a596f324a04f4de32152b996401f42` and the matching self-contained CLI package, with standalone `codex` excluded from `PATH`. The first production `detectSetupInference()` call completed in 2,313 ms and returned authenticated `codex-cli` / ChatGPT subscription on the first pass. The powered-on `gui/501` session was neither restarted nor logged out. Full proof: https://github.com/openclaw/openclaw/pull/128819#issuecomment-5399740614
- Production LOC: +7/-1; tests: +39/-4. The production growth is limited to the named app-binary timeout contract.

## Maintainer Decision

Accept the app-specific 3,000 ms `--version` probe budget. It applies only after generic PATH discovery fails and only to the enumerated macOS ChatGPT/Codex app-bundle executables; generic CLI and non-macOS probes remain at 1,500 ms. A matching cold or hung app binary may therefore hold this discovery step for up to 1.5 seconds longer than before. That bounded availability cost is intentional. Exact-head packaged detection completed in 2,313 ms.

Direct inspection of `openai/codex@a6e63f9f32525d171676ac49c4e87ab00d76f0ce` confirms:

- `codex-rs/arg0/src/lib.rs:157-173` performs dotenv and PATH-alias setup before CLI parsing.
- `codex-rs/cli/src/main.rs:99-106,1050-1056` makes `--version` a Clap-owned parser exit before subcommand config or authentication work.
- `codex-rs/cli/src/main.rs:1515-1528` routes `login status` separately to `run_login_status`.
- `codex-rs/cli/src/login.rs:443-464` loads configuration and authentication only on that login-status path.
- `codex-rs/login/src/auth/storage.rs:265-299,431-440` shows auth storage can load from the keyring with file fallback.
- `codex-rs/keyring-store/src/lib.rs:41-68` shows the default keyring load reaches the OS credential store.

The existing `login status` auth and keyring semantics are unchanged.
