### PR TITLE
fix(update): reject incomplete Control UI bundles

### DIFF
--- a/src/commands/doctor-ui.ts
+++ b/src/commands/doctor-ui.ts
@@ -5,8 +5,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import {
   ensureControlUiAssetsBuilt,
-  isControlUiStartupAssetsReady,
-  resolveControlUiDistIndexHealth,
+  resolveControlUiAssetHealth,
   resolveControlUiDistIndexPathForRoot,
 } from "../infra/control-ui-assets.js";
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
@@ -52,10 +51,7 @@ export async function detectUiProtocolFreshnessIssues(
     return [];
   }
 
-  const uiHealth = await resolveControlUiDistIndexHealth({
-    root,
-    argv1: opts.argv1 ?? process.argv[1],
-  });
+  const uiHealth = await resolveControlUiAssetHealth({ root });
   const uiIndexPath = uiHealth.indexPath ?? resolveControlUiDistIndexPathForRoot(root);
   const uiSourcesPath = path.join(root, "ui/package.json");
 
@@ -65,7 +61,7 @@ export async function detectUiProtocolFreshnessIssues(
       fs.stat(uiSourcesPath).catch(() => null),
     ]);
     const canBuild = uiSourcesStats !== null;
-    if (!uiStats || !isControlUiStartupAssetsReady(path.dirname(uiIndexPath))) {
+    if (!uiStats || uiHealth.kind !== "ready") {
       return [{ kind: "missing-assets", root, uiIndexPath, canBuild }];
     }
     if (!canBuild) {

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -80,7 +80,7 @@ vi.mock("../process/exec.js", () => ({
 
 let ensureControlUiAssetsBuilt: typeof import("./control-ui-assets.js").ensureControlUiAssetsBuilt;
 let isControlUiStartupAssetsReady: typeof import("./control-ui-assets.js").isControlUiStartupAssetsReady;
-let resolveControlUiDistIndexHealth: typeof import("./control-ui-assets.js").resolveControlUiDistIndexHealth;
+let resolveControlUiAssetHealth: typeof import("./control-ui-assets.js").resolveControlUiAssetHealth;
 let isPackageProvenControlUiRootSync: typeof import("./control-ui-assets.js").isPackageProvenControlUiRootSync;
 let resolveControlUiRootOverrideSync: typeof import("./control-ui-assets.js").resolveControlUiRootOverrideSync;
 let resolveControlUiRootSync: typeof import("./control-ui-assets.js").resolveControlUiRootSync;
@@ -91,7 +91,7 @@ describe("control UI assets helpers (fs-mocked)", () => {
     ({
       ensureControlUiAssetsBuilt,
       isControlUiStartupAssetsReady,
-      resolveControlUiDistIndexHealth,
+      resolveControlUiAssetHealth,
       isPackageProvenControlUiRootSync,
       resolveControlUiRootOverrideSync,
       resolveControlUiRootSync,
@@ -107,19 +107,30 @@ describe("control UI assets helpers (fs-mocked)", () => {
     vi.mocked(openclawRoot.resolveOpenClawPackageRootSync).mockReset().mockReturnValue(null);
   });
 
-  it("reports health for missing + existing dist assets", async () => {
+  it("distinguishes unresolved, missing, incomplete, and ready startup bundles", async () => {
     const root = abs("fixtures/health");
     const indexPath = path.join(root, "dist", "control-ui", "index.html");
 
-    await expect(resolveControlUiDistIndexHealth({ root })).resolves.toEqual({
+    await expect(resolveControlUiAssetHealth({ argv1: "" })).resolves.toEqual({
+      kind: "missing-index",
+      indexPath: null,
+    });
+    await expect(resolveControlUiAssetHealth({ root })).resolves.toEqual({
+      kind: "missing-index",
       indexPath,
-      exists: false,
     });
 
-    setFile(indexPath, "<html></html>\n");
-    await expect(resolveControlUiDistIndexHealth({ root })).resolves.toEqual({
+    setFile(indexPath, '<script src="./assets/startup.js"></script>');
+    await expect(resolveControlUiAssetHealth({ root })).resolves.toEqual({
+      kind: "incomplete",
       indexPath,
-      exists: true,
+      missingAsset: "assets/startup.js",
+    });
+
+    setFile(path.join(root, "dist", "control-ui", "assets", "startup.js"));
+    await expect(resolveControlUiAssetHealth({ root })).resolves.toEqual({
+      kind: "ready",
+      indexPath,
     });
   });
 

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -8,34 +8,29 @@ import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import * as controlUiFsRuntime from "./control-ui-assets.fs.runtime.js";
 import { resolveOpenClawPackageRoot, resolveOpenClawPackageRootSync } from "./openclaw-root.js";
 
-const CONTROL_UI_DIST_PATH_SEGMENTS = ["dist", "control-ui", "index.html"] as const;
-
 export function resolveControlUiDistIndexPathForRoot(root: string): string {
-  return path.join(root, ...CONTROL_UI_DIST_PATH_SEGMENTS);
+  return path.join(root, "dist", "control-ui", "index.html");
 }
 
-type ControlUiDistIndexHealth = {
-  indexPath: string | null;
-  exists: boolean;
-};
+type ControlUiAssetHealth =
+  | { kind: "missing-index"; indexPath: string | null }
+  | { kind: "incomplete"; indexPath: string; missingAsset: string }
+  | { kind: "ready"; indexPath: string };
 
-export async function resolveControlUiDistIndexHealth(
+export async function resolveControlUiAssetHealth(
   opts: {
     root?: string;
     argv1?: string;
     moduleUrl?: string;
   } = {},
-): Promise<ControlUiDistIndexHealth> {
+): Promise<ControlUiAssetHealth> {
   const indexPath = opts.root
     ? resolveControlUiDistIndexPathForRoot(opts.root)
     : await resolveControlUiDistIndexPath({
         argv1: opts.argv1 ?? process.argv[1],
         moduleUrl: opts.moduleUrl,
       });
-  return {
-    indexPath,
-    exists: Boolean(indexPath && controlUiFsRuntime.existsSync(indexPath)),
-  };
+  return inspectControlUiAssetHealth(indexPath);
 }
 
 function resolveControlUiRepoRoot(opts: {
@@ -282,15 +277,18 @@ function controlUiAssetsFailure(message: string, built = false): EnsureControlUi
   return { ok: false, built, message };
 }
 
-function findMissingControlUiStartupAsset(indexPath: string): string | undefined {
+function inspectControlUiAssetHealth(indexPath: string | null): ControlUiAssetHealth {
+  if (!indexPath) {
+    return { kind: "missing-index", indexPath };
+  }
   let html: string;
   try {
     if (controlUiFsRuntime.statSync(indexPath).size > 256 * 1024) {
-      return "index.html exceeds its size limit";
+      return { kind: "incomplete", indexPath, missingAsset: "index.html exceeds its size limit" };
     }
     html = controlUiFsRuntime.readFileSync(indexPath, "utf8");
   } catch {
-    return "index.html";
+    return { kind: "missing-index", indexPath };
   }
   let references = 0;
   for (const tag of html.matchAll(/<(?:link|script)\b[^>]*>/giu)) {
@@ -305,17 +303,21 @@ function findMissingControlUiStartupAsset(indexPath: string): string | undefined
     }
     const asset = reference.slice(marker);
     if (++references > 128 || reference.split("/").includes("..")) {
-      return references > 128 ? "too many startup assets" : asset;
+      return {
+        kind: "incomplete",
+        indexPath,
+        missingAsset: references > 128 ? "too many startup assets" : asset,
+      };
     }
     if (!controlUiFsRuntime.existsSync(path.join(path.dirname(indexPath), asset))) {
-      return asset;
+      return { kind: "incomplete", indexPath, missingAsset: asset };
     }
   }
-  return undefined;
+  return { kind: "ready", indexPath };
 }
 
 export function isControlUiStartupAssetsReady(root: string): boolean {
-  return !findMissingControlUiStartupAsset(path.join(root, "index.html"));
+  return inspectControlUiAssetHealth(path.join(root, "index.html")).kind === "ready";
 }
 
 function summarizeCommandOutput(text: string): string | undefined {
@@ -335,15 +337,14 @@ export async function ensureControlUiAssetsBuilt(
   opts: EnsureControlUiAssetsOptions = {},
 ): Promise<EnsureControlUiAssetsResult> {
   const argv1 = opts.argv1 ?? process.argv[1];
-  const health = await resolveControlUiDistIndexHealth({
+  const health = await resolveControlUiAssetHealth({
     ...(opts.root ? { root: opts.root } : {}),
     argv1,
     moduleUrl: opts.moduleUrl,
   });
   const indexFromDist = health.indexPath;
-  let missingStartupAsset =
-    health.exists && indexFromDist ? findMissingControlUiStartupAsset(indexFromDist) : undefined;
-  if (!opts.force && health.exists && !missingStartupAsset) {
+  let missingStartupAsset = health.kind === "incomplete" ? health.missingAsset : undefined;
+  if (!opts.force && health.kind === "ready") {
     return { ok: true, built: false };
   }
   if (!opts.force && !opts.root) {
@@ -354,8 +355,10 @@ export async function ensureControlUiAssetsBuilt(
       execPath: opts.execPath,
     });
     if (detectedRoot) {
-      missingStartupAsset = findMissingControlUiStartupAsset(path.join(detectedRoot, "index.html"));
-      if (!missingStartupAsset) {
+      const detectedHealth = inspectControlUiAssetHealth(path.join(detectedRoot, "index.html"));
+      missingStartupAsset =
+        detectedHealth.kind === "incomplete" ? detectedHealth.missingAsset : undefined;
+      if (detectedHealth.kind === "ready") {
         return { ok: true, built: false };
       }
     }
@@ -379,11 +382,7 @@ export async function ensureControlUiAssetsBuilt(
   }
 
   const indexPath = resolveControlUiDistIndexPathForRoot(repoRoot);
-  if (
-    !opts.force &&
-    controlUiFsRuntime.existsSync(indexPath) &&
-    !findMissingControlUiStartupAsset(indexPath)
-  ) {
+  if (!opts.force && inspectControlUiAssetHealth(indexPath).kind === "ready") {
     return { ok: true, built: false };
   }
 
@@ -429,16 +428,16 @@ export async function ensureControlUiAssetsBuilt(
     );
   }
 
-  if (!controlUiFsRuntime.existsSync(indexPath)) {
+  const builtHealth = inspectControlUiAssetHealth(indexPath);
+  if (builtHealth.kind === "missing-index") {
     return controlUiAssetsFailure(
       `Control UI build completed but ${indexPath} is still missing.`,
       true,
     );
   }
-  const missingBuiltAsset = findMissingControlUiStartupAsset(indexPath);
-  if (missingBuiltAsset) {
+  if (builtHealth.kind === "incomplete") {
     return controlUiAssetsFailure(
-      `Control UI build completed but startup asset ${missingBuiltAsset} is missing.`,
+      `Control UI build completed but startup asset ${builtHealth.missingAsset} is missing.`,
       true,
     );
   }

--- a/src/infra/update-runner-git-recovery.ts
+++ b/src/infra/update-runner-git-recovery.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { resolveControlUiDistIndexHealth } from "./control-ui-assets.js";
+import { resolveControlUiAssetHealth } from "./control-ui-assets.js";
 import type { UpdateChannel } from "./update-channels.js";
 import {
   managerInstallArgs,
@@ -124,14 +124,14 @@ export async function rebuildRolledBackGitRuntime(params: {
         () => true,
         () => false,
       ),
-      resolveControlUiDistIndexHealth({ root: params.gitRoot }),
+      resolveControlUiAssetHealth({ root: params.gitRoot }),
     ]);
     const verified =
       commit === params.expectedSha &&
       buildHead === params.expectedSha &&
       runtimeHead === params.expectedSha &&
       entryExists &&
-      uiHealth.exists;
+      uiHealth.kind === "ready";
     params.steps.push({
       name: "git rollback runtime verify",
       command: `verify rollback runtime ${params.expectedSha}`,
@@ -141,7 +141,7 @@ export async function rebuildRolledBackGitRuntime(params: {
       ...(verified
         ? {}
         : {
-            stderrTail: `rollback runtime mismatch (build=${commit ?? "missing"}, buildStamp=${buildHead ?? "missing"}, runtimeStamp=${runtimeHead ?? "missing"}, entry=${entryExists}, ui=${uiHealth.exists})`,
+            stderrTail: `rollback runtime mismatch (build=${commit ?? "missing"}, buildStamp=${buildHead ?? "missing"}, runtimeStamp=${runtimeHead ?? "missing"}, entry=${entryExists}, ui=${uiHealth.kind})`,
           }),
     });
     return verified

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
-  resolveControlUiDistIndexHealth,
+  resolveControlUiAssetHealth,
   resolveControlUiDistIndexPathForRoot,
 } from "./control-ui-assets.js";
 import { readPackageVersion } from "./package-json.js";
@@ -452,8 +452,8 @@ export async function updateGitCheckout(params: {
     if (buildCleanCheck.stdoutTail?.trim()) {
       return await rollbackError("build-dirty");
     }
-    const builtUiIndexHealth = await resolveControlUiDistIndexHealth({ root: gitRoot });
-    if (!builtUiIndexHealth.exists) {
+    const builtUiHealth = await resolveControlUiAssetHealth({ root: gitRoot });
+    if (builtUiHealth.kind !== "ready") {
       const uiBuildStep = await runStep(
         step(
           "ui:build (build fallback)",
@@ -512,13 +512,12 @@ export async function updateGitCheckout(params: {
       return await rollbackError("doctor-failed");
     }
 
-    const uiIndexHealth = await resolveControlUiDistIndexHealth({ root: gitRoot });
-    if (!uiIndexHealth.exists) {
-      const repairArgv = managerScriptArgs(manager.manager, "ui:build");
+    const uiHealth = await resolveControlUiAssetHealth({ root: gitRoot });
+    if (uiHealth.kind !== "ready") {
       const repairStep = await runStep({
         runCommand,
         name: "ui:build (post-doctor repair)",
-        argv: repairArgv,
+        argv: managerScriptArgs(manager.manager, "ui:build"),
         cwd: gitRoot,
         timeoutMs,
         env: manager.env,
@@ -529,8 +528,8 @@ export async function updateGitCheckout(params: {
       if (repairStep.exitCode !== 0) {
         return await rollbackError("ui-build-failed");
       }
-      const repairedHealth = await resolveControlUiDistIndexHealth({ root: gitRoot });
-      if (!repairedHealth.exists) {
+      const repairedHealth = await resolveControlUiAssetHealth({ root: gitRoot });
+      if (repairedHealth.kind !== "ready") {
         const uiIndexPath =
           repairedHealth.indexPath ?? resolveControlUiDistIndexPathForRoot(gitRoot);
         steps.push({
@@ -539,7 +538,10 @@ export async function updateGitCheckout(params: {
           cwd: gitRoot,
           durationMs: 0,
           exitCode: 1,
-          stderrTail: `missing ${uiIndexPath}`,
+          stderrTail:
+            repairedHealth.kind === "incomplete"
+              ? `missing startup asset ${repairedHealth.missingAsset} referenced by ${uiIndexPath}`
+              : `missing ${uiIndexPath}`,
         });
         return await rollbackError("ui-assets-missing");
       }

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -2935,162 +2935,219 @@ describe("runGatewayUpdate", () => {
     expect(result.steps.at(-1)?.name).toMatch(/^git rollback/);
   });
 
-  it("rebuilds and verifies the original runtime before allowing restart after rollback", async () => {
-    await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
-    const beforeSha = "a".repeat(40);
-    const targetSha = "b".repeat(40);
-    const stableTag = "v1.0.1-1";
-    let currentHead = beforeSha;
-    let buildCount = 0;
-    const calls: string[] = [];
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
-    const writeRuntime = async (head: string) => {
-      const distRoot = path.join(tempDir, "dist");
-      await fs.mkdir(path.join(distRoot, "control-ui"), { recursive: true });
-      await Promise.all([
-        fs.writeFile(path.join(distRoot, "entry.js"), "export {};\n", "utf8"),
-        fs.writeFile(
-          path.join(distRoot, "build-info.json"),
-          `${JSON.stringify({ commit: head })}\n`,
-          "utf8",
-        ),
-        fs.writeFile(path.join(distRoot, ".buildstamp"), `${JSON.stringify({ head })}\n`, "utf8"),
-        fs.writeFile(
-          path.join(distRoot, ".runtime-postbuildstamp"),
-          `${JSON.stringify({ head })}\n`,
-          "utf8",
-        ),
-        fs.writeFile(path.join(distRoot, "control-ui", "index.html"), "<html></html>", "utf8"),
-      ]);
-    };
-    const runCommand = async (argv: string[]) => {
-      const key = argv.join(" ");
-      calls.push(key);
-      if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
-        return toCommandResult({ stdout: tempDir });
-      }
-      if (key === `git -C ${tempDir} rev-parse HEAD`) {
-        return toCommandResult({ stdout: `${currentHead}\n` });
-      }
-      if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
-        return toCommandResult({ stdout: "main\n" });
-      }
-      if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
+  it.each([
+    { bundle: "complete", missingRollbackStartupAsset: false, serviceRestartSafe: true },
+    { bundle: "incomplete", missingRollbackStartupAsset: true, serviceRestartSafe: false },
+  ])(
+    "allows rollback restart only with a $bundle startup bundle",
+    async ({ missingRollbackStartupAsset, serviceRestartSafe }) => {
+      await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
+      const beforeSha = "a".repeat(40);
+      const targetSha = "b".repeat(40);
+      const stableTag = "v1.0.1-1";
+      let currentHead = beforeSha;
+      let buildCount = 0;
+      const calls: string[] = [];
+      const doctorNodePath = await resolveStableNodePath(process.execPath);
+      const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
+      const writeRuntime = async (head: string) => {
+        const distRoot = path.join(tempDir, "dist");
+        const startupAsset = path.join(distRoot, "control-ui", "assets", "startup.js");
+        await fs.mkdir(path.dirname(startupAsset), { recursive: true });
+        if (missingRollbackStartupAsset && head === beforeSha) {
+          await fs.rm(startupAsset, { force: true });
+        } else {
+          await fs.writeFile(startupAsset, "export {};\n", "utf8");
+        }
+        await Promise.all([
+          fs.writeFile(path.join(distRoot, "entry.js"), "export {};\n", "utf8"),
+          fs.writeFile(
+            path.join(distRoot, "build-info.json"),
+            `${JSON.stringify({ commit: head })}\n`,
+            "utf8",
+          ),
+          fs.writeFile(path.join(distRoot, ".buildstamp"), `${JSON.stringify({ head })}\n`, "utf8"),
+          fs.writeFile(
+            path.join(distRoot, ".runtime-postbuildstamp"),
+            `${JSON.stringify({ head })}\n`,
+            "utf8",
+          ),
+          fs.writeFile(
+            path.join(distRoot, "control-ui", "index.html"),
+            '<script type="module" src="./assets/startup.js"></script>',
+            "utf8",
+          ),
+        ]);
+      };
+      const runCommand = async (argv: string[]) => {
+        const key = argv.join(" ");
+        calls.push(key);
+        if (key === `git -C ${tempDir} rev-parse --show-toplevel`) {
+          return toCommandResult({ stdout: tempDir });
+        }
+        if (key === `git -C ${tempDir} rev-parse HEAD`) {
+          return toCommandResult({ stdout: `${currentHead}\n` });
+        }
+        if (key === `git -C ${tempDir} rev-parse --abbrev-ref HEAD`) {
+          return toCommandResult({ stdout: "main\n" });
+        }
+        if (key === `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`) {
+          return toCommandResult();
+        }
+        if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
+          return toCommandResult();
+        }
+        if (key === `git -C ${tempDir} tag --list v* --sort=-v:refname`) {
+          return toCommandResult({ stdout: `${stableTag}\n` });
+        }
+        if (key === `git -C ${tempDir} checkout --detach ${stableTag}`) {
+          currentHead = targetSha;
+          return toCommandResult();
+        }
+        if (key === `git -C ${tempDir} checkout --force main`) {
+          return toCommandResult();
+        }
+        if (key === `git -C ${tempDir} reset --hard ${beforeSha}`) {
+          currentHead = beforeSha;
+          return toCommandResult();
+        }
+        if (key === "pnpm install") {
+          return toCommandResult();
+        }
+        if (key === "pnpm build") {
+          buildCount += 1;
+          await writeRuntime(currentHead);
+          return toCommandResult();
+        }
+        if (key === doctorCommand) {
+          return toCommandResult({ code: 1, stderr: "doctor failed after build" });
+        }
         return toCommandResult();
-      }
-      if (key === `git -C ${tempDir} fetch --all --prune --tags`) {
-        return toCommandResult();
-      }
-      if (key === `git -C ${tempDir} tag --list v* --sort=-v:refname`) {
-        return toCommandResult({ stdout: `${stableTag}\n` });
-      }
-      if (key === `git -C ${tempDir} checkout --detach ${stableTag}`) {
-        currentHead = targetSha;
-        return toCommandResult();
-      }
-      if (key === `git -C ${tempDir} checkout --force main`) {
-        return toCommandResult();
-      }
-      if (key === `git -C ${tempDir} reset --hard ${beforeSha}`) {
-        currentHead = beforeSha;
-        return toCommandResult();
-      }
-      if (key === "pnpm install") {
-        return toCommandResult();
-      }
-      if (key === "pnpm build") {
-        buildCount += 1;
-        await writeRuntime(currentHead);
-        return toCommandResult();
-      }
-      if (key === doctorCommand) {
-        return toCommandResult({ code: 1, stderr: "doctor failed after build" });
-      }
-      return toCommandResult();
-    };
+      };
 
-    const result = await runWithCommand(runCommand, { channel: "stable" });
+      const result = await runWithCommand(runCommand, { channel: "stable" });
 
-    expect(result).toMatchObject({
-      status: "error",
-      reason: "doctor-failed",
-      recovery: { serviceRestartSafe: true },
-    });
-    expect(buildCount).toBe(2);
-    expect(currentHead).toBe(beforeSha);
-    expect(
-      JSON.parse(await fs.readFile(path.join(tempDir, "dist", "build-info.json"), "utf8")),
-    ).toMatchObject({ commit: beforeSha });
-    expect(result.steps.at(-1)).toMatchObject({
-      name: "git rollback runtime verify",
-      exitCode: 0,
-    });
-    expect(calls.indexOf(doctorCommand)).toBeLessThan(
-      calls.lastIndexOf(`git -C ${tempDir} rev-parse HEAD`),
-    );
-    expect(calls.lastIndexOf("pnpm install")).toBeLessThan(calls.lastIndexOf("pnpm build"));
-  });
+      expect(result).toMatchObject({
+        status: "error",
+        reason: "doctor-failed",
+        recovery: serviceRestartSafe
+          ? { serviceRestartSafe: true }
+          : { serviceRestartSafe: false, reason: "runtime-verification-failed" },
+      });
+      expect(buildCount).toBe(2);
+      expect(currentHead).toBe(beforeSha);
+      expect(
+        JSON.parse(await fs.readFile(path.join(tempDir, "dist", "build-info.json"), "utf8")),
+      ).toMatchObject({ commit: beforeSha });
+      expect(result.steps.at(-1)).toMatchObject({
+        name: "git rollback runtime verify",
+        exitCode: serviceRestartSafe ? 0 : 1,
+      });
+      expect(calls.indexOf(doctorCommand)).toBeLessThan(
+        calls.lastIndexOf(`git -C ${tempDir} rev-parse HEAD`),
+      );
+      expect(calls.lastIndexOf("pnpm install")).toBeLessThan(calls.lastIndexOf("pnpm build"));
+    },
+  );
 
-  it("repairs UI assets when doctor run removes control-ui files", async () => {
-    await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
-    const uiIndexPath = await setupUiIndex();
+  it.each(["missing", "incomplete"] as const)(
+    "repairs %s Control UI assets left by the doctor pass",
+    async (doctorBundle) => {
+      await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
+      const uiIndexPath = await setupUiIndex();
+      const startupAsset = path.join(path.dirname(uiIndexPath), "assets", "startup.js");
 
-    const stableTag = "v1.0.1-1";
-    const { runCommand, calls, doctorKey, getUiBuildCount } = await createStableTagRunner({
-      stableTag,
-      uiIndexPath,
-      onUiBuild: async (count) => {
+      const stableTag = "v1.0.1-1";
+      const { runCommand, calls, doctorKey, getUiBuildCount } = await createStableTagRunner({
+        stableTag,
+        uiIndexPath,
+        onUiBuild: async () => {
+          await fs.mkdir(path.dirname(startupAsset), { recursive: true });
+          await fs.writeFile(uiIndexPath, '<script src="./assets/startup.js"></script>', "utf-8");
+          await fs.writeFile(startupAsset, "export {};\n", "utf-8");
+        },
+        onDoctor: async () => {
+          if (doctorBundle === "missing") {
+            await removeControlUiAssets();
+          } else {
+            await fs.writeFile(uiIndexPath, '<script src="./assets/startup.js"></script>', "utf-8");
+          }
+        },
+      });
+
+      const result = await runWithCommand(runCommand, { channel: "stable" });
+
+      expect(result.status).toBe("ok");
+      expect(getUiBuildCount()).toBe(1);
+      expect(await pathExists(uiIndexPath)).toBe(true);
+      expect(calls).toContain(doctorKey);
+      expect(calls.indexOf("pnpm ui:build")).toBeGreaterThan(calls.indexOf(doctorKey));
+    },
+  );
+
+  it.each(["missing", "incomplete"] as const)(
+    "repairs a %s checkout startup bundle before the doctor pass",
+    async (checkoutBundle) => {
+      await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
+      const uiIndexPath = path.join(tempDir, "dist", "control-ui", "index.html");
+      const startupAsset = path.join(path.dirname(uiIndexPath), "assets", "startup.js");
+      if (checkoutBundle === "incomplete") {
         await fs.mkdir(path.dirname(uiIndexPath), { recursive: true });
-        await fs.writeFile(uiIndexPath, `<html>${count}</html>`, "utf-8");
-      },
-      onDoctor: removeControlUiAssets,
-    });
+        await fs.writeFile(uiIndexPath, '<script src="./assets/startup.js"></script>', "utf-8");
+      }
+      const stableTag = "v1.0.1-1";
+      const { runCommand, calls, doctorKey, getUiBuildCount } = await createStableTagRunner({
+        stableTag,
+        uiIndexPath,
+        onUiBuild: async () => {
+          await fs.mkdir(path.dirname(startupAsset), { recursive: true });
+          await fs.writeFile(uiIndexPath, '<script src="./assets/startup.js"></script>', "utf-8");
+          await fs.writeFile(startupAsset, "export {};\n", "utf-8");
+        },
+      });
 
-    const result = await runWithCommand(runCommand, { channel: "stable" });
+      const result = await runWithCommand(runCommand, { channel: "stable" });
 
-    expect(result.status).toBe("ok");
-    expect(getUiBuildCount()).toBe(1);
-    expect(await pathExists(uiIndexPath)).toBe(true);
-    expect(calls).toContain(doctorKey);
-  });
+      expect(result.status).toBe("ok");
+      expect(getUiBuildCount()).toBe(1);
+      expect(calls.indexOf("pnpm ui:build")).toBeLessThan(calls.indexOf(doctorKey));
+    },
+  );
 
-  it("builds Control UI separately only when the checkout build omitted it", async () => {
-    await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
-    const uiIndexPath = path.join(tempDir, "dist", "control-ui", "index.html");
-    const stableTag = "v1.0.1-1";
-    const { runCommand, calls, doctorKey, getUiBuildCount } = await createStableTagRunner({
-      stableTag,
-      uiIndexPath,
-      onUiBuild: async () => {
-        await fs.mkdir(path.dirname(uiIndexPath), { recursive: true });
-        await fs.writeFile(uiIndexPath, "<html>built</html>", "utf-8");
-      },
-    });
+  it.each(["missing", "incomplete"] as const)(
+    "fails when the post-doctor repair leaves a %s startup bundle",
+    async (repairedBundle) => {
+      await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
+      const uiIndexPath = await setupUiIndex();
 
-    const result = await runWithCommand(runCommand, { channel: "stable" });
+      const stableTag = "v1.0.1-1";
+      const { runCommand } = await createStableTagRunner({
+        stableTag,
+        uiIndexPath,
+        onDoctor: removeControlUiAssets,
+        onUiBuild: async () => {
+          if (repairedBundle === "incomplete") {
+            await fs.mkdir(path.dirname(uiIndexPath), { recursive: true });
+            await fs.writeFile(uiIndexPath, '<script src="./assets/startup.js"></script>', "utf-8");
+          }
+        },
+      });
 
-    expect(result.status).toBe("ok");
-    expect(getUiBuildCount()).toBe(1);
-    expect(calls.indexOf("pnpm ui:build")).toBeLessThan(calls.indexOf(doctorKey));
-  });
+      const result = await runWithCommand(runCommand, { channel: "stable" });
 
-  it("fails when UI assets are still missing after post-doctor repair", async () => {
-    await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
-    const uiIndexPath = await setupUiIndex();
-
-    const stableTag = "v1.0.1-1";
-    const { runCommand } = await createStableTagRunner({
-      stableTag,
-      uiIndexPath,
-      onDoctor: removeControlUiAssets,
-    });
-
-    const result = await runWithCommand(runCommand, { channel: "stable" });
-
-    expect(result.status).toBe("error");
-    expect(result.reason).toBe("ui-assets-missing");
-    expect(result.steps.at(-1)?.name).toMatch(/^git rollback/);
-  });
+      expect(result.status).toBe("error");
+      expect(result.reason).toBe("ui-assets-missing");
+      expect(result.steps).toContainEqual(
+        expect.objectContaining({
+          name: "ui assets verify",
+          exitCode: 1,
+          stderrTail: expect.stringContaining(
+            repairedBundle === "incomplete" ? "assets/startup.js" : uiIndexPath,
+          ),
+        }),
+      );
+      expect(result.steps.at(-1)?.name).toMatch(/^git rollback/);
+    },
+  );
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Closes #128654

## What Problem This Solves

Fixes an issue where an update could accept a Control UI bundle whose `index.html` existed but referenced missing startup JavaScript or CSS. The restarted Gateway would then enter its terminal failed asset state and return HTTP 503 for fresh Control UI documents.

This was observed live on `team.openclaw.ai`: two consecutive fresh chat navigations returned `Control UI assets could not be prepared`, while an already-cached shell remained visible. A replacement Gateway generation recovered later.

## Why This Change Was Made

Control UI asset health now has one canonical owner and three explicit outcomes: missing index, incomplete startup bundle, or ready. Doctor, Git update verification, post-repair verification, and rollback restart safety all consume that same complete invariant.

An index that references a missing first-party startup asset now triggers the existing owned UI repair flow. If repair remains incomplete, the update fails and rollback is not declared restart-safe. The old index-only helper and duplicate checks are removed.

The Gateway’s asynchronous fresh-install preparation and sanitized terminal 503 response remain unchanged. Readiness probe semantics are also unchanged; changing them is a separate deployment/product decision.

## User Impact

Managed updates can no longer report success and restart into a Control UI bundle that is structurally unable to serve its boot assets. Operators get repair or an explicit failed update instead of a deceptively healthy Gateway whose fresh UI pages return 503.

Production LOC: +53/-56 (net -3). Tests: +221/-153 (net +68).

## Evidence

- Four regression scenarios were confirmed failing before the repair: incomplete post-build bundle, incomplete post-doctor bundle, incomplete repair result, and rollback with a missing referenced startup asset.
- Focused asset/update/doctor/Gateway suites: 124 tests passed in parent verification; implementation sweep covered 149 focused tests.
- Full `node scripts/check-changed.mjs` and `pnpm build` passed.
- Real temporary-filesystem proof through the production asset-health seam:
  - index referencing absent `assets/startup.js` => `incomplete`
  - after creating the referenced asset => `ready`
- `git diff --check` and fresh structured autoreview: clean.
- The exact production deployment trigger still requires origin/build logs; this PR fixes the independently demonstrated updater integrity gap without speculating about that trigger.
- AI-assisted implementation; maintainer reviewed the lifecycle owner, update/rollback behavior, tests, and live filesystem proof directly.
