### PR TITLE
fix(cli): render models refresh JSON failures

### DIFF
--- a/src/commands/models/refresh.test.ts
+++ b/src/commands/models/refresh.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExpectedCliError } from "../../cli/failure-output.js";
 
 const mocks = vi.hoisted(() => ({ refresh: vi.fn(), getConfig: vi.fn(() => ({})) }));
 vi.mock("../../config/config.js", () => ({ getRuntimeConfig: mocks.getConfig }));
@@ -21,7 +22,7 @@ function runtime() {
 beforeEach(() => mocks.refresh.mockReset());
 
 describe("models refresh", () => {
-  it("prints updated, fresh, disabled, error, and JSON results", async () => {
+  it("prints updated, fresh, and disabled human results", async () => {
     const updatedRuntime = runtime();
     mocks.refresh.mockResolvedValueOnce({
       status: "updated",
@@ -50,38 +51,64 @@ describe("models refresh", () => {
     expect(disabledRuntime.log).toHaveBeenCalledWith(
       "Remote catalog refresh is disabled (models.catalogRefresh.enabled=false)",
     );
+  });
 
-    const errorRuntime = runtime();
+  it.each([
+    { name: "human", options: {} },
+    { name: "JSON", options: { json: true } },
+  ])("delegates $name refresh failures to the canonical CLI error owner", async ({ options }) => {
+    const commandRuntime = runtime();
     mocks.refresh.mockResolvedValueOnce({
       status: "error",
       providers: 0,
       models: 0,
       error: "boom",
     });
-    await modelsRefreshCommand({}, errorRuntime);
-    expect(errorRuntime.error).toHaveBeenCalledWith("Remote catalog refresh failed: boom");
-    expect(errorRuntime.exit).toHaveBeenCalledWith(1);
 
-    const jsonRuntime = runtime();
-    mocks.refresh.mockResolvedValueOnce({ status: "disabled", providers: 0, models: 0 });
-    await modelsRefreshCommand({ json: true }, jsonRuntime);
-    expect(jsonRuntime.writeJson).toHaveBeenCalledWith(
-      { status: "disabled", providers: 0, models: 0 },
-      0,
-    );
-    expect(jsonRuntime.log).not.toHaveBeenCalled();
+    const execution = modelsRefreshCommand(options, commandRuntime);
+
+    await expect(execution).rejects.toBeInstanceOf(ExpectedCliError);
+    await expect(execution).rejects.toMatchObject({
+      message: "Remote catalog refresh failed: boom",
+      humanOutput: "Remote catalog refresh failed: boom",
+      machineOutput: "Remote catalog refresh failed: boom",
+    });
+    expect(commandRuntime.writeJson).not.toHaveBeenCalled();
+    expect(commandRuntime.log).not.toHaveBeenCalled();
+    expect(commandRuntime.error).not.toHaveBeenCalled();
+    expect(commandRuntime.exit).not.toHaveBeenCalled();
   });
 
-  it("writes refresh errors to structured stdout before exiting in JSON mode", async () => {
-    const jsonRuntime = runtime();
-    const result = { status: "error", providers: 0, models: 0, error: "boom" };
+  it.each([
+    {
+      status: "updated",
+      providers: 2,
+      models: 3,
+      generatedAt: 1_753_500_000_000,
+    },
+    {
+      status: "unchanged",
+      providers: 2,
+      models: 3,
+      generatedAt: 1_753_500_000_000,
+    },
+    {
+      status: "fresh",
+      providers: 2,
+      models: 3,
+      generatedAt: 1_753_500_000_000,
+      nextCheckInMs: 1_000,
+    },
+    { status: "disabled", providers: 0, models: 0 },
+  ])("preserves the $status JSON domain payload", async (result) => {
+    const commandRuntime = runtime();
     mocks.refresh.mockResolvedValueOnce(result);
 
-    await modelsRefreshCommand({ json: true }, jsonRuntime);
+    await modelsRefreshCommand({ json: true }, commandRuntime);
 
-    expect(jsonRuntime.writeJson).toHaveBeenCalledWith(result, 0);
-    expect(jsonRuntime.exit).toHaveBeenCalledWith(1);
-    expect(jsonRuntime.log).not.toHaveBeenCalled();
-    expect(jsonRuntime.error).not.toHaveBeenCalled();
+    expect(commandRuntime.writeJson).toHaveBeenCalledWith(result, 0);
+    expect(commandRuntime.log).not.toHaveBeenCalled();
+    expect(commandRuntime.error).not.toHaveBeenCalled();
+    expect(commandRuntime.exit).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/models/refresh.ts
+++ b/src/commands/models/refresh.ts
@@ -1,3 +1,4 @@
+import { ExpectedCliError } from "../../cli/failure-output.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import { refreshRemoteModelCatalog } from "../../model-catalog/remote-refresh.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
@@ -7,20 +8,16 @@ export async function modelsRefreshCommand(
   runtime: RuntimeEnv,
 ): Promise<void> {
   const result = await refreshRemoteModelCatalog({ config: getRuntimeConfig(), force: true });
+  if (result.status === "error") {
+    const message = `Remote catalog refresh failed: ${result.error}`;
+    throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
+  }
   if (options.json) {
     writeRuntimeJson(runtime, result, 0);
-    if (result.status === "error") {
-      runtime.exit(1);
-    }
     return;
   }
   if (result.status === "disabled") {
     runtime.log("Remote catalog refresh is disabled (models.catalogRefresh.enabled=false)");
-    return;
-  }
-  if (result.status === "error") {
-    runtime.error(`Remote catalog refresh failed: ${result.error}`);
-    runtime.exit(1);
     return;
   }
   runtime.log(

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 
@@ -226,6 +227,179 @@ describe("cli json stdout contract", () => {
         expect(result.stderr).toBe("");
       },
       { prefix: "openclaw-hooks-json-success-e2e-" },
+    );
+  });
+
+  it.each([
+    { name: "leaf JSON", args: ["models", "refresh", "--json"] },
+    { name: "parent JSON", args: ["models", "--json", "refresh"] },
+    { name: "human output", args: ["models", "refresh"], human: true },
+    {
+      name: "forced Commander JSON",
+      args: ["models", "refresh", "--json"],
+      commander: true,
+    },
+    {
+      name: "dual-TTY JSON",
+      args: ["models", "refresh", "--json"],
+      tty: true,
+    },
+  ])("renders model catalog refresh failures canonically for $name", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const preload = Buffer.from(
+          [
+            'import net from "node:net";',
+            'net.Socket.prototype.connect = function () { throw new Error("AUTOQA_NETWORK_FORBIDDEN"); };',
+            'globalThis.fetch = async () => { throw new Error("offline fixture"); };',
+            "globalThis.fetch.mock = {};",
+            ...("tty" in testCase
+              ? [
+                  'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });',
+                  'Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });',
+                ]
+              : []),
+          ].join("\n"),
+        ).toString("base64");
+        const result = runBuiltCli(tempHome, testCase.args, {
+          NODE_OPTIONS: `--import=data:text/javascript;base64,${preload}`,
+          OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+          OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+          ...("commander" in testCase ? { OPENCLAW_DISABLE_ROUTE_FIRST: "1" } : {}),
+          ...("tty" in testCase ? { FORCE_COLOR: "1" } : {}),
+        });
+        const message = "Remote catalog refresh failed: Error: offline fixture";
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(result.stdout, result.stderr).not.toMatch(/[\u001B\u0007]/u);
+        if ("human" in testCase) {
+          expect(result.stdout).toBe("");
+        } else {
+          expect(JSON.parse(result.stdout)).toEqual({
+            ok: false,
+            error: { type: "cli_error", message },
+          });
+        }
+        expect(result.stderr).toContain(message);
+        expect(result.stderr.split(message)).toHaveLength(2);
+        expect(result.stderr).not.toContain("AUTOQA_NETWORK_FORBIDDEN");
+        if ("tty" in testCase) {
+          expect(result.stderr).toContain("\u001B[?25h");
+        }
+      },
+      { prefix: "openclaw-models-refresh-json-failure-e2e-" },
+    );
+  });
+
+  it("preserves model catalog refresh success payloads and persisted rows", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const stateDir = path.join(tempHome, "isolated-state");
+        const configPath = path.join(tempHome, "openclaw.json");
+        const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+        const generatedAt = Date.now() + 60_000;
+        const bundle = {
+          schemaVersion: 1,
+          generatedAt,
+          sourceCommit: "autoqa-model-catalog-fixture",
+          providers: { openai: { models: [{ id: "gpt-5.6-luna" }] } },
+        };
+        const updatedBundle = { ...bundle, generatedAt: generatedAt + 1_000 };
+        const preloadFor = (response: "initial" | "updated" | "unchanged" | "failure") => {
+          const fixture = response === "initial" ? bundle : updatedBundle;
+          const fetchResponse =
+            response === "failure"
+              ? 'throw new Error("offline fixture");'
+              : response === "unchanged"
+                ? "return new Response(null, { status: 304 });"
+                : `return new Response(JSON.stringify(${JSON.stringify(fixture)}), { headers: { etag: '\"fixture\"' } });`;
+          return Buffer.from(
+            [
+              'import net from "node:net";',
+              'import module from "node:module";',
+              'net.Socket.prototype.connect = function () { throw new Error("AUTOQA_NETWORK_FORBIDDEN"); };',
+              "const createRequire = module.createRequire;",
+              'module.createRequire = (...args) => new Proxy(createRequire(...args), { apply(target, receiver, request) { return String(request[0]).endsWith("/build-info.json") ? { builtAt: "2020-01-01T00:00:00.000Z" } : Reflect.apply(target, receiver, request); } });',
+              "module.syncBuiltinESMExports();",
+              `globalThis.fetch = async () => { ${fetchResponse} };`,
+              "globalThis.fetch.mock = {};",
+            ].join("\n"),
+          ).toString("base64");
+        };
+        const runRefresh = (
+          args: string[],
+          response: "initial" | "updated" | "unchanged" | "failure",
+        ) =>
+          runBuiltCli(tempHome, ["models", ...args], {
+            NODE_OPTIONS: `--import=data:text/javascript;base64,${preloadFor(response)}`,
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_STATE_DIR: stateDir,
+          });
+        const readCatalogRow = () => {
+          const database = new DatabaseSync(databasePath, { readOnly: true });
+          try {
+            return database.prepare("SELECT * FROM model_catalog_remote WHERE id = 1").get();
+          } finally {
+            database.close();
+          }
+        };
+
+        const human = runRefresh(["refresh"], "initial");
+        expect(human.status, human.stderr).toBe(0);
+        expect(human.stdout).toContain("Remote catalog refresh: updated (1 providers, 1 models;");
+        expect(human.stdout).toContain(
+          "A running Gateway applies the updated catalog after its next restart.",
+        );
+
+        const updated = runRefresh(["refresh", "--json"], "updated");
+        expect(updated.status, updated.stderr).toBe(0);
+        expect(JSON.parse(updated.stdout)).toEqual({
+          status: "updated",
+          generatedAt: updatedBundle.generatedAt,
+          providers: 1,
+          models: 1,
+        });
+
+        const unchanged = runRefresh(["--json", "refresh"], "unchanged");
+        expect(unchanged.status, unchanged.stderr).toBe(0);
+        expect(JSON.parse(unchanged.stdout)).toEqual({
+          status: "unchanged",
+          generatedAt: updatedBundle.generatedAt,
+          providers: 1,
+          models: 1,
+        });
+        const persistedRow = readCatalogRow();
+        expect(persistedRow).toMatchObject({
+          generated_at: updatedBundle.generatedAt,
+          bundle_json: JSON.stringify(updatedBundle),
+        });
+
+        const failure = runRefresh(["refresh", "--json"], "failure");
+        expect(failure.status, failure.stderr).toBe(1);
+        expect(JSON.parse(failure.stdout)).toEqual({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message: "Remote catalog refresh failed: Error: offline fixture",
+          },
+        });
+        expect(readCatalogRow()).toEqual(persistedRow);
+
+        await fs.writeFile(
+          configPath,
+          `${JSON.stringify({ models: { catalogRefresh: { enabled: false } } })}\n`,
+          "utf8",
+        );
+        const disabled = runRefresh(["refresh", "--json"], "failure");
+        expect(disabled.status, disabled.stderr).toBe(0);
+        expect(JSON.parse(disabled.stdout)).toEqual({
+          status: "disabled",
+          providers: 0,
+          models: 0,
+        });
+        expect(readCatalogRow()).toEqual(persistedRow);
+      },
+      { prefix: "openclaw-models-refresh-persistence-e2e-" },
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw models refresh --json` returned the internal remote-catalog error union and exit code 1 instead of the documented canonical CLI failure envelope.

Fixes https://github.com/openclaw/openclaw/issues/128979.

## Why This Change Was Made

The CLI presentation owner now converts only `status: "error"` results into `ExpectedCliError`, allowing the existing root renderer to own human/JSON failure output and terminal finalization. The remote-catalog union, SQLite behavior, and successful `updated`, `unchanged`, `fresh`, and `disabled` payloads remain unchanged.

Production delta: +5/-8, net -3 lines. Tests: +222/-21, net +201 lines.

## User Impact

Failed model-catalog refreshes produce one canonical `cli_error` document. Successful JSON payloads, provider/model counts, disabled behavior, and human restart guidance remain unchanged.

## Evidence

- Pre-fix owner and built-process regressions reproduced the legacy error result instead of the canonical envelope.
- Focused owner/sibling proof covers model refresh, list, registration, and failure rendering.
- Built-process proof covers leaf/parent JSON, human output, forced Commander, dual TTY, successful updated/unchanged results, disabled behavior, SQLite persistence, and failure no-mutation.
- CLI startup build and complete changed-file gates passed.
- Fresh final P1 autoreview: no actionable findings, correctness 0.97.
- `git diff --check`: passed.
