### PR TITLE
fix: generated media loses filenames, durations, and dimensions

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -37,6 +37,7 @@ function createMockContext(overrides?: {
       pendingMessagingTargets: new Map(),
       pendingMessagingMediaUrls: new Map(),
       pendingToolMediaUrls: [],
+      pendingToolMediaAttachments: [],
       pendingToolMediaTrustByUrl: new Map(),
       pendingToolAudioAsVoice: false,
       messagingToolSentTexts: [],
@@ -293,6 +294,70 @@ describe("handleToolExecutionEnd media emission", () => {
 
     expect(onToolResult).not.toHaveBeenCalled();
     expect(ctx.state.pendingToolMediaUrls).toEqual(["https://example.com/file.png"]);
+  });
+
+  it("aligns retained attachment metadata after filtering local media and merging duplicates", async () => {
+    const ctx = createMockContext();
+    ctx.state.pendingToolMediaUrls.push("https://example.com/existing.png");
+    ctx.state.pendingToolMediaAttachments?.push({});
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "plugin_tool",
+      toolCallId: "generated-media",
+      isError: false,
+      result: {
+        details: {
+          media: {
+            mediaUrls: [
+              "/tmp/private.png",
+              "https://example.com/existing.png",
+              "https://example.com/video.mp4",
+            ],
+            attachments: [
+              { type: "image", path: "/tmp/private.png", name: "private.png" },
+              {
+                type: "image",
+                url: "https://example.com/existing.png",
+                name: "existing.png",
+                width: 320,
+              },
+              {
+                type: "video",
+                url: "https://example.com/video.mp4",
+                name: "friendly-video.mp4",
+                durationMs: 5_000,
+                width: 1280,
+                height: 720,
+                trustedLocalMedia: true,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(ctx.state.pendingToolMediaUrls).toEqual([
+      "https://example.com/existing.png",
+      "https://example.com/video.mp4",
+    ]);
+    expect(ctx.state.pendingToolMediaAttachments).toEqual([
+      {
+        type: "image",
+        url: "https://example.com/existing.png",
+        name: "existing.png",
+        width: 320,
+      },
+      {
+        type: "video",
+        url: "https://example.com/video.mp4",
+        name: "friendly-video.mp4",
+        durationMs: 5_000,
+        width: 1280,
+        height: 720,
+      },
+    ]);
+    expect(ctx.state.pendingToolMediaTrustByUrl.get("https://example.com/video.mp4")).toBe(false);
   });
 
   it("does NOT emit local media for MCP-provenance results", async () => {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
@@ -458,10 +458,19 @@ export function hasMessagingRichContent(record: Record<string, unknown>): boolea
 
 function queuePendingToolMedia(
   ctx: ToolHandlerContext,
-  mediaReply: { mediaUrls: string[]; audioAsVoice?: boolean; trustedLocalMedia?: boolean },
+  mediaReply: NonNullable<ReturnType<typeof extractToolResultMediaArtifact>>,
+  allowedMediaUrls: string[],
 ) {
-  const seen = new Set(ctx.state.pendingToolMediaUrls.map((url) => url.trim()));
-  for (const mediaUrl of mediaReply.mediaUrls) {
+  const indexByUrl = new Map(
+    ctx.state.pendingToolMediaUrls.map((url, index) => [url.trim(), index]),
+  );
+  const attachments = (ctx.state.pendingToolMediaAttachments ??= ctx.state.pendingToolMediaUrls.map(
+    () => ({}),
+  ));
+  const attachmentsByUrl = new Map(
+    mediaReply.mediaUrls.map((url, index) => [url.trim(), mediaReply.attachments?.[index]]),
+  );
+  for (const mediaUrl of allowedMediaUrls) {
     const normalized = mediaUrl.trim();
     if (!normalized) {
       continue;
@@ -471,11 +480,17 @@ function queuePendingToolMedia(
     } else if (!ctx.state.pendingToolMediaTrustByUrl.has(normalized)) {
       ctx.state.pendingToolMediaTrustByUrl.set(normalized, false);
     }
-    if (seen.has(normalized)) {
+    const attachment = attachmentsByUrl.get(normalized);
+    const existingIndex = indexByUrl.get(normalized);
+    if (existingIndex !== undefined) {
+      if (attachment && Object.keys(attachments[existingIndex] ?? {}).length === 0) {
+        attachments[existingIndex] = attachment;
+      }
       continue;
     }
-    seen.add(normalized);
+    indexByUrl.set(normalized, ctx.state.pendingToolMediaUrls.length);
     ctx.state.pendingToolMediaUrls.push(normalized);
+    attachments.push(attachment ?? {});
   }
   if (mediaReply.audioAsVoice) {
     ctx.state.pendingToolAudioAsVoice = true;
@@ -701,9 +716,5 @@ export async function emitToolResultOutput(params: {
   if (mediaUrls.length === 0) {
     return;
   }
-  queuePendingToolMedia(ctx, {
-    mediaUrls,
-    ...(mediaReply.audioAsVoice ? { audioAsVoice: true } : {}),
-    ...(mediaReply.trustedLocalMedia ? { trustedLocalMedia: true } : {}),
-  });
+  queuePendingToolMedia(ctx, mediaReply, mediaUrls);
 }

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -370,6 +370,7 @@ type ToolHandlerState = Pick<
   | "pendingMessagingTexts"
   | "pendingMessagingMediaUrls"
   | "pendingToolMediaUrls"
+  | "pendingToolMediaAttachments"
   | "pendingToolMediaTrustByUrl"
   | "pendingToolAudioAsVoice"
   | "deterministicApprovalPromptPending"

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -323,6 +323,44 @@ describe("subscribeEmbeddedAgentSession", () => {
     },
   );
 
+  it("delivers generated media after dropping malformed provider attachment metadata", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createSubscribedHarness({
+      runId: "generated-malformed-metadata",
+      onBlockReply,
+      blockReplyBreak: "message_end",
+      builtinToolNames: new Set(["music_generate"]),
+    });
+    const path = "/tmp/generated-song.mp3";
+
+    emitToolRun({
+      emit,
+      toolName: "music_generate",
+      toolCallId: "music-tool",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "Generated media." }],
+        details: {
+          media: {
+            mediaUrls: [path],
+            attachments: [{ type: "audio", path, name: 1, mimeType: null, durationMs: -1 }],
+          },
+        },
+      },
+    });
+    await subscription.waitForPendingEvents();
+    emitMessageStartAndEndForAssistantText({ emit, text: "Here is your generated song." });
+    emit({ type: "agent_end", messages: [], willRetry: false });
+    await subscription.waitForPendingEvents();
+
+    expect(onBlockReply).toHaveBeenCalledOnce();
+    expect(onBlockReply.mock.calls[0]?.[0]).toMatchObject({
+      text: "Here is your generated song.",
+      mediaUrls: [path],
+      attachments: [{ type: "audio", path }],
+    });
+  });
+
   it("does not double-count usage when done and message_end carry the same snapshot", () => {
     const { emit, subscription } = createSubscribedSessionHarness({ runId: "run" });
     const usage = {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -331,7 +331,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       blockReplyBreak: "message_end",
       builtinToolNames: new Set(["music_generate"]),
     });
-    const path = "/tmp/generated-song.mp3";
+    const mediaPath = "/tmp/generated-song.mp3";
 
     emitToolRun({
       emit,
@@ -342,8 +342,10 @@ describe("subscribeEmbeddedAgentSession", () => {
         content: [{ type: "text", text: "Generated media." }],
         details: {
           media: {
-            mediaUrls: [path],
-            attachments: [{ type: "audio", path, name: 1, mimeType: null, durationMs: -1 }],
+            mediaUrls: [mediaPath],
+            attachments: [
+              { type: "audio", path: mediaPath, name: 1, mimeType: null, durationMs: -1 },
+            ],
           },
         },
       },
@@ -356,8 +358,8 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(onBlockReply).toHaveBeenCalledOnce();
     expect(onBlockReply.mock.calls[0]?.[0]).toMatchObject({
       text: "Here is your generated song.",
-      mediaUrls: [path],
-      attachments: [{ type: "audio", path }],
+      mediaUrls: [mediaPath],
+      attachments: [{ type: "audio", path: mediaPath }],
     });
   });
 

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -539,6 +539,73 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
   });
 
+  it.each([
+    {
+      toolName: "image_generate",
+      type: "image",
+      mimeType: "image/png",
+      metadata: { width: 640, height: 480 },
+    },
+    {
+      toolName: "music_generate",
+      type: "audio",
+      mimeType: "audio/mpeg",
+      metadata: { durationMs: 2_000 },
+    },
+    {
+      toolName: "video_generate",
+      type: "video",
+      mimeType: "video/mp4",
+      metadata: { durationMs: 5_000, width: 1280, height: 720 },
+    },
+  ] as const)(
+    "delivers generated $type attachment metadata with the assistant reply",
+    async ({ toolName, type, mimeType, metadata }) => {
+      const onBlockReply = vi.fn();
+      const { emit, subscription } = createSubscribedHarness({
+        runId: `generated-${type}`,
+        onBlockReply,
+        blockReplyBreak: "message_end",
+        builtinToolNames: new Set([toolName]),
+      });
+      const attachment = {
+        type,
+        path: `/tmp/generated-${type}`,
+        name: `friendly-${type}`,
+        mimeType,
+        sizeBytes: 137,
+        ...metadata,
+      };
+
+      emitToolRun({
+        emit,
+        toolName,
+        toolCallId: `${type}-tool`,
+        isError: false,
+        result: {
+          content: [{ type: "text", text: "Generated media." }],
+          details: { media: { mediaUrls: [attachment.path], attachments: [attachment] } },
+        },
+      });
+      await subscription.waitForPendingEvents();
+      expect(subscription.getPendingToolMediaReply()).toMatchObject({
+        mediaUrls: [attachment.path],
+        attachments: [attachment],
+      });
+
+      emitMessageStartAndEndForAssistantText({ emit, text: "Here is your generated file." });
+      emit({ type: "agent_end", messages: [], willRetry: false });
+      await subscription.waitForPendingEvents();
+
+      expect(onBlockReply).toHaveBeenCalledOnce();
+      expect(onBlockReply.mock.calls[0]?.[0]).toMatchObject({
+        text: "Here is your generated file.",
+        mediaUrls: [attachment.path],
+        attachments: [attachment],
+      });
+    },
+  );
+
   it("does not duplicate generated image media when the assistant reply has MEDIA lines", async () => {
     const onToolResult = vi.fn();
     const onBlockReply = vi.fn();

--- a/src/agents/embedded-agent-subscribe.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.media.test.ts
@@ -89,6 +89,59 @@ describe("extractToolResultMediaArtifact", () => {
         "/tmp/stems.zip",
         "https://example.test/stems.zip",
       ],
+      attachments: [
+        { type: "audio", path: "/tmp/song.mp3", mimeType: "audio/mpeg" },
+        { type: "image", url: "https://example.test/cover.png" },
+        { type: "file" },
+        { type: "file" },
+      ],
+    });
+  });
+
+  it("aligns generated attachment metadata with deduplicated media references", () => {
+    expect(
+      extractToolResultMediaArtifact({
+        details: {
+          media: {
+            mediaUrls: [" /tmp/song.mp3 ", "/tmp/cover.png", "/tmp/song.mp3"],
+            attachments: [
+              {
+                type: "image",
+                path: "/tmp/cover.png",
+                name: "cover.png",
+                width: 640,
+                height: 480,
+              },
+              {
+                type: "audio",
+                path: "/tmp/song.mp3",
+                name: "friendly-song.mp3",
+                mimeType: "audio/mpeg",
+                durationMs: 2_000,
+                trustedLocalMedia: true,
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      mediaUrls: ["/tmp/song.mp3", "/tmp/cover.png"],
+      attachments: [
+        {
+          type: "audio",
+          path: "/tmp/song.mp3",
+          name: "friendly-song.mp3",
+          mimeType: "audio/mpeg",
+          durationMs: 2_000,
+        },
+        {
+          type: "image",
+          path: "/tmp/cover.png",
+          name: "cover.png",
+          width: 640,
+          height: 480,
+        },
+      ],
     });
   });
 

--- a/src/agents/embedded-agent-subscribe.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.media.test.ts
@@ -162,7 +162,7 @@ describe("extractToolResultMediaArtifact", () => {
                 sizeBytes: Infinity,
                 durationMs: -1,
                 width: "1920",
-                height: NaN,
+                height: Number.NaN,
                 trustedLocalMedia: true,
               },
               {

--- a/src/agents/embedded-agent-subscribe.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.media.test.ts
@@ -145,6 +145,47 @@ describe("extractToolResultMediaArtifact", () => {
     });
   });
 
+  it("drops malformed provider attachment metadata while preserving valid media references", () => {
+    expect(
+      extractToolResultMediaArtifact({
+        details: {
+          media: {
+            attachments: [
+              {
+                type: "document",
+                path: "/tmp/generated.mp3",
+                url: false,
+                mediaUrl: {},
+                filePath: 12,
+                mimeType: 7,
+                name: 1,
+                sizeBytes: Infinity,
+                durationMs: -1,
+                width: "1920",
+                height: NaN,
+                trustedLocalMedia: true,
+              },
+              {
+                type: "audio",
+                path: "/tmp/empty.mp3",
+                sizeBytes: 0,
+                durationMs: 0,
+                width: 0,
+                height: 0,
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      mediaUrls: ["/tmp/generated.mp3", "/tmp/empty.mp3"],
+      attachments: [
+        { path: "/tmp/generated.mp3" },
+        { type: "audio", path: "/tmp/empty.mp3", sizeBytes: 0, durationMs: 0 },
+      ],
+    });
+  });
+
   it("returns undefined when content has no text or image blocks", () => {
     expect(extractToolResultMediaArtifact({ content: [{ type: "other" }] })).toBeUndefined();
   });

--- a/src/agents/embedded-agent-tool-media.ts
+++ b/src/agents/embedded-agent-tool-media.ts
@@ -1,4 +1,8 @@
 /** Extracts and trust-filters media from embedded-agent tool results. */
+import {
+  asNonNegativeFiniteNumber,
+  asPositiveFiniteNumber,
+} from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyMediaAttachment } from "../auto-reply/reply-payload.js";
 import { extractToolResultText } from "./embedded-agent-tool-results.js";
@@ -278,9 +282,23 @@ function collectStructuredMedia(media: Record<string, unknown>): ToolResultMedia
       return;
     }
     const record = value as Record<string, unknown>;
-    // Result attachments are provider-controlled; trust remains owned by the run/tool policy.
+    // Provider metadata can break Gateway delivery; media trust remains policy-owned.
     const attachment: ReplyMediaAttachment = Object.fromEntries(
-      Object.entries(record).filter(([key]) => REPLY_ATTACHMENT_METADATA_KEYS.has(key)),
+      Object.entries(record).filter(([key, entry]) => {
+        if (!REPLY_ATTACHMENT_METADATA_KEYS.has(key)) {
+          return false;
+        }
+        if (key === "type") {
+          return entry === "image" || entry === "audio" || entry === "video" || entry === "file";
+        }
+        if (key === "width" || key === "height") {
+          return asPositiveFiniteNumber(entry) !== undefined;
+        }
+        if (key === "sizeBytes" || key === "durationMs") {
+          return asNonNegativeFiniteNumber(entry) !== undefined;
+        }
+        return typeof entry === "string";
+      }),
     );
     for (const key of ["media", "path", "url", "mediaUrl", "filePath", "fileUrl"]) {
       pushString(record[key], attachment);

--- a/src/agents/embedded-agent-tool-media.ts
+++ b/src/agents/embedded-agent-tool-media.ts
@@ -279,9 +279,9 @@ function collectStructuredMedia(media: Record<string, unknown>): ToolResultMedia
     }
     const record = value as Record<string, unknown>;
     // Result attachments are provider-controlled; trust remains owned by the run/tool policy.
-    const attachment = Object.fromEntries(
+    const attachment: ReplyMediaAttachment = Object.fromEntries(
       Object.entries(record).filter(([key]) => REPLY_ATTACHMENT_METADATA_KEYS.has(key)),
-    ) as ReplyMediaAttachment;
+    );
     for (const key of ["media", "path", "url", "mediaUrl", "filePath", "fileUrl"]) {
       pushString(record[key], attachment);
     }

--- a/src/agents/embedded-agent-tool-media.ts
+++ b/src/agents/embedded-agent-tool-media.ts
@@ -1,6 +1,6 @@
 /** Extracts and trust-filters media from embedded-agent tool results. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import type { ReplyMediaAttachment } from "../auto-reply/reply-payload.js";
 import { extractToolResultText } from "./embedded-agent-tool-results.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
 import { readToolResultDetails } from "./tool-result-error.js";
@@ -232,6 +232,7 @@ export function filterToolResultMediaUrls(
  */
 type ToolResultMediaArtifact = {
   mediaUrls: string[];
+  attachments?: ReplyMediaAttachment[];
   audioAsVoice?: boolean;
   trustedLocalMedia?: boolean;
 };
@@ -247,28 +248,43 @@ function readToolResultDetailsMedia(
   return media;
 }
 
-function collectStructuredMediaUrls(media: Record<string, unknown>): string[] {
-  const urls: string[] = [];
-  const pushString = (value: unknown) => {
-    if (typeof value !== "string") {
-      return;
-    }
-    const normalized = value.trim();
-    if (normalized) {
-      urls.push(normalized);
+const REPLY_ATTACHMENT_METADATA_KEYS = new Set([
+  "type",
+  "path",
+  "url",
+  "mediaUrl",
+  "filePath",
+  "mimeType",
+  "name",
+  "sizeBytes",
+  "durationMs",
+  "width",
+  "height",
+]);
+
+function collectStructuredMedia(media: Record<string, unknown>): ToolResultMediaArtifact {
+  const mediaUrls: string[] = [];
+  const seen = new Set<string>();
+  const attachmentsByUrl = new Map<string, ReplyMediaAttachment>();
+  const pushString = (value: unknown, attachment?: ReplyMediaAttachment) => {
+    pushUniqueMessagingMediaUrl(mediaUrls, seen, value);
+    const normalized = typeof value === "string" ? value.trim() : "";
+    if (normalized && attachment && !attachmentsByUrl.has(normalized)) {
+      attachmentsByUrl.set(normalized, attachment);
     }
   };
   const pushAttachment = (value: unknown) => {
     if (!value || typeof value !== "object" || Array.isArray(value)) {
       return;
     }
-    const attachment = value as Record<string, unknown>;
-    pushString(attachment.media);
-    pushString(attachment.path);
-    pushString(attachment.url);
-    pushString(attachment.mediaUrl);
-    pushString(attachment.filePath);
-    pushString(attachment.fileUrl);
+    const record = value as Record<string, unknown>;
+    // Result attachments are provider-controlled; trust remains owned by the run/tool policy.
+    const attachment = Object.fromEntries(
+      Object.entries(record).filter(([key]) => REPLY_ATTACHMENT_METADATA_KEYS.has(key)),
+    ) as ReplyMediaAttachment;
+    for (const key of ["media", "path", "url", "mediaUrl", "filePath", "fileUrl"]) {
+      pushString(record[key], attachment);
+    }
   };
   pushString(media.media);
   pushString(media.path);
@@ -286,7 +302,12 @@ function collectStructuredMediaUrls(media: Record<string, unknown>): string[] {
       pushAttachment(attachment);
     }
   }
-  return uniqueStrings(urls);
+  return {
+    mediaUrls,
+    ...(attachmentsByUrl.size > 0
+      ? { attachments: mediaUrls.map((url) => attachmentsByUrl.get(url) ?? {}) }
+      : {}),
+  };
 }
 
 function isNonOutboundToolResultMedia(media: Record<string, unknown>): boolean {
@@ -318,10 +339,10 @@ export function extractToolResultMediaArtifact(
     if (isNonOutboundToolResultMedia(detailsMedia)) {
       return undefined;
     }
-    const mediaUrls = collectStructuredMediaUrls(detailsMedia);
-    if (mediaUrls.length > 0) {
+    const structuredMedia = collectStructuredMedia(detailsMedia);
+    if (structuredMedia.mediaUrls.length > 0) {
       return {
-        mediaUrls,
+        ...structuredMedia,
         ...(detailsMedia.audioAsVoice === true ? { audioAsVoice: true } : {}),
         ...(detailsMedia.trustedLocalMedia === true ? { trustedLocalMedia: true } : {}),
       };

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -1357,7 +1357,7 @@ describe("createManagedOutgoingImageBlocks", () => {
 
       const { result } = await requestManagedImage({
         stateDir,
-        pathName: block.url,
+        pathName: String(block.url),
         authResponse: { authMethod: "token" },
       });
 

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -1338,6 +1338,35 @@ describe("createManagedOutgoingImageBlocks", () => {
   });
 
   it.each([
+    { providedName: "friendly-cover.png", expectedName: "friendly-cover.png" },
+    { providedName: "../album\\cover\r\n.png", expectedName: "cover.png" },
+  ])(
+    "preserves safe generated image filenames in the record and HTTP response",
+    async ({ providedName, expectedName }) => {
+      const blocks = await createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [`data:image/png;base64,${TINY_PNG_BASE64}`],
+        attachments: [{ type: "image", name: providedName }],
+        stateDir,
+        messageId: "msg-1",
+      });
+      const block = requireBlock(blocks);
+      const attachmentId = requireAttachmentIdFromUrl(block.url);
+
+      expect(readManagedImageRecord(attachmentId, stateDir)?.original.filename).toBe(expectedName);
+
+      const { result } = await requestManagedImage({
+        stateDir,
+        pathName: block.url,
+        authResponse: { authMethod: "token" },
+      });
+
+      expect(result.statusCode).toBe(200);
+      expect(result.headers["content-disposition"]).toContain(`filename="${expectedName}"`);
+    },
+  );
+
+  it.each([
     { kind: "audio" as const, contentType: "audio/mpeg", fileName: "theme.mp3" },
     { kind: "video" as const, contentType: "video/mp4", fileName: "clip.mp4" },
   ])(
@@ -1763,6 +1792,23 @@ describe("createManagedOutgoingImageBlocks", () => {
 
     expect(blocks).toHaveLength(2);
     expect(blocks[0]?.type).toBe("image");
+    expect(requireBlock(blocks, 1).type).toBe("text");
+  });
+
+  it("updates generated image filenames to the actual format after resizing", async () => {
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [await createPngDataUrl(200, 120)],
+      attachments: [{ type: "image", name: "generated-poster.webp" }],
+      stateDir,
+      limits: { maxWidth: 64, maxHeight: 64, maxPixels: 4096 },
+    });
+    const block = requireBlock(blocks);
+    const record = readManagedImageRecord(requireAttachmentIdFromUrl(block.url), stateDir);
+
+    expect(record?.original.contentType).toBe("image/jpeg");
+    expect(record?.original.filename).toBe("generated-poster.jpg");
+    expect(record?.original.mediaId).toMatch(/\.jpg$/);
     expect(requireBlock(blocks, 1).type).toBe("text");
   });
 

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -12,6 +12,7 @@ import {
   createSolidPngBuffer,
 } from "../../test/helpers/image-fixtures.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { extractToolResultMediaArtifact } from "../agents/embedded-agent-tool-media.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { resolveExistingAgentSessionStoreTargetsReadOnlyResult } from "../config/sessions/targets-read-availability.js";
 import { createPinnedLookup } from "../infra/net/ssrf.js";
@@ -1376,6 +1377,45 @@ describe("createManagedOutgoingImageBlocks", () => {
       });
     },
   );
+
+  it("prepares generated audio when provider attachment metadata contains malformed values", async () => {
+    const sourcePath = path.join(stateDir, "workspace", "theme.mp3");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    const extracted = extractToolResultMediaArtifact({
+      details: {
+        media: {
+          mediaUrls: [sourcePath],
+          attachments: [
+            {
+              type: "audio",
+              path: sourcePath,
+              name: 1,
+              mimeType: false,
+              durationMs: -1,
+              width: Infinity,
+            },
+          ],
+        },
+      },
+    });
+    const onPrepareError = vi.fn();
+
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: extracted?.mediaUrls,
+      attachments: extracted?.attachments,
+      stateDir,
+      localRoots: [path.dirname(sourcePath)],
+      allowLocalNonImage: true,
+      continueOnPrepareError: true,
+      onPrepareError,
+    });
+
+    expect(onPrepareError).not.toHaveBeenCalled();
+    expect(blocks).toHaveLength(1);
+    expect(requireBlock(blocks)).toMatchObject({ type: "audio", fileName: "theme.mp3" });
+  });
 
   it("marks exotic managed media metadata for playback transcoding", async () => {
     const sourcePath = path.join(stateDir, "workspace", "voice.caf");

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -1407,6 +1407,88 @@ describe("createManagedOutgoingImageBlocks", () => {
     },
   );
 
+  it.each([
+    {
+      kind: "audio" as const,
+      sourceName: "theme.mp3",
+      providedName: "../album\\cover\r\n.mp3",
+      expectedName: "cover.mp3",
+    },
+    {
+      kind: "video" as const,
+      sourceName: "clip.mp4",
+      providedName: "../album\\NUL\r\n.webp",
+      expectedName: "NUL_.mp4",
+    },
+  ])(
+    "sanitizes generated $kind filenames in media blocks, records, and downloads",
+    async ({ kind, sourceName, providedName, expectedName }) => {
+      const sourcePath = path.join(stateDir, "workspace", sourceName);
+      await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+      await fs.writeFile(
+        sourcePath,
+        kind === "audio"
+          ? Buffer.from([0xff, 0xfb, 0x90, 0x00])
+          : Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32]),
+      );
+      const blocks = await createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [sourcePath],
+        attachments: [{ type: kind, path: sourcePath, name: providedName }],
+        stateDir,
+        localRoots: [path.dirname(sourcePath)],
+        allowLocalNonImage: true,
+        messageId: "msg-1",
+      });
+      const block = requireBlock(blocks);
+      const pathName = String(block.url);
+
+      expect(block).toMatchObject({ type: kind, fileName: expectedName });
+      expect(
+        readManagedImageRecord(requireAttachmentIdFromUrl(pathName), stateDir)?.original.filename,
+      ).toBe(expectedName);
+
+      const { result } = await requestManagedImage({
+        stateDir,
+        pathName,
+        authResponse: { authMethod: "token" },
+        transcriptMessages: [
+          {
+            role: "assistant",
+            content: [{ type: kind, url: pathName, openUrl: pathName }],
+            __openclaw: { id: "msg-1" },
+          },
+        ],
+      });
+
+      expect(result.statusCode).toBe(200);
+      expect(result.headers["content-disposition"]).toContain(`filename="${expectedName}"`);
+    },
+  );
+
+  it.each([
+    { kind: "audio" as const, contentType: "audio/mpeg" },
+    { kind: "video" as const, contentType: "video/mp4" },
+  ])(
+    "preserves generated $kind labels without attachment metadata",
+    async ({ kind, contentType }) => {
+      const buffer =
+        kind === "audio"
+          ? Buffer.from([0xff, 0xfb, 0x90, 0x00])
+          : Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32]);
+      const blocks = await createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [`data:${contentType};base64,${buffer.toString("base64")}`],
+        stateDir,
+      });
+
+      expect(requireBlock(blocks)).toMatchObject({
+        type: kind,
+        fileName: `Generated ${kind} 1`,
+      });
+    },
+  );
+
   it("prepares generated audio when provider attachment metadata contains malformed values", async () => {
     const sourcePath = path.join(stateDir, "workspace", "theme.mp3");
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -22,6 +22,7 @@ import {
   resolveExistingAgentSessionStoreTargetsReadOnlyResult,
   type SessionStoreTargetsReadCache,
 } from "../config/sessions/targets-read-availability.js";
+import { sanitizeUntrustedFileName } from "../infra/fs-safe-advanced.js";
 import { openLocalFileSafely, readLocalFileSafely } from "../infra/fs-safe.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { loadPendingSessionDeliveries } from "../infra/session-delivery-queue-storage.js";
@@ -861,9 +862,13 @@ function buildManagedImageResizeWarningBlock(params: {
   };
 }
 
-function toRecordFilename(filePath: string) {
-  const name = path.basename(filePath).trim();
-  return name || null;
+function toRecordFilename(filePath: string, attachmentName?: string) {
+  const fallback = path.basename(filePath).trim();
+  if (!attachmentName) {
+    return fallback || null;
+  }
+  const safeName = sanitizeUntrustedFileName(attachmentName, fallback);
+  return `${path.parse(safeName).name}${path.extname(filePath)}`;
 }
 
 function asArray(value: string[] | undefined | null) {
@@ -1546,7 +1551,7 @@ export async function createManagedOutgoingMediaBlocks(params: {
           sizeBytes: originalStats.sizeBytes,
           filename:
             mediaKind === "image"
-              ? toRecordFilename(savedOriginal.path)
+              ? toRecordFilename(savedOriginal.path, attachmentMetadata?.name)
               : attachmentMetadata?.name?.trim() || label,
         },
       };

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -862,9 +862,9 @@ function buildManagedImageResizeWarningBlock(params: {
   };
 }
 
-function toRecordFilename(filePath: string, attachmentName?: string) {
-  const fallback = path.basename(filePath).trim();
-  if (!attachmentName) {
+function toRecordFilename(filePath: string, attachmentName?: string, fallbackName?: string) {
+  const fallback = fallbackName ?? path.basename(filePath).trim();
+  if (!attachmentName?.trim()) {
     return fallback || null;
   }
   const safeName = sanitizeUntrustedFileName(attachmentName, fallback);
@@ -1549,10 +1549,11 @@ export async function createManagedOutgoingMediaBlocks(params: {
           width: originalStats.width,
           height: originalStats.height,
           sizeBytes: originalStats.sizeBytes,
-          filename:
-            mediaKind === "image"
-              ? toRecordFilename(savedOriginal.path, attachmentMetadata?.name)
-              : attachmentMetadata?.name?.trim() || label,
+          filename: toRecordFilename(
+            savedOriginal.path,
+            attachmentMetadata?.name,
+            mediaKind === "image" ? undefined : label,
+          ),
         },
       };
       let playback: "native" | "transcode" | undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users generating images, music, or videos would lose attachment names, media types, durations, and image/video dimensions when the generated file was attached to the assistant's reply.

## Why This Change Was Made

Generated-media tools already produce authoritative attachment descriptors, but the private media extractor and pending-media queue previously retained only their URLs. Keep the original descriptors aligned with URL deduplication and filtering at that producer boundary so the existing reply and gateway display owners receive the same metadata already preserved for background-generated media. Provider-supplied trust markers and unknown attachment fields remain excluded; existing local-media trust and filtering policy is unchanged.

## User Impact

Generated audio and video retain their intended filenames and durations, generated videos retain their dimensions, and generated images retain their original attachment metadata across normal assistant-reply delivery.

## Evidence

- Reproduced the failure through the real embedded subscriber lifecycle for `image_generate`, `music_generate`, and `video_generate`: each tool produced complete attachment metadata, but the pending and delivered reply contained only its URL. All three production event chains now preserve the complete descriptor.
- Focused committed owner and production-boundary tests: **159 passed** across media extraction, tool completion, and full subscriber delivery.
- Independent owner/sibling verification: **244 passed**, including prior failed-delivery restoration, internal events, terminal lifecycle, URL filtering, duplicate metadata enrichment, and forged trust/unknown-field rejection.
- Fresh authenticated full committed Codex review: clean; secret scan clean.
- Production delta: **+33 lines**, justified by preserving the existing user-visible attachment contract through its canonical private extraction and queue owner. No public API, configuration, security-policy, or persistence changes.
