### PR TITLE
fix(ai): restore raw call_id on continuation wire delta, canonicalize for eligibility

### DIFF
--- a/packages/ai/src/transports.ts
+++ b/packages/ai/src/transports.ts
@@ -15,6 +15,7 @@ export * from "./transports/openai-completions-transport.js";
 export * from "./transports/openai-reasoning-compat.js";
 export * from "./transports/openai-responses-payload-policy.js";
 export * from "./transports/openai-responses-replay.js";
+export * from "./transports/openai-responses-tool-call-id-shape.js";
 export * from "./transports/openai-responses-transport.js";
 export * from "./transports/openai-transport-params.js";
 export * from "./transports/openai-transport-shared.js";

--- a/packages/ai/src/transports/json-unsafe-integers.ts
+++ b/packages/ai/src/transports/json-unsafe-integers.ts
@@ -76,8 +76,19 @@ function isUnsafeIntegerLiteral(token: string): boolean {
   return digits > MAX_SAFE_INTEGER_ABS_STR;
 }
 
-/** Quotes integer literals above Number.MAX_SAFE_INTEGER before JSON.parse. */
-export function quoteUnsafeIntegerLiterals(input: string): string {
+/**
+ * Quotes integer literals above Number.MAX_SAFE_INTEGER before JSON.parse.
+ *
+ * The optional `tag` is prefixed inside the quotes around each converted
+ * literal. Every real caller of this function wants the plain digit string
+ * back and leaves `tag` at its default `""`. A caller that instead compares
+ * two independently-serialized payloads needs `tag` non-empty: without it, a
+ * quoted unsafe integer is byte-identical to a genuine JSON string holding
+ * the same digits, so a real number-to-string argument change would compare
+ * equal to the unchanged number. A control character a caller can't type
+ * makes that collision impossible.
+ */
+export function quoteUnsafeIntegerLiterals(input: string, tag = ""): string {
   let out = "";
   let inString = false;
   let escaped = false;
@@ -109,7 +120,7 @@ export function quoteUnsafeIntegerLiterals(input: string): string {
       const parsed = parseJsonNumberToken(input, idx);
       if (parsed) {
         if (parsed.isInteger && isUnsafeIntegerLiteral(parsed.token)) {
-          out += `"${parsed.token}"`;
+          out += `"${tag}${parsed.token}"`;
         } else {
           out += parsed.token;
         }

--- a/packages/ai/src/transports/json-unsafe-integers.ts
+++ b/packages/ai/src/transports/json-unsafe-integers.ts
@@ -78,17 +78,8 @@ function isUnsafeIntegerLiteral(token: string): boolean {
 
 /**
  * Quotes integer literals above Number.MAX_SAFE_INTEGER before JSON.parse.
- *
- * The optional `tag` is prefixed inside the quotes around each converted
- * literal. Every real caller of this function wants the plain digit string
- * back and leaves `tag` at its default `""`. A caller that instead compares
- * two independently-serialized payloads needs `tag` non-empty: without it, a
- * quoted unsafe integer is byte-identical to a genuine JSON string holding
- * the same digits, so a real number-to-string argument change would compare
- * equal to the unchanged number. A control character a caller can't type
- * makes that collision impossible.
  */
-export function quoteUnsafeIntegerLiterals(input: string, tag = ""): string {
+export function quoteUnsafeIntegerLiterals(input: string): string {
   let out = "";
   let inString = false;
   let escaped = false;
@@ -120,7 +111,7 @@ export function quoteUnsafeIntegerLiterals(input: string, tag = ""): string {
       const parsed = parseJsonNumberToken(input, idx);
       if (parsed) {
         if (parsed.isInteger && isUnsafeIntegerLiteral(parsed.token)) {
-          out += `"${tag}${parsed.token}"`;
+          out += `"${parsed.token}"`;
         } else {
           out += parsed.token;
         }

--- a/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
@@ -1,0 +1,172 @@
+import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupSessionResources } from "../session-resources.js";
+import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+
+// Live coverage, against the real native api.openai.com endpoint, for the
+// argument-canonicalization half of this PR: HTTP continuation must still
+// hold across a real multi-round tool-calling turn whose argument contains
+// an integer value ABOVE Number.MAX_SAFE_INTEGER. This isolates the
+// native-only path this PR's own code (claimOpenAIResponsesHttpContinuation)
+// actually gates on, rather than the stack this PR's prior live evidence
+// used, which also carried #128633's separate compat-endpoint opt-in.
+//
+// This test caught a real regression on first run: an earlier revision of
+// this fix tagged the cached side's unsafe integer to distinguish it from a
+// genuine same-digits string, but AssistantMessage.arguments already stores
+// every unsafe integer as a string (parseJsonObjectPreservingUnsafeIntegers,
+// precision-preserving), so an *unmodified* replay of this exact call always
+// re-serializes it as a same-digits string -- tagging only the cached side
+// made every real large-integer tool call permanently ineligible for
+// continuation on its very next round. Confirmed live: this test failed
+// (fell through to a full-history resend) before that tag was removed, and
+// passes now. See the unit regression test with the same shape
+// (`treats a cached number-typed unsafe integer as equal to its own
+// replayed string-typed round-trip`) for the deterministic version of this
+// proof.
+//
+// (The call_id-reshaping half of this PR is not exercisable here: a real
+// native OpenAI tool-call id already arrives in the call_*/fc_*-paired shape
+// normalizeOpenAIResponsesToolCallIds produces, so its idempotent
+// short-circuit correctly leaves it unchanged -- an earlier version of this
+// test asserted the id WOULD change and failed for exactly that reason.
+// That half stays covered by the existing unit tests using the real
+// transform function directly.)
+const LIVE = process.env.OPENCLAW_LIVE_TEST === "1";
+const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
+const describeLive = LIVE && OPENAI_KEY ? describe : describe.skip;
+const LIVE_MODEL_ID = process.env.OPENCLAW_LIVE_RESPONSES_MODEL || "gpt-5.6-luna";
+const LIVE_TIMEOUT_MS = 120_000;
+
+class GlobalFetchRequestCapture {
+  readonly requests: Array<Record<string, unknown>> = [];
+  private readonly realFetch = globalThis.fetch;
+
+  install(): void {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const body = init?.body;
+      if (url.includes("api.openai.com") && typeof body === "string") {
+        try {
+          this.requests.push(JSON.parse(body) as Record<string, unknown>);
+        } catch {
+          // Non-JSON body on this host is unexpected for a Responses call.
+        }
+      }
+      return this.realFetch(input, init);
+    }) as typeof fetch;
+  }
+
+  restore(): void {
+    globalThis.fetch = this.realFetch;
+  }
+}
+
+function userMessage(text: string, timestamp: number) {
+  return { role: "user" as const, content: text, timestamp };
+}
+
+const recordValueTool = {
+  name: "record_value",
+  description: "Record an integer value for the test harness.",
+  parameters: { type: "object", properties: { n: { type: "integer" } }, required: ["n"] },
+};
+
+function model(): Model<"openai-responses"> {
+  return {
+    id: LIVE_MODEL_ID,
+    name: LIVE_MODEL_ID,
+    api: "openai-responses",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8192,
+  } satisfies Model<"openai-responses">;
+}
+
+async function run(context: Context, sessionId: string): Promise<AssistantMessage> {
+  const stream = await createOpenAIResponsesTransportStreamFn()(model(), context, {
+    apiKey: OPENAI_KEY,
+    sessionId,
+    transport: "sse",
+    reasoningEffort: "low",
+    maxTokens: 256,
+    onPayload: (payload: Record<string, unknown>) => ({ ...payload, store: true }),
+  } as never);
+  return stream.result();
+}
+
+describeLive(
+  "HTTP continuation across a real unsafe-integer tool-call argument (real api.openai.com)",
+  () => {
+    afterEach(() => {
+      cleanupSessionResources();
+    });
+
+    it(
+      "continues a real tool-calling round whose argument is above Number.MAX_SAFE_INTEGER",
+      async () => {
+        const capture = new GlobalFetchRequestCapture();
+        capture.install();
+        try {
+          const sessionId = "live-toolcall-arg-canonicalization";
+          const unsafeInt = "9007199254740993"; // > Number.MAX_SAFE_INTEGER
+          const firstUser = userMessage(
+            `This is an automated test. Call the record_value tool with exactly n=${unsafeInt}. ` +
+              "Do not round or alter the number.",
+            1,
+          );
+          const callTurn = await run(
+            { messages: [firstUser], tools: [recordValueTool] },
+            sessionId,
+          );
+          const toolCall = callTurn.content.find((block) => block.type === "toolCall") as
+            | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
+            | undefined;
+          expect(toolCall).toBeDefined();
+          expect(String(toolCall?.arguments.n)).toBe(unsafeInt);
+
+          const toolResultMsg = {
+            role: "toolResult" as const,
+            toolCallId: toolCall?.id ?? "",
+            content: [{ type: "text" as const, text: "recorded" }],
+            timestamp: 2,
+          };
+          const round1Messages: Context["messages"] = [firstUser, callTurn, toolResultMsg];
+          const afterToolResult = await run(
+            { messages: round1Messages, tools: [recordValueTool] },
+            sessionId,
+          );
+          expect(afterToolResult.stopReason).toBe("stop");
+
+          // Exactly two requests reached the real API -- a rejected
+          // previous_response_id (the recovery path is a silent
+          // full-history resend) would show up as a third.
+          expect(capture.requests).toHaveLength(2);
+          const secondRequest = capture.requests[1];
+          expect(secondRequest).toHaveProperty("previous_response_id");
+          expect(typeof secondRequest?.previous_response_id).toBe("string");
+          expect((secondRequest?.previous_response_id as string).length).toBeGreaterThan(0);
+          // toolCall.id is OpenClaw's own internal call_id|fc_id pairing;
+          // the wire delta's call_id must be restored to the bare provider
+          // call_id (the part before the pairing separator), not the
+          // compound internal id.
+          const rawCallId = toolCall?.id.split("|")[0];
+          expect(secondRequest?.input).toEqual([
+            {
+              type: "function_call_output",
+              call_id: rawCallId,
+              output: "recorded",
+            },
+          ]);
+        } finally {
+          capture.restore();
+        }
+      },
+      LIVE_TIMEOUT_MS,
+    );
+  },
+);

--- a/packages/ai/src/transports/openai-responses-continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.test.ts
@@ -171,12 +171,13 @@ describe("OpenAI Responses continuation", () => {
       lastResponseItems: [{ type: "reasoning" }, toolCall] as never,
     };
     // The exact reshape normalizeOpenAIResponsesToolCallIds would have
-    // produced for rawCallId (verified against
-    // normalizeOpenAIResponsesFunctionCallId directly) -- not a
-    // hand-approximated shape, so the restore-to-raw path under test
-    // actually has to recognize it via the real transform, not a lucky
-    // string match.
-    const reshapedCallId = "call_chatcmpl-tool-20cf1f2fabdd434da069764b4dca72eb_d7218567a7";
+    // produced for the paired "rawCallId|fc_1" (verified against
+    // normalizeOpenAIResponsesFunctionCallId directly, then split back to
+    // just the call_id half the way the request builder splits it onto the
+    // wire) -- not a hand-approximated shape, so the restore-to-raw path
+    // under test actually has to recognize it via the real transform, not a
+    // lucky string match.
+    const reshapedCallId = "call_chatcmpl-tool-20cf1f2fabdd434da069764b4dca72eb_f_3b92d47627";
     const replayedToolCall = {
       ...toolCall,
       id: "fc_1",

--- a/packages/ai/src/transports/openai-responses-continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.test.ts
@@ -284,6 +284,42 @@ describe("OpenAI Responses continuation", () => {
     );
   });
 
+  it("does not treat an unsafe-integer argument as equal to a same-digits string (type collision)", () => {
+    // quoteUnsafeIntegerLiterals converts an unsafe integer literal into a
+    // quoted string before JSON.parse; without a distinguishing tag that
+    // output is byte-identical to a genuine JSON string holding the same
+    // digits, so a real number-to-string argument change would otherwise
+    // compare equal and wrongly reuse the stale continuation state.
+    const toolCall = {
+      type: "function_call",
+      id: "fc_1",
+      status: "completed",
+      call_id: "call_original_abc",
+      name: "exec",
+      arguments: '{"n":9007199254740993}',
+    };
+    const state: ResponsesContinuationState = {
+      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
+      lastResponseId: "resp_1",
+      lastResponseItems: [toolCall] as never,
+    };
+    const replayedToolCall = { ...toolCall, arguments: '{"n":"9007199254740993"}' };
+    const toolResult = {
+      type: "function_call_output",
+      call_id: "call_original_abc",
+      output: "hi\n",
+    };
+    const nextRoundRequest: ResponsesContinuationRequest = {
+      model: "gpt-5.6-luna",
+      store: true,
+      input: [firstUser, replayedToolCall, toolResult] as never,
+    };
+
+    expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
+      "history_changed",
+    );
+  });
+
   it("ignores turn correlation headers but isolates explicit authorization", () => {
     const first = claim({ turn: "1" });
     first?.commit(continuationState().lastRequest, {

--- a/packages/ai/src/transports/openai-responses-continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.test.ts
@@ -147,6 +147,142 @@ describe("OpenAI Responses continuation", () => {
     );
   });
 
+  it("continues a tool-calling round despite replay re-sanitizing call_id and re-serializing arguments, and restores the raw call_id on the wire delta", () => {
+    // Real shape: the cached lastResponseItems is the raw provider response
+    // (bare call_id, compact JSON string), but replaying history for the
+    // next round runs it through normalizeOpenAIResponsesToolCallIds
+    // (embedded-agent-helpers) for provider-format compatibility -- a real,
+    // necessary id reshape, not a change to what the model actually said.
+    // Before this fixed, that reshape made every multi-round tool-calling
+    // turn permanently ineligible for continuation (history_changed on
+    // every attempt, confirmed live against a real gateway).
+    const rawCallId = "chatcmpl-tool-20cf1f2fabdd434da069764b4dca72eb";
+    const toolCall = {
+      type: "function_call",
+      id: "fc_1",
+      status: "completed",
+      call_id: rawCallId,
+      name: "exec",
+      arguments: '{"command":"echo hi"}',
+    };
+    const state: ResponsesContinuationState = {
+      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
+      lastResponseId: "resp_1",
+      lastResponseItems: [{ type: "reasoning" }, toolCall] as never,
+    };
+    // The exact reshape normalizeOpenAIResponsesToolCallIds would have
+    // produced for rawCallId (verified against
+    // normalizeOpenAIResponsesFunctionCallId directly) -- not a
+    // hand-approximated shape, so the restore-to-raw path under test
+    // actually has to recognize it via the real transform, not a lucky
+    // string match.
+    const reshapedCallId = "call_chatcmpl-tool-20cf1f2fabdd434da069764b4dca72eb_d7218567a7";
+    const replayedToolCall = {
+      ...toolCall,
+      id: "fc_1",
+      call_id: reshapedCallId,
+      arguments: '{"command": "echo hi"}',
+    };
+    const toolResult = {
+      type: "function_call_output",
+      call_id: reshapedCallId,
+      output: "hi\n",
+    };
+    const nextRoundRequest: ResponsesContinuationRequest = {
+      model: "gpt-5.6-luna",
+      store: true,
+      input: [firstUser, { type: "reasoning" }, replayedToolCall, toolResult] as never,
+    };
+
+    const result = resolveResponsesContinuationRequest(state, nextRoundRequest);
+
+    // The wire delta must carry the RAW call_id the provider actually
+    // returned, not the client's replay-local reshape of it -- a server
+    // that reconstructs full history from its own cached copy of the raw
+    // response (e.g. a proxy virtualizing previous_response_id
+    // server-side) has no way to know about the client's reshape, and
+    // pairs function_call_output.call_id against the function_call it
+    // cached verbatim.
+    expect(result).toMatchObject({
+      continuationStatus: "continued",
+      request: {
+        previous_response_id: "resp_1",
+        input: [{ type: "function_call_output", call_id: rawCallId, output: "hi\n" }],
+      },
+    });
+  });
+
+  it("does not tolerate an unrelated function-call id change as the known replay reshape", () => {
+    // A changed call_id that ISN'T the client's own reshape of the cached raw
+    // id (e.g. the model made a genuinely different tool call, or a
+    // corrupted replay) must still be treated as real history drift --
+    // canonicalizeReplayedCallId only forgives ids that reshape TO the same
+    // value as the cached raw one, never an arbitrary difference.
+    const toolCall = {
+      type: "function_call",
+      id: "fc_1",
+      status: "completed",
+      call_id: "call_original_abc",
+      name: "exec",
+      arguments: '{"command":"echo hi"}',
+    };
+    const state: ResponsesContinuationState = {
+      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
+      lastResponseId: "resp_1",
+      lastResponseItems: [toolCall] as never,
+    };
+    const replayedToolCall = { ...toolCall, call_id: "call_unrelated_xyz" };
+    const toolResult = {
+      type: "function_call_output",
+      call_id: "call_unrelated_xyz",
+      output: "hi\n",
+    };
+    const nextRoundRequest: ResponsesContinuationRequest = {
+      model: "gpt-5.6-luna",
+      store: true,
+      input: [firstUser, replayedToolCall, toolResult] as never,
+    };
+
+    expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
+      "history_changed",
+    );
+  });
+
+  it("does not treat two different unsafe-integer arguments as equal (lossless comparison)", () => {
+    // Number.MAX_SAFE_INTEGER + 1 and + 2 both round to the same double
+    // under plain JSON.parse; a lossless comparator must still tell them
+    // apart so a genuinely changed argument is never mistaken for a
+    // re-serialization whitespace difference.
+    const toolCall = {
+      type: "function_call",
+      id: "fc_1",
+      status: "completed",
+      call_id: "call_original_abc",
+      name: "exec",
+      arguments: '{"n":9007199254740993}',
+    };
+    const state: ResponsesContinuationState = {
+      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
+      lastResponseId: "resp_1",
+      lastResponseItems: [toolCall] as never,
+    };
+    const replayedToolCall = { ...toolCall, arguments: '{"n": 9007199254740994}' };
+    const toolResult = {
+      type: "function_call_output",
+      call_id: "call_original_abc",
+      output: "hi\n",
+    };
+    const nextRoundRequest: ResponsesContinuationRequest = {
+      model: "gpt-5.6-luna",
+      store: true,
+      input: [firstUser, replayedToolCall, toolResult] as never,
+    };
+
+    expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
+      "history_changed",
+    );
+  });
+
   it("ignores turn correlation headers but isolates explicit authorization", () => {
     const first = claim({ turn: "1" });
     first?.commit(continuationState().lastRequest, {

--- a/packages/ai/src/transports/openai-responses-continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.test.ts
@@ -284,12 +284,19 @@ describe("OpenAI Responses continuation", () => {
     );
   });
 
-  it("does not treat an unsafe-integer argument as equal to a same-digits string (type collision)", () => {
-    // quoteUnsafeIntegerLiterals converts an unsafe integer literal into a
-    // quoted string before JSON.parse; without a distinguishing tag that
-    // output is byte-identical to a genuine JSON string holding the same
-    // digits, so a real number-to-string argument change would otherwise
-    // compare equal and wrongly reuse the stale continuation state.
+  it("treats a cached number-typed unsafe integer as equal to its own replayed string-typed round-trip", () => {
+    // Real shape, confirmed live against a real tool-calling round: the
+    // cached side is the raw provider text (a bare, unsafe-integer number),
+    // but AssistantMessage.arguments already stores every unsafe integer as
+    // a string (parseJsonObjectPreservingUnsafeIntegers,
+    // transport-stream-shared.ts, precision-preserving), so the *unmodified*
+    // replay of this exact same historical tool call always re-serializes it
+    // back as a same-digits JSON string. This is the client's own necessary
+    // representation of the same value, not a real argument change -- an
+    // earlier revision of this fix (a distinguishing tag on the cached side
+    // only) treated this as a genuine change, permanently breaking
+    // continuation for the very next round of any real tool call carrying an
+    // out-of-range integer.
     const toolCall = {
       type: "function_call",
       id: "fc_1",
@@ -316,7 +323,38 @@ describe("OpenAI Responses continuation", () => {
     };
 
     expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
-      "history_changed",
+      "continued",
+    );
+  });
+
+  it("treats a whitespace-only re-serialization of the same unsafe integer as equal", () => {
+    const toolCall = {
+      type: "function_call",
+      id: "fc_1",
+      status: "completed",
+      call_id: "call_original_abc",
+      name: "exec",
+      arguments: '{"n":9007199254740993}',
+    };
+    const state: ResponsesContinuationState = {
+      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
+      lastResponseId: "resp_1",
+      lastResponseItems: [toolCall] as never,
+    };
+    const replayedToolCall = { ...toolCall, arguments: '{"n": 9007199254740993}' };
+    const toolResult = {
+      type: "function_call_output",
+      call_id: "call_original_abc",
+      output: "hi\n",
+    };
+    const nextRoundRequest: ResponsesContinuationRequest = {
+      model: "gpt-5.6-luna",
+      store: true,
+      input: [firstUser, replayedToolCall, toolResult] as never,
+    };
+
+    expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
+      "continued",
     );
   });
 

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -4,7 +4,11 @@ import type { ResponseInput, ResponseOutputItem } from "openai/resources/respons
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
 import { quoteUnsafeIntegerLiterals } from "./json-unsafe-integers.js";
-import { normalizeOpenAIResponsesFunctionCallId } from "./openai-responses-tool-call-id-shape.js";
+import {
+  normalizeOpenAIResponsesFunctionCallId,
+  shouldNormalizeOpenAIResponsesToolCallId,
+  splitOpenAIFunctionCallPairing,
+} from "./openai-responses-tool-call-id-shape.js";
 import { sha256Hex } from "./transport-utils.js";
 
 const HTTP_CONTINUATION_IDLE_TTL_MS = 5 * 60 * 1000;
@@ -95,7 +99,31 @@ function canonicalizeReplayedCallId(value: unknown): unknown {
   return typeof value === "string" ? normalizeOpenAIResponsesFunctionCallId(value) : value;
 }
 
-function normalizeAssistantReplayInput(input: readonly unknown[]): unknown[] {
+// A cached raw provider `function_call` still carries its separate,
+// un-reshaped `call_id` and item `id` fields exactly as the provider
+// returned them. Replay pairs those two into one `call_id|fc_id` string
+// before reshaping (normalizeOpenAIResponsesToolCallIds, mirrored by
+// normalizeOpenAIResponsesFunctionCallId), then the request builder splits
+// the reshaped pair back into separate wire fields -- so the replayed
+// call_id already reflects a hash of the *pair*, not of call_id alone.
+// Canonicalizing only the bare cached call_id (dropping id) hashes a
+// different input and never matches, permanently forcing history_changed.
+function canonicalizeCachedCallId(callId: unknown, itemId: unknown): unknown {
+  if (typeof callId !== "string") {
+    return callId;
+  }
+  const paired = typeof itemId === "string" && itemId ? `${callId}|${itemId}` : callId;
+  // Already-valid call_*/fc_* ids (the common case once a provider itself
+  // returns provider-shaped ids) never get reshaped by replay either --
+  // mirror that exact idempotent short-circuit, or a validly-shaped pair
+  // would be needlessly re-hashed here into a value replay never produces.
+  if (!shouldNormalizeOpenAIResponsesToolCallId(paired)) {
+    return callId;
+  }
+  return splitOpenAIFunctionCallPairing(normalizeOpenAIResponsesFunctionCallId(paired)).callId;
+}
+
+function normalizeAssistantReplayInput(input: readonly unknown[], isCachedRaw = false): unknown[] {
   return input.map((item) => {
     if (!isRecord(item)) {
       return item;
@@ -110,9 +138,11 @@ function normalizeAssistantReplayInput(input: readonly unknown[]): unknown[] {
     ) {
       return item;
     }
-    const { id: _id, status: _status, ...stableItem } = item;
+    const { id: rawId, status: _status, ...stableItem } = item;
     if ("call_id" in stableItem) {
-      stableItem.call_id = canonicalizeReplayedCallId(stableItem.call_id);
+      stableItem.call_id = isCachedRaw
+        ? canonicalizeCachedCallId(stableItem.call_id, rawId)
+        : canonicalizeReplayedCallId(stableItem.call_id);
     }
     if (item.type === "function_call" && "arguments" in stableItem) {
       stableItem.arguments = normalizeFunctionCallArguments(stableItem.arguments);
@@ -151,8 +181,10 @@ function restoreRawCallIdsInDelta(
       continue;
     }
     const rawCallId = item.call_id;
-    const reshaped = normalizeOpenAIResponsesFunctionCallId(rawCallId);
-    if (reshaped !== rawCallId) {
+    // Mirror the eligibility comparison's pairing: the delta's call_id was
+    // reshaped from the paired call_id|id, not the bare call_id alone.
+    const reshaped = canonicalizeCachedCallId(rawCallId, item.id);
+    if (typeof reshaped === "string" && reshaped !== rawCallId) {
       rawCallIdByReshaped.set(reshaped, rawCallId);
     }
   }
@@ -196,7 +228,7 @@ export function resolveResponsesContinuationRequest(
     ) ||
     !jsonValuesEqual(
       normalizeAssistantReplayInput(currentInput.slice(previousInput.length, baselineLength)),
-      normalizeAssistantReplayInput(continuation.lastResponseItems),
+      normalizeAssistantReplayInput(continuation.lastResponseItems, true),
     )
   ) {
     return { request, continuationStatus: "history_changed" };

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -3,6 +3,8 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ResponseInput, ResponseOutputItem } from "openai/resources/responses/responses.js";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
+import { quoteUnsafeIntegerLiterals } from "./json-unsafe-integers.js";
+import { normalizeOpenAIResponsesFunctionCallId } from "./openai-responses-tool-call-id-shape.js";
 import { sha256Hex } from "./transport-utils.js";
 
 const HTTP_CONTINUATION_IDLE_TTL_MS = 5 * 60 * 1000;
@@ -59,6 +61,40 @@ function requestWithoutInput(request: ResponsesContinuationRequest): ResponsesCo
   return { ...rest, metadata };
 }
 
+// A function_call's `arguments` is a JSON-encoded string, not a nested
+// object -- jsonValuesEqual only normalizes key order at the *parsed* level,
+// so two byte-different-but-semantically-identical encodings (e.g. a
+// re-`JSON.stringify` picking up different whitespace) would otherwise read
+// as a real content change. Round-trip through parse/stringify so only the
+// actual argument values are compared; leave non-JSON strings untouched.
+// quoteUnsafeIntegerLiterals runs first: plain JSON.parse silently rounds any
+// integer literal past Number.MAX_SAFE_INTEGER, so two genuinely DIFFERENT
+// unsafe integers could otherwise parse to the same JS number and wrongly
+// compare equal, sending a stale delta instead of the real changed argument.
+function normalizeFunctionCallArguments(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(JSON.parse(quoteUnsafeIntegerLiterals(value)));
+  } catch {
+    return value;
+  }
+}
+
+// Canonicalizes a call_id/fc_id through the exact same shaping replay applies
+// (normalizeOpenAIResponsesToolCallIds in embedded-agent-helpers, mirrored
+// here as normalizeOpenAIResponsesFunctionCallId since packages/ai cannot
+// import from src/agents). Idempotent on an already-reshaped id -- it only
+// touches ids that don't already match the provider's own call_*/fc_* shape
+// -- so a raw provider id and the client's replayed reshaping of that same
+// id both canonicalize to the same value. This replaces a blanket call_id
+// drop: dropping it entirely would treat *any* changed function-call id as
+// the same known reshape, masking a genuinely different tool call.
+function canonicalizeReplayedCallId(value: unknown): unknown {
+  return typeof value === "string" ? normalizeOpenAIResponsesFunctionCallId(value) : value;
+}
+
 function normalizeAssistantReplayInput(input: readonly unknown[]): unknown[] {
   return input.map((item) => {
     if (!isRecord(item)) {
@@ -67,10 +103,20 @@ function normalizeAssistantReplayInput(input: readonly unknown[]): unknown[] {
     if (item.type === "reasoning") {
       return { type: "reasoning" };
     }
-    if (item.type !== "function_call" && !(item.type === "message" && item.role === "assistant")) {
+    if (
+      item.type !== "function_call" &&
+      item.type !== "function_call_output" &&
+      !(item.type === "message" && item.role === "assistant")
+    ) {
       return item;
     }
     const { id: _id, status: _status, ...stableItem } = item;
+    if ("call_id" in stableItem) {
+      stableItem.call_id = canonicalizeReplayedCallId(stableItem.call_id);
+    }
+    if (item.type === "function_call" && "arguments" in stableItem) {
+      stableItem.arguments = normalizeFunctionCallArguments(stableItem.arguments);
+    }
     if (item.type === "message" && Array.isArray(stableItem.content)) {
       stableItem.content = stableItem.content.map((part) => {
         if (!isRecord(part) || part.type !== "output_text") {
@@ -81,6 +127,44 @@ function normalizeAssistantReplayInput(input: readonly unknown[]): unknown[] {
       });
     }
     return stableItem;
+  });
+}
+
+// The wire-bound delta (sent under previous_response_id) still carries
+// whatever call_id the client's own replay reshaping produced for a
+// function_call_output referencing a call from continuation.lastResponseItems
+// -- that's the exact id mismatch normalizeAssistantReplayInput tolerates
+// for the eligibility comparison above, but the comparison result is never
+// sent. Rewrite it back to the raw id the provider actually returned (and
+// this module cached) before the delta goes out, so a server that
+// reconstructs full history from its own cached copy of that raw response
+// (e.g. a proxy virtualizing previous_response_id server-side) sees a
+// function_call_output whose call_id matches the function_call it's pairing
+// against, instead of an orphaned id it silently drops.
+function restoreRawCallIdsInDelta(
+  delta: readonly unknown[],
+  cachedResponseItems: readonly unknown[],
+): unknown[] {
+  const rawCallIdByReshaped = new Map<string, string>();
+  for (const item of cachedResponseItems) {
+    if (!isRecord(item) || item.type !== "function_call" || typeof item.call_id !== "string") {
+      continue;
+    }
+    const rawCallId = item.call_id;
+    const reshaped = normalizeOpenAIResponsesFunctionCallId(rawCallId);
+    if (reshaped !== rawCallId) {
+      rawCallIdByReshaped.set(reshaped, rawCallId);
+    }
+  }
+  if (rawCallIdByReshaped.size === 0) {
+    return delta as unknown[];
+  }
+  return delta.map((item) => {
+    if (!isRecord(item) || typeof item.call_id !== "string") {
+      return item;
+    }
+    const rawCallId = rawCallIdByReshaped.get(item.call_id);
+    return rawCallId ? { ...item, call_id: rawCallId } : item;
   });
 }
 
@@ -121,7 +205,10 @@ export function resolveResponsesContinuationRequest(
     request: {
       ...request,
       previous_response_id: continuation.lastResponseId,
-      input: currentInput.slice(baselineLength),
+      input: restoreRawCallIdsInDelta(
+        currentInput.slice(baselineLength),
+        continuation.lastResponseItems,
+      ) as ResponseInput,
     },
     continuationStatus: "continued",
   };

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -75,12 +75,20 @@ function requestWithoutInput(request: ResponsesContinuationRequest): ResponsesCo
 // integer literal past Number.MAX_SAFE_INTEGER, so two genuinely DIFFERENT
 // unsafe integers could otherwise parse to the same JS number and wrongly
 // compare equal, sending a stale delta instead of the real changed argument.
+// The tag distinguishes a stringified unsafe integer from a genuine JSON
+// string holding the same digits -- without it `{"n":9007199254740993}` and
+// `{"n":"9007199254740993"}` both parse to the identical JS string and wrongly
+// compare equal, hiding a real number-to-string argument change.
+const UNSAFE_INTEGER_COMPARISON_TAG = "\u0000openclaw-unsafe-integer\u0000";
+
 function normalizeFunctionCallArguments(value: unknown): unknown {
   if (typeof value !== "string") {
     return value;
   }
   try {
-    return JSON.stringify(JSON.parse(quoteUnsafeIntegerLiterals(value)));
+    return JSON.stringify(
+      JSON.parse(quoteUnsafeIntegerLiterals(value, UNSAFE_INTEGER_COMPARISON_TAG)),
+    );
   } catch {
     return value;
   }

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -75,20 +75,32 @@ function requestWithoutInput(request: ResponsesContinuationRequest): ResponsesCo
 // integer literal past Number.MAX_SAFE_INTEGER, so two genuinely DIFFERENT
 // unsafe integers could otherwise parse to the same JS number and wrongly
 // compare equal, sending a stale delta instead of the real changed argument.
-// The tag distinguishes a stringified unsafe integer from a genuine JSON
-// string holding the same digits -- without it `{"n":9007199254740993}` and
-// `{"n":"9007199254740993"}` both parse to the identical JS string and wrongly
-// compare equal, hiding a real number-to-string argument change.
-const UNSAFE_INTEGER_COMPARISON_TAG = "\u0000openclaw-unsafe-integer\u0000";
-
+//
+// No distinguishing tag: an earlier revision quoted unsafe integers with a
+// tag to also catch a stringified unsafe integer colliding with a genuine
+// same-digits JSON string -- but on the *cached* side this compares against,
+// `arguments` is the raw provider text (a bare number), while the *replayed*
+// side is rebuilt from AssistantMessage.arguments, which
+// parseJsonObjectPreservingUnsafeIntegers (transport-stream-shared.ts)
+// already stores as a string for every unsafe integer, precision-preserving.
+// So a real, unmodified tool-calling round *always* replays an unsafe
+// integer as a same-digits string against a cached bare number -- tagging
+// only the cached side made every real large-integer tool call permanently
+// ineligible for continuation on its very next round (confirmed live: an
+// actual tool call with a real out-of-range integer, replayed unmodified,
+// still landed as history_changed). Plain (untagged) quoting can't tell a
+// converted integer apart from a genuine same-digit string either, but that
+// is not the risk here: both sides of this comparison replay the *same*
+// historical tool call, and the client-side "unsafe integers become
+// strings" convention already applies uniformly to how that call is cached
+// and replayed -- there is no independent second call in this comparison
+// for a same-digit string to collide with.
 function normalizeFunctionCallArguments(value: unknown): unknown {
   if (typeof value !== "string") {
     return value;
   }
   try {
-    return JSON.stringify(
-      JSON.parse(quoteUnsafeIntegerLiterals(value, UNSAFE_INTEGER_COMPARISON_TAG)),
-    );
+    return JSON.stringify(JSON.parse(quoteUnsafeIntegerLiterals(value)));
   } catch {
     return value;
   }

--- a/packages/ai/src/transports/openai-responses-tool-call-id-shape.ts
+++ b/packages/ai/src/transports/openai-responses-tool-call-id-shape.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure OpenAI Responses `call_*`/`fc_*` tool-call-id shape helpers.
+ *
+ * Moved out of embedded-agent-helpers/openai.ts (the AgentMessage[]-walking
+ * caller lives in src/agents and imports from packages/ai, so the reverse
+ * import direction is not available) so the continuation transport can
+ * recognize its own cached raw ids after this same reshaping and restore
+ * them on a replayed wire request -- see openai-responses-continuation.ts.
+ */
+import { sha256Hex } from "./transport-utils.js";
+
+export const OPENAI_RESPONSES_ID_MAX_LENGTH = 64;
+export const OPENAI_RESPONSES_CALL_ID_RE = /^call_[A-Za-z0-9_-]{1,59}$/;
+export const OPENAI_RESPONSES_FUNCTION_CALL_ITEM_ID_RE = /^fc_[A-Za-z0-9_-]{1,61}$/;
+
+export function splitOpenAIFunctionCallPairing(id: string): {
+  callId: string;
+  itemId?: string;
+} {
+  const separator = id.indexOf("|");
+  if (separator <= 0 || separator >= id.length - 1) {
+    return { callId: id };
+  }
+  return {
+    callId: id.slice(0, separator),
+    itemId: id.slice(separator + 1),
+  };
+}
+
+function shortOpenAIResponsesIdHash(id: string): string {
+  return sha256Hex(id).slice(0, 10);
+}
+
+function sanitizeOpenAIResponsesIdTail(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function normalizeOpenAIResponsesIdPart(params: {
+  value: string;
+  prefix: "call_" | "fc_";
+  isValid: (value: string) => boolean;
+}): string {
+  const trimmed = params.value.trim();
+  if (params.isValid(trimmed)) {
+    return trimmed;
+  }
+
+  const rawTail = trimmed.startsWith(params.prefix) ? trimmed.slice(params.prefix.length) : trimmed;
+  const hash = shortOpenAIResponsesIdHash(trimmed || params.prefix);
+  const maxTailLength = OPENAI_RESPONSES_ID_MAX_LENGTH - params.prefix.length;
+  const hashSuffix = `_${hash}`;
+  const safeTail = sanitizeOpenAIResponsesIdTail(rawTail);
+  const clippedBase = safeTail.slice(0, Math.max(1, maxTailLength - hashSuffix.length));
+  const tail = `${clippedBase || "id"}${hashSuffix}`.slice(0, maxTailLength);
+  return `${params.prefix}${tail}`;
+}
+
+/** Same shaping `normalizeOpenAIResponsesToolCallIds` applies to a replayed `call_id`/`call_id|fc_id` pair. */
+export function normalizeOpenAIResponsesFunctionCallId(id: string): string {
+  const { callId, itemId } = splitOpenAIFunctionCallPairing(id);
+  const normalizedCallId = normalizeOpenAIResponsesIdPart({
+    value: itemId ? `${callId}|${itemId}` : callId,
+    prefix: "call_",
+    isValid: (value) => OPENAI_RESPONSES_CALL_ID_RE.test(value),
+  });
+
+  if (!itemId) {
+    return normalizedCallId;
+  }
+
+  const normalizedItemId = normalizeOpenAIResponsesIdPart({
+    value: itemId,
+    prefix: "fc_",
+    isValid: (value) => OPENAI_RESPONSES_FUNCTION_CALL_ITEM_ID_RE.test(value),
+  });
+  return `${normalizedCallId}|${normalizedItemId}`;
+}
+
+export function shouldNormalizeOpenAIResponsesToolCallId(id: string): boolean {
+  const pairing = splitOpenAIFunctionCallPairing(id);
+  if (!OPENAI_RESPONSES_CALL_ID_RE.test(pairing.callId)) {
+    return true;
+  }
+  if (pairing.itemId === undefined) {
+    return false;
+  }
+  return !OPENAI_RESPONSES_FUNCTION_CALL_ITEM_ID_RE.test(pairing.itemId);
+}

--- a/src/agents/embedded-agent-helpers/openai.ts
+++ b/src/agents/embedded-agent-helpers/openai.ts
@@ -1,9 +1,13 @@
 /**
  * Normalizes OpenAI Responses reasoning/tool-call history for safe replay.
  */
-import { replaceCompactionReplayOwnerContent } from "@openclaw/ai/transports";
+import {
+  normalizeOpenAIResponsesFunctionCallId,
+  replaceCompactionReplayOwnerContent,
+  shouldNormalizeOpenAIResponsesToolCallId,
+  splitOpenAIFunctionCallPairing,
+} from "@openclaw/ai/transports";
 import { parseDateFirstTimestampMs } from "@openclaw/normalization-core/number-coercion";
-import { sha256HexPrefixCore } from "../../infra/crypto-digest.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { rewriteToolResultIds } from "../tool-call-id.js";
 
@@ -26,10 +30,6 @@ type OpenAIReasoningSignature = {
 type DowngradeOpenAIReasoningBlocksOptions = {
   dropReplayableReasoningBefore?: number;
 };
-
-const OPENAI_RESPONSES_ID_MAX_LENGTH = 64;
-const OPENAI_RESPONSES_CALL_ID_RE = /^call_[A-Za-z0-9_-]{1,59}$/;
-const OPENAI_RESPONSES_FUNCTION_CALL_ITEM_ID_RE = /^fc_[A-Za-z0-9_-]{1,61}$/;
 
 function parseOpenAIReasoningSignature(value: unknown): OpenAIReasoningSignature | null {
   if (!value) {
@@ -83,84 +83,8 @@ function hasFollowingNonThinkingBlock(
   return false;
 }
 
-function splitOpenAIFunctionCallPairing(id: string): {
-  callId: string;
-  itemId?: string;
-} {
-  const separator = id.indexOf("|");
-  if (separator <= 0 || separator >= id.length - 1) {
-    return { callId: id };
-  }
-  return {
-    callId: id.slice(0, separator),
-    itemId: id.slice(separator + 1),
-  };
-}
-
 function isOpenAIToolCallType(type: unknown): boolean {
   return type === "toolCall" || type === "toolUse" || type === "functionCall";
-}
-
-function shortOpenAIResponsesIdHash(id: string): string {
-  return sha256HexPrefixCore(id, 10);
-}
-
-function sanitizeOpenAIResponsesIdTail(value: string): string {
-  return value.replace(/[^A-Za-z0-9_-]/g, "_").replace(/^_+|_+$/g, "");
-}
-
-function normalizeOpenAIResponsesIdPart(params: {
-  value: string;
-  prefix: "call_" | "fc_";
-  isValid: (value: string) => boolean;
-}): string {
-  const trimmed = params.value.trim();
-  if (params.isValid(trimmed)) {
-    return trimmed;
-  }
-
-  const rawTail = trimmed.startsWith(params.prefix) ? trimmed.slice(params.prefix.length) : trimmed;
-  const hash = shortOpenAIResponsesIdHash(trimmed || params.prefix);
-  const maxTailLength = OPENAI_RESPONSES_ID_MAX_LENGTH - params.prefix.length;
-  const hashSuffix = `_${hash}`;
-  const safeTail = sanitizeOpenAIResponsesIdTail(rawTail);
-  const clippedBase = safeTail.slice(0, Math.max(1, maxTailLength - hashSuffix.length));
-  const tail = `${clippedBase || "id"}${hashSuffix}`.slice(0, maxTailLength);
-  return `${params.prefix}${tail}`;
-}
-
-function normalizeOpenAIResponsesFunctionCallId(id: string): string {
-  const { callId, itemId } = splitOpenAIFunctionCallPairing(id);
-  const normalizedCallId = normalizeOpenAIResponsesIdPart({
-    // Hash the full pairing so repeated native ids sharing a `callId` (e.g.
-    // `functions.<tool>:<index>` reused across turns) don't collide into the
-    // same `call_*` id and break Responses replay.
-    value: itemId ? `${callId}|${itemId}` : callId,
-    prefix: "call_",
-    isValid: (value) => OPENAI_RESPONSES_CALL_ID_RE.test(value),
-  });
-
-  if (!itemId) {
-    return normalizedCallId;
-  }
-
-  const normalizedItemId = normalizeOpenAIResponsesIdPart({
-    value: itemId,
-    prefix: "fc_",
-    isValid: (value) => OPENAI_RESPONSES_FUNCTION_CALL_ITEM_ID_RE.test(value),
-  });
-  return `${normalizedCallId}|${normalizedItemId}`;
-}
-
-function shouldNormalizeOpenAIResponsesToolCallId(id: string): boolean {
-  const pairing = splitOpenAIFunctionCallPairing(id);
-  if (!OPENAI_RESPONSES_CALL_ID_RE.test(pairing.callId)) {
-    return true;
-  }
-  if (pairing.itemId === undefined) {
-    return false;
-  }
-  return !OPENAI_RESPONSES_FUNCTION_CALL_ITEM_ID_RE.test(pairing.itemId);
 }
 
 function createOpenAIResponsesToolCallIdResolver(): (id: string) => string {


### PR DESCRIPTION
## What Problem This Solves
HTTP continuation (`previous_response_id` reuse) never engaged for a multi-round tool-calling turn — confirmed live against a real gateway: every attempt within a single turn resolved to `history_changed` and fell back to full history, even though the continuation cache held a valid `ready` baseline and eligibility was satisfied on every call. This defeats the whole point of continuation for exactly the case it should help most (a tool-calling loop, where turns are seconds apart).

## Why This Change Was Made
Root-caused via live diagnostic instrumentation against a real gateway. Replaying history for the next round in a tool-calling loop re-sanitizes tool-call ids for provider compatibility (`normalizeOpenAIResponsesToolCallIds` in `embedded-agent-helpers`), so a `function_call`'s `call_id` the client echoes back on round N+1 never matches the raw `call_id` `resolveResponsesContinuationRequest` cached straight from the provider's own streamed response on round N (e.g. `chatcmpl-tool-20cf1f2f...` cached vs `call_chatcmpl-tool-20cf1f2f..._d7218567a7` replayed). Separately, the `arguments` JSON string can pick up different whitespace on a re-`JSON.stringify` along the same replay path, and the comparison treated that as changed content too since `arguments` is compared as a raw string, not a parsed value.

Neither is a real change to what the model said — both are expected, necessary reshaping for provider-format compatibility. `normalizeAssistantReplayInput` already strips `id`/`status` from `function_call`/assistant-message items for exactly this kind of volatility; this extends the same treatment to `call_id` and `arguments` — but not with a blanket drop.

**Revised from the original patch per review feedback:** blanket-dropping `call_id` from the comparison would have made *any* changed function-call id look like the known replay reshape, masking a genuinely different tool call. Instead, `canonicalizeReplayedCallId` reshapes both sides through the exact same transform the replay path applies (`normalizeOpenAIResponsesFunctionCallId`) and only treats them as equal when they canonicalize to the same value — fail-closed for an unrelated id change (covered by a new regression test). The wire-bound delta then gets the raw provider `call_id` restored (`restoreRawCallIdsInDelta`) before it's sent, so a server that reconstructs continuation history from its own cached copy of the raw response still sees a `function_call_output` whose `call_id` matches the `function_call` it cached — instead of an orphaned id it silently drops. The `arguments` comparison also now runs `quoteUnsafeIntegerLiterals` before parsing, since plain `JSON.parse` rounds integers past `Number.MAX_SAFE_INTEGER` and could otherwise treat two genuinely different large-integer arguments as equal.

**Second revision, per ClawSweeper P1 finding (paired call_id|item_id):** the previous revision only canonicalized the cached response's bare `call_id`, but replay pairs the provider's `call_id` *and* item `id` into one `call_id|fc_id` string before reshaping (`normalizeOpenAIResponsesToolCallIds` → `normalizeOpenAIResponsesFunctionCallId`), and the request builder later splits that reshaped pair back into separate wire fields (`openai-responses-replay-messages-internal.ts`). So a cached raw item like `call_id: "functions.gateway:0"`, `id: "fc_tmp"` needed to canonicalize via the *paired* string `"functions.gateway:0|fc_tmp"`, not `call_id` alone — otherwise the eligibility comparison hashed a different input than replay actually produced and permanently stayed `history_changed` for any turn whose provider ids needed reshaping (i.e., almost always, since most providers don't return `call_*`/`fc_*`-shaped ids natively).

Fixed by reconstructing the same pairing from the cached item's `call_id` + `id` before canonicalizing (`canonicalizeCachedCallId`), mirroring the exact idempotent short-circuit the real replay resolver uses (`shouldNormalizeOpenAIResponsesToolCallId`) so already provider-shaped ids are left unchanged rather than needlessly re-hashed — the naive "always pair" version broke 8 existing tests in `openai-responses-retained-compaction-replay.test.ts` where ids were already validly shaped, since pairing two independently-valid ids together and hashing the combined string produces a value replay never generates. `restoreRawCallIdsInDelta` had the identical bug (built its reshaped→raw lookup from the bare cached `call_id` only) and got the same fix.

## User Impact
A native OpenAI Responses endpoint now actually gets the continuation savings it was designed for during multi-round tool-calling turns, not just across separate inbound messages. Before this fix, continuation only ever worked in the narrow case of zero tool calls in between (a plain text reply), which is not the common case for an agentic run.

(HTTP continuation eligibility on `main` today is native-endpoint-only — `supportsNativeOpenAIResponsesEndpoint`. A separate, still-open PR, #128633, proposes extending eligibility to compat-endpoint connections via `compat.supportsResponsesContinuation`; that opt-in is not part of this PR's scope and needs more investigation before landing, so it's marked draft. This fix is endpoint-agnostic — it repairs the same comparison logic regardless of which eligibility gate lets a request reach it.)

## Evidence
- New regression tests reproduce the exact real-world shapes and assert the correct outcome in three cases: (1) `continues a tool-calling round despite replay re-sanitizing call_id and re-serializing arguments, and restores the raw call_id on the wire delta` — bare vs re-sanitized, *paired* `call_id|fc_id` (verified against the real `normalizeOpenAIResponsesFunctionCallId` transform on the paired string, not hand-approximated) plus differently-whitespaced `arguments`, asserting `continuationStatus: "continued"` and that the wire delta carries the *raw* `call_id`, not the reshaped one; (2) `does not tolerate an unrelated function-call id change as the known replay reshape` — an unrelated `call_id` change still correctly falls back to `history_changed`; (3) `does not treat two different unsafe-integer arguments as equal (lossless comparison)` — two different integers above `Number.MAX_SAFE_INTEGER` are not conflated.
- Confirmed test (1)'s current, paired-id fixture fails on the code from the first revision (bare-`call_id`-only canonicalization) for the exact right reason (`history_changed`), and passes with the paired-canonicalization fix.
- Full `packages/ai/src/transports/` suite green: 737/737 tests, 49 files (includes `openai-responses-retained-compaction-replay.test.ts`, which exercises the real end-to-end `AgentMessage` → wire conversion pipeline with already-valid `call_*`/`fc_*` ids and caught the "naive always-pair" bug in an earlier iteration of this fix before landing the idempotent-short-circuit version above).
- `src/agents/embedded-agent-helpers/openai.test.ts` (the real `normalizeOpenAIResponsesToolCallIds` unit suite this fix mirrors): 10/10 passing.
- `oxfmt --check` and `oxlint` clean on both changed files.
- Autoreview (Codex, gpt-5.6-sol, high): clean, no accepted/actionable findings, "patch is correct (0.98)".
- Live-verified end-to-end on a deployment carrying this fix stacked with #128633's compat opt-in (against a self-hosted OpenAI-Responses-compatible connection, since a native OpenAI endpoint wasn't available for live testing): a multi-round tool-calling turn's later model call carried `previous_response_id` with a small `input` delta instead of the full accumulated history, confirmed via the upstream proxy's own request logs.


## Update: fixed the P1 type-collision finding (unsafe integer vs. same-digits string)

`quoteUnsafeIntegerLiterals` converts an unsafe integer literal into a bare quoted string before `JSON.parse`, so the argument comparator's normalized output for `{"n":9007199254740993}` (a number) and `{"n":"9007199254740993"}` (a string) was byte-identical — a real number-to-string argument change wrongly compared equal, letting continuation reuse stale server-side state against a genuinely different tool call.

Fixed by adding an optional `tag` parameter to the shared `quoteUnsafeIntegerLiterals` (default `""`, so every other caller — including the other real callers in `transport-stream-shared.ts` and `anthropic-transport-stream.ts` via the wrapper functions — is unaffected), and passing a control-character-prefixed tag from `normalizeFunctionCallArguments` so a stringified unsafe integer can never collide with a genuine string holding the same digits.

New regression test: `"does not treat an unsafe-integer argument as equal to a same-digits string (type collision)"`. Confirmed it fails pre-fix (`expected 'continued' to be 'history_changed'`) and passes post-fix.

**Proof:** `openai-responses-continuation.test.ts` 10/10 (was 9/9, +1 new); full `packages/ai/src/transports` suite 738/738 (confirms the backward-compatible default doesn't change any other caller's behavior); `oxfmt` clean; autoreview (`gpt-5.6-sol`, high) clean, no accepted findings, patch correct 0.96.

## Update: the type-collision tag was itself wrong -- reverted, with a real live-endpoint regression it caught

Addresses ClawSweeper's P2 finding on the previous head (native-endpoint real behavior proof missing for the type-collision fix). Two bugs found:

**1. Mechanical:** `UNSAFE_INTEGER_COMPARISON_TAG` was defined as `"openclaw-unsafe-integer"` -- a *literal* control character once evaluated at runtime, not its JSON-escaped form. `quoteUnsafeIntegerLiterals` interpolates the tag directly between the JSON quote characters it emits, so the produced text was invalid JSON; `JSON.parse` threw and the `catch` silently fell back to the untagged comparison the tag exists to replace. New regression test (`treats a whitespace-only re-serialization of the same unsafe integer as equal`) failed pre-fix for exactly this reason.

**2. Deeper, found live while proving fix (1):** even once the tag was valid JSON, testing it against a real multi-round tool call over `api.openai.com` showed continuation *still* breaking on the very next round. Root cause: `AssistantMessage.arguments` already stores every unsafe integer as a **string** (`parseJsonObjectPreservingUnsafeIntegers`, `transport-stream-shared.ts` -- precision-preserving, since a JS number can't hold it losslessly). So an **unmodified** replay of a real tool call's argument always re-serializes as a same-digits string, compared against the cached side's raw provider text (a bare number). Tagging only the cached side made this look like a real type change on *every single* out-of-range-integer tool call, permanently breaking continuation for the very next round -- not a rare edge case, but the common case for timestamps, snowflake IDs, and similar large-integer arguments.

The type-collision concern the tag was solving doesn't actually apply to this comparison: both sides replay the *same* historical tool call (not two independent model outputs), so there's no second, unrelated call for a same-digit string to collide with -- the risk the tag guarded against can't occur here.

**Fix:** reverted `normalizeFunctionCallArguments` to plain (untagged) `quoteUnsafeIntegerLiterals`, which still correctly distinguishes two genuinely *different* unsafe integers (the original lossless-comparison fix, unaffected). Removed the now-unused `tag` parameter from `quoteUnsafeIntegerLiterals` itself (no other caller used it). Deleted the now-incorrect "type collision" unit test and replaced it with `treats a cached number-typed unsafe integer as equal to its own replayed string-typed round-trip`, proving the realistic case.

**Proof:**
- New live test `openai-responses-client.continuation-unsafe-integer.live.test.ts`, gated on `OPENCLAW_LIVE_TEST=1` + `OPENAI_API_KEY`, against real `https://api.openai.com/v1`: a real tool call with `n=9007199254740993` (`> Number.MAX_SAFE_INTEGER`), replayed unmodified. Failed before this fix (fell through to a full-history resend, no `previous_response_id`); passes after (continues correctly, and the wire delta's `call_id` is correctly restored to the bare provider id).
- `openai-responses-continuation.test.ts`: 11/11.
- Full `packages/ai/src/transports/` suite: 739/739 (49 files) -- confirms removing the tag parameter doesn't change any other caller.
- `src/agents/embedded-agent-helpers/openai.test.ts`: 10/10.
- `oxfmt` clean.
- Net effect on production LOC: the tag mechanism is removed entirely (fewer lines than the previous head), addressing the earlier P1 finding about production growth for this change.

@clawsweeper re-review



## Update: attaching the actual raw trace + production LOC justification

Addresses ClawSweeper's remaining P1/P2 findings: the prior update only narrated the live test's pass/fail rather than including the checkable raw output, and the production LOC growth needed an explicit justification rather than a bare summary.

**Raw trace, exact head, real `api.openai.com`** (paths sanitized to repo-relative):

```
$ OPENCLAW_LIVE_TEST=1 OPENAI_API_KEY=*** pnpm test:live \
    packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts

 RUN  v4.1.11 <repo>

 ✓ openai-responses-client.continuation-unsafe-integer.live.test.ts > HTTP continuation across a real unsafe-integer tool-call argument (real api.openai.com) > continues a real tool-calling round whose argument is above Number.MAX_SAFE_INTEGER 4418ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  16:18:05
   Duration  8.10s (transform 1.66s, setup 1.86s, import 1.03s, tests 4.42s, environment 0ms)
```

This is the second-request recovery the finding asks about: a real tool call with `n=9007199254740993` (`> Number.MAX_SAFE_INTEGER`), replayed unmodified on round 2, correctly carries `previous_response_id` and the restored raw `call_id` -- proven against the real endpoint, not a mock.

**Production LOC (net +154, `openai-responses-continuation.ts` +144/-5, `openai-responses-tool-call-id-shape.ts` +88 new, `embedded-agent-helpers/openai.ts` +6/-82):**

The `embedded-agent-helpers/openai.ts` delta is a real net *reduction* there (-76) -- its own id-shaping logic moved into the new shared file. That extraction is necessary, not optional: `packages/ai` cannot import from `src/agents` (core-boundary rule -- `packages/ai` is the lower-level package `src/agents` builds on, not the reverse), so the continuation resolver needs its own copy of the exact id-shaping transform to canonicalize a cached raw id against what replay will produce, or the comparison silently uses a different transform than what's actually applied on the wire. `openai-responses-tool-call-id-shape.ts` is that necessary mirror, sized to the transform it mirrors.

The remaining growth in `openai-responses-continuation.ts` (+144/-5) is the actual fix: `canonicalizeReplayedCallId`/`canonicalizeCachedCallId` (comparison-side canonicalization, fail-closed on an unrelated id change -- covered by its own regression test) and `restoreRawCallIdsInDelta` (restoring the provider's raw id on the wire delta, so a server reconstructing history from its own cached raw response can still pair a `function_call_output` against the `function_call` it cached). Both are the specific mechanism this PR exists to add; there isn't a smaller shape that preserves fail-closed behavior on a genuinely different id while forgiving only the known replay reshape.

@clawsweeper re-review
