### PR TITLE
fix(reef): avoid shutdown delays during friend reconciliation

### DIFF
--- a/extensions/reef/src/channel-lifecycle.ts
+++ b/extensions/reef/src/channel-lifecycle.ts
@@ -5,13 +5,13 @@ const CONTINUE_AFTER_RECONCILE_ERROR = () => true;
 const STOP_AFTER_RECONCILE_ERROR = () => false;
 
 async function runReconcileStep(params: {
-  reconcile: () => Promise<void>;
+  reconcile: (signal: AbortSignal) => Promise<void>;
   onReconcileError: (error: unknown) => void;
   shouldContinueAfterError: (error: unknown) => boolean;
   signal: AbortSignal;
 }): Promise<void> {
   try {
-    await params.reconcile();
+    await params.reconcile(params.signal);
   } catch (error) {
     if (params.signal.aborted) {
       return;
@@ -30,7 +30,7 @@ async function runReconcileStep(params: {
 export async function runReefChannelLifecycle(params: {
   parentSignal: AbortSignal;
   startInbox: (signal: AbortSignal) => Promise<void>;
-  reconcile: () => Promise<void>;
+  reconcile: (signal: AbortSignal) => Promise<void>;
   onReconcileError: (error: unknown) => void;
   // Startup may continue only for errors the channel classifies as retryable.
   // Periodic reconcile remains best-effort once the account is already active.

--- a/extensions/reef/src/channel.test.ts
+++ b/extensions/reef/src/channel.test.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
@@ -13,8 +15,11 @@ import { generateIdentity } from "../protocol/index.js";
 import { runReefChannelLifecycle } from "./channel-lifecycle.js";
 import { reefPlugin } from "./channel.js";
 import { resolveReefConfig } from "./config-schema.js";
+import { reefKeys } from "./flow.test-helpers.js";
+import { ReefFriendManager } from "./friends.js";
 import { resolveReefInboundDispatchContent } from "./inbound.js";
 import { setReefRuntime } from "./runtime.js";
+import { ReefTransportClient } from "./transport.js";
 import { openReefTrustStore } from "./trust-store.js";
 
 function deferred() {
@@ -348,6 +353,69 @@ describe("Reef channel lifecycle", () => {
     await expect(lifecycle).resolves.toBeUndefined();
     expect(onReady).not.toHaveBeenCalled();
     expect(inbox.seen).toHaveLength(0);
+  });
+
+  it.each([
+    { phase: "friend reconciliation", completedRequests: 0 },
+    { phase: "pairing-candidate surfacing", completedRequests: 1 },
+  ])("promptly aborts a stalled $phase request", async ({ completedRequests }) => {
+    const requestStarted = deferred();
+    let requests = 0;
+    const server = http.createServer((_request, response) => {
+      if (requests++ < completedRequests) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ friendships: [] }));
+        return;
+      }
+      requestStarted.resolve();
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    const parent = new AbortController();
+    const inbox = hangingInbox();
+    const relayUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    const transport = new ReefTransportClient(
+      relayUrl,
+      "alice",
+      reefKeys(),
+      fetch,
+      () => 1_752_300_000,
+      1_000,
+    );
+    const friends = new ReefFriendManager(
+      transport,
+      {} as ConstructorParameters<typeof ReefFriendManager>[1],
+      { list: async () => [], remove: async () => false },
+    );
+    const lifecycle = runReefChannelLifecycle({
+      parentSignal: parent.signal,
+      startInbox: inbox.startInbox,
+      reconcile: async (signal) => {
+        await friends.reconcile(signal);
+        await friends.surfacePairingCandidates(async () => {}, signal);
+      },
+      onReconcileError: () => {},
+    });
+
+    try {
+      await requestStarted.promise;
+      const abortedAt = performance.now();
+      parent.abort();
+      await lifecycle;
+
+      expect(performance.now() - abortedAt).toBeLessThan(500);
+      expect(inbox.seen).toHaveLength(0);
+    } finally {
+      parent.abort();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      await lifecycle;
+    }
   });
 
   it("does not start the inbox when the parent aborts during activation", async () => {

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -426,8 +426,8 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           signal: ctx.abortSignal,
         },
       );
-      const reconcile = async () => {
-        await friends.reconcile();
+      const reconcile = async (signal: AbortSignal) => {
+        await friends.reconcile(signal);
         await friends.surfacePairingCandidates(async ({ peer, fingerprint, approvalToken }) => {
           await pairing.issueChallenge({
             senderId: peer,
@@ -435,7 +435,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
             meta: { reefApproval: approvalToken },
             sendPairingReply: async () => {},
           });
-        });
+        }, signal);
       };
       // Attempt the peer-key refresh before recovery can dispatch an agent
       // turn. The lifecycle activates only after that attempt is classified.
@@ -488,16 +488,17 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         await runReefChannelLifecycle({
           parentSignal: ctx.abortSignal,
           startInbox: (signal) => inbox.start(signal),
-          reconcile: async () => {
+          reconcile: async (signal) => {
             // The overdue sweep must run even while the relay is unreachable:
             // that outage is exactly when queued sends go unconfirmed, and the
             // notices themselves are local.
             let reconcileError: Error | undefined;
             try {
-              await reconcile();
+              await reconcile(signal);
             } catch (error) {
               reconcileError = error instanceof Error ? error : new Error(String(error));
             }
+            signal.throwIfAborted();
             await notifyOverdueReefDeliveries({ trust, ownerNotice });
             if (reconcileError) {
               throw reconcileError;

--- a/extensions/reef/src/friends.ts
+++ b/extensions/reef/src/friends.ts
@@ -142,9 +142,9 @@ export class ReefFriendManager {
     return listed;
   }
 
-  surfacePairingCandidates(issue: PairingChallenge): Promise<void> {
+  surfacePairingCandidates(issue: PairingChallenge, signal?: AbortSignal): Promise<void> {
     return this.#serialize(async () => {
-      const { friendships } = await this.transport.listFriends();
+      const { friendships } = await this.transport.listFriends(signal);
       const approvals = await this.#loadPairingApprovals(friendships);
 
       for (const friend of friendships) {
@@ -183,9 +183,9 @@ export class ReefFriendManager {
     });
   }
 
-  reconcile(): Promise<string[]> {
+  reconcile(signal?: AbortSignal): Promise<string[]> {
     return this.#serialize(async () => {
-      const { friendships } = await this.transport.listFriends();
+      const { friendships } = await this.transport.listFriends(signal);
       const approvals = await this.#loadPairingApprovals(friendships);
       const changed = new Set<string>();
 

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -219,8 +219,8 @@ export class ReefTransportClient {
     }
     return { peer: friend.peer, status };
   }
-  listFriends(): Promise<{ friendships: RelayFriend[] }> {
-    return this.signed("GET", "/v1/friends");
+  listFriends(signal?: AbortSignal): Promise<{ friendships: RelayFriend[] }> {
+    return this.signed("GET", "/v1/friends", undefined, signal);
   }
   removeFriend(peer: string): Promise<void> {
     return this.signed("DELETE", `/v1/friends/${encodeURIComponent(peer)}`);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping or replacing a Reef channel while friend reconciliation was waiting on the relay could leave the old account task running until the full relay deadline. That can exceed the Gateway's bounded channel-stop window even though the lifecycle has already been aborted.

The observed startup timeout itself remained retryable and Reef recovered to connected/ready; the defect was cancellation ownership during shutdown, not the timeout duration, retry policy, log severity, or peer-trust policy.

## Why This Change Was Made

The Reef account lifecycle now passes its abort signal through both friend-list requests and the existing transport deadline, and it stops before dispatching local overdue-delivery notices after cancellation. The existing 15-second request deadline, 30-second reconciliation cadence, error reporting, serialization, and fail-closed trust checks are unchanged.

This PR is AI-assisted. I reviewed the source, live evidence, regression behavior, and final diff.

## User Impact

Gateway shutdowns, reloads, and account replacements no longer wait for a stalled Reef friend-reconciliation request after the account lifecycle has ended. Transient relay failures during normal startup continue to recover as before, and unrefreshed or changed peer keys remain fail-closed.

## Evidence

- Sanitized live canary evidence showed transient `TimeoutError` entries followed by Reef returning to `running`, `connected`, `lifecycle: ready`, with a later promotion producing zero Reef timeout entries.
- Pre-fix real-HTTP reproduction: after abort, a stalled `/v1/friends` request remained pending after 100 ms and settled after 804 ms only when its artificial 800 ms deadline fired.
- Post-fix reproduction: the same lifecycle settled 3 ms after abort.
- Regression coverage exercises both the initial friend reconciliation and the second pairing-candidate friend-list request against a real stalled local HTTP server.
- `node scripts/run-vitest.mjs extensions/reef/src/channel.test.ts` — 17 passed.
- `node scripts/run-vitest.mjs extensions/reef/src/friends.test.ts` — 21 passed.
- `node scripts/run-vitest.mjs extensions/reef/src/transport.test.ts` — 39 passed.
- `node scripts/run-vitest.mjs extensions/reef/src/transport.timeout.test.ts` — 3 passed.
- `node scripts/check-changed.mjs -- extensions/reef/src/channel-lifecycle.ts extensions/reef/src/channel.ts extensions/reef/src/friends.ts extensions/reef/src/transport.ts extensions/reef/src/channel.test.ts` — passed, including extension typechecks, lint, import-cycle, dead-code, and repository guards.
- Fresh uncommitted autoreview: no accepted/actionable findings.
- Live patched-head proof was not run because deploying an unmerged branch would mutate the operator canary; the patched owner boundary is instead exercised with real local HTTP, exact-head CI, and the repository Testbox landing gate.
- Production LOC: +15/-14 (net +1). Tests: +68/-0.
