### PR TITLE
fix(tui): prevent stale picker selections from changing the wrong agent

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -404,6 +404,91 @@ describe("tui command handlers", () => {
     expect(harness.closeOverlay).toHaveBeenCalledExactlyOnceWith(harness.overlayHandle);
   });
 
+  it.each([
+    {
+      name: "model",
+      command: "/models",
+      value: "private/research-only",
+      initialSession: "agent:research:incident",
+      replacementSession: "agent:ops:main",
+    },
+    {
+      name: "session",
+      command: "/sessions",
+      value: "agent:research:incident",
+      initialSession: "agent:research:incident",
+      replacementSession: "agent:ops:main",
+    },
+    {
+      name: "global model",
+      command: "/models",
+      value: "private/research-only",
+      initialSession: "global",
+      replacementSession: "global",
+    },
+    {
+      name: "global session",
+      command: "/sessions",
+      value: "agent:research:incident",
+      initialSession: "global",
+      replacementSession: "global",
+    },
+  ])(
+    "retires an open $name picker after its selected agent is replaced",
+    async ({ command, value, initialSession, replacementSession }) => {
+      const harness = createHarness({
+        currentAgentId: "research",
+        currentSessionKey: initialSession,
+        agents: [{ id: "research" }],
+        listModels: vi.fn().mockResolvedValue([{ provider: "private", id: "research-only" }]),
+        listSessions: vi
+          .fn()
+          .mockResolvedValue({ sessions: [{ key: "agent:research:incident", updatedAt: 1 }] }),
+      });
+
+      await harness.handleCommand(command);
+      const selector = firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay;
+      harness.state.currentAgentId = "ops";
+      harness.state.currentSessionKey = replacementSession;
+      selector.onSelect?.({ value });
+      await flushAsyncSelect();
+
+      expect(harness.patchSession).not.toHaveBeenCalled();
+      expect(harness.setSession).not.toHaveBeenCalled();
+      expect(harness.closeOverlay).toHaveBeenCalledExactlyOnceWith(harness.overlayHandle);
+    },
+  );
+
+  it.each([
+    { name: "agent", command: "/agents", value: "ops", session: "" },
+    {
+      name: "session",
+      command: "/sessions",
+      value: "agent:research:next",
+      session: "agent:research:next",
+    },
+  ])(
+    "accepts an intentional $name picker selection for its current owner",
+    async ({ command, value, session }) => {
+      const harness = createHarness({
+        currentAgentId: "research",
+        currentSessionKey: "agent:research:incident",
+        agents: [{ id: "research" }, { id: "ops" }],
+        listSessions: vi
+          .fn()
+          .mockResolvedValue({ sessions: [{ key: "agent:research:next", updatedAt: 1 }] }),
+      });
+
+      await harness.handleCommand(command);
+      const selector = firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay;
+      selector.onSelect?.({ value });
+      await flushAsyncSelect();
+
+      expect(harness.setSession).toHaveBeenCalledExactlyOnceWith(session);
+      expect(harness.closeOverlay).toHaveBeenCalledExactlyOnceWith(harness.overlayHandle);
+    },
+  );
+
   it("bounds Ctrl+P hydration to recent non-global TUI sessions", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       sessions: [

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -308,17 +308,17 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const openSelector = (
-    selector: {
-      onSelect?: (item: SelectItem) => void;
-      onCancel?: () => void;
-    },
+    selector: { onSelect?: (item: SelectItem) => void; onCancel?: () => void },
     onSelect: (value: string) => Promise<void>,
     request: { overlay?: OverlayHandle },
   ) => {
+    const selection = captureSessionSelection();
     selector.onSelect = (item) => {
       void (async () => {
         try {
-          await onSelect(item.value);
+          if (isCurrentSessionSelection(selection)) {
+            await onSelect(item.value);
+          }
         } catch (err) {
           // A rejected selection must not strand the overlay open with an
           // unhandled rejection; close it and surface the cause in chat.


### PR DESCRIPTION
Follow-up to #117285.

## What Problem This Solves

Fixes an issue where users selecting an already-visible TUI model or session would change the wrong agent when an authoritative agent-roster refresh replaced the selected agent while its picker remained open. A research-only model could be applied to the replacement agent, and a stale session could switch the terminal back into the removed agent. The same failure also affected globally scoped sessions because different agents share the literal `global` session key.

## Why This Change Was Made

The shared selector owner now captures its complete agent-and-session selection when the overlay opens and validates that identity again immediately before running its selection callback. Obsolete selections are discarded and their exact overlay is closed; valid agent-picker selections can still intentionally switch agents. The production change is net-neutral: five lines added and five removed.

## User Impact

Model and session picker selections can no longer leak agent-private choices across roster replacements. Normal agent switching, same-agent session selection, context selection, compact terminal focus, and globally scoped sessions continue to work.

## Evidence

- Untouched-current-main RED through the real `TuiMainScreen`, real overlay stack, real `ChatLog`, and both production session/command owners: selecting the stale research model issued `{ key: "agent:ops:main", model: "private/research-only" }` after the roster selected `ops`.
- New owner regressions failed on unmodified production for both the stale model patch and stale session switch before the fix. The final table also covers same-key global-agent collisions and preserves intentional agent/session selections.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-tui-stale-picker-selection-vitest-cache node scripts/run-vitest.mjs run --configLoader runner --no-cache --maxWorkers 1 src/tui/tui-command-handlers.test.ts src/tui/tui-session-actions.test.ts` — **261 passed**.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-tui-stale-picker-selection-pty-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner --no-cache --maxWorkers 1 src/tui/tui-pty-harness.e2e.test.ts src/tui/tui-session-identity-pty.e2e.test.ts -t 'selects model and session pickers through authenticated real PTY frames|keeps Enter focused on model and session pickers|restores a remembered global session'` — **3 real PTY scenarios passed**, including authenticated picker frames, compact-terminal picker focus, and remembered global-session ownership.
- Independent real-owner replay against the pinned pi-tui `0.84.2` renderer passed all **4** combinations of agent/global session scope and stale model/session overlay; each obsolete exact overlay disappeared without modifying or reselecting the replacement agent.
- `node_modules/.bin/oxlint --type-aware --type-check src/tui/tui-command-handlers.ts src/tui/tui-command-handlers.test.ts` and `git diff --check` passed.
- Mandatory fresh autoreview found no actionable findings; independent exact-diff review and separate focused behavioral replay passed **7/7**.

