### PR TITLE
fix(cli): write telemetry JSON to stdout

### DIFF
--- a/src/cli/telemetry-cli.test.ts
+++ b/src/cli/telemetry-cli.test.ts
@@ -54,6 +54,7 @@ describe("telemetry cli", () => {
     vi.clearAllMocks();
     mocks.runtimeLogs.length = 0;
     mocks.runtimeErrors.length = 0;
+    mocks.defaultRuntime.writeJson.mockImplementation(() => {});
     mocks.getRuntimeConfig.mockReturnValue(config);
     mocks.buildTelemetryPayload.mockReturnValue(payload);
     mocks.buildTelemetryUserAgent.mockReturnValue(
@@ -82,18 +83,21 @@ describe("telemetry cli", () => {
   it("reports the same state and canonical payload as one JSON document", async () => {
     await runTelemetryCli(["show", "--json"]);
 
-    expect(mocks.runtimeLogs).toHaveLength(1);
-    expect(JSON.parse(mocks.runtimeLogs[0] ?? "")).toEqual({
-      featureStatsEnabled: true,
-      reason: "enabled",
-      endpoint: "https://telemetry.openclaw.ai/api/latest-version",
-      lastPingAt: "2026-08-22T12:00:00.000Z",
-      request: {
-        method: "POST",
-        userAgent: "openclaw/2026.8.2 (darwin; node/26.0.1; arm64; gateway)",
-        payload,
+    expect(mocks.defaultRuntime.writeJson).toHaveBeenCalledExactlyOnceWith(
+      {
+        featureStatsEnabled: true,
+        reason: "enabled",
+        endpoint: "https://telemetry.openclaw.ai/api/latest-version",
+        lastPingAt: "2026-08-22T12:00:00.000Z",
+        request: {
+          method: "POST",
+          userAgent: "openclaw/2026.8.2 (darwin; node/26.0.1; arm64; gateway)",
+          payload,
+        },
       },
-    });
+      0,
+    );
+    expect(mocks.defaultRuntime.log).not.toHaveBeenCalled();
   });
 
   it("reports a null JSON request when update checks are disabled", async () => {
@@ -105,12 +109,16 @@ describe("telemetry cli", () => {
 
     await runTelemetryCli(["show", "--json"]);
 
-    expect(JSON.parse(mocks.runtimeLogs[0] ?? "")).toMatchObject({
-      featureStatsEnabled: false,
-      reason: "update-disabled",
-      lastPingAt: null,
-      request: null,
-    });
+    expect(mocks.defaultRuntime.writeJson).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        featureStatsEnabled: false,
+        reason: "update-disabled",
+        lastPingAt: null,
+        request: null,
+      }),
+      0,
+    );
+    expect(mocks.defaultRuntime.log).not.toHaveBeenCalled();
   });
 
   it("shows only the update request headers when feature statistics are disabled", async () => {

--- a/src/cli/telemetry-cli.ts
+++ b/src/cli/telemetry-cli.ts
@@ -26,8 +26,8 @@ async function showTelemetry(options: { json?: boolean }): Promise<void> {
     : undefined;
 
   if (options.json) {
-    defaultRuntime.log(
-      JSON.stringify({
+    defaultRuntime.writeJson(
+      {
         featureStatsEnabled: telemetry.enabled,
         reason: telemetry.reason,
         endpoint: telemetry.endpoint,
@@ -39,7 +39,8 @@ async function showTelemetry(options: { json?: boolean }): Promise<void> {
               ...(payload ? { payload } : {}),
             }
           : null,
-      }),
+      },
+      0,
     );
     return;
   }

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -231,6 +231,49 @@ describe("cli json stdout contract", () => {
   });
 
   it.each([
+    { name: "piped stdout", tty: false },
+    { name: "dual TTYs", tty: true },
+  ])("writes successful telemetry show JSON to clean $name", async ({ tty }) => {
+    await withTempHome(
+      async (tempHome) => {
+        const ttyPreload = Buffer.from(
+          [
+            'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });',
+            'Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });',
+          ].join("\n"),
+        ).toString("base64");
+        const result = runBuiltCli(tempHome, ["telemetry", "show", "--json"], {
+          OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+          OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+          ...(tty
+            ? {
+                NODE_OPTIONS: `--import=data:text/javascript;base64,${ttyPreload}`,
+                FORCE_COLOR: "1",
+              }
+            : {}),
+        });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout, result.stderr).not.toMatch(/[\u001B\u0007]/u);
+        const payload = JSON.parse(result.stdout);
+        expect(payload).toEqual({
+          featureStatsEnabled: false,
+          reason: "never-asked",
+          endpoint: "https://telemetry.openclaw.ai/api/latest-version",
+          lastPingAt: null,
+          request: {
+            method: "GET",
+            userAgent: expect.stringMatching(/^openclaw\/[^ ]+ \(.+; gateway\)$/u),
+          },
+        });
+        expect(result.stdout).toBe(`${JSON.stringify(payload)}\n`);
+        expect(result.stderr).not.toContain('"featureStatsEnabled"');
+      },
+      { prefix: "openclaw-telemetry-json-success-e2e-" },
+    );
+  });
+
+  it.each([
     { name: "leaf JSON", args: ["models", "refresh", "--json"] },
     { name: "parent JSON", args: ["models", "--json", "refresh"] },
     { name: "human output", args: ["models", "refresh"], human: true },


### PR DESCRIPTION
## What Problem This Solves

`openclaw telemetry show --json` exited 0 with empty stdout because it serialized through the logger, which JSON mode redirects to stderr.

Fixes https://github.com/openclaw/openclaw/issues/129002.

## Why This Change Was Made

The telemetry command now hands the unchanged payload to the runtime's real JSON writer with compact encoding. Human output, telemetry status calculation, consent/update behavior, and exit semantics are unchanged.

Production delta: +4/-3, net +1 line. Tests: +68/-17, net +51 lines.

## User Impact

Telemetry JSON is now available on clean stdout as advertised, with no ANSI contamination or duplicate stderr document.

## Evidence

- Pre-fix built process: exit 0, stdout empty, JSON on stderr.
- Focused owner/runtime proof: 47 tests passed.
- Built-process proof: piped and dual-TTY telemetry JSON cases pass with one compact stdout document and clean stderr.
- Full build and complete changed-file gates passed.
- Fresh P1 autoreview: no actionable findings.
- `git diff --check`: passed.
