### PR TITLE
fix(crabbox): dispose heartbeat generations

### DIFF
--- a/extensions/crabbox/index.test.ts
+++ b/extensions/crabbox/index.test.ts
@@ -1,0 +1,148 @@
+import { fileURLToPath } from "node:url";
+import type {
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
+  WorkerProvider,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import * as processRuntime from "openclaw/plugin-sdk/process-runtime";
+import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+const PROFILE = {
+  binary: "/mock/crabbox",
+  class: "standard",
+  idleTimeout: "12s",
+  provider: "aws",
+  ttl: "24h",
+};
+
+function commandResult(overrides: Partial<SpawnResult> = {}): SpawnResult {
+  return {
+    stdout: "",
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: "exit",
+    ...overrides,
+  };
+}
+
+function inspectResult(leaseId: string): SpawnResult {
+  return commandResult({
+    stdout: JSON.stringify({
+      host: "worker.example.test",
+      id: leaseId,
+      ready: true,
+      sshHost: "worker.example.test",
+      sshKey: "/mock/worker-key",
+      sshPort: 2222,
+      sshUser: "openclaw",
+      state: "running",
+    }),
+  });
+}
+
+function registerCrabboxGeneration() {
+  const providers: WorkerProvider[] = [];
+  const services: OpenClawPluginService[] = [];
+  plugin.register(
+    createTestPluginApi({
+      id: "crabbox",
+      rootDir: fileURLToPath(new URL(".", import.meta.url)),
+      registerService: (service) => services.push(service),
+      registerWorkerProvider: (provider) => providers.push(provider),
+    }),
+  );
+  return { provider: providers[0]!, services };
+}
+
+function stopGeneration(services: OpenClawPluginService[]): void | Promise<void> {
+  return services[0]?.stop?.({} as OpenClawPluginServiceContext);
+}
+
+describe("Crabbox plugin generation lifecycle", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("registers cleanup that fences pending heartbeats and late starts", async () => {
+    vi.useFakeTimers();
+    const runCommand = vi
+      .spyOn(processRuntime, "runCommandWithTimeout")
+      .mockImplementation(async (argv) => inspectResult(argv[argv.indexOf("--id") + 1]!));
+    const generation = registerCrabboxGeneration();
+    const lease = { leaseId: "cbx_pending", profile: PROFILE };
+
+    expect(generation.services).toHaveLength(1);
+    await generation.provider.inspect(lease);
+    await stopGeneration(generation.services);
+    await generation.provider.inspect(lease);
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(runCommand.mock.calls.filter(([argv]) => argv[1] === "heartbeat")).toEqual([]);
+  });
+
+  it("aborts all in-flight heartbeats and fences late completions", async () => {
+    vi.useFakeTimers();
+    const signals: AbortSignal[] = [];
+    const finishHeartbeats: Array<() => void> = [];
+    const runCommand = vi
+      .spyOn(processRuntime, "runCommandWithTimeout")
+      .mockImplementation(async (argv, options) => {
+        const leaseId = argv[argv.indexOf("--id") + 1]!;
+        if (argv[1] !== "heartbeat") {
+          return inspectResult(leaseId);
+        }
+        if (typeof options === "number" || !options.signal) {
+          throw new Error("heartbeat is missing its abort signal");
+        }
+        signals.push(options.signal);
+        return await new Promise<SpawnResult>((resolve) => {
+          finishHeartbeats.push(() => resolve(commandResult()));
+        });
+      });
+    const generation = registerCrabboxGeneration();
+
+    for (const leaseId of ["cbx_first", "cbx_second"]) {
+      await generation.provider.inspect({ leaseId, profile: PROFILE });
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    expect(signals).toHaveLength(2);
+
+    await stopGeneration(generation.services);
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+    for (const finish of finishHeartbeats) {
+      finish();
+    }
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(runCommand.mock.calls.filter(([argv]) => argv[1] === "heartbeat")).toHaveLength(2);
+  });
+
+  it("keeps a replacement provider generation independently usable", async () => {
+    vi.useFakeTimers();
+    const runCommand = vi
+      .spyOn(processRuntime, "runCommandWithTimeout")
+      .mockImplementation(async (argv) =>
+        argv[1] === "inspect" ? inspectResult(argv[argv.indexOf("--id") + 1]!) : commandResult(),
+      );
+    const retiring = registerCrabboxGeneration();
+    const replacement = registerCrabboxGeneration();
+
+    await retiring.provider.inspect({ leaseId: "cbx_retiring", profile: PROFILE });
+    await replacement.provider.inspect({ leaseId: "cbx_replacement", profile: PROFILE });
+    await stopGeneration(retiring.services);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    const heartbeatLeaseIds = runCommand.mock.calls
+      .filter(([argv]) => argv[1] === "heartbeat")
+      .map(([argv]) => argv[argv.indexOf("--id") + 1]);
+    expect(heartbeatLeaseIds).toEqual(["cbx_replacement", "cbx_replacement"]);
+
+    await stopGeneration(replacement.services);
+  });
+});

--- a/extensions/crabbox/index.ts
+++ b/extensions/crabbox/index.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { definePluginEntry, type OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
 import { createCrabboxWorkerProvider, resolveOpenClawRoot } from "./src/crabbox-worker-provider.js";
 
 const workerWallpaperPath = fileURLToPath(
@@ -11,12 +11,19 @@ export default definePluginEntry({
   name: "Crabbox Worker Provider",
   description: "Cloud worker provider backed by the Crabbox CLI",
   register(api) {
-    api.registerWorkerProvider(
-      createCrabboxWorkerProvider({
-        openclawRoot: resolveOpenClawRoot(api.rootDir),
-        wallpaperPath: workerWallpaperPath,
-        warn: (message) => api.logger.warn(message),
-      }),
-    );
+    const provider = createCrabboxWorkerProvider({
+      openclawRoot: resolveOpenClawRoot(api.rootDir),
+      wallpaperPath: workerWallpaperPath,
+      warn: (message) => api.logger.warn(message),
+    });
+    api.registerWorkerProvider(provider);
+    // Worker sidecars stop first; plugin services own generation-wide heartbeat cleanup.
+    api.registerService({
+      id: "crabbox-worker-cleanup",
+      start() {},
+      stop() {
+        provider.dispose();
+      },
+    } satisfies OpenClawPluginService);
   },
 });

--- a/extensions/crabbox/src/crabbox-worker-heartbeat.ts
+++ b/extensions/crabbox/src/crabbox-worker-heartbeat.ts
@@ -41,7 +41,8 @@ export function createCrabboxHeartbeatManager(dependencies: {
   warn: (message: string) => void;
 }) {
   const entries = new Map<string, HeartbeatEntry>();
-  const isCurrent = (entry: HeartbeatEntry) => entries.get(entry.id) === entry;
+  let disposed = false;
+  const isCurrent = (entry: HeartbeatEntry) => !disposed && entries.get(entry.id) === entry;
   const warn = (entry: HeartbeatEntry, message: string) =>
     dependencies.warn(
       `${message}; cloud worker machines may be reaped after ${entry.idleTimeout} of coordinator-idle time`,
@@ -100,25 +101,33 @@ export function createCrabboxHeartbeatManager(dependencies: {
     schedule(entry);
   };
 
+  const stop = (leaseId: string): void => {
+    const entry = entries.get(leaseId);
+    if (!entry) {
+      return;
+    }
+    entries.delete(leaseId);
+    if (entry.timer) {
+      clearTimeout(entry.timer);
+    }
+    entry.controller?.abort();
+  };
+
   return {
     start(context: HeartbeatContext): void {
-      if (entries.has(context.id)) {
+      if (disposed || entries.has(context.id)) {
         return;
       }
       const entry = { ...context, failureWarned: false };
       entries.set(context.id, entry);
       schedule(entry, 0);
     },
-    stop(leaseId: string): void {
-      const entry = entries.get(leaseId);
-      if (!entry) {
-        return;
+    stop,
+    dispose(): void {
+      disposed = true;
+      for (const leaseId of entries.keys()) {
+        stop(leaseId);
       }
-      entries.delete(leaseId);
-      if (entry.timer) {
-        clearTimeout(entry.timer);
-      }
-      entry.controller?.abort();
     },
   };
 }

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -454,7 +454,7 @@ async function rejectAwsProfileAfterLeaseReconciliation(
 
 export function createCrabboxWorkerProvider(
   dependencies: CrabboxWorkerProviderDependencies,
-): WorkerProvider {
+): WorkerProvider & { dispose: () => void } {
   const wallpaperBase64 = loadCrabboxWorkerWallpaperBase64(dependencies.wallpaperPath);
   const runCommand = dependencies.runCommand ?? runCommandWithTimeout;
   const warn = dependencies.warn ?? (() => {});
@@ -524,6 +524,7 @@ export function createCrabboxWorkerProvider(
 
   return {
     id: CRABBOX_WORKER_PROVIDER_ID,
+    dispose: () => heartbeats.dispose(),
     listMachineOptions,
     supportedExecutionModes: ["worker-turn"],
     provisionBeforeInstallation: true,


### PR DESCRIPTION
Closes #128948

## What Problem This Solves

Crabbox lease heartbeats were owned only per lease. The bundled plugin registered a worker provider but no plugin service that could dispose the provider generation, so Gateway shutdown or plugin-generation replacement could leave pending heartbeat timers and in-flight Crabbox commands alive. Late completions could then reschedule work from a retired generation alongside its replacement.

## Why This Change Was Made

The existing Gateway lifecycle already stops worker-environment sidecars before plugin services. Crabbox now registers a small cleanup service that disposes the same provider generation it registered. The heartbeat manager has one irreversible generation fence: disposal clears every pending timer, removes every entry, aborts every in-flight command, ignores late starts, and makes late completions unable to reschedule. A newly constructed provider generation owns a new independent manager.

The disposal method remains private to the bundled Crabbox implementation; the public WorkerProvider contract, core registry, protocol, config, provider command semantics, and per-lease destroy path are unchanged. This reuses the existing plugin-service lifecycle pattern rather than adding a core-wide provider shutdown API.

Production LOC: +37/-20 (net +17) | Tests: +148/-0 (net +148)

The production growth adds the missing generation owner and folds all timer/controller cleanup through the existing per-entry stop path.

AI-assisted: yes. I reviewed plugin service replacement/shutdown ordering, worker-environment sidecar ordering, heartbeat timer/controller ownership, late completion behavior, per-lease destroy, and replacement-generation isolation.

## User Impact

Gateway shutdown, restart, and plugin replacement no longer leave retired Crabbox keepalive work running. Active heartbeat commands are aborted, pending timers are cleared, and a replacement generation continues heartbeating without overlap from the old one.

## Evidence

- Pre-fix regressions: all three new lifecycle cases failed because no cleanup service was registered, in-flight heartbeat signals remained unaborted, and the retired generation continued heartbeating after replacement.
- Focused owner proof: `node scripts/run-vitest.mjs extensions/crabbox extensions/mxc/test/plugin.test.ts` passed 143 tests across five files on the exact rebased head.
- Full changed-file gate: `node scripts/check-changed.mjs` passed, including extension production/test typechecks, type-aware lint, formatting, doctor contract guards, plugin boundaries, dead exports, database-first, and import cycles.
- Coverage uses the real Crabbox plugin entry and provider with a mocked process runner. It proves pending timers and late starts are fenced, multiple in-flight heartbeats are aborted, late completions do not reschedule, disposal is generation-local, and a replacement provider keeps running.
- Fresh P0/P1 autoreview: no accepted/actionable findings (0.94).
- No live Machine0, Crabbox API/CLI, or provider request was made: another campaign session exclusively owns the current Machine0 proof lease. This repair is process-local lifecycle ownership and is deterministically covered without external side effects.
