### PR TITLE
fix: release onboarding handles telemetry consent

### DIFF
--- a/scripts/e2e/lib/onboard/scenario.sh
+++ b/scripts/e2e/lib/onboard/scenario.sh
@@ -243,6 +243,8 @@ send_skills_flow() {
 }
 
 send_guided_skip_ui_flow() {
+  wait_for_log "Help make OpenClaw better?" 120 || return $?
+  send $'\r' 0.8
   wait_for_log "What should we call your first agent?" 120 || return $?
   send $'\r' 0.8
   wait_for_log "How should I set things up?" 120 || return $?

--- a/scripts/e2e/lib/release-typed-onboarding/scenario.sh
+++ b/scripts/e2e/lib/release-typed-onboarding/scenario.sh
@@ -105,6 +105,8 @@ exec 3>"$input_fifo"
 
 wait_for_log "Continue?" 60
 send $'y\r' 0.4
+wait_for_log "Help make OpenClaw better?" 60
+send $'\r' 0.4
 wait_for_log "What should we call your first agent?" 60
 send $'\r' 0.4
 wait_for_log "to search" 60

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -2733,16 +2733,20 @@ docker_e2e_docker_run_cmd run demo
     expect(script).not.toContain("/tmp/openclaw-channel-add.log");
   });
 
-  it("keeps real-TTY onboarding drivers aligned with the first-agent prompt", () => {
+  it("keeps real-TTY onboarding drivers aligned with the guided prompt sequence", () => {
     expectOrderedScriptFragments(readFileSync(RELEASE_TYPED_ONBOARDING_SCENARIO_PATH, "utf8"), [
       'wait_for_log "Continue?"',
       "send $'y\\r'",
+      'wait_for_log "Help make OpenClaw better?"',
+      "send $'\\r'",
       'wait_for_log "What should we call your first agent?"',
       "send $'\\r'",
       'wait_for_log "to search"',
       "send $'ollama\\r'",
     ]);
     expectOrderedScriptFragments(readFileSync(ONBOARD_SCENARIO_PATH, "utf8"), [
+      'wait_for_log "Help make OpenClaw better?"',
+      "send $'\\r'",
       'wait_for_log "What should we call your first agent?"',
       "send $'\\r'",
       'wait_for_log "How should I set things up?"',


### PR DESCRIPTION
## What Problem This Solves

Release Docker onboarding and typed-package acceptance stalled after the intentional telemetry consent prompt began appearing before the first-agent name prompt.

Related release evidence:
- [Failed umbrella run](https://github.com/openclaw/openclaw/actions/runs/32764738787)
- [Failed Release Checks child](https://github.com/openclaw/openclaw/actions/runs/32766198480)
- Frozen validation target: `a5b59204446d3720822cbf40d81641a7d1a098c7`

## Why This Change Was Made

Both real-TTY onboarding drivers now wait for the canonical telemetry consent prompt and accept its default “No thanks” choice before advancing to agent naming. Ordered regression coverage audits both driver sequences. Production onboarding and telemetry behavior are unchanged.

AI-assisted: yes (Codex). I inspected the production prompt owner, history, sibling drivers, generated changes, and proof.

## User Impact

Release validation can complete interactive onboarding with telemetry consent present in the wizard. Operators see no production behavior change.

## Evidence

- Immutable failed artifacts showed both drivers timing out on `What should we call your first agent?` while the telemetry default `No thanks` remained selected.
- Regression-first proof: the focused driver-order guard failed before the script changes and passed afterward.
- `bash -n scripts/e2e/lib/onboard/scenario.sh scripts/e2e/lib/release-typed-onboarding/scenario.sh`: passed.
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts`: passed, 199/199.
- `node scripts/check-changed.mjs -- scripts/e2e/lib/onboard/scenario.sh scripts/e2e/lib/release-typed-onboarding/scenario.sh test/scripts/docker-build-helper.test.ts`: passed.
- Fresh mandatory autoreview: no accepted or actionable findings; patch rated correct with 0.99 confidence.
- [Exact-head targeted Docker proof](https://github.com/openclaw/openclaw/actions/runs/32794441186) at `c7c8132fe603d575cfaf295b8c8e8c76af8538ba`: both `onboard` and `release-typed-onboarding` lanes passed.
- Full build was not run because the patch changes only E2E driver scripts and their static regression guard.
- Crabbox was not allocated because source ownership, history, and real-flow Docker proof conclusively isolated this to stale harness sequencing.
