### PR TITLE
fix(qa): repair cloud disappearance proof

### DIFF
--- a/qa/scenarios/runtime/cloud-worker-disappearance.yaml
+++ b/qa/scenarios/runtime/cloud-worker-disappearance.yaml
@@ -8,12 +8,12 @@ scenario:
     secondary:
       - gateway.session-apis-sessions-list
       - gateway.restart-and-stop-gateway-restart
-  objective: Prove an isolated Gateway records an unexpected worker disappearance as a durable per-session failure and keeps another session on the same environment isolated.
+  objective: Prove an isolated Gateway records an unexpected worker disappearance as a durable per-session failure and keeps another session on its own logical environment isolated.
   successCriteria:
     - A real qa-channel turn succeeds through the mock OpenAI provider before worker state is injected.
-    - The static-SSH mock worker provider reports its seeded active lease as unknown during restart reconciliation.
+    - The static-SSH worker provider reports the seeded lease identity as unknown.
     - The active placement becomes failed with a bounded cloud-worker-disappeared terminal reason and timestamp.
-    - A second failed session referencing the same environment retains its own distinct terminal reason.
+    - A second failed session referencing a different logical environment retains its own distinct terminal reason.
     - Two additional Gateway replacements preserve both terminal reasons and the original terminal timestamps.
     - environments.list continues to expose the environment-scoped orphaned error independently.
   docsRefs:

--- a/test/e2e/qa-lab/runtime/cloud-worker-disappearance-proof.ts
+++ b/test/e2e/qa-lab/runtime/cloud-worker-disappearance-proof.ts
@@ -25,6 +25,7 @@ const VERDICT_FILE = "cloud-worker-disappearance-verdict.json";
 const BUNDLE_HASH = "a".repeat(64);
 const MANIFEST_REF = `sha256:${"b".repeat(64)}`;
 const ENVIRONMENT_ID = "qa-static-worker-loss";
+const INDEPENDENT_ENVIRONMENT_ID = "qa-static-worker-independent";
 const INDEPENDENT_REASON = "independent session failure";
 
 type ProducerOptions = { artifactBase: string; repoRoot: string };
@@ -193,7 +194,7 @@ function seedUnknownWorkerState(
       from: "requested",
       to: "provisioning",
       expectedGeneration: other.generation,
-      patch: { environmentId: ENVIRONMENT_ID },
+      patch: { environmentId: INDEPENDENT_ENVIRONMENT_ID },
     });
     store.fail({
       sessionId: isolated.sessionId,
@@ -231,13 +232,15 @@ async function waitForFailedPlacement(gateway: Gateway, session: SessionIdentity
 
 async function runProof(options: ProducerOptions) {
   const state = createQaBusState();
-  const bus = await startQaBusServer({ state });
-  const mock = await startQaMockOpenAiServer();
-  const transport = createQaChannelTransport(state);
+  let bus: Awaited<ReturnType<typeof startQaBusServer>> | undefined;
+  let mock: Awaited<ReturnType<typeof startQaMockOpenAiServer>> | undefined;
   let gateway: Gateway | undefined;
   let verdict: Record<string, unknown> | undefined;
   let proofError: unknown;
   try {
+    bus = await startQaBusServer({ state });
+    mock = await startQaMockOpenAiServer();
+    const transport = createQaChannelTransport(state);
     const inspection = await createStaticSshWorkerProvider().inspect({
       leaseId: "static-ssh:",
       profile: { settings: {} },
@@ -280,12 +283,18 @@ async function runProof(options: ProducerOptions) {
     });
     const first = await waitForFailedPlacement(gateway, lost);
     const independent = await waitForFailedPlacement(gateway, isolated);
+    if (
+      first.environmentId !== ENVIRONMENT_ID ||
+      independent.environmentId !== INDEPENDENT_ENVIRONMENT_ID
+    ) {
+      throw new Error("session placements did not retain their distinct environment identities");
+    }
     const firstReason = String(first.terminalReason ?? "");
     if (!firstReason.startsWith("cloud worker disappeared:") || firstReason.length > 1_024) {
       throw new Error(`unexpected disappearance reason: ${firstReason}`);
     }
     if (independent.terminalReason !== INDEPENDENT_REASON || firstReason === INDEPENDENT_REASON) {
-      throw new Error("sessions sharing an environment leaked terminal reasons");
+      throw new Error("independent session placements leaked terminal reasons");
     }
     const terminalAtMs = first.terminalAtMs;
     const isolatedTerminalAtMs = independent.terminalAtMs;
@@ -327,15 +336,19 @@ async function runProof(options: ProducerOptions) {
       gatewayReplacementCount: 3,
       disappearance: {
         sessionId: lost.sessionId,
+        environmentId: ENVIRONMENT_ID,
         terminalReason: firstReason,
         terminalAtMs,
         durableAcrossRestarts: true,
       },
       isolation: {
-        sharedEnvironmentId: ENVIRONMENT_ID,
+        environmentId: INDEPENDENT_ENVIRONMENT_ID,
         otherSessionId: isolated.sessionId,
         otherTerminalReason: independent.terminalReason,
+        otherTerminalAtMs: isolatedTerminalAtMs,
+        distinctEnvironments: true,
         reasonsDistinct: true,
+        durableAcrossRestarts: true,
       },
       environment: { state: worker.state, error: worker.error },
     };
@@ -347,21 +360,22 @@ async function runProof(options: ProducerOptions) {
     );
   } catch (error) {
     proofError = error;
-  }
-  const cleanup = await Promise.allSettled([
-    gateway?.stop() ?? Promise.resolve(),
-    bus.stop(),
-    mock.stop(),
-  ]);
-  const cleanupFailures = cleanup.flatMap((result) =>
-    result.status === "rejected" ? [result.reason] : [],
-  );
-  if (cleanupFailures.length > 0) {
-    proofError = new AggregateError(
-      proofError ? [proofError, ...cleanupFailures] : cleanupFailures,
-      "cloud worker disappearance cleanup failed",
-      proofError ? { cause: proofError } : undefined,
+  } finally {
+    const cleanup = await Promise.allSettled([
+      gateway?.stop() ?? Promise.resolve(),
+      bus?.stop() ?? Promise.resolve(),
+      mock?.stop() ?? Promise.resolve(),
+    ]);
+    const cleanupFailures = cleanup.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
     );
+    if (cleanupFailures.length > 0) {
+      proofError = new AggregateError(
+        proofError ? [proofError, ...cleanupFailures] : cleanupFailures,
+        "cloud worker disappearance cleanup failed",
+        proofError ? { cause: proofError } : undefined,
+      );
+    }
   }
   if (proofError) {
     throw proofError;


### PR DESCRIPTION
Closes #129048

## What Problem This Solves

The registered cloud-worker disappearance QA scenario no longer reached reconciliation. Its state fixture attached an active lost session and an independent failed session to the same worker environment, so current Gateway startup correctly rejected the impossible topology with `Worker environment qa-static-worker-loss has multiple placement owners`.

## Why This Change Was Made

Static-SSH sessions can share a physical host, but each logical lease/session still owns a distinct worker environment. The fixture now gives the independent failed placement its own environment identity and explicitly verifies both identities after recovery. The scenario wording and verdict no longer claim an unsupported shared-environment state; they retain the intended per-session terminal-reason isolation and restart-durability checks.

The script also now places QA bus and mock-provider startup inside its cleanup owner. Partial startup failures stop only acquired resources, and cleanup failures remain aggregated with the original proof error.

Production LOC: 0 | QA scenario metadata: +3/-3 | Test support: +34/-20 (net +14)

AI-assisted: yes. I reviewed current worker environment ownership, static-SSH logical leases, placement failure persistence, restart recovery, environment projection, and partial-startup cleanup.

## User Impact

Maintainers and CI regain a truthful current-main disappearance/restart proof. Invalid fixture state no longer prevents the scenario from checking durable worker-loss diagnostics, independent session failure facts, and `environments.list` orphan reporting.

## Evidence

- Pre-fix real producer run: the replacement Gateway failed during sidecar startup because `qa-static-worker-loss` had multiple placement owners.
- Post-fix exact-head producer run passed in 48.6 seconds across three Gateway generations.
- The verdict proves:
  - the lost active placement failed with `cloud worker disappeared: Worker provider no longer recognizes lease`;
  - its terminal reason/timestamp survived two additional restarts;
  - the independent failed placement kept its own reason/timestamp on a distinct environment across the same restarts;
  - `environments.list` retained the orphaned environment error;
  - no proof process remained after cleanup.
- `node scripts/check-changed.mjs` passed the fail-safe all-lanes plan: full core/UI/extension/script/test typechecks, full lint, formatting, metadata/architecture guards, database-first, and import cycles.
- Fresh exact-branch P0/P1 autoreview has no accepted/actionable findings (0.94).
- Evidence files are under `.artifacts/qa/cloud-worker-disappearance-repaired/qa-evidence.json` and `cloud-worker-disappearance-verdict.json`.
