### PR TITLE
fix(update): avoid rollback while systemd service is still stopping

### DIFF
--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -1,6 +1,5 @@
 type ManagedSystemdPostExitState = {
   activeState: string;
-  generation?: "replacement";
   id?: string;
   loadState?: string;
   mainPid?: "parent" | "replacement" | "none";
@@ -17,12 +16,12 @@ export type ManagedServiceManagerBoundaryOptions = {
     pendingBootstrapFailures?: number;
     pendingOperationInProgress?: number;
   };
-  lateCommand?: "park" | "commit";
   overdueCommit?: boolean;
   systemdFault?: "start-failed" | "dead-restored-pid";
   systemdHandoffDeadlineMs?: number;
   systemdHandoffFailure?: boolean;
   systemdPostExitStates?: ManagedSystemdPostExitState[];
+  systemdStopDelayMs?: number;
   updaterExitCode?: number;
 };
 
@@ -53,7 +52,6 @@ type ManagedTestApi = {
 };
 
 type ManagedExpectation = {
-  toBeGreaterThan(expected: number): void;
   toBeNull(): void;
   toBeUndefined(): void;
   toEqual(expected: unknown): void;
@@ -75,77 +73,62 @@ export function registerManagedSystemdHandoffConvergenceTests(
   itUnix: ManagedTestApi,
   expect: ManagedExpect,
 ): void {
-  itUnix(
-    "waits for the same systemd execution to finish deactivating after its parent exits",
-    async () => {
-      const { commands, sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
-        systemdPostExitStates: [
-          { activeState: "deactivating", mainPid: "parent" },
-          { activeState: "deactivating", mainPid: "none" },
-          { activeState: "inactive", mainPid: "none" },
-        ],
-        updaterExitCode: 0,
-      });
+  itUnix("waits for the exact systemd stop job to finish after parent exit", async () => {
+    const { commands, sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
+      systemdStopDelayMs: 100,
+      updaterExitCode: 0,
+    });
 
-      expect(commands.map((command) => command.split(" ")[1])).toEqual([
-        "show",
-        "--no-block",
-        "show",
-        "show",
-        "show",
-      ]);
-      expect(state).toMatchObject({ parked: true, postExitShows: 3 });
-      expect(state.reset).toBeUndefined();
-      expect(state.restored).toBeUndefined();
-      expect(sentinel).toBeNull();
-    },
-  );
+    expect(commands.map((command) => command.split(" ")[1])).toEqual(["show", "stop", "show"]);
+    expect(state).toMatchObject({ parked: true, stopCompleted: true });
+    expect(state.reset).toBeUndefined();
+    expect(state.restored).toBeUndefined();
+    expect(sentinel).toBeNull();
+  });
 
   itUnix.each([
-    ["a replaced execution generation", { activeState: "deactivating", generation: "replacement" }],
-    ["a replacement main PID", { activeState: "deactivating", mainPid: "replacement" }],
-    ["an active service", { activeState: "active", mainPid: "parent" }],
+    ["a replacement main PID", { activeState: "inactive", mainPid: "replacement" }],
+    ["an active service", { activeState: "active", mainPid: "replacement" }],
     ["a restarting service", { activeState: "activating", mainPid: "none" }],
     ["a failed service", { activeState: "failed", mainPid: "none" }],
     ["an inactive service retaining a main PID", { activeState: "inactive", mainPid: "parent" }],
-    ["a replaced service unit", { activeState: "deactivating", id: "replacement.service" }],
-    ["an unloaded service unit", { activeState: "deactivating", loadState: "not-found" }],
-  ] as const)("fails closed immediately when systemd reports %s", async (_label, invalidState) => {
-    const { commands, sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
-      systemdHandoffFailure: true,
-      systemdPostExitStates: [
-        { activeState: "deactivating", mainPid: "none" },
-        invalidState,
-        { activeState: "inactive", mainPid: "none" },
-      ],
-    });
+    ["a replaced service unit", { activeState: "inactive", id: "replacement.service" }],
+    ["an unloaded service unit", { activeState: "inactive", loadState: "not-found" }],
+  ] as const)(
+    "fails closed after stop completion when systemd reports %s",
+    async (_label, invalidState) => {
+      const { commands, sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
+        systemdHandoffFailure: true,
+        systemdPostExitStates: [invalidState],
+      });
 
-    expect(state).toMatchObject({ parked: true, postExitShows: 2, reset: true, restored: true });
-    expect(commands.filter((command) => command.includes("reset-failed"))).toHaveLength(1);
-    expect(sentinel).toMatchObject({
-      payload: {
-        status: "error",
-        stats: {
-          reason: "managed-service-handoff-helper-failed",
-          steps: expect.arrayContaining([
-            expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
-          ]),
+      expect(state).toMatchObject({ parked: true, stopCompleted: true, postExitShows: 1 });
+      expect(commands.filter((command) => command.includes("reset-failed"))).toHaveLength(1);
+      expect(sentinel).toMatchObject({
+        payload: {
+          status: "error",
+          stats: {
+            reason: "managed-service-handoff-helper-failed",
+            steps: expect.arrayContaining([
+              expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
+            ]),
+          },
         },
-      },
-    });
-  });
+      });
+    },
+  );
 
   itUnix(
-    "fails closed when systemd stop convergence exhausts the existing parent-exit deadline",
+    "fails closed when the exact systemd stop job exhausts the parent-exit deadline",
     async () => {
       const { sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
-        systemdHandoffDeadlineMs: 1_500,
+        systemdHandoffDeadlineMs: 5_000,
         systemdHandoffFailure: true,
-        systemdPostExitStates: [{ activeState: "deactivating", mainPid: "none" }],
+        systemdStopDelayMs: 6_000,
       });
 
       expect(state).toMatchObject({ parked: true, reset: true, restored: true });
-      expect(state.postExitShows).toBeGreaterThan(1);
+      expect(state.stopCompleted).toBeUndefined();
       expect(sentinel).toMatchObject({
         payload: { status: "error", stats: { reason: "managed-service-handoff-helper-failed" } },
       });
@@ -166,11 +149,19 @@ const fs = require("node:fs");
 const args = process.argv.slice(2);
 const statePath = ${JSON.stringify(statePath)};
 const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : {};
+const sleep = (ms) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 fs.appendFileSync(${JSON.stringify(commandsPath)}, args.join(" ") + "\\n");
 const action = args.find((arg) => ["show", "stop", "reset-failed", "start", "print", "disable", "bootout", "enable", "bootstrap", "kickstart"].includes(arg));
 if (${JSON.stringify(kind)} === "systemd") {
-  if (action === "stop") state.parked = true;
-  if (action === "stop" && ${Boolean(options?.lateCommand)}) setTimeout(() => {}, 200);
+  if (action === "stop") {
+    state.parked = true;
+    fs.writeFileSync(statePath, JSON.stringify(state));
+    for (;;) {
+      try { process.kill(${parentPid}, 0); sleep(10); } catch { break; }
+    }
+    sleep(${options?.systemdStopDelayMs ?? 0});
+    state.stopCompleted = true;
+  }
   if (action === "reset-failed") state.reset = true;
   if (action === "start" && ${JSON.stringify(options?.systemdFault)} === "start-failed") {
     state.startFailed = true;
@@ -189,12 +180,13 @@ if (${JSON.stringify(kind)} === "systemd") {
       : observation?.mainPid === "replacement" ? ${process.pid}
       : observation?.mainPid === "none" ? 0
       : state.restored ? restoredPid : active ? ${parentPid} : 0;
+    const observedGeneration = state.restored ? "222" : active ? "111" : "0";
     process.stdout.write([
       "Id=" + (observation?.id || "openclaw-gateway.service"),
       "LoadState=" + (observation?.loadState || "loaded"),
       "ActiveState=" + (observation?.activeState || (active ? "active" : "inactive")),
       "MainPID=" + observedPid,
-      "ExecMainStartTimestampMonotonic=" + (state.restored || observation?.generation === "replacement" ? "222" : "111"),
+      "ExecMainStartTimestampMonotonic=" + observedGeneration,
     ].join("\\n") + "\\n");
   }
   } else {

--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -1,6 +1,8 @@
 type ManagedSystemdPostExitState = {
   activeState: string;
+  generation?: "cleared" | "parked" | "replacement";
   id?: string;
+  invocation?: "cleared" | "parked" | "replacement";
   loadState?: string;
   mainPid?: "parent" | "replacement" | "none";
 };
@@ -75,19 +77,45 @@ export function registerManagedSystemdHandoffConvergenceTests(
 ): void {
   itUnix("waits for the exact systemd stop job to finish after parent exit", async () => {
     const { commands, sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
+      systemdPostExitStates: [
+        { activeState: "deactivating", mainPid: "none" },
+        { activeState: "inactive", mainPid: "none" },
+      ],
       systemdStopDelayMs: 100,
       updaterExitCode: 0,
     });
 
-    expect(commands.map((command) => command.split(" ")[1])).toEqual(["show", "stop", "show"]);
-    expect(state).toMatchObject({ parked: true, stopCompleted: true });
+    expect(commands.map((command) => command.split(" ")[1])).toEqual([
+      "show",
+      "stop",
+      "show",
+      "show",
+    ]);
+    expect(state).toMatchObject({ parked: true, postExitShows: 2, stopCompleted: true });
     expect(state.reset).toBeUndefined();
     expect(state.restored).toBeUndefined();
     expect(sentinel).toBeNull();
   });
 
   itUnix.each([
-    ["a replacement main PID", { activeState: "inactive", mainPid: "replacement" }],
+    [
+      "an inactive replacement generation",
+      {
+        activeState: "inactive",
+        generation: "replacement",
+        invocation: "replacement",
+        mainPid: "none",
+      },
+    ],
+    [
+      "a cleared generation with the parked invocation",
+      { activeState: "inactive", generation: "cleared", invocation: "parked", mainPid: "none" },
+    ],
+    [
+      "the parked generation with a cleared invocation",
+      { activeState: "inactive", generation: "parked", invocation: "cleared", mainPid: "none" },
+    ],
+    ["a replacement main PID", { activeState: "deactivating", mainPid: "replacement" }],
     ["an active service", { activeState: "active", mainPid: "replacement" }],
     ["a restarting service", { activeState: "activating", mainPid: "none" }],
     ["a failed service", { activeState: "failed", mainPid: "none" }],
@@ -180,13 +208,24 @@ if (${JSON.stringify(kind)} === "systemd") {
       : observation?.mainPid === "replacement" ? ${process.pid}
       : observation?.mainPid === "none" ? 0
       : state.restored ? restoredPid : active ? ${parentPid} : 0;
-    const observedGeneration = state.restored ? "222" : active ? "111" : "0";
+    const observedGeneration = state.restored || observation?.generation === "replacement" ? "222"
+      : observation?.generation === "parked" ? "111"
+        : observation?.generation === "cleared" ? "0"
+          : active || observation?.activeState === "deactivating" ? "111" : "0";
+    const observedInvocation = state.restored || observation?.invocation === "replacement"
+      ? "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      : observation?.invocation === "parked" ? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        : observation?.invocation === "cleared" ? ""
+          : active || observation?.activeState === "deactivating"
+            ? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            : "";
     process.stdout.write([
       "Id=" + (observation?.id || "openclaw-gateway.service"),
       "LoadState=" + (observation?.loadState || "loaded"),
       "ActiveState=" + (observation?.activeState || (active ? "active" : "inactive")),
       "MainPID=" + observedPid,
       "ExecMainStartTimestampMonotonic=" + observedGeneration,
+      "InvocationID=" + observedInvocation,
     ].join("\\n") + "\\n");
   }
   } else {

--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -1,3 +1,5 @@
+import { expect, it } from "vitest";
+
 export type ManagedServiceManagerBoundaryOptions = {
   cancelAfterPark?: boolean;
   parentExitTimeoutMs?: number;
@@ -12,6 +14,16 @@ export type ManagedServiceManagerBoundaryOptions = {
   lateCommand?: "park" | "commit";
   overdueCommit?: boolean;
   systemdFault?: "start-failed" | "dead-restored-pid";
+  systemdHandoffDeadlineMs?: number;
+  systemdHandoffFailure?: boolean;
+  systemdPostExitStates?: Array<{
+    activeState: string;
+    generation?: "replacement";
+    id?: string;
+    loadState?: string;
+    mainPid?: "parent" | "replacement" | "none";
+  }>;
+  updaterExitCode?: number;
 };
 
 export type ManagedServiceCommandTiming = {
@@ -19,6 +31,100 @@ export type ManagedServiceCommandTiming = {
   startedAtMs: number;
   timeoutMs: number;
 };
+
+export type ManagedServiceManagerBoundaryResult = {
+  commands: string[];
+  parentSignal: NodeJS.Signals | null;
+  state: Record<string, unknown>;
+  sentinel: unknown;
+  commandTimings: ManagedServiceCommandTiming[];
+};
+
+export function registerManagedSystemdHandoffConvergenceTests(
+  runManagedServiceManagerBoundary: (
+    kind: "systemd",
+    options?: ManagedServiceManagerBoundaryOptions,
+  ) => Promise<ManagedServiceManagerBoundaryResult>,
+): void {
+  const itUnix = it.runIf(process.platform !== "win32");
+
+  itUnix(
+    "waits for the same systemd execution to finish deactivating after its parent exits",
+    async () => {
+      const { commands, sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
+        systemdPostExitStates: [
+          { activeState: "deactivating", mainPid: "parent" },
+          { activeState: "deactivating", mainPid: "none" },
+          { activeState: "inactive", mainPid: "none" },
+        ],
+        updaterExitCode: 0,
+      });
+
+      expect(commands.map((command) => command.split(" ")[1])).toEqual([
+        "show",
+        "--no-block",
+        "show",
+        "show",
+        "show",
+      ]);
+      expect(state).toMatchObject({ parked: true, postExitShows: 3 });
+      expect(state.reset).toBeUndefined();
+      expect(state.restored).toBeUndefined();
+      expect(sentinel).toBeNull();
+    },
+  );
+
+  itUnix.each([
+    ["a replaced execution generation", { activeState: "deactivating", generation: "replacement" }],
+    ["a replacement main PID", { activeState: "deactivating", mainPid: "replacement" }],
+    ["an active service", { activeState: "active", mainPid: "parent" }],
+    ["a restarting service", { activeState: "activating", mainPid: "none" }],
+    ["a failed service", { activeState: "failed", mainPid: "none" }],
+    ["an inactive service retaining a main PID", { activeState: "inactive", mainPid: "parent" }],
+    ["a replaced service unit", { activeState: "deactivating", id: "replacement.service" }],
+    ["an unloaded service unit", { activeState: "deactivating", loadState: "not-found" }],
+  ] as const)("fails closed immediately when systemd reports %s", async (_label, invalidState) => {
+    const { commands, sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
+      systemdHandoffFailure: true,
+      systemdPostExitStates: [
+        { activeState: "deactivating", mainPid: "none" },
+        invalidState,
+        { activeState: "inactive", mainPid: "none" },
+      ],
+    });
+
+    expect(state).toMatchObject({ parked: true, postExitShows: 2, reset: true, restored: true });
+    expect(commands.filter((command) => command.includes("reset-failed"))).toHaveLength(1);
+    expect(sentinel).toMatchObject({
+      payload: {
+        status: "error",
+        stats: {
+          reason: "managed-service-handoff-helper-failed",
+          steps: expect.arrayContaining([
+            expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
+          ]),
+        },
+      },
+    });
+  });
+
+  itUnix(
+    "fails closed when systemd stop convergence exhausts the existing parent-exit deadline",
+    async () => {
+      const { sentinel, state } = await runManagedServiceManagerBoundary("systemd", {
+        systemdHandoffDeadlineMs: 1_500,
+        systemdHandoffFailure: true,
+        systemdPostExitStates: [{ activeState: "deactivating", mainPid: "none" }],
+      });
+
+      expect(state).toMatchObject({ parked: true, reset: true, restored: true });
+      expect(state.postExitShows).toBeGreaterThan(1);
+      expect(sentinel).toMatchObject({
+        payload: { status: "error", stats: { reason: "managed-service-handoff-helper-failed" } },
+      });
+    },
+  );
+}
 
 export function createManagedServiceManagerFixtureScript(params: {
   kind: "systemd" | "launchd";
@@ -47,12 +153,21 @@ if (${JSON.stringify(kind)} === "systemd") {
   if (action === "show") {
     const active = !state.parked || state.restored;
     const restoredPid = ${JSON.stringify(options?.systemdFault)} === "dead-restored-pid" ? 2147483647 : ${process.pid};
+    const postExitStates = ${JSON.stringify(options?.systemdPostExitStates ?? [])};
+    const observation = state.parked && !state.restored && postExitStates.length
+      ? postExitStates[Math.min(state.postExitShows || 0, postExitStates.length - 1)]
+      : undefined;
+    if (observation) state.postExitShows = (state.postExitShows || 0) + 1;
+    const observedPid = observation?.mainPid === "parent" ? ${parentPid}
+      : observation?.mainPid === "replacement" ? ${process.pid}
+      : observation?.mainPid === "none" ? 0
+      : state.restored ? restoredPid : active ? ${parentPid} : 0;
     process.stdout.write([
-      "Id=openclaw-gateway.service",
-      "LoadState=loaded",
-      "ActiveState=" + (active ? "active" : "inactive"),
-      "MainPID=" + (state.restored ? restoredPid : active ? ${parentPid} : 0),
-      "ExecMainStartTimestampMonotonic=" + (state.restored ? "222" : "111"),
+      "Id=" + (observation?.id || "openclaw-gateway.service"),
+      "LoadState=" + (observation?.loadState || "loaded"),
+      "ActiveState=" + (observation?.activeState || (active ? "active" : "inactive")),
+      "MainPID=" + observedPid,
+      "ExecMainStartTimestampMonotonic=" + (state.restored || observation?.generation === "replacement" ? "222" : "111"),
     ].join("\\n") + "\\n");
   }
   } else {

--- a/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test-support.ts
@@ -1,4 +1,10 @@
-import { expect, it } from "vitest";
+type ManagedSystemdPostExitState = {
+  activeState: string;
+  generation?: "replacement";
+  id?: string;
+  loadState?: string;
+  mainPid?: "parent" | "replacement" | "none";
+};
 
 export type ManagedServiceManagerBoundaryOptions = {
   cancelAfterPark?: boolean;
@@ -16,13 +22,7 @@ export type ManagedServiceManagerBoundaryOptions = {
   systemdFault?: "start-failed" | "dead-restored-pid";
   systemdHandoffDeadlineMs?: number;
   systemdHandoffFailure?: boolean;
-  systemdPostExitStates?: Array<{
-    activeState: string;
-    generation?: "replacement";
-    id?: string;
-    loadState?: string;
-    mainPid?: "parent" | "replacement" | "none";
-  }>;
+  systemdPostExitStates?: ManagedSystemdPostExitState[];
   updaterExitCode?: number;
 };
 
@@ -40,14 +40,41 @@ export type ManagedServiceManagerBoundaryResult = {
   commandTimings: ManagedServiceCommandTiming[];
 };
 
+type ManagedSystemdFailureCase = readonly [string, ManagedSystemdPostExitState];
+
+type ManagedTestApi = {
+  (name: string, callback: () => Promise<void>): void;
+  each(
+    cases: readonly ManagedSystemdFailureCase[],
+  ): (
+    name: string,
+    callback: (label: string, value: ManagedSystemdPostExitState) => Promise<void>,
+  ) => void;
+};
+
+type ManagedExpectation = {
+  toBeGreaterThan(expected: number): void;
+  toBeNull(): void;
+  toBeUndefined(): void;
+  toEqual(expected: unknown): void;
+  toHaveLength(expected: number): void;
+  toMatchObject(expected: unknown): void;
+};
+
+type ManagedExpect = {
+  (actual: unknown): ManagedExpectation;
+  arrayContaining(expected: readonly unknown[]): unknown;
+  objectContaining(expected: object): unknown;
+};
+
 export function registerManagedSystemdHandoffConvergenceTests(
   runManagedServiceManagerBoundary: (
     kind: "systemd",
     options?: ManagedServiceManagerBoundaryOptions,
   ) => Promise<ManagedServiceManagerBoundaryResult>,
+  itUnix: ManagedTestApi,
+  expect: ManagedExpect,
 ): void {
-  const itUnix = it.runIf(process.platform !== "win32");
-
   itUnix(
     "waits for the same systemd execution to finish deactivating after its parent exits",
     async () => {

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -677,7 +677,7 @@ describe("managed service update handoff", () => {
     });
   });
 
-  registerManagedSystemdHandoffConvergenceTests(runManagedServiceManagerBoundary);
+  registerManagedSystemdHandoffConvergenceTests(runManagedServiceManagerBoundary, itUnix, expect);
 
   itUnix.each([
     ["without a late control command", undefined],

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -311,22 +311,6 @@ async function runManagedServiceManagerBoundary(
     });
     await expect(pathExists(commandsPath)).resolves.toBe(false);
     if (options?.parentExitTimeoutMs !== undefined) {
-      if (options.lateCommand) {
-        await vi.waitFor(
-          async () => {
-            await expect(fs.readFile(commandsPath, "utf8")).resolves.toContain(
-              "--no-block stop openclaw-gateway.service",
-            );
-          },
-          { interval: 5, timeout: options.parentExitTimeoutMs + 3_000 },
-        );
-        const response = waitForHandoffResponse(
-          runningHelper.stdout,
-          options.lateCommand === "park" ? "parked" : "restore-after-exit",
-        );
-        runningHelper.stdin?.write(`${options.lateCommand}\n`);
-        await response;
-      }
       const timeout = options.parentExitTimeoutMs + (options.launchdTeardown ? 8_000 : 3_000);
       let timer: ReturnType<typeof setTimeout> | undefined;
       try {
@@ -356,6 +340,14 @@ async function runManagedServiceManagerBoundary(
       expect(parent.exitCode).toBeNull();
       expect(parent.signalCode).toBeNull();
       await expect(pathExists(updaterPath)).resolves.toBe(false);
+    } else if (options?.overdueCommit) {
+      const cancelled = waitForHandoffResponse(runningHelper.stdout, "cancelled");
+      runningHelper.stdin?.write("park\n");
+      await cancelled;
+      expect(await completion, stderr).toBe(0);
+      expect(parent.exitCode).toBeNull();
+      expect(parent.signalCode).toBeNull();
+      await expect(pathExists(updaterPath)).resolves.toBe(false);
     } else {
       const parked = waitForHandoffResponse(runningHelper.stdout, "parked");
       runningHelper.stdin?.write("park\n");
@@ -367,17 +359,6 @@ async function runManagedServiceManagerBoundary(
         runningHelper.stdin?.write("cancel\n");
         await restoring;
         expect(stdout).not.toContain("committed\n");
-        parent.stdin?.end();
-        expect(await completion, stderr).toBe(0);
-        await expect(pathExists(updaterPath)).resolves.toBe(false);
-      } else if (options?.overdueCommit) {
-        runningHelper.stdin?.write("commit\n");
-        await vi.waitFor(
-          () => expect(stdout).toMatch(/(?:committed|restore-after-exit)\n/u),
-          FAST_WAIT_OPTS,
-        );
-        expect(stdout).not.toContain("committed\n");
-        expect(stdout).toContain("restore-after-exit\n");
         parent.stdin?.end();
         expect(await completion, stderr).toBe(0);
         await expect(pathExists(updaterPath)).resolves.toBe(false);
@@ -662,7 +643,7 @@ describe("managed service update handoff", () => {
     expect(commands[0]).toContain(
       "--property=Id,LoadState,ActiveState,MainPID,ExecMainStartTimestampMonotonic",
     );
-    expect(commands[1]).toContain("--no-block stop openclaw-gateway.service");
+    expect(commands[1]).toContain("stop openclaw-gateway.service");
     expect(state).toMatchObject({ parked: true, reset: true, restored: true });
     expect(sentinel).toMatchObject({
       payload: {
@@ -679,40 +660,6 @@ describe("managed service update handoff", () => {
 
   registerManagedSystemdHandoffConvergenceTests(runManagedServiceManagerBoundary, itUnix, expect);
 
-  itUnix.each([
-    ["without a late control command", undefined],
-    ["with an idempotent late park", "park"],
-    ["with a fenced late commit", "commit"],
-  ] as const)(
-    "restores a stalled managed parent when the deadline expires before park %s",
-    async (_label, lateCommand) => {
-      const { commands, parentSignal, sentinel, state } = await runManagedServiceManagerBoundary(
-        "systemd",
-        { parentExitTimeoutMs: 500, ...(lateCommand ? { lateCommand } : {}) },
-      );
-
-      expect(parentSignal).toBe("SIGKILL");
-      expect(commands).toEqual(
-        expect.arrayContaining([
-          expect.stringContaining("--no-block stop openclaw-gateway.service"),
-          expect.stringContaining("start openclaw-gateway.service"),
-        ]),
-      );
-      expect(state).toMatchObject({ parked: true, reset: true, restored: true });
-      expect(sentinel).toMatchObject({
-        payload: {
-          status: "error",
-          stats: {
-            reason: "managed-service-handoff-cancelled",
-            steps: expect.arrayContaining([
-              expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
-            ]),
-          },
-        },
-      });
-    },
-  );
-
   itUnix("rejects an overdue commit before its delayed deadline callback executes", async () => {
     const { commands, parentSignal, sentinel, state } = await runManagedServiceManagerBoundary(
       "systemd",
@@ -720,20 +667,17 @@ describe("managed service update handoff", () => {
     );
 
     expect(parentSignal).toBeNull();
-    expect(commands.filter((command) => command.includes("reset-failed"))).toHaveLength(1);
+    expect(
+      commands.filter((command) => command.includes("stop openclaw-gateway.service")),
+    ).toHaveLength(0);
     expect(
       commands.filter((command) => command.includes("start openclaw-gateway.service")),
-    ).toHaveLength(1);
-    expect(state).toMatchObject({ parked: true, reset: true, restored: true });
+    ).toHaveLength(0);
+    expect(state).toEqual({});
     expect(sentinel).toMatchObject({
       payload: {
         status: "error",
-        stats: {
-          reason: "managed-service-handoff-cancelled",
-          steps: expect.arrayContaining([
-            expect.objectContaining({ name: "service-restore", log: { exitCode: 0 } }),
-          ]),
-        },
+        stats: { reason: "managed-service-handoff-cancelled", steps: [] },
       },
     });
   });
@@ -746,10 +690,10 @@ describe("managed service update handoff", () => {
     async (_label, systemdFault, expectedState) => {
       const { commands, parentSignal, sentinel, state } = await runManagedServiceManagerBoundary(
         "systemd",
-        { parentExitTimeoutMs: 500, systemdFault },
+        { cancelAfterPark: true, systemdFault },
       );
 
-      expect(parentSignal).toBe("SIGKILL");
+      expect(parentSignal).toBeNull();
       expect(commands.filter((command) => command.includes("reset-failed"))).toHaveLength(1);
       expect(
         commands.filter((command) => command.includes("start openclaw-gateway.service")),

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -641,7 +641,7 @@ describe("managed service update handoff", () => {
     expect(verbs).toEqual(["show", "stop", "show", "reset-failed", "start", "show"]);
     expect(commands.every((command) => command.startsWith("--user "))).toBe(true);
     expect(commands[0]).toContain(
-      "--property=Id,LoadState,ActiveState,MainPID,ExecMainStartTimestampMonotonic",
+      "--property=Id,LoadState,ActiveState,MainPID,ExecMainStartTimestampMonotonic,InvocationID",
     );
     expect(commands[1]).toContain("stop openclaw-gateway.service");
     expect(state).toMatchObject({ parked: true, reset: true, restored: true });

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -24,8 +24,10 @@ import {
 import {
   createManagedServiceLaunchdClockPreload,
   createManagedServiceManagerFixtureScript,
+  registerManagedSystemdHandoffConvergenceTests,
   type ManagedServiceCommandTiming,
   type ManagedServiceManagerBoundaryOptions,
+  type ManagedServiceManagerBoundaryResult,
 } from "./update-managed-service-handoff-lifecycle.test-support.js";
 import { signalMockManagedUpdateHandoffReady } from "./update-managed-service-handoff.test-support.js";
 
@@ -146,13 +148,7 @@ function readRestartSentinelPayload(env: NodeJS.ProcessEnv, key = "current"): un
 async function runManagedServiceManagerBoundary(
   kind: "systemd" | "launchd",
   options?: ManagedServiceManagerBoundaryOptions,
-): Promise<{
-  commands: string[];
-  parentSignal: NodeJS.Signals | null;
-  state: Record<string, unknown>;
-  sentinel: unknown;
-  commandTimings: ManagedServiceCommandTiming[];
-}> {
+): Promise<ManagedServiceManagerBoundaryResult> {
   const { spawn } =
     await vi.importActual<typeof import("node:child_process")>("node:child_process");
   const { startManagedServiceUpdateHandoff } = await import("./update-managed-service-handoff.js");
@@ -239,6 +235,9 @@ async function runManagedServiceManagerBoundary(
               parentExitTimeoutMs: options.parentExitTimeoutMs,
             }),
         ...(options?.overdueCommit ? { parentExitDeadlineAt: Date.now() - 1 } : {}),
+        ...(options?.systemdHandoffDeadlineMs === undefined
+          ? {}
+          : { parentExitDeadlineAt: Date.now() + options.systemdHandoffDeadlineMs }),
         serviceRecovery: recovery,
         commandArgv: [
           process.execPath,
@@ -253,7 +252,7 @@ async function runManagedServiceManagerBoundary(
                   `fs.writeFileSync(${JSON.stringify(statePath)}, JSON.stringify(state));`,
                 ]
               : []),
-            `fs.writeFileSync(${JSON.stringify(updaterPath)}, "ran");process.exit(7);`,
+            `fs.writeFileSync(${JSON.stringify(updaterPath)}, "ran");process.exit(${options?.updaterExitCode ?? 7});`,
           ].join(""),
         ],
         sensitivePaths: [],
@@ -389,8 +388,10 @@ async function runManagedServiceManagerBoundary(
         parent.stdin?.end();
         const code = await completion;
         const helperLog = await fs.readFile(String(generated.logPath), "utf8").catch(() => "");
-        expect(code, `${stderr}\n${helperLog}`).toBe(7);
-        await expect(fs.readFile(updaterPath, "utf8")).resolves.toBe("ran");
+        expect(code, `${stderr}\n${helperLog}`).toBe(
+          options?.systemdHandoffFailure ? 1 : (options?.updaterExitCode ?? 7),
+        );
+        await expect(pathExists(updaterPath)).resolves.toBe(!options?.systemdHandoffFailure);
       }
     }
     expect(readLease()).toBeNull();
@@ -675,6 +676,8 @@ describe("managed service update handoff", () => {
       },
     });
   });
+
+  registerManagedSystemdHandoffConvergenceTests(runManagedServiceManagerBoundary);
 
   itUnix.each([
     ["without a late control command", undefined],

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -695,7 +695,7 @@ function runServiceCommand(command, args, onSpawn, deadline, timeoutCap) {
 
 async function inspectSystemdService(unit, deadline) {
   const result = await runServiceCommand("systemctl", ["--user", "show", unit,
-    "--property=Id,LoadState,ActiveState,MainPID,ExecMainStartTimestampMonotonic"], undefined, deadline);
+    "--property=Id,LoadState,ActiveState,MainPID,ExecMainStartTimestampMonotonic,InvocationID"], undefined, deadline);
   if (result.code !== 0) return null;
   return Object.fromEntries(result.stdout.trim().split(/\r?\n/).map((line) => {
     const index = line.indexOf("=");
@@ -708,6 +708,7 @@ function isLaunchdNotLoaded(result) {
 }
 
 let parkedServiceGeneration = null;
+let parkedServiceInvocation = null;
 let restorationArmed = false;
 let pendingServiceStop;
 
@@ -722,11 +723,12 @@ async function parkGatewayService() {
     if (!current || current.Id !== recovery.unit || current.LoadState !== "loaded" ||
       current.ActiveState !== "active" || current.MainPID !== String(params.parentPid) ||
       !/^[1-9]\d*$/.test(current.ExecMainStartTimestampMonotonic || "") ||
-      !ownsManagedUpdateLease() ||
+      !/^[a-f0-9]{32}$/i.test(current.InvocationID || "") || !ownsManagedUpdateLease() ||
       readProcessStartIdentity(params.parentPid) !== params.parentStartIdentity) {
       throw new Error("systemd service does not match the exact active gateway parent");
     }
     parkedServiceGeneration = current.ExecMainStartTimestampMonotonic;
+    parkedServiceInvocation = current.InvocationID;
     // Keep the exact stop job open across parent exit; its completion is the
     // authoritative systemd fact, even after inactive-unit metadata is collected.
     await new Promise((resolve, reject) => {
@@ -957,10 +959,30 @@ async function restoreGatewayService(reason) {
         throw new Error("systemd stop failed or exceeded the parent-exit deadline");
       }
       const unit = params.serviceRecovery.unit;
-      const current = await inspectSystemdService(unit, params.parentExitDeadlineAt);
-      if (!current || current.Id !== unit || current.LoadState !== "loaded" ||
-        current.ActiveState !== "inactive" || current.MainPID !== "0") {
-        throw new Error("systemd service remained active or changed execution generation");
+      for (;;) {
+        const current = await inspectSystemdService(unit, params.parentExitDeadlineAt);
+        if (!current || current.Id !== unit || current.LoadState !== "loaded" ||
+          Date.now() >= params.parentExitDeadlineAt) {
+          throw new Error("systemd service remained active or changed execution generation");
+        }
+        if (current.ActiveState === "inactive" && current.MainPID === "0") {
+          const retainedIdentity =
+            current.ExecMainStartTimestampMonotonic === parkedServiceGeneration &&
+            current.InvocationID === parkedServiceInvocation;
+          const clearedIdentity =
+            current.ExecMainStartTimestampMonotonic === "0" && !current.InvocationID;
+          if (!retainedIdentity && !clearedIdentity) {
+            throw new Error("systemd service remained active or changed execution generation");
+          }
+          break;
+        }
+        if (current.ActiveState !== "deactivating" || current.MainPID !== "0" ||
+          current.ExecMainStartTimestampMonotonic !== parkedServiceGeneration ||
+          current.InvocationID !== parkedServiceInvocation) {
+          throw new Error("systemd service remained active or changed execution generation");
+        }
+        // The exact stop job has completed; systemd may publish inactive a moment later.
+        await sleep(Math.min(25, Math.max(0, params.parentExitDeadlineAt - Date.now())));
       }
     }
     if (params.serviceRecovery?.kind === "launchd") {

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -693,9 +693,9 @@ function runServiceCommand(command, args, onSpawn, deadline) {
   });
 }
 
-async function inspectSystemdService(unit) {
+async function inspectSystemdService(unit, deadline) {
   const result = await runServiceCommand("systemctl", ["--user", "show", unit,
-    "--property=Id,LoadState,ActiveState,MainPID,ExecMainStartTimestampMonotonic"]);
+    "--property=Id,LoadState,ActiveState,MainPID,ExecMainStartTimestampMonotonic"], undefined, deadline);
   if (result.code !== 0) return null;
   return Object.fromEntries(result.stdout.trim().split(/\r?\n/).map((line) => {
     const index = line.indexOf("=");
@@ -940,11 +940,19 @@ async function restoreGatewayService(reason) {
     }
     if (params.serviceRecovery?.kind === "systemd") {
       const unit = params.serviceRecovery.unit;
-      const current = await inspectSystemdService(unit);
-      if (!current || current.Id !== unit || current.LoadState !== "loaded" ||
-        current.ActiveState !== "inactive" || current.MainPID !== "0" ||
-        current.ExecMainStartTimestampMonotonic !== parkedServiceGeneration) {
-        throw new Error("systemd service remained active or changed execution generation");
+      for (;;) {
+        const current = await inspectSystemdService(unit, params.parentExitDeadlineAt);
+        if (!current || current.Id !== unit || current.LoadState !== "loaded" ||
+          current.ExecMainStartTimestampMonotonic !== parkedServiceGeneration ||
+          (current.MainPID !== "0" && current.MainPID !== String(params.parentPid)) ||
+          (current.ActiveState !== "deactivating" &&
+            (current.ActiveState !== "inactive" || current.MainPID !== "0")) ||
+          Date.now() >= params.parentExitDeadlineAt) {
+          throw new Error("systemd service remained active or changed execution generation");
+        }
+        if (current.ActiveState === "inactive") break;
+        // systemd observes parent exit before the same-generation stop becomes inactive.
+        await sleep(Math.min(25, Math.max(0, params.parentExitDeadlineAt - Date.now())));
       }
     }
     if (params.serviceRecovery?.kind === "launchd") {

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -674,10 +674,10 @@ function markUpdateSentinelFailureIfPending(reason, restored) {
   return recorded;
 }
 
-function runServiceCommand(command, args, onSpawn, deadline) {
+function runServiceCommand(command, args, onSpawn, deadline, timeoutCap) {
   if (!ownsManagedUpdateLease()) return Promise.resolve({ code: 1, stdout: "", stderr: "" });
   return new Promise((resolve) => {
-    const cap = args[0] === "bootout" ? ${PARENT_EXIT_SHUTDOWN_RESERVE_MS} : 5000;
+    const cap = timeoutCap ?? (args[0] === "bootout" ? ${PARENT_EXIT_SHUTDOWN_RESERVE_MS} : 5000);
     const remaining = deadline === undefined ? cap : deadline - Date.now();
     if (remaining <= 0) return resolve({ code: 1, stdout: "", stderr: "" });
     let stdout = "", stderr = "";
@@ -727,10 +727,23 @@ async function parkGatewayService() {
       throw new Error("systemd service does not match the exact active gateway parent");
     }
     parkedServiceGeneration = current.ExecMainStartTimestampMonotonic;
-    // A submitted stop can kill its parent even when the transport later times out.
-    restorationArmed = true;
-    const stopped = await runServiceCommand("systemctl", ["--user", "--no-block", "stop", recovery.unit]);
-    if (stopped.code !== 0) throw new Error("systemd stop submission failed: " + stopped.stderr);
+    // Keep the exact stop job open across parent exit; its completion is the
+    // authoritative systemd fact, even after inactive-unit metadata is collected.
+    await new Promise((resolve, reject) => {
+      pendingServiceStop = runServiceCommand(
+        "systemctl",
+        ["--user", "stop", recovery.unit],
+        () => {
+          restorationArmed = true;
+          resolve();
+        },
+        params.parentExitDeadlineAt,
+        params.parentExitTimeoutMs,
+      );
+      pendingServiceStop.then((result) => {
+        if (!restorationArmed) reject(new Error("systemd stop failed: " + result.stderr));
+      });
+    });
     return;
   }
   if (recovery.kind !== "launchd") throw new Error("unsupported managed update supervisor");
@@ -930,7 +943,8 @@ async function restoreGatewayService(reason) {
     }
     clearTimeout(parentExitDeadline);
     const stopped = pendingServiceStop ? await pendingServiceStop : null;
-    if (stopped && stopped.code !== 0 && !isLaunchdNotLoaded(stopped)) {
+    if (stopped && stopped.code !== 0 && params.serviceRecovery?.kind === "launchd" &&
+      !isLaunchdNotLoaded(stopped)) {
       throw new Error("launchctl bootout failed: " + stopped.stderr);
     }
     if (outcome !== "update") {
@@ -939,20 +953,14 @@ async function restoreGatewayService(reason) {
       return;
     }
     if (params.serviceRecovery?.kind === "systemd") {
+      if (!stopped || stopped.code !== 0 || Date.now() >= params.parentExitDeadlineAt) {
+        throw new Error("systemd stop failed or exceeded the parent-exit deadline");
+      }
       const unit = params.serviceRecovery.unit;
-      for (;;) {
-        const current = await inspectSystemdService(unit, params.parentExitDeadlineAt);
-        if (!current || current.Id !== unit || current.LoadState !== "loaded" ||
-          current.ExecMainStartTimestampMonotonic !== parkedServiceGeneration ||
-          (current.MainPID !== "0" && current.MainPID !== String(params.parentPid)) ||
-          (current.ActiveState !== "deactivating" &&
-            (current.ActiveState !== "inactive" || current.MainPID !== "0")) ||
-          Date.now() >= params.parentExitDeadlineAt) {
-          throw new Error("systemd service remained active or changed execution generation");
-        }
-        if (current.ActiveState === "inactive") break;
-        // systemd observes parent exit before the same-generation stop becomes inactive.
-        await sleep(Math.min(25, Math.max(0, params.parentExitDeadlineAt - Date.now())));
+      const current = await inspectSystemdService(unit, params.parentExitDeadlineAt);
+      if (!current || current.Id !== unit || current.LoadState !== "loaded" ||
+        current.ActiveState !== "inactive" || current.MainPID !== "0") {
+        throw new Error("systemd service remained active or changed execution generation");
       }
     }
     if (params.serviceRecovery?.kind === "launchd") {


### PR DESCRIPTION
Closes #128987
Related: #119515, #127413

## What Problem This Solves

Fixes an issue where Gateway-managed updates on user-systemd hosts could roll back before running the frozen update command when the exact service execution was still legitimately stopping immediately after the Gateway parent exited.

## Why This Change Was Made

The detached handoff helper now owns the exact blocking `systemctl --user stop` job across parent exit, keeps it within the existing deadline, and verifies coherent execution identity while systemd publishes the terminal inactive state. Retained generation and invocation metadata must both match the parked execution; cleared metadata must clear as a pair. Unit, load, PID, identity, state, and deadline drift still fail closed, and overdue park requests do not mutate the live service.

AI-assisted: yes.

## User Impact

Managed updates no longer mistake normal systemd stop convergence for service replacement and roll back without applying the target. Invalid or replaced service generations remain fenced, while genuine failure and cancellation paths retain predecessor recovery.

## Evidence

- Live production RED: an exact-target handoff preserved the Gateway through bounded drain, then failed at the one-shot post-exit systemd check with `systemd service remained active or changed execution generation`; predecessor recovery succeeded and the update command never ran.
- Exact-head isolated user-systemd proof at `49373bd3ccf4928434ff065abbbac33f0e3489ba`: a root-owned temporary user unit entered `stop-post`, the handoff held the exact stop job for 2,208 ms, then launched the frozen updater only after `inactive` / `MainPID=0`; the updater exited 0, terminal generation metadata was coherently cleared, and the managed handoff lease was absent afterward.
- Post-fix: `node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-lifecycle.test.ts` — 32 passed on the final rebased stack.
- Targeted formatting, oxlint, conflict-marker, max-lines-ratchet, assertion-safety, dependency-pin, plugin-boundary, wrapper-shadowing, and package-patch checks passed.
- Hosted changed gate `run_d7eb3b8539e5` reached the dead-export scan, then its 4 GiB Daytona fallback exhausted memory inside `oxc-parser`; exact-head hosted CI is the authoritative full-gate proof.
- Mandatory P0/P1 autoreview reported no actionable findings after the final coherent-identity repair.
- systemd contract proof: `src/core/service.c` maps stop states to `UNIT_DEACTIVATING` before `SERVICE_DEAD` becomes `UNIT_INACTIVE`; live systemd 259 proof confirmed `InvocationID` and `ExecMainStartTimestampMonotonic` clear together after inactive collection.
- Production LOC: +53/-15 (net +38). Tests/support: +211/-91 (net +120). The production growth replaces lossy state inference with one deadline-bounded stop-job ownership protocol.
- UI proof is not applicable; this is a detached service-lifecycle repair.
