### PR TITLE
fix(sessions): prevent long histories from exhausting gateway memory

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
@@ -445,6 +445,13 @@ export async function prepareEmbeddedAttemptSessionManager(input: {
         ? SessionManager.open(
             attempt.sessionTarget as SessionTranscriptRuntimeTarget,
             input.effectiveCwd,
+            {
+              maxBytes: Math.min(
+                64 * 1024 * 1024,
+                Math.max(1024 * 1024, (attempt.contextTokenBudget ?? 128_000) * 8),
+              ),
+              maxEvents: 10_000,
+            },
           )
         : SessionManager.inMemory(input.effectiveCwd)),
     {

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-helpers.ts
@@ -1,8 +1,8 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveSessionStorePathCore } from "../../../config/sessions/paths.js";
 import {
+  findTranscriptEvent,
   loadSessionEntry,
-  loadTranscriptEvents,
   resolveSessionTranscriptRuntimeTarget,
   updateSessionEntry,
 } from "../../../config/sessions/session-accessor.js";
@@ -181,13 +181,12 @@ export async function resolveExistingAttemptTranscriptState(params: {
   let hasBootstrapTranscriptState = false;
   if (storePath && sessionKey) {
     try {
-      const sqliteEvents = await loadTranscriptEvents({
-        agentId,
-        sessionId,
-        sessionKey,
-        storePath,
-      });
-      hasBootstrapTranscriptState = sqliteEvents.some(isTranscriptMessageEvent);
+      hasBootstrapTranscriptState = Boolean(
+        await findTranscriptEvent(
+          { agentId, sessionId, sessionKey, storePath },
+          isTranscriptMessageEvent,
+        ),
+      );
     } catch {
       hasBootstrapTranscriptState = false;
     }

--- a/src/agents/sessions/session-manager-branching.ts
+++ b/src/agents/sessions/session-manager-branching.ts
@@ -102,6 +102,7 @@ export class SessionManagerBranching extends SessionManagerEntries {
   }
 
   async createBranchedSession(leafId: string): Promise<string | undefined> {
+    this.ensureCompletePersistedHistory();
     const previousSessionId = this.sessionId;
     const branchPath = this.collectBranchedSessionPath(leafId);
     if (branchPath.entries.length === 0) {

--- a/src/agents/sessions/session-manager-core.ts
+++ b/src/agents/sessions/session-manager-core.ts
@@ -1,5 +1,6 @@
 import {
   loadTranscriptEventsSync,
+  readSessionTranscriptBoundedActiveContextCore,
   replaceTranscriptEventsSync,
   type SessionTranscriptRuntimeTarget,
 } from "../../config/sessions/session-accessor.js";
@@ -23,6 +24,7 @@ import type {
 } from "./session-manager-types.js";
 
 export type SessionManagerPersistenceTarget = SessionTranscriptRuntimeTarget;
+export type SessionManagerBoundedContextLimits = { maxBytes: number; maxEvents: number };
 
 export class SessionManagerCore {
   migrated = false;
@@ -42,14 +44,25 @@ export class SessionManagerCore {
   protected pendingDeliberateAppend = false;
   protected persistenceTarget: SessionManagerPersistenceTarget | undefined;
   protected persistenceHeaderPending = false;
+  protected boundedContextLimits: SessionManagerBoundedContextLimits | undefined;
+  protected boundedContextTruncated = false;
+  protected persistedBoundaryCount: number | undefined;
 
   constructor(
     cwd: string,
     persistenceTarget?: SessionManagerPersistenceTarget,
     loadedEntries?: FileEntry[],
+    boundedContext?: {
+      boundaryCount: number;
+      limits: SessionManagerBoundedContextLimits;
+      truncated: boolean;
+    },
   ) {
     this.cwd = cwd;
     this.persistenceTarget = persistenceTarget;
+    this.boundedContextLimits = boundedContext?.limits;
+    this.boundedContextTruncated = boundedContext?.truncated ?? false;
+    this.persistedBoundaryCount = boundedContext?.boundaryCount;
     if (persistenceTarget || loadedEntries) {
       this.setLoadedSessionTarget(persistenceTarget, loadedEntries ?? []);
     } else {
@@ -58,7 +71,12 @@ export class SessionManagerCore {
   }
 
   setSessionTarget(target: SessionManagerPersistenceTarget): void {
-    const entries = loadTranscriptEventsSync(target) as FileEntry[];
+    const bounded = this.boundedContextLimits
+      ? readSessionTranscriptBoundedActiveContextCore(target, this.boundedContextLimits)
+      : undefined;
+    const entries = (bounded?.events ?? loadTranscriptEventsSync(target)) as FileEntry[];
+    this.boundedContextTruncated = bounded?.truncated ?? false;
+    this.persistedBoundaryCount = bounded?.boundaryCount;
     const header = entries.find(
       (entry) => typeof entry === "object" && entry !== null && entry.type === "session",
     );
@@ -105,6 +123,17 @@ export class SessionManagerCore {
       this.setSessionTarget(this.persistenceTarget);
       this.cwd = runtimeCwd;
     }
+  }
+
+  /** Whole-transcript rewrites and historical branch operations must never discard unloaded rows. */
+  protected ensureCompletePersistedHistory(): void {
+    if (!this.persistenceTarget || !this.boundedContextTruncated) {
+      return;
+    }
+    const limits = this.boundedContextLimits;
+    this.boundedContextLimits = undefined;
+    this.setSessionTarget(this.persistenceTarget);
+    this.boundedContextLimits = limits;
   }
 
   newSession(options?: NewSessionOptions): string | undefined {

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -216,6 +216,9 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     this.appendEntry(entry, {
       invalidateSerializedPrefixCache: fromHook === true || details !== undefined,
     });
+    if (this.persistedBoundaryCount !== undefined) {
+      this.persistedBoundaryCount += 1;
+    }
     return entry.id;
   }
 
@@ -229,6 +232,9 @@ export class SessionManagerEntries extends SessionManagerPersistence {
       ...(firstKeptEntryId ? { firstKeptEntryId } : {}),
     };
     this.appendEntry(entry);
+    if (this.persistedBoundaryCount !== undefined) {
+      this.persistedBoundaryCount += 1;
+    }
     return entry.id;
   }
 
@@ -393,8 +399,11 @@ export class SessionManagerEntries extends SessionManagerPersistence {
   }
 
   getBoundaryCount(): number {
-    return this.getBranch().filter((entry) => entry.type === "compaction" || entry.type === "reset")
-      .length;
+    return (
+      this.persistedBoundaryCount ??
+      this.getBranch().filter((entry) => entry.type === "compaction" || entry.type === "reset")
+        .length
+    );
   }
 
   getHeader(): SessionHeader | null {
@@ -446,6 +455,9 @@ export class SessionManagerEntries extends SessionManagerPersistence {
   }
 
   branch(branchFromId: string): void {
+    if (!this.byId.has(branchFromId)) {
+      this.ensureCompletePersistedHistory();
+    }
     const branchTargetId = this.resolveBranchTargetId(branchFromId);
     if (branchTargetId === undefined) {
       throw new Error(`Entry ${branchFromId} not found`);
@@ -469,6 +481,9 @@ export class SessionManagerEntries extends SessionManagerPersistence {
     details?: unknown,
     fromHook?: boolean,
   ): string {
+    if (branchFromId !== null && !this.byId.has(branchFromId)) {
+      this.ensureCompletePersistedHistory();
+    }
     const branchTargetId = branchFromId === null ? null : this.resolveBranchTargetId(branchFromId);
     if (branchTargetId === undefined) {
       throw new Error(`Entry ${branchFromId} not found`);

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -35,6 +35,7 @@ export class SessionManagerPersistence extends SessionManagerCore {
     predicate: (entry: SessionEntry) => boolean,
     options?: { preserveTrailing?: (entry: SessionEntry) => boolean },
   ): number {
+    this.ensureCompletePersistedHistory();
     let preservedStart = this.fileEntries.length;
     while (preservedStart > 1) {
       const entry = this.fileEntries[preservedStart - 1];

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -34,6 +34,43 @@ function openMarker(marker: string, sessionKey: string, cwd: string): SessionMan
 }
 
 describe("SessionManager.open", () => {
+  it("bounds runtime hydration while preserving older durable transcript rows on rewrites", async () => {
+    const dir = tempDirs.make("openclaw-session-manager-bounded-");
+    const storePath = path.join(dir, "sessions.json");
+    const scope = {
+      agentId: "main",
+      sessionId: "bounded-runtime-session",
+      sessionKey: "agent:main:bounded-runtime-session",
+      storePath,
+    };
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+    for (const content of ["oldest", "middle", "latest"]) {
+      await appendTranscriptMessage(scope, { cwd: dir, message: { role: "user", content } });
+    }
+
+    const manager = SessionManager.openBounded(scope, {
+      cwd: dir,
+      maxBytes: 4096,
+      maxEvents: 2,
+    });
+
+    expect(manager.buildSessionContext().messages).toMatchObject([
+      { content: "middle" },
+      { content: "latest" },
+    ]);
+    expect(manager.getEntries()).toHaveLength(2);
+    expect(
+      manager.removeTrailingEntries(
+        (entry) => entry.type === "message" && entry.message.content === "latest",
+      ),
+    ).toBe(1);
+    await expect(loadTranscriptEvents(scope)).resolves.toMatchObject([
+      { type: "session" },
+      { message: { content: "oldest" } },
+      { message: { content: "middle" } },
+    ]);
+  });
+
   it("opens SQLite markers without creating marker-named files and persists assistant replies", async () => {
     const dir = tempDirs.make("openclaw-session-manager-");
     const storePath = path.join(dir, "sessions.json");

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -7,13 +7,17 @@
 import {
   appendTranscriptMessageSync,
   loadTranscriptEventsSync,
+  readSessionTranscriptBoundedActiveContextCore,
   type SessionTranscriptRuntimeTarget,
 } from "../../config/sessions/session-accessor.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { Message } from "../../llm/types.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import { SessionManagerBranching } from "./session-manager-branching.js";
-import type { SessionManagerPersistenceTarget } from "./session-manager-core.js";
+import type {
+  SessionManagerBoundedContextLimits,
+  SessionManagerPersistenceTarget,
+} from "./session-manager-core.js";
 import type { AppendPersistenceOptions, FileEntry } from "./session-manager-types.js";
 
 export { CURRENT_SESSION_VERSION };
@@ -51,8 +55,13 @@ export class SessionManager extends SessionManagerBranching {
     cwd: string,
     persistenceTarget?: SessionManagerPersistenceTarget,
     loadedEntries?: FileEntry[],
+    boundedContext?: {
+      boundaryCount: number;
+      limits: SessionManagerBoundedContextLimits;
+      truncated: boolean;
+    },
   ) {
-    super(cwd, persistenceTarget, loadedEntries);
+    super(cwd, persistenceTarget, loadedEntries, boundedContext);
   }
 
   /** Makes pending append-oriented persistence durable without rewriting committed entries. */
@@ -75,12 +84,41 @@ export class SessionManager extends SessionManagerBranching {
     return super.appendMessageWithTranscriptAnchor(message, options);
   }
 
-  static open(target: SessionTranscriptRuntimeTarget, cwdOverride?: string): SessionManager {
+  static open(
+    target: SessionTranscriptRuntimeTarget,
+    cwdOverride?: string,
+    contextLimits?: SessionManagerBoundedContextLimits,
+  ): SessionManager {
+    if (contextLimits) {
+      return SessionManager.openBounded(target, {
+        ...contextLimits,
+        ...(cwdOverride !== undefined ? { cwd: cwdOverride } : {}),
+      });
+    }
     const entries = loadTranscriptEventsSync(target) as FileEntry[];
     const header = entries.find(
       (entry) => typeof entry === "object" && entry !== null && entry.type === "session",
     );
     return new SessionManager(cwdOverride ?? header?.cwd ?? process.cwd(), target, entries);
+  }
+
+  /** Opens only the selected model-context tail while preserving the complete durable transcript. */
+  static openBounded(
+    target: SessionTranscriptRuntimeTarget,
+    options: SessionManagerBoundedContextLimits & { cwd?: string },
+  ): SessionManager {
+    const { cwd, ...limits } = options;
+    const context = readSessionTranscriptBoundedActiveContextCore(target, limits);
+    // SAFETY: bounded context rows use the same persisted transcript codec as the full open path.
+    const entries = context.events as FileEntry[];
+    const header = entries.find(
+      (entry) => typeof entry === "object" && entry !== null && entry.type === "session",
+    );
+    return new SessionManager(cwd ?? header?.cwd ?? process.cwd(), target, entries, {
+      boundaryCount: context.boundaryCount,
+      limits,
+      truncated: context.truncated,
+    });
   }
 
   /** Appends to the current transcript leaf without hydrating its history. */

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -13,6 +13,7 @@ import {
   readRecentSessionTranscriptMessageEvents,
   readSessionTranscriptActivePathEntryRelation,
   readSessionTranscriptActiveStats,
+  readSessionTranscriptBoundedActiveContextCore,
   readSessionTranscriptBoundedMessageTailPage,
   readSessionTranscriptMessageAnchorPage,
   readSessionTranscriptMessageEventById,
@@ -380,6 +381,68 @@ describe("SQLite active transcript event projection", () => {
     expect(page.scannedMessages).toBe(2);
     expect(page.serializedBytes).toBeLessThanOrEqual(512);
     expect(page.events.map(({ event }) => (event as { id?: unknown }).id)).toEqual(["small"]);
+  });
+
+  it("reads only the newest bounded active context while retaining its transcript header", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        { eventId: "old", parentId: null, message: { role: "user", content: "old" } },
+        { eventId: "middle", parentId: "old", message: { role: "assistant", content: "middle" } },
+        { eventId: "new", parentId: "middle", message: { role: "user", content: "new" } },
+      ],
+      touchSessionEntry: false,
+    });
+
+    const context = readSessionTranscriptBoundedActiveContextCore(scope, {
+      maxBytes: 1024,
+      maxEvents: 2,
+    });
+
+    expect(context.events.map((event) => (event as { id?: string }).id)).toEqual([
+      scope.sessionId,
+      "middle",
+      "new",
+    ]);
+    expect(context.activeLeafEntryId).toBe("new");
+    expect(context.totalEvents).toBe(3);
+    expect(context.truncated).toBe(true);
+    expect(context.serializedBytes).toBeLessThanOrEqual(1024);
+  });
+
+  it("retains the latest compaction summary when an active context tail is truncated", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [{ eventId: "old", parentId: null, message: { role: "user", content: "old" } }],
+      touchSessionEntry: false,
+    });
+    await appendTranscriptEvent(scope, {
+      type: "compaction",
+      id: "summary",
+      parentId: "old",
+      timestamp: "2026-08-24T00:00:00.000Z",
+      summary: "earlier work",
+      firstKeptEntryId: "old",
+      tokensBefore: 100,
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        { eventId: "middle", parentId: "summary", message: { role: "user", content: "middle" } },
+        { eventId: "new", parentId: "middle", message: { role: "assistant", content: "new" } },
+      ],
+      touchSessionEntry: false,
+    });
+
+    const context = readSessionTranscriptBoundedActiveContextCore(scope, {
+      maxBytes: 2048,
+      maxEvents: 1,
+    });
+
+    expect(context.events.map((event) => (event as { id?: string }).id)).toEqual([
+      scope.sessionId,
+      "summary",
+      "new",
+    ]);
+    expect(context.events.at(-1)).toMatchObject({ parentId: "summary" });
+    expect(context.boundaryCount).toBe(1);
   });
 
   it("fails fast and schedules maintenance when out-of-band state is dirty", async () => {
@@ -980,6 +1043,10 @@ describe("SQLite active transcript event projection", () => {
       maxLines: 3,
       maxMessages: 10,
     });
+    const boundedContext = readSessionTranscriptBoundedActiveContextCore(scope, {
+      maxBytes: 1024 * 1024,
+      maxEvents: 25,
+    });
     const byId = readSessionTranscriptMessageEventById(scope, "m100000");
     const anchor = readSessionTranscriptMessageAnchorPage(scope, {
       maxMessages: 5,
@@ -991,6 +1058,9 @@ describe("SQLite active transcript event projection", () => {
       Array.from({ length: 25 }, (_, index) => 99_976 + index),
     );
     expect(recent.totalMessages).toBe(100_000);
+    expect(boundedContext.totalEvents).toBe(100_000);
+    expect(boundedContext.events).toHaveLength(26);
+    expect(boundedContext.events.at(-1)).toMatchObject({ id: "m100000" });
     expect(recent.events).toHaveLength(10);
     expect(recent.events.at(-1)?.seq).toBe(100_000);
     expect(lineCappedRecent.events).toHaveLength(3);

--- a/src/config/sessions/session-accessor.sqlite-active-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.ts
@@ -67,6 +67,15 @@ export type SessionTranscriptBoundedMessageTailPage = SessionTranscriptMessageEv
   };
 };
 
+export type SessionTranscriptBoundedActiveContext = {
+  activeLeafEntryId: string | null;
+  boundaryCount: number;
+  events: TranscriptEvent[];
+  serializedBytes: number;
+  totalEvents: number;
+  truncated: boolean;
+};
+
 function parseMessageEventRow(row: {
   event_json: string;
   message_position: number | null;
@@ -147,6 +156,159 @@ export function readRecentSessionTranscriptActiveEvents(
     )
       .rows.toReversed()
       .map((row) => JSON.parse(row.event_json) as TranscriptEvent);
+  });
+}
+
+/** Reads one byte-bounded active branch without materializing abandoned transcript history. */
+export function readSessionTranscriptBoundedActiveContextCore(
+  scope: SessionTranscriptReadScope,
+  options: { maxBytes: number; maxEvents: number },
+): SessionTranscriptBoundedActiveContext {
+  const maxBytes = normalizeVisibleMessageLimit(
+    options.maxBytes,
+    DEFAULT_VISIBLE_MESSAGE_MAX_BYTES,
+    MAX_VISIBLE_MESSAGE_MAX_BYTES,
+    "maxBytes",
+  );
+  const maxEvents = normalizeVisibleMessageLimit(
+    options.maxEvents,
+    DEFAULT_VISIBLE_MESSAGE_MAX_MESSAGES,
+    MAX_VISIBLE_MESSAGE_MAX_MESSAGES,
+    "maxEvents",
+  );
+  return withCurrentProjectionSnapshot(scope, (projection) => {
+    const db = getActiveTranscriptKysely(projection.database);
+    const fence = resolveSqliteSessionTranscriptReadFence({
+      database: projection.database,
+      ...projection.resolved,
+    });
+    const header = executeSqliteQueryTakeFirstSync(
+      projection.database.db,
+      db
+        .selectFrom("transcript_events")
+        .select("event_json")
+        .where("session_id", "=", projection.resolved.sessionId)
+        .orderBy("seq", "asc")
+        .limit(1),
+    );
+    const metadata = executeSqliteQuerySync(
+      projection.database.db,
+      db
+        .selectFrom("session_transcript_active_events as active")
+        .innerJoin("transcript_events as event", (join) =>
+          join
+            .onRef("event.session_id", "=", "active.session_id")
+            .onRef("event.seq", "=", "active.event_seq"),
+        )
+        .select([
+          "active.active_position",
+          "active.event_seq",
+          /* kysely-allow-raw: inspect payload size before materializing bounded context rows. */
+          sql<number>`LENGTH(CAST(event.event_json AS BLOB)) + 1`.as("serialized_bytes"),
+        ])
+        .where("active.session_id", "=", projection.resolved.sessionId)
+        .$if(fence !== undefined, (query) =>
+          query.where("active.event_seq", "<", fence!.beforeRawSeq),
+        )
+        .orderBy("active.active_position", "desc")
+        .limit(maxEvents + 1),
+    ).rows;
+    const selectedSequences: number[] = [];
+    let serializedBytes = 0;
+    for (const row of metadata) {
+      if (
+        selectedSequences.length >= maxEvents ||
+        serializedBytes + row.serialized_bytes > maxBytes
+      ) {
+        break;
+      }
+      selectedSequences.push(row.event_seq);
+      serializedBytes += row.serialized_bytes;
+    }
+    const selectedRows =
+      selectedSequences.length === 0
+        ? []
+        : executeSqliteQuerySync(
+            projection.database.db,
+            db
+              .selectFrom("transcript_events")
+              .select(["event_json", "seq"])
+              .where("session_id", "=", projection.resolved.sessionId)
+              .where("seq", "in", selectedSequences)
+              .orderBy("seq", "asc"),
+          ).rows;
+    const boundary = executeSqliteQueryTakeFirstSync(
+      projection.database.db,
+      db
+        .selectFrom("transcript_event_identities as identity")
+        .innerJoin("session_transcript_active_events as active", (join) =>
+          join
+            .onRef("active.session_id", "=", "identity.session_id")
+            .onRef("active.event_seq", "=", "identity.seq"),
+        )
+        .innerJoin("transcript_events as event", (join) =>
+          join
+            .onRef("event.session_id", "=", "identity.session_id")
+            .onRef("event.seq", "=", "identity.seq"),
+        )
+        .select(["event.event_json", "identity.seq"])
+        .where("identity.session_id", "=", projection.resolved.sessionId)
+        .where("identity.event_type", "in", ["compaction", "reset"])
+        .$if(fence !== undefined, (query) => query.where("identity.seq", "<", fence!.beforeRawSeq))
+        .orderBy("active.active_position", "desc")
+        .limit(1),
+    );
+    const boundaryCount = executeSqliteQueryTakeFirstSync(
+      projection.database.db,
+      db
+        .selectFrom("transcript_event_identities as identity")
+        .innerJoin("session_transcript_active_events as active", (join) =>
+          join
+            .onRef("active.session_id", "=", "identity.session_id")
+            .onRef("active.event_seq", "=", "identity.seq"),
+        )
+        .select((eb) => eb.fn.count<number>("identity.seq").as("boundary_count"))
+        .where("identity.session_id", "=", projection.resolved.sessionId)
+        .where("identity.event_type", "in", ["compaction", "reset"])
+        .$if(fence !== undefined, (query) => query.where("identity.seq", "<", fence!.beforeRawSeq)),
+    )?.boundary_count;
+    const events: TranscriptEvent[] = header ? [JSON.parse(header.event_json)] : [];
+    let injectedBoundary: { id?: unknown } | undefined;
+    if (boundary && !selectedSequences.includes(boundary.seq)) {
+      const boundaryBytes = Buffer.byteLength(boundary.event_json, "utf8") + 1;
+      if (serializedBytes + boundaryBytes <= maxBytes) {
+        const event: TranscriptEvent = JSON.parse(boundary.event_json);
+        events.push(event);
+        if (event !== null && typeof event === "object" && "id" in event) {
+          injectedBoundary = event;
+        }
+        serializedBytes += boundaryBytes;
+      }
+    }
+    events.push(
+      ...selectedRows.map((row, index) => {
+        const event: TranscriptEvent = JSON.parse(row.event_json);
+        if (
+          index === 0 &&
+          typeof injectedBoundary?.id === "string" &&
+          event !== null &&
+          typeof event === "object" &&
+          "parentId" in event &&
+          event.parentId !== injectedBoundary.id
+        ) {
+          return { ...event, parentId: injectedBoundary.id };
+        }
+        return event;
+      }),
+    );
+    return {
+      activeLeafEntryId: projection.state.leafEventId,
+      boundaryCount: boundaryCount ?? 0,
+      events,
+      serializedBytes,
+      totalEvents: projection.state.activeEventCount,
+      truncated: metadata.length > selectedSequences.length,
+    };
   });
 }
 

--- a/src/config/sessions/session-accessor.transcript.ts
+++ b/src/config/sessions/session-accessor.transcript.ts
@@ -74,13 +74,13 @@ export async function preflightSessionTranscriptForManualCompact(
   scope: SessionTranscriptRuntimeScope,
   params: { maxLines: number; sessionFile?: string },
 ): Promise<SessionTranscriptManualTrimPreflightResult> {
-  const events = await loadTranscriptEvents(scope);
-  if (events.length === 0) {
+  const eventCount = readTranscriptStatsSync(scope).eventCount;
+  if (eventCount === 0) {
     return { compacted: false, reason: "no transcript" };
   }
 
   const maxLines = Math.max(1, Math.floor(params.maxLines));
-  return events.length > maxLines ? { compacted: true } : { compacted: false, kept: events.length };
+  return eventCount > maxLines ? { compacted: true } : { compacted: false, kept: eventCount };
 }
 
 export async function trimSessionTranscriptForManualCompact(

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -264,6 +264,7 @@ export {
 export { readActiveTranscriptEntryAnchor } from "./session-accessor.sqlite-transcript-anchor.js";
 export {
   isSessionTranscriptProjectionUnavailableError,
+  readSessionTranscriptBoundedActiveContextCore,
   readRecentSessionTranscriptActiveEvents,
   readSessionTranscriptActiveStats,
   readSessionTranscriptBoundedMessageTailPage,
@@ -283,6 +284,7 @@ export {
   type SessionTranscriptTitleProbe,
 } from "./session-accessor.sqlite-title-probes.js";
 export type {
+  SessionTranscriptBoundedActiveContext,
   SessionTranscriptBoundedMessageTailPage,
   SessionTranscriptMessageAnchorPage,
   SessionTranscriptMessageEvent,

--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -16,8 +16,8 @@ import {
 } from "../../config/sessions.js";
 import {
   applySessionPatchProjection,
-  loadTranscriptEvents,
   preflightSessionTranscriptForManualCompact,
+  readTranscriptStatsSync,
   trimSessionTranscriptForManualCompact,
 } from "../../config/sessions/session-accessor.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -149,13 +149,13 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
         return;
       }
     } else {
-      const transcriptEvents = await loadTranscriptEvents({
+      const transcriptStats = readTranscriptStatsSync({
         agentId: target.agentId,
         sessionId,
         sessionKey: compactTarget.primaryKey,
         storePath,
       });
-      if (transcriptEvents.length === 0) {
+      if (transcriptStats.eventCount === 0) {
         respond(
           true,
           {
@@ -350,13 +350,13 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
             return;
           }
 
-          const transcriptEvents = await loadTranscriptEvents({
+          const transcriptStats = readTranscriptStatsSync({
             agentId: target.agentId,
             sessionId,
             sessionKey: compactTarget.primaryKey,
             storePath,
           });
-          if (transcriptEvents.length === 0) {
+          if (transcriptStats.eventCount === 0) {
             respond(
               true,
               {

--- a/src/plugin-sdk/session-transcript-runtime.read-fence.test.ts
+++ b/src/plugin-sdk/session-transcript-runtime.read-fence.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   appendSessionTranscriptMessageByIdentity,
   readLatestAssistantTextByIdentity,
+  readSessionTranscriptBoundedActiveContext,
   readSessionTranscriptEvents,
   readSessionTranscriptRawDelta,
   readVisibleSessionTranscriptMessageEntries,
@@ -70,12 +71,17 @@ describe("session transcript runtime read fence", () => {
       const events = await readSessionTranscriptEvents(scope);
       const visible = await readVisibleSessionTranscriptMessageEntries(scope);
       const latest = await readLatestAssistantTextByIdentity(scope);
+      const bounded = readSessionTranscriptBoundedActiveContext({
+        ...scope,
+        maxBytes: 100_000,
+        maxEvents: 100,
+      });
       const page = await readSessionTranscriptRawDelta({
         ...scope,
         maxBytes: 100_000,
         maxEvents: 100,
       });
-      return { events, latest, page, visible };
+      return { bounded, events, latest, page, visible };
     });
 
     expect(
@@ -94,6 +100,17 @@ describe("session transcript runtime read fence", () => {
       priorAssistant.messageId,
     ]);
     expect(fenced.latest).toMatchObject({ id: priorAssistant.messageId, text: "prior answer" });
+    expect(
+      fenced.bounded.events.flatMap((event) =>
+        event &&
+        typeof event === "object" &&
+        "type" in event &&
+        event.type === "message" &&
+        "id" in event
+          ? [event.id]
+          : [],
+      ),
+    ).toEqual([priorUser.messageId, priorAssistant.messageId]);
     expect(fenced.page).toMatchObject({ kind: "page", hasMore: false });
     if (fenced.page.kind !== "page") {
       throw new Error("expected fenced raw transcript page");

--- a/src/plugin-sdk/session-transcript-runtime.ts
+++ b/src/plugin-sdk/session-transcript-runtime.ts
@@ -9,6 +9,7 @@ import {
   loadTranscriptEvents,
   publishTranscriptUpdate,
   persistSessionTranscriptTurn,
+  readSessionTranscriptBoundedActiveContextCore as readBoundedActiveContext,
   readTranscriptRawDelta,
   readSessionTranscriptVisibleMessageDeltaCore as readVisibleMessageDelta,
   readLatestTranscriptAssistantText,
@@ -19,6 +20,7 @@ import {
   type TranscriptUpdatePayload,
   type SessionTranscriptRawDeltaLimits,
   type SessionTranscriptRawDeltaResult,
+  type SessionTranscriptBoundedActiveContext,
   type SessionTranscriptVisibleMessageDeltaLimits,
 } from "../config/sessions/session-accessor.js";
 import { resolveMirroredTranscriptText } from "../config/sessions/transcript-mirror.js";
@@ -213,6 +215,14 @@ export async function readSessionTranscriptEvents(
   params: SessionTranscriptTargetParams,
 ): Promise<SessionTranscriptEvent[]> {
   return await loadTranscriptEvents(params);
+}
+
+/** Reads the selected transcript branch under explicit event and serialized-byte limits. */
+export function readSessionTranscriptBoundedActiveContext(
+  params: SessionTranscriptTargetParams & { maxBytes: number; maxEvents: number },
+): SessionTranscriptBoundedActiveContext {
+  const { maxBytes, maxEvents, ...target } = params;
+  return readBoundedActiveContext(target, { maxBytes, maxEvents });
 }
 
 /** Reads one bounded raw page; the opaque cursor survives append and resets after replacement. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users continuing long-lived sessions could experience slow requests or gateway out-of-memory crashes when their persisted conversation history becomes large.

## Why This Change Was Made

Normal requests now hydrate only the active transcript context needed for the current model budget, while retaining complete history in SQLite. Existence/count checks use storage-level metadata, and bounded active-context reads preserve compaction summaries, active branches, admission fences, and safe full-history behavior before destructive historical rewrites.

## User Impact

Users can keep long-running conversation histories without normal gateway request memory growing indefinitely with total historical transcript size. Older persisted messages remain available.

## Evidence

- 242 focused tests pass across seven session-storage, plugin SDK, SessionManager, and embedded-runner test files.
- Regression coverage includes a 100,000-message transcript, compaction boundaries, admission fences, and non-destructive historical rewrites.
- Formatting, assertion-safety ratchet, wrapper-shadowing, SDK boundaries, and mandatory security autoreview pass.
- Full-workspace TypeScript checking currently encounters the same unrelated shared-dependency errors on an untouched upstream `main` checkout.

Stack: foundation for the separately reviewed Codex mirrored-session context change.
