### PR TITLE
fix(workboard): stop persisting the dispatcher's sentinel owner as agentId

### DIFF
--- a/extensions/workboard/src/dispatcher-ownership.test.ts
+++ b/extensions/workboard/src/dispatcher-ownership.test.ts
@@ -84,6 +84,51 @@ describe("Workboard dispatcher ownership", () => {
     await expect(store.get(unassigned.id)).resolves.toMatchObject({ status: "ready" });
   });
 
+  it("never persists the dispatcher's synthetic owner as the card's agentId (#128860)", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Ownerless card",
+      status: "ready",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-sentinel-not-assigned" });
+
+    await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    const dispatched = await store.get(card.id);
+    expect(dispatched?.agentId).toBeUndefined();
+    expect(dispatched).toMatchObject({
+      status: "running",
+      metadata: { claim: { ownerId: "workboard-dispatcher" } },
+    });
+  });
+
+  it("still assigns agentId when dispatch is given an explicit --owner", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Ownerless card, explicit owner",
+      status: "ready",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-explicit-owner" });
+
+    await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 1, ownerId: "alice" },
+    });
+
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      status: "running",
+      agentId: "alice",
+      metadata: { claim: { ownerId: "alice" } },
+    });
+  });
+
   it("bounds failed worker attempts without draining the ready queue", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const cards = [];

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -467,6 +467,10 @@ async function runWorkboardDispatch(
             workspaceAccess: card.metadata?.automation?.workspaceAccess,
           },
           adoptWorkspaceAccess: persistWorkspaceAccess ? workspaceAccess : undefined,
+          // An explicit --owner is a deliberate assignment; a resolved fallback
+          // (active claim owner or the dispatcher's own sentinel identity) is
+          // not, and must never become the card's owner of record (#128860).
+          assignOwnerToCard: ownerOverride !== undefined,
         },
       );
       claimValue = claimed.token;

--- a/extensions/workboard/src/store-inputs.ts
+++ b/extensions/workboard/src/store-inputs.ts
@@ -96,6 +96,12 @@ export type WorkboardClaimOptions = {
   };
   /** Trusted legacy-card adoption; applied only while expectedAuthority still matches. */
   adoptWorkspaceAccess?: WorkboardWorkspaceAccess;
+  /**
+   * Trusted dispatcher guard; false when `ownerId` is a synthetic dispatch
+   * identity rather than a deliberate assignment, so it must not become the
+   * card's owner of record. Defaults to true for direct/tool/gateway claims.
+   */
+  assignOwnerToCard?: boolean;
 };
 export type WorkboardHeartbeatInput = {
   token?: unknown;

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -136,6 +136,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
         throw new Error(`card already claimed by ${activeClaim.ownerId}.`);
       }
       const metadata = clearDiagnostics(guarded.metadata, ["stranded_ready"]);
+      const shouldAssignOwner = options.assignOwnerToCard ?? true;
       const card = await this.updateCard(
         id,
         {
@@ -143,7 +144,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
             guarded.status === "backlog" || guarded.status === "todo" || guarded.status === "ready"
               ? "running"
               : guarded.status,
-          agentId: guarded.agentId ?? ownerId,
+          agentId: shouldAssignOwner ? (guarded.agentId ?? ownerId) : guarded.agentId,
           ...(options.adoptWorkspaceAccess && !guarded.metadata?.automation?.workspaceAccess
             ? { workspaceAccess: options.adoptWorkspaceAccess }
             : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes #128860. When the Workboard dispatcher starts a card that has no
`agentId`, it persists the internal fallback identity `"workboard-dispatcher"`
into the card's `agentId`. That value is not a configured agent, but from then
on the card is indistinguishable from one a user (or a board default) actually
assigned — `agentId` reports a phantom agent via the API/dashboard, and the
distinction between "never assigned" and "assigned" is destroyed and
unrecoverable after the card's first run.

Root cause: `extensions/workboard/src/dispatcher.ts`'s `resolveDispatchOwner`
resolves a **local, transient** owner for claim/concurrency-slot purposes —
falling back to the `DEFAULT_WORKBOARD_DISPATCH_OWNER` sentinel when the card
has no `agentId`, no active claim, and no explicit `--owner` override — and
`WorkboardWorkflowStore.claim()` (`extensions/workboard/src/store-workflow.ts`)
unconditionally wrote that resolved owner into the card via
`agentId: guarded.agentId ?? ownerId`. The fallback is fine as a same-run
concurrency key; the bug is that it leaked into the persisted assignment.

## Why This Change Was Made

`claim()` is called from three places with very different intent:
- `dispatcher.ts` — automatic dispatch, where the fallback owner is a
  synthetic dispatch identity, not a deliberate assignment.
- `gateway.ts` / `tools.ts` — a direct claim (CLI/gateway RPC or an agent
  tool), where the caller's `ownerId` genuinely is a deliberate assignment and
  must keep landing in `agentId` exactly as before.

So the fix adds a trusted, dispatcher-only `assignOwnerToCard` option on
`WorkboardClaimOptions` (`store-inputs.ts`), defaulting to `true` (unchanged
behavior for the two direct-claim call sites). `dispatcher.ts` now passes
`assignOwnerToCard: ownerOverride !== undefined` — an explicit `--owner` is
still a deliberate assignment and is still persisted; the sentinel/reused
active-claim-owner fallback is not. Concurrency-slot accounting
(`workboardCardSlotOwner` in `store-constants.ts`) already reads
`metadata.claim.ownerId` first, so ownerless cards continue sharing a single
worker slot exactly as before — only the persisted `agentId` changes.

## User Impact

- Dispatching an ownerless card no longer assigns it to a nonexistent
  `workboard-dispatcher` "agent". `agentId` stays unset until a real owner
  (explicit `--owner`, a board default, or a direct claim/tool call) assigns
  one.
- No behavior change for cards that already have an `agentId`, for explicit
  `--owner` dispatch, or for direct claims via the gateway/tool surface.
- Worker concurrency slotting (one active run per owner) is unaffected.

## Evidence

New regression test in `extensions/workboard/src/dispatcher-ownership.test.ts`
proves the failing behavior before the fix and the fix afterward.

Confirmed the new test fails on pre-fix source
(`git checkout HEAD~1 -- <changed source files>`, keeping only the new test):

```
FAIL extensions/workboard/src/dispatcher-ownership.test.ts > Workboard dispatcher ownership
  > never persists the dispatcher's synthetic owner as the card's agentId (#128860)
AssertionError: expected 'workboard-dispatcher' to be undefined
- Expected: undefined
+ Received: "workboard-dispatcher"
```

With the fix restored, full file passes (30/30, includes the new "explicit
--owner still assigns" compat case):

```
$ pnpm test extensions/workboard/src/dispatcher-ownership.test.ts
 Test Files  1 passed (1)
      Tests  30 passed (30)
```

Full `workboard` extension suite, unaffected:

```
$ pnpm test extensions/workboard
 Test Files  18 passed (18)
      Tests  339 passed (339)
```

Typecheck/lint on the changed files, clean:

```
$ pnpm tsgo:extensions        # exit 0
$ pnpm tsgo:extensions:test   # exit 0
$ node scripts/run-oxlint.mjs extensions/workboard/src/dispatcher.ts \
    extensions/workboard/src/store-inputs.ts \
    extensions/workboard/src/store-workflow.ts \
    extensions/workboard/src/dispatcher-ownership.test.ts   # exit 0
```

Note: `#116375` (open, unmerged) separately teaches dispatch to adopt a
board's `orchestration.defaultAssignee` into `agentId` before claiming — it
does not touch the no-default-assignee path, and its own test explicitly
documents that a board with no default still gets `agentId:
"workboard-dispatcher"` on current `main`. This PR is the independent fix for
that remaining case (and for the identical fallback used when there is no
board default at all).

---
AI-assisted change: implemented and validated by an autonomous coding agent.
