### PR TITLE
fix: show selected account after subscription billing errors

### DIFF
--- a/src/agents/failover/user-copy.test.ts
+++ b/src/agents/failover/user-copy.test.ts
@@ -62,7 +62,7 @@ describe("failover user copy", () => {
         authMode: "oauth",
       }),
     ).toBe(
-      "⚠️ Anthropic (claude) returned a billing error — check your account for subscription or usage limits, then try again.",
+      "⚠️ Anthropic (claude) returned a billing error — check your account for subscription or usage limits, then try again. Run `openclaw models auth list --provider anthropic` to verify the account OpenClaw selected.",
     );
     expect(renderBillingReplyCopy({})).toBe(BILLING_ERROR_USER_MESSAGE);
   });

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -65,8 +65,11 @@ export function formatBillingErrorMessage(
     providerName && modelName ? `${providerName} (${modelName})` : providerName || undefined;
   const isSubscriptionAuth = authMode === "oauth" || authMode === "token";
   if (isSubscriptionAuth) {
+    const accountHint = providerName
+      ? ` Run \`openclaw models auth list --provider ${normalizeLowercaseStringOrEmpty(providerName)}\` to verify the account OpenClaw selected.`
+      : "";
     return providerLabel
-      ? `⚠️ ${providerLabel} returned a billing error — check your account for subscription or usage limits, then try again.`
+      ? `⚠️ ${providerLabel} returned a billing error — check your account for subscription or usage limits, then try again.${accountHint}`
       : "⚠️ API provider returned a billing error — check your account for subscription or usage limits, then try again.";
   }
   return providerLabel


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where subscription users receiving a billing error could not tell which local account OpenClaw selected.

This became especially confusing after the native Claude Agent SDK cutover. The error suggested checking an account, but did not identify a safe way to inspect it.

## Why This Change Was Made

Subscription billing errors now include the existing provider-scoped auth-list command. That command shows the selected local profile and account identity without exposing credentials in shared chats.

API-key billing guidance remains unchanged. The native Claude login, setup-token, and API-key authentication paths also remain unchanged.

## User Impact

Users can run `openclaw models auth list --provider anthropic` after a Claude subscription error. They can then confirm that OpenClaw selected the account authenticated by `claude auth login`.

## Evidence

- Regression proof: the focused test failed before the production change because the recovery command was absent.
- `node scripts/run-vitest.mjs src/agents/failover/user-copy.test.ts` — 6 tests passed.
- `node scripts/run-oxlint.mjs src/agents/failover/user-copy.ts src/agents/failover/user-copy.test.ts` — passed.
- `pnpm tsgo` — passed.
- `pnpm check:test-types` — passed.
- `git diff --check` — passed.

Production delta: +4/-1 lines. Test delta: +1/-1 lines.
