### PR TITLE
fix: plugin prerelease checks accept active registry reuse

### DIFF
--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -3089,7 +3089,7 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
-  it("does not widen active registry reuse to non-matching plugin tool owners", () => {
+  it("filters non-matching plugin tool owners while reusing the active registry", () => {
     installToolManifestSnapshot({
       config: createContext().config,
       plugin: createToolManifest("optional-demo", ["optional_tool"]),
@@ -3126,7 +3126,7 @@ describe("resolvePluginTools optional tools", () => {
     expectResolvedToolNames(tools, ["optional_tool"]);
     expect(heavyFactory).not.toHaveBeenCalled();
     expect(resolveCompatibleRuntimePluginRegistryMock).toHaveBeenCalledOnce();
-    expectLoaderSelectedOnlyPluginIds(["optional-demo"]);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
   it("does not let disabled bundled tool owners poison explicit runtime allowlists", () => {
@@ -3186,7 +3186,7 @@ describe("resolvePluginTools optional tools", () => {
     expectResolvedToolNames(tools, ["memory_search", "memory_get"]);
     expect(memorySearchFactory).toHaveBeenCalledTimes(1);
     expect(resolveCompatibleRuntimePluginRegistryMock).toHaveBeenCalledOnce();
-    expectLoaderSelectedOnlyPluginIds(["memory-core"]);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
   it("keeps a cold-loaded standalone registry scoped through tool callbacks", async () => {


### PR DESCRIPTION
Closes #129119

## What Problem This Solves

Resolves a release-blocking Plugin Prerelease failure where two optional-plugin tests expected a scoped plugin-loader call even though the compatible active runtime registry already contained the requested plugin tools.

## Why This Change Was Made

The tests now assert the intended load-once lifecycle: compatible active-registry reuse does not call the loader, while the existing assertions continue to prove that unrelated heavy factories are not executed and disabled bundled tool owners do not poison explicit allowlists. This is an AI-assisted, test-only correction aligned with the intentional containment-reuse behavior introduced in #128639; production behavior is unchanged.

## User Impact

No user-visible runtime behavior changes. Release validation can accurately verify optional-plugin isolation without rejecting the supported active-registry reuse path.

## Evidence

- Frozen failing target: `a5b59204446d3720822cbf40d81641a7d1a098c7`
- Immutable failure: [Plugin Prerelease job](https://github.com/openclaw/openclaw/actions/runs/32766197433/job/97556489742), with both failures reproduced independently and in original shard order before editing.
- Focused post-fix proof: both exact tests passed together (2 passed, 84 skipped).
- File proof: `src/plugins/tools.optional.test.ts` passed all 86 tests.
- Clean remote shard parity: Blacksmith Testbox lease `tbx_01m0v5rj90g2bmx7jh2dr3e612`, [run 32794556797](https://github.com/openclaw/openclaw/actions/runs/32794556797), command `CI=1 NODE_OPTIONS=--max-old-space-size=8192 OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm test -- test/vitest/vitest.plugins.config.ts --`. The changed file passed 86/86 and the shard passed 3,840 tests; only the two pre-existing geolocation metadata failures remained. Testbox cleanup completed.
- Changed-file gates passed, including formatting, dead-export checks, temp-creation audit, core test typecheck, oxlint, and `git diff --check`.
- Full build omitted because the diff changes only test names/assertions (3 additions, 3 deletions; zero production LOC).
- Mandatory autoreview: clean, no accepted/actionable findings.

