### PR TITLE
fix(gateway): settle live fixtures before Codex reconnects

### DIFF
--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -709,7 +709,6 @@ async function writeLiveGatewayConfig(params: {
       },
       entries: {
         dev: {
-          default: true,
           workspace: params.workspace,
           thinkingDefault: CODEX_HARNESS_THINKING,
           model: { primary: params.modelKey },
@@ -2156,6 +2155,7 @@ describeLive("gateway live (Codex harness)", () => {
           auth: { mode: "token", token },
           controlUiEnabled: false,
         });
+        await server.startupSettled;
         client = await connectTestGatewayClient({
           url: `ws://127.0.0.1:${port}`,
           token,

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -2480,6 +2480,7 @@ describeLive("gateway live (Codex harness)", () => {
               auth: { mode: "token", token },
               controlUiEnabled: false,
             });
+            await server.startupSettled;
             client = await connectTestGatewayClient({
               url: `ws://127.0.0.1:${port}`,
               token,

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1867,7 +1867,7 @@ describe("buildLiveGatewayConfig", () => {
     const cfg = buildLiveGatewayConfig({
       cfg: {
         agents: {
-          entries: { ops: { default: true } },
+          entries: { ops: {} },
         },
         bindings: [{ agentId: "ops", match: { channel: "telegram" } }],
         broadcast: {
@@ -1898,7 +1898,6 @@ describe("buildLiveGatewayConfig", () => {
         agents: {
           entries: {
             dev: {
-              default: true,
               agentDir: "/operator/agent",
               workspace: "/operator/workspace",
             },

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1882,7 +1882,6 @@ describe("buildLiveGatewayConfig", () => {
 
     expect(cfg.agents?.entries).toEqual({
       [GATEWAY_LIVE_AGENT_ID]: {
-        default: true,
         agentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
         workspace: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
         sandbox: { mode: "off" },
@@ -1911,7 +1910,6 @@ describe("buildLiveGatewayConfig", () => {
 
     expect(cfg.agents?.entries).toEqual({
       [GATEWAY_LIVE_AGENT_ID]: {
-        default: true,
         agentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
         workspace: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
         sandbox: { mode: "off" },
@@ -4735,7 +4733,6 @@ function buildLiveGatewayConfig(params: {
   const providers = Object.keys(nextProviders).length > 0 ? nextProviders : baseProviders;
   const configuredAgents = {
     [GATEWAY_LIVE_AGENT_ID]: {
-      default: true,
       agentDir: params.liveAgentDir,
       workspace: params.liveAgentWorkspaceDir,
       sandbox: { mode: "off" },

--- a/src/gateway/gateway-trajectory-export.live.test.ts
+++ b/src/gateway/gateway-trajectory-export.live.test.ts
@@ -109,7 +109,7 @@ async function writeLiveGatewayConfig(params: {
     commands: { ownerAllowFrom: ["*"] },
     plugins: { allow: ["codex"] },
     agents: {
-      entries: { dev: { default: true, tools: { exec: { host: "node" } } } },
+      entries: { dev: { tools: { exec: { host: "node" } } } },
       defaults: {
         workspace: params.workspace,
         skipBootstrap: true,

--- a/src/gateway/gateway.compaction-hot-reload.e2e.test.ts
+++ b/src/gateway/gateway.compaction-hot-reload.e2e.test.ts
@@ -186,7 +186,7 @@ describe("gateway compaction hot reload", () => {
                 memoryFlush: { enabled: false },
               },
             },
-            entries: { dev: { default: true } },
+            entries: { dev: {} },
           },
           models: {
             mode: "replace",

--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -29,8 +29,13 @@ import {
   createContractsVitestConfig,
   pluginContractPatterns,
 } from "./vitest/vitest.contracts-shared.ts";
+import { createGatewayMethodsIsolatedVitestConfig } from "./vitest/vitest.gateway-methods-isolated.config.ts";
+import { createGatewayMethodsVitestConfig } from "./vitest/vitest.gateway-methods.config.ts";
 import { createGatewayServerIsolatedVitestConfig } from "./vitest/vitest.gateway-server-isolated.config.ts";
-import { gatewayServerIsolatedTestFiles } from "./vitest/vitest.gateway-server-paths.mjs";
+import {
+  gatewayMethodsIsolatedTestFiles,
+  gatewayServerIsolatedTestFiles,
+} from "./vitest/vitest.gateway-server-paths.mjs";
 import { createGatewayVitestConfig } from "./vitest/vitest.gateway.config.ts";
 import { createPluginSdkLightVitestConfig } from "./vitest/vitest.plugin-sdk-light.config.ts";
 import {
@@ -45,6 +50,7 @@ import unitFastRootConfig from "./vitest/vitest.unit-fast-root.config.ts";
 import { createUnitFastVitestConfig } from "./vitest/vitest.unit-fast.config.ts";
 
 const patternFiles = createPatternFileHelper("openclaw-vitest-projects-config-");
+const scopedGatewayMethodsIsolatedTestFiles = ["server-methods/agent.test.ts"];
 
 function requireTestConfig<T extends { test?: unknown }>(config: T): NonNullable<T["test"]> {
   if (!config.test) {
@@ -82,23 +88,37 @@ describe("projects vitest config", () => {
     expect(agentConfigs.size).toBe(agentVitestProjectConfigs.length);
   });
 
-  it("keeps module-mocking Gateway server tests isolated in every aggregate", () => {
-    const isolatedProject = "test/vitest/vitest.gateway-server-isolated.config.ts";
+  it("keeps module-mocking Gateway tests isolated in every aggregate", () => {
+    const methodsIsolatedProject = "test/vitest/vitest.gateway-methods-isolated.config.ts";
+    const serverIsolatedProject = "test/vitest/vitest.gateway-server-isolated.config.ts";
     const agenticShard = fullSuiteVitestShards.find((shard) => shard.name === "agentic");
-    const isolatedConfig = requireTestConfig(createGatewayServerIsolatedVitestConfig({}));
+    const methodsConfig = requireTestConfig(createGatewayMethodsVitestConfig({}));
+    const methodsIsolatedConfig = requireTestConfig(createGatewayMethodsIsolatedVitestConfig({}));
+    const serverIsolatedConfig = requireTestConfig(createGatewayServerIsolatedVitestConfig({}));
     const gatewayFallback = requireTestConfig(createGatewayVitestConfig());
 
-    expect(rootVitestProjects).toContain(isolatedProject);
-    expect(agenticShard?.projects).toContain(isolatedProject);
-    expect(isolatedConfig.isolate).toBe(true);
-    expect(isolatedConfig.runner).toBeUndefined();
-    expect(isolatedConfig.include).toEqual(gatewayServerIsolatedTestFiles);
+    expect(rootVitestProjects).toContain(methodsIsolatedProject);
+    expect(rootVitestProjects).toContain(serverIsolatedProject);
+    expect(agenticShard?.projects).toContain(methodsIsolatedProject);
+    expect(agenticShard?.projects).toContain(serverIsolatedProject);
+    expect(methodsIsolatedConfig.isolate).toBe(true);
+    expect(normalizeConfigPath(methodsIsolatedConfig.runner)).toBe("test/non-isolated-runner.ts");
+    expect(methodsIsolatedConfig.include).toEqual(scopedGatewayMethodsIsolatedTestFiles);
+    expect(serverIsolatedConfig.isolate).toBe(true);
+    expect(serverIsolatedConfig.runner).toBeUndefined();
+    expect(serverIsolatedConfig.include).toEqual(gatewayServerIsolatedTestFiles);
+    expect(methodsConfig.exclude).toContain("server-methods/agent.test.ts");
+    expect(gatewayFallback.exclude).toContain("server-methods/agent.test.ts");
     expect(gatewayFallback.exclude).toContain("server.sessions.compaction-read-errors.test.ts");
   });
 
-  it("limits isolated Gateway include files to the project's owned tests", () => {
+  it("limits isolated Gateway include files to each project's owned tests", () => {
     const unrelatedTest = "src/gateway/worker-environments/workspace-sync-scripts.test.ts";
-    const mixedIncludeFile = patternFiles.writePatternFile("mixed-include.json", [
+    const methodsIncludeFile = patternFiles.writePatternFile("methods-mixed-include.json", [
+      ...gatewayMethodsIsolatedTestFiles,
+      unrelatedTest,
+    ]);
+    const serverIncludeFile = patternFiles.writePatternFile("server-mixed-include.json", [
       ...gatewayServerIsolatedTestFiles,
       unrelatedTest,
     ]);
@@ -108,11 +128,25 @@ describe("projects vitest config", () => {
 
     expect(
       requireTestConfig(
+        createGatewayMethodsIsolatedVitestConfig({
+          OPENCLAW_VITEST_INCLUDE_FILE: methodsIncludeFile,
+        }),
+      ).include,
+    ).toEqual(scopedGatewayMethodsIsolatedTestFiles);
+    expect(
+      requireTestConfig(
         createGatewayServerIsolatedVitestConfig({
-          OPENCLAW_VITEST_INCLUDE_FILE: mixedIncludeFile,
+          OPENCLAW_VITEST_INCLUDE_FILE: serverIncludeFile,
         }),
       ).include,
     ).toEqual(gatewayServerIsolatedTestFiles);
+    expect(
+      requireTestConfig(
+        createGatewayMethodsIsolatedVitestConfig({
+          OPENCLAW_VITEST_INCLUDE_FILE: unrelatedIncludeFile,
+        }),
+      ).include,
+    ).toEqual([]);
     expect(
       requireTestConfig(
         createGatewayServerIsolatedVitestConfig({

--- a/test/vitest/vitest.config.ts
+++ b/test/vitest/vitest.config.ts
@@ -24,6 +24,7 @@ const rootVitestProjects = [
   "test/vitest/vitest.gateway-core.config.ts",
   "test/vitest/vitest.gateway-client.config.ts",
   "test/vitest/vitest.gateway-methods.config.ts",
+  "test/vitest/vitest.gateway-methods-isolated.config.ts",
   "test/vitest/vitest.gateway-server.config.ts",
   "test/vitest/vitest.gateway-server-isolated.config.ts",
   "test/vitest/vitest.hooks.config.ts",

--- a/test/vitest/vitest.gateway-methods-isolated.config.ts
+++ b/test/vitest/vitest.gateway-methods-isolated.config.ts
@@ -1,0 +1,20 @@
+// Vitest Gateway methods isolated config gives deep module mocks a fresh graph
+// while retaining the shared Gateway methods runner and setup.
+import { gatewayMethodsIsolatedTestFiles } from "./vitest.gateway-server-paths.mjs";
+import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
+
+export function createGatewayMethodsIsolatedVitestConfig(
+  env: Record<string, string | undefined> = process.env,
+) {
+  return createScopedVitestConfig(gatewayMethodsIsolatedTestFiles, {
+    dir: "src/gateway",
+    env,
+    intersectIncludeFile: true,
+    isolate: true,
+    name: "gateway-methods-isolated",
+    passWithNoTests: true,
+    useNonIsolatedRunner: true,
+  });
+}
+
+export default createGatewayMethodsIsolatedVitestConfig();

--- a/test/vitest/vitest.gateway-methods.config.ts
+++ b/test/vitest/vitest.gateway-methods.config.ts
@@ -1,10 +1,12 @@
 // Vitest gateway methods config wires the gateway methods test shard.
+import { gatewayMethodsIsolatedTestFiles } from "./vitest.gateway-server-paths.mjs";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
 export function createGatewayMethodsVitestConfig(env?: Record<string, string | undefined>) {
   return createScopedVitestConfig(["src/gateway/server-methods/**/*.test.ts"], {
     dir: "src/gateway",
     env,
+    exclude: gatewayMethodsIsolatedTestFiles,
     // Gateway child projects share one include file; preserve this project's ownership.
     intersectIncludeFile: true,
     name: "gateway-methods",

--- a/test/vitest/vitest.gateway-server-isolated.config.ts
+++ b/test/vitest/vitest.gateway-server-isolated.config.ts
@@ -1,5 +1,5 @@
-// Vitest gateway server isolated config wires module-mocking Gateway tests out of
-// the shared module cache.
+// Vitest gateway isolated config wires module-mocking Gateway tests out of the
+// shared module cache.
 import { defineConfig } from "vitest/config";
 import { gatewayServerIsolatedTestFiles } from "./vitest.gateway-server-paths.mjs";
 import {

--- a/test/vitest/vitest.gateway-server-paths.d.mts
+++ b/test/vitest/vitest.gateway-server-paths.d.mts
@@ -1,3 +1,4 @@
+export const gatewayMethodsIsolatedTestFiles: string[];
 export const gatewayServerBackedHttpTestFiles: string[];
 export const gatewayServerExcludedTestFiles: string[];
 export const gatewayServerIsolatedTestFiles: string[];

--- a/test/vitest/vitest.gateway-server-paths.mjs
+++ b/test/vitest/vitest.gateway-server-paths.mjs
@@ -7,11 +7,12 @@ export const gatewayServerBackedHttpTestFiles = [
   "src/gateway/probe.auth.integration.test.ts",
 ];
 
+// Gateway method tests whose deep module mocks can be defeated by a neighbour's
+// shared cache. These keep the shared methods runner but use a fresh module graph.
+export const gatewayMethodsIsolatedTestFiles = ["src/gateway/server-methods/agent.test.ts"];
+
 // Gateway server tests that replace a module the Gateway reaches only through
-// re-exports. `gateway-server` is `isolate: false`, so a neighbour that boots a
-// full Gateway leaves those importers bound to the real implementation and the
-// mock silently never fires. These run in `gateway-server-isolated` instead,
-// which gives each file a fresh module graph.
+// re-exports. These need both a fresh graph and the plain Vitest runner.
 export const gatewayServerIsolatedTestFiles = [
   "src/gateway/server.sessions.compaction-read-errors.test.ts",
 ];

--- a/test/vitest/vitest.gateway.config.ts
+++ b/test/vitest/vitest.gateway.config.ts
@@ -1,4 +1,7 @@
-import { gatewayServerIsolatedTestFiles } from "./vitest.gateway-server-paths.mjs";
+import {
+  gatewayMethodsIsolatedTestFiles,
+  gatewayServerIsolatedTestFiles,
+} from "./vitest.gateway-server-paths.mjs";
 // Vitest gateway config wires the gateway test shard.
 import { createProjectShardVitestConfig } from "./vitest.project-shard-config.ts";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
@@ -7,6 +10,7 @@ const gatewayProjectConfigs = [
   "test/vitest/vitest.gateway-core.config.ts",
   "test/vitest/vitest.gateway-client.config.ts",
   "test/vitest/vitest.gateway-methods.config.ts",
+  "test/vitest/vitest.gateway-methods-isolated.config.ts",
   "test/vitest/vitest.gateway-server.config.ts",
   "test/vitest/vitest.gateway-server-isolated.config.ts",
 ] as const;
@@ -19,6 +23,7 @@ export function createGatewayVitestConfig(env?: Record<string, string | undefine
       "src/gateway/gateway.test.ts",
       "src/gateway/server.startup-matrix-migration.integration.test.ts",
       "src/gateway/sessions-history-http.test.ts",
+      ...gatewayMethodsIsolatedTestFiles,
       ...gatewayServerIsolatedTestFiles,
     ],
     name: "gateway",

--- a/test/vitest/vitest.scoped-config.ts
+++ b/test/vitest/vitest.scoped-config.ts
@@ -142,6 +142,7 @@ const SCOPED_PROJECT_GROUP_ORDER_BY_NAME = new Map(
     "extension-zalo",
     "extensions",
     "gateway",
+    "gateway-methods-isolated",
     "hooks",
     "infra",
     "logging",

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -106,6 +106,7 @@ export const fullSuiteVitestShards = [
       "test/vitest/vitest.gateway-core.config.ts",
       "test/vitest/vitest.gateway-client.config.ts",
       "test/vitest/vitest.gateway-methods.config.ts",
+      "test/vitest/vitest.gateway-methods-isolated.config.ts",
       "test/vitest/vitest.gateway-server.config.ts",
       "test/vitest/vitest.gateway-server-isolated.config.ts",
       "test/vitest/vitest.cli-process.config.ts",


### PR DESCRIPTION
Related: #127710

## What Problem This Solves

Fixes an issue where release validation could connect a Codex backend before the Gateway had finished mandatory sidecar startup, producing fixture-induced missing prepared-runtime failures during initial connection or restart/resume checks. The same live fixtures also serialized retired per-agent `default` markers and therefore exercised migration code instead of the canonical keyed-agent configuration.

## Why This Change Was Made

Codex live validation now awaits the Gateway-owned `startupSettled` promise after every start and before each client connection. All remaining serialized live Gateway configs use keyed agent entries without retired default markers. The already-landed CLI fixture slice is no longer part of this branch, and no production runtime behavior changes.

## User Impact

Maintainers can trust the affected release checks to validate prepared-runtime publication and restart/resume behavior rather than fixture startup races or legacy config normalization. This PR does not claim to fix the separate production race discussed in #127710.

## Evidence

- Immutable failure: [release checks run 32766198480](https://github.com/openclaw/openclaw/actions/runs/32766198480) recorded a real Codex child as succeeded while parent delivery remained pending with the prepared reply dispatch runtime unavailable.
- Real-behavior proof on the earlier equivalent startup-settlement head:
  - [Targeted restart/resume run 32827223494](https://github.com/openclaw/openclaw/actions/runs/32827223494) passed the real Codex harness across three complete Gateway restarts.
  - [Combined subagent-delivery and restart/resume run 32827737717](https://github.com/openclaw/openclaw/actions/runs/32827737717) passed full Gateway startup, native Codex turns, parent delivery, and repeated thread resume.
  - ClawSweeper marked this linked Testbox proof sufficient.
- Current rebased head:
  - direct canonical config-builder proof: 13/13 passed, with 132 provider cases intentionally excluded from the focused run;
  - `gateway.compaction-hot-reload.e2e.test.ts`: 1/1 passed against the built CLI and full Gateway path;
  - exact-head CI run https://github.com/openclaw/openclaw/actions/runs/32905507930 exposed a shared-module-cache collision in `agent.test.ts`: the Gateway methods project could bind production imports before the suite's deep mocks. The canonical failed-job rerun expanded the same leak to 11 selected-agent/session failures;
  - `agent.test.ts` now owns a dedicated isolated Gateway-methods project that retains the shared runner and setup. The complete 284-test suite passes in 35 seconds, and the 23-test project ownership audit passes;
  - `pnpm check:changed` passed after the routing repair;
  - fresh Codex autoreview reported no accepted/actionable findings.
- Exact Codex contract inspected at `97729885d4707a123db31ae80f5fb0eeda6b7706`:
  - `codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs:124-139` binds spawned agents to the parent thread and turn;
  - `codex-rs/app-server/src/bespoke_event_handling.rs:1277-1302` emits terminal turn status and final agent message through `TurnCompleted`.
- Both ClawSweeper rank-up moves are complete: `buildLiveGatewayConfig` no longer emits the retired marker, and the reduced branch is rebased and re-proved on current `main`.
- An attempted full provider-file run passed 144 tests but its single provider-matrix case exceeded the existing 180-second models.json setup budget after 294 seconds; the focused builder proof above avoids that unrelated live-provider setup lane.

LOC classification against current `main`:

- production: 0;
- tests/live-test support and CI routing: +90/-27 (net +63).

AI-assisted. I reviewed the Gateway lifecycle owner, every changed fixture, the exact Codex protocol source, and the validation results.