### PR TITLE
fix(plugins): report Git plugin updates when their package version is unchanged

### DIFF
--- a/src/plugins/update-attempt.ts
+++ b/src/plugins/update-attempt.ts
@@ -236,6 +236,42 @@ type PluginUpdateAttemptResult =
   | { kind: "exception"; message: string }
   | ({ kind: "result"; result: PluginUpdateInstallResult } & PluginUpdateAttemptState);
 
+function isPluginUpdateUnchanged(
+  params: Parameters<typeof buildPluginUpdateVersionOutcome>[0],
+): boolean {
+  const { record, result, currentVersion, nextVersion } = params;
+  const nextCommit = record.source === "git" && "git" in result ? result.git.commit : undefined;
+  return record.gitCommit && nextCommit
+    ? record.gitCommit === nextCommit
+    : Boolean(currentVersion && nextVersion && currentVersion === nextVersion);
+}
+
+export function buildPluginUpdateVersionOutcome(params: {
+  pluginId: string;
+  record: UpdatablePluginInstallRecord;
+  result: PluginUpdateSuccess;
+  currentVersion?: string;
+  nextVersion?: string;
+  channelFallbackSuffix: string;
+  channelFallback?: PluginUpdateChannelFallback;
+}): PluginUpdateOutcome {
+  const currentLabel = params.currentVersion ?? "unknown";
+  const unchanged = isPluginUpdateUnchanged(params);
+  const verb = isPackageVersionDowngrade(params.currentVersion, params.nextVersion)
+    ? "Downgraded"
+    : "Updated";
+  return {
+    pluginId: params.pluginId,
+    status: unchanged ? "unchanged" : "updated",
+    currentVersion: params.currentVersion,
+    nextVersion: params.nextVersion,
+    message: unchanged
+      ? `${params.pluginId} already at ${currentLabel}.${params.channelFallbackSuffix}`
+      : `${verb} ${params.pluginId}: ${currentLabel} -> ${params.nextVersion ?? "unknown"}.${params.channelFallbackSuffix}`,
+    ...(params.channelFallback ? { channelFallback: params.channelFallback } : {}),
+  };
+}
+
 export async function buildDryRunPluginUpdateOutcome(params: {
   pluginId: string;
   record: UpdatablePluginInstallRecord;
@@ -268,16 +304,7 @@ export async function buildDryRunPluginUpdateOutcome(params: {
       : undefined);
   const nextVersion = resolvedProbeVersion ?? "unknown";
   const currentLabel = params.currentVersion ?? "unknown";
-  const gitProbe =
-    params.record.source === "git" && "git" in params.result ? params.result.git : undefined;
-  const unchanged =
-    params.record.source === "git" && params.record.gitCommit && gitProbe?.commit
-      ? params.record.gitCommit === gitProbe.commit
-      : Boolean(
-          params.currentVersion &&
-          resolvedProbeVersion &&
-          params.currentVersion === resolvedProbeVersion,
-        );
+  const unchanged = isPluginUpdateUnchanged({ ...params, nextVersion: resolvedProbeVersion });
   const newerExactPinnedDefaultLine =
     unchanged &&
     params.record.source === "npm" &&

--- a/src/plugins/update-claw-lifecycle.ts
+++ b/src/plugins/update-claw-lifecycle.ts
@@ -1,10 +1,8 @@
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
-import { isPackageVersionDowngrade } from "../infra/package-update-utils.js";
 import { markClawPackageIndependentlyOwned } from "../state/claw-package-adoption.js";
 import { withClawPackageLifecycleLease } from "../state/claw-package-lifecycle-lease.js";
 import type { ClawHubRiskAcknowledgementRequest } from "./clawhub.js";
 import { installPluginFromNpmSpec } from "./install.js";
-import type { PluginUpdateChannelFallback, PluginUpdateOutcome } from "./update-source.js";
 
 type ClawHubInstallRecord = {
   source?: string;
@@ -39,33 +37,6 @@ export function resolveClawHubRiskAcknowledgementOptions(params: {
   return {
     ...(params.acknowledgeClawHubRisk ? { acknowledgeClawHubRisk: true } : {}),
     ...(!params.dryRun && params.onClawHubRisk ? { onClawHubRisk: params.onClawHubRisk } : {}),
-  };
-}
-
-export function buildPluginUpdateVersionOutcome(params: {
-  pluginId: string;
-  currentVersion?: string;
-  nextVersion?: string;
-  channelFallbackSuffix: string;
-  channelFallback?: PluginUpdateChannelFallback;
-}): PluginUpdateOutcome {
-  const currentLabel = params.currentVersion ?? "unknown";
-  const nextLabel = params.nextVersion ?? "unknown";
-  const unchanged = Boolean(
-    params.currentVersion && params.nextVersion && params.currentVersion === params.nextVersion,
-  );
-  const verb = isPackageVersionDowngrade(params.currentVersion, params.nextVersion)
-    ? "Downgraded"
-    : "Updated";
-  return {
-    pluginId: params.pluginId,
-    status: unchanged ? "unchanged" : "updated",
-    currentVersion: params.currentVersion,
-    nextVersion: params.nextVersion,
-    message: unchanged
-      ? `${params.pluginId} already at ${currentLabel}.${params.channelFallbackSuffix}`
-      : `${verb} ${params.pluginId}: ${currentLabel} -> ${nextLabel}.${params.channelFallbackSuffix}`,
-    ...(params.channelFallback ? { channelFallback: params.channelFallback } : {}),
   };
 }
 

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -28,6 +28,7 @@ import { auditDeclaredOpenClawHostDependency } from "./plugin-peer-link.js";
 import {
   buildClawHubTrustSkippedOutcome,
   buildDryRunPluginUpdateOutcome,
+  buildPluginUpdateVersionOutcome,
   formatClawHubInstallFailure,
   formatGitInstallFailure,
   formatMarketplaceInstallFailure,
@@ -42,7 +43,6 @@ import {
   type NpmPluginUpdateSuccess,
 } from "./update-attempt.js";
 import {
-  buildPluginUpdateVersionOutcome,
   createTrackedNpmUpdateInstaller,
   resolveClawHubRiskAcknowledgementOptions,
   resolveRecordedClawHubPackage,
@@ -701,6 +701,8 @@ export async function updateNpmInstalledPlugins(params: {
     outcomes.push(
       buildPluginUpdateVersionOutcome({
         pluginId,
+        record,
+        result,
         currentVersion,
         nextVersion,
         channelFallbackSuffix,

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -4665,10 +4665,11 @@ describe("updateNpmInstalledPlugins", () => {
   });
 
   it("updates git installs and records resolved commit metadata", async () => {
+    const installPath = createInstalledPackageDir({ name: "demo", version: "1.3.0" });
     installPluginFromGitSpecMock.mockResolvedValue({
       ok: true,
       pluginId: "demo",
-      targetDir: "/tmp/demo",
+      targetDir: installPath,
       version: "1.3.0",
       extensions: ["index.ts"],
       git: {
@@ -4682,7 +4683,7 @@ describe("updateNpmInstalledPlugins", () => {
     const result = await updatePlugin(
       createGitInstallConfig({
         pluginId: "demo",
-        installPath: "/tmp/demo",
+        installPath,
         spec: "git:github.com/acme/demo@main",
         commit: "abc123",
       }),
@@ -4693,10 +4694,19 @@ describe("updateNpmInstalledPlugins", () => {
     expect(gitInstallCall()?.expectedPluginId).toBe("demo");
     expect(gitInstallCall()?.mode).toBe("update");
     expect(result.changed).toBe(true);
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "demo",
+        status: "updated",
+        currentVersion: "1.3.0",
+        nextVersion: "1.3.0",
+        message: "Updated demo: 1.3.0 -> 1.3.0.",
+      },
+    ]);
     expectRecordFields(result.config.plugins?.installs?.demo, {
       source: "git",
       spec: "git:github.com/acme/demo@main",
-      installPath: "/tmp/demo",
+      installPath,
       version: "1.3.0",
       gitUrl: "https://github.com/acme/demo.git",
       gitRef: "main",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators updating a Git-installed plugin were told the plugin was already up to date even though its Git commit advanced, whenever both commits advertised the same package version. This also caused aggregate update summaries to count the plugin as unchanged.

## Why This Change Was Made

Dry-run plugin updates already compare Git commit identity before package versions, but real updates used a duplicate version-only formatter misplaced in the ClawHub lifecycle module. Move the generic real-update formatter beside its dry-run sibling and reuse one commit-aware update identity decision for both flows, preserving package-version behavior for npm, ClawHub, and marketplace plugins. Production LOC is exactly neutral.

## User Impact

Git plugin updates now correctly report an update when their checked-out commit changes, even when the package version does not. Same-commit Git checks, version-based plugin sources, downgrades, and channel fallback messages retain their existing behavior.

## Evidence

- Authentic pre-fix regression uses a real installed `demo@1.3.0` package and updates commit `abc123` to `def456`: the old code reports `status: unchanged` and `demo already at 1.3.0.`; the repair reports `status: updated` and `Updated demo: 1.3.0 -> 1.3.0.`.
- `node scripts/run-vitest.mjs src/plugins/update.test.ts` — all 146 plugin lifecycle tests pass across Git, npm, ClawHub, marketplace, dry runs, downgrade handling, and fallback behavior.
- `node --import tsx scripts/check-deadcode-exports.mts` — production, full-tree, and scripts scans all pass with zero unused exports.
- Focused oxlint and oxfmt, assertion-safety and max-lines ratchets, `git diff --check`, and zero runtime import cycles pass.
- Local whole-repository TypeScript checking is unavailable in this linked checkout because its shared installed dependencies predate current `main` (installed `markdown-it 14.3.0`/`pi-tui 0.82.1` versus required `15.0.0`/`0.84.2`). Exact-head hosted CI supplies the authoritative clean-install TypeScript proof before landing.
- Production LOC: `+40/-40` (net zero); focused regression test: `+13/-3`.
- Fresh independent source-aware review verified commit precedence, same-commit behavior, missing-commit fallback, all plugin sources, downgrade messages, owner boundaries, and the real installed-package regression.
