### PR TITLE
refactor(brave): share provider search lifecycle

### DIFF
--- a/extensions/brave/src/brave-web-search-provider.runtime.ts
+++ b/extensions/brave/src/brave-web-search-provider.runtime.ts
@@ -483,74 +483,46 @@ export async function executeBraveSearch(
   const start = Date.now();
   const timeoutSeconds = resolveSearchTimeoutSeconds(searchConfig);
   const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
-
-  if (braveMode === "llm-context") {
-    const { results, sources } = await runBraveLlmContextSearch({
-      baseUrl: braveBaseUrl,
-      endpointMode: braveEndpointMode,
-      query,
-      apiKey,
-      timeoutSeconds,
-      diagnostics,
-      signal: options?.signal,
-      country: country ?? undefined,
-      search_lang: normalizedLanguage.search_lang,
-      freshness,
-      dateAfter,
-      dateBefore,
-    });
-    options?.signal?.throwIfAborted();
-    const payload = {
-      query,
-      provider: "brave",
-      mode: "llm-context" as const,
-      count: results.length,
-      tookMs: Date.now() - start,
-      externalContent: {
-        untrusted: true,
-        source: "web_search",
-        provider: "brave",
-        wrapped: true,
-      },
-      results: results.map((entry) => ({
-        title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
-        url: entry.url,
-        snippets: entry.snippets.map((snippet) => wrapWebContent(snippet, "web_search")),
-        siteName: entry.siteName,
-      })),
-      sources,
-    };
-    writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
-    logBraveHttp(diagnostics, "cache write", {
-      mode: "llm-context",
-      query,
-      cacheKey,
-      ttlMs: cacheTtlMs,
-      count: results.length,
-    });
-    return payload;
-  }
-
-  const results = await runBraveWebSearch({
+  const request = {
     baseUrl: braveBaseUrl,
     endpointMode: braveEndpointMode,
     query,
-    count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
     apiKey,
     timeoutSeconds,
     diagnostics,
     signal: options?.signal,
     country: country ?? undefined,
     search_lang: normalizedLanguage.search_lang,
-    ui_lang: normalizedLanguage.ui_lang,
     freshness,
     dateAfter,
     dateBefore,
-  });
+  };
+  const response =
+    braveMode === "llm-context"
+      ? { ...(await runBraveLlmContextSearch(request)), mode: "llm-context" as const }
+      : {
+          results: await runBraveWebSearch({
+            ...request,
+            count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+            ui_lang: normalizedLanguage.ui_lang,
+          }),
+          mode: "web" as const,
+        };
+  // A completed upstream response must not write cache state after its caller aborts.
   options?.signal?.throwIfAborted();
+  const results =
+    response.mode === "llm-context"
+      ? response.results.map((entry) => ({
+          title: entry.title ? wrapWebContent(entry.title, "web_search") : "",
+          url: entry.url,
+          snippets: entry.snippets.map((snippet) => wrapWebContent(snippet, "web_search")),
+          siteName: entry.siteName,
+        }))
+      : response.results;
   const payload = {
     query,
     provider: "brave",
+    ...(response.mode === "llm-context" ? { mode: response.mode } : {}),
     count: results.length,
     tookMs: Date.now() - start,
     externalContent: {
@@ -560,10 +532,11 @@ export async function executeBraveSearch(
       wrapped: true,
     },
     results,
+    ...(response.mode === "llm-context" ? { sources: response.sources } : {}),
   };
   writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
   logBraveHttp(diagnostics, "cache write", {
-    mode: "web",
+    mode: response.mode,
     query,
     cacheKey,
     ttlMs: cacheTtlMs,

--- a/extensions/brave/src/brave-web-search-provider.shared.ts
+++ b/extensions/brave/src/brave-web-search-provider.shared.ts
@@ -2,6 +2,7 @@
  * Brave Search request normalization and result mapping. It validates Brave
  * country/language params and converts LLM-context responses into web results.
  */
+import { resolveSiteName } from "openclaw/plugin-sdk/provider-web-search";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -211,17 +212,6 @@ export function normalizeBraveLanguageParams(params: { search_lang?: string; ui_
   }
 
   return { search_lang, ui_lang };
-}
-
-function resolveSiteName(url: string | undefined): string | undefined {
-  if (!url) {
-    return undefined;
-  }
-  try {
-    return new URL(url).hostname;
-  } catch {
-    return undefined;
-  }
 }
 
 /** Map Brave LLM Context API grounding results into web-search result rows. */

--- a/extensions/brave/src/brave-web-search-provider.test.ts
+++ b/extensions/brave/src/brave-web-search-provider.test.ts
@@ -228,6 +228,46 @@ describe("brave web search provider", () => {
     },
   );
 
+  it.each(["web", "llm-context"] as const)(
+    "does not cache a %s response completed after caller cancellation",
+    async (mode) => {
+      const controller = new AbortController();
+      const reason = new Error(`Brave ${mode} canceled after response`);
+      const payload =
+        mode === "web" ? { web: { results: [] } } : { grounding: { generic: [] }, sources: [] };
+      let firstRequest = true;
+      const fetchMock = vi.fn(async () => {
+        if (!firstRequest) {
+          return jsonResponse(payload);
+        }
+        firstRequest = false;
+        let emitted = false;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            pull(stream) {
+              if (!emitted) {
+                emitted = true;
+                stream.enqueue(new TextEncoder().encode(JSON.stringify(payload)));
+                return;
+              }
+              stream.close();
+              controller.abort(reason);
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      });
+      global.fetch = fetchMock as typeof global.fetch;
+      const tool = createBraveTool({ webSearch: { apiKey: "brave-test-key", mode } });
+      const args = { query: `brave post-response cancellation ${mode}` };
+
+      await expect(tool.execute(args, { signal: controller.signal })).rejects.toBe(reason);
+      await tool.execute(args);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
   it("normalizes brave language parameters and swaps reversed ui/search inputs", () => {
     expect(
       testing.normalizeBraveLanguageParams({


### PR DESCRIPTION
## What Problem This Solves

Brave's regular web search and LLM-context search maintained duplicate provider request, result, cancellation, and cache-write flows. The plugin also carried a private hostname parser identical to the existing provider SDK implementation, leaving identical behavior in multiple owners.

## Why This Change Was Made

Both Brave modes now reuse one provider-private request/result lifecycle while keeping their existing distinct endpoint parameters, source shapes, authentication, SSRF policies, bounded responses, and diagnostics. The shared lifecycle preserves a single post-response cancellation fence before result shaping or cache writes, and LLM-context hostname extraction now uses the identical canonical SDK helper.

## User Impact

No user-visible behavior, public plugin API, provider selection, model/configuration, authentication, endpoint policy, response bounds, or search results change. Brave web and LLM-context searches retain their existing cache partitioning, timeout, source metadata, private endpoint restrictions, and caller cancellation behavior.

## Evidence

- Production: +27/-64 (net -37) across two plugin-private owner modules; one existing owner test adds 40 lines of meaningful real-fetch coverage.
- Complete Brave provider and config-merge suites: 34/34 tests passed.
- New parameterized streaming-response tests first passed against the original production code for both web and LLM-context modes. Removing only the shared post-response cancellation fence made both cases fail by returning canceled results; restoring the fence returned both owner suites to 34/34 passing and verified the next request refetches instead of reading poisoned cache.
- `node --import tsx scripts/check-deadcode-exports.mts`: production, full-tree, and script unused-export scans all passed with zero entries.
- `node_modules/.bin/oxfmt --check extensions/brave/src/brave-web-search-provider.runtime.ts extensions/brave/src/brave-web-search-provider.shared.ts extensions/brave/src/brave-web-search-provider.test.ts`
- `node scripts/check-changed.mjs --dry-run -- extensions/brave/src/brave-web-search-provider.runtime.ts extensions/brave/src/brave-web-search-provider.shared.ts extensions/brave/src/brave-web-search-provider.test.ts`
- Independent owner-boundary source reviews and the required autoreview reported no actionable findings; exact-head hosted CI, independent immutable-head review, and repository-native Testbox preparation run before landing.
