### PR TITLE
fix(tui): preserve internal punctuation in wrapped hyperlinks

### DIFF
--- a/src/tui/osc8-hyperlinks.test.ts
+++ b/src/tui/osc8-hyperlinks.test.ts
@@ -175,6 +175,68 @@ describe("addOsc8Hyperlinks", () => {
     expect(result[1]).toContain(`\x1b]8;;${fullUrl}\x07`);
   });
 
+  it.each([
+    { punctuation: ".", first: "https://example.", second: "test/path" },
+    { punctuation: "?", first: "https://example.test/path?", second: "query=1" },
+    { punctuation: "_", first: "https://example.test/path_", second: "value" },
+    { punctuation: ",", first: "https://example.test/path,", second: "value" },
+    { punctuation: ";", first: "https://example.test/path;", second: "value" },
+    { punctuation: "!", first: "https://example.test/path!", second: "value" },
+    { punctuation: ":", first: "https://example.test/path:", second: "value" },
+    { punctuation: "*", first: "https://example.test/path*", second: "value" },
+    { punctuation: "~", first: "https://example.test/path~", second: "value" },
+    { punctuation: "Unicode .", first: "https://例子.", second: "测试/路径" },
+  ])("keeps internal $punctuation clickable when a URL wraps after it", ({ first, second }) => {
+    const url = `${first}${second}`;
+
+    expect(addOsc8Hyperlinks([first, second], [url])).toEqual([
+      `\x1b]8;;${url}\x07${first}\x1b]8;;\x07`,
+      `\x1b]8;;${url}\x07${second}\x1b]8;;\x07`,
+    ]);
+  });
+
+  it("keeps sentence punctuation unlinked before an unrelated following line", () => {
+    const url = "https://example.test/path";
+
+    expect(addOsc8Hyperlinks([`${url}.`, "unrelated text"], [url])).toEqual([
+      `\x1b]8;;${url}\x07${url}\x1b]8;;\x07.`,
+      "unrelated text",
+    ]);
+  });
+
+  it.each([
+    { label: "shorter", alternate: "https://example.test/a" },
+    { label: "authored dotted", alternate: "https://example.test/a." },
+  ])("prefers the actual wrapped URL over a $label known URL", ({ alternate }) => {
+    const url = "https://example.test/a.b";
+
+    expect(addOsc8Hyperlinks(["https://example.test/a.", "b"], [alternate, url])).toEqual([
+      `\x1b]8;;${url}\x07https://example.test/a.\x1b]8;;\x07`,
+      `\x1b]8;;${url}\x07b\x1b]8;;\x07`,
+    ]);
+  });
+
+  it("preserves separate authored and wrapped bare URLs in the same rendered message", () => {
+    const authored = "https://example.test/a.";
+    const wrapped = "https://example.test/a.b";
+    const first = `Docs (${authored}) and https://example.test/a.`;
+    const urls = extractUrls(`[Docs](${authored}) and ${wrapped}`);
+
+    expect(addOsc8Hyperlinks([first, "b"], urls)).toEqual([
+      `Docs (\x1b]8;;${authored}\x07${authored}\x1b]8;;\x07) and \x1b]8;;${wrapped}\x07https://example.test/a.\x1b]8;;\x07`,
+      `\x1b]8;;${wrapped}\x07b\x1b]8;;\x07`,
+    ]);
+  });
+
+  it("preserves internal punctuation across three wrapped URL lines", () => {
+    const url = "https://example.test/path_value";
+    const fragments = ["https://example.", "test/path_", "value"];
+
+    expect(addOsc8Hyperlinks(fragments, [url])).toEqual(
+      fragments.map((fragment) => `\x1b]8;;${url}\x07${fragment}\x1b]8;;\x07`),
+    );
+  });
+
   it("wraps a URL with a bracketed IPv6 authority", () => {
     const url = "http://[::1]:8080/path";
     expect(addOsc8Hyperlinks([url], [url])).toEqual([`\x1b]8;;${url}\x07${url}\x1b]8;;\x07`]);

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -138,39 +138,35 @@ function findUrlRanges(
   let match: RegExpExecArray | null;
 
   while ((match = urlRe.exec(visibleText)) !== null) {
-    const fragment = trimUrlTrailingPunctuation(match[0], knownUrls);
     const start = match.index;
+    const nextToken =
+      nextVisibleText
+        ?.trimStart()
+        .match(/^[^\s\]>\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]+/)?.[0] ?? "";
+    const nextFragment = trimUrlTrailingPunctuation(nextToken);
+    const continuationUrl =
+      visibleText.slice(start + match[0].length).trim().length === 0 && nextFragment.length > 0
+        ? knownUrls.reduce(
+            (longest, known) =>
+              known.length > longest.length &&
+              known.startsWith(match[0]) &&
+              known.slice(match[0].length).startsWith(nextFragment)
+                ? known
+                : longest,
+            "",
+          )
+        : "";
+    const fragment = continuationUrl ? match[0] : trimUrlTrailingPunctuation(match[0], knownUrls);
 
     // Resolve fragment to a known URL (exact > prefix > superstring)
-    let resolvedUrl = fragment;
-    let found = false;
+    let resolvedUrl = continuationUrl || fragment;
+    let found = Boolean(continuationUrl);
 
     // A wrap may split immediately after the scheme. Only accept that fragment
     // when the next line actually continues a known URL; otherwise a stray
     // `https://` could inherit an unrelated target from the URL list.
     if (!hasUrlContent(fragment)) {
-      const hasUnpunctuatedSchemeAtLineEnd =
-        fragment === match[0] && visibleText.slice(start + match[0].length).trim().length === 0;
-      if (!hasUnpunctuatedSchemeAtLineEnd) {
-        continue;
-      }
-      const nextToken =
-        nextVisibleText
-          ?.trimStart()
-          .match(/^[^\s\]>\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]+/)?.[0] ?? "";
-      const nextFragment = trimUrlTrailingPunctuation(nextToken);
-      for (const known of knownUrls) {
-        if (!known.startsWith(fragment)) {
-          continue;
-        }
-        const remaining = known.slice(fragment.length);
-        const continuesKnownUrl = nextFragment.length > 0 && remaining.startsWith(nextFragment);
-        if (continuesKnownUrl && known.length > resolvedUrl.length) {
-          resolvedUrl = known;
-          found = true;
-        }
-      }
-      if (!found) {
+      if (!continuationUrl || fragment !== match[0]) {
         continue;
       }
     }

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -138,6 +138,7 @@ function findUrlRanges(
   let match: RegExpExecArray | null;
 
   while ((match = urlRe.exec(visibleText)) !== null) {
+    const matchedUrl = match[0];
     const start = match.index;
     const nextToken =
       nextVisibleText
@@ -145,18 +146,20 @@ function findUrlRanges(
         .match(/^[^\s\]>\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]+/)?.[0] ?? "";
     const nextFragment = trimUrlTrailingPunctuation(nextToken);
     const continuationUrl =
-      visibleText.slice(start + match[0].length).trim().length === 0 && nextFragment.length > 0
+      visibleText.slice(start + matchedUrl.length).trim().length === 0 && nextFragment.length > 0
         ? knownUrls.reduce(
             (longest, known) =>
               known.length > longest.length &&
-              known.startsWith(match[0]) &&
-              known.slice(match[0].length).startsWith(nextFragment)
+              known.startsWith(matchedUrl) &&
+              known.slice(matchedUrl.length).startsWith(nextFragment)
                 ? known
                 : longest,
             "",
           )
         : "";
-    const fragment = continuationUrl ? match[0] : trimUrlTrailingPunctuation(match[0], knownUrls);
+    const fragment = continuationUrl
+      ? matchedUrl
+      : trimUrlTrailingPunctuation(matchedUrl, knownUrls);
 
     // Resolve fragment to a known URL (exact > prefix > superstring)
     let resolvedUrl = continuationUrl || fragment;
@@ -166,7 +169,7 @@ function findUrlRanges(
     // when the next line actually continues a known URL; otherwise a stray
     // `https://` could inherit an unrelated target from the URL list.
     if (!hasUrlContent(fragment)) {
-      if (!continuationUrl || fragment !== match[0]) {
+      if (!continuationUrl || fragment !== matchedUrl) {
         continue;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

The recent TUI sentence-punctuation hyperlink repair correctly excluded trailing prose punctuation, but accidentally treated internal URL punctuation as prose when the terminal wrapped immediately after it. For example, a narrow terminal rendered `https://example.test/path.` followed by `more` on the next line, but only linked the prefix before the dot; the dot and entire continuation were no longer clickable. Query separators, underscores, commas, semicolons, colons, exclamation marks, stars, and tildes were affected too.

## Why This Change Was Made

The existing OSC 8 hyperlink owner trimmed the current line's fragment before checking whether that exact raw fragment and the immediately following rendered text continued a known complete URL. The owner now resolves the longest corroborated full-URL continuation before applying sentence-punctuation policy, preserving genuine internal punctuation and both wrapped fragments. Exact authored Markdown destinations, unrelated sentence punctuation, Unicode URLs, three-line wraps, and messages mixing authored and bare links retain their established behavior.

The existing scheme-only continuation logic is absorbed into the same canonical full-target check. Production code decreases by one line (+24/-25); tests add 62 lines. No dependency, configuration, changelog, or public-contract changes.

## User Impact

Users can click either visible half of a wrapped terminal URL and open its complete intended destination, including domain dots, query-string separators, and underscore-containing paths. Sentence-ending punctuation remains outside ordinary bare-link targets, and explicitly authored Markdown destinations retain intentional punctuation.

## Evidence

- Nine internal-punctuation regression cases failed against the frozen current-main baseline, and two additional authored-destination ambiguity regressions failed against the first attempted repair; all pass with the canonical owner fix.
- Five focused owner and sibling suites pass: **249 tests**.
- A real 26-column `runTui()` pseudo-terminal using pinned `@earendil-works/pi-tui@0.84.2` emitted the exact full-target OSC 8 hyperlink on both visible fragments for all three representative URL classes:
  - `https://example.test/path.` + `more`
  - `https://example.test/path?` + `q=proof`
  - `https://example.test/path_` + `value`
- Each exact full URL appeared in eight terminal hyperlink-open sequences, covering four occurrences of each wrapped fragment.
- Type-aware lint, formatting, and `git diff --check` pass.
- The exact strict core TypeScript compiler diagnostic found by hosted CI was reproduced locally, repaired with a behavior-preserving stable match snapshot, and verified clean with the repository's canonical `tsgo` runner.
- Fresh authenticated Codex autoreview, secret scanning, and a separate independent adversarial review covering 22 cases report no actionable findings.
- Production delta: **+24/-25 (net -1 line)**; tests: **+62 lines**.
