### PR TITLE
fix(reply): preserve distinct streamed location messages

### DIFF
--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -56,6 +56,9 @@ describe("createBlockReplyContentKey", () => {
     });
     expect(a).toBe(b);
     expect(a).not.toBe(c);
+    expect(createBlockReplyContentKey({ location: { latitude: 1, longitude: 2 } })).not.toBe(
+      createBlockReplyContentKey({ location: { latitude: 3, longitude: 4 } }),
+    );
   });
 });
 
@@ -190,6 +193,17 @@ describe("createBlockReplyPipeline dedup with threading", () => {
       expected: [
         { mediaUrl: "file:///voice.ogg", audioAsVoice: true },
         { text: "After", audioAsVoice: true },
+      ],
+    },
+    {
+      name: "distinct portable location replies",
+      payloads: [
+        { location: { latitude: 1, longitude: 2 } },
+        { location: { latitude: 3, longitude: 4 } },
+      ],
+      expected: [
+        { location: { latitude: 1, longitude: 2 } },
+        { location: { latitude: 3, longitude: 4 } },
       ],
     },
   ])("preserves streamed delivery order for $name", async ({ payloads, expected }) => {

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -53,35 +53,34 @@ export function createAudioAsVoiceBuffer(params: {
   };
 }
 
-/** Creates a stable duplicate key for a complete outbound payload. */
-function createBlockReplyPayloadKey(payload: ReplyPayload): string {
+function createBlockReplyContentIdentity(payload: ReplyPayload) {
   const reply = resolveSendableOutboundReplyParts(payload);
-  return JSON.stringify({
-    statusNotice: isReplyPayloadStatusNotice(payload),
+  return {
     text: reply.trimmedText,
     mediaList: reply.mediaUrls,
     presentation: payload.presentation ?? null,
     presentationTextMode: payload.presentationTextMode ?? null,
     interactive: payload.interactive ?? null,
     channelData: payload.channelData ?? null,
+    location: payload.location ?? null,
+  };
+}
+
+/** Creates a stable duplicate key for a complete outbound payload. */
+function createBlockReplyPayloadKey(payload: ReplyPayload): string {
+  return JSON.stringify({
+    ...createBlockReplyContentIdentity(payload),
+    statusNotice: isReplyPayloadStatusNotice(payload),
     replyToId: payload.replyToId ?? null,
   });
 }
 
 /** Creates a duplicate key that ignores reply target for final suppression. */
 export function createBlockReplyContentKey(payload: ReplyPayload): string {
-  const reply = resolveSendableOutboundReplyParts(payload);
   // Content-only key used for final-payload suppression after block streaming.
   // This intentionally ignores replyToId so a streamed threaded payload and the
   // later final payload still collapse when they carry the same content.
-  return JSON.stringify({
-    text: reply.trimmedText,
-    mediaList: reply.mediaUrls,
-    presentation: payload.presentation ?? null,
-    presentationTextMode: payload.presentationTextMode ?? null,
-    interactive: payload.interactive ?? null,
-    channelData: payload.channelData ?? null,
-  });
+  return JSON.stringify(createBlockReplyContentIdentity(payload));
 }
 
 function resolveBlockReplyTimeoutMs(timeoutMs: number): number {


### PR DESCRIPTION
## What Problem This Solves

Distinct location-only streamed replies generated identical deduplication keys. The second location was silently dropped, and final-reply bookkeeping could incorrectly report a different location as already delivered.

## Why This Change Was Made

The streaming pipeline duplicated its content-identity fields across full-payload and reply-independent key builders, and both copies omitted the existing portable location payload. A single private canonical content identity now includes location and feeds both builders. Full-payload keys still include status-notice and reply-thread identity; final suppression still intentionally ignores reply targets.

## User Impact

Multiple distinct location messages in one streamed reply are delivered in their original order, and a delivered location no longer suppresses a different final location. Text, media, rich presentation, status notices, and reply threading retain their existing behavior. Production code is smaller by one line; no configuration, protocol, persistence, public SDK, or dependency changes are introduced.

## Evidence

- Authentic pre-fix owner regression failed twice: distinct location content keys compared equal, and the real coalescing/audio-buffer streaming pipeline delivered one location when two were expected.
- Post-fix `node scripts/run-vitest.mjs src/auto-reply/reply/block-reply-pipeline.test.ts src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts src/auto-reply/reply/reply-delivery.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/channels/message/send.test.ts`: **133 tests passed across five files and three shards**, including existing portable-location outbound delivery.
- `./node_modules/.bin/oxfmt --check src/auto-reply/reply/block-reply-pipeline.ts src/auto-reply/reply/block-reply-pipeline.test.ts` passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/block-reply-pipeline.ts src/auto-reply/reply/block-reply-pipeline.test.ts` and `git diff --check` passed.
- The isolated checkout reuses an older shared dependency installation; whole-program local typecheck reaches unrelated current-main Google-provider, Markdown, and TUI dependency/type mismatches. Exact-head hosted CI supplies the clean-install authoritative typecheck.
- Independent source-aware owner/caller/sibling review: clean; production **+12/-13 (net -1)**, tests **+14/-0**.
- No disposable live channel was available without touching the operator's running channels; the real streaming-owner delivery regression and existing portable-location channel-send boundary were exercised directly instead.
