### PR TITLE
fix(chat): faster, reliable older history and live updates

### DIFF
--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -345,28 +345,6 @@ export function projectChatDisplayMessages(
   return projectChatDisplayMessagesWithState(messages, options).messages;
 }
 
-function limitChatDisplayMessages<T>(messages: T[], maxMessages?: number): T[] {
-  if (
-    typeof maxMessages !== "number" ||
-    !Number.isFinite(maxMessages) ||
-    maxMessages <= 0 ||
-    messages.length <= maxMessages
-  ) {
-    return messages;
-  }
-  return messages.slice(-Math.floor(maxMessages));
-}
-
-export function projectRecentChatDisplayMessages(
-  messages: unknown[],
-  options?: ChatDisplayProjectionOptions & { maxMessages?: number },
-): Array<Record<string, unknown>> {
-  return limitChatDisplayMessages(
-    projectChatDisplayMessages(messages, options),
-    options?.maxMessages,
-  );
-}
-
 export function projectChatDisplayMessage(
   message: unknown,
   options?: ChatDisplayProjectionOptions,

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -4,7 +4,6 @@ export {
   projectChatDisplayMessage,
   projectChatDisplayMessages,
   projectChatDisplayMessagesWithState,
-  projectRecentChatDisplayMessages,
 } from "./chat-display-projection.core.js";
 export {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -35,7 +35,7 @@ import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   augmentChatHistoryWithCanvasBlocks,
   dropPreSessionStartAnnouncePairs,
-  projectRecentChatDisplayMessages,
+  projectChatDisplayMessages,
   resolveEffectiveChatHistoryMaxChars,
   sanitizeChatHistoryMessages,
 } from "../chat-display-projection.js";
@@ -1146,7 +1146,7 @@ describe("sanitizeChatHistoryMessages", () => {
   });
 });
 
-describe("projectRecentChatDisplayMessages", () => {
+describe("projectChatDisplayMessages", () => {
   const safeFailureContent = [
     { type: "text", text: "The agent run failed before producing a reply." },
   ];
@@ -1317,7 +1317,7 @@ describe("projectRecentChatDisplayMessages", () => {
   ];
 
   it.each(displayErrorCases)("$name", ({ message, content, visibleText }) => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       { role: "assistant", stopReason: "error", timestamp: 1, ...message },
     ]);
     expect(result).toEqual([
@@ -1371,7 +1371,7 @@ describe("projectRecentChatDisplayMessages", () => {
   ])(
     "projects empty context-overflow assistant errors with recovery guidance: $name",
     ({ fields }) => {
-      const result = projectRecentChatDisplayMessages([
+      const result = projectChatDisplayMessages([
         {
           role: "assistant",
           content: [],
@@ -1405,7 +1405,7 @@ describe("projectRecentChatDisplayMessages", () => {
     ["input_text", ""],
     ["input_text", "NO_REPLY"],
   ])("projects hidden %s assistant errors %j as a generic safe failure", (type, text) => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       {
         role: "assistant",
         content: [{ type, text }],
@@ -1423,7 +1423,7 @@ describe("projectRecentChatDisplayMessages", () => {
   it.each(["NO_REPLY", STREAM_ERROR_FALLBACK_TEXT])(
     "projects display-hidden assistant error text %j as a generic safe failure",
     (text) => {
-      const result = projectRecentChatDisplayMessages([
+      const result = projectChatDisplayMessages([
         {
           role: "assistant",
           content: [{ type: "text", text }],
@@ -1446,7 +1446,7 @@ describe("projectRecentChatDisplayMessages", () => {
   it.each([undefined, ""])(
     "projects repaired stream errors with errorMessage %j as a generic safe failure",
     (errorMessage) => {
-      const result = projectRecentChatDisplayMessages([
+      const result = projectChatDisplayMessages([
         assistantHistoryMessage(STREAM_ERROR_FALLBACK_TEXT, {
           stopReason: "error",
           ...(errorMessage === undefined ? {} : { errorMessage }),
@@ -1492,7 +1492,7 @@ describe("projectRecentChatDisplayMessages", () => {
       expected: [{ type: "text", text: "I'm running on ollama-cloud now." }],
     },
   ])("removes an internal stream-error prefix from same-message $name", ({ content, expected }) => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       {
         role: "assistant",
         content,
@@ -1516,7 +1516,7 @@ describe("projectRecentChatDisplayMessages", () => {
 
   it("keeps intentional mentions of the internal fallback inside a real assistant reply", () => {
     const text = `Diagnostic note: ${STREAM_ERROR_FALLBACK_TEXT}`;
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       assistantHistoryMessage(text, { stopReason: "error" }),
     ]);
 
@@ -1527,7 +1527,7 @@ describe("projectRecentChatDisplayMessages", () => {
     "keeps literal fallback-prefixed assistant text without error provenance %j",
     (stopReason) => {
       const text = `${STREAM_ERROR_FALLBACK_TEXT} actual quoted text`;
-      const result = projectRecentChatDisplayMessages([
+      const result = projectChatDisplayMessages([
         assistantHistoryMessage(text, stopReason ? { stopReason } : {}),
       ]);
 
@@ -1536,7 +1536,7 @@ describe("projectRecentChatDisplayMessages", () => {
   );
 
   it("removes a synthetic error prefix while preserving displayable image content", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       {
         role: "assistant",
         content: [
@@ -1553,7 +1553,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("drops a repaired stream-error placeholder before same-turn assistant content", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       userHistoryMessage("hello", { timestamp: 1 }),
       assistantHistoryMessage(STREAM_ERROR_FALLBACK_TEXT, {
         stopReason: "error",
@@ -1570,7 +1570,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps a genuine failed turn before a new forwarded inter-session turn", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       assistantHistoryMessage(STREAM_ERROR_FALLBACK_TEXT, {
         stopReason: "error",
         timestamp: 1,
@@ -1588,7 +1588,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps genuine stream-error failures when a hidden assistant row has text", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       assistantHistoryMessage(STREAM_ERROR_FALLBACK_TEXT, { stopReason: "error" }),
       assistantHistoryMessage("internal-only assistant content", { display: false }),
     ]);
@@ -1601,7 +1601,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps a stream-error placeholder when the next user turn starts first", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       assistantHistoryMessage(STREAM_ERROR_FALLBACK_TEXT, { stopReason: "error", timestamp: 1 }),
       userHistoryMessage("retry", { timestamp: 2 }),
       assistantHistoryMessage("fresh answer", { timestamp: 3 }),
@@ -1618,7 +1618,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("projects sessions_send inter-session turns as forwarded assistant-side display messages", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       {
         role: "user",
         content: [
@@ -1648,13 +1648,13 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("projects empty sessions_send inter-session turns before empty user filtering", () => {
-    const result = projectRecentChatDisplayMessages([sessionsSendHistoryMessage("", 1)]);
+    const result = projectChatDisplayMessages([sessionsSendHistoryMessage("", 1)]);
 
     expect(result).toEqual([projectedSessionsSendHistoryMessage("", 1)]);
   });
 
   it("does not let sessions_send inter-session turns clear pending message-tool mirrors", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       {
         role: "assistant",
         content: [
@@ -1719,7 +1719,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps forwarded sessions_send control-token text visible after stripping provenance", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       {
         role: "user",
         content: [
@@ -1741,15 +1741,13 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps forwarded sessions_send heartbeat-looking text visible", () => {
-    const result = projectRecentChatDisplayMessages([
-      sessionsSendHistoryMessage("HEARTBEAT_OK", 1),
-    ]);
+    const result = projectChatDisplayMessages([sessionsSendHistoryMessage("HEARTBEAT_OK", 1)]);
 
     expect(result).toEqual([projectedSessionsSendHistoryMessage("HEARTBEAT_OK", 1)]);
   });
 
   it("keeps forwarded sessions_send heartbeat-looking text visible after a heartbeat prompt", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       userHistoryMessage(HEARTBEAT_PROMPT, { timestamp: 1 }),
       sessionsSendHistoryMessage("HEARTBEAT_OK", 2),
     ]);
@@ -1762,7 +1760,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("marks only the first visible message after each hidden heartbeat input", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       userHistoryMessage(HEARTBEAT_PROMPT, { __openclaw: { seq: 1 } }),
       assistantHistoryMessage("First run started.", { __openclaw: { seq: 2 } }),
       assistantHistoryMessage("First run finished.", { __openclaw: { seq: 3 } }),
@@ -1799,7 +1797,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("does not project user-authored sessions_send envelope text without provenance", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       {
         role: "user",
         content: [
@@ -1836,7 +1834,7 @@ describe("projectRecentChatDisplayMessages", () => {
     const visibleText = "forwarded report";
     const textSha256 = createHash("sha256").update(visibleText).digest("hex");
 
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       sessionsSendHistoryMessage(visibleText, 1),
       ttsSupplementHistoryMessage({ textSha256 }, 2),
     ]);
@@ -1848,7 +1846,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("preserves structured trace alongside visible assistant progress text", () => {
-    const result = projectRecentChatDisplayMessages(
+    const result = projectChatDisplayMessages(
       [
         userHistoryMessage("fix it", { timestamp: 1 }),
         {
@@ -1915,7 +1913,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("projects pure keyed commentary as a durable preamble", () => {
-    const result = projectRecentChatDisplayMessages(
+    const result = projectChatDisplayMessages(
       [
         userHistoryMessage("status", { timestamp: 1 }),
         {
@@ -1953,7 +1951,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("drops duplicate ACP gateway-injected assistant replies from chat history", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       userHistoryMessage("good morning", { timestamp: 1 }),
       assistantHistoryMessage("Good morning.", {
         provider: "openclaw",
@@ -1979,7 +1977,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("drops channel-final delivery mirrors that duplicate the preceding assistant reply", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       {
         role: "user",
         content: "yo big boy",
@@ -2010,7 +2008,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps a channel-final delivery mirror after a filtered user turn", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       assistantHistoryMessage("Repeated reply", {
         provider: "openai",
         model: "gpt-5.5",
@@ -2035,7 +2033,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps adjacent channel-final delivery mirrors from distinct sends", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       deliveryMirrorHistoryMessage("Repeated reply", "message-1", 1),
       deliveryMirrorHistoryMessage("Repeated reply", "message-2", 2),
     ]);
@@ -2044,7 +2042,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps channel-final mirrors after unmarked assistant replies", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       assistantHistoryMessage("Repeated reply", {
         provider: "openai",
         model: "gpt-5.5",
@@ -2057,7 +2055,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps channel-final mirrors after forwarded sessions_send messages", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       sessionsSendHistoryMessage("Forwarded status", 1),
       deliveryMirrorHistoryMessage("Forwarded status", "message-forwarded", 2),
     ]);
@@ -2078,7 +2076,7 @@ describe("projectRecentChatDisplayMessages", () => {
   });
 
   it("keeps gateway-injected assistant replies when they are not duplicate ACP text", () => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       assistantHistoryMessage("First answer.", {
         provider: "openclaw",
         model: "acp-runtime",
@@ -2103,27 +2101,6 @@ describe("projectRecentChatDisplayMessages", () => {
         timestamp: 2,
       }),
     ]);
-  });
-
-  it("applies history limits after dropping display-hidden messages", () => {
-    const result = projectRecentChatDisplayMessages(
-      [
-        { role: "user", content: "older visible", timestamp: 1 },
-        { role: "assistant", content: "older answer", timestamp: 2 },
-        { role: "assistant", content: "NO_REPLY", timestamp: 3 },
-        { role: "assistant", content: "ANNOUNCE_SKIP", timestamp: 4 },
-        {
-          role: "custom",
-          customType: "openclaw.runtime-context",
-          content: "hidden runtime context",
-          display: false,
-          timestamp: 5,
-        },
-      ],
-      { maxMessages: 1 },
-    );
-
-    expect(result).toEqual([{ role: "assistant", content: "older answer", timestamp: 2 }]);
   });
 
   it.each([
@@ -2159,7 +2136,7 @@ describe("projectRecentChatDisplayMessages", () => {
       expectedPath: undefined,
     },
   ])("keeps $name media-only users through canonical display projection", (testCase) => {
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       { role: "user", content: "", timestamp: 1, ...testCase.message },
       { role: "user", content: "", timestamp: 2 },
     ]);
@@ -2176,7 +2153,7 @@ describe("projectRecentChatDisplayMessages", () => {
     const spokenText = "Here is the answer.";
     const textSha256 = createHash("sha256").update(visibleText).digest("hex");
 
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       userHistoryMessage("first", { timestamp: 1 }),
       assistantHistoryMessage(visibleText, { timestamp: 2 }),
       userHistoryMessage("second", { timestamp: 3 }),
@@ -2194,7 +2171,7 @@ describe("projectRecentChatDisplayMessages", () => {
     const projectedVisibleText = "Visible answer ".repeat(8).trim();
     const textSha256 = createHash("sha256").update(projectedVisibleText).digest("hex");
 
-    const result = projectRecentChatDisplayMessages(
+    const result = projectChatDisplayMessages(
       [
         assistantHistoryMessage(projectedVisibleText, { timestamp: 1 }),
         ttsSupplementHistoryMessage({ textSha256 }, 2),
@@ -2216,7 +2193,7 @@ describe("projectRecentChatDisplayMessages", () => {
     const textSha256 = createHash("sha256").update(visibleText).digest("hex");
     const ttsSupplement = { textSha256 };
 
-    const result = projectRecentChatDisplayMessages([
+    const result = projectChatDisplayMessages([
       assistantHistoryMessage(visibleText, { timestamp: 1 }),
       userHistoryMessage("again", { timestamp: 2 }),
       ttsSupplementHistoryMessage(ttsSupplement, 3, visibleText),

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -625,36 +625,52 @@ describe("SessionHistorySseState", () => {
     expect(snapshot.rawTranscriptSeq).toBe(99);
   });
 
-  test("refreshes limited SSE history from bounded async tail reads", async () => {
-    const fullReadSpy = vi
-      .spyOn(sessionTranscriptReaders, "readSessionMessagesAsync")
-      .mockResolvedValue([]);
-    const tailReadSpy = vi
-      .spyOn(sessionTranscriptReaders, "readRecentSessionMessagesWithStatsAsync")
-      .mockResolvedValueOnce({
-        messages: [assistantTextMessage("tail two", 8)],
-        totalMessages: 8,
-      });
-    try {
-      const state = newState([assistantTextMessage("tail one", 7)], {
-        rawTranscriptSeq: 7,
-        totalRawMessages: 7,
-        limit: 1,
-      });
+  test.each([
+    { name: "latest page", cursor: undefined, expectedSeq: 8 },
+    { name: "older cursor page", cursor: "8", expectedSeq: 7 },
+  ])(
+    "refreshes limited SSE history from bounded async reads ($name)",
+    async ({ cursor, expectedSeq }) => {
+      const fullReadSpy = vi
+        .spyOn(sessionTranscriptReaders, "readSessionMessagesWithSourceAsync")
+        .mockResolvedValue({ messages: [] });
+      const tailReadSpy = vi
+        .spyOn(sessionTranscriptReaders, "readRecentSessionMessagesWithStatsAsync")
+        .mockResolvedValueOnce({
+          messages: [assistantTextMessage("tail two", expectedSeq)],
+          totalMessages: 8,
+        });
+      const pageReadSpy = vi
+        .spyOn(sessionTranscriptReaders, "readSessionMessagesPageWithStatsAsync")
+        .mockResolvedValueOnce({ messages: [], totalMessages: 8 })
+        .mockResolvedValueOnce({
+          messages: [assistantTextMessage("tail two", expectedSeq)],
+          totalMessages: 8,
+        });
+      try {
+        const state = newState([assistantTextMessage("tail one", 7)], {
+          rawTranscriptSeq: 7,
+          totalRawMessages: 7,
+          limit: 1,
+          cursor,
+        });
 
-      expect(state.snapshot().messages[0]?.["__openclaw"]?.seq).toBe(7);
-      const refreshed = await state.refreshAsync();
+        expect(state.snapshot().messages[0]?.["__openclaw"]?.seq).toBe(7);
+        const refreshed = await state.refreshAsync();
 
-      expect(refreshed.hasMore).toBe(true);
-      expect(refreshed.nextCursor).toBe("8");
-      expect(refreshed.messages[0]?.["__openclaw"]?.seq).toBe(8);
-      expect(tailReadSpy).toHaveBeenCalledTimes(1);
-      expect(fullReadSpy).not.toHaveBeenCalled();
-    } finally {
-      fullReadSpy.mockRestore();
-      tailReadSpy.mockRestore();
-    }
-  });
+        expect(refreshed.hasMore).toBe(true);
+        expect(refreshed.nextCursor).toBe(String(expectedSeq));
+        expect(refreshed.messages[0]?.["__openclaw"]?.seq).toBe(expectedSeq);
+        expect(tailReadSpy).toHaveBeenCalledTimes(cursor ? 0 : 1);
+        expect(pageReadSpy).toHaveBeenCalledTimes(cursor ? 2 : 0);
+        expect(fullReadSpy).not.toHaveBeenCalled();
+      } finally {
+        fullReadSpy.mockRestore();
+        tailReadSpy.mockRestore();
+        pageReadSpy.mockRestore();
+      }
+    },
+  );
 
   test("strips legacy internal envelopes before exposing history", () => {
     const snapshot = buildSessionHistorySnapshot({

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -14,6 +14,7 @@ import { readIncrementalChatHistoryTail } from "./session-history-tail.js";
 import { resolveTranscriptPathForComparison } from "./session-transcript-path.js";
 import {
   attachOpenClawTranscriptMeta,
+  readSessionMessagesPageWithStatsAsync,
   readSessionMessagesWithSourceAsync,
   type ReadRecentSessionMessagesResult,
 } from "./session-transcript-readers.js";
@@ -60,10 +61,18 @@ type SessionHistoryTranscriptTarget = {
 };
 
 type SessionHistoryRawSnapshot = {
+  projection?: ReturnType<typeof projectChatDisplayMessagesWithState>;
   rawMessages: unknown[];
   rawTranscriptSeq?: number;
   totalRawMessages?: number;
   transcriptPath?: string;
+};
+
+type SessionHistoryStateSnapshot = SessionHistoryRawSnapshot & {
+  target: SessionHistoryTranscriptTarget;
+  maxChars?: number;
+  limit?: number;
+  cursor?: string;
 };
 
 function readMessageIdempotencyKey(message: unknown): string | undefined {
@@ -76,19 +85,41 @@ function readMessageIdempotencyKey(message: unknown): string | undefined {
 
 /** Shares the bounded visible-message scanner across HTTP snapshots and SSE refreshes. */
 export async function readBoundedSessionHistorySnapshotAsync(params: {
+  cursor?: string;
   target: SessionHistoryTranscriptTarget;
   limit: number;
   maxChars: number;
-}): Promise<ReadRecentSessionMessagesResult> {
+}): Promise<
+  ReadRecentSessionMessagesResult & {
+    projection: ReturnType<typeof projectChatDisplayMessagesWithState>;
+  }
+> {
+  const cursorSeq = resolveCursorSeq(params.cursor);
+  const offset =
+    cursorSeq === undefined
+      ? undefined
+      : Math.max(
+          0,
+          (
+            await readSessionMessagesPageWithStatsAsync(params.target, {
+              offset: 0,
+              maxMessages: 0,
+              allowResetArchiveFallback: true,
+            })
+          ).totalMessages -
+            cursorSeq +
+            1,
+        );
   const tail = await readIncrementalChatHistoryTail({
     entry: params.target.sessionEntry,
     readScope: params.target,
     effectiveMaxChars: params.maxChars,
     max: params.limit,
     maxBytes: getMaxChatHistoryMessagesBytes(),
+    ...(offset === undefined ? {} : { offset }),
     preserveProjectionContext: true,
   });
-  return { ...tail.readPage, messages: tail.rawMessages };
+  return { ...tail.readPage, messages: tail.rawMessages, projection: tail.projection };
 }
 
 export function resolveCursorSeq(cursor: string | undefined): number | undefined {
@@ -183,6 +214,7 @@ function paginateSessionMessages(
 
 /** Builds the display history snapshot and raw transcript sequence watermark. */
 export function buildSessionHistorySnapshot(params: {
+  projection?: ReturnType<typeof projectChatDisplayMessagesWithState>;
   rawMessages: unknown[];
   maxChars?: number;
   limit?: number;
@@ -190,18 +222,20 @@ export function buildSessionHistorySnapshot(params: {
   rawTranscriptSeq?: number;
   totalRawMessages?: number;
 }): SessionHistorySnapshot {
-  const projected = projectChatDisplayMessagesWithState(params.rawMessages, {
-    includeCommentaryFallbacks: true,
-    maxChars: params.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
-    resolveCurrentUserProfileDisplay,
-  });
+  const projected =
+    params.projection ??
+    projectChatDisplayMessagesWithState(params.rawMessages, {
+      includeCommentaryFallbacks: true,
+      maxChars: params.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
+      resolveCurrentUserProfileDisplay,
+    });
   const visibleMessages = toSessionHistoryMessages(projected.messages);
   const rawHistoryMessages = toSessionHistoryMessages(params.rawMessages);
   const history = paginateSessionMessages(visibleMessages, params.limit, params.cursor);
   if (
-    !params.cursor &&
     typeof params.totalRawMessages === "number" &&
-    params.totalRawMessages > params.rawMessages.length
+    params.totalRawMessages > params.rawMessages.length &&
+    (!params.cursor || (resolveMessageSeq(rawHistoryMessages[0]) ?? 0) > 1)
   ) {
     const firstSeq = resolveMessageSeq(history.messages[0] ?? rawHistoryMessages[0]);
     history.hasMore = true;
@@ -232,51 +266,16 @@ export class SessionHistorySseState {
   private streamErrorFallbackPending: boolean;
   private transcriptPath: string | undefined;
 
-  static fromRawSnapshot(params: {
-    target: SessionHistoryTranscriptTarget;
-    rawMessages: unknown[];
-    rawTranscriptSeq?: number;
-    totalRawMessages?: number;
-    transcriptPath?: string;
-    maxChars?: number;
-    limit?: number;
-    cursor?: string;
-  }): SessionHistorySseState {
-    return new SessionHistorySseState({
-      target: params.target,
-      maxChars: params.maxChars,
-      limit: params.limit,
-      cursor: params.cursor,
-      initialRawMessages: params.rawMessages,
-      rawTranscriptSeq: params.rawTranscriptSeq,
-      totalRawMessages: params.totalRawMessages,
-      transcriptPath: params.transcriptPath,
-    });
+  static fromRawSnapshot(params: SessionHistoryStateSnapshot): SessionHistorySseState {
+    return new SessionHistorySseState(params);
   }
 
-  private constructor(params: {
-    target: SessionHistoryTranscriptTarget;
-    maxChars?: number;
-    limit?: number;
-    cursor?: string;
-    initialRawMessages: unknown[];
-    rawTranscriptSeq?: number;
-    totalRawMessages?: number;
-    transcriptPath?: string;
-  }) {
+  private constructor(params: SessionHistoryStateSnapshot) {
     this.target = params.target;
     this.maxChars = params.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
     this.limit = params.limit;
     this.cursor = params.cursor;
-    const snapshot = this.buildSnapshot({
-      rawMessages: params.initialRawMessages,
-      ...(typeof params.rawTranscriptSeq === "number"
-        ? { rawTranscriptSeq: params.rawTranscriptSeq }
-        : {}),
-      ...(typeof params.totalRawMessages === "number"
-        ? { totalRawMessages: params.totalRawMessages }
-        : {}),
-    });
+    const snapshot = this.buildSnapshot(params);
     this.sentHistory = snapshot.history;
     this.rawTranscriptSeq = snapshot.rawTranscriptSeq;
     this.turnBoundaryPending = snapshot.turnBoundaryPending;
@@ -449,27 +448,26 @@ export class SessionHistorySseState {
 
   private buildSnapshot(rawSnapshot: SessionHistoryRawSnapshot): SessionHistorySnapshot {
     return buildSessionHistorySnapshot({
+      projection: rawSnapshot.projection,
       rawMessages: rawSnapshot.rawMessages,
       maxChars: this.maxChars,
       limit: this.limit,
       cursor: this.cursor,
-      ...(typeof rawSnapshot.rawTranscriptSeq === "number"
-        ? { rawTranscriptSeq: rawSnapshot.rawTranscriptSeq }
-        : {}),
-      ...(typeof rawSnapshot.totalRawMessages === "number"
-        ? { totalRawMessages: rawSnapshot.totalRawMessages }
-        : {}),
+      rawTranscriptSeq: rawSnapshot.rawTranscriptSeq,
+      totalRawMessages: rawSnapshot.totalRawMessages,
     });
   }
 
   private async readRawSnapshotAsync(): Promise<SessionHistoryRawSnapshot> {
-    if (this.cursor === undefined && typeof this.limit === "number") {
+    if (typeof this.limit === "number") {
       const snapshot = await readBoundedSessionHistorySnapshotAsync({
+        cursor: this.cursor,
         target: this.target,
         limit: this.limit,
         maxChars: this.maxChars,
       });
       return {
+        projection: snapshot.projection,
         rawMessages: snapshot.messages,
         rawTranscriptSeq: snapshot.totalMessages,
         totalRawMessages: snapshot.totalMessages,

--- a/src/gateway/session-history-tail.ts
+++ b/src/gateway/session-history-tail.ts
@@ -4,8 +4,7 @@ import type { SessionEntry } from "../config/sessions.js";
 import {
   dropPreSessionStartAnnouncePairs,
   isHeartbeatHistoryTurnBoundaryMessage,
-  projectChatDisplayMessages,
-  projectRecentChatDisplayMessages,
+  projectChatDisplayMessagesWithState,
 } from "./chat-display-projection.js";
 import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
 import {
@@ -17,6 +16,7 @@ import {
 
 const SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_MESSAGES = 8_000;
 const SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES = 100;
+const SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_CHUNK_MESSAGES = 400;
 
 export function readChatHistoryMessageSeq(message: unknown): number | undefined {
   const metadata = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
@@ -53,6 +53,7 @@ export function dropChatHistoryOverreadContextMessage(
 
 export type IncrementalChatHistoryTail = {
   overreadContextMessage: unknown;
+  projection: ReturnType<typeof projectChatDisplayMessagesWithState>;
   projected: unknown[];
   rawMessages: unknown[];
   rawPageMessages: number;
@@ -73,9 +74,10 @@ export async function readIncrementalChatHistoryTail(params: {
   const rawHistoryWindowMessages = Math.max(1, Math.floor(params.max)) * 20 + 20;
   // Sequence-cursor transports group tool results and derived mirrors together,
   // so their initial read keeps the established wider projection context.
-  const initialMessages = params.preserveProjectionContext
-    ? rawHistoryWindowMessages
-    : Math.min(rawHistoryWindowMessages, Math.max(1, offset === 0 ? params.max * 3 : params.max));
+  const initialMessages =
+    params.preserveProjectionContext && offset === 0
+      ? rawHistoryWindowMessages
+      : Math.min(rawHistoryWindowMessages, Math.max(1, offset === 0 ? params.max * 3 : params.max));
   const readPage =
     offset === 0
       ? await readRecentSessionMessagesWithStatsAsync(params.readScope, {
@@ -101,42 +103,43 @@ export async function readIncrementalChatHistoryTail(params: {
     readPage.messages,
     overreadContextMessage,
   );
-  const filteredRawMessages = () =>
-    dropChatHistoryOverreadContextMessage(
-      dropPreSessionStartAnnouncePairs(
-        overreadContextMessage === undefined
-          ? rawMessages
-          : [overreadContextMessage, ...rawMessages],
-        sessionStartedAt,
-      ),
-      overreadContextMessage,
-    );
   const project = () => {
-    const options = {
+    const filteredRawMessages =
+      sessionStartedAt === undefined
+        ? rawMessages
+        : dropChatHistoryOverreadContextMessage(
+            dropPreSessionStartAnnouncePairs(
+              overreadContextMessage === undefined
+                ? rawMessages
+                : [overreadContextMessage, ...rawMessages],
+              sessionStartedAt,
+            ),
+            overreadContextMessage,
+          );
+    const projection = projectChatDisplayMessagesWithState(filteredRawMessages, {
       includeCommentaryFallbacks: true,
       maxChars: params.effectiveMaxChars,
       resolveCurrentUserProfileDisplay,
       turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
-    };
-    return offset === 0
-      ? projectRecentChatDisplayMessages(filteredRawMessages(), {
-          ...options,
-          maxMessages: params.max,
-        })
-      : capOffsetChatHistoryProjectedMessages(
-          projectChatDisplayMessages(filteredRawMessages(), options),
-          params.max,
-        );
+    });
+    const projected =
+      offset === 0
+        ? projection.messages.length > params.max
+          ? projection.messages.slice(-params.max)
+          : projection.messages
+        : capOffsetChatHistoryProjectedMessages(projection.messages, params.max);
+    return { filteredRawMessages, projected, projection };
   };
-  let projected = project();
+  let result = project();
   let scanLimit = rawHistoryWindowMessages;
   let scannedBytes = 0;
+  let nextChunkMessages = SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES;
   while (offset + rawPageMessages < readPage.totalMessages) {
-    if (projected.length >= params.max) {
+    if (result.projected.length >= params.max) {
       break;
     }
     if (rawPageMessages >= rawHistoryWindowMessages) {
-      if (projected.length > 0) {
+      if (result.projected.length > 0) {
         break;
       }
       scanLimit = rawHistoryWindowMessages + SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_MESSAGES;
@@ -144,10 +147,7 @@ export async function readIncrementalChatHistoryTail(params: {
     if (rawPageMessages >= scanLimit) {
       break;
     }
-    const chunkMessages = Math.min(
-      SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES,
-      scanLimit - rawPageMessages,
-    );
+    const chunkMessages = Math.min(nextChunkMessages, scanLimit - rawPageMessages);
     const page = await readSessionMessagesPageWithStatsAsync(params.readScope, {
       offset: offset + rawPageMessages,
       maxMessages: chunkMessages + 1,
@@ -164,16 +164,22 @@ export async function readIncrementalChatHistoryTail(params: {
       contextMessage,
     );
     overreadContextMessage = contextMessage;
-    projected = project();
+    result = project();
     scannedBytes += Buffer.byteLength(JSON.stringify(page.messages), "utf8");
     if (rawPageMessages > rawHistoryWindowMessages && scannedBytes >= params.maxBytes) {
       break;
     }
+    // Grow sparse scans geometrically while bounding each indexed page's allocation.
+    nextChunkMessages = Math.min(
+      nextChunkMessages * 2,
+      SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_CHUNK_MESSAGES,
+    );
   }
   return {
     overreadContextMessage,
-    projected,
-    rawMessages: filteredRawMessages(),
+    projected: result.projected,
+    projection: result.projection,
+    rawMessages: result.filteredRawMessages,
     rawPageMessages,
     readPage,
   };

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -143,15 +143,7 @@ function extractMessageRecordsFromEventEntries(
   });
 }
 
-function readSqliteMessageRecordsSync(target: ResolvedTranscriptReadTarget): SqliteMessageRecord[] {
-  return extractMessageRecordsFromEventEntries(
-    readSessionTranscriptMessageEvents(toTranscriptReadScope(target)),
-  );
-}
-
-async function readSqliteMessageRecords(
-  target: ResolvedTranscriptReadTarget,
-): Promise<SqliteMessageRecord[]> {
+function readSqliteMessageRecords(target: ResolvedTranscriptReadTarget): SqliteMessageRecord[] {
   return extractMessageRecordsFromEventEntries(
     readSessionTranscriptMessageEvents(toTranscriptReadScope(target)),
   );
@@ -171,7 +163,7 @@ async function readSqliteHistoryMessages(target: ResolvedTranscriptReadTarget): 
 }
 
 function readSqliteMessagesSync(target: ResolvedTranscriptReadTarget): unknown[] {
-  return readSqliteMessageRecordsSync(target).map(sqliteRecordMessageWithSeq);
+  return readSqliteMessageRecords(target).map(sqliteRecordMessageWithSeq);
 }
 
 function normalizeRecentSqliteReadOptions(opts?: Partial<ReadRecentSessionMessagesOptions>) {
@@ -340,7 +332,7 @@ export async function visitSessionMessagesAsync(
 ): Promise<number> {
   const target = resolveTranscriptReadTarget(scope);
   let count = 0;
-  for (const record of await readSqliteMessageRecords(target)) {
+  for (const record of readSqliteMessageRecords(target)) {
     visit(record.message, record.seq);
     count += 1;
   }

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import { replaceTranscriptEvents } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import {
@@ -286,7 +287,7 @@ async function withGatewayHarness<T>(
 
 type SessionHistoryMessage = {
   content?: Array<{ text?: string }>;
-  __openclaw?: { id?: string; seq?: number };
+  __openclaw?: { id?: string; seq?: number; turnBoundary?: boolean };
 };
 
 type SessionHistoryBody = {
@@ -864,6 +865,14 @@ describe("session history HTTP endpoints", () => {
       expectOpenClawMetadata(body.messages?.[0]?.["__openclaw"], {
         seq: 2,
       });
+
+      const older = await readSessionHistoryBody(harness.port, "agent:main:main", {
+        query: `?limit=1&cursor=${body.nextCursor}`,
+      });
+      expect(older.messages?.map((message) => message.content?.[0]?.text)).toEqual([
+        "restored first",
+      ]);
+      expect(older.hasMore).toBe(false);
     });
   });
 
@@ -1068,6 +1077,29 @@ describe("session history HTTP endpoints", () => {
       expect(firstBody.hasMore).toBe(true);
       expect(firstBody.nextCursor).toBe("2");
 
+      const databasePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+        agentId: AGENT_ID,
+      }).path;
+      if (!databasePath) {
+        throw new Error("expected session database path");
+      }
+      runOpenClawAgentWriteTransaction(
+        (database) => {
+          const db = getNodeSqliteKysely<Pick<OpenClawAgentKyselyDatabase, "transcript_events">>(
+            database.db,
+          );
+          executeSqliteQuerySync(
+            database.db,
+            db
+              .updateTable("transcript_events")
+              .set({ event_json: "{" })
+              .where("session_id", "=", "sess-main")
+              .where("event_json", "like", "%third message%"),
+          );
+        },
+        { agentId: AGENT_ID, path: databasePath },
+      );
+
       const secondPage = await fetchSessionHistory(harness.port, "agent:main:main", {
         query: `?limit=2&cursor=${encodeURIComponent(firstBody.nextCursor ?? "")}`,
       });
@@ -1215,49 +1247,62 @@ describe("session history HTTP endpoints", () => {
     });
   });
 
-  test("backfills REST and SSE history past an all-silent bounded tail", async () => {
-    const storePath = await createSessionStoreFile();
-    const sessionId = "sess-silent-tail";
-    const sessionKey = "agent:main:main";
-    await writeSessionStore({
-      entries: { main: { sessionId, updatedAt: Date.now() } },
-      storePath,
-    });
-    await replaceTranscriptEvents({ agentId: AGENT_ID, sessionId, sessionKey, storePath }, [
-      { type: "session", version: 1, id: sessionId },
-      { message: { role: "assistant", content: "reachable older history" } },
-      ...Array.from({ length: 40 }, () => ({
-        message: { role: "assistant", content: "NO_REPLY" },
-      })),
-    ]);
-
-    await withGatewayHarness(async (harness) => {
-      const firstPage = await readSessionHistoryBody(harness.port, sessionKey, {
-        query: "?limit=1",
+  test.each([
+    { name: "all-silent tail", heartbeatBoundary: false, silentMessages: 40 },
+    { name: "heartbeat context boundary", heartbeatBoundary: true, silentMessages: 39 },
+  ])(
+    "backfills REST and SSE history past an all-silent bounded tail ($name)",
+    async ({ heartbeatBoundary, silentMessages }) => {
+      const storePath = await createSessionStoreFile();
+      const sessionId = "sess-silent-tail";
+      const sessionKey = "agent:main:main";
+      await writeSessionStore({
+        entries: { main: { sessionId, updatedAt: Date.now() } },
+        storePath,
       });
-      expect(firstPage.messages?.map((message) => message.content)).toEqual([
-        "reachable older history",
+      await replaceTranscriptEvents({ agentId: AGENT_ID, sessionId, sessionKey, storePath }, [
+        { type: "session", version: 1, id: sessionId },
+        ...(heartbeatBoundary ? [{ message: { role: "user", content: HEARTBEAT_PROMPT } }] : []),
+        { message: { role: "assistant", content: "reachable older history" } },
+        ...Array.from({ length: silentMessages }, () => ({
+          message: { role: "assistant", content: "NO_REPLY" },
+        })),
       ]);
-      expect(firstPage.hasMore).toBe(false);
-      expect(firstPage.nextCursor).toBeUndefined();
 
-      const stream = await openSessionHistorySse(harness.port, sessionKey, {
-        query: "?limit=1",
-      });
-      try {
-        const event = await readSseEvent(stream.reader, stream.streamState);
-        expect(event.event).toBe("history");
-        const history = event.data as SessionHistoryBody;
-        expect(history.messages?.map((message) => message.content)).toEqual([
+      await withGatewayHarness(async (harness) => {
+        const firstPage = await readSessionHistoryBody(harness.port, sessionKey, {
+          query: "?limit=1",
+        });
+        expect(firstPage.messages?.map((message) => message.content)).toEqual([
           "reachable older history",
         ]);
-        expect(history.hasMore).toBe(false);
-        expect(history.nextCursor).toBeUndefined();
-      } finally {
-        await stream.reader.cancel();
-      }
-    });
-  });
+        expect(firstPage.hasMore).toBe(heartbeatBoundary);
+        expect(firstPage.nextCursor).toBe(heartbeatBoundary ? "2" : undefined);
+        expect(firstPage.messages?.[0]?.["__openclaw"]?.turnBoundary === true).toBe(
+          heartbeatBoundary,
+        );
+
+        const stream = await openSessionHistorySse(harness.port, sessionKey, {
+          query: "?limit=1",
+        });
+        try {
+          const event = await readSseEvent(stream.reader, stream.streamState);
+          expect(event.event).toBe("history");
+          const history = event.data as SessionHistoryBody;
+          expect(history.messages?.map((message) => message.content)).toEqual([
+            "reachable older history",
+          ]);
+          expect(history.hasMore).toBe(heartbeatBoundary);
+          expect(history.nextCursor).toBe(heartbeatBoundary ? "2" : undefined);
+          expect(history.messages?.[0]?.["__openclaw"]?.turnBoundary === true).toBe(
+            heartbeatBoundary,
+          );
+        } finally {
+          await stream.reader.cancel();
+        }
+      });
+    },
+  );
 
   test("caps all-digit direct REST history limits that exceed safe integer range", async () => {
     const { storePath } = await seedSession({ text: "first message" });

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -218,43 +218,35 @@ export async function handleSessionHistoryHttpRequest(
     return true;
   }
   const effectiveMaxChars = DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
+  const historyTarget = {
+    agentId: target.agentId,
+    sessionEntry: entry,
+    sessionId: entry.sessionId,
+    sessionKey: target.canonicalKey,
+    storePath: target.storePath,
+  };
   let boundedSnapshot:
     | Awaited<ReturnType<typeof readBoundedSessionHistorySnapshotAsync>>
     | undefined;
   let fullSnapshot: Awaited<ReturnType<typeof readSessionMessagesWithSourceAsync>> | undefined;
   try {
     boundedSnapshot =
-      cursor === undefined && typeof limit === "number"
+      typeof limit === "number"
         ? await readBoundedSessionHistorySnapshotAsync({
-            target: {
-              agentId: target.agentId,
-              sessionEntry: entry,
-              sessionId: entry.sessionId,
-              sessionKey: target.canonicalKey,
-              storePath: target.storePath,
-            },
+            cursor,
+            target: historyTarget,
             limit,
             maxChars: effectiveMaxChars,
           })
         : undefined;
-    // Cursor reads still need an arbitrary historical window. The common first
-    // page path is bounded above so `limit=1` cannot materialize huge transcripts.
+    // Requests without a limit preserve the public complete-history contract.
     fullSnapshot =
-      boundedSnapshot === undefined && entry?.sessionId
-        ? await readSessionMessagesWithSourceAsync(
-            {
-              agentId: target.agentId,
-              sessionEntry: entry,
-              sessionId: entry.sessionId,
-              sessionKey: target.canonicalKey,
-              storePath: target.storePath,
-            },
-            {
-              mode: "full",
-              reason: "session history cursor pagination",
-              allowResetArchiveFallback: true,
-            },
-          )
+      boundedSnapshot === undefined
+        ? await readSessionMessagesWithSourceAsync(historyTarget, {
+            mode: "full",
+            reason: "session history cursor pagination",
+            allowResetArchiveFallback: true,
+          })
         : undefined;
   } catch (error) {
     if (!isSessionTranscriptProjectionUnavailableError(error)) {
@@ -274,6 +266,7 @@ export async function handleSessionHistoryHttpRequest(
   const rawSnapshot = boundedSnapshot?.messages ?? fullSnapshot?.messages ?? [];
   if (!shouldStreamSse(req)) {
     const history = buildSessionHistorySnapshot({
+      projection: boundedSnapshot?.projection,
       rawMessages: rawSnapshot,
       maxChars: effectiveMaxChars,
       limit,
@@ -288,27 +281,20 @@ export async function handleSessionHistoryHttpRequest(
     return true;
   }
 
-  const transcriptCandidates = entry?.sessionId
-    ? new Set(
-        resolveSessionTranscriptCandidates(
-          entry.sessionId,
-          target.storePath,
-          undefined,
-          target.agentId,
-        )
-          .map((candidate) => resolveTranscriptPathForComparison(candidate))
-          .filter((candidate): candidate is string => typeof candidate === "string"),
-      )
-    : new Set<string>();
+  const transcriptCandidates = new Set(
+    resolveSessionTranscriptCandidates(
+      historyTarget.sessionId,
+      target.storePath,
+      undefined,
+      target.agentId,
+    )
+      .map((candidate) => resolveTranscriptPathForComparison(candidate))
+      .filter((candidate): candidate is string => typeof candidate === "string"),
+  );
 
   const sseState = SessionHistorySseState.fromRawSnapshot({
-    target: {
-      agentId: target.agentId,
-      sessionEntry: entry,
-      sessionId: entry.sessionId,
-      sessionKey: target.canonicalKey,
-      storePath: target.storePath,
-    },
+    projection: boundedSnapshot?.projection,
+    target: historyTarget,
     rawMessages: rawSnapshot,
     rawTranscriptSeq: boundedSnapshot?.totalMessages,
     totalRawMessages: boundedSnapshot?.totalMessages,
@@ -494,11 +480,8 @@ export async function handleSessionHistoryHttpRequest(
     // transcript write in the gateway would otherwise append a Promise-chain
     // entry capturing `update.message` to every open SSE stream's queue —
     // O(streams × updates) for busy deployments.
-    if (!entry?.sessionId) {
-      return;
-    }
     const updateMatchesIdentity =
-      update.target?.sessionId === entry.sessionId &&
+      update.target?.sessionId === historyTarget.sessionId &&
       normalizeAgentId(update.target.agentId) === normalizeAgentId(target.agentId);
     const updatePath = resolveTranscriptPathForComparison(update.sessionFile);
     if (!updateMatchesIdentity && (!updatePath || !transcriptCandidates.has(updatePath))) {

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -219,7 +219,6 @@ vi.mock("../config/sessions/startup-migration.js", () => ({
 
 vi.mock("../gateway/chat-display-projection.js", () => ({
   projectChatDisplayMessages: (messages: unknown[]) => messages,
-  projectRecentChatDisplayMessages: (messages: unknown[]) => messages,
   resolveEffectiveChatHistoryMaxChars: () => 100_000,
 }));
 


### PR DESCRIPTION
Related: #128844, #128810

## What Problem This Solves

Fixes an issue where users paging backward through chat history could receive a 500 error, unnecessary transcript-wide reads, or inconsistent turn boundaries when newer unrelated transcript events were malformed or filtered. Long sessions containing many silent entries also performed repeated projection work across HTTP, server-sent events, WebSocket chat, and embedded history.

## Why This Change Was Made

Read explicitly limited older pages through the existing indexed transcript scanner, using the authoritative logical display-sequence count to derive the bounded offset. Carry the already prepared display projection across the shared history boundary, grow sparse scans adaptively, and remove superseded projection and transcript-reader wrappers. Reset archives and events sharing a display sequence keep their existing semantics.

This is a follow-up to #128844 and #128810: the transcript remains the single source of truth. There are no transcript copies, new SQLite tables, schema-version changes, protocol changes, or configuration changes. Production code shrinks by 44 lines while regression coverage grows.

## User Impact

Older chat pages load without traversing unrelated newer transcript content, HTTP and live event streams consistently preserve turn boundaries, and silent-entry-heavy history is substantially faster. A 4,040-entry representative sparse transcript drops from 41 projection passes and 83,640 projected rows to 13 passes and 25,620 rows, improving approximately 94 ms to 25 ms (about 3.7x faster).

## Evidence

- 659 tests passed against the current main baseline, including real listening Gateway HTTP, authenticated bearer access, revocation, WebSocket history, SSE streaming and refresh, reset archives, SQLite query plans, embedded-agent history, and the TUI.
- The live HTTP regression first reproduces an older-page 500 by poisoning an unrelated newest SQLite transcript row, then proves the repaired owner returns 200 with the requested older page.
- Real Gateway HTTP and SSE regressions both confirm filtered-heartbeat overread retains the same turn-boundary metadata.
- Eight real Chromium browser suites passed all 46 history-recovery, session-management, geometry, disclosure, redaction, messaging, and streaming checks. Browser suites exercise the real UI with mocked Gateway transport; the listening-Gateway suites above exercise the real backend transports.
- Independent structured review returned clean. Focused TypeScript, formatting, lint, dead-export, import-cycle, database-first, and unchanged-schema checks passed.

```text
Production: +129/-173 (net -44)
Tests:      +167/-130 (net +37)
SQLite:     no new tables; no schema changes
```
