### PR TITLE
fix: QA MCP parity check uses configured agent

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.e2e.test.ts
@@ -129,6 +129,16 @@ describe("Gateway and node-host MCP live process parity", () => {
             return {
               ...withoutPlugins,
               mcp: { servers: sessionMcpServers },
+              agents: {
+                ...cfg.agents,
+                entries: {
+                  ...cfg.agents?.entries,
+                  qa: {
+                    ...cfg.agents?.entries?.qa,
+                    tools: { ...cfg.agents?.entries?.qa?.tools, profile: "full" },
+                  },
+                },
+              },
               tools: { ...cfg.tools, profile: "full" },
               gateway: {
                 ...cfg.gateway,
@@ -366,7 +376,7 @@ describe("Gateway and node-host MCP live process parity", () => {
 
         phase = "reading effective MCP inventory";
         const created = (await gateway.call("sessions.create", {
-          agentId: "main",
+          agentId: "qa",
           label: "QA MCP parity inventory",
         })) as { key?: string };
         if (!created.key) {


### PR DESCRIPTION
## What Problem This Solves

The QA MCP E2E test requested `sessions.create` with agent ID `main`, but its isolated Gateway fixture configures only `qa`. Release checks therefore failed with `Unknown agent id "main"`.

Failure: https://github.com/openclaw/openclaw/actions/runs/32766198480/job/97556689237

## Why This Change Was Made

Use the fixture-owned `qa` agent for the session and give that agent the full tool profile required by this MCP inventory test. This matches the sibling live runtime-pair lane and preserves the production validation instead of relying on an implicit default agent or weakening the tool inventory assertion.

The first focused rerun with only the agent ID change cleared the original unknown-agent failure and reached the MCP inventory assertion. It exposed that the fixture's `qa` agent still inherited the coding profile, so this patch explicitly enables the full profile for this test.

Codex protocol inspection confirmed there is no Codex-side OpenClaw agent-ID/default-agent contract: `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:57-149` defines thread-start parameters without an OpenClaw agent ID, and `codex-rs/app-server/src/request_processors/thread_processor.rs:1019-1054,1309-1334` consumes those parameters and creates the Codex thread ID internally.

## User Impact

Release validation can exercise the isolated Gateway and node-host MCP parity flow with the agent that the QA fixture actually configures. Production agent validation is unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-node-mcp.e2e.test.ts --reporter=verbose` — 1 test passed on final rebased commit `1bbc901`
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.test.ts` — 4 tests passed
- `node scripts/run-vitest.mjs extensions/qa-lab/src/qa-gateway-config.test.ts` — 25 tests passed
- `node scripts/check-changed.mjs -- test/e2e/qa-lab/runtime/gateway-node-mcp.e2e.test.ts` — passed
- `pnpm exec oxfmt --check test/e2e/qa-lab/runtime/gateway-node-mcp.e2e.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed
- Mandatory branch autoreview — clean, patch correct at 0.99 confidence
- Crabbox was not used because the defect is isolated to the QA fixture and does not implicate production default-agent behavior.

AI-assisted: Codex helped investigate and review this test-only patch. I verified the diff, repository ownership, sibling lanes, and test results.
