### PR TITLE
fix(agents): front-load exec retention-loss disclosure past session caps

### DIFF
--- a/src/agents/bash-tools.exec-output.ts
+++ b/src/agents/bash-tools.exec-output.ts
@@ -9,6 +9,10 @@ export const EXEC_NO_OUTPUT_PLACEHOLDER = "(no output)";
 const EXEC_TIMEOUT_RETRY_GUIDANCE =
   "The command was terminated, but external side effects may already have completed. Verify the resulting state before retrying. Do not automatically rerun non-idempotent commands. Use a higher timeout only when the command is known to be safe to retry.";
 
+// Irreversible loss leads model-visible output so later head-preserving caps retain it.
+export const EXEC_RETENTION_CAP_NOTE =
+  "[earlier output was discarded at the retention cap and cannot be recovered]\n\n";
+
 /** Render command output with a stable placeholder for empty output. */
 export function renderExecOutputText(value: string | undefined): string {
   return value || EXEC_NO_OUTPUT_PLACEHOLDER;

--- a/src/agents/bash-tools.exec-support.test.ts
+++ b/src/agents/bash-tools.exec-support.test.ts
@@ -12,13 +12,15 @@ describe("exec foreground retention", () => {
         aggregated: "retained output",
         timedOut: false,
       },
+      warningText: "w".repeat(80_000),
       aggregateOutputDropped: true,
     });
 
-    expect(result.content[0]).toMatchObject({
-      type: "text",
-      text: expect.stringContaining("discarded at the retention cap and cannot be recovered"),
-    });
+    const content = result.content[0];
+    expect(content).toMatchObject({ type: "text" });
+    expect(content?.type === "text" ? content.text : "").toMatch(
+      /^\[earlier output was discarded at the retention cap and cannot be recovered\]/,
+    );
     expect((result.details as { aggregated?: string }).aggregated).toBe("retained output");
   });
 });

--- a/src/agents/bash-tools.exec-support.ts
+++ b/src/agents/bash-tools.exec-support.ts
@@ -2,7 +2,7 @@ import type { ExecHost } from "../infra/exec-approvals.js";
 import { requireValidExecTarget } from "../infra/exec-approvals.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
-import { renderExecOutputText } from "./bash-tools.exec-output.js";
+import { EXEC_RETENTION_CAP_NOTE, renderExecOutputText } from "./bash-tools.exec-output.js";
 import type { ExecToolArgs } from "./bash-tools.exec-request-preparation.js";
 import { type ExecProcessOutcome, resolveExecTarget } from "./bash-tools.exec-runtime.js";
 import type {
@@ -31,9 +31,7 @@ export function buildExecForegroundResult(params: {
   aggregateOutputDropped?: boolean;
 }): AgentToolResult<ExecToolDetails> {
   const warningText = params.warningText?.trim() ? `${params.warningText}\n\n` : "";
-  const retentionCapNote = params.aggregateOutputDropped
-    ? "\n\n[earlier output was discarded at the retention cap and cannot be recovered]"
-    : "";
+  const retentionCapNote = params.aggregateOutputDropped ? EXEC_RETENTION_CAP_NOTE : "";
   if (params.outcome.status === "failed") {
     const linuxOomGuidance =
       params.outcome.failureKind === "signal" &&
@@ -44,7 +42,7 @@ export function buildExecForegroundResult(params: {
           "SIGKILL alone does not identify whether the Linux OOM killer, an operator, or another process sent it. " +
           "Check cgroup memory events or kernel logs. If they show memory pressure, narrow the command or adjust memory, concurrency, or resource limits."
         : "";
-    const outputText = `${warningText}${params.outcome.reason}${linuxOomGuidance}${retentionCapNote}`;
+    const outputText = `${retentionCapNote}${warningText}${params.outcome.reason}${linuxOomGuidance}`;
     return failedTextResult(outputText, {
       status: "failed",
       exitCode: params.outcome.exitCode ?? null,
@@ -58,7 +56,7 @@ export function buildExecForegroundResult(params: {
       cwd: params.cwd,
     });
   }
-  const outputText = `${warningText}${renderExecOutputText(params.outcome.aggregated)}${retentionCapNote}`;
+  const outputText = `${retentionCapNote}${warningText}${renderExecOutputText(params.outcome.aggregated)}`;
   return textResult(outputText, {
     status: "completed",
     exitCode: params.outcome.exitCode,

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -456,15 +456,15 @@ test("terminal polls compact tiny stream chunks and never reopen frozen output",
   const terminal = await pollSession(processTool, "compact-first", sessionId);
   expect(terminal.content[0]).toMatchObject({
     text:
+      "[earlier output was discarded at the retention cap and cannot be recovered]\n\n" +
+      "[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]\n\n" +
       "oe".repeat(1_000) +
-      "\n\n[earlier output was discarded at the retention cap and cannot be recovered]" +
-      "\n\n[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]" +
       "\n\nProcess exited with code 0.",
   });
   appendOutput(session, "stderr", "late".repeat(1_000));
   const repeated = await pollSession(processTool, "compact-second", sessionId);
   expect(repeated.content[0]).toMatchObject({
-    text: "(no new output)\n\n[earlier output was discarded at the retention cap and cannot be recovered]\n\nProcess exited with code 0.",
+    text: "[earlier output was discarded at the retention cap and cannot be recovered]\n\n(no new output)\n\nProcess exited with code 0.",
   });
   expect(session.totalOutputChars).toBe(4_000);
   expect(session.pendingOutput).toBe("");
@@ -472,8 +472,8 @@ test("terminal polls compact tiny stream chunks and never reopen frozen output",
   const log = await processTool.execute("compact-log", { action: "log", sessionId });
   expect(log.content[0]).toMatchObject({
     text:
-      "oe".repeat(1_500) +
-      "\n\n[earlier output was discarded at the retention cap and cannot be recovered]",
+      "[earlier output was discarded at the retention cap and cannot be recovered]\n\n" +
+      "oe".repeat(1_500),
   });
 });
 
@@ -753,6 +753,11 @@ test.each([
     expect(runningLogText).toContain("discarded at the retention cap and cannot be recovered");
     expect(runningPollText).toContain("discarded at the retention cap and cannot be recovered");
     expect(finishedLogText).toContain("discarded at the retention cap and cannot be recovered");
+    for (const resultText of [text, runningLogText, runningPollText, finishedLogText]) {
+      expect(resultText).toMatch(
+        /^\[earlier output was discarded at the retention cap and cannot be recovered\]/,
+      );
+    }
     expect(text).not.toContain("action=log with offset and limit");
   },
 );

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -24,7 +24,11 @@ import {
   setJobTtlMs,
 } from "./bash-process-registry.js";
 import { describeProcessTool } from "./bash-tools.descriptions.js";
-import { appendExecTimeoutRetryGuidance, renderExecExitLabel } from "./bash-tools.exec-output.js";
+import {
+  EXEC_RETENTION_CAP_NOTE,
+  appendExecTimeoutRetryGuidance,
+  renderExecExitLabel,
+} from "./bash-tools.exec-output.js";
 import {
   handleProcessSendKeys,
   type WritableStdin,
@@ -100,9 +104,7 @@ function defaultTailNote(totalLines: number, usingDefaultTail: boolean) {
 }
 
 function retentionCapNote(session: Pick<ProcessSession, "totalOutputChars" | "aggregated">) {
-  return session.totalOutputChars > session.aggregated.length
-    ? "\n\n[earlier output was discarded at the retention cap and cannot be recovered]"
-    : "";
+  return session.totalOutputChars > session.aggregated.length ? EXEC_RETENTION_CAP_NOTE : "";
 }
 
 const MAX_POLL_WAIT_MS = 30_000;
@@ -215,8 +217,8 @@ function finishedPollResult(
   // the exact process; a reused slug must never point the model at successor logs.
   const retainedOutputNote = outputDropped
     ? getFinishedSession(sessionId) === finished
-      ? "\n\n[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]"
-      : "\n\n[earlier output is omitted from this poll; omitted output is no longer available through action=log]"
+      ? "[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]\n\n"
+      : "[earlier output is omitted from this poll; omitted output is no longer available through action=log]\n\n"
     : "";
   return attachInternalToolResultAcknowledgement(
     {
@@ -224,9 +226,9 @@ function finishedPollResult(
         {
           type: "text",
           text: appendExecTimeoutRetryGuidance(
-            (output || "(no new output)") +
-              retentionCapNote(finished) +
+            retentionCapNote(finished) +
               retainedOutputNote +
+              (output || "(no new output)") +
               `\n\nProcess exited with ${renderExecExitLabel(finished)}.`,
             finished.exitReason,
           ),
@@ -484,7 +486,7 @@ export function createProcessTool(
           const output = unreadOutput.trim();
           const aggregateOutputNote = retentionCapNote(scopedSession);
           const retainedOutputNote = outputDropped
-            ? "\n\n[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]"
+            ? "[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]\n\n"
             : "";
           const hasNewOutput = output.length > 0;
           const retryInMs = recordPollRetrySuggestion(params.sessionId, hasNewOutput);
@@ -495,9 +497,9 @@ export function createProcessTool(
                 {
                   type: "text",
                   text:
-                    (output || "(no new output)") +
                     aggregateOutputNote +
                     retainedOutputNote +
+                    (output || "(no new output)") +
                     (buildInputWaitHint(runtime) || "\n\nProcess still running."),
                 },
               ],
@@ -530,9 +532,9 @@ export function createProcessTool(
           );
           const runtime = scopedSession ? describeRunningSession(scopedSession) : undefined;
           const text =
+            retentionCapNote(record) +
             (slice || (scopedSession ? "(no output yet)" : "(no output recorded)")) +
-            defaultTailNote(totalLines, window.usingDefaultTail) +
-            retentionCapNote(record);
+            defaultTailNote(totalLines, window.usingDefaultTail);
           return {
             content: [
               {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -6,6 +6,7 @@ import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { createOpenClawReadTool } from "./agent-tools.read.js";
+import { buildExecForegroundResult } from "./bash-tools.exec-support.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
 import { redactTranscriptMessage } from "./transcript-redact.js";
@@ -191,6 +192,34 @@ describe("installSessionToolResultGuard", () => {
     expect(text).toMatch(
       /\[\.\.\. \d+ more characters truncated; rerun with narrower args if needed\]$/,
     );
+  });
+
+  it("keeps the exec retention-loss disclosure through the session result cap", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, { maxToolResultChars: 4_000 });
+    const result = buildExecForegroundResult({
+      outcome: {
+        status: "completed",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 1,
+        aggregated: "x".repeat(80_000),
+        timedOut: false,
+      },
+      aggregateOutputDropped: true,
+    });
+    const content = result.content[0];
+    if (!content || content.type !== "text") {
+      throw new Error("expected text result");
+    }
+
+    appendToolResultText(sm, content.text);
+
+    const text = getToolResultText(getPersistedMessages(sm));
+    expect(text).toMatch(
+      /^\[earlier output was discarded at the retention cap and cannot be recovered\]/,
+    );
+    expect(text).toMatch(/\[\.\.\. \d+ more characters truncated/);
   });
 
   it("honors tiny configured tool-result caps truthfully", () => {


### PR DESCRIPTION
## What Problem This Solves

OpenClaw can discard early exec output at its aggregate retention cap. The exec and process tools disclose that loss, but they placed the disclosure after the retained output. The session result cap keeps the head, so it could remove the producer disclosure while keeping only its own later truncation notice.

The persisted transcript then looked fully accounted for even though an earlier, unrecoverable loss was hidden. This can make an agent retry the same read without knowing why the output is incomplete.

Partially addresses #128967. The separate find and grep stderr-tail paths remain tracked there.

## Root Cause

The exec/process owner retained a capped output tail and appended the aggregate-loss notice. The SQLite transcript guard then applied a second, head-preserving cap. That composition removed the first notice.

`process poll` also appended its retained-output omission note. Under the same cap, the transcript could lose the distinction between output discarded at the aggregate cap and output still available through `process log`.

## Fix

- Own the aggregate-retention wording once in the shared exec output renderer.
- Put the unrecoverable aggregate-loss notice before foreground exec output and every process poll/log result.
- Put the poll omission notice before poll output, while keeping the ordinary log paging note after the slice it describes.
- Keep retention sizes, session limits, process lifecycle, configuration, storage schema, and documented behavior unchanged.

## Evidence

The live proof runs a real Node child that writes 250,000 characters through the production foreground exec and background process paths. It persists each tool result through the guarded SQLite session manager, reopens the database, and inspects the stored text.

Exact main `eeec0d4b2a0cada60046aba548d005cd7ace125a` is red:

- Foreground exec, process poll, and process log each return the aggregate-loss notice before persistence.
- After SQLite reopen, all three stored results lose that notice.
- All three still contain the session result-cap notice, proving the later cap hid only the earlier disclosure.

Exact candidate `34f704e3fdbd7308a05fd98960a7d43332412254` is green:

- All three reopened results retain the aggregate-loss notice.
- All three retain the session result-cap notice.
- Poll also retains the separate note that earlier output is omitted from this poll and remains available through `process log`.

Regression proof:

- The new owner-boundary persistence test fails on pre-fix main because stored text begins with retained output instead of the loss notice.
- The repaired head passes 90 focused tests across foreground exec, process poll/log, and session result persistence.
- Formatting, Oxlint, diff checks, and all permitted changed-file ratchets pass locally. Hosted CI owns repository-wide type checks and builds.

## Scope

Production is +4 lines after unifying the duplicate notice text. Tests are +36 lines. No configuration, dependency, protocol, schema, migration, or documentation contract changes.
