### PR TITLE
fix(ui): show when connected chats cannot receive live messages

### DIFF
--- a/ui/src/pages/chat/chat-history-subscription-errors.test.ts
+++ b/ui/src/pages/chat/chat-history-subscription-errors.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
 import {
   disposeSelectedSessionMessageSubscription,
   syncSelectedSessionMessageSubscription,
-  type ChatState,
 } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 
@@ -11,12 +11,16 @@ type Subscription = { key: string; agentId: null };
 
 function createSubscriptionState(options?: {
   previous?: Subscription;
-  subscribeMessages?: ReturnType<typeof vi.fn>;
-  unsubscribeMessages?: ReturnType<typeof vi.fn>;
+  subscribeMessages?: ReturnType<typeof vi.fn<SessionCapability["subscribeMessages"]>>;
+  unsubscribeMessages?: ReturnType<typeof vi.fn<SessionCapability["unsubscribeMessages"]>>;
 }) {
   const selected = { key: "agent:main:selected", agentId: null } satisfies Subscription;
-  const subscribeMessages = options?.subscribeMessages ?? vi.fn(async () => selected);
-  const unsubscribeMessages = options?.unsubscribeMessages ?? vi.fn(async () => undefined);
+  const subscribeMessages =
+    options?.subscribeMessages ??
+    vi.fn<SessionCapability["subscribeMessages"]>(async () => selected);
+  const unsubscribeMessages =
+    options?.unsubscribeMessages ??
+    vi.fn<SessionCapability["unsubscribeMessages"]>(async () => undefined);
   const state = {
     ...makeChatHost({ requestHandlers: {}, sessionKey: selected.key }),
     connectionEpoch: 1,
@@ -26,7 +30,7 @@ function createSubscriptionState(options?: {
     chatSessionMessageSubscription: options?.previous ?? null,
     sessions: { subscribeMessages, unsubscribeMessages },
     requestUpdate: vi.fn(),
-  } satisfies ChatState;
+  } satisfies Parameters<typeof syncSelectedSessionMessageSubscription>[0];
 
   return { selected, state, subscribeMessages, unsubscribeMessages };
 }
@@ -34,7 +38,9 @@ function createSubscriptionState(options?: {
 describe("visible chat message subscription failures", () => {
   it("shows a failed initial subscription in the existing chat error surface", async () => {
     const { state } = createSubscriptionState({
-      subscribeMessages: vi.fn().mockRejectedValue(new Error("Live messages unavailable")),
+      subscribeMessages: vi
+        .fn<SessionCapability["subscribeMessages"]>()
+        .mockRejectedValue(new Error("Live messages unavailable")),
     });
 
     await syncSelectedSessionMessageSubscription(state);
@@ -49,7 +55,7 @@ describe("visible chat message subscription failures", () => {
   it("shows a failed previous subscription release without losing its owned lease", async () => {
     const previous = { key: "agent:main:previous", agentId: null } satisfies Subscription;
     const unsubscribeMessages = vi
-      .fn()
+      .fn<SessionCapability["unsubscribeMessages"]>()
       .mockRejectedValueOnce(new Error("Previous observer release failed"))
       .mockResolvedValueOnce(undefined);
     const { state } = createSubscriptionState({ previous, unsubscribeMessages });
@@ -65,7 +71,7 @@ describe("visible chat message subscription failures", () => {
   it("keeps a dual-release warning until its exact previous lease is released", async () => {
     const previous = { key: "agent:main:previous", agentId: null } satisfies Subscription;
     const unsubscribeMessages = vi
-      .fn()
+      .fn<SessionCapability["unsubscribeMessages"]>()
       .mockRejectedValueOnce(new Error("Previous observer release failed"))
       .mockRejectedValueOnce(new Error("Replacement observer release failed"))
       .mockRejectedValueOnce(new Error("Previous observer still unavailable"))
@@ -97,7 +103,7 @@ describe("visible chat message subscription failures", () => {
   it("clears its own visible warning after the selected subscription recovers", async () => {
     const selected = { key: "agent:main:selected", agentId: null } satisfies Subscription;
     const subscribeMessages = vi
-      .fn()
+      .fn<SessionCapability["subscribeMessages"]>()
       .mockRejectedValueOnce(new Error("Live messages unavailable"))
       .mockResolvedValueOnce(selected);
     const { state } = createSubscriptionState({ subscribeMessages });
@@ -116,7 +122,7 @@ describe("visible chat message subscription failures", () => {
   it("never clears an unrelated chat failure published before subscription recovery", async () => {
     const selected = { key: "agent:main:selected", agentId: null } satisfies Subscription;
     const subscribeMessages = vi
-      .fn()
+      .fn<SessionCapability["subscribeMessages"]>()
       .mockRejectedValueOnce(new Error("Live messages unavailable"))
       .mockResolvedValueOnce(selected);
     const { state } = createSubscriptionState({ subscribeMessages });
@@ -139,7 +145,7 @@ describe("visible chat message subscription failures", () => {
       rejectSubscription = reject;
     });
     const { state } = createSubscriptionState({
-      subscribeMessages: vi.fn().mockReturnValue(pending),
+      subscribeMessages: vi.fn<SessionCapability["subscribeMessages"]>().mockReturnValue(pending),
     });
 
     const sync = syncSelectedSessionMessageSubscription(state);
@@ -159,7 +165,7 @@ describe("visible chat message subscription failures", () => {
       rejectSubscription = reject;
     });
     const { state } = createSubscriptionState({
-      subscribeMessages: vi.fn().mockReturnValue(pending),
+      subscribeMessages: vi.fn<SessionCapability["subscribeMessages"]>().mockReturnValue(pending),
     });
 
     const sync = syncSelectedSessionMessageSubscription(state);

--- a/ui/src/pages/chat/chat-history-subscription-errors.test.ts
+++ b/ui/src/pages/chat/chat-history-subscription-errors.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import {
+  disposeSelectedSessionMessageSubscription,
+  syncSelectedSessionMessageSubscription,
+  type ChatState,
+} from "./chat-history.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
+
+type Subscription = { key: string; agentId: null };
+
+function createSubscriptionState(options?: {
+  previous?: Subscription;
+  subscribeMessages?: ReturnType<typeof vi.fn>;
+  unsubscribeMessages?: ReturnType<typeof vi.fn>;
+}) {
+  const selected = { key: "agent:main:selected", agentId: null } satisfies Subscription;
+  const subscribeMessages = options?.subscribeMessages ?? vi.fn(async () => selected);
+  const unsubscribeMessages = options?.unsubscribeMessages ?? vi.fn(async () => undefined);
+  const state = {
+    ...makeChatHost({ requestHandlers: {}, sessionKey: selected.key }),
+    connectionEpoch: 1,
+    chatError: null as string | null,
+    sessionsError: null as string | null,
+    chatSessionMessageSubscriptionRequestedKey: options?.previous?.key ?? null,
+    chatSessionMessageSubscription: options?.previous ?? null,
+    sessions: { subscribeMessages, unsubscribeMessages },
+    requestUpdate: vi.fn(),
+  } satisfies ChatState;
+
+  return { selected, state, subscribeMessages, unsubscribeMessages };
+}
+
+describe("visible chat message subscription failures", () => {
+  it("shows a failed initial subscription in the existing chat error surface", async () => {
+    const { state } = createSubscriptionState({
+      subscribeMessages: vi.fn().mockRejectedValue(new Error("Live messages unavailable")),
+    });
+
+    await syncSelectedSessionMessageSubscription(state);
+
+    expect(state.chatSessionMessageSubscription).toBeNull();
+    expect(state.sessionsError).toBe("Live messages unavailable");
+    expect(state.lastError).toBe("Live messages unavailable");
+    expect(state.chatError).toBe("Live messages unavailable");
+    expect(state.requestUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("shows a failed previous subscription release without losing its owned lease", async () => {
+    const previous = { key: "agent:main:previous", agentId: null } satisfies Subscription;
+    const unsubscribeMessages = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Previous observer release failed"))
+      .mockResolvedValueOnce(undefined);
+    const { state } = createSubscriptionState({ previous, unsubscribeMessages });
+
+    await syncSelectedSessionMessageSubscription(state);
+
+    expect(state.chatSessionMessageSubscription).toBe(previous);
+    expect(state.lastError).toBe("Previous observer release failed");
+    expect(state.chatError).toBe(state.lastError);
+    expect(state.requestUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a dual-release warning until its exact previous lease is released", async () => {
+    const previous = { key: "agent:main:previous", agentId: null } satisfies Subscription;
+    const unsubscribeMessages = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Previous observer release failed"))
+      .mockRejectedValueOnce(new Error("Replacement observer release failed"))
+      .mockRejectedValueOnce(new Error("Previous observer still unavailable"))
+      .mockResolvedValueOnce(undefined);
+    const { selected, state } = createSubscriptionState({ previous, unsubscribeMessages });
+
+    await syncSelectedSessionMessageSubscription(state);
+
+    const warning =
+      "Previous observer release failed; replacement release failed: Replacement observer release failed";
+    expect(state.chatSessionMessageSubscription).toEqual(selected);
+    expect(state.lastError).toBe(warning);
+    expect(state.chatError).toBe(warning);
+
+    await syncSelectedSessionMessageSubscription(state);
+
+    expect(state.lastError).toBe(warning);
+    expect(state.chatError).toBe(warning);
+
+    await syncSelectedSessionMessageSubscription(state);
+
+    expect(state.chatSessionMessageSubscription).toEqual(selected);
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
+    expect(state.sessionsError).toBeNull();
+    expect(unsubscribeMessages).toHaveBeenCalledTimes(4);
+  });
+
+  it("clears its own visible warning after the selected subscription recovers", async () => {
+    const selected = { key: "agent:main:selected", agentId: null } satisfies Subscription;
+    const subscribeMessages = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Live messages unavailable"))
+      .mockResolvedValueOnce(selected);
+    const { state } = createSubscriptionState({ subscribeMessages });
+
+    await syncSelectedSessionMessageSubscription(state);
+    expect(state.lastError).toBe("Live messages unavailable");
+
+    await syncSelectedSessionMessageSubscription(state);
+
+    expect(state.chatSessionMessageSubscription).toBe(selected);
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
+    expect(state.sessionsError).toBeNull();
+  });
+
+  it("never clears an unrelated chat failure published before subscription recovery", async () => {
+    const selected = { key: "agent:main:selected", agentId: null } satisfies Subscription;
+    const subscribeMessages = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Live messages unavailable"))
+      .mockResolvedValueOnce(selected);
+    const { state } = createSubscriptionState({ subscribeMessages });
+
+    await syncSelectedSessionMessageSubscription(state);
+    state.lastError = "Sending the message failed";
+    state.chatError = "Sending the message failed";
+    state.sessionsError = "Session list refresh failed";
+
+    await syncSelectedSessionMessageSubscription(state);
+
+    expect(state.lastError).toBe("Sending the message failed");
+    expect(state.chatError).toBe("Sending the message failed");
+    expect(state.sessionsError).toBe("Session list refresh failed");
+  });
+
+  it("never publishes a failed subscription after its pane is disposed", async () => {
+    let rejectSubscription: (error: Error) => void = () => undefined;
+    const pending = new Promise<Subscription>((_resolve, reject) => {
+      rejectSubscription = reject;
+    });
+    const { state } = createSubscriptionState({
+      subscribeMessages: vi.fn().mockReturnValue(pending),
+    });
+
+    const sync = syncSelectedSessionMessageSubscription(state);
+    await Promise.resolve();
+    disposeSelectedSessionMessageSubscription(state);
+    rejectSubscription(new Error("Retired observer unavailable"));
+    await sync;
+
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
+    expect(state.requestUpdate).not.toHaveBeenCalled();
+  });
+
+  it("never publishes a failed subscription from a replaced same-client generation", async () => {
+    let rejectSubscription: (error: Error) => void = () => undefined;
+    const pending = new Promise<Subscription>((_resolve, reject) => {
+      rejectSubscription = reject;
+    });
+    const { state } = createSubscriptionState({
+      subscribeMessages: vi.fn().mockReturnValue(pending),
+    });
+
+    const sync = syncSelectedSessionMessageSubscription(state);
+    await Promise.resolve();
+    state.connectionEpoch += 1;
+    rejectSubscription(new Error("Prior connection generation unavailable"));
+    await sync;
+
+    expect(state.lastError).toBeNull();
+    expect(state.chatError).toBeNull();
+    expect(state.requestUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -101,6 +101,7 @@ type ChatHistoryPaneRequests = {
   historyVersion: number;
   branchVersion: number;
   subscriptionGeneration: number;
+  subscriptionError?: string;
   pendingSubscriptionReleases: Set<SessionMessageSubscription>;
   inFlightHistory?: InFlightChatHistoryRequest;
 };
@@ -587,6 +588,7 @@ function isCurrentSelectedSessionMessageSubscriptionSync(
   params: {
     generation: number;
     client: GatewayBrowserClient;
+    connectionEpoch: number;
     requestedKey: string;
     requestedAgentId?: string | null;
   },
@@ -594,6 +596,7 @@ function isCurrentSelectedSessionMessageSubscriptionSync(
   return (
     getChatHistoryPaneRequests(state).subscriptionGeneration === params.generation &&
     state.client === params.client &&
+    state.connectionEpoch === params.connectionEpoch &&
     state.connected &&
     state.sessionKey.trim() === params.requestedKey &&
     resolveSelectedSessionMessageSubscriptionAgentId(state, params.requestedKey) ===
@@ -666,6 +669,7 @@ export async function syncSelectedSessionMessageSubscription(
     return;
   }
   const client = state.client;
+  const connectionEpoch = state.connectionEpoch;
   const nextKey = state.sessionKey.trim();
   if (!nextKey) {
     return;
@@ -694,16 +698,45 @@ export async function syncSelectedSessionMessageSubscription(
     selectedAgentChanged ||
     previousCanonicalKey === null ||
     previousRequestedKey === null;
-  if (!shouldUnsubscribePrevious && !shouldSubscribe) {
-    return;
-  }
   const isCurrent = () =>
     isCurrentSelectedSessionMessageSubscriptionSync(state, {
       generation,
       client,
+      connectionEpoch,
       requestedKey: nextKey,
       requestedAgentId: nextSubscriptionAgentId,
     });
+  const clearRecoveredError = () => {
+    const message = paneRequests.subscriptionError;
+    if (!message || paneRequests.pendingSubscriptionReleases.size > 0) {
+      return;
+    }
+    paneRequests.subscriptionError = undefined;
+    for (const field of ["sessionsError", "lastError", "chatError"] as const) {
+      if (state[field] === message) {
+        state[field] = null;
+      }
+    }
+    state.requestUpdate?.();
+  };
+  const publishError = (error: unknown) => {
+    const message = formatUiError(error);
+    paneRequests.subscriptionError = message;
+    state.sessionsError = message;
+    setChatError(state, message);
+    state.requestUpdate?.();
+  };
+  if (!shouldUnsubscribePrevious && !shouldSubscribe) {
+    if (
+      isCurrent() &&
+      previousSubscription &&
+      areUiSessionKeysEquivalent(previousSubscription.key, nextKey) &&
+      (previousSubscription.agentId ?? null) === nextSubscriptionAgentId
+    ) {
+      clearRecoveredError();
+    }
+    return;
+  }
   try {
     let unsubscribePromise: Promise<void> = Promise.resolve();
     if (shouldUnsubscribePrevious && previousSubscription) {
@@ -734,7 +767,9 @@ export async function syncSelectedSessionMessageSubscription(
             }
             state.chatSessionMessageSubscriptionRequestedKey = nextKey;
             state.chatSessionMessageSubscription = subscribeResult.value;
-            state.sessionsError = `${formatUiError(unsubscribeResult.reason)}; replacement release failed: ${formatUiError(replacementReleaseError)}`;
+            publishError(
+              `${formatUiError(unsubscribeResult.reason)}; replacement release failed: ${formatUiError(replacementReleaseError)}`,
+            );
           } else {
             paneRequests.pendingSubscriptionReleases.add(subscribeResult.value);
           }
@@ -742,7 +777,7 @@ export async function syncSelectedSessionMessageSubscription(
         }
       }
       if (isCurrent()) {
-        state.sessionsError = formatUiError(unsubscribeResult.reason);
+        publishError(unsubscribeResult.reason);
       }
       return;
     }
@@ -774,9 +809,10 @@ export async function syncSelectedSessionMessageSubscription(
     }
     state.chatSessionMessageSubscriptionRequestedKey = nextKey;
     state.chatSessionMessageSubscription = subscribed;
+    clearRecoveredError();
   } catch (err) {
     if (isCurrent()) {
-      state.sessionsError = formatUiError(err);
+      publishError(err);
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Opening or reconnecting an existing Control UI chat can fail to subscribe to live session messages while the Gateway still says **Connected**. The failure was recorded only in hidden session-list state and never triggered a render, so the chat looked healthy even though new conversation updates could no longer arrive.

## Why This Change Was Made

The existing pane-owned subscription lifecycle now publishes current-generation subscription acquisition and observer-release failures through the existing redacted chat error surface. Its existing private pane request record remembers the exact warning it owns, so recovery clears that warning only after the selected observer is active and all previous observer cleanup has succeeded. Replaced clients, same-client reconnect generations, disposed panes, other sessions/agents, and intervening unrelated errors remain isolated.

## User Impact

Connected chats immediately display an accessible warning when live messages cannot arrive instead of silently appearing healthy. The warning disappears after the exact subscription or previous-observer cleanup recovers, without erasing unrelated errors.

## Evidence

**Before:** The real production subscription owner fails, the Gateway still reports Connected, and the real production chat notices render no warning.

![Before: connected chat silently fails to receive live messages](https://github.com/user-attachments/assets/cfafcb0d-7fad-4a1a-a899-8d55db18c751)

**After:** The same production subscription failure appears immediately as an accessible visible warning.

![After: connected chat visibly reports that live messages are unavailable](https://github.com/user-attachments/assets/b9d1a334-408a-4eb6-abf1-bb8cb7f0c8ce)

Both screenshots exercise the actual production subscription owner, production Lit notices, production composer, and isolated Chromium using exclusively synthetic data.

- The checked-in regression failed on the unmodified owner, then passed across initial rejection, previous-observer release failure, dual-release recovery, successful selected subscription recovery, unrelated intervening errors, disposed panes, and same-client reconnect generations.
- Owner verification: **104 tests across 8 suites passed**; independent verification: **268 tests across 9 suites passed**, including an independently repeated real-browser failure and recovery check and redacted-error proof.
- Production delta is **+36 lines** because the existing private pane owner must fence the current connection generation, remember its exact warning, cover all three lease-failure paths, and clear only recovered owner-owned errors after previous cleanup. No new cache, public API, configuration, authentication behavior, or security surface is introduced.
- Focused lint, formatting, Control UI localization verification, max-lines ratchet, assertion-safety ratchet, secret scanning, and full authenticated committed-branch review passed.
