### PR TITLE
fix: prevent live Codex checks from racing runtime startup

### DIFF
--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -709,7 +709,6 @@ async function writeLiveGatewayConfig(params: {
       },
       entries: {
         dev: {
-          default: true,
           workspace: params.workspace,
           thinkingDefault: CODEX_HARNESS_THINKING,
           model: { primary: params.modelKey },
@@ -1989,13 +1988,14 @@ async function verifyCodexSubagentProbe(params: {
 
 async function verifyCodexNativeSubagentBridgeProbe(params: {
   client: GatewayClient;
+  configPath: string;
   sessionKey: string;
 }): Promise<void> {
   const runId = randomUUID();
   const childToken = `CODEX-NATIVE-CHILD-${runId.slice(0, 6).toUpperCase()}`;
   const parentToken = `CODEX-NATIVE-PARENT-${runId.slice(0, 6).toUpperCase()}`;
   const { listTaskRecords } = await import("../tasks/runtime-internal.js");
-  const { text, events } = await requestAgentTextWithEvents({
+  const request = requestAgentTextWithEvents({
     // Native Codex waiting pauses this parent turn; task delivery resumes it separately.
     acceptYieldedTimeout: true,
     client: params.client,
@@ -2005,11 +2005,20 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
     message: [
       "Bridge probe.",
       "You must use the Codex native spawn_agent tool exactly once before replying.",
-      `Give the subagent this exact instruction: Reply exactly ${childToken} and nothing else.`,
+      `Give the subagent this exact instruction: Use the exec tool to run sleep 5, then reply exactly ${childToken} and nothing else.`,
       "Wait for the subagent result. Do not answer from your own knowledge.",
       `After the subagent result returns, reply exactly ${parentToken} ${childToken} and nothing else.`,
     ].join("\n"),
   });
+  const childDeadline = Date.now() + 60_000;
+  let childTask = listCodexNativeTasks().find((entry) => entry.status === "running");
+  while (!childTask && Date.now() < childDeadline) {
+    await delay(100);
+    childTask = listCodexNativeTasks().find((entry) => entry.status === "running");
+  }
+  expect(childTask, "expected a running Codex-native child before config refresh").toBeDefined();
+  await refreshGatewayConfigDuringNativeChild(params.configPath);
+  const { text, events } = await request;
   logCodexLiveStep("native-subagent-bridge-probe:initial-reply", { text });
   expect(
     events.some((event) => event.stream === "codex_app_server.lifecycle"),
@@ -2043,6 +2052,39 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
         entry.deliveryStatus === "delivered" &&
         entry.terminalSummary?.includes(childToken),
     );
+  }
+}
+
+async function refreshGatewayConfigDuringNativeChild(configPath: string): Promise<void> {
+  const { registerPreparedModelRuntimePublicationListener } =
+    await import("../agents/prepared-model-runtime.js");
+  let invalidated = false;
+  let unsubscribe = () => {};
+  const published = new Promise<void>((resolve, reject) => {
+    unsubscribe = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "invalidated") {
+        invalidated = true;
+      } else if (invalidated && event.phase === "published") {
+        resolve();
+      } else if (invalidated && event.phase === "failed") {
+        reject(event.error);
+      }
+    });
+  });
+  try {
+    const config = JSON.parse(await fs.readFile(configPath, "utf8")) as OpenClawConfig;
+    config.agents ??= {};
+    config.agents.defaults ??= {};
+    config.agents.defaults.userTimezone = "UTC";
+    await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`);
+    await Promise.race([
+      published,
+      delay(60_000).then(() => {
+        throw new Error("timed out waiting for prepared runtime publication after config refresh");
+      }),
+    ]);
+  } finally {
+    unsubscribe();
   }
 }
 
@@ -2156,6 +2198,7 @@ describeLive("gateway live (Codex harness)", () => {
           auth: { mode: "token", token },
           controlUiEnabled: false,
         });
+        await server.startupSettled;
         client = await connectTestGatewayClient({
           url: `ws://127.0.0.1:${port}`,
           token,
@@ -2216,7 +2259,11 @@ describeLive("gateway live (Codex harness)", () => {
               logCodexLiveStep("subagent-probe:start", { sessionKey });
               await verifyCodexSubagentProbe({ client: activeClient, sessionKey });
               logCodexLiveStep("native-subagent-bridge-probe:start", { sessionKey });
-              await verifyCodexNativeSubagentBridgeProbe({ client: activeClient, sessionKey });
+              await verifyCodexNativeSubagentBridgeProbe({
+                client: activeClient,
+                configPath,
+                sessionKey,
+              });
               logCodexLiveStep("subagent-probe:done");
               if (CODEX_HARNESS_SUBAGENT_ONLY) {
                 return;

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -4522,7 +4522,6 @@ function buildLiveGatewayConfig(params: {
   const providers = Object.keys(nextProviders).length > 0 ? nextProviders : baseProviders;
   const configuredAgents = {
     [GATEWAY_LIVE_AGENT_ID]: {
-      default: true,
       agentDir: params.liveAgentDir,
       workspace: params.liveAgentWorkspaceDir,
       sandbox: { mode: "off" },
@@ -4779,6 +4778,10 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
           controlUiEnabled: false,
         }),
         `${params.label}: gateway-start`,
+      );
+      await withGatewayLiveProbeTimeout(
+        server.startupSettled,
+        `${params.label}: gateway-startup-settled`,
       );
 
       client = await withGatewayLiveProbeTimeout(
@@ -5922,6 +5925,10 @@ describeLive("gateway live (dev agent, profile keys)", () => {
             controlUiEnabled: false,
           }),
           "zai-fallback: gateway-start",
+        );
+        await withGatewayLiveProbeTimeout(
+          server.startupSettled,
+          "zai-fallback: gateway-startup-settled",
         );
 
         client = await withGatewayLiveProbeTimeout(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release live checks could report that a prepared reply runtime disappeared while a Codex native subagent completed, even though the failure was caused by non-canonical test startup and config fixtures.

## Why This Change Was Made

The live Gateway fixtures now omit the retired per-agent default marker and wait for full startup settlement before connecting. The Codex bridge probe also performs a deliberate config refresh while a real child is running, so continuation delivery is tested against the intended lifecycle boundary instead of an accidental legacy-normalization race.

AI-assisted: yes. I inspected and validated the resulting source and test behavior.

## User Impact

No direct product behavior changes. Release validation now distinguishes real prepared-runtime continuation failures from harness-induced startup races.

## Evidence

- Immutable failure evidence at validation SHA `a5b59204446d3720822cbf40d81641a7d1a098c7`: the Codex child reached `succeeded`, but its task stayed `deliveryStatus=pending` with `prepared reply dispatch runtime was not published for dev` in [release checks run 32766198480](https://github.com/openclaw/openclaw/actions/runs/32766198480).
- Full non-minimal Gateway proof on Blacksmith Testbox `tbx_01m0v4swt347ndw7sa9fvp1nhp`, [Actions run 32793434208](https://github.com/openclaw/openclaw/actions/runs/32793434208): three bounded real Codex child/config-refresh runs passed (251.3s, 235.0s, and exact-final-diff 242.7s). The lease was stopped successfully.
- Exact successful command: `CI=1 OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_CODEX_HARNESS=1 OPENCLAW_LIVE_CODEX_HARNESS_SUBAGENT_PROBE=1 OPENCLAW_LIVE_CODEX_HARNESS_THINKING=low OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:live:codex-harness`.
- `node --import tsx scripts/check-deadcode-exports.mts` passed all three Knip scans with zero entries after the first aggregate changed-gate attempt hit its 600-second subprocess timeout.
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 node scripts/check-changed.mjs -- src/gateway/gateway-codex-harness.live.test.ts src/gateway/gateway-models.profiles.live.test.ts` passed the remaining formatting, guards, core-test typecheck, and focused lint lanes.
- Fresh post-rebase autoreview: `env -u CODEX_HOME .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` reported no actionable findings.
- Upstream Codex contract inspected directly: `codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs:124`-`140` binds child lineage to the parent thread/turn; `codex-rs/app-server/src/bespoke_event_handling.rs:1277`-`1302` emits terminal turn status and final assistant output; `codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs:184`-`195` exposes `parentThreadId`.
- Production LOC: `+0/-0`. Tests: `+59/-5`.
