### PR TITLE
fix(cron): script notifications reach the wrong agent or topic

### DIFF
--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -540,25 +540,34 @@ async function executeScriptCronJob(
   }
 
   const notify = result.notify?.trim() ? result.notify : undefined;
-  if (job.sessionTarget === "main" && notify) {
-    enqueueCronSystemEvent(state, notify, {
-      agentId: job.agentId,
-      contextKey: `cron:${job.id}:script`,
-    });
-  }
-  if (result.wake) {
-    const eventText = notify ?? `script job ${job.name} completed`;
-    if (job.sessionTarget !== "main" || !notify) {
-      enqueueCronSystemEvent(state, eventText, {
-        agentId: job.agentId,
-        contextKey: `cron:${job.id}:script-wake`,
+  if ((job.sessionTarget === "main" && notify) || result.wake) {
+    const agentId = resolveCronJobEffectiveAgentId(
+      job,
+      state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId,
+    );
+    const deliveryContext =
+      job.sessionTarget === "main" ? resolveMainSessionCronDeliveryContext(state, job) : undefined;
+    const eventOptions = { agentId, ...(deliveryContext ? { deliveryContext } : {}) };
+    if (job.sessionTarget === "main" && notify) {
+      enqueueCronSystemEvent(state, notify, {
+        ...eventOptions,
+        contextKey: `cron:${job.id}:script`,
       });
     }
-    requestCronHeartbeat(state, {
-      intent: result.wake === "now" ? "immediate" : "event",
-      reason: `cron:${job.id}:script`,
-      agentId: job.agentId,
-    });
+    if (result.wake) {
+      const eventText = notify ?? `script job ${job.name} completed`;
+      if (job.sessionTarget !== "main" || !notify) {
+        enqueueCronSystemEvent(state, eventText, {
+          ...eventOptions,
+          contextKey: `cron:${job.id}:script-wake`,
+        });
+      }
+      requestCronHeartbeat(state, {
+        intent: result.wake === "now" ? "immediate" : "event",
+        reason: `cron:${job.id}:script`,
+        agentId,
+      });
+    }
   }
   return {
     status: "ok" as const,

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -523,6 +523,185 @@ describe("cron service timer seam coverage", () => {
     });
   });
 
+  it.each([
+    {
+      name: "main notification and immediate wake use the session owner and thread",
+      sessionTarget: "main",
+      sessionKey: "agent:ops:telegram:group:42:topic:77",
+      defaultAgentId: "main",
+      notify: "queue changed",
+      wake: "now",
+      expectedAgentId: "ops",
+      expectedIntent: "immediate",
+      expectDeliveryContext: true,
+    },
+    {
+      name: "main notification and deferred wake use the current configured owner",
+      sessionTarget: "main",
+      defaultAgentId: "stale-main",
+      currentDefaultAgentId: "ops",
+      notify: "queue changed",
+      wake: "next-heartbeat",
+      expectedAgentId: "ops",
+      expectedIntent: "event",
+    },
+    {
+      name: "isolated script wake uses the session owner without main delivery context",
+      sessionTarget: "isolated",
+      sessionKey: "agent:ops:telegram:group:42:topic:77",
+      defaultAgentId: "main",
+      notify: "queue changed",
+      wake: "now",
+      expectedAgentId: "ops",
+      expectedIntent: "immediate",
+    },
+    {
+      name: "explicit script owner wins over the current configured default",
+      sessionTarget: "main",
+      agentId: "ops",
+      sessionKey: "agent:ops:telegram:group:42:topic:77",
+      defaultAgentId: "main",
+      currentDefaultAgentId: "other",
+      notify: "queue changed",
+      wake: "next-heartbeat",
+      expectedAgentId: "ops",
+      expectedIntent: "event",
+      expectDeliveryContext: true,
+    },
+    {
+      name: "main wake-only completion keeps its session owner and thread",
+      sessionTarget: "main",
+      sessionKey: "agent:ops:telegram:group:42:topic:77",
+      defaultAgentId: "main",
+      wake: "now",
+      expectedAgentId: "ops",
+      expectedIntent: "immediate",
+      expectDeliveryContext: true,
+    },
+    {
+      name: "main notification without a wake keeps its session owner and thread",
+      sessionTarget: "main",
+      sessionKey: "agent:ops:telegram:group:42:topic:77",
+      defaultAgentId: "main",
+      notify: "queue changed",
+      expectedAgentId: "ops",
+      expectDeliveryContext: true,
+    },
+  ] as const)("routes script side effects: $name", async (testCase) => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-08-24T12:00:00.000Z");
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    const sessionKey = "sessionKey" in testCase ? testCase.sessionKey : undefined;
+    const explicitAgentId = "agentId" in testCase ? testCase.agentId : undefined;
+    const currentDefaultAgentId =
+      "currentDefaultAgentId" in testCase ? testCase.currentDefaultAgentId : undefined;
+    const notify = "notify" in testCase ? testCase.notify : undefined;
+    const wake = "wake" in testCase ? testCase.wake : undefined;
+    const job = {
+      ...createDueScriptJob({ now, sessionTarget: testCase.sessionTarget }),
+      agentId: explicitAgentId,
+      ...(sessionKey ? { sessionKey } : {}),
+    };
+    const sessionStorePath = path.join(path.dirname(path.dirname(storePath)), "sessions.json");
+    const deliveryContext = {
+      channel: "telegram",
+      to: "telegram:42",
+      accountId: "ops-bot",
+      threadId: 77,
+    };
+    if (sessionKey) {
+      await upsertSessionEntryCore(
+        { storePath: sessionStorePath, sessionKey },
+        {
+          sessionId: "ops-telegram-session",
+          updatedAt: now,
+          delivery: normalizeSessionDeliveryState({ context: deliveryContext }),
+        },
+      );
+    }
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      cronConfig: { triggers: { enabled: true } },
+      log: logger,
+      nowMs: () => now,
+      defaultAgentId: testCase.defaultAgentId,
+      ...(currentDefaultAgentId ? { resolveDefaultAgentId: () => currentDefaultAgentId } : {}),
+      resolveSessionStorePath: () => sessionStorePath,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      runScriptJob: vi.fn(async () => ({
+        status: "ok" as const,
+        ...(notify ? { notify } : {}),
+        ...(wake ? { wake } : {}),
+      })),
+    });
+
+    await expect(executeJobCore(state, job)).resolves.toMatchObject({ status: "ok" });
+
+    expect(enqueueSystemEvent).toHaveBeenCalledOnce();
+    const [eventText, eventOptions] = enqueueSystemEvent.mock.calls[0] as [
+      string,
+      {
+        agentId?: string;
+        contextKey?: string;
+        deliveryContext?: typeof deliveryContext;
+      },
+    ];
+    expect(eventText).toBe(notify ?? "script job script job completed");
+    expect(eventOptions.agentId).toBe(testCase.expectedAgentId);
+    if ("expectDeliveryContext" in testCase && testCase.expectDeliveryContext) {
+      expect(eventOptions.deliveryContext).toEqual(deliveryContext);
+    } else {
+      expect(eventOptions).not.toHaveProperty("deliveryContext");
+    }
+    if ("expectedIntent" in testCase) {
+      expect(requestHeartbeat).toHaveBeenCalledExactlyOnceWith({
+        source: "cron",
+        intent: testCase.expectedIntent,
+        reason: "cron:script-job:script",
+        agentId: testCase.expectedAgentId,
+      });
+    } else {
+      expect(requestHeartbeat).not.toHaveBeenCalled();
+    }
+  });
+
+  it.each(["main", "isolated"] as const)(
+    "does not resolve an owner for a quiet %s script without side effects",
+    async (sessionTarget) => {
+      const { storePath } = await makeStorePath();
+      const now = Date.parse("2026-08-24T12:00:00.000Z");
+      const enqueueSystemEvent = vi.fn();
+      const requestHeartbeat = vi.fn();
+      const resolveDefaultAgentId = vi.fn(() => undefined);
+      const job = {
+        ...createDueScriptJob({ now, sessionTarget }),
+        agentId: undefined,
+      };
+      const state = createCronServiceState({
+        storePath,
+        cronEnabled: true,
+        cronConfig: { triggers: { enabled: true } },
+        log: logger,
+        nowMs: () => now,
+        defaultAgentId: undefined,
+        resolveDefaultAgentId,
+        enqueueSystemEvent,
+        requestHeartbeat,
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+        runScriptJob: vi.fn(async () => ({ status: "ok" as const })),
+      });
+
+      await expect(executeJobCore(state, job)).resolves.toMatchObject({ status: "ok" });
+      expect(resolveDefaultAgentId).not.toHaveBeenCalled();
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
+      expect(requestHeartbeat).not.toHaveBeenCalled();
+    },
+  );
+
   it("delivers nothing and enqueues nothing when notify and wake are absent", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-07-18T12:00:00.000Z");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running scheduled script automations would receive notifications or wakeups in the wrong agent's conversation when the script inherited its owning agent from its session or the current configured default. Main-session scripts also dropped the conversation's Telegram topic and account, so notifications could be delivered to the wrong thread even when the agent was explicitly configured.

## Why This Change Was Made

Scheduled script side effects now reuse the existing scheduler-owned agent-resolution contract: explicit agent, then the agent recorded in the session key, then the current configured default. Main-session notification and wake-only events also retain the existing session-owned delivery context, while isolated scripts retain their own routing and quiet scripts never resolve an unnecessary owner.

The repair adds nine production lines at the existing scheduler owner; it does not change authorization, configuration, persistence, public APIs, or job schemas.

## User Impact

Scheduled script notifications and wakeups consistently reach the correct agent and conversation across main and isolated jobs, including inherited and dynamically configured owners. Telegram main-session notifications preserve their account and topic for both normal notifications and wake-only completions. Existing explicit-owner, quiet-script, and single-event behavior remains unchanged.

## Evidence

- Added six real scheduler-owner regressions that failed before the fix: session-inherited main owner, current-default owner, isolated wake owner, explicit-owner Telegram account/topic, wake-only Telegram account/topic, and notification-only Telegram account/topic. The same cases pass after the fix, along with two ownerless quiet-script controls.
- `node scripts/run-vitest.mjs src/cron/service/timer.test.ts -t 'routes script side effects|does not resolve an owner'`: 8 passed.
- `node scripts/run-vitest.mjs src/cron/service/timer.test.ts src/cron/service/timer.regression.test.ts src/cron/service/wake-origin-delivery.test.ts src/cron/service.runs-one-shot-main-job-disables-it.test.ts src/gateway/server-cron.test.ts src/cron/command-runner.test.ts`: 239 passed across Gateway integration, scheduler ownership, command siblings, lifecycle cancellation, origin-thread routing, and main-session one-shots.
- Independent full scheduler-owner verification: 29 passed. The route regression uses an actual session-store entry containing the Telegram account and numeric topic rather than reconstructing thread identity from a session string.
- Targeted typed lint, formatting, and patch-whitespace checks passed. Local whole-repository TypeScript graphs encounter existing unrelated shared dependency-install drift; no changed scheduler file reports a TypeScript diagnostic.
