### PR TITLE
fix(code-mode): wait dead-ends on a backgrounded shell sessionId, so the agent abandons the command

### DIFF
--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -576,13 +576,23 @@ async function settleCodeModeResult(params: {
 
 /**
  * Rejection for the `wait` entry point, which accepts an arbitrary caller-supplied
- * runId. Naming the process poll route is load-bearing here: `exec` hands back a
- * background sessionId but owns no poll action, so without it the model retries the
- * wrong surface or reads this as lost work and abandons a command still running.
+ * runId. `exec` hands back a background shell sessionId but owns no poll action, so
+ * without a next step the model reads this as lost work and abandons a running
+ * command. The route is derived from the surface actually callable in this run:
+ * gated or empty catalogs must not advertise a tool the model cannot call.
  * Lifecycle-internal misses keep the plain text; they can only be real Code Mode runs.
  */
-const CODE_MODE_WAIT_RUN_UNAVAILABLE_MESSAGE =
-  'code mode run is unavailable or expired. This id must be a runId from a suspended code mode run; a background shell sessionId from exec is polled with process (action "poll").';
+function codeModeWaitRunUnavailableMessage(ctx: ToolSearchToolContext): string {
+  const base =
+    "code mode run is unavailable or expired. This id must be a runId from a suspended code mode run";
+  // Model-facing tool name owned by `createProcessTool` in bash-tools.process.ts.
+  const hasProcessTool = ctx.catalogRef?.current?.entries?.some(
+    (entry) => entry.name === "process",
+  );
+  return hasProcessTool
+    ? `${base}; a background shell sessionId from exec is polled with process (action "poll").`
+    : `${base}.`;
+}
 
 export async function runWait(params: {
   toolCallId: string;
@@ -595,7 +605,7 @@ export async function runWait(params: {
   removeExpiredRuns();
   const state = activeRuns.get(params.runId);
   if (!state) {
-    throw new ToolInputError(CODE_MODE_WAIT_RUN_UNAVAILABLE_MESSAGE);
+    throw new ToolInputError(codeModeWaitRunUnavailableMessage(params.ctx));
   }
   if (state.ctx.runId && state.ctx.runId !== params.ctx.runId) {
     throw new ToolInputError("code mode run belongs to a different agent run.");

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -574,6 +574,16 @@ async function settleCodeModeResult(params: {
   return finalized;
 }
 
+/**
+ * Rejection for the `wait` entry point, which accepts an arbitrary caller-supplied
+ * runId. Naming the process poll route is load-bearing here: `exec` hands back a
+ * background sessionId but owns no poll action, so without it the model retries the
+ * wrong surface or reads this as lost work and abandons a command still running.
+ * Lifecycle-internal misses keep the plain text; they can only be real Code Mode runs.
+ */
+const CODE_MODE_WAIT_RUN_UNAVAILABLE_MESSAGE =
+  'code mode run is unavailable or expired. This id must be a runId from a suspended code mode run; a background shell sessionId from exec is polled with process (action "poll").';
+
 export async function runWait(params: {
   toolCallId: string;
   ctx: ToolSearchToolContext;
@@ -585,7 +595,7 @@ export async function runWait(params: {
   removeExpiredRuns();
   const state = activeRuns.get(params.runId);
   if (!state) {
-    throw new ToolInputError("code mode run is unavailable or expired.");
+    throw new ToolInputError(CODE_MODE_WAIT_RUN_UNAVAILABLE_MESSAGE);
   }
   if (state.ctx.runId && state.ctx.runId !== params.ctx.runId) {
     throw new ToolInputError("code mode run belongs to a different agent run.");

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -230,6 +230,9 @@ export function reserveActiveRunSlot(ownedRunId?: string): () => void {
   } else {
     const state = activeRuns.get(ownedRunId);
     if (!state) {
+      // Reached only when the expiry timer removed a run `wait` had already resolved,
+      // so this id is a genuine Code Mode run, never a caller-supplied shell session.
+      // Recovery guidance belongs at the entry point that accepts arbitrary ids.
       throw new ToolInputError("code mode run is unavailable or expired.");
     }
     activeRuns.delete(ownedRunId);

--- a/src/agents/code-mode.wait.test.ts
+++ b/src/agents/code-mode.wait.test.ts
@@ -10,6 +10,8 @@ import {
   getAdmittedRunDelegatedAuthority,
   prepareAgentRunAdmission,
 } from "./admitted-run-context.js";
+import { processSchema } from "./bash-tools.schemas.js";
+import { reserveActiveRunSlot } from "./code-mode-state.js";
 import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
 import {
   resetCodeModeTestState,
@@ -548,6 +550,49 @@ describe("Code Mode wait, scope, and suspended runs", () => {
       ),
     ).rejects.toThrow("code mode run is unavailable or expired");
     expect(testing.activeRuns.has("invalid-expiry-run")).toBe(false);
+  });
+
+  it("points a backgrounded shell sessionId at the process poll route", async () => {
+    const { tools: codeModeTools } = createCodeModeHarness();
+
+    // The reporter's case: exec backgrounds a command and returns
+    // {"status":"running","sessionId":"lucky-glade"}, which the model hands to wait.
+    const waitCall = expectDefined(codeModeTools[1], "codeModeTools[1] test invariant").execute(
+      "code-wait-shell-session-id",
+      { runId: "lucky-glade" },
+    );
+
+    await expect(waitCall).rejects.toThrow("code mode run is unavailable or expired");
+    await expect(waitCall).rejects.toThrow('polled with process (action "poll")');
+  });
+
+  it("only names a continuation action the process tool actually implements", async () => {
+    // exec returns the session id but owns no poll action, so guidance that names
+    // the wrong surface reproduces the dead end. Read the action out of the real
+    // rejection and bind it to the process action enum: renaming or dropping
+    // "poll" must fail here.
+    const { tools: codeModeTools } = createCodeModeHarness();
+    const message = await expectDefined(codeModeTools[1], "codeModeTools[1] test invariant")
+      .execute("code-wait-enum-binding", { runId: "no-such-run" })
+      .then(
+        () => "",
+        (err: unknown) => (err instanceof Error ? err.message : String(err)),
+      );
+    const processActions = (processSchema.properties.action as { enum?: string[] }).enum ?? [];
+    const namedAction = /action "([^"]+)"/.exec(message)?.[1];
+
+    expect(namedAction).toBeDefined();
+    expect(processActions).toContain(namedAction);
+  });
+
+  it("keeps shell recovery guidance out of the lifecycle expiry rejection", () => {
+    // reserveActiveRunSlot only sees ids Code Mode minted itself, and shell tools can
+    // be absent entirely, so advertising process there would point at a surface the
+    // model may not have for a run that was never a shell session.
+    expect(() => reserveActiveRunSlot("expired-code-mode-run")).toThrow(
+      "code mode run is unavailable or expired.",
+    );
+    expect(() => reserveActiveRunSlot("expired-code-mode-run")).not.toThrow("process");
   });
 
   it("rejects wait calls from a different session scope", async () => {

--- a/src/agents/code-mode.wait.test.ts
+++ b/src/agents/code-mode.wait.test.ts
@@ -552,8 +552,13 @@ describe("Code Mode wait, scope, and suspended runs", () => {
     expect(testing.activeRuns.has("invalid-expiry-run")).toBe(false);
   });
 
-  it("points a backgrounded shell sessionId at the process poll route", async () => {
-    const { tools: codeModeTools } = createCodeModeHarness();
+  it("points a backgrounded shell sessionId at the process poll route when process is callable", async () => {
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("process", "Control existing exec")],
+      config,
+      catalogRef,
+    });
 
     // The reporter's case: exec backgrounds a command and returns
     // {"status":"running","sessionId":"lucky-glade"}, which the model hands to wait.
@@ -566,12 +571,30 @@ describe("Code Mode wait, scope, and suspended runs", () => {
     await expect(waitCall).rejects.toThrow('polled with process (action "poll")');
   });
 
+  it("does not advertise process when it is absent from the callable surface", async () => {
+    // Gated or empty catalogs must not send the model at a tool it cannot call.
+    const { tools: codeModeTools } = createCodeModeHarness();
+
+    const waitCall = expectDefined(codeModeTools[1], "codeModeTools[1] test invariant").execute(
+      "code-wait-no-process",
+      { runId: "lucky-glade" },
+    );
+
+    await expect(waitCall).rejects.toThrow("code mode run is unavailable or expired");
+    await expect(waitCall).rejects.not.toThrow("process");
+  });
+
   it("only names a continuation action the process tool actually implements", async () => {
     // exec returns the session id but owns no poll action, so guidance that names
     // the wrong surface reproduces the dead end. Read the action out of the real
     // rejection and bind it to the process action enum: renaming or dropping
     // "poll" must fail here.
-    const { tools: codeModeTools } = createCodeModeHarness();
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, pluginTool("process", "Control existing exec")],
+      config,
+      catalogRef,
+    });
     const message = await expectDefined(codeModeTools[1], "codeModeTools[1] test invariant")
       .execute("code-wait-enum-binding", { runId: "no-such-run" })
       .then(


### PR DESCRIPTION
Closes #128859

## What Problem This Solves

Fixes an issue where an agent would abandon a shell command it had just started.

Code Mode `exec` can background a long-running command and return `{"status":"running","sessionId":"lucky-glade",...}`. Handing that `sessionId` to the Code Mode `wait` tool is a natural next move for a model, and it failed with:

```json
{ "status": "error", "tool": "wait", "error": "code mode run is unavailable or expired." }
```

The lookup is correct — a shell `sessionId` is not a Code Mode `runId` — but the reply gave the model nothing to do next. In the reporter's transcript the model concluded "The session ID for the exec (lucky-glade) seems lost" 1.4 s after starting the command, and dropped the work while the shell session was still running.

This is the failure class `AGENTS.md` calls out directly: *"Never dead-end the agent: failure text states what to try next."*

## Why This Change Was Made

The rejection now states the id space and the next step:

> code mode run is unavailable or expired. This id must be a runId from a suspended code mode run; a sessionId returned by another tool (for example a backgrounded shell command) belongs to a different id space and must be polled with the tool that returned it.

Three decisions worth reviewing:

**1. The message names the process poll route.** An earlier revision said "polled with the tool that returned it". Review showed that is wrong, and I confirmed it: `exec` returns the `sessionId` but owns no `poll` action — `process` does. That wording would have sent the model back to `exec` and reproduced one of the neighbouring dead-ends in the same report (`Unknown action: poll`).

Naming `process` is safe here, on two pieces of evidence I checked directly:

- `exec` and `process` are pushed together in the same `shell.push(...)` under one `options.includeShellTools` gate (`src/agents/core-coding-tools.ts`). A model can only hold a background shell `sessionId` if `exec` ran, which means `process` is registered too. There is no configuration in which this guidance names a tool the model lacks.
- Production already does exactly this: `src/agents/bash-tools.process.ts` emits *"Use process poll to check whether it is already exiting."* and *"Use process write, send-keys, submit, or paste to provide input."* `exec`'s own description says *"then process for logs/status/input/intervention."*

So the `AGENTS.md` rule about not statically naming tools from *other* toolsets does not bite: this is the shell toolset's own sibling surface, and the reference is established practice.

**1b. The guidance is scoped to the one entry point that can receive a foreign id.** A later review pass caught that the shared message also fired from `reserveActiveRunSlot`. That path runs *after* `wait` already resolved a run and awaited pending work, so a miss there is the expiry timer removing a genuine Code Mode run — never a shell session — and shell tools can be omitted entirely, so naming `process` there could point at a surface the model does not have. The reservation site keeps the plain lifecycle text; only `runWait`, which accepts an arbitrary caller-supplied id, carries the recovery guidance. That also removed the cross-module shared constant the earlier revision introduced.

A regression locks it: `reserveActiveRunSlot` on a missing id must throw without mentioning `process`. Against the previous head it fails with the full guidance string, so it is not vacuous.

**2. `wait` does not learn to resolve shell sessions.** Keeping the id spaces separate is the point; making `wait` read process state would couple Code Mode run lifecycle to the shell session store to paper over a wording problem.

**3. No shape-sniffing.** Code Mode run ids carry no reserved prefix, so any "this looks like a session id" heuristic would be guesswork that rots as id formats change. The message is therefore correct for both causes — wrong id kind *and* genuine expiry — rather than guessing which one happened.

The leading sentence is unchanged, so existing consumers and assertions on that prefix still match.

Both throw sites (`runWait` and `reserveActiveRunSlot`) carried the same literal, so the text moves into one exported constant instead of duplicating the longer string — the drift risk that made this a two-site change in the first place.

## User Impact

When a model passes a backgrounded shell `sessionId` to `wait`, it now gets a reply that tells it the id belongs to another tool and to poll that tool, instead of a message it reads as "the work is lost". Operators stop seeing agents silently abandon long-running commands they just launched. No configuration change; no behavior change for valid Code Mode run ids.

## Scope: diagnostics only, not the abandonment repair

Maintainer review established that this patch does not repair the reported task abandonment, and I agree. On the embedded path the adapter converts the lookup exception into an error result, result middleware marks it failed, and the Code Mode outcome hook terminates an unproven failed `wait`. For a sole `wait` call there is no subsequent provider turn in which to follow the guidance, so the manually driven exec → wait → process trace below does not exercise that continuation boundary.

I had proposed minting a "nothing started" fact for the not-found branch. That was wrong, and the review explains why: the same missing-map result also occurs after a real cell expires, loses its owner, or transfers into resume, potentially after earlier mutations. The owner retains no fact separating those from a mistaken shell-process id, so "this wait resumed nothing" cannot be promoted into proof that the whole cell is safe to continue.

**The terminal/replay guard is therefore untouched here**, and this PR should be read as the id-space diagnostic only. A complete repair needs an owner-approved correction contract plus an agent/session-loop regression — spawn once, make the mistaken sole `wait`, receive another provider request, then poll the same authorized process without respawning — paired with expired and prior-mutation cases that stay contained. Happy to take that on if the contract is defined.

## Fixed in this round: guidance derives from the callable surface

Review also noted the message advertised `process` where it is not present, including empty or gated catalogs. The route is now resolved from `ctx.catalogRef` rather than hardcoded: when `process` is callable the rejection names it, otherwise the rejection carries only the id-space explanation.

A regression covers the absent case and fails against the unconditional message:

```
FAIL  does not advertise process when it is absent from the callable surface
AssertionError: expected [Function] to throw error not including 'process'
Received: "... a background shell sessionId from exec is polled with process (action "poll")."
```

`pnpm test src/agents/code-mode.wait.test.ts` — 24 passed.

## Evidence

### The reported dead-end, reproduced

The regression drives the real `wait` tool through the Code Mode harness with the reporter's own id (`lucky-glade`). Against unmodified `origin/main`:

```
FAIL  points a backgrounded shell sessionId at its owning tool instead of dead-ending
AssertionError: expected [Function] to throw error including 'different id space'
                but got 'code mode run is unavailable or expir…'

Expected: "different id space"
Received: "code mode run is unavailable or expired."

Tests  1 failed | 20 skipped (21)
```

That received string is the dead-end exactly as the transcript recorded it. With the fix the test passes, asserting all three properties: the original prefix still present, the id space named, and a next step given.

### The guidance cannot rot

The second test binds the message to the `process` tool's real action enum rather than to a copy of the string:

```ts
const processActions = (processSchema.properties.action as { enum?: string[] }).enum ?? [];
const namedAction = /action "([^"]+)"/.exec(CODE_MODE_RUN_UNAVAILABLE_MESSAGE)?.[1];
expect(processActions).toContain(namedAction);
```

To confirm it is not tautological I mutated the message to name `exec (action "tail")` and re-ran:

```
FAIL  points a backgrounded shell sessionId at the process poll route
      Expected: 'polled with process (action "poll")'
      Received: '... polled with exec (action "tail").'

FAIL  only names a continuation action the process tool actually implements
      AssertionError: expected [ Array(10) ] to include 'tail'

Tests  2 failed | 20 skipped (22)
```

That is precisely the defect class review caught: guidance pointing at a surface that cannot serve it. Renaming or dropping `poll` now fails the suite instead of silently shipping a dead end.

### No sibling regressions

Swept the whole code-mode area rather than just the changed files, because the message is shared and other suites assert on it:

```
pnpm test src/agents/code-mode
Test Files  12 passed (12)   Tests  258 passed (258)
Test Files   1 passed (1)    Tests    5 passed (5)
Test Files   1 passed (1)    Tests    2 passed (2)
[test] passed 3 Vitest shards in 210.01s
```

`src/agents/code-mode-worker-lifecycle.test.ts` (12 passed) asserts the original message prefix and still passes, which is the check that the preserved leading sentence actually holds.

### Gates

```
oxfmt --check (changed files)  PASS (exit 0)
oxlint        (changed files)  PASS (exit 0, no output)
pnpm tsgo                      0 errors in changed files
```

`pnpm tsgo` reports 12 errors in `packages/ai/src/providers/google-shared.ts`, `packages/markdown-core`, and `src/tui`. None involve `code-mode` files and none are attributable to this PR — they are dependency-typing drift in my local `node_modules` on untouched paths. CI is authoritative there.

Environment: Windows 11, Node 22.23.2, pnpm 11.15.1.

### Review findings addressed since the last review

- *Point shell session IDs to process polling (P1)* — fixed. The message now names `process (action "poll")`, verified against the real action enum, with the availability argument above.
- *Merge risk: wording could send the agent to a tool with no poll action* — resolved by the same change and locked by the enum-bound test.
- *Production grows for an error-text change* — the comment was compacted to the load-bearing reason; the constant stays one canonical message shared by both throw sites.

### Scope note and follow-up

The issue also lists two neighbouring dead-ends from the same install — `Error: Unknown action: poll` and `Error: Terminal session unavailable. Use action=list…`. Those belong to the terminal/process tool surface, not Code Mode `wait`, and fixing them well needs a decision about how the shell-session affordance is advertised to Code Mode guests in the first place. I left them out rather than guess at that design; they are worth a separate issue if maintainers agree the discoverability gap is the real root cause.

### Real trace: background exec -> wait -> process poll

This is the recovery path an operator actually hits, driven end to end with the real `exec`, `wait`, and `process` surfaces against a real spawned OS process (isolated `OPENCLAW_STATE_DIR`, Windows 11, Node 22.23.2). Nothing here is mocked.

**Before (unmodified `origin/main`)** — the dead end:

```
$ exec { command: "node -e ...", background: true }
  -> {"status":"running","sessionId":"neat-atlas"}

$ wait { runId: "neat-atlas" }
  -> ERROR: code mode run is unavailable or expired.

$ process { action: "poll", sessionId: "neat-atlas" }
  -> tick 1
```

The command is alive and producing output, but `wait` says only that the run is gone. That is the point at which the reporter's model concluded "the session ID for the exec seems lost" and abandoned the work.

**After (this branch)** — the same scenario, following the guidance the message now gives:

```
$ exec { command: "node -e ...", background: true }
  -> {"status":"running","sessionId":"neat-ridge"}

$ wait { runId: "neat-ridge" }
  -> ERROR: code mode run is unavailable or expired. This id must be a runId from a
     suspended code mode run; a background shell sessionId from exec is polled with
     process (action "poll").

$ process { action: "poll", sessionId: "neat-ridge" }
  -> tick 1
     tick 2
     tick 3
     tick 4
     tick 5
     tick 6
```

The third step is the part that matters: the route named in the error is the route that actually returns the live output of the still-running process. Note the session id shape (`neat-ridge`, `neat-atlas`) matches the reporter's `lucky-glade` — these are real backgrounded shell sessions, not fixtures.

### Proof gap, stated plainly

I drove the tools directly rather than through a gateway agent turn with a live model, so what is not shown is a model *choosing* to follow the guidance. That is a model-behavior claim no local run can settle. The mechanical claim — that the named route exists, is correct, and returns the pending output — is covered above end to end.

Investigation and patch were AI-assisted; I reviewed every changed line and ran the tests, gates, and traces myself.