### PR TITLE
fix(cli): render Gateway validation JSON failures

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvOverride } from "../config/test-helpers.js";
+import { ExpectedCliError } from "./failure-output.js";
 import { registerGatewayCli } from "./gateway-cli.js";
 
 type GatewayCliDependencies = Parameters<typeof registerGatewayCli>[1];
@@ -156,7 +157,11 @@ describe("gateway-cli coverage", () => {
     await expectGatewayExit(["gateway", "call", "health", "--timeout", "1000ms", "--json"]);
 
     expect(callGateway).not.toHaveBeenCalled();
-    expect(runtimeErrors.join("\n")).toContain("Gateway call failed: Invalid --timeout");
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: expect.stringContaining("Invalid --timeout") },
+    });
+    expect(runtimeErrors).toHaveLength(0);
   });
 
   it("renders gateway request failures without the client error class in human mode", async () => {
@@ -311,7 +316,29 @@ describe("gateway-cli coverage", () => {
     ]);
 
     expect(callGateway).not.toHaveBeenCalled();
-    expect(runtimeErrors.join("\n")).toContain("Use --agent or --all-agents, not both");
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: "Use --agent or --all-agents, not both" },
+    });
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
+  it("preserves expected CLI machine output for ordinary Gateway command failures", async () => {
+    callGateway.mockRejectedValueOnce(
+      new ExpectedCliError({
+        message: "validation failed",
+        humanOutput: "human recovery guidance",
+        machineOutput: "machine recovery guidance\n",
+      }),
+    );
+
+    await expectGatewayExit(["gateway", "call", "health", "--json"]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: "machine recovery guidance" },
+    });
+    expect(runtimeErrors).toHaveLength(0);
   });
 
   it("writes JSON for gateway health transport failures in JSON mode", async () => {
@@ -585,7 +612,11 @@ describe("gateway-cli coverage", () => {
 
     await expectGatewayExit(["gateway", "diagnostics", "export", flag, value, "--json"]);
 
-    expect(runtimeErrors.join("\n")).toContain(`${flag} must be a positive integer`);
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: `${flag} must be a positive integer.` },
+    });
+    expect(runtimeErrors).toHaveLength(0);
     expect(callGateway).not.toHaveBeenCalled();
   });
 
@@ -663,11 +694,33 @@ describe("gateway-cli coverage", () => {
     expect(runtimeErrors.join("\n")).toContain("--params must be valid JSON.");
   });
 
+  it("renders invalid gateway call params as JSON before calling Gateway", async () => {
+    await expectGatewayExit([
+      "gateway",
+      "call",
+      "system-presence",
+      "--params",
+      "not-json",
+      "--json",
+    ]);
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: "--params must be valid JSON." },
+    });
+    expect(runtimeErrors).toHaveLength(0);
+  });
+
   it("validates gateway call timeout before opening a transport", async () => {
     callGateway.mockClear();
     await expectGatewayExit(["gateway", "call", "health", "--timeout", "nope", "--json"]);
 
     expect(callGateway).not.toHaveBeenCalled();
-    expect(runtimeErrors.join("\n")).toContain("Invalid --timeout");
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: expect.stringContaining("Invalid --timeout") },
+    });
+    expect(runtimeErrors).toHaveLength(0);
   });
 });

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -372,28 +372,27 @@ describe("gateway register option collisions", () => {
     {
       name: "call",
       args: ["call", "health"],
-      failure: "Gateway call failed",
     },
     {
       name: "usage-cost",
       args: ["usage-cost"],
-      failure: "Gateway usage cost failed",
     },
     {
       name: "live stability",
       args: ["stability"],
-      failure: "Gateway stability failed",
     },
-  ])("rejects combining --url and --port for gateway $name", async ({ args, failure }) => {
+  ])("rejects combining --url and --port for gateway $name", async ({ args }) => {
     await sharedProgram.parseAsync(
       ["gateway", ...args, "--url", "ws://127.0.0.1:19084", "--port", "19084", "--json"],
       { from: "user" },
     );
 
     expect(callGatewayCli).not.toHaveBeenCalled();
-    expect(defaultRuntime.error).toHaveBeenCalledWith(
-      `${failure}: Use either --url or --port, not both.`,
-    );
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      ok: false,
+      error: { type: "cli_error", message: "Use either --url or --port, not both." },
+    });
+    expect(defaultRuntime.error).not.toHaveBeenCalled();
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -20,7 +20,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
-import { rethrowExpectedCliError } from "../failure-output.js";
+import { formatCliJsonFailure, rethrowExpectedCliError } from "../failure-output.js";
 import { parseGatewayPortOption } from "../gateway-port-option.js";
 import { addGatewayClientOptions, callGatewayFromCliWithTransport } from "../gateway-rpc.js";
 import { formatHelpExamples } from "../help-format.js";
@@ -146,15 +146,14 @@ async function runGatewayCommand(
         formatGatewayClientRequestErrorJson,
         formatGatewayTransportErrorJson,
       } = await import("../../gateway/call.js");
-      const payload =
+      defaultRuntime.writeJson(
         formatGatewayAuthErrorJson(err) ??
-        formatGatewayClientRequestErrorJson(err) ??
-        formatGatewayTransportErrorJson(err);
-      if (payload) {
-        defaultRuntime.writeJson(payload);
-        defaultRuntime.exit(1);
-        return;
-      }
+          formatGatewayClientRequestErrorJson(err) ??
+          formatGatewayTransportErrorJson(err) ??
+          formatCliJsonFailure(err),
+      );
+      defaultRuntime.exit(1);
+      return;
     }
     const message = formatErrorMessage(err);
     defaultRuntime.error(label ? `${label}: ${message}` : message);

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -166,6 +166,123 @@ describe("cli json stdout contract", () => {
 
   it.each([
     {
+      name: "invalid call params in JSON mode",
+      args: ["gateway", "call", "system-presence", "--params", "not-json", "--json"],
+      message: "--params must be valid JSON.",
+    },
+    {
+      name: "invalid call params in human mode",
+      args: ["gateway", "call", "system-presence", "--params", "not-json"],
+      message: "--params must be valid JSON.",
+      human: true,
+    },
+    {
+      name: "invalid call params through forced Commander",
+      args: ["gateway", "call", "system-presence", "--params", "not-json", "--json"],
+      message: "--params must be valid JSON.",
+      commander: true,
+    },
+    {
+      name: "invalid call params with dual TTYs",
+      args: ["gateway", "call", "system-presence", "--params", "not-json", "--json"],
+      message: "--params must be valid JSON.",
+      tty: true,
+    },
+    {
+      name: "contradictory usage options in JSON mode",
+      args: ["gateway", "usage-cost", "--agent", "alpha", "--all-agents", "--json"],
+      message: "Use --agent or --all-agents, not both",
+    },
+    {
+      name: "contradictory usage options in human mode",
+      args: ["gateway", "usage-cost", "--agent", "alpha", "--all-agents"],
+      message: "Use --agent or --all-agents, not both",
+      human: true,
+    },
+    {
+      name: "contradictory usage options through forced Commander",
+      args: ["gateway", "usage-cost", "--agent", "alpha", "--all-agents", "--json"],
+      message: "Use --agent or --all-agents, not both",
+      commander: true,
+    },
+    {
+      name: "contradictory usage options with dual TTYs",
+      args: ["gateway", "usage-cost", "--agent", "alpha", "--all-agents", "--json"],
+      message: "Use --agent or --all-agents, not both",
+      tty: true,
+    },
+    {
+      name: "specialized explicit Gateway authentication failure",
+      args: ["gateway", "call", "system-presence", "--url", "ws://127.0.0.1:29793", "--json"],
+      specializedAuth: true,
+    },
+  ])("renders Gateway query failures through the Gateway owner for $name", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const configPath = path.join(tempHome, "missing-openclaw.json");
+        const stateDir = path.join(tempHome, "isolated-state");
+        const gatewayError = "AUTOQA_INJECTED_GATEWAY_FAILURE";
+        const preload = Buffer.from(
+          [
+            'import net from "node:net";',
+            `net.Socket.prototype.connect = function () { throw new Error(${JSON.stringify(gatewayError)}); };`,
+            ...("tty" in testCase
+              ? [
+                  'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });',
+                  'Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });',
+                ]
+              : []),
+          ].join("\n"),
+        ).toString("base64");
+        const result = runBuiltCli(tempHome, testCase.args, {
+          NODE_OPTIONS: `--import=data:text/javascript;base64,${preload}`,
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_STATE_DIR: stateDir,
+          ...("commander" in testCase ? { OPENCLAW_DISABLE_ROUTE_FIRST: "1" } : {}),
+          ...("tty" in testCase ? { FORCE_COLOR: "1", NO_COLOR: undefined } : {}),
+        });
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(result.stdout, result.stderr).not.toMatch(/[\u001B\u0007]/u);
+        expect(result.stdout).not.toContain(gatewayError);
+        expect(result.stderr).not.toContain(gatewayError);
+        if ("human" in testCase) {
+          expect(result.stdout).toBe("");
+          expect(result.stderr).toContain(testCase.message);
+        } else if ("specializedAuth" in testCase) {
+          expect(JSON.parse(result.stdout)).toEqual({
+            ok: false,
+            error: {
+              type: "gateway_credentials_required",
+              message: [
+                "gateway url override requires explicit credentials",
+                "Fix: pass --token or --password with --url (or gatewayToken in tools).",
+                "For the default local or SSH-tunneled Gateway, remove --url to use the configured target.",
+                `Config: ${configPath}`,
+              ].join("\n"),
+            },
+          });
+          expect(result.stderr).toBe("");
+        } else {
+          expect(JSON.parse(result.stdout)).toEqual({
+            ok: false,
+            error: { type: "cli_error", message: testCase.message },
+          });
+          expect(result.stderr).not.toContain(testCase.message);
+        }
+        if ("tty" in testCase) {
+          expect(result.stderr).toContain("\u001B[?25h");
+        }
+        await expect(fs.stat(stateDir)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(fs.stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+      },
+      { prefix: "openclaw-gateway-query-json-failure-e2e-" },
+    );
+  });
+
+  it.each([
+    {
       name: "bare report with parent JSON",
       args: ["hooks", "--agent", "retired", "--json"],
     },


### PR DESCRIPTION
## What Problem This Solves

Gateway query commands returned exit code 1 with empty stdout for ordinary command-owned validation failures because their JSON handler only recognized specialized Gateway errors.

Fixes https://github.com/openclaw/openclaw/issues/129042.

## Why This Change Was Made

`runGatewayCommand` preserves the existing authentication, client-request, and transport formatters in their current precedence, then uses the canonical CLI failure envelope as the final fallback for ordinary errors. Human output, specialized payload shapes, Gateway methods/parameters/authentication, and exit behavior remain unchanged.

Production delta: +8/-9, net -1 line. Tests: +180/-11, net +169 lines.

## User Impact

Invalid Gateway query arguments now produce parseable JSON instead of empty stdout, while established Gateway-specific error payloads remain compatible.

## Evidence

- Pre-fix owner and built-process regressions reproduced empty stdout without opening a Gateway connection.
- Focused owner/sibling proof: 81 tests passed.
- Built-process proof: nine JSON/human/Commander/dual-TTY/local-validation/specialized-auth cases passed.
- CLI startup build and complete changed-file gates passed.
- Fresh final P1 autoreview: no actionable findings.
- `git diff --check`: passed.

Route-first Gateway health configuration failures are tracked separately in task #101.
