### PR TITLE
fix: prevent custom Ollama cloud models from stalling indefinitely

### DIFF
--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
@@ -441,18 +441,8 @@ describe("resolveLlmIdleTimeoutMs", () => {
   ])(
     "keeps hosted watchdogs for custom Ollama model %s through %s",
     (id, baseUrl, localIdleTimeoutMs) => {
-      const cfg = {
-        models: {
-          providers: {
-            "local-ollama": {
-              api: "ollama",
-              apiKey: "ollama-local",
-              baseUrl,
-              models: [],
-            },
-          },
-        },
-      } as unknown as OpenClawConfig;
+      const providerConfig = { api: "ollama", apiKey: "ollama-local", baseUrl, models: [] };
+      const cfg = { models: { providers: { "local-ollama": providerConfig } } } as OpenClawConfig;
       const model = { provider: "local-ollama", id, baseUrl };
 
       expect({

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
@@ -434,6 +434,42 @@ describe("resolveLlmIdleTimeoutMs", () => {
   });
 
   it.each([
+    ["kimi-k2.5:cloud", "http://127.0.0.1:11434", 0],
+    ["gpt-oss:120b-cloud", "http://127.0.0.1:11434", 0],
+    ["kimi-k2.5:cloud", "http://ollama-box:11434", SELF_HOSTED_LLM_IDLE_TIMEOUT_MS],
+    ["gpt-oss:120b-cloud", "http://ollama-box:11434", SELF_HOSTED_LLM_IDLE_TIMEOUT_MS],
+  ])(
+    "keeps hosted watchdogs for custom Ollama model %s through %s",
+    (id, baseUrl, localIdleTimeoutMs) => {
+      const cfg = {
+        models: {
+          providers: {
+            "local-ollama": {
+              api: "ollama",
+              apiKey: "ollama-local",
+              baseUrl,
+              models: [],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const model = { provider: "local-ollama", id, baseUrl };
+
+      expect({
+        idle: resolveLlmIdleTimeoutMs({ cfg, model }),
+        firstEvent: resolveLlmFirstEventTimeoutMs({ cfg, model }),
+        cron: resolveLlmIdleTimeoutMs({ cfg, trigger: "cron", runTimeoutMs: 600_000, model }),
+        local: resolveLlmIdleTimeoutMs({ cfg, model: { ...model, id: "gemma4:latest" } }),
+      }).toEqual({
+        idle: DEFAULT_LLM_IDLE_TIMEOUT_MS,
+        firstEvent: CLOUD_LLM_FIRST_EVENT_TIMEOUT_MS,
+        cron: CRON_LLM_IDLE_TIMEOUT_MS,
+        local: localIdleTimeoutMs,
+      });
+    },
+  );
+
+  it.each([
     "http://172.32.0.1:11434",
     "http://192.169.1.1:11434",
     "http://100.63.255.254:11434",

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.ts
@@ -185,20 +185,6 @@ function hasConfiguredLocalProviderSignal(params: {
   );
 }
 
-function isOllamaCloudModel(model: { id?: string; provider?: string } | undefined): boolean {
-  const rawModelId = model?.id;
-  if (typeof rawModelId !== "string") {
-    return false;
-  }
-
-  const provider = model?.provider?.trim().toLowerCase();
-  if (provider && !provider.startsWith("ollama")) {
-    return false;
-  }
-
-  return isCloudModelRef(rawModelId);
-}
-
 type RuntimeModelLocality = {
   isLocalRuntimeModel: boolean;
   isExplicitLocalHostnameRuntimeModel: boolean;
@@ -221,7 +207,7 @@ function resolveRuntimeModelLocality(params?: {
       isSelfHostedHostnameRuntimeModel: false,
     };
   }
-  const notCloudModel = !isOllamaCloudModel(params?.model);
+  const notCloudModel = !isCloudModelRef(params?.model?.id);
   return {
     isLocalRuntimeModel: isLocalProviderBaseUrl(baseUrl) && notCloudModel,
     isExplicitLocalHostnameRuntimeModel: isExplicitLocalHostnameBaseUrl(baseUrl) && notCloudModel,
@@ -262,7 +248,7 @@ export function resolveLlmIdleTimeoutMs(params?: {
     isSelfHostedHostnameRuntimeModel,
   } = resolveRuntimeModelLocality(params);
   const isSelfHostedRuntimeModel =
-    isSelfHostedProviderId(params?.model?.provider) && !isOllamaCloudModel(params?.model);
+    isSelfHostedProviderId(params?.model?.provider) && !isCloudModelRef(params?.model?.id);
   const timeoutBounds = [
     runTimeoutIsNoTimeout ? undefined : runTimeoutMs,
     hasExplicitRunTimeout ? undefined : agentTimeoutMs,
@@ -378,7 +364,7 @@ export function resolveLlmFirstEventTimeoutMs(params?: {
     isSelfHostedHostnameRuntimeModel,
   } = resolveRuntimeModelLocality(params);
   const isSelfHostedRuntimeModel =
-    isSelfHostedProviderId(params?.model?.provider) && !isOllamaCloudModel(params?.model);
+    isSelfHostedProviderId(params?.model?.provider) && !isCloudModelRef(params?.model?.id);
   const timeoutBounds = [
     // Unlimited run budget bounds total cost, not first-token liveness. Omit
     // the sentinel from bounds so provider-class defaults still apply.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running hosted Ollama models through a custom local provider such as `local-ollama` could wait indefinitely for model progress or exhaust an entire scheduled run before fallback. OpenClaw already documents custom providers using `api: "ollama"` and hosted `:cloud` models behind a local Ollama server, but their watchdogs incorrectly depended on the provider ID beginning with `ollama`.

## Why This Change Was Made

Use the existing model-catalog hosted-source classifier directly at every embedded-run timeout ownership decision. This removes the duplicate provider-name-based classifier, preserves every existing timeout policy, and keeps genuinely local models on their existing local-provider path. Production code is net **-14 lines**.

## User Impact

Custom Ollama providers now give hosted `:cloud` and `:120b-cloud` models the same 120-second idle and first-event watchdogs and 60-second scheduled-run stall bound as the canonical Ollama provider. Unsuffixed local models retain their existing local timeout behavior on both loopback and self-hosted LAN endpoints.

## Evidence

- Added four owner-boundary regression cases spanning both hosted suffixes and both loopback/single-label hosts. Before the fix, all four failed: loopback returned idle `0ms`, first event `300000ms`, cron `600000ms`; self-hosted returned `300000ms`, `300000ms`, `600000ms`. After the fix, every hosted case returns `120000ms`, `120000ms`, `60000ms` while unsuffixed local controls stay unchanged.
- Focused owner, cancellation, actual HTTP transport, canonical catalog, and provider-policy siblings: **169 tests passed across five files and four Vitest shards**.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-qa-ollama-alias OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --configLoader runner src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts src/agents/embedded-agent-runner/run/llm-idle-timeout.abort.test.ts src/agents/embedded-agent-runner/model.provider-hooks.timeout.test.ts packages/model-catalog-core/src/model-catalog-refs.test.ts extensions/ollama/provider-policy-api.test.ts`
- Targeted formatting and `git diff --check` passed; independent review and structured autoreview reported no actionable findings.
- Trusted Linux changed-gate run: https://github.com/openclaw/openclaw/actions/runs/32816906400
- Existing supported configuration: https://docs.openclaw.ai/providers/ollama
