### PR TITLE
fix: release live gateway checks misroute scoped models

### DIFF
--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -10,8 +10,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef, type SecretInput } from "../config/types.secrets.js";
 import { parseLiveCsvFilter } from "../media-generation/live-test-helpers.js";
-import { withBundledPluginEnablementCompat } from "../plugins/bundled-compat.js";
-import { resolveOwningPluginIdsForProviderRef } from "../plugins/providers.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import {
   discoverAuthStorage,
@@ -47,6 +45,7 @@ import { ensureOpenClawModelsJson } from "./models-config.js";
 import type { StreamFn } from "./runtime/index.js";
 import {
   appendPrioritizedDynamicLiveModels,
+  applyLiveProviderPluginDiscoveryCompat,
   DEFAULT_SMALL_LIVE_MODEL_LIMIT,
   isHighSignalLiveModelRef,
   isPrioritizedHighSignalLiveModelRef,
@@ -56,6 +55,7 @@ import {
   selectHighSignalLiveItems,
   selectSmallLiveItems,
   shouldExcludeProviderFromDefaultHighSignalLiveSweep,
+  resolveLiveProviderDiscoveryProviderIds,
 } from "./test-helpers/live-model-dynamic-candidates.js";
 import {
   buildLiveModelFileProbeContext,
@@ -200,93 +200,16 @@ function findUnmatchedExplicitLiveModelRefs(params: {
   return unmatched;
 }
 
-function resolveLiveProviderDiscoveryProviderIds(params: {
-  providerFilter: Set<string> | null;
-  explicitRefs: readonly { provider: string; id: string }[];
-  priorityRefs?: readonly { provider: string; id: string }[];
-}): string[] | undefined {
-  // Narrow startup discovery to providers that can affect the requested live target set.
-  const providers = new Set<string>();
-  for (const provider of params.providerFilter ?? []) {
-    const normalized = normalizeProviderId(provider);
-    if (normalized) {
-      providers.add(normalized);
-    }
-  }
-  for (const ref of params.explicitRefs) {
-    providers.add(ref.provider);
-  }
-  for (const ref of params.priorityRefs ?? []) {
-    providers.add(ref.provider);
-  }
-  return providers.size > 0
-    ? [...providers].toSorted((left, right) => left.localeCompare(right))
-    : undefined;
-}
-
-function resolveLiveProviderDiscoveryPluginIds(params: {
-  config?: OpenClawConfig;
-  providers: readonly string[] | undefined;
-  env?: NodeJS.ProcessEnv;
-}): string[] {
-  const pluginIds = new Set<string>();
-  for (const provider of params.providers ?? []) {
-    const owners =
-      resolveOwningPluginIdsForProviderRef({
-        provider,
-        config: params.config,
-        env: params.env,
-      }) ?? [];
-    if (owners.length === 0) {
-      pluginIds.add(provider);
-      continue;
-    }
-    for (const owner of owners) {
-      pluginIds.add(owner);
-    }
-  }
-  return [...pluginIds].toSorted((left, right) => left.localeCompare(right));
-}
-
 function applyLiveProviderDiscoveryPluginCompat(params: {
   config: OpenClawConfig;
   providers: readonly string[] | undefined;
   env?: NodeJS.ProcessEnv;
 }): OpenClawConfig {
-  const pluginIds = resolveLiveProviderDiscoveryPluginIds(params);
-  const pluginConfig =
-    pluginIds.length > 0 ? enableLiveProviderPlugins(params.config, pluginIds) : params.config;
   return applyLiveOllamaProviderEnvCompat({
-    config: pluginConfig,
+    config: applyLiveProviderPluginDiscoveryCompat(params),
     providers: params.providers,
     env: params.env,
   });
-}
-
-function enableLiveProviderPlugins(
-  config: OpenClawConfig,
-  pluginIds: readonly string[],
-): OpenClawConfig {
-  const compatConfig =
-    withBundledPluginEnablementCompat({
-      config,
-      pluginIds,
-    }) ?? config;
-  const entries = { ...compatConfig.plugins?.entries };
-  const allow = new Set(compatConfig.plugins?.allow ?? []);
-  for (const pluginId of pluginIds) {
-    allow.add(pluginId);
-    entries[pluginId] ??= { enabled: true };
-  }
-  return {
-    ...compatConfig,
-    plugins: {
-      ...compatConfig.plugins,
-      enabled: true,
-      allow: [...allow].toSorted((left, right) => left.localeCompare(right)),
-      entries,
-    },
-  };
 }
 
 function applyLiveOllamaProviderEnvCompat(params: {

--- a/src/agents/test-helpers/live-model-dynamic-candidates.ts
+++ b/src/agents/test-helpers/live-model-dynamic-candidates.ts
@@ -11,11 +11,13 @@ import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/numb
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Model } from "../../llm/types.js";
+import { withBundledPluginEnablementCompat } from "../../plugins/bundled-compat.js";
 import type {
   prepareProviderDynamicModel,
   runProviderDynamicModel,
 } from "../../plugins/provider-runtime.js";
 import { resolveProviderModernModelRef } from "../../plugins/provider-runtime.js";
+import { resolveOwningPluginIdsForProviderRef } from "../../plugins/providers.js";
 import type { ProviderResolveDynamicModelContext } from "../../plugins/types.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { liveProvidersShareOwningPlugin } from "../live-provider-owner.js";
@@ -322,6 +324,76 @@ function liveModelKey(provider: string, id: string): string | null {
   const normalizedProvider = normalizeProviderId(provider);
   const normalizedId = normalizeLowercaseStringOrEmpty(id);
   return normalizedProvider && normalizedId ? `${normalizedProvider}/${normalizedId}` : null;
+}
+
+export function resolveLiveProviderDiscoveryProviderIds(params: {
+  providerFilter: ReadonlySet<string> | null;
+  explicitRefs: readonly { provider: string; id: string }[];
+  priorityRefs?: readonly { provider: string; id: string }[];
+}): string[] | undefined {
+  const providers = new Set<string>();
+  for (const provider of params.providerFilter ?? []) {
+    const normalized = normalizeProviderId(provider);
+    if (normalized) {
+      providers.add(normalized);
+    }
+  }
+  for (const ref of params.explicitRefs) {
+    providers.add(ref.provider);
+  }
+  for (const ref of params.priorityRefs ?? []) {
+    providers.add(ref.provider);
+  }
+  return providers.size > 0
+    ? [...providers].toSorted((left, right) => left.localeCompare(right))
+    : undefined;
+}
+
+export function applyLiveProviderPluginDiscoveryCompat(params: {
+  config: OpenClawConfig;
+  providers: readonly string[] | undefined;
+  env?: NodeJS.ProcessEnv;
+}): OpenClawConfig {
+  const pluginIds = new Set<string>();
+  for (const provider of params.providers ?? []) {
+    const owners =
+      resolveOwningPluginIdsForProviderRef({
+        provider,
+        config: params.config,
+        env: params.env,
+      }) ?? [];
+    if (owners.length === 0) {
+      pluginIds.add(provider);
+      continue;
+    }
+    for (const owner of owners) {
+      pluginIds.add(owner);
+    }
+  }
+  if (pluginIds.size === 0) {
+    return params.config;
+  }
+  const orderedPluginIds = [...pluginIds].toSorted((left, right) => left.localeCompare(right));
+  const compatConfig =
+    withBundledPluginEnablementCompat({
+      config: params.config,
+      pluginIds: orderedPluginIds,
+    }) ?? params.config;
+  const entries = { ...compatConfig.plugins?.entries };
+  const allow = new Set(compatConfig.plugins?.allow ?? []);
+  for (const pluginId of orderedPluginIds) {
+    allow.add(pluginId);
+    entries[pluginId] ??= { enabled: true };
+  }
+  return {
+    ...compatConfig,
+    plugins: {
+      ...compatConfig.plugins,
+      enabled: true,
+      allow: [...allow].toSorted((left, right) => left.localeCompare(right)),
+      entries,
+    },
+  };
 }
 
 /**

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -50,6 +50,7 @@ import { ensureOpenClawModelsJson } from "../agents/models-config.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import {
   appendPrioritizedDynamicLiveModels,
+  applyLiveProviderPluginDiscoveryCompat,
   DEFAULT_HIGH_SIGNAL_LIVE_MODEL_LIMIT,
   DEFAULT_SMALL_LIVE_MODEL_LIMIT,
   getHighSignalLiveModelPriorityIndex,
@@ -61,6 +62,7 @@ import {
   selectHighSignalLiveItems,
   selectSmallLiveItems,
   shouldExcludeProviderFromDefaultHighSignalLiveSweep,
+  resolveLiveProviderDiscoveryProviderIds,
 } from "../agents/test-helpers/live-model-dynamic-candidates.js";
 import { createLiveTargetMatcher } from "../agents/test-helpers/live-target-matcher.js";
 import { mergeWorkspaceSetupState } from "../agents/workspace-state-store.js";
@@ -194,12 +196,6 @@ function parseFilter(raw?: string): Set<string> | null {
   return ids.length ? new Set(ids) : null;
 }
 
-function providerFilterList(): string[] | undefined {
-  return PROVIDERS
-    ? [...PROVIDERS].toSorted((left, right) => left.localeCompare(right))
-    : undefined;
-}
-
 function listHighSignalLiveModelProviders(): string[] {
   return [...new Set(listPrioritizedHighSignalLiveModelRefs().map((ref) => ref.provider))].toSorted(
     (left, right) => left.localeCompare(right),
@@ -268,12 +264,13 @@ function filterGatewayLiveModelRefsByProvider(
 }
 
 function resolvePrioritizedGatewayLiveModelRefs(params: {
+  explicitRefs: readonly { provider: string; id: string }[];
   providerFilter: ReadonlySet<string> | null;
   useExplicit: boolean;
   useSmall: boolean;
 }): Array<{ provider: string; id: string }> {
   if (params.useExplicit) {
-    return [];
+    return filterGatewayLiveModelRefsByProvider(params.explicitRefs, params.providerFilter);
   }
   // High-signal refs can be plugin-resolved models absent from the static
   // catalog; omitting them leaves provider-scoped live lanes with zero coverage.
@@ -1491,7 +1488,7 @@ describe("resolveExplicitLiveModelCandidates", () => {
     expect(candidates).toEqual([model]);
   });
 
-  it("keeps provider-qualified explicit refs usable when the registry is empty", () => {
+  it("fails closed when canonical metadata is unavailable for an explicit ref", () => {
     const matcher = createLiveTargetMatcher({
       providerFilter: new Set(["openai"]),
       modelFilter: new Set(["openai/gpt-5.5"]),
@@ -1513,11 +1510,7 @@ describe("resolveExplicitLiveModelCandidates", () => {
       targetMatcher: matcher,
     });
 
-    if (!candidates) {
-      throw new Error("expected explicit fallback candidates");
-    }
-    expect(candidates).toEqual([createExplicitLiveFallbackModel("openai", "gpt-5.5")]);
-    expect(candidates[0]?.contextWindow).toBeGreaterThanOrEqual(4_000);
+    expect(candidates).toBeNull();
   });
 
   it("uses the Bedrock Converse API for explicit Bedrock fallback candidates", () => {
@@ -1633,6 +1626,7 @@ describe("providerScopedModelRegistryProviders", () => {
   it("loads provider-scoped dynamic refs for default high-signal sweeps", () => {
     expect(
       resolvePrioritizedGatewayLiveModelRefs({
+        explicitRefs: [],
         providerFilter: new Set(["openrouter"]),
         useExplicit: false,
         useSmall: false,
@@ -1644,6 +1638,7 @@ describe("providerScopedModelRegistryProviders", () => {
     ]);
     expect(
       resolvePrioritizedGatewayLiveModelRefs({
+        explicitRefs: [],
         providerFilter: new Set(["fireworks"]),
         useExplicit: false,
         useSmall: false,
@@ -1651,14 +1646,15 @@ describe("providerScopedModelRegistryProviders", () => {
     ).toEqual([{ provider: "fireworks", id: "accounts/fireworks/models/glm-5p1" }]);
   });
 
-  it("leaves explicit gateway model refs to targeted registry lookup", () => {
+  it("loads explicit gateway model refs through dynamic discovery", () => {
     expect(
       resolvePrioritizedGatewayLiveModelRefs({
+        explicitRefs: [{ provider: "openrouter", id: "openai/gpt-5.2-chat" }],
         providerFilter: new Set(["openrouter"]),
         useExplicit: true,
         useSmall: false,
       }),
-    ).toEqual([]);
+    ).toEqual([{ provider: "openrouter", id: "openai/gpt-5.2-chat" }]);
   });
 
   it("does not count small models outside a provider-scoped gateway sweep", () => {
@@ -4554,7 +4550,12 @@ function resolveExplicitLiveModelCandidates(params: {
     }
     const model =
       params.modelRegistry.find(ref.provider, ref.modelId) ??
-      createExplicitLiveFallbackModel(ref.provider, ref.modelId);
+      (ref.provider === "amazon-bedrock"
+        ? createExplicitLiveFallbackModel(ref.provider, ref.modelId)
+        : undefined);
+    if (!model) {
+      return null;
+    }
     if (
       !params.targetMatcher.matchesProvider(model.provider) ||
       !params.targetMatcher.matchesModel(model.provider, model.id)
@@ -5762,15 +5763,43 @@ describeLive("gateway live (dev agent, profile keys)", () => {
     "runs meaningful prompts across models with available keys",
     async () =>
       await withSuppressedGatewayLiveWarnings(async () => {
-        const providerList = providerFilterList();
+        const rawModels = await resolveGatewayLiveRequestedModels();
+        const useModern = !rawModels || rawModels === "modern" || rawModels === "all";
+        const useSmall = rawModels === "small";
+        const useExplicit = Boolean(rawModels) && !useModern && !useSmall;
+        const filter = useExplicit ? parseFilter(rawModels) : null;
+        const explicitRefs = useExplicit
+          ? [...(filter ?? [])].flatMap((raw) => {
+              const ref = parseExplicitLiveModelRef(raw, PROVIDERS);
+              return ref ? [{ provider: ref.provider, id: ref.modelId }] : [];
+            })
+          : [];
+        const priorityRefs = filterGatewayLiveModelRefsByProvider(
+          useExplicit
+            ? explicitRefs
+            : useSmall
+              ? listPrioritizedSmallLiveModelRefs()
+              : listPrioritizedHighSignalLiveModelRefs(),
+          PROVIDERS,
+        );
+        const providerList = resolveLiveProviderDiscoveryProviderIds({
+          providerFilter: PROVIDERS,
+          explicitRefs,
+          priorityRefs,
+        });
         const providerLog = providerList?.join(",") ?? "all";
         logProgress(`[all-models] discover candidates providers=${providerLog}`);
         logProgress("[all-models] loading config");
         clearRuntimeConfigSnapshot();
-        const cfg = await withGatewayLiveSetupTimeout(
+        const loadedCfg = await withGatewayLiveSetupTimeout(
           readLiveTestConfig(),
           "[all-models] load config",
         );
+        const cfg = applyLiveProviderPluginDiscoveryCompat({
+          config: loadedCfg,
+          providers: providerList,
+          env: process.env,
+        });
         const workspaceDir = resolveAgentWorkspaceDir(cfg, DEFAULT_AGENT_ID);
         logProgress("[all-models] preparing models.json");
         const modelsJsonResult = await withGatewayLiveSetupTimeout(
@@ -5781,12 +5810,6 @@ describeLive("gateway live (dev agent, profile keys)", () => {
           "[all-models] prepare models.json",
         );
         const agentDir = modelsJsonResult.agentDir;
-
-        const rawModels = await resolveGatewayLiveRequestedModels();
-        const useModern = !rawModels || rawModels === "modern" || rawModels === "all";
-        const useSmall = rawModels === "small";
-        const useExplicit = Boolean(rawModels) && !useModern && !useSmall;
-        const filter = useExplicit ? parseFilter(rawModels) : null;
         const providerScopedModelProviders = providerScopedModelRegistryProviders({
           providerList,
           useSmall,
@@ -5829,6 +5852,7 @@ describeLive("gateway live (dev agent, profile keys)", () => {
           all = authBacked.all;
         }
         const prioritizedRefs = resolvePrioritizedGatewayLiveModelRefs({
+          explicitRefs,
           providerFilter: PROVIDERS,
           useExplicit,
           useSmall,


### PR DESCRIPTION
## What Problem This Solves

Fixes release live gateway checks that could reject valid provider profiles or send requests to the wrong endpoint when scoped model discovery produced an empty registry. The gateway harness synthesized generic model metadata, so MiniMax used an OpenAI Responses route, OpenCode Go lost its fixed-thinking policy, and OpenAI/Google capability checks ran without canonical provider metadata.

## Why This Change Was Made

The gateway live suite now uses the same provider-owner discovery and dynamic model resolution path as the direct live-model suite. It activates only providers in the selected scope, resolves explicit refs through provider plugins, and fails closed when canonical metadata is unavailable. Amazon Bedrock retains its explicit provider-specific fallback.

This PR is AI-assisted.

## User Impact

Release operators get live-profile results against each provider's declared transport and capabilities. Missing catalog metadata fails during selection instead of producing misleading provider, thinking-level, or credential failures. This changes only test-harness behavior; production model behavior and credentials are unchanged.

## Evidence

- Before: Release Checks [run 32766198480](https://github.com/openclaw/openclaw/actions/runs/32766198480) synthesized models after provider-scoped discovery returned empty. MiniMax was sent to `/anthropic/responses`, OpenCode Go rejected `thinking=low`, and OpenAI Ultra was projected as High before a provider request.
- Repair Doctrine: the fail-closed regression first failed because an unresolved OpenAI ref produced invented `openai-responses` metadata instead of no candidate.
- [Blacksmith run 32795721657](https://github.com/openclaw/openclaw/actions/runs/32795721657): 3 targeted gateway regressions passed.
- [Blacksmith run 32795825140](https://github.com/openclaw/openclaw/actions/runs/32795825140): dynamic-candidate helper tests passed (4), direct live-discovery tests passed (20), and the full gateway live harness test file passed (137; 2 skipped).
- [Blacksmith run 32796079795](https://github.com/openclaw/openclaw/actions/runs/32796079795): full `check-changed` passed for all three changed files.
- Mandatory autoreview completed with no accepted or actionable findings (confidence 0.99).
- Operator boundary: the OpenAI host and Docker lanes still reported authentication drift after model selection; release credentials require operator correction. If canonical OpenCode discovery reports the deprecated `opencode-go/glm-5` unavailable, the lane owner must update the target. This patch intentionally adds no credential or provider-ID exceptions.
