### PR TITLE
fix(gateway): use secure telemetry jitter

### DIFF
--- a/src/gateway/server-maintenance.telemetry.test.ts
+++ b/src/gateway/server-maintenance.telemetry.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createGatewayMaintenanceStateForTest } from "./test-helpers.maintenance-state.js";
 
-const { checkTelemetryUpdateMock } = vi.hoisted(() => ({
+const { checkTelemetryUpdateMock, generateSecureIntMock } = vi.hoisted(() => ({
   checkTelemetryUpdateMock: vi.fn<typeof import("../infra/telemetry.js").checkTelemetryUpdate>(),
+  generateSecureIntMock: vi.fn<typeof import("../infra/secure-random.js").generateSecureInt>(),
+}));
+
+vi.mock("../infra/secure-random.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/secure-random.js")>()),
+  generateSecureInt: generateSecureIntMock,
 }));
 
 vi.mock("../infra/device-bootstrap.js", () => ({
@@ -29,11 +35,12 @@ describe("gateway telemetry maintenance", () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     checkTelemetryUpdateMock.mockReset();
+    generateSecureIntMock.mockReset();
   });
 
   it("uses one jittered maintenance schedule and silently retries failed checks", async () => {
     vi.useFakeTimers();
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    generateSecureIntMock.mockReturnValue(150_000);
     checkTelemetryUpdateMock.mockRejectedValueOnce(new Error("offline")).mockResolvedValue(null);
     const logHealth = { info: vi.fn(), error: vi.fn() };
     const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
@@ -45,12 +52,14 @@ describe("gateway telemetry maintenance", () => {
       runManagedOutgoingMediaGc: async () => undefined,
     });
 
+    expect(generateSecureIntMock).toHaveBeenNthCalledWith(1, 5 * 60_000);
     await vi.advanceTimersByTimeAsync(120_000);
     expect(checkTelemetryUpdateMock).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(30_000);
     expect(checkTelemetryUpdateMock).toHaveBeenCalledWith({}, { surface: "gateway" });
     expect(logHealth.error).not.toHaveBeenCalled();
+    expect(generateSecureIntMock).toHaveBeenNthCalledWith(2, 5 * 60_000);
 
     await vi.advanceTimersByTimeAsync(420_000);
     expect(checkTelemetryUpdateMock).toHaveBeenCalledTimes(1);
@@ -63,7 +72,7 @@ describe("gateway telemetry maintenance", () => {
 
   it("never checks telemetry for Nix-managed gateways", async () => {
     vi.useFakeTimers();
-    vi.spyOn(Math, "random").mockReturnValue(0);
+    generateSecureIntMock.mockReturnValue(0);
     const broadcast = vi.fn();
     const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
     const timers = startGatewayMaintenanceTimers({

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -14,6 +14,7 @@ import { pruneExpiredDeliveryQueueTombstones } from "../infra/delivery-queue-sql
 import { pruneExpiredDevicePairSetupCompletions } from "../infra/device-bootstrap.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { pruneOrphanedDeliveryQueueMedia } from "../infra/outbound/delivery-queue-media-spool.js";
+import { generateSecureInt } from "../infra/secure-random.js";
 import { checkTelemetryUpdate } from "../infra/telemetry.js";
 import { cleanOldMedia, pruneOutboundMedia, prunePlaybackTranscodeCache } from "../media/store.js";
 import { isGatewayWorkAdmissionClosed } from "../process/gateway-work-admission.js";
@@ -130,8 +131,7 @@ export function startGatewayMaintenanceTimers(params: {
     logger: params.logHealth,
   });
 
-  let nextTelemetryCheckAtMs =
-    Date.now() + Math.floor(Math.random() * TELEMETRY_MAINTENANCE_INTERVAL_MS);
+  let nextTelemetryCheckAtMs = Date.now() + generateSecureInt(TELEMETRY_MAINTENANCE_INTERVAL_MS);
   // periodic keepalive
   const tickInterval = setInterval(() => {
     void hostThawRecovery.tick();
@@ -140,7 +140,7 @@ export function startGatewayMaintenanceTimers(params: {
       nextTelemetryCheckAtMs =
         now +
         TELEMETRY_MAINTENANCE_INTERVAL_MS +
-        Math.floor(Math.random() * TELEMETRY_MAINTENANCE_INTERVAL_MS);
+        generateSecureInt(TELEMETRY_MAINTENANCE_INTERVAL_MS);
       void checkTelemetryUpdate(params.getRuntimeConfig(), { surface: "gateway" }).catch(() => {});
     }
     const payload = { ts: now };


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release preparation could reject the gateway telemetry maintenance source because its jitter combined `Date.now()` with `Math.random()`, even though the value was scheduling jitter rather than a temporary-path identifier.

## Why This Change Was Made

The gateway now uses the canonical `generateSecureInt()` helper for both telemetry jitter calculations. Its `[0, maxExclusive)` contract preserves the existing initial `[0, 5m)` and repeat `[5m, 10m)` cadence while satisfying the repository random-ID guardrail. No telemetry behavior, configuration, or temp-path logic changes.

## User Impact

Maintainers can prepare releases without this false-positive guard failure. Gateway telemetry checks retain the same randomized cadence.

## Evidence

- AWS Crabbox `cbx_0870260b8ec8`, exact source base `935c555c98d6b38af76faa6a0b1370353d1828df`
- `node scripts/run-vitest.mjs src/gateway/server-maintenance.telemetry.test.ts` — 2/2 passed
- `pnpm run check:temp-path-guardrails` — passed
- `pnpm format:check src/gateway/server-maintenance.ts src/gateway/server-maintenance.telemetry.test.ts` — passed
- `node scripts/run-oxlint.mjs src/gateway/server-maintenance.ts src/gateway/server-maintenance.telemetry.test.ts` — 0 warnings, 0 errors
- `git diff --check` — passed
- signed commit: `308c01645650b3268af2f3a2675e3005db4e71be`
