### PR TITLE
fix(tui): preserve slash command alias completions

### DIFF
--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -64,6 +64,29 @@ describe("getSlashCommands", () => {
     ]);
   });
 
+  it.each([
+    { command: "think", alias: "thinking", level: "max" },
+    { command: "think", alias: "t", level: "max" },
+    { command: "think", alias: "t", level: "default" },
+    { command: "verbose", alias: "v", level: "full" },
+    { command: "reasoning", alias: "reason", level: "stream" },
+    { command: "elevated", alias: "elev", level: "ask" },
+  ])("keeps /$command $level completion on its /$alias alias", ({ command, alias, level }) => {
+    for (const local of [false, true]) {
+      const commands = getSlashCommands({
+        local,
+        thinkingLevels: [{ id: "max", label: "max" }],
+      });
+      const canonical = commands.find((candidate) => candidate.name === command);
+      const alternate = commands.find((candidate) => candidate.name === alias);
+
+      expect(alternate?.getArgumentCompletions?.(level)).toEqual(
+        canonical?.getArgumentCompletions?.(level),
+      );
+      expect(shouldSubmitExactArgumentCompletion(`/${alias} ${level}`, commands)).toBe(true);
+    }
+  });
+
   it.each([{}, { local: true }])("exposes usage cost in completion and help", (options) => {
     const commands = getSlashCommands(options);
     const usage = commands.find((command) => command.name === "usage");
@@ -92,9 +115,12 @@ describe("getSlashCommands", () => {
   it("keeps session status on the shared command path and exposes gateway status separately", () => {
     const commands = getSlashCommands();
     const status = commands.find((command) => command.name === "status");
+    const identityAlias = commands.find((command) => command.name === "id");
     const gatewayStatus = commands.find((command) => command.name === "gateway-status");
     const openclaw = commands.find((command) => command.name === "openclaw");
     expect(status?.description).toBe("Show current status.");
+    expect(identityAlias?.description).toBe("Show your sender id.");
+    expect(identityAlias?.getArgumentCompletions?.("")).toBeUndefined();
     expect(gatewayStatus?.description).toBe("Show gateway status summary");
     expect(openclaw?.description).toBe("Return to OpenClaw");
   });
@@ -172,7 +198,7 @@ describe("getSlashCommands", () => {
       dynamicCommands: [
         {
           name: "dreaming",
-          textAliases: ["/dreaming"],
+          textAliases: ["/dreaming", "/dream"],
           description: "Enable or disable memory dreaming.",
           source: "plugin",
           scope: "both",
@@ -184,6 +210,9 @@ describe("getSlashCommands", () => {
     expect(commands.find((command) => command.name === "dreaming")?.description).toBe(
       "Enable or disable memory dreaming.",
     );
+    expect(
+      commands.find((command) => command.name === "dream")?.getArgumentCompletions?.(""),
+    ).toBeUndefined();
   });
 
   it("only advertises shared commands that local mode can route", () => {

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -203,7 +203,7 @@ function normalizeSlashCommandName(value: string): string {
 
 function appendSlashCommand(
   commands: SlashCommand[],
-  seen: Set<string>,
+  seen: Map<string, SlashCommand["getArgumentCompletions"]>,
   name: string,
   description: string,
   getArgumentCompletions?: SlashCommand["getArgumentCompletions"],
@@ -212,7 +212,7 @@ function appendSlashCommand(
   if (!normalizedName || seen.has(normalizedName)) {
     return;
   }
-  seen.add(normalizedName);
+  seen.set(normalizedName, getArgumentCompletions);
   commands.push({ name: normalizedName, description, getArgumentCompletions });
 }
 
@@ -247,7 +247,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     ? options.thinkingLevels.map((level) => level.label)
     : listThinkingLevelLabels(options.provider, options.model, undefined, options.agentRuntime);
   const commands: SlashCommand[] = [];
-  const seen = new Set<string>();
+  const seen = new Map<string, SlashCommand["getArgumentCompletions"]>();
   for (const command of TUI_COMMAND_DESCRIPTORS) {
     if (
       command.shared ||
@@ -287,7 +287,7 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     }
     const aliases = command.textAliases.length > 0 ? command.textAliases : [`/${command.key}`];
     for (const alias of aliases) {
-      appendSlashCommand(commands, seen, alias, command.description);
+      appendSlashCommand(commands, seen, alias, command.description, seen.get(command.key));
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where terminal users choosing documented slash-command aliases such as `/thinking`, `/t`, `/v`, or `/reason` would see no supported argument suggestions even though `/think`, `/verbose`, and `/reasoning` displayed the correct session-specific choices. The broken aliases are present in the shipped `v2026.7.1` slash-command reference and affect both Gateway-backed and embedded terminal sessions.

## Why This Change Was Made

The TUI command owner was merging shared command aliases by name while discarding the canonical command's existing argument-completion provider. Its existing deduplication index now retains that provider and reuses it for every shared alias, preserving one canonical source of session-specific choices without changing command execution, the Gateway protocol, provider policy, or dynamic plugin commands.

## User Impact

Typing `/t`, `/thinking`, `/v`, or `/reason` now offers the same supported values and one-Enter completion behavior as the corresponding full command. Session-specific thinking levels and `/t default` are included; the already-working `/elev` alias and commands without completions keep their existing behavior.

## Evidence

- Regression-first owner proof: five alias cases failed before the fix while the existing `/elev` sibling passed.
- Focused terminal command, editor, autocomplete, submission, and history suites: **105 tests passed** across five files, including Gateway and embedded command modes and callback-free shared/dynamic aliases.
- Real interactive terminal before: `/think ses` displayed the session-owned suggestion and `/t ses` displayed none. After: both commands displayed the same session-owned suggestion.
- Direct installed renderer contract: `@earendil-works/pi-tui` 0.84.2 requires an argument-completion provider on each command alias.
- Changed-file type-aware lint, formatter, and whitespace checks passed; independent maintainer challenge and fresh structured P0/P1 review found no actionable issues.
- Production: **+4/-4, net 0**. Tests: **+30/-1**.

