### PR TITLE
fix(agents): remove external databases during offline delete

### DIFF
--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -5,6 +5,7 @@ import {
   formatSharedAuthStoreOwnerDeleteError,
   isSharedAuthStoreOwner,
 } from "../agents/agent-delete-safety.js";
+import { normalizeAgentDirRegistryPath } from "../agents/agent-dir-registry.js";
 import {
   beginAgentDeletion,
   claimCompletedAgentDeletion,
@@ -44,10 +45,15 @@ import {
   isGatewayTransportError,
 } from "../gateway/call.js";
 import { withAgentExecApprovalsRemoved } from "../infra/exec-approvals.js";
+import { isPathInside } from "../infra/path-guards.js";
+import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { normalizeAgentId, normalizeAgentIdStrict } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
-import { unregisterOpenClawAgentDatabases } from "../state/openclaw-agent-db-registry.js";
+import {
+  listOpenClawRegisteredAgentDatabases,
+  unregisterOpenClawAgentDatabases,
+} from "../state/openclaw-agent-db-registry.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { createClackPrompter } from "../wizard/clack-prompter.js";
 import { createQuietRuntime } from "./agents.command-shared.js";
@@ -352,8 +358,26 @@ export async function agentsDeleteCommand(
     }
   }
   if (deleteFiles) {
+    const canonicalAgentDir = normalizeAgentDirRegistryPath(agentDir);
+    const survivingDatabasePaths = new Set(
+      listOpenClawRegisteredAgentDatabases()
+        .filter((entry) => normalizeAgentId(entry.agentId) !== agentId)
+        .flatMap((entry) => resolveSqliteDatabaseFilePaths(entry.path))
+        .map((pathname) => normalizeAgentDirRegistryPath(pathname)),
+    );
+    const databasePaths = deletion.entry.databasePaths.filter((pathname) => {
+      const canonicalPath = normalizeAgentDirRegistryPath(pathname);
+      return (
+        !isPathInside(canonicalAgentDir, canonicalPath) &&
+        !survivingDatabasePaths.has(canonicalPath) &&
+        findOverlappingWorkspaceAgentIds(result.config, agentId, canonicalPath).length === 0
+      );
+    });
     await removePath(agentDir);
     await removePath(sessionsDir);
+    for (const databasePath of databasePaths) {
+      await removePath(databasePath);
+    }
   }
   if (workspaceCleanupError) {
     throw workspaceCleanupError;

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -674,7 +674,7 @@ describe("agents delete command", () => {
   });
 
   it("deregisters the agent database after offline deletion", async () => {
-    await withStateDirEnv("openclaw-agents-delete-registry-", async ({ stateDir }) => {
+    await withStateDirEnv("openclaw-agents-delete-registry-", async ({ tempRoot, stateDir }) => {
       const cfg: OpenClawConfig = {
         agents: {
           list: [
@@ -685,15 +685,53 @@ describe("agents delete command", () => {
       };
       await arrangeAgentsDeleteTest({ stateDir, cfg, sessions: {} });
       const databasePath = path.join(stateDir, "agents", "ops", "agent", "openclaw-agent.sqlite");
+      const externalDatabaseDir = path.join(tempRoot, "external-databases");
+      await fs.mkdir(externalDatabaseDir);
+      const externalDatabasePath = path.join(externalDatabaseDir, "ops.sqlite");
+      const sharedDatabasePath = path.join(externalDatabaseDir, "shared.sqlite");
+      const externalDatabasePaths = [
+        externalDatabasePath,
+        `${externalDatabasePath}-wal`,
+        `${externalDatabasePath}-shm`,
+        `${externalDatabasePath}-journal`,
+      ];
+      await Promise.all(
+        [...externalDatabasePaths, sharedDatabasePath].map((sqlitePath) =>
+          fs.writeFile(sqlitePath, ""),
+        ),
+      );
+      const canonicalExternalDatabaseDir = await fs.realpath(externalDatabaseDir);
       registerOpenClawAgentDatabase({ agentId: "ops", path: databasePath });
+      registerOpenClawAgentDatabase({ agentId: "ops", path: externalDatabasePath });
+      registerOpenClawAgentDatabase({ agentId: "ops", path: sharedDatabasePath });
+      registerOpenClawAgentDatabase({ agentId: "main", path: sharedDatabasePath });
       recordAgentProvenance("ops", { createdVia: "operator" });
       recordAgentProvenance("child", { createdVia: "agent", creatorAgentId: "ops" });
       expect(listOpenClawRegisteredAgentDatabases().map((entry) => entry.agentId)).toContain("ops");
 
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
-      expect(listOpenClawRegisteredAgentDatabases().map((entry) => entry.agentId)).not.toContain(
-        "ops",
+      for (const sqlitePath of externalDatabasePaths) {
+        expect(fsSafeMocks.movePathToTrash).toHaveBeenCalledWith(
+          path.join(canonicalExternalDatabaseDir, path.basename(sqlitePath)),
+          { allowedRoots: [canonicalExternalDatabaseDir] },
+        );
+      }
+      expect(readJsonLogs()[0]?.removed).toEqual(
+        expect.arrayContaining(
+          externalDatabasePaths.map((sqlitePath) => ({ path: sqlitePath, method: "trash" })),
+        ),
+      );
+      expect(fsSafeMocks.movePathToTrash).not.toHaveBeenCalledWith(
+        path.join(canonicalExternalDatabaseDir, path.basename(sharedDatabasePath)),
+        expect.anything(),
+      );
+      const registeredDatabases = listOpenClawRegisteredAgentDatabases();
+      expect(registeredDatabases.map((entry) => entry.agentId)).not.toContain("ops");
+      expect(registeredDatabases).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ agentId: "main", path: sharedDatabasePath }),
+        ]),
       );
       expect(readAgentDeletionJournal("ops")?.cleanupCompleted).toBe(true);
       expect(readAgentProvenance("ops")).toBeUndefined();


### PR DESCRIPTION
Closes #129014

## What Problem This Solves

Fixes an issue where operators deleting an agent while the Gateway was unavailable could leave registered agent databases outside the agent directory on disk. The offline fallback removed their registry ownership and completed the deletion journal, so the stale files were no longer discoverable or retryable.

## Why This Change Was Made

The deletion journal already owns the complete database file inventory, including SQLite WAL, SHM, and rollback-journal sidecars. The offline command now processes that durable inventory through its existing Trash result collector, skips files already covered by the deleted agent directory, and preserves paths still owned by a surviving agent or overlapping a surviving workspace. Registry cleanup and journal completion remain gated on every selected cleanup target succeeding.

This intentionally does not change Gateway deletion or plugin-owned offline binding cleanup.

## User Impact

Offline `openclaw agents delete` now removes externally located agent database files with the same lifecycle guarantees as normal Gateway deletion. Shared database paths remain intact, and a Trash failure keeps the durable ownership and recovery journal available for a later retry.

Production LOC: +25/-1 (net +24) | Tests: +41/-3

## Evidence

- Pre-fix regression failed because the external database group never reached the Trash boundary; only the workspace and agent directory were processed.
- `node scripts/run-vitest.mjs src/commands/agents.delete.test.ts` — 17 passed.
- `node scripts/run-vitest.mjs src/commands/agents.delete.workspace.test.ts` — 10 passed.
- Focused Gateway sibling ownership/Trash cases — 3 passed.
- Focused agent database registry external/multiple-path cases — 2 passed.
- `node scripts/check-changed.mjs -- src/commands/agents.commands.delete.ts src/commands/agents.delete.test.ts` — passed after rebasing onto current `main`.
- Mandatory Codex autoreview — no accepted/actionable findings.

A separate live CLI run was not used because the final operation moves real paths into the host Trash. The regression exercises the actual offline command owner boundary with isolated config, state SQLite, database registry, deletion journal, and filesystem paths while mocking only Gateway reachability and the final Trash transport.

- [x] AI-assisted
- [x] I understand the change and verified the owner boundary
