### PR TITLE
fix(agents): keep Unicode filename reads inside workspace

### DIFF
--- a/src/agents/agent-tools.unicode-read-workspace.test.ts
+++ b/src/agents/agent-tools.unicode-read-workspace.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import "./test-helpers/fast-coding-tools.js";
+import "./test-helpers/fast-openclaw-tools.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { createOpenClawCodingTools } from "./agent-tools.js";
+import { expectReadWriteEditTools, getTextContent } from "./test-helpers/agent-tools-fs-helpers.js";
+
+vi.mock("../infra/shell-env.js", async () => {
+  const mod =
+    await vi.importActual<typeof import("../infra/shell-env.js")>("../infra/shell-env.js");
+  return { ...mod, getShellPathFromLoginShell: () => null };
+});
+
+async function withTempDir<T>(prefix: string, fn: (dir: string) => Promise<T>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("workspace-only Unicode read fallback", () => {
+  it("does not follow a filename fallback into a sibling workspace", async (context) => {
+    await withTempDir("openclaw-unicode-parent-", async (rootDir) => {
+      const workspaceDir = path.join(rootDir, "cafe\u0301");
+      const outsideDir = path.join(rootDir, "caf\u00e9");
+      await fs.mkdir(workspaceDir);
+      try {
+        await fs.mkdir(outsideDir);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+          context.skip();
+          return;
+        }
+        throw error;
+      }
+      await fs.writeFile(path.join(outsideDir, "secret.txt"), "outside secret", "utf8");
+
+      const config: OpenClawConfig = { tools: { fs: { workspaceOnly: true } } };
+      const tools = createOpenClawCodingTools({ workspaceDir, config });
+      const { readTool } = expectReadWriteEditTools(tools);
+
+      await expect(
+        readTool.execute("ws-read-unicode-parent", { path: "secret.txt" }),
+      ).rejects.toThrow(/File not found/i);
+    });
+  });
+
+  it("keeps filename fallback working inside the guarded workspace", async () => {
+    await withTempDir("openclaw-unicode-leaf-", async (workspaceDir) => {
+      await fs.writeFile(path.join(workspaceDir, "d\u2019accord.txt"), "allowed fallback", "utf8");
+
+      const config: OpenClawConfig = { tools: { fs: { workspaceOnly: true } } };
+      const tools = createOpenClawCodingTools({ workspaceDir, config });
+      const { readTool } = expectReadWriteEditTools(tools);
+
+      const result = await readTool.execute("ws-read-unicode-leaf", { path: "d'accord.txt" });
+      expect(getTextContent(result)).toContain("allowed fallback");
+    });
+  });
+});

--- a/src/agents/sessions/tools/path-utils.test.ts
+++ b/src/agents/sessions/tools/path-utils.test.ts
@@ -2,7 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
-import { resolveToCwd } from "./path-utils.js";
+import { getReadPathVariants, resolveToCwd } from "./path-utils.js";
 
 describe("resolveToCwd", () => {
   const cwd = path.resolve("workspace");
@@ -42,4 +42,16 @@ describe("resolveToCwd", () => {
       expect(resolveToCwd("~\\notes.txt", cwd)).toBe(path.resolve(cwd, "~\\notes.txt"));
     },
   );
+});
+
+describe("getReadPathVariants", () => {
+  it("keeps the parent path unchanged for every filename fallback", () => {
+    const cwd = path.resolve("workspace");
+    const parent = path.join(cwd, "cafe\u0301 d'accord 9.30 PM\u202Farchive");
+    const filePath = path.join(parent, "re\u0301sume\u0301 9.30 PM d'accord.txt");
+    const variants = getReadPathVariants(filePath);
+
+    expect(variants.length).toBeGreaterThan(0);
+    expect(new Set(variants.map((variant) => path.dirname(variant)))).toEqual(new Set([parent]));
+  });
 });

--- a/src/agents/sessions/tools/path-utils.ts
+++ b/src/agents/sessions/tools/path-utils.ts
@@ -3,7 +3,7 @@
  *
  * Expands user/file URL inputs and resolves read/write paths against the active cwd with macOS filename variants.
  */
-import { isAbsolute, resolve as resolvePath } from "node:path";
+import { basename, isAbsolute, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expandHomePrefix, resolveOsHomeDir } from "../../../infra/home-dir.js";
 
@@ -55,19 +55,23 @@ export function resolveToCwd(filePath: string, cwd: string): string {
   return isAbsolute(expanded) ? expanded : resolvePath(cwd, expanded);
 }
 
-/** Equivalent spellings worth probing after an exact read path misses. */
+/** Equivalent filename spellings worth probing after an exact read path misses. */
 export function getReadPathVariants(filePath: string): string[] {
   const variants = new Set<string>();
-  const asciiSpace = normalizeUnicodeSpaces(filePath);
+  const fileName = basename(filePath);
+  const parentPrefix = filePath.slice(0, filePath.length - fileName.length);
+  // The caller may already have authorized the parent directory. Only vary the
+  // basename so a fallback cannot escape that validated boundary.
+  const asciiSpace = normalizeUnicodeSpaces(fileName);
   for (const spaced of [asciiSpace, tryMacOSScreenshotPath(asciiSpace)]) {
     const straightQuotes = spaced.replace(/[\u2018\u2019]/g, "'");
     const curlyQuotes = spaced.replace(/['\u2018]/g, "\u2019");
     for (const quoted of [straightQuotes, curlyQuotes]) {
-      variants.add(quoted.normalize("NFC"));
+      variants.add(`${parentPrefix}${quoted.normalize("NFC")}`);
       // macOS filesystems resolve NFC/NFD spellings to the same entry; probing both
       // makes one file look ambiguous. Other platforms can store both distinctly.
       if (process.platform !== "darwin") {
-        variants.add(quoted.normalize("NFD"));
+        variants.add(`${parentPrefix}${quoted.normalize("NFD")}`);
       }
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where workspace-only file reads could let Unicode filename fallback change the spelling of a parent directory instead of only the requested filename.

## Why This Change Was Made

Read-path variants now transform only the basename while preserving the already-authorized parent directory byte-for-byte. The focused regression covers every existing filename transform and the composed workspace-only read flow.

## User Impact

Workspace-only reads remain inside the authorized directory while retaining supported Unicode, spacing, and quote fallback for filenames within that directory. Exact-path reads are unchanged.

## Evidence

- Focused local tests: `node scripts/run-vitest.mjs src/agents/agent-tools.unicode-read-workspace.test.ts src/agents/sessions/tools/path-utils.test.ts src/agents/sessions/tools/read.test.ts --reporter=verbose`
- Changed-file gate: `node scripts/check-changed.mjs`
- Linux filesystem proof: [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/32779475742) (2/2 focused workspace tests passed)
- Local pre-commit review: no findings
