### PR TITLE
fix(agents): native runs ignore the selected 200K context window

### DIFF
--- a/src/agents/embedded-agent-runner/run/setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/setup.test.ts
@@ -380,7 +380,10 @@ describe("resolveEmbeddedRuntimeModelPolicy", () => {
       cfg: {
         models: {
           providers: {
-            anthropic: { models: [{ id: "claude-sonnet-5", contextTokens: 1_000_000 }] },
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [createConfiguredModel({ id: "claude-sonnet-5", contextTokens: 1_000_000 })],
+            },
           },
         },
       } satisfies OpenClawConfig,

--- a/src/agents/embedded-agent-runner/run/setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/setup.test.ts
@@ -338,6 +338,63 @@ describe("resolveEmbeddedRuntimeModelPolicy", () => {
     expect(unselected.effectiveModel.contextWindow).toBe(1_000_000);
   });
 
+  it("keeps the session-selected context window ahead of discovered and configured caps", () => {
+    // The selection is passed as the lowest-priority input, so a discovered
+    // contextTokens value or a models.providers entry would otherwise leave a
+    // 200k session budgeting against the wider window while the session row
+    // and model projections already report the selected 200k.
+    const runtimeModel: ProviderRuntimeModel = {
+      provider: "anthropic",
+      id: "claude-sonnet-5",
+      name: "Claude Sonnet 5",
+      baseUrl: "https://api.anthropic.com",
+      api: "anthropic-messages",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_000_000,
+      contextTokens: 272_000,
+      maxTokens: 128_000,
+      contextWindows: [
+        { id: "200k", label: "200K", contextWindow: 200_000 },
+        { id: "1m", label: "1M", contextWindow: 1_000_000 },
+      ],
+      contextWindowDefault: "1m",
+    };
+    const resolve = (params: { cfg?: OpenClawConfig; contextWindow?: string }) =>
+      resolveEmbeddedRuntimeModelPolicy({
+        cfg: params.cfg,
+        provider: "anthropic",
+        modelId: "claude-sonnet-5",
+        runtimeModel,
+        nativeModelOwned: false,
+        ...(params.contextWindow ? { contextWindow: params.contextWindow } : {}),
+      });
+
+    const discovered = resolve({ contextWindow: "200k" });
+    expect(discovered.contextTokenBudget).toBe(200_000);
+    expect(discovered.effectiveModel.contextWindow).toBe(200_000);
+
+    const configured = resolve({
+      contextWindow: "200k",
+      cfg: {
+        models: {
+          providers: {
+            anthropic: { models: [{ id: "claude-sonnet-5", contextTokens: 1_000_000 }] },
+          },
+        },
+      } satisfies OpenClawConfig,
+    });
+    expect(configured.contextTokenBudget).toBe(200_000);
+    expect(configured.effectiveModel.contextWindow).toBe(200_000);
+
+    // Without a selection the declared default resolves to the wider option, so
+    // the tighter discovered cap still owns the budget.
+    const unselected = resolve({});
+    expect(unselected.contextTokenBudget).toBe(272_000);
+    expect(unselected.effectiveModel.contextWindow).toBe(272_000);
+  });
+
   it("preserves the effective budget and adds an authored cap for plugin transports (#124702)", () => {
     const resolve = (models: ModelDefinitionConfig[]) =>
       resolveEmbeddedRunEffectiveModel({

--- a/src/agents/embedded-agent-runner/run/setup.ts
+++ b/src/agents/embedded-agent-runner/run/setup.ts
@@ -219,18 +219,28 @@ function resolveEffectiveRuntimeModel(params: {
   // The session-selected context-window option caps native runs too; the CLI
   // backend maps the option id to argv/env separately, but budget and payload
   // sizing must honor the selection on every runtime path.
-  const selectedWindowTokens = resolveModelContextWindowProfile({
+  const contextWindowProfile = resolveModelContextWindowProfile({
     catalogEntry: params.runtimeModel,
     selected: params.contextWindow,
-  }).contextTokens;
-  const ctxInfo = resolveContextWindowInfo({
+  });
+  const resolvedCtxInfo = resolveContextWindowInfo({
     cfg: params.cfg,
     provider: params.contextConfigProvider ?? params.provider,
     modelId: params.modelId,
     modelContextTokens: readAgentModelContextTokens(params.runtimeModel),
-    modelContextWindow: selectedWindowTokens,
+    modelContextWindow: contextWindowProfile.contextTokens,
     defaultTokens: DEFAULT_CONTEXT_TOKENS,
   });
+  // resolveContextWindowInfo ranks the passed selection below both the
+  // discovered model cap and models.providers.*.models[].contextTokens, so a
+  // 200k session would keep budgeting against the wider window. Only an
+  // effective option caps here; the bare catalog scalar stays subordinate.
+  const ctxInfo =
+    contextWindowProfile.contextWindow &&
+    contextWindowProfile.contextTokens !== undefined &&
+    resolvedCtxInfo.tokens > contextWindowProfile.contextTokens
+      ? { ...resolvedCtxInfo, tokens: contextWindowProfile.contextTokens, source: "model" as const }
+      : resolvedCtxInfo;
 
   // Apply contextTokens cap to model so session runtime's auto-compaction
   // threshold uses the effective limit, not the native context window.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who select **200K** in the Claude model picker would keep running
against the wider window on native (non-CLI) sessions whenever the same model also carries a
context cap, either a discovered `contextTokens` value or an authored
`models.providers.<provider>.models[].contextTokens` entry.

The selection is honored on the other surfaces, so the session disagrees with itself: the session
row and model projections report the selected 200,000 while the native run budgets and
auto-compacts against the larger number. Operators see a context meter that does not match when
compaction actually fires, and prompts are sized past the window they chose.

## Why This Change Was Made

`resolveEffectiveRuntimeModel` passed the resolved option into `resolveContextWindowInfo` as
`modelContextWindow`, which is that helper's lowest-priority input
(`src/agents/context-window-guard.ts`): a discovered `contextTokens` wins over it, and a
`models.providers` entry wins over both. The selection therefore only survived when the model had
no other cap at all, which is exactly the case the shipped test covers.

Three of the four consumers of `resolveModelContextWindowProfile` already clamp the resolved
window with the selected option, and all four landed together in `041938bc2f7` (#127951):

| consumer | clamps the resolved window |
| --- | --- |
| `src/agents/cli-runner/prepare.ts` | yes |
| `src/gateway/session-utils-model.ts` | yes |
| `src/gateway/session-utils-row.ts` | yes |
| `src/agents/embedded-agent-runner/run/setup.ts` | no |

The comment already sitting above the CLI clamp states the invariant this change restores for the
native path: "the selected (or default) option must apply after it or a 200k session would
auto-compact against a 1M budget."

This change mirrors that clamp, including its guard: only an effective option caps the window, so
a model's bare catalog scalar stays subordinate and models that declare no selectable windows are
untouched.

## User Impact

Selecting 200K now bounds native runs the same way it already bounds CLI-backed runs. The run's
context budget, the payload sizing derived from it, and the auto-compaction threshold all match
the number the session already reports. Users who cap a model with `contextTokens` for cost
control no longer silently lose the picker selection. Models without selectable context windows
keep their current behavior.

## Evidence

**Live probe against the production resolvers.** No mocks and no test harness: this imports the
real `resolveEmbeddedRuntimeModelPolicy` and the real `resolveModelContextWindowProfile` through
`node --import tsx` and prints what each returns for the same 200K selection. `reportedByProjections`
is the value every session projection derives from that selection; `nativeRunBudget` is what the
embedded run actually uses.

Before, on `e1a700840a7`:

```text
[
  {
    "scenario": "discovered contextTokens = 272000",
    "selectedOption": "200k",
    "reportedByProjections": 200000,
    "nativeRunBudget": 272000,
    "autoCompactWindow": 272000,
    "agrees": false
  },
  {
    "scenario": "models.providers contextTokens = 1000000",
    "selectedOption": "200k",
    "reportedByProjections": 200000,
    "nativeRunBudget": 1000000,
    "autoCompactWindow": 1000000,
    "agrees": false
  }
]
```

After:

```text
[
  {
    "scenario": "discovered contextTokens = 272000",
    "selectedOption": "200k",
    "reportedByProjections": 200000,
    "nativeRunBudget": 200000,
    "autoCompactWindow": 200000,
    "agrees": true
  },
  {
    "scenario": "models.providers contextTokens = 1000000",
    "selectedOption": "200k",
    "reportedByProjections": 200000,
    "nativeRunBudget": 200000,
    "autoCompactWindow": 200000,
    "agrees": true
  }
]
```

**Focused suite** (Windows 11, Node 24.18.1):

```text
node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/run/setup.test.ts
 Test Files  1 passed (1)
      Tests  23 passed (23)
```

**The new test is a regression test.** Reverting only `setup.ts` and re-running the same suite
fails on the new case while every pre-existing case still passes:

```text
 FAIL  src/agents/embedded-agent-runner/run/setup.test.ts >
       resolveEmbeddedRuntimeModelPolicy >
       keeps the session-selected context window ahead of discovered and configured caps
AssertionError: expected 272000 to be 200000 // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 22 passed (23)
```

**Existing expectations are unaffected.** The two pre-existing cases in the same `describe`
(`modelsConfig` at 1,000,000 and discovered `contextTokens` at 272,000) use fixtures without
`contextWindows`, so the guard never engages for them, and the shipped selection case (no cap,
`cfg: undefined`) is unchanged. The new test also asserts the unselected path: with the declared
`1m` default resolving to the wider option, the tighter discovered cap still owns the budget.

**Neighbouring surfaces and local gates:**

```text
node scripts/run-vitest.mjs run src/agents/context-window-guard.test.ts \
  src/agents/embedded-agent-runner/run/setup.test.ts      passed 2 Vitest shards
node scripts/run-vitest.mjs run \
  src/agents/embedded-agent-runner/run/attempt-session-runtime-prepare.test.ts
                                                          Tests  3 passed (3)
oxlint -c .oxlintrc.json <changed files>                  clean
oxfmt --check <changed files>                             All matched files use the correct format.
node --import tsx scripts/check-max-lines-ratchet.mts --base origin/main
                                                          max-lines ratchet OK
node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main
                                                          assertion SAFETY ratchet OK
```
