### PR TITLE
fix(whatsapp): newly-paired senders receive no approval confirmation

### DIFF
--- a/extensions/whatsapp/src/channel.test.ts
+++ b/extensions/whatsapp/src/channel.test.ts
@@ -1,0 +1,62 @@
+// Whatsapp tests cover channel plugin pairing behavior.
+import { PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk/channel-status";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  sendMessageWhatsApp: vi.fn(async () => ({ messageId: "wa-1", toJid: "jid" })),
+  sendPollWhatsApp: vi.fn(async () => ({ messageId: "poll-1", toJid: "jid" })),
+  sendTypingWhatsApp: vi.fn(async () => undefined),
+}));
+
+vi.mock("./send.js", () => ({
+  sendMessageWhatsApp: hoisted.sendMessageWhatsApp,
+  sendPollWhatsApp: hoisted.sendPollWhatsApp,
+  sendTypingWhatsApp: hoisted.sendTypingWhatsApp,
+}));
+
+vi.mock("./runtime.js", () => ({
+  getWhatsAppRuntime: () => ({
+    logging: {
+      shouldLogVerbose: () => false,
+    },
+  }),
+  getOptionalWhatsAppRuntime: () => undefined,
+}));
+
+let whatsappPlugin: typeof import("./channel.js").whatsappPlugin;
+let normalizeWhatsAppMessagingTarget: typeof import("./normalize.js").normalizeWhatsAppMessagingTarget;
+
+describe("whatsappPlugin.pairing", () => {
+  beforeAll(async () => {
+    ({ whatsappPlugin } = await import("./channel.js"));
+    ({ normalizeWhatsAppMessagingTarget } = await import("./normalize.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("declares a notifyApproval callback", () => {
+    expect(whatsappPlugin.pairing?.notifyApproval).toBeTypeOf("function");
+  });
+
+  it("sends the pairing approved message to the paired sender", async () => {
+    const notify = whatsappPlugin.pairing?.notifyApproval;
+    if (!notify) {
+      throw new Error("whatsapp pairing notifyApproval unavailable");
+    }
+    const senderId = "15551230000@s.whatsapp.net";
+    const cfg = {} as OpenClawConfig;
+
+    await notify({ cfg, id: senderId });
+
+    const target = normalizeWhatsAppMessagingTarget(senderId) ?? senderId;
+    expect(hoisted.sendMessageWhatsApp).toHaveBeenCalledTimes(1);
+    expect(hoisted.sendMessageWhatsApp).toHaveBeenCalledWith(target, PAIRING_APPROVED_MESSAGE, {
+      verbose: false,
+      cfg,
+      accountId: "default",
+    });
+  });
+});

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -2,6 +2,7 @@
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { buildDmGroupAccountAllowlistAdapter } from "openclaw/plugin-sdk/allowlist-config-edit";
 import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import { PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk/channel-status";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   createComputedAccountStatusAdapter,
@@ -37,7 +38,7 @@ import {
   normalizeWhatsAppTarget,
 } from "./normalize.js";
 import { getWhatsAppRuntime } from "./runtime.js";
-import { sendTypingWhatsApp } from "./send.js";
+import { sendMessageWhatsApp, sendTypingWhatsApp } from "./send.js";
 import { resolveWhatsAppOutboundSessionRoute } from "./session-route.js";
 import { whatsappSetupContract } from "./setup-core.js";
 import { createWhatsAppPluginBase, whatsappSetupWizardProxy } from "./shared.js";
@@ -73,6 +74,15 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
     pairing: {
       idLabel: "whatsappSenderId",
       normalizeAllowEntry: (entry) => normalizeWhatsAppAllowFromEntry(entry) ?? "",
+      notifyApproval: async ({ cfg, id, accountId }) => {
+        const account = resolveWhatsAppAccount({ cfg, accountId });
+        const target = normalizeWhatsAppMessagingTarget(id) ?? id;
+        await sendMessageWhatsApp(target, PAIRING_APPROVED_MESSAGE, {
+          verbose: false,
+          cfg,
+          accountId: account.accountId,
+        });
+      },
     },
     outbound: whatsappChannelOutbound,
     threading: {


### PR DESCRIPTION
Closes #56619

## What Problem This Solves

Fixes an issue where users pairing a WhatsApp sender would never receive an approval confirmation message. The shared pairing-approval path is documented and works for Slack, Feishu, and Synology Chat, but WhatsApp's channel adapter ships no `notifyApproval` callback, so the shared notifier (`src/channels/plugins/pairing.ts`) returns early and the approval is a silent no-op. The Control UI also hides the "notify on approval" option for WhatsApp, because `notifySupported` is derived from `Boolean(adapter.notifyApproval)`.

## Why This Change Was Made

Adds the missing `notifyApproval` callback to `whatsappPlugin.pairing`, modeled on the existing Slack implementation. When an approval fires, WhatsApp resolves the account, normalizes the sender JID, and sends `PAIRING_APPROVED_MESSAGE` (the shared confirmation string) via `sendMessageWhatsApp`. The change is purely additive — the shared notifier and the `notifySupported` UI surface already handle the optional callback, so no shared, gateway, or protocol code is touched. WhatsApp's send path is simpler than Slack's (no write token or team-scoped target formatting), so the callback stays minimal.

This is a small, scoped gap-filler that brings WhatsApp to parity with the three sibling channels that already ship this callback. The broader operator-approvals refactor (`docs/refactor/operator-approvals.md`, #103505) is a future reshape of the approval lifecycle; this PR does not introduce a new approval abstraction — it wires the existing per-channel notify seam that the shared notifier already calls, so it composes with rather than preempts that later work.

## User Impact

WhatsApp senders who complete pairing approval now receive a confirmation message, matching the behavior of Slack, Feishu, and Synology Chat. Operators also see the "notify on approval" option enabled for WhatsApp in the Control UI.

## Evidence

- New test `extensions/whatsapp/src/channel.test.ts` asserts `whatsappPlugin.pairing.notifyApproval` is defined and sends `PAIRING_APPROVED_MESSAGE` to the paired sender. Red on `main` (callback is `undefined`); green on this branch.
- `pnpm test:extension whatsapp` — the two new tests pass (included in the 1341 passing). The 7 failures in `session.test.ts` are pre-existing on `main` (verified: same 7 fail on an unmodified `main` checkout — they require WhatsApp credential/auth state unavailable in the test environment and are unrelated to this change).
- Prior art: Slack (`extensions/slack/src/channel.ts`), Synology Chat, and Feishu all implement the same `notifyApproval` callback.