### PR TITLE
fix(ci): preserve iOS Fastlane root after cwd changes

### DIFF
--- a/scripts/lib/ios-fastlane.sh
+++ b/scripts/lib/ios-fastlane.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
+# BASH_SOURCE may be relative, so resolve it before callers change directories.
+_OPENCLAW_IOS_FASTLANE_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
 run_ios_fastlane() {
   local gemfile=""
-  gemfile="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/apps/ios/Gemfile"
+  gemfile="${_OPENCLAW_IOS_FASTLANE_REPO_ROOT}/apps/ios/Gemfile"
 
   local setup_hint=""
   setup_hint="Install Ruby 3.4.10, then run: cd apps/ios && gem install bundler -v 2.6.9 && bundle _2.6.9_ install"

--- a/test/scripts/ios-release-wrapper-args.test.ts
+++ b/test/scripts/ios-release-wrapper-args.test.ts
@@ -156,7 +156,11 @@ describe("iOS release shell wrapper arguments", () => {
     expect(script).toContain('export GIT_COMMIT="${RELEASE_GIT_COMMIT}"');
   });
 
-  function runSharedFastlane(options: { fastlaneExit: number; bundleGemfile?: string }) {
+  function runSharedFastlane(options: {
+    fastlaneExit: number;
+    bundleGemfile?: string;
+    changeDirectoryAfterSource?: boolean;
+  }) {
     const binDir = tempDirs.make("openclaw-fastlane-test-");
     const bundle = path.join(binDir, "bundle");
     const fastlane = path.join(binDir, "fastlane");
@@ -175,7 +179,12 @@ describe("iOS release shell wrapper arguments", () => {
     chmodSync(fastlane, 0o755);
     return spawnSync(
       BASH_BIN,
-      ["-c", "source scripts/lib/ios-fastlane.sh; run_ios_fastlane ios release_plan"],
+      [
+        "-c",
+        options.changeDirectoryAfterSource
+          ? "source scripts/lib/ios-fastlane.sh; cd apps/ios; run_ios_fastlane ios release_plan"
+          : "source scripts/lib/ios-fastlane.sh; run_ios_fastlane ios release_plan",
+      ],
       {
         cwd: process.cwd(),
         env: {
@@ -197,6 +206,16 @@ describe("iOS release shell wrapper arguments", () => {
   it("overrides a hostile inherited Gemfile in the shared runner", () => {
     const result = runSharedFastlane({
       bundleGemfile: "/tmp/hostile/Gemfile",
+      fastlaneExit: 0,
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  it("keeps the repository Gemfile after the caller changes directories", () => {
+    const result = runSharedFastlane({
+      bundleGemfile: "/tmp/hostile/Gemfile",
+      changeDirectoryAfterSource: true,
       fastlaneExit: 0,
     });
 


### PR DESCRIPTION
Related: #128460

## What Problem This Solves

Fixes an issue where iOS release or screenshot jobs that source the shared Fastlane wrapper and then change directories would fail before invoking Fastlane. The hosted iPhone screenshot shard hit `cd: scripts/lib/../..: No such file or directory` while capturing the Apple Watch screenshot.

## Why This Change Was Made

The wrapper now resolves and stores the physical repository root when it is sourced, while a relative `BASH_SOURCE[0]` still refers to the caller's original working directory. Later invocations reuse that absolute root for the canonical `apps/ios/Gemfile`.

The locked Bundler path, hostile `BUNDLE_GEMFILE` override, and fail-closed behavior remain unchanged.

## User Impact

iOS CI and maintainer release commands can source the wrapper from the repository root, change into `apps/ios`, and still execute the repository-pinned Fastlane bundle.

## Evidence

- Hosted failure: https://github.com/openclaw/openclaw/actions/runs/32771128402/job/97574420208
- Regression test failed before the repair with status `1` after `source scripts/lib/ios-fastlane.sh; cd apps/ios`
- `node scripts/run-vitest.mjs test/scripts/ios-release-wrapper-args.test.ts test/scripts/ios-release-fastlane-gates.test.ts` - 52 passed
- The regression combines the cwd change with a hostile inherited `BUNDLE_GEMFILE`; the fake Bundler accepts only the canonical repository Gemfile
- `bash -n scripts/lib/ios-fastlane.sh`
- Targeted `oxfmt --check`
- `git diff --check`

Production LOC: `+4/-1` | Tests: `+21/-2`

Regression source: https://github.com/openclaw/openclaw/pull/128735
