### PR TITLE
[BACKPORT #127162] perf(sessions): avoid loading full transcripts for newest-event checks

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -357,14 +357,14 @@ export function findSqliteTranscriptEventInDatabase(
   match: (event: TranscriptEvent) => boolean,
 ): { event: TranscriptEvent } | undefined {
   const db = getSessionKysely(database.db);
-  const rows = executeSqliteQuerySync(
+  const rows = iterateSqliteQuerySync(
     database.db,
     db
       .selectFrom("transcript_events")
       .select(["event_json"])
       .where("session_id", "=", sessionId)
       .orderBy("seq", "desc"),
-  ).rows;
+  );
   for (const row of rows) {
     try {
       const event = JSON.parse(row.event_json) as TranscriptEvent;

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -501,6 +501,36 @@ describe("session accessor seam", () => {
       [header, older, newer],
     );
 
+    const databasePath = expectDefined(
+      resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+      "transcript find database path",
+    );
+    const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+    const originalPrepare = database.db.prepare.bind(database.db);
+    let transcriptRowsRead = 0;
+    // Count SQLite rows rather than matcher calls: eager materialization happens before matching.
+    const prepareSpy = vi.spyOn(database.db, "prepare").mockImplementation((sql) => {
+      const statement = originalPrepare(sql);
+      return new Proxy(statement, {
+        get(target, property) {
+          if (property === "iterate") {
+            return (...params: Parameters<typeof target.iterate>) => {
+              const iterator = target.iterate(...params);
+              return (function* () {
+                for (const row of iterator) {
+                  if ("event_json" in row) {
+                    transcriptRowsRead += 1;
+                  }
+                  yield row;
+                }
+              })() as ReturnType<typeof target.iterate>;
+            };
+          }
+          const value = Reflect.get(target, property, target) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+    });
     const seen: unknown[] = [];
     const found = await findTranscriptEvent(
       { sessionId: "session-find", sessionKey: "agent:main:main", storePath },
@@ -508,10 +538,11 @@ describe("session accessor seam", () => {
         seen.push(event);
         return (event as { type?: string }).type === "message";
       },
-    );
+    ).finally(() => prepareSpy.mockRestore());
     // Newest-first with early exit: the older message is never visited.
     expect(found).toEqual({ event: newer });
     expect(seen).toEqual([newer]);
+    expect(transcriptRowsRead).toBe(1);
 
     await replaceSqliteTranscriptEvents(
       { agentId: "main", sessionId: "session-falsy", sessionKey: "agent:main:falsy", storePath },


### PR DESCRIPTION
## What Problem This Solves

On the pinned release branch, newest-event transcript lookups load every SQLite `event_json` row before testing the newest event. An existence or idempotency check therefore incurs CPU and heap usage proportional to the entire session transcript even when the newest row already answers the query.

## Why This Change Was Made

Cleanly backport upstream #127162 (`096a9708208a4f4af863069f6cc1e260e8f2120d`) to `sjf_openclaw_2026-07-31`. Consume the existing synchronous SQLite iterator directly and stop stepping rows as soon as the matcher succeeds. No schema, protocol, ordering, malformed-row handling, or public API changes.

## User Impact

Recent-event checks no longer allocate the full transcript. The upstream 10,002-row, roughly 40 MiB fixture reduced five newest-row probes from 50,010 SQLite rows and +217 MiB heap to five rows and +0.7 MiB heap.

## Evidence

- Existing upstream regression instruments SQLite statement iteration and proves a newest-event match steps exactly one transcript row.
- 88 focused tests passed: 85 session-accessor tests and three gateway parent-id tests.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- Focused repository-native oxlint, `oxfmt --check`, and `git diff --check` passed.

Upstream: https://github.com/openclaw/openclaw/pull/127162
