### PR TITLE
fix(ui): update the new-session model picker when catalogs load

### DIFF
--- a/ui/src/app/app-host.chat-metadata.test.ts
+++ b/ui/src/app/app-host.chat-metadata.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-it("invalidates chat metadata on config changes and same-client reconnects", () => {
+it("invalidates chat metadata on config changes and same-client disconnects", () => {
   vi.useFakeTimers();
   const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
   const connected = {
@@ -42,6 +42,5 @@ it("invalidates chat metadata on config changes and same-client reconnects", () 
 
   rememberChatMetadata(client, "main", { commands: [], models: [] });
   shell.synchronizeGateway({ ...connected, phase: "reconnecting" });
-  shell.synchronizeGateway(connected);
   expect(peekChatMetadata(client, "main")).toBeUndefined();
 });

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -723,9 +723,9 @@ class OpenClawShell
   }
 
   private synchronizeGateway(snapshot: ApplicationContext["gateway"]["snapshot"]) {
-    if (this.previousGatewayPhase !== "connected" && snapshot.phase === "connected") {
-      // A reconnect can retain the browser client, so object identity alone
-      // cannot keep metadata from crossing logical Gateway connections.
+    if (this.previousGatewayPhase === "connected" && snapshot.phase !== "connected") {
+      // A disconnect can retain the browser client, so object identity alone
+      // cannot keep metadata alive across logical Gateway connections.
       if (snapshot.client) {
         invalidateChatMetadataStore(snapshot.client);
       }

--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -207,10 +207,10 @@ suite.define(() => {
         .poll(() => page.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').textContent())
         .toContain(recoveredModel.name);
 
-      // The picker's own revalidation lands after the rows render, so wait for it.
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(3);
+      // Opening the picker consumes the recovered ready snapshot without
+      // revalidating it.
+      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
       expect(await gateway.getRequests("chat.metadata")).toEqual([
-        expect.objectContaining({ params: { agentId: "main" } }),
         expect.objectContaining({ params: { agentId: "main" } }),
         expect.objectContaining({ params: { agentId: "main" } }),
       ]);
@@ -219,7 +219,7 @@ suite.define(() => {
     }
   });
 
-  it("shows a retryable CLI-agent failure and recovers both picker catalogs", async () => {
+  it("recovers a failed CLI-agent catalog without reloading ready model metadata", async () => {
     if (captureCatalogRetryProof) {
       await mkdir(catalogRetryProofDir, { recursive: true });
     }
@@ -298,7 +298,7 @@ suite.define(() => {
         ),
       ).toBe("GPT-5.6 Luna");
       expect(await page.getByText("Models unavailable", { exact: true }).count()).toBe(0);
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
+      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(1);
       if (captureCatalogRetryProof) {
         await page.screenshot({
           animations: "disabled",
@@ -336,7 +336,7 @@ suite.define(() => {
           catalogDiscoveryRequests(await gateway.getRequests("sessions.catalog.list")),
         )
         .toHaveLength(3);
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(3);
+      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(1);
       await expect
         .poll(() => page.locator('[data-chat-model-target="anthropic"]').isVisible())
         .toBe(true);

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -727,7 +727,7 @@ suite.define(() => {
     });
   });
 
-  it("blocks an immediate submit until remembered model and worktree choices validate", async () => {
+  it("reuses ready model metadata while a remembered worktree choice validates", async () => {
     await withNewSessionPage(BASE_CONTEXT, async (page) => {
       const models = MODELS;
       const branches = GIT_BRANCHES;
@@ -755,23 +755,23 @@ suite.define(() => {
       await waitForCommittedChatRoute(page);
       const metadataRequests = (await gateway.getRequests("chat.metadata")).length;
       const branchRequests = (await gateway.getRequests("worktrees.branches")).length;
-      await gateway.deferNext("chat.metadata");
       await gateway.deferNext("worktrees.branches");
       await navigateInApp(page, "new-session");
       await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
       await expect
         .poll(async () => (await gateway.getRequests("chat.metadata")).length)
-        .toBe(metadataRequests + 1);
+        .toBe(metadataRequests);
       await expect
         .poll(async () => (await gateway.getRequests("worktrees.branches")).length)
         .toBe(branchRequests + 1);
+      await expect
+        .poll(() => modelSelect.getAttribute("data-chat-select-value"))
+        .toBe("anthropic/claude-sonnet-4-6");
 
       await page.locator(".new-session-page__message").fill("keep both remembered choices");
       const start = page.getByRole("button", { name: "Start session" });
       await expect.poll(() => start.isDisabled()).toBe(true);
 
-      await gateway.resolveDeferred("chat.metadata", { models });
-      await expect.poll(() => start.isDisabled()).toBe(true);
       await gateway.rejectDeferred("worktrees.branches", {
         code: "UNAVAILABLE",
         message: "branch lookup unavailable",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5774,6 +5774,7 @@ export const en: TranslationMap = {
       refreshingModels: "Refreshing models…",
       modelsUnavailable: "Models unavailable",
       noModelsAvailable: "No models available",
+      emptyModelsAction: "Manage models",
       providerModels: "{provider} models",
       fastResponsesAria: "Fast responses: {state}",
     },

--- a/ui/src/lib/chat/chat-metadata-store.test.ts
+++ b/ui/src/lib/chat/chat-metadata-store.test.ts
@@ -10,6 +10,7 @@ import {
   peekChatMetadata,
   rememberChatMetadata,
   revalidateChatMetadata,
+  subscribeChatMetadata,
   type ChatMetadataResult,
 } from "./chat-metadata-store.ts";
 
@@ -98,6 +99,21 @@ describe("chat metadata store", () => {
     expect(peekChatMetadata(client, "main")).toBe(result);
     await expect(loadChatMetadata(client, "main")).resolves.toBe(result);
     expect(request).not.toHaveBeenCalled();
+  });
+
+  it("notifies subscribers across publication and invalidation", () => {
+    const client = clientWith(vi.fn());
+    const listener = vi.fn();
+    const unsubscribe = subscribeChatMetadata(client, "main", listener);
+
+    rememberChatMetadata(client, "main", metadata("first-model"));
+    invalidateChatMetadataStore(client);
+    rememberChatMetadata(client, "main", metadata("second-model"));
+
+    expect(listener).toHaveBeenCalledTimes(3);
+    unsubscribe();
+    rememberChatMetadata(client, "main", metadata("ignored-model"));
+    expect(listener).toHaveBeenCalledTimes(3);
   });
 
   it("drops every agent snapshot when the client store is invalidated", async () => {

--- a/ui/src/lib/chat/chat-metadata-store.test.ts
+++ b/ui/src/lib/chat/chat-metadata-store.test.ts
@@ -116,6 +116,20 @@ describe("chat metadata store", () => {
     expect(listener).toHaveBeenCalledTimes(3);
   });
 
+  it("keeps a ready snapshot after its last subscriber releases", async () => {
+    const result = metadata("cached-after-release");
+    const request = vi.fn();
+    const client = clientWith(request);
+    const unsubscribe = subscribeChatMetadata(client, "main", () => undefined);
+    rememberChatMetadata(client, "main", result);
+
+    unsubscribe();
+
+    expect(peekChatMetadata(client, "main")).toBe(result);
+    await expect(loadChatMetadata(client, "main")).resolves.toBe(result);
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("drops every agent snapshot when the client store is invalidated", async () => {
     const main = metadata("main-model");
     const worker = metadata("worker-model");

--- a/ui/src/lib/chat/chat-metadata-store.ts
+++ b/ui/src/lib/chat/chat-metadata-store.ts
@@ -15,6 +15,7 @@ type ChatMetadataEntry = {
   loadPending?: Promise<ChatMetadataResult>;
   revalidationPending?: Promise<ChatMetadataResult>;
   latestRequest?: Promise<ChatMetadataResult>;
+  listeners: Set<() => void>;
 };
 
 const chatMetadataCache = new WeakMap<GatewayBrowserClient, Map<string, ChatMetadataEntry>>();
@@ -35,7 +36,7 @@ function metadataEntryFor(
   }
   let entry = cache.get(key);
   if (!entry) {
-    entry = {};
+    entry = { listeners: new Set() };
     cache.set(key, entry);
   }
   return entry;
@@ -45,6 +46,16 @@ function waitForMetadataRetry(delayMs: number): Promise<void> {
   return new Promise((resolve) => {
     globalThis.setTimeout(resolve, delayMs);
   });
+}
+
+function notifyChatMetadataListeners(entry: ChatMetadataEntry): void {
+  for (const listener of Array.from(entry.listeners)) {
+    try {
+      listener();
+    } catch (error) {
+      console.error("[chat-metadata] listener error:", error);
+    }
+  }
 }
 
 async function requestChatMetadata(
@@ -102,6 +113,7 @@ function beginChatMetadataRequest(
       // The newest request owns the snapshot even when an older load settles later.
       if (entry.latestRequest === pending) {
         entry.result = result;
+        notifyChatMetadataListeners(entry);
       }
       return result;
     })
@@ -120,6 +132,16 @@ export function peekChatMetadata(
   agentId: string | null | undefined,
 ): ChatMetadataResult | undefined {
   return chatMetadataCache.get(client)?.get(chatMetadataAgentKey(agentId))?.result;
+}
+
+export function subscribeChatMetadata(
+  client: GatewayBrowserClient,
+  agentId: string | null | undefined,
+  listener: () => void,
+): () => void {
+  const entry = metadataEntryFor(client, agentId);
+  entry.listeners.add(listener);
+  return () => entry.listeners.delete(listener);
 }
 
 export function loadChatMetadata(
@@ -169,8 +191,22 @@ export function rememberChatMetadata(
   entry.loadPending = undefined;
   entry.revalidationPending = undefined;
   entry.latestRequest = undefined;
+  notifyChatMetadataListeners(entry);
 }
 
 export function invalidateChatMetadataStore(client: GatewayBrowserClient): void {
-  chatMetadataCache.delete(client);
+  const entries = chatMetadataCache.get(client)?.values();
+  if (!entries) {
+    return;
+  }
+  const invalidated = Array.from(entries);
+  for (const entry of invalidated) {
+    entry.result = undefined;
+    entry.loadPending = undefined;
+    entry.revalidationPending = undefined;
+    entry.latestRequest = undefined;
+  }
+  for (const entry of invalidated) {
+    notifyChatMetadataListeners(entry);
+  }
 }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5669,6 +5669,7 @@ describe("chat model controls", () => {
     expect(
       container.querySelector('[data-chat-model-catalog-state="ready"]')?.textContent,
     ).toContain("Authentication failed. Review the provider credential or sign-in, then retry.");
+    expect(container.textContent).toContain("Review connection");
     container.querySelector<HTMLButtonElement>('[data-chat-model-setup="true"]')?.click();
     expect(onModelSetup).toHaveBeenCalledOnce();
   });
@@ -5685,6 +5686,8 @@ describe("chat model controls", () => {
       container.querySelector('[data-chat-model-catalog-state="ready"]')?.textContent,
     ).toContain("No models available");
     expect(container.textContent).not.toContain("Authentication failed");
+    expect(container.textContent).toContain("Manage models");
+    expect(container.textContent).not.toContain("Review connection");
     container.querySelector<HTMLButtonElement>('[data-chat-model-setup="true"]')?.click();
     expect(onModelSetup).toHaveBeenCalledOnce();
   });

--- a/ui/src/pages/chat/components/chat-model-picker.ts
+++ b/ui/src/pages/chat/components/chat-model-picker.ts
@@ -294,7 +294,9 @@ function renderCatalogState(
                 onModelSetup();
               }}
             >
-              ${t("modelSetup.connectionFailure.action")}
+              ${hasOptions
+                ? t("modelSetup.connectionFailure.action")
+                : t("chat.modelControls.emptyModelsAction")}
             </button>
           `
         : nothing}

--- a/ui/src/pages/new-session/model-control.catalog-targets.test.ts
+++ b/ui/src/pages/new-session/model-control.catalog-targets.test.ts
@@ -12,7 +12,7 @@ function catalogCalls(request: ReturnType<typeof vi.fn>) {
 }
 
 describe("new-session CLI-agent model targets", () => {
-  it("retries failed discovery with model metadata when the picker reopens", async () => {
+  it("retries only failed discovery when the picker reopens", async () => {
     const { context, request } = contextWith(models, "openclaw", ["sessions.catalog.list"]);
     request.mockImplementation((method: string) => {
       if (method === "sessions.catalog.list") {
@@ -54,7 +54,7 @@ describe("new-session CLI-agent model targets", () => {
     picker!.dispatchEvent(new Event("toggle"));
 
     await vi.waitFor(() => {
-      expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(2);
+      expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(1);
       expect(catalogCalls(request)).toHaveLength(2);
     });
     await vi.waitFor(() => {
@@ -72,7 +72,7 @@ describe("new-session CLI-agent model targets", () => {
     expect(catalogCalls(request)).toHaveLength(2);
   });
 
-  it("retries both catalogs from the visible discovery error action", async () => {
+  it("retries only failed discovery from its visible error action", async () => {
     const { context, request } = contextWith(models, "openclaw", ["sessions.catalog.list"]);
     request.mockImplementation((method: string) => {
       if (method === "sessions.catalog.list") {
@@ -96,7 +96,7 @@ describe("new-session CLI-agent model targets", () => {
     });
 
     await vi.waitFor(() => {
-      expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(2);
+      expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(1);
       expect(catalogCalls(request)).toHaveLength(2);
     });
     expect(

--- a/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
+++ b/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ModelCatalogEntry } from "../../api/types.ts";
+import {
+  rememberChatMetadata,
+  revalidateChatMetadata,
+} from "../../lib/chat/chat-metadata-store.ts";
+import { contextWith, deferred, renderControl } from "./model-control.test-support.ts";
+import { NewSessionModelControl } from "./model-control.ts";
+
+describe("new-session model metadata lifecycle", () => {
+  it("keeps a ready catalog authoritative across control teardown", async () => {
+    const models: ModelCatalogEntry[] = [
+      {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+        available: false,
+      },
+    ];
+    const agent = { id: "main", model: { primary: "openai/gpt-5.6-luna" } };
+    const { context, request } = contextWith(models);
+    const firstControl = new NewSessionModelControl(() => undefined);
+    firstControl.load(context, "main", true, { agent });
+    await vi.waitFor(() => expect(firstControl.isModelUnavailable(agent)).toBe(true));
+    firstControl.reset();
+
+    const remountedControl = new NewSessionModelControl(() => undefined);
+    remountedControl.load(context, "main", true, { agent });
+
+    const container = renderControl(remountedControl, context, "main", agent);
+    expect(container.querySelector('[data-chat-model-catalog-state="ready"]')).not.toBeNull();
+    expect(remountedControl.isModelUnavailable(agent)).toBe(true);
+    expect(
+      container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]'),
+    ).not.toBeNull();
+    expect(container.textContent).toContain(
+      "Authentication failed. Review the provider credential or sign-in, then retry.",
+    );
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a shared metadata request alive when its first control is torn down", async () => {
+    const models: ModelCatalogEntry[] = [
+      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
+    ];
+    const pending = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith([]);
+    request.mockImplementationOnce((_method, _params, options?: { signal?: AbortSignal }) => {
+      options?.signal?.addEventListener(
+        "abort",
+        () => pending.reject(new DOMException("metadata request aborted", "AbortError")),
+        { once: true },
+      );
+      return pending.promise;
+    });
+    const firstControl = new NewSessionModelControl(() => undefined);
+    firstControl.load(context, "main", true);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+
+    firstControl.reset();
+    const remountedControl = new NewSessionModelControl(() => undefined);
+    remountedControl.load(context, "main", true);
+    pending.resolve({ models });
+
+    await vi.waitFor(() => {
+      const container = renderControl(remountedControl, context);
+      expect(container.querySelector("[data-chat-model-catalog-state]")).toBeNull();
+      expect(
+        container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]'),
+      ).not.toBeNull();
+    });
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("reapplies an updated preference against the attached ready snapshot", async () => {
+    const models: ModelCatalogEntry[] = [
+      {
+        id: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        provider: "openai",
+        reasoning: true,
+        thinkingLevels: [{ id: "high", label: "high" }],
+      },
+      {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+        reasoning: true,
+        thinkingLevels: [{ id: "low", label: "low" }],
+      },
+    ];
+    const refresh = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith([]);
+    const client = context.gateway.snapshot.client!;
+    rememberChatMetadata(client, "main", { commands: [], models });
+    request.mockReturnValueOnce(refresh.promise);
+    const pendingRefresh = revalidateChatMetadata(client, "main");
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true, {
+      preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "high" },
+    });
+    expect(control.selected).toBe("openai/gpt-5.6-sol");
+    expect(control.thinkingLevel).toBe("high");
+
+    control.load(context, "main", true, {
+      preference: { model: "openai/gpt-5.6-luna", thinkingLevel: "low" },
+    });
+
+    expect(control.selected).toBe("openai/gpt-5.6-luna");
+    expect(control.thinkingLevel).toBe("low");
+    expect(request).toHaveBeenCalledOnce();
+    refresh.resolve({ models });
+    await pendingRefresh;
+  });
+});

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { rememberChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { DraftCloudProfile } from "./discovery.ts";
 import { contextWith, deferred, renderControl } from "./model-control.test-support.ts";
@@ -192,8 +193,7 @@ describe("new-session model runtime", () => {
     picker!.open = true;
     picker!.dispatchEvent(new Event("toggle"));
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-
+    expect(request).toHaveBeenCalledOnce();
     expect(request.mock.calls.some(([method]) => method === "sessions.catalog.list")).toBe(false);
     expect(container.querySelector("[data-chat-model-target-group]")).toBeNull();
   });
@@ -605,6 +605,34 @@ describe("new-session model runtime", () => {
     expect(container.textContent).toContain("Models unavailable");
     expect(container.textContent).not.toContain("Authentication failed");
     expect(container.textContent).not.toContain("GPT-5.6 Luna");
+  });
+
+  it("updates a verified-empty catalog when shared chat metadata publishes models", async () => {
+    const { context, request } = contextWith([]);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector('[data-chat-model-catalog-state="ready"]'),
+      ).not.toBeNull(),
+    );
+    expect(renderControl(control, context).textContent).toContain("No models available");
+
+    rememberChatMetadata(context.gateway.snapshot.client!, "main", {
+      commands: [],
+      models: [{ id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" }],
+    });
+
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector(
+          '[data-chat-model-option="openai/gpt-5.6-luna"]',
+        ),
+      ).not.toBeNull(),
+    );
+    expect(renderControl(control, context).textContent).not.toContain("No models available");
+    expect(request).toHaveBeenCalledOnce();
   });
 
   it("treats a disconnected stale all-cold catalog as offline and non-authoritative", async () => {

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import { rememberChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
+import {
+  invalidateChatMetadataStore,
+  rememberChatMetadata,
+  revalidateChatMetadata,
+} from "../../lib/chat/chat-metadata-store.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { DraftCloudProfile } from "./discovery.ts";
 import { contextWith, deferred, renderControl } from "./model-control.test-support.ts";
@@ -299,7 +303,7 @@ describe("new-session model runtime", () => {
     pending.resolve({ models: [] });
   });
 
-  it("does not auth-block a cached all-cold catalog until revalidation completes", async () => {
+  it("keeps a ready catalog authoritative across control teardown", async () => {
     const models: ModelCatalogEntry[] = [
       {
         id: "gpt-5.6-luna",
@@ -309,32 +313,25 @@ describe("new-session model runtime", () => {
       },
     ];
     const agent = { id: "main", model: { primary: "openai/gpt-5.6-luna" } };
-    const refresh = deferred<{ models: ModelCatalogEntry[] }>();
     const { context, request } = contextWith(models);
     const firstControl = new NewSessionModelControl(() => undefined);
     firstControl.load(context, "main", true, { agent });
     await vi.waitFor(() => expect(firstControl.isModelUnavailable(agent)).toBe(true));
-    request.mockReturnValueOnce(refresh.promise);
+    firstControl.reset();
 
     const remountedControl = new NewSessionModelControl(() => undefined);
     remountedControl.load(context, "main", true, { agent });
 
-    let container = renderControl(remountedControl, context, "main", agent);
-    expect(container.querySelector('[data-chat-model-catalog-state="refreshing"]')).not.toBeNull();
-    expect(remountedControl.isModelUnavailable(agent)).toBe(false);
-    expect(container.textContent).not.toContain(
-      "Authentication failed. Review the provider credential or sign-in, then retry.",
-    );
+    const container = renderControl(remountedControl, context, "main", agent);
+    expect(container.querySelector('[data-chat-model-catalog-state="ready"]')).not.toBeNull();
+    expect(remountedControl.isModelUnavailable(agent)).toBe(true);
     expect(
       container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]'),
     ).not.toBeNull();
-    refresh.resolve({ models });
-    await vi.waitFor(() => expect(remountedControl.isModelUnavailable(agent)).toBe(true));
-    container = renderControl(remountedControl, context, "main", agent);
-    expect(container.querySelector('[data-chat-model-catalog-state="ready"]')).not.toBeNull();
     expect(container.textContent).toContain(
       "Authentication failed. Review the provider credential or sign-in, then retry.",
     );
+    expect(request).toHaveBeenCalledOnce();
   });
 
   it("keeps a shared metadata request alive when its first control is torn down", async () => {
@@ -587,6 +584,7 @@ describe("new-session model runtime", () => {
     );
     request.mockReturnValueOnce(refresh.promise);
 
+    control.invalidate(false);
     control.load(context, "main", true);
     expect(renderControl(control, context).textContent).toContain("No models available");
     expect(renderControl(control, context).textContent).not.toContain("Authentication failed");
@@ -644,7 +642,7 @@ describe("new-session model runtime", () => {
         available: false,
       },
     ];
-    const { context } = contextWith(coldModels);
+    const { context, request } = contextWith(coldModels);
     const control = new NewSessionModelControl(() => undefined);
     const agent = { id: "main", model: { primary: "openai/gpt-5.6-luna" } };
     control.load(context, "main", true, { agent });
@@ -654,16 +652,19 @@ describe("new-session model runtime", () => {
       ...context,
       gateway: {
         ...context.gateway,
-        snapshot: { ...context.gateway.snapshot, client: null, phase: "reconnecting" },
+        snapshot: { ...context.gateway.snapshot, phase: "reconnecting" },
       },
     } as unknown as ApplicationContext;
-    control.load(offlineContext, "main", true, { agent });
+    (context.gateway as { snapshot: ApplicationContext["gateway"]["snapshot"] }).snapshot =
+      offlineContext.gateway.snapshot;
+    invalidateChatMetadataStore(context.gateway.snapshot.client!);
 
     const container = renderControl(control, offlineContext, "main", agent);
     expect(container.querySelector('[data-chat-model-catalog-state="offline"]')).not.toBeNull();
     expect(container.textContent).toContain("Offline");
     expect(container.textContent).not.toContain("Authentication failed");
     expect(control.isModelUnavailable(agent)).toBe(false);
+    expect(request).toHaveBeenCalledOnce();
   });
 
   it("drops the stale auth gate on refresh error and restores selection after recovery", async () => {
@@ -685,6 +686,7 @@ describe("new-session model runtime", () => {
     await vi.waitFor(() => expect(control.isModelUnavailable(agent)).toBe(true));
 
     request.mockRejectedValueOnce(new Error("refresh failed"));
+    control.invalidate(false);
     control.load(context, "main", true, { agent });
     await vi.waitFor(() =>
       expect(
@@ -733,7 +735,7 @@ describe("new-session model runtime", () => {
     expect(control.thinkingLevel).toBe("high");
   });
 
-  it("preserves a live selection when an ordinary metadata refresh fails", async () => {
+  it("preserves a live selection when an invalidated metadata refresh fails", async () => {
     const { context, request } = contextWith([]);
     const notify = vi.fn();
     const control = new NewSessionModelControl(notify);
@@ -744,6 +746,7 @@ describe("new-session model runtime", () => {
     });
     control.selected = "anthropic/claude-sonnet-4-6";
     control.thinkingLevel = "high";
+    control.invalidate(false);
     request.mockRejectedValueOnce(new Error("metadata unavailable"));
 
     control.load(context, "main", true);
@@ -777,6 +780,7 @@ describe("new-session model runtime", () => {
     );
     request.mockReturnValueOnce(refresh.promise);
 
+    control.invalidate(false);
     control.load(context, "main", true, {
       agent,
       preference: { model: "openai/gpt-5.6-luna" },
@@ -839,8 +843,9 @@ describe("new-session model runtime", () => {
       ).not.toBeNull(),
     );
 
-    control.invalidate(false);
     request.mockReturnValueOnce(reconnect.promise);
+    invalidateChatMetadataStore(context.gateway.snapshot.client!);
+    control.invalidate(false);
     control.load(context, "main", true);
 
     expect(
@@ -915,6 +920,48 @@ describe("new-session model runtime", () => {
     pending.resolve({ models: [] });
   });
 
+  it("reapplies an updated preference against the attached ready snapshot", async () => {
+    const models: ModelCatalogEntry[] = [
+      {
+        id: "gpt-5.6-sol",
+        name: "GPT-5.6 Sol",
+        provider: "openai",
+        reasoning: true,
+        thinkingLevels: [{ id: "high", label: "high" }],
+      },
+      {
+        id: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        provider: "openai",
+        reasoning: true,
+        thinkingLevels: [{ id: "low", label: "low" }],
+      },
+    ];
+    const refresh = deferred<{ models: ModelCatalogEntry[] }>();
+    const { context, request } = contextWith([]);
+    const client = context.gateway.snapshot.client!;
+    rememberChatMetadata(client, "main", { commands: [], models });
+    request.mockReturnValueOnce(refresh.promise);
+    const pendingRefresh = revalidateChatMetadata(client, "main");
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true, {
+      preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "high" },
+    });
+    expect(control.selected).toBe("openai/gpt-5.6-sol");
+    expect(control.thinkingLevel).toBe("high");
+
+    control.load(context, "main", true, {
+      preference: { model: "openai/gpt-5.6-luna", thinkingLevel: "low" },
+    });
+
+    expect(control.selected).toBe("openai/gpt-5.6-luna");
+    expect(control.thinkingLevel).toBe("low");
+    expect(request).toHaveBeenCalledOnce();
+    refresh.resolve({ models });
+    await pendingRefresh;
+  });
+
   it("drops a stored model and its reasoning override when the model is unavailable", async () => {
     const { context, request } = contextWith([
       { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai", reasoning: true },
@@ -933,8 +980,8 @@ describe("new-session model runtime", () => {
       preference: { model: "anthropic/retired-model", thinkingLevel: "high" },
     });
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(control.selected).toBe(""));
+    expect(request).toHaveBeenCalledOnce();
+    expect(control.selected).toBe("");
     expect(control.thinkingLevel).toBe("");
     expect(onSelectionChange).toHaveBeenLastCalledWith({ model: "", thinkingLevel: "" });
   });
@@ -965,8 +1012,8 @@ describe("new-session model runtime", () => {
       preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "retired" },
     });
 
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    await vi.waitFor(() => expect(control.thinkingLevel).toBe(""));
+    expect(request).toHaveBeenCalledOnce();
+    expect(control.thinkingLevel).toBe("");
     expect(control.selected).toBe("openai/gpt-5.6-sol");
     expect(onSelectionChange).toHaveBeenLastCalledWith({
       model: "openai/gpt-5.6-sol",

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -4,7 +4,6 @@ import type { ApplicationContext } from "../../app/context.ts";
 import {
   invalidateChatMetadataStore,
   rememberChatMetadata,
-  revalidateChatMetadata,
 } from "../../lib/chat/chat-metadata-store.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import type { DraftCloudProfile } from "./discovery.ts";
@@ -301,70 +300,6 @@ describe("new-session model runtime", () => {
     ).toBe("true");
     expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(0);
     pending.resolve({ models: [] });
-  });
-
-  it("keeps a ready catalog authoritative across control teardown", async () => {
-    const models: ModelCatalogEntry[] = [
-      {
-        id: "gpt-5.6-luna",
-        name: "GPT-5.6 Luna",
-        provider: "openai",
-        available: false,
-      },
-    ];
-    const agent = { id: "main", model: { primary: "openai/gpt-5.6-luna" } };
-    const { context, request } = contextWith(models);
-    const firstControl = new NewSessionModelControl(() => undefined);
-    firstControl.load(context, "main", true, { agent });
-    await vi.waitFor(() => expect(firstControl.isModelUnavailable(agent)).toBe(true));
-    firstControl.reset();
-
-    const remountedControl = new NewSessionModelControl(() => undefined);
-    remountedControl.load(context, "main", true, { agent });
-
-    const container = renderControl(remountedControl, context, "main", agent);
-    expect(container.querySelector('[data-chat-model-catalog-state="ready"]')).not.toBeNull();
-    expect(remountedControl.isModelUnavailable(agent)).toBe(true);
-    expect(
-      container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]'),
-    ).not.toBeNull();
-    expect(container.textContent).toContain(
-      "Authentication failed. Review the provider credential or sign-in, then retry.",
-    );
-    expect(request).toHaveBeenCalledOnce();
-  });
-
-  it("keeps a shared metadata request alive when its first control is torn down", async () => {
-    const models: ModelCatalogEntry[] = [
-      { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
-    ];
-    const pending = deferred<{ models: ModelCatalogEntry[] }>();
-    const { context, request } = contextWith([]);
-    request.mockImplementationOnce((_method, _params, options?: { signal?: AbortSignal }) => {
-      options?.signal?.addEventListener(
-        "abort",
-        () => pending.reject(new DOMException("metadata request aborted", "AbortError")),
-        { once: true },
-      );
-      return pending.promise;
-    });
-    const firstControl = new NewSessionModelControl(() => undefined);
-    firstControl.load(context, "main", true);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-
-    firstControl.reset();
-    const remountedControl = new NewSessionModelControl(() => undefined);
-    remountedControl.load(context, "main", true);
-    pending.resolve({ models });
-
-    await vi.waitFor(() => {
-      const container = renderControl(remountedControl, context);
-      expect(container.querySelector("[data-chat-model-catalog-state]")).toBeNull();
-      expect(
-        container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]'),
-      ).not.toBeNull();
-    });
-    expect(request).toHaveBeenCalledOnce();
   });
 
   it("waits for selected-agent defaults after chat metadata resolves", async () => {
@@ -918,48 +853,6 @@ describe("new-session model runtime", () => {
 
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
     pending.resolve({ models: [] });
-  });
-
-  it("reapplies an updated preference against the attached ready snapshot", async () => {
-    const models: ModelCatalogEntry[] = [
-      {
-        id: "gpt-5.6-sol",
-        name: "GPT-5.6 Sol",
-        provider: "openai",
-        reasoning: true,
-        thinkingLevels: [{ id: "high", label: "high" }],
-      },
-      {
-        id: "gpt-5.6-luna",
-        name: "GPT-5.6 Luna",
-        provider: "openai",
-        reasoning: true,
-        thinkingLevels: [{ id: "low", label: "low" }],
-      },
-    ];
-    const refresh = deferred<{ models: ModelCatalogEntry[] }>();
-    const { context, request } = contextWith([]);
-    const client = context.gateway.snapshot.client!;
-    rememberChatMetadata(client, "main", { commands: [], models });
-    request.mockReturnValueOnce(refresh.promise);
-    const pendingRefresh = revalidateChatMetadata(client, "main");
-    const control = new NewSessionModelControl(() => undefined);
-
-    control.load(context, "main", true, {
-      preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "high" },
-    });
-    expect(control.selected).toBe("openai/gpt-5.6-sol");
-    expect(control.thinkingLevel).toBe("high");
-
-    control.load(context, "main", true, {
-      preference: { model: "openai/gpt-5.6-luna", thinkingLevel: "low" },
-    });
-
-    expect(control.selected).toBe("openai/gpt-5.6-luna");
-    expect(control.thinkingLevel).toBe("low");
-    expect(request).toHaveBeenCalledOnce();
-    refresh.resolve({ models });
-    await pendingRefresh;
   });
 
   it("drops a stored model and its reasoning override when the model is unavailable", async () => {

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -5,7 +5,11 @@ import type {
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
-import { peekChatMetadata, revalidateChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
+import {
+  peekChatMetadata,
+  revalidateChatMetadata,
+  subscribeChatMetadata,
+} from "../../lib/chat/chat-metadata-store.ts";
 import {
   buildQualifiedChatModelValue,
   normalizeChatModelProviderId,
@@ -113,6 +117,7 @@ export class NewSessionModelControl {
       }
     | undefined;
   private metadataClient: NewSessionMetadataClient | undefined;
+  private metadataUnsubscribe: (() => void) | undefined;
   private restoringPreference = false;
   private pendingPreference: NewSessionPreference | null | undefined;
   private pendingAgent: GatewayAgentRow | undefined;
@@ -143,6 +148,31 @@ export class NewSessionModelControl {
     }
     this.activeMetadataRequest = undefined;
     this.metadataRequestId += 1;
+  }
+
+  private clearMetadataSubscription() {
+    this.metadataUnsubscribe?.();
+    this.metadataUnsubscribe = undefined;
+  }
+
+  private bindMetadataSubscription(client: NewSessionMetadataClient, agentId: string) {
+    if (this.metadataClient === client && this.metadataUnsubscribe) {
+      return;
+    }
+    this.clearMetadataSubscription();
+    this.metadataClient = client;
+    this.metadataUnsubscribe = subscribeChatMetadata(client, agentId, () => {
+      if (this.metadataClient !== client || this.agentId !== agentId) {
+        return;
+      }
+      const result = peekChatMetadata(client, agentId);
+      if (!result) {
+        this.startMetadataRequest(client, agentId);
+        return;
+      }
+      this.cancelMetadataRequest();
+      this.publishMetadataCatalog(Array.isArray(result.models) ? result.models : [], "ready");
+    });
   }
 
   private clearCatalogTargets() {
@@ -257,14 +287,13 @@ export class NewSessionModelControl {
     void revalidateChatMetadata(client, agentId, {
       startupRetryWindowMs: 60_000,
     }).then(
-      (result) => {
-        // Only the request that still owns the control may publish catalog data
-        // or restore preferences.
+      () => {
+        // Accepted results publish through the store subscription. The request
+        // only retains ownership here when a newer writer superseded it.
         if (this.activeMetadataRequest?.id !== requestId) {
           return;
         }
         this.activeMetadataRequest = undefined;
-        this.publishMetadataCatalog(Array.isArray(result.models) ? result.models : [], "ready");
       },
       () => {
         if (this.activeMetadataRequest?.id !== requestId) {
@@ -291,10 +320,9 @@ export class NewSessionModelControl {
     );
   }
 
-  private refreshPickerCatalogs() {
+  private retryPickerCatalogs() {
     const metadataClient = this.metadataClient;
-    if (metadataClient && this.agentId) {
-      // Picker open is the retry; start directly so preference restoration is not re-armed.
+    if (this.metadataState.status === "error" && metadataClient && this.agentId) {
       this.startMetadataRequest(metadataClient, this.agentId);
     }
     const targetDiscovery = this.catalogTargetDiscovery;
@@ -336,6 +364,7 @@ export class NewSessionModelControl {
     if (resetSelection) {
       this.agentId = "";
       this.metadataClient = undefined;
+      this.clearMetadataSubscription();
       this.selected = "";
       this.contextWindow = "";
       this.thinkingLevel = "";
@@ -369,6 +398,7 @@ export class NewSessionModelControl {
       // Catalog availability belongs to an agent. A real owner change clears
       // the snapshot; same-agent refreshes retain it until replacement.
       this.cancelMetadataRequest();
+      this.clearMetadataSubscription();
       this.agentId = normalizedAgentId;
       this.metadataClient = undefined;
       this.selected = "";
@@ -383,6 +413,7 @@ export class NewSessionModelControl {
     const selectionGeneration = this.selectionGeneration;
     if (!context || snapshot?.phase !== "connected" || !client || !normalizedAgentId || !enabled) {
       this.cancelMetadataRequest();
+      this.clearMetadataSubscription();
       this.metadataClient = undefined;
       this.restoringPreference = false;
       if (context && snapshot?.phase !== "connected") {
@@ -394,7 +425,7 @@ export class NewSessionModelControl {
       this.notify();
       return;
     }
-    this.metadataClient = client;
+    this.bindMetadataSubscription(client, normalizedAgentId);
     this.pendingPreference = options.preference;
     this.pendingAgent = options.agent;
     this.pendingContext = context;
@@ -627,7 +658,7 @@ export class NewSessionModelControl {
       },
       onModelPickerTargetRetry: (groupId) => {
         if (groupId === "cliAgents") {
-          this.refreshPickerCatalogs();
+          this.retryPickerCatalogs();
         }
       },
       onThinkingSelect: (value) => {
@@ -643,7 +674,7 @@ export class NewSessionModelControl {
         this.notify();
       },
       onModelSetup: () => options.context?.navigate("model-setup"),
-      onModelPickerOpen: () => this.refreshPickerCatalogs(),
+      onModelPickerOpen: () => this.retryPickerCatalogs(),
       onRequestUpdate: this.notify,
     });
   }

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -167,6 +167,13 @@ export class NewSessionModelControl {
       }
       const result = peekChatMetadata(client, agentId);
       if (!result) {
+        const snapshot = this.pendingContext?.gateway.snapshot;
+        if (snapshot?.phase !== "connected" || snapshot.client !== client) {
+          this.cancelMetadataRequest();
+          this.restoringPreference = false;
+          this.updateMetadataState({ ...this.metadataState, status: "offline" });
+          return;
+        }
         this.startMetadataRequest(client, agentId);
         return;
       }
@@ -433,11 +440,23 @@ export class NewSessionModelControl {
     this.restoringPreference = Boolean(
       options.preference?.model || options.preference?.thinkingLevel,
     );
-    if (
+    const activeRequestMatches =
       this.activeMetadataRequest?.client === client &&
-      this.activeMetadataRequest.agentId === normalizedAgentId
-    ) {
-      this.notify();
+      this.activeMetadataRequest.agentId === normalizedAgentId;
+    const cached = peekChatMetadata(client, normalizedAgentId);
+    if (activeRequestMatches) {
+      if (cached) {
+        this.publishMetadataCatalog(
+          Array.isArray(cached.models) ? cached.models : [],
+          "refreshing",
+        );
+      } else {
+        this.notify();
+      }
+      return;
+    }
+    if (cached && this.metadataState.status !== "error") {
+      this.publishMetadataCatalog(Array.isArray(cached.models) ? cached.models : [], "ready");
       return;
     }
     this.startMetadataRequest(client, normalizedAgentId);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the new-session model picker could keep showing `No models available` after the gateway had already published a populated model catalog. Opening the picker appeared to repair the state only because that user gesture forced another metadata request.

The same empty state also showed `Review connection` when the gateway connection was healthy and the catalog was simply verified empty.

## Why This Change Was Made

### Root cause on `main`

At current `main` commit `8b147db2f35f025acdf90a19c5c1df54184786ad`:

- The shared metadata store is a silent `WeakMap`: accepted requests and `rememberChatMetadata` replace the snapshot without notifying mounted consumers ([store entry](https://github.com/openclaw/openclaw/blob/8b147db2f35f025acdf90a19c5c1df54184786ad/ui/src/lib/chat/chat-metadata-store.ts#L13-L20), [request publication](https://github.com/openclaw/openclaw/blob/8b147db2f35f025acdf90a19c5c1df54184786ad/ui/src/lib/chat/chat-metadata-store.ts#L95-L115), [remember and invalidate](https://github.com/openclaw/openclaw/blob/8b147db2f35f025acdf90a19c5c1df54184786ad/ui/src/lib/chat/chat-metadata-store.ts#L162-L175)).
- `NewSessionModelControl` copies the current snapshot into private state and only replaces that copy from its own request completion ([snapshot projection](https://github.com/openclaw/openclaw/blob/8b147db2f35f025acdf90a19c5c1df54184786ad/ui/src/pages/new-session/model-control.ts#L230-L267)). A later shared publication therefore does not invalidate the trigger.
- Picker open unconditionally starts another metadata request, masking the frozen projection after the click ([open refresh](https://github.com/openclaw/openclaw/blob/8b147db2f35f025acdf90a19c5c1df54184786ad/ui/src/pages/new-session/model-control.ts#L294-L299)).
- The verified-empty and unavailable-model states share the same `Review connection` action ([catalog action](https://github.com/openclaw/openclaw/blob/8b147db2f35f025acdf90a19c5c1df54184786ad/ui/src/pages/chat/components/chat-model-picker.ts#L286-L298)).

### Single state path

The shared metadata store now owns change notification for accepted requests, remembered startup metadata, and invalidation. `NewSessionModelControl` subscribes by gateway client and profile and re-reads the canonical store snapshot on notification ([subscription path](https://github.com/openclaw/openclaw/blob/cf89ffc5be5417c4efb2ebb7021664878366a1b5/ui/src/pages/new-session/model-control.ts#L158-L182)).

A verified `ready` snapshot persists when the last control unsubscribes. A remounted control consumes that snapshot without forcing another RPC, while config changes and connected-to-disconnected transitions explicitly invalidate it ([disconnect owner](https://github.com/openclaw/openclaw/blob/cf89ffc5be5417c4efb2ebb7021664878366a1b5/ui/src/app/app-host.ts#L725-L733)). Disconnect notification records an offline state instead of requesting metadata from a dead transport.

Every repeated `load()` reapplies its current model and thinking preference immediately against the available snapshot before coalescing an in-flight refresh. Healthy cached loads do not refresh; errors retain the explicit retry path ([load reconciliation](https://github.com/openclaw/openclaw/blob/cf89ffc5be5417c4efb2ebb7021664878366a1b5/ui/src/pages/new-session/model-control.ts#L435-L462)). Picker open retries only after an actual error.

A never-loaded snapshot remains `Loading models…`. A verified-empty catalog shows `No models available` with `Manage models`; `Review connection` remains on the unavailable-model/authentication path.

## User Impact

The `/new` trigger updates as soon as the model catalog arrives, without requiring the picker to open. Navigating away and back reuses a verified catalog instead of issuing another request. Updated remembered model/thinking choices apply immediately. Empty, loading, offline, and connection-failure states now describe different conditions and give the appropriate next action.

## Evidence

### Regression: red to green

Command:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  ui/src/pages/new-session/model-control.test.ts \
  ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
```

- Before the original notification repair, the later-publication regression failed because the Luna option remained absent after `rememberChatMetadata` published it.
- Before the fix-first follow-up, the teardown regression did not render the cached snapshot as `ready`, and the repeated-load regression kept `openai/gpt-5.6-sol` instead of immediately applying `openai/gpt-5.6-luna`.
- After both repairs: 44 tests passed. The ready teardown path performs one total `chat.metadata` RPC, and updated model/thinking preferences apply synchronously ([teardown regression](https://github.com/openclaw/openclaw/blob/cf89ffc5be5417c4efb2ebb7021664878366a1b5/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts#L11-L40), [preference regression](https://github.com/openclaw/openclaw/blob/cf89ffc5be5417c4efb2ebb7021664878366a1b5/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts#L75-L115)).

Focused changed-surface validation:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  ui/src/lib/chat/chat-metadata-store.test.ts \
  ui/src/pages/new-session/model-control.test.ts \
  ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts \
  ui/src/pages/new-session/model-control.catalog-targets.test.ts \
  ui/src/pages/chat/chat-view.test.ts
```

Result: 5 files passed, 325 tests passed.

Focused consumer validation:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  ui/src/app/app-host.chat-metadata.test.ts \
  ui/src/pages/agents/agents-page.test.ts \
  ui/src/pages/chat/chat-commands.test.ts \
  ui/src/pages/chat/chat-history.test.ts \
  ui/src/pages/chat/chat-state.test.ts
```

Result: 5 files passed, 151 tests passed.

Focused browser lifecycle validation:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run \
  --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/new-session-page.model-catalog.e2e.test.ts \
  ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
```

Result: 2 files passed, 17 tests passed. The checks assert that picker open, ready-cache remount, and CLI-catalog retry do not issue an extra `chat.metadata` request. All thirteen changed files also pass `oxfmt --check` and `git diff --check`; structured review reported no actionable findings.

Remote exact-head validation at `cf89ffc5be5417c4efb2ebb7021664878366a1b5`:

```bash
node --import tsx scripts/run-oxlint-shards.mts --only=core --split-core --core-stripe=5/5 --threads=1
pnpm tsgo:ui
```

Result: the lint stripe passed with 0 warnings and 0 errors across 4,843 files; the UI typecheck passed.

Exact-head CI:

```bash
node scripts/watch-pr-ci.mjs 129019 cf89ffc5be5417c4efb2ebb7021664878366a1b5
```

Result: `GREEN` on run `32815230323`, with all 12 Control UI E2E shards and `openclaw/ci-gate` passing.

### Isolated live validation

- Started a source gateway with a fresh temporary state directory, channels skipped, Control UI serving disabled, and dedicated loopback port `38559`.
- Started the source Control UI on dedicated loopback port `5258`; `/new` and the changed model-control module both returned HTTP 200.
- A real WebSocket client connected to that gateway, found the default `main` profile, and `chat.metadata` returned a verified empty catalog (`modelCount: 0`).

This establishes the isolated source route, gateway transport, and verified-empty response used by the honest empty-state branch. No screenshot is claimed because the browser surface was unavailable during this validation.

### Production and test LOC

- Production: +110/-21 (net +89).
- Tests and test support: +215/-99 (net +116 raw; includes lifecycle-test relocation).

The production growth establishes the missing notification owner, lifecycle-safe subscription, explicit disconnect invalidation, and distinct catalog-state copy in one shared path. It replaces the picker-open compensation instead of adding a parallel refresh path.

### Blast radius

The production consumers of `chat-metadata-store` are exactly:

- `ui/src/app/app-host.ts`: contract intentionally changes from reconnect-time invalidation to immediate disconnect/config invalidation; mounted controls are notified without an offline RPC. Covered by `ui/src/app/app-host.chat-metadata.test.ts`, the disconnect-order model-control regression, and store invalidation tests.
- `ui/src/pages/agents/agents-page.ts`: no caller contract change for peek/load/revalidate; latest-request and reconnect fencing remain intact. Covered by `ui/src/pages/agents/agents-page.test.ts`.
- `ui/src/pages/chat/chat-commands.ts`: no caller contract change; read-only peek and post-invalidation cache behavior are unchanged. Covered by `ui/src/pages/chat/chat-commands.test.ts`.
- `ui/src/pages/chat/chat-history.ts`: type-only consumer of `ChatMetadataResult`; the result shape did not change. Covered by `ui/src/pages/chat/chat-history.test.ts`.
- `ui/src/pages/chat/chat-state-refresh.ts`: load/peek results are unchanged; `rememberChatMetadata` now additionally notifies subscribers while retaining pending-request supersession. Covered by `ui/src/pages/chat/chat-state.test.ts`.
- `ui/src/pages/new-session/model-control.ts`: contract intentionally changes to subscribe, reuse ready snapshots across teardown, reapply current preferences, and refresh only after error/invalidation. Covered by `ui/src/pages/new-session/model-control.test.ts` and `ui/src/pages/new-session/model-control.catalog-targets.test.ts`.
