### PR TITLE
fix(stepfun): preserve selected models when repeating onboarding

### DIFF
--- a/extensions/stepfun/index.test.ts
+++ b/extensions/stepfun/index.test.ts
@@ -7,7 +7,7 @@ import {
   requireRegisteredProvider,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import stepfunPlugin from "./index.js";
 import {
   STEPFUN_DEFAULT_MODEL_REF,
@@ -159,4 +159,57 @@ describe("stepfun provider registration", () => {
       },
     ]);
   });
+
+  it.each([
+    { providerId: "stepfun", methodId: "standard-api-key-cn" },
+    { providerId: "stepfun", methodId: "standard-api-key-intl" },
+    { providerId: "stepfun-plan", methodId: "plan-api-key-cn" },
+    { providerId: "stepfun-plan", methodId: "plan-api-key-intl" },
+  ])(
+    "preserves an existing primary when repeating $methodId onboarding",
+    async ({ providerId, methodId }) => {
+      const { providers } = await registerProviderPlugin({
+        plugin: stepfunPlugin,
+        id: "stepfun",
+        name: "StepFun",
+      });
+      const provider = requireRegisteredProvider(providers, providerId);
+      const method = provider.auth.find((entry) => entry.id === methodId);
+      if (!method?.runNonInteractive) {
+        throw new Error(`expected StepFun non-interactive auth method ${methodId}`);
+      }
+
+      const result = await method.runNonInteractive({
+        authChoice: method.wizard?.choiceId,
+        config: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "anthropic/claude-sonnet-4-6",
+                fallbacks: ["openai/gpt-5.6-luna"],
+              },
+              models: { "anthropic/claude-sonnet-4-6": { alias: "Existing" } },
+            },
+          },
+        },
+        opts: {},
+        env: {},
+        runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+        resolveApiKey: vi.fn(async () => ({ key: "fixture-value", source: "profile" })),
+        toApiKeyCredential: vi.fn(() => null),
+      } as never);
+
+      expect(result?.agents?.defaults?.model).toEqual({
+        primary: "anthropic/claude-sonnet-4-6",
+        fallbacks: ["openai/gpt-5.6-luna"],
+      });
+      expect(result?.agents?.defaults?.models?.["anthropic/claude-sonnet-4-6"]).toEqual({
+        alias: "Existing",
+      });
+      expect(result?.agents?.defaults?.models?.[`${providerId}/step-3.5-flash`]).toEqual(
+        expect.objectContaining({ alias: expect.any(String) }),
+      );
+      expect(result?.models?.providers?.[providerId]).toBeDefined();
+    },
+  );
 });

--- a/extensions/stepfun/index.ts
+++ b/extensions/stepfun/index.ts
@@ -1,4 +1,3 @@
-// Stepfun plugin entrypoint registers its OpenClaw integration.
 import {
   definePluginEntry,
   type OpenClawConfig,
@@ -151,6 +150,7 @@ function createStepFunApiKeyMethod(params: {
     profileIds: resolveProfileIds(params.region),
     allowProfile: false,
     defaultModel: params.defaultModel,
+    preserveExistingPrimary: true,
     expectedProviders: [STEPFUN_PROVIDER_ID, STEPFUN_PLAN_PROVIDER_ID],
     applyConfig: params.applyConfig,
     wizard: {


### PR DESCRIPTION
Related: #103623. That existing pull request stays open because its separate proposal to change the StepFun default model is intentionally excluded here.

## What Problem This Solves

Fixes an issue where users repeating non-interactive StepFun onboarding would silently lose their existing selected primary model and fallbacks. All four affected public auth choices behaved incorrectly: StepFun Standard and Step Plan, each for China and Global.

## Why This Change Was Made

The shared provider API-key setup flow overwrites an existing primary unless the provider owner opts into its existing preservation contract. StepFun already has one owner-local method builder for all four auth choices, so that builder now enables the same preservation behavior used by Cerebras. Fresh StepFun onboarding keeps the shipped, documented Step 3.5 defaults; this does not change model catalogs, manifests, API-key ownership, other providers, or the separate Step 3.7 product proposal in #103623.

Production delta is net zero: one provider-owner option replaces a redundant generated file comment. The focused regression was independently extracted from @lit26's work in #103623, and Tianning Li is credited in the commit trailer.

## User Impact

Operators can safely repeat any StepFun Standard or Step Plan auth setup without replacing their chosen model, existing fallbacks, or model aliases. New setups still select `stepfun/step-3.5-flash` or `stepfun-plan/step-3.5-flash` as documented.

## Evidence

Frozen reviewed head: `d80591270e5c4b7ff0e3a7b8e73d9e6e206d83cb`.

Before the fix, the new registered-provider boundary regression failed for all four public auth choices: both Standard choices replaced the selected model with `stepfun/step-3.5-flash`, and both Step Plan choices replaced it with `stepfun-plan/step-3.5-flash`.

After the fix:

```text
node scripts/run-vitest.mjs extensions/stepfun/index.test.ts extensions/cerebras/onboard.test.ts -- --reporter=verbose

StepFun: 6 passed, including four previously failing non-interactive setup regressions
Cerebras: 5 passed, including existing-primary preservation
Total: 11 passed

node_modules/.bin/oxfmt --check extensions/stepfun/index.ts extensions/stepfun/index.test.ts
All matched files use the correct format.

git diff --check
clean
```

Actual source-backed OpenClaw CLI proof ran against the reviewed current-main code with an isolated state directory, a linked local StepFun plugin, fake fixture credentials, and no external provider request or Gateway service:

```text
OpenClaw 2026.8.1 (ebc70fa)

Fresh onboarding:
  --auth-choice stepfun-standard-api-key-intl
  persisted primary: stepfun/step-3.5-flash

Repeat onboarding after selecting stepfun/step-3.7-flash:
  --auth-choice stepfun-standard-api-key-cn    PASS
  --auth-choice stepfun-standard-api-key-intl  PASS
  --auth-choice stepfun-plan-api-key-cn        PASS
  --auth-choice stepfun-plan-api-key-intl      PASS

After every run:
  primary:   stepfun/step-3.7-flash
  fallbacks: [stepfun/step-3.5-flash]
  profiles:  stepfun:cn, stepfun:intl, stepfun-plan:cn, stepfun-plan:intl
```

The table-driven regression additionally proves that an unrelated Anthropic primary and its fallback remain intact, that its existing alias survives, and that the new StepFun provider catalog and alias are still installed. Independent maintainer verification confirmed named-agent ownership remains unchanged because this patch only opts the StepFun owner into the existing shared default-preservation contract. Fresh structured code review found no actionable P0/P1 issues, and a separate read-only reviewer independently verified this exact commit.

The delegated changed-check run could not start its checks because Blacksmith's checkout synchronization timed out before the command executed (run `32815991786`); the lease stopped cleanly. Full required hosted CI on this exact PR head is therefore required before landing.
