### PR TITLE
improve(ci): run temp path guard in hosted checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2660,6 +2660,14 @@ jobs:
               fi
               pnpm tool-display:check
               pnpm check:host-env-policy:swift
+              if has_package_script "check:temp-path-guardrails"; then
+                pnpm check:temp-path-guardrails
+              elif [[ "$FROZEN_TARGET" == "true" ]]; then
+                echo "[skip] frozen target predates the temp path guardrails"
+              else
+                echo "Current CI targets must provide the check:temp-path-guardrails package script." >&2
+                exit 1
+              fi
               if [[ "$FROZEN_TARGET" == "true" ]]; then
                 pnpm dup:check:coverage
               else

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1156,6 +1156,52 @@ function runProtocolSinceFixture(checkout: string, baseSha: string) {
   });
 }
 
+function runGuardCheckFixture(options: { frozenTarget: boolean; scripts: string[] }): {
+  calls: string[];
+  output: string;
+  status: number | null;
+} {
+  const root = tempDirs.make("openclaw-ci-guards-");
+  const fakeBin = path.join(root, "bin");
+  const callsPath = path.join(root, "pnpm-calls.txt");
+  mkdirSync(fakeBin);
+  writeFileSync(
+    path.join(root, "package.json"),
+    `${JSON.stringify({
+      scripts: Object.fromEntries(options.scripts.map((name) => [name, "true"])),
+    })}\n`,
+  );
+  writeExecutable(path.join(fakeBin, "pnpm"), [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    'printf "%s\\n" "$*" >> "$PNPM_CALLS"',
+  ]);
+  const checkShardRun = readCiWorkflow().jobs["check-shard"].steps.find(
+    (step: WorkflowStep) => step.name === "Run check shard",
+  ).run;
+  const run = spawnSync("bash", ["-c", checkShardRun], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      FROZEN_TARGET: options.frozenTarget ? "true" : "false",
+      FORMAT_CHECK: "false",
+      HISTORICAL_TARGET: options.frozenTarget ? "true" : "false",
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      PNPM_CALLS: callsPath,
+      PR_BASE_SHA: "",
+      TASK: "guards",
+    },
+  });
+  return {
+    calls: existsSync(callsPath)
+      ? readFileSync(callsPath, "utf8").trim().split("\n").filter(Boolean)
+      : [],
+    output: `${run.stdout}${run.stderr}`,
+    status: run.status,
+  };
+}
+
 function runDependencyCheckFixture(options: {
   historicalTarget: boolean;
   releaseToolingEntry?: boolean;
@@ -6189,6 +6235,50 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
     expect(checkShardStep.run).toContain(
       'timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags --depth=1 origin "+${PR_BASE_SHA}:refs/remotes/origin/ci-base"',
+    );
+  });
+
+  it("runs temp path guardrails in the hosted guard shard", () => {
+    const requiredScripts = ["check:doctor-deprecation-registry", "check:coercion-helpers"];
+    const current = runGuardCheckFixture({
+      frozenTarget: false,
+      scripts: [...requiredScripts, "check:temp-path-guardrails"],
+    });
+    expect(current.status, current.output).toBe(0);
+    expect(current.calls).toContain("check:temp-path-guardrails");
+    expect(current.calls.indexOf("check:temp-path-guardrails")).toBeLessThan(
+      current.calls.indexOf("dup:check"),
+    );
+
+    const frozenMissing = runGuardCheckFixture({
+      frozenTarget: true,
+      scripts: requiredScripts,
+    });
+    expect(frozenMissing.status, frozenMissing.output).toBe(0);
+    expect(frozenMissing.calls).not.toContain("check:temp-path-guardrails");
+    expect(frozenMissing.calls).toContain("dup:check:coverage");
+    expect(frozenMissing.output).toContain(
+      "[skip] frozen target predates the temp path guardrails",
+    );
+
+    const currentMissing = runGuardCheckFixture({
+      frozenTarget: false,
+      scripts: requiredScripts,
+    });
+    expect(currentMissing.status).toBe(1);
+    expect(currentMissing.calls).not.toContain("check:temp-path-guardrails");
+    expect(currentMissing.calls).not.toContain("dup:check");
+    expect(currentMissing.output).toContain(
+      "Current CI targets must provide the check:temp-path-guardrails package script.",
+    );
+
+    const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
+    const preflightGuards = workflow.slice(
+      workflow.indexOf("guards)"),
+      workflow.indexOf("npm-lock)"),
+    );
+    expect(preflightGuards.indexOf("pnpm check:temp-path-guardrails")).toBeLessThan(
+      preflightGuards.indexOf("pnpm dup:check"),
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the required hosted guard shard omitted `check:temp-path-guardrails`, allowing weak temporary-path identifiers to reach late release validation even though the local aggregate check and release pretag check already reject them.

## Why This Change Was Made

Runs the existing guard in the hosted `guards` shard before duplicate scanning. Current targets fail closed when the package script is missing, while frozen release targets retain an explicit compatibility skip.

## User Impact

Maintainers receive the same temporary-path safety signal in ordinary hosted CI instead of discovering it during release qualification.

## Evidence

- parent fix landed through https://github.com/openclaw/openclaw/pull/128998
- rebased onto exact `main` `7c71d417fba20b95d42252f265cea24c25635af2`
- exact PR head `4ea459578f20103c5d7e3fa7a3fd9589ea943f7f`
- `pnpm check:temp-path-guardrails`
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t "runs temp path guardrails in the hosted guard shard"`: 1 passed, 130 skipped
- `pnpm format:check -- .github/workflows/ci.yml test/scripts/ci-workflow-guards.test.ts`
- `git diff --check origin/main...HEAD`

The AWS Crabbox `pnpm check:workflows` pre-commit fallback hung twice inside actionlint without producing a lint diagnostic. The bounded retry reached its 10-minute limit with one actionlint worker blocked at 0% CPU; its log SHA-256 is `8e37ed8c635dfe4981ddffbaa77a8f4261b03216979681a79b990c9394a0067b`. Exact-head hosted `Workflow Sanity / actionlint` is therefore the authoritative workflow-lint proof for this head.


### Exact-head hosted proof

- `Workflow Sanity / actionlint`: https://github.com/openclaw/openclaw/actions/runs/32817900665/job/97709804380
- `check-guards`: https://github.com/openclaw/openclaw/actions/runs/32817933194/job/97710030671
- `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/32817933194/job/97711713364
- ClawSweeper reviewed exact head `4ea459578f20103c5d7e3fa7a3fd9589ea943f7f` with no findings. Its sole rank-up move, confirming actionlint and `check-guards`, is satisfied by the runs above.
