### PR TITLE
fix(ui): retain cloud profiles after refresh failure

### DIFF
--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -1,11 +1,15 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { expect, it } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { CLOUD_PROFILE_RETRY_DELAYS_MS } from "../pages/new-session/cloud-profile-discovery.ts";
 import {
   ONE_PIXEL_PNG_B64,
   SESSION_LIST_DEFAULTS,
   TARGET_REPO,
   WORKSPACE,
   captureUiProof,
+  captureUiProofEnabled,
   controlUiSessionPath,
   controlUiSessionUrl,
   createNewSessionPageE2eSuite,
@@ -21,13 +25,25 @@ import {
 const suite = createNewSessionPageE2eSuite();
 const SESSION_PLACEMENT_STARTUP_RUNTIME_REQUEST =
   /\/assets\/session-placement-startup\.runtime-[^/?]+\.js(?:\?.*)?$/;
+const cloudProfileRefreshProofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "cloud-profile-refresh-retention",
+);
 
 suite.define(() => {
   it("dispatches a cloud target before sending its first turn and shows placement", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(cloudProfileRefreshProofDir, { recursive: true });
+    }
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
+      ...(captureUiProofEnabled
+        ? { recordVideo: { dir: cloudProfileRefreshProofDir, size: { height: 900, width: 1280 } } }
+        : {}),
     });
     const page = await context.newPage();
     const runtimeLoad = createDeferred();
@@ -269,6 +285,69 @@ suite.define(() => {
         .toBeGreaterThan(failedProfileRequests);
       await expect.poll(() => startButton.isDisabled()).toBe(false);
 
+      if (captureUiProofEnabled) {
+        await trigger.click();
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(cloudProfileRefreshProofDir, "01-before-refresh.png"),
+        });
+        await page.keyboard.press("Escape");
+      }
+
+      await page.clock.install();
+      await gateway.setMethodResponse("environments.list", {
+        __mockError: { code: "UNAVAILABLE", message: "profile catalog remains unavailable" },
+      });
+      await gateway.deferNext("environments.list");
+      const requestsBeforePersistentFailure = (await gateway.getRequests("environments.list"))
+        .length;
+      await gateway.emitGatewayEvent("node.runnerInventory.changed");
+      await gateway.waitForRequest("environments.list", {
+        after: requestsBeforePersistentFailure,
+      });
+      await expect.poll(() => startButton.isDisabled()).toBe(true);
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(cloudProfileRefreshProofDir, "02-refresh-pending.png"),
+        });
+      }
+      await gateway.rejectDeferred("environments.list", {
+        code: "UNAVAILABLE",
+        message: "profile catalog remains unavailable",
+      });
+
+      for (const delayMs of CLOUD_PROFILE_RETRY_DELAYS_MS) {
+        const requestsBeforeRetry = (await gateway.getRequests("environments.list")).length;
+        await page.clock.runFor(delayMs + 1);
+        await gateway.waitForRequest("environments.list", { after: requestsBeforeRetry });
+      }
+      await page.clock.resume();
+      expect(await gateway.getRequests("environments.list")).toHaveLength(
+        requestsBeforePersistentFailure + 1 + CLOUD_PROFILE_RETRY_DELAYS_MS.length,
+      );
+      await expect.poll(() => trigger.getAttribute("data-cloud-profile")).toBe("aws");
+      await expect.poll(() => trigger.getAttribute("data-machine-class")).toBe("fast");
+      await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("aws · Fast");
+      await expect.poll(() => startButton.isDisabled()).toBe(false);
+      await trigger.click();
+      const retainedCloudProfile = place.getByRole("button", { name: "Cloud · aws" });
+      await expect.poll(() => retainedCloudProfile.isDisabled()).toBe(false);
+      expect(await retainedCloudProfile.getAttribute("title")).toBe(
+        "Cloud worker provider: crabbox",
+      );
+      await expect.poll(() => place.getByRole("button", { name: /Fast/ }).isVisible()).toBe(true);
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(cloudProfileRefreshProofDir, "03-after-retry-exhaustion.png"),
+        });
+      }
+      await page.keyboard.press("Escape");
+
       await startButton.click();
 
       const create = await gateway.waitForRequest("sessions.create");
@@ -297,6 +376,13 @@ suite.define(() => {
         profileId: "aws",
         machineClass: "fast",
       });
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(cloudProfileRefreshProofDir, "04-session-dispatch.png"),
+        });
+      }
       const describeRequestsAfterNavigation = (await gateway.getRequests("sessions.describe"))
         .length;
       await expect.poll(() => page.url()).toContain(controlUiSessionPath(sessionKey));

--- a/ui/src/pages/new-session/draft-gateway-state.ts
+++ b/ui/src/pages/new-session/draft-gateway-state.ts
@@ -134,9 +134,7 @@ export class DraftGatewayState {
         this.callbacks.requestUpdate();
       },
       onError: () => {
-        // Keep the last environment catalog across a transient client refresh on this Gateway.
-        this.cloudProfilesValue = [];
-        this.cloudProfilesReadyValue = false;
+        // A failed refresh cannot invalidate this Gateway's last successful place catalog.
         this.scheduleCloudProfileRetry();
         this.callbacks.requestUpdate();
       },
@@ -497,8 +495,10 @@ export class DraftGatewayState {
       return;
     }
     if (this.cloudProfileRetryAttempt >= CLOUD_PROFILE_RETRY_DELAYS_MS.length) {
-      this.applyCloudProfiles([]);
-      this.cloudProfilesReadyValue = true;
+      if (!this.cloudProfilesReadyValue) {
+        this.applyCloudProfiles([]);
+        this.cloudProfilesReadyValue = true;
+      }
       return;
     }
     const delayMs = CLOUD_PROFILE_RETRY_DELAYS_MS[this.cloudProfileRetryAttempt];


### PR DESCRIPTION
Closes #128988

## What Problem This Solves

A persistent `environments.list` refresh failure on the New Session page erased the last successful cloud profile and machine catalog. After all retries failed, a selected `aws · Fast` destination degraded into a disabled `Cloud · aws` placeholder with “This session target is unavailable,” even though the Gateway had never authoritatively removed that profile.

## Why This Change Was Made

The Gateway discovery state already owns one same-Gateway catalog snapshot. Failed reads now leave that last successful profile, environment, machine metadata, and readiness fact intact while retrying. Retry exhaustion no longer turns a failed refresh into an authoritative empty response when a successful snapshot exists.

Initial discovery behavior remains unchanged: if no catalog has ever loaded, exhausting retries still resolves to an empty ready result so stored placement preferences can settle. A real successful empty response and Gateway owner/identity invalidation still clear the snapshot. No fallback cache, compatibility path, config, or duplicated discovery state was added.

Production LOC: +5/-5 (net 0) | Tests: +86/-0

AI-assisted: yes. I reviewed New Session profile discovery ownership, retry exhaustion, Gateway identity invalidation, preference restoration, submit gates, machine selection, and dispatch payloads.

## User Impact

Operators can keep using an already discovered Cloud destination during a catalog outage. The selected profile and machine remain visible and enabled after retries exhaust, and session creation still dispatches the same authoritative `profileId` and `machineClass` for Gateway validation.

## Evidence

- Pre-fix Chromium RED: after the complete production retry schedule, the selected label degraded from `aws · Fast` to `aws · fast`; the picker showed a disabled `Cloud · aws` row and “This session target is unavailable.”
- Post-fix Chromium E2E: the same five persistent failures retain the enabled AWS profile, `Fast` machine metadata, re-enable Start session after requests settle, and dispatch `profileId: "aws"` plus `machineClass: "fast"`.
- Focused proof: 1 real Chromium E2E and 95 new-session state tests passed on the exact rebased head.
- `node scripts/check-changed.mjs` passed UI/core-test typechecks, lint, formatting, i18n verification, dead exports, architecture guards, and package/dependency checks.
- Autoreview P1 addressed: initial discovery without a prior successful snapshot preserves its old terminal-empty behavior. Fresh exact-branch P0/P1 autoreview has no accepted/actionable findings (0.94).
- Inspected visual proof includes a pre-fix broken screenshot, post-fix before/pending/after/dispatch screenshots, and a 38-second Chromium recording. It will be attached in the PR conversation.
- No live provider request was required: this is a Control UI projection/cache-ownership bug exercised against the real browser/Gateway request boundary with deterministic responses and production retry timing.
