### PR TITLE
fix: status checks exceed CPU limit after SQLite lock hardening

### DIFF
--- a/src/state/openclaw-state-db-readonly.test.ts
+++ b/src/state/openclaw-state-db-readonly.test.ts
@@ -1,0 +1,86 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../test-utils/temp-dir.js";
+
+const snapshotMocks = vi.hoisted(() => ({
+  isolated: vi.fn(),
+  inProcess: vi.fn(),
+}));
+
+vi.mock("../infra/sqlite-readonly-location.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/sqlite-readonly-location.js")>();
+  snapshotMocks.isolated.mockImplementation(actual.prepareSqliteReadOnlyLocationSync);
+  snapshotMocks.inProcess.mockImplementation(actual.prepareSqliteReadOnlyLocationSyncInProcess);
+  return {
+    ...actual,
+    prepareSqliteReadOnlyLocationSync: snapshotMocks.isolated,
+    prepareSqliteReadOnlyLocationSyncInProcess: snapshotMocks.inProcess,
+  };
+});
+
+const { withExistingOpenClawStateDatabaseArtifactPreservingReadOnly } =
+  await import("./openclaw-state-db-readonly.js");
+const { closeOpenClawStateDatabaseForTest, openOpenClawStateDatabase } =
+  await import("./openclaw-state-db.js");
+
+function createOptions(stateDir: string) {
+  return {
+    env: { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_TEST_FAST: "1" },
+    path: path.join(stateDir, "state", "openclaw.sqlite"),
+  };
+}
+
+beforeEach(() => {
+  snapshotMocks.isolated.mockClear();
+  snapshotMocks.inProcess.mockClear();
+});
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("artifact-preserving shared-state reads", () => {
+  it("prepares snapshots in-process when this process has no writable handle", async () => {
+    await withTempDir("openclaw-state-readonly-in-process-", async (stateDir) => {
+      const options = createOptions(stateDir);
+      openOpenClawStateDatabase(options);
+      closeOpenClawStateDatabaseForTest();
+
+      expect(
+        withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(() => "read", options),
+      ).toBe("read");
+      expect(snapshotMocks.inProcess).toHaveBeenCalledOnce();
+      expect(snapshotMocks.isolated).not.toHaveBeenCalled();
+    });
+  });
+
+  it("keeps snapshot preparation isolated while a writable handle has a transaction", async () => {
+    await withTempDir("openclaw-state-readonly-isolated-", async (stateDir) => {
+      const options = createOptions(stateDir);
+      const opened = openOpenClawStateDatabase(options);
+      opened.db.exec("BEGIN");
+      try {
+        expect(
+          withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(() => "read", options),
+        ).toBe("read");
+        expect(snapshotMocks.isolated).toHaveBeenCalledOnce();
+        expect(snapshotMocks.inProcess).not.toHaveBeenCalled();
+      } finally {
+        opened.db.exec("ROLLBACK");
+      }
+    });
+  });
+
+  it("reuses an idle writable handle without preparing a snapshot", async () => {
+    await withTempDir("openclaw-state-readonly-reuse-", async (stateDir) => {
+      const options = createOptions(stateDir);
+      openOpenClawStateDatabase(options);
+
+      expect(
+        withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(() => "read", options),
+      ).toBe("read");
+      expect(snapshotMocks.isolated).not.toHaveBeenCalled();
+      expect(snapshotMocks.inProcess).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
-import { prepareSqliteReadOnlyLocationSync } from "../infra/sqlite-readonly-location.js";
+import {
+  prepareSqliteReadOnlyLocationSync,
+  prepareSqliteReadOnlyLocationSyncInProcess,
+} from "../infra/sqlite-readonly-location.js";
 import {
   createNewerSqliteSchemaVersionError,
   readSqliteUserVersion,
@@ -149,7 +152,12 @@ export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnly<T>(
   if (existingPath === undefined) {
     return undefined;
   }
-  const prepared = prepareSqliteReadOnlyLocationSync(existingPath);
+  // In-process preparation is safe only when this process holds no writable
+  // handle. Otherwise closing the snapshot source can drop the writer's POSIX locks.
+  const prepare = getOpenClawStateDatabaseIfOpen(options)
+    ? prepareSqliteReadOnlyLocationSync
+    : prepareSqliteReadOnlyLocationSyncInProcess;
+  const prepared = prepare(existingPath);
   try {
     return withFreshOpenClawStateDatabaseReadOnly(
       operation,


### PR DESCRIPTION
Related: #127855

## What Problem This Solves

Fixes an issue where operators running status checks could intermittently exceed the aggregate CPU limit after artifact-preserving SQLite reads started spawning a snapshot worker. The status process had no writable database handle, so the worker added CPU and process-start overhead without protecting any process-local WAL locks.

## Why This Change Was Made

The shared-state lifecycle owner now prepares artifact-preserving snapshots in-process only when the current process has no writable handle for that database. It still reuses an idle writable handle and retains child-process isolation while a writable handle has an active transaction, preserving the POSIX WAL-lock safety added in #127855.

No SQLite schema, configuration, authentication, or successful-read semantics change.

## User Impact

Status and other read-only shared-state checks keep the same results while avoiding an unnecessary Node worker when the caller owns no writable database handle. This reduces CPU and startup overhead without weakening WAL-lock safety.

## Evidence

- Before lifecycle-owner repair: Blacksmith Testbox `tbx_01m0tt5748h677wca6kqv62ht4`, Kova `kova-260824-211825-12b996`: 3 PASS / 2 FAIL at the unchanged 200% `status-cli` CPU gate.
- After repair: [Blacksmith run 32781092246](https://github.com/openclaw/openclaw/actions/runs/32781092246), Testbox `tbx_01m0tvpk9abnpw6ntpgxjfe273`, Kova `kova-260824-214538-079fff`: 5/5 scenario repetitions passed; peak observed `status-cli` CPU was 148%. The release profile reported `PARTIAL` only because the focused run intentionally omitted 51 unrelated required entries; it had zero blocking findings.
- `pnpm test src/state/openclaw-state-db-readonly.test.ts src/infra/sqlite-readonly-location.test.ts src/gateway/probe.auth.integration.test.ts src/gateway/probe.test.ts src/gateway/probe.device-auth-scope.test.ts` — 91 passed, 1 existing platform skip.
- `node scripts/check-changed.mjs` — passed.
- `pnpm build` — passed; only existing third-party warnings.
- `env -u CODEX_HOME .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean, no actionable findings (0.99 confidence).
- `git diff --check origin/main...HEAD` — passed.

Production LOC: +10/-2. Test LOC: +86/-0.

AI-assisted: yes. The implementation, safety boundary, and evidence were reviewed by the author.
