### PR TITLE
improve(ci): add trusted FRV proof broker

### DIFF
--- a/.github/workflows/frv-proof-broker.yml
+++ b/.github/workflows/frv-proof-broker.yml
@@ -1,5 +1,5 @@
 name: FRV Proof Broker
-run-name: FRV Proof Broker PR #${{ inputs.pr_number }} ${{ inputs.correlation }}
+run-name: FRV Proof Broker PR #${{ inputs.pr_number }} run ${{ github.run_id }}
 
 on:
   workflow_dispatch:
@@ -12,11 +12,6 @@ on:
         description: Exact lowercase 40-character pull request head SHA
         required: true
         type: string
-      correlation:
-        description: Unique operator correlation identifier
-        required: true
-        type: string
-
 permissions: {}
 
 concurrency:
@@ -30,6 +25,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       actions: write
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout trusted main broker
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/frv-proof-broker.yml
+++ b/.github/workflows/frv-proof-broker.yml
@@ -1,0 +1,59 @@
+name: FRV Proof Broker
+run-name: FRV Proof Broker PR #${{ inputs.pr_number }} ${{ inputs.correlation }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Open OpenClaw pull request containing the FRV recovery candidate
+        required: true
+        type: string
+      head_sha:
+        description: Exact lowercase 40-character pull request head SHA
+        required: true
+        type: string
+      correlation:
+        description: Unique operator correlation identifier
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: frv-proof-broker
+  cancel-in-progress: false
+
+jobs:
+  prove:
+    name: Prove failed-job rerun boundary
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      actions: write
+    steps:
+      - name: Checkout trusted main broker
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: Run trusted FRV proof broker
+        id: proof
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FRV_PROOF_RECEIPT: ${{ runner.temp }}/frv-proof-receipt.json
+        run: node scripts/frv-proof-broker.mjs
+
+      - name: Upload proof receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: frv-proof-${{ github.run_id }}
+          path: ${{ steps.proof.outputs.receipt_path }}
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/frv-proof-fixture.yml
+++ b/.github/workflows/frv-proof-fixture.yml
@@ -1,0 +1,47 @@
+name: FRV Proof Fixture
+run-name: FRV Proof Fixture [${{ inputs.operation }}] ${{ inputs.correlation }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Fixed harmless operation used by the FRV recovery proof
+        required: true
+        default: noop
+        type: choice
+        options:
+          - noop
+      correlation:
+        description: Broker-generated correlation identifier
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  fixture:
+    name: Fail once, then pass
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Exercise failed-job rerun
+        env:
+          CORRELATION: ${{ inputs.correlation }}
+          OPERATION: ${{ inputs.operation }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          [[ "$OPERATION" == "noop" ]] || {
+            echo "FRV proof fixture accepts only the fixed noop operation." >&2
+            exit 2
+          }
+          [[ "$CORRELATION" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$ ]] || {
+            echo "FRV proof fixture correlation is invalid." >&2
+            exit 2
+          }
+          if [[ "$RUN_ATTEMPT" == "1" ]]; then
+            echo "Intentional first-attempt failure for $CORRELATION." >&2
+            exit 42
+          fi
+          echo "No-op fixture passed on rerun attempt $RUN_ATTEMPT."

--- a/scripts/frv-proof-broker.d.mts
+++ b/scripts/frv-proof-broker.d.mts
@@ -1,0 +1,53 @@
+export type BrokerContext = {
+  actor: string;
+  correlation: string;
+  headSha: string;
+  prNumber: number;
+  repository: "openclaw/openclaw";
+  runId: number;
+  workflowSha: string;
+};
+
+export type GitHubApi = {
+  request(method: string, path: string, body?: unknown): Promise<unknown>;
+};
+
+export type FixtureRunExpectation = {
+  attempt: number;
+  branch: string;
+  conclusion: "failure" | "success";
+  correlation: string;
+  headSha: string;
+  repository: string;
+  runId?: number;
+};
+
+export type ProofReceipt = {
+  actor: string;
+  correlation: string;
+  fixtureRunAttempt: 2;
+  fixtureRunId: number;
+  headSha: string;
+  operation: "noop";
+  prNumber: number;
+  repository: "openclaw/openclaw";
+  sourceRef: "refs/heads/main";
+  workflowSha: string;
+};
+
+export function validateBrokerRequest(event: unknown, env: NodeJS.ProcessEnv): BrokerContext;
+export function validateFixtureRun(
+  value: unknown,
+  expected: FixtureRunExpectation,
+): Record<string, unknown>;
+export function runProofBroker(options: {
+  api: GitHubApi;
+  env: NodeJS.ProcessEnv;
+  event: unknown;
+  sleep?: (milliseconds: number) => Promise<void>;
+}): Promise<ProofReceipt>;
+export function createGitHubApi(options: {
+  repository: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+}): GitHubApi;

--- a/scripts/frv-proof-broker.mjs
+++ b/scripts/frv-proof-broker.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const REPOSITORY = "openclaw/openclaw";
+const BROKER_WORKFLOW = ".github/workflows/frv-proof-broker.yml";
+const FIXTURE_WORKFLOW = ".github/workflows/frv-proof-fixture.yml";
+const FIXTURE_WORKFLOW_ID = "frv-proof-fixture.yml";
+const FIXTURE_NAME = "FRV Proof Fixture";
+const FIXTURE_OPERATION = "noop";
+const SHA_PATTERN = /^[0-9a-f]{40}$/u;
+const CORRELATION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u;
+const POLL_INTERVAL_MS = 5_000;
+const POLL_LIMIT = 120;
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+function requiredPositiveInteger(value, label) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return number;
+}
+
+function assertExactKeys(value, expected, label) {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const compare = (left, right) => left.localeCompare(right);
+  const actual = Object.keys(value).toSorted(compare);
+  const wanted = [...expected].toSorted(compare);
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    throw new Error(`${label} keys must be exactly: ${wanted.join(", ")}`);
+  }
+}
+
+function requiredEnv(env, name) {
+  return requiredString(env[name], name);
+}
+
+export function validateBrokerRequest(event, env) {
+  if (!isRecord(event)) {
+    throw new Error("GITHUB_EVENT_PATH must contain an object");
+  }
+  const repository = requiredEnv(env, "GITHUB_REPOSITORY");
+  if (repository !== REPOSITORY) {
+    throw new Error(`FRV proof broker requires repository ${REPOSITORY}`);
+  }
+  if (requiredEnv(env, "GITHUB_EVENT_NAME") !== "workflow_dispatch") {
+    throw new Error("FRV proof broker requires workflow_dispatch");
+  }
+  if (requiredEnv(env, "GITHUB_REF") !== "refs/heads/main") {
+    throw new Error("FRV proof broker must run from refs/heads/main");
+  }
+  const workflowSha = requiredEnv(env, "GITHUB_WORKFLOW_SHA");
+  const eventSha = requiredEnv(env, "GITHUB_SHA");
+  if (!SHA_PATTERN.test(workflowSha) || workflowSha !== eventSha) {
+    throw new Error("FRV proof broker requires one exact trusted workflow SHA");
+  }
+  const expectedWorkflowRef = `${REPOSITORY}/${BROKER_WORKFLOW}@refs/heads/main`;
+  if (requiredEnv(env, "GITHUB_WORKFLOW_REF") !== expectedWorkflowRef) {
+    throw new Error(`FRV proof broker requires ${expectedWorkflowRef}`);
+  }
+  const actor = requiredEnv(env, "GITHUB_ACTOR");
+  if (actor !== requiredEnv(env, "GITHUB_TRIGGERING_ACTOR")) {
+    throw new Error("FRV proof broker actor must match the triggering actor");
+  }
+  const runId = requiredPositiveInteger(requiredEnv(env, "GITHUB_RUN_ID"), "GITHUB_RUN_ID");
+
+  assertExactKeys(event.inputs, ["correlation", "head_sha", "pr_number"], "workflow inputs");
+  const inputs = event.inputs;
+  const prNumber = requiredPositiveInteger(inputs.pr_number, "pr_number");
+  const headSha = requiredString(inputs.head_sha, "head_sha");
+  if (!SHA_PATTERN.test(headSha)) {
+    throw new Error("head_sha must be exactly 40 lowercase hex characters");
+  }
+  const correlation = requiredString(inputs.correlation, "correlation");
+  if (!CORRELATION_PATTERN.test(correlation)) {
+    throw new Error("correlation must be 1-64 safe identifier characters");
+  }
+
+  return {
+    actor,
+    correlation,
+    headSha,
+    prNumber,
+    repository: REPOSITORY,
+    runId,
+    workflowSha,
+  };
+}
+
+function record(value, label) {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function nestedRecord(value, key, label) {
+  return record(record(value, label)[key], `${label}.${key}`);
+}
+
+function validateActorPermission(value, actor) {
+  const permission = requiredString(record(value, "actor permission").permission, "permission");
+  if (!new Set(["admin", "maintain", "write"]).has(permission)) {
+    throw new Error(`actor ${actor} lacks repository write permission`);
+  }
+}
+
+function validatePullRequest(value, context) {
+  const pull = record(value, "pull request");
+  if (pull.number !== context.prNumber || pull.state !== "open") {
+    throw new Error("proof target must be the requested open pull request");
+  }
+  if (nestedRecord(pull, "head", "pull request").sha !== context.headSha) {
+    throw new Error("pull request head SHA does not match the requested exact head");
+  }
+  if (nestedRecord(pull, "head", "pull request").repo?.full_name !== context.repository) {
+    throw new Error("pull request head must belong to the trusted repository");
+  }
+  if (nestedRecord(pull, "base", "pull request").ref !== "main") {
+    throw new Error("pull request base must be main");
+  }
+  if (nestedRecord(pull, "base", "pull request").repo?.full_name !== context.repository) {
+    throw new Error("pull request base repository does not match");
+  }
+}
+
+function validateFixtureWorkflow(value) {
+  const workflow = record(value, "fixture workflow");
+  if (
+    workflow.name !== FIXTURE_NAME ||
+    workflow.path !== FIXTURE_WORKFLOW ||
+    workflow.state !== "active"
+  ) {
+    throw new Error("fixture workflow identity does not match the fixed active workflow");
+  }
+  requiredPositiveInteger(workflow.id, "fixture workflow id");
+}
+
+function validateMainRef(value, workflowSha) {
+  const ref = record(value, "main ref");
+  if (ref.ref !== "refs/heads/main") {
+    throw new Error("main ref identity does not match");
+  }
+  const mainSha = requiredString(nestedRecord(ref, "object", "main ref").sha, "main ref SHA");
+  if (!SHA_PATTERN.test(mainSha) || mainSha !== workflowSha) {
+    throw new Error("trusted main moved before fixture dispatch");
+  }
+}
+
+export function validateFixtureRun(value, expected) {
+  const run = record(value, "fixture run");
+  if (nestedRecord(run, "repository", "fixture run").full_name !== expected.repository) {
+    throw new Error("fixture run repository does not match");
+  }
+  if (run.path !== FIXTURE_WORKFLOW) {
+    throw new Error("fixture run workflow does not match");
+  }
+  if (run.head_sha !== expected.headSha || run.head_branch !== expected.branch) {
+    throw new Error("fixture run source does not match the trusted main workflow SHA");
+  }
+  if (run.event !== "workflow_dispatch") {
+    throw new Error("fixture run event does not match");
+  }
+  const expectedTitle = `${FIXTURE_NAME} [${FIXTURE_OPERATION}] ${expected.correlation}`;
+  if (run.display_title !== expectedTitle) {
+    throw new Error("fixture run operation or correlation does not match");
+  }
+  const runId = requiredPositiveInteger(run.id, "fixture run id");
+  if (expected.runId !== undefined && runId !== expected.runId) {
+    throw new Error("fixture run id changed");
+  }
+  if (requiredPositiveInteger(run.run_attempt, "fixture run attempt") !== expected.attempt) {
+    throw new Error("fixture run attempt does not match");
+  }
+  if (run.status !== "completed" || run.conclusion !== expected.conclusion) {
+    throw new Error(`fixture run must complete with ${expected.conclusion}`);
+  }
+  return run;
+}
+
+function fixtureRunIdentityMatches(value, context) {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    value.head_branch === "main" &&
+    value.event === "workflow_dispatch" &&
+    value.display_title === `${FIXTURE_NAME} [${FIXTURE_OPERATION}] ${context.correlation}`
+  );
+}
+
+async function waitForInitialRun(api, context, sleep) {
+  const branch = encodeURIComponent("main");
+  for (let poll = 0; poll < POLL_LIMIT; poll += 1) {
+    const response = record(
+      await api.request(
+        "GET",
+        `/actions/workflows/${FIXTURE_WORKFLOW_ID}/runs?event=workflow_dispatch&branch=${branch}&per_page=20`,
+      ),
+      "fixture workflow runs",
+    );
+    const runs = response.workflow_runs;
+    if (!Array.isArray(runs)) {
+      throw new Error("fixture workflow runs response is invalid");
+    }
+    const candidate = runs.find((run) => fixtureRunIdentityMatches(run, context));
+    if (candidate) {
+      const run = record(candidate, "fixture run");
+      if (run.status !== "completed") {
+        await sleep(POLL_INTERVAL_MS);
+        continue;
+      }
+      return validateFixtureRun(run, {
+        attempt: 1,
+        branch: "main",
+        conclusion: "failure",
+        correlation: context.correlation,
+        headSha: context.workflowSha,
+        repository: context.repository,
+      });
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error("timed out waiting for the broker-owned fixture run");
+}
+
+async function waitForRerun(api, context, fixtureRunId, sleep) {
+  for (let poll = 0; poll < POLL_LIMIT; poll += 1) {
+    const run = record(await api.request("GET", `/actions/runs/${fixtureRunId}`), "fixture run");
+    const attempt = requiredPositiveInteger(run.run_attempt, "fixture run attempt");
+    if (attempt < 2 || run.status !== "completed") {
+      await sleep(POLL_INTERVAL_MS);
+      continue;
+    }
+    return validateFixtureRun(run, {
+      attempt: 2,
+      branch: "main",
+      conclusion: "success",
+      correlation: context.correlation,
+      headSha: context.workflowSha,
+      repository: context.repository,
+      runId: fixtureRunId,
+    });
+  }
+  throw new Error("timed out waiting for the failed-job rerun");
+}
+
+async function validateReadOnlyPrerequisites(api, context) {
+  validateActorPermission(
+    await api.request("GET", `/collaborators/${encodeURIComponent(context.actor)}/permission`),
+    context.actor,
+  );
+  validatePullRequest(await api.request("GET", `/pulls/${context.prNumber}`), context);
+  validateFixtureWorkflow(await api.request("GET", `/actions/workflows/${FIXTURE_WORKFLOW_ID}`));
+  validateMainRef(await api.request("GET", "/git/ref/heads/main"), context.workflowSha);
+}
+
+export async function runProofBroker({ api, env, event, sleep = setTimeoutPromise }) {
+  const context = validateBrokerRequest(event, env);
+  await validateReadOnlyPrerequisites(api, context);
+
+  await api.request("POST", `/actions/workflows/${FIXTURE_WORKFLOW_ID}/dispatches`, {
+    inputs: {
+      correlation: context.correlation,
+      operation: FIXTURE_OPERATION,
+    },
+    ref: "main",
+  });
+  const initialRun = await waitForInitialRun(api, context, sleep);
+  const fixtureRunId = requiredPositiveInteger(initialRun.id, "fixture run id");
+  await api.request("POST", `/actions/runs/${fixtureRunId}/rerun-failed-jobs`);
+  await waitForRerun(api, context, fixtureRunId, sleep);
+  return {
+    actor: context.actor,
+    correlation: context.correlation,
+    fixtureRunAttempt: 2,
+    fixtureRunId,
+    headSha: context.headSha,
+    operation: FIXTURE_OPERATION,
+    prNumber: context.prNumber,
+    repository: context.repository,
+    sourceRef: "refs/heads/main",
+    workflowSha: context.workflowSha,
+  };
+}
+
+function setTimeoutPromise(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+export function createGitHubApi({ repository, token, fetchImpl = fetch }) {
+  if (repository !== REPOSITORY) {
+    throw new Error(`FRV proof broker requires repository ${REPOSITORY}`);
+  }
+  const baseUrl = `https://api.github.com/repos/${repository}`;
+  return {
+    async request(method, path, body) {
+      const response = await fetchImpl(`${baseUrl}${path}`, {
+        body: body === undefined ? undefined : JSON.stringify(body),
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method,
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!response.ok) {
+        const detail = (await response.text()).slice(0, 500);
+        throw new Error(`GitHub API ${method} ${path} failed (${response.status}): ${detail}`);
+      }
+      if (response.status === 204) {
+        return null;
+      }
+      return response.json();
+    },
+  };
+}
+
+async function main() {
+  const eventPath = requiredEnv(process.env, "GITHUB_EVENT_PATH");
+  const event = JSON.parse(readFileSync(eventPath, "utf8"));
+  const token = requiredEnv(process.env, "GH_TOKEN");
+  const api = createGitHubApi({ repository: REPOSITORY, token });
+  const receipt = await runProofBroker({ api, env: process.env, event });
+  const receiptPath = requiredEnv(process.env, "FRV_PROOF_RECEIPT");
+  writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, { mode: 0o600 });
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `receipt_path=${receiptPath}\n`);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      [
+        "## FRV failed-job rerun proof",
+        "",
+        `- Pull request: #${receipt.prNumber}`,
+        `- Exact head: \`${receipt.headSha}\``,
+        `- Trusted broker SHA: \`${receipt.workflowSha}\``,
+        `- Fixture run: \`${receipt.fixtureRunId}\`, attempt \`2\``,
+        "- Fixed operation: `noop`",
+        "- Fixture source: trusted `main` at the broker workflow SHA",
+        "",
+      ].join("\n"),
+    );
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  try {
+    await main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/frv-proof-broker.mjs
+++ b/scripts/frv-proof-broker.mjs
@@ -72,6 +72,10 @@ export function validateBrokerRequest(event, env) {
     throw new Error("FRV proof broker actor must match the triggering actor");
   }
   const runId = requiredPositiveInteger(requiredEnv(env, "GITHUB_RUN_ID"), "GITHUB_RUN_ID");
+  const runAttempt = requiredPositiveInteger(
+    requiredEnv(env, "GITHUB_RUN_ATTEMPT"),
+    "GITHUB_RUN_ATTEMPT",
+  );
 
   assertExactKeys(event.inputs, ["head_sha", "pr_number"], "workflow inputs");
   const inputs = event.inputs;
@@ -80,7 +84,7 @@ export function validateBrokerRequest(event, env) {
   if (!SHA_PATTERN.test(headSha)) {
     throw new Error("head_sha must be exactly 40 lowercase hex characters");
   }
-  const correlation = `frv-proof-${runId}`;
+  const correlation = `frv-proof-${runId}-${runAttempt}`;
 
   return {
     actor,
@@ -259,15 +263,19 @@ async function validateMutationAuthority(api, context) {
   validatePullRequest(await api.request("GET", `/pulls/${context.prNumber}`), context);
 }
 
-async function validateTrustedPrerequisites(api, context) {
+async function validateFixturePrerequisite(api) {
   validateFixtureWorkflow(await api.request("GET", `/actions/workflows/${FIXTURE_WORKFLOW_ID}`));
+}
+
+async function validateTrustedMain(api, context) {
   validateMainRef(await api.request("GET", "/git/ref/heads/main"), context.workflowSha);
 }
 
 export async function runProofBroker({ api, env, event, sleep = setTimeoutPromise }) {
   const context = validateBrokerRequest(event, env);
-  await validateTrustedPrerequisites(api, context);
+  await validateFixturePrerequisite(api);
   await validateMutationAuthority(api, context);
+  await validateTrustedMain(api, context);
 
   await api.request("POST", `/actions/workflows/${FIXTURE_WORKFLOW_ID}/dispatches`, {
     inputs: {

--- a/scripts/frv-proof-broker.mjs
+++ b/scripts/frv-proof-broker.mjs
@@ -251,19 +251,23 @@ async function waitForRerun(api, context, fixtureRunId, sleep) {
   throw new Error("timed out waiting for the failed-job rerun");
 }
 
-async function validateReadOnlyPrerequisites(api, context) {
+async function validateMutationAuthority(api, context) {
   validateActorPermission(
     await api.request("GET", `/collaborators/${encodeURIComponent(context.actor)}/permission`),
     context.actor,
   );
   validatePullRequest(await api.request("GET", `/pulls/${context.prNumber}`), context);
+}
+
+async function validateTrustedPrerequisites(api, context) {
   validateFixtureWorkflow(await api.request("GET", `/actions/workflows/${FIXTURE_WORKFLOW_ID}`));
   validateMainRef(await api.request("GET", "/git/ref/heads/main"), context.workflowSha);
 }
 
 export async function runProofBroker({ api, env, event, sleep = setTimeoutPromise }) {
   const context = validateBrokerRequest(event, env);
-  await validateReadOnlyPrerequisites(api, context);
+  await validateTrustedPrerequisites(api, context);
+  await validateMutationAuthority(api, context);
 
   await api.request("POST", `/actions/workflows/${FIXTURE_WORKFLOW_ID}/dispatches`, {
     inputs: {
@@ -274,6 +278,7 @@ export async function runProofBroker({ api, env, event, sleep = setTimeoutPromis
   });
   const initialRun = await waitForInitialRun(api, context, sleep);
   const fixtureRunId = requiredPositiveInteger(initialRun.id, "fixture run id");
+  await validateMutationAuthority(api, context);
   await api.request("POST", `/actions/runs/${fixtureRunId}/rerun-failed-jobs`);
   await waitForRerun(api, context, fixtureRunId, sleep);
   return {

--- a/scripts/frv-proof-broker.mjs
+++ b/scripts/frv-proof-broker.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
+import { isRecord } from "./lib/record-shared.mjs";
 
 const REPOSITORY = "openclaw/openclaw";
 const BROKER_WORKFLOW = ".github/workflows/frv-proof-broker.yml";
@@ -9,13 +10,8 @@ const FIXTURE_WORKFLOW_ID = "frv-proof-fixture.yml";
 const FIXTURE_NAME = "FRV Proof Fixture";
 const FIXTURE_OPERATION = "noop";
 const SHA_PATTERN = /^[0-9a-f]{40}$/u;
-const CORRELATION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/u;
 const POLL_INTERVAL_MS = 5_000;
 const POLL_LIMIT = 120;
-
-function isRecord(value) {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function requiredString(value, label) {
   if (typeof value !== "string" || value.length === 0) {
@@ -77,17 +73,14 @@ export function validateBrokerRequest(event, env) {
   }
   const runId = requiredPositiveInteger(requiredEnv(env, "GITHUB_RUN_ID"), "GITHUB_RUN_ID");
 
-  assertExactKeys(event.inputs, ["correlation", "head_sha", "pr_number"], "workflow inputs");
+  assertExactKeys(event.inputs, ["head_sha", "pr_number"], "workflow inputs");
   const inputs = event.inputs;
   const prNumber = requiredPositiveInteger(inputs.pr_number, "pr_number");
   const headSha = requiredString(inputs.head_sha, "head_sha");
   if (!SHA_PATTERN.test(headSha)) {
     throw new Error("head_sha must be exactly 40 lowercase hex characters");
   }
-  const correlation = requiredString(inputs.correlation, "correlation");
-  if (!CORRELATION_PATTERN.test(correlation)) {
-    throw new Error("correlation must be 1-64 safe identifier characters");
-  }
+  const correlation = `frv-proof-${runId}`;
 
   return {
     actor,

--- a/test/scripts/frv-proof-broker.test.ts
+++ b/test/scripts/frv-proof-broker.test.ts
@@ -12,6 +12,27 @@ const workflowSha = "a".repeat(40);
 const headSha = "b".repeat(40);
 const repository = "openclaw/openclaw";
 
+type BrokerWorkflow = {
+  concurrency: { "cancel-in-progress": boolean; group: string };
+  jobs: {
+    prove: {
+      permissions: Record<string, string>;
+      steps: Array<{ name?: string; with?: Record<string, unknown> }>;
+    };
+  };
+  on: { workflow_dispatch: { inputs: Record<string, unknown> } };
+};
+
+type FixtureWorkflow = {
+  jobs: { fixture: { permissions: Record<string, string> } };
+  on: {
+    workflow_dispatch: {
+      inputs: { operation: { default: string; options: string[]; type: string } };
+    };
+  };
+  permissions: Record<string, string>;
+};
+
 function brokerEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   return {
     GITHUB_ACTOR: "maintainer",
@@ -30,7 +51,6 @@ function brokerEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 function brokerEvent(overrides: Record<string, unknown> = {}) {
   return {
     inputs: {
-      correlation: "proof-128141",
       head_sha: headSha,
       pr_number: "128141",
       ...overrides,
@@ -41,7 +61,7 @@ function brokerEvent(overrides: Record<string, unknown> = {}) {
 function fixtureRun(overrides: Record<string, unknown> = {}) {
   return {
     conclusion: "failure",
-    display_title: "FRV Proof Fixture [noop] proof-128141",
+    display_title: "FRV Proof Fixture [noop] frv-proof-12345",
     event: "workflow_dispatch",
     head_branch: "main",
     head_sha: workflowSha,
@@ -122,16 +142,16 @@ function successfulApi(
 }
 
 describe("FRV proof broker request validation", () => {
-  it("accepts only the exact three operator inputs", () => {
+  it("accepts only the exact two operator inputs", () => {
     const parsed = validateBrokerRequest(brokerEvent(), brokerEnv());
     expect(parsed).toMatchObject({
-      correlation: "proof-128141",
+      correlation: "frv-proof-12345",
       headSha,
       prNumber: 128141,
       workflowSha,
     });
     expect(() =>
-      validateBrokerRequest(brokerEvent({ workflow: "full-release-validation.yml" }), brokerEnv()),
+      validateBrokerRequest(brokerEvent({ correlation: "operator-value" }), brokerEnv()),
     ).toThrow(/keys must be exactly/u);
   });
 
@@ -145,12 +165,9 @@ describe("FRV proof broker request validation", () => {
     expect(() => validateBrokerRequest(brokerEvent(), env)).toThrow();
   });
 
-  it("rejects malformed PR, SHA, and correlation inputs", () => {
+  it("rejects malformed PR and SHA inputs", () => {
     expect(() => validateBrokerRequest(brokerEvent({ pr_number: "0" }), brokerEnv())).toThrow();
     expect(() => validateBrokerRequest(brokerEvent({ head_sha: "ABC" }), brokerEnv())).toThrow();
-    expect(() =>
-      validateBrokerRequest(brokerEvent({ correlation: "unsafe correlation" }), brokerEnv()),
-    ).toThrow();
   });
 });
 
@@ -159,7 +176,7 @@ describe("FRV proof fixture identity", () => {
     attempt: 1,
     branch: "main",
     conclusion: "failure" as const,
-    correlation: "proof-128141",
+    correlation: "frv-proof-12345",
     headSha: workflowSha,
     repository,
     runId: 777,
@@ -175,7 +192,7 @@ describe("FRV proof fixture identity", () => {
     ["workflow", { path: ".github/workflows/full-release-validation.yml" }],
     ["run", { id: 778 }],
     ["attempt", { run_attempt: 2 }],
-    ["operation", { display_title: "FRV Proof Fixture [publish] proof-128141" }],
+    ["operation", { display_title: "FRV Proof Fixture [publish] frv-proof-12345" }],
   ])("rejects the wrong %s identity", (_label, overrides) => {
     expect(() => validateFixtureRun(fixtureRun(overrides), expected)).toThrow();
   });
@@ -216,7 +233,7 @@ describe("FRV proof broker mutation boundary", () => {
     expect(calls.filter((call) => call.method !== "GET")).toEqual([
       {
         body: {
-          inputs: { correlation: "proof-128141", operation: "noop" },
+          inputs: { correlation: "frv-proof-12345", operation: "noop" },
           ref: "main",
         },
         method: "POST",
@@ -297,12 +314,11 @@ describe("FRV proof broker mutation boundary", () => {
 describe("FRV proof workflows", () => {
   const brokerSource = readFileSync(".github/workflows/frv-proof-broker.yml", "utf8");
   const fixtureSource = readFileSync(".github/workflows/frv-proof-fixture.yml", "utf8");
-  const broker = parseYaml(brokerSource) as any;
-  const fixture = parseYaml(fixtureSource) as any;
+  const broker = parseYaml(brokerSource) as BrokerWorkflow;
+  const fixture = parseYaml(fixtureSource) as FixtureWorkflow;
 
-  it("exposes only PR number, exact head, and correlation as broker inputs", () => {
+  it("exposes only PR number and exact head as broker inputs", () => {
     expect(Object.keys(broker.on.workflow_dispatch.inputs).toSorted()).toEqual([
-      "correlation",
       "head_sha",
       "pr_number",
     ]);
@@ -314,8 +330,12 @@ describe("FRV proof workflows", () => {
 
   it("never checks out PR code with the write-capable broker token", () => {
     const job = broker.jobs.prove;
-    expect(job.permissions).toEqual({ actions: "write" });
-    const checkout = job.steps.find((step: any) => step.name === "Checkout trusted main broker");
+    expect(job.permissions).toEqual({
+      actions: "write",
+      contents: "read",
+      "pull-requests": "read",
+    });
+    const checkout = job.steps.find((step) => step.name === "Checkout trusted main broker");
     expect(checkout.with).toEqual({
       "fetch-depth": 1,
       "persist-credentials": false,

--- a/test/scripts/frv-proof-broker.test.ts
+++ b/test/scripts/frv-proof-broker.test.ts
@@ -39,6 +39,7 @@ function brokerEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
     GITHUB_EVENT_NAME: "workflow_dispatch",
     GITHUB_REF: "refs/heads/main",
     GITHUB_REPOSITORY: repository,
+    GITHUB_RUN_ATTEMPT: "1",
     GITHUB_RUN_ID: "12345",
     GITHUB_SHA: workflowSha,
     GITHUB_TRIGGERING_ACTOR: "maintainer",
@@ -61,7 +62,7 @@ function brokerEvent(overrides: Record<string, unknown> = {}) {
 function fixtureRun(overrides: Record<string, unknown> = {}) {
   return {
     conclusion: "failure",
-    display_title: "FRV Proof Fixture [noop] frv-proof-12345",
+    display_title: "FRV Proof Fixture [noop] frv-proof-12345-1",
     event: "workflow_dispatch",
     head_branch: "main",
     head_sha: workflowSha,
@@ -87,6 +88,7 @@ function pullRequest(overrides: Record<string, unknown> = {}) {
 function successfulApi(
   options: {
     initialRun?: Record<string, unknown>;
+    mainShas?: string[];
     permissions?: string[];
     pulls?: Array<Record<string, unknown>>;
     rerun?: Record<string, unknown>;
@@ -96,6 +98,7 @@ function successfulApi(
   const calls: Array<{ body?: unknown; method: string; path: string }> = [];
   let permissionRead = 0;
   let pullRead = 0;
+  let mainRead = 0;
   const initialRun = options.initialRun ?? fixtureRun();
   const rerun =
     options.rerun ??
@@ -125,7 +128,9 @@ function successfulApi(
         };
       }
       if (method === "GET" && path === "/git/ref/heads/main") {
-        return { object: { sha: workflowSha }, ref: "refs/heads/main" };
+        const sha = options.mainShas?.[mainRead] ?? workflowSha;
+        mainRead += 1;
+        return { object: { sha }, ref: "refs/heads/main" };
       }
       if (method === "POST" && path === "/actions/workflows/frv-proof-fixture.yml/dispatches") {
         return null;
@@ -152,7 +157,7 @@ describe("FRV proof broker request validation", () => {
   it("accepts only the exact two operator inputs", () => {
     const parsed = validateBrokerRequest(brokerEvent(), brokerEnv());
     expect(parsed).toMatchObject({
-      correlation: "frv-proof-12345",
+      correlation: "frv-proof-12345-1",
       headSha,
       prNumber: 128141,
       workflowSha,
@@ -175,6 +180,9 @@ describe("FRV proof broker request validation", () => {
   it("rejects malformed PR and SHA inputs", () => {
     expect(() => validateBrokerRequest(brokerEvent({ pr_number: "0" }), brokerEnv())).toThrow();
     expect(() => validateBrokerRequest(brokerEvent({ head_sha: "ABC" }), brokerEnv())).toThrow();
+    expect(() =>
+      validateBrokerRequest(brokerEvent(), brokerEnv({ GITHUB_RUN_ATTEMPT: "0" })),
+    ).toThrow(/GITHUB_RUN_ATTEMPT/u);
   });
 });
 
@@ -183,7 +191,7 @@ describe("FRV proof fixture identity", () => {
     attempt: 1,
     branch: "main",
     conclusion: "failure" as const,
-    correlation: "frv-proof-12345",
+    correlation: "frv-proof-12345-1",
     headSha: workflowSha,
     repository,
     runId: 777,
@@ -199,7 +207,7 @@ describe("FRV proof fixture identity", () => {
     ["workflow", { path: ".github/workflows/full-release-validation.yml" }],
     ["run", { id: 778 }],
     ["attempt", { run_attempt: 2 }],
-    ["operation", { display_title: "FRV Proof Fixture [publish] frv-proof-12345" }],
+    ["operation", { display_title: "FRV Proof Fixture [publish] frv-proof-12345-1" }],
   ])("rejects the wrong %s identity", (_label, overrides) => {
     expect(() => validateFixtureRun(fixtureRun(overrides), expected)).toThrow();
   });
@@ -217,9 +225,9 @@ describe("FRV proof broker mutation boundary", () => {
     const firstMutation = calls.findIndex((call) => call.method !== "GET");
     expect(calls.slice(0, firstMutation).map((call) => call.path)).toEqual([
       "/actions/workflows/frv-proof-fixture.yml",
-      "/git/ref/heads/main",
       "/collaborators/maintainer/permission",
       "/pulls/128141",
+      "/git/ref/heads/main",
     ]);
   });
 
@@ -240,7 +248,7 @@ describe("FRV proof broker mutation boundary", () => {
     expect(calls.filter((call) => call.method !== "GET")).toEqual([
       {
         body: {
-          inputs: { correlation: "frv-proof-12345", operation: "noop" },
+          inputs: { correlation: "frv-proof-12345-1", operation: "noop" },
           ref: "main",
         },
         method: "POST",
@@ -273,6 +281,41 @@ describe("FRV proof broker mutation boundary", () => {
     expect(calls.some((call) => call.method !== "GET")).toBe(false);
   });
 
+  it("rejects a moved main immediately before dispatch", async () => {
+    const { api, calls } = successfulApi({ mainShas: ["c".repeat(40)] });
+    await expect(
+      runProofBroker({
+        api,
+        env: brokerEnv(),
+        event: brokerEvent(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/trusted main moved/u);
+    expect(calls.some((call) => call.method !== "GET")).toBe(false);
+  });
+
+  it("does not adopt a fixture from a prior broker attempt", async () => {
+    const { api, calls } = successfulApi();
+    await expect(
+      runProofBroker({
+        api,
+        env: brokerEnv({ GITHUB_RUN_ATTEMPT: "2" }),
+        event: brokerEvent(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/timed out waiting/u);
+    expect(calls.filter((call) => call.method !== "GET")).toEqual([
+      {
+        body: {
+          inputs: { correlation: "frv-proof-12345-2", operation: "noop" },
+          ref: "main",
+        },
+        method: "POST",
+        path: "/actions/workflows/frv-proof-fixture.yml/dispatches",
+      },
+    ]);
+  });
+
   it("rejects revoked actor authority before rerunning", async () => {
     const { api, calls } = successfulApi({ permissions: ["maintain", "read"] });
     await expect(
@@ -286,7 +329,7 @@ describe("FRV proof broker mutation boundary", () => {
     expect(calls.filter((call) => call.method !== "GET")).toEqual([
       {
         body: {
-          inputs: { correlation: "frv-proof-12345", operation: "noop" },
+          inputs: { correlation: "frv-proof-12345-1", operation: "noop" },
           ref: "main",
         },
         method: "POST",

--- a/test/scripts/frv-proof-broker.test.ts
+++ b/test/scripts/frv-proof-broker.test.ts
@@ -336,7 +336,8 @@ describe("FRV proof workflows", () => {
       "pull-requests": "read",
     });
     const checkout = job.steps.find((step) => step.name === "Checkout trusted main broker");
-    expect(checkout.with).toEqual({
+    expect(checkout).toBeDefined();
+    expect(checkout?.with).toEqual({
       "fetch-depth": 1,
       "persist-credentials": false,
       ref: "${{ github.workflow_sha }}",

--- a/test/scripts/frv-proof-broker.test.ts
+++ b/test/scripts/frv-proof-broker.test.ts
@@ -1,0 +1,339 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
+import {
+  runProofBroker,
+  validateBrokerRequest,
+  validateFixtureRun,
+  type GitHubApi,
+} from "../../scripts/frv-proof-broker.mjs";
+
+const workflowSha = "a".repeat(40);
+const headSha = "b".repeat(40);
+const repository = "openclaw/openclaw";
+
+function brokerEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    GITHUB_ACTOR: "maintainer",
+    GITHUB_EVENT_NAME: "workflow_dispatch",
+    GITHUB_REF: "refs/heads/main",
+    GITHUB_REPOSITORY: repository,
+    GITHUB_RUN_ID: "12345",
+    GITHUB_SHA: workflowSha,
+    GITHUB_TRIGGERING_ACTOR: "maintainer",
+    GITHUB_WORKFLOW_REF: "openclaw/openclaw/.github/workflows/frv-proof-broker.yml@refs/heads/main",
+    GITHUB_WORKFLOW_SHA: workflowSha,
+    ...overrides,
+  };
+}
+
+function brokerEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    inputs: {
+      correlation: "proof-128141",
+      head_sha: headSha,
+      pr_number: "128141",
+      ...overrides,
+    },
+  };
+}
+
+function fixtureRun(overrides: Record<string, unknown> = {}) {
+  return {
+    conclusion: "failure",
+    display_title: "FRV Proof Fixture [noop] proof-128141",
+    event: "workflow_dispatch",
+    head_branch: "main",
+    head_sha: workflowSha,
+    id: 777,
+    path: ".github/workflows/frv-proof-fixture.yml",
+    repository: { full_name: repository },
+    run_attempt: 1,
+    status: "completed",
+    ...overrides,
+  };
+}
+
+function pullRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    base: { ref: "main", repo: { full_name: repository } },
+    head: { sha: headSha, repo: { full_name: repository } },
+    number: 128141,
+    state: "open",
+    ...overrides,
+  };
+}
+
+function successfulApi(
+  options: {
+    initialRun?: Record<string, unknown>;
+    pull?: Record<string, unknown>;
+    rerun?: Record<string, unknown>;
+    rerunError?: Error;
+  } = {},
+) {
+  const calls: Array<{ body?: unknown; method: string; path: string }> = [];
+  const initialRun = options.initialRun ?? fixtureRun();
+  const rerun =
+    options.rerun ??
+    fixtureRun({
+      conclusion: "success",
+      run_attempt: 2,
+    });
+  const api: GitHubApi = {
+    request: vi.fn(async (method: string, path: string, body?: unknown) => {
+      calls.push({ body, method, path });
+      if (method === "GET" && path === "/collaborators/maintainer/permission") {
+        return { permission: "maintain" };
+      }
+      if (method === "GET" && path === "/pulls/128141") {
+        return options.pull ?? pullRequest();
+      }
+      if (method === "GET" && path === "/actions/workflows/frv-proof-fixture.yml") {
+        return {
+          id: 99,
+          name: "FRV Proof Fixture",
+          path: ".github/workflows/frv-proof-fixture.yml",
+          state: "active",
+        };
+      }
+      if (method === "GET" && path === "/git/ref/heads/main") {
+        return { object: { sha: workflowSha }, ref: "refs/heads/main" };
+      }
+      if (method === "POST" && path === "/actions/workflows/frv-proof-fixture.yml/dispatches") {
+        return null;
+      }
+      if (method === "GET" && path.startsWith("/actions/workflows/frv-proof-fixture.yml/runs?")) {
+        return { workflow_runs: [initialRun] };
+      }
+      if (method === "POST" && path === "/actions/runs/777/rerun-failed-jobs") {
+        if (options.rerunError) {
+          throw options.rerunError;
+        }
+        return null;
+      }
+      if (method === "GET" && path === "/actions/runs/777") {
+        return rerun;
+      }
+      throw new Error(`unexpected API call: ${method} ${path}`);
+    }),
+  };
+  return { api, calls };
+}
+
+describe("FRV proof broker request validation", () => {
+  it("accepts only the exact three operator inputs", () => {
+    const parsed = validateBrokerRequest(brokerEvent(), brokerEnv());
+    expect(parsed).toMatchObject({
+      correlation: "proof-128141",
+      headSha,
+      prNumber: 128141,
+      workflowSha,
+    });
+    expect(() =>
+      validateBrokerRequest(brokerEvent({ workflow: "full-release-validation.yml" }), brokerEnv()),
+    ).toThrow(/keys must be exactly/u);
+  });
+
+  it.each([
+    ["repository", brokerEnv({ GITHUB_REPOSITORY: "attacker/fork" })],
+    ["workflow", brokerEnv({ GITHUB_WORKFLOW_REF: "openclaw/openclaw/other.yml@main" })],
+    ["ref", brokerEnv({ GITHUB_REF: "refs/pull/128141/merge" })],
+    ["workflow SHA", brokerEnv({ GITHUB_WORKFLOW_SHA: "c".repeat(40) })],
+    ["actor", brokerEnv({ GITHUB_TRIGGERING_ACTOR: "different-user" })],
+  ])("rejects the wrong %s before API access", (_label, env) => {
+    expect(() => validateBrokerRequest(brokerEvent(), env)).toThrow();
+  });
+
+  it("rejects malformed PR, SHA, and correlation inputs", () => {
+    expect(() => validateBrokerRequest(brokerEvent({ pr_number: "0" }), brokerEnv())).toThrow();
+    expect(() => validateBrokerRequest(brokerEvent({ head_sha: "ABC" }), brokerEnv())).toThrow();
+    expect(() =>
+      validateBrokerRequest(brokerEvent({ correlation: "unsafe correlation" }), brokerEnv()),
+    ).toThrow();
+  });
+});
+
+describe("FRV proof fixture identity", () => {
+  const expected = {
+    attempt: 1,
+    branch: "main",
+    conclusion: "failure" as const,
+    correlation: "proof-128141",
+    headSha: workflowSha,
+    repository,
+    runId: 777,
+  };
+
+  it("accepts the exact failed first attempt", () => {
+    expect(validateFixtureRun(fixtureRun(), expected).id).toBe(777);
+  });
+
+  it.each([
+    ["repository", { repository: { full_name: "attacker/fork" } }],
+    ["SHA", { head_sha: headSha }],
+    ["workflow", { path: ".github/workflows/full-release-validation.yml" }],
+    ["run", { id: 778 }],
+    ["attempt", { run_attempt: 2 }],
+    ["operation", { display_title: "FRV Proof Fixture [publish] proof-128141" }],
+  ])("rejects the wrong %s identity", (_label, overrides) => {
+    expect(() => validateFixtureRun(fixtureRun(overrides), expected)).toThrow();
+  });
+});
+
+describe("FRV proof broker mutation boundary", () => {
+  it("validates every read-only prerequisite before the first mutation", async () => {
+    const { api, calls } = successfulApi();
+    await runProofBroker({
+      api,
+      env: brokerEnv(),
+      event: brokerEvent(),
+      sleep: async () => {},
+    });
+    const firstMutation = calls.findIndex((call) => call.method !== "GET");
+    expect(calls.slice(0, firstMutation).map((call) => call.path)).toEqual([
+      "/collaborators/maintainer/permission",
+      "/pulls/128141",
+      "/actions/workflows/frv-proof-fixture.yml",
+      "/git/ref/heads/main",
+    ]);
+  });
+
+  it("uses only the fixed ref, fixture, operation, and exact failed run", async () => {
+    const { api, calls } = successfulApi();
+    const receipt = await runProofBroker({
+      api,
+      env: brokerEnv(),
+      event: brokerEvent(),
+      sleep: async () => {},
+    });
+    expect(receipt).toMatchObject({
+      fixtureRunAttempt: 2,
+      fixtureRunId: 777,
+      operation: "noop",
+      sourceRef: "refs/heads/main",
+    });
+    expect(calls.filter((call) => call.method !== "GET")).toEqual([
+      {
+        body: {
+          inputs: { correlation: "proof-128141", operation: "noop" },
+          ref: "main",
+        },
+        method: "POST",
+        path: "/actions/workflows/frv-proof-fixture.yml/dispatches",
+      },
+      {
+        body: undefined,
+        method: "POST",
+        path: "/actions/runs/777/rerun-failed-jobs",
+      },
+    ]);
+  });
+
+  it("rejects a mismatched PR head before any mutation", async () => {
+    const { api, calls } = successfulApi({
+      pull: pullRequest({
+        head: { sha: "c".repeat(40), repo: { full_name: repository } },
+      }),
+    });
+    await expect(
+      runProofBroker({
+        api,
+        env: brokerEnv(),
+        event: brokerEvent(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/head SHA/u);
+    expect(calls.some((call) => call.method !== "GET")).toBe(false);
+  });
+
+  it("does not mutate refs after a rerun failure", async () => {
+    const { api, calls } = successfulApi({ rerunError: new Error("rerun rejected") });
+    await expect(
+      runProofBroker({
+        api,
+        env: brokerEnv(),
+        event: brokerEvent(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/rerun rejected/u);
+    expect(calls.some((call) => call.path.startsWith("/git/refs"))).toBe(false);
+  });
+
+  it("does not rerun a fixture with the wrong workflow identity", async () => {
+    const { api, calls } = successfulApi({
+      initialRun: fixtureRun({ path: ".github/workflows/other.yml" }),
+    });
+    await expect(
+      runProofBroker({
+        api,
+        env: brokerEnv(),
+        event: brokerEvent(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/workflow does not match/u);
+    expect(calls.some((call) => call.path.endsWith("/rerun-failed-jobs"))).toBe(false);
+  });
+
+  it("rejects a main replacement race without creating or deleting refs", async () => {
+    const { api, calls } = successfulApi({
+      initialRun: fixtureRun({
+        head_sha: "c".repeat(40),
+      }),
+    });
+    await expect(
+      runProofBroker({
+        api,
+        env: brokerEnv(),
+        event: brokerEvent(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/trusted main workflow SHA/u);
+    expect(calls.some((call) => call.path.startsWith("/git/refs"))).toBe(false);
+    expect(calls.some((call) => call.path.endsWith("/rerun-failed-jobs"))).toBe(false);
+  });
+});
+
+describe("FRV proof workflows", () => {
+  const brokerSource = readFileSync(".github/workflows/frv-proof-broker.yml", "utf8");
+  const fixtureSource = readFileSync(".github/workflows/frv-proof-fixture.yml", "utf8");
+  const broker = parseYaml(brokerSource) as any;
+  const fixture = parseYaml(fixtureSource) as any;
+
+  it("exposes only PR number, exact head, and correlation as broker inputs", () => {
+    expect(Object.keys(broker.on.workflow_dispatch.inputs).toSorted()).toEqual([
+      "correlation",
+      "head_sha",
+      "pr_number",
+    ]);
+    expect(broker.concurrency).toEqual({
+      "cancel-in-progress": false,
+      group: "frv-proof-broker",
+    });
+  });
+
+  it("never checks out PR code with the write-capable broker token", () => {
+    const job = broker.jobs.prove;
+    expect(job.permissions).toEqual({ actions: "write" });
+    const checkout = job.steps.find((step: any) => step.name === "Checkout trusted main broker");
+    expect(checkout.with).toEqual({
+      "fetch-depth": 1,
+      "persist-credentials": false,
+      ref: "${{ github.workflow_sha }}",
+    });
+    expect(brokerSource).not.toContain("inputs.head_sha }}");
+    expect(brokerSource).not.toContain("pull/");
+    expect(brokerSource).not.toContain("contents: write");
+  });
+
+  it("keeps the fixture tokenless and fixes its behavior to noop", () => {
+    expect(fixture.permissions).toEqual({});
+    expect(fixture.jobs.fixture.permissions).toEqual({});
+    expect(fixture.on.workflow_dispatch.inputs.operation).toMatchObject({
+      default: "noop",
+      options: ["noop"],
+      type: "choice",
+    });
+    expect(fixtureSource).not.toContain("actions/checkout");
+  });
+});

--- a/test/scripts/frv-proof-broker.test.ts
+++ b/test/scripts/frv-proof-broker.test.ts
@@ -87,12 +87,15 @@ function pullRequest(overrides: Record<string, unknown> = {}) {
 function successfulApi(
   options: {
     initialRun?: Record<string, unknown>;
-    pull?: Record<string, unknown>;
+    permissions?: string[];
+    pulls?: Array<Record<string, unknown>>;
     rerun?: Record<string, unknown>;
     rerunError?: Error;
   } = {},
 ) {
   const calls: Array<{ body?: unknown; method: string; path: string }> = [];
+  let permissionRead = 0;
+  let pullRead = 0;
   const initialRun = options.initialRun ?? fixtureRun();
   const rerun =
     options.rerun ??
@@ -104,10 +107,14 @@ function successfulApi(
     request: vi.fn(async (method: string, path: string, body?: unknown) => {
       calls.push({ body, method, path });
       if (method === "GET" && path === "/collaborators/maintainer/permission") {
-        return { permission: "maintain" };
+        const permission = options.permissions?.[permissionRead] ?? "maintain";
+        permissionRead += 1;
+        return { permission };
       }
       if (method === "GET" && path === "/pulls/128141") {
-        return options.pull ?? pullRequest();
+        const pull = options.pulls?.[pullRead] ?? pullRequest();
+        pullRead += 1;
+        return pull;
       }
       if (method === "GET" && path === "/actions/workflows/frv-proof-fixture.yml") {
         return {
@@ -209,10 +216,10 @@ describe("FRV proof broker mutation boundary", () => {
     });
     const firstMutation = calls.findIndex((call) => call.method !== "GET");
     expect(calls.slice(0, firstMutation).map((call) => call.path)).toEqual([
-      "/collaborators/maintainer/permission",
-      "/pulls/128141",
       "/actions/workflows/frv-proof-fixture.yml",
       "/git/ref/heads/main",
+      "/collaborators/maintainer/permission",
+      "/pulls/128141",
     ]);
   });
 
@@ -249,9 +256,11 @@ describe("FRV proof broker mutation boundary", () => {
 
   it("rejects a mismatched PR head before any mutation", async () => {
     const { api, calls } = successfulApi({
-      pull: pullRequest({
-        head: { sha: "c".repeat(40), repo: { full_name: repository } },
-      }),
+      pulls: [
+        pullRequest({
+          head: { sha: "c".repeat(40), repo: { full_name: repository } },
+        }),
+      ],
     });
     await expect(
       runProofBroker({
@@ -262,6 +271,48 @@ describe("FRV proof broker mutation boundary", () => {
       }),
     ).rejects.toThrow(/head SHA/u);
     expect(calls.some((call) => call.method !== "GET")).toBe(false);
+  });
+
+  it("rejects revoked actor authority before rerunning", async () => {
+    const { api, calls } = successfulApi({ permissions: ["maintain", "read"] });
+    await expect(
+      runProofBroker({
+        api,
+        env: brokerEnv(),
+        event: brokerEvent(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/lacks repository write permission/u);
+    expect(calls.filter((call) => call.method !== "GET")).toEqual([
+      {
+        body: {
+          inputs: { correlation: "frv-proof-12345", operation: "noop" },
+          ref: "main",
+        },
+        method: "POST",
+        path: "/actions/workflows/frv-proof-fixture.yml/dispatches",
+      },
+    ]);
+  });
+
+  it("rejects a replaced PR head before rerunning", async () => {
+    const { api, calls } = successfulApi({
+      pulls: [
+        pullRequest(),
+        pullRequest({
+          head: { sha: "c".repeat(40), repo: { full_name: repository } },
+        }),
+      ],
+    });
+    await expect(
+      runProofBroker({
+        api,
+        env: brokerEnv(),
+        event: brokerEvent(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/head SHA/u);
+    expect(calls.some((call) => call.path.endsWith("/rerun-failed-jobs"))).toBe(false);
   });
 
   it("does not mutate refs after a rerun failure", async () => {


### PR DESCRIPTION
## Summary

- add a tokenless manual fixture that fails attempt 1 and passes only a failed-job rerun
- add a serialized trusted-`main` broker that dispatches only from the exact current `main` workflow SHA
- validate the requesting actor, repository, open PR head, trusted workflow SHA, fixed workflow/run identity, attempt, and operation before recovery mutation
- renew actor permission and the exact open PR-head claim immediately before both write operations
- derive fixture correlation from trusted `GITHUB_RUN_ID` and `GITHUB_RUN_ATTEMPT`, keeping PR-head code unexecuted

## Security boundary

- operator inputs are limited to PR number and exact head SHA; correlation is derived from the trusted broker run ID and attempt
- the broker checks out only `github.workflow_sha` from trusted `main`
- the trusted `main` SHA is renewed immediately before fixture dispatch
- the broker can dispatch only `frv-proof-fixture.yml` with the fixed `noop` operation
- the broker can rerun only the exact fixture run it created
- permission revocation or PR-head replacement after fixture polling blocks the rerun
- a fixture from an earlier broker attempt cannot match the current attempt correlation
- the broker creates, updates, and deletes no Git refs
- job permissions are limited to `actions: write`, `contents: read`, and `pull-requests: read`
- no contents write, OIDC, packages, deployments, releases, tags, or secrets are available

## Validation

- `node scripts/run-vitest.mjs test/scripts/frv-proof-broker.test.ts test/scripts/type-suppression-inventory.test.ts` (29 passed)
- `pnpm check:coercion-helpers`
- `pnpm check:script-erasability`
- focused `actionlint` 1.7.12
- `pnpm exec oxlint scripts/frv-proof-broker.mjs test/scripts/frv-proof-broker.test.ts`
- `pnpm format:check .github/workflows/frv-proof-broker.yml scripts/frv-proof-broker.mjs test/scripts/frv-proof-broker.test.ts`
- `git diff --check`

The broker proof itself is intentionally not dispatched by this PR.
