### PR TITLE
fix(matrix): let follow-ups steer active turns

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts
@@ -1,0 +1,278 @@
+import path from "node:path";
+import {
+  runChannelInboundEvent,
+  type ChannelInboundEventRunnerParams,
+} from "openclaw/plugin-sdk/channel-inbound";
+import type { FinalizedMsgContext, GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../runtime-api.js";
+import { installMatrixMonitorTestRuntime } from "../../test-runtime.js";
+import type { MatrixMonitorHandlerParams } from "./handler-types.js";
+import {
+  createMatrixHandlerTestHarness,
+  createMatrixTextMessageEvent,
+} from "./handler.test-helpers.js";
+import type { MatrixRawEvent } from "./types.js";
+
+type MatrixInboundRun = MatrixMonitorHandlerParams["core"]["channel"]["inbound"]["run"];
+type MatrixInboundRunParams = Parameters<MatrixInboundRun>[0];
+type TurnAdoptionLifecycle = NonNullable<GetReplyOptions["turnAdoptionLifecycle"]>;
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function createClaimSpies() {
+  return {
+    commit: vi.fn(async () => true),
+    release: vi.fn(),
+  };
+}
+
+function releaseSyntheticResolverAdmissionTicket(options: GetReplyOptions | undefined): void {
+  if (!options) {
+    throw new Error("expected reply options with an admission ticket");
+  }
+  const symbolOptions = options as GetReplyOptions & Record<symbol, unknown>;
+  const tickets = Object.getOwnPropertySymbols(options)
+    .map((key) => symbolOptions[key])
+    .filter(
+      (value): value is { wait: (signal?: AbortSignal) => Promise<boolean>; release: () => void } =>
+        typeof value === "object" &&
+        value !== null &&
+        "wait" in value &&
+        typeof value.wait === "function" &&
+        "release" in value &&
+        typeof value.release === "function",
+    );
+  const ticket = tickets.at(0);
+  if (tickets.length !== 1 || !ticket) {
+    throw new Error(`expected one reply admission ticket, received ${tickets.length}`);
+  }
+  // A real getReplyFromConfig run releases this ticket when runReplyAgent publishes
+  // queue/run ownership. The synthetic resolver must model the same handoff.
+  ticket.release();
+}
+
+describe("Matrix active-turn steering admission", () => {
+  it.each([
+    {
+      name: "configured steer mode",
+      followupBody: "use the monochrome version instead",
+      explicitSteer: false,
+    },
+    {
+      name: "an explicit /steer command",
+      followupBody: "/steer use the monochrome version instead",
+      explicitSteer: true,
+    },
+  ])(
+    "lets $name reach queue policy while the prior Matrix turn is active",
+    async ({ followupBody, explicitSteer }) => {
+      installMatrixMonitorTestRuntime();
+      const tempDir = tempDirs.make("openclaw-matrix-steer-");
+      const storePath = path.join(tempDir, "sessions.json");
+      const activeEventId = explicitSteer ? "$active-explicit-steer" : "$active-configured-steer";
+      const followupEventId = explicitSteer ? "$explicit-steer" : "$configured-steer";
+      const activeResolverStarted = createDeferred();
+      const releaseActiveResolver = createDeferred();
+      const followupTurnResolved = createDeferred();
+      const claimsByEvent = new Map<string, ReturnType<typeof createClaimSpies>>();
+      const inboundLifecycles = new Map<string, TurnAdoptionLifecycle | undefined>();
+      let followupResolverLifecycle: TurnAdoptionLifecycle | undefined;
+      let followupResolverContext: FinalizedMsgContext | undefined;
+
+      const cfg = {
+        session: { store: storePath },
+        messages: { queue: { mode: "steer" } },
+        channels: { matrix: { dm: { allowFrom: ["*"] } } },
+      } satisfies OpenClawConfig;
+      const inboundDeduper: NonNullable<MatrixMonitorHandlerParams["inboundDeduper"]> = {
+        claim: vi.fn(async ({ eventId }) => {
+          const claim = createClaimSpies();
+          claimsByEvent.set(eventId, claim);
+          return {
+            kind: "claimed" as const,
+            handle: {
+              keys: [eventId] as const,
+              commit: claim.commit,
+              release: claim.release,
+            },
+          };
+        }),
+      };
+      const queuePolicyResolver = vi.fn(
+        async (ctx: FinalizedMsgContext, options?: GetReplyOptions) => {
+          releaseSyntheticResolverAdmissionTicket(options);
+          const eventId = ctx.MessageSid;
+          if (eventId === activeEventId) {
+            await options?.turnAdoptionLifecycle?.onAdopted();
+            activeResolverStarted.resolve();
+            await releaseActiveResolver.promise;
+            return undefined;
+          }
+          if (eventId === followupEventId) {
+            followupResolverContext = ctx;
+            followupResolverLifecycle = options?.turnAdoptionLifecycle;
+            if (!followupResolverLifecycle?.onDeferred) {
+              throw new Error("expected Matrix follow-up deferral ownership");
+            }
+            expect(followupResolverLifecycle.onDeferred()).not.toBe(false);
+            await followupResolverLifecycle.onAdopted();
+          }
+          return undefined;
+        },
+      );
+      const runWithQueuePolicyResolver = (async (params: MatrixInboundRunParams) => {
+        const eventId = (params.raw as MatrixRawEvent).event_id;
+        if (eventId) {
+          inboundLifecycles.set(eventId, params.turnAdoptionLifecycle);
+        }
+        const adapter = params.adapter;
+        return await runChannelInboundEvent({
+          ...params,
+          adapter: {
+            ...adapter,
+            resolveTurn: async (...args: Parameters<typeof adapter.resolveTurn>) => {
+              const turn = await adapter.resolveTurn(...args);
+              if (eventId === followupEventId) {
+                followupTurnResolved.resolve();
+              }
+              if (!("route" in turn) || "runDispatch" in turn) {
+                throw new Error("expected Matrix to resolve a routed channel turn");
+              }
+              return { ...turn, replyResolver: queuePolicyResolver as never };
+            },
+          },
+        } as ChannelInboundEventRunnerParams<MatrixRawEvent>);
+      }) as MatrixInboundRun;
+      const runtime = { error: vi.fn() };
+      const { handler } = createMatrixHandlerTestHarness({
+        cfg,
+        inboundDeduper,
+        runtime: runtime as never,
+        shouldHandleTextCommands: () => true,
+        hasControlCommand: (text?: string) => text?.startsWith("/steer") === true,
+        runChannelInboundEvent: runWithQueuePolicyResolver,
+      });
+
+      let activeTurn: Promise<void> | undefined;
+      let followupTurn: Promise<void> | undefined;
+      try {
+        activeTurn = handler(
+          "!room:example.org",
+          createMatrixTextMessageEvent({
+            eventId: activeEventId,
+            body: "keep this run active",
+          }),
+        );
+        await vi.waitFor(() => expect(queuePolicyResolver).toHaveBeenCalledTimes(1));
+        await activeResolverStarted.promise;
+
+        followupTurn = handler(
+          "!room:example.org",
+          createMatrixTextMessageEvent({
+            eventId: followupEventId,
+            body: followupBody,
+          }),
+        );
+        await followupTurnResolved.promise;
+
+        // Before the fix, the second Matrix turn waits at reply-operation admission here;
+        // queue policy cannot see either configured steer mode or the explicit command.
+        await vi.waitFor(() => expect(queuePolicyResolver).toHaveBeenCalledTimes(2), {
+          timeout: 500,
+          interval: 10,
+        });
+
+        expect(followupResolverContext?.CommandBody).toBe(followupBody);
+        expect(inboundLifecycles.get(followupEventId)).toMatchObject({ admission: "exclusive" });
+        // Core wraps the lifecycle to record adoption state; invoking that wrapper must still
+        // settle the exact replay claim captured by the Matrix handler above.
+        expect(followupResolverLifecycle).toMatchObject({ admission: "exclusive" });
+        expect(claimsByEvent.get(followupEventId)?.commit).toHaveBeenCalledOnce();
+        expect(claimsByEvent.get(followupEventId)?.release).not.toHaveBeenCalled();
+        expect(runtime.error).not.toHaveBeenCalled();
+      } finally {
+        releaseActiveResolver.resolve();
+        const turns = [activeTurn, followupTurn].filter(
+          (turn): turn is Promise<void> => turn !== undefined,
+        );
+        await Promise.allSettled(turns);
+      }
+    },
+  );
+
+  it.each([
+    {
+      name: "adoption commits it",
+      eventId: "$adopted-followup",
+      settlement: "onAdopted" as const,
+      expectedCommits: 1,
+      expectedReleases: 0,
+    },
+    {
+      name: "abandonment releases it",
+      eventId: "$abandoned-followup",
+      settlement: "onAbandoned" as const,
+      expectedCommits: 0,
+      expectedReleases: 1,
+    },
+  ])(
+    "keeps a deferred replay claim past handler return until $name",
+    async ({ eventId, settlement, expectedCommits, expectedReleases }) => {
+      installMatrixMonitorTestRuntime();
+      const claim = createClaimSpies();
+      let deferredLifecycle: TurnAdoptionLifecycle | undefined;
+      const inboundDeduper: NonNullable<MatrixMonitorHandlerParams["inboundDeduper"]> = {
+        claim: vi.fn(async () => ({
+          kind: "claimed" as const,
+          handle: {
+            keys: [eventId] as const,
+            commit: claim.commit,
+            release: claim.release,
+          },
+        })),
+      };
+      const runWithDeferredOwnership = (async (params: MatrixInboundRunParams) => {
+        deferredLifecycle = params.turnAdoptionLifecycle;
+        expect(deferredLifecycle?.onDeferred?.()).not.toBe(false);
+        return {
+          admission: { kind: "dispatch" as const },
+          dispatched: true as const,
+          ctxPayload: {} as FinalizedMsgContext,
+          routeSessionKey: "agent:ops:main",
+          dispatchResult: {
+            queuedFinal: false,
+            counts: { final: 0, block: 0, tool: 0 },
+          },
+        };
+      }) as MatrixInboundRun;
+      const { handler } = createMatrixHandlerTestHarness({
+        inboundDeduper,
+        runChannelInboundEvent: runWithDeferredOwnership,
+      });
+
+      await handler(
+        "!room:example.org",
+        createMatrixTextMessageEvent({ eventId, body: "wait for the active turn" }),
+      );
+
+      expect(deferredLifecycle).toMatchObject({ admission: "exclusive" });
+      expect(claim.commit).not.toHaveBeenCalled();
+      expect(claim.release).not.toHaveBeenCalled();
+
+      await deferredLifecycle?.[settlement]?.();
+
+      expect(claim.commit).toHaveBeenCalledTimes(expectedCommits);
+      expect(claim.release).toHaveBeenCalledTimes(expectedReleases);
+    },
+  );
+});

--- a/extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts
@@ -173,7 +173,13 @@ describe("Matrix active-turn steering admission", () => {
             body: "keep this run active",
           }),
         );
-        await vi.waitFor(() => expect(queuePolicyResolver).toHaveBeenCalledTimes(1));
+        await vi.waitFor(() => expect(queuePolicyResolver).toHaveBeenCalledTimes(1), {
+          // This suite imports the full Matrix extension graph. Keep the
+          // active-turn admission assertion deterministic on saturated CI
+          // workers without weakening the behavior being asserted.
+          timeout: 10_000,
+          interval: 10,
+        });
         await activeResolverStarted.promise;
 
         followupTurn = handler(

--- a/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
@@ -106,6 +106,7 @@ type MatrixHandlerTestHarnessOptions = {
   };
   resolveHumanDelayConfig?: () => undefined;
   dispatchInboundMessage?: MatrixDispatchInboundMessage;
+  runChannelInboundEvent?: MatrixMonitorHandlerParams["core"]["channel"]["inbound"]["run"];
   runPrepared?: MatrixRunPreparedMock;
   inboundDeduper?: MatrixMonitorHandlerParams["inboundDeduper"];
   shouldAckReaction?: () => boolean;
@@ -218,7 +219,7 @@ export function createMatrixHandlerTestHarness(
         dispatchResult,
       };
     });
-  const run = vi.fn(
+  const defaultRun = vi.fn(
     async (
       params: Parameters<MatrixMonitorHandlerParams["core"]["channel"]["inbound"]["run"]>[0],
     ) => {
@@ -266,6 +267,7 @@ export function createMatrixHandlerTestHarness(
       });
     },
   );
+  const run = options.runChannelInboundEvent ?? defaultRun;
   const dmPolicy = options.dmPolicy ?? "open";
   const allowFrom = options.allowFrom ?? (dmPolicy === "open" ? ["*"] : []);
   const cfgForHandler =

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -155,11 +155,14 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
       const eventTs = event.origin_server_ts;
       const eventAge = event.unsigned?.age;
       const commitInboundEventIfClaimed = async () => {
-        if (!inboundReplayClaim) {
+        const claim = inboundReplayClaim;
+        if (!claim) {
           return;
         }
-        await inboundReplayClaim.commit();
-        inboundReplayClaim = undefined;
+        await claim.commit();
+        if (inboundReplayClaim === claim) {
+          inboundReplayClaim = undefined;
+        }
       };
       const readIngressPrefix = () =>
         readMatrixIngressPrefix({
@@ -450,11 +453,39 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         route: _route,
         sessionKey: _route.sessionKey,
       });
+      const replayClaimAtDispatch = inboundReplayClaim;
+      // Active-run deferral outlives this handler. Transfer the exact replay claim to the
+      // reply lane so adoption commits it and abandonment reopens it for Matrix replay.
+      const turnAdoptionLifecycle = replayClaimAtDispatch
+        ? {
+            admission: "exclusive" as const,
+            onDeferred: () => {
+              if (inboundReplayClaim !== replayClaimAtDispatch) {
+                return false;
+              }
+              inboundReplayClaim = undefined;
+              return undefined;
+            },
+            onAdopted: async () => {
+              if (inboundReplayClaim === replayClaimAtDispatch) {
+                inboundReplayClaim = undefined;
+              }
+              await replayClaimAtDispatch.commit();
+            },
+            onAbandoned: () => {
+              if (inboundReplayClaim === replayClaimAtDispatch) {
+                inboundReplayClaim = undefined;
+              }
+              replayClaimAtDispatch.release();
+            },
+          }
+        : undefined;
 
       const turnResult = await core.channel.inbound.run({
         channel: "matrix",
         accountId: _route.accountId,
         raw: event,
+        ...(turnAdoptionLifecycle ? { turnAdoptionLifecycle } : {}),
         adapter: {
           ingest: () => ({
             id: messageId,

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe.ts
@@ -1,7 +1,7 @@
 // Matrix inbound replay protection: /sync replays events after an unclean
 // shutdown and the decrypt bridge re-emits decrypted events, so each
-// (account, room, event) is claimed before handling and committed only after
-// reply dispatch succeeds; release on retryable failure reopens the event.
+// (account, room, event) is claimed before handling. Durable turn adoption or
+// terminal handling commits it; failure or abandonment before adoption releases it.
 import {
   createChannelReplayGuard,
   resolvePersistentDedupePluginStateNamespace,

--- a/src/auto-reply/command-turn-context.test.ts
+++ b/src/auto-reply/command-turn-context.test.ts
@@ -221,6 +221,32 @@ describe("resolveCommandTurnContext", () => {
         CommandTargetSessionKey: " legacy-target ",
       }),
     ).toBe("legacy-target");
+    expect(
+      resolveCommandTurnTargetSessionKey({
+        CommandTurn: createCommandTurnContext("text", {
+          authorized: true,
+          body: "/steer finish with a table",
+          commandName: "steer",
+        }),
+        CommandTargetSessionKey: " active-direct-session ",
+      }),
+    ).toBe("active-direct-session");
+    expect(
+      resolveCommandTurnTargetSessionKey({
+        CommandTurn: textTurn,
+        CommandTargetSessionKey: "must-not-retarget-status",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveCommandTurnTargetSessionKey({
+        CommandTurn: createCommandTurnContext("text", {
+          authorized: false,
+          body: "/steer denied",
+          commandName: "steer",
+        }),
+        CommandTargetSessionKey: "must-not-retarget-unauthorized",
+      }),
+    ).toBeUndefined();
     expect(isExplicitCommandTurn(undefined)).toBe(false);
   });
 });

--- a/src/auto-reply/command-turn-context.ts
+++ b/src/auto-reply/command-turn-context.ts
@@ -209,7 +209,7 @@ export function isExplicitCommandTurn(commandTurn: CommandTurnContext | undefine
   );
 }
 
-/** Resolves the target session override allowed only for native command invocations. */
+/** Resolves the target session override for trusted native or explicit steer command turns. */
 export function resolveCommandTurnTargetSessionKey(input: {
   CommandTurn?: CommandTurnContext;
   CommandSource?: unknown;
@@ -221,8 +221,13 @@ export function resolveCommandTurnTargetSessionKey(input: {
   commandText?: unknown;
   CommandTargetSessionKey?: unknown;
 }): string | undefined {
+  const commandTurn = resolveCommandTurnContext(input);
+  const isExplicitTextSteer =
+    isAuthorizedTextSlashCommandTurn(commandTurn) &&
+    (commandTurn.commandName?.toLowerCase() === "steer" ||
+      commandTurn.commandName?.toLowerCase() === "tell");
   if (
-    !isNativeCommandTurn(resolveCommandTurnContext(input)) ||
+    (!isNativeCommandTurn(commandTurn) && !isExplicitTextSteer) ||
     typeof input.CommandTargetSessionKey !== "string"
   ) {
     return undefined;

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -33,7 +33,6 @@ import {
   runBeforeAgentReplyForTurn,
 } from "../../plugins/before-agent-reply.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
-import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import type { TemplateContext } from "../templating.js";
 import { resolveActiveExplicitSteerSessionKey } from "./explicit-steer-routing.js";
@@ -994,7 +993,19 @@ describe("runReplyAgent active steering", () => {
       storePath,
     });
     const projectedUserRows = transcript.filter(
-      (entry) => entry.message?.role === "user" && entry.message.content === followupRun.prompt,
+      (entry): entry is { message: Record<string, unknown> } => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          return false;
+        }
+        const message = (entry as { message?: unknown }).message;
+        return Boolean(
+          message &&
+          typeof message === "object" &&
+          !Array.isArray(message) &&
+          (message as { role?: unknown }).role === "user" &&
+          (message as { content?: unknown }).content === followupRun.prompt,
+        );
+      },
     );
     expect(projectedUserRows).toHaveLength(1);
     expect(projectedUserRows[0]?.message).toMatchObject({
@@ -1025,7 +1036,7 @@ describe("runReplyAgent active steering", () => {
     const commandCtx = {
       CommandAuthorized: true,
       CommandBody: "/steer finish with a table",
-      CommandSource: "text",
+      CommandSource: "text" as const,
       CommandTurn: {
         kind: "text-slash" as const,
         source: "text" as const,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -36,6 +36,7 @@ import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-trans
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import type { TemplateContext } from "../templating.js";
+import { resolveActiveExplicitSteerSessionKey } from "./explicit-steer-routing.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import {
   clearSessionQueues,
@@ -370,6 +371,7 @@ function createMinimalRun(params?: {
   runOverrides?: Partial<FollowupRun["run"]>;
   bindActiveAuthority?: boolean;
   attachSteerBackend?: boolean;
+  activeBackendRunId?: string;
 }) {
   const typing = createMockTypingController();
   const opts = params?.opts;
@@ -442,23 +444,24 @@ function createMinimalRun(params?: {
       if (operation && params?.attachSteerBackend !== false) {
         operation.attachBackend({
           kind: "embedded",
+          runId: params?.activeBackendRunId,
           cancel: state.activeBackendCancelMock,
           claimPendingUserInputAnswer: async (prompt, options) => {
-            const result = state.queueEmbeddedAgentMessageMock(
+            const result = (await state.queueEmbeddedAgentMessageMock(
               operation.sessionId,
               prompt,
               options,
-            ) as boolean | { queued: boolean };
+            )) as boolean | { queued: boolean };
             return result === true || (typeof result === "object" && result.queued);
           },
           messageInjection: {
             isAvailable: () => true,
             queueMessage: async (prompt, options) => {
-              const result = state.queueEmbeddedAgentMessageMock(
+              const result = (await state.queueEmbeddedAgentMessageMock(
                 operation.sessionId,
                 prompt,
                 options,
-              ) as
+              )) as
                 | boolean
                 | {
                     queued: boolean;
@@ -923,39 +926,137 @@ describe("runReplyAgent active steering", () => {
     expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
   });
 
-  it("carries the prepared user-turn recorder into the embedded queue", async () => {
+  it("durably records an adopted steer once with the active run id for transcript projection", async () => {
+    const { sessionEntry, sessionStore, storePath } = await makeSessionFixture();
     const active = createReplyOperation({
       sessionKey: "main",
       sessionId: "session",
       resetTriggered: false,
     });
     active.setPhase("running");
-    state.queueEmbeddedAgentMessageMock.mockReturnValueOnce(true);
     const recorder = createUserTurnTranscriptRecorder({
       input: {
-        text: "visible group prompt",
+        text: "use the monochrome version instead",
+        idempotencyKey: "matrix:$explicit-steer",
         sender: { id: "user-42", name: "Ada" },
       },
-      target: createTestUserTurnTranscriptTarget(),
+      target: {
+        agentId: "main",
+        cwd: "/tmp",
+        sessionEntry,
+        sessionId: "session",
+        sessionKey: "main",
+        sessionStore,
+        storePath,
+      },
+    });
+    const events: string[] = [];
+    state.queueEmbeddedAgentMessageMock.mockImplementationOnce(
+      async (_sessionId: string, _prompt: string, options: unknown) => {
+        expect(requireRecord(options, "embedded queue options")).toMatchObject({
+          steeringMode: "all",
+          isInboundUserMessage: true,
+          waitForTranscriptCommit: true,
+          queueIdentity: expect.any(String),
+          userTurnTranscriptRecorder: recorder,
+        });
+        events.push("transcript-committed");
+        await recorder.persistApproved();
+        return true;
+      },
+    );
+    const onAdopted = vi.fn(() => {
+      events.push("adopted");
     });
     const { followupRun, run } = createMinimalRun({
+      activeBackendRunId: "active-run",
       isActive: true,
       shouldSteer: true,
       resolvedQueueMode: "steer",
+      sessionEntry,
+      sessionStore,
+      storePath,
+      opts: { turnAdoptionLifecycle: { onAdopted } },
     });
+    followupRun.prompt = "use the monochrome version instead";
     followupRun.userTurnTranscriptRecorder = recorder;
 
     await expect(run()).resolves.toBeUndefined();
 
-    expect(state.queueEmbeddedAgentMessageMock).toHaveBeenCalledWith(
-      "session",
-      "hello",
-      expect.objectContaining({
-        steeringMode: "all",
-        userTurnTranscriptRecorder: recorder,
-      }),
+    expect(events).toEqual(["transcript-committed", "adopted"]);
+    expect(onAdopted).toHaveBeenCalledOnce();
+    expect(parkedSteer.consume).toHaveBeenCalledOnce();
+    expect(parkedSteer.fallback).not.toHaveBeenCalled();
+    const transcript = await loadTranscriptEvents({
+      agentId: "main",
+      sessionId: "session",
+      sessionKey: "main",
+      storePath,
+    });
+    const projectedUserRows = transcript.filter(
+      (entry) => entry.message?.role === "user" && entry.message.content === followupRun.prompt,
     );
+    expect(projectedUserRows).toHaveLength(1);
+    expect(projectedUserRows[0]?.message).toMatchObject({
+      __openclaw: {
+        senderId: "user-42",
+        senderName: "Ada",
+        steerTargetRunId: "active-run",
+      },
+    });
+    expect(recorder.getPersistedMessage?.()).toMatchObject({
+      __openclaw: { steerTargetRunId: "active-run" },
+    });
     active.complete();
+  });
+
+  it("falls back once when the pre-resolved steer owner disappears before queue admission", async () => {
+    const active = createReplyOperation({
+      sessionKey: "main",
+      sessionId: "session",
+      resetTriggered: false,
+    });
+    active.setPhase("running");
+    active.attachBackend({
+      kind: "embedded",
+      cancel: vi.fn(),
+      messageInjection: { isAvailable: () => true, queueMessage: vi.fn() },
+    });
+    const commandCtx = {
+      CommandAuthorized: true,
+      CommandBody: "/steer finish with a table",
+      CommandSource: "text",
+      CommandTurn: {
+        kind: "text-slash" as const,
+        source: "text" as const,
+        authorized: true,
+        commandName: "steer",
+        body: "/steer finish with a table",
+      },
+      SessionKey: "main",
+    };
+    expect(
+      resolveActiveExplicitSteerSessionKey({ cfg: {}, ctx: commandCtx, sessionKey: "main" }),
+    ).toBe("main");
+
+    active.complete();
+    state.runEmbeddedAgentMock.mockImplementationOnce(runHookBackedEmbeddedAgent);
+    const { followupRun, run } = createMinimalRun({
+      isActive: true,
+      shouldSteer: true,
+      shouldFollowup: true,
+      resolvedQueueMode: "steer",
+    });
+    followupRun.prompt = "finish with a table";
+
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(parkedSteer.fallback).toHaveBeenCalledOnce();
+    expect(parkedSteer.consume).not.toHaveBeenCalled();
+    expect(vi.mocked(scheduleFollowupDrain)).toHaveBeenCalledOnce();
+    expect(state.runEmbeddedAgentMock).not.toHaveBeenCalled();
+    await requireScheduledFollowupRunner()(followupRun);
+    expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
   });
 
   it("steers against the session's registered run owner, not a source-keyed reservation", async () => {

--- a/src/auto-reply/reply/commands-steer.test.ts
+++ b/src/auto-reply/reply/commands-steer.test.ts
@@ -1,4 +1,4 @@
-// Tests /steer target capture, accepted delivery, and visible fallback.
+// Tests /steer target capture, prepared-path continuation, and visible fallback.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -104,7 +104,7 @@ describe("handleSteerCommand", () => {
     }
   });
 
-  it("matching authority /steer injects into the captured operation", async () => {
+  it("routes an active /steer through the prepared reply path without a premature ack", async () => {
     const params = buildParams("/steer keep going");
     params.opts = { toolsAllow: ["read"] };
     const { toolAuthorityFingerprint } = beginActiveOperation(
@@ -116,21 +116,16 @@ describe("handleSteerCommand", () => {
 
     const result = await handleSteerCommand(params, true);
 
-    expect(result).toEqual({
-      shouldContinue: false,
-      reply: { text: "steered current session." },
-    });
-    expect(queueMessage).toHaveBeenCalledWith("keep going", {
-      steeringMode: "all",
-      isInboundUserMessage: true,
-      toolAuthorityFingerprint,
-      debounceMs: 0,
-      taskSuggestionDeliveryMode: undefined,
-      onQueueAccepted: expect.any(Function),
-    });
+    expect(toolAuthorityFingerprint).toEqual(expect.any(String));
+    expect(result).toEqual({ shouldContinue: true, queueModeOverride: "steer" });
+    expect(params.ctx.BodyForAgent).toBe("keep going");
+    expect(params.command.commandBodyNormalized).toBe("keep going");
+    // Injection now happens only after the normal path has prepared durable
+    // transcript, identity, media, cancellation, and adoption ownership.
+    expect(queueMessage).not.toHaveBeenCalled();
   });
 
-  it("authorized sender with mismatched tool authority cannot inject via /steer", async () => {
+  it("defers tool-authority admission to the prepared steer path", async () => {
     const activeParams = buildParams("/steer keep going");
     activeParams.opts = { toolsAllow: ["exec"] };
     beginActiveOperation(
@@ -144,23 +139,22 @@ describe("handleSteerCommand", () => {
 
     const result = await handleSteerCommand(params, true);
 
-    expect(result).toEqual({ shouldContinue: true });
+    expect(result).toEqual({ shouldContinue: true, queueModeOverride: "steer" });
     expect(params.ctx.BodyForAgent).toBe("keep going");
     expect(params.command.commandBodyNormalized).toBe("keep going");
     expect(queueMessage).not.toHaveBeenCalled();
   });
 
-  it("passes the initiating surface task capability into steering", async () => {
+  it("keeps initiating surface options for prepared steering", async () => {
     beginActiveOperation("agent:main:main", "session-active", "gateway");
     const params = buildParams("/steer keep going");
     params.opts = { taskSuggestionDeliveryMode: "gateway" };
 
-    await handleSteerCommand(params, true);
+    const result = await handleSteerCommand(params, true);
 
-    expect(queueMessage).toHaveBeenCalledWith(
-      "keep going",
-      expect.objectContaining({ taskSuggestionDeliveryMode: "gateway" }),
-    );
+    expect(result).toEqual({ shouldContinue: true, queueModeOverride: "steer" });
+    expect(params.opts.taskSuggestionDeliveryMode).toBe("gateway");
+    expect(queueMessage).not.toHaveBeenCalled();
   });
 
   it("prefers the native command target over the slash-command source", async () => {
@@ -172,11 +166,9 @@ describe("handleSteerCommand", () => {
 
     const result = await handleSteerCommand(params, true);
 
-    expect(result).toEqual({
-      shouldContinue: false,
-      reply: { text: "steered current session." },
-    });
-    expect(queueMessage).toHaveBeenCalledWith("check the target", expect.any(Object));
+    expect(result).toEqual({ shouldContinue: true, queueModeOverride: "steer" });
+    expect(params.ctx.BodyForAgent).toBe("check the target");
+    expect(queueMessage).not.toHaveBeenCalled();
   });
 
   it("maps a text slash source lane to its active direct conversation", async () => {
@@ -184,9 +176,11 @@ describe("handleSteerCommand", () => {
     const params = buildParams("/steer use the active direct lane");
     params.sessionKey = "agent:main:telegram:slash:123";
 
-    await handleSteerCommand(params, true);
+    const result = await handleSteerCommand(params, true);
 
-    expect(queueMessage).toHaveBeenCalledWith("use the active direct lane", expect.any(Object));
+    expect(result).toEqual({ shouldContinue: true, queueModeOverride: "steer" });
+    expect(params.ctx.BodyForAgent).toBe("use the active direct lane");
+    expect(queueMessage).not.toHaveBeenCalled();
   });
 
   it("returns usage for an empty steer command", async () => {
@@ -210,15 +204,15 @@ describe("handleSteerCommand", () => {
     expect(queueMessage).not.toHaveBeenCalled();
   });
 
-  it("continues visibly as a normal prompt when captured injection rejects", async () => {
+  it("does not contact the backend before prepared admission", async () => {
     beginActiveOperation("agent:main:main");
-    queueMessage.mockRejectedValueOnce(new Error("runtime rejected"));
     const params = buildParams("/steer keep going");
 
     const result = await handleSteerCommand(params, true);
 
-    expect(result).toEqual({ shouldContinue: true });
+    expect(result).toEqual({ shouldContinue: true, queueModeOverride: "steer" });
     expect(params.ctx.BodyForAgent).toBe("keep going");
     expect(params.command.commandBodyNormalized).toBe("keep going");
+    expect(queueMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/commands-steer.test.ts
+++ b/src/auto-reply/reply/commands-steer.test.ts
@@ -1,5 +1,9 @@
 // Tests /steer target capture, prepared-path continuation, and visible fallback.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+} from "../../agents/embedded-agent-runner/runs.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { buildCommandTestParams } from "./commands.test-harness.js";
@@ -181,6 +185,30 @@ describe("handleSteerCommand", () => {
     expect(result).toEqual({ shouldContinue: true, queueModeOverride: "steer" });
     expect(params.ctx.BodyForAgent).toBe("use the active direct lane");
     expect(queueMessage).not.toHaveBeenCalled();
+  });
+
+  it("maps a text slash source lane after its active embedded owner's operation clears", async () => {
+    const sessionId = "session-direct-active";
+    const sessionKey = "agent:main:telegram:direct:123";
+    const handle = {
+      kind: "embedded" as const,
+      queueMessage: vi.fn(),
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: vi.fn(),
+    };
+    setActiveEmbeddedRun(sessionId, handle, sessionKey);
+    try {
+      const params = buildParams("/steer use the active direct lane");
+      params.sessionKey = "agent:main:telegram:slash:123";
+
+      const result = await handleSteerCommand(params, true);
+
+      expect(result).toEqual({ shouldContinue: true, queueModeOverride: "steer" });
+      expect(params.ctx.BodyForAgent).toBe("use the active direct lane");
+    } finally {
+      clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+    }
   });
 
   it("returns usage for an empty steer command", async () => {

--- a/src/auto-reply/reply/commands-steer.ts
+++ b/src/auto-reply/reply/commands-steer.ts
@@ -1,12 +1,5 @@
-// Implements steer commands that persist per-session agent guidance.
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  resolveInternalSessionKey,
-  resolveMainSessionAlias,
-} from "../../agents/tools/sessions-helpers.js";
+// Implements explicit steering through the durable prepared-reply queue path.
 import { logVerbose } from "../../globals.js";
-import { formatErrorMessage } from "../../infra/errors.js";
-import { isNativeCommandTurn, resolveCommandTurnContext } from "../command-turn-context.js";
 import { applyCommandTextToParams } from "./command-context-rewrite.js";
 import { commandReply, defineAuthorizedTextCommand } from "./command-gates.js";
 import type {
@@ -15,66 +8,11 @@ import type {
   HandleCommandsParams,
 } from "./commands-types.js";
 import {
-  beginReplyMessageInjectionTarget,
-  finalizeReplyMessageInjectionAttempt,
-  replyRunRegistry,
-  type ReplyMessageInjectionTarget,
-} from "./reply-run-registry.js";
-import { resolveInboundReplyToolAuthorityOverlay } from "./reply-tool-authority.js";
+  parseSteerMessage,
+  resolveActiveExplicitSteerSessionKey,
+} from "./explicit-steer-routing.js";
 
 const STEER_USAGE = "Usage: /steer <message>";
-
-function parseSteerMessage(raw: string): string | null {
-  const match = raw.trim().match(/^\/(?:steer|tell)(?:\s+([\s\S]*))?$/i);
-  if (!match) {
-    return null;
-  }
-  return (match[1] ?? "").trim();
-}
-
-function resolveSteerTargetSessionKey(params: HandleCommandsParams): string | undefined {
-  const commandTarget = normalizeOptionalString(params.ctx.CommandTargetSessionKey);
-  const commandSession = normalizeOptionalString(params.sessionKey);
-  const raw = isNativeCommandTurn(resolveCommandTurnContext(params.ctx))
-    ? commandTarget || commandSession
-    : commandSession || commandTarget;
-  if (!raw) {
-    return undefined;
-  }
-
-  const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
-  return resolveInternalSessionKey({ key: raw, alias, mainKey });
-}
-
-function listSteerCandidateSessionKeys(targetSessionKey: string): string[] {
-  const candidates = [targetSessionKey];
-  // Text slash turns still arrive on a source-only :slash: lane while the
-  // direct conversation owns the reply operation (#104844, #116763).
-  if (targetSessionKey.includes(":slash:")) {
-    candidates.push(
-      targetSessionKey.replace(":slash:", ":direct:"),
-      targetSessionKey.replace(":slash:", ":dm:"),
-    );
-  }
-  return [...new Set(candidates)];
-}
-
-function resolveSteerTarget(
-  targetSessionKey: string,
-): { sessionId: string; sessionKey: string; target: ReplyMessageInjectionTarget } | undefined {
-  const candidateKeys = listSteerCandidateSessionKeys(targetSessionKey);
-  for (const candidateKey of candidateKeys) {
-    const operation = replyRunRegistry.get(candidateKey);
-    const target = operation
-      ? replyRunRegistry.resolveCurrentMessageInjectionTarget(candidateKey)
-      : undefined;
-    if (operation && target) {
-      return { sessionId: operation.sessionId, sessionKey: candidateKey, target };
-    }
-  }
-
-  return undefined;
-}
 
 function continueWithSteerFallback(
   params: HandleCommandsParams,
@@ -93,62 +31,24 @@ export const handleSteerCommand: CommandHandler = defineAuthorizedTextCommand(
       return commandReply(STEER_USAGE);
     }
 
-    const targetSessionKey = resolveSteerTargetSessionKey(params);
-    if (!targetSessionKey) {
-      return continueWithSteerFallback(
-        params,
-        message,
-        "steer: no current session; continuing with /steer payload as a normal prompt",
-      );
-    }
-
-    const steerTarget = resolveSteerTarget(targetSessionKey);
-    if (!steerTarget) {
-      return continueWithSteerFallback(
-        params,
-        message,
-        `steer: no active run for ${targetSessionKey}; continuing with /steer payload as a normal prompt`,
-      );
-    }
-
-    const finalization = await finalizeReplyMessageInjectionAttempt({
-      target: steerTarget.target,
-      attempt: beginReplyMessageInjectionTarget(steerTarget.target, message, {
-        steeringMode: "all",
-        isInboundUserMessage: true,
-        toolAuthorityOverlay: resolveInboundReplyToolAuthorityOverlay({
-          ctx: params.ctx,
-          sessionEntry:
-            params.sessionStore?.[steerTarget.sessionKey] ??
-            (params.sessionKey === steerTarget.sessionKey ? params.sessionEntry : undefined),
-          senderIsOwner: params.command.senderIsOwner,
-          toolsAllow: params.opts?.toolsAllow,
-          disableTools: params.opts?.disableTools === true,
-        }),
-        debounceMs: 0,
-        ...(params.opts?.sourceReplyDeliveryMode
-          ? { sourceReplyDeliveryMode: params.opts.sourceReplyDeliveryMode }
-          : {}),
-        taskSuggestionDeliveryMode: params.opts?.taskSuggestionDeliveryMode,
-      }),
-    }).catch((err: unknown): CommandHandlerResult => {
-      return continueWithSteerFallback(
-        params,
-        message,
-        `steer: active session ${steerTarget.sessionId} threw while steering: ${formatErrorMessage(err)}; continuing with /steer payload as a normal prompt`,
-      );
+    const steerTargetSessionKey = resolveActiveExplicitSteerSessionKey({
+      cfg: params.cfg,
+      ctx: params.ctx,
+      sessionKey: params.sessionKey,
+      commandBody: params.command.commandBodyNormalized,
     });
-    if ("shouldContinue" in finalization) {
-      return finalization;
-    }
-    if (finalization.status === "rejected") {
+    if (!steerTargetSessionKey) {
       return continueWithSteerFallback(
         params,
         message,
-        `steer: active session ${steerTarget.sessionId} rejected steering injection (${finalization.outcome.reason}); continuing with /steer payload as a normal prompt`,
+        `steer: no active run; continuing with /steer payload as a normal prompt`,
       );
     }
-
-    return commandReply("steered current session.");
+    // Session routing resolves the active :direct:/:dm: alias before session
+    // preparation. From here the ordinary prepared reply path owns media,
+    // transcript persistence, stable queue identity, cancellation, lifecycle
+    // adoption, and fallback if the active run disappears before admission.
+    applyCommandTextToParams(params, message);
+    return { shouldContinue: true, queueModeOverride: "steer" };
   },
 );

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -1,4 +1,5 @@
 import type { FastMode } from "@openclaw/normalization-core/string-coerce";
+import type { QueueMode } from "../../../packages/gateway-protocol/src/schema/logs-chat.js";
 /** Shared command handler context and result contracts. */
 import type { BlockReplyChunking } from "../../agents/embedded-agent-block-chunker.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
@@ -94,6 +95,8 @@ export type HandleCommandsParams = {
 /** Result returned by a command handler. */
 export type CommandHandlerResult = {
   reply?: ReplyPayload;
+  /** Turn-local queue override requested by an authorized continuation command. */
+  queueModeOverride?: QueueMode;
   sessionCompaction?: Awaited<
     ReturnType<NonNullable<NonNullable<PluginCommandContext["runtimeContext"]>["compactCurrent"]>>
   >;

--- a/src/auto-reply/reply/explicit-steer-routing.ts
+++ b/src/auto-reply/reply/explicit-steer-routing.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveActiveEmbeddedRunSessionId } from "../../agents/embedded-agent-runner/run-state.js";
 import {
   resolveInternalSessionKey,
   resolveMainSessionAlias,
@@ -84,7 +85,10 @@ export function resolveActiveExplicitSteerSessionKey(params: {
   }
   for (const candidateKey of listSteerCandidateSessionKeys(sourceSessionKey)) {
     const operation = replyRunRegistry.get(candidateKey);
-    if (operation && replyRunRegistry.resolveCurrentMessageInjectionTarget(candidateKey)) {
+    const hasActiveOwner = operation
+      ? replyRunRegistry.resolveCurrentMessageInjectionTarget(candidateKey) !== undefined
+      : resolveActiveEmbeddedRunSessionId(candidateKey) !== undefined;
+    if (hasActiveOwner) {
       return candidateKey;
     }
   }

--- a/src/auto-reply/reply/explicit-steer-routing.ts
+++ b/src/auto-reply/reply/explicit-steer-routing.ts
@@ -1,0 +1,92 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  resolveInternalSessionKey,
+  resolveMainSessionAlias,
+} from "../../agents/tools/sessions-helpers.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  isAuthorizedTextSlashCommandTurn,
+  isNativeCommandTurn,
+  resolveCommandTurnContext,
+} from "../command-turn-context.js";
+import type { MsgContext } from "../templating.js";
+import { replyRunRegistry } from "./reply-run-registry.js";
+
+export function parseSteerMessage(raw: string): string | null {
+  const match = raw.trim().match(/^\/(?:steer|tell)(?:\s+([\s\S]*))?$/i);
+  if (!match) {
+    return null;
+  }
+  return (match[1] ?? "").trim();
+}
+
+function listSteerCandidateSessionKeys(targetSessionKey: string): string[] {
+  const candidates = [targetSessionKey];
+  // Authorized text slash turns can still arrive on a source-only :slash:
+  // lane while the direct conversation owns the active reply operation.
+  if (targetSessionKey.includes(":slash:")) {
+    candidates.push(
+      targetSessionKey.replace(":slash:", ":direct:"),
+      targetSessionKey.replace(":slash:", ":dm:"),
+    );
+  }
+  return [...new Set(candidates)];
+}
+
+function resolveSteerSourceSessionKey(params: {
+  cfg: OpenClawConfig;
+  ctx: MsgContext;
+  sessionKey?: string;
+}): string | undefined {
+  const commandTarget = normalizeOptionalString(params.ctx.CommandTargetSessionKey);
+  const commandSession = normalizeOptionalString(params.sessionKey ?? params.ctx.SessionKey);
+  const raw = isNativeCommandTurn(resolveCommandTurnContext(params.ctx))
+    ? commandTarget || commandSession
+    : commandSession || commandTarget;
+  if (!raw) {
+    return undefined;
+  }
+
+  const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
+  return resolveInternalSessionKey({ key: raw, alias, mainKey });
+}
+
+/**
+ * Resolve an authorized explicit steer command to the exact session that owns
+ * an injectable active reply. This is intentionally read-only: callers decide
+ * whether to retarget session preparation or continue as an ordinary prompt.
+ */
+export function resolveActiveExplicitSteerSessionKey(params: {
+  cfg: OpenClawConfig;
+  ctx: MsgContext;
+  sessionKey?: string;
+  commandBody?: string;
+}): string | undefined {
+  const commandTurn = resolveCommandTurnContext(params.ctx);
+  if (!isNativeCommandTurn(commandTurn) && !isAuthorizedTextSlashCommandTurn(commandTurn)) {
+    return undefined;
+  }
+  const commandBody =
+    params.commandBody ??
+    commandTurn.body ??
+    normalizeOptionalString(params.ctx.CommandBody) ??
+    normalizeOptionalString(params.ctx.BodyForCommands) ??
+    normalizeOptionalString(params.ctx.Body) ??
+    "";
+  const message = parseSteerMessage(commandBody);
+  if (!message) {
+    return undefined;
+  }
+
+  const sourceSessionKey = resolveSteerSourceSessionKey(params);
+  if (!sourceSessionKey) {
+    return undefined;
+  }
+  for (const candidateKey of listSteerCandidateSessionKeys(sourceSessionKey)) {
+    const operation = replyRunRegistry.get(candidateKey);
+    if (operation && replyRunRegistry.resolveCurrentMessageInjectionTarget(candidateKey)) {
+      return candidateKey;
+    }
+  }
+  return undefined;
+}

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -301,6 +301,41 @@ describe("handleInlineActions", () => {
     ]);
   });
 
+  it("propagates an explicit steer queue override into the prepared-turn result", async () => {
+    const typing = createTypingController();
+    const ctx = buildTestCtx({
+      Body: "/steer use the monochrome version",
+      CommandBody: "/steer use the monochrome version",
+    });
+    handleCommandsMock.mockImplementationOnce(async (params) => {
+      params.command.rawBodyNormalized = "use the monochrome version";
+      params.command.commandBodyNormalized = "use the monochrome version";
+      params.ctx.agentText = "use the monochrome version";
+      return { shouldContinue: true, queueModeOverride: "steer" };
+    });
+
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: "/steer use the monochrome version",
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: "/steer use the monochrome version",
+        commandBodyNormalized: "/steer use the monochrome version",
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+      },
+    });
+
+    expect(result).toMatchObject({
+      kind: "continue",
+      cleanedBody: "use the monochrome version",
+      queueModeOverride: "steer",
+    });
+  });
+
   it("delivers a continuing mixed directive ack as a status block without losing metadata", async () => {
     const typing = createTypingController();
     const ctx = buildTestCtx({

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -1,5 +1,6 @@
 /** Handles inline slash commands, skill invocations, and abort actions before model runs. */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import type { QueueMode } from "../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { collectTextContentBlocks } from "../../agents/content-blocks.js";
 import type { BlockReplyChunking } from "../../agents/embedded-agent-block-chunker.js";
 import type { ExecPolicyOverrides } from "../../agents/exec-defaults.js";
@@ -140,6 +141,7 @@ type InlineActionResult =
       directives: InlineDirectives;
       abortedLastRun: boolean;
       cleanedBody: string;
+      queueModeOverride?: QueueMode;
       explicitSkillSelections?: ExplicitSkillSelection[];
     };
 
@@ -560,6 +562,7 @@ export async function handleInlineActions(params: {
       isGroup,
     }) && inlineStatusRequested;
   let didSendInlineStatus = false;
+  let queueModeOverride: QueueMode | undefined;
   if (handleInlineStatus) {
     const { buildStatusReply } = await loadCommandsRuntime();
     const inlineStatusReply = await buildStatusReply({
@@ -641,6 +644,7 @@ export async function handleInlineActions(params: {
       commandBodyNormalized: inlineCommand.command,
     };
     const inlineResult = await runCommands(inlineCommandContext);
+    queueModeOverride = inlineResult.queueModeOverride;
     notifyInlineCommandSessionMetadataChanges();
     if (inlineResult.reply) {
       if (!inlineCommand.cleaned) {
@@ -693,6 +697,7 @@ export async function handleInlineActions(params: {
   const commandBodyBeforeRun = command.commandBodyNormalized;
   const bodyBeforeRun = sessionCtx.agentText;
   const commandResult = await runCommands(command);
+  queueModeOverride = commandResult.queueModeOverride ?? queueModeOverride;
   notifyInlineCommandSessionMetadataChanges();
   if (!commandResult.shouldContinue) {
     typing.cleanup();
@@ -712,6 +717,7 @@ export async function handleInlineActions(params: {
     directives,
     abortedLastRun,
     cleanedBody,
+    ...(queueModeOverride ? { queueModeOverride } : {}),
     ...(explicitSkillSelections ? { explicitSkillSelections } : {}),
   };
 }

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -1,5 +1,6 @@
 // Handles native slash commands before full get-reply pipeline execution.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { QueueMode } from "../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import {
   resolveModelRefFromString,
   resolveThinkingDefaultWithRuntimeCatalog,
@@ -143,7 +144,8 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
   opts?: GetReplyOptions;
   skillFilter?: string[];
 }): Promise<
-  { handled: true; reply: ReplyPayload | ReplyPayload[] | undefined } | { handled: false }
+  | { handled: true; reply: ReplyPayload | ReplyPayload[] | undefined }
+  | { handled: false; queueModeOverride?: QueueMode }
 > {
   if (!shouldRunNativeSlashCommandFastPath(params.ctx)) {
     return { handled: false };
@@ -497,5 +499,13 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
       reply: markCommandReplyForDelivery(inlineActionResult.reply),
     };
   }
-  return { handled: false };
+  return {
+    handled: false,
+    ...((inlineActionResult.queueModeOverride ?? commandResult.queueModeOverride)
+      ? {
+          queueModeOverride:
+            inlineActionResult.queueModeOverride ?? commandResult.queueModeOverride,
+        }
+      : {}),
+  };
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -51,6 +51,7 @@ import type { RuntimeMsgContext as MsgContext } from "../templating.js";
 import { normalizeThinkLevel, normalizeVerboseLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { resolveDefaultModel } from "./directive-handling.defaults.js";
+import { resolveActiveExplicitSteerSessionKey } from "./explicit-steer-routing.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
 import {
@@ -337,6 +338,16 @@ export async function getReplyFromConfig(
   const finalized = resolverTiming.measureSync("reply.finalize_context", () =>
     finalizeInboundContext(ctx),
   );
+  // Resolve legacy text-slash source lanes before any session-scoped work.
+  // The explicit steer command itself still flows through normal command and
+  // prepared-reply handling; this only gives that path the active owner's key.
+  const explicitSteerTargetSessionKey = resolverTiming.measureSync(
+    "reply.resolve_explicit_steer_target",
+    () => resolveActiveExplicitSteerSessionKey({ cfg, ctx: finalized }),
+  );
+  if (explicitSteerTargetSessionKey) {
+    finalized.CommandTargetSessionKey = explicitSteerTargetSessionKey;
+  }
   const initialAgentScope = resolverTiming.measureSync("reply.resolve_agent_scope", () => {
     const targetSessionKey = resolveCommandTurnTargetSessionKey(finalized);
     const resolvedAgentSessionKey = targetSessionKey || finalized.SessionKey;
@@ -501,6 +512,9 @@ export async function getReplyFromConfig(
     logResolverTiming("completed", "native_slash_command_fast_path");
     return nativeSlashCommandFastReply.reply;
   }
+  const optsWithCommandQueueOverride = nativeSlashCommandFastReply.queueModeOverride
+    ? { ...optsWithSkillFilter, queueModeOverride: nativeSlashCommandFastReply.queueModeOverride }
+    : optsWithSkillFilter;
 
   const workspace = await traceGetReplyPhase("reply.ensure_workspace", async () =>
     useFastTestBootstrap
@@ -670,8 +684,8 @@ export async function getReplyFromConfig(
   // Utility-model narration is turn-local decoration. Initialize the durable
   // session first, then keep it completely outside model-locked native runs.
   const optsWithSessionSkillOverrides = sessionEntry.toolOverrides?.skills
-    ? { ...optsWithSkillFilter, skillOverrides: sessionEntry.toolOverrides.skills }
-    : optsWithSkillFilter;
+    ? { ...optsWithCommandQueueOverride, skillOverrides: sessionEntry.toolOverrides.skills }
+    : optsWithCommandQueueOverride;
   const resolvedOpts = attachProgressNarratorToReplyOptions({
     cfg,
     agentId,
@@ -1112,6 +1126,8 @@ export async function getReplyFromConfig(
   directives = inlineActionResult.directives;
   cleanedBody = inlineActionResult.cleanedBody;
   const explicitSkillSelections = inlineActionResult.explicitSkillSelections;
+  const queueModeOverride = inlineActionResult.queueModeOverride;
+  const preparedReplyOpts = withExtractedFileImages(resolvedOpts, extractedFileImages);
   abortedLastRun = inlineActionResult.abortedLastRun ?? abortedLastRun;
   const runAutoFallbackPrimaryProbe = directives.hasModelDirective
     ? undefined
@@ -1275,7 +1291,7 @@ export async function getReplyFromConfig(
       perMessageQueueMode,
       perMessageQueueOptions,
       typing,
-      opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
+      opts: queueModeOverride ? { ...preparedReplyOpts, queueModeOverride } : preparedReplyOpts,
       defaultModel,
       timeoutMs,
       isNewSession,


### PR DESCRIPTION
AI-assisted: yes.

Related: #110568, #119287

## What Problem This Solves

Matrix users can send a follow-up while an agent turn is active, but two different admission paths prevented the existing steering machinery from behaving end to end:

1. An ordinary Matrix follow-up could remain behind the active turn before configured queue policy had a chance to adopt it.
2. An explicit `/steer` command could reach and change the active agent run while bypassing the normal prepared-turn persistence path. The command therefore did not create the durable user transcript row that session history and the Control UI project.

The second failure was observable on a real Matrix session: the explicit `/steer` changed the active Codex run, but the command itself was absent from the durable OpenClaw transcript and from the Control UI session view.

## Why This Change Was Made

The Matrix handler already claims inbound events through the shared replay guard, but it did not carry that ownership into the shared turn-adoption lifecycle. Shared reply admission could therefore hold a second visible Matrix turn until the first operation settled, before active-run queue policy evaluated it.

The first commit adapts that exact replay claim to the existing exclusive turn-adoption lifecycle:

- a deferred turn transfers claim settlement to the reply lane;
- durable adoption commits the claim; and
- abandonment releases it for Matrix replay.

The explicit command path had a separate problem. It directly injected text into the active run and returned an immediate acknowledgement, skipping the established prepared reply path that supplies transcript recording, stable queue identity, media, abort propagation, and adoption lifecycle handling. The second commit makes authorized `/steer` strip only its command prefix, preserve its body, and continue through the normal prepared-turn path with a turn-local `steer` queue override. Legacy authorized text-slash direct/DM alias resolution is preserved before that continuation.

The result uses the same queue-policy, run-adoption, transcript, and race-fallback contracts as an ordinary prepared follow-up. It does not add Matrix-specific steering semantics, change default queue policy, add configuration, or alter the durable replay-key format.

## User Impact

- Ordinary Matrix follow-ups can reach the existing active-run queue-policy path while the prior turn is still running.
- Authorized `/steer <message>` reaches that same path with `<message>` intact and is persisted as a normal user turn when adopted.
- Session history and the Control UI can project the explicit steer because it now has one durable user transcript row linked to the active run by `steerTargetRunId`.
- If the active run disappears during the admission race, the message follows the established fallback path instead of being lost.

Idle Matrix messages, access and mention gates, room-history ordering, duplicate suppression, and non-Matrix channel behavior remain on their existing paths.

## Evidence

Frozen review base: `dca05ea39ac4a69a595dd2aa6a94f9a3ba0e2d44`

Exact submitted head: `df949a9c792d725c2119f40ea4751759079bad8d`

### Second production proof after co-installation with Matrix turn-taking

The unchanged four-commit PR head `df949a9c792d725c2119f40ea4751759079bad8d` was also applied in the production composition ending at `c2c1b914710736dbf5f7a68e525a59d57a211bd3`; all four submitted and installed commits have pairwise-identical stable patch IDs. This composition also contained the current Matrix multi-agent turn-taking candidate, providing a compatibility exercise rather than an isolated handler test.

At 16:24:08 IDT, a normal Matrix event (redacted ID `$nZn6...`) selected Forge for a multi-tool operational assessment. After Forge's original run had started and emitted progress plus its first tool call, a second ordinary Matrix event (redacted ID `$EOm...`) changed the required final sentence. The configured queue mode was `steer`; the source event did not use a command prefix.

- Forge's durable transcript stored the initial request once, then stored the follow-up once with `steerTargetRunId` equal to the already-active run `c4b9a660-72ae-49df-85bf-b72e808585bf`.
- The native Codex app-server log recorded `turn/steer` request `13`, mode `Steer`, client identity ending in `steer:1`, and the expected active Codex turn. The update was injected into that turn after the first assistant progress message and first tool call, rather than becoming a second run.
- The original run completed successfully after 14 tool calls and 14 matching results. Its six-point final ended with the replacement sentence: `Recommendation: review the current settings.`
- The Matrix wire exposed one Forge response lineage (`5599f793...`) tied to the original trigger, progressing from revision 0 through revision 17 `final`; no second response root or duplicate final was emitted.
- The five non-selected agents had no durable source-prompt row or marker-triggered full-run trajectory for either event.

This independently reconfirms ordinary configured steering, same-run durable persistence, Codex `turn/steer` delivery, successful terminal completion, and compatibility with the enhanced multi-agent Matrix handler on the submitted PR head.


The submitted range contains four focused commits:

1. `8946c1183c305c366ab9f496e1d6fe5bd415c1a8` — Matrix replay-claim/adoption lifecycle.
2. `7e042db452e6c5a58b9bc188f0b31b8da27faf6a` — durable explicit-steer prepared-turn routing.
3. `b35b5e48887c3a5ccb89babc89ecf5e265c2ab0a` — deterministic wait hardening for the active-turn regression.
4. `df949a9c792d725c2119f40ea4751759079bad8d` — test-only type and lint narrowing for the new active-steering coverage.

### Ordinary Matrix follow-up

- **Fail-before:** in a disposable checkout at `9b36c8bc56ab990266ba3aca245cdb552b5ba09e`, the focused regression failed both parameterized cases: after the second Matrix event resolved, the shared reply resolver had still been called only once (`expected 2, received 1`). This reproduced the block before queue-policy evaluation for both configured `steer` mode and explicit `/steer` ingress.
- **Pass-after:** `extensions/matrix/src/matrix/monitor/handler.active-turn-steering.test.ts` passes **4/4** after hardening its timing-sensitive initial admission wait with a bounded CI-load-aware window. The second event reaches real shared reply admission before the first settles; `CommandBody` is preserved; the exact top-level lifecycle arrives with exclusive admission; late adoption commits the replay claim once; and late abandonment releases it once without handler double-settlement.

### Explicit `/steer` persistence and Control UI projection

**Real fail-before observation:** during a real Matrix turn backed by the native Codex app-server, an explicit `/steer` instruction was accepted by the active run and changed its announced work/order. Read-only inspection afterward found no corresponding durable OpenClaw user transcript row, so the Control UI session view also had no command to display. A later ordinary follow-up in the same run did produce a durable row with `steerTargetRunId`, isolating the defect to the explicit command's direct-injection path rather than Matrix delivery or Control UI filtering.

**Automated pass-after coverage on the submitted head:** the focused command and end-to-end regressions establish that an authorized explicit steer:

- enters the prepared turn once with a turn-local `steer` override;
- records exactly one durable user row;
- attaches the active run through `steerTargetRunId`;
- transfers and settles the adoption lifecycle once;
- preserves the command body and legacy authorized direct/DM target mapping; and
- falls back through normal reply admission if the active run settles during the race.

### Real Matrix after-fix proof for both steering paths

The submitted changes were installed in a production candidate at `73657a73c372dee6596dfff7cd7b204875e042ca` and exercised end to end through the real self-hosted Matrix → OpenClaw → Codex app-server stack. The test used the existing **System Maintenance** room, Sentinel's production Matrix account, OpenClaw session `cf4ef821-6010-4f97-bf82-1f0753471dfd`, and active OpenClaw run `091127a5-3d06-475d-9794-a87101c2aa89`.

The initial Matrix request deliberately started a multi-tool task: list all 50 U.S. states alphabetically, create a DOCX, and convert it to PDF. While that original run remained active, the user sent two follow-ups through Matrix:

1. An ordinary follow-up, relying on the configured default `steer` queue mode:

   ```text
   Actually, reverse alphabetical order.
   ```

2. An explicit command:

   ```text
   /steer actually alphabetical order
   ```

Read-only correlation across the Matrix server, Sentinel's durable OpenClaw transcript, and the Codex app-server log establishes the exact path for each source event.

#### Ordinary configured-steer follow-up

- Raw Matrix event `$5rGt…` was stored by Synapse at `2026-08-25 06:39:49.985 IDT` with body `Actually, reverse alphabetical order.` and no command prefix.
- OpenClaw persisted exactly one user row at transcript sequence `357`, message `81e0177e…`, with the same Matrix transport event ID and the same visible content.
- That row recorded `__openclaw.steerTargetRunId = 091127a5-3d06-475d-9794-a87101c2aa89`.
- At `06:39:50 IDT`, the Codex app server recorded `turn/steer` request `13`, client identity `openclaw:<turn>:steer:1`, `mode: Steer`, and the expected active Codex turn `01a03700-832b-7a90-8e3d-0f6b1a36269a`, carrying the exact follow-up payload.
- The running agent acknowledged the correction and changed the working artifact order from alphabetical to reverse alphabetical without starting a replacement run.

#### Explicit `/steer` follow-up

- Raw Matrix event `$D27d…` was stored by Synapse at `2026-08-25 06:40:40.332 IDT` with body `/steer actually alphabetical order`.
- OpenClaw stripped only the authorized command prefix and persisted exactly one normal user row at transcript sequence `373`, message `9e0c4924…`, with visible content `actually alphabetical order` and the same source Matrix transport event ID.
- That row recorded the exact same `__openclaw.steerTargetRunId = 091127a5-3d06-475d-9794-a87101c2aa89`.
- At `06:40:41 IDT`, the Codex app server recorded `turn/steer` request `14`, client identity `openclaw:<turn>:steer:2`, `mode: Steer`, and the same expected active Codex turn, carrying the stripped payload.
- The original run acknowledged the second correction, rebuilt the artifacts in Alabama-through-Wyoming order, and did not create a second run.

The Control UI screenshot shows both follow-ups as distinct durable user rows in that same live session. In particular, the second row displays the explicit command's stripped payload, proving that the command no longer disappears after direct injection:

![Control UI showing durable ordinary and explicit steering follow-ups](https://raw.githubusercontent.com/bdjben/openclaw/codex/pr-evidence-128907-20260825/.github/pr-evidence/128907/system-maintenance-steering-proof.png)

The screenshot's source PNG is stored outside the PR diff on the fork-only evidence branch `codex/pr-evidence-128907-20260825`; its local and GitHub-hosted SHA-256 hashes both equal `bc83725e0e63fdaaab3d8f91d505e30b9730d95d5e8d84bc959b7a349339a918`.

The same active run then completed the requested task end to end. Its durable transcript recorded the second correction, regenerated artifacts, validation, progress `5/5`, Matrix attachment delivery receipts, and a terminal row at sequence `425` with `runTerminal = true` for the same run ID.

This production trace exercises the complete regression boundary:

```text
Matrix source event
  → configured queue-mode selection or explicit-command parsing
  → normal prepared-message/transcript persistence
  → active-run association
  → Codex app-server turn/steer request
  → behavior change inside the original running turn
  → durable Control UI replay
  → successful terminal completion and Matrix delivery
```

Neither source message disappeared, neither was duplicated, both targeted the same active OpenClaw run and Codex turn, and the final artifacts reflected the latest steering instruction.

### Focused verification on the exact head

- Active-steering end-to-end suite: **26 passed, 132 skipped, 0 failed**.
- Matrix active-turn steering: **4/4**.
- Explicit steer command routing: **8/8**.
- Structured command-turn context: **11/11**.
- Turn-local queue override: **1/1**.
- Prepared-turn/end-to-end adoption and persistence: **2/2**.
- Exact messaging test-type shard passes.
- Focused `oxlint`, repository formatting check, and `git diff --check` pass.
- A saturated parallel sweep passed 106/107 tests; its sole timeout was an unrelated native-compact timing case, which passed **1/1** on immediate isolated rerun.
- Core production TypeScript check passes.

### Real Matrix after-fix proof for ordinary configured steering

On 2026-08-25, the lifecycle patch was cleanly cherry-picked into a production OpenClaw installation connected to a real self-hosted Matrix deployment and exercised with production Matrix accounts. The production commit was `fb4184a99ccb89a20bcdcc570fa7e264bf638938`; its stable patch-id was `7e011d63b334405665e880c60ec0e519837e8d4f`, exactly matching the then-submitted lifecycle head `4afb4e40b5438a06e2fe9fe802243508c544c35e`. The checkout was clean and the configured global queue mode was `steer`.

The user began a normal Matrix turn requesting an alphabetically ordered result. After the active turn had already progressed far enough to show forward-order interim output, the user sent an ordinary Matrix follow-up changing the requirement to reverse alphabetical order. This was a real Matrix ingress event, not a Control UI injection. The final Matrix response honored the follow-up and returned the reverse ordering.

The redacted durable trace establishes that this was adoption into the original active run, not a queued second run:

```json
{
  "trace": "real-matrix-production-after-fix",
  "queueMode": "steer",
  "activeRunStartedAt": "2026-08-25T01:28:06.704Z",
  "followupTranscriptCreatedAt": "2026-08-25T01:29:13.472Z",
  "activeRunEndedAt": "2026-08-25T01:29:32.789Z",
  "followupWasMatrixTransport": true,
  "followupSteerTargetMatchedActiveRun": true,
  "targetStartedBeforeFollowup": true,
  "targetEndedAfterFollowup": true,
  "distinctRunStartsInWindow": 1,
  "onlyTargetRunStarted": true,
  "assistantRowsAfterFollowup": 1,
  "supersededForwardAssistantRowsAfterFollowup": 0,
  "reverseOrderAssistantRowsAfterFollowup": 1,
  "transcriptIdentityRowsForFollowup": 1,
  "identitySequenceMatchedTranscript": true,
  "matrixReplayRowsForExactTransportTuple": 1,
  "replayKeyMatchedExactTransportTuple": true,
  "replayClaimWasRecordedDuringActiveRun": true,
  "replayClaimWasUnexpiredAtVerification": true
}
```

Room, homeserver endpoint, account identity, credentials, and raw event/session/run identifiers are intentionally omitted. The trace was derived from the Matrix client observation plus read-only inspection of the production agent transcript/event-identity store, run lifecycle records, and Matrix inbound replay store after the turn completed.

### Downstream protocol audit

OpenAI Codex at `c941572917b9295c7318b28aab27709202a645c7` defines `turn/steer` with a required active-turn precondition in [`TurnSteerParams`](https://github.com/openai/codex/blob/c941572917b9295c7318b28aab27709202a645c7/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L175-L197); the app server validates and dispatches it in [`turn_processor.rs`](https://github.com/openai/codex/blob/c941572917b9295c7318b28aab27709202a645c7/codex-rs/app-server/src/request_processors/turn_processor.rs#L900-L1027), and core validates the active regular turn and queues pending input in [`turn_input.rs`](https://github.com/openai/codex/blob/c941572917b9295c7318b28aab27709202a645c7/codex-rs/core/src/session/turn_input.rs#L477-L563).

## Scope

The exact frozen range is 15 files, `+682/-177`. It introduces no schema migration, dependency, or changelog change.
