### PR TITLE
fix(sessions): retain completed summaries on multi-store cleanup partial failure (#127583)

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2670,7 +2670,7 @@ src/config/schema.hints.ts	15
 src/config/schema.tags.ts	1
 src/config/schema.ts	3
 src/config/sessions/archive-compression.ts	1
-src/config/sessions/cleanup-service.ts	4
+src/config/sessions/cleanup-service.ts	3
 src/config/sessions/conversation-delivery-store.ts	2
 src/config/sessions/group.ts	1
 src/config/sessions/legacy-main-session-migration-operations.ts	1

--- a/src/commands/sessions-cleanup.runtime.test.ts
+++ b/src/commands/sessions-cleanup.runtime.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionCleanupSummary } from "../config/sessions.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { runLocalSessionsCleanup } from "./sessions-cleanup.runtime.js";
+
+const runSessionsCleanup = vi.hoisted(() => vi.fn());
+
+vi.mock("../config/sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/sessions.js")>()),
+  runSessionsCleanup,
+}));
+vi.mock("../plugins/loader.js", () => ({
+  loadPluginRegistryHandle: vi.fn(() => ({})),
+}));
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  loadPluginMetadataSnapshot: vi.fn(() => ({
+    plugins: [],
+    manifestRegistry: {},
+    discovery: {},
+    index: {},
+  })),
+}));
+vi.mock("../plugins/installed-plugin-index-install-records.js", () => ({
+  extractPluginInstallRecordsFromInstalledPluginIndex: vi.fn(() => []),
+}));
+vi.mock("../plugins/activation-planner.js", () => ({
+  resolveManifestActivationPluginIds: vi.fn(() => []),
+}));
+vi.mock("../plugins/activation-context.js", () => ({
+  withActivatedPluginIds: vi.fn((args: { config: unknown }) => args.config),
+}));
+vi.mock("../plugins/runtime/gateway-request-scope.js", () => ({
+  withPluginRuntimeRegistryScope: vi.fn((_registry: unknown, run: () => unknown) => run()),
+}));
+vi.mock("../agents/agent-scope-config.js", () => ({
+  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-test-workspace"),
+}));
+
+const runtime: RuntimeEnv = {
+  log: () => {},
+  error: () => {},
+  exit: () => {},
+};
+
+function summary(agentId: string): SessionCleanupSummary {
+  return {
+    agentId,
+    storePath: `/tmp/${agentId}/sessions.json`,
+    mode: "enforce",
+    dryRun: false,
+    beforeCount: 1,
+    afterCount: 0,
+    missing: 1,
+    dmScopeRetired: 0,
+    modelRunPruned: 0,
+    pruned: 0,
+    capped: 0,
+    unreferencedArtifacts: { scannedFiles: 0, removedFiles: 0, freedBytes: 0, olderThanMs: 0 },
+    diskBudget: null,
+    wouldMutate: true,
+    applied: true,
+    appliedCount: 0,
+  };
+}
+
+describe("runLocalSessionsCleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps prior store summaries when a later target returns a failure", async () => {
+    const mainSummary = summary("main");
+    runSessionsCleanup
+      .mockResolvedValueOnce({
+        mode: "enforce",
+        previewResults: [],
+        appliedSummaries: [mainSummary],
+      })
+      .mockRejectedValueOnce(new Error("injected later-store failure"));
+
+    const result = await runLocalSessionsCleanup(
+      {
+        cfg: {},
+        opts: { enforce: true },
+        targets: [
+          { agentId: "main", storePath: "/tmp/main/sessions.json" },
+          { agentId: "work", storePath: "/tmp/work/sessions.json" },
+        ],
+      },
+      runtime,
+    );
+
+    expect(result.appliedSummaries).toEqual([mainSummary]);
+    expect(result.failure).toMatchObject({
+      target: { agentId: "work", storePath: "/tmp/work/sessions.json" },
+    });
+  });
+});

--- a/src/commands/sessions-cleanup.runtime.test.ts
+++ b/src/commands/sessions-cleanup.runtime.test.ts
@@ -93,6 +93,7 @@ describe("runLocalSessionsCleanup", () => {
     expect(result.appliedSummaries).toEqual([mainSummary]);
     expect(result.failure).toMatchObject({
       target: { agentId: "work", storePath: "/tmp/work/sessions.json" },
+      lifecycleCommitted: false,
     });
   });
 });

--- a/src/commands/sessions-cleanup.runtime.ts
+++ b/src/commands/sessions-cleanup.runtime.ts
@@ -1,5 +1,6 @@
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
 import {
+  createSessionsCleanupFailure,
   resolveSessionCleanupAction,
   runSessionsCleanup,
   type SessionStoreTarget,
@@ -109,6 +110,7 @@ export async function runLocalSessionsCleanup(
 ): Promise<CleanupRunResult> {
   const ownersByWorkspace = new Map<string, ReturnType<typeof prepareCleanupHarnessOwners>>();
   const results: CleanupRunResult[] = [];
+  let failure: CleanupRunResult["failure"];
   for (const target of params.targets) {
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, target.agentId);
     let owners = ownersByWorkspace.get(workspaceDir);
@@ -116,11 +118,26 @@ export async function runLocalSessionsCleanup(
       owners = prepareCleanupHarnessOwners(params.cfg, workspaceDir);
       ownersByWorkspace.set(workspaceDir, owners);
     }
-    const result = await withPluginRuntimeRegistryScope(owners.registry, () =>
-      runSessionsCleanup({ ...params, targets: [target] }),
-    );
+    let result: CleanupRunResult;
+    try {
+      result = await withPluginRuntimeRegistryScope(owners.registry, () =>
+        runSessionsCleanup({ ...params, targets: [target] }),
+      );
+    } catch (cause) {
+      // The local runner changes plugin scope per store, so it owns combining
+      // earlier results with the same partial outcome as the cleanup service.
+      if (results.length === 0) {
+        throw cause;
+      }
+      failure = createSessionsCleanupFailure(target, cause);
+      break;
+    }
     warnUnavailableCleanupOwners(owners, result, runtime);
     results.push(result);
+    if (result.failure) {
+      failure = result.failure;
+      break;
+    }
   }
   const first = results[0];
   if (!first) {
@@ -130,5 +147,6 @@ export async function runLocalSessionsCleanup(
     mode: first.mode,
     previewResults: results.flatMap((result) => result.previewResults),
     appliedSummaries: results.flatMap((result) => result.appliedSummaries),
+    ...(failure ? { failure } : {}),
   };
 }

--- a/src/commands/sessions-cleanup.runtime.ts
+++ b/src/commands/sessions-cleanup.runtime.ts
@@ -3,6 +3,7 @@ import {
   createSessionsCleanupFailure,
   resolveSessionCleanupAction,
   runSessionsCleanup,
+  SessionsCleanupFailureError,
   type SessionStoreTarget,
   type SessionsCleanupOptions,
 } from "../config/sessions.js";
@@ -129,7 +130,10 @@ export async function runLocalSessionsCleanup(
       if (results.length === 0) {
         throw cause;
       }
-      failure = createSessionsCleanupFailure(target, cause);
+      failure =
+        cause instanceof SessionsCleanupFailureError
+          ? cause.failure
+          : createSessionsCleanupFailure(target, cause, false);
       break;
     }
     warnUnavailableCleanupOwners(owners, result, runtime);

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -310,6 +310,7 @@ describe("sessionsCleanupCommand", () => {
         failingAgentId: "work",
         failingStorePath: "/gateway/work/openclaw-agent.sqlite",
         message: "Session cleanup failed for agent 'work': injected failure",
+        lifecycleCommitted: false,
       },
     };
     mocks.callGateway.mockRejectedValue(Object.assign(new Error("request failed"), { details }));

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -10,7 +10,6 @@ const mocks = vi.hoisted(() => ({
   resolveSessionCleanupAction: vi.fn(),
   runSessionsCleanup: vi.fn(),
   runLocalSessionsCleanup: vi.fn(),
-  serializeSessionCleanupResult: vi.fn(),
   callGateway: vi.fn(),
 }));
 
@@ -26,10 +25,10 @@ vi.mock("./session-store-targets.js", () => ({
   resolveSessionStoreTargetsOrExit: mocks.resolveSessionStoreTargetsOrExit,
 }));
 
-vi.mock("../config/sessions.js", () => ({
+vi.mock("../config/sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/sessions.js")>()),
   resolveSessionCleanupAction: mocks.resolveSessionCleanupAction,
   runSessionsCleanup: mocks.runSessionsCleanup,
-  serializeSessionCleanupResult: mocks.serializeSessionCleanupResult,
 }));
 
 vi.mock("../gateway/call.js", async () => ({
@@ -41,15 +40,17 @@ vi.mock("../gateway/call.js", async () => ({
 
 import { sessionsCleanupCommand } from "./sessions-cleanup.js";
 
-function makeRuntime(): { runtime: RuntimeEnv; logs: string[] } {
+function makeRuntime(): { runtime: RuntimeEnv; logs: string[]; errors: string[] } {
   const logs: string[] = [];
+  const errors: string[] = [];
   return {
     runtime: {
       log: (msg: unknown) => logs.push(String(msg)),
-      error: () => {},
+      error: (msg: unknown) => errors.push(String(msg)),
       exit: () => {},
     },
     logs,
+    errors,
   };
 }
 
@@ -70,6 +71,7 @@ function gatewayTransportError(kind: "closed" | "timeout", code?: number): Gatew
 describe("sessionsCleanupCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.exitCode = undefined;
     mocks.runLocalSessionsCleanup.mockImplementation((params) => mocks.runSessionsCleanup(params));
     mocks.loadConfig.mockReturnValue({ session: { store: "/cfg/sessions.json" } });
     mocks.resolveSessionStoreTargetsOrExit.mockReturnValue([
@@ -98,19 +100,6 @@ describe("sessionsCleanupCommand", () => {
           return "cap-overflow";
         }
         return "keep";
-      },
-    );
-    mocks.serializeSessionCleanupResult.mockImplementation(
-      (params: { mode: string; dryRun: boolean; summaries: Record<string, unknown>[] }) => {
-        if (params.summaries.length === 1) {
-          return params.summaries[0] ?? {};
-        }
-        return {
-          allAgents: true,
-          mode: params.mode,
-          dryRun: params.dryRun,
-          stores: params.summaries,
-        };
       },
     );
     mocks.runSessionsCleanup.mockResolvedValue({
@@ -285,6 +274,66 @@ describe("sessionsCleanupCommand", () => {
       applied: true,
       appliedCount: 1,
     });
+  });
+
+  it("renders rejected Gateway partial details and exits nonzero", async () => {
+    const details = {
+      allAgents: true,
+      mode: "enforce",
+      dryRun: false,
+      stores: [
+        {
+          agentId: "main",
+          storePath: "/gateway/main/openclaw-agent.sqlite",
+          mode: "enforce",
+          dryRun: false,
+          beforeCount: 1,
+          afterCount: 0,
+          missing: 1,
+          dmScopeRetired: 0,
+          modelRunPruned: 0,
+          pruned: 0,
+          capped: 0,
+          unreferencedArtifacts: {
+            scannedFiles: 0,
+            removedFiles: 0,
+            freedBytes: 0,
+            olderThanMs: 0,
+          },
+          diskBudget: null,
+          wouldMutate: true,
+          applied: true,
+          appliedCount: 0,
+        },
+      ],
+      partialError: {
+        failingAgentId: "work",
+        failingStorePath: "/gateway/work/openclaw-agent.sqlite",
+        message: "Session cleanup failed for agent 'work': injected failure",
+      },
+    };
+    mocks.callGateway.mockRejectedValue(Object.assign(new Error("request failed"), { details }));
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand({ allAgents: true, enforce: true, json: true }, runtime);
+
+    expect(JSON.parse(logs[0] ?? "{}")).toEqual(details);
+    expect(process.exitCode).toBe(1);
+    expect(mocks.runLocalSessionsCleanup).not.toHaveBeenCalled();
+  });
+
+  it("does not render rejected Gateway details without a partial marker", async () => {
+    const error = Object.assign(new Error("request failed"), {
+      details: { allAgents: true, mode: "enforce", dryRun: false, stores: [] },
+    });
+    mocks.callGateway.mockRejectedValue(error);
+
+    const { runtime } = makeRuntime();
+    await expect(sessionsCleanupCommand({ allAgents: true, enforce: true }, runtime)).rejects.toBe(
+      error,
+    );
+
+    expect(process.exitCode).toBeUndefined();
   });
 
   it("preserves a Gateway-owned store path in human output", async () => {

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -289,9 +289,11 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
   if (gatewayCleanup.delegated) {
     // The Gateway owns this path. Preserve its syntax because resolving a remote
     // Windows path on a POSIX client (or vice versa) would fabricate a local path.
+    const partialError =
+      "partialError" in gatewayCleanup.result ? gatewayCleanup.result.partialError : undefined;
     if (opts.json) {
       writeRuntimeJson(runtime, gatewayCleanup.result);
-      if ("partialError" in gatewayCleanup.result) {
+      if (partialError) {
         process.exitCode = 1;
       }
       return;
@@ -302,8 +304,8 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
       runtime,
       locallyOwned: false,
     });
-    if ("partialError" in gatewayCleanup.result) {
-      runtime.error(`[error] ${gatewayCleanup.result.partialError.message}`);
+    if (partialError) {
+      runtime.error(`[error] ${partialError.message}`);
       process.exitCode = 1;
     }
     return;

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -4,12 +4,14 @@
  * It can delegate cleanup to a live gateway or run local store maintenance,
  * with dry-run tables that explain every planned pruning action.
  */
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { getRuntimeConfig } from "../config/config.js";
 import {
   resolveSessionCleanupAction,
+  isSessionsCleanupPartialResult,
   runSessionsCleanup,
   serializeSessionCleanupResult,
   type SessionCleanupSummary,
@@ -274,6 +276,9 @@ async function maybeRunGatewayCleanup(
       // mutation; timeouts and established closes must not replay it locally.
       return { delegated: false };
     }
+    if (isRecord(error) && isSessionsCleanupPartialResult(error.details)) {
+      return { delegated: true, result: error.details };
+    }
     throw error;
   }
 }
@@ -286,6 +291,9 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
     // Windows path on a POSIX client (or vice versa) would fabricate a local path.
     if (opts.json) {
       writeRuntimeJson(runtime, gatewayCleanup.result);
+      if ("partialError" in gatewayCleanup.result) {
+        process.exitCode = 1;
+      }
       return;
     }
     renderAppliedSummaries({
@@ -294,6 +302,10 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
       runtime,
       locallyOwned: false,
     });
+    if ("partialError" in gatewayCleanup.result) {
+      runtime.error(`[error] ${gatewayCleanup.result.partialError.message}`);
+      process.exitCode = 1;
+    }
     return;
   }
 
@@ -319,7 +331,7 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
     const { runLocalSessionsCleanup } = await import("./sessions-cleanup.runtime.js");
     cleanupResult = await runLocalSessionsCleanup(cleanupParams, runtime);
   }
-  const { mode, previewResults, appliedSummaries } = cleanupResult;
+  const { mode, previewResults, appliedSummaries, failure } = cleanupResult;
 
   if (opts.dryRun) {
     if (opts.json) {
@@ -356,10 +368,18 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
         mode,
         dryRun: false,
         summaries: appliedSummaries.map(toDisplayedCleanupSummary),
+        failure,
       }),
     );
+    if (failure) {
+      process.exitCode = 1;
+    }
     return;
   }
 
   renderAppliedSummaries({ summaries: appliedSummaries, runtime, locallyOwned: true });
+  if (failure) {
+    runtime.error(`[error] ${failure.message}`);
+    process.exitCode = 1;
+  }
 }

--- a/src/config/sessions/cleanup-result.ts
+++ b/src/config/sessions/cleanup-result.ts
@@ -31,22 +31,36 @@ export type SessionCleanupSummary = {
 export type SessionsCleanupFailure = {
   target: SessionStoreTarget;
   message: string;
+  lifecycleCommitted: boolean;
 };
 
 export function createSessionsCleanupFailure(
   target: SessionStoreTarget,
   cause: unknown,
+  lifecycleCommitted: boolean,
 ): SessionsCleanupFailure {
   return {
     target,
     message: `Session cleanup failed for agent '${target.agentId}': ${formatErrorMessage(cause)}`,
+    lifecycleCommitted,
   };
+}
+
+export class SessionsCleanupFailureError extends Error {
+  constructor(
+    readonly failure: SessionsCleanupFailure,
+    cause: unknown,
+  ) {
+    super(failure.message, { cause });
+    this.name = "SessionsCleanupFailureError";
+  }
 }
 
 export type SessionsCleanupPartialErrorDetail = {
   failingAgentId: string;
   failingStorePath: string;
   message: string;
+  lifecycleCommitted: boolean;
 };
 
 type SessionsCleanupAggregateResult = {
@@ -97,6 +111,7 @@ export function serializeSessionCleanupResult(params: {
               { agentId: params.failure.target.agentId },
             ).path,
             message: params.failure.message,
+            lifecycleCommitted: params.failure.lifecycleCommitted,
           },
         }
       : {}),
@@ -142,6 +157,7 @@ export function isSessionsCleanupPartialResult(
     value.stores.every(isSessionCleanupSummary) &&
     typeof value.partialError.failingAgentId === "string" &&
     typeof value.partialError.failingStorePath === "string" &&
-    typeof value.partialError.message === "string"
+    typeof value.partialError.message === "string" &&
+    typeof value.partialError.lifecycleCommitted === "boolean"
   );
 }

--- a/src/config/sessions/cleanup-result.ts
+++ b/src/config/sessions/cleanup-result.ts
@@ -1,0 +1,147 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { formatErrorMessage } from "../../infra/errors.js";
+import type {
+  SessionDiskBudgetSweepResult,
+  SessionUnreferencedArtifactSweepResult,
+} from "./disk-budget.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
+import type { SessionStoreTarget } from "./targets.js";
+
+export type SessionCleanupSummary = {
+  agentId: string;
+  storePath: string;
+  mode: ResolvedSessionMaintenanceConfig["mode"];
+  dryRun: boolean;
+  beforeCount: number;
+  afterCount: number;
+  missing: number;
+  dmScopeRetired: number;
+  modelRunPruned: number;
+  archived?: number;
+  pruned: number;
+  capped: number;
+  unreferencedArtifacts: SessionUnreferencedArtifactSweepResult;
+  diskBudget: SessionDiskBudgetSweepResult | null;
+  wouldMutate: boolean;
+  applied?: true;
+  appliedCount?: number;
+};
+
+export type SessionsCleanupFailure = {
+  target: SessionStoreTarget;
+  message: string;
+};
+
+export function createSessionsCleanupFailure(
+  target: SessionStoreTarget,
+  cause: unknown,
+): SessionsCleanupFailure {
+  return {
+    target,
+    message: `Session cleanup failed for agent '${target.agentId}': ${formatErrorMessage(cause)}`,
+  };
+}
+
+export type SessionsCleanupPartialErrorDetail = {
+  failingAgentId: string;
+  failingStorePath: string;
+  message: string;
+};
+
+type SessionsCleanupAggregateResult = {
+  allAgents: true;
+  mode: ResolvedSessionMaintenanceConfig["mode"];
+  dryRun: boolean;
+  stores: SessionCleanupSummary[];
+};
+
+export type SessionsCleanupPartialResult = SessionsCleanupAggregateResult & {
+  partialError: SessionsCleanupPartialErrorDetail;
+};
+
+export type SessionsCleanupResult =
+  | SessionCleanupSummary
+  | (SessionsCleanupAggregateResult & { partialError?: never })
+  | SessionsCleanupPartialResult;
+
+export function serializeSessionCleanupResult(params: {
+  mode: ResolvedSessionMaintenanceConfig["mode"];
+  dryRun: boolean;
+  summaries: SessionCleanupSummary[];
+  failure?: SessionsCleanupFailure;
+}): SessionsCleanupResult {
+  const summaries = params.summaries.map((summary) => ({
+    ...summary,
+    storePath: resolveSqliteTargetFromSessionStorePath(summary.storePath, {
+      agentId: summary.agentId,
+    }).path,
+  }));
+  const [summary] = summaries;
+  // A partial failure exists only after another store completed, so it always
+  // uses the aggregate shape and never fabricates a scalar store summary.
+  if (summary && summaries.length === 1 && !params.failure) {
+    return summary;
+  }
+  return {
+    allAgents: true,
+    mode: params.mode,
+    dryRun: params.dryRun,
+    stores: summaries,
+    ...(params.failure
+      ? {
+          partialError: {
+            failingAgentId: params.failure.target.agentId,
+            failingStorePath: resolveSqliteTargetFromSessionStorePath(
+              params.failure.target.storePath,
+              { agentId: params.failure.target.agentId },
+            ).path,
+            message: params.failure.message,
+          },
+        }
+      : {}),
+  };
+}
+
+function isSessionCleanupSummary(value: unknown): value is SessionCleanupSummary {
+  if (!isRecord(value) || !isRecord(value.unreferencedArtifacts)) {
+    return false;
+  }
+  return (
+    typeof value.agentId === "string" &&
+    typeof value.storePath === "string" &&
+    (value.mode === "enforce" || value.mode === "warn") &&
+    typeof value.dryRun === "boolean" &&
+    typeof value.beforeCount === "number" &&
+    typeof value.afterCount === "number" &&
+    typeof value.missing === "number" &&
+    typeof value.dmScopeRetired === "number" &&
+    typeof value.modelRunPruned === "number" &&
+    (value.archived === undefined || typeof value.archived === "number") &&
+    typeof value.pruned === "number" &&
+    typeof value.capped === "number" &&
+    typeof value.unreferencedArtifacts.removedFiles === "number" &&
+    (value.diskBudget === null || isRecord(value.diskBudget)) &&
+    typeof value.wouldMutate === "boolean" &&
+    (value.applied === undefined || value.applied === true) &&
+    (value.appliedCount === undefined || typeof value.appliedCount === "number")
+  );
+}
+
+export function isSessionsCleanupPartialResult(
+  value: unknown,
+): value is SessionsCleanupPartialResult {
+  if (!isRecord(value) || !isRecord(value.partialError)) {
+    return false;
+  }
+  return (
+    value.allAgents === true &&
+    (value.mode === "enforce" || value.mode === "warn") &&
+    typeof value.dryRun === "boolean" &&
+    Array.isArray(value.stores) &&
+    value.stores.every(isSessionCleanupSummary) &&
+    typeof value.partialError.failingAgentId === "string" &&
+    typeof value.partialError.failingStorePath === "string" &&
+    typeof value.partialError.message === "string"
+  );
+}

--- a/src/config/sessions/cleanup-service.applied-summary.test.ts
+++ b/src/config/sessions/cleanup-service.applied-summary.test.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 
@@ -27,10 +30,12 @@ vi.mock("./disk-budget.js", async (importOriginal) => {
 
 import { runSessionsCleanup } from "./cleanup-service.js";
 import {
+  appendTranscriptEventSync,
   appendTranscriptMessageSync,
   loadSessionEntry,
   replaceSessionEntry,
 } from "./session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -116,5 +121,55 @@ describe("sessions cleanup applied summary", () => {
       wouldMutate: false,
     });
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({ sessionId });
+  });
+
+  it("returns earlier committed summaries when a later store rejects", async () => {
+    const rootDir = tempDirs.make("openclaw-cleanup-partial-");
+    const main = {
+      agentId: "main",
+      sessionId: "main-message-free",
+      sessionKey: "agent:main:message-free",
+      storePath: path.join(rootDir, "agents", "main", "sessions", "sessions.json"),
+    };
+    const failing = {
+      agentId: "work",
+      sessionId: "work-message-free",
+      sessionKey: "agent:work:message-free",
+      storePath: path.join(rootDir, "agents", "work", "sessions", "sessions.json"),
+    };
+    const stores = [main, failing];
+    for (const store of stores) {
+      await replaceSessionEntry(store, {
+        sessionId: store.sessionId,
+        updatedAt: Date.now() - 100_000_000,
+      });
+      appendTranscriptEventSync(store, { type: "proof", content: store.agentId });
+    }
+    const failingSqlitePath = resolveSqliteTargetFromSessionStorePath(failing.storePath, {
+      agentId: failing.agentId,
+    }).path;
+    openOpenClawAgentDatabase({ agentId: failing.agentId, path: failingSqlitePath }).db.exec(`
+      CREATE TRIGGER fail_second_store_delete
+      BEFORE DELETE ON session_windows
+      WHEN OLD.session_id = '${failing.sessionId}'
+      BEGIN
+        SELECT RAISE(ABORT, 'injected second-store lifecycle failure');
+      END;
+    `);
+
+    const outcome = await runSessionsCleanup({
+      cfg: {},
+      opts: { enforce: true, fixMissing: true },
+      targets: stores,
+    });
+
+    expect(loadSessionEntry(main)).toBeUndefined();
+    expect(loadSessionEntry(failing)).toMatchObject({ sessionId: failing.sessionId });
+    expect(outcome).toMatchObject({
+      appliedSummaries: [expect.objectContaining({ agentId: "main", applied: true })],
+      failure: expect.objectContaining({
+        target: expect.objectContaining({ agentId: "work" }),
+      }),
+    });
   });
 });

--- a/src/config/sessions/cleanup-service.applied-summary.test.ts
+++ b/src/config/sessions/cleanup-service.applied-summary.test.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../types.openclaw.js";
 
 const cleanupRace = vi.hoisted(() => ({
   afterPreview: undefined as (() => void) | undefined,
+  postCommitFailureStorePath: undefined as string | undefined,
 }));
 
 vi.mock("./disk-budget.js", async (importOriginal) => {
@@ -22,6 +23,9 @@ vi.mock("./disk-budget.js", async (importOriginal) => {
         const afterPreview = cleanupRace.afterPreview;
         cleanupRace.afterPreview = undefined;
         afterPreview();
+      }
+      if (!params.dryRun && cleanupRace.postCommitFailureStorePath === params.storePath) {
+        throw new Error("injected post-commit artifact failure");
       }
       return result;
     }),
@@ -42,6 +46,7 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 describe("sessions cleanup applied summary", () => {
   afterEach(() => {
     cleanupRace.afterPreview = undefined;
+    cleanupRace.postCommitFailureStorePath = undefined;
     closeOpenClawAgentDatabasesForTest();
   });
 
@@ -123,53 +128,68 @@ describe("sessions cleanup applied summary", () => {
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({ sessionId });
   });
 
-  it("returns earlier committed summaries when a later store rejects", async () => {
-    const rootDir = tempDirs.make("openclaw-cleanup-partial-");
-    const main = {
-      agentId: "main",
-      sessionId: "main-message-free",
-      sessionKey: "agent:main:message-free",
-      storePath: path.join(rootDir, "agents", "main", "sessions", "sessions.json"),
-    };
-    const failing = {
-      agentId: "work",
-      sessionId: "work-message-free",
-      sessionKey: "agent:work:message-free",
-      storePath: path.join(rootDir, "agents", "work", "sessions", "sessions.json"),
-    };
-    const stores = [main, failing];
-    for (const store of stores) {
-      await replaceSessionEntry(store, {
-        sessionId: store.sessionId,
-        updatedAt: Date.now() - 100_000_000,
+  it.each([
+    { fault: "before commit", lifecycleCommitted: false },
+    { fault: "after commit", lifecycleCommitted: true },
+  ])(
+    "returns earlier committed summaries when a later store fails $fault",
+    async ({ lifecycleCommitted }) => {
+      const rootDir = tempDirs.make("openclaw-cleanup-partial-");
+      const main = {
+        agentId: "main",
+        sessionId: "main-message-free",
+        sessionKey: "agent:main:message-free",
+        storePath: path.join(rootDir, "agents", "main", "sessions", "sessions.json"),
+      };
+      const failing = {
+        agentId: "work",
+        sessionId: "work-message-free",
+        sessionKey: "agent:work:message-free",
+        storePath: path.join(rootDir, "agents", "work", "sessions", "sessions.json"),
+      };
+      const stores = [main, failing];
+      for (const store of stores) {
+        await replaceSessionEntry(store, {
+          sessionId: store.sessionId,
+          updatedAt: Date.now() - 100_000_000,
+        });
+        appendTranscriptEventSync(store, { type: "proof", content: store.agentId });
+      }
+      const failingSqlitePath = resolveSqliteTargetFromSessionStorePath(failing.storePath, {
+        agentId: failing.agentId,
+      }).path;
+      if (lifecycleCommitted) {
+        cleanupRace.postCommitFailureStorePath = failing.storePath;
+      } else {
+        openOpenClawAgentDatabase({ agentId: failing.agentId, path: failingSqlitePath }).db.exec(`
+          CREATE TRIGGER fail_second_store_delete
+          BEFORE DELETE ON session_windows
+          WHEN OLD.session_id = '${failing.sessionId}'
+          BEGIN
+            SELECT RAISE(ABORT, 'injected second-store lifecycle failure');
+          END;
+        `);
+      }
+
+      const outcome = await runSessionsCleanup({
+        cfg: {},
+        opts: { enforce: true, fixMissing: true },
+        targets: stores,
       });
-      appendTranscriptEventSync(store, { type: "proof", content: store.agentId });
-    }
-    const failingSqlitePath = resolveSqliteTargetFromSessionStorePath(failing.storePath, {
-      agentId: failing.agentId,
-    }).path;
-    openOpenClawAgentDatabase({ agentId: failing.agentId, path: failingSqlitePath }).db.exec(`
-      CREATE TRIGGER fail_second_store_delete
-      BEFORE DELETE ON session_windows
-      WHEN OLD.session_id = '${failing.sessionId}'
-      BEGIN
-        SELECT RAISE(ABORT, 'injected second-store lifecycle failure');
-      END;
-    `);
 
-    const outcome = await runSessionsCleanup({
-      cfg: {},
-      opts: { enforce: true, fixMissing: true },
-      targets: stores,
-    });
-
-    expect(loadSessionEntry(main)).toBeUndefined();
-    expect(loadSessionEntry(failing)).toMatchObject({ sessionId: failing.sessionId });
-    expect(outcome).toMatchObject({
-      appliedSummaries: [expect.objectContaining({ agentId: "main", applied: true })],
-      failure: expect.objectContaining({
-        target: expect.objectContaining({ agentId: "work" }),
-      }),
-    });
-  });
+      expect(loadSessionEntry(main)).toBeUndefined();
+      if (lifecycleCommitted) {
+        expect(loadSessionEntry(failing)).toBeUndefined();
+      } else {
+        expect(loadSessionEntry(failing)).toMatchObject({ sessionId: failing.sessionId });
+      }
+      expect(outcome).toMatchObject({
+        appliedSummaries: [expect.objectContaining({ agentId: "main", applied: true })],
+        failure: expect.objectContaining({
+          target: expect.objectContaining({ agentId: "work" }),
+          lifecycleCommitted,
+        }),
+      });
+    },
+  );
 });

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -7,10 +7,13 @@ import { getLogger } from "../../logging/logger.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import {
+  createSessionsCleanupFailure,
+  type SessionCleanupSummary,
+  type SessionsCleanupFailure,
+} from "./cleanup-result.js";
+import {
   pruneUnreferencedSessionArtifacts,
   resolveSessionArtifactCanonicalPathsForEntry,
-  type SessionDiskBudgetSweepResult,
-  type SessionUnreferencedArtifactSweepResult,
 } from "./disk-budget.js";
 import { resolveSessionStorePathCore } from "./paths.js";
 import {
@@ -44,6 +47,17 @@ import {
 } from "./targets.js";
 import type { SessionEntry } from "./types.js";
 
+export {
+  createSessionsCleanupFailure,
+  isSessionsCleanupPartialResult,
+  serializeSessionCleanupResult,
+  type SessionCleanupSummary,
+  type SessionsCleanupFailure,
+  type SessionsCleanupPartialErrorDetail,
+  type SessionsCleanupPartialResult,
+  type SessionsCleanupResult,
+} from "./cleanup-result.js";
+
 export type SessionsCleanupOptions = SessionStoreSelectionOptions & {
   dryRun?: boolean;
   enforce?: boolean;
@@ -62,35 +76,6 @@ type SessionCleanupAction =
   | "cap-overflow"
   | "retire-dm-scope";
 
-export type SessionCleanupSummary = {
-  agentId: string;
-  storePath: string;
-  mode: ResolvedSessionMaintenanceConfig["mode"];
-  dryRun: boolean;
-  beforeCount: number;
-  afterCount: number;
-  missing: number;
-  dmScopeRetired: number;
-  modelRunPruned: number;
-  archived?: number;
-  pruned: number;
-  capped: number;
-  unreferencedArtifacts: SessionUnreferencedArtifactSweepResult;
-  diskBudget: SessionDiskBudgetSweepResult | null;
-  wouldMutate: boolean;
-  applied?: true;
-  appliedCount?: number;
-};
-
-export type SessionsCleanupResult =
-  | SessionCleanupSummary
-  | {
-      allAgents: true;
-      mode: ResolvedSessionMaintenanceConfig["mode"];
-      dryRun: boolean;
-      stores: SessionCleanupSummary[];
-    };
-
 type SessionsCleanupRunResult = {
   mode: ResolvedSessionMaintenanceConfig["mode"];
   previewResults: Array<{
@@ -104,7 +89,7 @@ type SessionsCleanupRunResult = {
     dmScopeRetiredKeys: Set<string>;
   }>;
   appliedSummaries: SessionCleanupSummary[];
-};
+} & ({ failure?: never } | { failure: SessionsCleanupFailure });
 
 function resolveCleanupSqlitePath(target: SessionStoreTarget): string {
   return resolveSqliteTargetFromSessionStorePath(target.storePath, { agentId: target.agentId })
@@ -259,28 +244,6 @@ function retireMainScopeDirectSessionEntries(params: {
     }
   }
   return retired;
-}
-
-export function serializeSessionCleanupResult(params: {
-  mode: ResolvedSessionMaintenanceConfig["mode"];
-  dryRun: boolean;
-  summaries: SessionCleanupSummary[];
-}): SessionsCleanupResult {
-  const summaries = params.summaries.map((summary) => ({
-    ...summary,
-    storePath: resolveSqliteTargetFromSessionStorePath(summary.storePath, {
-      agentId: summary.agentId,
-    }).path,
-  }));
-  if (summaries.length === 1) {
-    return summaries[0] ?? ({} as SessionCleanupSummary);
-  }
-  return {
-    allAgents: true,
-    mode: params.mode,
-    dryRun: params.dryRun,
-    stores: summaries,
-  };
 }
 
 function pruneMissingTranscriptEntries(params: {
@@ -566,124 +529,140 @@ export async function runSessionsCleanup(params: {
   }
 
   const appliedSummaries: SessionCleanupSummary[] = [];
-  if (!opts.dryRun) {
-    for (const target of targets) {
-      const applyStore = loadCleanupSessionStore(target, { createIfMissing: true });
-      const missingRemovals: SessionEntryLifecycleRemoval[] = [];
-      const dmScopeRetiredRemovals: SessionEntryLifecycleRemoval[] = [];
-      if (opts.fixMissing) {
-        pruneMissingTranscriptEntries({
-          store: applyStore,
-          target,
-          onPruned: (sessionKey, entry, inspection) => {
-            missingRemovals.push({
-              sessionKey,
-              expectedEntry: structuredClone(entry),
-              archiveRemovedTranscript: true,
-              ...(inspection ? { expectedTranscriptSnapshot: inspection.snapshot } : {}),
-            });
+  let failingTarget: SessionStoreTarget | undefined;
+  try {
+    if (!opts.dryRun) {
+      for (const target of targets) {
+        failingTarget = target;
+        const applyStore = loadCleanupSessionStore(target, { createIfMissing: true });
+        const missingRemovals: SessionEntryLifecycleRemoval[] = [];
+        const dmScopeRetiredRemovals: SessionEntryLifecycleRemoval[] = [];
+        if (opts.fixMissing) {
+          pruneMissingTranscriptEntries({
+            store: applyStore,
+            target,
+            onPruned: (sessionKey, entry, inspection) => {
+              missingRemovals.push({
+                sessionKey,
+                expectedEntry: structuredClone(entry),
+                archiveRemovedTranscript: true,
+                ...(inspection ? { expectedTranscriptSnapshot: inspection.snapshot } : {}),
+              });
+            },
+          });
+        }
+        if (opts.fixDmScope) {
+          retireMainScopeDirectSessionEntries({
+            cfg,
+            store: applyStore,
+            targetAgentId: target.agentId,
+            activeKey: opts.activeKey,
+            onRetired: (sessionKey, entry) => {
+              dmScopeRetiredRemovals.push({
+                sessionKey,
+                expectedEntry: structuredClone(entry),
+                archiveRemovedTranscript: true,
+              });
+            },
+          });
+        }
+        const removals: SessionEntryLifecycleRemoval[] = [
+          ...missingRemovals,
+          ...dmScopeRetiredRemovals,
+        ];
+        const lifecycleResult = await applySessionEntryLifecycleMutation({
+          agentId: target.agentId,
+          storePath: target.storePath,
+          removals,
+          activeSessionKey: opts.activeKey,
+          maintenanceOverride: {
+            ...maintenance,
+            mode,
           },
         });
-      }
-      if (opts.fixDmScope) {
-        retireMainScopeDirectSessionEntries({
-          cfg,
-          store: applyStore,
-          targetAgentId: target.agentId,
-          activeKey: opts.activeKey,
-          onRetired: (sessionKey, entry) => {
-            dmScopeRetiredRemovals.push({
-              sessionKey,
-              expectedEntry: structuredClone(entry),
-              archiveRemovedTranscript: true,
-            });
-          },
-        });
-      }
-      const removals: SessionEntryLifecycleRemoval[] = [
-        ...missingRemovals,
-        ...dmScopeRetiredRemovals,
-      ];
-      const lifecycleResult = await applySessionEntryLifecycleMutation({
-        agentId: target.agentId,
-        storePath: target.storePath,
-        removals,
-        activeSessionKey: opts.activeKey,
-        maintenanceOverride: {
-          ...maintenance,
+        const postApplyStore = loadCleanupSessionStore(target, { createIfMissing: true });
+        const appliedUnreferencedArtifacts =
+          mode === "warn"
+            ? null
+            : await pruneUnreferencedSessionArtifacts({
+                store: postApplyStore,
+                storePath: target.storePath,
+                olderThanMs: maintenance.pruneAfterMs,
+                dryRun: false,
+              });
+        const removedSessionKeys = new Set(lifecycleResult.removedSessionKeys);
+        const unreferencedArtifacts =
+          mode === "warn"
+            ? {
+                scannedFiles: 0,
+                removedFiles: 0,
+                freedBytes: 0,
+                olderThanMs: maintenance.pruneAfterMs,
+              }
+            : (appliedUnreferencedArtifacts ?? {
+                scannedFiles: 0,
+                removedFiles: 0,
+                freedBytes: 0,
+                olderThanMs: maintenance.pruneAfterMs,
+              });
+        const appliedDiskBudget = await enforceSqliteSessionHistoryDiskBudget({
+          agentId: target.agentId,
+          storePath: target.storePath,
           mode,
-        },
-      });
-      const postApplyStore = loadCleanupSessionStore(target, { createIfMissing: true });
-      const appliedUnreferencedArtifacts =
-        mode === "warn"
-          ? null
-          : await pruneUnreferencedSessionArtifacts({
-              store: postApplyStore,
-              storePath: target.storePath,
-              olderThanMs: maintenance.pruneAfterMs,
-              dryRun: false,
-            });
-      const removedSessionKeys = new Set(lifecycleResult.removedSessionKeys);
-      const unreferencedArtifacts =
-        mode === "warn"
-          ? {
-              scannedFiles: 0,
-              removedFiles: 0,
-              freedBytes: 0,
-              olderThanMs: maintenance.pruneAfterMs,
-            }
-          : (appliedUnreferencedArtifacts ?? {
-              scannedFiles: 0,
-              removedFiles: 0,
-              freedBytes: 0,
-              olderThanMs: maintenance.pruneAfterMs,
-            });
-      const appliedDiskBudget = await enforceSqliteSessionHistoryDiskBudget({
-        agentId: target.agentId,
-        storePath: target.storePath,
-        mode,
-        maintenance,
-      });
-      const missing = missingRemovals.filter(({ sessionKey }) =>
-        removedSessionKeys.has(sessionKey),
-      ).length;
-      const dmScopeRetired = dmScopeRetiredRemovals.filter(({ sessionKey }) =>
-        removedSessionKeys.has(sessionKey),
-      ).length;
-      const maintenanceRemovedEntries =
-        lifecycleResult.modelRunPruned + lifecycleResult.pruned + lifecycleResult.capped;
-      const summary: SessionCleanupSummary = {
-        agentId: target.agentId,
-        storePath: target.storePath,
-        mode,
-        dryRun: false,
-        beforeCount: lifecycleResult.beforeCount,
-        afterCount: lifecycleResult.afterCount,
-        missing,
-        dmScopeRetired,
-        modelRunPruned: lifecycleResult.modelRunPruned,
-        archived: lifecycleResult.archived,
-        pruned: lifecycleResult.pruned,
-        capped: lifecycleResult.capped,
-        unreferencedArtifacts,
-        diskBudget: appliedDiskBudget,
-        wouldMutate:
-          lifecycleResult.removedEntries > 0 ||
-          lifecycleResult.archived > 0 ||
-          maintenanceRemovedEntries > 0 ||
-          unreferencedArtifacts.removedFiles > 0 ||
-          (appliedDiskBudget?.removedEntries ?? 0) > 0 ||
-          (appliedDiskBudget?.removedFiles ?? 0) > 0 ||
-          // Checkpoint/incremental-vacuum reclamation mutates the store
-          // even when no session or archive was removed.
-          (appliedDiskBudget != null &&
-            appliedDiskBudget.totalBytesAfter < appliedDiskBudget.totalBytesBefore),
-        applied: true,
-        appliedCount: lifecycleResult.afterCount,
-      };
-      appliedSummaries.push(summary);
+          maintenance,
+        });
+        const missing = missingRemovals.filter(({ sessionKey }) =>
+          removedSessionKeys.has(sessionKey),
+        ).length;
+        const dmScopeRetired = dmScopeRetiredRemovals.filter(({ sessionKey }) =>
+          removedSessionKeys.has(sessionKey),
+        ).length;
+        const maintenanceRemovedEntries =
+          lifecycleResult.modelRunPruned + lifecycleResult.pruned + lifecycleResult.capped;
+        const summary: SessionCleanupSummary = {
+          agentId: target.agentId,
+          storePath: target.storePath,
+          mode,
+          dryRun: false,
+          beforeCount: lifecycleResult.beforeCount,
+          afterCount: lifecycleResult.afterCount,
+          missing,
+          dmScopeRetired,
+          modelRunPruned: lifecycleResult.modelRunPruned,
+          archived: lifecycleResult.archived,
+          pruned: lifecycleResult.pruned,
+          capped: lifecycleResult.capped,
+          unreferencedArtifacts,
+          diskBudget: appliedDiskBudget,
+          wouldMutate:
+            lifecycleResult.removedEntries > 0 ||
+            lifecycleResult.archived > 0 ||
+            maintenanceRemovedEntries > 0 ||
+            unreferencedArtifacts.removedFiles > 0 ||
+            (appliedDiskBudget?.removedEntries ?? 0) > 0 ||
+            (appliedDiskBudget?.removedFiles ?? 0) > 0 ||
+            // Checkpoint/incremental-vacuum reclamation mutates the store
+            // even when no session or archive was removed.
+            (appliedDiskBudget != null &&
+              appliedDiskBudget.totalBytesAfter < appliedDiskBudget.totalBytesBefore),
+          applied: true,
+          appliedCount: lifecycleResult.afterCount,
+        };
+        appliedSummaries.push(summary);
+      }
     }
+  } catch (cause) {
+    // A first-store failure preserves the existing rejection contract. Once a
+    // store commits, the owner must return its summary with the later failure.
+    if (!failingTarget || appliedSummaries.length === 0) {
+      throw cause;
+    }
+    return {
+      mode,
+      previewResults,
+      appliedSummaries,
+      failure: createSessionsCleanupFailure(failingTarget, cause),
+    };
   }
 
   return { mode, previewResults, appliedSummaries };

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -8,6 +8,7 @@ import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-ke
 import type { OpenClawConfig } from "../types.openclaw.js";
 import {
   createSessionsCleanupFailure,
+  SessionsCleanupFailureError,
   type SessionCleanupSummary,
   type SessionsCleanupFailure,
 } from "./cleanup-result.js";
@@ -51,6 +52,7 @@ export {
   createSessionsCleanupFailure,
   isSessionsCleanupPartialResult,
   serializeSessionCleanupResult,
+  SessionsCleanupFailureError,
   type SessionCleanupSummary,
   type SessionsCleanupFailure,
   type SessionsCleanupPartialErrorDetail,
@@ -530,10 +532,12 @@ export async function runSessionsCleanup(params: {
 
   const appliedSummaries: SessionCleanupSummary[] = [];
   let failingTarget: SessionStoreTarget | undefined;
+  let failingTargetLifecycleCommitted = false;
   try {
     if (!opts.dryRun) {
       for (const target of targets) {
         failingTarget = target;
+        failingTargetLifecycleCommitted = false;
         const applyStore = loadCleanupSessionStore(target, { createIfMissing: true });
         const missingRemovals: SessionEntryLifecycleRemoval[] = [];
         const dmScopeRetiredRemovals: SessionEntryLifecycleRemoval[] = [];
@@ -578,6 +582,9 @@ export async function runSessionsCleanup(params: {
           maintenanceOverride: {
             ...maintenance,
             mode,
+          },
+          onLifecycleCommitted: () => {
+            failingTargetLifecycleCommitted = true;
           },
         });
         const postApplyStore = loadCleanupSessionStore(target, { createIfMissing: true });
@@ -654,14 +661,22 @@ export async function runSessionsCleanup(params: {
   } catch (cause) {
     // A first-store failure preserves the existing rejection contract. Once a
     // store commits, the owner must return its summary with the later failure.
-    if (!failingTarget || appliedSummaries.length === 0) {
+    if (!failingTarget) {
       throw cause;
+    }
+    const failure = createSessionsCleanupFailure(
+      failingTarget,
+      cause,
+      failingTargetLifecycleCommitted,
+    );
+    if (appliedSummaries.length === 0) {
+      throw new SessionsCleanupFailureError(failure, cause);
     }
     return {
       mode,
       previewResults,
       appliedSummaries,
-      failure: createSessionsCleanupFailure(failingTarget, cause),
+      failure,
     };
   }
 

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -259,6 +259,8 @@ export async function applySessionEntryLifecycleMutation(params: {
   afterUpsertsInTransaction?: (database: OpenClawAgentDatabase) => void;
   /** Synchronous caller-authority guard checked immediately before lifecycle writes. */
   beforeCommitInTransaction?: () => void;
+  /** Runs after the SQLite commit and before fallible artifact publication. */
+  onLifecycleCommitted?: () => void;
 }): Promise<SessionEntryLifecycleMutationResult> {
   const resolved = resolveSqliteScope({
     ...(params.agentId ? { agentId: params.agentId } : {}),
@@ -313,6 +315,7 @@ export async function applySessionEntryLifecycleMutation(params: {
         ),
     };
   });
+  params.onLifecycleCommitted?.();
 
   function commitProjectedLifecycleMutation(
     removalPlans: MaterializedSessionStateDeletePlan[],

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -530,7 +530,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
           );
         }
       }
-      if (failure) {
+      if (failure?.lifecycleCommitted) {
         emitSessionsChanged(context, { reason: "cleanup", sessionKey: undefined });
       }
     } catch (error) {

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -496,7 +496,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
-      const { mode, appliedSummaries } = await runSessionsCleanup({
+      const { mode, appliedSummaries, failure } = await runSessionsCleanup({
         cfg: context.getRuntimeConfig(),
         opts: {
           agent: params.agent,
@@ -511,8 +511,17 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
         mode,
         dryRun: false,
         summaries: appliedSummaries,
+        failure,
       });
-      respond(true, result, undefined);
+      if (failure) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, failure.message, { details: result }),
+        );
+      } else {
+        respond(true, result, undefined);
+      }
       for (const summary of appliedSummaries) {
         emitSessionsChanged(context, { reason: "cleanup", sessionKey: undefined });
         if (summary.wouldMutate) {
@@ -520,6 +529,9 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
             `sessions.cleanup applied ${summary.storePath}: ${summary.beforeCount} -> ${summary.afterCount}`,
           );
         }
+      }
+      if (failure) {
+        emitSessionsChanged(context, { reason: "cleanup", sessionKey: undefined });
       }
     } catch (error) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatErrorMessage(error)));

--- a/src/gateway/server.sessions.cleanup-partial.test.ts
+++ b/src/gateway/server.sessions.cleanup-partial.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, test, vi } from "vitest";
 import type { SessionCleanupSummary } from "../config/sessions.js";
+import { flushPendingSessionsChangedEvents } from "./server-methods/session-change-event.js";
 import { directSessionReq } from "./test/server-sessions.test-helpers.js";
 
 const runSessionsCleanup = vi.hoisted(() => vi.fn());
@@ -13,65 +14,75 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test("sessions.cleanup rejects with committed summaries when a later store fails", async () => {
-  const appliedSummary: SessionCleanupSummary = {
-    agentId: "main",
-    storePath: "/tmp/main/sessions.json",
-    mode: "enforce",
-    dryRun: false,
-    beforeCount: 1,
-    afterCount: 0,
-    missing: 1,
-    dmScopeRetired: 0,
-    modelRunPruned: 0,
-    pruned: 0,
-    capped: 0,
-    unreferencedArtifacts: { scannedFiles: 0, removedFiles: 0, freedBytes: 0, olderThanMs: 0 },
-    diskBudget: null,
-    wouldMutate: true,
-    applied: true,
-    appliedCount: 0,
-  };
-  runSessionsCleanup.mockResolvedValue({
-    mode: "enforce",
-    previewResults: [],
-    appliedSummaries: [appliedSummary],
-    failure: {
-      target: { agentId: "work", storePath: "/tmp/work/sessions.json" },
-      message: "Session cleanup failed for agent 'work': injected failure",
-    },
-  });
-  const broadcastToConnIds = vi.fn();
-
-  const result = await directSessionReq(
-    "sessions.cleanup",
-    { allAgents: true, enforce: true },
-    {
-      context: {
-        broadcastToConnIds,
-        getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+test.each([
+  { lifecycleCommitted: false, expectedBroadcasts: 1 },
+  { lifecycleCommitted: true, expectedBroadcasts: 2 },
+])(
+  "sessions.cleanup reports a later store failure with lifecycleCommitted=$lifecycleCommitted",
+  async ({ lifecycleCommitted, expectedBroadcasts }) => {
+    const appliedSummary: SessionCleanupSummary = {
+      agentId: "main",
+      storePath: "/tmp/main/sessions.json",
+      mode: "enforce",
+      dryRun: false,
+      beforeCount: 1,
+      afterCount: 0,
+      missing: 1,
+      dmScopeRetired: 0,
+      modelRunPruned: 0,
+      pruned: 0,
+      capped: 0,
+      unreferencedArtifacts: { scannedFiles: 0, removedFiles: 0, freedBytes: 0, olderThanMs: 0 },
+      diskBudget: null,
+      wouldMutate: true,
+      applied: true,
+      appliedCount: 0,
+    };
+    runSessionsCleanup.mockResolvedValue({
+      mode: "enforce",
+      previewResults: [],
+      appliedSummaries: [appliedSummary],
+      failure: {
+        target: { agentId: "work", storePath: "/tmp/work/sessions.json" },
+        message: "Session cleanup failed for agent 'work': injected failure",
+        lifecycleCommitted,
       },
-    },
-  );
+    });
+    const broadcastToConnIds = vi.fn();
 
-  expect(result).toMatchObject({
-    ok: false,
-    error: {
-      code: "INVALID_REQUEST",
-      details: {
-        allAgents: true,
-        stores: [expect.objectContaining({ agentId: "main", applied: true })],
-        partialError: expect.objectContaining({
-          failingAgentId: "work",
-          message: expect.stringContaining("injected failure"),
-        }),
+    const result = await directSessionReq(
+      "sessions.cleanup",
+      { allAgents: true, enforce: true },
+      {
+        context: {
+          broadcastToConnIds,
+          getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+        },
       },
-    },
-  });
-  expect(broadcastToConnIds).toHaveBeenCalledWith(
-    "sessions.changed",
-    expect.objectContaining({ reason: "cleanup" }),
-    expect.any(Set),
-    expect.objectContaining({ dropIfSlow: true }),
-  );
-});
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        details: {
+          allAgents: true,
+          stores: [expect.objectContaining({ agentId: "main", applied: true })],
+          partialError: expect.objectContaining({
+            failingAgentId: "work",
+            lifecycleCommitted,
+            message: expect.stringContaining("injected failure"),
+          }),
+        },
+      },
+    });
+    expect(broadcastToConnIds).toHaveBeenCalledWith(
+      "sessions.changed",
+      expect.objectContaining({ reason: "cleanup" }),
+      expect.any(Set),
+      expect.objectContaining({ dropIfSlow: true }),
+    );
+    flushPendingSessionsChangedEvents();
+    expect(broadcastToConnIds).toHaveBeenCalledTimes(expectedBroadcasts);
+  },
+);

--- a/src/gateway/server.sessions.cleanup-partial.test.ts
+++ b/src/gateway/server.sessions.cleanup-partial.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import type { SessionCleanupSummary } from "../config/sessions.js";
+import { directSessionReq } from "./test/server-sessions.test-helpers.js";
+
+const runSessionsCleanup = vi.hoisted(() => vi.fn());
+
+vi.mock("../config/sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/sessions.js")>()),
+  runSessionsCleanup,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+test("sessions.cleanup rejects with committed summaries when a later store fails", async () => {
+  const appliedSummary: SessionCleanupSummary = {
+    agentId: "main",
+    storePath: "/tmp/main/sessions.json",
+    mode: "enforce",
+    dryRun: false,
+    beforeCount: 1,
+    afterCount: 0,
+    missing: 1,
+    dmScopeRetired: 0,
+    modelRunPruned: 0,
+    pruned: 0,
+    capped: 0,
+    unreferencedArtifacts: { scannedFiles: 0, removedFiles: 0, freedBytes: 0, olderThanMs: 0 },
+    diskBudget: null,
+    wouldMutate: true,
+    applied: true,
+    appliedCount: 0,
+  };
+  runSessionsCleanup.mockResolvedValue({
+    mode: "enforce",
+    previewResults: [],
+    appliedSummaries: [appliedSummary],
+    failure: {
+      target: { agentId: "work", storePath: "/tmp/work/sessions.json" },
+      message: "Session cleanup failed for agent 'work': injected failure",
+    },
+  });
+  const broadcastToConnIds = vi.fn();
+
+  const result = await directSessionReq(
+    "sessions.cleanup",
+    { allAgents: true, enforce: true },
+    {
+      context: {
+        broadcastToConnIds,
+        getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
+      },
+    },
+  );
+
+  expect(result).toMatchObject({
+    ok: false,
+    error: {
+      code: "INVALID_REQUEST",
+      details: {
+        allAgents: true,
+        stores: [expect.objectContaining({ agentId: "main", applied: true })],
+        partialError: expect.objectContaining({
+          failingAgentId: "work",
+          message: expect.stringContaining("injected failure"),
+        }),
+      },
+    },
+  });
+  expect(broadcastToConnIds).toHaveBeenCalledWith(
+    "sessions.changed",
+    expect.objectContaining({ reason: "cleanup" }),
+    expect.any(Set),
+    expect.objectContaining({ dropIfSlow: true }),
+  );
+});

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -648,14 +648,22 @@ export async function directSessionReq<TPayload = unknown>(
     sessionMutationAuthorization?: SessionsHandlerOptions["sessionMutationAuthorization"];
     coercePayload?: (payload: unknown) => TPayload;
   },
-): Promise<{ ok: boolean; payload?: TPayload; error?: { code?: string; message?: string } }> {
+): Promise<{
+  ok: boolean;
+  payload?: TPayload;
+  error?: { code?: string; message?: string; details?: unknown };
+}> {
   const sessionsHandlers = await getSessionsHandlers();
   const { getRuntimeConfig } = await getGatewayConfigModule();
   const loadGatewayModelCatalog =
     (opts?.context?.loadGatewayModelCatalog as GatewayRequestContext["loadGatewayModelCatalog"]) ??
     (async () => agentDiscoveryMock.models);
   let result:
-    | { ok: boolean; payload?: TPayload; error?: { code?: string; message?: string } }
+    | {
+        ok: boolean;
+        payload?: TPayload;
+        error?: { code?: string; message?: string; details?: unknown };
+      }
     | undefined;
   const handler = sessionsHandlers[method];
   if (!handler) {


### PR DESCRIPTION
Closes #127583

## What Problem This Solves

`openclaw sessions cleanup --all-agents` applies agent stores in order. If a later store failed, earlier stores remained durably changed but the cleanup owner returned only the later error. The CLI and Gateway could not report which stores had completed.

## Why This Change Was Made

- The cleanup service now owns one partial result: completed store summaries plus the failing target.
- The SQLite lifecycle owner records whether the failing target committed before later artifact work failed.
- The local plugin-aware runner combines per-store calls into that same result and stops on the first failure.
- The Gateway rejects partial cleanup with the completed summaries in typed error details.
- The CLI renders only validated partial details and exits with status 1.
- Single-store failures keep their existing rejection behavior.

The result serializer and types now live together in `src/config/sessions/cleanup-result.ts`. Partial results always use the existing `allAgents` envelope, so the code does not invent a synthetic successful store summary.

## User Impact

Operators can see which stores completed before a later cleanup failure. Scripts receive structured JSON and a nonzero exit status. Gateway subscribers also receive a session-change invalidation for the partial operation.

## Evidence

Exact current-main proof at `03e9ecb1482e86cdb3a1ceefeeb90de7822a25ab` used two real SQLite agent stores and a SQLite trigger that rejected deletion in the second store:

- the first store committed;
- the second store stayed intact;
- the returned `ERR_SQLITE_ERROR` contained no completed summary or failing-target result.

The same test passes on exact head `61e1fab88e5f8eece325ee4bf93c77848582d2e7`: the result contains the committed `main` summary and the failing `work` target. Separate pre-commit and post-commit faults prove `lifecycleCommitted: false` and `true`. Gateway tests prove that only the post-commit failure adds an invalidation for the failing store.

```text
node scripts/run-vitest.mjs +  src/config/sessions/cleanup-service.applied-summary.test.ts +  src/config/sessions/cleanup-service.fix-missing.test.ts +  src/config/sessions/cleanup-service.serialization.test.ts +  src/commands/sessions-cleanup.runtime.test.ts +  src/commands/sessions-cleanup.test.ts +  src/gateway/server.sessions.cleanup-partial.test.ts

Test Files  6 passed
Tests       32 passed
```

Additional local checks passed:

- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <changed files>`
- `pnpm check:max-lines-ratchet --base origin/main`
- `pnpm check:assertion-safety --base origin/main`
- `pnpm check:coercion-helpers`
- `pnpm check:import-cycles`
- `git diff --check`

Production delta is +389/-173, net +216. The new partial-result contract, lifecycle commit signal, and untrusted Gateway-details validator account for the growth. The absorbing refactor moved the existing cleanup result types and serializer out of the oversized cleanup service and removed its empty-summary assertion. Tests and test support are +341/-21. No SQLite schema, persistence, configuration, or protocol-version change is included.
