### PR TITLE
fix(docs): document OpenAI API auth for audio understanding alongside OAuth for reasoning

### DIFF
--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -55,6 +55,86 @@ openclaw doctor --lint --only core/doctor/local-audio-acceleration --severity-mi
 
 The provider inventory reports the local fallback winner separately from global provider selection, plus capable, requested, and observed backend fields. After transcription runs, `/status` reports the requested or observed backend in the media line. Explicit audio-capable `tools.media.models` CLI entries still bypass auto-selection; use their backend-specific flags such as sherpa `--provider=cuda` or whisper.cpp `--no-gpu`/`--device`.
 
+## OpenAI transcription alongside ChatGPT/Codex OAuth
+
+An OpenAI API key and a ChatGPT/Codex OAuth login are separate credentials even
+though both use the `openai` provider. To keep OAuth first for normal text and
+reasoning requests while using an API key for speech-to-text, create a dedicated
+API-key profile and select it only on the audio model entry.
+
+Repeat these steps for every agent that can receive audio. For a single-agent
+installation, run them once for that agent.
+
+1. List the agent's OpenAI profiles so you can copy the exact OAuth profile ID:
+
+   ```bash
+   openclaw models auth list --agent AGENT_NAME_HERE --provider openai
+   ```
+
+2. Create a dedicated API-key profile. This command prompts for the key; paste it
+   into the prompt rather than putting it in the command line:
+
+   ```bash
+   openclaw models auth paste-api-key --agent AGENT_NAME_HERE --provider openai --profile-id openai:CUSTOM_PROFILE_NAME_HERE
+   ```
+
+   Example:
+
+   ```bash
+   openclaw models auth paste-api-key --agent smith --provider openai --profile-id openai:audio
+   ```
+
+3. Put the OAuth profile first and the audio API-key profile second in the agent's
+   OpenAI auth order. Replace the first profile ID with the exact OAuth profile ID
+   reported by the list command:
+
+   ```bash
+   openclaw models auth order set --agent AGENT_NAME_HERE --provider openai openai:YOUR_OPENAI_ACCOUNT_EMAIL_ADDRESS openai:CUSTOM_PROFILE_NAME_HERE
+   ```
+
+   Example:
+
+   ```bash
+   openclaw models auth order set --agent smith --provider openai openai:youremailaddress@email.com openai:audio
+   ```
+
+4. Configure the OpenAI transcription model and explicitly select the API-key
+   profile:
+
+   ```json5
+   {
+     tools: {
+       media: {
+         models: [
+           {
+             provider: "openai",
+             model: "gpt-transcribe",
+             profile: "openai:audio",
+             baseUrl: "https://api.openai.com/v1",
+             capabilities: ["audio"],
+           },
+         ],
+         audio: { enabled: true },
+       },
+     },
+   }
+   ```
+
+   If you chose a different custom profile name, use that exact profile ID in
+   `profile`. You can also substitute `gpt-4o-mini-transcribe` for the model.
+
+The `profile` field is not required when OpenClaw can unambiguously select a
+compatible API-key profile, but it is strongly recommended. Explicit selection
+keeps audio routing deterministic if another OpenAI API-key profile exists now or
+is added later. The auth order still keeps the OAuth profile first for ordinary
+provider resolution.
+
+<Warning>
+Do not set `models.providers.openai.apiKey` merely to enable transcription on an
+installation that uses ChatGPT/Codex OAuth for normal inference. That setting is
+provider-wide rather than scoped to the audio model entry.
+</Warning>
+
 ## Config examples
 
 ### Provider + CLI fallback (OpenAI + Whisper CLI)


### PR DESCRIPTION
## Summary

- document how to keep ChatGPT/Codex OAuth first for normal OpenAI text and reasoning requests while using an OpenAI API key for inbound audio transcription
- add the exact per-agent `paste-api-key` and `auth order set` commands
- add a complete `tools.media` example with an explicitly selected audio profile and explain why `profile` is optional but strongly recommended
- warn against using provider-wide `models.providers.openai.apiKey` for this scoped mixed-auth setup

The example uses `gpt-transcribe` and notes that `gpt-4o-mini-transcribe` can be substituted. Maintainers can adjust the model recommendation independently of the credential-routing procedure.

Related context: #51054 documented the broader media credential discovery gap, but the current audio page still did not show the mixed ChatGPT/Codex OAuth plus OpenAI API-key topology.

AI-assisted: yes. The commands, schema, and real behavior were operator-verified on a live installation.

## Verification

- `openclaw models auth paste-api-key --help`
- `openclaw models auth order set --help`
- `node_modules/.bin/oxfmt --check --config .oxfmtrc.jsonc docs/nodes/audio.md`
- `pnpm dlx --config.resolution-mode=highest markdownlint-cli2 --config config/markdownlint-cli2.jsonc docs/nodes/audio.md`
- `node scripts/check-docs-mdx.mjs docs/nodes/audio.md`
- `node scripts/docs-link-audit.mjs` (`6555` internal links checked, `0` broken)
- exact JSON example validated with `openclaw config validate --json`
- `git diff --check`

## Real behavior proof

Behavior addressed: OpenAI audio transcription needs an API-key credential, while normal agent reasoning can remain on ChatGPT/Codex OAuth under the same canonical `openai` provider.

Real environment tested: A live multi-agent OpenClaw 2026.8.1 installation using ChatGPT/Codex OAuth for normal inference and a dedicated OpenAI API-key profile for Matrix voice-note transcription.

Exact steps or command run after this patch: Created a dedicated `openai:audio` profile with `openclaw models auth paste-api-key --agent AGENT_NAME_HERE --provider openai --profile-id openai:audio`, set OAuth first with `openclaw models auth order set --agent AGENT_NAME_HERE --provider openai OPENAI_OAUTH_PROFILE_ID openai:audio`, configured the documented `tools.media` entry, and sent fresh voice notes through the automatic inbound path.

Evidence after fix: Fresh voice notes were transcribed automatically with both `gpt-transcribe` and `gpt-4o-mini-transcribe`; no manual transcription fallback was used. The effective media route selected the dedicated API-key profile, while the normal ChatGPT/Codex OAuth route remained unchanged.

Observed result after fix: Automatic speech-to-text succeeded, explicit audio profile selection remained deterministic, and ordinary OpenAI reasoning continued to prefer the OAuth profile.

What was not tested: No runtime code changes are included. The repository-wide docs formatter is already red on four unrelated `origin/main` files (`docs/channels/slack.md`, `docs/concepts/usage-tracking.md`, `docs/gateway/restart-recovery.md`, and `docs/plugins/sdk-entrypoints.md`), so verification was scoped to the changed page plus repository-wide link audit. Local `codex review --base origin/main` was attempted but could not authenticate (HTTP 401); the diff was reviewed manually instead.
