### PR TITLE
fix(codex): prevent long sessions from exhausting gateway memory

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -83,6 +83,7 @@ type CodexWorkspaceBootstrapContext = CodexBootstrapContext & {
 /** Reads mirrored Codex session history for harness hooks. */
 export async function readMirroredSessionHistoryMessages(params: {
   agentId?: string;
+  contextTokenBudget?: number;
   sessionFile: string;
   sessionId: string;
   sessionKey?: string;

--- a/extensions/codex/src/app-server/run-attempt-context.ts
+++ b/extensions/codex/src/app-server/run-attempt-context.ts
@@ -65,6 +65,9 @@ export async function prepareCodexAttemptContext(
   const { toolBridge } = attemptTools;
   const activeTranscriptTarget = {
     agentId: sessionAgentId,
+    ...(effectiveContextTokenBudget !== undefined
+      ? { contextTokenBudget: effectiveContextTokenBudget }
+      : {}),
     sessionFile: activeSessionFile,
     sessionId: activeSessionId,
     sessionKey: contextSessionKey,

--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -236,6 +236,39 @@ describe("readCodexMirroredSessionHistoryMessages", () => {
     ]);
   });
 
+  it("loads only the byte-bounded recent context from a large persisted SQLite transcript", async () => {
+    const { marker, sessionKey, sessionTarget } = await writeSqliteSession();
+    for (let index = 0; index < 8; index += 1) {
+      await appendSessionTranscriptMessageByIdentity({
+        ...sessionTarget,
+        message: {
+          role: "user",
+          content: `${index}:${"x".repeat(180_000)}`,
+          timestamp: index + 3,
+        },
+      });
+    }
+
+    const messages = await readCodexMirroredSessionHistoryMessages({
+      agentId: "main",
+      contextTokenBudget: 1,
+      sessionFile: marker,
+      sessionId: sessionTarget.sessionId,
+      sessionKey,
+      sessionTarget,
+    });
+
+    expect(messages).toBeDefined();
+    expect(messages?.length).toBeLessThan(8);
+    expect(messages?.at(-1)).toMatchObject({
+      role: "user",
+      content: expect.stringMatching(/^7:/),
+    });
+    expect(messages).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ content: "sqlite prompt" })]),
+    );
+  });
+
   it.each([
     ["agent id", { agentId: "other" }],
     ["session id", { sessionId: "another-session" }],

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -10,7 +10,7 @@ import {
   migrateSessionEntries,
   parseSessionEntries,
 } from "openclaw/plugin-sdk/agent-sessions";
-import { readCodexSessionTranscriptEventsBeforeAdmission } from "openclaw/plugin-sdk/codex-session-transcript-runtime";
+import { readCodexSessionTranscriptBoundedContextBeforeAdmission } from "openclaw/plugin-sdk/codex-session-transcript-runtime";
 import {
   getSessionEntry,
   parseSqliteSessionFileMarker,
@@ -18,7 +18,7 @@ import {
   type SqliteSessionFileMarker,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import {
-  readSessionTranscriptEvents,
+  readSessionTranscriptBoundedActiveContext,
   type TranscriptTurnAdmission,
   type SessionTranscriptTargetParams,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
@@ -30,11 +30,46 @@ function isMissingFileError(error: unknown): boolean {
 
 export type CodexMirroredSessionHistoryTarget = {
   agentId?: string;
+  contextTokenBudget?: number;
   sessionFile: string;
   sessionId: string;
   sessionKey?: string;
   sessionTarget?: Partial<SessionTranscriptTargetParams>;
 };
+
+const DEFAULT_CODEX_HISTORY_CONTEXT_TOKENS = 128_000;
+const MAX_CODEX_HISTORY_CONTEXT_BYTES = 64 * 1024 * 1024;
+const MAX_CODEX_HISTORY_CONTEXT_EVENTS = 10_000;
+
+function resolveCodexHistoryContextLimits(target: CodexMirroredSessionHistoryTarget): {
+  maxBytes: number;
+  maxEvents: number;
+} {
+  const tokenBudget =
+    typeof target.contextTokenBudget === "number" &&
+    Number.isFinite(target.contextTokenBudget) &&
+    target.contextTokenBudget > 0
+      ? Math.floor(target.contextTokenBudget)
+      : DEFAULT_CODEX_HISTORY_CONTEXT_TOKENS;
+  return {
+    maxBytes: Math.min(MAX_CODEX_HISTORY_CONTEXT_BYTES, Math.max(1024 * 1024, tokenBudget * 8)),
+    maxEvents: MAX_CODEX_HISTORY_CONTEXT_EVENTS,
+  };
+}
+
+async function readBoundedCodexSessionEntries(
+  target: SessionTranscriptTargetParams,
+  limits: { maxBytes: number; maxEvents: number },
+  admission?: TranscriptTurnAdmission,
+): Promise<unknown[]> {
+  const context = admission
+    ? await readCodexSessionTranscriptBoundedContextBeforeAdmission(
+        { ...target, ...limits },
+        admission,
+      )
+    : readSessionTranscriptBoundedActiveContext({ ...target, ...limits });
+  return context.events;
+}
 
 /** Returns sanitized session-context messages for a Codex mirrored session file. */
 export async function readCodexMirroredSessionHistoryMessages(
@@ -89,6 +124,7 @@ async function readCodexMirroredSessionEntries(
   target: CodexMirroredSessionHistoryTarget,
   admission?: TranscriptTurnAdmission,
 ): Promise<SessionEntry[]> {
+  const limits = resolveCodexHistoryContextLimits(target);
   if (target.sessionTarget) {
     const { agentId, sessionId, sessionKey, storePath } = target.sessionTarget;
     if (
@@ -108,9 +144,11 @@ async function readCodexMirroredSessionEntries(
       sessionKey,
       storePath,
     };
-    return (await (admission
-      ? readCodexSessionTranscriptEventsBeforeAdmission(transcriptTarget, admission)
-      : readSessionTranscriptEvents(transcriptTarget))) as SessionEntry[];
+    return (await readBoundedCodexSessionEntries(
+      transcriptTarget,
+      limits,
+      admission,
+    )) as SessionEntry[];
   }
   const sqliteMarker = parseSqliteSessionFileMarker(target.sessionFile);
   if (sqliteMarker) {
@@ -130,9 +168,11 @@ async function readCodexMirroredSessionEntries(
       sessionKey,
       storePath: sqliteMarker.storePath,
     };
-    return (await (admission
-      ? readCodexSessionTranscriptEventsBeforeAdmission(transcriptTarget, admission)
-      : readSessionTranscriptEvents(transcriptTarget))) as SessionEntry[];
+    return (await readBoundedCodexSessionEntries(
+      transcriptTarget,
+      limits,
+      admission,
+    )) as SessionEntry[];
   }
   if (admission) {
     if (
@@ -142,13 +182,14 @@ async function readCodexMirroredSessionEntries(
     ) {
       return [];
     }
-    return (await readCodexSessionTranscriptEventsBeforeAdmission(
+    return (await readBoundedCodexSessionEntries(
       {
         agentId: admission.agentId,
         sessionId: admission.sessionId,
         sessionKey: admission.sessionKey,
         storePath: admission.storePath,
       },
+      limits,
       admission,
     )) as SessionEntry[];
   }

--- a/src/plugin-sdk/codex-session-transcript-runtime.ts
+++ b/src/plugin-sdk/codex-session-transcript-runtime.ts
@@ -19,6 +19,7 @@ import {
 } from "./session-transcript-lock-runtime.js";
 import {
   publishSessionTranscriptUpdateByIdentity,
+  readSessionTranscriptBoundedActiveContext,
   readSessionTranscriptEvents,
   resolveSessionTranscriptIdentity,
   type SessionTranscriptTargetParams,
@@ -42,6 +43,26 @@ export async function readCodexSessionTranscriptEventsBeforeAdmission(
   return await runWithSessionTranscriptReadFence(
     admission,
     async () => await readSessionTranscriptEvents(params),
+  );
+}
+
+/** Reads one bounded Codex context strictly before the admitted current user message. */
+export async function readCodexSessionTranscriptBoundedContextBeforeAdmission(
+  params: SessionTranscriptTargetParams & { maxBytes: number; maxEvents: number },
+  admission: TranscriptTurnAdmission,
+) {
+  const target = await resolveSessionTranscriptIdentity(params);
+  if (
+    target.agentId !== admission.agentId ||
+    target.sessionId !== admission.sessionId ||
+    target.sessionKey !== admission.sessionKey
+  ) {
+    throw new SessionTranscriptReadFenceError(
+      "Current-turn transcript admission belongs to a different transcript target",
+    );
+  }
+  return runWithSessionTranscriptReadFence(admission, () =>
+    readSessionTranscriptBoundedActiveContext(params),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users continuing long-lived Codex-backed sessions could experience gateway out-of-memory crashes when mirrored transcript history becomes large.

## Why This Change Was Made

Codex mirrored-session reads now reuse the bounded active-context storage API from the parent pull request. The effective model context budget determines how much current context is loaded while preserving compaction summaries, active branches, admission fences, images, provenance, and complete persisted history.

This matches the Codex source contracts in `codex-rs/app-server-protocol/src/protocol/v2/thread.rs` (resume by thread ID) and `codex-rs/core/src/agent/control/spawn.rs` (bounded/latest model-context reconstruction).

## User Impact

Users can continue Codex-backed sessions without each normal request converting the entire stored conversation into JavaScript objects. Historical messages remain stored in SQLite.

## Evidence

- 246 focused tests pass across eight Codex app-server and transcript-mirror test files.
- A persisted SQLite regression test verifies that older messages remain stored but are excluded from the bounded current context.
- Formatting, assertion-safety ratchet, wrapper-shadowing, and mandatory security autoreview pass.
- Full-workspace TypeScript checking currently encounters the same unrelated shared-dependency errors on an untouched upstream `main` checkout.

Stack: based on `codex/bounded-transcript-core`; review this pull request as the Codex-specific follow-up only.
