### PR TITLE
fix: attachments fail when data URLs contain MIME parameters or wrapped base64

### DIFF
--- a/src/infra/outbound/message-action-params.attachments.test.ts
+++ b/src/infra/outbound/message-action-params.attachments.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 // Covers message-action media hydration, sandbox path normalization,
 // attachments, and channel/plugin media source aliases.
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
@@ -17,12 +18,17 @@ import {
   setMessageActionTestPlugin as setTestPlugin,
 } from "./message-action-runner.test-helpers.js";
 
+const { hydrateAttachmentParamsForAction, normalizeSandboxMediaParams } =
+  await import("./message-action-params.js");
 const loadWebMedia = messageActionRunnerMocks.loadWebMedia;
 
 const onePixelPng = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5m8gAAAABJRU5ErkJggg==",
   "base64",
 );
+const onePixelPngBase64 = onePixelPng.toString("base64");
+const wrappedOnePixelPngBase64 = onePixelPngBase64.match(/.{1,24}/g)?.join("\r\n") ?? "";
+const parameterizedPngDataUrl = `data:image/png;charset=utf-8;name=../../ignored.svg;base64,${wrappedOnePixelPngBase64}`;
 
 function firstMockArg(
   mock: { mock: { calls: readonly unknown[][] } },
@@ -99,6 +105,106 @@ describe("runMessageAction media behavior", () => {
   beforeEach(async () => {
     await resetMessageActionMediaMocks();
   });
+
+  it.each(["send", "sendAttachment", "reply", "upload-file", "setGroupIcon"] as const)(
+    "normalizes parameterized, line-wrapped image data URLs for %s",
+    async (action) => {
+      const args: Record<string, unknown> = { buffer: parameterizedPngDataUrl };
+
+      await hydrateAttachmentParamsForAction({
+        cfg: {},
+        channel: "imessage",
+        args,
+        action,
+        dryRun: true,
+        mediaPolicy: { mode: "host" },
+      });
+
+      expect(args.contentType).toBe("image/png");
+      if (action === "send") {
+        expect(args.media).toBe("buffer://message-send/attachment");
+        expect(args.filename).toBe("attachment.png");
+      } else {
+        expect(canonicalizeBase64(String(args.buffer))).toBe(onePixelPngBase64);
+      }
+      expect(args.filename).not.toBe("../../ignored.svg");
+    },
+  );
+
+  it.each(["send", "sendAttachment", "reply", "upload-file", "setGroupIcon"] as const)(
+    "keeps explicit content type authoritative for %s data URLs",
+    async (action) => {
+      const args: Record<string, unknown> = {
+        buffer: parameterizedPngDataUrl,
+        contentType: "image/jpeg",
+      };
+
+      await hydrateAttachmentParamsForAction({
+        cfg: {},
+        channel: "imessage",
+        args,
+        action,
+        dryRun: true,
+        mediaPolicy: { mode: "host" },
+      });
+
+      expect(args.contentType).toBe("image/jpeg");
+      expect(args.filename).toBe("attachment.jpg");
+    },
+  );
+
+  it.each([
+    ["duplicate marker", "image/png;base64;base64"],
+    ["marker before another parameter", "image/png;base64;charset=utf-8"],
+    ["missing MIME type", ";base64"],
+    ["metadata newline", "image/png;name=bad\r\nvalue;base64"],
+  ])("rejects a data URL with a %s", async (_label, metadata) => {
+    await expect(
+      hydrateAttachmentParamsForAction({
+        cfg: {},
+        channel: "imessage",
+        args: { buffer: `data:${metadata},${onePixelPngBase64}` },
+        action: "send",
+        dryRun: true,
+        mediaPolicy: { mode: "host" },
+      }),
+    ).rejects.toThrow(/invalid base64/i);
+  });
+
+  it("rejects an oversized parameterized data URL before decoding its payload", async () => {
+    const fromSpy = vi.spyOn(Buffer, "from");
+    try {
+      await expect(
+        hydrateAttachmentParamsForAction({
+          cfg: { agents: { defaults: { mediaMaxMb: 0.00001 } } },
+          channel: "imessage",
+          args: { buffer: parameterizedPngDataUrl },
+          action: "send",
+          dryRun: true,
+          mediaPolicy: { mode: "host" },
+        }),
+      ).rejects.toThrow(/too large|limit/i);
+      const base64Calls = (fromSpy.mock.calls as ReadonlyArray<readonly unknown[]>).filter(
+        (call) => call[1] === "base64",
+      );
+      expect(base64Calls).toHaveLength(0);
+    } finally {
+      fromSpy.mockRestore();
+    }
+  });
+
+  it.each(["media", "mediaUrl", "path", "filePath"])(
+    "keeps data URLs forbidden in the %s source field",
+    async (field) => {
+      await expect(
+        normalizeSandboxMediaParams({
+          args: { [field]: parameterizedPngDataUrl },
+          mediaPolicy: { mode: "host" },
+        }),
+      ).rejects.toThrow(/data: URLs are not supported for media/i);
+    },
+  );
+
   describe("sendAttachment hydration", () => {
     const cfg = {
       channels: {
@@ -207,6 +313,25 @@ describe("runMessageAction media behavior", () => {
       expect(options.hostReadCapability).toBe(true);
       expect(options.sandboxValidated).not.toBe(true);
     });
+
+    it.each(["sendAttachment", "upload-file"] as const)(
+      "delivers parameterized wrapped image data URLs through the %s handler",
+      async (action) => {
+        const result = await runMessageAction({
+          cfg,
+          action,
+          params: {
+            channel: "attachmentchat",
+            target: "+15551234567",
+            buffer: parameterizedPngDataUrl,
+          },
+        });
+
+        const payload = requireActionPayload(result);
+        expect(payload.contentType).toBe("image/png");
+        expect(canonicalizeBase64(String(payload.buffer))).toBe(onePixelPngBase64);
+      },
+    );
 
     it("allows host-local image attachment paths when fs root expansion is enabled", async () => {
       await restoreRealMediaLoader();
@@ -476,6 +601,23 @@ describe("runMessageAction media behavior", () => {
       expect(handlerParams.buffer).toBe(Buffer.from("hello").toString("base64"));
       expect(handlerParams.filename).toBe("pic.png");
       expect(handlerParams.contentType).toBe("image/png");
+    });
+
+    it("delivers parameterized wrapped image data URLs through the reply handler", async () => {
+      await runMessageAction({
+        cfg,
+        action: "reply",
+        params: {
+          channel: "replychat",
+          target: "+15551234567",
+          messageId: "parent-id",
+          buffer: parameterizedPngDataUrl,
+        },
+      });
+
+      const handlerParams = firstMockArg(handleActionMock, "handleAction");
+      expect(handlerParams.contentType).toBe("image/png");
+      expect(canonicalizeBase64(String(handlerParams.buffer))).toBe(onePixelPngBase64);
     });
 
     it("hydrates buffer and metadata from attachments[] before the reply handler runs", async () => {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -273,11 +273,11 @@ function normalizeBase64Payload(params: { base64?: string; contentType?: string 
   if (!params.base64) {
     return { base64: params.base64, contentType: params.contentType };
   }
-  const match = /^data:([^;]+);base64,(.*)$/i.exec(params.base64.trim());
+  const match = /^data:([^;,\s]+)(;(?!base64)[^,;\s]+)*;base64,(.*)$/is.exec(params.base64.trim());
   if (!match) {
     return { base64: params.base64, contentType: params.contentType };
   }
-  const [, mime, payload] = match;
+  const [, mime, , payload] = match;
   return {
     base64: payload,
     contentType: params.contentType ?? mime,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users sending or uploading an image, voice recording, or video would see an invalid-base64 error when an otherwise valid attachment data URL contained MIME parameters or line-wrapped base64. Replies, attachment uploads, and group-icon actions also failed to pass the decoded payload and content type expected by channel handlers.

## Why This Change Was Made

Normalize legitimate parameterized and line-wrapped data URLs at the existing shared attachment-buffer owner, so Gateway sends and every attachment action receive the same canonical MIME and payload handling. Keep explicit content types authoritative, reject ambiguous base64 markers and malformed metadata, preserve decoded-size enforcement before decoding, and continue rejecting data URLs in path- or URL-shaped media fields. This changes no public API, configuration, dependencies, or security policy and adds zero net production lines.

## User Impact

Image, audio, and video attachments supplied as ordinary standards-compatible data URLs now send successfully across supported channels even when their base64 is wrapped or their MIME type includes parameters. Existing malformed-input, attachment-size, and local-file/network access protections remain unchanged.

## Evidence

- Captured the original regression as nine failing owner and channel-action cases before the production change; all 34 focused attachment-owner tests pass afterward.
- Independent review reran 170 tests covering the shared media base64 contract, outbound owner and sibling actions, and 78 current iMessage channel tests.
- Checked-in PNG bytes and real ffmpeg-generated WAV and MP4 bytes retain their exact content and MIME type through send, sendAttachment, reply, upload-file, and setGroupIcon actions.
- Regression cases cover explicit content-type precedence, duplicate or misplaced base64 markers, missing MIME types, newline injection in metadata, oversized payload rejection before decoding, ignored filename-like MIME parameters, and continued rejection of data URLs in media/path fields.
- Focused typed lint, formatting, and authenticated independent code review pass; changed files have no TypeScript diagnostics. A complete local repository typecheck is unavailable with the existing shared install because unrelated installed Google GenAI, markdown-it, and TUI packages are older than the current repository pins.
