### PR TITLE
refactor(media): reuse canonical auto image selection

### DIFF
--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -613,49 +613,23 @@ export async function resolveAutoImageModel(params: {
   activeModel?: ActiveMediaModel;
 }): Promise<ActiveMediaModel | null> {
   const providerRegistry = buildProviderRegistry(undefined, params.cfg);
-  const toActive = (entry: MediaUnderstandingModelConfig | null): ActiveMediaModel | null => {
-    if (!entry || entry.type === "cli") {
-      return null;
+  const entries = await resolveAutoEntries({
+    ...params,
+    providerRegistry,
+    capability: "image",
+    nativeVisionActive: false,
+  });
+  for (const entry of entries) {
+    if (entry.type === "cli") {
+      continue;
     }
     const provider = entry.provider;
     const model = entry.model?.trim();
-    if (!provider || !model) {
-      return null;
+    if (provider && model) {
+      return { provider, model };
     }
-    return { provider, model };
-  };
-  const configuredImageModel = resolveImageModelFromAgentDefaults({
-    cfg: params.cfg,
-    agentId: params.agentId,
-  })
-    .map((entry) => toActive(entry))
-    .find((entry): entry is ActiveMediaModel => entry !== null);
-  if (configuredImageModel) {
-    return configuredImageModel;
   }
-  const activeEntry = await resolveActiveModelEntry({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    agentDir: params.agentDir,
-    workspaceDir: params.workspaceDir,
-    providerRegistry,
-    capability: "image",
-    activeModel: params.activeModel,
-  });
-  const resolvedActive = toActive(activeEntry);
-  if (resolvedActive) {
-    return resolvedActive;
-  }
-  const keyEntry = await resolveKeyEntry({
-    cfg: params.cfg,
-    agentId: params.agentId,
-    agentDir: params.agentDir,
-    workspaceDir: params.workspaceDir,
-    providerRegistry,
-    capability: "image",
-    activeModel: params.activeModel,
-  });
-  return toActive(keyEntry);
+  return null;
 }
 
 async function resolveActiveModelEntry(params: {

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -644,6 +644,46 @@ describe("runCapability image skip", () => {
     });
   });
 
+  it("uses a valid imageModel fallback after a malformed primary", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          imageModel: {
+            primary: "openrouter/",
+            fallbacks: ["openrouter/google/gemini-2.5-flash"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await expect(resolveAutoImageModel({ cfg })).resolves.toEqual({
+      provider: "openrouter",
+      model: "google/gemini-2.5-flash",
+    });
+  });
+
+  it("resolves a providerless imageModel on its unique configured provider", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          imageModel: { primary: "moondream" },
+        },
+      },
+      models: {
+        providers: {
+          ollama: {
+            models: [{ id: "moondream", input: ["text", "image"] }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await expect(resolveAutoImageModel({ cfg })).resolves.toEqual({
+      provider: "ollama",
+      model: "moondream",
+    });
+  });
+
   it("runs providerless configured imageModel fallbacks on the unique configured provider", async () => {
     await withMediaFixture(
       {
@@ -1108,11 +1148,20 @@ describe("runCapability image skip", () => {
       await expect(
         resolveAutoImageModel({
           cfg,
+          agentId: "image-agent",
+          agentDir: "/tmp/openclaw-agent",
+          workspaceDir: "/tmp/openclaw-workspace",
           activeModel: { provider: "openrouter", model: "google/gemini-2.5-flash" },
         }),
       ).resolves.toEqual({
         provider: "openrouter",
         model: "google/gemini-2.5-flash",
+      });
+      expect(loadModelCatalog).toHaveBeenCalledWith({
+        config: cfg,
+        agentId: "image-agent",
+        agentDir: "/tmp/openclaw-agent",
+        workspaceDir: "/tmp/openclaw-workspace",
       });
     } finally {
       setActivePluginRegistry(createEmptyPluginRegistry());


### PR DESCRIPTION
## What Problem This Solves

The exported auto image-model resolver used by Telegram sticker description duplicated the canonical media-understanding selection order. That duplicate path could drift from the runtime path that already owns configured image defaults, active models, and keyed-provider fallback selection.

## Why This Change Was Made

The resolver now delegates selection to `resolveAutoEntries` with image capability and native vision disabled, then projects the first usable non-CLI provider/model entry. This removes the duplicate selection policy without adding auth, normalization, registry validation, or native-vision behavior.

Production LOC: +12/-38 (net -26)  
Tests: +49/-0

## User Impact

No user-visible behavior change is intended. Telegram sticker image-model selection and the general media-understanding runtime now share one canonical automatic selection path.

## Evidence

- `node scripts/run-vitest.mjs src/media-understanding/runner.vision-skip.test.ts`: 24 tests passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/sticker-cache.describe.test.ts`: 2 tests passed.
- Targeted formatting and lint passed.
- `git diff --check` passed.
- Independent exact-head scope review found no blocking issues.
- Exact-head autoreview reported no findings and rated the patch correct with 0.98 confidence.

The broader core typecheck is not counted as passing evidence because the shared `node_modules` currently has unrelated stale dependency/type errors involving `google-shared`, `markdown-it`, and `pi-tui`. None of those diagnostics involve the changed files.
