### PR TITLE
fix(codex): turns using dotted MCP tool names end muted with no reply

### DIFF
--- a/extensions/codex/src/app-server/settled-turn-projection.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.test.ts
@@ -88,6 +88,44 @@ describe("projectSettledCodexMessages", () => {
     ]);
   });
 
+  it("projects dotted namespaced tool names recorded from Codex MCP calls", () => {
+    const name = "codex_apps.slack.slack_send";
+    expect(
+      projectSettledCodexMessages([
+        message({
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call-1", name, arguments: { channel: "C1" } }],
+        }),
+        message({
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: name,
+          content: [{ type: "text", text: "Sent." }],
+        }),
+      ]),
+    ).toEqual([
+      { type: "function_call", call_id: "call-1", name, arguments: '{"channel":"C1"}' },
+      { type: "function_call_output", call_id: "call-1", output: "Sent." },
+    ]);
+  });
+
+  it("rejects tool names outside the projectable charset and names the offender", () => {
+    expect(() =>
+      projectSettledCodexMessages([
+        message({
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call-1", name: "bad tool", arguments: {} }],
+        }),
+        message({
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "bad tool",
+          content: [{ type: "text", text: "failed" }],
+        }),
+      ]),
+    ).toThrow("invalid tool name: bad tool");
+  });
+
   it("preserves failed tool-result status in the projected output", () => {
     expect(
       projectSettledCodexMessages([

--- a/extensions/codex/src/app-server/settled-turn-projection.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.ts
@@ -7,7 +7,12 @@ import { readUpstreamUserText } from "./upstream-prompt-provenance.js";
 const MAX_RESPONSE_ITEMS = 200;
 const MAX_PROJECTION_BYTES = 512 * 1024;
 const MAX_TEXT_BYTES = 64 * 1024;
-const TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/u;
+// Projected names replay as function_call history items, which Codex
+// thread/inject_items deserializes as free-form strings (ResponseItem::FunctionCall).
+// Codex records MCP and connector calls under dotted namespaced ids
+// ("codex_apps.slack.slack_send"), so "." must stay projectable or any turn
+// that used such a tool can never finalize.
+const TOOL_NAME_PATTERN = /^[a-zA-Z0-9._-]{1,128}$/u;
 const TOOL_ERROR_STATUS_PREFIX = "[Tool result status: error]\n";
 
 type ProjectedToolReference = { id: string; name: string };
@@ -55,7 +60,9 @@ function requireCallId(value: unknown): string {
 function requireToolName(value: unknown): string {
   const name = normalizeOptionalString(value);
   if (!name || !TOOL_NAME_PATTERN.test(name)) {
-    throw new Error("Codex settled-turn projection found an invalid tool name");
+    throw new Error(
+      `Codex settled-turn projection found an invalid tool name${name ? `: ${name.slice(0, 64)}` : ""}`,
+    );
   }
   return name;
 }


### PR DESCRIPTION
Closes #128899

## What Problem This Solves

Fixes an issue where users messaging a Codex-harness agent would get **no reply and no error notice** when the turn had called a natively namespaced MCP/connector tool (Codex records these under dotted ids such as `codex_apps.slack.slack_send`) and settled without assistant text. Isolated settled-turn finalization rejected the recorded tool name, the harness error has no embedded fallback, and the run ended `errored` + `mute` — the worst-class silent failure.

## Why This Change Was Made

The settled-turn projection validated recorded tool names with `/^[a-zA-Z0-9_-]{1,128}$/`, a charset that only constrains *registering* function tools — not replayed history. The projection's own producer (`event-projector-items.ts` `itemName()`) records native MCP calls as `server.tool`, so the validator rejected the projection's own recorded transcript and finalization could never succeed for such turns, including on retry.

Dots are legal where these names actually go: `thread/inject_items` deserializes each item as `ResponseItem` (codex-rs `app-server/src/request_processors/turn_processor.rs:863`) whose `FunctionCall.name` is an unrestricted `String` (codex-rs `protocol/src/models.rs:1012`; namespaced ids are first-class in `protocol/src/tool_name.rs`), and the Responses API round-trips these names in-thread. The fix admits `.` in the projection pattern and keeps the rest of the fail-closed posture unchanged. The rejection error now names the offending tool (bounded to 64 chars) so any remaining charset gap is diagnosable from logs instead of requiring transcript-store forensics.

Persisted transcripts already containing dotted names finalize correctly with no migration, and OpenClaw-registered dynamic tools are unaffected (validated dot-free at registration, `dynamic-tools.ts`).

## User Impact

Agents that use Codex connector/MCP tools (e.g. `codex_apps.*`) now deliver their reply instead of going silent when a turn needs isolated finalization. No config change required; existing sessions benefit immediately.

## Evidence

Production failure chain this reproduces (Slack channel, `openai/gpt-5.6-sol`):

```
WARN  settled post-tool turn lacked a final answer: ... — running isolated finalization
WARN  Codex agent harness failed; not falling back to embedded OpenClaw backend
      {harnessId: codex, error: 'Codex settled-turn projection found an invalid tool name'}
WARN  settled-turn finalization failed closed
INFO  recorded message-tool-only run outcome {outcome: 'mute', runStatus: 'errored'}
```

Regression test fails on pre-fix code with the production error, passes post-fix:

```
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/settled-turn-projection.test.ts   # with src change reverted
FAIL  settled-turn-projection.test.ts > projects dotted namespaced tool names recorded from Codex MCP calls
Error: Codex settled-turn projection found an invalid tool name
 ❯ requireToolName extensions/codex/src/app-server/settled-turn-projection.ts:58:11
Tests  2 failed | 19 passed (21)
```

Post-fix, full projection suite:

```
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/settled-turn-projection.test.ts
Tests  21 passed (21)
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/settled-turn-finalizer.test.ts extensions/codex/src/app-server/settled-turn-context.test.ts
Tests  31 passed (31)
```

Checks:

```
$ node scripts/check-changed.mjs -- extensions/codex/src/app-server/settled-turn-projection.ts extensions/codex/src/app-server/settled-turn-projection.test.ts
all lanes passed (format, lint, guards, import cycles)
```

Live repro note: triggering this live requires a connector-enabled Codex account plus a turn that settles with tool output and no assistant text, which cannot be forced deterministically on demand; the projection boundary test reproduces the exact production failure signature above, and the production logs are the live before-observation.

Follow-ups (separate PRs, same incident): the `errored` `message_tool_only` suppression branch in `src/auto-reply/reply/followup-delivery.ts` still records no visible outcome for non-interactive turns, and `settled-turn-finalization.ts`'s `failed` branch attaches no failure signal to the terminal — both keep genuine finalization failures silent.
