### PR TITLE
improve(test): skip Control UI update recordings unless requested

### DIFF
--- a/ui/src/e2e/update-coalesced.e2e.test.ts
+++ b/ui/src/e2e/update-coalesced.e2e.test.ts
@@ -10,6 +10,7 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const NATIVE_UPDATE_DECLINED_EVENT = "openclaw:native-update-declined";
 const MANAGED_UPDATE_HANDOFF_RESPONSE = {
   ok: true,
@@ -26,6 +27,17 @@ async function openUpdateConfirmation(page: Page): Promise<void> {
   await updateIssue.locator(".sidebar-update-card__action").click();
 }
 
+async function captureUpdateProof(
+  page: Page,
+  artifactDir: string,
+  fileName: string,
+): Promise<void> {
+  if (!captureUiProofEnabled) {
+    return;
+  }
+  await page.screenshot({ path: path.join(artifactDir, fileName) });
+}
+
 suite.define(() => {
   it("explains a disabled update to a read-only mobile operator", async () => {
     const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-read-only-mobile");
@@ -35,7 +47,9 @@ suite.define(() => {
         hasTouch: true,
         isMobile: true,
         locale: "en-US",
-        recordVideo: { dir: artifactDir, size: { height: 1200, width: 555 } },
+        recordVideo: captureUiProofEnabled
+          ? { dir: artifactDir, size: { height: 1200, width: 555 } }
+          : undefined,
         serviceWorkers: "block",
         viewport: { height: 1200, width: 555 },
       },
@@ -65,7 +79,7 @@ suite.define(() => {
         expect(await action.evaluate((element) => (element as HTMLButtonElement).disabled)).toBe(
           false,
         );
-        await page.screenshot({ path: path.join(artifactDir, "disabled-update.png") });
+        await captureUpdateProof(page, artifactDir, "disabled-update.png");
 
         const actionBounds = await action.boundingBox();
         if (!actionBounds) {
@@ -86,7 +100,7 @@ suite.define(() => {
         await expect.poll(() => tooltip.getAttribute("data-e2e-after-show")).not.toBeNull();
         expect(await tooltip.textContent()).toContain("Administrator access is required");
         expect(await gateway.getRequests("update.run")).toHaveLength(0);
-        await page.screenshot({ path: path.join(artifactDir, "disabled-update-tooltip.png") });
+        await captureUpdateProof(page, artifactDir, "disabled-update-tooltip.png");
       },
     );
   });
@@ -96,7 +110,9 @@ suite.define(() => {
     await suite.withPage(
       {
         locale: "en-US",
-        recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
+        recordVideo: captureUiProofEnabled
+          ? { dir: artifactDir, size: { height: 720, width: 1280 } }
+          : undefined,
         serviceWorkers: "block",
         viewport: { height: 720, width: 1280 },
       },
@@ -145,7 +161,7 @@ suite.define(() => {
         await updateIssue.locator(".sidebar-update-card__compact-reason").waitFor();
         expect(await page.locator(".sidebar-footer-update").count()).toBe(1);
         expect(pageErrors).toEqual([]);
-        await page.screenshot({ path: path.join(artifactDir, "package-update-failure.png") });
+        await captureUpdateProof(page, artifactDir, "package-update-failure.png");
       },
     );
   });
@@ -155,7 +171,9 @@ suite.define(() => {
     await suite.withPage(
       {
         locale: "en-US",
-        recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
+        recordVideo: captureUiProofEnabled
+          ? { dir: artifactDir, size: { height: 720, width: 1280 } }
+          : undefined,
         serviceWorkers: "block",
         viewport: { height: 720, width: 1280 },
       },
@@ -203,7 +221,7 @@ suite.define(() => {
           .waitFor();
         expect(await page.locator(".sidebar-footer-update").count()).toBe(1);
         expect(pageErrors).toEqual([]);
-        await page.screenshot({ path: path.join(artifactDir, "coalesced-restart-banner.png") });
+        await captureUpdateProof(page, artifactDir, "coalesced-restart-banner.png");
       },
     );
   });
@@ -232,7 +250,9 @@ suite.define(() => {
       await suite.withPage(
         {
           locale: "en-US",
-          recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } },
+          recordVideo: captureUiProofEnabled
+            ? { dir: artifactDir, size: { height: 720, width: 1280 } }
+            : undefined,
           serviceWorkers: "block",
           viewport: { height: 720, width: 1280 },
         },
@@ -293,9 +313,7 @@ suite.define(() => {
           expect(await gateway.getRequests("update.run")).toHaveLength(1);
           expect(await gateway.getRequests("update.status")).toHaveLength(expectedStatusRequests);
           expect(pageErrors).toEqual([]);
-          await page.screenshot({
-            path: path.join(artifactDir, `managed-handoff-${artifactName}.png`),
-          });
+          await captureUpdateProof(page, artifactDir, `managed-handoff-${artifactName}.png`);
         },
       );
     },
@@ -367,7 +385,7 @@ suite.define(() => {
       );
       await expect.poll(async () => (await gateway.getRequests("update.run")).length).toBe(1);
       expect(pageErrors).toEqual([]);
-      await page.screenshot({ path: path.join(artifactDir, "gateway-update-target.png") });
+      await captureUpdateProof(page, artifactDir, "gateway-update-target.png");
     } finally {
       await context.close();
     }


### PR DESCRIPTION
## What Problem This Solves

Ordinary Control UI update end-to-end runs recorded five browser videos and seven screenshots even when nobody requested visual proof. Besides slowing the standard CI path, the unconditional recordings made otherwise unrelated update coverage fail on machines without Playwright's optional FFmpeg browser component.

## Why This Change Was Made

The update end-to-end suite now follows the existing `OPENCLAW_CAPTURE_UI_PROOF=1` opt-in contract already used by neighboring Control UI suites. Real browser interactions, Gateway responses, authorization checks, both managed-handoff orderings, and native update ownership remain unchanged; explicit proof runs still capture every existing artifact.

## User Impact

No production behavior changes. Developers and CI retain all six meaningful browser scenarios while the measured update suite improves from 22.41 seconds to 20.47 seconds on average (-1.94 seconds; -8.67%), with 33.8% less combined user/system CPU.

## Evidence

- One Blacksmith Testbox, one worker, excluded warmup, two untouched retained baselines, and eight order-balanced/interleaved retained comparisons with distinct module caches and import diagnostics.
- Capture enabled: 21.38, 21.18, 23.56, and 23.51 seconds; capture disabled: 19.55, 19.70, 20.82, and 21.79 seconds. All 48 browser cases passed; the imported-module count stayed unchanged.
- Explicit capture mode still produced all seven expected screenshots and five browser videos, including both response-first and disconnect-first managed-handoff recordings.
- A reversible production fault changing the read-only update button's `aria-disabled` value to `false` failed the unchanged real-browser assertion with capture disabled; restoring the owner passed all six browser cases and all ten component-owner tests.
- Full hydrated Testbox `pnpm check:changed` passed, including core test typechecking, dependency and coercion guards, Knip, UI i18n, format, and lint: https://github.com/openclaw/openclaw/actions/runs/32814261024
- Fresh canonical independent autoreview passed without actionable findings. Production LOC: +0/-0; existing test-owner LOC: +30/-12. No snapshots, baselines, dependencies, product code, or lifecycle timing were changed.
