### PR TITLE
fix(crabbox): preserve terminal provider errors

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-command-error.ts
+++ b/extensions/crabbox/src/crabbox-worker-command-error.ts
@@ -1,7 +1,7 @@
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { WorkerProviderError } from "openclaw/plugin-sdk/plugin-entry";
 import type { SpawnResult } from "openclaw/plugin-sdk/process-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const MAX_COMMAND_DETAIL_CHARS = 512;
 
@@ -11,7 +11,7 @@ function crabboxCommandDetail(result: SpawnResult): string {
     return "";
   }
   const compressed = redactSensitiveText(raw).replace(/\s+/gu, " ");
-  const redacted = truncateUtf16Safe(compressed, MAX_COMMAND_DETAIL_CHARS);
+  const redacted = sliceUtf16Safe(compressed, -MAX_COMMAND_DETAIL_CHARS);
   return redacted ? `: ${redacted}` : "";
 }
 

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -2391,41 +2391,55 @@ describe("Crabbox worker provider", () => {
     await expect(cliMissing.inspect(lease)).rejects.toThrow("inspect could not start");
   });
 
-  it("bounds and redacts CLI failure details", async () => {
+  it("retains the redacted terminal provider failure after verbose provisioning progress", async () => {
     const secret = ["sk", "abcdefghijklmnop"].join("-");
+    const terminalCause = "machine0 provider rejected authenticated provisioning";
+    const failurePrefix = "Crabbox warmup failed with exit code 5: ";
     const provider = providerWithRunner(async () =>
       commandResult({
-        code: 2,
-        stderr: `${secret} ${"failure ".repeat(200)}`,
+        code: 5,
+        stderr: [
+          "coordinator lease class=standard preferred_type=machine0",
+          "provisioning progress ".repeat(100),
+          `token=${secret}`,
+          terminalCause,
+        ].join("\n"),
         stdout: "stdout must not replace stderr",
       }),
     );
 
-    const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
+    const error = await provider
+      .provision({ ...PROFILE, provider: "machine0" }, OPERATION_ID)
+      .catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(Error);
     const message = error instanceof Error ? error.message : "";
+    expect(message).toContain(terminalCause);
     expect(message).not.toContain(secret);
     expect(message).not.toContain("stdout must not replace stderr");
-    expect(message).toHaveLength(INSPECT_FAILURE_PREFIX.length + 512);
+    expect(message).toHaveLength(failurePrefix.length + 512);
+    expect(message.startsWith(failurePrefix)).toBe(true);
   });
 
-  it("preserves UTF-16 boundaries in provider failure details", async () => {
-    const prefix = "x".repeat(511);
+  it("preserves UTF-16 boundaries at the start of terminal provider failure details", async () => {
+    const suffix = "x".repeat(511);
     const provider = providerWithRunner(async () =>
-      commandResult({ code: 2, stderr: `${prefix}😀after` }),
+      commandResult({ code: 2, stderr: `progress😀${suffix}` }),
     );
 
     const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(Error);
     const message = error instanceof Error ? error.message : "";
-    expect(message).toBe(`${INSPECT_FAILURE_PREFIX}${prefix}`);
+    expect(message).toBe(`${INSPECT_FAILURE_PREFIX}${suffix}`);
     expect(hasLoneSurrogate(message)).toBe(false);
   });
 
-  it("keeps a complete boundary pair when falling back to stdout", async () => {
+  it.each([
+    { name: "exactly at the bound", prefix: "" },
+    { name: "beyond the bound", prefix: "earlier progress " },
+  ])("keeps a complete stdout boundary pair $name", async ({ prefix }) => {
     const detail = `${"x".repeat(510)}😀`;
     const provider = providerWithRunner(async () =>
-      commandResult({ code: 2, stdout: `${detail}after` }),
+      commandResult({ code: 2, stdout: `${prefix}${detail}` }),
     );
 
     const error = await provider.inspect(lifecycleLease()).catch((cause: unknown) => cause);


### PR DESCRIPTION
Closes #129013

## What Problem This Solves

OpenClaw bounded Crabbox command failures by keeping the first 512 characters of the already tail-captured stderr stream. Verbose provisioning context therefore survived while the provider’s final actionable error—written immediately before process exit—was discarded. The authenticated Machine0 proof for #128185 failed with exit code 5 but surfaced only provisioning context, making the quota attempt non-diagnostic.

## Why This Change Was Made

The process runner already captures the final 64 KiB of each stream. The Crabbox plugin now keeps the UTF-16-safe final 512 characters of its preferred stderr detail after redaction and whitespace compression. Short errors remain byte-for-byte unchanged; stderr still takes precedence over stdout; the 512-character model/operator-visible bound and secret redaction remain unchanged.

This follows Crabbox’s real CLI contract: [`provider_coordinator.go`](https://github.com/openclaw/crabbox/blob/19bd2f510ad40449af86ef14f1d060183788cab7/internal/cli/provider_coordinator.go#L212) writes coordinator/provisioning context early, while [`cmd/crabbox/main.go`](https://github.com/openclaw/crabbox/blob/19bd2f510ad40449af86ef14f1d060183788cab7/cmd/crabbox/main.go#L29-L38) writes the returned provider error to stderr immediately before exit. No provider-specific text parsing, larger prompt/error budget, output-buffer growth, fallback stream, or Machine0 special case was added.

Production LOC: +2/-2 (net 0) | Tests: +25/-11 (net +14)

AI-assisted: yes. I reviewed the OpenClaw process capture mode, Crabbox CLI stream/exit contract, redaction, stderr precedence, UTF-16 boundaries, and the authenticated Machine0 failure evidence.

## User Impact

Cloud-worker provisioning failures now preserve the terminal provider cause needed for the next action—capacity, credentials, config, quota, or provider repair—instead of ending with stale progress text. Operators get a bounded, redacted, actionable failure without exposing secrets or increasing model context.

## Evidence

- Pre-fix RED: three focused regressions failed, including an exit-code-5 Machine0-shaped warmup whose terminal provider cause was absent.
- Post-fix focused proof: 127 Crabbox provider tests passed on the exact rebased head.
- Full changed-file gate passed extension production/test typechecks, type-aware lint, formatting, doctor contract guards, plugin boundaries, dead exports, database-first, and import cycles.
- Coverage proves verbose progress followed by a terminal provider error retains the terminal cause; a secret in the retained suffix is redacted; stdout cannot replace stderr; the detail remains exactly bounded; and suffix slicing preserves UTF-16 pairs both at and beyond the limit.
- Fresh exact-branch P0/P1 autoreview has no accepted/actionable findings (0.96).
- No new Machine0/provider request was made. The prior authenticated failure and direct upstream source contract are sufficient to repair the error projection; a later authorized quota-window retry is still required before #128185 can land.
