### PR TITLE
refactor(scripts): remove impossible cross-os gateway branches

### DIFF
--- a/scripts/lib/cross-os-release-checks/config.ts
+++ b/scripts/lib/cross-os-release-checks/config.ts
@@ -525,22 +525,6 @@ export function shouldUseManagedGatewayService(platform = process.platform) {
   return platform === "win32";
 }
 
-export function shouldUseManagedGatewayForInstallerRuntime(platform = process.platform) {
-  return shouldUseManagedGatewayService(platform) && platform !== "win32";
-}
-
-export function shouldExerciseManagedGatewayLifecycleAfterInstall(platform = process.platform) {
-  return shouldUseManagedGatewayService(platform);
-}
-
-export function shouldStopManagedGatewayBeforeManualFallback(platform = process.platform) {
-  return shouldUseManagedGatewayService(platform);
-}
-
-export function shouldRunBundledPluginPostinstall(_options?: { lane?: LaneState }) {
-  return true;
-}
-
 export function looksLikeCommitSha(ref: string) {
   return /^[0-9a-f]{7,40}$/iu.test(ref.trim());
 }
@@ -562,10 +546,6 @@ export function shouldRunMainChannelDevUpdate(ref: string) {
     return false;
   }
   return resolveExpectedDevUpdateRef(ref) === "main";
-}
-
-export function shouldSkipInstallerDaemonHealthCheck(platform = process.platform) {
-  return platform === "win32";
 }
 
 export function buildRealUpdateEnv(env: NodeJS.ProcessEnv) {

--- a/scripts/lib/cross-os-release-checks/install.ts
+++ b/scripts/lib/cross-os-release-checks/install.ts
@@ -23,7 +23,6 @@ import {
   PUBLISHED_INSTALLER_BASE_URL,
   installTimeoutMs,
   resolvePackDestinationTarball,
-  shouldRunBundledPluginPostinstall,
 } from "./config.ts";
 import { readLogTextWindow } from "./logs.ts";
 import { runCommand } from "./process.ts";
@@ -400,10 +399,7 @@ export async function installTarballPackage(params: {
     timeoutMs: params.timeoutMs,
     ignoreScripts: params.ignoreScripts,
   });
-  if (
-    params.restoreBundledPluginPostinstall !== false &&
-    shouldRunBundledPluginPostinstall({ lane: params.lane })
-  ) {
+  if (params.restoreBundledPluginPostinstall !== false) {
     await runBundledPluginPostinstall({
       lane: params.lane,
       env: params.env,

--- a/scripts/lib/cross-os-release-checks/installed.ts
+++ b/scripts/lib/cross-os-release-checks/installed.ts
@@ -28,7 +28,7 @@ import {
   looksLikeCommitSha,
   resolveExplicitBaselineVersion,
   resolveExpectedDevUpdateRef,
-  shouldSkipInstallerDaemonHealthCheck,
+  shouldUseManagedGatewayService,
 } from "./config.ts";
 import {
   installedEntryPath,
@@ -447,7 +447,7 @@ export async function runOnboardWithInstalledCli(params: {
       authChoice: params.providerConfig.authChoice,
       gatewayPort: params.lane.gatewayPort,
       installDaemon: params.installDaemon,
-      skipHealth: !params.installDaemon || shouldSkipInstallerDaemonHealthCheck(),
+      skipHealth: !params.installDaemon || shouldUseManagedGatewayService(),
     });
     await runInstalledCli({
       cliPath: params.cliPath,

--- a/scripts/lib/cross-os-release-checks/lanes.ts
+++ b/scripts/lib/cross-os-release-checks/lanes.ts
@@ -18,11 +18,8 @@ import {
   normalizeRequestedRef,
   resolveDevUpdateVerificationRef,
   resolveExpectedDevUpdateRef,
-  shouldExerciseManagedGatewayLifecycleAfterInstall,
   shouldRunMainChannelDevUpdate,
   shouldRunPackagedUpgradeStatusProbe,
-  shouldStopManagedGatewayBeforeManualFallback,
-  shouldUseManagedGatewayForInstallerRuntime,
   shouldUseManagedGatewayService,
   updateTimeoutMs,
   verifyPackagedUpgradeUpdateResult,
@@ -45,7 +42,6 @@ import {
 } from "./install.ts";
 import {
   ensureDevUpdateGitInstall,
-  ensureManagedGatewayReady,
   resolveInstalledGatewayStopArgs,
   resolveInstallerTargetVersion,
   runInstalledAgentTurn,
@@ -446,7 +442,6 @@ export async function runInstallerFreshSuite(
   const lane = createLaneState("installer-fresh");
   const cleanup: Cleanup[] = [];
   const usesManagedGateway = shouldUseManagedGatewayService();
-  const useManagedGatewayAfterInstall = shouldUseManagedGatewayForInstallerRuntime();
   const manualGateway: { current: GatewayHandle | null } = { current: null };
   const managedHostLease: { current: ManagedGatewayInstallerHostLease | null } = { current: null };
   let managedHostOwned = false;
@@ -550,7 +545,7 @@ export async function runInstallerFreshSuite(
       allocateGatewayPort: gatewayPortReservation === null,
     });
 
-    if (shouldExerciseManagedGatewayLifecycleAfterInstall()) {
+    if (usesManagedGateway) {
       await exerciseManagedGatewayLifecycle({
         lane,
         cliPath: freshShell.cliPath,
@@ -568,56 +563,54 @@ export async function runInstallerFreshSuite(
       logPath: join(params.logsDir, "installer-fresh-models-set.log"),
     });
 
-    if (!useManagedGatewayAfterInstall) {
-      // Keep the Windows installer lane validating Scheduled Task registration during
-      // onboarding and lifecycle commands, but use a manual gateway for the runtime
-      // checks after that so the installer validation does not depend on the more
-      // failure-prone managed Windows session state for the remainder of the lane.
-      if (shouldStopManagedGatewayBeforeManualFallback()) {
-        logLanePhase(lane, "gateway-stop-managed");
-        await runInstalledCli({
+    // Keep the Windows installer lane validating Scheduled Task registration during
+    // onboarding and lifecycle commands, but use a manual gateway for the runtime
+    // checks after that so the installer validation does not depend on the more
+    // failure-prone managed Windows session state for the remainder of the lane.
+    if (usesManagedGateway) {
+      logLanePhase(lane, "gateway-stop-managed");
+      await runInstalledCli({
+        cliPath: freshShell.cliPath,
+        args: await resolveInstalledGatewayStopArgs({
           cliPath: freshShell.cliPath,
-          args: await resolveInstalledGatewayStopArgs({
-            cliPath: freshShell.cliPath,
-            cwd: lane.homeDir,
-            env,
-            logPath: join(params.logsDir, "installer-fresh-gateway-stop-managed-help.log"),
-          }),
-          env,
           cwd: lane.homeDir,
-          logPath: join(params.logsDir, "installer-fresh-gateway-stop-managed.log"),
-          timeoutMs: 2 * 60 * 1000,
-          check: false,
-        });
-        await waitForInstalledGatewayToStop({
-          lane,
-          cliPath: freshShell.cliPath,
           env,
-          logPath: join(params.logsDir, "installer-fresh-gateway-stop-managed-status.log"),
-        });
-      }
-      await gatewayPortReservation?.release();
-      logLanePhase(lane, "gateway-start");
-      const gateway = await startManualGatewayFromInstalledCli({
-        lane,
-        cliPath: freshShell.cliPath,
+          logPath: join(params.logsDir, "installer-fresh-gateway-stop-managed-help.log"),
+        }),
         env,
-        logPath: join(params.logsDir, "installer-fresh-gateway.log"),
+        cwd: lane.homeDir,
+        logPath: join(params.logsDir, "installer-fresh-gateway-stop-managed.log"),
+        timeoutMs: 2 * 60 * 1000,
+        check: false,
       });
-      manualGateway.current = gateway;
-      if (!usesManagedGateway) {
-        cleanup.push(() => stopGateway(manualGateway.current));
-      }
-      logLanePhase(lane, "gateway-status");
-      await waitForInstalledGateway({
+      await waitForInstalledGatewayToStop({
         lane,
         cliPath: freshShell.cliPath,
         env,
-        gatewayHolder: manualGateway,
-        gatewayLogPath: join(params.logsDir, "installer-fresh-gateway.log"),
-        logPath: join(params.logsDir, "installer-fresh-gateway-status.log"),
+        logPath: join(params.logsDir, "installer-fresh-gateway-stop-managed-status.log"),
       });
     }
+    await gatewayPortReservation?.release();
+    logLanePhase(lane, "gateway-start");
+    const gateway = await startManualGatewayFromInstalledCli({
+      lane,
+      cliPath: freshShell.cliPath,
+      env,
+      logPath: join(params.logsDir, "installer-fresh-gateway.log"),
+    });
+    manualGateway.current = gateway;
+    if (!usesManagedGateway) {
+      cleanup.push(() => stopGateway(manualGateway.current));
+    }
+    logLanePhase(lane, "gateway-status");
+    await waitForInstalledGateway({
+      lane,
+      cliPath: freshShell.cliPath,
+      env,
+      gatewayHolder: manualGateway,
+      gatewayLogPath: join(params.logsDir, "installer-fresh-gateway.log"),
+      logPath: join(params.logsDir, "installer-fresh-gateway-status.log"),
+    });
 
     logLanePhase(lane, "dashboard");
     await runDashboardSmoke({
@@ -738,11 +731,9 @@ export async function runDevUpdateSuite(
     logsDir: params.logsDir,
     suiteName: "dev-update",
   });
-  const usesManagedGateway = shouldUseManagedGatewayService();
   // Keep dev-update on a manual gateway even on Windows. The packaged lanes
   // already cover the Scheduled Task path, while repaired git installs live in
   // an ephemeral checkout that has proven flaky as a managed service in CI.
-  const useManagedGatewayAfterDevUpdate = usesManagedGateway && process.platform !== "win32";
   const requestedRef = resolveExpectedDevUpdateRef(params.ref);
   if (!shouldRunMainChannelDevUpdate(requestedRef)) {
     throw new Error(
@@ -819,7 +810,7 @@ export async function runDevUpdateSuite(
       cliPath: verifiedShell.cliPath,
       env,
       providerConfig: params.providerConfig,
-      installDaemon: useManagedGatewayAfterDevUpdate,
+      installDaemon: false,
       logPath: join(params.logsDir, "dev-update-onboard.log"),
     });
 
@@ -832,34 +823,24 @@ export async function runDevUpdateSuite(
       logPath: join(params.logsDir, "dev-update-models-set.log"),
     });
 
-    if (!useManagedGatewayAfterDevUpdate) {
-      logLanePhase(lane, "gateway-start");
-      const gateway = await startManualGatewayFromInstalledCli({
-        lane,
-        cliPath: verifiedShell.cliPath,
-        env,
-        logPath: join(params.logsDir, "dev-update-gateway.log"),
-      });
-      manualGateway.current = gateway;
-      cleanup.push(() => stopGateway(manualGateway.current));
-      logLanePhase(lane, "gateway-status");
-      await waitForInstalledGateway({
-        lane,
-        cliPath: verifiedShell.cliPath,
-        env,
-        gatewayHolder: manualGateway,
-        gatewayLogPath: join(params.logsDir, "dev-update-gateway.log"),
-        logPath: join(params.logsDir, "dev-update-gateway-status.log"),
-      });
-    } else {
-      logLanePhase(lane, "gateway-ready");
-      await ensureManagedGatewayReady({
-        lane,
-        cliPath: verifiedShell.cliPath,
-        env,
-        logPath: join(params.logsDir, "dev-update-gateway-ready.log"),
-      });
-    }
+    logLanePhase(lane, "gateway-start");
+    const gateway = await startManualGatewayFromInstalledCli({
+      lane,
+      cliPath: verifiedShell.cliPath,
+      env,
+      logPath: join(params.logsDir, "dev-update-gateway.log"),
+    });
+    manualGateway.current = gateway;
+    cleanup.push(() => stopGateway(manualGateway.current));
+    logLanePhase(lane, "gateway-status");
+    await waitForInstalledGateway({
+      lane,
+      cliPath: verifiedShell.cliPath,
+      env,
+      gatewayHolder: manualGateway,
+      gatewayLogPath: join(params.logsDir, "dev-update-gateway.log"),
+      logPath: join(params.logsDir, "dev-update-gateway-status.log"),
+    });
 
     logLanePhase(lane, "dashboard");
     await runDashboardSmoke({

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -98,15 +98,11 @@ import {
   resolveStaticFileContentType,
   startStaticFileServer,
   trimForSummary,
-  shouldExerciseManagedGatewayLifecycleAfterInstall,
   shouldRunPackagedUpgradeStatusProbe,
   shouldRunWindowsInstalledBrowserOverrideImportSmoke,
-  shouldSkipInstallerDaemonHealthCheck,
-  shouldStopManagedGatewayBeforeManualFallback,
   shouldRunMainChannelDevUpdate,
   shouldRetryCrossOsAgentTurnError,
   shouldSkipOptionalCrossOsAgentTurnError,
-  shouldUseManagedGatewayForInstallerRuntime,
   shouldUseManagedGatewayService,
   verifyDashboardAssetUrls,
   verifyDevUpdateStatus,
@@ -1631,18 +1627,6 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       inputs: ["win32", "darwin", "linux"] as const,
       expected: [true, false, false],
     },
-    {
-      name: "stops the managed gateway before the manual fallback only on Windows",
-      decide: shouldStopManagedGatewayBeforeManualFallback,
-      inputs: ["win32", "darwin", "linux"] as const,
-      expected: [true, false, false],
-    },
-    {
-      name: "skips daemon health during installed onboarding only on native Windows",
-      decide: shouldSkipInstallerDaemonHealthCheck,
-      inputs: ["win32", "darwin", "linux"] as const,
-      expected: [true, false, false],
-    },
   ])("$name", ({ decide, inputs, expected }) => {
     expect(inputs.map((platform) => decide(platform))).toEqual(expected);
   });
@@ -1673,13 +1657,6 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       "--json",
       "--skip-health",
     ]);
-  });
-
-  it("keeps the Windows installer runtime on the manual gateway after managed lifecycle checks", () => {
-    expect(shouldExerciseManagedGatewayLifecycleAfterInstall("win32")).toBe(true);
-    expect(shouldUseManagedGatewayForInstallerRuntime("win32")).toBe(false);
-    expect(shouldExerciseManagedGatewayLifecycleAfterInstall("darwin")).toBe(false);
-    expect(shouldUseManagedGatewayForInstallerRuntime("darwin")).toBe(false);
   });
 
   it("runs the installed browser override import smoke only on native Windows", () => {


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's cross-OS release checks carried two mathematically unreachable managed-gateway paths, several duplicate Windows-only policy wrappers, and a plugin-postinstall predicate that always returned true. These dead alternatives made the actual installer and dev-update lifecycle harder to inspect and kept implementation-only tests alive.

## Why This Change Was Made

The existing `shouldUseManagedGatewayService` already owns the Windows policy. Both supposedly optional managed-runtime conditions require a platform to simultaneously be and not be Windows, so installer and dev-update runtime always use their existing manual Gateway path. This change removes the unreachable branches and duplicate wrappers, applies the canonical policy directly, and retains the explicit bundled-plugin-postinstall opt-out.

Windows still acquires and releases its exclusive host lease, registers and exercises the managed service, stops and waits for it, and then starts the manual Gateway. Non-Windows port reservation, cleanup, onboarding health policy, phase/log ordering, published installer selection, and the separate live `ensureManagedGatewayReady` consumers remain unchanged.

## User Impact

No user-visible behavior change. Maintainers get a smaller, clearer release-validation owner with **43 fewer production lines** and **23 fewer implementation-coupled test lines**, without changing package, release, or platform contracts.

## Evidence

- Focused owner, workflow, and log suites: **143 tests passed** across `test/scripts/openclaw-cross-os-release-checks.test.ts`, `test/scripts/openclaw-cross-os-release-workflow.test.ts`, and `test/scripts/cross-os-release-logs.test.ts`.
- Native release script resolved installer-fresh matrices for Linux, Windows, and macOS; its Windows dev-update matrix also passed.
- Actual release-workflow shell wrapper resolved the Windows installer-fresh lane successfully.
- Existing tests retain Windows host identity, exclusive lease, service preflight, manual Gateway startup/restart, POSIX port reservation, onboarding arguments, and full platform matrix coverage.
- Changed-lane classification, scoped script oxlint, formatter verification, and `git diff --check` passed.
- Independent owner-boundary review accepted with no findings; fresh structured autoreview passed.
- Production: **+61/-104 (net -43)**. Tests: **+0/-23**.
