### PR TITLE
fix(slack): reject file downloads outside requested conversation

### DIFF
--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -729,7 +729,10 @@ describe("handleSlackAction", () => {
     expect(requireRecordArg(downloadSlackFile, "downloadSlackFile", 0, 1).maxBytes).toBe(
       20 * 1024 * 1024,
     );
-    expect(requireDetails(result).ok).toBe(false);
+    expect(requireDetails(result)).toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/requested Slack channel or explicit thread/i),
+    });
   });
 
   it("fails closed for downloadFile when no channel target can be authorized", async () => {

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -925,7 +925,8 @@ export async function handleSlackAction(
         if (!downloaded) {
           return jsonResult({
             ok: false,
-            error: "File could not be downloaded (not found, too large, or inaccessible).",
+            error:
+              "File could not be downloaded. Confirm the fileId came from the requested Slack channel or explicit thread and that the file is accessible and within the size limit.",
           });
         }
         if (!isImageContentType(downloaded.contentType)) {

--- a/extensions/slack/src/actions.download-file.test.ts
+++ b/extensions/slack/src/actions.download-file.test.ts
@@ -35,6 +35,7 @@ function makeSlackFileInfo(overrides?: Record<string, unknown>) {
     name: "image.png",
     mimetype: "image/png",
     url_private_download: "https://files.slack.com/files-pri/T1-F123/image.png",
+    channels: ["C123"],
     ...overrides,
   };
 }
@@ -109,6 +110,7 @@ describe("downloadSlackFile", () => {
       client,
       token: "xoxb-test",
       maxBytes: 1024,
+      channelId: "C123",
     });
 
     expect(result).toBeNull();
@@ -123,6 +125,7 @@ describe("downloadSlackFile", () => {
       client,
       token: "xoxb-test",
       maxBytes: 1024,
+      channelId: "C123",
     });
 
     expect(client.files.info).toHaveBeenCalledWith({ file: "F123" });
@@ -143,6 +146,7 @@ describe("downloadSlackFile", () => {
       client,
       token: "xoxb-test",
       maxBytes: 1024,
+      channelId: "C123",
     });
 
     expect(resolveSlackMedia).toHaveBeenCalledWith(expect.objectContaining({ client }));
@@ -169,6 +173,7 @@ describe("downloadSlackFile", () => {
       client,
       token: "xoxb-test",
       maxBytes: 1024,
+      channelId: "C123",
     });
 
     expect(resolveSlackMedia).toHaveBeenCalledWith({
@@ -217,7 +222,10 @@ describe("downloadSlackFile", () => {
     { name: "DM metadata", file: { ims: ["C123"] } },
     {
       name: "share metadata",
-      file: { shares: { private: { C123: [{ ts: "111.111" }] } } },
+      file: {
+        channels: undefined,
+        shares: { private: { C123: [{ ts: "111.111" }] } },
+      },
     },
   ])("downloads when $name proves the requested channel", async ({ file }) => {
     const client = createClient();
@@ -349,7 +357,39 @@ describe("downloadSlackFile", () => {
     ).toBe(false);
   });
 
-  it("returns null when file metadata does not prove the requested channel", async () => {
+  it.each([
+    { name: "absent channel/share evidence", file: { channels: undefined } },
+    {
+      name: "malformed shares container",
+      file: { channels: undefined, shares: "invalid" },
+    },
+    {
+      name: "requested channel with a non-array share value",
+      file: { channels: undefined, shares: { private: { C123: {} } } },
+    },
+    {
+      name: "requested channel with an empty share array",
+      file: { channels: undefined, shares: { private: { C123: [] } } },
+    },
+    {
+      name: "requested channel with a share entry lacking timestamps",
+      file: { channels: undefined, shares: { private: { C123: [{}] } } },
+    },
+  ])("returns null for $name", async ({ file }) => {
+    const client = createClient();
+    client.files.info.mockResolvedValueOnce({ file: makeSlackFileInfo(file) });
+
+    const result = await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+      channelId: "C123",
+    });
+
+    expectNoMediaDownload(result);
+  });
+
+  it("returns null when the requested channel is empty after normalization", async () => {
     const client = createClient();
     mockSuccessfulMediaDownload(client);
 
@@ -357,7 +397,7 @@ describe("downloadSlackFile", () => {
       client,
       token: "xoxb-test",
       maxBytes: 1024,
-      channelId: "C123",
+      channelId: "   ",
     });
 
     expectNoMediaDownload(result);
@@ -387,6 +427,7 @@ describe("downloadSlackFile", () => {
       cfg,
       accountId: "default",
       maxBytes: 1024,
+      channelId: "C123",
     });
 
     expect(createSlackLookupClientMock).toHaveBeenCalledWith("xoxb-from-cfg", {

--- a/extensions/slack/src/actions.download-file.test.ts
+++ b/extensions/slack/src/actions.download-file.test.ts
@@ -3,7 +3,7 @@ import type { WebClient } from "@slack/web-api";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const resolveSlackMedia = vi.fn();
+const resolveSlackMedia = vi.fn<typeof import("./monitor/media.js").resolveSlackMedia>();
 const createSlackLookupClientMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./monitor/media.js", () => ({
@@ -53,6 +53,14 @@ function expectNoMediaDownload(result: Awaited<ReturnType<typeof downloadSlackFi
   expect(resolveSlackMedia).not.toHaveBeenCalled();
 }
 
+function requireRefreshedFileAdmission() {
+  const admission = resolveSlackMedia.mock.calls[0]?.[0].isRefreshedFileAllowed;
+  if (!admission) {
+    throw new Error("Expected refreshed Slack file admission");
+  }
+  return admission;
+}
+
 function expectResolveSlackMediaCalledWithDefaults(client: ReturnType<typeof createClient>) {
   expect(resolveSlackMedia).toHaveBeenCalledWith({
     files: [
@@ -65,6 +73,7 @@ function expectResolveSlackMediaCalledWithDefaults(client: ReturnType<typeof cre
       },
     ],
     client,
+    isRefreshedFileAllowed: expect.any(Function),
     token: "xoxb-test",
     maxBytes: 1024,
   });
@@ -173,6 +182,7 @@ describe("downloadSlackFile", () => {
         },
       ],
       client,
+      isRefreshedFileAllowed: expect.any(Function),
       token: "xoxb-test",
       maxBytes: 1024,
     });
@@ -310,6 +320,35 @@ describe("downloadSlackFile", () => {
     expect(result).toEqual(makeResolvedSlackMedia());
   });
 
+  it("reapplies the requested channel and thread scope to refreshed metadata", async () => {
+    const client = createClient();
+    client.files.info.mockResolvedValueOnce({
+      file: makeSlackFileInfo({
+        shares: { private: { C123: [{ ts: "111.111" }] } },
+      }),
+    });
+    resolveSlackMedia.mockResolvedValueOnce([makeResolvedSlackMedia()]);
+
+    await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+      channelId: "C123",
+      threadId: "111.111",
+    });
+
+    const isAllowed = requireRefreshedFileAdmission();
+    expect(
+      isAllowed(makeSlackFileInfo({ shares: { private: { C123: [{ ts: "111.111" }] } } })),
+    ).toBe(true);
+    expect(
+      isAllowed(makeSlackFileInfo({ shares: { private: { C999: [{ ts: "111.111" }] } } })),
+    ).toBe(false);
+    expect(
+      isAllowed(makeSlackFileInfo({ shares: { private: { C123: [{ ts: "222.222" }] } } })),
+    ).toBe(false);
+  });
+
   it("returns null when file metadata does not prove the requested channel", async () => {
     const client = createClient();
     mockSuccessfulMediaDownload(client);
@@ -364,6 +403,7 @@ describe("downloadSlackFile", () => {
         },
       ],
       client,
+      isRefreshedFileAllowed: expect.any(Function),
       token: "xoxb-from-cfg",
       maxBytes: 1024,
     });

--- a/extensions/slack/src/actions.download-file.test.ts
+++ b/extensions/slack/src/actions.download-file.test.ts
@@ -201,6 +201,52 @@ describe("downloadSlackFile", () => {
     expectNoMediaDownload(result);
   });
 
+  it.each([
+    { name: "public channel metadata", file: { channels: ["C123"] } },
+    { name: "private channel metadata", file: { groups: ["C123"] } },
+    { name: "DM metadata", file: { ims: ["C123"] } },
+    {
+      name: "share metadata",
+      file: { shares: { private: { C123: [{ ts: "111.111" }] } } },
+    },
+  ])("downloads when $name proves the requested channel", async ({ file }) => {
+    const client = createClient();
+    client.files.info.mockResolvedValueOnce({
+      file: makeSlackFileInfo(file),
+    });
+    resolveSlackMedia.mockResolvedValueOnce([makeResolvedSlackMedia()]);
+
+    const result = await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+      channelId: "C123",
+    });
+
+    expect(result).toEqual(makeResolvedSlackMedia());
+  });
+
+  it("accepts positive channel proof even when Slack reports additional shares", async () => {
+    const client = createClient();
+    client.files.info.mockResolvedValueOnce({
+      file: makeSlackFileInfo({
+        channels: ["C123"],
+        has_more_shares: true,
+        skipped_shares: true,
+      }),
+    });
+    resolveSlackMedia.mockResolvedValueOnce([makeResolvedSlackMedia()]);
+
+    const result = await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+      channelId: "C123",
+    });
+
+    expect(result).toEqual(makeResolvedSlackMedia());
+  });
+
   it("returns null when thread scope definitely mismatches file share thread", async () => {
     const client = createClient();
     client.files.info.mockResolvedValueOnce({
@@ -224,9 +270,11 @@ describe("downloadSlackFile", () => {
     expectNoMediaDownload(result);
   });
 
-  it("keeps legacy behavior when file metadata does not expose channel/thread shares", async () => {
+  it("returns null when file metadata proves the channel but not the requested thread", async () => {
     const client = createClient();
-    mockSuccessfulMediaDownload(client);
+    client.files.info.mockResolvedValueOnce({
+      file: makeSlackFileInfo({ channels: ["C123"] }),
+    });
 
     const result = await downloadSlackFile("F123", {
       client,
@@ -236,9 +284,44 @@ describe("downloadSlackFile", () => {
       threadId: "222.222",
     });
 
+    expectNoMediaDownload(result);
+  });
+
+  it.each([
+    { name: "share message timestamp", share: { ts: "111.111" } },
+    { name: "thread timestamp", share: { ts: "222.222", thread_ts: "111.111" } },
+  ])("downloads when $name proves the requested thread", async ({ share }) => {
+    const client = createClient();
+    client.files.info.mockResolvedValueOnce({
+      file: makeSlackFileInfo({
+        shares: { private: { C123: [share] } },
+      }),
+    });
+    resolveSlackMedia.mockResolvedValueOnce([makeResolvedSlackMedia()]);
+
+    const result = await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+      channelId: "C123",
+      threadId: "111.111",
+    });
+
     expect(result).toEqual(makeResolvedSlackMedia());
-    expect(resolveSlackMedia).toHaveBeenCalledTimes(1);
-    expectResolveSlackMediaCalledWithDefaults(client);
+  });
+
+  it("returns null when file metadata does not prove the requested channel", async () => {
+    const client = createClient();
+    mockSuccessfulMediaDownload(client);
+
+    const result = await downloadSlackFile("F123", {
+      client,
+      token: "xoxb-test",
+      maxBytes: 1024,
+      channelId: "C123",
+    });
+
+    expectNoMediaDownload(result);
   });
 
   it("resolves the bot token from cfg when no explicit token or client is provided", async () => {

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -683,7 +683,7 @@ function collectSlackThreadShares(
   return matches;
 }
 
-function hasSlackScopeMismatch(params: {
+function lacksSlackScopeProof(params: {
   file: SlackFileInfoSummary;
   channelId?: string;
   threadId?: string;
@@ -696,9 +696,8 @@ function hasSlackScopeMismatch(params: {
 
   const directIds = collectSlackDirectShareChannelIds(params.file);
   const sharedIds = collectSlackSharedChannelIds(params.file);
-  const hasChannelEvidence = directIds.size > 0 || sharedIds.size > 0;
   const inChannel = directIds.has(channelId) || sharedIds.has(channelId);
-  if (hasChannelEvidence && !inChannel) {
+  if (!inChannel) {
     return true;
   }
 
@@ -706,13 +705,7 @@ function hasSlackScopeMismatch(params: {
     return false;
   }
   const threadShares = collectSlackThreadShares(params.file, channelId);
-  if (threadShares.length === 0) {
-    return false;
-  }
   const threadEvidence = threadShares.filter((entry) => entry.threadTs || entry.ts);
-  if (threadEvidence.length === 0) {
-    return false;
-  }
   return !threadEvidence.some((entry) => entry.threadTs === threadId || entry.ts === threadId);
 }
 
@@ -735,7 +728,7 @@ export async function downloadSlackFile(
   if (!file?.url_private_download && !file?.url_private) {
     return null;
   }
-  if (hasSlackScopeMismatch({ file, channelId: opts.channelId, threadId: opts.threadId })) {
+  if (lacksSlackScopeProof({ file, channelId: opts.channelId, threadId: opts.threadId })) {
     return null;
   }
 

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -646,57 +646,48 @@ function collectSlackShareMaps(file: SlackFileInfoSummary): Array<Record<string,
   );
 }
 
-function collectSlackSharedChannelIds(file: SlackFileInfoSummary): Set<string> {
-  const ids = new Set<string>();
+function collectSlackShares(file: SlackFileInfoSummary): SlackFileThreadShare[] {
+  const shares: SlackFileThreadShare[] = [];
   for (const shareMap of collectSlackShareMaps(file)) {
-    for (const channelId of Object.keys(shareMap)) {
-      const normalized = normalizeOptionalString(channelId);
-      if (normalized) {
-        ids.add(normalized);
-      }
-    }
-  }
-  return ids;
-}
-
-function collectSlackThreadShares(
-  file: SlackFileInfoSummary,
-  channelId: string,
-): SlackFileThreadShare[] {
-  const matches: SlackFileThreadShare[] = [];
-  for (const shareMap of collectSlackShareMaps(file)) {
-    const rawEntries = shareMap[channelId];
-    if (!Array.isArray(rawEntries)) {
-      continue;
-    }
-    for (const rawEntry of rawEntries) {
-      if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+    for (const [rawChannelId, rawEntries] of Object.entries(shareMap)) {
+      const channelId = normalizeOptionalString(rawChannelId);
+      if (!channelId || !Array.isArray(rawEntries)) {
         continue;
       }
-      const entry = rawEntry as Record<string, unknown>;
-      const ts = typeof entry.ts === "string" ? normalizeOptionalString(entry.ts) : undefined;
-      const threadTs =
-        typeof entry.thread_ts === "string" ? normalizeOptionalString(entry.thread_ts) : undefined;
-      matches.push({ channelId, ts, threadTs });
+      for (const rawEntry of rawEntries) {
+        if (!rawEntry || typeof rawEntry !== "object" || Array.isArray(rawEntry)) {
+          continue;
+        }
+        const entry = rawEntry as Record<string, unknown>;
+        const ts = typeof entry.ts === "string" ? normalizeOptionalString(entry.ts) : undefined;
+        const threadTs =
+          typeof entry.thread_ts === "string"
+            ? normalizeOptionalString(entry.thread_ts)
+            : undefined;
+        if (ts || threadTs) {
+          shares.push({ channelId, ts, threadTs });
+        }
+      }
     }
   }
-  return matches;
+  return shares;
 }
 
 function lacksSlackScopeProof(params: {
   file: SlackFileInfoSummary;
-  channelId?: string;
+  channelId: string;
   threadId?: string;
 }): boolean {
   const channelId = normalizeOptionalString(params.channelId);
   if (!channelId) {
-    return false;
+    return true;
   }
   const threadId = normalizeOptionalString(params.threadId);
 
   const directIds = collectSlackDirectShareChannelIds(params.file);
-  const sharedIds = collectSlackSharedChannelIds(params.file);
-  const inChannel = directIds.has(channelId) || sharedIds.has(channelId);
+  const shares = collectSlackShares(params.file);
+  const inChannel =
+    directIds.has(channelId) || shares.some((entry) => entry.channelId === channelId);
   if (!inChannel) {
     return true;
   }
@@ -704,9 +695,10 @@ function lacksSlackScopeProof(params: {
   if (!threadId) {
     return false;
   }
-  const threadShares = collectSlackThreadShares(params.file, channelId);
-  const threadEvidence = threadShares.filter((entry) => entry.threadTs || entry.ts);
-  return !threadEvidence.some((entry) => entry.threadTs === threadId || entry.ts === threadId);
+  return !shares.some(
+    (entry) =>
+      entry.channelId === channelId && (entry.threadTs === threadId || entry.ts === threadId),
+  );
 }
 
 /**
@@ -716,7 +708,7 @@ function lacksSlackScopeProof(params: {
  */
 export async function downloadSlackFile(
   fileId: string,
-  opts: SlackActionClientOpts & { maxBytes: number; channelId?: string; threadId?: string },
+  opts: SlackActionClientOpts & { maxBytes: number; channelId: string; threadId?: string },
 ): Promise<SlackMediaResult | null> {
   const token = resolveToken(opts.token, opts.accountId, opts.cfg);
   const client = await getClient(opts);

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -720,6 +720,8 @@ export async function downloadSlackFile(
 ): Promise<SlackMediaResult | null> {
   const token = resolveToken(opts.token, opts.accountId, opts.cfg);
   const client = await getClient(opts);
+  const isFileAllowed = (file: SlackFileInfoSummary) =>
+    !lacksSlackScopeProof({ file, channelId: opts.channelId, threadId: opts.threadId });
 
   // Fetch fresh file metadata (includes a current url_private_download).
   const info = await client.files.info({ file: fileId });
@@ -728,7 +730,7 @@ export async function downloadSlackFile(
   if (!file?.url_private_download && !file?.url_private) {
     return null;
   }
-  if (lacksSlackScopeProof({ file, channelId: opts.channelId, threadId: opts.threadId })) {
+  if (!isFileAllowed(file)) {
     return null;
   }
 
@@ -743,6 +745,7 @@ export async function downloadSlackFile(
       },
     ],
     client,
+    isRefreshedFileAllowed: isFileAllowed,
     token,
     maxBytes: opts.maxBytes,
   });

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -700,6 +700,45 @@ describe("resolveSlackMedia", () => {
     ]);
   });
 
+  it("rejects a refreshed URL when its file metadata fails caller admission", async () => {
+    saveMediaBufferMock.mockResolvedValue(createSavedMedia("/tmp/test.jpg", "image/jpeg"));
+    const mockClient = {
+      files: {
+        info: vi.fn().mockResolvedValue({
+          file: {
+            url_private_download: "https://files.slack.com/fresh.jpg",
+          },
+        }),
+      },
+    } as unknown as WebClient & { files: { info: ReturnType<typeof vi.fn> } };
+    mockFetch.mockResolvedValueOnce(new Response("expired", { status: 404 })).mockResolvedValueOnce(
+      new Response(Buffer.from("image data"), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      }),
+    );
+
+    const result = await resolveSlackMedia({
+      files: [
+        {
+          id: "F123",
+          name: "test.jpg",
+          url_private_download: "https://files.slack.com/stale.jpg",
+        },
+      ],
+      client: mockClient,
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+      isRefreshedFileAllowed: () => false,
+    });
+
+    expect(result).toBeNull();
+    expect(mockClient.files.info).toHaveBeenCalledWith({ file: "F123" });
+    expect(mockFetch.mock.calls.map((call) => call[0])).toEqual([
+      "https://files.slack.com/stale.jpg",
+    ]);
+  });
+
   it("rejects HTML auth pages for non-HTML files", async () => {
     mockFetch.mockResolvedValueOnce(
       new Response("<!DOCTYPE html><html><body>login</body></html>", {

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -212,6 +212,7 @@ const MAX_SLACK_FORWARDED_ATTACHMENTS = 8;
 async function fetchFreshSlackFileUrl(params: {
   file: SlackFile;
   client?: SlackWebClient;
+  isRefreshedFileAllowed?: (file: SlackFile) => boolean;
 }): Promise<string | null> {
   if (!params.file.id || !params.client) {
     return null;
@@ -219,6 +220,10 @@ async function fetchFreshSlackFileUrl(params: {
   try {
     const info = await params.client.files.info({ file: params.file.id });
     const freshFile = info.file as SlackFile | undefined;
+    if (freshFile && params.isRefreshedFileAllowed?.(freshFile) === false) {
+      logVerbose(`slack: refreshed file metadata rejected for file id=${params.file.id}`);
+      return null;
+    }
     const freshUrl = freshFile?.url_private_download ?? freshFile?.url_private;
     if (freshUrl) {
       logVerbose(`slack: refreshed file URL via files.info for file id=${params.file.id}`);
@@ -320,6 +325,7 @@ function resolveForwardedAttachmentImageUrl(
 export async function resolveSlackMedia(params: {
   files?: SlackFile[];
   client?: SlackWebClient;
+  isRefreshedFileAllowed?: (file: SlackFile) => boolean;
   token: string;
   maxBytes: number;
   readIdleTimeoutMs?: number;
@@ -331,6 +337,12 @@ export async function resolveSlackMedia(params: {
   const files = params.files ?? [];
   const limitedFiles =
     files.length > MAX_SLACK_MEDIA_FILES ? files.slice(0, MAX_SLACK_MEDIA_FILES) : files;
+  const refreshFileUrl = (file: SlackFile) =>
+    fetchFreshSlackFileUrl({
+      file,
+      client: params.client,
+      isRefreshedFileAllowed: params.isRefreshedFileAllowed,
+    });
 
   const { results } = await runTasksWithConcurrency({
     tasks: limitedFiles.map((file) => async (): Promise<SlackMediaResult | null> => {
@@ -341,7 +353,7 @@ export async function resolveSlackMedia(params: {
         return preloaded;
       }
       const eventUrl = file.url_private_download ?? file.url_private;
-      const url = eventUrl ?? (await fetchFreshSlackFileUrl({ file, client: params.client }));
+      const url = eventUrl ?? (await refreshFileUrl(file));
       if (!url) {
         return null;
       }
@@ -359,7 +371,7 @@ export async function resolveSlackMedia(params: {
         return result;
       }
 
-      const freshUrl = await fetchFreshSlackFileUrl({ file, client: params.client });
+      const freshUrl = await refreshFileUrl(file);
       if (!freshUrl) {
         return null;
       }

--- a/src/infra/outbound/message-action-execution.test.ts
+++ b/src/infra/outbound/message-action-execution.test.ts
@@ -368,8 +368,6 @@ describe("runMessageAction plugin dispatch", () => {
         await runMessageAction({
           cfg,
           action: "download-file",
-          accountId: "default",
-          requesterAccountId: "default",
           conversationReadOrigin: "direct-operator",
           params: {
             channel: "forumchat",
@@ -412,8 +410,6 @@ describe("runMessageAction plugin dispatch", () => {
       await runMessageAction({
         cfg,
         action: "download-file",
-        accountId: "default",
-        requesterAccountId: "default",
         conversationReadOrigin: "direct-operator",
         params: {
           channel: "forumchat",

--- a/src/infra/outbound/message-action-execution.test.ts
+++ b/src/infra/outbound/message-action-execution.test.ts
@@ -298,8 +298,8 @@ describe("runMessageAction plugin dispatch", () => {
         pluginId: "forumchat",
         label: "Forum Chat",
         blurb: "Forum chat threaded action dispatch test plugin.",
-        actions: ["sticker"],
-        gatewayActions: executionMode === "gateway" ? ["sticker"] : [],
+        actions: ["sticker", "download-file"],
+        gatewayActions: executionMode === "gateway" ? ["sticker", "download-file"] : [],
         capabilities: { chatTypes: ["channel"] },
         threading,
         handleAction,
@@ -358,6 +358,83 @@ describe("runMessageAction plugin dispatch", () => {
         expect(handleAction).toHaveBeenCalledTimes(executionMode === "local" ? 1 : 0);
       },
     );
+
+    it.each(["local", "gateway"] as const)(
+      "does not add an implicit thread scope to download-file before %s dispatch",
+      async (executionMode) => {
+        setTestPlugin(createThreadedPlugin(executionMode), "forumchat");
+        mocks.callGatewayLeastPrivilege.mockResolvedValue({ ok: true });
+
+        await runMessageAction({
+          cfg,
+          action: "download-file",
+          accountId: "default",
+          requesterAccountId: "default",
+          conversationReadOrigin: "direct-operator",
+          params: {
+            channel: "forumchat",
+            channelId: "forum:123",
+            fileId: "F123",
+          },
+          toolContext: {
+            currentChannelProvider: "forumchat",
+            currentChannelId: "forum:123",
+            currentThreadTs: "42",
+          },
+          gateway: executionMode === "gateway" ? { clientName: "cli", mode: "cli" } : undefined,
+          dryRun: false,
+        });
+
+        const dispatchedParams =
+          executionMode === "gateway"
+            ? readRecordField(
+                readRecordField(
+                  readMockCallArg(mocks.callGatewayLeastPrivilege, "gateway call"),
+                  "params",
+                  "gateway call params",
+                ),
+                "params",
+                "gateway action params",
+              )
+            : readRecordField(readFirstPluginCall(handleAction), "params", "plugin params");
+        expect(dispatchedParams.threadId).toBeUndefined();
+        expectRecordFields(
+          dispatchedParams,
+          { channelId: "forum:123", fileId: "F123" },
+          `${executionMode} download-file params`,
+        );
+      },
+    );
+
+    it("preserves an explicit download-file thread scope", async () => {
+      setTestPlugin(createThreadedPlugin("local"), "forumchat");
+
+      await runMessageAction({
+        cfg,
+        action: "download-file",
+        accountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "direct-operator",
+        params: {
+          channel: "forumchat",
+          channelId: "forum:123",
+          fileId: "F123",
+          threadId: "99",
+        },
+        toolContext: {
+          currentChannelProvider: "forumchat",
+          currentChannelId: "forum:123",
+          currentThreadTs: "42",
+        },
+        dryRun: false,
+      });
+
+      expectRecordFields(
+        readRecordField(readFirstPluginCall(handleAction), "params", "plugin params"),
+        { channelId: "forum:123", fileId: "F123", threadId: "99" },
+        "local download-file params",
+      );
+    });
   });
   describe("poll plugin forwarding", () => {
     const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>

--- a/src/infra/outbound/message-action-execution.ts
+++ b/src/infra/outbound/message-action-execution.ts
@@ -612,7 +612,9 @@ export async function executeMessagePlugin(
   // gateway or local dispatch to keep both execution modes on the same topic.
   const targetForThreading =
     normalizeOptionalString(params.to) ?? normalizeOptionalString(params.channelId) ?? "";
-  if (targetForThreading) {
+  // File downloads authorize caller-supplied resource scope. Ambient threading
+  // must not silently narrow a channel-only request to the current thread.
+  if (targetForThreading && action !== "download-file") {
     resolveAndApplyOutboundThreadId(params, {
       cfg,
       to: targetForThreading,


### PR DESCRIPTION
## What Problem This Solves

Slack file downloads could proceed when fresh `files.info` metadata exposed the requested channel only as a share-map key whose value contained no valid share records. The lower-level download boundary also accepted omitted or blank channel scope, and an ambient thread could silently narrow a channel-only request.

## Why This Change Was Made

Slack downloads now require a nonblank requested channel and positive membership from fresh metadata. Direct `channels`, `groups`, and `ims` membership remains valid. Share maps count only when the requested channel has at least one record with a normalized `ts` or `thread_ts`; malformed values, empty arrays, and timestamp-free entries fail closed. An explicitly requested thread must exactly match one of those timestamps.

The same predicate is reapplied if a stale file URL refreshes metadata before retry. Ambient thread context is not injected into a channel-only request.

## User Impact

Files with normal public-channel, private-channel, DM, or matching-thread metadata continue to download. Downloads are rejected when Slack metadata cannot positively bind the file to the requested conversation. No configuration, protocol, or default changes are introduced.

## Evidence

- Pre-fix focused proof added malformed-evidence cases first. On the previous PR head, four cases failed as expected: a keyed non-array value, an empty share array, a share entry without timestamps, and a blank requested channel all still reached media download.
- `pnpm test extensions/slack/src/actions.download-file.test.ts extensions/slack/src/action-runtime.test.ts extensions/slack/src/message-action-dispatch.test.ts src/infra/outbound/message-action-execution.test.ts -- --reporter=verbose`
  - 194 tests passed across Slack download admission, action runtime, dispatch, and shared message-action execution.
- `pnpm check:changed` passed, including formatting, typechecks, lint, database-first, media helper, and import-cycle guards.
- The installed `@slack/web-api` 8.0.0 contract marks channel/share fields and individual timestamps optional, while share-map values are arrays. The runtime therefore validates those shapes before admitting them as proof.
- Read-only live Slack inspection separately confirmed that fresh `files.info` responses supplied usable direct or timestamped share evidence for configured bot and user identities in public-channel and DM flows. Private-channel membership and malformed metadata are covered by dependency-contract analysis and focused unit tests; they were not claimed as live proof.
- Authenticated final-effect proof on exact head `c7fb1e775cc8fcdfbeef86e3703351e5f3a24c17` passed in [Crabbox run `run_0874708c0849`](https://crabbox.openclaw.ai/portal/runs/run_0874708c0849) (`provider=aws`, lease `cbx_209a26a51049`):
  - A disposable file with real direct membership and one timestamped share downloaded through the production Undici transport (`GET files.slack.com` → `200`), and its bytes matched the uploaded fixture.
  - The denied case made one real stale media request, refreshed through live `files.info`, received metadata bound only to a different disposable conversation, returned `null`, and made zero requests to the refreshed media URL.
  - Network observation used Node `diagnostics_channel`; `fetch` was not replaced. Channel, file, and workspace identifiers were retained only as SHA-256 prefixes. Both disposable Slack files and the downloaded local media were deleted.
- Local structured autoreview reported no accepted or actionable findings.
- Production LOC: +55/-52 (net +3). Tests: +287/-8 (net +279).

<details>
<summary>Redacted authenticated transport trace</summary>

```json
{
  "proof": "slack-file-scope-final-effect",
  "head": "c7fb1e775cc8fcdfbeef86e3703351e5f3a24c17",
  "allowedPath": {
    "metadata": {
      "directMembership": true,
      "timestampedShareCount": 1,
      "hasMoreShares": false,
      "skippedShares": false
    },
    "result": "downloaded",
    "contentMatched": true,
    "transportTrace": [
      {
        "sequence": 1,
        "kind": "allowed-media",
        "method": "GET",
        "host": "files.slack.com",
        "status": 200
      }
    ]
  },
  "deniedRefreshPath": {
    "initialMetadata": {
      "directMembership": true,
      "timestampedShareCount": 1
    },
    "refreshedMetadataAgainstRequestedScope": {
      "directMembership": false,
      "timestampedShareCount": 0
    },
    "refreshedMetadataAtSourceScope": {
      "directMembership": true,
      "timestampedShareCount": 1
    },
    "metadataCalls": 2,
    "result": null,
    "staleMediaRequests": 1,
    "refreshedMediaRequests": 0,
    "transportTrace": [
      {
        "sequence": 1,
        "kind": "stale-media",
        "method": "GET",
        "host": "files.slack.com",
        "status": 302
      }
    ]
  },
  "evidenceContract": {
    "metadataSource": "live Slack files.info",
    "mediaTransport": "production Undici path",
    "networkObserver": "diagnostics_channel only; fetch was not replaced"
  },
  "cleanup": {
    "disposableFilesDeleted": 2,
    "downloadedMediaDeleted": true
  }
}
```

</details>
