### PR TITLE
fix(tui): keep action prompts scoped to their session owner

### DIFF
--- a/src/tui/tui-plugin-approvals.test.ts
+++ b/src/tui/tui-plugin-approvals.test.ts
@@ -221,6 +221,14 @@ describe("TUI plugin approvals", () => {
       visible: false,
     },
     {
+      label: "rejects a missing session key even with explicit owner evidence",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      approvalAgent: "main",
+      approvalSession: null,
+      visible: false,
+    },
+    {
       label: "rejects a matching canonical key with a contradictory explicit owner",
       selectedAgent: "main",
       selectedSession: "agent:main:support",

--- a/src/tui/tui-plugin-approvals.test.ts
+++ b/src/tui/tui-plugin-approvals.test.ts
@@ -165,23 +165,134 @@ describe("TUI plugin approvals", () => {
         id: "plugin:other",
         request: {
           ...approvalPayload().request,
+          agentId: "other",
           sessionKey: "agent:other:main",
         },
       }),
     );
     expect(harness.openOverlay).not.toHaveBeenCalled();
 
+    harness.setAgentId("other");
     harness.setSessionKey("agent:other:main");
     harness.controller.sessionChanged();
     expect(harness.openOverlay).toHaveBeenCalledTimes(1);
 
     harness.controller.handleEvent("plugin.approval.resolved", { id: "plugin:other" });
+    harness.setAgentId("main");
     harness.setSessionKey("agent:main:main");
     harness.listPluginApprovals.mockResolvedValueOnce([approvalPayload()]);
     await harness.controller.refresh();
 
     expect(harness.listPluginApprovals).toHaveBeenCalledTimes(1);
     expect(harness.openOverlay).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      label: "shows a fixed-store alias owned by the active agent",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      approvalAgent: "main",
+      approvalSession: "support",
+      visible: true,
+    },
+    {
+      label: "matches normalized agent identities for a fixed-store alias",
+      selectedAgent: "Main",
+      selectedSession: "agent:main:support",
+      approvalAgent: " MAIN ",
+      approvalSession: "support",
+      visible: true,
+    },
+    {
+      label: "rejects a fixed-store alias owned by another agent",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      approvalAgent: "work",
+      approvalSession: "support",
+      visible: false,
+    },
+    {
+      label: "rejects a fixed-store alias without explicit owner evidence",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      approvalAgent: null,
+      approvalSession: "support",
+      visible: false,
+    },
+    {
+      label: "rejects a matching canonical key with a contradictory explicit owner",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      approvalAgent: "work",
+      approvalSession: "agent:main:support",
+      visible: false,
+    },
+    {
+      label: "accepts a canonical key whose parsed owner identifies the active agent",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      approvalAgent: null,
+      approvalSession: "agent:main:support",
+      visible: true,
+    },
+    {
+      label: "rejects a different agent's canonical key with a colliding alias",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      approvalAgent: "work",
+      approvalSession: "agent:work:support",
+      visible: false,
+    },
+    {
+      label: "rejects an ownerless foreign canonical key against a bare selected alias",
+      selectedAgent: "main",
+      selectedSession: "support",
+      approvalAgent: null,
+      approvalSession: "agent:work:support",
+      visible: false,
+    },
+    {
+      label: "rejects a foreign canonical key with a misleading explicit owner",
+      selectedAgent: "main",
+      selectedSession: "support",
+      approvalAgent: "main",
+      approvalSession: "agent:work:support",
+      visible: false,
+    },
+    {
+      label: "rejects a global approval without explicit owner evidence",
+      selectedAgent: "main",
+      selectedSession: "global",
+      approvalAgent: null,
+      approvalSession: "global",
+      visible: false,
+    },
+    {
+      label: "preserves case-sensitive opaque session references",
+      selectedAgent: "main",
+      selectedSession: "agent:main:matrix:group:!Room:example.org",
+      approvalAgent: "main",
+      approvalSession: "matrix:group:!room:example.org",
+      visible: false,
+    },
+  ])("$label", ({ selectedAgent, selectedSession, approvalAgent, approvalSession, visible }) => {
+    const harness = createHarness();
+    harness.setAgentId(selectedAgent);
+    harness.setSessionKey(selectedSession);
+
+    harness.controller.handleEvent(
+      "plugin.approval.requested",
+      approvalPayload({
+        request: {
+          ...approvalPayload().request,
+          agentId: approvalAgent,
+          sessionKey: approvalSession,
+        },
+      }),
+    );
+
+    expect(harness.openOverlay).toHaveBeenCalledTimes(visible ? 1 : 0);
   });
 
   it("preserves requested events received while a refresh is in flight", async () => {

--- a/src/tui/tui-plugin-approvals.ts
+++ b/src/tui/tui-plugin-approvals.ts
@@ -13,6 +13,7 @@ import { createTuiRefreshCoalescer } from "./coalesced-refresh.js";
 import { selectListTheme, tuiTheme as theme } from "./theme/theme.js";
 import type { TuiApprovalDecision, TuiBackend, TuiPluginApproval } from "./tui-backend.js";
 import { sanitizeRenderableText } from "./tui-formatters.js";
+import { matchesOwnedTuiSession } from "./tui-session-events.js";
 
 type ApprovalSelector = Component & {
   onSelect?: (item: SelectItem) => void;
@@ -264,17 +265,8 @@ export function createTuiPluginApprovalController(deps: TuiPluginApprovalControl
     }
   };
 
-  const matchesActiveSession = (approval: TuiPluginApproval) => {
-    const sessionKey = approval.request.sessionKey?.trim();
-    if (!sessionKey || sessionKey !== deps.getSessionKey()) {
-      return false;
-    }
-    if (sessionKey !== "global") {
-      return true;
-    }
-    const agentId = approval.request.agentId?.trim();
-    return Boolean(agentId && agentId === deps.getAgentId());
-  };
+  const matchesActiveSession = (approval: TuiPluginApproval) =>
+    matchesOwnedTuiSession(deps.getSessionKey(), deps.getAgentId(), approval.request);
 
   const prune = () => {
     const now = nowMs();

--- a/src/tui/tui-session-events.ts
+++ b/src/tui/tui-session-events.ts
@@ -12,6 +12,7 @@ type TuiSessionEvent = {
   sessionKey?: string;
   agentId?: string;
 };
+type OwnedTuiEvent = { sessionKey?: string | null; agentId?: string | null };
 
 /** Reads the durable user identity without mistaking another run's prompt for this one. */
 export function readTuiSessionUserMessage(event: SessionMessageEvent): {
@@ -76,7 +77,7 @@ export function matchesSelectedTuiSession(
 }
 
 /** Requires explicit ownership for aliases before presenting actionable session prompts. */
-export function matchesOwnedTuiSession(session: string, agentId: string, event: TuiSessionEvent) {
+export function matchesOwnedTuiSession(session: string, agentId: string, event: OwnedTuiEvent) {
   const owner = normalizeLowercaseStringOrEmpty(event.agentId);
   const selected = normalizeLowercaseStringOrEmpty(agentId);
   return (

--- a/src/tui/tui-session-events.ts
+++ b/src/tui/tui-session-events.ts
@@ -58,12 +58,7 @@ export function matchesSelectedTuiSession(
 
   const parsedEvent = parseAgentSessionKey(eventSessionKey);
   const parsedSelection = parseAgentSessionKey(state.currentSessionKey);
-  if (
-    parsedEvent &&
-    parsedSelection &&
-    normalizeLowercaseStringOrEmpty(parsedEvent.agentId) !==
-      normalizeLowercaseStringOrEmpty(parsedSelection.agentId)
-  ) {
+  if (parsedEvent && parsedSelection && parsedEvent.agentId !== parsedSelection.agentId) {
     return false;
   }
 
@@ -78,4 +73,15 @@ export function matchesSelectedTuiSession(
     return true;
   }
   return eventAgentId ? eventAgentId === selectedAgentId : selectedAgentId === defaultAgentId;
+}
+
+/** Requires explicit ownership for aliases before presenting actionable session prompts. */
+export function matchesOwnedTuiSession(session: string, agentId: string, event: TuiSessionEvent) {
+  const owner = normalizeLowercaseStringOrEmpty(event.agentId);
+  const selected = normalizeLowercaseStringOrEmpty(agentId);
+  return (
+    agentSessionKeysMatchByRequestKey(event.sessionKey, session) &&
+    (parseAgentSessionKey(event.sessionKey)?.agentId || owner) === selected &&
+    (!owner || owner === selected)
+  );
 }

--- a/src/tui/tui-task-suggestions.test.ts
+++ b/src/tui/tui-task-suggestions.test.ts
@@ -457,6 +457,87 @@ describe("TUI task suggestions", () => {
     expect(harness.openOverlay).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    {
+      label: "shows a fixed-store alias owned by the active agent",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      suggestionAgent: "main",
+      suggestionSession: "support",
+      visible: true,
+    },
+    {
+      label: "rejects a fixed-store alias owned by another agent",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      suggestionAgent: "work",
+      suggestionSession: "support",
+      visible: false,
+    },
+    {
+      label: "rejects a fixed-store alias without explicit owner evidence",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      suggestionAgent: undefined,
+      suggestionSession: "support",
+      visible: false,
+    },
+    {
+      label: "rejects a matching canonical key with a contradictory explicit owner",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      suggestionAgent: "work",
+      suggestionSession: "agent:main:support",
+      visible: false,
+    },
+    {
+      label: "accepts a canonical key whose parsed owner identifies the active agent",
+      selectedAgent: "main",
+      selectedSession: "agent:main:support",
+      suggestionAgent: undefined,
+      suggestionSession: "agent:main:support",
+      visible: true,
+    },
+    {
+      label: "rejects a foreign canonical key against a bare selected alias",
+      selectedAgent: "main",
+      selectedSession: "support",
+      suggestionAgent: "main",
+      suggestionSession: "agent:work:support",
+      visible: false,
+    },
+    {
+      label: "rejects a global suggestion without explicit owner evidence",
+      selectedAgent: "main",
+      selectedSession: "global",
+      suggestionAgent: undefined,
+      suggestionSession: "global",
+      visible: false,
+    },
+    {
+      label: "preserves case-sensitive opaque session references",
+      selectedAgent: "main",
+      selectedSession: "agent:main:matrix:group:!Room:example.org",
+      suggestionAgent: "main",
+      suggestionSession: "matrix:group:!room:example.org",
+      visible: false,
+    },
+  ])(
+    "$label",
+    ({ selectedAgent, selectedSession, suggestionAgent, suggestionSession, visible }) => {
+      const harness = createHarness();
+      harness.setAgentId(selectedAgent);
+      harness.setSessionKey(selectedSession);
+
+      harness.controller.handleEvent("task.suggestion", {
+        action: "created",
+        suggestion: suggestionPayload({ agentId: suggestionAgent, sessionKey: suggestionSession }),
+      });
+
+      expect(harness.openOverlay).toHaveBeenCalledTimes(visible ? 1 : 0);
+    },
+  );
+
   it("closes a suggestion resolved by another client", () => {
     const harness = createHarness();
     harness.controller.handleEvent("task.suggestion", {

--- a/src/tui/tui-task-suggestions.ts
+++ b/src/tui/tui-task-suggestions.ts
@@ -13,6 +13,7 @@ import { createTuiRefreshCoalescer } from "./coalesced-refresh.js";
 import { selectListTheme, tuiTheme as theme } from "./theme/theme.js";
 import type { TuiBackend, TuiTaskSuggestionAcceptMode } from "./tui-backend.js";
 import { sanitizeRenderableText } from "./tui-formatters.js";
+import { matchesOwnedTuiSession } from "./tui-session-events.js";
 
 type TaskSelector = Component & {
   onSelect?: (item: SelectItem) => void;
@@ -274,8 +275,7 @@ export function createTuiTaskSuggestionController(deps: TaskSuggestionController
   };
 
   const matchesSession = (suggestion: TaskSuggestion) =>
-    suggestion.sessionKey === deps.getSessionKey() &&
-    (suggestion.sessionKey !== "global" || suggestion.agentId === deps.getAgentId());
+    matchesOwnedTuiSession(deps.getSessionKey(), deps.getAgentId(), suggestion);
 
   const availableActions = () => {
     const capabilities = deps.client.getTaskSuggestionActionCapabilities?.() ?? {


### PR DESCRIPTION
## What Problem This Solves

Gateway-backed terminal sessions could silently hide their own plugin-approval prompts and suggested follow-up tasks when a configured shared session store represented the selected session by its supported bare alias. The same duplicated prompt filters could also display a canonical session prompt whose explicit agent owner contradicted the selected agent.

An operator could see an agent apparently hang until an invisible approval expired, miss legitimate follow-up work, or inspect a prompt attributed to the wrong agent.

## Why This Change Was Made

Both Gateway producers deliberately preserve supported bare session keys while retaining the authoritative agent owner:

- `plugin.approval.request` stores and broadcasts its resolved session-store key plus `request.agentId`.
- `taskSuggestions.create` preserves the requested session key and broadcasts its resolved `agentId`.

The two TUI prompt controllers instead compared session-key strings directly and validated agent ownership only for the literal global session. This duplicated policy disagreed with the Gateway's supported alias contract and failed to reject contradictory explicit owners on canonical keys.

Move the shared action-bearing prompt decision into the existing TUI session-event owner as `matchesOwnedTuiSession`, then use it for both approval and task overlays. Bare and global aliases require an explicit matching agent; canonical keys must identify the selected agent; any supplied agent must agree; ordinary and case-sensitive provider session identities remain distinct. The existing more permissive non-actionable session-event matcher retains its public behavior. Gateway authorization, approval resolution, task acceptance, protocol, configuration, and storage remain unchanged.

Production: **+17/-19, net -2 lines across three files**. Tests: **+192/-0 across two files**.

## User Impact

- Approvals for the selected agent/session become visible instead of silently timing out behind a supported fixed-store session alias.
- Follow-up task suggestions for the selected agent/session become visible and actionable under the same alias.
- Prompts with a missing alias owner, a foreign owner, or contradictory canonical owner stay hidden, including global sessions and bare selected-session edge cases.
- Switching sessions still hides stale approvals and never changes the server-side authorization boundary.

## Evidence

Both failures were reproduced on the frozen base before editing through the actual production Gateway RPC handler, its real broadcast payload, and the real TUI prompt controller:

```text
plugin.approval.request -> plugin.approval.requested:
  selectedSession=agent:main:support, requestSessionKey=support, requestAgentId=main
  BEFORE approvalOverlays=0 APPROVAL_SILENTLY_HIDDEN
  AFTER  approvalOverlays=1 APPROVAL_VISIBLE

taskSuggestions.create -> task.suggestion:
  selectedSession=agent:main:support, suggestionSessionKey=support, suggestionAgentId=main
  BEFORE taskOverlays=0 TASK_SILENTLY_HIDDEN
  AFTER  taskOverlays=1 TASK_VISIBLE
```

Regression-first owner tests demonstrated two failures independently on each prompt surface: the legitimate owned alias was hidden, and a matching canonical key with an explicitly conflicting owner was shown. The expanded matrices additionally cover ownerless aliases, foreign agents, a bare selected session with a foreign canonical incoming key, global-owner requirements, normalized agent identifiers, and case-sensitive Matrix room identities.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/tui/tui-plugin-approvals.test.ts src/tui/tui-task-suggestions.test.ts src/tui/tui-session-events.test.ts src/tui/tui-event-handlers.test.ts src/tui/tui-session-run-coordinator.test.ts --configLoader runner
# 267 passed across five TUI owner/session/event suites

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-methods/plugin-approval.test.ts src/gateway/server-methods/plugin-approval.agent-runtime.test.ts src/gateway/server-methods/task-suggestions.test.ts --configLoader runner
# 79 passed across the actual Gateway producer, approval authority, and task-action owners

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner src/tui/tui-pty-harness.e2e.test.ts src/tui/tui-session-identity-pty.e2e.test.ts -t 'presents and resolves workspace skill approval in the TUI|presents and starts a suggested task in the TUI|hides a stale approval when startup restores the remembered session'
# 3 actual runTui interactive-terminal scenarios passed

node_modules/.bin/oxfmt --check src/tui/tui-plugin-approvals.ts src/tui/tui-plugin-approvals.test.ts src/tui/tui-session-events.ts src/tui/tui-task-suggestions.ts src/tui/tui-task-suggestions.test.ts
node_modules/.bin/oxlint src/tui/tui-plugin-approvals.ts src/tui/tui-plugin-approvals.test.ts src/tui/tui-session-events.ts src/tui/tui-task-suggestions.ts src/tui/tui-task-suggestions.test.ts
git diff --check
```

The PTY lane runs the actual terminal and `runTui()` loop with its fixture backend; actual Gateway RPC producer and broadcast behavior was independently executed end to end in the before/after proofs above. An independent reviewer also executed the complete strict-ownership adversarial matrix and both production Gateway-to-controller paths.
