### PR TITLE
fix(telegram): resolve rich text chunk limit for richMessages accounts

### DIFF
--- a/extensions/telegram/src/outbound-adapter.chunk-limit.test.ts
+++ b/extensions/telegram/src/outbound-adapter.chunk-limit.test.ts
@@ -1,0 +1,44 @@
+// Rich-enabled Telegram accounts must get the 32768-char rich text budget,
+// not the 4096 plain-Markdown cap; an explicit textChunkLimit still wins.
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./send.js", () => ({
+  pinMessageTelegram: vi.fn(),
+  reactMessageTelegram: vi.fn(),
+  sendPollTelegram: vi.fn(),
+  sendLocationTelegram: vi.fn(),
+  sendMessageTelegram: vi.fn(),
+}));
+
+import { telegramOutbound } from "./outbound-adapter.js";
+
+describe("telegramOutbound.resolveEffectiveTextChunkLimit", () => {
+  it("raises the limit to the rich text budget for rich accounts", () => {
+    const limit = telegramOutbound.resolveEffectiveTextChunkLimit?.({
+      cfg: { channels: { telegram: { richMessages: true } } } as never,
+      accountId: "default",
+      fallbackLimit: 4000,
+    });
+    expect(limit).toBe(32768);
+  });
+
+  it("keeps the 4096 cap for non-rich accounts", () => {
+    const limit = telegramOutbound.resolveEffectiveTextChunkLimit?.({
+      cfg: { channels: { telegram: {} } } as never,
+      accountId: "default",
+      fallbackLimit: 4000,
+    });
+    expect(limit).toBe(4000);
+  });
+
+  it("honors an explicit lower textChunkLimit even for rich accounts", () => {
+    const limit = telegramOutbound.resolveEffectiveTextChunkLimit?.({
+      cfg: {
+        channels: { telegram: { richMessages: true, textChunkLimit: 1500 } },
+      } as never,
+      accountId: "default",
+      fallbackLimit: 4000,
+    });
+    expect(limit).toBe(1500);
+  });
+});

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -10,7 +10,10 @@ import {
   createAttachedChannelResultAdapter,
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
-import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
+import {
+  chunkMarkdownTextWithMode,
+  resolveTextChunkLimit,
+} from "openclaw/plugin-sdk/reply-chunking";
 import {
   resolveSendableOutboundReplyParts,
   sendPayloadMediaSequenceOrFallback,
@@ -33,6 +36,7 @@ import {
   resolveTelegramPromptContextSource,
 } from "./prompt-context-projection.js";
 import { registerTelegramQuestionDelivery } from "./question-finalization.js";
+import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
 import { loadTelegramSendModule, type TelegramSendModule } from "./send-runtime.js";
 import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
 
@@ -572,8 +576,18 @@ export function createTelegramOutboundAdapter(
         gatewayClientScopes,
       });
     },
-    resolveEffectiveTextChunkLimit: ({ fallbackLimit }) =>
-      typeof fallbackLimit === "number" ? Math.min(fallbackLimit, 4096) : 4096,
+    resolveEffectiveTextChunkLimit: ({ cfg, accountId, fallbackLimit }) =>
+      mergeTelegramAccountConfig(cfg, accountId ?? resolveDefaultTelegramAccountId(cfg))
+        .richMessages === true
+        ? Math.min(
+            resolveTextChunkLimit(cfg, "telegram", accountId, {
+              fallbackLimit: TELEGRAM_RICH_TEXT_LIMIT,
+            }),
+            TELEGRAM_RICH_TEXT_LIMIT,
+          )
+        : typeof fallbackLimit === "number"
+          ? Math.min(fallbackLimit, 4096)
+          : 4096,
     pollMaxOptions: TELEGRAM_POLL_OPTION_LIMIT,
     supportsPollDurationSeconds: true,
     supportsAnonymousPolls: true,


### PR DESCRIPTION
Closes #128993

## What Problem This Solves

Fixes an issue where Telegram accounts with `richMessages: true` would silently lose content when the assistant sent a long reply containing rich HTML media blocks (galleries, tables, collages). The outbound delivery path chunked the text at 4096 characters before the Telegram rich-message sender ever saw it, so a media block or a heading/list that straddled the 4096-char boundary was cut in half — the tail of that block and everything after it in the same logical message was dropped, with no warning logged.

## Why This Change Was Made

`resolveEffectiveTextChunkLimit` in `extensions/telegram/src/outbound-adapter.ts` unconditionally clamped the shared outbound chunk limit to 4096, ignoring whether the account has `richMessages` enabled (which already gives the account a 32768-char budget and an HTML-aware splitter, `splitTelegramHtmlChunks`/`splitTelegramRichMarkdownChunks`, that never cuts inside a media block). The fix resolves the account's `richMessages` setting the same way the rest of this file already does (`mergeTelegramAccountConfig`), and for rich accounts reuses the existing `resolveTextChunkLimit` + `TELEGRAM_RICH_TEXT_LIMIT` (32768) pattern already used by `send-message-text.ts` and `bot-message.ts` for the same purpose. Non-rich accounts are unaffected. An explicit `channels.telegram.textChunkLimit` (global or per-account) still wins over the rich default, so an operator's configured lower limit is never silently overridden.

## User Impact

Operators running `richMessages: true` no longer have long assistant replies silently truncated mid-gallery/mid-table when the reply exceeds 4096 characters; the existing rich-message splitter now gets the full 32768-char document and performs the block-safe split it was already built to do.

## Evidence

Root cause, confirmed by reverting only the fix and re-running the new regression test (`git checkout HEAD~1 -- extensions/telegram/src/outbound-adapter.ts`, since the fix and test were committed together):

```
 FAIL  |extension-telegram| extensions/telegram/src/outbound-adapter.chunk-limit.test.ts > telegramOutbound.resolveEffectiveTextChunkLimit > raises the limit to the rich text budget for rich accounts
AssertionError: expected 4000 to be 32768 // Object.is equality
 FAIL  |extension-telegram| extensions/telegram/src/outbound-adapter.chunk-limit.test.ts > telegramOutbound.resolveEffectiveTextChunkLimit > honors an explicit lower textChunkLimit even for rich accounts
AssertionError: expected 4000 to be 1500 // Object.is equality
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

With the fix restored:

```
$ node scripts/run-vitest.mjs extensions/telegram/src/outbound-adapter.chunk-limit.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full adapter test sweep (existing suites covering the same handler, unchanged behavior confirmed):

```
$ node scripts/run-vitest.mjs extensions/telegram/src/outbound-adapter.chunk-limit.test.ts extensions/telegram/src/outbound-adapter.test.ts extensions/telegram/src/outbound-adapter.sanitize.test.ts extensions/telegram/src/outbound-adapter.presentation.test.ts extensions/telegram/src/outbound-adapter.normalize-payload.test.ts extensions/telegram/src/outbound-adapter.web-app.test.ts
 Test Files  6 passed (6)
      Tests  62 passed (62)
```

Lint/format/typecheck on the changed files:

```
$ node scripts/run-oxlint.mjs extensions/telegram/src/outbound-adapter.ts extensions/telegram/src/outbound-adapter.chunk-limit.test.ts
(clean, exit 0)

$ ./node_modules/.bin/oxfmt --check extensions/telegram/src/outbound-adapter.ts extensions/telegram/src/outbound-adapter.chunk-limit.test.ts
All matched files use the correct format.

$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
(clean, no diagnostics)

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
(clean, no diagnostics)
```

Diff size: production change is +17/-3 in `extensions/telegram/src/outbound-adapter.ts` (one file), plus a new 44-line focused test file.

Note: `node scripts/check-max-lines-ratchet.mts --base origin/main` reports pre-existing baseline drift on unrelated files (`extensions/ollama/src/stream.runtime.ts`, several `src/agents/**` test files) that this PR does not touch — confirmed unrelated to this change.

---
AI-assisted: this PR was prepared by an autonomous coding agent (Claude), including the root-cause analysis, the fix, and the regression test above.
