### PR TITLE
fix(twitch): prevent stopped accounts from reconnecting after delayed startup

### DIFF
--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { expectDefined } from "@openclaw/normalization-core";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveTwitchToken } from "./token.js";
 import { TwitchClientManager } from "./twitch-client.js";
@@ -295,6 +296,94 @@ describe("TwitchClientManager", () => {
 
       await expect(connection).rejects.toThrow("Twitch connection cancelled");
       expect(mockQuit).toHaveBeenCalledTimes(2);
+    });
+
+    it.each(["account", "all"] as const)(
+      "does not create a client when %s disconnect completes during authentication setup",
+      async (scope) => {
+        const authentication = createDeferred<string>();
+        mockAddUserForToken.mockImplementationOnce(() => authentication.promise);
+        const account = {
+          ...testAccount,
+          clientSecret: "test-client-secret",
+          refreshToken: "test-refresh-token",
+        };
+        manager.onMessage(account, vi.fn());
+        const connection = manager.getClient(account);
+
+        expect(mockAddUserForToken).toHaveBeenCalledOnce();
+        if (scope === "account") {
+          await manager.disconnect(account);
+        } else {
+          await manager.disconnectAll();
+        }
+        authentication.resolve("123456");
+
+        await expect(connection).rejects.toThrow("Twitch connection cancelled");
+        expect(mockConnect).not.toHaveBeenCalled();
+        expect(managerState(manager).clients.size).toBe(0);
+        expect(managerState(manager).messageHandlers.has(manager.getAccountKey(account))).toBe(
+          false,
+        );
+      },
+    );
+
+    it("keeps a restarted account connection when stale authentication resolves afterward", async () => {
+      const authentication = createDeferred<string>();
+      mockAddUserForToken.mockImplementationOnce(() => authentication.promise);
+      const account = {
+        ...testAccount,
+        clientSecret: "test-client-secret",
+        refreshToken: "test-refresh-token",
+      };
+      const staleConnection = manager.getClient(account);
+      const staleOutcome = staleConnection.then(
+        () => "connected" as const,
+        () => "cancelled" as const,
+      );
+
+      await manager.disconnect(account);
+      const currentConnection = manager.getClient(account);
+
+      try {
+        expect(mockAddUserForToken).toHaveBeenCalledTimes(2);
+        const activeClient = await currentConnection;
+        authentication.resolve("123456");
+
+        expect(await staleOutcome).toBe("cancelled");
+        expect(managerState(manager).clients.get(manager.getAccountKey(account))).toBe(
+          activeClient,
+        );
+        expect(mockConnect).toHaveBeenCalledOnce();
+      } finally {
+        authentication.resolve("123456");
+        await Promise.allSettled([staleConnection, currentConnection]);
+      }
+    });
+
+    it("keeps another account connected when cancelling an authentication-pending account", async () => {
+      const authentication = createDeferred<string>();
+      mockAddUserForToken.mockImplementationOnce(() => authentication.promise);
+      const account = {
+        ...testAccount,
+        clientSecret: "test-client-secret",
+        refreshToken: "test-refresh-token",
+      };
+      const staleConnection = manager.getClient(account);
+      const staleOutcome = staleConnection.then(
+        () => "connected" as const,
+        () => "cancelled" as const,
+      );
+      const activeClient = await manager.getClient(testAccount2);
+
+      await manager.disconnect(account);
+      authentication.resolve("123456");
+
+      expect(await staleOutcome).toBe("cancelled");
+      expect(managerState(manager).clients.get(manager.getAccountKey(testAccount2))).toBe(
+        activeClient,
+      );
+      expect(mockConnect).toHaveBeenCalledOnce();
     });
 
     it("should create separate clients for different accounts", async () => {

--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -125,7 +125,13 @@ export class TwitchClientManager {
       return pending;
     }
 
-    const connection = this.createConnectedClient(key, account, cfg, accountId);
+    const connection: Promise<ChatClient> = this.createConnectedClient(
+      key,
+      account,
+      () => this.connectionPromises.get(key) === connection,
+      cfg,
+      accountId,
+    );
     this.connectionPromises.set(key, connection);
     try {
       return await connection;
@@ -139,6 +145,7 @@ export class TwitchClientManager {
   private async createConnectedClient(
     key: string,
     account: TwitchAccountConfig,
+    ownsConnection: () => boolean,
     cfg?: OpenClawConfig,
     accountId?: string,
   ): Promise<ChatClient> {
@@ -163,6 +170,9 @@ export class TwitchClientManager {
     const normalizedToken = normalizeToken(tokenResolution.token);
 
     const authProvider = await this.createAuthProvider(account, normalizedToken);
+    if (!ownsConnection()) {
+      throw new Error(`Twitch connection cancelled for ${account.username}`);
+    }
 
     const client = new ChatClient({
       authProvider,
@@ -373,19 +383,21 @@ export class TwitchClientManager {
     const key = this.getAccountKey(account);
     const client = this.clients.get(key);
     const pendingClient = this.pendingClients.get(key);
+    const pendingConnection = this.connectionPromises.delete(key);
 
     if (pendingClient) {
       pendingClient.quit();
       this.pendingClients.delete(key);
-      this.connectionPromises.delete(key);
-      this.clearMessageHandler(key);
     }
 
     if (client) {
       client.quit();
       this.clients.delete(key);
-      this.clearMessageHandler(key);
       this.logger.info(`Disconnected ${key}`);
+    }
+
+    if (pendingConnection || pendingClient || client) {
+      this.clearMessageHandler(key);
     }
   }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators stopping or restarting a Twitch account could leave an unregistered chat connection running after shutdown when the provider's initial account lookup was still in flight. A stopped account could reconnect after its manager had been removed, and an account restart could remain attached to the stale startup attempt.

## Why This Change Was Made

The Twitch client manager previously awaited provider initialization before creating and registering its pending chat client, so account shutdown had no client to cancel during that window. Reuse the existing per-account connection promise as the exact startup ownership record, validate that identity before constructing a chat client, and retire pending account work and message handlers together during disconnect. This remains entirely within the private Twitch lifecycle owner and does not change provider credentials, authentication policy, configuration, or public plugin contracts.

## User Impact

Stopping a Twitch account reliably prevents delayed connection startup and clears its pending message handler. Restarting the same account creates exactly one fresh connection, while other active Twitch accounts continue unaffected.

## Evidence

- Four new owner-level tests fail on current `main` and pass with the fix: account shutdown during deferred provider initialization, global shutdown during deferred initialization, same-account restart while an older initialization resolves, and cancellation without disturbing another account.
- Independent review identified an additional pending-handler cleanup gap; the account-shutdown regression was extended, reproduced the failure, and now passes.
- The actual production client manager and registry were exercised through account removal and replacement: the retired manager creates zero connections, the replacement creates exactly one, and no stopped-account handlers remain.
- Full focused owner and sibling proof passed independently twice: `node scripts/run-vitest.mjs extensions/twitch/src/twitch-client.test.ts extensions/twitch/src/client-manager-registry.test.ts extensions/twitch/src/monitor.test.ts extensions/twitch/src/plugin.lifecycle.test.ts extensions/twitch/src/twitch-ingress.test.ts extensions/twitch/src/outbound.test.ts` — six suites, 90 tests passed per run.
- Scoped formatting and lint passed; authenticated full committed-branch review reported no actionable findings.
- Production delta: +12 lines, required for exact startup-attempt ownership and unified account-lifecycle cleanup.
- Live Twitch account stop/restart is concretely infeasible for this change because no isolated, authenticated disposable Twitch account is available, and manipulating the operator's live channel or production credentials is not authorized. Instead, the actual production client manager, actual registry removal/replacement flow, and real Twurple chat-client construction were exercised with a controlled asynchronous provider boundary; the six owner/sibling suites also passed 90 tests independently twice.
- Exact reviewed-head hosted CI run 32791495885 completed successfully, including the required `openclaw/ci-gate`. The repository-native landing workflow validates the exact current-main merge boundary and post-merge ancestry; an age-only rebase is unnecessary for this conflict-free change.
- ClawSweeper's owner-test output separately shows all 47 Twitch client-manager tests passing twice. Its reported live-verification failure is an output-matching harness mismatch: it searched for a suite-title string that the successful Vitest reporter does not print.
