### PR TITLE
fix: keep verbose health available when channel probes stall

### DIFF
--- a/docs/gateway/health.md
+++ b/docs/gateway/health.md
@@ -93,8 +93,10 @@ When no `x-openclaw-session-key` header or `user` field is provided, `/v1/chat/c
 sockets from the CLI). By default it returns a fresh cached gateway snapshot and the
 gateway refreshes that cache in the background; `--verbose` forces a live probe instead.
 The command reports linked creds/auth age when available, per-channel probe summaries,
-session-store summary, and probe duration. It exits non-zero if the gateway is
-unreachable or the probe fails/times out.
+session-store summary, and probe duration. Live probes use bounded account concurrency
+and a Gateway-owned deadline, so one slow account returns a structured timeout while
+completed sibling results remain available. The command exits non-zero if the gateway is
+unreachable or the Gateway call itself times out.
 
 ### Queue warnings
 
@@ -120,7 +122,7 @@ payloads, claim owners or tokens, recorded errors, or session and target identif
 Options:
 
 - `--json`: machine-readable JSON output
-- `--timeout <ms>`: override the default 10s probe timeout
+- `--timeout <ms>`: override the default 10s Gateway connection timeout; it does not widen the Gateway's internal live-probe deadline
 - `--verbose`: force a live probe and print gateway connection details
 - `--debug`: alias for `--verbose`
 

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelAccountSnapshot, ChannelPlugin } from "../channels/plugins/types.public.js";
 import type { HealthSummary } from "../gateway/health/types.js";
@@ -490,7 +489,7 @@ describe("collectGatewayHealthSnapshot", () => {
     vi.unstubAllEnvs();
   });
 
-  it("clamps oversized probe timeouts", async () => {
+  it("does not let callers widen the gateway probe deadline", async () => {
     testConfig = {
       session: { store: "/tmp/x" },
       channels: { telegram: { botToken: "123:test" } },
@@ -504,7 +503,9 @@ describe("collectGatewayHealthSnapshot", () => {
 
     await getHealthSnapshot({ timeoutMs: Number.MAX_SAFE_INTEGER });
 
-    expect(timeouts).toEqual([MAX_TIMER_TIMEOUT_MS]);
+    expect(timeouts).toHaveLength(1);
+    expect(timeouts[0]).toBeGreaterThan(0);
+    expect(timeouts[0]).toBeLessThanOrEqual(7_000);
   });
 
   it("includes active plugin load errors in the health snapshot", async () => {

--- a/src/gateway/health/collector.deadline.test.ts
+++ b/src/gateway/health/collector.deadline.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+type DeadlineAccount = {
+  accountId: string;
+  enabled: boolean;
+  configured: boolean;
+};
+
+let testConfig: OpenClawConfig = {};
+let healthPluginsForTest: ChannelPlugin[] = [];
+let collectGatewayHealthSnapshot: typeof import("./collector.js").collectGatewayHealthSnapshot;
+let createChannelTestPluginBase: typeof import("../../test-utils/channel-plugins.js").createChannelTestPluginBase;
+
+function createDeadlinePlugin(params: {
+  accountIds: string[];
+  probe: (account: DeadlineAccount) => Promise<Record<string, unknown>>;
+}): ChannelPlugin {
+  const resolveAccount = (_cfg: OpenClawConfig, accountId?: string | null): DeadlineAccount => ({
+    accountId: accountId?.trim() || "default",
+    enabled: true,
+    configured: true,
+  });
+  return {
+    ...createChannelTestPluginBase({ id: "deadline-test", label: "Deadline Test" }),
+    config: {
+      listAccountIds: () => params.accountIds,
+      resolveAccount,
+      inspectAccount: resolveAccount,
+      isEnabled: (account) => (account as DeadlineAccount).enabled,
+      isConfigured: (account) => (account as DeadlineAccount).configured,
+    },
+    status: {
+      probeAccount: async ({ account }) => await params.probe(account as DeadlineAccount),
+      buildChannelSummary: ({ snapshot }) => ({ ...snapshot }),
+    },
+  };
+}
+
+async function collectDeadlineSnapshot(params: {
+  timeoutMs: number;
+  audience?: "public" | "admin";
+}) {
+  return await collectGatewayHealthSnapshot({
+    audience: params.audience ?? "admin",
+    probe: true,
+    timeoutMs: params.timeoutMs,
+  });
+}
+
+describe("gateway health collection deadline", () => {
+  beforeAll(async () => {
+    vi.doMock("../../config/config.js", () => ({
+      getRuntimeConfig: () => testConfig,
+    }));
+    vi.doMock("../../config/sessions/paths.js", () => ({
+      resolveSessionStorePathCore: () => "/tmp/sessions.json",
+    }));
+    vi.doMock("../../config/sessions/session-accessor.js", () => ({
+      listSessionEntriesReadOnly: () => [],
+    }));
+    vi.doMock("../../channels/plugins/read-only.js", () => ({
+      listReadOnlyChannelPluginsForConfig: () => healthPluginsForTest,
+    }));
+    const [health, channelTestUtils] = await Promise.all([
+      import("./collector.js"),
+      import("../../test-utils/channel-plugins.js"),
+    ]);
+    collectGatewayHealthSnapshot = health.collectGatewayHealthSnapshot;
+    createChannelTestPluginBase = channelTestUtils.createChannelTestPluginBase;
+  });
+
+  beforeEach(async () => {
+    testConfig = {};
+    healthPluginsForTest = [];
+    await collectGatewayHealthSnapshot({ audience: "admin", probe: false, timeoutMs: 50 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("preserves healthy accounts when one probe never settles", async () => {
+    vi.useFakeTimers();
+    const accountIds = ["default", "fast-1", "fast-2", "fast-3", "fast-4", "fast-5"];
+    const started: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+    healthPluginsForTest = [
+      createDeadlinePlugin({
+        accountIds,
+        probe: async (account) => {
+          started.push(account.accountId);
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          if (account.accountId === "default") {
+            return await new Promise<Record<string, unknown>>(() => {});
+          }
+          await Promise.resolve();
+          active -= 1;
+          return { ok: true, accountId: account.accountId };
+        },
+      }),
+    ];
+
+    const snapshotPromise = collectDeadlineSnapshot({ timeoutMs: 50 });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(50);
+    const snap = await snapshotPromise;
+    const channel = snap.channels["deadline-test"];
+
+    expect(started).toEqual(accountIds);
+    expect(maxActive).toBeLessThanOrEqual(5);
+    expect(channel?.probe).toMatchObject({ ok: false, timedOut: true });
+    for (const accountId of accountIds.slice(1)) {
+      expect(channel?.accounts?.[accountId]?.probe).toMatchObject({ ok: true });
+    }
+  }, 1_000);
+
+  it("does not start queued probes after the aggregate deadline", async () => {
+    vi.useFakeTimers();
+    const accountIds = [
+      "default",
+      "blocked-1",
+      "blocked-2",
+      "blocked-3",
+      "blocked-4",
+      "queued-1",
+      "queued-2",
+    ];
+    const started: string[] = [];
+    healthPluginsForTest = [
+      createDeadlinePlugin({
+        accountIds,
+        probe: async (account) => {
+          started.push(account.accountId);
+          return await new Promise<Record<string, unknown>>(() => {});
+        },
+      }),
+    ];
+
+    const snapshotPromise = collectDeadlineSnapshot({ timeoutMs: 50, audience: "public" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(started).toEqual(accountIds.slice(0, 5));
+    await vi.advanceTimersByTimeAsync(50);
+    const snap = await snapshotPromise;
+    const channel = snap.channels["deadline-test"];
+
+    expect(started).toEqual(accountIds.slice(0, 5));
+    for (const accountId of accountIds) {
+      expect(channel?.accounts?.[accountId]?.probe).toMatchObject({
+        ok: false,
+        timedOut: true,
+      });
+    }
+  }, 1_000);
+});

--- a/src/gateway/health/collector.deadline.test.ts
+++ b/src/gateway/health/collector.deadline.test.ts
@@ -85,6 +85,7 @@ describe("gateway health collection deadline", () => {
     vi.useFakeTimers();
     const accountIds = ["default", "fast-1", "fast-2", "fast-3", "fast-4", "fast-5"];
     const started: string[] = [];
+    let releaseSlowProbe: (() => void) | undefined;
     let active = 0;
     let maxActive = 0;
     healthPluginsForTest = [
@@ -95,7 +96,12 @@ describe("gateway health collection deadline", () => {
           active += 1;
           maxActive = Math.max(maxActive, active);
           if (account.accountId === "default") {
-            return await new Promise<Record<string, unknown>>(() => {});
+            return await new Promise<Record<string, unknown>>((resolve) => {
+              releaseSlowProbe = () => {
+                active -= 1;
+                resolve({ ok: true });
+              };
+            });
           }
           await Promise.resolve();
           active -= 1;
@@ -116,6 +122,8 @@ describe("gateway health collection deadline", () => {
     for (const accountId of accountIds.slice(1)) {
       expect(channel?.accounts?.[accountId]?.probe).toMatchObject({ ok: true });
     }
+    releaseSlowProbe?.();
+    await vi.advanceTimersByTimeAsync(0);
   }, 1_000);
 
   it("does not start queued probes after the aggregate deadline", async () => {
@@ -130,12 +138,15 @@ describe("gateway health collection deadline", () => {
       "queued-2",
     ];
     const started: string[] = [];
+    const releaseProbes: Array<() => void> = [];
     healthPluginsForTest = [
       createDeadlinePlugin({
         accountIds,
         probe: async (account) => {
           started.push(account.accountId);
-          return await new Promise<Record<string, unknown>>(() => {});
+          return await new Promise<Record<string, unknown>>((resolve) => {
+            releaseProbes.push(() => resolve({ ok: true }));
+          });
         },
       }),
     ];
@@ -154,5 +165,61 @@ describe("gateway health collection deadline", () => {
         timedOut: true,
       });
     }
+    for (const release of releaseProbes) {
+      release();
+    }
+    await vi.advanceTimersByTimeAsync(0);
+  }, 1_000);
+
+  it("retains timed-out permits across repeated health collections", async () => {
+    vi.useFakeTimers();
+    const accountIds = ["default", "blocked-1", "blocked-2", "blocked-3", "blocked-4"];
+    const started: string[] = [];
+    const releaseProbes: Array<() => void> = [];
+    let active = 0;
+    let maxActive = 0;
+    healthPluginsForTest = [
+      createDeadlinePlugin({
+        accountIds,
+        probe: async (account) => {
+          started.push(account.accountId);
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          return await new Promise<Record<string, unknown>>((resolve) => {
+            releaseProbes.push(() => {
+              active -= 1;
+              resolve({ ok: true });
+            });
+          });
+        },
+      }),
+    ];
+
+    const firstSnapshot = collectDeadlineSnapshot({ timeoutMs: 50 });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(started).toEqual(accountIds);
+    await vi.advanceTimersByTimeAsync(50);
+    await firstSnapshot;
+
+    const secondSnapshot = collectDeadlineSnapshot({ timeoutMs: 50 });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(started).toEqual(accountIds);
+    await vi.advanceTimersByTimeAsync(50);
+    const second = await secondSnapshot;
+
+    expect(started).toEqual(accountIds);
+    expect(active).toBe(5);
+    expect(maxActive).toBe(5);
+    for (const accountId of accountIds) {
+      expect(second.channels["deadline-test"]?.accounts?.[accountId]?.probe).toMatchObject({
+        ok: false,
+        timedOut: true,
+      });
+    }
+    for (const release of releaseProbes) {
+      release();
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    expect(active).toBe(0);
   }, 1_000);
 });

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -232,6 +232,92 @@ type HealthChannelPlan = {
   accountSummaries: Record<string, ChannelAccountHealthSummary>;
 };
 
+type HealthOperationRelease = () => void;
+type HealthOperationWaiter = {
+  deadlineAtMs: number;
+  resolve: (release: HealthOperationRelease | null) => void;
+  timer: ReturnType<typeof setTimeout>;
+  settled: boolean;
+};
+
+// Permits outlive response deadlines so an unfinished plugin hook cannot be
+// replaced by later health refreshes and amplify process-wide probe work.
+let activeHealthOperations = 0;
+const healthOperationWaiters: HealthOperationWaiter[] = [];
+
+function settleHealthOperationWaiter(
+  waiter: HealthOperationWaiter,
+  release: HealthOperationRelease | null,
+): void {
+  if (waiter.settled) {
+    return;
+  }
+  waiter.settled = true;
+  clearTimeout(waiter.timer);
+  waiter.resolve(release);
+}
+
+function releaseNextHealthOperationWaiter(): void {
+  while (healthOperationWaiters.length > 0) {
+    const waiter = healthOperationWaiters.shift();
+    if (!waiter || waiter.settled) {
+      continue;
+    }
+    if (Date.now() >= waiter.deadlineAtMs) {
+      settleHealthOperationWaiter(waiter, null);
+      continue;
+    }
+    settleHealthOperationWaiter(waiter, createHealthOperationRelease());
+    return;
+  }
+}
+
+function createHealthOperationRelease(): HealthOperationRelease {
+  activeHealthOperations += 1;
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    activeHealthOperations -= 1;
+    releaseNextHealthOperationWaiter();
+  };
+}
+
+async function acquireHealthOperationPermit(
+  deadlineAtMs: number,
+): Promise<HealthOperationRelease | null> {
+  if (Date.now() >= deadlineAtMs) {
+    return null;
+  }
+  if (activeHealthOperations < HEALTH_PROBE_CONCURRENCY) {
+    return createHealthOperationRelease();
+  }
+
+  return await new Promise<HealthOperationRelease | null>((resolve) => {
+    const waiter: HealthOperationWaiter = {
+      deadlineAtMs,
+      resolve,
+      timer: setTimeout(
+        () => {
+          const index = healthOperationWaiters.indexOf(waiter);
+          if (index >= 0) {
+            healthOperationWaiters.splice(index, 1);
+          }
+          settleHealthOperationWaiter(waiter, null);
+        },
+        Math.max(1, deadlineAtMs - Date.now()),
+      ),
+      settled: false,
+    };
+    if (typeof waiter.timer === "object" && "unref" in waiter.timer) {
+      waiter.timer.unref();
+    }
+    healthOperationWaiters.push(waiter);
+  });
+}
+
 function buildHealthTimeoutRecord(
   accountId: string,
   timeoutMs: number,
@@ -386,6 +472,22 @@ async function buildHealthAccountRecord(params: {
   return record;
 }
 
+async function runHealthAccountWithinDeadline(
+  params: Parameters<typeof buildHealthAccountRecord>[0],
+): Promise<ChannelAccountHealthSummary> {
+  const release = await acquireHealthOperationPermit(params.deadlineAtMs);
+  if (!release) {
+    return buildHealthTimeoutRecord(params.accountId, params.timeoutMs);
+  }
+
+  const operation = buildHealthAccountRecord(params);
+  void operation.then(release, release);
+  const result = await awaitWithinDeadline(() => operation, params.deadlineAtMs);
+  return result === ABSOLUTE_DEADLINE_EXPIRED
+    ? buildHealthTimeoutRecord(params.accountId, params.timeoutMs)
+    : result;
+}
+
 /** Collects the gateway-owned health snapshot for an explicit trust audience. */
 export async function collectGatewayHealthSnapshot(params: {
   audience: HealthSnapshotAudience;
@@ -499,31 +601,21 @@ export async function collectGatewayHealthSnapshot(params: {
     plan.accountIds.map((accountId) => ({ plan, accountId })),
   );
   const { results: accountResults } = await runTasksWithConcurrency({
-    tasks: accountTasks.map(({ plan, accountId }) => async () => {
-      const result = await awaitWithinDeadline(
-        () =>
-          buildHealthAccountRecord({
-            plugin: plan.plugin,
-            cfg,
-            accountId,
-            defaultAccountId: plan.defaultAccountId,
-            includeSensitive,
-            probe: params.probe,
-            deadlineAtMs,
-            timeoutMs,
-            runtimeSnapshot: params.runtimeSnapshot,
-          }),
-        deadlineAtMs,
-      );
-      return {
-        plan,
+    tasks: accountTasks.map(({ plan, accountId }) => async () => ({
+      plan,
+      accountId,
+      record: await runHealthAccountWithinDeadline({
+        plugin: plan.plugin,
+        cfg,
         accountId,
-        record:
-          result === ABSOLUTE_DEADLINE_EXPIRED
-            ? buildHealthTimeoutRecord(accountId, timeoutMs)
-            : result,
-      };
-    }),
+        defaultAccountId: plan.defaultAccountId,
+        includeSensitive,
+        probe: params.probe,
+        deadlineAtMs,
+        timeoutMs,
+        runtimeSnapshot: params.runtimeSnapshot,
+      }),
+    })),
     limit: params.probe ? HEALTH_PROBE_CONCURRENCY : 1,
     throwOnError: true,
   });

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -6,6 +6,7 @@ import { redactChannelStatusSummaryBaseUrl } from "../../channels/account-snapsh
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import { listReadOnlyChannelPluginsForConfig } from "../../channels/plugins/read-only.js";
 import { buildChannelAccountSnapshotFromAccount } from "../../channels/plugins/status.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../../config/legacy.default-agent-owner.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
@@ -24,6 +25,8 @@ import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import { listPluginServiceHealthFailures } from "../../plugins/service-health.js";
 import { buildChannelAccountBindings, resolvePreferredAccountId } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { ABSOLUTE_DEADLINE_EXPIRED, awaitWithinDeadline } from "../../utils/absolute-deadline.js";
+import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
@@ -43,7 +46,9 @@ import type {
   PluginHealthSummary,
 } from "./types.js";
 
-const DEFAULT_HEALTH_TIMEOUT_MS = 10_000;
+// `status --all` gives live health 8s, so the Gateway must finish first.
+const HEALTH_COLLECTION_TIMEOUT_MS = 7_000;
+const HEALTH_PROBE_CONCURRENCY = 5;
 const HEALTH_RECENT_SESSION_LIMIT = 5;
 const healthLog = createSubsystemLogger("health");
 
@@ -219,6 +224,168 @@ function buildPluginHealthSummary(): PluginHealthSummary | undefined {
   return { loaded, errors, unavailable };
 }
 
+type HealthChannelPlan = {
+  plugin: ChannelPlugin;
+  defaultAccountId: string;
+  preferredAccountId: string;
+  accountIds: string[];
+  accountSummaries: Record<string, ChannelAccountHealthSummary>;
+};
+
+function buildHealthTimeoutRecord(
+  accountId: string,
+  timeoutMs: number,
+): ChannelAccountHealthSummary {
+  const error = `health collection timed out after ${timeoutMs}ms`;
+  return {
+    accountId,
+    lastError: error,
+    probe: { ok: false, timedOut: true, error },
+  };
+}
+
+function resolveHealthProbeTimeoutMs(deadlineAtMs: number): number {
+  return Math.max(1, deadlineAtMs - Date.now());
+}
+
+async function buildHealthAccountRecord(params: {
+  plugin: ChannelPlugin;
+  cfg: OpenClawConfig;
+  accountId: string;
+  defaultAccountId: string;
+  includeSensitive: boolean;
+  probe: boolean;
+  deadlineAtMs: number;
+  timeoutMs: number;
+  runtimeSnapshot?: ChannelRuntimeSnapshot;
+}): Promise<ChannelAccountHealthSummary> {
+  const timedOut = () => buildHealthTimeoutRecord(params.accountId, params.timeoutMs);
+  const { probeAccount, snapshotAccount, enabled, configured, diagnostics } =
+    await resolveHealthAccountContext({
+      plugin: params.plugin,
+      cfg: params.cfg,
+      accountId: params.accountId,
+    });
+  if (Date.now() >= params.deadlineAtMs) {
+    return timedOut();
+  }
+  if (diagnostics.length > 0) {
+    debugHealth(params.cfg, "account.diagnostics", {
+      channel: params.plugin.id,
+      accountId: params.accountId,
+      diagnostics,
+    });
+  }
+
+  let probe: unknown;
+  let lastProbeAt: number | null = null;
+  if (enabled && configured && params.probe && params.plugin.status?.probeAccount) {
+    try {
+      probe = await params.plugin.status.probeAccount({
+        account: probeAccount,
+        timeoutMs: resolveHealthProbeTimeoutMs(params.deadlineAtMs),
+        cfg: params.cfg,
+      });
+      lastProbeAt = Date.now();
+    } catch (error) {
+      probe = { ok: false, error: formatErrorMessage(error) };
+      lastProbeAt = Date.now();
+    }
+  }
+  if (Date.now() >= params.deadlineAtMs) {
+    return timedOut();
+  }
+
+  const probeRecord =
+    probe && typeof probe === "object" ? (probe as Record<string, unknown>) : null;
+  const bot =
+    probeRecord && typeof probeRecord.bot === "object"
+      ? (probeRecord.bot as { username?: string | null })
+      : null;
+  if (bot?.username) {
+    debugHealth(params.cfg, "probe.bot", {
+      channel: params.plugin.id,
+      accountId: params.accountId,
+      username: bot.username,
+    });
+  }
+
+  const runtimeSnapshot =
+    params.runtimeSnapshot?.channelAccounts[params.plugin.id]?.[params.accountId] ??
+    (params.accountId === params.defaultAccountId
+      ? params.runtimeSnapshot?.channels[params.plugin.id]
+      : undefined);
+  const nonSensitiveProbeFailure = buildNonSensitiveProbeFailure(params.plugin.id, probe);
+  const snapshotProbe = params.includeSensitive ? probe : nonSensitiveProbeFailure;
+  const snapshot: ChannelAccountSnapshot = await buildChannelAccountSnapshotFromAccount({
+    plugin: params.plugin,
+    cfg: params.cfg,
+    accountId: params.accountId,
+    account: snapshotAccount,
+    runtime: runtimeSnapshot,
+    probe: snapshotProbe,
+    enabledFallback: enabled,
+    configuredFallback: configured,
+  });
+  if (Date.now() >= params.deadlineAtMs) {
+    return timedOut();
+  }
+  if (lastProbeAt) {
+    snapshot.lastProbeAt = lastProbeAt;
+  }
+  const healthState = resolveChannelHealthState(snapshot, {
+    channelId: params.plugin.id,
+    now: Date.now(),
+    staleEventThresholdMs: DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
+    channelConnectGraceMs: DEFAULT_CHANNEL_CONNECT_GRACE_MS,
+  });
+  if (healthState !== undefined) {
+    snapshot.healthState = healthState;
+  }
+
+  const summary = params.plugin.status?.buildChannelSummary
+    ? await params.plugin.status.buildChannelSummary({
+        account: probeAccount,
+        cfg: params.cfg,
+        defaultAccountId: params.accountId,
+        snapshot,
+      })
+    : undefined;
+  if (Date.now() >= params.deadlineAtMs) {
+    return timedOut();
+  }
+  // Summary hooks overlay the safe snapshot, so reapply URL redaction after the final merge.
+  const record = redactChannelStatusSummaryBaseUrl(
+    summary && typeof summary === "object"
+      ? ({ ...snapshot, ...summary } as ChannelAccountHealthSummary)
+      : ({
+          ...snapshot,
+          accountId: params.accountId,
+          configured,
+        } satisfies ChannelAccountHealthSummary),
+  );
+  if (record.configured === undefined) {
+    record.configured = configured;
+  }
+  if (params.includeSensitive && record.probe === undefined && probe !== undefined) {
+    record.probe = probe;
+  }
+  if (!params.includeSensitive) {
+    const summaryProbeFailure = buildNonSensitiveProbeFailure(params.plugin.id, record.probe);
+    const safeProbeFailure = summaryProbeFailure ?? nonSensitiveProbeFailure;
+    if (safeProbeFailure) {
+      record.probe = safeProbeFailure;
+    } else {
+      delete record.probe;
+    }
+  }
+  if (record.lastProbeAt === undefined && lastProbeAt) {
+    record.lastProbeAt = lastProbeAt;
+  }
+  record.accountId = params.accountId;
+  return record;
+}
+
 /** Collects the gateway-owned health snapshot for an explicit trust audience. */
 export async function collectGatewayHealthSnapshot(params: {
   audience: HealthSnapshotAudience;
@@ -228,6 +395,12 @@ export async function collectGatewayHealthSnapshot(params: {
   eventLoop?: HealthSummary["eventLoop"];
   configReloadHotReloadStatus?: GatewayHotReloadStatus;
 }): Promise<HealthSummary> {
+  const start = Date.now();
+  const timeoutMs = Math.min(
+    resolveTimerTimeoutMs(params.timeoutMs, HEALTH_COLLECTION_TIMEOUT_MS, 50),
+    HEALTH_COLLECTION_TIMEOUT_MS,
+  );
+  const deadlineAtMs = start + timeoutMs;
   const cfg = await readRuntimeHealthConfig();
   const { defaultAgentId, ordered } = resolveHealthAgentOrder(cfg);
   const channelBindings = buildChannelAccountBindings(cfg);
@@ -271,8 +444,6 @@ export async function collectGatewayHealthSnapshot(params: {
       summaryAgent?.agentId,
     ));
 
-  const start = Date.now();
-  const cappedTimeout = resolveTimerTimeoutMs(params.timeoutMs, DEFAULT_HEALTH_TIMEOUT_MS, 50);
   const includeSensitive = params.audience === "admin";
   const channels: Record<string, ChannelHealthSummary> = {};
   const plugins = listReadOnlyChannelPluginsForConfig(cfg, {
@@ -280,8 +451,7 @@ export async function collectGatewayHealthSnapshot(params: {
   });
   const channelOrder = plugins.map((plugin) => plugin.id);
   const channelLabels: Record<string, string> = {};
-
-  for (const plugin of plugins) {
+  const channelPlans: HealthChannelPlan[] = plugins.map((plugin) => {
     channelLabels[plugin.id] = plugin.meta.label ?? plugin.id;
     const accountIds = plugin.config.listAccountIds(cfg);
     const defaultAccountId = resolveChannelDefaultAccountId({
@@ -317,122 +487,69 @@ export async function collectGatewayHealthSnapshot(params: {
       preferredAccountId,
       accountIdsToProbe,
     });
-    const accountSummaries: Record<string, ChannelAccountHealthSummary> = {};
-
-    for (const accountId of accountIdsToProbe) {
-      const { probeAccount, snapshotAccount, enabled, configured, diagnostics } =
-        await resolveHealthAccountContext({
-          plugin,
-          cfg,
-          accountId,
-        });
-      if (diagnostics.length > 0) {
-        debugHealth(cfg, "account.diagnostics", { channel: plugin.id, accountId, diagnostics });
-      }
-
-      let probe: unknown;
-      let lastProbeAt: number | null = null;
-      if (enabled && configured && params.probe && plugin.status?.probeAccount) {
-        try {
-          probe = await plugin.status.probeAccount({
-            account: probeAccount,
-            timeoutMs: cappedTimeout,
+    return {
+      plugin,
+      defaultAccountId,
+      preferredAccountId,
+      accountIds: accountIdsToProbe,
+      accountSummaries: {},
+    };
+  });
+  const accountTasks = channelPlans.flatMap((plan) =>
+    plan.accountIds.map((accountId) => ({ plan, accountId })),
+  );
+  const { results: accountResults } = await runTasksWithConcurrency({
+    tasks: accountTasks.map(({ plan, accountId }) => async () => {
+      const result = await awaitWithinDeadline(
+        () =>
+          buildHealthAccountRecord({
+            plugin: plan.plugin,
             cfg,
-          });
-          lastProbeAt = Date.now();
-        } catch (error) {
-          probe = { ok: false, error: formatErrorMessage(error) };
-          lastProbeAt = Date.now();
-        }
-      }
-
-      const probeRecord =
-        probe && typeof probe === "object" ? (probe as Record<string, unknown>) : null;
-      const bot =
-        probeRecord && typeof probeRecord.bot === "object"
-          ? (probeRecord.bot as { username?: string | null })
-          : null;
-      if (bot?.username) {
-        debugHealth(cfg, "probe.bot", { channel: plugin.id, accountId, username: bot.username });
-      }
-
-      const runtimeSnapshot =
-        params.runtimeSnapshot?.channelAccounts[plugin.id]?.[accountId] ??
-        (accountId === defaultAccountId ? params.runtimeSnapshot?.channels[plugin.id] : undefined);
-      const nonSensitiveProbeFailure = buildNonSensitiveProbeFailure(plugin.id, probe);
-      const snapshotProbe = includeSensitive ? probe : nonSensitiveProbeFailure;
-      const snapshot: ChannelAccountSnapshot = await buildChannelAccountSnapshotFromAccount({
-        plugin,
-        cfg,
-        accountId,
-        account: snapshotAccount,
-        runtime: runtimeSnapshot,
-        probe: snapshotProbe,
-        enabledFallback: enabled,
-        configuredFallback: configured,
-      });
-      if (lastProbeAt) {
-        snapshot.lastProbeAt = lastProbeAt;
-      }
-      const healthState = resolveChannelHealthState(snapshot, {
-        channelId: plugin.id,
-        now: Date.now(),
-        staleEventThresholdMs: DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
-        channelConnectGraceMs: DEFAULT_CHANNEL_CONNECT_GRACE_MS,
-      });
-      if (healthState !== undefined) {
-        snapshot.healthState = healthState;
-      }
-
-      const summary = plugin.status?.buildChannelSummary
-        ? await plugin.status.buildChannelSummary({
-            account: probeAccount,
-            cfg,
-            defaultAccountId: accountId,
-            snapshot,
-          })
-        : undefined;
-      // Summary hooks overlay the safe snapshot, so reapply URL redaction after the final merge.
-      const record = redactChannelStatusSummaryBaseUrl(
-        summary && typeof summary === "object"
-          ? ({ ...snapshot, ...summary } as ChannelAccountHealthSummary)
-          : ({ ...snapshot, accountId, configured } satisfies ChannelAccountHealthSummary),
+            accountId,
+            defaultAccountId: plan.defaultAccountId,
+            includeSensitive,
+            probe: params.probe,
+            deadlineAtMs,
+            timeoutMs,
+            runtimeSnapshot: params.runtimeSnapshot,
+          }),
+        deadlineAtMs,
       );
-      if (record.configured === undefined) {
-        record.configured = configured;
-      }
-      if (includeSensitive && record.probe === undefined && probe !== undefined) {
-        record.probe = probe;
-      }
-      if (!includeSensitive) {
-        const summaryProbeFailure = buildNonSensitiveProbeFailure(plugin.id, record.probe);
-        const safeProbeFailure = summaryProbeFailure ?? nonSensitiveProbeFailure;
-        if (safeProbeFailure) {
-          record.probe = safeProbeFailure;
-        } else {
-          delete record.probe;
-        }
-      }
-      if (record.lastProbeAt === undefined && lastProbeAt) {
-        record.lastProbeAt = lastProbeAt;
-      }
-      record.accountId = accountId;
-      accountSummaries[accountId] = record;
+      return {
+        plan,
+        accountId,
+        record:
+          result === ABSOLUTE_DEADLINE_EXPIRED
+            ? buildHealthTimeoutRecord(accountId, timeoutMs)
+            : result,
+      };
+    }),
+    limit: params.probe ? HEALTH_PROBE_CONCURRENCY : 1,
+    throwOnError: true,
+  });
+  for (const result of accountResults) {
+    if (result) {
+      result.plan.accountSummaries[result.accountId] = result.record;
     }
+  }
 
+  for (const plan of channelPlans) {
     const defaultSummary =
-      accountSummaries[preferredAccountId] ??
-      accountSummaries[defaultAccountId] ??
-      accountSummaries[accountIdsToProbe[0] ?? preferredAccountId];
+      plan.accountSummaries[plan.preferredAccountId] ??
+      plan.accountSummaries[plan.defaultAccountId] ??
+      plan.accountSummaries[plan.accountIds[0] ?? plan.preferredAccountId];
     const fallbackSummary =
       defaultSummary ??
-      accountSummaries[
-        expectDefined(Object.keys(accountSummaries)[0], "object.keys(account summaries) entry at 0")
+      plan.accountSummaries[
+        expectDefined(
+          Object.keys(plan.accountSummaries)[0],
+          "object.keys(account summaries) entry at 0",
+        )
       ];
     if (fallbackSummary) {
-      channels[plugin.id] = {
+      channels[plan.plugin.id] = {
         ...fallbackSummary,
-        accounts: accountSummaries,
+        accounts: plan.accountSummaries,
       } satisfies ChannelHealthSummary;
     }
   }

--- a/src/gateway/server-methods/nodes.invoke-deadline.ts
+++ b/src/gateway/server-methods/nodes.invoke-deadline.ts
@@ -1,44 +1,12 @@
-import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+import { ABSOLUTE_DEADLINE_EXPIRED, awaitWithinDeadline } from "../../utils/absolute-deadline.js";
 
-export const NODE_INVOKE_DEADLINE_EXPIRED = Symbol("node invoke deadline expired");
+export const NODE_INVOKE_DEADLINE_EXPIRED: typeof ABSOLUTE_DEADLINE_EXPIRED =
+  ABSOLUTE_DEADLINE_EXPIRED;
 
 /** Bounds node pairing, wake, policy, and transport preparation by one absolute deadline. */
 export async function awaitNodeInvokeWithinDeadline<T>(
   operation: () => Promise<T>,
   deadlineAtMs: number | undefined,
 ): Promise<T | typeof NODE_INVOKE_DEADLINE_EXPIRED> {
-  if (deadlineAtMs === undefined) {
-    return await operation();
-  }
-  if (Math.max(0, deadlineAtMs - Date.now()) === 0) {
-    return NODE_INVOKE_DEADLINE_EXPIRED;
-  }
-
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    // Arm the timer before plugin or push code can synchronously consume the
-    // budget; timer callbacks alone cannot establish an absolute deadline.
-    const deadline = new Promise<typeof NODE_INVOKE_DEADLINE_EXPIRED>((resolve) => {
-      // Node overflows long timer delays, so rearm against the real deadline.
-      const waitForDeadline = () => {
-        const remainingMs = Math.max(0, deadlineAtMs - Date.now());
-        if (remainingMs === 0) {
-          resolve(NODE_INVOKE_DEADLINE_EXPIRED);
-          return;
-        }
-        timer = setTimeout(waitForDeadline, Math.min(remainingMs, MAX_TIMER_TIMEOUT_MS));
-      };
-      waitForDeadline();
-    });
-    return await Promise.race([
-      deadline,
-      operation().then((result) =>
-        Date.now() >= deadlineAtMs ? NODE_INVOKE_DEADLINE_EXPIRED : result,
-      ),
-    ]);
-  } finally {
-    if (timer !== undefined) {
-      clearTimeout(timer);
-    }
-  }
+  return await awaitWithinDeadline(operation, deadlineAtMs);
 }

--- a/src/utils/absolute-deadline.ts
+++ b/src/utils/absolute-deadline.ts
@@ -1,0 +1,44 @@
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+
+export const ABSOLUTE_DEADLINE_EXPIRED = Symbol("absolute deadline expired");
+
+/** Bounds one operation by an absolute wall-clock deadline. */
+export async function awaitWithinDeadline<T>(
+  operation: () => Promise<T>,
+  deadlineAtMs: number | undefined,
+): Promise<T | typeof ABSOLUTE_DEADLINE_EXPIRED> {
+  if (deadlineAtMs === undefined) {
+    return await operation();
+  }
+  if (Math.max(0, deadlineAtMs - Date.now()) === 0) {
+    return ABSOLUTE_DEADLINE_EXPIRED;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    // Arm the timer before caller code can synchronously consume the budget;
+    // timer callbacks alone cannot establish an absolute deadline.
+    const deadline = new Promise<typeof ABSOLUTE_DEADLINE_EXPIRED>((resolve) => {
+      // Node overflows long timer delays, so rearm against the real deadline.
+      const waitForDeadline = () => {
+        const remainingMs = Math.max(0, deadlineAtMs - Date.now());
+        if (remainingMs === 0) {
+          resolve(ABSOLUTE_DEADLINE_EXPIRED);
+          return;
+        }
+        timer = setTimeout(waitForDeadline, Math.min(remainingMs, MAX_TIMER_TIMEOUT_MS));
+      };
+      waitForDeadline();
+    });
+    return await Promise.race([
+      deadline,
+      operation().then((result) =>
+        Date.now() >= deadlineAtMs ? ABSOLUTE_DEADLINE_EXPIRED : result,
+      ),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}


### PR DESCRIPTION
Closes #128890

## What Problem This Solves

Fixes an issue where operators running verbose health or deep status would receive a global Gateway transport timeout when one configured channel probe was slow or never settled. The timeout hid healthy sibling channels and made the diagnostic command least useful when one channel was offline.

## Why This Change Was Made

The Gateway now owns a fixed live-health deadline below the tightest first-party client budget and probes channel accounts through a bounded, deterministic worker pool. Accounts that outlive the deadline return a Gateway-generated structured timeout record while completed sibling results remain available. Process-wide permits remain occupied until the underlying plugin work actually settles, so repeated health requests cannot replace stalled probes and grow outstanding work beyond five. The absolute-deadline primitive is shared with node invocation instead of adding a second timing implementation.

The CLI timeout remains a connection budget and cannot widen the Gateway's internal live-probe deadline.

## User Impact

Verbose health and deep/all status return a useful partial snapshot even when a channel plugin or external dependency stalls. Operators can see the timed-out account alongside healthy channels without manually increasing an unrelated client timeout.

## Evidence

Before the fix, the managed live Gateway returned a structured snapshot only with an enlarged client timeout; the latest observed verbose health call took about 11 seconds while the default client budget is 10 seconds.

After the fix, a session-owned Gateway on an isolated state directory and distinct loopback port exercised the real offline iMessage probe through the rebased build. The default 10-second health command returned `ok: true` in 8,089ms wall time with `durationMs: 7003` and a structured `timedOut: true` iMessage account result. The operator Gateway and live state were not modified.

Focused regression and sibling proof:

- `pnpm test src/gateway/health/collector.deadline.test.ts src/commands/health.snapshot.test.ts src/commands/health.test.ts src/commands/status-runtime-shared.test.ts src/commands/status-all/report-data.test.ts src/gateway/server-methods/nodes.invoke-wake.test.ts`
  - 135 tests passed across the Gateway and command shards after the final rebase.
- `pnpm check:changed -- src/utils/absolute-deadline.ts src/gateway/server-methods/nodes.invoke-deadline.ts src/gateway/health/collector.ts src/gateway/health/collector.deadline.test.ts src/commands/health.snapshot.test.ts docs/gateway/health.md`
  - formatting, core and test typechecks, lint, dead exports, import cycles, architecture, database, and security guards passed.
- `pnpm build`
  - completed successfully.
- Mandatory uncommitted, rebased-branch, and post-review-fix autoreviews completed with no accepted or actionable findings.
- Exact-head CI for the final retained-permit head passed at https://github.com/openclaw/openclaw/actions/runs/32800924919.

The fake-timer regressions prove that a never-settling account cannot block healthy siblings, concurrency stays bounded at five, queued hooks do not start after the aggregate deadline, deterministic account order is retained, and the Gateway-generated timeout marker survives the public projection. A repeated-collection regression specifically keeps five underlying probes unresolved across two health calls and proves the second call starts no replacement work; capacity is released only when the original plugin promises settle.

ClawSweeper's P1 outstanding-work finding is addressed by the process-lifetime permit owner and the repeated-collection regression. The implementation keeps the current plugin API rather than introducing an unshipped cancellation contract.

Production LOC: +368 / -147 (net +221). The growth establishes the missing Gateway deadline, deterministic concurrency, and the process-wide availability boundary that retains capacity until timed-out plugin work settles; the existing node-specific absolute-deadline implementation was reduced to a wrapper over the shared primitive. Tests: +229 / -3. Docs: +5 / -3.

AI-assisted: yes. The implementation and proof were reviewed and understood by the maintainer.

