### PR TITLE
fix(gateway): publish cloud placement changes

### DIFF
--- a/src/gateway/server-methods/sessions-dispatch.test-support.ts
+++ b/src/gateway/server-methods/sessions-dispatch.test-support.ts
@@ -147,6 +147,7 @@ export function makeDispatchTestContext(
     });
   }
   return {
+    getSessionEventSubscriberConnIds: () => new Set(),
     getRuntimeConfig: () => ({
       cloudWorkers: {
         profiles: {

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -573,7 +573,11 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
       if (error instanceof SessionMutationAuthorizationChangedError) {
         throw error;
       }
-      emitSessionsChanged(context, { reason: "move", sessionKey: target.canonicalKey });
+      try {
+        emitSessionsChanged(context, { reason: "move", sessionKey: target.canonicalKey });
+      } catch {
+        // Reporting cannot replace the placement owner's failure response.
+      }
       respondWorkerDispatchError(error, respond);
     }
   },
@@ -602,6 +606,22 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
     }
     const { target, entry, sessionId } = resolved;
     const existingPlacement = placementReader.getMany([sessionId]).get(sessionId);
+    const reportPlacementChange = (placement: WorkerSessionPlacementRecord | undefined): void => {
+      if (
+        !placement ||
+        (existingPlacement &&
+          placement.state === existingPlacement.state &&
+          placement.generation === existingPlacement.generation &&
+          placement.updatedAtMs === existingPlacement.updatedAtMs)
+      ) {
+        return;
+      }
+      try {
+        emitSessionsChanged(context, { reason: "reclaim", sessionKey: target.canonicalKey });
+      } catch {
+        // Reporting cannot replace a committed reclaim outcome.
+      }
+    };
     if (
       existingPlacement?.state !== "failed" &&
       !resolveManagedSessionWorktree({
@@ -613,8 +633,9 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
     ) {
       return;
     }
+    let placement: WorkerSessionPlacementRecord;
     try {
-      const placement = await placementService.reclaim(
+      placement = await placementService.reclaim(
         {
           sessionId,
           sessionKey: target.canonicalKey,
@@ -622,9 +643,15 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
         },
         sessionMutationAuthorization?.assertCurrent,
       );
-      respondWorkerPlacement({ respond, key: target.canonicalKey, sessionId, context, placement });
     } catch (error) {
+      if (error instanceof SessionMutationAuthorizationChangedError) {
+        throw error;
+      }
+      reportPlacementChange(placementReader.getMany([sessionId]).get(sessionId));
       respondWorkerDispatchError(error, respond);
+      return;
     }
+    reportPlacementChange(placement);
+    respondWorkerPlacement({ respond, key: target.canonicalKey, sessionId, context, placement });
   },
 };

--- a/src/gateway/server-methods/sessions.dispatch.abandonment.test.ts
+++ b/src/gateway/server-methods/sessions.dispatch.abandonment.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createWorkerPlacementMoveService } from "../worker-environments/placement-move-service.js";
 import type { WorkerSessionPlacementRecord } from "../worker-environments/placement-store.js";
+import { readSessionsMutationVersion } from "./session-change-event.js";
 import {
   dispatchTestSessionId as sessionId,
   dispatchTestSessionKey as sessionKey,
@@ -103,16 +104,20 @@ describe("sessions.move abandonment", () => {
       resolveDestination: vi.fn(),
     });
 
-    const respond = await invokeSessionMove(
-      makeDispatchTestContext({
-        getSessionEventSubscriberConnIds: () => new Set(),
-        workerPlacementDispatchService: { dispatch: vi.fn(), move: moves.move } as never,
-        workerSessionPlacementService: {
-          getMany: () => new Map([[sessionId, existing]]),
-        },
-      }),
-      { expected: source, target: { kind: "gateway" }, abandonSource: true },
-    );
+    const context = makeDispatchTestContext({
+      getSessionEventSubscriberConnIds: () => {
+        throw new Error("session subscribers unavailable");
+      },
+      workerPlacementDispatchService: { dispatch: vi.fn(), move: moves.move } as never,
+      workerSessionPlacementService: {
+        getMany: () => new Map([[sessionId, existing]]),
+      },
+    });
+    const respond = await invokeSessionMove(context, {
+      expected: source,
+      target: { kind: "gateway" },
+      abandonSource: true,
+    });
 
     expect(respond).toHaveBeenCalledWith(
       true,
@@ -125,6 +130,7 @@ describe("sessions.move abandonment", () => {
       undefined,
     );
     expect(validateAbandonSource).toHaveBeenCalledTimes(joined ? 0 : 1);
+    expect(readSessionsMutationVersion(context)).toBe(2);
     expect(recordPlacementMoveError).not.toHaveBeenCalled();
     expect(remoteSettlementObserved).toBe(false);
   });

--- a/src/gateway/server-methods/sessions.reclaim.test.ts
+++ b/src/gateway/server-methods/sessions.reclaim.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { WorkerSessionPlacementRecord } from "../worker-environments/placement-store.js";
+import {
+  flushPendingSessionsChangedEvents,
+  readSessionsMutationVersion,
+} from "./session-change-event.js";
 import {
   dispatchTestSessionId,
   dispatchTestSessionKey,
@@ -71,14 +76,13 @@ describe("sessions.reclaim", () => {
   it("returns an already reclaimed placement as idempotent success", async () => {
     const reclaimed = makeReclaimedPlacement();
     const reclaim = vi.fn().mockResolvedValue(reclaimed);
-    const respond = await invokeSessionReclaim(
-      makeDispatchTestContext({
-        workerPlacementDispatchService: { dispatch: vi.fn(), reclaim },
-        workerSessionPlacementService: {
-          getMany: () => new Map([[dispatchTestSessionId, reclaimed]]),
-        },
-      }),
-    );
+    const context = makeDispatchTestContext({
+      workerPlacementDispatchService: { dispatch: vi.fn(), reclaim },
+      workerSessionPlacementService: {
+        getMany: () => new Map([[dispatchTestSessionId, reclaimed]]),
+      },
+    });
+    const respond = await invokeSessionReclaim(context);
 
     expect(reclaim).toHaveBeenCalledWith(
       {
@@ -96,6 +100,7 @@ describe("sessions.reclaim", () => {
       }),
       undefined,
     );
+    expect(readSessionsMutationVersion(context)).toBe(0);
   });
 
   it("delegates a failed placement to the reclaim owner", async () => {
@@ -167,4 +172,101 @@ describe("sessions.reclaim", () => {
       undefined,
     );
   });
+
+  it("does not let session change reporting failure replace a committed reclaim", async () => {
+    const active = {
+      ...makeReclaimedPlacement(),
+      state: "active",
+      generation: 3,
+      updatedAtMs: 1,
+      recoveryError: null,
+    } as WorkerSessionPlacementRecord;
+    const reclaimed = makeReclaimedPlacement();
+    const context = makeDispatchTestContext({
+      getSessionEventSubscriberConnIds: () => {
+        throw new Error("session subscribers unavailable");
+      },
+      workerPlacementDispatchService: {
+        dispatch: vi.fn(),
+        reclaim: vi.fn().mockResolvedValue(reclaimed),
+      },
+      workerSessionPlacementService: {
+        getMany: () => new Map([[dispatchTestSessionId, active]]),
+      },
+    });
+
+    const respond = await invokeSessionReclaim(context);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        ok: true,
+        placement: expect.objectContaining({ state: "reclaimed" }),
+      }),
+      undefined,
+    );
+    expect(readSessionsMutationVersion(context)).toBe(1);
+  });
+
+  it.each(["success", "persisted failure"] as const)(
+    "publishes a %s placement change to another session subscriber",
+    async (outcome) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        let placement: WorkerSessionPlacementRecord = {
+          ...makeReclaimedPlacement(),
+          state: "active",
+          generation: 3,
+          updatedAtMs: 1,
+          recoveryError: null,
+          terminalReason: null,
+          terminalAtMs: null,
+        };
+        const reclaimError = new Error("worker teardown failed after committing placement");
+        const reclaim = vi.fn(async () => {
+          if (outcome === "persisted failure") {
+            placement = {
+              ...placement,
+              state: "failed",
+              generation: placement.generation + 1,
+              updatedAtMs: placement.updatedAtMs + 1,
+              recoveryError: reclaimError.message,
+            } as WorkerSessionPlacementRecord;
+            throw reclaimError;
+          }
+          placement = makeReclaimedPlacement();
+          return placement;
+        });
+        const context = makeDispatchTestContext({
+          broadcastToConnIds: vi.fn(),
+          chatAbortControllers: new Map(),
+          getSessionEventSubscriberConnIds: () => new Set(["another-client"]),
+          workerPlacementDispatchService: { dispatch: vi.fn(), reclaim },
+          workerSessionPlacementService: {
+            getMany: () => new Map([[dispatchTestSessionId, placement]]),
+          },
+        });
+
+        try {
+          const respond = await invokeSessionReclaim(context);
+
+          expect(respond).toHaveBeenCalledWith(
+            outcome === "success",
+            outcome === "success" ? expect.objectContaining({ ok: true }) : undefined,
+            outcome === "success"
+              ? undefined
+              : expect.objectContaining({ message: reclaimError.message }),
+          );
+          expect(context.broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
+            "sessions.changed",
+            expect.objectContaining({ reason: "reclaim", sessionKey: dispatchTestSessionKey }),
+            new Set(["another-client"]),
+            expect.objectContaining({ agentId: "main", dropIfSlow: true }),
+          );
+          expect(readSessionsMutationVersion(context)).toBe(1);
+        } finally {
+          flushPendingSessionsChangedEvents(context);
+        }
+      });
+    },
+  );
 });

--- a/src/gateway/server-worker-placement-change-events.ts
+++ b/src/gateway/server-worker-placement-change-events.ts
@@ -1,0 +1,83 @@
+import { formatErrorMessage } from "../infra/errors.js";
+import { emitSessionsChanged } from "./server-methods/session-change-event.js";
+import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
+
+export function createGatewayWorkerPlacementChangePublisher(params: {
+  placements: Pick<WorkerSessionPlacementStore, "list">;
+  getSessionChangeContext?: () => Parameters<typeof emitSessionsChanged>[0] | undefined;
+  warn: (message: string) => void;
+}) {
+  const warnPlacementChangeFailure = (error: unknown): void => {
+    try {
+      params.warn(`Worker placement session change reporting failed: ${formatErrorMessage(error)}`);
+    } catch {
+      // Reporting failures must never replace a committed placement outcome.
+    }
+  };
+  const snapshotPlacements = () =>
+    new Map(
+      params.placements.list().map((placement) => [
+        placement.sessionId,
+        {
+          state: placement.state,
+          generation: placement.generation,
+          updatedAtMs: placement.updatedAtMs,
+          sessionKey: placement.sessionKey,
+          agentId: placement.agentId,
+        },
+      ]),
+    );
+
+  return async <T>(operation: () => Promise<T>): Promise<T> => {
+    let context: ReturnType<NonNullable<typeof params.getSessionChangeContext>>;
+    let before: ReturnType<typeof snapshotPlacements> | undefined;
+    try {
+      context = params.getSessionChangeContext?.();
+      if (context) {
+        before = snapshotPlacements();
+      }
+    } catch (error) {
+      warnPlacementChangeFailure(error);
+    }
+    if (!context || !before) {
+      return await operation();
+    }
+    try {
+      return await operation();
+    } finally {
+      try {
+        const after = snapshotPlacements();
+        for (const [sessionId, previous] of before) {
+          const current = after.get(sessionId);
+          if (
+            current &&
+            current.state === previous.state &&
+            current.generation === previous.generation &&
+            current.updatedAtMs === previous.updatedAtMs &&
+            current.sessionKey === previous.sessionKey &&
+            current.agentId === previous.agentId
+          ) {
+            after.delete(sessionId);
+            continue;
+          }
+          if (!current) {
+            after.set(sessionId, previous);
+          }
+        }
+        for (const placement of after.values()) {
+          try {
+            emitSessionsChanged(context, {
+              reason: "placement",
+              sessionKey: placement.sessionKey,
+              agentId: placement.agentId,
+            });
+          } catch (error) {
+            warnPlacementChangeFailure(error);
+          }
+        }
+      } catch (error) {
+        warnPlacementChangeFailure(error);
+      }
+    }
+  };
+}

--- a/src/gateway/server-worker-placement-recovery-events.test.ts
+++ b/src/gateway/server-worker-placement-recovery-events.test.ts
@@ -4,6 +4,7 @@ import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 const runtimeMocks = vi.hoisted(() => ({
   createDispatch: vi.fn(),
   createDiskSpace: vi.fn(),
+  createSessionEvidenceResolver: vi.fn(),
 }));
 
 vi.mock("./worker-environments/placement-dispatch.js", async (importOriginal) => {
@@ -18,96 +19,175 @@ vi.mock("./worker-environments/placement-disk-space.js", async (importOriginal) 
   return { ...actual, createWorkerPlacementDiskSpaceMonitor: runtimeMocks.createDiskSpace };
 });
 
+vi.mock("./server-worker-placement-session-evidence.js", () => ({
+  createWorkerPlacementSessionEvidenceResolver: runtimeMocks.createSessionEvidenceResolver,
+}));
+
 import {
   flushPendingSessionsChangedEvents,
   readSessionsMutationVersion,
 } from "./server-methods/session-change-event.js";
 import { createGatewayWorkerPlacementRuntime } from "./server-worker-placement-startup.js";
 
-describe("worker placement recovery session events", () => {
-  it("publishes a later recovered move through the Gateway session event and cache fence", async () => {
-    await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      vi.useFakeTimers();
-      const context = {
-        broadcastToConnIds: vi.fn(),
-        chatAbortControllers: new Map(),
-        getRuntimeConfig: () => ({}),
-        getSessionEventSubscriberConnIds: () => new Set(["session-observer"]),
-      };
-      const recovered = {
-        sessionId: "session-recovered",
-        sessionKey: "agent:main:move-source",
-        agentId: "main",
-        state: "local" as const,
-      };
-      let currentPlacement: typeof recovered | undefined;
-      let sweepCount = 0;
-      runtimeMocks.createDiskSpace.mockReturnValue({
-        read: vi.fn(),
-        version: vi.fn(() => 0),
-        sweep: vi.fn().mockResolvedValue(undefined),
+type RecoveryPlacement = {
+  sessionId: string;
+  sessionKey: string;
+  agentId: string;
+  state: "active" | "failed" | "local" | "reclaimed";
+  generation: number;
+  updatedAtMs: number;
+  environmentId: string | null;
+  activeOwnerEpoch: number | null;
+  turnClaim: null;
+};
+
+function recoveryPlacement(state: RecoveryPlacement["state"] = "active"): RecoveryPlacement {
+  return {
+    sessionId: "session-recovered",
+    sessionKey: "agent:main:move-source",
+    agentId: "main",
+    state,
+    generation: 1,
+    updatedAtMs: 1,
+    environmentId: state === "local" ? null : "environment-recovered",
+    activeOwnerEpoch: state === "active" ? 1 : null,
+    turnClaim: null,
+  };
+}
+
+async function withRecoveryRuntime(
+  options: {
+    placement?: RecoveryPlacement;
+    startup?: (placements: Map<string, RecoveryPlacement>) => Promise<void> | void;
+    sweep?: (placements: Map<string, RecoveryPlacement>) => Promise<void> | void;
+    evidence?: "current" | "absent";
+    broadcast?: () => void;
+    hasContext?: boolean;
+    hasSubscribers?: boolean;
+  },
+  verify: (runtime: {
+    context: {
+      broadcastToConnIds: ReturnType<typeof vi.fn>;
+      chatAbortControllers: Map<never, never>;
+      getRuntimeConfig: () => object;
+      getSessionEventSubscriberConnIds: () => Set<string>;
+    };
+    environments: { start: ReturnType<typeof vi.fn> };
+    listPlacements: ReturnType<typeof vi.fn>;
+    placements: Map<string, RecoveryPlacement>;
+    runtime: ReturnType<typeof createGatewayWorkerPlacementRuntime>;
+    start: () => Promise<void>;
+    warn: ReturnType<typeof vi.fn>;
+  }) => Promise<void>,
+): Promise<void> {
+  await withOpenClawTestState({ scenario: "minimal" }, async () => {
+    vi.useFakeTimers();
+    const placements = new Map<string, RecoveryPlacement>();
+    if (options.placement) {
+      placements.set(options.placement.sessionId, options.placement);
+    }
+    const context = {
+      broadcastToConnIds: vi.fn(options.broadcast),
+      chatAbortControllers: new Map<never, never>(),
+      getRuntimeConfig: () => ({}),
+      getSessionEventSubscriberConnIds: () =>
+        new Set(options.hasSubscribers === false ? [] : ["session-observer"]),
+    };
+    runtimeMocks.createDiskSpace.mockReturnValue({
+      read: vi.fn(),
+      version: vi.fn(() => 0),
+      sweep: vi.fn().mockResolvedValue(undefined),
+    });
+    runtimeMocks.createSessionEvidenceResolver.mockResolvedValue(
+      async () => options.evidence ?? "current",
+    );
+    runtimeMocks.createDispatch.mockImplementation(() => ({
+      dispatch: vi.fn(),
+      forceDestroyEnvironment: vi.fn(),
+      reclaim: vi.fn(),
+      reconcile: vi.fn(async () => await options.startup?.(placements)),
+      reconcileActive: vi.fn(async () => await options.sweep?.(placements)),
+    }));
+    const environments = {
+      installReconcileEnvironmentGuard: vi.fn(() => vi.fn()),
+      start: vi.fn(),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const warn = vi.fn();
+    const listPlacements = vi.fn(() => [...placements.values()]);
+    const runtime = createGatewayWorkerPlacementRuntime({
+      placements: {
+        workspaceResultInstanceId: () => "gateway-test",
+        get: (sessionId: string) => placements.get(sessionId),
+        list: listPlacements,
+        retireSessionPlacement: ({ sessionId }: { sessionId: string }) => {
+          placements.delete(sessionId);
+        },
+        pruneOrphanedWorkspaceReconciliations: () => [],
+        listWorkspaceReconciliationOwners: () => [],
+        listPendingWorkspaceResults: () => [],
+      } as never,
+      environments: environments as never,
+      gatewayNamespace: "gateway-test",
+      getSessionChangeContext: options.hasContext === false ? undefined : () => context,
+      revokeSessionAuthority: vi.fn(),
+      warn,
+    });
+    const sidecar = { current: null as Awaited<ReturnType<typeof runtime.startRuntime>> };
+
+    try {
+      await verify({
+        context,
+        environments,
+        listPlacements,
+        placements,
+        runtime,
+        start: async () => {
+          sidecar.current = await runtime.startRuntime({
+            isClosePreludeStarted: () => false,
+            registerSidecar: vi.fn(),
+            unregisterSidecar: vi.fn(),
+          });
+          if (!sidecar.current) {
+            throw new Error("worker placement runtime did not start");
+          }
+        },
+        warn,
       });
-      runtimeMocks.createDispatch.mockImplementation((options) => ({
-        dispatch: vi.fn(),
-        forceDestroyEnvironment: vi.fn(),
-        reclaim: vi.fn(),
-        reconcile: vi.fn().mockResolvedValue(undefined),
-        reconcileActive: vi.fn(async () => {
+    } finally {
+      await sidecar.current?.stop();
+      flushPendingSessionsChangedEvents(context);
+      vi.useRealTimers();
+    }
+  });
+}
+
+describe("worker placement recovery session events", () => {
+  it("publishes a recovered move once and ignores an unchanged periodic sweep", async () => {
+    const recovered = recoveryPlacement("local");
+    let sweepCount = 0;
+    await withRecoveryRuntime(
+      {
+        sweep: (placements) => {
           sweepCount += 1;
           if (sweepCount === 2) {
-            currentPlacement = recovered;
-            options.onRecoveredMoveTransition?.(recovered);
+            placements.set(recovered.sessionId, recovered);
           }
-        }),
-      }));
-      const environments = {
-        installReconcileEnvironmentGuard: vi.fn(() => vi.fn()),
-        start: vi.fn(),
-        stop: vi.fn().mockResolvedValue(undefined),
-      };
-      const runtime = createGatewayWorkerPlacementRuntime({
-        placements: {
-          workspaceResultInstanceId: () => "gateway-test",
-          get: () => currentPlacement,
-          list: () => [],
-          retireSessionPlacement: vi.fn(),
-          pruneOrphanedWorkspaceReconciliations: () => [],
-          listWorkspaceReconciliationOwners: () => [],
-          listPendingWorkspaceResults: () => [],
-        } as never,
-        environments: environments as never,
-        gatewayNamespace: "gateway-test",
-        getSessionChangeContext: () => {
-          expect(currentPlacement).toBe(recovered);
-          return context;
         },
-        revokeSessionAuthority: vi.fn(),
-        warn: vi.fn(),
-      });
-      const initialMutationVersion = readSessionsMutationVersion(context);
-      let sidecar: Awaited<ReturnType<typeof runtime.startRuntime>> = null;
-
-      try {
-        sidecar = await runtime.startRuntime({
-          isClosePreludeStarted: () => false,
-          registerSidecar: vi.fn(),
-          unregisterSidecar: vi.fn(),
-        });
-        if (!sidecar) {
-          throw new Error("worker placement runtime did not start");
-        }
-
-        await vi.dynamicImportSettled();
+      },
+      async ({ context, start }) => {
+        const initialMutationVersion = readSessionsMutationVersion(context);
+        await start();
         await vi.advanceTimersByTimeAsync(60_000);
         expect(context.broadcastToConnIds).not.toHaveBeenCalled();
         expect(readSessionsMutationVersion(context)).toBe(initialMutationVersion);
 
         await vi.advanceTimersByTimeAsync(60_000);
 
-        expect(context.broadcastToConnIds).toHaveBeenCalledWith(
+        expect(context.broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
           "sessions.changed",
           expect.objectContaining({
-            reason: "move",
+            reason: "placement",
             sessionKey: recovered.sessionKey,
             agentId: recovered.agentId,
           }),
@@ -115,11 +195,152 @@ describe("worker placement recovery session events", () => {
           expect.objectContaining({ agentId: recovered.agentId, dropIfSlow: true }),
         );
         expect(readSessionsMutationVersion(context)).toBe(initialMutationVersion + 1);
-      } finally {
-        await sidecar?.stop();
-        flushPendingSessionsChangedEvents(context);
-        vi.useRealTimers();
-      }
-    });
+        expect(runtimeMocks.createDispatch.mock.lastCall?.[0]).not.toHaveProperty(
+          "onRecoveredMoveTransition",
+        );
+      },
+    );
+  });
+
+  it.each(["reconcile", "reconcileActive"] as const)(
+    "publishes a non-move transition from externally requested %s",
+    async (method) => {
+      const current = recoveryPlacement();
+      const transition = (placements: Map<string, RecoveryPlacement>) => {
+        placements.set(current.sessionId, {
+          ...current,
+          state: "failed",
+          generation: current.generation + 1,
+          updatedAtMs: current.updatedAtMs + 1,
+        });
+      };
+      await withRecoveryRuntime(
+        {
+          placement: current,
+          ...(method === "reconcile" ? { startup: transition } : { sweep: transition }),
+        },
+        async ({ context, runtime }) => {
+          if (method === "reconcile") {
+            await runtime.dispatchService.reconcile("startup");
+          } else {
+            await runtime.dispatchService.reconcileActive("environment-recovered");
+          }
+
+          expect(context.broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
+            "sessions.changed",
+            expect.objectContaining({ reason: "placement", sessionKey: current.sessionKey }),
+            new Set(["session-observer"]),
+            expect.objectContaining({ agentId: current.agentId }),
+          );
+          expect(readSessionsMutationVersion(context)).toBe(1);
+        },
+      );
+    },
+  );
+
+  it("skips placement snapshots when the session change context is unavailable", async () => {
+    const sweep = vi.fn();
+    await withRecoveryRuntime(
+      { sweep, hasContext: false },
+      async ({ context, listPlacements, runtime }) => {
+        await runtime.dispatchService.reconcileActive();
+
+        expect(sweep).toHaveBeenCalledOnce();
+        expect(listPlacements).not.toHaveBeenCalled();
+        expect(context.broadcastToConnIds).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("advances the sessions list fence without connected subscribers", async () => {
+    const recovered = recoveryPlacement();
+    await withRecoveryRuntime(
+      {
+        hasSubscribers: false,
+        sweep: (placements) => void placements.set(recovered.sessionId, recovered),
+      },
+      async ({ context, listPlacements, runtime }) => {
+        await runtime.dispatchService.reconcileActive();
+
+        expect(listPlacements).toHaveBeenCalledTimes(2);
+        expect(readSessionsMutationVersion(context)).toBe(1);
+        expect(context.broadcastToConnIds).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("publishes a committed transition without replacing a later reconciliation error", async () => {
+    const current = recoveryPlacement();
+    const reconcileError = new Error("reconciliation failed after committing placement");
+    await withRecoveryRuntime(
+      {
+        placement: current,
+        sweep: (placements) => {
+          placements.set(current.sessionId, { ...current, state: "failed", generation: 2 });
+          throw reconcileError;
+        },
+      },
+      async ({ context, runtime }) => {
+        await expect(runtime.dispatchService.reconcileActive()).rejects.toBe(reconcileError);
+        expect(context.broadcastToConnIds).toHaveBeenCalledOnce();
+        expect(readSessionsMutationVersion(context)).toBe(1);
+      },
+    );
+  });
+
+  it("publishes startup reconciliation before the runtime becomes ready", async () => {
+    const recovered = recoveryPlacement();
+    await withRecoveryRuntime(
+      { startup: (placements) => void placements.set(recovered.sessionId, recovered) },
+      async ({ context, environments, start }) => {
+        context.broadcastToConnIds.mockImplementation(() => {
+          expect(environments.start).not.toHaveBeenCalled();
+        });
+
+        await start();
+
+        expect(context.broadcastToConnIds).toHaveBeenCalledOnce();
+        expect(context.broadcastToConnIds.mock.calls[0]?.[1]).toMatchObject({
+          reason: "placement",
+          sessionKey: recovered.sessionKey,
+        });
+        expect(environments.start).toHaveBeenCalledOnce();
+      },
+    );
+  });
+
+  it("publishes session placement retirement after startup", async () => {
+    const current = recoveryPlacement("local");
+    await withRecoveryRuntime(
+      { placement: current, evidence: "absent" },
+      async ({ context, placements, start }) => {
+        await start();
+        await vi.dynamicImportSettled();
+
+        expect(placements.has(current.sessionId)).toBe(false);
+        expect(context.broadcastToConnIds).toHaveBeenCalledOnce();
+        expect(context.broadcastToConnIds.mock.calls[0]?.[1]).toMatchObject({
+          reason: "placement",
+          sessionKey: current.sessionKey,
+        });
+      },
+    );
+  });
+
+  it("does not let broadcast reporting failures overturn reconciliation", async () => {
+    const recovered = recoveryPlacement();
+    await withRecoveryRuntime(
+      {
+        broadcast: () => {
+          throw new Error("session broadcast failed");
+        },
+        sweep: (placements) => void placements.set(recovered.sessionId, recovered),
+      },
+      async ({ context, runtime, warn }) => {
+        await expect(runtime.dispatchService.reconcileActive()).resolves.toBeUndefined();
+        expect(context.broadcastToConnIds).toHaveBeenCalledOnce();
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("session broadcast failed"));
+      },
+    );
   });
 });

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -16,6 +16,7 @@ import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { createGitHubPublicationRuntime } from "./github-publication-runtime.js";
 import type { NodeWorkerSupervisorTransport } from "./node-registry-private.js";
 import { emitSessionsChanged } from "./server-methods/session-change-event.js";
+import { createGatewayWorkerPlacementChangePublisher } from "./server-worker-placement-change-events.js";
 import { createGatewayWorkerPlacementMoveBarrier } from "./server-worker-placement-move-barrier.js";
 import { createGatewayWorkerPlacementMoveDestinationResolver } from "./server-worker-placement-move-destination.js";
 import { createGatewayWorkerPlacementReclaimBarriers } from "./server-worker-placement-reclaim.js";
@@ -217,7 +218,8 @@ export function createGatewayWorkerPlacementRuntime(
       remoteWorkspaceDir: placement.remoteWorkspaceDir,
     };
   };
-  const dispatchService = coordinateWorkerPlacementDispatch(
+  const publishPlacementChanges = createGatewayWorkerPlacementChangePublisher(params);
+  const rawDispatchService = coordinateWorkerPlacementDispatch(
     createWorkerPlacementDispatchService({
       placements: params.placements,
       environments: params.environments,
@@ -378,16 +380,6 @@ export function createGatewayWorkerPlacementRuntime(
           void nodeWorkspaceRetention.schedule(request.deviceId);
         }
       },
-      onRecoveredMoveTransition: (placement) => {
-        const context = params.getSessionChangeContext?.();
-        if (context) {
-          emitSessionsChanged(context, {
-            reason: "move",
-            sessionKey: placement.sessionKey,
-            agentId: placement.agentId,
-          });
-        }
-      },
       runMoveBarrier,
       resolveMoveDestination: createGatewayWorkerPlacementMoveDestinationResolver({
         environments: params.environments,
@@ -413,6 +405,13 @@ export function createGatewayWorkerPlacementRuntime(
         )?.gitAuthor,
     }),
   );
+  const dispatchService = {
+    ...rawDispatchService,
+    reconcile: (mode: Parameters<typeof rawDispatchService.reconcile>[0]) =>
+      publishPlacementChanges(() => rawDispatchService.reconcile(mode)),
+    reconcileActive: (environmentId?: string) =>
+      publishPlacementChanges(() => rawDispatchService.reconcileActive(environmentId)),
+  };
   const sessionRetirement = createPlacementSessionRetirement({
     placements: params.placements,
     environments: params.environments,
@@ -547,12 +546,12 @@ export function createGatewayWorkerPlacementRuntime(
       }
       return trackOperation(
         placementReconcile,
-        (async () => {
+        publishPlacementChanges(async () => {
           await sessionRetirement.reconcile();
-          await dispatchService.reconcileActive();
+          await rawDispatchService.reconcileActive();
           await reconcilePublications();
           void nodeWorkspaceRetention.schedule();
-        })(),
+        }),
         "Worker placement reconcile sweep failed",
       );
     };
@@ -639,10 +638,10 @@ export function createGatewayWorkerPlacementRuntime(
       if (hooks.isClosePreludeStarted()) {
         return await stopBeforeReady();
       }
-      const startupReconcile = (async () => {
-        await dispatchService.reconcile("startup");
+      const startupReconcile = publishPlacementChanges(async () => {
+        await rawDispatchService.reconcile("startup");
         await reconcilePublications();
-      })();
+      });
       placementReconcile.current = startupReconcile;
       try {
         await startupReconcile;
@@ -664,7 +663,7 @@ export function createGatewayWorkerPlacementRuntime(
       }
       void trackOperation(
         placementReconcile,
-        sessionRetirement.reconcile(),
+        publishPlacementChanges(() => sessionRetirement.reconcile()),
         "Worker placement reconcile sweep failed",
       );
       void sweepDiskSpace();

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -105,7 +105,6 @@ type WorkerPlacementDispatchOptions = WorkerPlacementReclaimBarriers & {
     target: WorkerPlacementMoveRequest["target"],
   ) => Promise<WorkerPlacementMoveDestination | undefined>;
   onActivated?: (request: WorkerPlacementDispatchRequest) => void;
-  onRecoveredMoveTransition?: (placement: WorkerDispatchPlacement) => void;
   workspaceOperations: WorkerWorkspaceOperationCoordinator;
   resolveWorkspacePath: (params: {
     sessionId: string;
@@ -671,8 +670,6 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
     validateAbandonSource: abandonment.validateAbandonSource,
     abandonSource: abandonment.abandonSource,
     resolveDestination: options.resolveMoveDestination,
-    onRecoveredTransition: (placement) =>
-      reportTransition(options.onRecoveredMoveTransition, placement),
   });
   recoverPlacementMoves = moveService.recoverAll;
 

--- a/src/gateway/worker-environments/placement-move-service.ts
+++ b/src/gateway/worker-environments/placement-move-service.ts
@@ -67,8 +67,17 @@ export function createWorkerPlacementMoveService(options: {
     identity: MoveSessionIdentity,
     target: WorkerPlacementMoveTarget,
   ) => Promise<WorkerPlacementMoveDestination | undefined>;
-  onRecoveredTransition?: (placement: WorkerDispatchPlacement) => void;
 }) {
+  const reportTransition = (
+    observer: ((placement: WorkerDispatchPlacement) => void) | undefined,
+    placement: WorkerDispatchPlacement,
+  ): void => {
+    try {
+      observer?.(placement);
+    } catch {
+      // Reporting cannot overturn a durable move transition.
+    }
+  };
   const recordError = (intent: WorkerPlacementMoveIntent, error: unknown): void => {
     options.placements.recordPlacementMoveError({
       operationId: intent.operationId,
@@ -162,11 +171,11 @@ export function createWorkerPlacementMoveService(options: {
         },
       });
       intent = begun.intent;
-      onTransition?.(begun.placement);
+      reportTransition(onTransition, begun.placement);
       const local = request.abandonSource
         ? await options.abandonSource(request, intent, authorize)
         : await options.reclaimSource(request, intent, authorize);
-      onTransition?.(local);
+      reportTransition(onTransition, local);
       if (local.state !== "local") {
         throw new Error(`Session ${request.sessionKey} move did not return to local placement`);
       }
@@ -192,15 +201,12 @@ export function createWorkerPlacementMoveService(options: {
     }
   };
 
-  const recover = async (
-    intent: WorkerPlacementMoveIntent,
-  ): Promise<WorkerDispatchPlacement | undefined> => {
+  const recover = async (intent: WorkerPlacementMoveIntent): Promise<void> => {
     try {
       let placement = options.placements.get(intent.sessionId);
       if (!placement) {
         throw new Error(`Session ${intent.sessionId} placement move lost its session placement`);
       }
-      const initialPlacement = placement;
       const identity = {
         sessionId: placement.sessionId,
         sessionKey: placement.sessionKey,
@@ -217,7 +223,7 @@ export function createWorkerPlacementMoveService(options: {
             operationId: intent.operationId,
             sessionId: intent.sessionId,
           });
-          return placement;
+          return;
         }
         if (
           placement.state !== "active" &&
@@ -229,7 +235,8 @@ export function createWorkerPlacementMoveService(options: {
             `Session ${identity.sessionKey} abandonment recovery is waiting in ${placement.state}`,
           );
         }
-        return await options.abandonSource(identity, intent);
+        await options.abandonSource(identity, intent);
+        return;
       }
       if (placement.state === "failed") {
         if (
@@ -246,7 +253,7 @@ export function createWorkerPlacementMoveService(options: {
           operationId: intent.operationId,
           sessionId: intent.sessionId,
         });
-        return placement;
+        return;
       } else if (placement.state === "draining") {
         const local = await options.reclaimSource(identity, intent);
         if (local.state !== "local") {
@@ -261,7 +268,7 @@ export function createWorkerPlacementMoveService(options: {
           environment.state !== "failed" &&
           environment.state !== "orphaned"
         ) {
-          return undefined;
+          return;
         }
         placement = options.placements.completePlacementMoveSourceToLocal({
           operationId: intent.operationId,
@@ -275,17 +282,18 @@ export function createWorkerPlacementMoveService(options: {
         if (stillSource) {
           throw new Error(`Session ${identity.sessionKey} move recovery found an active source`);
         }
-        return options.placements.completePlacementMoveToWorker({
+        options.placements.completePlacementMoveToWorker({
           operationId: intent.operationId,
           sessionId: intent.sessionId,
           expectedGeneration: placement.generation,
           environmentId: placement.environmentId,
           ownerEpoch: placement.activeOwnerEpoch,
         });
+        return;
       } else if (placement.state !== "local") {
         // Generic dispatch recovery owns requested through starting. A later
         // coordinated sweep either observes active or retries from failed/local.
-        return undefined;
+        return;
       }
       if (intent.target.kind === "gateway") {
         if (options.placements.getPlacementMove(intent.sessionId)) {
@@ -293,11 +301,10 @@ export function createWorkerPlacementMoveService(options: {
             operationId: intent.operationId,
             sessionId: intent.sessionId,
           });
-          return placement;
         }
-        return placement === initialPlacement ? undefined : placement;
+        return;
       }
-      const failed = options.placements.fail({
+      options.placements.fail({
         sessionId: placement.sessionId,
         expectedGeneration: placement.generation,
         recoveryError: RESTART_AUTHORITY_EXPIRED,
@@ -306,7 +313,6 @@ export function createWorkerPlacementMoveService(options: {
         operationId: intent.operationId,
         sessionId: intent.sessionId,
       });
-      return failed;
     } catch (error) {
       recordError(intent, error);
       throw error;
@@ -324,13 +330,7 @@ export function createWorkerPlacementMoveService(options: {
       ) {
         protectedSessions.add(intent.sessionId);
       }
-      await recover(intent)
-        .then((placement) => {
-          if (placement) {
-            options.onRecoveredTransition?.(placement);
-          }
-        })
-        .catch(() => undefined);
+      await recover(intent).catch(() => undefined);
     }
     return protectedSessions;
   };

--- a/src/gateway/worker-environments/placement-store.move.test.ts
+++ b/src/gateway/worker-environments/placement-store.move.test.ts
@@ -8,10 +8,7 @@ import {
   type OpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
 import { createWorkerPlacementMoveService } from "./placement-move-service.js";
-import type {
-  WorkerSessionPlacementIdentity,
-  WorkerSessionPlacementRecord,
-} from "./placement-record.js";
+import type { WorkerSessionPlacementIdentity } from "./placement-record.js";
 import {
   createWorkerSessionPlacementStore,
   type WorkerSessionPlacementStore,
@@ -526,7 +523,7 @@ describe("worker session placement moves", () => {
     expect(store.getPlacementMove(SESSION.sessionId)).toBeUndefined();
   });
 
-  it("reports a persisted abandonment only after a later sweep completes its durable local placement", async () => {
+  it("completes a persisted abandonment only after a later sweep makes its placement local", async () => {
     const active = advanceToActive();
     seedAttachedEnvironment({
       environmentId: active.environmentId,
@@ -555,11 +552,6 @@ describe("worker session placement moves", () => {
       expectedGeneration: reconciling.generation,
       recoveryError,
     });
-    const recoveredTransitions = vi.fn((placement: WorkerSessionPlacementRecord) => {
-      expect(store.get(active.sessionId)).toEqual(placement);
-      expect(store.getPlacementMove(active.sessionId)).toBeUndefined();
-      throw new Error("session subscriber reporting failed");
-    });
     const abandonSource = vi
       .fn()
       .mockRejectedValueOnce(new Error("device teardown is still pending"))
@@ -580,7 +572,6 @@ describe("worker session placement moves", () => {
       validateAbandonSource: vi.fn(),
       abandonSource,
       resolveDestination: vi.fn(),
-      onRecoveredTransition: recoveredTransitions,
     });
 
     await moves.recoverAll();
@@ -589,24 +580,18 @@ describe("worker session placement moves", () => {
     expect(store.getPlacementMove(active.sessionId)?.lastError).toBe(
       "device teardown is still pending",
     );
-    expect(recoveredTransitions).not.toHaveBeenCalled();
-
     await moves.recoverAll();
 
-    expect(recoveredTransitions).toHaveBeenCalledOnce();
-    expect(recoveredTransitions).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: active.sessionId,
-        sessionKey: active.sessionKey,
-        agentId: active.agentId,
-        state: "local",
-        generation: failed.generation + 1,
-      }),
-    );
+    expect(store.get(active.sessionId)).toMatchObject({
+      sessionId: active.sessionId,
+      state: "local",
+      generation: failed.generation + 1,
+    });
+    expect(store.getPlacementMove(active.sessionId)).toBeUndefined();
     expect(abandonSource).toHaveBeenCalledTimes(2);
   });
 
-  it("reports an ordinary reconciled move only after its Gateway placement is durable", async () => {
+  it("completes an ordinary reconciled move with one durable Gateway placement", async () => {
     const active = advanceToActive();
     seedAttachedEnvironment({
       environmentId: active.environmentId,
@@ -628,10 +613,6 @@ describe("worker session placement moves", () => {
       ownerEpoch: active.activeOwnerEpoch,
       expectedGeneration: begun.placement.generation,
     });
-    const recoveredTransitions = vi.fn((placement: WorkerSessionPlacementRecord) => {
-      expect(store.get(active.sessionId)).toEqual(placement);
-      expect(store.getPlacementMove(active.sessionId)).toBeUndefined();
-    });
     const moves = createWorkerPlacementMoveService({
       placements: store,
       environments: { get: () => undefined },
@@ -641,17 +622,15 @@ describe("worker session placement moves", () => {
       validateAbandonSource: vi.fn(),
       abandonSource: vi.fn(),
       resolveDestination: vi.fn(),
-      onRecoveredTransition: recoveredTransitions,
     });
 
     await moves.recoverAll();
 
-    expect(recoveredTransitions).toHaveBeenCalledOnce();
-    expect(recoveredTransitions).toHaveBeenCalledWith(
-      expect.objectContaining({ state: "local", generation: reconciling.generation + 1 }),
-    );
+    const recovered = store.get(active.sessionId);
+    expect(recovered).toMatchObject({ state: "local", generation: reconciling.generation + 1 });
+    expect(store.getPlacementMove(active.sessionId)).toBeUndefined();
     await moves.recoverAll();
-    expect(recoveredTransitions).toHaveBeenCalledOnce();
+    expect(store.get(active.sessionId)).toEqual(recovered);
   });
 
   it("fails a pending profile move after restart loses request authority", async () => {
@@ -686,10 +665,6 @@ describe("worker session placement moves", () => {
       throw new Error("failed destination must not reclaim the old source");
     });
     const restartedStore = createWorkerSessionPlacementStore({ database, now: () => nowMs });
-    const recoveredTransitions = vi.fn((placement: WorkerSessionPlacementRecord) => {
-      expect(restartedStore.get(source.sessionId)).toEqual(placement);
-      expect(restartedStore.getPlacementMove(source.sessionId)).toBeUndefined();
-    });
     const moves = createWorkerPlacementMoveService({
       placements: restartedStore,
       environments: { get: () => undefined },
@@ -700,7 +675,6 @@ describe("worker session placement moves", () => {
       abandonSource: vi.fn(async () => {
         throw new Error("unexpected source abandonment");
       }),
-      onRecoveredTransition: recoveredTransitions,
       resolveDestination: async (_identity, target) => {
         if (target.kind !== "profile") {
           throw new Error("expected profile move target");
@@ -717,14 +691,6 @@ describe("worker session placement moves", () => {
 
     expect(reclaimSource).not.toHaveBeenCalled();
     expect(dispatch).not.toHaveBeenCalled();
-    expect(recoveredTransitions).toHaveBeenCalledWith(
-      expect.objectContaining({
-        state: "failed",
-        generation: local.generation + 1,
-        recoveryError:
-          "Cloud worker move request authority expired after Gateway restart; retry move",
-      }),
-    );
     expect(restartedStore.get(source.sessionId)).toMatchObject({
       state: "failed",
       generation: local.generation + 1,


### PR DESCRIPTION
Closes #128908

## What Problem This Solves

Cloud-worker placement reconciliation could commit durable startup, periodic, externally requested, partial-failure, or retirement transitions without emitting `sessions.changed`. Direct `sessions.reclaim` also omitted the event. Connected Control UI and plugin consumers could therefore keep stale placement state, and a post-mutation `sessions.list` request could reuse an older projection fence until another mutation or reconnect.

## Why This Change Was Made

The old implementation had one recovered-move callback, but placement reconciliation has several mutation owners. This change replaces that special case with one Gateway-owned before/after placement publisher around every reconciliation entry point. It snapshots the stable placement identity/version fields, emits once per changed session in a `finally` block, covers removals, and preserves the original reconciliation result when event reporting fails. Operations without a Gateway session-change context remain unwrapped; no-subscriber mutations still advance the synchronous sessions-list fence.

Direct reclaim compares the authoritative placement before and after the operation, including a placement persisted before a thrown teardown error. Changed outcomes emit reason `reclaim`; idempotent reclaim stays silent; authorization changes still propagate. Move transition observers now share the existing no-throw reporting invariant, so a broken subscriber cannot interrupt a durable move.

The recovered-move callback and its return-value plumbing are deleted. No schema, protocol, config, fallback, or provider-specific path is added.

Production LOC: +154/-48 (net +106) | Tests/test support: +438/-142 (net +296)

The production growth establishes one generic publication owner across startup, periodic, external, retirement, partial-failure, and direct-RPC paths. I attempted the net-neutral shape first; transition-specific callbacks would be smaller locally but preserve the bug class and duplicate lifecycle policy.

AI-assisted: yes. I reviewed placement reconciliation entry points, move recovery, session retirement, direct reclaim, cache-fence semantics, subscriber/plugin delivery, partial commits, error preservation, and idempotency.

## User Impact

Cloud session placement status now refreshes immediately after background recovery, failure, retirement, and explicit reclaim. Connected clients no longer need a later poll or reconnect to discover the durable state. Unchanged sweeps and idempotent reclaims remain silent, and notification failures cannot replace the actual placement outcome.

## Evidence

- Pre-fix owner proof: focused regressions committed placement transitions through startup, periodic, external, retirement, partial-failure, move, and reclaim paths and observed no session event/cache-fence advance.
- Post-fix owner proof: 201 tests passed across 13 placement startup, maintenance, cleanup, move, dispatch, recovery, reclaim, authorization, and store suites.
- `node scripts/check-changed.mjs` passed, including production/test typechecks, lint, formatting, max-lines, database-first, schema v9, dead exports, architecture boundaries, and import cycles.
- Fresh P0/P1 autoreview: no accepted/actionable findings (0.88).
- Coverage includes added/removed/unchanged placements, no-context and no-subscriber behavior, startup ordering before environment readiness, partial commits followed by errors, retirement, direct reclaim success/persisted failure/idempotency, authorization changes, and notification failures that must not replace committed outcomes.
- Live provider fault injection and Control UI video are not attached: reproducing a deterministic background recovery/retirement transition in a real cloud lease would require intentionally faulting an external worker. The changed boundary is Gateway-local and is exercised through the real `sessions.changed` broadcaster and mutation fence; the campaign's final current-main cloud matrix will cover normal live reconciliation.
