### PR TITLE
chore: upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/codeql-android-critical-security.yml
+++ b/.github/workflows/codeql-android-critical-security.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: false
 
       - name: Setup Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "21"


### PR DESCRIPTION
## What Problem This Solves

Keeps the Android CodeQL workflow on the current supported setup-java release.

## Why This Change Was Made

Upgrades the SHA-pinned actions/setup-java reference to v6.0.0 while preserving the repository’s pinning convention.

## User Impact

No user-visible impact; CI uses the current setup-java major release.

## Evidence

Verified the workflow YAML contains the v6.0.0 commit (`dd06d9cba3e5552c54d9f8ea23572deb30010f7c`) and no older setup-java reference remains.

AI-assisted: GitHub Copilot was used to prepare this change.