### PR TITLE
fix(memory): search warns about stale index during session catch-up

### DIFF
--- a/extensions/memory-core/src/memory-tool-manager.test-mocks.ts
+++ b/extensions/memory-core/src/memory-tool-manager.test-mocks.ts
@@ -27,6 +27,7 @@ type MemoryManagerParams = {
 
 let workspaceDir = "/workspace";
 let statusDirty = false;
+let pendingSyncSources: MemorySource[] | undefined;
 let customStatus: Record<string, unknown> | undefined;
 let sourceCounts: Array<{ source: MemorySource; files: number; chunks: number }> = [
   { source: "memory", files: 1, chunks: 1 },
@@ -56,6 +57,7 @@ const stubManager = {
     files: 1,
     chunks: 1,
     dirty: statusDirty,
+    pendingSyncSources,
     workspaceDir,
     dbPath: "/workspace/.memory/index.sqlite",
     provider: "builtin",
@@ -95,6 +97,10 @@ export function setMemoryStatusDirty(next: boolean): void {
   statusDirty = next;
 }
 
+export function setMemoryPendingSyncSources(next: MemorySource[] | undefined): void {
+  pendingSyncSources = next;
+}
+
 export function setMemorySourceCounts(
   next: Array<{ source: MemorySource; files: number; chunks: number }>,
 ): void {
@@ -131,6 +137,7 @@ export function resetMemoryToolMockState(overrides?: {
 }): void {
   workspaceDir = "/workspace";
   statusDirty = false;
+  pendingSyncSources = undefined;
   customStatus = undefined;
   sourceCounts = [{ source: "memory", files: 1, chunks: 1 }];
   getManagerImpl = undefined;

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -498,6 +498,23 @@ describe("memory index", () => {
     await pendingSync;
   });
 
+  it("reports session-only refreshes from the manager sync owner", async () => {
+    const manager = await getPersistentManager(
+      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+    );
+    await manager.sync({ reason: "test" });
+
+    Reflect.set(manager, "dirty", false);
+    Reflect.set(manager, "sessionsDirty", true);
+    Reflect.set(manager, "syncing", new Promise<void>(() => {}));
+    try {
+      expect(manager.status().pendingSyncSources).toEqual(["sessions"]);
+    } finally {
+      Reflect.set(manager, "syncing", null);
+      Reflect.set(manager, "sessionsDirty", false);
+    }
+  });
+
   it("waits for dirty sync before querying", async () => {
     providerFixture.forceNoProvider = true;
     const manager = await getPersistentManager(

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -482,12 +482,22 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       requestedProvider: this.requestedProvider,
       configuredModel: this.settings.model || undefined,
     });
+    const pendingSyncSources: MemorySource[] = [];
+    if (this.syncing) {
+      if (this.dirty) {
+        pendingSyncSources.push("memory");
+      }
+      if (this.sessionsDirty) {
+        pendingSyncSources.push("sessions");
+      }
+    }
 
     return {
       backend: "builtin",
       files: aggregateState.files,
       chunks: aggregateState.chunks,
       dirty: this.dirty || this.sessionsDirty || this.indexIdentityDirty,
+      pendingSyncSources: pendingSyncSources.length > 0 ? pendingSyncSources : undefined,
       workspaceDir: this.workspaceDir,
       dbPath: this.settings.store.databasePath,
       provider: providerInfo.provider,

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -12,6 +12,7 @@ import {
   resetMemoryToolMockState,
   setMemoryCloseImpl,
   setMemoryCustomStatus,
+  setMemoryPendingSyncSources,
   setMemorySearchImpl,
   setMemorySearchManagerImpl,
   setMemorySourceCounts,
@@ -552,6 +553,25 @@ describe("memory_search unavailable payloads", () => {
       action: "Run: openclaw memory status --index --agent main",
     });
     expect(getMemorySyncMockCalls()).toBe(0);
+  });
+
+  it("does not qualify results while session-only catch-up is in progress", async () => {
+    setMemoryStatusDirty(true);
+    setMemoryPendingSyncSources(["sessions"]);
+    setMemorySearchImpl(async () => []);
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+
+    const result = await tool.execute("session-catch-up", { query: "hidden codeword" });
+
+    expect(result.details).toMatchObject({ results: [] });
+    expect(result.details).not.toHaveProperty("stale");
+    expect(result.details).not.toHaveProperty("warning");
+    expect(result.details).not.toHaveProperty("action");
   });
 
   it("surfaces embedding bootstrap degradation when keyword search has no hits", async () => {

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -147,6 +147,8 @@ export type MemoryProviderStatus = {
   files?: number;
   chunks?: number;
   dirty?: boolean;
+  /** Sources currently being refreshed by an admitted sync. */
+  pendingSyncSources?: MemorySource[];
   workspaceDir?: string;
   dbPath?: string;
   extraPaths?: MemoryExtraPath[];
@@ -186,7 +188,7 @@ export type MemoryProviderStatus = {
 };
 
 export function resolveMemorySearchStaleness(
-  status: Pick<MemoryProviderStatus, "dirty" | "custom">,
+  status: Pick<MemoryProviderStatus, "dirty" | "pendingSyncSources" | "custom">,
   agentId?: string,
 ): { stale: true; warning: string; action: string } | null {
   const identity = status.custom?.indexIdentity as Record<string, unknown> | undefined;
@@ -195,7 +197,11 @@ export function resolveMemorySearchStaleness(
     typeof identity.reason === "string"
       ? identity.reason.trim()
       : undefined;
-  if (!status.dirty && !identityReason) {
+  const refreshingSessionsOnly =
+    status.dirty === true &&
+    status.pendingSyncSources?.length === 1 &&
+    status.pendingSyncSources[0] === "sessions";
+  if ((!status.dirty || refreshingSessionsOnly) && !identityReason) {
     return null;
   }
   return {

--- a/src/gateway/server-methods/memory-search.test.ts
+++ b/src/gateway/server-methods/memory-search.test.ts
@@ -2,7 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentSelectionRequiredError } from "../../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { MemorySearchResult } from "../../memory-host-sdk/host/types.js";
+import type { MemoryProviderStatus, MemorySearchResult } from "../../memory-host-sdk/host/types.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -56,12 +56,14 @@ async function invokeMemorySearch(params: unknown, cfg: OpenClawConfig) {
 function createStubManager() {
   return {
     search: vi.fn(async (): Promise<MemorySearchResult[]> => []),
-    status: vi.fn(() => ({
-      backend: "builtin" as const,
-      provider: "none",
-      dirty: false,
-      custom: { searchMode: "fts-only" },
-    })),
+    status: vi.fn(
+      (): MemoryProviderStatus => ({
+        backend: "builtin" as const,
+        provider: "none",
+        dirty: false,
+        custom: { searchMode: "fts-only" },
+      }),
+    ),
     close: vi.fn(async () => undefined),
   };
 }
@@ -280,6 +282,32 @@ describe("memory.search gateway method", () => {
         stale: true,
         warning: "Memory index is dirty. Search results may be incomplete.",
         action: "Run: openclaw memory status --index --agent main",
+      },
+      undefined,
+    );
+  });
+
+  it("does not qualify results while session-only catch-up is in progress", async () => {
+    const cfg = createConfig(testState.workspaceDir);
+    const manager = createStubManager();
+    manager.status.mockReturnValue({
+      backend: "builtin",
+      provider: "none",
+      dirty: true,
+      pendingSyncSources: ["sessions"],
+      custom: { searchMode: "fts-only" },
+    });
+    getActiveMemorySearchManagerCore.mockResolvedValue({ manager });
+
+    const respond = await invokeMemorySearch({ query: "hidden codeword" }, cfg);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        agentId: "main",
+        provider: "none",
+        searchMode: "fts-only",
+        results: [],
       },
       undefined,
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where memory searches reported a stale index warning and remediation command while background session transcript catch-up was actively running. Session-only catch-up is non-blocking, so this warning incorrectly suggested that available search results required operator intervention.

## Why This Change Was Made

The memory manager now reports which sources an admitted sync is refreshing. The shared search-staleness policy omits stale metadata only when `sessions` is the sole pending source. Memory-file dirtiness, index identity mismatches, and session dirtiness that remains after a completed or failed sync still produce the existing warning.

## User Impact

Memory search results no longer include a false stale-index warning during routine session catch-up. Operators still receive actionable warnings for index states that require attention.

## Evidence

- Before the fix, the gateway regression failed because the response included `stale`, `warning`, and `action` during session-only catch-up.
- `node scripts/run-vitest.mjs extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory/manager-search-orchestration.test.ts src/gateway/server-methods/memory-search.test.ts` passes 66 tests on the rebased head.
- `node scripts/check-changed.mjs --timed` passed all selected core, core-test, extension, and extension-test lanes before the mechanical rebase. The rebase changed none of the six touched files.
- Fresh branch autoreview reported no actionable findings and rated the patch correct at 0.99 confidence.
- AI-assisted: Codex was used to investigate and implement this fix. I reviewed the behavior, code, tests, and validation results.
