### PR TITLE
fix(secrets): keep the Gateway alive when the egress proxy cannot normalize a host

### DIFF
--- a/src/secrets/egress-proxy/proxy-server.test.ts
+++ b/src/secrets/egress-proxy/proxy-server.test.ts
@@ -199,6 +199,35 @@ async function forwardedRequest(auth?: string, protocol = "https"): Promise<numb
   });
 }
 
+// Absolute-form request target whose host `new URL` accepts but the proxy cannot normalize.
+// Resolves 0 if the proxy never answers, so a regression reports a failed assertion
+// instead of hanging the suite.
+async function unnormalizableForwardedRequest(): Promise<number> {
+  const proxyUrl = new URL(proxy.proxyOrigin);
+  return await new Promise<number>((resolve, reject) => {
+    const request = httpRequest(
+      {
+        hostname: proxyUrl.hostname,
+        port: proxyUrl.port,
+        path: "http://not_a_valid_host.test/probe",
+        method: "GET",
+        headers: { "Proxy-Authorization": basicProxyAuth(registeredPassword(proxyEnv)) },
+        timeout: 2_000,
+      },
+      (response) => {
+        response.resume();
+        response.once("end", () => resolve(response.statusCode ?? 0));
+      },
+    );
+    request.once("timeout", () => {
+      request.destroy();
+      resolve(0);
+    });
+    request.once("error", reject);
+    request.end();
+  });
+}
+
 function tamperSentinel(sentinel: string): string {
   const index = SECRET_SENTINEL_PREFIX.length;
   const replacement = sentinel[index] === "A" ? "B" : "A";
@@ -285,6 +314,30 @@ describe("secret egress proxy", () => {
 
     expect(uncaught).toEqual([]);
     // The listener must still serve traffic after the reset.
+    const stillAlive = await rawConnect({ auth: basicProxyAuth(registeredPassword(proxyEnv)) });
+    expect(stillAlive.response).toContain("200 Connection Established");
+    stillAlive.socket.destroy();
+  });
+
+  it("refuses a forwarded target the proxy cannot normalize instead of crashing the Gateway", async () => {
+    // `new URL` accepts hostnames the proxy rejects, so an agent running
+    // `curl http://my_service:8080/` against a compose service name reaches the request
+    // listener with an unnormalizable host. The proxy runs inside the Gateway process.
+    const uncaught: Error[] = [];
+    const onUncaught = (error: Error) => uncaught.push(error);
+    process.on("uncaughtException", onUncaught);
+    let status: number;
+    try {
+      status = await unnormalizableForwardedRequest();
+    } finally {
+      process.off("uncaughtException", onUncaught);
+    }
+
+    expect(uncaught).toEqual([]);
+    expect(status).toBe(400);
+    expect(originRequests).toEqual([]);
+    expect(auditEvents.at(-1)).toMatchObject({ kind: "refused", reason: "upstream-error" });
+    // The listener must still serve traffic after the refusal.
     const stillAlive = await rawConnect({ auth: basicProxyAuth(registeredPassword(proxyEnv)) });
     expect(stillAlive.response).toContain("200 Connection Established");
     stillAlive.socket.destroy();

--- a/src/secrets/egress-proxy/proxy-server.ts
+++ b/src/secrets/egress-proxy/proxy-server.ts
@@ -456,8 +456,13 @@ export async function startSecretEgressProxyServer(params: {
 
   const proxy = createHttpServer((request, response) => {
     let target: URL;
+    let host: string;
     try {
       target = new URL(request.url ?? "");
+      // `new URL` accepts hostnames normalizeHostname rejects (underscore labels are ordinary
+      // compose service names), and the proxy runs inside the Gateway process, so an escaping
+      // throw would exit it. Refuse here exactly like the CONNECT sibling does.
+      host = normalizeHostname(target.hostname);
     } catch {
       audit({
         kind: "refused",
@@ -468,7 +473,6 @@ export async function startSecretEgressProxyServer(params: {
       sendHttpRefusal(response, 400);
       return;
     }
-    const host = normalizeHostname(target.hostname);
     const authorization = authorize(request.headers);
     if (typeof authorization === "string") {
       audit({ kind: "refused", host, substituted: false, reason: authorization });


### PR DESCRIPTION
Closes #128828

**AI-assisted** (Claude Code) — I understand what the code does and verified every claim below. **Allow edits from maintainers** is enabled.

## What Problem This Solves

Fixes an issue where operators running `secrets.egressProxy.enabled: true` lose the whole Gateway when an agent runs `curl http://my_service:8080/health` against a compose-style hostname.

## Why This Change Was Made

`new URL()` accepts hostname labels that `normalizeHostname` rejects. At `src/secrets/egress-proxy/proxy-server.ts:471` that call sat outside the `try` guarding the target parse, so its throw escaped the `node:http` request listener as an `uncaughtException` with no `code`, and `src/index.ts:117-142` answered with `process.exit(1)` — the proxy runs in-process with the Gateway. Normalizing inside that `try` refuses with 400, matching the already-guarded CONNECT sibling at `:500-507`. One logical production line; valid hosts are unaffected.

## User Impact

The request is refused with 400 and audited; the Gateway keeps serving. Normalization ran before `authorize()`, so no proxy credential was needed to trigger the exit.

## Evidence

Regression test in `src/secrets/egress-proxy/proxy-server.test.ts` asserts no `uncaughtException`, a 400, and a still-serving listener.

- Negative control (production file reverted, test kept): **1 failed** — `expected [ Error { "Invalid proxy target hostname" } ] to deeply equal []`.
- With the fix, `src/secrets`: **76 files, 825 tests passed**.
- `pnpm tsgo:core`, `pnpm tsgo:test:src`, `oxfmt --check` clean; `check-changed.mjs` exit 0. macOS 26.5.1, Node v26.7.0.
- `autoreview` skill, `--mode branch --base origin/main`: **clean, no accepted/actionable findings**; `patch is correct (0.87)`.

Session note: `normalizeHostname` was executed at the tip — `my_service`, `ex_ample.com`, and `foo_bar.internal` throw; `foo.bar` normalizes.
