### PR TITLE
fix(update): fail the git updater when the final HEAD verification probe errors

### DIFF
--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -551,6 +551,9 @@ export async function updateGitCheckout(params: {
     const afterShaStep = await runStep(
       step("git rev-parse HEAD (after)", ["git", "-C", gitRoot, "rev-parse", "HEAD"], gitRoot),
     );
+    if (afterShaStep.exitCode !== 0) {
+      return await rollbackError("head-verification-failed");
+    }
     if (
       devTarget?.mode === "tracked" &&
       devPreflight?.status === "ok" &&

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -1701,6 +1701,43 @@ describe("runGatewayUpdate", () => {
     expect(calls).toContain(`git -C ${tempDir} reset --hard abc123`);
   });
 
+  it("rolls back and reports error when the final HEAD verification probe fails", async () => {
+    await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
+    await setupUiIndex();
+    const stableTag = "v1.0.1-1";
+    const doctorNodePath = await resolveStableNodePath(process.execPath);
+    const { runner, calls } = createRunner({
+      ...buildStableTagResponses(stableTag),
+      [`git -C ${tempDir} rev-parse --abbrev-ref HEAD`]: { stdout: "main" },
+      "pnpm install": { stdout: "" },
+      "pnpm build": { stdout: "" },
+      "pnpm ui:build": { stdout: "" },
+      [`${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`]: {
+        stdout: "",
+      },
+    });
+    let revParseHeadCount = 0;
+    const runCommand = async (argv: string[]) => {
+      const key = argv.join(" ");
+      if (key === `git -C ${tempDir} rev-parse HEAD`) {
+        revParseHeadCount += 1;
+        if (revParseHeadCount === 2) {
+          return toCommandResult({ code: 1, stderr: "fatal: not a valid object name HEAD" });
+        }
+      }
+      return runner(argv);
+    };
+
+    const result = await runWithCommand(runCommand, { channel: "stable" });
+
+    expect(result.status).toBe("error");
+    expect(result.reason).toBe("head-verification-failed");
+    expect(result.after).toBeUndefined();
+    expect(calls).toContain(`git -C ${tempDir} reset --hard`);
+    expect(calls).toContain(`git -C ${tempDir} checkout --force main`);
+    expect(calls).toContain(`git -C ${tempDir} reset --hard abc123`);
+  });
+
   it("uses stable tag when beta tag is older than release", async () => {
     await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
     await setupUiIndex();


### PR DESCRIPTION
Closes #127412

## What Problem This Solves

The git updater could report a successful update even when the final "which commit did we land on?" verification check failed, leaving the installed revision unproven and the result internally contradictory (`status:"ok"`, failed final step, `null` SHA). This fix makes a failed HEAD verification probe route through the same rollback-and-error path as every other failed update step.

- Problem: `updateGitCheckout` classified blocking step failures via `findBlockingGitFailure(steps)` *before* appending the final `git rev-parse HEAD (after)` probe. The probe's own nonzero exit was therefore invisible to the failure classifier, so a failed verification could still yield `status:"ok"` with a fabricated `after` identity and no rollback.
- Solution: After running the HEAD probe, check its exit code and route a failure through the existing `rollbackError("head-verification-failed")` path — identical to `checkout-failed`, `deps-install-failed`, etc. — which rolls back the checkout and returns an error result with no fabricated `after` identity.
- What changed: `src/infra/update-runner-git.ts` (3-line guard after the probe), `src/infra/update-runner.test.ts` (regression test covering stable channel).
- What did NOT change: The probe itself, the tracked-dev SHA-mismatch guard, the success path, `buildError`/`rollbackError` internals, or any other failure reason. No new API, schema field, or runtime mechanism.

## Why This Change Was Made

The updater's final HEAD probe exists to prove which revision is installed after a live checkout/build mutation. Letting its failure pass silently undermines restart safety: the updater proceeds toward service finalization without proving the installed revision, and the result is self-contradictory (`status:"ok"` + failed final step + unverified SHA).

- Best fix: Yes. The minimal fix is an explicit guard that reuses the existing `rollbackError` path, matching every other failure reason. It rolls back the source checkout (the probe failure may indicate a corrupted HEAD), returns `status:"error"`, and — because `buildError` omits the `after` field — never fabricates a SHA.
- Alternative: Reorder so `findBlockingGitFailure(steps)` runs *after* appending the probe, letting it catch the probe's nonzero exit. Rejected because the probe name `"git rev-parse HEAD (after)"` matches `isSupersededTargetRefFailure`'s `isTargetRefProbe` check (`startsWith("git rev-parse ")`). While it would not be filtered today (it is the last step, so `followingSteps` is empty), relying on "no subsequent rev-parse step exists" is fragile and semantically muddled — it is a HEAD verification probe, not a target-ref probe. The explicit guard is clear and intent-revealing.
- Risk: The guard triggers rollback (`git reset --hard` + checkout restore) when the probe fails. In normal operation the probe almost always succeeds, so this only activates in genuinely abnormal states (e.g., corrupted HEAD, permission issues). The rollback is the same one already used for all other failures, so no new recovery behavior is introduced.

## User Impact

When a git update's final HEAD verification fails, operators now see a clear `head-verification-failed` error with the checkout rolled back, instead of a silent success with an unproven revision. No configuration changes; normal updates are unaffected.

## Evidence

### Real-behavior proof on a disposable git checkout

The mocked-command regression test (below) is supplemented with after-fix behavior on a **real git checkout**: real `git init` + real commit + real tag + a real local file remote, so `git fetch`/`checkout`/`rev-parse`/`status` all execute against a live repository.

**How the final HEAD probe is made to fail for real.** A `runCommand` wrapper counts `git rev-parse HEAD` invocations. On the 2nd call (the `"git rev-parse HEAD (after)"` probe) it FIRST runs a real `git symbolic-ref HEAD refs/heads/nonexistent` against the live repo, THEN delegates to the real `runCommandWithTimeout`. Real git therefore genuinely exits 128 — a filesystem/git-state mutation, not a mocked exit code:

```
genuine rev-parse HEAD exit code after symbolic-ref break: 128
```

Build-toolchain commands (`pnpm install/build/ui:build`, `openclaw doctor`) are short-circuited to exit 0; the bug under test is the routing of the FINAL HEAD verification probe, which is independent of the build toolchain. All git commands that constitute the checkout mutation and the probe itself run for real.

Driver: `node --import tsx scripts/proof-head-verify-129036.ts` (worktree at head `0c8fa144948`).

**BEFORE the fix** (guard reverted, `src/infra/update-runner-git.ts` at `HEAD~1`):

```
result.status   : ok
result.reason   : (undefined)
result.after    : {"sha":"HEAD","version":"1.0.0"}
result.recovery : undefined
rollback cmds   : (none — only the normal `git checkout --detach v1.0.1-1`)
rev-parse HEAD calls seen by runner: 2
genuine rev-parse HEAD exit code after symbolic-ref break: 128
```

The failed final probe is invisible to `findBlockingGitFailure` (it ran before the probe), so the updater returns `status:"ok"` with a self-contradictory `after` identity (`sha:"HEAD"`, not a real SHA) and performs **no rollback**.

**AFTER the fix** (head `0c8fa144948`, guard present) — stable across repeated runs:

```
result.status   : error
result.reason   : head-verification-failed
result.after    : undefined
result.recovery : {"serviceRestartSafe":false,"reason":"runtime-verification-failed"}
rollback cmds   :
  - git -C <root> checkout --detach v1.0.1-1
  - git -C <root> reset --hard
  - git -C <root> clean -fd -e dist/control-ui/
  - git -C <root> checkout --force master
  - git -C <root> reset --hard <beforeSha>
rev-parse HEAD calls seen by runner: 3
genuine rev-parse HEAD exit code after symbolic-ref break: 128
```

The same failed probe now routes through `rollbackError("head-verification-failed")`: `status:"error"`, dedicated reason, **no fabricated `after`**, and the full rollback sequence (`reset --hard` → `clean -fd` → `checkout --force <branch>` → `reset --hard <beforeSha>`) is executed — identical to `checkout-failed`, `deps-install-failed`, etc.

Behavior matrix (final HEAD probe exit code => updater result):

```
probe exitCode=0 (normal)   => status:"ok", after.sha populated, no rollback
probe exitCode!=0 (failure) => status:"error", reason:"head-verification-failed", after undefined, checkout rolled back
```

### Focused regression test

Pre-fix: the regression test fails because the probe failure is invisible — the updater reports success.

```
$ node scripts/run-vitest.mjs src/infra/update-runner.test.ts -t "final HEAD verification probe fails" --run

 FAIL  src/infra/update-runner.test.ts > rolls back and reports error when the final HEAD verification probe fails
AssertionError: expected 'ok' to be 'error' // Object.is equality

Expected: "error"
Received: "ok"

 ❯ src/infra/update-runner.test.ts:1733
    expect(result.status).toBe("error");
Tests  1 failed | 78 skipped (79)
```

Post-fix: the same scenario fails closed with rollback.

```
$ node scripts/run-vitest.mjs src/infra/update-runner.test.ts -t "final HEAD verification probe fails" --run

 Test Files  1 passed (1)
      Tests  1 passed | 78 skipped (79)
```

The regression test asserts `status:"error"`, `reason:"head-verification-failed"`, `result.after` is undefined, and that rollback commands (`git reset --hard`, `git checkout --force main`, `git reset --hard abc123`) were issued.

What was not tested: No live gateway restart or real `openclaw update` invocation against a production checkout was performed; the real-behavior proof uses a disposable git checkout with a local file remote and short-circuited build-toolchain commands (the final-HEAD-probe routing is independent of the build toolchain). Five pre-existing `tracked dev` tests in the same file fail on this machine due to a local git configuration issue (confirmed failing on clean `origin/main`); they are unrelated to this change.

## AI Assistance

- AI-assisted: Yes
- Tools: Codex CLI (gpt-5.6-sol)
- Prompts / session excerpts: available on request
- Confirmed understanding of code changes: Yes — the guard routes a failed `git rev-parse HEAD (after)` probe through the existing `rollbackError` path, matching all other failure reasons; `buildError` omits `after`, so no SHA is fabricated.
- autoreview: N/A (no autoreview skill available in this environment)
