### PR TITLE
fix(auto-reply): make the direct-chat prompt honor this run's source-reply delivery mode

### DIFF
--- a/src/auto-reply/reply/get-reply-run-context.ts
+++ b/src/auto-reply/reply/get-reply-run-context.ts
@@ -55,6 +55,7 @@ import { resolveSessionStableReplyMode } from "./session-stable-reply-mode.js";
 import {
   isDirectedSourceReplyTurn,
   isSyntheticSourceReplyTurn,
+  resolveSourceConversationContextMode,
 } from "./source-reply-delivery-mode.js";
 import { shouldApplyStartupContext, buildSessionStartupContextPrelude } from "./startup-context.js";
 import { resolveTypingMode } from "./typing-mode.js";
@@ -230,7 +231,10 @@ export async function prepareReplyRunContext(params: RunPreparedReplyParams) {
   // miss — a prompt/policy contradiction, not a delivery fault.
   const sessionStableConversationContext =
     sourceConversationContextByMode[
-      sessionPromptSourceReplyDeliveryMode ?? sourceReplyDeliveryMode ?? "automatic"
+      resolveSourceConversationContextMode({
+        sessionPinnedMode: sessionPromptSourceReplyDeliveryMode,
+        runMode: sourceReplyDeliveryMode,
+      })
     ];
   // Claude CLI fixes the system prompt at session creation; group intro must stay session-stable.
   const groupIntro = isGroupChat ? buildGroupIntro({ sessionEntry, defaultActivation }) : "";

--- a/src/auto-reply/reply/get-reply-run-context.ts
+++ b/src/auto-reply/reply/get-reply-run-context.ts
@@ -219,8 +219,19 @@ export async function prepareReplyRunContext(params: RunPreparedReplyParams) {
   };
   // CLI sessions keep their creation-time conversation prompt. Embedded attempts
   // can instead select the variant owned by their final prepared harness.
+  //
+  // The fallback must be this run's ACTUAL mode, not a hardcoded "automatic".
+  // sessionPromptSourceReplyDeliveryMode is only set for CLI sessions, so every
+  // other run used to be told "your replies are automatically sent to this
+  // conversation" even when delivery was message_tool_only. The agent then
+  // answered in plain text, the reply was never posted, and
+  // resolveStrandedReplyRecovery re-prompted once silently and then surfaced
+  // "I generated a reply but could not deliver it to this chat" on the second
+  // miss — a prompt/policy contradiction, not a delivery fault.
   const sessionStableConversationContext =
-    sourceConversationContextByMode[sessionPromptSourceReplyDeliveryMode ?? "automatic"];
+    sourceConversationContextByMode[
+      sessionPromptSourceReplyDeliveryMode ?? sourceReplyDeliveryMode ?? "automatic"
+    ];
   // Claude CLI fixes the system prompt at session creation; group intro must stay session-stable.
   const groupIntro = isGroupChat ? buildGroupIntro({ sessionEntry, defaultActivation }) : "";
   const isDirectedTurn = isDirectedSourceReplyTurn(ctx, cfg, isDirectChat, inboundEventKind);

--- a/src/auto-reply/reply/source-reply-delivery-mode.test.ts
+++ b/src/auto-reply/reply/source-reply-delivery-mode.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CommandTurnContext } from "../command-turn-context.js";
 import {
+  resolveSourceConversationContextMode,
   resolveSourceReplyDeliveryMode,
   resolveSourceReplyVisibilityPolicy,
 } from "./source-reply-delivery-mode.js";
@@ -713,5 +714,68 @@ describe("resolveSourceReplyVisibilityPolicy", () => {
         deliverySuppressionReason: "sourceReplyDeliveryMode: message_tool_only",
       },
     );
+  });
+});
+
+describe("resolveSourceConversationContextMode", () => {
+  it("uses the run's mode when no session-pinned mode exists", () => {
+    // The regression. sessionPinnedMode is set only for CLI sessions, so every
+    // other run hit the old hardcoded "automatic" fallback and was told its
+    // plain-text final would be delivered while delivery required
+    // message(action=send). Asserting the run mode wins here is the whole point
+    // of the helper.
+    expect(
+      resolveSourceConversationContextMode({
+        sessionPinnedMode: undefined,
+        runMode: "message_tool_only",
+      }),
+    ).toBe("message_tool_only");
+  });
+
+  it("keeps a CLI session pinned to its creation-time mode", () => {
+    // CLI sessions fix the system prompt at creation, so the pin must win even
+    // when the current turn resolves differently — otherwise the prompt would
+    // describe a mode the already-created session does not use.
+    expect(
+      resolveSourceConversationContextMode({
+        sessionPinnedMode: "automatic",
+        runMode: "message_tool_only",
+      }),
+    ).toBe("automatic");
+    expect(
+      resolveSourceConversationContextMode({
+        sessionPinnedMode: "message_tool_only",
+        runMode: "automatic",
+      }),
+    ).toBe("message_tool_only");
+  });
+
+  it("passes automatic through unchanged", () => {
+    expect(
+      resolveSourceConversationContextMode({
+        sessionPinnedMode: undefined,
+        runMode: "automatic",
+      }),
+    ).toBe("automatic");
+  });
+
+  it("defaults to automatic only when neither mode is known", () => {
+    expect(
+      resolveSourceConversationContextMode({
+        sessionPinnedMode: undefined,
+        runMode: undefined,
+      }),
+    ).toBe("automatic");
+  });
+
+  it("never reports automatic while the run is message_tool_only and unpinned", () => {
+    // The invariant stated directly rather than via prompt-string matching: an
+    // unpinned run must never be described by the automatic variant, because
+    // that is precisely the contradiction that strands replies.
+    for (const runMode of ["automatic", "message_tool_only"] as const) {
+      expect(resolveSourceConversationContextMode({ sessionPinnedMode: undefined, runMode })).toBe(
+        runMode,
+      );
+    }
   });
 });

--- a/src/auto-reply/reply/source-reply-delivery-mode.ts
+++ b/src/auto-reply/reply/source-reply-delivery-mode.ts
@@ -231,3 +231,26 @@ export function resolveSourceReplyVisibilityPolicy(params: {
     deliverySuppressionReason,
   };
 }
+
+/**
+ * Which delivery-mode variant of the conversation context a run must inject.
+ *
+ * The prompt and the delivery path MUST agree about the mode. When they diverge
+ * the agent is told its plain-text final will be posted while delivery expects
+ * `message(action=send)`; the reply is then stranded, silently retried once, and
+ * surfaced to the user as "I generated a reply but could not deliver it to this
+ * chat" on the second miss. That is a prompt/policy contradiction rather than a
+ * delivery fault, which makes it expensive to diagnose from the symptom.
+ *
+ * `sessionPinnedMode` exists because CLI sessions fix their system prompt at
+ * session creation, so those runs must keep the variant they were created with
+ * even if the current turn resolves differently. It is undefined for every other
+ * run — which is exactly why the fallback must be the run's own mode and not a
+ * hardcoded "automatic".
+ */
+export function resolveSourceConversationContextMode(params: {
+  sessionPinnedMode: SourceReplyDeliveryMode | undefined;
+  runMode: SourceReplyDeliveryMode | undefined;
+}): SourceReplyDeliveryMode {
+  return params.sessionPinnedMode ?? params.runMode ?? "automatic";
+}


### PR DESCRIPTION
> **⚠️ Correction (2026-08-24, round 1): the root cause stated in the original body was wrong, and this patch is a no-op.** ClawSweeper's [P1] was right. The proof and the mutation evidence are in [the round-1 comment](https://github.com/openclaw/openclaw/pull/128832#issuecomment-5400803269). I am recommending this PR be **closed** rather than patched further; the body below has been corrected rather than deleted so the review record stays legible. Do not merge.

## What Problem This Solves

Agents in `message_tool_only` conversations repeatedly surface:

> I generated a reply but could not deliver it to this chat. Please try again.

It reads like a delivery or transport failure. It isn't — the effective delivery mode was `message_tool_only` and the agent produced a plain-text final without calling `message(action=send)`, so nothing was ever posted. `resolveStrandedReplyRecovery` re-prompts once **silently** and only emits the visible failure on the second miss, so the reported frequency understates the real rate — roughly half the occurrences are invisible.

The phenomenon is real and frequent. Seven days of gateway logs in the reporting deployment carry **914** occurrences of the metadata-only operator signal `[source-reply/private-final] agent produced a long private final reply without calling the configured delivery tool (message_tool_only)`, which fires only when the effective mode *was* tool-only and the tool was not called.

### What this PR got wrong

The original diagnosis claimed `sessionPromptSourceReplyDeliveryMode` "is set only for CLI sessions", leaving every other run to take a hardcoded `"automatic"` prompt variant while delivery enforced `message_tool_only`. **That is false.** `src/auto-reply/reply/get-reply-run-context.ts:136-148` already ends its resolution chain with `: sourceReplyDeliveryMode`, and `resolveSessionStableReplyMode` returns a non-optional `SourceReplyDeliveryMode`. So `sessionPromptSourceReplyDeliveryMode === undefined` implies `sourceReplyDeliveryMode === undefined`, which makes `sessionPinnedMode ?? runMode ?? "automatic"` identical to `sessionPinnedMode ?? "automatic"` for every reachable input. The changed branch cannot be entered.

### Where the real repair belongs

Prompt/enforcement agreement is maintained by `SourceReplyDeliveryRuntime` (`source-reply-delivery-runtime.ts:41-89`), which rewrites the delivery-owned prompt component in place at a recorded offset when `runtime-preparation.ts:535-545` finally resolves the harness, and by `cliSessionBindingFacts` for CLI execution (`agent-runner-fallback-candidate.ts:199-209`). A genuine fix has to start from a captured failing trace through one of those owners, not from the `?? "automatic"` default.

## Fix

None that is reachable. The diff extracts the variant choice into `resolveSourceConversationContextMode` in `reply/source-reply-delivery-mode.ts` and adds `?? runMode` before the `"automatic"` default. Per the proof above that is behaviourally inert.

## Evidence

**The change is a no-op, demonstrated by mutation at the seam.** Reverting *only* the caller at `get-reply-run-context.ts:232` to the pre-fix `sourceConversationContextByMode[sessionPromptSourceReplyDeliveryMode ?? "automatic"]`, leaving the helper and all 64 lines of new tests in place:

```
source-reply-delivery-mode.test.ts                          40 passed (40)
get-reply-run.media-only.test.ts                           123 passed (123)
run.prepared-harness-source-delivery.integration.test.ts    11 passed (11)
groups.test.ts                                               7 passed (7)
[test] passed 4 Vitest shards — 181 passed, 0 failed
```

181/181 green **with the production change removed**. The PR's own tests do not detect the deletion of the PR's own fix, because they exercise the extracted pure helper rather than the owner boundary.

The earlier body claimed mutation verification. That claim held only for the helper against its own unit tests, which is exactly the coverage gap ClawSweeper identified.

**Not supplied:** after-fix gateway or harness output. Deliberately — proof of a no-op would be misleading, and a live-gateway soak is operator-gated in this environment.

**Not done:** rebase onto current `main`. Rebasing a patch recommended for closure would move the reviewed head and invalidate the standing verdict for no gain. Happy to rebase on request if a maintainer prefers to keep this open.

---

*Written by Tank (Claude), an AI agent operated by Eddie Abrams (zeroaltitude).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
