### PR TITLE
fix(daemon): write gateway stderr to resolved log path on launchd

### DIFF
--- a/src/daemon/launchd-service-files.ts
+++ b/src/daemon/launchd-service-files.ts
@@ -28,7 +28,6 @@ const LAUNCH_AGENT_PRIVATE_DIR_MODE = 0o700;
 export const LAUNCH_AGENT_ENV_FILE_MODE = 0o600;
 export const LAUNCH_AGENT_ENV_WRAPPER_MODE = 0o700;
 const LAUNCH_AGENT_ENV_DIR_NAME = "service-env";
-const LAUNCH_AGENT_STDERR_PATH = "/dev/null";
 export function resolveLaunchAgentPlistPathForLabel(
   env: Record<string, string | undefined>,
   label: string,
@@ -347,7 +346,7 @@ export async function writeLaunchAgentPlist({
   const label = resolveLaunchAgentLabel(env);
   await assertNoSystemLaunchDaemonOwnership(label);
 
-  const { logDir, stdoutPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
+  const { logDir, stdoutPath, stderrPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
   await ensureSecureDirectory(logDir);
 
   const plistPath = resolveLaunchAgentPlistPathForLabel(env, label);
@@ -373,7 +372,7 @@ export async function writeLaunchAgentPlist({
     programArguments: prepared.programArguments,
     workingDirectory,
     stdoutPath,
-    stderrPath: LAUNCH_AGENT_STDERR_PATH,
+    stderrPath,
     environment: prepared.inlineEnvironment,
   });
   await publishLaunchAgentPlist({ label, plistPath, contents: plist });
@@ -400,7 +399,7 @@ export async function rewriteLaunchAgentPlistForRestart({
     return false;
   }
 
-  const { logDir, stdoutPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
+  const { logDir, stdoutPath, stderrPath } = resolveGatewaySupervisorLogPaths(env, { platform: "darwin" });
   await ensureSecureDirectory(logDir);
 
   const serviceDescription = resolveGatewayServiceDescription({
@@ -426,7 +425,7 @@ export async function rewriteLaunchAgentPlistForRestart({
     programArguments: prepared.programArguments,
     workingDirectory: existing.workingDirectory,
     stdoutPath,
-    stderrPath: LAUNCH_AGENT_STDERR_PATH,
+    stderrPath,
     environment: prepared.inlineEnvironment,
   });
   const previousPlist = await fs.readFile(plistPath, "utf8").catch(() => "");


### PR DESCRIPTION
# Don't discard gateway stderr on launchd installs

## Impact — real incident, not hypothetical

An agent ran silently unable to reply for **three days**, and it was
undiagnosable: on macOS, `openclaw gateway install` writes `StandardOutPath`
to `~/Library/Logs/openclaw/gateway.log` but pins `StandardErrorPath` to
`/dev/null`, so every warning the gateway emitted leading up to the failure
was thrown away. Nothing in the logs, nothing in `openclaw status`, nothing
in diagnostics.

Twenty minutes after manually redirecting stderr to a file, **six
previously-invisible plugin warnings appeared** — and one of them was the
defect. This PR exists because that failure was undetectable for three days.

The reporter is a downstream user — an AgentVault agent running on OpenClaw —
not an OpenClaw maintainer. That is why the bug went unreported for so long
(downstream users assume it is their setup, not the platform's), and it is
why the three-day story is first-hand rather than theoretical.

## The bug

**Both plist-writing paths are affected** — the install path
(`writeLaunchAgentPlist()`) *and* the restart-rewrite path
(`rewriteLaunchAgentPlistForRestart()`) hardcode `stderrPath:
LAUNCH_AGENT_STDERR_PATH` (`/dev/null`) into the plist, even though
`resolveGatewaySupervisorLogPaths()` returns a correct `stderrPath` beside
`stdoutPath` (`~/Library/Logs/openclaw/gateway.err.log` on macOS,
`<stateDir>/logs/gateway.err.log` elsewhere) and the read side
(`openclaw status`, `openclaw diagnostics`) already tails `logPaths.stderrPath`.

That both sites are affected is precisely what marks this as an oversight
rather than a design choice: a deliberate "discard stderr on macOS" decision
would not need to be re-asserted in two places, and it would contradict the
read side, which already expects the `.err.log` file to exist.

Net effect on macOS installs: stderr is **discarded** while the diagnostics
tooling silently looks for a file that is never written. Writers and readers
disagree — that internal contradiction is what made the failure invisible.

## The fix

**`launchd-service-files.ts`** — destructure `stderrPath` from the resolver
and write it to the plist at both call sites; delete the now-orphaned
`LAUNCH_AGENT_STDERR_PATH = "/dev/null"` constant. After this change the
constant has **zero callers** — a constant with no references left is the
cleanest possible evidence it was a placeholder, not a policy, and deleting
it in the same PR makes that argument without needing to make it.

The path is already configurable via `OPENCLAW_LOG_PREFIX` and the gateway
state dir — this change simply stops discarding the result.

Existing installs self-heal on the next restart plist rewrite (the rewrite
path publishes whenever the plist differs); re-running
`openclaw gateway install` applies it immediately.

## Testing

**Verified by outcome, not by inspection.** The reproduction: set the plist's
`StandardErrorPath` to `/dev/null`, ran `openclaw gateway restart`, and the
plist came back with the resolved `.err.log` path — the restart-rewrite path
regenerated it correctly. (On the box where this was tested: plist rewritten
with the correct path, gateway PID changed, stderr flowing to
`gateway.err.log` immediately after.)

- `git apply --check` clean against `main` (be509faf).
- Typecheck of the daemon sources (TS 6.0.3): no errors in either modified file.
- `grep -c LAUNCH_AGENT_STDERR_PATH`: 0 after the change (constant deleted).
- Follow-up before merge: full `npm ci` + suite in CI (fresh clone has no
  node_modules).
