### PR TITLE
fix(cli): explain empty capability listings

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -875,6 +875,16 @@ describe("capability cli", () => {
     });
   });
 
+  it("renders an explicit empty model list without changing JSON output", async () => {
+    mocks.loadModelCatalog.mockResolvedValue([]);
+
+    await runCapability("model", "list", "--json");
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith([]);
+
+    await runCapability("model", "list");
+    expect(mocks.runtime.log).toHaveBeenCalledWith("No results found.");
+  });
+
   it("reports model providers configured through their environment key", async () => {
     vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
 

--- a/src/cli/capability-cli/shared.ts
+++ b/src/cli/capability-cli/shared.ts
@@ -90,7 +90,7 @@ export function formatEnvelopeForText(value: unknown): string {
 
 export function providerSummaryText(value: unknown): string {
   const providers = value as Array<Record<string, unknown>>;
-  return providers.map((entry) => JSON.stringify(entry)).join("\n");
+  return providers.map((entry) => JSON.stringify(entry)).join("\n") || "No results found.";
 }
 
 function hasOwnKeys(value: unknown): boolean {


### PR DESCRIPTION
## What Problem This Solves

Successful capability inventory commands printed a completely blank line when no models, providers, or voices were available. Operators could not distinguish an intentionally empty result from a broken command or a command that never ran.

## Why This Change Was Made

The shared human-readable inventory formatter joined an empty array into an empty string and sent it directly to the runtime logger. The canonical formatter now returns `No results found.` for empty inventories while leaving nonempty records unchanged.

## User Impact

The default human output for model listings, model providers, audio providers, image providers, embedding providers, and TTS voices now explicitly reports an empty result. Every `--json` response continues to return the exact existing empty array, and populated listings retain identical output.

## Evidence

- Authentic pre-fix regression exercised the real Commander command parser; JSON returned `[]` correctly, while the normal human invocation logged an empty string and failed the expected visible-result assertion.
- `node scripts/run-vitest.mjs src/cli/capability-cli.test.ts`: **189 tests passed**, including the combined human-output and unchanged-JSON regression.
- `./node_modules/.bin/oxfmt --check src/cli/capability-cli/shared.ts src/cli/capability-cli.test.ts` passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/capability-cli.test.ts src/cli/capability-cli/shared.ts` and `git diff --check` passed.
- Independent review traced all six renderer consumers and confirmed that JSON branches return before the human formatter; configured Codex structured autoreview returned no actionable findings.
- Production **+1/-1 (net zero)**; tests **+10/-0**. No configuration, protocol, persistence, public SDK, dependency, or security changes.
