### PR TITLE
fix(qa): clean partial cloud proof startup

### DIFF
--- a/test/e2e/qa-lab/runtime/cloud-worker-midturn-loss-proof.ts
+++ b/test/e2e/qa-lab/runtime/cloud-worker-midturn-loss-proof.ts
@@ -269,18 +269,21 @@ function waitForChatError(events: readonly GatewayEvent[], runId: string) {
 }
 
 async function runProof(options: ProducerOptions) {
+  const state = createQaBusState();
   // openclaw-temp-dir: allow standalone QA producer owns and removes this fixture root.
   const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cloud-midturn-loss-"));
-  const state = createQaBusState();
-  const bus = await startQaBusServer({ state });
-  const provider = await startMidturnProvider();
-  const ssh = await createSshdFixture(fixtureRoot);
-  let sshd = await ssh.start();
+  let bus: Awaited<ReturnType<typeof startQaBusServer>> | undefined;
+  let provider: Awaited<ReturnType<typeof startMidturnProvider>> | undefined;
+  let sshd: Parameters<typeof stopSshd>[0] = undefined;
   let gateway: Gateway | undefined;
   let operator: GatewayClient | undefined;
   let proofError: unknown;
   let verdict: Record<string, unknown> | undefined;
   try {
+    bus = await startQaBusServer({ state });
+    provider = await startMidturnProvider();
+    const ssh = await createSshdFixture(fixtureRoot);
+    sshd = await ssh.start();
     const repo = await initializeRepository(fixtureRoot);
     const sshPrivateKey = await fs.readFile(ssh.clientKeyPath, "utf8");
     const transport = createQaChannelTransport(state);
@@ -435,9 +438,10 @@ async function runProof(options: ProducerOptions) {
         : undefined;
     });
     const recoveryCounts = markerCounts(historyAfterRecovery);
+    const recoveryContext = provider.contextRequest;
     if (
-      !COMMITTED_MARKERS.every((marker) => provider.contextRequest.includes(marker)) ||
-      provider.contextRequest.includes(VOLATILE_TEXT) ||
+      !COMMITTED_MARKERS.every((marker) => recoveryContext.includes(marker)) ||
+      recoveryContext.includes(VOLATILE_TEXT) ||
       Object.values(recoveryCounts).some((count) => count !== 1)
     ) {
       throw new Error(
@@ -517,25 +521,25 @@ async function runProof(options: ProducerOptions) {
     );
   } catch (error) {
     proofError = error;
-  }
-
-  const cleanup = await Promise.allSettled([
-    operator?.stopAndWait({ timeoutMs: 1_000 }) ?? Promise.resolve(),
-    gateway?.stop() ?? Promise.resolve(),
-    stopSshd(sshd),
-    provider.stop(),
-    bus.stop(),
-    fs.rm(fixtureRoot, { recursive: true, force: true }),
-  ]);
-  const cleanupFailures = cleanup.flatMap((result) =>
-    result.status === "rejected" ? [result.reason] : [],
-  );
-  if (cleanupFailures.length > 0) {
-    proofError = new AggregateError(
-      proofError ? [proofError, ...cleanupFailures] : cleanupFailures,
-      "cloud worker mid-turn loss cleanup failed",
-      proofError ? { cause: proofError } : undefined,
+  } finally {
+    const cleanup = await Promise.allSettled([
+      operator?.stopAndWait({ timeoutMs: 1_000 }) ?? Promise.resolve(),
+      gateway?.stop() ?? Promise.resolve(),
+      stopSshd(sshd),
+      provider?.stop() ?? Promise.resolve(),
+      bus?.stop() ?? Promise.resolve(),
+      fs.rm(fixtureRoot, { recursive: true, force: true }),
+    ]);
+    const cleanupFailures = cleanup.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
     );
+    if (cleanupFailures.length > 0) {
+      proofError = new AggregateError(
+        proofError ? [proofError, ...cleanupFailures] : cleanupFailures,
+        "cloud worker mid-turn loss cleanup failed",
+        proofError ? { cause: proofError } : undefined,
+      );
+    }
   }
   if (proofError) {
     throw proofError;


### PR DESCRIPTION
Closes #128974

## What Problem This Solves

The cloud-worker mid-turn-loss QA producer could report a setup failure but never terminate. It started the QA bus and mock model provider before entering its cleanup owner; if SSH fixture setup failed—for example, passwordless sudo was unavailable—the failure bypassed teardown, leaving both listening servers and the fixture root alive until an outer job timeout or manual kill.

## Why This Change Was Made

All fallible resource acquisition now runs inside one `try`/`finally` owner. Handles remain explicitly optional until acquired. Cleanup stops only acquired operator/Gateway/sshd/provider/bus resources, always removes the fixture root, and preserves the existing behavior that combines cleanup failures with the original proof failure through `AggregateError`.

This is not a call reordering that moves the leak to another setup step; every partial-startup state after fixture-root creation has one teardown path. Production LOC: 0. Test support: +29/-25 (net +4).

AI-assisted: yes. I reviewed the producer's partial acquisition order, server/process ownership, failure evidence path, AggregateError precedence, and real process/temp cleanup.

## User Impact

Failed mid-turn-loss proof runs now terminate promptly and truthfully. They no longer occupy ports, retain mock servers, leak fixture directories, or stall remote QA jobs after already writing failure evidence.

## Evidence

- Pre-fix real reproduction: the macOS sudo preflight failed after 212ms and wrote failure evidence, but the producer stayed alive for more than 20 minutes with two listening servers and an empty fixture root until manually stopped.
- Post-fix exact-head reproduction: the same command records `sudo: a password is required`, exits naturally with code 1 immediately after printing evidence, leaves no proof process, and leaves no `openclaw-cloud-midturn-loss-*` fixture directory.
- Focused support proof: `node scripts/run-vitest.mjs extensions/qa-lab/src/bus-server.test.ts test/e2e/qa-lab/runtime/script-evidence.test.ts` passed 29 tests across two shards.
- Changed-file gate: `node scripts/check-changed.mjs -- test/e2e/qa-lab/runtime/cloud-worker-midturn-loss-proof.ts` passed root test-support typecheck, script lint, formatting, package/dependency guards, and related checks.
- Autoreview P1 fixed: the optional sshd handle is initialized explicitly before unconditional cleanup. Fresh exact-branch P0/P1 autoreview has no accepted/actionable findings (0.96).
- Remote Linux/static-SSH product proof remains blocked on this host: no installed Crabbox binary and Blacksmith CLI is unauthenticated. This PR repairs the proof harness blocker; it does not claim the Linux product scenario passed.
