### PR TITLE
test(gateway): fix flaky settled-run-ownership assertion in gateway chat suite

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -2572,13 +2572,19 @@ describe("gateway server chat", () => {
         });
         expectAgentWaitTimeout(waitWhileChatActive);
 
+        // Match the published ownership fact, not the `reason` label: sessions.changed
+        // coalesces bursts per session key and keeps only the newest payload, so any
+        // same-key mutation inside that window legitimately replaces the label while
+        // the row (activeRunIds/lastRunId) is still rebuilt at broadcast time.
         const settledSessionChange = onceMessage(
           ws,
           (event) =>
             event.type === "event" &&
             event.event === "sessions.changed" &&
-            event.payload?.reason === "chat.run.settled" &&
             event.payload?.sessionKey === "agent:main:main" &&
+            event.payload?.hasActiveRun === false &&
+            Array.isArray(event.payload?.activeRunIds) &&
+            event.payload.activeRunIds.length === 0 &&
             event.payload?.lastRunId === runId,
           8_000,
         );


### PR DESCRIPTION
## What Problem This Solves

Resolves a flaky CI failure in the gateway chat suite: `gateway server chat > agent.wait ignores lifecycle completion while same-runId chat.send is active` intermittently failed with `Gateway did not publish settled run ownership after chat.send cleanup`, burning its full 8s wait even though the gateway had published run-ownership settlement correctly. Observed on `checks-node-compact-small-6` (lane `agentic-control-plane-agent-chat-hosted-2`) during #128788; it passed on rerun.

## Why This Change Was Made

The assertion matched `sessions.changed` on its `reason === "chat.run.settled"` label. That label is best-effort by design: `emitSessionsChanged` coalesces per `(agentId, sessionKey)` and keeps only the newest payload, so any same-key emit inside the 100ms debounce / 500ms ceiling replaces an earlier `reason` while the row itself is still rebuilt at broadcast time. `session-change-event.test.ts` already pins that dropping behavior as intended, and the literal `chat.run.settled` string is produced in exactly one place and consumed by no runtime code — the TUI settles from `activeRunIds: []` for any reason other than `new`/`reset`.

The test now waits for the published ownership *fact* — `sessionKey`, `hasActiveRun === false`, empty `activeRunIds`, `lastRunId === runId` — the same fields the TUI and Control UI consume. That is a stricter contract than the label and is immune to coalescing. The timeout is unchanged, nothing is retried, and no assertion was weakened.

**The producer is deliberately untouched.** The settle emit sits in the dispatch tail's unconditional `finally` (`chat-send-agent-dispatch.ts:520`); `dispatch` cannot reject (`.catch(handleError)`) and `finalize()` catches internally, so the emit cannot be skipped. A deferred change always produces a trailing broadcast, and that broadcast reloads the session row and recomputes `activeRunIds`/`hasActiveRun`/`lastRunId` at send time. The settlement fact therefore cannot be lost or reordered — worst case it is 500ms late. Only the cosmetic label is droppable.

## User Impact

No user-visible or runtime change; test-only. Operators and CI get one less spurious red on the gateway chat lane.

## Evidence

**Root-cause A/B (the regression proof).** Injecting a single competing same-key `emitSessionsChanged` immediately after the settle — exactly the supersession a contended runner can produce — reproduces the CI failure verbatim with the old matcher and passes with the new one:

- old matcher + injected supersession → `Error: Gateway did not publish settled run ownership after chat.send cleanup` at line 2588, `1 failed`
- new matcher + same injected supersession → `1 passed`

**Producer measurements** (instrumented emit path + client socket, since reverted). Delivery latency from unblocking the reply to the matching event, against the 8s budget:

- isolated single test: 113ms
- full 61-test file under 48–56 CPU hogs, 6 runs: 159–217ms, 0 failures, **0** supersessions of the settled label across 72 settled emits
- exact CI lane (all 24 files on `vitest.gateway-server.config.ts`, `OPENCLAW_VITEST_MAX_WORKERS=3`, 60 hogs), 5 runs: 115–151ms, 0 failures

~40–70x margin; the failure never reproduced naturally in ~17 loaded runs.

**CI signature.** In the failing job the test's own duration was 8398ms — exactly its timeout and nothing more — while its neighbours ran in 407ms and 287ms on a `blacksmith-4vcpu-ubuntu-2404` runner with three workers. Consistent with a transient stall or label supersession in that window, not with a slow machine and not with a lost settlement.

**Validation:** `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts` → 61 passed (30.6s). `node scripts/check-changed.mjs` → exit 0. Autoreview (codex/gpt-5.6-sol, high) → clean, no accepted findings.
