### PR TITLE
fix(memory): exhausted-quota embedding errors retry forever and starve the sync queue

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1615,7 +1615,6 @@ packages/memory-host-sdk/src/host/memory-schema-migration.ts	1
 packages/memory-host-sdk/src/host/memory-schema-recall.ts	1
 packages/memory-host-sdk/src/host/memory-schema.ts	7
 packages/memory-host-sdk/src/host/multimodal.ts	1
-packages/memory-host-sdk/src/host/post-json.ts	1
 packages/memory-host-sdk/src/host/read-file.ts	1
 packages/memory-host-sdk/src/host/read-retry.ts	4
 packages/memory-host-sdk/src/host/session-files.ts	15
@@ -3386,7 +3385,7 @@ src/logging/diagnostic.ts	2
 src/logging/json-console-line.ts	2
 src/logging/levels.ts	2
 src/logging/log-file-shared.ts	1
-src/logging/logger.ts	13
+src/logging/logger.ts	14
 src/logging/node-require.ts	2
 src/logging/parse-log-line.ts	1
 src/logging/redact-internal-state.ts	1

--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -129,6 +129,16 @@ still indexes text for keyword search, and `memory_search` includes the
 redacted embedding-bootstrap reason in `debug.embeddingBootstrap` even when
 there are no matches.
 
+**Provider quota and auth failures.** Account-level rejections (an exhausted
+quota such as OpenAI's `insufficient_quota`, billing, or auth failures) are
+terminal: the engine does not retry them, marks the provider degraded in
+`memory status` (with the provider error code and the next retry time), and
+pauses embedding attempts for 10 minutes before probing again. Keyword search
+keeps working, an existing semantic index is preserved rather than rewritten,
+and indexing resumes automatically once the provider recovers. Genuine
+rate-limit 429s are still retried and honor the provider's `Retry-After` hint
+(capped at 30 seconds).
+
 **Explicit provider unavailable.** If you name any other provider explicitly
 (for example `openai`, `ollama`, `gemini`) and it becomes unavailable at
 request time (bad auth, network failure), `memory_search` reports memory as

--- a/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
@@ -5,7 +5,7 @@ import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
 type EmbeddingQueryRetryHarness = {
   provider: EmbeddingProvider;
   embedQueryWithRetry: (text: string, signal?: AbortSignal) => Promise<number[]>;
-  markLocalEmbeddingProviderDegraded: (error: unknown) => void;
+  markEmbeddingProviderDegraded: ReturnType<typeof vi.fn>;
   resolveEmbeddingTimeout: () => number;
   withProviderUse: <T>(provider: EmbeddingProvider, run: () => Promise<T>) => Promise<T>;
 };
@@ -26,7 +26,7 @@ function createEmbeddingQueryRetryHarness(
   return Object.assign(Object.create(MemoryManagerEmbeddingOps.prototype), {
     provider,
     resolveEmbeddingTimeout: () => timeoutMs,
-    markLocalEmbeddingProviderDegraded: vi.fn(),
+    markEmbeddingProviderDegraded: vi.fn(),
     withProviderUse: async <T>(_provider: EmbeddingProvider, run: () => Promise<T>) => await run(),
   }) as EmbeddingQueryRetryHarness;
 }
@@ -107,5 +107,23 @@ describe("memory embedding query retry cancellation", () => {
       true,
     );
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("fails exhausted-quota provider errors after a single attempt", async () => {
+    const embedQuery = vi.fn<EmbeddingProvider["embedQuery"]>().mockRejectedValue(
+      Object.assign(new Error("openai embeddings failed: 429 You have no credits remaining."), {
+        status: 429,
+        code: "insufficient_quota",
+      }),
+    );
+    const manager = createEmbeddingQueryRetryHarness(embedQuery);
+
+    await expect(manager.embedQueryWithRetry("search terms")).rejects.toMatchObject({
+      code: "MEMORY_EMBEDDING_OPERATION_FAILED",
+      operation: "query",
+    });
+
+    expect(embedQuery).toHaveBeenCalledOnce();
+    expect(manager.markEmbeddingProviderDegraded).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -52,6 +52,7 @@ import {
   filterNonEmptyMemoryChunks,
   isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingTransportError,
+  MEMORY_EMBEDDING_RETRY_MAX_DELAY_MS,
   resolveMemoryEmbeddingRetryDelay,
   runMemoryEmbeddingBatchRetryWithSplit,
   runMemoryEmbeddingRetryLoop,
@@ -79,7 +80,6 @@ const EMBEDDING_BATCH_MAX_TOKENS = 8000;
 const EMBEDDING_INDEX_CONCURRENCY = 4;
 const EMBEDDING_RETRY_MAX_ATTEMPTS = 3;
 const EMBEDDING_RETRY_BASE_DELAY_MS = 500;
-const EMBEDDING_RETRY_MAX_DELAY_MS = 8000;
 const EMBEDDING_QUERY_TIMEOUT_REMOTE_MS = 60_000;
 const EMBEDDING_QUERY_TIMEOUT_LOCAL_MS = 5 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
@@ -313,7 +313,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected abstract batchFailureLastError?: string;
   protected abstract batchFailureLastProvider?: string;
   protected abstract batchFailureLock: Promise<void>;
-  protected abstract markLocalEmbeddingProviderDegraded(err: unknown): void;
+  protected abstract markEmbeddingProviderDegraded(err: unknown): void;
   private activeProviderUses = new Map<EmbeddingProvider, number>();
   private providerIdleWaiters = new Map<EmbeddingProvider, Set<() => void>>();
   private syncProviderGenerationRelease: (() => void) | null = null;
@@ -702,7 +702,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           error: formatErrorMessage(err),
         });
       }
-      this.markLocalEmbeddingProviderDegraded(err);
+      this.markEmbeddingProviderDegraded(err);
       throw createMemoryEmbeddingOperationError({
         operation: params.operation,
         providerId: provider.id,
@@ -719,7 +719,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     const waitMs = resolveMemoryEmbeddingRetryDelay(
       delayMs,
       Math.random(),
-      EMBEDDING_RETRY_MAX_DELAY_MS,
+      MEMORY_EMBEDDING_RETRY_MAX_DELAY_MS,
     );
     log.warn(`memory embeddings retryable error; ${action} in ${waitMs}ms`);
     await sleepWithAbort(waitMs, signal);
@@ -777,7 +777,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       );
     } catch (err) {
       if (markDegraded) {
-        this.markLocalEmbeddingProviderDegraded(err);
+        this.markEmbeddingProviderDegraded(err);
       }
       throw createMemoryEmbeddingOperationError({
         operation: "query",

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildMemoryEmbeddingBatches,
   filterNonEmptyMemoryChunks,
+  isMemoryEmbeddingProviderAccessError,
   isRetryableMemoryEmbeddingError,
   isSplittableMemoryEmbeddingTransportError,
   resolveMemoryEmbeddingRetryDelay,
@@ -18,6 +19,21 @@ function chunk(text: string) {
     text,
     hash: text,
   };
+}
+
+function providerHttpError(
+  status: number,
+  message: string,
+  extra?: { code?: string; errorType?: string; retryAfterMs?: number },
+) {
+  return Object.assign(new Error(message), { status, ...extra });
+}
+
+function quotaExhaustedError() {
+  return providerHttpError(429, "openai embeddings failed: 429 You have no credits remaining.", {
+    code: "credit_balance_exhausted",
+    errorType: "insufficient_quota",
+  });
 }
 
 describe("memory embedding policy", () => {
@@ -180,6 +196,143 @@ describe("memory embedding policy", () => {
     );
     expect(isRetryableMemoryEmbeddingError("worker terminated by user")).toBe(false);
     expect(isRetryableMemoryEmbeddingError("embedding validation failed")).toBe(false);
+  });
+
+  it("classifies structured provider statuses ahead of message text", () => {
+    expect(isRetryableMemoryEmbeddingError(quotaExhaustedError())).toBe(false);
+    // Legacy shape: some responses only carry insufficient_quota as the code.
+    expect(
+      isRetryableMemoryEmbeddingError(
+        providerHttpError(429, "openai embeddings failed: 429 quota", {
+          code: "insufficient_quota",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isRetryableMemoryEmbeddingError(
+        providerHttpError(429, "openai embeddings failed: 429 rate limited"),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableMemoryEmbeddingError(providerHttpError(503, "voyage embeddings failed: 503 busy")),
+    ).toBe(true);
+    // A definitive 4xx is terminal even when its body mentions a retryable phrase.
+    expect(
+      isRetryableMemoryEmbeddingError(
+        providerHttpError(400, "openai embeddings failed: 400 rate limit docs at ..."),
+      ),
+    ).toBe(false);
+  });
+
+  it("reads structured facts through operation-error wrappers", () => {
+    const wrapped = Object.assign(new Error("wrapped"), {
+      code: "MEMORY_EMBEDDING_OPERATION_FAILED",
+      cause: quotaExhaustedError(),
+    });
+
+    expect(isRetryableMemoryEmbeddingError(wrapped)).toBe(false);
+    expect(isMemoryEmbeddingProviderAccessError(wrapped)).toBe(true);
+  });
+
+  it("does not treat payload numbers in provider messages as HTTP statuses", () => {
+    expect(
+      isRetryableMemoryEmbeddingError(
+        "gemini embeddings failed: expected 512 dimensions, received 3",
+      ),
+    ).toBe(false);
+    expect(isRetryableMemoryEmbeddingError("chunk 4290 of 5000 rejected")).toBe(false);
+    expect(
+      isRetryableMemoryEmbeddingError("GitHub Copilot model discovery HTTP 429: slow down"),
+    ).toBe(true);
+    expect(isRetryableMemoryEmbeddingError("request failed with status code 502")).toBe(true);
+  });
+
+  it("classifies account-level access errors for degradation", () => {
+    expect(isMemoryEmbeddingProviderAccessError(quotaExhaustedError())).toBe(true);
+    expect(isMemoryEmbeddingProviderAccessError(providerHttpError(401, "unauthorized"))).toBe(true);
+    expect(isMemoryEmbeddingProviderAccessError(providerHttpError(402, "payment required"))).toBe(
+      true,
+    );
+    expect(isMemoryEmbeddingProviderAccessError(providerHttpError(403, "forbidden"))).toBe(true);
+    expect(isMemoryEmbeddingProviderAccessError(providerHttpError(429, "plain rate limit"))).toBe(
+      false,
+    );
+    expect(isMemoryEmbeddingProviderAccessError(providerHttpError(500, "server error"))).toBe(
+      false,
+    );
+    expect(isMemoryEmbeddingProviderAccessError(new Error("fetch failed"))).toBe(false);
+  });
+
+  it("stops retrying exhausted-quota provider errors after the first attempt", async () => {
+    const run = vi.fn(async () => {
+      throw quotaExhaustedError();
+    });
+    const waitForRetry = vi.fn(async () => {});
+
+    await expect(
+      runMemoryEmbeddingRetryLoop({
+        run,
+        isRetryable: isRetryableMemoryEmbeddingError,
+        waitForRetry,
+        maxAttempts: 3,
+        baseDelayMs: 500,
+      }),
+    ).rejects.toThrow("You have no credits remaining");
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(waitForRetry).not.toHaveBeenCalled();
+  });
+
+  it("honors Retry-After hints for genuine rate-limit 429s", async () => {
+    const waits: number[] = [];
+    let calls = 0;
+
+    const result = await runMemoryEmbeddingRetryLoop({
+      run: async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw providerHttpError(429, "openai embeddings failed: 429 rate limited", {
+            retryAfterMs: 20_000,
+          });
+        }
+        return "ok";
+      },
+      isRetryable: isRetryableMemoryEmbeddingError,
+      waitForRetry: async (delayMs) => {
+        waits.push(delayMs);
+      },
+      maxAttempts: 3,
+      baseDelayMs: 500,
+    });
+
+    expect(result).toBe("ok");
+    expect(calls).toBe(2);
+    expect(waits).toEqual([20_000]);
+  });
+
+  it("caps oversized Retry-After hints so the sync slot cannot be camped", async () => {
+    const waits: number[] = [];
+    let calls = 0;
+
+    await runMemoryEmbeddingRetryLoop({
+      run: async () => {
+        calls += 1;
+        if (calls === 1) {
+          throw providerHttpError(429, "openai embeddings failed: 429 rate limited", {
+            retryAfterMs: 120_000,
+          });
+        }
+        return "ok";
+      },
+      isRetryable: isRetryableMemoryEmbeddingError,
+      waitForRetry: async (delayMs) => {
+        waits.push(delayMs);
+      },
+      maxAttempts: 2,
+      baseDelayMs: 500,
+    });
+
+    expect(waits).toEqual([30_000]);
   });
 
   it("splits OpenAI 431 oversized embedding batches without retrying the same request", async () => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -1,5 +1,9 @@
 // Memory Core plugin module implements manager embedding policy behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import {
+  isRemoteProviderQuotaError,
+  readRemoteProviderErrorFacts,
+} from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 
 type MemoryEmbeddingTextPart = {
@@ -82,8 +86,11 @@ export function buildMemoryEmbeddingBatches<T extends MemoryEmbeddingChunk>(
   return batches;
 }
 
+// Message fallback for providers that throw plain errors without a structured
+// status (Bedrock, Copilot, local runtimes). Status numbers must sit next to
+// an HTTP-ish marker so payload numbers ("512 dimensions") never match.
 const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE =
-  /(rate[_ ]limit|too many requests|429|resource has been exhausted|5\d\d|cloudflare|tokens per day)/i;
+  /(rate[_ ]limit|too many requests|resource has been exhausted|cloudflare|tokens per day|(?::\s*|\bhttp\s+|\bstatus\s+|\bcode\s+|\()(?:429|5\d\d)\b)/i;
 
 const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|socket terminated|network error|read ECONN|timed out|connection (?:reset|refused|aborted|timed out)|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN)/i;
@@ -99,12 +106,42 @@ export function isSplittableMemoryEmbeddingTransportError(message: string): bool
   return SPLITTABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE.test(message);
 }
 
-export function isRetryableMemoryEmbeddingError(message: string): boolean {
+export function isRetryableMemoryEmbeddingError(err: unknown): boolean {
+  // Exhausted quota is a terminal 429: retrying burns paid requests that can
+  // never succeed until an operator restores billing.
+  if (isRemoteProviderQuotaError(err)) {
+    return false;
+  }
+  const status = readRemoteProviderErrorFacts(err).status;
+  if (status !== undefined) {
+    // 408/429/5xx are transient by HTTP contract; any other 4xx means the
+    // provider definitively rejected this request or credential.
+    return status === 408 || status === 429 || status >= 500;
+  }
+  const message = formatErrorMessage(err);
   return (
     RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE.test(message) ||
     isRetryableMemoryEmbeddingTransportError(message)
   );
 }
+
+/**
+ * Account-level provider rejections (quota, billing, auth) that keep failing
+ * until an operator acts; callers pause embeddings instead of retrying them
+ * on every sync.
+ */
+export function isMemoryEmbeddingProviderAccessError(err: unknown): boolean {
+  if (isRemoteProviderQuotaError(err)) {
+    return true;
+  }
+  const status = readRemoteProviderErrorFacts(err).status;
+  return status === 401 || status === 402 || status === 403;
+}
+
+// Caps both jittered backoff and honored Retry-After hints. Retry sleeps run
+// inside the single-flight sync slot, so an unbounded server hint would starve
+// every queued session sync behind it.
+export const MEMORY_EMBEDDING_RETRY_MAX_DELAY_MS = 30_000;
 
 export function resolveMemoryEmbeddingRetryDelay(
   delayMs: number,
@@ -116,7 +153,7 @@ export function resolveMemoryEmbeddingRetryDelay(
 
 export async function runMemoryEmbeddingRetryLoop<T>(params: {
   run: () => Promise<T>;
-  isRetryable: (message: string) => boolean;
+  isRetryable: (err: unknown) => boolean;
   waitForRetry: (delayMs: number) => Promise<void>;
   maxAttempts: number;
   baseDelayMs: number;
@@ -129,7 +166,11 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
     maxDelayMs: Number.MAX_SAFE_INTEGER,
     // Caller cancellation wins even when its timeout resembles a retryable
     // provider error; otherwise abandoned searches start another request.
-    shouldRetry: (err) => !params.signal?.aborted && params.isRetryable(formatErrorMessage(err)),
+    shouldRetry: (err) => !params.signal?.aborted && params.isRetryable(err),
+    // A genuine rate-limit hint beats exponential guessing at when the
+    // provider will accept the next request.
+    retryAfterMs: (err) => readRemoteProviderErrorFacts(err).retryAfterMs,
+    retryAfterMaxDelayMs: MEMORY_EMBEDDING_RETRY_MAX_DELAY_MS,
     sleep: params.waitForRetry,
   });
 }
@@ -137,7 +178,7 @@ export async function runMemoryEmbeddingRetryLoop<T>(params: {
 export async function runMemoryEmbeddingBatchRetryWithSplit<TInput, TOutput>(params: {
   items: TInput[];
   run: (items: TInput[]) => Promise<TOutput[]>;
-  isRetryable: (message: string) => boolean;
+  isRetryable: (err: unknown) => boolean;
   isSplittable: (message: string) => boolean;
   waitForRetry: (delayMs: number) => Promise<void>;
   maxAttempts: number;

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts
@@ -332,7 +332,7 @@ describe("memory index", () => {
         embedBatch: (texts: string[]) => Promise<number[][]>;
         close: () => Promise<void>;
       } | null;
-      markLocalEmbeddingProviderDegraded: (err: unknown) => void;
+      markEmbeddingProviderDegraded: (err: unknown) => void;
     };
     const provider = degraded.provider;
     if (!provider) {
@@ -341,7 +341,7 @@ describe("memory index", () => {
     provider.embedQuery = async () => {
       throw providerFixture.createLocalWorkerExitError();
     };
-    degraded.markLocalEmbeddingProviderDegraded = () => {
+    degraded.markEmbeddingProviderDegraded = () => {
       degraded.provider = null;
     };
 

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle-leases.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle-leases.test.ts
@@ -33,7 +33,7 @@ describe("memory index", () => {
       providerKey: string;
       computeProviderKey: () => string;
       ensureProviderInitialized: () => Promise<void>;
-      markLocalEmbeddingProviderDegraded: (err: unknown) => void;
+      markEmbeddingProviderDegraded: (err: unknown) => void;
       activateFallbackProvider: (reason: string) => Promise<boolean>;
       beginSyncProviderGeneration: () => void;
       endSyncProviderGeneration: () => void;
@@ -53,7 +53,7 @@ describe("memory index", () => {
     }
     fields.provider.id = "local";
     fields.providerKey = fields.computeProviderKey();
-    fields.markLocalEmbeddingProviderDegraded(providerFixture.createLocalWorkerExitError());
+    fields.markEmbeddingProviderDegraded(providerFixture.createLocalWorkerExitError());
     await vi.waitFor(() => {
       expect(fields.provider).toBeNull();
       expect(providerFixture.providerCloseCalls).toBe(1);

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.test.ts
@@ -1,8 +1,10 @@
 // Memory Core tests cover manager provider lifecycle availability behavior.
+import fs from "node:fs/promises";
 import path from "node:path";
 import { hashText } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { describe, expect, it, vi } from "vitest";
 import { createManagerIndexFixture } from "./manager-index.test-support.js";
+import { clearMemoryEmbeddingProbeCache } from "./manager-provider-lifecycle.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
 
@@ -87,14 +89,101 @@ describe("memory index", () => {
 
     (
       manager as unknown as {
-        markLocalEmbeddingProviderDegraded: (err: unknown) => void;
+        markEmbeddingProviderDegraded: (err: unknown) => void;
       }
-    ).markLocalEmbeddingProviderDegraded(providerFixture.createLocalWorkerExitError());
+    ).markEmbeddingProviderDegraded(providerFixture.createLocalWorkerExitError());
 
     expect(manager.getCachedEmbeddingAvailability()).toBeNull();
     await expect(manager.probeEmbeddingAvailability()).resolves.toMatchObject({
       ok: false,
       error: expect.stringContaining("Local embeddings degraded"),
+    });
+  });
+
+  it("pauses remote embeddings with backoff after an exhausted-quota sync failure", async () => {
+    const cfg = createCfg({
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test" });
+
+    const fields = manager as unknown as {
+      dirty: boolean;
+      provider: {
+        id: string;
+        model: string;
+        embedQuery: (text: string) => Promise<number[]>;
+        embedBatch: (texts: string[]) => Promise<number[][]>;
+        close: () => Promise<void>;
+      } | null;
+    };
+    let quotaCalls = 0;
+    const quotaExhaustedError = () =>
+      Object.assign(new Error("openai embeddings failed: 429 You have no credits remaining."), {
+        status: 429,
+        code: "credit_balance_exhausted",
+        errorType: "insufficient_quota",
+      });
+    const failingProvider = {
+      id: "mock",
+      model: "mock-embed",
+      embedQuery: async (): Promise<number[]> => {
+        quotaCalls += 1;
+        throw quotaExhaustedError();
+      },
+      embedBatch: async (): Promise<number[][]> => {
+        quotaCalls += 1;
+        throw quotaExhaustedError();
+      },
+      close: async () => {},
+    };
+    fields.provider = failingProvider;
+    await fs.writeFile(
+      path.join(fixture.paths.memory, "2026-01-13.md"),
+      "# Log\nAlpha quota incident note.",
+    );
+    fields.dirty = true;
+
+    // The failing sync must degrade after a single attempt (no retry storm)
+    // and refuse the keyword-only rewrite that would wipe semantic vectors.
+    await expect(manager.sync({ reason: "interval" })).rejects.toThrow(
+      /Refusing to run sync in fts-only fallback mode/,
+    );
+    expect(quotaCalls).toBe(1);
+
+    const degradedState = manager.status().custom?.providerState as {
+      mode: string;
+      code?: string;
+      retryAtMs?: number;
+    };
+    expect(degradedState.mode).toBe("degraded");
+    expect(degradedState.code).toBe("credit_balance_exhausted");
+    // Access errors back off far longer than the ordinary 30s probe window.
+    expect(degradedState.retryAtMs ?? 0).toBeGreaterThan(Date.now() + 60_000);
+
+    // Keyword-only search remains usable while embeddings are paused.
+    await expect(manager.search("alpha")).resolves.not.toStrictEqual([]);
+    expect(quotaCalls).toBe(1);
+
+    // Syncs inside the backoff window make no provider requests at all.
+    fields.dirty = true;
+    await expect(manager.sync({ reason: "interval" })).rejects.toThrow(
+      /Refusing to run sync in fts-only fallback mode/,
+    );
+    expect(quotaCalls).toBe(1);
+
+    // Once the backoff expires, the next sync retries and recovers.
+    clearMemoryEmbeddingProbeCache();
+    fields.provider = {
+      ...failingProvider,
+      embedQuery: async (text: string) => [text.length, 0, 0, 0],
+      embedBatch: async (texts: string[]) => texts.map((text) => [text.length, 0, 0, 0]),
+    };
+    fields.dirty = true;
+    await expect(manager.sync({ reason: "interval" })).resolves.toBeUndefined();
+    expect(manager.status().custom?.providerState).toMatchObject({
+      mode: "active",
+      providerId: "mock",
     });
   });
 
@@ -115,7 +204,7 @@ describe("memory index", () => {
         embedBatch: (texts: string[]) => Promise<number[][]>;
         close: () => Promise<void>;
       } | null;
-      markLocalEmbeddingProviderDegraded: (err: unknown) => void;
+      markEmbeddingProviderDegraded: (err: unknown) => void;
       activateFallbackProvider: (reason: string) => Promise<boolean>;
       withTimeout: <T>(promise: Promise<T>, timeoutMs: number, message: string) => Promise<T>;
     };
@@ -123,7 +212,7 @@ describe("memory index", () => {
       throw new Error("Expected a test embedding provider");
     }
     fields.provider.id = "local";
-    fields.markLocalEmbeddingProviderDegraded(providerFixture.createLocalWorkerExitError());
+    fields.markEmbeddingProviderDegraded(providerFixture.createLocalWorkerExitError());
     await vi.waitFor(() => expect(providerFixture.providerCloseCalls).toBe(1));
 
     const callsBeforeFallback = providerFixture.providerCalls.length;
@@ -268,7 +357,7 @@ describe("memory index", () => {
       providerKey: string;
       computeProviderKey: () => string;
       ensureProviderInitialized: () => Promise<void>;
-      markLocalEmbeddingProviderDegraded: (err: unknown) => void;
+      markEmbeddingProviderDegraded: (err: unknown) => void;
       activateFallbackProvider: (reason: string) => Promise<boolean>;
       withTimeout: <T>(promise: Promise<T>, timeoutMs: number, message: string) => Promise<T>;
       indexFile: (
@@ -378,7 +467,7 @@ describe("memory index", () => {
         5_000,
         "concurrent embeddings did not start",
       );
-      fields.markLocalEmbeddingProviderDegraded(providerFixture.createLocalWorkerExitError());
+      fields.markEmbeddingProviderDegraded(providerFixture.createLocalWorkerExitError());
       await vi.waitFor(() => expect(fields.provider).toBeNull());
       fallbackPromise = fields.activateFallbackProvider("local worker exited");
       releaseFirstEmbedding();

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
@@ -6,6 +6,7 @@ import {
   toErrorObject,
 } from "openclaw/plugin-sdk/error-runtime";
 import { listRegisteredMemoryEmbeddingProviderAdapters } from "openclaw/plugin-sdk/memory-core-host-embedding-registry";
+import { readRemoteProviderErrorFacts } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   createSubsystemLogger,
   resolveAgentDir,
@@ -27,6 +28,7 @@ import {
   type EmbeddingProviderResult,
 } from "./embeddings.js";
 import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
+import { isMemoryEmbeddingProviderAccessError } from "./manager-embedding-policy.js";
 import {
   createDegradedMemoryProviderLifecycle,
   createPendingMemoryProviderLifecycle,
@@ -36,6 +38,10 @@ import {
 import type { MemoryIndexIdentityState } from "./manager-reindex-state.js";
 
 const EMBEDDING_PROBE_CACHE_TTL_MS = 30_000;
+// Backoff for account-level provider rejections (quota, billing, auth). These
+// only clear when an operator acts, so re-probing every 30s would burn one
+// doomed paid request per sync tick; one probe per backoff window is enough.
+const EMBEDDING_ACCESS_ERROR_BACKOFF_MS = 10 * 60_000;
 const log = createSubsystemLogger("memory");
 
 export type MemoryEmbeddingProviderRequirement = {
@@ -55,6 +61,13 @@ const EMBEDDING_PROBE_CACHE = new Map<string, EmbeddingProbeCacheEntry>();
 
 export function clearMemoryEmbeddingProbeCache(): void {
   EMBEDDING_PROBE_CACHE.clear();
+}
+
+/** Probe-failure TTL doubles as the retry backoff for the failed provider. */
+function resolveEmbeddingProbeFailureBackoffMs(err: unknown): number {
+  return isMemoryEmbeddingProviderAccessError(err)
+    ? EMBEDDING_ACCESS_ERROR_BACKOFF_MS
+    : EMBEDDING_PROBE_CACHE_TTL_MS;
 }
 
 export function resolveEffectiveMemorySearchSettings(
@@ -113,7 +126,6 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
   protected abstract readonly requestedProvider: EmbeddingProviderRequest;
   protected abstract providerInitPromise: Promise<void> | null;
   protected abstract providerInitialized: boolean;
-  protected abstract embeddingBootstrapFailure?: MemoryEmbeddingBootstrapDebug;
   protected abstract providerRetirementPromise: Promise<void>;
   protected abstract providersPendingRetirement: Set<EmbeddingProvider>;
   protected abstract closing: boolean;
@@ -163,17 +175,21 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
       this.provider = null;
       this.providerRuntime = undefined;
     }
+    const backoffMs = resolveEmbeddingProbeFailureBackoffMs(err);
+    const errorFacts = readRemoteProviderErrorFacts(err);
     this.providerInitialized = true;
     this.providerUnavailableReason = reason;
     this.providerLifecycle = createDegradedMemoryProviderLifecycle({
       providerId: provider,
       reason,
+      code: errorFacts.code ?? errorFacts.errorType,
+      retryAtMs: Date.now() + backoffMs,
     });
     this.embeddingBootstrapFailure = debug;
     this.providerKey = this.computeProviderKey();
     this.batch = this.resolveBatchConfig();
     this.vector.semanticAvailable = false;
-    this.cacheProbeResult({ ok: false, error: reason });
+    this.cacheProbeResult({ ok: false, error: reason }, { ttlMs: backoffMs });
     return debug;
   }
 
@@ -337,24 +353,43 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
     this.providerLifecycle = createPendingMemoryProviderLifecycle(this.requestedProvider);
   }
 
-  protected markLocalEmbeddingProviderDegraded(err: unknown): void {
-    if (this.provider?.id !== "local") {
+  protected markEmbeddingProviderDegraded(err: unknown): void {
+    if (this.provider?.id === "local") {
+      const message = formatErrorMessage(err);
+      const degradedProvider = this.provider;
+      void this.retireCurrentProvider();
+      this.providerUnavailableReason = `Local embeddings degraded: ${message}`;
+      this.providerLifecycle = createDegradedMemoryProviderLifecycle({
+        providerId: degradedProvider.id,
+        reason: message,
+      });
+      EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
+      this.providerKey = this.computeProviderKey();
+      this.batch = this.resolveBatchConfig();
+      this.vector.semanticAvailable = false;
+      log.warn("memory embeddings: local provider degraded after transport failure", {
+        error: message,
+      });
       return;
     }
-    const message = formatErrorMessage(err);
-    const degradedProvider = this.provider;
-    void this.retireCurrentProvider();
-    this.providerUnavailableReason = `Local embeddings degraded: ${message}`;
-    this.providerLifecycle = createDegradedMemoryProviderLifecycle({
-      providerId: degradedProvider.id,
-      reason: message,
+    // Remote providers degrade only on account-level rejections (quota,
+    // billing, auth): request-scoped 4xx must not pause the whole provider,
+    // and required mode stays fail-fast so a broken explicit provider remains
+    // operator-visible instead of silently dropping to keyword search.
+    if (
+      !this.provider ||
+      this.providerRequirement.mode !== "optional" ||
+      !isMemoryEmbeddingProviderAccessError(err)
+    ) {
+      return;
+    }
+    this.markEmbeddingBootstrapFailure(err, {
+      retainProvider: true,
+      provider: this.provider.id,
     });
-    EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
-    this.providerKey = this.computeProviderKey();
-    this.batch = this.resolveBatchConfig();
-    this.vector.semanticAvailable = false;
-    log.warn("memory embeddings: local provider degraded after transport failure", {
-      error: message,
+    log.warn("memory embeddings: provider access error; pausing embeddings until backoff expires", {
+      provider: this.provider.id,
+      error: this.providerUnavailableReason,
     });
   }
 
@@ -541,12 +576,15 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
     return await this.ensureVectorReady();
   }
 
-  protected cacheProbeResult(result: MemoryEmbeddingProbeResult): MemoryEmbeddingProbeResult {
+  protected cacheProbeResult(
+    result: MemoryEmbeddingProbeResult,
+    options?: { ttlMs?: number },
+  ): MemoryEmbeddingProbeResult {
     const checkedAtMs = Date.now();
     EMBEDDING_PROBE_CACHE.set(this.cacheKey, {
       result,
       checkedAtMs,
-      expireAtMs: checkedAtMs + EMBEDDING_PROBE_CACHE_TTL_MS,
+      expireAtMs: checkedAtMs + (options?.ttlMs ?? EMBEDDING_PROBE_CACHE_TTL_MS),
     });
     return result;
   }
@@ -590,7 +628,10 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
         return this.cacheProbeResult({ ok: true });
       } catch (err) {
         const message = formatErrorMessage(err);
-        return this.cacheProbeResult({ ok: false, error: message });
+        return this.cacheProbeResult(
+          { ok: false, error: message },
+          { ttlMs: resolveEmbeddingProbeFailureBackoffMs(err) },
+        );
       }
     });
   }

--- a/extensions/memory-core/src/memory/manager-provider-state.ts
+++ b/extensions/memory-core/src/memory/manager-provider-state.ts
@@ -34,6 +34,8 @@ export type MemoryProviderLifecycleState =
       providerId: string;
       reason: string;
       code?: string;
+      /** When the manager may attempt the degraded provider again. */
+      retryAtMs?: number;
     }
   | {
       mode: "fallback-active";
@@ -57,12 +59,14 @@ export function createDegradedMemoryProviderLifecycle(params: {
   providerId: string;
   reason: string;
   code?: string;
+  retryAtMs?: number;
 }): MemoryProviderLifecycleState {
   return {
     mode: "degraded",
     providerId: params.providerId,
     reason: params.reason,
     ...(params.code ? { code: params.code } : {}),
+    ...(params.retryAtMs !== undefined ? { retryAtMs: params.retryAtMs } : {}),
   };
 }
 

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -290,7 +290,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
           if (opts?.signal?.aborted) {
             throw err;
           }
-          this.markLocalEmbeddingProviderDegraded(err);
+          this.markEmbeddingProviderDegraded(err);
           const message = formatErrorMessage(err);
           const activatedFallback = this.shouldFallbackOnError(err)
             ? await this.activateFallbackProvider(message).catch((fallbackErr: unknown) => {
@@ -332,13 +332,19 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
             } catch (fallbackErr) {
               releaseFallbackProvider();
               if (!opts?.signal?.aborted) {
-                this.markLocalEmbeddingProviderDegraded(fallbackErr);
+                this.markEmbeddingProviderDegraded(fallbackErr);
               }
               throw fallbackErr;
             } finally {
               releaseFallbackProvider();
             }
-          } else if (!this.provider && this.fts.enabled && this.fts.available) {
+          } else if (
+            // Degradation may retain the provider handle for later recovery;
+            // the bootstrap-failure record still means keyword-only for now.
+            (!this.provider || this.embeddingBootstrapFailure !== undefined) &&
+            this.fts.enabled &&
+            this.fts.available
+          ) {
             this.assertRequiredProviderAvailable("search");
             log.warn(
               `memory search: embeddings unavailable; using keyword-only results: ${message}`,

--- a/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.interval.test.ts
@@ -33,6 +33,8 @@ class IntervalSyncHarness extends MemoryManagerSyncOps {
   protected readonly vector = { enabled: false, available: false };
   protected readonly cache = { enabled: false };
   protected providerUnavailableReason?: string;
+  protected embeddingBootstrapFailure = undefined;
+  protected clearEmbeddingBootstrapFailureAfterRecovery(): void {}
   protected providerLifecycle = { mode: "active" as const, providerId: "test" };
   protected db = {} as DatabaseSync;
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -173,6 +173,8 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
   protected readonly vector = { enabled: false, available: false };
   protected readonly cache = { enabled: false };
   protected providerUnavailableReason?: string;
+  protected embeddingBootstrapFailure = undefined;
+  protected clearEmbeddingBootstrapFailureAfterRecovery(): void {}
   protected providerLifecycle = { mode: "active" as const, providerId: "test" };
   protected db: DatabaseSync;
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   MEMORY_CHUNKING_VERSION,
+  type MemorySearchRuntimeDebug,
   type MemorySyncParams,
   type MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
@@ -74,6 +75,10 @@ const log = createSubsystemLogger("memory");
 export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
   private fallbackProviderInitPromise: Promise<boolean> | null = null;
   protected syncProviderGeneration: MemorySyncProviderGeneration | null = null;
+  protected abstract embeddingBootstrapFailure?: NonNullable<
+    MemorySearchRuntimeDebug["embeddingBootstrap"]
+  >;
+  protected abstract clearEmbeddingBootstrapFailureAfterRecovery(): void;
 
   protected beginSyncProviderGeneration(_options?: { forceFtsOnly?: boolean }): void {}
   protected endSyncProviderGeneration(): void {}
@@ -143,7 +148,12 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     ) {
       return;
     }
-    this.resetProviderInitializationForRetry();
+    // A recorded degradation keeps the provider handle and its backoff-until
+    // probe entry for recovery; resetting here would flip the lifecycle back
+    // to pending and re-create the provider on every blocked sync tick.
+    if (this.embeddingBootstrapFailure === undefined) {
+      this.resetProviderInitializationForRetry();
+    }
     throw new Error(
       `Memory sync aborted: embedding provider "${this.settings.provider}" is configured but unavailable. ` +
         `Refusing to run sync in fts-only fallback mode to protect existing vector index (current model: ${existingMeta.model}).`,
@@ -490,6 +500,9 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     this.providerLifecycle = fallbackState.lifecycle;
     this.providerKey = this.computeProviderKey();
     this.batch = this.resolveBatchConfig();
+    // Any bootstrap-failure record and cached failed probe describe the
+    // retired primary; a healthy fallback must not stay keyword-only on them.
+    this.clearEmbeddingBootstrapFailureAfterRecovery();
     log.warn(`memory embeddings: switched to fallback provider (${fallbackRequest.provider})`, {
       reason,
     });

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -127,6 +127,8 @@ class SessionSyncYieldHarness extends MemoryManagerSyncOps {
   protected readonly vector = { enabled: false, available: false };
   protected readonly cache = { enabled: false };
   protected providerUnavailableReason?: string;
+  protected embeddingBootstrapFailure = undefined;
+  protected clearEmbeddingBootstrapFailureAfterRecovery(): void {}
   protected providerLifecycle = { mode: "active" as const, providerId: "test" };
   protected db = createDbMock();
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -379,9 +379,14 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       try {
         await runGeneration(forceFtsOnly);
       } catch (err) {
+        // Account-level provider failures mark the bootstrap failure mid-run
+        // (markEmbeddingProviderDegraded); finish this sync keyword-only
+        // instead of failing it and re-hitting the provider on the next tick.
         const canDegrade =
           this.providerRequirement.mode === "optional" &&
-          (options?.allowEmbeddingBootstrapFallback || hadBootstrapFailure) &&
+          (options?.allowEmbeddingBootstrapFallback ||
+            hadBootstrapFailure ||
+            this.embeddingBootstrapFailure !== undefined) &&
           this.shouldFallbackOnError(err);
         if (!canDegrade) {
           throw err;

--- a/packages/memory-host-sdk/src/engine-embeddings.ts
+++ b/packages/memory-host-sdk/src/engine-embeddings.ts
@@ -69,6 +69,11 @@ export {
 } from "./host/embeddings-remote-provider.js";
 export { fetchRemoteEmbeddingVectors } from "./host/embeddings-remote-fetch.js";
 export {
+  isRemoteProviderQuotaError,
+  readRemoteProviderErrorFacts,
+  type RemoteProviderErrorFacts,
+} from "./host/post-json.js";
+export {
   estimateStructuredEmbeddingInputBytes,
   estimateUtf8Bytes,
 } from "./host/embedding-input-limits.js";

--- a/packages/memory-host-sdk/src/host/batch-http.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-http.test.ts
@@ -1,7 +1,8 @@
 // Memory Host SDK tests cover batch http behavior.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("./post-json.js", () => ({
+vi.mock("./post-json.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./post-json.js")>()),
   postJson: vi.fn(),
 }));
 
@@ -17,7 +18,6 @@ type PostJsonParams = {
   headers?: unknown;
   body?: unknown;
   errorPrefix?: unknown;
-  attachStatus?: unknown;
 };
 
 function requirePostJsonParams(
@@ -78,7 +78,6 @@ describe("postJsonWithRetry", () => {
     expect(postJsonParams.headers).toEqual({ Authorization: "Bearer test" });
     expect(postJsonParams.body).toEqual({ chunks: ["a", "b"] });
     expect(postJsonParams.errorPrefix).toBe("memory batch failed");
-    expect(postJsonParams.attachStatus).toBe(true);
 
     const retryOptions = requireFirstRetryOptions(retryAsyncMock);
     expect(retryOptions.attempts).toBe(3);
@@ -87,6 +86,8 @@ describe("postJsonWithRetry", () => {
     expect(retryOptions.shouldRetry({ status: 429 })).toBe(true);
     expect(retryOptions.shouldRetry({ status: 503 })).toBe(true);
     expect(retryOptions.shouldRetry({ status: 400 })).toBe(false);
+    // Exhausted quota is terminal even though it arrives as a 429.
+    expect(retryOptions.shouldRetry({ status: 429, code: "insufficient_quota" })).toBe(false);
   });
 
   it("attaches status to non-ok errors", async () => {

--- a/packages/memory-host-sdk/src/host/batch-http.ts
+++ b/packages/memory-host-sdk/src/host/batch-http.ts
@@ -1,7 +1,7 @@
 // Memory Host SDK module implements batch http behavior.
 import { retryAsync } from "@openclaw/retry";
 import type { SsrFPolicy } from "./openclaw-runtime-network.js";
-import { postJson } from "./post-json.js";
+import { isRemoteProviderQuotaError, postJson } from "./post-json.js";
 
 // JSON POST helper for batch APIs with provider-style transient retry.
 
@@ -25,7 +25,6 @@ export async function postJsonWithRetry<T>(params: {
         fetchImpl: params.fetchImpl,
         body: params.body,
         errorPrefix: params.errorPrefix,
-        attachStatus: true,
         parse: async (payload) => payload as T,
       });
     },
@@ -35,6 +34,10 @@ export async function postJsonWithRetry<T>(params: {
       maxDelayMs: 2000,
       jitter: 0.2,
       shouldRetry: (err) => {
+        // Exhausted quota is a terminal 429: retrying burns the same request.
+        if (isRemoteProviderQuotaError(err)) {
+          return false;
+        }
         const status = (err as { status?: number }).status;
         return status === 429 || (typeof status === "number" && status >= 500);
       },

--- a/packages/memory-host-sdk/src/host/post-json.test.ts
+++ b/packages/memory-host-sdk/src/host/post-json.test.ts
@@ -1,6 +1,6 @@
 // Memory Host SDK tests cover post json behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { postJson } from "./post-json.js";
+import { isRemoteProviderQuotaError, postJson, readRemoteProviderErrorFacts } from "./post-json.js";
 import { withRemoteHttpResponse } from "./remote-http.js";
 
 vi.mock("./remote-http.js", () => ({
@@ -119,7 +119,7 @@ describe("postJson", () => {
     expect(canceled).toBe(true);
   });
 
-  it("attaches status to thrown error when requested", async () => {
+  it("attaches status to every thrown non-ok error", async () => {
     remoteHttpMock.mockImplementationOnce(async (params) => {
       return await params.onResponse(textResponse("bad gateway", 502));
     });
@@ -131,7 +131,6 @@ describe("postJson", () => {
         headers: {},
         body: {},
         errorPrefix: "post failed",
-        attachStatus: true,
         parse: () => ({}),
       });
     } catch (caught) {
@@ -141,6 +140,65 @@ describe("postJson", () => {
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toBe("post failed: 502 bad gateway");
     expect((error as { status?: unknown }).status).toBe(502);
+    expect((error as { code?: unknown }).code).toBeUndefined();
+    expect((error as { retryAfterMs?: unknown }).retryAfterMs).toBeUndefined();
+  });
+
+  it("attaches provider error code, type, and Retry-After delay to quota errors", async () => {
+    remoteHttpMock.mockImplementationOnce(async (params) => {
+      return await params.onResponse(
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "You have no credits remaining.",
+              type: "insufficient_quota",
+              code: "credit_balance_exhausted",
+            },
+          }),
+          { status: 429, headers: { "retry-after": "17" } },
+        ),
+      );
+    });
+
+    let error: unknown;
+    try {
+      await postJson({
+        url: "https://memory.example/v1/post",
+        headers: {},
+        body: {},
+        errorPrefix: "openai embeddings failed",
+        parse: () => ({}),
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("openai embeddings failed: 429");
+    expect((error as { status?: unknown }).status).toBe(429);
+    expect((error as { code?: unknown }).code).toBe("credit_balance_exhausted");
+    expect((error as { errorType?: unknown }).errorType).toBe("insufficient_quota");
+    expect((error as { retryAfterMs?: unknown }).retryAfterMs).toBe(17_000);
+    expect(isRemoteProviderQuotaError(error)).toBe(true);
+  });
+
+  it("ignores prose-shaped error body codes", async () => {
+    remoteHttpMock.mockImplementationOnce(async (params) => {
+      return await params.onResponse(
+        new Response(JSON.stringify({ error: { code: "not a machine code!" } }), { status: 400 }),
+      );
+    });
+
+    const error: unknown = await postJson({
+      url: "https://memory.example/v1/post",
+      headers: {},
+      body: {},
+      errorPrefix: "post failed",
+      parse: () => ({}),
+    }).catch((caught: unknown) => caught);
+
+    expect((error as { status?: unknown }).status).toBe(400);
+    expect((error as { code?: unknown }).code).toBeUndefined();
   });
 
   it("bounds non-ok response bodies before formatting the error", async () => {
@@ -260,5 +318,43 @@ describe("postJson", () => {
       }),
     ).rejects.toThrow("post failed: response body too large");
     expect(canceled).toBe(true);
+  });
+});
+
+describe("readRemoteProviderErrorFacts", () => {
+  it("reads facts through wrapper cause chains", () => {
+    const transport = Object.assign(new Error("openai embeddings failed: 429 no credits"), {
+      status: 429,
+      code: "credit_balance_exhausted",
+      errorType: "insufficient_quota",
+      retryAfterMs: 12_000,
+    });
+    const wrapped = Object.assign(new Error(transport.message), {
+      code: "MEMORY_EMBEDDING_OPERATION_FAILED",
+      cause: transport,
+    });
+
+    expect(readRemoteProviderErrorFacts(wrapped)).toEqual({
+      status: 429,
+      code: "credit_balance_exhausted",
+      errorType: "insufficient_quota",
+      retryAfterMs: 12_000,
+    });
+    expect(isRemoteProviderQuotaError(wrapped)).toBe(true);
+  });
+
+  it("recognizes legacy responses that only carry the insufficient_quota code", () => {
+    expect(
+      isRemoteProviderQuotaError(
+        Object.assign(new Error("quota"), { status: 429, code: "insufficient_quota" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns no facts for errors without a numeric status", () => {
+    expect(readRemoteProviderErrorFacts(new Error("fetch failed"))).toEqual({});
+    expect(isRemoteProviderQuotaError(new Error("insufficient_quota mentioned in prose"))).toBe(
+      false,
+    );
   });
 });

--- a/packages/memory-host-sdk/src/host/post-json.ts
+++ b/packages/memory-host-sdk/src/host/post-json.ts
@@ -1,4 +1,7 @@
 // Memory Host SDK module implements post json behavior.
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+// Release harnesses execute source before workspace package dist files exist.
+import { parseRetryAfterHeaderSeconds } from "../../../../src/infra/retry-after.js";
 import { formatErrorMessage } from "./error-utils.js";
 import type { SsrFPolicy } from "./openclaw-runtime-network.js";
 import { withRemoteHttpResponse } from "./remote-http.js";
@@ -9,7 +12,89 @@ import {
 
 // Shared JSON POST helper for guarded remote memory provider calls.
 
-/** POST JSON, parse bounded response JSON, and attach status metadata when requested. */
+/** Structured facts attached to non-ok remote provider errors. */
+export type RemoteProviderErrorFacts = {
+  status?: number;
+  code?: string;
+  errorType?: string;
+  retryAfterMs?: number;
+};
+
+// OpenAI's documented billing/quota rejections: `error.type` stays the broad
+// "insufficient_quota" while `error.code` names the specific cause
+// (https://developers.openai.com/api/docs/guides/error-codes). None of these
+// can succeed on retry until an operator restores billing or raises limits.
+const PROVIDER_QUOTA_EXHAUSTED_CODES: ReadonlySet<string> = new Set([
+  "insufficient_quota",
+  "credit_balance_exhausted",
+  "organization_spend_limit_exceeded",
+  "project_spend_limit_exceeded",
+  "organization_usage_limit_exceeded",
+]);
+
+// Provider error codes are short machine tokens; anything else is prose we
+// must not carry into lifecycle state or diagnostics as a "code".
+const PROVIDER_ERROR_CODE_RE = /^[A-Za-z][A-Za-z0-9_.:-]{0,63}$/;
+
+function asProviderErrorCode(value: unknown): string | undefined {
+  return typeof value === "string" && PROVIDER_ERROR_CODE_RE.test(value) ? value : undefined;
+}
+
+/** Extract machine error code/type from an OpenAI-compatible error body snippet. */
+function readProviderErrorBodyFacts(bodyText: string): { code?: string; errorType?: string } {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(bodyText);
+  } catch {
+    return {};
+  }
+  const root = asOptionalRecord(payload);
+  const subject = asOptionalRecord(root?.error) ?? root;
+  const code = asProviderErrorCode(subject?.code);
+  const errorType = asProviderErrorCode(subject?.type);
+  return {
+    ...(code !== undefined ? { code } : {}),
+    ...(errorType !== undefined ? { errorType } : {}),
+  };
+}
+
+/** Read structured provider facts from an error or any error in its cause chain. */
+export function readRemoteProviderErrorFacts(err: unknown): RemoteProviderErrorFacts {
+  // Wrappers (retry failures, memory operation errors) keep the transport
+  // error in the cause chain; the first level with a numeric status owns all
+  // facts so unrelated wrapper `code` fields cannot mix in.
+  let current = asOptionalRecord(err);
+  for (let depth = 0; depth < 5 && current; depth += 1) {
+    if (typeof current.status === "number" && Number.isFinite(current.status)) {
+      const code = typeof current.code === "string" && current.code ? current.code : undefined;
+      const errorType =
+        typeof current.errorType === "string" && current.errorType ? current.errorType : undefined;
+      const retryAfterMs =
+        typeof current.retryAfterMs === "number" && Number.isFinite(current.retryAfterMs)
+          ? current.retryAfterMs
+          : undefined;
+      return {
+        status: current.status,
+        ...(code !== undefined ? { code } : {}),
+        ...(errorType !== undefined ? { errorType } : {}),
+        ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+      };
+    }
+    current = asOptionalRecord(current.cause);
+  }
+  return {};
+}
+
+/** Whether an error reports exhausted provider quota, which no retry can fix. */
+export function isRemoteProviderQuotaError(err: unknown): boolean {
+  const facts = readRemoteProviderErrorFacts(err);
+  return (
+    (facts.code !== undefined && PROVIDER_QUOTA_EXHAUSTED_CODES.has(facts.code)) ||
+    (facts.errorType !== undefined && PROVIDER_QUOTA_EXHAUSTED_CODES.has(facts.errorType))
+  );
+}
+
+/** POST JSON, parse bounded response JSON, and attach provider facts on failure. */
 export async function postJson<T>(params: {
   url: string;
   headers: Record<string, string>;
@@ -18,7 +103,6 @@ export async function postJson<T>(params: {
   signal?: AbortSignal;
   body: unknown;
   errorPrefix: string;
-  attachStatus?: boolean;
   maxResponseBytes?: number;
   parse: (payload: unknown) => T | Promise<T>;
 }): Promise<T> {
@@ -35,13 +119,16 @@ export async function postJson<T>(params: {
     onResponse: async (res) => {
       if (!res.ok) {
         const text = await readMemoryHostResponseTextSnippet(res, { signal: params.signal });
-        const err = new Error(
-          `${params.errorPrefix}: ${res.status} ${formatErrorMessage(text)}`,
-        ) as Error & {
-          status?: number;
-        };
-        if (params.attachStatus) {
-          err.status = res.status;
+        // Structured facts let retry and degradation policy classify the
+        // failure without parsing redacted human-facing message text.
+        const err: Error & RemoteProviderErrorFacts = Object.assign(
+          new Error(`${params.errorPrefix}: ${res.status} ${formatErrorMessage(text)}`),
+          { status: res.status },
+        );
+        Object.assign(err, readProviderErrorBodyFacts(text));
+        const retryAfterSeconds = parseRetryAfterHeaderSeconds(res.headers.get("retry-after"));
+        if (retryAfterSeconds !== undefined) {
+          err.retryAfterMs = Math.round(retryAfterSeconds * 1000);
         }
         throw err;
       }

--- a/packages/memory-host-sdk/src/host/remote-error-redaction.test.ts
+++ b/packages/memory-host-sdk/src/host/remote-error-redaction.test.ts
@@ -166,7 +166,6 @@ describe.sequential("memory remote error redaction", () => {
         ssrfPolicy: buildRemoteBaseUrlPolicy(baseUrl),
         body: {},
         errorPrefix: "post failed",
-        attachStatus: true,
         parse: (payload) => payload,
       });
 

--- a/src/plugin-sdk/memory-core-host-engine-embeddings.ts
+++ b/src/plugin-sdk/memory-core-host-engine-embeddings.ts
@@ -36,11 +36,13 @@ export {
   hasNonTextEmbeddingParts,
   isEmbeddingBatchUnavailableError,
   isMissingEmbeddingApiKeyError,
+  isRemoteProviderQuotaError,
   mapBatchEmbeddingsByIndex,
   normalizeBatchBaseUrl,
   normalizeEmbeddingModelWithPrefixes,
   postJsonWithRetry,
   readEmbeddingBatchJsonl,
+  readRemoteProviderErrorFacts,
   resolveEmbeddingEndpointUrl,
   resolveBatchCompletionFromStatus,
   resolveCompletedBatchResult,
@@ -64,6 +66,7 @@ export type {
   ProviderBatchOutputLine,
   RemoteEmbeddingClient,
   RemoteEmbeddingProviderId,
+  RemoteProviderErrorFacts,
 } from "../../packages/memory-host-sdk/src/engine-embeddings.js";
 export {
   getMemoryEmbeddingProvider,


### PR DESCRIPTION
Closes #128938
Related: #128900 (different root cause from the same 2026-08-24 incident)

## What Problem This Solves

Fixes an issue where operators whose OpenAI embedding key ran out of credits would see every memory sync retry the terminal `429 insufficient_quota` ("You have no credits remaining") response three times with backoff sleeps inside the single-flight sync slot, fail, and repeat identically on the next sync tick — starving queued session syncs, burning doomed paid requests around the clock, and breaking `memory_search` (it threw after the same retry storm instead of returning keyword results).

## Why This Change Was Made

Root-cause repair across the three owning boundaries instead of patching the reported symptom:

- **HTTP boundary records structured facts.** `postJson` (openai/voyage/mistral/lmstudio/deepinfra embedding + batch calls) now always attaches `status`, the provider error `code` from OpenAI-compatible error bodies, and `retryAfterMs` from the `Retry-After` header to thrown errors (the `attachStatus` flag is deleted — one canonical behavior). Gemini already threw `ProviderHttpError` with the same field names; `readRemoteProviderErrorFacts` reads both families through wrapper cause chains.
- **Classification uses facts before message text.** `insufficient_quota` (OpenAI's documented terminal quota code) is never retried, other definitive 4xx are terminal, 408/429/5xx stay retryable, and genuine rate-limit 429s honor `Retry-After` via the retry runner's native `retryAfterMs` support (capped at 30s so a huge hint cannot camp the sync slot). The message-regex fallback remains for providers without structured status (Bedrock, Copilot, local runtimes), with the bare `429`/`5\d\d` footgun anchored to HTTP-ish markers so payload numbers like "512 dimensions" no longer classify as retryable. The batch path (`postJsonWithRetry`) stops retrying quota 429s too.
- **Degradation lifecycle widened to remote providers with backoff-until.** `markLocalEmbeddingProviderDegraded` (which began `if (provider?.id !== "local") return`, so remote providers could never degrade) is now `markEmbeddingProviderDegraded`: in optional requirement mode, account-level rejections (quota, 401/402/403) mark the existing bootstrap-failure record with a 10-minute probe backoff (vs the ordinary 30s), keep the provider handle for recovery, and surface `code` + `retryAtMs` on the degraded lifecycle state in `memory status`. Searches degrade to keyword-only results; syncs make zero provider requests until the backoff expires, then re-probe once and recover automatically. An existing semantic index is protected from a keyword-only rewrite by the pre-existing `assertFtsOnlySyncAllowed` guard, which no longer resets the recorded degradation. Activating a configured fallback provider clears the stale failure record so a healthy fallback is not pinned to keyword-only mode. Required mode stays fail-fast (explicit providers keep failing loudly, now after a single attempt).

Non-goals: retryable-but-exhausted transient failures (real 5xx outages, rate-limit storms) keep today's fail-and-retry-next-sync semantics; only account-level terminal errors trigger the pause. Gemini's `RESOURCE_EXHAUSTED` is deliberately not in the terminal set because Google uses it for per-minute limits as well.

## User Impact

With an exhausted or unauthorized embedding key, memory keeps working instead of thrashing: syncs stop hammering the provider (one probe per 10 minutes instead of 3 requests + sleeps per sync tick), queued session syncs are no longer starved, `memory_search` returns keyword results instead of throwing, `memory status` shows the degraded provider with the error code and next retry time, and semantic indexing resumes on its own once billing is fixed. Genuine rate-limit 429s now wait what the provider asked for instead of a guessed backoff.

## Evidence

All regression tests fail on pre-fix code for the intended reasons (verified by stashing the production diff and re-running):

- `manager-provider-lifecycle.test.ts` › "pauses remote embeddings with backoff after an exhausted-quota sync failure": pre-fix the sync rejects with the raw quota error after a 3-attempt retry storm (test observed ~2.0s of retry sleeps pre-fix vs instant post-fix) and every subsequent sync re-hits the provider; post-fix one request, `degraded` lifecycle with `code: "insufficient_quota"` and a >60s `retryAtMs`, keyword search still serving results, zero requests inside the backoff window, automatic recovery after it.
- `manager-embedding-policy.test.ts`: structured quota error not retryable / not retried; 4xx terminal; `Retry-After` honored (20s hint → 20s wait) and capped (120s hint → 30s); "expected 512 dimensions" no longer classified retryable.
- `manager-embedding-ops.retry.test.ts`: quota error fails after a single provider attempt and marks degradation.
- `post-json.test.ts` / `batch-http.test.ts`: `status`/`code`/`retryAfterMs` attached (pre-fix: undefined); batch retry refuses quota 429s (pre-fix: retried).

Validation on this branch:

- `node scripts/run-vitest.mjs extensions/memory-core` — 89 files, 1169 tests passed; touched test files re-run green after the final contract adjustment.
- `node scripts/run-vitest.mjs packages/memory-host-sdk` — 36 files, 309 tests passed; post-json/batch-http re-run green.
- `node scripts/check-changed.mjs` — all lanes green (format, oxlint, tsgo typecheck, ratchets, coercion/dependency guards).
- `pnpm plugin-sdk:surface:check` and `pnpm build` — green (new `memory-core-host-engine-embeddings` exports: `readRemoteProviderErrorFacts`, `isRemoteProviderQuotaError`).
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` (codex / gpt-5.6-sol, high): clean — no accepted/actionable findings, "overall: patch is correct (0.98)".

Live-verify note: reproducing a genuine `insufficient_quota` requires an OpenAI account with exhausted billing, which is not available to this environment; the boundary regression test drives the exact recorded provider response shape (status 429 + `insufficient_quota` body + `Retry-After` header) through the real classification, retry, sync, and search paths.

Production LOC: +233/−45 (net +188), tests +353/−19. The growth is the new structured provider-error facts contract at the HTTP boundary and the remote degradation lifecycle — a capability the bug fix requires; absorbed reductions include deleting the `attachStatus` option, consolidating the retry-delay cap constant, and one assertion-safety baseline shrink.
