### PR TITLE
fix(browser): keep action URLs out of Gateway transport

### DIFF
--- a/extensions/browser/cli-output-mode.ts
+++ b/extensions/browser/cli-output-mode.ts
@@ -89,7 +89,7 @@ export function isBrowserMachineOutput(params: { argv: readonly string[] }): boo
     (path[0] === "storage" && ["local", "session"].includes(path[1] ?? "") && path[2] === "get") ||
     (path[0] === "extension" && path[1] === "native-host") ||
     (path[0] === "extension" &&
-      ["install", "status", "uninstall-host"].includes(path[1] ?? "") &&
+      ["install", "status", "uninstall-host", "pair", "cdp"].includes(path[1] ?? "") &&
       params.argv.includes("--json"))
   );
 }

--- a/extensions/browser/src/cli/browser-cli-extension.test.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.test.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "../../test-support.js";
 import type { installChromeExtensionBootstrap } from "../browser/extension-install.js";
 import { relayKeyIdFromHex } from "../browser/extension-relay/auth-v2-crypto.js";
@@ -12,7 +12,11 @@ const relayMocks = vi.hoisted(() => {
   }
   return { relayKey, ensureExtensionRelayToken: vi.fn(() => relayKey) };
 });
-const installMocks = vi.hoisted(() => ({ installChromeExtensionBootstrap: vi.fn() }));
+const installMocks = vi.hoisted(() => ({
+  browserExtensionStatus: vi.fn(),
+  installChromeExtensionBootstrap: vi.fn(),
+  uninstallChromeExtensionNativeHosts: vi.fn(),
+}));
 
 vi.mock("../browser/extension-relay/relay-auth.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../browser/extension-relay/relay-auth.js")>()),
@@ -21,15 +25,44 @@ vi.mock("../browser/extension-relay/relay-auth.js", async (importOriginal) => ({
 
 vi.mock("../browser/extension-install.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../browser/extension-install.js")>()),
+  browserExtensionStatus: installMocks.browserExtensionStatus,
   installChromeExtensionBootstrap: installMocks.installChromeExtensionBootstrap,
+  uninstallChromeExtensionNativeHosts: installMocks.uninstallChromeExtensionNativeHosts,
 }));
 
 const { defaultRuntime: runtime, resetRuntimeCapture } = createCliRuntimeCapture();
 
+function createExtensionStatus() {
+  return {
+    platform: "linux" as const,
+    platformSupport: "automatic" as const,
+    installedCopy: { path: "/stable/openclaw-extension", present: true, owned: true },
+    bundledPath: "/bundled/openclaw-extension",
+    approvedPaths: ["/stable/openclaw-extension"],
+    discovered: [],
+    storeDiscovered: [],
+    registrations: [],
+    manualSetupRequired: false,
+    issues: [],
+  };
+}
+
 describe("browser extension pairing Gateway URL", () => {
+  beforeEach(() => {
+    installMocks.browserExtensionStatus.mockResolvedValue(createExtensionStatus());
+    installMocks.installChromeExtensionBootstrap.mockResolvedValue(createExtensionStatus());
+    installMocks.uninstallChromeExtensionNativeHosts.mockResolvedValue({
+      removed: [],
+      refused: [],
+      manualRequired: false,
+    });
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
+    installMocks.browserExtensionStatus.mockReset();
     installMocks.installChromeExtensionBootstrap.mockReset();
+    installMocks.uninstallChromeExtensionNativeHosts.mockReset();
     resetRuntimeCapture();
   });
 
@@ -122,6 +155,43 @@ describe("browser extension pairing Gateway URL", () => {
     });
     expect(logSpy).not.toHaveBeenCalled();
   });
+
+  it.each(["install", "status", "uninstall-host", "pair", "cdp"])(
+    "honors browser-level and leaf JSON placement for extension %s",
+    async (subcommand) => {
+      vi.spyOn(cliCoreApiModule, "getRuntimeConfig").mockReturnValue({});
+      const logSpy = vi
+        .spyOn(cliCoreApiModule.defaultRuntime, "log")
+        .mockImplementation(runtime.log);
+      const writeJsonSpy = vi
+        .spyOn(cliCoreApiModule.defaultRuntime, "writeJson")
+        .mockImplementation(runtime.writeJson);
+      const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
+      const placements = [
+        ["browser", "--json", "extension", subcommand],
+        ["browser", "extension", subcommand, "--json"],
+      ];
+
+      for (const argv of placements) {
+        const program = new Command().enablePositionalOptions();
+        const browser = program.command("browser").option("--json", "Output JSON", false);
+        registerBrowserExtensionCommands(browser, (command) => {
+          let owner: Command | null = command;
+          while (owner && owner.name() !== "browser") {
+            owner = owner.parent;
+          }
+          return owner?.opts() ?? {};
+        });
+        writeJsonSpy.mockClear();
+        logSpy.mockClear();
+
+        await program.parseAsync(argv, { from: "user" });
+
+        expect(writeJsonSpy, argv.join(" ")).toHaveBeenCalledTimes(1);
+        expect(logSpy, argv.join(" ")).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("pairs with the allocated extension relay when another profile pins the default port", async () => {
     vi.spyOn(cliCoreApiModule, "getRuntimeConfig").mockReturnValue({

--- a/extensions/browser/src/cli/browser-cli-extension.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.ts
@@ -141,7 +141,7 @@ async function buildCdpEndpoint(options: {
 /** Register `openclaw browser extension` lifecycle and compatibility commands. */
 export function registerBrowserExtensionCommands(
   browser: Command,
-  _parentOpts: (cmd: Command) => BrowserParentOpts,
+  parentOpts: (cmd: Command) => BrowserParentOpts,
   pluginRoot?: string,
 ) {
   const extension = browser
@@ -168,13 +168,14 @@ export function registerBrowserExtensionCommands(
       "How long to wait after pre-registration for Chrome to verify the extension",
       String(30_000),
     )
-    .action(async (opts) => {
+    .action(async (opts, command) => {
       await runCommandWithRuntime(
         defaultRuntime,
         async () => {
+          const json = opts.json === true || parentOpts(command).json === true;
           const waitMs = normalizeExtensionInstallWaitMs(opts.waitMs);
           const bundledDir = resolveChromeExtensionDir(pluginRoot);
-          if (opts.json !== true) {
+          if (!json) {
             defaultRuntime.log(
               info("Preparing the OpenClaw Chrome native bootstrap. Keep Chrome running…"),
             );
@@ -183,10 +184,9 @@ export function registerBrowserExtensionCommands(
             bundledDir,
             pluginRoot: resolveBrowserPluginRoot(pluginRoot),
             waitMs,
-            onProgress:
-              opts.json === true ? undefined : (message) => defaultRuntime.log(info(message)),
+            onProgress: json ? undefined : (message) => defaultRuntime.log(info(message)),
           });
-          if (opts.json === true) {
+          if (json) {
             defaultRuntime.writeJson(status);
           } else {
             for (const issue of status.issues) {
@@ -219,12 +219,13 @@ export function registerBrowserExtensionCommands(
     .command("status")
     .description("Inspect extension copies, Chrome IDs, and native-host registrations")
     .option("--json", "Print a machine-readable status report")
-    .action(async (opts) => {
+    .action(async (opts, command) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const json = opts.json === true || parentOpts(command).json === true;
         const status = await browserExtensionStatus({
           bundledDir: resolveChromeExtensionDir(pluginRoot),
         });
-        if (opts.json === true) {
+        if (json) {
           defaultRuntime.writeJson(status);
           return;
         }
@@ -245,10 +246,11 @@ export function registerBrowserExtensionCommands(
     .command("uninstall-host")
     .description("Remove only OpenClaw-owned Chrome native-host registrations")
     .option("--json", "Print a machine-readable removal report")
-    .action(async (opts) => {
+    .action(async (opts, command) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const json = opts.json === true || parentOpts(command).json === true;
         const result = await uninstallChromeExtensionNativeHosts();
-        if (opts.json === true) {
+        if (json) {
           defaultRuntime.writeJson(result);
           return;
         }
@@ -271,12 +273,13 @@ export function registerBrowserExtensionCommands(
       "--gateway-url <url>",
       "Print a remote pairing string for a Chrome on another machine (e.g. wss://gateway.example.com)",
     )
-    .action(async (opts) => {
+    .action(async (opts, command) => {
       await runCommandWithRuntime(
         defaultRuntime,
         async () => {
+          const json = opts.json === true || parentOpts(command).json === true;
           const result = await buildPairingString(opts.gatewayUrl);
-          if (opts.json === true) {
+          if (json) {
             defaultRuntime.writeJson({
               pairingString: result.pairing,
               relayPort: result.relayPort,
@@ -319,10 +322,11 @@ export function registerBrowserExtensionCommands(
       "--legacy-bearer",
       "Print the legacy Bearer header while browser.extensionRelay.allowLegacyAuth is enabled",
     )
-    .action(async (opts) => {
+    .action(async (opts, command) => {
       await runCommandWithRuntime(
         defaultRuntime,
         async () => {
+          const json = opts.json === true || parentOpts(command).json === true;
           const legacyBearer = opts.legacyBearer === true;
           const endpoint = await buildCdpEndpoint({ legacyBearer });
           if (legacyBearer) {
@@ -332,7 +336,7 @@ export function registerBrowserExtensionCommands(
               ),
             );
           }
-          if (opts.json === true) {
+          if (json) {
             defaultRuntime.writeJson(endpoint);
             return;
           }

--- a/extensions/browser/src/cli/browser-cli-state.cookies-storage.ts
+++ b/extensions/browser/src/cli/browser-cli-state.cookies-storage.ts
@@ -10,11 +10,8 @@ import {
 } from "./browser-cli-shared.js";
 import { danger, defaultRuntime, inheritOptionFromParent } from "./core-api.js";
 
-function resolveUrl(opts: { url?: string }, command: Command): string | undefined {
-  return (
-    normalizeOptionalString(opts.url) ??
-    normalizeOptionalString(inheritOptionFromParent<string>(command, "url"))
-  );
+function resolveUrl(opts: { url?: string }): string | undefined {
+  return normalizeOptionalString(opts.url);
 }
 
 function resolveTargetId(rawTargetId: unknown, command: Command): string | undefined {
@@ -88,7 +85,7 @@ export function registerBrowserCookiesAndStorageCommands(
       const parent = parentOpts(cmd);
       const profile = parent?.browserProfile;
       const targetId = resolveTargetId(opts.targetId, cmd);
-      const url = resolveUrl(opts, cmd);
+      const url = resolveUrl(opts);
       if (!url) {
         defaultRuntime.error(danger("Missing required --url option for cookies set"));
         defaultRuntime.exit(1);

--- a/extensions/browser/src/cli/browser-cli-state.option-collisions.test.ts
+++ b/extensions/browser/src/cli/browser-cli-state.option-collisions.test.ts
@@ -95,34 +95,16 @@ describe("browser state option collisions", () => {
     expect((request as { body?: { targetId?: string } }).body?.targetId).toBe("tab-1");
   });
 
-  it("resolves --url via parent when addGatewayClientOptions captures it", async () => {
+  it("does not inherit the parent Gateway URL as the cookie scope", async () => {
     const program = createStateProgram({ withGatewayUrl: true });
     await program.parseAsync(
-      [
-        "browser",
-        "--url",
-        "ws://gw",
-        "cookies",
-        "set",
-        "session",
-        "abc",
-        "--url",
-        "https://example.com",
-      ],
+      ["browser", "--url", "wss://gateway.example.com", "cookies", "set", "session", "abc"],
       { from: "user" },
     );
-    const request = getLastRequest() as { body?: { cookie?: { url?: string } } };
-    expect(request.body?.cookie?.url).toBe("https://example.com");
-  });
 
-  it("inherits --url from parent when subcommand does not provide it", async () => {
-    const program = createStateProgram({ withGatewayUrl: true });
-    await program.parseAsync(
-      ["browser", "--url", "https://inherited.example.com", "cookies", "set", "session", "abc"],
-      { from: "user" },
-    );
-    const request = getLastRequest() as { body?: { cookie?: { url?: string } } };
-    expect(request.body?.cookie?.url).toBe("https://inherited.example.com");
+    expect(mocks.callBrowserRequest).not.toHaveBeenCalled();
+    expectErrorMessage("Missing required --url option for cookies set");
+    expect(getBrowserCliRuntime().exit).toHaveBeenCalledWith(1);
   });
 
   it("accepts legacy parent `--json` by parsing payload via positional headers fallback", async () => {

--- a/extensions/browser/src/cli/browser-cli.lazy.test.ts
+++ b/extensions/browser/src/cli/browser-cli.lazy.test.ts
@@ -43,18 +43,41 @@ const cookieSyncMocks = vi.hoisted(() => ({
 const inspectMocks = vi.hoisted(() => ({
   registerBrowserInspectCommands: vi.fn(),
 }));
-const actionInputMocks = vi.hoisted(() => ({
-  registerBrowserActionInputCommands: vi.fn(),
-}));
+const actionInputMocks = vi.hoisted(() => {
+  const waitAction = vi.fn();
+  const registerBrowserActionInputCommands = vi.fn(
+    (browser: Command, parentOpts: (command: Command) => unknown) => {
+      browser
+        .command("wait")
+        .option("--url <pattern>")
+        .action((opts, command) => waitAction(opts, parentOpts(command)));
+    },
+  );
+  return { registerBrowserActionInputCommands, waitAction };
+});
 const actionObserveMocks = vi.hoisted(() => ({
   registerBrowserActionObserveCommands: vi.fn(),
 }));
 const debugMocks = vi.hoisted(() => ({
   registerBrowserDebugCommands: vi.fn(),
 }));
-const stateMocks = vi.hoisted(() => ({
-  registerBrowserStateCommands: vi.fn(),
-}));
+const stateMocks = vi.hoisted(() => {
+  const cookieSetAction = vi.fn();
+  const registerBrowserStateCommands = vi.fn(
+    (browser: Command, parentOpts: (command: Command) => unknown) => {
+      browser
+        .command("cookies")
+        .command("set")
+        .argument("<name>")
+        .argument("<value>")
+        .option("--url <url>")
+        .action((name, value, opts, command) =>
+          cookieSetAction(name, value, opts, parentOpts(command)),
+        );
+    },
+  );
+  return { cookieSetAction, registerBrowserStateCommands };
+});
 const extensionMocks = vi.hoisted(() => ({
   registerBrowserExtensionCommands: vi.fn(),
 }));
@@ -101,6 +124,17 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     expect(isBrowserMachineOutput({ argv: ["node", "openclaw", ...args] })).toBe(true);
   });
 
+  it.each(["install", "status", "uninstall-host", "pair", "cdp"])(
+    "declares explicit JSON output for extension %s",
+    (subcommand) => {
+      expect(
+        isBrowserMachineOutput({
+          argv: ["node", "openclaw", "browser", "extension", subcommand, "--json"],
+        }),
+      ).toBe(true);
+    },
+  );
+
   it("keeps human browser commands out of machine-output mode", () => {
     expect(isBrowserMachineOutput({ argv: ["node", "openclaw", "browser", "status"] })).toBe(false);
     expect(
@@ -128,9 +162,11 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     cookieSyncMocks.registerBrowserCookieSyncCommand.mockClear();
     inspectMocks.registerBrowserInspectCommands.mockClear();
     actionInputMocks.registerBrowserActionInputCommands.mockClear();
+    actionInputMocks.waitAction.mockClear();
     actionObserveMocks.registerBrowserActionObserveCommands.mockClear();
     debugMocks.registerBrowserDebugCommands.mockClear();
     stateMocks.registerBrowserStateCommands.mockClear();
+    stateMocks.cookieSetAction.mockClear();
     extensionMocks.registerBrowserExtensionCommands.mockClear();
   });
 
@@ -215,6 +251,104 @@ describe("registerBrowserCli lazy browser subcommands", () => {
       "tabs action",
     );
     expect(tabsCommand.parent?.opts().json).toBe(true);
+  });
+
+  it("keeps wait action URLs out of Gateway transport options", async () => {
+    const program = new Command().name("openclaw").enablePositionalOptions();
+    registerBrowserCli(program, ["node", "openclaw", "browser", "wait", "--url", "**/done"]);
+
+    await program.parseAsync(["browser", "wait", "--url", "**/done"], { from: "user" });
+
+    const [opts, parent] = requireFirstCall(actionInputMocks.waitAction, "wait action call");
+    expect(opts).toMatchObject({ url: "**/done" });
+    expect(parent).not.toHaveProperty("url");
+  });
+
+  it("keeps explicit Gateway and wait URLs under their separate owners", async () => {
+    const program = new Command().name("openclaw").enablePositionalOptions();
+    registerBrowserCli(program, [
+      "node",
+      "openclaw",
+      "browser",
+      "--url",
+      "ws://127.0.0.1:18789",
+      "wait",
+      "--url",
+      "**/done",
+    ]);
+
+    await program.parseAsync(
+      ["browser", "--url", "ws://127.0.0.1:18789", "wait", "--url", "**/done"],
+      { from: "user" },
+    );
+
+    const [opts, parent] = requireFirstCall(actionInputMocks.waitAction, "wait action call");
+    expect(opts).toMatchObject({ url: "**/done" });
+    expect(parent).toMatchObject({ url: "ws://127.0.0.1:18789" });
+  });
+
+  it("keeps cookie action URLs out of Gateway transport options", async () => {
+    const program = new Command().name("openclaw").enablePositionalOptions();
+    registerBrowserCli(program, [
+      "node",
+      "openclaw",
+      "browser",
+      "cookies",
+      "set",
+      "session",
+      "abc",
+      "--url",
+      "https://example.com",
+    ]);
+
+    await program.parseAsync(
+      ["browser", "cookies", "set", "session", "abc", "--url", "https://example.com"],
+      { from: "user" },
+    );
+
+    const cookieCall = requireFirstCall(stateMocks.cookieSetAction, "cookie set action call");
+    const opts = cookieCall[2];
+    const parent = cookieCall[3];
+    expect(opts).toMatchObject({ url: "https://example.com" });
+    expect(parent).not.toHaveProperty("url");
+  });
+
+  it("keeps explicit Gateway and cookie URLs under their separate owners", async () => {
+    const program = new Command().name("openclaw").enablePositionalOptions();
+    registerBrowserCli(program, [
+      "node",
+      "openclaw",
+      "browser",
+      "--url",
+      "ws://127.0.0.1:18789",
+      "cookies",
+      "set",
+      "session",
+      "abc",
+      "--url",
+      "https://example.com",
+    ]);
+
+    await program.parseAsync(
+      [
+        "browser",
+        "--url",
+        "ws://127.0.0.1:18789",
+        "cookies",
+        "set",
+        "session",
+        "abc",
+        "--url",
+        "https://example.com",
+      ],
+      { from: "user" },
+    );
+
+    const cookieCall = requireFirstCall(stateMocks.cookieSetAction, "cookie set action call");
+    const opts = cookieCall[2];
+    const parent = cookieCall[3];
+    expect(opts).toMatchObject({ url: "https://example.com" });
+    expect(parent).toMatchObject({ url: "ws://127.0.0.1:18789" });
   });
 
   it("accepts the shipped trailing browser profile order after lazy loading", async () => {

--- a/extensions/browser/src/cli/browser-cli.ts
+++ b/extensions/browser/src/cli/browser-cli.ts
@@ -167,10 +167,6 @@ function buildBrowserCommandGroups(params: {
   }));
 }
 
-function resolveBrowserParentOpts(cmd: Command): BrowserParentOpts {
-  return cmd.optsWithGlobals<BrowserParentOpts>();
-}
-
 function registerLazyBrowserCommands(
   browser: Command,
   parentOpts: (cmd: Command) => BrowserParentOpts,
@@ -217,7 +213,7 @@ export function registerBrowserCli(
 
   addGatewayClientOptions(browser);
 
-  const parentOpts = resolveBrowserParentOpts;
+  const parentOpts = () => browser.opts<BrowserParentOpts>();
 
   registerLazyBrowserCommands(browser, parentOpts, argv, pluginRoot);
 }


### PR DESCRIPTION
Closes #128869

## What Problem This Solves

Fixes an issue where Browser CLI users could have a leaf action URL treated as the Gateway transport URL, or receive human extension output when requesting browser-level JSON. Affected commands included `cookies set --url`, `wait --url`, and all JSON-capable `browser extension` leaves.

## Why This Change Was Made

The `browser` command now exclusively owns Gateway transport/profile/output options instead of resolving them from the active leaf through Commander globals. Cookie URL scope is leaf-only, extension commands honor either their local JSON flag or the browser parent flag, and machine-output classification includes `extension pair` and `extension cdp`.

This is the plugin-local owner fix: it does not change Gateway protocol, transport policy, or unrelated CLI option inheritance.

## User Impact

Browser cookie and wait actions retain their own URL without redirecting Gateway transport. A parent Gateway URL is no longer accepted as a cookie scope. `browser --json extension <command>` and `browser extension <command> --json` now produce equivalent machine output for all supported extension commands.

## Evidence

- Pre-fix regression: 10 deterministic failures across real lazy parsing, cookie validation, extension output, and machine-output classification
- `pnpm test:extension browser`: 191 files passed, 2 skipped; 2,634 tests passed, 6 skipped
- Focused parser/owner tests: 50/50 passed
- `pnpm build`
- `node scripts/check-changed.mjs`
- Dist-backed CLI proof: `browser --json extension status` returned structured JSON from the exact committed build
- Fresh autoreview: clean, no accepted/actionable findings
- Production LOC: +23/-26 (net -3)
- Tests: +217/-31

AI-assisted: yes
