### PR TITLE
fix: QA MCP parity fails during effective tool inventory

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.e2e.test.ts
@@ -36,6 +36,7 @@ import {
 } from "./gateway-node-mcp.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const QA_AGENT_ID = "qa";
 
 describe("Gateway and node-host MCP live process parity", () => {
   it(
@@ -129,7 +130,19 @@ describe("Gateway and node-host MCP live process parity", () => {
             return {
               ...withoutPlugins,
               mcp: { servers: sessionMcpServers },
-              tools: { ...cfg.tools, profile: "full" },
+              agents: {
+                ...cfg.agents,
+                entries: {
+                  ...cfg.agents?.entries,
+                  [QA_AGENT_ID]: {
+                    ...cfg.agents?.entries?.[QA_AGENT_ID],
+                    tools: {
+                      ...cfg.agents?.entries?.[QA_AGENT_ID]?.tools,
+                      profile: "full",
+                    },
+                  },
+                },
+              },
               gateway: {
                 ...cfg.gateway,
                 nodes: {
@@ -189,7 +202,7 @@ describe("Gateway and node-host MCP live process parity", () => {
         phase = "loading session MCP catalog";
         sessionRuntime = createSessionMcpRuntime({
           sessionId: `qa-mcp-parity-${randomUUID()}`,
-          sessionKey: `agent:main:qa-mcp-parity-${randomUUID()}`,
+          sessionKey: `agent:${QA_AGENT_ID}:qa-mcp-parity-${randomUUID()}`,
           workspaceDir: sessionWorkspace,
           cfg: { plugins: { enabled: false }, mcp: { servers: sessionMcpServers } },
         });
@@ -366,7 +379,7 @@ describe("Gateway and node-host MCP live process parity", () => {
 
         phase = "reading effective MCP inventory";
         const created = (await gateway.call("sessions.create", {
-          agentId: "main",
+          agentId: QA_AGENT_ID,
           label: "QA MCP parity inventory",
         })) as { key?: string };
         if (!created.key) {


### PR DESCRIPTION
## What Problem This Solves

The Gateway/node MCP parity E2E failed during effective tool inventory because the isolated QA gateway configures the `qa` agent, while the test requested `sessions.create` for unconfigured agent `main`.

## Why This Change Was Made

Use one canonical `QA_AGENT_ID` for the test session owner and configure that existing agent with full tool visibility. Production unknown-agent validation and the effective-inventory assertions remain unchanged.

## User Impact

No product runtime behavior changes. Release validation can complete the real Gateway/node MCP inventory and withdrawal flow.

## Evidence

- Frozen release failure: [Release Checks repo E2E job](https://github.com/openclaw/openclaw/actions/runs/32766198480/job/97557440911) at `a5b59204446d3720822cbf40d81641a7d1a098c7`
- Before: the focused E2E reproduced `Unknown agent id "main"`
- After: focused Gateway/node MCP parity E2E passed
- Sibling Gateway/node MCP stress E2E passed
- Private QA build passed at `9b510f3a710`
- `check-changed` passed, including formatting, test-root typecheck, and script lint
- Fresh branch autoreview: no actionable findings (0.99 confidence)

AI-assisted: Codex was used for investigation, implementation, and validation.
