### PR TITLE
fix(android): select writable calendars for new events

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CalendarHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CalendarHandler.kt
@@ -223,12 +223,12 @@ private object SystemCalendarDataSource : CalendarDataSource {
   }
 
   private fun findDefaultCalendarId(resolver: ContentResolver): Long? {
-    val projection = arrayOf(CalendarContract.Calendars._ID)
     resolver
       .query(
         CalendarContract.Calendars.CONTENT_URI,
-        projection,
-        "${CalendarContract.Calendars.VISIBLE}=1",
+        arrayOf(CalendarContract.Calendars._ID),
+        "${CalendarContract.Calendars.VISIBLE}=1 AND " +
+          "${CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL}>=${CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR}",
         null,
         // Prefer Android's primary visible calendar, then lowest id for deterministic fallback.
         "${CalendarContract.Calendars.IS_PRIMARY} DESC, ${CalendarContract.Calendars._ID} ASC",

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/CalendarHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/CalendarHandlerTest.kt
@@ -1,6 +1,15 @@
 package ai.openclaw.app.node
 
+import android.Manifest
+import android.app.Application
+import android.content.ContentProvider
+import android.content.ContentUris
+import android.content.ContentValues
 import android.content.Context
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import android.net.Uri
+import android.provider.CalendarContract
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -10,6 +19,8 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowContentResolver
 import java.time.Instant
 import java.util.TimeZone
 
@@ -129,6 +140,65 @@ class CalendarHandlerTest : NodeHandlerRobolectricTest() {
   }
 
   @Test
+  fun handleCalendarAdd_choosesWritableCalendarOverReadOnlyPrimary() {
+    val provider =
+      registerCalendarProvider(
+        TestCalendar(id = 11, title = "Subscribed", primary = true, access = CalendarContract.Calendars.CAL_ACCESS_READ),
+        TestCalendar(id = 22, title = "Writable", primary = false, access = CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR),
+      )
+
+    val result = CalendarHandler(appContext()).handleCalendarAdd(calendarAddParams())
+
+    assertTrue(result.ok)
+    assertEquals(22L, provider.insertedCalendarId)
+  }
+
+  @Test
+  fun handleCalendarAdd_returnsNotFoundWhenOnlyVisibleCalendarIsReadOnly() {
+    val provider =
+      registerCalendarProvider(
+        TestCalendar(id = 11, title = "Subscribed", primary = true, access = CalendarContract.Calendars.CAL_ACCESS_READ),
+      )
+
+    val result = CalendarHandler(appContext()).handleCalendarAdd(calendarAddParams())
+
+    assertFalse(result.ok)
+    assertEquals("CALENDAR_NOT_FOUND", result.error?.code)
+    assertNull(provider.insertedCalendarId)
+  }
+
+  @Test
+  fun handleCalendarAdd_preservesWritablePrimaryPreference() {
+    val provider =
+      registerCalendarProvider(
+        TestCalendar(id = 11, title = "Primary", primary = true, access = CalendarContract.Calendars.CAL_ACCESS_OWNER),
+        TestCalendar(id = 22, title = "Other", primary = false, access = CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR),
+      )
+
+    val result = CalendarHandler(appContext()).handleCalendarAdd(calendarAddParams())
+
+    assertTrue(result.ok)
+    assertEquals(11L, provider.insertedCalendarId)
+  }
+
+  @Test
+  fun handleCalendarAdd_preservesExplicitReadOnlyCalendarSelection() {
+    val provider =
+      registerCalendarProvider(
+        TestCalendar(id = 11, title = "Subscribed", primary = true, access = CalendarContract.Calendars.CAL_ACCESS_READ),
+        TestCalendar(id = 22, title = "Writable", primary = false, access = CalendarContract.Calendars.CAL_ACCESS_OWNER),
+      )
+
+    val byId = CalendarHandler(appContext()).handleCalendarAdd(calendarAddParams("\"calendarId\":11"))
+    assertTrue(byId.ok)
+    assertEquals(11L, provider.insertedCalendarId)
+
+    val byTitle = CalendarHandler(appContext()).handleCalendarAdd(calendarAddParams("\"calendarTitle\":\"Subscribed\""))
+    assertTrue(byTitle.ok)
+    assertEquals(11L, provider.insertedCalendarId)
+  }
+
+  @Test
   fun handleCalendarAdd_normalizesAllDayEventForAndroidProvider() {
     val source = FakeCalendarDataSource(canRead = true, canWrite = true)
     val handler = CalendarHandler.forTesting(appContext(), source)
@@ -179,6 +249,104 @@ class CalendarHandlerTest : NodeHandlerRobolectricTest() {
     assertEquals(Instant.parse("2026-07-05T09:15:00Z").toEpochMilli(), request.startMs)
     assertEquals(Instant.parse("2026-07-05T10:45:00Z").toEpochMilli(), request.endMs)
   }
+
+  private fun registerCalendarProvider(vararg calendars: TestCalendar): TestCalendarProvider {
+    val app = appContext() as Application
+    shadowOf(app).grantPermissions(Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_CALENDAR)
+    return TestCalendarProvider(calendars.toList()).also { provider ->
+      ShadowContentResolver.registerProviderInternal(CalendarContract.AUTHORITY, provider)
+    }
+  }
+
+  private fun calendarAddParams(extra: String? = null): String = """{"title":"Meeting","startISO":"2026-07-05T09:00:00Z","endISO":"2026-07-05T10:00:00Z"${extra?.let { ",$it" }.orEmpty()}}"""
+}
+
+private data class TestCalendar(
+  val id: Long,
+  val title: String,
+  val primary: Boolean,
+  val access: Int,
+)
+
+private class TestCalendarProvider(
+  calendars: List<TestCalendar>,
+) : ContentProvider() {
+  private val database =
+    SQLiteDatabase.create(null).apply {
+      execSQL(
+        "CREATE TABLE calendars (_id INTEGER PRIMARY KEY, calendar_displayName TEXT, visible INTEGER, " +
+          "isPrimary INTEGER, calendar_access_level INTEGER)",
+      )
+      execSQL(
+        "CREATE TABLE events (_id INTEGER PRIMARY KEY AUTOINCREMENT, calendar_id INTEGER, title TEXT, " +
+          "dtstart INTEGER, dtend INTEGER, allDay INTEGER, eventTimezone TEXT, eventLocation TEXT, " +
+          "description TEXT, calendar_displayName TEXT)",
+      )
+      for (calendar in calendars) {
+        insert(
+          "calendars",
+          null,
+          ContentValues().apply {
+            put(CalendarContract.Calendars._ID, calendar.id)
+            put(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME, calendar.title)
+            put(CalendarContract.Calendars.VISIBLE, 1)
+            put(CalendarContract.Calendars.IS_PRIMARY, if (calendar.primary) 1 else 0)
+            put(CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL, calendar.access)
+          },
+        )
+      }
+    }
+
+  var insertedCalendarId: Long? = null
+    private set
+
+  override fun onCreate(): Boolean = true
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+    sortOrder: String?,
+  ): Cursor = database.query(uri.pathSegments.first(), projection, selection, selectionArgs, null, null, sortOrder)
+
+  override fun insert(
+    uri: Uri,
+    values: ContentValues?,
+  ): Uri {
+    val event = ContentValues(requireNotNull(values))
+    val calendarId = event.getAsLong(CalendarContract.Events.CALENDAR_ID)
+    insertedCalendarId = calendarId
+    database
+      .query(
+        "calendars",
+        arrayOf(CalendarContract.Calendars.CALENDAR_DISPLAY_NAME),
+        "${CalendarContract.Calendars._ID}=?",
+        arrayOf(calendarId.toString()),
+        null,
+        null,
+        null,
+      ).use { cursor ->
+        if (cursor.moveToFirst()) event.put(CalendarContract.Events.CALENDAR_DISPLAY_NAME, cursor.getString(0))
+      }
+    val eventId = database.insertOrThrow("events", null, event)
+    return ContentUris.withAppendedId(uri, eventId)
+  }
+
+  override fun delete(
+    uri: Uri,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+  ): Int = 0
+
+  override fun update(
+    uri: Uri,
+    values: ContentValues?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+  ): Int = 0
+
+  override fun getType(uri: Uri): String? = null
 }
 
 private class FakeCalendarDataSource(


### PR DESCRIPTION
## What Problem This Solves

Android `calendar.add` currently chooses the first visible primary calendar when the caller does not specify `calendarId` or `calendarTitle`. Android's CalendarProvider can still accept writes into a calendar whose declared access level is read-only, so an event is silently stored in the wrong subscribed calendar even when a writable calendar is available.

## Why This Change Was Made

Require the existing default-calendar lookup to select visible calendars with at least `CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR`. Android defines that level as the minimum permission to modify a calendar. Keep the existing primary-calendar preference among eligible calendars and preserve explicit calendar ID/title selection, Android runtime permissions, event validation, and public command shape.

The query absorbs the change by inlining its single-use projection. Production delta: +3/-3, net zero. Permanent owner tests: +168.

## Evidence

Fail-first owner coverage invokes the production `SystemCalendarDataSource` through a real `ContentResolver` and SQLite-backed test provider:

- Frozen baseline: 13 tests, two intended failures. A visible read-only primary with access level 200 receives the event instead of the writable contributor-level calendar; a read-only-only setup incorrectly succeeds.
- Fixed owner suite: all 13 tests pass, including writable-primary preference and unchanged explicit `calendarId` / `calendarTitle` behavior.
- Full Android hosted-equivalent lint passes for all four modules: app, benchmark, wear, and wear-shared.
- Structured review completed with no accepted or actionable findings.

Real Android API 36 CalendarProvider proof uses the same signed Play application and instrumentation APK before and after the fix. Both runtime calendar permissions are granted, local calendars are inserted using Android's actual sync-adapter contract, and the application invokes its production `CalendarHandler`.

Frozen baseline:

```text
READONLY_ID=1 ACCESS=200 PRIMARY=1
WRITABLE_ID=2 ACCESS=500 PRIMARY=0
EVENT_CALENDAR_ID=1 EXPECTED_WRITABLE_ID=2
READONLY_RESULT_OK=true ERROR=null
Tests run: 3, Failures: 2
```

Fixed application on the same Android provider:

```text
READONLY_ID=1 ACCESS=200 PRIMARY=1
WRITABLE_ID=2 ACCESS=500 PRIMARY=0
EVENT_CALENDAR_ID=2 EXPECTED_WRITABLE_ID=2
READONLY_RESULT_OK=false ERROR=CALENDAR_NOT_FOUND
EXPLICIT_ID_AND_TITLE_OK=true
OK (3 tests)
```

The final provider query returns no rows after proof cleanup. No device permissions, installed-app visibility, explicit calendar-selection behavior, configuration, or gateway policy are changed.
