### PR TITLE
fix(deepseek): doubled-bar DSML tool calls are delivered as text and never executed

### DIFF
--- a/packages/ai/src/transports/deepseek-dsml-grammar.ts
+++ b/packages/ai/src/transports/deepseek-dsml-grammar.ts
@@ -1,0 +1,6 @@
+// Keep the shipped single-bar forms and the doubled full-width form observed
+// in provider output identical across tool recovery and visible-text filtering.
+export const DEEPSEEK_DSML_MARKERS = ["|", "｜", "｜｜"].map((bar) => `${bar}DSML${bar}`);
+export const DEEPSEEK_DSML_MARKER_PATTERN = `(${DEEPSEEK_DSML_MARKERS.map((marker) =>
+  marker.replaceAll("|", "\\|"),
+).join("|")})`;

--- a/packages/ai/src/transports/deepseek-text-filter.ts
+++ b/packages/ai/src/transports/deepseek-text-filter.ts
@@ -1,19 +1,16 @@
+import { DEEPSEEK_DSML_MARKERS } from "./deepseek-dsml-grammar.js";
+
 /**
  * DeepSeek DSML streaming text filter.
  * Removes provider-emitted DSML tool markup while buffering split tag prefixes
  * across streamed chunks.
  */
 const DSML_KINDS = ["tool_use_error", "tool_calls", "tool_call", "function_calls"] as const;
-const DSML_BARS = ["|", "｜"] as const;
 
-const DSML_OPEN_TOKENS = DSML_BARS.flatMap((bar) =>
-  DSML_KINDS.map((kind) => `<${bar}DSML${bar}${kind}>`),
-);
-const DSML_CLOSE_TOKENS = DSML_BARS.flatMap((bar) =>
-  DSML_KINDS.map((kind) => `</${bar}DSML${bar}${kind}>`),
+const DSML_OPEN_TOKENS = DEEPSEEK_DSML_MARKERS.flatMap((marker) =>
+  DSML_KINDS.map((kind) => `<${marker}${kind}>`),
 );
 const MAX_OPEN_TOKEN_LEN = Math.max(...DSML_OPEN_TOKENS.map((token) => token.length));
-const MAX_CLOSE_TOKEN_LEN = Math.max(...DSML_CLOSE_TOKENS.map((token) => token.length));
 
 interface DeepSeekTextFilter {
   /** Push one streamed text chunk and receive any safe visible text segments. */
@@ -25,7 +22,8 @@ interface DeepSeekTextFilter {
 /** Create an incremental text filter that strips DeepSeek DSML tool blocks. */
 export function createDeepSeekTextFilter(): DeepSeekTextFilter {
   let buffer = "";
-  let insideDsml = false;
+  // Only the matching delimiter and kind may end the block being suppressed.
+  let closeToken: string | undefined;
 
   const consume = (final: boolean): string[] => {
     const output: string[] = [];
@@ -36,19 +34,19 @@ export function createDeepSeekTextFilter(): DeepSeekTextFilter {
     };
 
     while (buffer) {
-      if (insideDsml) {
-        const close = findEarliestToken(buffer, DSML_CLOSE_TOKENS);
-        if (close) {
-          buffer = buffer.slice(close.index + close.token.length);
-          insideDsml = false;
+      if (closeToken) {
+        const closeIndex = buffer.indexOf(closeToken);
+        if (closeIndex !== -1) {
+          buffer = buffer.slice(closeIndex + closeToken.length);
+          closeToken = undefined;
           continue;
         }
         // Keep a suffix that could still become a closing tag once the next
         // streamed chunk arrives; on final flush, drop the unterminated block.
-        const keep = final ? 0 : Math.min(buffer.length, MAX_CLOSE_TOKEN_LEN - 1);
+        const keep = final ? 0 : Math.min(buffer.length, closeToken.length - 1);
         buffer = buffer.slice(buffer.length - keep);
         if (final) {
-          insideDsml = false;
+          closeToken = undefined;
         }
         return output;
       }
@@ -57,7 +55,7 @@ export function createDeepSeekTextFilter(): DeepSeekTextFilter {
       if (open) {
         emit(buffer.slice(0, open.index));
         buffer = buffer.slice(open.index + open.token.length);
-        insideDsml = true;
+        closeToken = open.token.replace("<", "</");
         continue;
       }
 

--- a/packages/ai/src/transports/openai-completions-dsml.recovery.test.ts
+++ b/packages/ai/src/transports/openai-completions-dsml.recovery.test.ts
@@ -293,7 +293,11 @@ describe("openai completions DSML", () => {
     expect(output.content).toEqual([]);
   });
 
-  it("emits recovered DeepSeek content-filter terminals as errors", async () => {
+  it.each([
+    { finishReason: "stop", allowed: true },
+    { finishReason: "length", allowed: false },
+    { finishReason: "content_filter", allowed: false },
+  ])("gates doubled DSML over HTTP on $finishReason", async ({ finishReason, allowed }) => {
     const server = createServer((req, res) => {
       req.resume();
       req.on("end", () => {
@@ -302,17 +306,12 @@ describe("openai completions DSML", () => {
           "cache-control": "no-cache",
           connection: "keep-alive",
         });
-        res.write(
-          `data: ${JSON.stringify(
-            makeCompletionsChunk(
-              {
-                content:
-                  '<|DSML|tool_calls><|DSML|invoke name="read">{"path":"/tmp/partial.md"}</|DSML|invoke></|DSML|tool_calls>',
-              },
-              "content_filter",
-            ),
-          )}\n\n`,
-        );
+        const content =
+          '<｜｜DSML｜｜tool_calls><｜｜DSML｜｜invoke name="exec"><｜｜DSML｜｜parameter name="code" string="true">return "ready";</｜｜DSML｜｜parameter></｜｜DSML｜｜invoke></｜｜DSML｜｜tool_calls>';
+        for (const char of content) {
+          res.write(`data: ${JSON.stringify(makeCompletionsChunk({ content: char }))}\n\n`);
+        }
+        res.write(`data: ${JSON.stringify(makeCompletionsChunk({}, finishReason))}\n\n`);
         res.end("data: [DONE]\n\n");
       });
     });
@@ -335,36 +334,39 @@ describe("openai completions DSML", () => {
           systemPrompt: "system",
           messages: [{ role: "user", content: "Read the file", timestamp: Date.now() }],
           tools: [],
-        } as never,
-        { apiKey: "test-key" } as never,
+        },
+        { apiKey: "test-key" },
       );
 
-      const terminalEvents: Array<{
-        type: string;
-        reason?: string;
-        error?: Record<string, unknown>;
-      }> = [];
-      for await (const event of stream as AsyncIterable<{
-        type: string;
-        reason?: string;
-        error?: Record<string, unknown>;
-      }>) {
-        if (event.type === "done" || event.type === "error") {
-          terminalEvents.push(event);
-        }
+      const events = [];
+      for await (const event of stream) {
+        events.push(event);
       }
-
-      expect(terminalEvents).toEqual([
-        expect.objectContaining({
+      const terminal = events.at(-1);
+      if (finishReason === "content_filter") {
+        expect(terminal).toMatchObject({
           type: "error",
           reason: "error",
-          error: expect.objectContaining({
+          error: {
             stopReason: "error",
             errorMessage: "Provider finish_reason: content_filter",
             content: [],
-          }),
-        }),
-      ]);
+          },
+        });
+      } else {
+        expect(terminal).toMatchObject({
+          type: "done",
+          reason: allowed ? "toolUse" : "length",
+          message: {
+            stopReason: allowed ? "toolUse" : "length",
+            content: allowed
+              ? [{ type: "toolCall", name: "exec", arguments: { code: 'return "ready";' } }]
+              : [],
+          },
+        });
+      }
+      expect(events.filter((event) => event.type === "toolcall_end")).toHaveLength(allowed ? 1 : 0);
+      expect(events.filter((event) => event.type === "text_delta")).toEqual([]);
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
@@ -431,26 +433,51 @@ describe("openai completions DSML", () => {
     ]);
   });
 
-  it("does not recover malformed DeepSeek DSML tool calls", async () => {
+  it.each([
+    {
+      name: "empty arguments",
+      body: '<|DSML|invoke name="read"></|DSML|invoke>',
+    },
+    {
+      name: "asymmetric invoke marker",
+      body: '<|DSML｜invoke name="read">{"path":"/tmp/unexecuted"}</|DSML|invoke>',
+    },
+    {
+      name: "foreign invoke close",
+      body: '<|DSML|invoke name="read">{"path":"/tmp/unexecuted"}</｜DSML｜invoke>',
+    },
+    {
+      name: "asymmetric parameter marker",
+      body: '<|DSML|invoke name="read"><|DSML｜parameter name="path">/tmp/unexecuted</|DSML|parameter></|DSML|invoke>',
+    },
+    {
+      name: "foreign parameter close",
+      body: '<|DSML|invoke name="read"><|DSML|parameter name="path">/tmp/unexecuted</｜DSML｜parameter></|DSML|invoke>',
+    },
+    {
+      name: "doubled invoke with single close",
+      body: '<｜｜DSML｜｜invoke name="read">{"path":"/tmp/unexecuted"}</｜DSML｜invoke>',
+    },
+    {
+      name: "mixed doubled marker",
+      body: '<|｜DSML|｜invoke name="read">{"path":"/tmp/unexecuted"}</|｜DSML|｜invoke>',
+    },
+  ])("does not authorize DSML with $name", async ({ body }) => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);
-
+    const events: CapturedStreamEvent[] = [];
+    const content = `<|DSML|tool_calls>${body}</|DSML|tool_calls>`;
     await processCompletionsStream(
       streamChunks([
-        makeCompletionsChunk(
-          {
-            content:
-              '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="session_status">\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
-          },
-          "stop",
-        ),
+        ...Array.from(content, (char) => makeCompletionsChunk({ content: char })),
+        makeCompletionsChunk({}, "stop"),
       ]),
       output,
       model,
-      { push() {} },
+      { push: (event) => events.push(event as CapturedStreamEvent) },
     );
-
     expect(output.stopReason).toBe("stop");
     expect(output.content).toEqual([]);
+    expect(events.filter((event) => event.type?.startsWith("toolcall_"))).toEqual([]);
   });
 });

--- a/packages/ai/src/transports/openai-completions-dsml.recovery.test.ts
+++ b/packages/ai/src/transports/openai-completions-dsml.recovery.test.ts
@@ -328,7 +328,7 @@ describe("openai completions DSML", () => {
         ...createDeepSeekCompletionsModel(),
         baseUrl: `http://127.0.0.1:${address.port}/v1`,
       });
-      const stream = createOpenAICompletionsTransportStreamFn()(
+      const stream = await createOpenAICompletionsTransportStreamFn()(
         model,
         {
           systemPrompt: "system",

--- a/packages/ai/src/transports/openai-completions-dsml.test.ts
+++ b/packages/ai/src/transports/openai-completions-dsml.test.ts
@@ -235,20 +235,16 @@ describe("openai completions DSML", () => {
     expect(JSON.stringify(events)).not.toContain("DSML");
   });
 
-  it("recovers DeepSeek DSML parameter tool calls emitted as text", async () => {
+  it.each(["|", "｜", "｜｜"])("recovers streamed %s DSML parameter tool calls", async (bar) => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);
     const events: CapturedStreamEvent[] = [];
 
+    const content = `<${bar}DSML${bar}tool_calls><${bar}DSML${bar}invoke name="session_status"><${bar}DSML${bar}parameter name="sessionKey" string="true">current</${bar}DSML${bar}parameter></${bar}DSML${bar}invoke></${bar}DSML${bar}tool_calls>`;
     await processCompletionsStream(
       streamChunks([
-        makeCompletionsChunk(
-          {
-            content:
-              '<｜DSML｜tool_calls>\n<｜DSML｜invoke name="session_status">\n<｜DSML｜parameter name="sessionKey" string="true">current</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>',
-          },
-          "stop",
-        ),
+        ...Array.from(content, (char) => makeCompletionsChunk({ content: char })),
+        makeCompletionsChunk({}, "stop"),
       ]),
       output,
       model,

--- a/packages/ai/src/transports/openai-completions-dsml.ts
+++ b/packages/ai/src/transports/openai-completions-dsml.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { DEEPSEEK_DSML_MARKERS, DEEPSEEK_DSML_MARKER_PATTERN } from "./deepseek-dsml-grammar.js";
 import { measureUtf8AppendBytes } from "./openai-transport-shared.js";
 
 export type RecoveredDeepSeekDsmlToolCall = {
@@ -10,28 +11,22 @@ export type RecoveredDeepSeekDsmlToolCall = {
 
 type DeepSeekDsmlRecoveredPart = { kind: "text"; text: string } | RecoveredDeepSeekDsmlToolCall;
 
-const DEEPSEEK_DSML_BARS = ["|", "｜"] as const;
 const DEEPSEEK_DSML_TOOL_KINDS = ["tool_calls", "tool_call", "function_calls"] as const;
-const DEEPSEEK_DSML_TOOL_OPEN_TOKENS = DEEPSEEK_DSML_BARS.flatMap((bar) =>
-  DEEPSEEK_DSML_TOOL_KINDS.map((kind) => `<${bar}DSML${bar}${kind}>`),
+const DEEPSEEK_DSML_TOOL_OPEN_TOKENS = DEEPSEEK_DSML_MARKERS.flatMap((marker) =>
+  DEEPSEEK_DSML_TOOL_KINDS.map((kind) => `<${marker}${kind}>`),
 );
-const DEEPSEEK_DSML_TOOL_CLOSE_TOKENS = DEEPSEEK_DSML_BARS.flatMap((bar) =>
-  DEEPSEEK_DSML_TOOL_KINDS.map((kind) => `</${bar}DSML${bar}${kind}>`),
+const DEEPSEEK_DSML_INVOKE_OPEN_PREFIXES = DEEPSEEK_DSML_MARKERS.map(
+  (marker) => `<${marker}invoke`,
 );
-const DEEPSEEK_DSML_INVOKE_OPEN_PREFIXES = DEEPSEEK_DSML_BARS.map(
-  (bar) => `<${bar}DSML${bar}invoke`,
-);
-const DEEPSEEK_DSML_INVOKE_CLOSE_TOKENS = DEEPSEEK_DSML_BARS.map(
-  (bar) => `</${bar}DSML${bar}invoke>`,
+const DEEPSEEK_DSML_INVOKE_OPEN_TAG = new RegExp(
+  `^<${DEEPSEEK_DSML_MARKER_PATTERN}invoke\\b[^<>]*>$`,
 );
 const DEEPSEEK_DSML_TOOL_MAX_OPEN_TOKEN_LEN = Math.max(
   ...DEEPSEEK_DSML_TOOL_OPEN_TOKENS.map((token) => token.length),
 );
 const DEEPSEEK_DSML_RECOVERY_MAX_BOUNDARY_LEN = Math.max(
-  ...DEEPSEEK_DSML_TOOL_OPEN_TOKENS.map((token) => token.length),
-  ...DEEPSEEK_DSML_TOOL_CLOSE_TOKENS.map((token) => token.length),
-  ...DEEPSEEK_DSML_INVOKE_OPEN_PREFIXES.map((token) => token.length),
-  ...DEEPSEEK_DSML_INVOKE_CLOSE_TOKENS.map((token) => token.length),
+  ...DEEPSEEK_DSML_TOOL_OPEN_TOKENS.map((token) => token.length + 1),
+  ...DEEPSEEK_DSML_INVOKE_OPEN_PREFIXES.map((token) => token.length + 2),
 );
 
 // Match the shared Chat tool-argument and post-tool-call buffer limits.
@@ -40,8 +35,7 @@ const DEEPSEEK_DSML_SCAN_BATCH_CHARS = 64 * 1_024;
 
 type DeepSeekDsmlToolBlockScanState = {
   offset: number;
-  mode: "outer" | "invoke-open" | "invoke-body";
-  invokeOpenStart: number;
+  invoke?: { kind: "open"; start: number } | { kind: "body"; closeToken: string };
 };
 
 export function createDsmlRecoverer() {
@@ -50,15 +44,11 @@ export function createDsmlRecoverer() {
   let bufferEndsWithHighSurrogate = false;
   let pendingScanChars = 0;
   let activeOpenToken: string | null = null;
-  let blockScanState: DeepSeekDsmlToolBlockScanState = {
-    offset: 0,
-    mode: "outer",
-    invokeOpenStart: -1,
-  };
+  let blockScanState: DeepSeekDsmlToolBlockScanState = { offset: 0 };
   const resetBlockScan = () => {
     activeOpenToken = null;
     pendingScanChars = 0;
-    blockScanState = { offset: 0, mode: "outer", invokeOpenStart: -1 };
+    blockScanState = { offset: 0 };
   };
 
   const consume = (final: boolean): DeepSeekDsmlRecoveredPart[] => {
@@ -175,20 +165,18 @@ export function createDsmlRecoverer() {
 
 function parseDeepSeekDsmlToolCallBlock(body: string): RecoveredDeepSeekDsmlToolCall[] {
   const toolCalls: RecoveredDeepSeekDsmlToolCall[] = [];
-  const invokeOpenRegex = /<[|｜]DSML[|｜]invoke\b([^<>]*)>/g;
+  const invokeOpenRegex = new RegExp(`<${DEEPSEEK_DSML_MARKER_PATTERN}invoke\\b([^<>]*)>`, "g");
   let openMatch: RegExpExecArray | null;
   while ((openMatch = invokeOpenRegex.exec(body)) !== null) {
     const invokeBodyStart = openMatch.index + openMatch[0].length;
-    const invokeClose = findEarliestStringToken(body.slice(invokeBodyStart), [
-      "</|DSML|invoke>",
-      "</｜DSML｜invoke>",
-    ]);
-    if (!invokeClose) {
+    const invokeCloseToken = `</${openMatch[1]}invoke>`;
+    const invokeCloseIndex = body.indexOf(invokeCloseToken, invokeBodyStart);
+    if (invokeCloseIndex === -1) {
       break;
     }
-    const invokeBody = body.slice(invokeBodyStart, invokeBodyStart + invokeClose.index);
-    invokeOpenRegex.lastIndex = invokeBodyStart + invokeClose.index + invokeClose.token.length;
-    const invokeName = parseXmlAttribute(openMatch[1] ?? "", "name");
+    const invokeBody = body.slice(invokeBodyStart, invokeCloseIndex);
+    invokeOpenRegex.lastIndex = invokeCloseIndex + invokeCloseToken.length;
+    const invokeName = parseXmlAttribute(openMatch[2] ?? "", "name");
     if (!invokeName) {
       continue;
     }
@@ -208,14 +196,17 @@ function parseDeepSeekDsmlToolCallBlock(body: string): RecoveredDeepSeekDsmlTool
 
 function parseDeepSeekDsmlInvokeArguments(body: string): Record<string, unknown> | null {
   const args: Record<string, unknown> = {};
-  const parameterRegex = /<[|｜]DSML[|｜]parameter\b([^>]*)>([\s\S]*?)<\/[|｜]DSML[|｜]parameter>/g;
+  const parameterRegex = new RegExp(
+    `<${DEEPSEEK_DSML_MARKER_PATTERN}parameter\\b([^>]*)>([\\s\\S]*?)</\\1parameter>`,
+    "g",
+  );
   let parameterMatch: RegExpExecArray | null;
   while ((parameterMatch = parameterRegex.exec(body)) !== null) {
-    const name = parseXmlAttribute(parameterMatch[1] ?? "", "name");
+    const name = parseXmlAttribute(parameterMatch[2] ?? "", "name");
     if (!name) {
       continue;
     }
-    const rawValue = parameterMatch[2] ?? "";
+    const rawValue = parameterMatch[3] ?? "";
     if (rawValue.length === 0) {
       continue;
     }
@@ -291,7 +282,7 @@ function scanDeepSeekDsmlToolBlock(
   | { kind: "nested-open"; index: number; token: string }
   | { kind: "incomplete" } {
   while (state.offset < text.length) {
-    if (state.mode === "invoke-open") {
+    if (state.invoke?.kind === "open") {
       const nextOpen = text.indexOf("<", state.offset);
       const nextClose = text.indexOf(">", state.offset);
       if (nextClose === -1 && nextOpen === -1) {
@@ -299,36 +290,31 @@ function scanDeepSeekDsmlToolBlock(
         return { kind: "incomplete" };
       }
       if (nextOpen !== -1 && (nextClose === -1 || nextOpen < nextClose)) {
-        state.mode = "outer";
+        state.invoke = undefined;
         state.offset = nextOpen;
-        state.invokeOpenStart = -1;
         continue;
       }
-      const invokeOpenTag = text.slice(state.invokeOpenStart, nextClose + 1);
-      if (!/^<[|｜]DSML[|｜]invoke\b[^<>]*>$/.test(invokeOpenTag)) {
-        state.mode = "outer";
-        state.offset = state.invokeOpenStart + 1;
-        state.invokeOpenStart = -1;
+      const invokeOpenTag = text.slice(state.invoke.start, nextClose + 1);
+      const open = DEEPSEEK_DSML_INVOKE_OPEN_TAG.exec(invokeOpenTag);
+      if (!open) {
+        state.offset = state.invoke.start + 1;
+        state.invoke = undefined;
         continue;
       }
-      state.mode = "invoke-body";
+      // Carry the exact opener across chunks; a foreign close cannot authorize a call.
+      state.invoke = { kind: "body", closeToken: `</${open[1]}invoke>` };
       state.offset = nextClose + 1;
-      state.invokeOpenStart = -1;
       continue;
     }
 
-    if (state.mode === "invoke-body") {
-      const invokeClose = findEarliestStringToken(
-        text,
-        DEEPSEEK_DSML_INVOKE_CLOSE_TOKENS,
-        state.offset,
-      );
-      if (!invokeClose) {
+    if (state.invoke?.kind === "body") {
+      const invokeCloseIndex = text.indexOf(state.invoke.closeToken, state.offset);
+      if (invokeCloseIndex === -1) {
         state.offset = Math.max(0, text.length - DEEPSEEK_DSML_RECOVERY_MAX_BOUNDARY_LEN + 1);
         return { kind: "incomplete" };
       }
-      state.mode = "outer";
-      state.offset = invokeClose.index + invokeClose.token.length;
+      state.offset = invokeCloseIndex + state.invoke.closeToken.length;
+      state.invoke = undefined;
       continue;
     }
 
@@ -356,8 +342,7 @@ function scanDeepSeekDsmlToolBlock(
       return { kind: "incomplete" };
     }
     if (next.kind === "invoke-open") {
-      state.mode = "invoke-open";
-      state.invokeOpenStart = next.index;
+      state.invoke = { kind: "open", start: next.index };
       state.offset = next.index + next.token.length;
       continue;
     }

--- a/src/agents/deepseek-text-filter.test.ts
+++ b/src/agents/deepseek-text-filter.test.ts
@@ -20,6 +20,27 @@ describe("createDeepSeekTextFilter", () => {
       expected: "before  after",
     },
     {
+      name: "doubled full-width streamed error",
+      chunks: Array.from(
+        "before <｜｜DSML｜｜tool_use_error>hidden</｜｜DSML｜｜tool_use_error> after",
+      ),
+      expected: "before  after",
+    },
+    {
+      name: "foreign close stays inside the filtered block",
+      chunks: Array.from(
+        "before <｜DSML｜tool_use_error>hidden</|DSML|tool_use_error>still hidden</｜DSML｜tool_use_error> after",
+      ),
+      expected: "before  after",
+    },
+    {
+      name: "doubled open ignores a single close",
+      chunks: Array.from(
+        "before <｜｜DSML｜｜tool_use_error>hidden</｜DSML｜tool_use_error>still hidden</｜｜DSML｜｜tool_use_error> after",
+      ),
+      expected: "before  after",
+    },
+    {
       name: "split open token",
       chunks: ["before ", "<｜DS", "ML｜tool_calls>body</｜DSML｜tool_calls>", " after"],
       expected: "before  after",

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -4564,7 +4564,7 @@ describe("gateway send mirroring", () => {
       expect(mocks.deliverOutboundPayloads).toHaveBeenCalledOnce();
       expect(deliveryCall()).toMatchObject({
         to: testCase.expectedTarget,
-        accountId: testCase.accountId,
+        accountId: testCase.accountId ?? "default",
         payloads: [
           expect.objectContaining({ text: testCase.nativeDeclines ? "prepared hello" : "hello" }),
         ],

--- a/src/node-host/portal-stream-command.test.ts
+++ b/src/node-host/portal-stream-command.test.ts
@@ -156,6 +156,17 @@ describe("node worker portal stream command", () => {
   );
 
   it("closes an attached Gateway socket without a readiness frame when loopback refuses", async () => {
+    let attached = false;
+    let closed = false;
+    const frames: unknown[] = [];
+    // Allocate the Gateway first so it cannot reuse the released target port.
+    const gatewayUrl = await listenGateway((ws) => {
+      attached = true;
+      ws.on("message", (data) => frames.push(data));
+      ws.once("close", () => {
+        closed = true;
+      });
+    });
     const unavailable = net.createServer();
     await new Promise<void>((resolve) => {
       unavailable.listen(0, "127.0.0.1", resolve);
@@ -171,17 +182,6 @@ describe("node worker portal stream command", () => {
           return;
         }
         resolve();
-      });
-    });
-
-    let attached = false;
-    let closed = false;
-    const frames: unknown[] = [];
-    const gatewayUrl = await listenGateway((ws) => {
-      attached = true;
-      ws.on("message", (data) => frames.push(data));
-      ws.once("close", () => {
-        closed = true;
       });
     });
 


### PR DESCRIPTION
Closes #128858

## What Problem This Solves

Fixes an issue where DeepSeek users see doubled-fullwidth DSML tool markup in a reply while the requested tool never runs. This also affects Code Mode when the recovered call is `exec`.

## Why This Change Was Made

Recovery and visible-text filtering now share one internal delimiter grammar: the existing ASCII/fullwidth single bars and the observed doubled-fullwidth form. Each invocation, parameter, and suppressed block must close with its opening marker. The scanner carries the exact pending invocation close instead of independent mode/sentinel state and redundant close-token lists.

This maintainer revision preserves @sashankh's fix and credit while consolidating the implementation and extending existing fixtures. It does not add unobserved doubled-ASCII syntax, configuration, public exports, storage, retries, or a provider fallback. The 256 KB buffer cap, nested-wrapper rejection, and stop/length/refusal authorization boundary remain intact.

## User Impact

Recognized doubled-bar tool calls execute normally and their markup does not leak into replies. Malformed mixed markers and foreign closing tags cannot authorize a tool invocation. Single-bar output keeps working.

## Evidence

On baseline `bcac331e0746`, the new/extended tests produce 11 intended failures: eight recovery/transport failures and three text-filter failures. On this revision, all **821 tests across 52 transport/filter files pass**. Coverage includes character-by-character chunks, real HTTP/SSE, successful stop versus length/content-filter terminals, existing buffer/nesting/surrogate limits, and malformed delimiter rejection. Fresh independent Codex autoreview found no actionable findings at its P0 threshold.

Production LOC: **+60/-71 (net -11)**. Tests: **+99/-55 (net +44)**. This replaces duplicated delimiter policy and scanner state rather than adding a second parsing path.

The official [DeepSeek V4 encoder](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/encoding/encoding_dsv4.py) uses single fullwidth bars; the doubled form is the reporter's observed provider output, not a claim about the documented encoder. Final-effect proof used real HTTP/SSE through an isolated built Gateway, the managed DeepSeek transport, Code Mode, and the real write handler. Before the patch, doubled bars leaked and wrote nothing; an asymmetric inner invocation wrongly wrote the nonce file. After the patch, single/doubled forms each execute exactly once with the exact nonce file, while mismatched/asymmetric forms execute zero tools and create no file. No DSML appears in the delivered reply. The provider socket is synthetic in this deterministic reproduction, not presented as an actual DeepSeek emission.

Authenticated `deepseek/deepseek-v4-flash` through the same Gateway also completed read/calculate/write/readback, background process polling, three yields, caught and uncaught errors, sixteen-call fan-out, and timer/catalog composition. The completed seven-model stress results are recorded below. We did not observe the intermittent doubled-bar emission from the real provider in this sample.

Local full compilation completed, but its postbuild checker hit stale workspace-package exports in the borrowed dependency tree. An isolated runtime linked to this checkout's freshly built packages passed the same canonical native control-plane check (49 modules) and served the live proofs. The shared dependency tree was not modified. Hosted changed checks passed; all final-head CI checks passed before the native prepare/merge flow.

Provenance: the single-bar filter originated in @samzong's #78331 (merged by @steipete, May 9); recovery originated in @steipete's #88946 (also merged by @steipete, June 2). The August #122122 split carried the assumption forward rather than introducing it. GitHub timelines show no recorded automerge enablement/trigger for the original merges.

Review follow-through: the prior review's boundary-proof and exact-head-CI requests remain landing gates. Its production-growth concern is resolved by the net-negative consolidation. The automated persistent-data warning is inapplicable: only transient parsing and tests change; no SQLite/schema/state format changes. Native Codex's separate V8/freeform protocol is untouched; OpenClaw's managed completions transport owns this fix.

Named follow-up: historical/imported transcript stripping in `src/hooks/bundled/session-memory/transcript.ts` independently recognizes single-bar DSML. This transport repair prevents new doubled-bar leakage but does not rewrite or repair historical transcript projections. General malformed proxy output (#114888) remains separate.

CI follow-up at `fa78b88a7422`: await the stream factory's declared sync/async union in the HTTP fixture (the runtime result was already synchronous and passing), and correct one inherited Twitch test assertion to expect the resolved default account. The two Twitch failures came from #132226 normalizing account identity after #131689 introduced the fixture. Request omission remains tested; only the downstream expected resolved account changes. All 128 gateway-send tests pass. Fresh autoreview of both fixture corrections is clean. No production behavior changed after the live Gateway build.

Stress result: 77 primary live cases across OpenAI GPT-5.6 Luna/Terra/Sol, Claude Sonnet 4.6/Haiku 4.5, Gemini 3.5 Flash, and DeepSeek V4 Flash; plus 14 concurrent sessions. All returned HTTP 200. Strict transcript/file verification found three model adherence failures (Haiku shell sessionId passed to outer wait; Gemini shadowed text(); DeepSeek omitted return), preserved as failures rather than counted as runtime passes. Explicit corrected code passes for Gemini and DeepSeek. Haiku background recovery remains an open product case tracked by #128859/#128886. File outcomes, yield chains, bounded errors, pending-call rejection without writes, and post-timeout recovery are inspected independently of final response prose. Where nested readback/process receipts are absent, proof is labeled partial rather than inferred.

Final CI stability follow-up: the unrelated portal refusal fixture released its target port before allocating the Gateway. A controlled real-socket reproduction forcing reuse produced a successful connection and one readiness frame (the same unexpected resolved outcome as CI); allocating the Gateway first produces ECONNREFUSED and zero readiness frames. The test now allocates the Gateway first. This is a test-only setup reorder, no production change; all23 portal/stream sibling tests and fresh autoreview pass. The CI log lacks port identities, so attributing that particular run to reuse remains an inference; the underlying fixture race is directly reproduced and removed. Test LOC includes an additional +11/-11 move (discounted as a pure move, net0).

Landed as [8af1b4aceeab](https://github.com/openclaw/openclaw/commit/8af1b4aceeab436a920126c15672c0b57fb238c6). Final head a382bf86ceae passed [CI](https://github.com/openclaw/openclaw/actions/runs/33238203126); the hosted changed-file check passed exit0. The merged production files were compared byte-for-byte with the live-tested build and are identical. #128858 is closed as completed.
