### PR TITLE
refactor(gateway): consolidate post-ready maintenance scheduling

### DIFF
--- a/src/gateway/server-runtime-services.test.ts
+++ b/src/gateway/server-runtime-services.test.ts
@@ -120,7 +120,6 @@ import {
 
 const {
   activateGatewayScheduledServices,
-  runGatewayPostReadyMaintenance,
   scheduleGatewayIdleTask,
   scheduleGatewayPostReadyMaintenance,
   startGatewayChannelHealthMonitor,
@@ -811,24 +810,22 @@ describe("server-runtime-services", () => {
   });
 
   it("starts cron and records memory when post-ready maintenance fails", async () => {
+    vi.useFakeTimers();
     const cron = { start: vi.fn(async () => undefined) };
     const log = createLog();
     const recordPostReadyMemory = vi.fn();
 
-    await runGatewayPostReadyMaintenance({
-      startMaintenance: vi.fn(async () => {
-        throw new Error("timers unavailable");
+    scheduleGatewayPostReadyMaintenance(
+      createPostReadyMaintenanceScheduleParams({
+        startMaintenance: vi.fn(async () => {
+          throw new Error("timers unavailable");
+        }),
+        cronState: createTestCronState(cron),
+        log,
+        recordPostReadyMemory,
       }),
-      applyMaintenance: vi.fn(),
-      shouldStartCron: () => true,
-      markCronStartHandled: vi.fn(),
-      cronState: createTestCronState(cron),
-      cronReconciliation: createTestCronReconciliation(),
-      cronConfig: {} as never,
-      logCron: { error: vi.fn() },
-      log,
-      recordPostReadyMemory,
-    });
+    );
+    await vi.advanceTimersByTimeAsync(1);
 
     expect(log.warn).toHaveBeenCalledWith(
       "gateway post-ready maintenance startup failed: Error: timers unavailable",

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -92,40 +92,6 @@ export async function clearGatewayMaintenanceHandles(
   maintenance.skillCuratorCleanup();
 }
 
-/** Runs maintenance that is intentionally delayed until after the gateway is ready. */
-export async function runGatewayPostReadyMaintenance(params: {
-  startMaintenance: () => Promise<GatewayMaintenanceHandles | null>;
-  applyMaintenance: (maintenance: GatewayMaintenanceHandles) => Promise<void> | void;
-  shouldStartCron: () => boolean;
-  markCronStartHandled: () => void;
-  cronState: GatewayCronState;
-  cronReconciliation: GatewayCronReconciliation;
-  cronConfig: OpenClawConfig;
-  logCron: { error: (message: string) => void };
-  log: GatewayPostReadyLogger;
-  recordPostReadyMemory: () => void;
-}): Promise<void> {
-  try {
-    const maintenance = await params.startMaintenance();
-    if (maintenance) {
-      await params.applyMaintenance(maintenance);
-    }
-  } catch (err) {
-    params.log.warn(`gateway post-ready maintenance startup failed: ${String(err)}`);
-  }
-  if (params.shouldStartCron()) {
-    params.markCronStartHandled();
-    startGatewayCronWithLogging({
-      cronState: params.cronState,
-      cronReconciliation: params.cronReconciliation,
-      reason: "startup",
-      config: params.cronConfig,
-      logCron: params.logCron,
-    });
-  }
-  params.recordPostReadyMemory();
-}
-
 /** Schedules post-ready maintenance and cancels/cleans handles if shutdown wins the race. */
 export function scheduleGatewayPostReadyMaintenance(params: {
   delayMs: number;
@@ -147,42 +113,35 @@ export function scheduleGatewayPostReadyMaintenance(params: {
     if (params.isClosing()) {
       return;
     }
-    void runWithGatewayIndependentRootWorkAdmission(async () =>
-      runGatewayPostReadyMaintenance({
-        startMaintenance: async () => {
-          if (params.isClosing()) {
-            return null;
-          }
+    void runWithGatewayIndependentRootWorkAdmission(async () => {
+      try {
+        if (!params.isClosing()) {
           const maintenance = await params.startMaintenance();
           if (params.isClosing()) {
             // Maintenance can allocate intervals before shutdown is observed; clear them here
             // instead of handing live timers to a closing gateway.
             await clearGatewayMaintenanceHandles(maintenance);
-            return null;
+          } else if (maintenance) {
+            await params.applyMaintenance(maintenance);
           }
-          return maintenance;
-        },
-        applyMaintenance: async (maintenance) => {
-          if (params.isClosing()) {
-            await clearGatewayMaintenanceHandles(maintenance);
-            return;
-          }
-          await params.applyMaintenance(maintenance);
-        },
-        shouldStartCron: () => !params.isClosing() && params.shouldStartCron(),
-        markCronStartHandled: params.markCronStartHandled,
-        cronState: params.cronState,
-        cronReconciliation: params.cronReconciliation,
-        cronConfig: params.cronConfig,
-        logCron: params.logCron,
-        log: params.log,
-        recordPostReadyMemory: () => {
-          if (!params.isClosing()) {
-            params.recordPostReadyMemory();
-          }
-        },
-      }),
-    ).catch((err: unknown) =>
+        }
+      } catch (err) {
+        params.log.warn(`gateway post-ready maintenance startup failed: ${String(err)}`);
+      }
+      if (!params.isClosing() && params.shouldStartCron()) {
+        params.markCronStartHandled();
+        startGatewayCronWithLogging({
+          cronState: params.cronState,
+          cronReconciliation: params.cronReconciliation,
+          reason: "startup",
+          config: params.cronConfig,
+          logCron: params.logCron,
+        });
+      }
+      if (!params.isClosing()) {
+        params.recordPostReadyMemory();
+      }
+    }).catch((err: unknown) =>
       params.log.warn(`gateway post-ready maintenance deferred task failed: ${String(err)}`),
     );
   }, params.delayMs);


### PR DESCRIPTION
## Summary

- Consolidate post-ready Gateway maintenance scheduling at the lifecycle owner, removing the duplicated scheduling path without changing startup, shutdown, reload, race handling, or media initialization.
- Remove 41 lines of production code and three lines of obsolete test indirection while retaining the existing Gateway ownership boundary.

## Verification

- Eight focused Gateway boot, kernel, startup, race, media, shutdown, and reload suites passed: 605 tests.
- Assertion and maximum-line ratchets passed.
- Repository formatting and diff checks passed.
- Fresh structured autoreview and independent owner-boundary source review reported no actionable findings.
