### PR TITLE
fix(macos): keep Gateway profile Keychain reads noninteractive

### DIFF
--- a/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
@@ -58,7 +58,11 @@ struct MacGatewayProfileKeychainOperations: Sendable {
             query[kSecReturnData as String] = true
             query[kSecMatchLimit as String] = kSecMatchLimitOne
             var result: CFTypeRef?
-            let status = SecItemCopyMatching(query as CFDictionary, &result)
+            let status = MacGatewayProfileStore.performKeychainOperation(
+                allowInteraction: allowInteraction)
+            {
+                SecItemCopyMatching(query as CFDictionary, &result)
+            }
             if status == errSecSuccess, let data = result as? Data {
                 return .data(data)
             }
@@ -75,15 +79,19 @@ struct MacGatewayProfileKeychainOperations: Sendable {
                 service: service,
                 account: account,
                 allowInteraction: allowInteraction)
-            let update = SecItemUpdate(
-                query as CFDictionary,
-                [kSecValueData as String: data] as CFDictionary)
-            if update == errSecSuccess { return update }
-            if update != errSecItemNotFound { return update }
-            var add = query
-            add[kSecValueData as String] = data
-            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-            return SecItemAdd(add as CFDictionary, nil)
+            return MacGatewayProfileStore.performKeychainOperation(
+                allowInteraction: allowInteraction)
+            {
+                let update = SecItemUpdate(
+                    query as CFDictionary,
+                    [kSecValueData as String: data] as CFDictionary)
+                if update == errSecSuccess { return update }
+                if update != errSecItemNotFound { return update }
+                var add = query
+                add[kSecValueData as String] = data
+                add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+                return SecItemAdd(add as CFDictionary, nil)
+            }
         })
 }
 
@@ -93,6 +101,7 @@ actor MacGatewayProfileStore {
     static let shared = MacGatewayProfileStore()
 
     @TaskLocal static var keychainOperations = MacGatewayProfileKeychainOperations.live
+    private static let keychainInteractionLock = NSLock()
 
     static let didChangeNotification = Notification.Name("openclaw.gateway-profiles.did-change")
 
@@ -140,6 +149,26 @@ actor MacGatewayProfileStore {
             true
         default:
             false
+        }
+    }
+
+    fileprivate static func performKeychainOperation(
+        allowInteraction: Bool,
+        operation: () -> OSStatus) -> OSStatus
+    {
+        guard !allowInteraction else { return operation() }
+        // LAContext.interactionNotAllowed covers Data Protection items, but a legacy
+        // login-Keychain ACL can still summon SecurityAgent. The legacy process switch
+        // is the only API that suppresses that UI; keep its scope serialized and minimal.
+        return self.keychainInteractionLock.withLock {
+            var previousInteraction = DarwinBoolean(false)
+            let readStatus = SecKeychainGetUserInteractionAllowed(&previousInteraction)
+            guard readStatus == errSecSuccess else { return readStatus }
+            let disableStatus = SecKeychainSetUserInteractionAllowed(false)
+            guard disableStatus == errSecSuccess else { return disableStatus }
+            let operationStatus = operation()
+            let restoreStatus = SecKeychainSetUserInteractionAllowed(previousInteraction.boolValue)
+            return restoreStatus == errSecSuccess ? operationStatus : restoreStatus
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
@@ -1,5 +1,6 @@
 import CryptoKit
 import Foundation
+import LocalAuthentication
 import OpenClawKit
 import Security
 
@@ -32,10 +33,66 @@ enum MacGatewayProfileError: LocalizedError, Equatable {
     }
 }
 
+enum MacGatewayProfileKeychainLoad: Sendable {
+    case data(Data)
+    case missing
+    case unavailable(OSStatus)
+    case failed(OSStatus)
+}
+
+struct MacGatewayProfileKeychainOperations: Sendable {
+    let load: @Sendable (_ service: String, _ account: String, _ allowInteraction: Bool) ->
+        MacGatewayProfileKeychainLoad
+    let save: @Sendable (
+        _ data: Data,
+        _ service: String,
+        _ account: String,
+        _ allowInteraction: Bool) -> OSStatus
+
+    static let live = MacGatewayProfileKeychainOperations(
+        load: { service, account, allowInteraction in
+            var query = MacGatewayProfileStore.baseQuery(
+                service: service,
+                account: account,
+                allowInteraction: allowInteraction)
+            query[kSecReturnData as String] = true
+            query[kSecMatchLimit as String] = kSecMatchLimitOne
+            var result: CFTypeRef?
+            let status = SecItemCopyMatching(query as CFDictionary, &result)
+            if status == errSecSuccess, let data = result as? Data {
+                return .data(data)
+            }
+            if status == errSecItemNotFound {
+                return .missing
+            }
+            if MacGatewayProfileStore.isUnavailableKeychainStatus(status) {
+                return .unavailable(status)
+            }
+            return .failed(status)
+        },
+        save: { data, service, account, allowInteraction in
+            let query = MacGatewayProfileStore.baseQuery(
+                service: service,
+                account: account,
+                allowInteraction: allowInteraction)
+            let update = SecItemUpdate(
+                query as CFDictionary,
+                [kSecValueData as String: data] as CFDictionary)
+            if update == errSecSuccess { return update }
+            if update != errSecItemNotFound { return update }
+            var add = query
+            add[kSecValueData as String] = data
+            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            return SecItemAdd(add as CFDictionary, nil)
+        })
+}
+
 /// Persistent gateway identities and credentials for independently routed windows.
 /// Profiles are Keychain-backed so endpoint ownership and its secrets commit together.
 actor MacGatewayProfileStore {
     static let shared = MacGatewayProfileStore()
+
+    @TaskLocal static var keychainOperations = MacGatewayProfileKeychainOperations.live
 
     static let didChangeNotification = Notification.Name("openclaw.gateway-profiles.did-change")
 
@@ -73,11 +130,25 @@ actor MacGatewayProfileStore {
     private static let registryAccount = "registry-v1"
     private static let currentLegacyPrimaryMigrationVersion = 1
 
+    static func isUnavailableKeychainStatus(_ status: OSStatus) -> Bool {
+        switch status {
+        case errSecNotAvailable,
+             errSecAuthFailed,
+             errSecNoSuchKeychain,
+             errSecInteractionNotAllowed,
+             errSecUserCanceled:
+            true
+        default:
+            false
+        }
+    }
+
     /// Registry reads are prompt-bearing: when this binary is missing from the
     /// item's ACL, every SecItemCopyMatching raises a login-keychain dialog, and
     /// catalog refreshes fire per control-channel state change. Cache the one
     /// registry for the process lifetime; saves keep it coherent.
     private var cachedRegistry: Registry?
+    private var cachedRegistryKeychainUnavailable = false
 
     static func migratingLegacyPrimaryConnection(
         root: [String: Any],
@@ -116,7 +187,7 @@ actor MacGatewayProfileStore {
         password: String?) throws -> MacGatewayProfile
     {
         let profile = try Self.makeProfile(name: name, url: url)
-        var registry = try self.loadRegistry()
+        var registry = try self.loadRegistryForMutation()
         let id = profile.id
         let savedCredentials = registry.profiles.first { $0.profile.id == id }?.credentials
         let credentials = Self.resolvedCredentials(
@@ -146,7 +217,7 @@ actor MacGatewayProfileStore {
     }
 
     func remove(profileID: String) throws {
-        var registry = try self.loadRegistry()
+        var registry = try self.loadRegistryForMutation()
         guard registry.profiles.contains(where: { $0.profile.id == profileID }) else {
             throw MacGatewayProfileError.profileNotFound
         }
@@ -171,15 +242,39 @@ actor MacGatewayProfileStore {
             deviceAuthGatewayID: stored.profile.id)
     }
 
-    private func loadRegistry() throws -> Registry {
-        if let cachedRegistry { return cachedRegistry }
-        let registry: Registry = if let data = try Self.load(account: Self.registryAccount) {
-            try Self.decodeRegistry(data)
-        } else {
-            Registry()
+    private func loadRegistry(allowInteraction: Bool = false) throws -> Registry {
+        if let cachedRegistry,
+           !self.cachedRegistryKeychainUnavailable || !allowInteraction
+        {
+            return cachedRegistry
+        }
+        let load = Self.keychainOperations.load(
+            Self.service,
+            Self.registryAccount,
+            allowInteraction)
+        let registry: Registry
+        switch load {
+        case let .data(data):
+            registry = try Self.decodeRegistry(data)
+            self.cachedRegistryKeychainUnavailable = false
+        case .missing:
+            registry = Registry()
+            self.cachedRegistryKeychainUnavailable = false
+        case let .unavailable(status):
+            guard !allowInteraction else { throw MacGatewayProfileError.keychain(status) }
+            registry = Registry()
+            self.cachedRegistryKeychainUnavailable = true
+        case let .failed(status):
+            throw MacGatewayProfileError.keychain(status)
         }
         self.cachedRegistry = registry
         return registry
+    }
+
+    private func loadRegistryForMutation() throws -> Registry {
+        try Self.migratingLegacyPrimaryConnection(
+            root: OpenClawConfigFile.loadDict(),
+            registry: self.loadRegistry(allowInteraction: true))
     }
 
     private func loadRegistryMigratingLegacyPrimary() throws -> Registry {
@@ -193,13 +288,30 @@ actor MacGatewayProfileStore {
             root: OpenClawConfigFile.loadDict(),
             registry: registry)
         guard migrated != registry else { return registry }
-        try self.saveRegistry(migrated)
+        do {
+            try self.saveRegistry(migrated, allowInteraction: false)
+        } catch let error as MacGatewayProfileError {
+            guard case let .keychain(status) = error,
+                  Self.isUnavailableKeychainStatus(status)
+            else { throw error }
+            // Local onboarding does not need saved remote profiles. Keep the
+            // migration receipt in memory so a missing or locked login
+            // keychain cannot prompt repeatedly or block the local route.
+            self.cachedRegistry = migrated
+            self.cachedRegistryKeychainUnavailable = true
+        }
         return migrated
     }
 
-    private func saveRegistry(_ registry: Registry) throws {
-        try Self.save(JSONEncoder().encode(registry), account: Self.registryAccount)
+    private func saveRegistry(_ registry: Registry, allowInteraction: Bool = true) throws {
+        let status = try Self.keychainOperations.save(
+            JSONEncoder().encode(registry),
+            Self.service,
+            Self.registryAccount,
+            allowInteraction)
+        guard status == errSecSuccess else { throw MacGatewayProfileError.keychain(status) }
         self.cachedRegistry = registry
+        self.cachedRegistryKeychainUnavailable = false
     }
 
     private static func decodeRegistry(_ data: Data) throws -> Registry {
@@ -290,40 +402,23 @@ actor MacGatewayProfileStore {
         return value?.isEmpty == false ? value : nil
     }
 
-    private static func load(account: String) throws -> Data? {
-        var query = self.baseQuery(account: account)
-        query[kSecReturnData as String] = true
-        query[kSecMatchLimit as String] = kSecMatchLimitOne
-        var result: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        if status == errSecItemNotFound { return nil }
-        guard status == errSecSuccess, let data = result as? Data else {
-            throw MacGatewayProfileError.keychain(status)
-        }
-        return data
-    }
-
-    private static func save(_ data: Data, account: String) throws {
-        let query = self.baseQuery(account: account)
-        let update = SecItemUpdate(
-            query as CFDictionary,
-            [kSecValueData as String: data] as CFDictionary)
-        if update == errSecSuccess { return }
-        guard update == errSecItemNotFound else { throw MacGatewayProfileError.keychain(update) }
-        var add = query
-        add[kSecValueData as String] = data
-        add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-        let status = SecItemAdd(add as CFDictionary, nil)
-        guard status == errSecSuccess else { throw MacGatewayProfileError.keychain(status) }
-    }
-
-    private static func baseQuery(account: String) -> [String: Any] {
-        [
+    static func baseQuery(
+        service: String = MacGatewayProfileStore.service,
+        account: String,
+        allowInteraction: Bool = true) -> [String: Any]
+    {
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: self.service,
+            kSecAttrService as String: service,
             kSecAttrAccount as String: account,
             kSecAttrSynchronizable as String: false,
         ]
+        if !allowInteraction {
+            let authenticationContext = LAContext()
+            authenticationContext.interactionNotAllowed = true
+            query[kSecUseAuthenticationContext as String] = authenticationContext
+        }
+        return query
     }
 }
 

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift
@@ -1,8 +1,125 @@
 import Foundation
+import LocalAuthentication
+import Security
 import Testing
 @testable import OpenClaw
 
 struct MacGatewayProfilesTests {
+    @Test func `gateway profile keychain access never opens authentication UI`() throws {
+        let query = MacGatewayProfileStore.baseQuery(
+            account: "registry-v1",
+            allowInteraction: false)
+        let authenticationContext = try #require(
+            query[kSecUseAuthenticationContext as String] as? LAContext)
+
+        #expect(authenticationContext.interactionNotAllowed)
+        #expect(MacGatewayProfileStore.baseQuery(account: "registry-v1")[
+            kSecUseAuthenticationContext as String,
+        ] == nil)
+        #expect(MacGatewayProfileStore.isUnavailableKeychainStatus(errSecNoSuchKeychain))
+        #expect(MacGatewayProfileStore.isUnavailableKeychainStatus(errSecInteractionNotAllowed))
+        #expect(!MacGatewayProfileStore.isUnavailableKeychainStatus(errSecParam))
+    }
+
+    @Test func `authorized mutation reloads profiles hidden by an unavailable keychain`() async throws {
+        let configPath = TestIsolation.tempConfigPath()
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+        try await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            let existingURL = try #require(URL(string: "wss://existing.example"))
+            let existing = MacGatewayProfileStore.StoredProfile(
+                profile: MacGatewayProfile(id: "existing", name: "Existing", url: existingURL),
+                credentials: .init(token: "existing-token", password: nil))
+            let fake = try MacGatewayProfileFakeKeychain(registry: .init(profiles: [existing]))
+            let store = MacGatewayProfileStore()
+
+            try await MacGatewayProfileStore.$keychainOperations.withValue(fake.operations) {
+                #expect(try await store.profiles().isEmpty)
+
+                let added = try await store.upsert(
+                    name: "Added",
+                    url: #require(URL(string: "wss://added.example")),
+                    token: "added-token",
+                    password: nil)
+                #expect(fake.loadAllowInteraction == [false, true])
+                #expect(Set(fake.savedRegistry?.profiles.map(\.profile.id) ?? []) ==
+                    Set([added.id, "existing"]))
+
+                try await store.remove(profileID: added.id)
+                #expect(fake.savedRegistry?.profiles.map(\.profile.id) == ["existing"])
+            }
+        }
+    }
+
+    @Test func `authorized remove commits pending migration without dropping hidden profiles`() async throws {
+        let configPath = TestIsolation.tempConfigPath()
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+        try await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            let legacyURL = try #require(URL(string: "wss://legacy.example"))
+            let legacyID = try MacGatewayProfileStore.profileID(
+                url: MacGatewayProfileStore.canonicalURL(legacyURL))
+            #expect(OpenClawConfigFile.saveDict(
+                self.remoteRoot(
+                    url: legacyURL.absoluteString,
+                    token: "legacy-token",
+                    password: "legacy-password"),
+                allowGatewayAuthMutation: true))
+            let hidden = try MacGatewayProfileStore.StoredProfile(
+                profile: MacGatewayProfile(
+                    id: "hidden",
+                    name: "Hidden",
+                    url: #require(URL(string: "wss://hidden.example"))),
+                credentials: .init(token: "hidden-token", password: nil))
+            let fake = try MacGatewayProfileFakeKeychain(registry: .init(profiles: [hidden]))
+            let store = MacGatewayProfileStore()
+
+            try await MacGatewayProfileStore.$keychainOperations.withValue(fake.operations) {
+                #expect(try await store.profiles().map(\.id) == [legacyID])
+                try await store.remove(profileID: legacyID)
+                #expect(fake.loadAllowInteraction == [false, true])
+                #expect(fake.savedRegistry?.legacyPrimaryMigrationVersion == 1)
+                #expect(fake.savedRegistry?.profiles.map(\.profile.id) == ["hidden"])
+            }
+        }
+    }
+
+    @Test func `blank same-route upsert preserves migrated credentials and hidden profiles`() async throws {
+        let configPath = TestIsolation.tempConfigPath()
+        defer { try? FileManager.default.removeItem(atPath: configPath) }
+        try await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configPath]) {
+            let legacyURL = try #require(URL(string: "wss://legacy.example"))
+            #expect(OpenClawConfigFile.saveDict(
+                self.remoteRoot(
+                    url: legacyURL.absoluteString,
+                    token: "legacy-token",
+                    password: "legacy-password"),
+                allowGatewayAuthMutation: true))
+            let hidden = try MacGatewayProfileStore.StoredProfile(
+                profile: MacGatewayProfile(
+                    id: "hidden",
+                    name: "Hidden",
+                    url: #require(URL(string: "wss://hidden.example"))),
+                credentials: .init(token: "hidden-token", password: nil))
+            let fake = try MacGatewayProfileFakeKeychain(registry: .init(profiles: [hidden]))
+            let store = MacGatewayProfileStore()
+
+            try await MacGatewayProfileStore.$keychainOperations.withValue(fake.operations) {
+                #expect(try await store.profiles().count == 1)
+                let saved = try await store.upsert(
+                    name: "",
+                    url: legacyURL,
+                    token: nil,
+                    password: nil)
+                let savedProfiles = fake.savedRegistry?.profiles ?? []
+                #expect(fake.loadAllowInteraction == [false, true])
+                #expect(Set(savedProfiles.map(\.profile.id)) == Set(["hidden", saved.id]))
+                let migrated = try #require(savedProfiles.first { $0.profile.id == saved.id })
+                #expect(migrated.credentials == .init(
+                    token: "legacy-token",
+                    password: "legacy-password"))
+            }
+        }
+    }
+
     @Test func `canonical route identity normalizes authority but preserves path`() throws {
         let implicit = try MacGatewayProfileStore.canonicalURL(
             #require(URL(string: "WSS://Studio.Example/alpha")))
@@ -220,5 +337,38 @@ struct MacGatewayProfilesTests {
         if let token { remote["token"] = token }
         if let password { remote["password"] = password }
         return ["gateway": ["mode": mode, "remote": remote]]
+    }
+}
+
+private final class MacGatewayProfileFakeKeychain: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data: Data
+    private(set) var loadAllowInteraction: [Bool] = []
+    private(set) var savedRegistry: MacGatewayProfileStore.Registry?
+
+    init(registry: MacGatewayProfileStore.Registry) throws {
+        self.data = try JSONEncoder().encode(registry)
+    }
+
+    var operations: MacGatewayProfileKeychainOperations {
+        MacGatewayProfileKeychainOperations(
+            load: { [self] _, _, allowInteraction in
+                self.lock.withLock {
+                    self.loadAllowInteraction.append(allowInteraction)
+                    return allowInteraction
+                        ? .data(self.data)
+                        : .unavailable(errSecInteractionNotAllowed)
+                }
+            },
+            save: { [self] data, _, _, allowInteraction in
+                self.lock.withLock {
+                    guard allowInteraction else { return errSecInteractionNotAllowed }
+                    self.data = data
+                    self.savedRegistry = try? JSONDecoder().decode(
+                        MacGatewayProfileStore.Registry.self,
+                        from: data)
+                    return errSecSuccess
+                }
+            })
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Automatic macOS Gateway-profile reads and legacy migration can open login-Keychain authentication UI when a development signature does not own the saved item. Treating an unavailable Keychain like an empty registry can also make a later explicit mutation overwrite hidden profiles or discard a pending legacy-profile migration and its credentials.

## Why This Change Was Made

Automatic reads and migration use a noninteractive `LAContext` and distinguish missing, temporarily unavailable, and failed Keychain states. A real legacy login-Keychain ACL proved that modern no-UI controls still summon SecurityAgent, so noninteractive reads and saves also use the legacy process interaction switch inside a serialized capture/disable/restore boundary. Explicit add/remove operations remain interaction-allowed, reload authoritative Keychain data, reapply the existing idempotent legacy migration, and commit the migration plus mutation in one registry save.

## User Impact

Background refresh and local onboarding no longer trigger surprise Keychain dialogs or fail because the login Keychain is unavailable. Explicit profile changes may still request authorization, and they preserve hidden profiles, migrated credentials, and the migration receipt. There is no persisted schema change.

## Evidence

- Test-only baseline failed on current `main` because the noninteractive Keychain contract did not exist.
- Follow-up migration tests failed before the mutation-loader repair with `profileNotFound` and lost credentials; after the repair all 17 `MacGatewayProfilesTests` pass.
- Focused SwiftFormat and strict SwiftLint checks pass for both changed files; `git diff --check` passes.
- Prior Base-VM acceptance with the same noninteractive Keychain boundary showed no Keychain dialog and completed onboarding.
- Exact-head macOS proof found a real prompt at `5c39e305c257` with a legacy item restricted to `/usr/bin/security`, then verified `61dba15e6b82` launches without a prompt against the same item.
- A GUI-run arm64 diagnostic proved `kSecUseAuthenticationUIFail` still prompts for the legacy item, while `SecKeychainSetUserInteractionAllowed(false)` returns without UI and restores the previous process state.
- Production LOC: +165/-41; tests: +150. The production growth introduces an explicit unavailable/missing/failure state model, an injectable Keychain boundary, and the serialized legacy compatibility boundary; the canonical migration transform remains single-source and idempotent.

Proof gap: real legacy-ACL prompt suppression is exact-head tested; authorized mutation preservation is covered at the Keychain boundary with hidden-profile and migrated-credential regressions rather than UI automation.
