### PR TITLE
test(inworld): make voices timeout proof hermetic

### DIFF
--- a/extensions/inworld/voices-timeout.test.ts
+++ b/extensions/inworld/voices-timeout.test.ts
@@ -1,69 +1,52 @@
-import { clearTimeout as clearRealTimeout, setTimeout as setRealTimeout } from "node:timers";
-import { withServer } from "openclaw/plugin-sdk/test-env";
+// Inworld voice list timeout proof.
+// fetchWithSsrFGuard treats a vi.fn fetch stub as hermetic (no DNS pinning, no
+// dispatcher) and passes its timeout abort signal via init.signal, so a
+// never-resolving signal-honoring stub plus fake timers exercises the real
+// abort path with no live sockets or wall-clock bounds to flake on loaded CI.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { listInworldVoices } from "./tts.js";
 
-describe("listInworldVoices live timeout", () => {
-  const originalFetch = globalThis.fetch;
-
+describe("listInworldVoices timeout", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
-  it(
-    "aborts a hanging voice list request within the configured timeout",
-    { timeout: 2_000 },
-    async () => {
-      let requestCount = 0;
-      let notifyRequest = () => {};
-      const requestReceived = new Promise<void>((resolve) => {
-        notifyRequest = resolve;
-      });
-      await withServer(
-        (request) => {
-          requestCount += 1;
-          notifyRequest();
-          request.resume();
-        },
-        async (baseUrl) => {
-          vi.stubGlobal(
-            "fetch",
-            vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-              return await originalFetch(`${baseUrl}/voices/v1/voices`, init);
-            }) as unknown as typeof globalThis.fetch,
-          );
-
-          let watchdog: ReturnType<typeof setRealTimeout> | undefined;
-          try {
-            vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-            const watchdogPromise = new Promise<never>((_, reject) => {
-              watchdog = setRealTimeout(
-                () => reject(new Error("voices list did not time out")),
-                1_000,
-              );
-            });
-            const request = Promise.race([
-              listInworldVoices({
-                apiKey: "test-key",
-                baseUrl: "https://custom.inworld.example.com",
-                timeoutMs: 250,
-              }),
-              watchdogPromise,
-            ]);
-            const rejection = expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
-
-            await Promise.race([requestReceived, watchdogPromise]);
-            expect(requestCount).toBe(1);
-            await vi.advanceTimersByTimeAsync(250);
-            await rejection;
-          } finally {
-            vi.useRealTimers();
-            if (watchdog) {
-              clearRealTimeout(watchdog);
-            }
+  it("aborts a hanging voice list request within the configured timeout", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const fetchMock = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) {
+            reject(new Error("guarded fetch did not pass an abort signal"));
+            return;
           }
-        },
-      );
-    },
-  );
+          signal.addEventListener(
+            "abort",
+            () =>
+              reject(signal.reason instanceof Error ? signal.reason : new Error("request aborted")),
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof globalThis.fetch);
+
+    const request = listInworldVoices({
+      apiKey: "test-key",
+      baseUrl: "https://custom.inworld.example.com",
+      timeoutMs: 250,
+    });
+    const rejection = expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
+
+    // Flush guard preflight microtasks so the request is in flight.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(249);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await rejection;
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

`extensions/inworld/voices-timeout.test.ts` ("aborts a hanging voice list request within the configured timeout") is flaky on loaded CI runners: it timed out at its 2000ms vitest budget on the `checks-node-changed-extensions-config-2` shard (run 32714053992 on the unrelated #128514). The test mixed fake timers with a real 2s vitest timeout, a real 1s watchdog `setTimeout`, and a live loopback HTTP server, so real socket/connection latency on a loaded shard raced the wall-clock bounds.

## Why This Change Was Made

PR #124694 already gave this test the same "deterministic" hybrid shape as the azure-speech sibling — in fact it edited both files in one commit — and the flake survived that shape, because the real I/O phases (TCP connect, request delivery, teardown) still run against hard real-time budgets.

The root-cause fix removes real time from the test entirely. `fetchWithSsrFGuard` has a designed hermetic seam for test-installed fetch mocks (`isMockedFetch` in `src/infra/net/runtime-fetch.ts`; `canUseMockedFetchWithoutDns` in `src/infra/net/fetch-guard.ts`): a `vi.fn` fetch stub skips DNS pinning and dispatchers and receives the guard's timeout abort signal via `init.signal`. The test now stubs fetch with a never-resolving promise that rejects with `signal.reason` on abort — exactly how a hanging real request behaves — and drives `buildTimeoutAbortSignal`'s timer with fake timers. No server, no watchdog, no custom vitest timeout.

The protected behavior is strengthened: the test now asserts the request is **not** aborted at 249ms and **is** aborted (with the guard's `request timed out` TimeoutError) at 250ms, proving the abort is timer-driven at the configured value rather than incidental.

## User Impact

None at runtime — test-only. CI shards stop failing unrelated PRs on this test under load.

## Evidence

- `node scripts/run-vitest.mjs extensions/inworld/voices-timeout.test.ts` — green; test body now ~15ms of fake-timer time (previously bounded real socket waits).
- Bounded stability loop: 10/10 consecutive local runs green, 0 failures.
- Full inworld suite: 3 files, 45 tests green.
- `node scripts/check-changed.mjs` — exit 0 (one oxlint `prefer-promise-reject-errors` finding surfaced mid-work and was fixed by narrowing `signal.reason` to an Error).
- Codex autoreview (`--mode uncommitted`): clean, no accepted/actionable findings.
- Production LOC delta: 0 (test-only; net −17 test lines).

Note: `extensions/azure-speech/voices-timeout.test.ts` still carries the identical flaky-by-construction shape (live loopback + real 1s watchdog + 2s budget); it just has not been caught flaking yet. Same hermetic rewrite applies verbatim there as a follow-up.
