### PR TITLE
fix(state): retire session_nodes entry-validity write-triggers (beta.3 schema)

### DIFF
--- a/src/commands/doctor-session-canonical-keys.test.ts
+++ b/src/commands/doctor-session-canonical-keys.test.ts
@@ -205,7 +205,7 @@ describe("doctor canonical session-key repair", () => {
         database.db
           .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
           .get("agent:main:main"),
-      ).toEqual({ entry_valid: 0 });
+      ).toEqual({ entry_valid: 1 });
       expect(await repairCanonicalSessionKeys({ apply: true, cfg, env })).toMatchObject({
         foundGroups: 1,
         removedRows: 0,

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -1277,7 +1277,7 @@ describe("sqlite session normalization", () => {
     });
   });
 
-  it("marks identity-only row updates pending validation", async () => {
+  it("keeps identity-only row updates valid after trigger retirement", async () => {
     const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
     const sessionKey = "agent:main:identity-update";
     await replaceSessionEntry(
@@ -1293,7 +1293,7 @@ describe("sqlite session normalization", () => {
       database.db
         .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
         .get(sessionKey),
-    ).toEqual({ entry_valid: 0 });
+    ).toEqual({ entry_valid: 1 });
   });
 
   it("writes a valid session beside an unrelated malformed legacy row", async () => {

--- a/src/infra/state-migrations.media-persistence.additive-schema.test.ts
+++ b/src/infra/state-migrations.media-persistence.additive-schema.test.ts
@@ -40,10 +40,10 @@ describe("legacy media persistence additive schema repair", () => {
     const { DatabaseSync } = requireNodeSqlite();
     const database = new DatabaseSync(databasePath);
     database.exec(`
-      DROP TRIGGER session_nodes_entry_valid_after_insert;
-      DROP TRIGGER session_nodes_entry_valid_after_entry_update;
-      DROP TRIGGER session_nodes_entry_valid_after_identity_update;
-      DROP INDEX idx_agent_session_nodes_entry_valid_pending;
+      DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_insert;
+      DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_entry_update;
+      DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_identity_update;
+      DROP INDEX IF EXISTS idx_agent_session_nodes_entry_valid_pending;
       DROP TABLE session_key_contract;
       ALTER TABLE session_nodes DROP COLUMN entry_valid;
     `);

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -29,6 +29,7 @@ import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-age
 import {
   ensureSessionAdditiveColumns,
   ensureSessionEntryValidityProjection,
+  SESSION_NODE_ENTRY_VALID_TRIGGER_NAMES,
 } from "./openclaw-agent-db-session-migrations.js";
 import { MESSAGE_TOOL_RUN_OUTCOMES_TABLE } from "./openclaw-agent-message-tool-outcome-schema.js";
 import {
@@ -85,6 +86,26 @@ const AGENT_SCHEMA_COMPATIBILITY = {
     {
       tableName: MEMORY_INDEX_SOURCES_TABLE,
       triggers: MEMORY_PATH_FTS_TRIGGER_DEFINITIONS,
+    },
+    {
+      // Retired in the same revision that removed them from the canonical
+      // schema: old databases may still carry them, and they must not be
+      // treated as a drift violation while migrations drop them.
+      tableName: "session_nodes",
+      triggers: [
+        {
+          name: "session_nodes_entry_valid_after_insert",
+          sql: "CREATE TRIGGER IF NOT EXISTS main.session_nodes_entry_valid_after_insert\nAFTER INSERT ON session_nodes\nBEGIN\n  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;\nEND;",
+        },
+        {
+          name: "session_nodes_entry_valid_after_entry_update",
+          sql: "CREATE TRIGGER IF NOT EXISTS main.session_nodes_entry_valid_after_entry_update\nAFTER UPDATE OF entry_json ON session_nodes\nBEGIN\n  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;\nEND;",
+        },
+        {
+          name: "session_nodes_entry_valid_after_identity_update",
+          sql: "CREATE TRIGGER IF NOT EXISTS main.session_nodes_entry_valid_after_identity_update\nAFTER UPDATE OF current_session_id, updated_at ON session_nodes\nBEGIN\n  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;\nEND;",
+        },
+      ],
     },
   ],
 } satisfies SqliteSchemaCompatibility;

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -29,7 +29,6 @@ import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-age
 import {
   ensureSessionAdditiveColumns,
   ensureSessionEntryValidityProjection,
-  SESSION_NODE_ENTRY_VALID_TRIGGER_NAMES,
 } from "./openclaw-agent-db-session-migrations.js";
 import { MESSAGE_TOOL_RUN_OUTCOMES_TABLE } from "./openclaw-agent-message-tool-outcome-schema.js";
 import {

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -57,6 +57,22 @@ type ExistingAgentSchemaMeta = {
   schemaVersion: number | null;
 };
 
+/** The retired session_nodes entry-validity write-triggers, kept as an optional canonical group. */
+const SESSION_NODE_ENTRY_VALID_TRIGGER_DEFINITIONS = [
+  {
+    name: "session_nodes_entry_valid_after_insert",
+    sql: "CREATE TRIGGER IF NOT EXISTS main.session_nodes_entry_valid_after_insert\nAFTER INSERT ON session_nodes\nBEGIN\n  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;\nEND;",
+  },
+  {
+    name: "session_nodes_entry_valid_after_entry_update",
+    sql: "CREATE TRIGGER IF NOT EXISTS main.session_nodes_entry_valid_after_entry_update\nAFTER UPDATE OF entry_json ON session_nodes\nBEGIN\n  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;\nEND;",
+  },
+  {
+    name: "session_nodes_entry_valid_after_identity_update",
+    sql: "CREATE TRIGGER IF NOT EXISTS main.session_nodes_entry_valid_after_identity_update\nAFTER UPDATE OF current_session_id, updated_at ON session_nodes\nBEGIN\n  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;\nEND;",
+  },
+];
+
 const AGENT_SCHEMA_COMPATIBILITY = {
   allowCompatibleAdditiveColumns: true,
   allowedMissingTables: [
@@ -92,20 +108,7 @@ const AGENT_SCHEMA_COMPATIBILITY = {
       // schema: old databases may still carry them, and they must not be
       // treated as a drift violation while migrations drop them.
       tableName: "session_nodes",
-      triggers: [
-        {
-          name: "session_nodes_entry_valid_after_insert",
-          sql: "CREATE TRIGGER IF NOT EXISTS main.session_nodes_entry_valid_after_insert\nAFTER INSERT ON session_nodes\nBEGIN\n  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;\nEND;",
-        },
-        {
-          name: "session_nodes_entry_valid_after_entry_update",
-          sql: "CREATE TRIGGER IF NOT EXISTS main.session_nodes_entry_valid_after_entry_update\nAFTER UPDATE OF entry_json ON session_nodes\nBEGIN\n  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;\nEND;",
-        },
-        {
-          name: "session_nodes_entry_valid_after_identity_update",
-          sql: "CREATE TRIGGER IF NOT EXISTS main.session_nodes_entry_valid_after_identity_update\nAFTER UPDATE OF current_session_id, updated_at ON session_nodes\nBEGIN\n  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;\nEND;",
-        },
-      ],
+      triggers: SESSION_NODE_ENTRY_VALID_TRIGGER_DEFINITIONS,
     },
   ],
 } satisfies SqliteSchemaCompatibility;

--- a/src/state/openclaw-agent-db-session-migrations.ts
+++ b/src/state/openclaw-agent-db-session-migrations.ts
@@ -113,7 +113,7 @@ function migratedConversation(
 }
 
 /** The retired session_nodes entry-validity write-triggers (see ensureSessionEntryValidityProjection). */
-export const SESSION_NODE_ENTRY_VALID_TRIGGER_NAMES = [
+const SESSION_NODE_ENTRY_VALID_TRIGGER_NAMES = [
   "session_nodes_entry_valid_after_insert",
   "session_nodes_entry_valid_after_entry_update",
   "session_nodes_entry_valid_after_identity_update",

--- a/src/state/openclaw-agent-db-session-migrations.ts
+++ b/src/state/openclaw-agent-db-session-migrations.ts
@@ -112,6 +112,13 @@ function migratedConversation(
   };
 }
 
+/** The retired session_nodes entry-validity write-triggers (see ensureSessionEntryValidityProjection). */
+export const SESSION_NODE_ENTRY_VALID_TRIGGER_NAMES = [
+  "session_nodes_entry_valid_after_insert",
+  "session_nodes_entry_valid_after_entry_update",
+  "session_nodes_entry_valid_after_identity_update",
+] as const;
+
 /** Backfills canonical external addresses once when conversation routing becomes active. */
 export function backfillSessionConversations(db: DatabaseSync): void {
   if (
@@ -326,23 +333,18 @@ export function ensureSessionEntryValidityProjection(db: DatabaseSync): void {
       "ALTER TABLE session_nodes ADD COLUMN entry_valid INTEGER NOT NULL DEFAULT 0 CHECK (entry_valid IN (-1, 0, 1))",
     );
   }
-  db.exec(`
-    CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_insert
-    AFTER INSERT ON session_nodes
-    BEGIN
-      UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-    END;
-    CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_entry_update
-    AFTER UPDATE OF entry_json ON session_nodes
-    BEGIN
-      UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-    END;
-    CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_identity_update
-    AFTER UPDATE OF current_session_id, updated_at ON session_nodes
-    BEGIN
-      UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-    END;
-  `);
+  // The write-triggers are retired in this revision: they mark every insert and
+  // update as pending (entry_valid = 0) and rely on each writer settling the row
+  // immediately after, but any read that lands inside that window — or a
+  // best-effort writer such as prompt-error entries that never settles — sees an
+  // invalid row and the whole turn fails with
+  // SessionCanonicalKeyMigrationRequiredError. Writers already settle explicitly
+  // (upsertSessionNode sets entry_valid = 1 right after the write), so the
+  // triggers only widen the failure window. Drop them and settle any rows they
+  // left pending instead.
+  for (const trigger of SESSION_NODE_ENTRY_VALID_TRIGGER_NAMES) {
+    db.exec(`DROP TRIGGER IF EXISTS ${trigger}`);
+  }
   const selectPending = db.prepare(
     "SELECT current_session_id, entry_json, session_key, updated_at FROM session_nodes WHERE entry_valid = 0 ORDER BY session_key LIMIT 256",
   );

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3487,11 +3487,11 @@ describe("openclaw agent database", () => {
       );
     try {
       shippedSchema.exec(`
-        DROP TRIGGER session_nodes_entry_valid_after_insert;
-        DROP TRIGGER session_nodes_entry_valid_after_entry_update;
-        DROP TRIGGER session_nodes_entry_valid_after_identity_update;
+        DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_insert;
+        DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_entry_update;
+        DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_identity_update;
         DROP TRIGGER session_conversations_route_context_invalidate_after_update;
-        DROP INDEX idx_agent_session_nodes_entry_valid_pending;
+        DROP INDEX IF EXISTS idx_agent_session_nodes_entry_valid_pending;
         DROP TABLE session_key_contract;
         ALTER TABLE session_nodes DROP COLUMN entry_valid;
         ALTER TABLE session_conversations DROP COLUMN route_context_json;
@@ -3545,10 +3545,10 @@ describe("openclaw agent database", () => {
           1000,
         );
       drifted.exec(`
-        DROP TRIGGER session_nodes_entry_valid_after_insert;
-        DROP TRIGGER session_nodes_entry_valid_after_entry_update;
-        DROP TRIGGER session_nodes_entry_valid_after_identity_update;
-        DROP INDEX idx_agent_session_nodes_entry_valid_pending;
+        DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_insert;
+        DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_entry_update;
+        DROP TRIGGER IF EXISTS session_nodes_entry_valid_after_identity_update;
+        DROP INDEX IF EXISTS idx_agent_session_nodes_entry_valid_pending;
         DROP TABLE session_key_contract;
         ALTER TABLE session_nodes DROP COLUMN entry_valid;
       `);

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -91,24 +91,6 @@ CREATE TABLE IF NOT EXISTS session_key_contract (
 
 INSERT OR IGNORE INTO session_key_contract (id, main_key, updated_at) VALUES (1, 'main', 0);
 
-CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_insert
-AFTER INSERT ON session_nodes
-BEGIN
-  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-END;
-
-CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_entry_update
-AFTER UPDATE OF entry_json ON session_nodes
-BEGIN
-  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-END;
-
-CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_identity_update
-AFTER UPDATE OF current_session_id, updated_at ON session_nodes
-BEGIN
-  UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key;
-END;
-
 CREATE TABLE IF NOT EXISTS session_windows (
   session_id TEXT NOT NULL PRIMARY KEY,
   session_key TEXT NOT NULL,


### PR DESCRIPTION
## What Problem This Solves

The `session_nodes` `entry_valid` write-triggers (introduced with the 2026.8.1 session-entry-validity projection) mark **every** insert/update as pending (`entry_valid = 0`) and rely on each writer settling the row immediately afterwards. Two gaps make this deadly in practice:

1. **A read racing the write→settle window** observes `entry_valid = 0` and the session-key validator throws `SessionCanonicalKeyMigrationRequiredError`, failing the whole turn. With a provider fallback configured, this surfaces as noisy `model fallback` decisions (M3 → deepseek fallback) even though the primary model is healthy.
2. **Best-effort writers that never settle** (e.g. `prompt-error` entries, which are intentionally best-effort and only logged on failure) leave rows permanently pending, so every later read of that session tears down with the same error — and `openclaw doctor --fix` cannot clear it because the triggers recreate pending rows on the next write. Observed as a repeating `WARN ... failed to persist prompt error entry: ... invalid persisted session row requires repair for agent:main:main` and a **gateway refusing to start** after upgrade when the first read of a stale pending row fires (schema check treats the triggers as canonical).

## The Fix

Writers already settle explicitly (`upsertSessionNode` sets `entry_valid = 1` immediately after the write), so the triggers only widen the failure window. This change:

- **removes the three triggers from the canonical agent schema** (`openclaw-agent-schema.sql`);
- **retires them in `ensureSessionEntryValidityProjection`**: drops any pre-existing triggers and settles rows they left pending (the existing bounded pending-settle loop already handles `entry_valid = 0` rows);
- **records the trigger definitions as an optional canonical trigger group** so a database that still carries them (pre-upgrade) is not treated as a drift violation while migrations drop them.

## Tests

`pnpm test:unit` (schema/conformance suites).

Relates to #124098 (same root cause; this revision is adapted to the 2026.8.1-beta.3 schema where triggers are part of the canonical schema and gated by the schema-consistency check).

## Evidence

**Before** — an upgraded host running 2026.8.1-beta.3, gateway log (02:19–02:21 CST, the exact failing minute the user reported):

```
WARN [agent/embedded] failed to persist prompt error entry: SessionCanonicalKeyMigrationRequiredError: invalid persisted session row requires repair for agent:main:main; stop the Gateway and run openclaw doctor --fix
WARN model fallback decision: decision=candidate_failed requestedModel=MiniMax-M3 error=invalid persisted session row requires repair ... fallbackStepFromModel=minimax/MiniMax-M3 fallbackStepToModel=deepseek/deepseek-v4-flash
```

The model fallback WARNs fired even though the M3 provider itself was healthy (HTTP 200): the session-key validator tripped on a row left at entry_valid = 0 by the trigger→settle race, which the fallback chain then misclassified as a candidate failure. openclaw doctor --fix did not clear it.

**After** — same host, after retiring the triggers (dist + DB rebuilt, ensureSessionEntryValidityProjection settle loop applied), gateway restart:

```
2026-08-25T02:33:26 [gateway] restart-loop breaker recovered; channel auto-start restored
2026-08-25T02:34:18 [feishu] starting feishu[default] (mode: websocket)
2026-08-25T02:34:19 [gateway] ready
2026-08-25T02:34:19 [feishu] WebSocket client started
```

Observed over the following hour: no further SessionCanonicalKeyMigrationRequiredError, no further model fallback decisions; session_nodes carries no entry_valid = 0 rows after the settle loop.

**Unit tests** (this branch): vitest run over the schema/session-accessor suites — see checks above.