### PR TITLE
fix(slack): wake yielded parents after subagent completion

### DIFF
--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -3,6 +3,7 @@ import type { App } from "@slack/bolt";
 import { formatAllowlistMatchMeta } from "openclaw/plugin-sdk/allow-from";
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
 import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
+import type { ChannelInboundTurnPlan } from "openclaw/plugin-sdk/channel-inbound";
 import type {
   OpenClawConfig,
   SlackReactionNotificationMode,
@@ -84,6 +85,7 @@ export type SlackMonitorContext = {
   runtime: RuntimeEnv;
   channelRuntime?: ChannelRuntimeSurface;
   buildContext?: BuildChannelInboundContext;
+  dispatchReplyFromConfig?: ChannelInboundTurnPlan["dispatchReplyFromConfig"];
 
   botUserId: string;
   botId?: string;
@@ -557,6 +559,7 @@ export function createSlackMonitorContext(params: {
     return false;
   };
 
+  const channelRuntime = params.channelRuntime as PluginRuntime["channel"] | undefined;
   const ctx: SlackMonitorContext = {
     cfg: params.cfg,
     accountId: params.accountId,
@@ -564,8 +567,8 @@ export function createSlackMonitorContext(params: {
     app: params.app,
     runtime: params.runtime,
     channelRuntime: params.channelRuntime,
-    buildContext: (params.channelRuntime as PluginRuntime["channel"] | undefined)?.inbound
-      .buildContext,
+    buildContext: channelRuntime?.inbound.buildContext,
+    dispatchReplyFromConfig: channelRuntime?.reply?.dispatchReplyFromConfig,
     botUserId: params.botUserId,
     botId: params.botId,
     identityHealth: params.identityHealth,

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -47,6 +47,7 @@ let mockedSlackStreamingMode: "off" | "partial" | "block" | "progress" = "partia
 let mockedSlackDraftMode: "replace" | "status_final" | "append" = "append";
 let mockedPinnedMainDmOwner: string | undefined;
 let capturedReplyOptions: GetReplyOptions | undefined;
+let capturedDispatchReplyFromConfig: unknown;
 let capturedStatusReactionOptions: { enabled?: boolean; initialEmoji?: string } | undefined;
 const statusReactionControllerMock = {
   setQueued: vi.fn(async () => {}),
@@ -349,6 +350,7 @@ function createPreparedSlackMessage(params?: {
   ackReactionPromise?: Promise<boolean> | null;
   relayIdentity?: { username?: string; iconUrl?: string; iconEmoji?: string };
   turnAdoptionLifecycle?: object;
+  dispatchReplyFromConfig?: unknown;
   eventScope?: {
     teamId: string;
     client: Record<string, unknown>;
@@ -380,6 +382,7 @@ function createPreparedSlackMessage(params?: {
       historyLimit: 0,
       channelHistories: new Map(),
       allowFrom: [],
+      dispatchReplyFromConfig: params?.dispatchReplyFromConfig,
       setSlackThreadStatus: params?.setSlackThreadStatus ?? (async () => undefined),
     },
     account: {
@@ -995,6 +998,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
     readAgentRunTerminalOutcome: () => mockedAgentRunTerminalOutcome,
     dispatchChannelInboundTurn: async (params: DispatchParams) => {
       capturedReplyOptions = params.replyOptions as typeof capturedReplyOptions;
+      capturedDispatchReplyFromConfig = params.dispatchReplyFromConfig;
       if (mockedReplyOptionEvents.length > 0) {
         for (const entry of mockedReplyOptionEvents) {
           if (entry.kind === "item") {
@@ -1149,6 +1153,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedSlackDraftMode = "append";
     mockedPinnedMainDmOwner = undefined;
     capturedReplyOptions = undefined;
+    capturedDispatchReplyFromConfig = undefined;
     capturedStatusReactionOptions = undefined;
     capturedTyping = undefined;
     mockedReplyThreadTs = THREAD_TS;
@@ -1189,6 +1194,14 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     await dispatchPreparedSlackMessage(createPreparedSlackMessage({ turnAdoptionLifecycle }));
 
     expect(capturedReplyOptions?.turnAdoptionLifecycle).toBe(turnAdoptionLifecycle);
+  });
+
+  it("forwards the instance-bound reply dispatcher", async () => {
+    const dispatchReplyFromConfig = vi.fn();
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage({ dispatchReplyFromConfig }));
+
+    expect(capturedDispatchReplyFromConfig).toBe(dispatchReplyFromConfig);
   });
 
   it("preserves provider previews for observer-only hooks", async () => {

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -390,6 +390,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       accountId: route.accountId,
       route: { agentId: route.agentId, sessionKey: route.sessionKey },
       ctxPayload: prepared.ctxPayload,
+      dispatchReplyFromConfig: ctx.dispatchReplyFromConfig,
       dispatcherOptions: {
         ...replyPipeline,
         // A channel transform marks intentional silence before core can synthesize an empty-reply error.

--- a/extensions/slack/src/monitor/slash.test-harness.ts
+++ b/extensions/slack/src/monitor/slash.test-harness.ts
@@ -31,6 +31,7 @@ vi.mock("./slash-dispatch.runtime.js", () => {
       cfg: unknown;
       ctxPayload: unknown;
       route: { sessionKey: string };
+      dispatchReplyFromConfig?: unknown;
       dispatcherOptions?: { onSettled?: () => unknown };
       delivery: { deliver?: unknown; onError?: unknown };
       replyOptions?: unknown;

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -641,6 +641,18 @@ describe("Slack native command argument menus", () => {
 
   beforeEach(() => {
     harness.postEphemeral.mockClear();
+    (harness.ctx as { dispatchReplyFromConfig?: unknown }).dispatchReplyFromConfig = undefined;
+  });
+
+  it("forwards the instance-bound reply dispatcher", async () => {
+    const dispatchReplyFromConfig = vi.fn();
+    (harness.ctx as { dispatchReplyFromConfig?: unknown }).dispatchReplyFromConfig =
+      dispatchReplyFromConfig;
+
+    await runCommandHandler(agentStatusHandler);
+
+    const { turnPlanMock } = getSlackSlashMocks();
+    expect(turnPlanMock).toHaveBeenCalledWith(expect.objectContaining({ dispatchReplyFromConfig }));
   });
 
   it("delivers native /login block replies before the command finishes", async () => {

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -854,6 +854,7 @@ export async function registerSlackMonitorSlashCommands(params: {
           sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
         },
         ctxPayload,
+        dispatchReplyFromConfig: ctx.dispatchReplyFromConfig,
         replyPipeline: {
           transformReplyPayload: (payload) => {
             if (payload.isReasoning === true) {


### PR DESCRIPTION
Closes #128883

## What Problem This Solves

Fixes an issue where Slack users spawning a detached subagent through the Codex harness could see the child finish, but the yielded parent would not wake and reply in the original thread.

## Why This Change Was Made

Slack now carries the Gateway-bound reply dispatcher already supplied by its channel runtime into both normal-message and slash-command turn plans. This preserves the existing closure-bound ownership path without adding persistence, retries, fallbacks, or core changes.

Codex 0.149.1 only sends the host the dynamic tool call IDs, name/namespace, and arguments, then consumes the host's content/success response; it does not transport OpenClaw's Gateway resolver ([request](https://github.com/openai/codex/blob/ff29a44391deccde0aba0f8390337d7f3c319ea4/codex-rs/app-server/src/bespoke_event_handling.rs#L1009-L1035), [response](https://github.com/openai/codex/blob/ff29a44391deccde0aba0f8390337d7f3c319ea4/codex-rs/core/src/tools/handlers/dynamic.rs#L135-L161)). The dispatcher therefore belongs at the Slack ingress boundary where it was being dropped.

Production LOC: +7/-2 (net +5) | Tests/test support: +26/-0

## User Impact

Detached subagent completions can wake a yielded parent and produce the expected follow-up in the originating Slack thread, including turns started through Slack slash commands.

## Evidence

### Regression proof

Before the production change, both new focused tests failed for the intended reason:

- normal Slack messages forwarded `undefined` instead of the sentinel dispatcher;
- slash-command turn plans omitted `dispatchReplyFromConfig`.

After the fix:

- `node scripts/run-vitest.mjs extensions/slack/src/monitor/provider.allowlist.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/slack/src/monitor/slash.test.ts` — 234 passed
- `pnpm test:extension slack` — 137 files, 2,496 tests passed
- changed-file validation — formatting, production/test typechecks, lint, plugin boundaries, storage/media guards, and import-cycle checks passed
- pinned Knip 6.32.2 production/full-tree/script export scans passed
- isolated Codex autoreview — no findings; patch correct (0.99 confidence)

### Live Slack + Codex proof

Tested on a real macOS Gateway running OpenClaw `2026.8.1-beta.3`, the Slack channel plugin, and the Codex 0.149.1 harness after applying the equivalent dist patch and restarting the managed Gateway.

In a fresh Slack thread, the parent was instructed to spawn one detached child that slept for 15 seconds, return `SPAWNED_128883` immediately, and return `WAKE_128883_OK` only when completion later woke it automatically.

Observed:

1. the parent immediately replied `SPAWNED_128883`;
2. the detached child completed successfully after 24 seconds including startup overhead;
3. without polling or another user message, the parent automatically replied `WAKE_128883_OK`.

<img width="856" height="614" alt="Screenshot 2026-08-25 at 1 37 38 AM" src="https://github.com/user-attachments/assets/85255807-9ebb-45d0-a308-fdcc4f4019bb" />


AI-assisted: Codex was used for implementation and review; the maintainer directed the scope and validated the live behavior.
