### PR TITLE
fix(test): publish runtime in CLI live harness

### DIFF
--- a/src/gateway/gateway-cli-backend.live-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.test.ts
@@ -43,7 +43,7 @@ describe("gateway cli backend live helpers", () => {
     delete process.env.ANTHROPIC_API_KEY_OLD;
   });
 
-  it("applies and restores live env including minimal gateway mode", async () => {
+  it("applies and restores live env including full gateway mode", async () => {
     const { applyCliBackendLiveEnv, restoreCliBackendLiveEnv, snapshotCliBackendLiveEnv } =
       liveHelpers;
 
@@ -74,7 +74,7 @@ describe("gateway cli backend live helpers", () => {
     expect(process.env.OPENCLAW_SKIP_CANVAS_HOST).toBe("1");
     expect(process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER).toBe("1");
     expect(process.env.OPENCLAW_BUNDLED_PLUGINS_DIR).toBe("old-bundled");
-    expect(process.env.OPENCLAW_TEST_MINIMAL_GATEWAY).toBe("1");
+    expect(process.env.OPENCLAW_TEST_MINIMAL_GATEWAY).toBe("0");
     expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(process.env.ANTHROPIC_API_KEY_OLD).toBeUndefined();
 

--- a/src/gateway/gateway-cli-backend.live-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.ts
@@ -553,7 +553,7 @@ export function applyCliBackendLiveEnv(preservedEnv: ReadonlySet<string>): void 
   process.env.OPENCLAW_SKIP_CRON = "1";
   process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
   process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER = "1";
-  process.env.OPENCLAW_TEST_MINIMAL_GATEWAY = "1";
+  process.env.OPENCLAW_TEST_MINIMAL_GATEWAY = "0";
   if (!preservedEnv.has("ANTHROPIC_API_KEY")) {
     delete process.env.ANTHROPIC_API_KEY;
   }

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -284,11 +284,6 @@ describeLive("gateway live (cli backend)", () => {
 
       clearRuntimeConfigSnapshot();
       applyCliBackendLiveEnv(preservedEnv);
-      if (CLI_CACHE_PROBE) {
-        // Cache proof crosses the production prepared-runtime and MCP dispatch boundary.
-        // Minimal Gateway mode intentionally omits that publication and cannot prove this path.
-        setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "0");
-      }
 
       const token = `test-${randomUUID()}`;
       setTestEnvValue("OPENCLAW_GATEWAY_TOKEN", token);


### PR DESCRIPTION
Related: #128965

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where the CLI backend live harness could reject ordinary agent RPCs before the Gateway published its prepared reply-dispatch runtime.

## Why This Change Was Made

The shared CLI live environment now uses full Gateway startup for every probe, including the cache path. This replaces the broader uneditable #128965 patch with the narrow three-file owner fix and preserves Josh Lehman's contribution through commit co-authorship.

## User Impact

No production behavior changes. Release validation can exercise CLI backend agent requests through the same prepared-runtime publication boundary required by the production Gateway.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/gateway-cli-backend.live-helpers.test.ts` - 11 tests passed.
- `node_modules/.bin/oxfmt --check src/gateway/gateway-cli-backend.live-helpers.ts src/gateway/gateway-cli-backend.live.test.ts src/gateway/gateway-cli-backend.live-helpers.test.ts` - passed.
- `git diff --check` - passed.
- `node scripts/check-changed.mjs -- <three changed files>` - all targeted guards passed through dead-export scanning; the final core typecheck hit unrelated stale local dependency typings in `packages/ai`, `packages/markdown-core`, and `src/tui`.
- Autoreview's secret scan passed; its Codex review engine was unavailable because the standalone CLI is not installed on this host.

Production LOC: +1/-1 (net 0). Test and live-test support: +2/-7 (net -5).

AI-assisted: yes. The scoped diff and generated commit were reviewed directly before publication.

- Hydrated Blacksmith Testbox full agent-RPC Docker proof: passed at exact head `4a8a00647fa638ffd6040b8515b9795e6ae0581f` in 207.55s; emitted `agent-request:done {"status":"ok"}` with no prepared-runtime assertion. Run: https://github.com/openclaw/openclaw/actions/runs/32818734175

