### PR TITLE
fix(media): preserve correct filenames for transparent image attachments

### DIFF
--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -13,7 +13,7 @@ import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { resizeToJpeg } from "./media-services.js";
+import { createImageProcessor, resizeToJpeg } from "./media-services.js";
 import { encodePngRgba, fillPixel } from "./png-encode.js";
 
 let effectiveImageBytesCap: typeof import("./web-media.js").effectiveImageBytesCap;
@@ -485,6 +485,35 @@ describe("loadWebMedia", () => {
       expect(result.fileName).toBe("portrait.jpg");
       expect(result.buffer.subarray(0, 3)).toEqual(Buffer.from([0xff, 0xd8, 0xff]));
       expect(readJpegDimensions(result.buffer)).toEqual({ width: 32, height: 32 });
+    }
+  });
+
+  it("renames transparent WebP images converted to PNG across direct and local image owners", async () => {
+    const { optimizeImageBufferForWebMedia } = await import("./web-media.js");
+    const sourcePng = createLargeTransparentColorBlockPng(64);
+    const sourceWebp = (await createImageProcessor().encode(sourcePng, { format: "webp" })).data;
+    const imageCompression = { models: [{ maxSidePx: 32, preferredSidePx: 32 }] };
+
+    const direct = await optimizeImageBufferForWebMedia({
+      buffer: sourceWebp,
+      contentType: "image/webp",
+      fileName: "portrait.WebP",
+      maxBytes: 1024 * 1024,
+      imageCompression,
+    });
+    const convertedPath = path.join(fixtureRoot, "portrait.WebP");
+    await fs.writeFile(convertedPath, sourceWebp);
+    const loaded = await loadWebMedia(convertedPath, {
+      maxBytes: 1024 * 1024,
+      localRoots: [fixtureRoot],
+      imageCompression,
+    });
+
+    for (const result of [direct, loaded]) {
+      expect(result.kind).toBe("image");
+      expect(result.contentType).toBe("image/png");
+      expect(result.fileName).toBe("portrait.png");
+      expect(readPngDimensions(result.buffer)).toEqual({ width: 32, height: 32 });
     }
   });
 

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -604,7 +604,7 @@ function assertHostReadMediaAllowed(params: {
   );
 }
 
-function toJpegFileName(fileName?: string): string | undefined {
+function toImageFileName(fileName: string | undefined, mimeType: string): string | undefined {
   if (!fileName) {
     return undefined;
   }
@@ -613,10 +613,10 @@ function toJpegFileName(fileName?: string): string | undefined {
     return fileName;
   }
   const parsed = path.parse(trimmed);
-  if (!parsed.ext || HEIC_EXT_RE.test(parsed.ext)) {
-    return path.format({ dir: parsed.dir, name: parsed.name || trimmed, ext: ".jpg" });
-  }
-  return path.format({ dir: parsed.dir, name: parsed.name, ext: ".jpg" });
+  const ext = extensionForMime(mimeType);
+  return mimeType !== "image/jpeg" && parsed.ext.toLowerCase() === ext
+    ? fileName
+    : path.format({ dir: parsed.dir, name: parsed.name || trimmed, ext });
 }
 
 type OptimizedImage = {
@@ -994,7 +994,7 @@ export async function optimizeImageBufferForWebMedia(params: {
     buffer: optimized.buffer,
     contentType: optimized.mimeType,
     kind: "image",
-    fileName: optimized.format === "jpeg" ? toJpegFileName(params.fileName) : params.fileName,
+    fileName: toImageFileName(params.fileName, optimized.mimeType),
   };
 }
 
@@ -1054,7 +1054,7 @@ async function loadWebMediaInternal(
       throw new Error(formatCapReduce("Media", cap, optimized.buffer.length));
     }
 
-    const fileName = optimized.format === "jpeg" ? toJpegFileName(meta?.fileName) : meta?.fileName;
+    const fileName = toImageFileName(meta?.fileName, optimized.mimeType);
 
     return {
       buffer: optimized.buffer,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users sending transparent WebP images would receive attachments with a misleading `.webp` filename after OpenClaw resized and converted the actual image bytes to PNG. The incorrect filename reached both Telegram multipart uploads and Discord attachments.

## Why This Change Was Made

The shared image loader now derives attachment extensions from the actual encoded image MIME type across both direct-buffer and file-loading paths. It generalizes the existing private JPEG filename helper without changing image admission, security policy, public types, configuration, or production line count.

## User Impact

Transparent WebP images converted to PNG arrive as correctly named `.png` attachments. Existing JPEG `.jpg` naming, original mixed-case PNG filenames, unchanged WebP images, nameless attachments, GIF passthrough, and SVG rejection are preserved.

## Evidence

- Added a regression using genuine transparent WebP bytes produced by the existing Rastermill image processor. It first failed with `expected "portrait.png", received "portrait.WebP"`, then passed across both image-loading paths.
- Ran the exact committed owner, Rastermill adapter, and canonical MIME suites: **285 tests passed**. Independent review ran four owner/sibling suites: **289 tests passed**.
- Exercised real transparent WebP-to-PNG conversion through actual Telegram `InputFile` and Discord multipart attachment construction, verifying PNG bytes, preserved alpha, dimensions, and the `.png` filename.
- Verified opaque JPEG conversion, uppercase PNG preservation, unchanged WebP, missing filenames, GIF passthrough, SVG rejection, typed lint, formatting, assertion safety, and the maximum-lines ratchet.
- Production change is size-neutral: **7 lines added, 7 removed**.
- Local full core and owner-test typechecks encounter existing stale shared-install Google, `markdown-it`, and TUI dependency diagnostics; neither changed file produces a type error.
