### PR TITLE
fix(anthropic): keep Agent SDK session warm after first turn

### DIFF
--- a/extensions/anthropic/agent-sdk.runtime.test.ts
+++ b/extensions/anthropic/agent-sdk.runtime.test.ts
@@ -190,7 +190,7 @@ afterEach(async () => {
 });
 
 describe("Anthropic Agent SDK runtime ownership", () => {
-  it("keeps selected SDK credentials on their private descriptor and isolates side questions", () => {
+  it("pins SDK identity, keeps selected credentials private, and isolates side questions", () => {
     const backend = buildAnthropicCliBackend();
     const base = {
       workspaceDir: "/tmp/openclaw-workspace",
@@ -215,13 +215,19 @@ describe("Anthropic Agent SDK runtime ownership", () => {
 
     expect(credential).toEqual(
       expect.objectContaining({
-        env: { CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR: "3" },
+        env: {
+          CLAUDE_AGENT_SDK_VERSION: "0.3.232",
+          CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR: "3",
+        },
         secretInput: expect.objectContaining({ fd: 3 }),
         execute: expect.any(Function),
       }),
     );
     expect(emptyCredential).toEqual(
-      expect.objectContaining({ env: {}, execute: expect.any(Function) }),
+      expect.objectContaining({
+        env: { CLAUDE_AGENT_SDK_VERSION: "0.3.232" },
+        execute: expect.any(Function),
+      }),
     );
     expect(emptyCredential).not.toHaveProperty("secretInput");
     expect(sideQuestion).not.toHaveProperty("execute");

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -25,6 +25,7 @@ import {
   resolveClaudeCliExecutionArgs,
   resolveClaudeCliThinkingEnv,
 } from "./cli-shared.js";
+import anthropicPluginPackage from "./package.json" with { type: "json" };
 
 type ClaudeCliAuthCredential =
   | { type: "oauth"; access: string; expires: number }
@@ -42,6 +43,10 @@ type ClaudeCliPreparedExecution = CliBackendPreparedExecution & {
 };
 
 const CLAUDE_CLI_CREDENTIAL_FINGERPRINT_KEY = randomBytes(32);
+// Agent SDK query() writes this value into process.env. Seed it before core
+// fingerprints the child env so the first resumed turn keeps its warm query.
+const CLAUDE_AGENT_SDK_VERSION =
+  anthropicPluginPackage.dependencies["@anthropic-ai/claude-agent-sdk"];
 const CLAUDE_CLI_DEFAULT_ARGS = [
   "-p",
   "--output-format",
@@ -245,12 +250,6 @@ export function buildAnthropicCliBackend(
         };
         const authInput = resolveClaudeCliAuthInput(credentialContext.authCredential);
         const isolatedCompletion = credentialContext.isolatedCompletionPrompt !== undefined;
-        const env = {
-          ...resolveClaudeCliAutoCompactEnv(context.contextTokenBudget),
-          ...(context.contextWindow === "200k" ? { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" } : {}),
-          ...resolveClaudeCliThinkingEnv(context.thinkingLevel, context.modelId),
-          ...authInput?.env,
-        };
         const agentSdkExecution =
           !isolatedCompletion && context.executionMode === "agent"
             ? {
@@ -260,6 +259,13 @@ export function buildAnthropicCliBackend(
                 },
               }
             : undefined;
+        const env = {
+          ...(agentSdkExecution ? { CLAUDE_AGENT_SDK_VERSION } : {}),
+          ...resolveClaudeCliAutoCompactEnv(context.contextTokenBudget),
+          ...(context.contextWindow === "200k" ? { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" } : {}),
+          ...resolveClaudeCliThinkingEnv(context.thinkingLevel, context.modelId),
+          ...authInput?.env,
+        };
         return Object.keys(env).length > 0 || isolatedCompletion || agentSdkExecution
           ? {
               env,


### PR DESCRIPTION
## Summary

- seed `CLAUDE_AGENT_SDK_VERSION` from the Anthropic plugin manifest before core fingerprints the child environment
- keep the first resumed Agent SDK turn on the existing live query
- cover the prepared SDK identity alongside credential isolation

## Root cause

Agent SDK 0.3.232 assigns its version to `process.env` when `query()` starts. The first OpenClaw turn fingerprinted the inherited value; the second fingerprinted 0.3.232, treated the live query as stale, and restarted it. That discarded the warm prompt cache and made both first turns report zero cache reads.

## Proof

- pre-fix regression: expected SDK version, received an empty prepared environment
- `node scripts/run-vitest.mjs extensions/anthropic/agent-sdk.runtime.test.ts` — 26 passed
- `pnpm lint:extensions`
- `pnpm tsgo`
- `pnpm check:test-types`
- `pnpm build`
- live two-turn Claude Agent SDK probe with an inherited mismatched version: one live session; turn 2 read 51,255 cache tokens and wrote 168 (99.65% hit)

### Redacted live probe output

Command shape for each turn:

```text
OPENCLAW_CONFIG_PATH=<temp-config> OPENCLAW_STATE_DIR=<temp-state> node openclaw.mjs agent --agent main --session-key agent:main:cache-fixed --message <probe> --json
```

```json
{"turn":1,"usage":{"input":10,"output":4,"cacheRead":38104,"cacheWrite":13151}}
{"turn":2,"usage":{"input":10,"output":4,"cacheRead":51255,"cacheWrite":168}}
```

```text
cli exec: provider=claude-cli model=claude-haiku-4-5 ... useResume=false ...
cli live session start: provider=claude-cli model=claude-haiku-4-5 activeSessions=1
cli exec: provider=claude-cli model=claude-haiku-4-5 ... useResume=true ... reuse=reusable
```

Interpretation: only one live-session start occurred; the resumed turn reused it and achieved `51255 / (51255 + 168 + 10) = 99.65%` cache hits.

Production delta: +6 lines. No core/provider-generic exception; normalization remains owned by the Anthropic plugin.