### PR TITLE
fix(cron): preserve webhook delivery when the system clock jumps

### DIFF
--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -313,11 +313,27 @@ describe("CronService persists delivered status", () => {
   });
 
   it.each([
-    { name: "successful endpoint", responseStatus: 204, expectedStatus: "delivered" },
-    { name: "failing endpoint", responseStatus: 503, expectedStatus: "not-delivered" },
+    {
+      name: "successful endpoint",
+      responseStatus: 204,
+      expectedStatus: "delivered",
+      clockJumpMs: 0,
+    },
+    {
+      name: "failing endpoint",
+      responseStatus: 503,
+      expectedStatus: "not-delivered",
+      clockJumpMs: 0,
+    },
+    {
+      name: "forward wall-clock jump",
+      responseStatus: 204,
+      expectedStatus: "delivered",
+      clockJumpMs: 86_400_000,
+    },
   ])(
     "records command webhook delivery through a real HTTP server: $name",
-    async ({ responseStatus, expectedStatus }) => {
+    async ({ responseStatus, expectedStatus, clockJumpMs }) => {
       const requests: string[] = [];
       const server = createServer((request, response) => {
         let body = "";
@@ -338,6 +354,8 @@ describe("CronService persists delivered status", () => {
       const webhookUrl = `http://127.0.0.1:${address.port}/hook`;
       const store = await makeStorePath();
       const finished = createFinishedBarrier();
+      const started = createDeferred();
+      const finish = createDeferred();
       let finishedEvent: CronEvent | undefined;
       const cron = new CronService({
         storePath: store.storePath,
@@ -346,9 +364,16 @@ describe("CronService persists delivered status", () => {
         enqueueSystemEvent: vi.fn(),
         requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
-        runCommandJob: async ({ job, abortSignal }) =>
-          await runCronCommandJob({ job, abortSignal, nowMs: Date.now }),
+        runCommandJob: async ({ job, abortSignal }) => {
+          if (clockJumpMs > 0) {
+            started.resolve();
+            await finish.promise;
+            return { status: "ok", summary: "HOOKSCHED_PAYLOAD" };
+          }
+          return await runCronCommandJob({ job, abortSignal, nowMs: Date.now });
+        },
         sendCronWebhook: async ({ event, abortSignal }) => {
+          expect(abortSignal.aborted).toBe(false);
           const response = await fetch(webhookUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -378,11 +403,18 @@ describe("CronService persists delivered status", () => {
           payload: {
             kind: "command",
             argv: [process.execPath, "-e", "process.stdout.write('HOOKSCHED_PAYLOAD')"],
+            ...(clockJumpMs > 0 ? { timeoutSeconds: 1 } : {}),
           },
           delivery: { mode: "webhook", to: webhookUrl },
         });
         const finishedPromise = finished.waitForOk(job.id);
-        await cron.run(job.id, "force");
+        const run = cron.run(job.id, "force");
+        if (clockJumpMs > 0) {
+          await started.promise;
+          vi.setSystemTime(Date.now() + clockJumpMs);
+          finish.resolve();
+        }
+        await run;
         await finishedPromise;
 
         expect(requests).toHaveLength(1);

--- a/src/cron/service/agent-watchdog.ts
+++ b/src/cron/service/agent-watchdog.ts
@@ -54,7 +54,6 @@ type CronAgentWatchdog = {
   noteRunnerStarted: (info?: CronAgentExecutionStarted) => void;
   notePhase: (info: CronAgentExecutionPhaseUpdate) => void;
   activeExecution: () => CronAgentExecutionStarted | undefined;
-  deadlineAtMs: () => number | undefined;
   observedLaneWait: () => boolean;
   dispose: () => void;
 };
@@ -70,7 +69,6 @@ export function createCronAgentWatchdog(params: {
   let setupTimeoutId: NodeJS.Timeout | undefined;
   let preExecutionTimeoutId: NodeJS.Timeout | undefined;
   let activeExecution: CronAgentExecutionStarted | undefined;
-  let deadlineAtMs: number | undefined;
   let observedLaneWait = false;
   let waitingForLane = false;
 
@@ -85,7 +83,6 @@ export function createCronAgentWatchdog(params: {
     if (timeoutId || state === "disposed") {
       return;
     }
-    deadlineAtMs = Date.now() + params.jobTimeoutMs;
     timeoutId = setTimeout(() => {
       setTimedOut(timeoutErrorMessage(activeExecution));
     }, params.jobTimeoutMs);
@@ -189,7 +186,6 @@ export function createCronAgentWatchdog(params: {
       noteExecutionProgress(info);
     },
     activeExecution: () => activeExecution,
-    deadlineAtMs: () => deadlineAtMs,
     observedLaneWait: () => observedLaneWait,
     dispose: () => {
       state = "disposed";

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -245,7 +245,6 @@ export type CronServiceDeps = {
     job: CronJob;
     event: CronEvent;
     abortSignal: AbortSignal;
-    deadlineAtMs?: number;
     onDeliveryAccepted: () => void;
   }) => Promise<void>;
   cleanupTimedOutAgentRun?: (params: {

--- a/src/cron/service/timer-job-runner.ts
+++ b/src/cron/service/timer-job-runner.ts
@@ -60,7 +60,6 @@ async function deliverPrimaryWebhook(
   result: CronCoreRunOutcome,
   abortSignal: AbortSignal,
   progress: CronRunProgress,
-  deadlineAtMs?: number,
   assertRunCurrent?: () => void,
 ): Promise<CronCoreRunOutcome> {
   const settle = (settledResult: CronCoreRunOutcome) => {
@@ -90,15 +89,13 @@ async function deliverPrimaryWebhook(
     });
   }
 
-  const deadlineExceeded = () => deadlineAtMs !== undefined && Date.now() >= deadlineAtMs;
   const interruptionError = () => {
     const reason = abortErrorMessage(abortSignal);
-    return deadlineExceeded() ||
-      (abortSignal.reason instanceof Error && abortSignal.reason.name === "TimeoutError")
+    return abortSignal.reason instanceof Error && abortSignal.reason.name === "TimeoutError"
       ? `cron webhook delivery timed out: ${reason}`
       : `cron webhook delivery cancelled: ${reason}`;
   };
-  if (abortSignal.aborted || deadlineExceeded()) {
+  if (abortSignal.aborted) {
     return withPrimaryWebhookTrace({
       job,
       result,
@@ -115,7 +112,6 @@ async function deliverPrimaryWebhook(
     await state.deps.sendCronWebhook({
       job,
       abortSignal,
-      ...(deadlineAtMs !== undefined ? { deadlineAtMs } : {}),
       onDeliveryAccepted: () => {
         settle(deliveredResult);
       },
@@ -144,7 +140,7 @@ async function deliverPrimaryWebhook(
     if (progress.settledDeliveryResult) {
       return progress.settledDeliveryResult;
     }
-    if (abortSignal.aborted || deadlineExceeded()) {
+    if (abortSignal.aborted) {
       return withPrimaryWebhookTrace({
         job,
         result,
@@ -288,7 +284,6 @@ async function executeJobCoreWithTimeoutUnfinalized(
           result,
           runAbortController.signal,
           progress,
-          undefined,
           assertRunCurrent,
         );
       });
@@ -377,7 +372,6 @@ async function executeJobCoreWithTimeoutUnfinalized(
         result,
         runAbortController.signal,
         progress,
-        watchdog.deadlineAtMs(),
         assertRunCurrent,
       );
     });

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -903,13 +903,12 @@ export function buildGatewayCronService(params: {
       });
       return { ...result, ...completion };
     },
-    sendCronWebhook: async ({ job, event, abortSignal, deadlineAtMs, onDeliveryAccepted }) => {
+    sendCronWebhook: async ({ job, event, abortSignal, onDeliveryAccepted }) => {
       await sendGatewayCronWebhook({
         job,
         event,
         abortSignal,
         onDeliveryAccepted,
-        ...(deadlineAtMs !== undefined ? { deadlineAtMs } : {}),
         webhookToken: params.cfg.cron?.webhookToken,
         ssrfPolicy: webhookSsrfPolicy,
       });


### PR DESCRIPTION
Closes #128537

## What Problem This Solves

Fixes an issue where scheduled command jobs silently lose their webhook delivery when the system clock jumps forward while the command is running, even though the job's actual timeout has not expired.

## Why This Change Was Made

The cron watchdog already owns the authoritative monotonic timeout and exposes cancellation through its abort signal. Stop deriving and forwarding a second wall-clock deadline for primary cron webhooks; retain the existing true-timeout, operator-cancellation, run-generation, SSRF fetch-cap, and separately exposed explicit Gateway webhook deadline contracts.

## User Impact

Scheduled webhook notifications are delivered normally after system-clock corrections, VM resume, or other forward clock adjustments when their real timeout has not elapsed. Genuine timed-out or cancelled jobs remain fenced and cannot deliver stale webhooks.

## Evidence

- Reproduced against unchanged production with a real CronService, a real local HTTP server, a deferred command, a one-second monotonic watchdog, and a one-day wall-clock jump without advancing timers: expected webhook callback once, received zero callbacks.
- The repaired owner delivers exactly one actual HTTP request for the same clock jump; the existing parameterized integration also verifies successful and failing endpoints plus recorded delivery status.
- Five focused owner/sibling suites passed: 98 tests covering clock jumps, genuine hanging-webhook timeouts, operator cancellation, accepted-delivery lifecycle races, and the generic Gateway explicit-deadline contract.
- All five changed files pass formatter checks and scoped oxlint; the repository-wide production and cron-test typecheck currently encounters pre-existing stale shared-checkout dependency exports in unrelated Google, markdown-it, and TUI modules, so exact-head hosted CI is the authoritative full typecheck.
- Two independent owner-boundary reviews and a fresh structured automated review found no actionable issues. Production: +4/-16 (net -12); integration tests: +38/-6 (net +32).
