### PR TITLE
fix: diagnose gateway startup heap exhaustion

### DIFF
--- a/src/gateway/server-startup-trace.ts
+++ b/src/gateway/server-startup-trace.ts
@@ -171,6 +171,10 @@ export function createGatewayStartupTrace(log: GatewayLogger) {
     ): Promise<T> {
       const before = performance.now();
       const spanId = `gateway-startup-${++spanSequence}`;
+      const startMemory = process.memoryUsage();
+      log.info(
+        `startup heap diagnostic: start ${name} heapUsedMb=${Math.round(startMemory.heapUsed / 1024 / 1024)} rssMb=${Math.round(startMemory.rss / 1024 / 1024)}`,
+      );
       emitDiagnosticsTimelineEvent(
         {
           type: "span.start",
@@ -216,6 +220,10 @@ export function createGatewayStartupTrace(log: GatewayLogger) {
         throw error;
       } finally {
         const now = performance.now();
+        const endMemory = process.memoryUsage();
+        log.info(
+          `startup heap diagnostic: end ${name} heapUsedMb=${Math.round(endMemory.heapUsed / 1024 / 1024)} rssMb=${Math.round(endMemory.rss / 1024 / 1024)}`,
+        );
         const eventLoopSample = takeEventLoopSample();
         emit(name, now - before, now - started, eventLoopSample);
         emitEventLoopTimelineSample(name, eventLoopSample);

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -2,7 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { constants, DatabaseSync } from "node:sqlite";
 import { sql, type Generated } from "kysely";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
@@ -60,6 +60,46 @@ describe("kysely sync helpers", () => {
       { id: 1, name: "Ada" },
       { id: 2, name: "Grace" },
     ]);
+  });
+
+  it("identifies wide startup reads without logging private SQLite values", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec("create table transcript_events (session_id text, event_json text)");
+    database
+      .prepare("insert into transcript_events values (?, ?)")
+      .run("private-session", "private-message");
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const uptime = vi.spyOn(process, "uptime").mockReturnValue(1);
+    try {
+      const db = getNodeSqliteKysely<{
+        transcript_events: { session_id: string; event_json: string };
+      }>(database);
+
+      expect(
+        executeSqliteQuerySync(
+          database,
+          db
+            .selectFrom("transcript_events")
+            .select("event_json")
+            .where("session_id", "=", "private-session"),
+        ).rows,
+      ).toEqual([{ event_json: "private-message" }]);
+
+      const events = warning.mock.calls.map(([entry]) => JSON.parse(String(entry)));
+      expect(events.map((event) => event.event)).toEqual(["sqlite-read-start", "sqlite-read-end"]);
+      expect(events[1]).toMatchObject({
+        tables: ["transcript_events"],
+        columns: ["event_json"],
+        limited: false,
+        sessionScoped: true,
+        rowCount: 1,
+      });
+      expect(JSON.stringify(events)).not.toContain("private-session");
+      expect(JSON.stringify(events)).not.toContain("private-message");
+    } finally {
+      uptime.mockRestore();
+      warning.mockRestore();
+    }
   });
 
   it("returns identical results while repeated statements move from cold to warm", () => {

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -18,6 +18,79 @@ const authorizerActiveSymbol = Symbol("openclaw.kyselySyncAuthorizerActive");
 // Process-wide retention scales with open handles; repeated variable SQL can enter.
 const statementCacheCapacity = 32;
 const statementCacheEntryBytes = 64 * 1024;
+const startupHeapDiagnosticsWindowSeconds = 120;
+const startupHeapDiagnosticTables = [
+  "transcript_events",
+  "trajectory_runtime_events",
+  "session_transcript_active_events",
+  "session_nodes",
+  "session_windows",
+  "memory_index_chunks",
+  "plugin_state_entries",
+  "task_runs",
+  "session_state_events",
+  "channel_ingress_events",
+] as const;
+const startupHeapDiagnosticColumns = [
+  "event_json",
+  "entry_json",
+  "value_json",
+  "detail_json",
+  "payload_json",
+  "embedding",
+] as const;
+
+function describeStartupHeapQuery(sql: string):
+  | {
+      tables: string[];
+      columns: string[];
+      limited: boolean;
+      sessionScoped: boolean;
+      callers: string[];
+    }
+  | undefined {
+  if (process.uptime() > startupHeapDiagnosticsWindowSeconds || !/^select\b/i.test(sql)) {
+    return undefined;
+  }
+  const normalized = sql.toLowerCase();
+  const tables = startupHeapDiagnosticTables.filter((table) => normalized.includes(table));
+  if (tables.length === 0) {
+    return undefined;
+  }
+  const projection = normalized.slice(0, normalized.indexOf(" from "));
+  const columns = startupHeapDiagnosticColumns.filter((column) => projection.includes(column));
+  if (columns.length === 0 && !/(?:^|[\s,])(?:[\w"]+\.)?\*/.test(projection)) {
+    return undefined;
+  }
+  return {
+    tables: [...tables],
+    columns: [...columns],
+    limited: /\blimit\b/.test(normalized),
+    sessionScoped: /"?session_id"?\s*(?:=|in\b)/.test(normalized),
+    callers: (new Error().stack ?? "")
+      .split("\n")
+      .slice(3, 8)
+      .map((frame) => frame.trim()),
+  };
+}
+
+function emitStartupHeapQueryDiagnostic(
+  event: "sqlite-read-start" | "sqlite-read-end",
+  query: NonNullable<ReturnType<typeof describeStartupHeapQuery>>,
+  rowCount?: number,
+): void {
+  const memory = process.memoryUsage();
+  console.warn(
+    JSON.stringify({
+      subsystem: "startup-heap-diagnostic",
+      event,
+      ...query,
+      heapUsedMb: Math.round(memory.heapUsed / 1024 / 1024),
+      rssMb: Math.round(memory.rss / 1024 / 1024),
+      ...(rowCount === undefined ? {} : { rowCount }),
+    }),
+  );
+}
 
 type SqliteAuthorizer = Parameters<DatabaseSync["setAuthorizer"]>[0];
 
@@ -240,8 +313,17 @@ function executeCompiledSqliteQuerySync<Row>(
         // Node's all() snapshots the column count before SQLite can reprepare
         // an expired statement. Eagerly consuming iterate() reads it after step.
         const iterator = statement.iterate(...parameters);
+        const diagnostic = describeStartupHeapQuery(compiledQuery.sql);
+        if (diagnostic) {
+          // Emit before materialization so a fatal V8 OOM still identifies its query owner.
+          emitStartupHeapQueryDiagnostic("sqlite-read-start", diagnostic);
+        }
         try {
-          return { rows: [...iterator] as Row[] };
+          const rows = [...iterator] as Row[];
+          if (diagnostic) {
+            emitStartupHeapQueryDiagnostic("sqlite-read-end", diagnostic, rows.length);
+          }
+          return { rows };
         } catch (error) {
           try {
             iterator.return?.();

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -1012,11 +1012,28 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   let pruned = 0;
   const tasks = taskRegistryMaintenanceRuntime.listTaskRecords();
   const cronHistoryOverflowTaskIds = collectCronHistoryOverflowTaskIds(tasks);
+  const initialMemory = process.memoryUsage();
+  log.info("startup heap diagnostic: task maintenance start", {
+    taskCount: tasks.length,
+    overflowCount: cronHistoryOverflowTaskIds.size,
+    heapUsedMb: Math.round(initialMemory.heapUsed / 1024 / 1024),
+    rssMb: Math.round(initialMemory.rss / 1024 / 1024),
+  });
   const cronRecoveryContext = createCronRecoveryContext();
   const backingSessionContext = createBackingSessionLookupContext();
   const recoveryHookRegistered = hasDetachedTaskRecoveryHook();
   let processed = 0;
   for (const task of tasks) {
+    if (processed > 0 && processed % 500 === 0) {
+      const memory = process.memoryUsage();
+      log.info("startup heap diagnostic: task maintenance progress", {
+        processed,
+        taskCount: tasks.length,
+        pruned,
+        heapUsedMb: Math.round(memory.heapUsed / 1024 / 1024),
+        rssMb: Math.round(memory.rss / 1024 / 1024),
+      });
+    }
     const current = taskRegistryMaintenanceRuntime.getTaskById(task.taskId);
     if (!current) {
       continue;
@@ -1116,6 +1133,14 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
       log.warn("Failed to sweep expired plugin state entries", { error });
     }
   }
+  const finalMemory = process.memoryUsage();
+  log.info("startup heap diagnostic: task maintenance end", {
+    processed,
+    taskCount: tasks.length,
+    pruned,
+    heapUsedMb: Math.round(finalMemory.heapUsed / 1024 / 1024),
+    rssMb: Math.round(finalMemory.rss / 1024 / 1024),
+  });
   return { reconciled, recovered, cleanupStamped, pruned };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators cannot identify which gateway startup action exhausts the JavaScript heap because existing startup traces are emitted only after an action finishes.

## Why This Change Was Made

Add temporary, bounded startup diagnostics immediately before and after startup actions, unusually broad SQLite reads, and task maintenance. SQLite diagnostics include only allowlisted table and column names, query shape, row counts, call sites, and memory usage; SQL text, bound values, session identifiers, and message contents are excluded. There are no schema changes or changes to returned query results.

This is a diagnostic-only candidate for reproducing a startup crash. It should not be merged as the permanent fix before identifying the operation responsible.

## User Impact

Operators can identify the precise startup action and query shape preceding a gateway heap crash. There is no intended behavior change for end users.

## Evidence

- 54 focused gateway, SQLite, and task-maintenance tests pass.
- Added regression coverage proves private session identifiers and message contents never appear in emitted query diagnostics.
- Changed-file formatting and lint checks pass.
- Independent structured review found no accepted or actionable findings; the changed-content secret scan passed.
