### PR TITLE
fix(plugins): surface load errors in the default plugin list

### DIFF
--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -86,6 +86,13 @@ describe("plugins cli list", () => {
           error: "missing plugin module",
         }),
         createPluginRecord({ id: "healthy", description: "Healthy plugin" }),
+        createPluginRecord({
+          id: "disabled",
+          description: "Disabled plugin description",
+          enabled: false,
+          status: "disabled",
+          error: "workspace plugin (disabled by default)",
+        }),
       ],
       diagnostics: [],
     });
@@ -95,6 +102,7 @@ describe("plugins cli list", () => {
     const output = pluginsCliRuntimeLogs.join("\n");
     expect(output).toContain("missing plugin module");
     expect(output).toContain("Healthy plugin");
+    expect(output).toContain("Disabled plugin description");
   });
 
   it("includes imported state in JSON output", async () => {

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -73,6 +73,30 @@ describe("plugins cli list", () => {
     workshopMocks.detectToolPolicyDiagnostic.mockReset();
   });
 
+  it("shows plugin load errors and healthy descriptions in the default list", async () => {
+    buildPluginRegistrySnapshotReportMock.mockReturnValue({
+      workspaceDir: "/workspace",
+      registrySource: "persisted",
+      registryDiagnostics: [],
+      plugins: [
+        createPluginRecord({
+          id: "broken",
+          description: "Broken plugin description",
+          status: "error",
+          error: "missing plugin module",
+        }),
+        createPluginRecord({ id: "healthy", description: "Healthy plugin" }),
+      ],
+      diagnostics: [],
+    });
+
+    await runPluginsCommand(["plugins", "list"]);
+
+    const output = pluginsCliRuntimeLogs.join("\n");
+    expect(output).toContain("missing plugin module");
+    expect(output).toContain("Healthy plugin");
+  });
+
   it("includes imported state in JSON output", async () => {
     buildPluginRegistrySnapshotReportMock.mockReturnValue({
       workspaceDir: "/workspace",

--- a/src/cli/plugins-list-command.ts
+++ b/src/cli/plugins-list-command.ts
@@ -108,7 +108,7 @@ export async function runPluginsListCommand(
     });
     const usedRoots = new Set<keyof typeof sourceRoots>();
     const rows = list.map((plugin) => {
-      const desc = plugin.description ? theme.muted(plugin.description) : "";
+      const desc = plugin.error ? theme.error(plugin.error) : theme.muted(plugin.description ?? "");
       const formattedSource = formatPluginSourceForTable(plugin, sourceRoots);
       if (formattedSource.rootKey) {
         usedRoots.add(formattedSource.rootKey);

--- a/src/cli/plugins-list-command.ts
+++ b/src/cli/plugins-list-command.ts
@@ -108,12 +108,12 @@ export async function runPluginsListCommand(
     });
     const usedRoots = new Set<keyof typeof sourceRoots>();
     const rows = list.map((plugin) => {
-      const desc = plugin.error ? theme.error(plugin.error) : theme.muted(plugin.description ?? "");
+      const error = plugin.status === "error" && plugin.error;
+      const desc = error ? theme.error(error) : theme.muted(plugin.description ?? "");
       const formattedSource = formatPluginSourceForTable(plugin, sourceRoots);
       if (formattedSource.rootKey) {
         usedRoots.add(formattedSource.rootKey);
       }
-      const sourceLine = desc ? `${formattedSource.value}\n${desc}` : formattedSource.value;
       return {
         Name: plugin.name || plugin.id,
         ID: plugin.name && plugin.name !== plugin.id ? plugin.id : "",
@@ -124,7 +124,7 @@ export async function runPluginsListCommand(
             : plugin.enabled
               ? theme.success("enabled")
               : theme.warn("disabled"),
-        Source: sourceLine,
+        Source: desc ? `${formattedSource.value}\n${desc}` : formattedSource.value,
         Version: plugin.version ?? "",
       };
     });


### PR DESCRIPTION
## What Problem This Solves

The default `openclaw plugins list` table marked a failed plugin as `error` but hid the recorded reason the plugin failed to load. Operators received an unusable status label even though verbose and JSON output already had the exact actionable error.

## Why This Change Was Made

The compact table owner always selected the plugin description for its source-detail line and discarded `plugin.error`. It now prefers the already-recorded error only when the plugin status is actually `error`, while retaining the existing descriptions for both healthy plugins and disabled workspace plugins that carry explanatory error text. This repairs the owner directly with zero production-code growth.

## User Impact

`openclaw plugins list` now immediately shows why a plugin failed to load, without requiring users to discover `--verbose`, rerun doctor, or interpret JSON. Healthy plugin descriptions, table layout, status colors, source roots, JSON output, and verbose output remain unchanged.

## Evidence

- Authentic pre-fix regression exercised the real Commander parser with one failed and one healthy plugin; it failed because the rendered table omitted `missing plugin module` while showing the failed plugin's description.
- `node scripts/run-vitest.mjs src/cli/plugins-cli.list.test.ts src/cli/plugins-list-command.test.ts src/cli/plugins-list-format.test.ts`: **47 tests passed across three files and two shards**.
- The regression also verifies healthy plugin descriptions and disabled workspace plugin descriptions remain visible even when a disabled plugin carries explanatory `error` text.
- ClawSweeper identified the disabled-workspace sibling case; it was reproduced as an authentic failing Commander-parser regression and repaired in the same compact-table owner before landing.
- `./node_modules/.bin/oxfmt --check src/cli/plugins-cli.list.test.ts src/cli/plugins-list-command.ts` passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/plugins-cli.list.test.ts src/cli/plugins-list-command.ts` and `git diff --check` passed.
- Independent source-aware review and configured Codex structured autoreview both returned no actionable findings.
- Production **+3/-3 (net zero)**; tests **+32/-0**. No configuration, protocol, persistence, public SDK, dependency, or security changes.
