### PR TITLE
fix: release onboarding checks handle telemetry prompt

### DIFF
--- a/scripts/e2e/lib/onboard/interactive-driver.sh
+++ b/scripts/e2e/lib/onboard/interactive-driver.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+send() {
+  local payload="$1"
+  local delay="${2:-0.4}"
+  # Let prompts render before sending keystrokes.
+  sleep "$delay"
+  printf "%b" "$payload" >&3 2>/dev/null || true
+}
+
+log_contains() {
+  local needle="$1"
+  if [ -z "${WIZARD_LOG_PATH:-}" ] || [ ! -f "$WIZARD_LOG_PATH" ]; then
+    return 1
+  fi
+  if grep -a -F -q "$needle" "$WIZARD_LOG_PATH"; then
+    return 0
+  fi
+  node scripts/e2e/lib/onboard/log-contains.mjs "$WIZARD_LOG_PATH" "$needle"
+}
+
+wait_for_log() {
+  local needle="$1"
+  local timeout_s="${2:-45}"
+  local quiet_on_timeout="${3:-false}"
+  local start_s
+  start_s="$(date +%s)"
+  while true; do
+    if log_contains "$needle"; then
+      return 0
+    fi
+    if [ $(($(date +%s) - start_s)) -ge "$timeout_s" ]; then
+      if [ "$quiet_on_timeout" = "true" ]; then
+        return 1
+      fi
+      echo "Timeout waiting for log: $needle"
+      if [ -n "${WIZARD_LOG_PATH:-}" ] && [ -f "$WIZARD_LOG_PATH" ]; then
+        tail -n 140 "$WIZARD_LOG_PATH" || true
+      fi
+      return 1
+    fi
+    sleep 0.2
+  done
+}
+
+decline_telemetry_and_wait_for_agent_name() {
+  local timeout_s="${1:-45}"
+  wait_for_log "No thanks" "$timeout_s" || return $?
+  send $'\r' 0.4
+  wait_for_log "What should we call your first agent?" "$timeout_s"
+}

--- a/scripts/e2e/lib/onboard/scenario.sh
+++ b/scripts/e2e/lib/onboard/scenario.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 trap "" PIPE
 export TERM=xterm-256color
 source scripts/lib/openclaw-e2e-instance.sh
+source scripts/e2e/lib/onboard/interactive-driver.sh
 OPENCLAW_ONBOARD_SCENARIO_SOURCE_ONLY="${OPENCLAW_ONBOARD_SCENARIO_SOURCE_ONLY:-0}"
 if [ "$OPENCLAW_ONBOARD_SCENARIO_SOURCE_ONLY" != "1" ]; then
   openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_FUNCTION_B64:?missing OPENCLAW_TEST_STATE_FUNCTION_B64}"
@@ -35,49 +36,6 @@ fi
 if [ "$OPENCLAW_ONBOARD_SCENARIO_SOURCE_ONLY" != "1" ]; then
   openclaw_e2e_install_trash_shim
 fi
-
-send() {
-  local payload="$1"
-  local delay="${2:-0.4}"
-  # Let prompts render before sending keystrokes.
-  sleep "$delay"
-  printf "%b" "$payload" >&3 2>/dev/null || true
-}
-
-log_contains() {
-  local needle="$1"
-  if [ -z "${WIZARD_LOG_PATH:-}" ] || [ ! -f "$WIZARD_LOG_PATH" ]; then
-    return 1
-  fi
-  if grep -a -F -q "$needle" "$WIZARD_LOG_PATH"; then
-    return 0
-  fi
-  node scripts/e2e/lib/onboard/log-contains.mjs "$WIZARD_LOG_PATH" "$needle"
-}
-
-wait_for_log() {
-  local needle="$1"
-  local timeout_s="${2:-45}"
-  local quiet_on_timeout="${3:-false}"
-  local start_s
-  start_s="$(date +%s)"
-  while true; do
-    if log_contains "$needle"; then
-      return 0
-    fi
-    if [ $(($(date +%s) - start_s)) -ge "$timeout_s" ]; then
-      if [ "$quiet_on_timeout" = "true" ]; then
-        return 1
-      fi
-      echo "Timeout waiting for log: $needle"
-      if [ -n "${WIZARD_LOG_PATH:-}" ] && [ -f "$WIZARD_LOG_PATH" ]; then
-        tail -n 140 "$WIZARD_LOG_PATH" || true
-      fi
-      return 1
-    fi
-    sleep 0.2
-  done
-}
 
 wait_for_skills_prompt_or_ready() {
   local timeout_s="${1:-45}"
@@ -243,7 +201,7 @@ send_skills_flow() {
 }
 
 send_guided_skip_ui_flow() {
-  wait_for_log "What should we call your first agent?" 120 || return $?
+  decline_telemetry_and_wait_for_agent_name 120 || return $?
   send $'\r' 0.8
   wait_for_log "How should I set things up?" 120 || return $?
   send $'\r' 0.8

--- a/scripts/e2e/lib/release-typed-onboarding/scenario.sh
+++ b/scripts/e2e/lib/release-typed-onboarding/scenario.sh
@@ -5,6 +5,7 @@ export TERM=xterm-256color
 export NO_COLOR=1
 
 source scripts/lib/openclaw-e2e-instance.sh
+source scripts/e2e/lib/onboard/interactive-driver.sh
 
 openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_SCRIPT_B64:?missing OPENCLAW_TEST_STATE_SCRIPT_B64}"
 openclaw_e2e_install_trash_shim
@@ -24,6 +25,7 @@ LOG_DIR="$scenario_tmp/logs"
 mkdir -p "$LOG_DIR"
 INSTALL_LOG="$LOG_DIR/install.log"
 ONBOARD_LOG="$LOG_DIR/onboard.log"
+WIZARD_LOG_PATH="$ONBOARD_LOG"
 OPENAI_LOG="$LOG_DIR/openai.log"
 AGENT_LOG="$LOG_DIR/agent.log"
 MOCK_REQUEST_LOG="$scenario_tmp/openai-requests.jsonl"
@@ -55,36 +57,6 @@ dump_debug_logs() {
 }
 trap 'status=$?; dump_debug_logs "$status"; exit "$status"' ERR
 
-send() {
-  local payload="$1"
-  local delay="${2:-0.4}"
-  sleep "$delay"
-  printf "%b" "$payload" >&3 2>/dev/null || true
-}
-
-wait_for_log() {
-  local needle="$1"
-  local timeout_s="${2:-60}"
-  local start_s
-  start_s="$(date +%s)"
-  while true; do
-    if [ -f "$ONBOARD_LOG" ]; then
-      if grep -a -F -q "$needle" "$ONBOARD_LOG"; then
-        return 0
-      fi
-      if node scripts/e2e/lib/onboard/log-contains.mjs "$ONBOARD_LOG" "$needle"; then
-        return 0
-      fi
-    fi
-    if [ $(($(date +%s) - start_s)) -ge "$timeout_s" ]; then
-      echo "Timeout waiting for log: $needle" >&2
-      tail -n 120 "$ONBOARD_LOG" 2>/dev/null || true
-      return 1
-    fi
-    sleep 0.2
-  done
-}
-
 openclaw_e2e_install_package "$INSTALL_LOG"
 echo "Installed the OpenClaw package."
 command -v openclaw >/dev/null
@@ -105,7 +77,7 @@ exec 3>"$input_fifo"
 
 wait_for_log "Continue?" 60
 send $'y\r' 0.4
-wait_for_log "What should we call your first agent?" 60
+decline_telemetry_and_wait_for_agent_name 60
 send $'\r' 0.4
 wait_for_log "to search" 60
 send $'ollama\r' 0.4

--- a/test/scripts/e2e-shell-tempfiles.test.ts
+++ b/test/scripts/e2e-shell-tempfiles.test.ts
@@ -130,6 +130,44 @@ test ! -s ${JSON.stringify(sentPath)}
     expect(`${result.stdout}\n${result.stderr}`).not.toContain("Timeout waiting");
   });
 
+  it("declines telemetry before waiting for the first agent name", async () => {
+    const tempRoot = tempDirs.make("openclaw-onboard-telemetry-prompt-");
+    const fixturePath = path.join(tempRoot, "telemetry-prompt.sh");
+    const sentPath = path.join(tempRoot, "sent.txt");
+    const wizardLogPath = path.join(tempRoot, "onboard.log");
+    await writeFile(
+      fixturePath,
+      `#!/usr/bin/env bash
+set -euo pipefail
+
+export OPENCLAW_ONBOARD_SCENARIO_SOURCE_ONLY=1
+export OPENCLAW_ONBOARD_E2E_TMPDIR=${JSON.stringify(tempRoot)}
+OPENCLAW_ENTRY=node
+source scripts/e2e/lib/onboard/scenario.sh
+
+sleep() { :; }
+WIZARD_LOG_PATH=${JSON.stringify(wizardLogPath)}
+printf '%s\\n' \\
+  'No thanks' \\
+  'What should we call your first agent?' \\
+  'How should I set things up?' \\
+  'Use Current model?' >"$WIZARD_LOG_PATH"
+exec 3>${JSON.stringify(sentPath)}
+send_guided_skip_ui_flow
+exec 3>&-
+cleanup_onboard_artifacts
+`,
+    );
+
+    const result = spawnSync("bash", [fixturePath], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    await expect(readFile(sentPath, "utf8")).resolves.toBe("\r\r\r\r");
+  });
+
   it("checks local onboarding logs for systemd noise", async () => {
     const contents = await readFile("scripts/e2e/lib/onboard/scenario.sh", "utf8");
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release onboarding checks stalled when the interactive wizard displayed the telemetry consent prompt before the agent-name prompt. The package acceptance lane waited 121 seconds and exited while the telemetry choice was still visible in [release checks run 32766198480](https://github.com/openclaw/openclaw/actions/runs/32766198480/job/97560698211).

## Why This Change Was Made

The Docker onboarding and typed-package onboarding scenarios now share one interaction driver for prompt logging, input timing, telemetry decline, and the transition to agent naming. Both scenarios wait for the rendered `No thanks` choice, accept the default decline, and then wait for the agent-name prompt before continuing their existing flows.

## User Impact

There is no product behavior change. Release validation can complete interactive onboarding after the opt-in telemetry prompt, and the two onboarding harnesses use the same prompt transition.

## Evidence

- Regression before the fix: `node scripts/run-vitest.mjs test/scripts/e2e-shell-tempfiles.test.ts -t 'declines telemetry before waiting for the first agent name'` failed because the driver emitted three Enter keystrokes instead of four.
- Focused proof after the fix: `node scripts/run-vitest.mjs test/scripts/e2e-shell-tempfiles.test.ts` passed 10/10 tests.
- Shell syntax: `bash -n scripts/e2e/lib/onboard/interactive-driver.sh scripts/e2e/lib/onboard/scenario.sh scripts/e2e/lib/release-typed-onboarding/scenario.sh` passed.
- Changed-file gate: `node scripts/check-changed.mjs -- scripts/e2e/lib/onboard/interactive-driver.sh scripts/e2e/lib/onboard/scenario.sh scripts/e2e/lib/release-typed-onboarding/scenario.sh test/scripts/e2e-shell-tempfiles.test.ts` passed.
- Scheduler dry-run selected only `onboard` and `release-typed-onboarding`.
- Fresh branch autoreview against `origin/main`: no accepted or actionable findings; patch rated correct with 0.99 confidence.
- Exact-head remote Docker proof at `b39dca11e21246e5367f22baf5bc0acab5c3aef5`: [run 32794552723](https://github.com/openclaw/openclaw/actions/runs/32794552723) passed.
  - [Docker E2E targeted lanes (onboard)](https://github.com/openclaw/openclaw/actions/runs/32794552723/job/97644797332): passed.
  - [Docker E2E targeted lanes (release-typed-onboarding)](https://github.com/openclaw/openclaw/actions/runs/32794552723/job/97644797371): passed.

AI-assisted change. I reviewed the prompt sequence, shared-driver boundary, regression, and generated diff.
