### PR TITLE
fix: restore GitHub tools in managed Codex sessions

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -169,6 +169,18 @@ describe("embedded run retry dispatch", () => {
     expect(uncapped.preparedAttempt).not.toHaveProperty("authoredContextTokenCap");
   });
 
+  it.each([undefined, false, true])(
+    "preserves prepared GitHub publication capability (%s)",
+    async (githubPublicationAvailable) => {
+      const input = makeDispatchInput({}, createEmbeddedRunReplayState());
+      input.params.githubPublicationAvailable = githubPublicationAvailable;
+
+      const result = await dispatchEmbeddedRunAttempt(input);
+
+      expect(result.preparedAttempt.githubPublicationAvailable).toBe(githubPublicationAvailable);
+    },
+  );
+
   it.each([true, false])(
     "settles accepted spawns before a late post-compaction abort (yielded: %s)",
     async (yieldDetected) => {

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -283,6 +283,8 @@ export async function dispatchEmbeddedRunAttempt(input: {
     messageProvider: params.messageProvider,
     clientCaps: params.clientCaps,
     toolBindings: params.toolBindings,
+    // Preserve the Gateway's tri-state capability; undefined hides both GitHub tools.
+    githubPublicationAvailable: params.githubPublicationAvailable,
     chatType: params.chatType,
     agentAccountId: params.agentAccountId,
     messageTo: params.messageTo,


### PR DESCRIPTION
Related: #128807

## What Problem This Solves

Fixes an issue where managed Codex sessions with a configured GitHub identity could not use the dedicated GitHub identity or publication tools. The Gateway prepared the session/worktree capability, but the harness attempt received no capability value and hid both tools.

## Why This Change Was Made

The run-to-attempt dispatch now preserves the Gateway-owned tri-state capability exactly. It does not default unavailable state or move credentials into the worker; the existing Gateway publication boundary and downstream Codex registration remain unchanged.

The two production lines are the canonical field relay plus its formerly-buggy ownership comment. There is no net-neutral alternative that carries the prepared fact without either dropping it again or rediscovering protected state downstream.

## User Impact

RoboClaw and other managed Codex agents can inspect their effective GitHub identity and publish through the Gateway when their session owns an authorized worktree. Credential-free cloud workers remain credential-free.

## Evidence

Before the fix, live Team build `b71a09fd8a3e` contained #128807, had a healthy managed OAuth identity, and passed health/readiness, but an idle managed-worktree RoboClaw Codex turn reported `github_identity_status tool unavailable`. Its runtime tool report contained neither GitHub tool.

Local proof:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts` — 7 passed
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts -t 'exposes prepared GitHub tools'` — 4 passed, 87 skipped
- `pnpm check:changed` — passed
- `pnpm build` — passed
- `git diff --check` — passed
- Autoreview — clean, no accepted/actionable findings, 0.99 confidence
- Exact-head CI run `32793743077` — green for `a26ea1b3d4784a22ec3b39cf13fd76f88576c1e2`

Direct sibling Codex contract inspection:

- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:135-141` — `thread/start.dynamicTools` is optional input
- `codex-rs/app-server/src/request_processors/thread_processor.rs:1356-1404` — supplied dynamic tools are validated and passed into thread creation
- `codex-rs/core/src/session/mod.rs:669-724` — dynamic tools are fixed at thread start and persisted in session configuration

Post-fix live proof cannot run before merge because Team's supported updater deploys `main` only; deploying a PR branch would bypass the manager-owned deployment boundary. The live failure is reproduced, both owner and consumer boundaries are covered locally, and the same managed-worktree turn will be rerun immediately after merge and supported Team update.

Production LOC: +2. Test LOC: +12.

AI-assisted; the implementation and evidence were reviewed against the full run-to-attempt owner boundary and the upstream Codex dynamic-tool registration contract.
