### PR TITLE
test(core): deduplicate runtime fixtures

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -563,6 +563,33 @@ describe("agentLoop streaming updates", () => {
 });
 
 describe("runAgentLoop deferred tool hydration", () => {
+  function createDeferredToolStream(
+    toolCalls: AssistantMessage["content"],
+    contexts?: Context[],
+  ): StreamFn {
+    let streamCalls = 0;
+    return (_model, context) => {
+      contexts?.push({ ...context, tools: context.tools?.slice() });
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        streamCalls += 1;
+        const stopReason = streamCalls === 1 ? "toolUse" : "stop";
+        const message: AssistantMessage = {
+          role: "assistant",
+          content: streamCalls === 1 ? toolCalls : [{ type: "text", text: "done" }],
+          api: "faux",
+          provider: "faux",
+          model: "faux-1",
+          usage: TEST_USAGE,
+          stopReason,
+          timestamp: Date.now(),
+        };
+        stream.push({ type: "done", reason: stopReason, message });
+      });
+      return stream;
+    };
+  }
+
   it("hydrates an authorized deferred tool for execution and the continuation", async () => {
     const execute = vi.fn(
       async (): Promise<AgentToolResult<unknown>> => ({
@@ -582,49 +609,17 @@ describe("runAgentLoop deferred tool hydration", () => {
       execute,
     };
     const contexts: Context[] = [];
-    let streamCalls = 0;
-    const streamFn: StreamFn = (_model, context) => {
-      contexts.push({ ...context, tools: context.tools?.slice() });
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        streamCalls += 1;
-        const message =
-          streamCalls === 1
-            ? {
-                role: "assistant" as const,
-                content: [
-                  {
-                    type: "toolCall" as const,
-                    id: "call-hidden",
-                    name: "hidden_search",
-                    arguments: { query: "penguin" },
-                  },
-                ],
-                api: "faux",
-                provider: "faux",
-                model: "faux-1",
-                usage: TEST_USAGE,
-                stopReason: "toolUse" as const,
-                timestamp: Date.now(),
-              }
-            : {
-                role: "assistant" as const,
-                content: [{ type: "text" as const, text: "done" }],
-                api: "faux",
-                provider: "faux",
-                model: "faux-1",
-                usage: TEST_USAGE,
-                stopReason: "stop" as const,
-                timestamp: Date.now(),
-              };
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-      });
-      return stream;
-    };
+    const streamFn = createDeferredToolStream(
+      [
+        {
+          type: "toolCall",
+          id: "call-hidden",
+          name: "hidden_search",
+          arguments: { query: "penguin" },
+        },
+      ],
+      contexts,
+    );
     const resolveDeferredTool = vi.fn(() => hiddenTool);
 
     const messages = await runAgentLoop(
@@ -655,48 +650,9 @@ describe("runAgentLoop deferred tool hydration", () => {
   });
 
   it("resolves a missing deferred tool once across pre-scan and preparation", async () => {
-    let streamCalls = 0;
-    const streamFn: StreamFn = () => {
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        streamCalls += 1;
-        const message =
-          streamCalls === 1
-            ? {
-                role: "assistant" as const,
-                content: [
-                  {
-                    type: "toolCall" as const,
-                    id: "call-missing",
-                    name: "missing_deferred",
-                    arguments: {},
-                  },
-                ],
-                api: "faux",
-                provider: "faux",
-                model: "faux-1",
-                usage: TEST_USAGE,
-                stopReason: "toolUse" as const,
-                timestamp: Date.now(),
-              }
-            : {
-                role: "assistant" as const,
-                content: [{ type: "text" as const, text: "done" }],
-                api: "faux",
-                provider: "faux",
-                model: "faux-1",
-                usage: TEST_USAGE,
-                stopReason: "stop" as const,
-                timestamp: Date.now(),
-              };
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-      });
-      return stream;
-    };
+    const streamFn = createDeferredToolStream([
+      { type: "toolCall", id: "call-missing", name: "missing_deferred", arguments: {} },
+    ]);
     const resolveDeferredTool = vi.fn(() => undefined);
 
     const messages = await runAgentLoop(
@@ -723,48 +679,9 @@ describe("runAgentLoop deferred tool hydration", () => {
   });
 
   it("converts deferred resolver failures into one error tool result", async () => {
-    let streamCalls = 0;
-    const streamFn: StreamFn = () => {
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        streamCalls += 1;
-        const message =
-          streamCalls === 1
-            ? {
-                role: "assistant" as const,
-                content: [
-                  {
-                    type: "toolCall" as const,
-                    id: "call-failing-deferred",
-                    name: "failing_deferred",
-                    arguments: {},
-                  },
-                ],
-                api: "faux",
-                provider: "faux",
-                model: "faux-1",
-                usage: TEST_USAGE,
-                stopReason: "toolUse" as const,
-                timestamp: Date.now(),
-              }
-            : {
-                role: "assistant" as const,
-                content: [{ type: "text" as const, text: "done" }],
-                api: "faux",
-                provider: "faux",
-                model: "faux-1",
-                usage: TEST_USAGE,
-                stopReason: "stop" as const,
-                timestamp: Date.now(),
-              };
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-      });
-      return stream;
-    };
+    const streamFn = createDeferredToolStream([
+      { type: "toolCall", id: "call-failing-deferred", name: "failing_deferred", arguments: {} },
+    ]);
     const resolveDeferredTool = vi.fn(async () => {
       throw new Error("deferred hydration failed");
     });
@@ -808,49 +725,17 @@ describe("runAgentLoop deferred tool hydration", () => {
       execute,
     };
     const contexts: Context[] = [];
-    let streamCalls = 0;
-    const streamFn: StreamFn = (_model, context) => {
-      contexts.push({ ...context, tools: context.tools?.slice() });
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        streamCalls += 1;
-        const message =
-          streamCalls === 1
-            ? {
-                role: "assistant" as const,
-                content: [
-                  {
-                    type: "toolCall" as const,
-                    id: "call-requested-deferred",
-                    name: "requested_deferred",
-                    arguments: {},
-                  },
-                ],
-                api: "faux",
-                provider: "faux",
-                model: "faux-1",
-                usage: TEST_USAGE,
-                stopReason: "toolUse" as const,
-                timestamp: Date.now(),
-              }
-            : {
-                role: "assistant" as const,
-                content: [{ type: "text" as const, text: "done" }],
-                api: "faux",
-                provider: "faux",
-                model: "faux-1",
-                usage: TEST_USAGE,
-                stopReason: "stop" as const,
-                timestamp: Date.now(),
-              };
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-      });
-      return stream;
-    };
+    const streamFn = createDeferredToolStream(
+      [
+        {
+          type: "toolCall",
+          id: "call-requested-deferred",
+          name: "requested_deferred",
+          arguments: {},
+        },
+      ],
+      contexts,
+    );
 
     const messages = await runAgentLoop(
       [{ role: "user", content: "call requested tool", timestamp: Date.now() }],
@@ -912,50 +797,10 @@ describe("runAgentLoop deferred tool hydration", () => {
       executionMode: "sequential",
       execute,
     };
-    let streamCalls = 0;
-    const streamFn: StreamFn = () => {
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        streamCalls += 1;
-        const message =
-          streamCalls === 1
-            ? {
-                role: "assistant" as const,
-                content: [
-                  {
-                    type: "toolCall" as const,
-                    id: "call-hidden-1",
-                    name: "hidden_serial",
-                    arguments: { query: "one" },
-                  },
-                  {
-                    type: "toolCall" as const,
-                    id: "call-hidden-2",
-                    name: "hidden_serial",
-                    arguments: { query: "two" },
-                  },
-                ],
-                api: "faux",
-                provider: "faux",
-                model: "faux-1",
-                usage: TEST_USAGE,
-                stopReason: "toolUse" as const,
-                timestamp: Date.now(),
-              }
-            : {
-                role: "assistant" as const,
-                content: [{ type: "text" as const, text: "done" }],
-                api: "faux",
-                provider: "faux",
-                model: "faux-1",
-                usage: TEST_USAGE,
-                stopReason: "stop" as const,
-                timestamp: Date.now(),
-              };
-        stream.push({ type: "done", reason: message.stopReason, message });
-      });
-      return stream;
-    };
+    const streamFn = createDeferredToolStream([
+      { type: "toolCall", id: "call-hidden-1", name: "hidden_serial", arguments: { query: "one" } },
+      { type: "toolCall", id: "call-hidden-2", name: "hidden_serial", arguments: { query: "two" } },
+    ]);
     const resolveDeferredTool = vi.fn(() => hiddenTool);
 
     await runAgentLoop(
@@ -1028,11 +873,13 @@ describe("agentLoop tool termination", () => {
 
   function createTurnSequenceStream(
     turns: AssistantMessage["content"][],
-    requestMessages: Message[][],
+    requestMessages: Message[][] = [],
+    onRequest?: (context: Context, turn: number) => void,
   ): StreamFn {
     let turnIndex = 0;
     return (_activeModel, context) => {
       requestMessages.push(context.messages.slice());
+      onRequest?.(context, turnIndex + 1);
       const content = turns[turnIndex];
       turnIndex += 1;
       if (!content) {
@@ -1840,26 +1687,17 @@ describe("agentLoop tool termination", () => {
     const executed: string[] = [];
     const providerToolNames: string[][] = [];
     let turn = 0;
-    const streamFn: StreamFn = (_activeModel, context) => {
-      providerToolNames.push(context.tools?.map((tool) => tool.name) ?? []);
-      turn += 1;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message =
-          turn === 1
-            ? makeAssistantMessage([
-                { type: "toolCall", id: "loop-1", name: "read", arguments: {} },
-              ])
-            : makeAssistantMessage([{ type: "text", text: "recovered" }]);
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream(
+      [
+        [{ type: "toolCall", id: "loop-1", name: "read", arguments: {} }],
+        [{ type: "text", text: "recovered" }],
+      ],
+      [],
+      (context, currentTurn) => {
+        providerToolNames.push(context.tools?.map((tool) => tool.name) ?? []);
+        turn = currentTurn;
+      },
+    );
     const events = await collectEvents(
       agentLoop(
         [{ role: "user", content: "run", timestamp: 1 }],
@@ -1902,25 +1740,16 @@ describe("agentLoop tool termination", () => {
   it("does not taint the recovery turn with an unexecuted network tool source", async () => {
     const executed: string[] = [];
     let turn = 0;
-    const streamFn: StreamFn = () => {
-      turn += 1;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message =
-          turn === 1
-            ? makeAssistantMessage([
-                { type: "toolCall", id: "loop-1", name: "fetch", arguments: {} },
-              ])
-            : makeAssistantMessage([{ type: "text", text: "recovered" }]);
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream(
+      [
+        [{ type: "toolCall", id: "loop-1", name: "fetch", arguments: {} }],
+        [{ type: "text", text: "recovered" }],
+      ],
+      [],
+      (_context, currentTurn) => {
+        turn = currentTurn;
+      },
+    );
     const networkTool: AgentTool = {
       ...makeTool("fetch", executed),
       resultContentSource: "network",
@@ -2102,31 +1931,17 @@ describe("agentLoop tool termination", () => {
   it("executes a different recovery action and keeps the one-shot budget spent", async () => {
     const executed: string[] = [];
     let turn = 0;
-    const streamFn: StreamFn = () => {
-      turn += 1;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message =
-          turn === 1
-            ? makeAssistantMessage([
-                { type: "toolCall", id: "loop-1", name: "read", arguments: {} },
-              ])
-            : turn === 2
-              ? makeAssistantMessage([
-                  { type: "toolCall", id: "safe-1", name: "list", arguments: {} },
-                ])
-              : makeAssistantMessage([
-                  { type: "toolCall", id: "loop-2", name: "read", arguments: {} },
-                ]);
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream(
+      [
+        [{ type: "toolCall", id: "loop-1", name: "read", arguments: {} }],
+        [{ type: "toolCall", id: "safe-1", name: "list", arguments: {} }],
+        [{ type: "toolCall", id: "loop-2", name: "read", arguments: {} }],
+      ],
+      [],
+      (_context, currentTurn) => {
+        turn = currentTurn;
+      },
+    );
     const events = await collectEvents(
       agentLoop(
         [{ role: "user", content: "run", timestamp: 1 }],
@@ -2180,28 +1995,19 @@ describe("agentLoop tool termination", () => {
     async (toolExecution) => {
       const executed: string[] = [];
       let turn = 0;
-      const streamFn: StreamFn = () => {
-        turn += 1;
-        const stream = createAssistantMessageEventStream();
-        queueMicrotask(() => {
-          const message =
-            turn === 1
-              ? makeAssistantMessage([
-                  { type: "toolCall", id: "loop-1", name: "read", arguments: {} },
-                ])
-              : makeAssistantMessage([
-                  { type: "toolCall", id: "safe-1", name: "write", arguments: {} },
-                  { type: "toolCall", id: "loop-2", name: "read", arguments: {} },
-                ]);
-          stream.push({
-            type: "done",
-            reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-            message,
-          });
-          stream.end();
-        });
-        return stream;
-      };
+      const streamFn = createTurnSequenceStream(
+        [
+          [{ type: "toolCall", id: "loop-1", name: "read", arguments: {} }],
+          [
+            { type: "toolCall", id: "safe-1", name: "write", arguments: {} },
+            { type: "toolCall", id: "loop-2", name: "read", arguments: {} },
+          ],
+        ],
+        [],
+        (_context, currentTurn) => {
+          turn = currentTurn;
+        },
+      );
       const events = await collectEvents(
         agentLoop(
           [{ role: "user", content: "run", timestamp: 1 }],
@@ -2338,30 +2144,14 @@ describe("agentLoop tool termination", () => {
   ])(
     "persists $source tool-result taint through the assistant turn",
     async ({ source, tainted }) => {
-      let turn = 0;
       const tool: AgentTool = {
         ...makeTool("fetch", []),
         ...(source ? { resultContentSource: source } : {}),
       };
-      const streamFn: StreamFn = () => {
-        turn += 1;
-        const stream = createAssistantMessageEventStream();
-        queueMicrotask(() => {
-          const message =
-            turn === 1
-              ? makeAssistantMessage([
-                  { type: "toolCall", id: "call-fetch", name: tool.name, arguments: {} },
-                ])
-              : makeAssistantMessage([{ type: "text", text: "stored result" }]);
-          stream.push({
-            type: "done",
-            reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-            message,
-          });
-          stream.end();
-        });
-        return stream;
-      };
+      const streamFn = createTurnSequenceStream([
+        [{ type: "toolCall", id: "call-fetch", name: tool.name, arguments: {} }],
+        [{ type: "text", text: "stored result" }],
+      ]);
 
       const stream = agentLoop(
         [{ role: "user", content: "fetch", timestamp: 1 }],
@@ -2394,7 +2184,6 @@ describe("agentLoop tool termination", () => {
   ] as const)(
     "never stamps external provenance on %s %s calls that did not execute",
     async (toolExecution, failure) => {
-      let turn = 0;
       const executed: string[] = [];
       const tool: AgentTool = {
         ...makeTool("network_probe", executed),
@@ -2403,25 +2192,10 @@ describe("agentLoop tool termination", () => {
           ? { parameters: Type.Object({ query: Type.String() }) }
           : {}),
       };
-      const streamFn: StreamFn = () => {
-        const stream = createAssistantMessageEventStream();
-        queueMicrotask(() => {
-          turn += 1;
-          const message =
-            turn === 1
-              ? makeAssistantMessage([
-                  { type: "toolCall", id: "network-preflight", name: tool.name, arguments: {} },
-                ])
-              : makeAssistantMessage([{ type: "text", text: "local outcome" }]);
-          stream.push({
-            type: "done",
-            reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-            message,
-          });
-          stream.end();
-        });
-        return stream;
-      };
+      const streamFn = createTurnSequenceStream([
+        [{ type: "toolCall", id: "network-preflight", name: tool.name, arguments: {} }],
+        [{ type: "text", text: "local outcome" }],
+      ]);
       const stream = agentLoop(
         [{ role: "user", content: "network preflight", timestamp: 1 }],
         { systemPrompt: "", messages: [], tools: [tool] },
@@ -2469,21 +2243,9 @@ describe("agentLoop tool termination", () => {
           throw tainted ? new Error("remote failure after cancellation") : cancelReason;
         },
       };
-      const streamFn: StreamFn = () => {
-        const stream = createAssistantMessageEventStream();
-        queueMicrotask(() => {
-          const message = makeAssistantMessage([
-            { type: "toolCall", id: "network-cancel", name: tool.name, arguments: {} },
-          ]);
-          stream.push({
-            type: "done",
-            reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-            message,
-          });
-          stream.end();
-        });
-        return stream;
-      };
+      const streamFn = createTurnSequenceStream([
+        [{ type: "toolCall", id: "network-cancel", name: tool.name, arguments: {} }],
+      ]);
       const stream = agentLoop(
         [{ role: "user", content: failure, timestamp: 1 }],
         { systemPrompt: "", messages: [], tools: [tool] },
@@ -2558,26 +2320,10 @@ describe("agentLoop tool termination", () => {
   });
 
   it("marks lifecycle events from the concrete hidden tool instance", async () => {
-    let turn = 0;
-    const streamFn: StreamFn = () => {
-      turn += 1;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message =
-          turn === 1
-            ? makeAssistantMessage([
-                { type: "toolCall", id: "call-wait", name: "wait", arguments: {} },
-              ])
-            : makeAssistantMessage([{ type: "text", text: "done" }]);
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream([
+      [{ type: "toolCall", id: "call-wait", name: "wait", arguments: {} }],
+      [{ type: "text", text: "done" }],
+    ]);
     const hiddenTool: AgentTool = {
       ...makeTool("wait", []),
       hideFromChannelProgress: true,
@@ -2636,17 +2382,9 @@ describe("agentLoop tool termination", () => {
         };
       },
     };
-    const streamFn: StreamFn = () => {
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message = makeAssistantMessage([
-          { type: "toolCall", id: "call-delayed", name: tool.name, arguments: {} },
-        ]);
-        stream.push({ type: "done", reason: "toolUse", message });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream([
+      [{ type: "toolCall", id: "call-delayed", name: tool.name, arguments: {} }],
+    ]);
 
     const events = await collectEvents(
       agentLoop(
@@ -2673,29 +2411,17 @@ describe("agentLoop tool termination", () => {
   it("continues after a side-effect tool result when afterToolCall records it without terminate", async () => {
     const executed: string[] = [];
     let turn = 0;
-    const streamFn: StreamFn = () => {
-      turn += 1;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message =
-          turn === 1
-            ? makeAssistantMessage([
-                { type: "toolCall", id: "call-message", name: "message", arguments: {} },
-              ])
-            : turn === 2
-              ? makeAssistantMessage([
-                  { type: "toolCall", id: "call-exec", name: "exec", arguments: {} },
-                ])
-              : makeAssistantMessage([{ type: "text", text: "done" }]);
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream(
+      [
+        [{ type: "toolCall", id: "call-message", name: "message", arguments: {} }],
+        [{ type: "toolCall", id: "call-exec", name: "exec", arguments: {} }],
+        [{ type: "text", text: "done" }],
+      ],
+      [],
+      (_context, currentTurn) => {
+        turn = currentTurn;
+      },
+    );
     let recordedSideEffect = false;
 
     const stream = agentLoop(
@@ -2737,23 +2463,16 @@ describe("agentLoop tool termination", () => {
 
   it("normalizes a tool result with missing content before the next model turn", async () => {
     const contexts: Context[] = [];
-    let turn = 0;
-    const streamFn: StreamFn = (_activeModel, context) => {
-      contexts.push(context);
-      turn += 1;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message =
-          turn === 1
-            ? makeAssistantMessage([
-                { type: "toolCall", id: "call-empty", name: "empty", arguments: {} },
-              ])
-            : makeAssistantMessage([{ type: "text", text: "done" }]);
-        stream.push({ type: "done", reason: turn === 1 ? "toolUse" : "stop", message });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream(
+      [
+        [{ type: "toolCall", id: "call-empty", name: "empty", arguments: {} }],
+        [{ type: "text", text: "done" }],
+      ],
+      [],
+      (context) => {
+        contexts.push(context);
+      },
+    );
     const tool: AgentTool = {
       name: "empty",
       label: "empty",
@@ -2796,17 +2515,9 @@ describe("agentLoop tool termination", () => {
       parameters: Type.Object({}, { additionalProperties: false }),
       execute: async () => originalResult,
     };
-    const streamFn: StreamFn = () => {
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message = makeAssistantMessage([
-          { type: "toolCall", id: "call-patched", name: tool.name, arguments: {} },
-        ]);
-        stream.push({ type: "done", reason: "toolUse", message });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream([
+      [{ type: "toolCall", id: "call-patched", name: tool.name, arguments: {} }],
+    ]);
 
     const events = await collectEvents(
       agentLoop(
@@ -2835,26 +2546,10 @@ describe("agentLoop tool termination", () => {
 
   it("marks policy-blocked tool calls as not executed", async () => {
     const executed: string[] = [];
-    let turn = 0;
-    const streamFn: StreamFn = () => {
-      turn += 1;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message =
-          turn === 1
-            ? makeAssistantMessage([
-                { type: "toolCall", id: "call-cron", name: "cron", arguments: {} },
-              ])
-            : makeAssistantMessage([{ type: "text", text: "done" }]);
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream([
+      [{ type: "toolCall", id: "call-cron", name: "cron", arguments: {} }],
+      [{ type: "text", text: "done" }],
+    ]);
 
     const stream = agentLoop(
       [{ role: "user", content: "hello", timestamp: 1 }],
@@ -2886,26 +2581,10 @@ describe("agentLoop tool termination", () => {
     const afterToolOutcome = vi.fn(async () => ({
       details: { observed: "pre-execution" },
     }));
-    let turn = 0;
-    const streamFn: StreamFn = () => {
-      turn += 1;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message =
-          turn === 1
-            ? makeAssistantMessage([
-                { type: "toolCall", id: "call-edit", name: "edit", arguments: {} },
-              ])
-            : makeAssistantMessage([{ type: "text", text: "done" }]);
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream([
+      [{ type: "toolCall", id: "call-edit", name: "edit", arguments: {} }],
+      [{ type: "text", text: "done" }],
+    ]);
     const tool: AgentTool = {
       ...makeTool("edit", executed),
       parameters: Type.Object({ path: Type.String() }, { additionalProperties: false }),
@@ -2948,26 +2627,10 @@ describe("agentLoop tool termination", () => {
   it("runs the finalized-outcome hook after the executed-only hook", async () => {
     const executed: string[] = [];
     const order: string[] = [];
-    let turn = 0;
-    const streamFn: StreamFn = () => {
-      turn += 1;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message =
-          turn === 1
-            ? makeAssistantMessage([
-                { type: "toolCall", id: "call-read", name: "read", arguments: {} },
-              ])
-            : makeAssistantMessage([{ type: "text", text: "done" }]);
-        stream.push({
-          type: "done",
-          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
-          message,
-        });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream([
+      [{ type: "toolCall", id: "call-read", name: "read", arguments: {} }],
+      [{ type: "text", text: "done" }],
+    ]);
 
     const events = await collectEvents(
       agentLoop(
@@ -3003,23 +2666,16 @@ describe("agentLoop tool termination", () => {
   it("preserves a terminal result when the finalized-outcome hook throws", async () => {
     const executed: string[] = [];
     let turn = 0;
-    const streamFn: StreamFn = () => {
-      turn += 1;
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        const message =
-          turn === 1
-            ? makeAssistantMessage([
-                { type: "toolCall", id: "call-message", name: "message", arguments: {} },
-              ])
-            : makeAssistantMessage([
-                { type: "toolCall", id: "call-exec", name: "exec", arguments: {} },
-              ]);
-        stream.push({ type: "done", reason: "toolUse", message });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream(
+      [
+        [{ type: "toolCall", id: "call-message", name: "message", arguments: {} }],
+        [{ type: "toolCall", id: "call-exec", name: "exec", arguments: {} }],
+      ],
+      [],
+      (_context, currentTurn) => {
+        turn = currentTurn;
+      },
+    );
 
     const stream = agentLoop(
       [{ role: "user", content: "hello", timestamp: 1 }],
@@ -3446,21 +3102,12 @@ describe("agentLoop tool termination", () => {
     const afterToolCall = vi.fn(async () => undefined);
     const commitReadyCalls = vi.fn();
     const releaseSkippedCalls = vi.fn();
-    const streamFn: StreamFn = () => {
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => {
-        stream.push({
-          type: "done",
-          reason: "toolUse",
-          message: makeAssistantMessage([
-            { type: "toolCall", id: "call-paid", name: "paid", arguments: {} },
-            { type: "toolCall", id: "call-gated", name: "gated", arguments: {} },
-          ]),
-        });
-        stream.end();
-      });
-      return stream;
-    };
+    const streamFn = createTurnSequenceStream([
+      [
+        { type: "toolCall", id: "call-paid", name: "paid", arguments: {} },
+        { type: "toolCall", id: "call-gated", name: "gated", arguments: {} },
+      ],
+    ]);
     const events: AgentEvent[] = [];
 
     const abortedMessages = await runAgentLoop(

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -630,6 +630,12 @@ describe("update-cli", () => {
     });
   };
 
+  const mockPackageInstallAtCaseDir = (prefix = "openclaw-update") => {
+    const root = createCaseDir(prefix);
+    mockPackageInstallStatus(root);
+    return root;
+  };
+
   const primeNpmChannelTag = (tag: string, version: string | null): void => {
     vi.mocked(resolveNpmChannelTag).mockResolvedValue({ tag, version });
   };
@@ -931,18 +937,11 @@ describe("update-cli", () => {
   };
 
   const setupNonInteractiveDowngrade = async () => {
-    const tempDir = createCaseDir("openclaw-update");
+    const tempDir = mockPackageInstallAtCaseDir();
     setTty(false);
     readPackageVersion.mockResolvedValue("2.0.0");
-
-    mockPackageInstallStatus(tempDir);
     primeNpmChannelTag(isBetaTag(VERSION) ? "beta" : "latest", "0.0.1");
-    vi.mocked(runGatewayUpdate).mockResolvedValue({
-      status: "ok",
-      mode: "npm",
-      steps: [],
-      durationMs: 100,
-    });
+    vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult({ mode: "npm" }));
     vi.mocked(defaultRuntime.error).mockClear();
     vi.mocked(defaultRuntime.exit).mockClear();
 
@@ -978,13 +977,7 @@ describe("update-cli", () => {
     if (params?.gatewayUpdateImpl) {
       vi.mocked(runGatewayUpdate).mockImplementation(() => params.gatewayUpdateImpl!(root));
     } else {
-      vi.mocked(runGatewayUpdate).mockResolvedValue({
-        status: "ok",
-        mode: "npm",
-        root,
-        steps: [],
-        durationMs: 100,
-      });
+      vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult({ mode: "npm", root }));
     }
     serviceLoaded.mockResolvedValue(true);
     primeServiceCommand(["node", entrypoints[0], "gateway", "run"]);
@@ -1024,7 +1017,7 @@ describe("update-cli", () => {
       code: number;
       signal: NodeJS.Signals | null;
       killed: boolean;
-      termination: "exit";
+      termination: "exit" | "timeout";
     }> = {},
   ) => ({
     stdout: "",
@@ -1033,6 +1026,45 @@ describe("update-cli", () => {
     signal: null,
     killed: false,
     termination: "exit" as const,
+    ...overrides,
+  });
+
+  const mockNpmGlobalCommands = (
+    nodeModules: string,
+    handle?: (
+      ...args: Parameters<typeof runCommandWithTimeout>
+    ) =>
+      | Awaited<ReturnType<typeof runCommandWithTimeout>>
+      | undefined
+      | Promise<Awaited<ReturnType<typeof runCommandWithTimeout>> | undefined>,
+  ) => {
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
+      const handled = await handle?.(argv, options);
+      if (handled !== undefined) {
+        return handled;
+      }
+      if (argv[0] === "npm" && argv[1] === "--version") {
+        return commandResult({ stdout: "12.0.0\n" });
+      }
+      if (argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
+        return commandResult({ stdout: `${nodeModules}\n` });
+      }
+      return commandResult();
+    });
+  };
+
+  const packageTargetStatus = (
+    overrides: Partial<{
+      target: string;
+      version: string | null;
+      nodeEngine: string | null;
+      schemaVersions: { state: number; agent: number };
+      error: string;
+    }> = {},
+  ) => ({
+    target: "9999.0.0",
+    version: "9999.0.0",
+    nodeEngine: ">=22.19.0",
     ...overrides,
   });
 
@@ -1068,6 +1100,25 @@ describe("update-cli", () => {
     changed: false,
     config,
     outcomes: [],
+  });
+
+  const mockNpmPluginOutcomes = (outcomes: unknown[], changed = false) => {
+    updateNpmInstalledPlugins.mockResolvedValueOnce({ changed, config: baseConfig, outcomes });
+  };
+
+  const postCoreConvergenceResult = (
+    overrides: Partial<{
+      changes: string[];
+      warnings: Array<{ pluginId?: string; reason: string; message: string; guidance: string[] }>;
+      errored: boolean;
+    }> = {},
+  ) => ({
+    changes: [],
+    warnings: [],
+    errored: false,
+    smokeFailures: [],
+    installRecords: {},
+    ...overrides,
   });
 
   const mockNoopPostUpdatePluginConvergence = () => {
@@ -1106,6 +1157,18 @@ describe("update-cli", () => {
     ...overrides,
   });
 
+  const stableConfig = (overrides: Omit<OpenClawConfig, "update"> = {}): OpenClawConfig => ({
+    update: { channel: "stable" },
+    ...overrides,
+  });
+
+  const stableWhatsAppConfig = (): OpenClawConfig =>
+    stableConfig({
+      channels: {
+        whatsapp: { enabled: true, dmPolicy: "pairing" },
+      },
+    });
+
   const runPostCoreUpdate = (env: NodeJS.ProcessEnv = {}) => {
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
     return withEnvAsync(
@@ -1137,20 +1200,31 @@ describe("update-cli", () => {
     );
   };
 
+  const writeJsonFixture = (
+    filePath: string,
+    value: unknown,
+    trailingNewline = true,
+  ): Promise<void> =>
+    fs.writeFile(filePath, `${JSON.stringify(value)}${trailingNewline ? "\n" : ""}`, "utf-8");
+
   const writeOpenClawPackageFixture = async (
     root: string,
     version: string,
-    options: { entrySource?: string; inventory?: boolean } = {},
+    options: {
+      entryPath?: string;
+      entrySource?: string;
+      git?: boolean;
+      inventory?: boolean;
+    } = {},
   ) => {
-    const entryPath = path.join(root, "dist", "index.js");
+    const entryPath = options.entryPath ?? path.join(root, "dist", "index.js");
     await fs.mkdir(options.entrySource === undefined ? root : path.dirname(entryPath), {
       recursive: true,
     });
-    await fs.writeFile(
-      path.join(root, "package.json"),
-      JSON.stringify({ name: "openclaw", version }),
-      "utf-8",
-    );
+    if (options.git) {
+      await fs.mkdir(path.join(root, ".git"), { recursive: true });
+    }
+    await writeJsonFixture(path.join(root, "package.json"), { name: "openclaw", version }, false);
     if (options.entrySource !== undefined) {
       await fs.writeFile(entryPath, options.entrySource, "utf-8");
     }
@@ -1158,6 +1232,33 @@ describe("update-cli", () => {
       await writePackageDistInventory(root);
     }
     return entryPath;
+  };
+
+  const setupPostCoreConfigFixture = async (params: {
+    backupConfig?: OpenClawConfig;
+    postDoctorConfig: OpenClawConfig;
+    preUpdateConfig?: OpenClawConfig;
+    snapshotSuffix?: ".bak" | ".pre-update";
+    preserveParsed?: boolean;
+  }) => {
+    const tempDir = createCaseDir("openclaw-update");
+    const configPath = path.join(tempDir, "openclaw.json");
+    await fs.mkdir(tempDir, { recursive: true });
+    if (params.preUpdateConfig) {
+      await writeJsonFixture(
+        `${configPath}${params.snapshotSuffix ?? ".pre-update"}`,
+        params.preUpdateConfig,
+      );
+    }
+    if (params.backupConfig) {
+      await writeJsonFixture(`${configPath}.bak`, params.backupConfig);
+    }
+    await writeJsonFixture(configPath, params.postDoctorConfig);
+    mockPostDoctorSnapshot(configPath, params.postDoctorConfig, {
+      preserveParsed: params.preserveParsed,
+    });
+    mockNoopPostUpdatePluginConvergence();
+    return { tempDir, configPath };
   };
 
   const setupInstalledPackageAtNodeModules = async (nodeModules: string, version = "2026.4.21") => {
@@ -1172,6 +1273,63 @@ describe("update-cli", () => {
 
   const setupInstalledPackageRoot = (baseDir: string, version = "2026.4.21") =>
     setupInstalledPackageAtNodeModules(path.join(baseDir, "node_modules"), version);
+
+  const setupServicePackageAtPrefix = async (params: {
+    prefix: string;
+    version?: string;
+    withNpm?: boolean;
+  }) => {
+    const nodeModules = path.join(params.prefix, "lib", "node_modules");
+    const root = path.join(nodeModules, "openclaw");
+    const serviceNode = path.join(params.prefix, "bin", "node");
+    const serviceNpm = path.join(params.prefix, "bin", "npm");
+    await fs.mkdir(path.dirname(serviceNode), { recursive: true });
+    await fs.writeFile(serviceNode, "", "utf-8");
+    const serviceNpmReal =
+      params.withNpm === false
+        ? undefined
+        : await fs.writeFile(serviceNpm, "", "utf-8").then(() => fs.realpath(serviceNpm));
+    const entrypoint = await writeOpenClawPackageFixture(root, params.version ?? "2026.5.18", {
+      entrySource: "",
+      inventory: true,
+    });
+    return { nodeModules, root, serviceNode, serviceNpm, serviceNpmReal, entrypoint };
+  };
+
+  const mockServicePackageCommands = (params: {
+    nodeModules: string;
+    packageRoot: string;
+    targetVersion: string;
+    npmCommands: string[];
+    nodeVersions: Record<string, string>;
+  }) => {
+    const npmCommands = new Set(params.npmCommands);
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      const command = argv[0] ?? "";
+      if (argv[1] === "--version" && params.nodeVersions[command]) {
+        return commandResult({ stdout: `${params.nodeVersions[command]}\n` });
+      }
+      if (npmCommands.has(command) && argv[1] === "--version") {
+        return commandResult({ stdout: "12.0.0\n" });
+      }
+      if (npmCommands.has(command) && argv[1] === "root" && argv[2] === "-g") {
+        return commandResult({ stdout: `${params.nodeModules}\n` });
+      }
+      if (npmCommands.has(command) && argv[1] === "i") {
+        const stagePrefix = argv.includes("--prefix")
+          ? argv[argv.indexOf("--prefix") + 1]
+          : undefined;
+        const stageRoot = stagePrefix
+          ? path.join(stagePrefix, "lib", "node_modules", "openclaw")
+          : params.packageRoot;
+        await writeOpenClawPackageFixture(stageRoot, params.targetVersion, {
+          entrySource: "export {};\n",
+          inventory: true,
+        });
+      }
+      return commandResult();
+    });
+  };
 
   const mockRunningManagedGateway = (
     programArguments: string[] = ["openclaw", "gateway", "run"],
@@ -1269,12 +1427,16 @@ describe("update-cli", () => {
   };
 
   const mockNpmGlobalRoot = (nodeModules: string) => {
+    mockNpmGlobalCommands(nodeModules);
+  };
+
+  const mockPackageReplacementFailure = (message: string) => {
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (Array.isArray(argv) && argv[1] === "--version") {
+      if (argv[1] === "--version") {
         return commandResult({ stdout: "12.0.0\n" });
       }
-      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
-        return commandResult({ stdout: `${nodeModules}\n` });
+      if (argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g") {
+        throw new Error(message);
       }
       return commandResult();
     });
@@ -1313,7 +1475,7 @@ describe("update-cli", () => {
     const stateDir = tempDirs.make("openclaw-update-sentinel-state-");
     const metaDir = tempDirs.make("openclaw-update-sentinel-meta-");
     const metaPath = path.join(metaDir, "meta.json");
-    await fs.writeFile(metaPath, JSON.stringify({ version: 1, meta: params.meta }));
+    await writeJsonFixture(metaPath, { version: 1, meta: params.meta }, false);
     await params.beforeUpdate?.();
     await withEnvAsync(
       {
@@ -1328,7 +1490,7 @@ describe("update-cli", () => {
   };
 
   const setupInteractiveClawHubRisk = async () => {
-    mockPackageInstallStatus(createCaseDir("openclaw-update"));
+    mockPackageInstallAtCaseDir();
     setTty(true);
     setStdoutTty(true);
     await updateCommand({ channel: "beta", restart: false });
@@ -1679,15 +1841,9 @@ describe("update-cli", () => {
       ...baseConfig,
       update: { channel: "beta" as const },
     };
-    const managedSnapshot = {
-      ...baseSnapshot,
+    const managedSnapshot = configSnapshot(managedConfig, {
       path: path.join(managedState, "openclaw.json"),
-      parsed: managedConfig,
-      sourceConfig: managedConfig,
-      resolved: managedConfig,
-      config: managedConfig,
-      runtimeConfig: managedConfig,
-    };
+    });
     const managedRecords = {
       telegram: { source: "npm", spec: "@openclaw/telegram@beta" },
     } satisfies Record<string, PluginInstallRecord>;
@@ -1755,14 +1911,9 @@ describe("update-cli", () => {
     const personalState = path.join(fixtureRoot, "personal-profile");
     const { root, entrypoints } = setupUpdatedRootRefresh();
     const foreignRoot = tempDirs.make("openclaw-update-foreign-profile-");
-    const foreignEntrypoint = path.join(foreignRoot, "dist", "index.js");
-    await fs.mkdir(path.dirname(foreignEntrypoint), { recursive: true });
-    await fs.writeFile(
-      path.join(foreignRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.4.21" }),
-      "utf-8",
-    );
-    await fs.writeFile(foreignEntrypoint, "export {};\n", "utf-8");
+    const foreignEntrypoint = await writeOpenClawPackageFixture(foreignRoot, "2026.4.21", {
+      entrySource: "export {};\n",
+    });
     mockGitUpdateAfterMutation(
       makeOkUpdateResult({
         mode: "git",
@@ -2076,13 +2227,9 @@ describe("update-cli", () => {
     } as OpenClawConfig;
     let capturedRecords: unknown;
     let capturedSourceConfig: unknown;
-    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
-      ...baseSnapshot,
-      parsed: preUpdateConfig,
-      sourceConfig: preUpdateConfig,
-      config: preUpdateConfig,
-      runtimeConfig: preUpdateConfig,
-    });
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(
+      configSnapshot(preUpdateConfig, { resolved: baseConfig }),
+    );
     loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce(pluginInstallRecords);
     spawn.mockImplementationOnce((_node, _argv, options) => {
       const env = (options as { env?: NodeJS.ProcessEnv }).env;
@@ -2127,14 +2274,7 @@ describe("update-cli", () => {
         },
       },
     } as OpenClawConfig;
-    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
-      ...baseSnapshot,
-      parsed: preUpdateConfig,
-      sourceConfig: preUpdateConfig,
-      resolved: preUpdateConfig,
-      config: preUpdateConfig,
-      runtimeConfig: preUpdateConfig,
-    });
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue(configSnapshot(preUpdateConfig));
     const pluginInstallRecords = {
       msteams: {
         source: "npm",
@@ -2450,11 +2590,7 @@ describe("update-cli", () => {
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(
       "/tmp/openclaw-updated-entry.mjs",
     );
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: true,
-      config: baseConfig,
-      outcomes: [],
-    });
+    mockNpmPluginOutcomes([], true);
     let strictValidationEnv: string | undefined;
     vi.mocked(readConfigFileSnapshot).mockImplementation(async (options) => {
       if (!options) {
@@ -2486,13 +2622,11 @@ describe("update-cli", () => {
   it("runs the final fresh doctor for convergence-only current-process changes", async () => {
     mockGitUpdateAfterMutation();
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
-    runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
-      changes: ["Repaired configured plugin install records."],
-      warnings: [],
-      errored: false,
-      smokeFailures: [],
-      installRecords: {},
-    });
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce(
+      postCoreConvergenceResult({
+        changes: ["Repaired configured plugin install records."],
+      }),
+    );
 
     await updateCommand({ yes: true, restart: false });
 
@@ -2550,11 +2684,12 @@ describe("update-cli", () => {
     vi.mocked(runExec)
       .mockRejectedValueOnce(new Error("doctor process failed"))
       .mockRejectedValueOnce(new Error("config invalid"));
-    vi.mocked(readConfigFileSnapshot).mockResolvedValueOnce({
-      ...baseSnapshot,
-      valid: false,
-      issues: [{ path: "channels.signal.httpUrl", message: "legacy Signal transport field" }],
-    } as ConfigFileSnapshot);
+    vi.mocked(readConfigFileSnapshot).mockResolvedValueOnce(
+      configSnapshot(baseConfig, {
+        valid: false,
+        issues: [{ path: "channels.signal.httpUrl", message: "legacy Signal transport field" }],
+      }),
+    );
 
     const result = await completeChangedPostCorePluginUpdate();
 
@@ -2660,13 +2795,11 @@ describe("update-cli", () => {
 
   it("runs the final fresh doctor for convergence-only post-core changes", async () => {
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
-    runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
-      changes: ["Repaired configured plugin install records."],
-      warnings: [],
-      errored: false,
-      smokeFailures: [],
-      installRecords: {},
-    });
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce(
+      postCoreConvergenceResult({
+        changes: ["Repaired configured plugin install records."],
+      }),
+    );
 
     await runPostCoreCommand({ restart: false });
 
@@ -2730,17 +2863,9 @@ describe("update-cli", () => {
     const recordsPath = path.join(resultDir, "plugin-install-records.json");
     const installPath = path.join(resultDir, "demo-plugin");
     await fs.mkdir(installPath, { recursive: true });
-    await fs.writeFile(
-      recordsPath,
-      `${JSON.stringify({
-        demo: {
-          source: "npm",
-          spec: "@openclaw/demo@1.0.0",
-          installPath,
-        },
-      })}\n`,
-      "utf-8",
-    );
+    await writeJsonFixture(recordsPath, {
+      demo: { source: "npm", spec: "@openclaw/demo@1.0.0", installPath },
+    });
     pathExists.mockImplementation(async (candidate: string) => candidate === installPath);
 
     await runPostCoreCommand(
@@ -2761,17 +2886,13 @@ describe("update-cli", () => {
     const resultDir = createCaseDir("openclaw-post-core-disk-records");
     const recordsPath = path.join(resultDir, "plugin-install-records.json");
     await fs.mkdir(resultDir, { recursive: true });
-    await fs.writeFile(
-      recordsPath,
-      `${JSON.stringify({
-        stale: {
-          source: "npm",
-          spec: "@openclaw/stale@1.0.0",
-          installPath: "/tmp/stale-plugin",
-        },
-      })}\n`,
-      "utf-8",
-    );
+    await writeJsonFixture(recordsPath, {
+      stale: {
+        source: "npm",
+        spec: "@openclaw/stale@1.0.0",
+        installPath: "/tmp/stale-plugin",
+      },
+    });
     const postDoctorRecords = {
       codex: {
         source: "npm",
@@ -2871,26 +2992,22 @@ describe("update-cli", () => {
   });
 
   it("prints plugin channel fallbacks near the post-core plugin summary", async () => {
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: false,
-      config: baseConfig,
-      outcomes: [
-        {
-          pluginId: "lossless-claw",
-          status: "updated",
-          message: "Updated lossless-claw: 1.0.0 -> 1.0.1.",
-          channelFallback: {
-            requestedSpec: "lossless-claw@beta",
-            usedSpec: "lossless-claw",
-            requestedLabel: "@beta",
-            usedLabel: "@latest",
-            reason: "unavailable",
-            message:
-              "plugin channel fallback: lossless-claw used @latest because @beta was unavailable",
-          },
+    mockNpmPluginOutcomes([
+      {
+        pluginId: "lossless-claw",
+        status: "updated",
+        message: "Updated lossless-claw: 1.0.0 -> 1.0.1.",
+        channelFallback: {
+          requestedSpec: "lossless-claw@beta",
+          usedSpec: "lossless-claw",
+          requestedLabel: "@beta",
+          usedLabel: "@latest",
+          reason: "unavailable",
+          message:
+            "plugin channel fallback: lossless-claw used @latest because @beta was unavailable",
         },
-      ],
-    });
+      },
+    ]);
 
     await runPostCoreCommand({ restart: false }, { OPENCLAW_UPDATE_POST_CORE_CHANNEL: "beta" });
 
@@ -3192,17 +3309,13 @@ describe("update-cli", () => {
   });
 
   it("prints non-fatal plugin warnings in human update output", async () => {
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: false,
-      config: baseConfig,
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "error",
-          message: "Failed to update demo: registry timeout",
-        },
-      ],
-    });
+    mockNpmPluginOutcomes([
+      {
+        pluginId: "demo",
+        status: "error",
+        message: "Failed to update demo: registry timeout",
+      },
+    ]);
 
     await updateCommand({ yes: true, restart: false });
 
@@ -3219,10 +3332,8 @@ describe("update-cli", () => {
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(
       "/tmp/openclaw-updated-entry.mjs",
     );
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: true,
-      config: baseConfig,
-      outcomes: [
+    mockNpmPluginOutcomes(
+      [
         {
           pluginId: "demo",
           status: "skipped",
@@ -3230,7 +3341,8 @@ describe("update-cli", () => {
             'Disabled "demo" after plugin update failure; OpenClaw will continue without it. Failed to update demo: registry timeout',
         },
       ],
-    });
+      true,
+    );
     vi.mocked(defaultRuntime.writeJson).mockClear();
 
     await updateCommand({ json: true, restart: false });
@@ -3248,20 +3360,16 @@ describe("update-cli", () => {
 
   it("marks unacknowledged ClawHub risk skips as post-update warnings", async () => {
     const trustWarning = clawHubSuspiciousPayloadWarning;
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: false,
-      config: baseConfig,
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "skipped",
-          code: CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_RISK_ACKNOWLEDGEMENT_REQUIRED,
-          warning: trustWarning,
-          message:
-            "Skipped demo ClawHub update: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. Existing installed plugin left unchanged.",
-        },
-      ],
-    });
+    mockNpmPluginOutcomes([
+      {
+        pluginId: "demo",
+        status: "skipped",
+        code: CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_RISK_ACKNOWLEDGEMENT_REQUIRED,
+        warning: trustWarning,
+        message:
+          "Skipped demo ClawHub update: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. Existing installed plugin left unchanged.",
+      },
+    ]);
     vi.mocked(defaultRuntime.writeJson).mockClear();
 
     await updateCommand({ json: true, restart: false });
@@ -3285,20 +3393,16 @@ describe("update-cli", () => {
       "╭─ BLOCKED - ClawHub flagged this release as malicious ─╮\n" +
       "│ • Security scan: malicious                           │\n" +
       "╰──────────────────────────────────────────────────────╯";
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: false,
-      config: baseConfig,
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "skipped",
-          code: "clawhub_download_blocked",
-          warning: trustWarning,
-          message:
-            "Skipped demo ClawHub update: ClawHub blocked this release; update was not started. Existing installed plugin left unchanged.",
-        },
-      ],
-    });
+    mockNpmPluginOutcomes([
+      {
+        pluginId: "demo",
+        status: "skipped",
+        code: "clawhub_download_blocked",
+        warning: trustWarning,
+        message:
+          "Skipped demo ClawHub update: ClawHub blocked this release; update was not started. Existing installed plugin left unchanged.",
+      },
+    ]);
     vi.mocked(defaultRuntime.writeJson).mockClear();
 
     await updateCommand({ json: true, restart: false });
@@ -3314,19 +3418,15 @@ describe("update-cli", () => {
   });
 
   it("prints unacknowledged ClawHub risk skips in human post-update output", async () => {
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: false,
-      config: baseConfig,
-      outcomes: [
-        {
-          pluginId: "demo",
-          status: "skipped",
-          code: CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_RISK_ACKNOWLEDGEMENT_REQUIRED,
-          message:
-            "Skipped demo ClawHub update: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. Existing installed plugin left unchanged.",
-        },
-      ],
-    });
+    mockNpmPluginOutcomes([
+      {
+        pluginId: "demo",
+        status: "skipped",
+        code: CLAWHUB_INSTALL_ERROR_CODE.CLAWHUB_RISK_ACKNOWLEDGEMENT_REQUIRED,
+        message:
+          "Skipped demo ClawHub update: Update cancelled; rerun with --acknowledge-clawhub-risk to continue after reviewing the warning. Existing installed plugin left unchanged.",
+      },
+    ]);
 
     await updateCommand({ yes: true, restart: false });
 
@@ -3512,12 +3612,9 @@ describe("update-cli", () => {
 
   it("refuses an incompatible package target before service stop or install", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-schema-refusal"));
-    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
-      target: "9999.0.0",
-      version: "9999.0.0",
-      nodeEngine: ">=22.19.0",
-      schemaVersions: { state: 3, agent: 9 },
-    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+      packageTargetStatus({ schemaVersions: { state: 3, agent: 9 } }),
+    );
     databasePreflightMocks.preflightOpenClawDatabaseSchemas.mockReturnValue({
       incompatible: [
         {
@@ -3548,11 +3645,7 @@ describe("update-cli", () => {
 
   it("skips package schema preflight when target metadata is missing", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-schema-missing"));
-    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
-      target: "9999.0.0",
-      version: "9999.0.0",
-      nodeEngine: ">=22.19.0",
-    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(packageTargetStatus());
 
     await updateCommand({ yes: true, restart: false });
 
@@ -3562,12 +3655,9 @@ describe("update-cli", () => {
 
   it("refuses a package update when exact target metadata lookup fails", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-schema-metadata-failure"));
-    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
-      target: "9999.0.0",
-      version: null,
-      nodeEngine: null,
-      error: "registry timeout",
-    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+      packageTargetStatus({ version: null, nodeEngine: null, error: "registry timeout" }),
+    );
 
     await updateCommand({ yes: true });
 
@@ -3581,12 +3671,9 @@ describe("update-cli", () => {
 
   it("continues a package update when target schemas are compatible", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-schema-compatible"));
-    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
-      target: "9999.0.0",
-      version: "9999.0.0",
-      nodeEngine: ">=22.19.0",
-      schemaVersions: { state: 3, agent: 11 },
-    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+      packageTargetStatus({ schemaVersions: { state: 3, agent: 11 } }),
+    );
 
     await updateCommand({ yes: true, restart: false });
 
@@ -3596,12 +3683,9 @@ describe("update-cli", () => {
 
   it("reports an incompatible package target during dry-run", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-schema-dry-run"));
-    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
-      target: "9999.0.0",
-      version: "9999.0.0",
-      nodeEngine: ">=22.19.0",
-      schemaVersions: { state: 2, agent: 9 },
-    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+      packageTargetStatus({ schemaVersions: { state: 2, agent: 9 } }),
+    );
     databasePreflightMocks.preflightOpenClawDatabaseSchemas.mockReturnValue({
       incompatible: [
         {
@@ -3651,12 +3735,9 @@ describe("update-cli", () => {
 
   it("reports indeterminate package databases during dry-run", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-schema-indeterminate-dry-run"));
-    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
-      target: "9999.0.0",
-      version: "9999.0.0",
-      nodeEngine: ">=22.19.0",
-      schemaVersions: { state: 3, agent: 11 },
-    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+      packageTargetStatus({ schemaVersions: { state: 3, agent: 11 } }),
+    );
     databasePreflightMocks.preflightOpenClawDatabaseSchemas.mockReturnValue({
       incompatible: [],
       indeterminate: [
@@ -3679,12 +3760,9 @@ describe("update-cli", () => {
       OPENCLAW_STATE_DIR: "/managed/state",
     });
     serviceLoaded.mockResolvedValue(true);
-    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
-      target: "9999.0.0",
-      version: "9999.0.0",
-      nodeEngine: ">=22.19.0",
-      schemaVersions: { state: 3, agent: 11 },
-    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+      packageTargetStatus({ schemaVersions: { state: 3, agent: 11 } }),
+    );
     databasePreflightMocks.preflightOpenClawDatabaseSchemas
       .mockReturnValueOnce({ incompatible: [], indeterminate: [] })
       .mockReturnValueOnce({
@@ -3824,8 +3902,7 @@ describe("update-cli", () => {
   });
 
   it("parses update --acknowledge-clawhub-risk as the update command option", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     const program = new Command();
     program.name("openclaw");
     program.exitOverride();
@@ -3913,9 +3990,7 @@ describe("update-cli", () => {
   );
 
   it("falls back to latest when beta tag is older than release", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     vi.mocked(readConfigFileSnapshot).mockResolvedValue({
       ...baseSnapshot,
       config: { update: { channel: "beta" } } as OpenClawConfig,
@@ -3927,8 +4002,7 @@ describe("update-cli", () => {
   });
 
   it("installs the verified exact package and persists an explicit extended-stable channel", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     readPackageVersion.mockResolvedValue("2026.6.33");
 
     await updateCommand({ channel: "extended-stable", yes: true, restart: false });
@@ -3947,8 +4021,7 @@ describe("update-cli", () => {
   });
 
   it("uses the same exact resolver for a bare update with stored extended-stable", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     readPackageVersion.mockResolvedValue("2026.6.33");
     const config = { update: { channel: "extended-stable" } } as OpenClawConfig;
     vi.mocked(readConfigFileSnapshot).mockResolvedValue(configSnapshot(config));
@@ -3966,8 +4039,7 @@ describe("update-cli", () => {
   });
 
   it("fails closed without config or package mutation when extended-stable resolution fails", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     vi.mocked(resolveExtendedStablePackage).mockResolvedValueOnce({
       status: "failed",
       reason: "selector_missing",
@@ -3985,8 +4057,7 @@ describe("update-cli", () => {
   });
 
   it("fails a stored extended-stable update before launchd cleanup when resolution fails", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     const config = { update: { channel: "extended-stable" } } as OpenClawConfig;
     vi.mocked(readConfigFileSnapshot).mockResolvedValue(configSnapshot(config));
     vi.mocked(resolveExtendedStablePackage).mockResolvedValueOnce({
@@ -4008,8 +4079,7 @@ describe("update-cli", () => {
     { name: "explicit", explicit: true },
     { name: "stored", explicit: false },
   ])("rejects --tag for an $name extended-stable channel", async ({ explicit }) => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     if (!explicit) {
       const config = { update: { channel: "extended-stable" } } as OpenClawConfig;
       vi.mocked(readConfigFileSnapshot).mockResolvedValue(configSnapshot(config));
@@ -4047,9 +4117,8 @@ describe("update-cli", () => {
     { name: "refuses", yes: false, installs: false },
     { name: "allows with --yes", yes: true, installs: true },
   ])("$name an extended-stable downgrade in non-interactive mode", async ({ yes, installs }) => {
-    const tempDir = createCaseDir("openclaw-update");
     setTty(false);
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     readPackageVersion.mockResolvedValue("2026.7.10");
     vi.mocked(resolveExtendedStablePackage).mockResolvedValueOnce({
       status: "resolved",
@@ -4070,22 +4139,20 @@ describe("update-cli", () => {
   });
 
   it("retains extended-stable after a post-commit plugin convergence failure", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
-    runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
-      changes: [],
-      warnings: [
-        {
-          pluginId: "demo",
-          reason: "plugin smoke failed",
-          message: "plugin smoke failed",
-          guidance: ["Run openclaw update repair."],
-        },
-      ],
-      errored: true,
-      smokeFailures: [],
-      installRecords: {},
-    });
+    mockPackageInstallAtCaseDir();
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce(
+      postCoreConvergenceResult({
+        warnings: [
+          {
+            pluginId: "demo",
+            reason: "plugin smoke failed",
+            message: "plugin smoke failed",
+            guidance: ["Run openclaw update repair."],
+          },
+        ],
+        errored: true,
+      }),
+    );
 
     await updateCommand({ channel: "extended-stable", yes: true, json: true, restart: false });
 
@@ -4097,8 +4164,7 @@ describe("update-cli", () => {
   });
 
   it("refreshes package-manager updates when the installed version already matches the target", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     readPackageVersion.mockResolvedValue("2026.4.22");
     primeNpmChannelTag("latest", "2026.4.22");
 
@@ -4116,9 +4182,8 @@ describe("update-cli", () => {
   });
 
   it("runs the package update when latest target lookup is unresolved", async () => {
-    const tempDir = createCaseDir("openclaw-update");
     setTty(false);
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     readPackageVersion.mockResolvedValue("2026.4.22");
     primeNpmChannelTag("latest", null);
     mockCurrentProcessFreshDoctor();
@@ -4132,9 +4197,8 @@ describe("update-cli", () => {
   });
 
   it("blocks the package update when a non-latest dist-tag lookup is unresolved", async () => {
-    const tempDir = createCaseDir("openclaw-update");
     setTty(false);
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     readPackageVersion.mockResolvedValue("2026.4.22");
     vi.mocked(fetchNpmTagVersion).mockResolvedValue({
       tag: "next",
@@ -4150,8 +4214,7 @@ describe("update-cli", () => {
   });
 
   it("warns but still runs package updates when disk space looks low", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     mockCurrentProcessFreshDoctor();
     vi.spyOn(fsSync, "statfsSync").mockReturnValue(
       statfsFixture({
@@ -4319,11 +4382,9 @@ describe("update-cli", () => {
   it("blocks package updates when the target requires a newer Node runtime", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-update"));
     primeNpmChannelTag("latest", "2026.3.23-2");
-    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
-      target: "latest",
-      version: "2026.3.23-2",
-      nodeEngine: ">=22.19.0",
-    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+      packageTargetStatus({ target: "latest", version: "2026.3.23-2" }),
+    );
     nodeVersionSatisfiesEngine.mockReturnValue(false);
 
     await updateCommand({ yes: true });
@@ -4449,14 +4510,11 @@ describe("update-cli", () => {
       inventory: true,
     });
     readPackageVersion.mockResolvedValue("2026.3.23");
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (Array.isArray(argv) && argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
+    mockNpmGlobalCommands(nodeModules, async (argv) => {
+      if (argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
         return commandResult({ stdout: nodeModules });
       }
-      return commandResult();
+      return undefined;
     });
 
     await updateCommand({ yes: true, tag: "2026.3.23-2" });
@@ -4475,19 +4533,8 @@ describe("update-cli", () => {
     const { pkgRoot } = await setupInstalledPackageAtNodeModules(nodeModules, "2026.4.20");
     readPackageVersion.mockResolvedValue("2026.4.20");
     primeNpmChannelTag("latest", "2026.4.25");
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (Array.isArray(argv) && argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
-        return commandResult({ stdout: `${nodeModules}\n` });
-      }
-      if (
-        Array.isArray(argv) &&
-        argv[0] === "npm" &&
-        argv[1] === "i" &&
-        argv.includes("--prefix")
-      ) {
+    mockNpmGlobalCommands(nodeModules, async (argv) => {
+      if (argv[0] === "npm" && argv[1] === "i" && argv.includes("--prefix")) {
         const stagePrefix = argv[argv.indexOf("--prefix") + 1];
         if (typeof stagePrefix !== "string") {
           throw new Error("missing stage prefix");
@@ -4503,7 +4550,6 @@ describe("update-cli", () => {
           "utf-8",
         );
       }
-      return commandResult();
     });
 
     await updateCommand({ yes: true, restart: false });
@@ -4568,14 +4614,8 @@ describe("update-cli", () => {
     const { nodeModules, entryPath } = await setupInstalledPackageRoot(tempDir);
     primeNpmChannelTag("latest", "2026.4.21");
     mockFileBackedPathExists();
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) => {
-      if (Array.isArray(argv) && argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
-        return commandResult({ stdout: `${nodeModules}\n` });
-      }
-      if (Array.isArray(argv) && argv[1] === entryPath && argv[2] === "doctor") {
+    mockNpmGlobalCommands(nodeModules, async (argv, options) => {
+      if (argv[1] === entryPath && argv[2] === "doctor") {
         const env = options && typeof options !== "number" ? options.env : undefined;
         const resultPath = env?.[UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV];
         if (!resultPath) {
@@ -4592,7 +4632,7 @@ describe("update-cli", () => {
           code: UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE,
         });
       }
-      return commandResult();
+      return undefined;
     });
 
     await withEnvAsync({ OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION: "1" }, async () => {
@@ -4637,24 +4677,16 @@ describe("update-cli", () => {
     const { nodeModules, entryPath } = await setupInstalledPackageRoot(tempDir);
     primeNpmChannelTag("latest", "2026.4.21");
     mockFileBackedPathExists();
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (Array.isArray(argv) && argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
-        return commandResult({ stdout: `${nodeModules}\n` });
-      }
-      if (Array.isArray(argv) && argv[1] === entryPath && argv[2] === "doctor") {
-        return {
-          stdout: "",
+    mockNpmGlobalCommands(nodeModules, async (argv) => {
+      if (argv[1] === entryPath && argv[2] === "doctor") {
+        return commandResult({
           stderr: "doctor timed out",
           code: 124,
-          signal: null,
           killed: true,
           termination: "timeout",
-        };
+        });
       }
-      return commandResult();
+      return undefined;
     });
 
     await updateCommand({ yes: true, restart: false, json: true });
@@ -4680,16 +4712,7 @@ describe("update-cli", () => {
     );
     primeNpmChannelTag("latest", "2026.5.14");
     mockFileBackedPathExists();
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (!Array.isArray(argv)) {
-        return commandResult();
-      }
-      if (argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
-        return commandResult({ stdout: `${nodeModules}\n` });
-      }
+    mockNpmGlobalCommands(nodeModules, async (argv) => {
       if (argv[0] === "npm" && argv[1] === "i" && argv.includes("--prefix")) {
         const stagePrefix = argv[argv.indexOf("--prefix") + 1];
         const stagePackageRoot = path.join(
@@ -4698,17 +4721,11 @@ describe("update-cli", () => {
           "node_modules",
           "openclaw",
         );
-        const stageEntryPath = path.join(stagePackageRoot, "dist", "index.js");
-        await fs.mkdir(path.dirname(stageEntryPath), { recursive: true });
-        await fs.writeFile(
-          path.join(stagePackageRoot, "package.json"),
-          JSON.stringify({ name: "openclaw", version: "2026.5.14" }),
-          "utf-8",
-        );
-        await fs.writeFile(stageEntryPath, "export {};\n", "utf-8");
-        await writePackageDistInventory(stagePackageRoot);
+        await writeOpenClawPackageFixture(stagePackageRoot, "2026.5.14", {
+          entrySource: "export {};\n",
+          inventory: true,
+        });
       }
-      return commandResult();
     });
     readPackageVersion.mockImplementation(async (packageRoot: string) => {
       const manifest = JSON.parse(
@@ -4906,15 +4923,7 @@ describe("update-cli", () => {
     serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
     mockFileBackedPathExists();
     mockNpmGlobalRoot(nodeModules);
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g") {
-        throw new Error("package replacement failed");
-      }
-      return commandResult();
-    });
+    mockPackageReplacementFailure("package replacement failed");
 
     try {
       await expect(updateCommand({ yes: true })).rejects.toThrow("package replacement failed");
@@ -4947,15 +4956,7 @@ describe("update-cli", () => {
     serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
     mockFileBackedPathExists();
     mockNpmGlobalRoot(nodeModules);
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g") {
-        throw new Error("package replacement failed");
-      }
-      return commandResult();
-    });
+    mockPackageReplacementFailure("package replacement failed");
 
     try {
       await expect(updateCommand({ yes: true })).rejects.toThrow("package replacement failed");
@@ -5097,15 +5098,7 @@ describe("update-cli", () => {
     });
     serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
     suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g") {
-        throw new Error("update invariant broke");
-      }
-      return commandResult();
-    });
+    mockPackageReplacementFailure("update invariant broke");
     resumeScheduledTaskAutoStartAfterUpdate.mockRejectedValueOnce(new Error("task restore failed"));
 
     try {
@@ -5300,15 +5293,10 @@ describe("update-cli", () => {
   it("stops a managed gateway rooted at the git checkout when switching package installs to dev", async () => {
     const packageRoot = createCaseDir("openclaw-update-package-root");
     const gitRoot = tempDirs.make("openclaw-update-git-service-root-");
-    const serviceEntrypoint = path.join(gitRoot, "dist", "index.js");
-    await fs.mkdir(path.join(gitRoot, ".git"), { recursive: true });
-    await fs.mkdir(path.dirname(serviceEntrypoint), { recursive: true });
-    await fs.writeFile(
-      path.join(gitRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.4.21" }),
-      "utf-8",
-    );
-    await fs.writeFile(serviceEntrypoint, "export {};\n", "utf-8");
+    const serviceEntrypoint = await writeOpenClawPackageFixture(gitRoot, "2026.4.21", {
+      entrySource: "export {};\n",
+      git: true,
+    });
     const canonicalGitRoot = await fs.realpath(gitRoot);
     mockPackageInstallStatus(packageRoot);
     pathExists.mockImplementation(async (candidate: string) => candidate === gitRoot);
@@ -5333,21 +5321,11 @@ describe("update-cli", () => {
 
   it("stops a managed gateway rooted at the package install when switching package installs to dev", async () => {
     const packageRoot = tempDirs.make("openclaw-update-package-service-root-");
-    const packageEntrypoint = path.join(packageRoot, "dist", "index.js");
     const gitRoot = tempDirs.make("openclaw-update-git-service-root-");
-    await fs.mkdir(path.join(gitRoot, ".git"), { recursive: true });
-    await fs.mkdir(path.dirname(packageEntrypoint), { recursive: true });
-    await fs.writeFile(
-      path.join(gitRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.4.21" }),
-      "utf-8",
-    );
-    await fs.writeFile(
-      path.join(packageRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.4.20" }),
-      "utf-8",
-    );
-    await fs.writeFile(packageEntrypoint, "export {};\n", "utf-8");
+    const packageEntrypoint = await writeOpenClawPackageFixture(packageRoot, "2026.4.20", {
+      entrySource: "export {};\n",
+    });
+    await writeOpenClawPackageFixture(gitRoot, "2026.4.21", { git: true });
     const canonicalGitRoot = await fs.realpath(gitRoot);
     mockPackageInstallStatus(packageRoot);
     pathExists.mockImplementation(async (candidate: string) => candidate === gitRoot);
@@ -5389,25 +5367,13 @@ describe("update-cli", () => {
         expect(options?.cwd).toBe(publishedRoot);
         return makeOkUpdateResult({ mode: "git", root: publishedRoot });
       });
-      vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-        if (argv[1] === "--version") {
-          return commandResult({ stdout: "12.0.0\n" });
-        }
-        if (argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
-          return commandResult({ stdout: `${nodeModules}\n` });
-        }
+      mockNpmGlobalCommands(nodeModules, async (argv) => {
         if (argv[0] === "git" && argv[1] === "clone") {
           const stagingDir = requireValue(argv.at(-1), "Git clone staging directory");
-          await fs.mkdir(path.join(stagingDir, ".git"), { recursive: true });
-          await fs.writeFile(
-            path.join(stagingDir, "package.json"),
-            JSON.stringify({ name: "openclaw", version: "2026.8.17" }),
-            "utf8",
-          );
+          await writeOpenClawPackageFixture(stagingDir, "2026.8.17", { git: true });
           await fs.unlink(checkoutAlias);
           await fs.symlink(replacementRoot, checkoutAlias, "dir");
         }
-        return commandResult();
       });
 
       await withEnvAsync({ OPENCLAW_GIT_DIR: checkoutAlias }, async () => {
@@ -5435,28 +5401,17 @@ describe("update-cli", () => {
     });
     await fs.mkdir(path.dirname(shim), { recursive: true });
     await fs.writeFile(shim, "old package shim\n", { mode: 0o755 });
-    await fs.mkdir(path.join(gitRoot, ".git"), { recursive: true });
-    await fs.writeFile(
-      path.join(gitRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.8.18" }),
-      "utf8",
-    );
+    await writeOpenClawPackageFixture(gitRoot, "2026.8.18", { git: true });
     const packageBefore = await fs.readFile(path.join(packageRoot, "package.json"), "utf8");
     const shimBefore = await fs.readFile(shim, "utf8");
     mockPackageInstallStatus(packageRoot);
     mockFileBackedPathExists();
     mockGitUpdateAfterMutation(makeOkUpdateResult({ mode: "git", root: gitRoot }));
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
-        return commandResult({ stdout: `${nodeModules}\n` });
-      }
+    mockNpmGlobalCommands(nodeModules, async (argv) => {
       if (argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g") {
         return commandResult({ code: 1, stderr: "candidate verification fixture failure" });
       }
-      return commandResult();
+      return undefined;
     });
 
     await withEnvAsync({ OPENCLAW_GIT_DIR: gitRoot }, async () => {
@@ -5478,14 +5433,9 @@ describe("update-cli", () => {
 
   it("does not stop or restart a managed gateway owned by another git checkout", async () => {
     const otherRoot = tempDirs.make("openclaw-update-other-service-root-");
-    const otherEntrypoint = path.join(otherRoot, "dist", "index.js");
-    await fs.mkdir(path.dirname(otherEntrypoint), { recursive: true });
-    await fs.writeFile(
-      path.join(otherRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.4.21" }),
-      "utf-8",
-    );
-    await fs.writeFile(otherEntrypoint, "export {};\n", "utf-8");
+    const otherEntrypoint = await writeOpenClawPackageFixture(otherRoot, "2026.4.21", {
+      entrySource: "export {};\n",
+    });
     mockRunningManagedGateway(["node", otherEntrypoint, "gateway", "run"]);
     const preparations = mockGitUpdateAfterMutation();
 
@@ -5500,13 +5450,10 @@ describe("update-cli", () => {
 
   it("leaves a stopped git service down when plugin post-update fails", async () => {
     const serviceEntrypoint = path.join(process.cwd(), "dist", "index.js");
-    const invalidPostUpdateSnapshot: ConfigFileSnapshot = {
-      ...baseSnapshot,
+    const invalidPostUpdateSnapshot = configSnapshot(baseConfig, {
       valid: false,
       issues: [{ path: "plugins", message: "invalid plugin config" }],
-      config: baseConfig,
-      runtimeConfig: baseConfig,
-    };
+    });
     vi.mocked(readConfigFileSnapshot)
       .mockResolvedValueOnce(baseSnapshot)
       .mockResolvedValueOnce(baseSnapshot)
@@ -5527,11 +5474,7 @@ describe("update-cli", () => {
     const serviceEntrypoint = path.join(process.cwd(), "dist", "index.js");
     mockRunningManagedGateway(["node", serviceEntrypoint, "gateway", "run"]);
     mockGitUpdateAfterMutation();
-    updateNpmInstalledPlugins.mockResolvedValueOnce({
-      changed: true,
-      config: baseConfig,
-      outcomes: [],
-    });
+    mockNpmPluginOutcomes([], true);
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(
       "/tmp/openclaw-updated-entry.mjs",
     );
@@ -5629,22 +5572,11 @@ describe("update-cli", () => {
       inventory: true,
     });
 
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (Array.isArray(argv) && argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
-        return commandResult({ stdout: `${nodeModules}\n` });
-      }
-      if (
-        Array.isArray(argv) &&
-        argv[0] === "npm" &&
-        argv.includes("-g") &&
-        !argv.includes("--omit=optional")
-      ) {
+    mockNpmGlobalCommands(nodeModules, async (argv) => {
+      if (argv[0] === "npm" && argv.includes("-g") && !argv.includes("--omit=optional")) {
         return commandResult({ stderr: "node-gyp failed", code: 1 });
       }
-      return commandResult();
+      return undefined;
     });
 
     await updateCommand({ yes: true, restart: false });
@@ -5836,8 +5768,7 @@ describe("update-cli", () => {
   ] as const)("updateCommand reports outcomes: $name", runUpdateCliScenario);
 
   it("persists the requested channel only after a successful package update", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
 
     await updateCommand({ channel: "beta", yes: true });
 
@@ -5872,11 +5803,7 @@ describe("update-cli", () => {
     const serviceRoot = tempDirs.make("openclaw-service-root-");
     const serviceNode = path.join(path.dirname(serviceRoot), "bin", "node");
     await fs.mkdir(path.join(serviceRoot, "dist"), { recursive: true });
-    await fs.writeFile(
-      path.join(serviceRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.5.18" }),
-      "utf-8",
-    );
+    await writeOpenClawPackageFixture(serviceRoot, "2026.5.18");
     mockPackageInstallStatus(shellRoot);
     primeServiceCommand([serviceNode, path.join(serviceRoot, "dist", "index.js"), "gateway"]);
 
@@ -5898,19 +5825,13 @@ describe("update-cli", () => {
     await fs.mkdir(path.join(serviceRoot, "dist"), { recursive: true });
     await fs.mkdir(path.dirname(serviceNode), { recursive: true });
     await fs.writeFile(serviceNode, "", "utf-8");
-    await fs.writeFile(
-      path.join(serviceRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.5.18" }),
-      "utf-8",
-    );
+    await writeOpenClawPackageFixture(serviceRoot, "2026.5.18");
     mockPackageInstallStatus(shellRoot);
     primeServiceCommand([serviceNode, path.join(serviceRoot, "dist", "index.js"), "gateway"]);
     primeNpmChannelTag("latest", "2026.5.20");
-    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
-      target: "latest",
-      version: "2026.5.20",
-      nodeEngine: ">=22.19.0",
-    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+      packageTargetStatus({ target: "latest", version: "2026.5.20" }),
+    );
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
       if (Array.isArray(argv) && argv[0] === serviceNode && argv[1] === "--version") {
         return commandResult({ stdout: "v22.18.0\n" });
@@ -5935,64 +5856,25 @@ describe("update-cli", () => {
   it("runs managed service package follow-up commands with the service Node", async () => {
     const shellRoot = createCaseDir("openclaw-shell-root");
     const servicePrefix = tempDirs.make("openclaw-service-prefix-");
-    const nodeModules = path.join(servicePrefix, "lib", "node_modules");
-    const serviceRoot = path.join(nodeModules, "openclaw");
-    const serviceNode = path.join(servicePrefix, "bin", "node");
-    const serviceNpm = path.join(servicePrefix, "bin", "npm");
-    const entrypoint = path.join(serviceRoot, "dist", "index.js");
-    await fs.mkdir(path.dirname(entrypoint), { recursive: true });
-    await fs.mkdir(path.dirname(serviceNode), { recursive: true });
-    await fs.writeFile(serviceNode, "", "utf-8");
-    await fs.writeFile(serviceNpm, "", "utf-8");
-    const serviceNpmReal = await fs.realpath(serviceNpm);
-    await fs.writeFile(
-      path.join(serviceRoot, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.5.18" }),
-      "utf-8",
-    );
-    await fs.writeFile(entrypoint, "", "utf-8");
-    await writePackageDistInventory(serviceRoot);
+    const {
+      nodeModules,
+      root: serviceRoot,
+      serviceNode,
+      serviceNpm,
+      serviceNpmReal,
+      entrypoint,
+    } = await setupServicePackageAtPrefix({ prefix: servicePrefix });
     mockPackageInstallStatus(shellRoot);
     primeServiceCommand([serviceNode, entrypoint, "gateway"]);
     serviceLoaded.mockResolvedValue(true);
     primeNpmChannelTag("latest", "2026.5.20");
     mockFileBackedPathExists();
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (Array.isArray(argv) && argv[0] === serviceNode && argv[1] === "--version") {
-        return commandResult({ stdout: "v22.22.0\n" });
-      }
-      if (
-        Array.isArray(argv) &&
-        (argv[0] === serviceNpm || argv[0] === serviceNpmReal) &&
-        argv[1] === "--version"
-      ) {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (
-        Array.isArray(argv) &&
-        (argv[0] === serviceNpm || argv[0] === serviceNpmReal) &&
-        argv[1] === "root" &&
-        argv[2] === "-g"
-      ) {
-        return commandResult({ stdout: `${nodeModules}\n` });
-      }
-      if (
-        Array.isArray(argv) &&
-        (argv[0] === serviceNpm || argv[0] === serviceNpmReal) &&
-        argv[1] === "i"
-      ) {
-        const stagePrefix = argv.includes("--prefix")
-          ? argv[argv.indexOf("--prefix") + 1]
-          : undefined;
-        const stageRoot = stagePrefix
-          ? path.join(stagePrefix, "lib", "node_modules", "openclaw")
-          : serviceRoot;
-        await writeOpenClawPackageFixture(stageRoot, "2026.5.20", {
-          entrySource: "export {};\n",
-          inventory: true,
-        });
-      }
-      return commandResult();
+    mockServicePackageCommands({
+      nodeModules,
+      packageRoot: serviceRoot,
+      targetVersion: "2026.5.20",
+      npmCommands: [serviceNpm, serviceNpmReal!],
+      nodeVersions: { [serviceNode]: "v22.22.0" },
     });
 
     await updateCommand({ yes: true });
@@ -6028,76 +5910,30 @@ describe("update-cli", () => {
 
   it("refreshes the managed service to current Node when its baked Node cannot run the target", async () => {
     const servicePrefix = tempDirs.make("openclaw-service-prefix-");
-    const nodeModules = path.join(servicePrefix, "lib", "node_modules");
-    const root = path.join(nodeModules, "openclaw");
-    const serviceNode = path.join(servicePrefix, "bin", "node");
-    const serviceNpm = path.join(servicePrefix, "bin", "npm");
-    const entrypoint = path.join(root, "dist", "index.js");
-    await fs.mkdir(path.dirname(entrypoint), { recursive: true });
-    await fs.mkdir(path.dirname(serviceNode), { recursive: true });
-    await fs.writeFile(serviceNode, "", "utf-8");
-    await fs.writeFile(serviceNpm, "", "utf-8");
-    const serviceNpmReal = await fs.realpath(serviceNpm);
-    await fs.writeFile(
-      path.join(root, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.5.18" }),
-      "utf-8",
-    );
-    await fs.writeFile(entrypoint, "", "utf-8");
-    await writePackageDistInventory(root);
+    const { nodeModules, root, serviceNode, serviceNpm, serviceNpmReal, entrypoint } =
+      await setupServicePackageAtPrefix({ prefix: servicePrefix });
     // Same package root for both shell and service.
     mockPackageInstallStatus(root);
     primeServiceCommand([serviceNode, entrypoint, "gateway"]);
     serviceLoaded.mockResolvedValue(true);
     primeNpmChannelTag("latest", "2026.7.1");
-    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue({
-      target: "latest",
-      version: "2026.7.1",
-      nodeEngine: ">=24.15.0 <25",
-    });
+    vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(
+      packageTargetStatus({
+        target: "latest",
+        version: "2026.7.1",
+        nodeEngine: ">=24.15.0 <25",
+      }),
+    );
     nodeVersionSatisfiesEngine.mockImplementation(
       (version: string | null) => version === "24.15.0",
     );
     mockFileBackedPathExists();
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (Array.isArray(argv) && argv[0] === serviceNode && argv[1] === "--version") {
-        return commandResult({ stdout: "v24.14.0\n" });
-      }
-      if (Array.isArray(argv) && argv[0] === process.execPath && argv[1] === "--version") {
-        return commandResult({ stdout: "v24.15.0\n" });
-      }
-      if (
-        Array.isArray(argv) &&
-        (argv[0] === serviceNpm || argv[0] === serviceNpmReal) &&
-        argv[1] === "--version"
-      ) {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (
-        Array.isArray(argv) &&
-        (argv[0] === serviceNpm || argv[0] === serviceNpmReal) &&
-        argv[1] === "root" &&
-        argv[2] === "-g"
-      ) {
-        return commandResult({ stdout: `${nodeModules}\n` });
-      }
-      if (
-        Array.isArray(argv) &&
-        (argv[0] === serviceNpm || argv[0] === serviceNpmReal) &&
-        argv[1] === "i"
-      ) {
-        const stagePrefix = argv.includes("--prefix")
-          ? argv[argv.indexOf("--prefix") + 1]
-          : undefined;
-        const stageRoot = stagePrefix
-          ? path.join(stagePrefix, "lib", "node_modules", "openclaw")
-          : root;
-        await writeOpenClawPackageFixture(stageRoot, "2026.7.1", {
-          entrySource: "export {};\n",
-          inventory: true,
-        });
-      }
-      return commandResult();
+    mockServicePackageCommands({
+      nodeModules,
+      packageRoot: root,
+      targetVersion: "2026.7.1",
+      npmCommands: [serviceNpm, serviceNpmReal!],
+      nodeVersions: { [serviceNode]: "v24.14.0", [process.execPath]: "v24.15.0" },
     });
 
     await updateCommand({ yes: true });
@@ -6109,55 +5945,29 @@ describe("update-cli", () => {
 
   it("pins package install to the service root when nodes differ and no owning npm exists at the prefix", async () => {
     const servicePrefix = tempDirs.make("openclaw-no-npm-prefix-");
-    const nodeModules = path.join(servicePrefix, "lib", "node_modules");
-    const root = path.join(nodeModules, "openclaw");
-    const serviceNode = path.join(servicePrefix, "bin", "node");
-    const entrypoint = path.join(root, "dist", "index.js");
     // Create the node binary but intentionally do NOT create <prefix>/bin/npm
     // so resolvePreferredNpmCommand returns null and the PATH npm is used.
-    await fs.mkdir(path.dirname(entrypoint), { recursive: true });
-    await fs.mkdir(path.dirname(serviceNode), { recursive: true });
-    await fs.writeFile(serviceNode, "", "utf-8");
+    const { root, serviceNode, entrypoint } = await setupServicePackageAtPrefix({
+      prefix: servicePrefix,
+      withNpm: false,
+    });
     // No npm binary at servicePrefix/bin/npm!
-    await fs.writeFile(
-      path.join(root, "package.json"),
-      JSON.stringify({ name: "openclaw", version: "2026.5.18" }),
-      "utf-8",
-    );
-    await fs.writeFile(entrypoint, "", "utf-8");
-    await writePackageDistInventory(root);
     mockPackageInstallStatus(root);
     primeServiceCommand([serviceNode, entrypoint, "gateway"]);
     serviceLoaded.mockResolvedValue(true);
     primeNpmChannelTag("latest", "2026.5.20");
     mockFileBackedPathExists();
     // The PATH npm returns a DIFFERENT global root (simulates Node-B's npm).
+    // PATH npm returns Node-B's root, NOT the service root.
+    // Install step: create the expected package structure at the target.
     const nodeBGlobalRoot = path.join(tempDirs.make("node-b-global-"), "lib", "node_modules");
     await fs.mkdir(nodeBGlobalRoot, { recursive: true });
-    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
-      if (Array.isArray(argv) && argv[0] === serviceNode && argv[1] === "--version") {
-        return commandResult({ stdout: "v24.14.0\n" });
-      }
-      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "--version") {
-        return commandResult({ stdout: "12.0.0\n" });
-      }
-      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "root" && argv[2] === "-g") {
-        // PATH npm returns Node-B's root, NOT the service root.
-        return commandResult({ stdout: `${nodeBGlobalRoot}\n` });
-      }
-      if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "i") {
-        // Install step: create the expected package structure at the target.
-        const prefixIdx = argv.indexOf("--prefix");
-        const stagePrefix = prefixIdx >= 0 ? argv[prefixIdx + 1] : undefined;
-        const stageRoot = stagePrefix
-          ? path.join(stagePrefix, "lib", "node_modules", "openclaw")
-          : root;
-        await writeOpenClawPackageFixture(stageRoot, "2026.5.20", {
-          entrySource: "export {};\n",
-          inventory: true,
-        });
-      }
-      return commandResult();
+    mockServicePackageCommands({
+      nodeModules: nodeBGlobalRoot,
+      packageRoot: root,
+      targetVersion: "2026.5.20",
+      npmCommands: ["npm"],
+      nodeVersions: { [serviceNode]: "v24.14.0" },
     });
 
     await updateCommand({ yes: true });
@@ -6177,8 +5987,7 @@ describe("update-cli", () => {
   });
 
   it("repairs legacy config before persisting a requested update channel", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     mockCurrentProcessFreshDoctor();
     const legacyConfig = {
       channels: {
@@ -6279,8 +6088,7 @@ describe("update-cli", () => {
   });
 
   it("does not auto-repair legacy config when authored includes are present", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     const legacyConfigWithInclude = {
       $include: "./channels.json5",
       channels: {
@@ -6316,8 +6124,7 @@ describe("update-cli", () => {
   });
 
   it("does not repair legacy config during a dry run", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     const legacyConfig = {
       channels: {
         slack: {
@@ -6356,8 +6163,7 @@ describe("update-cli", () => {
   });
 
   it("does not persist the requested channel when the package update fails", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
       if (Array.isArray(argv) && argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g") {
         return commandResult({ stderr: "install failed", code: 1 });
@@ -6372,8 +6178,7 @@ describe("update-cli", () => {
   });
 
   it("keeps the requested channel when plugin sync writes config after update", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     syncPluginsForUpdateChannel.mockImplementation(async ({ config }) =>
       pluginSyncResult(config, true),
     );
@@ -6390,8 +6195,7 @@ describe("update-cli", () => {
   });
 
   it("refreshes post-doctor config before post-update plugin sync", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     const preUpdateConfig = { update: { channel: "stable" } } as OpenClawConfig;
     const postDoctorConfig = {
       update: { channel: "stable" },
@@ -6443,27 +6247,13 @@ describe("update-cli", () => {
   });
 
   it("restores pre-update channels when post-core resume sees post-doctor config without them", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    const configPath = path.join(tempDir, "openclaw.json");
-    const preUpdateConfig = {
-      update: { channel: "stable" },
-      channels: {
-        whatsapp: {
-          enabled: true,
-          dmPolicy: "pairing",
-        },
-      },
-    } as OpenClawConfig;
-    const postDoctorConfig = {
-      update: { channel: "stable" },
-      meta: { lastTouchedVersion: "2026.5.14" },
-    } as OpenClawConfig;
-    await fs.mkdir(tempDir, { recursive: true });
-    await fs.writeFile(`${configPath}.pre-update`, `${JSON.stringify(preUpdateConfig)}\n`, "utf-8");
-    await fs.writeFile(`${configPath}.bak`, `${JSON.stringify(postDoctorConfig)}\n`, "utf-8");
-    await fs.writeFile(configPath, `${JSON.stringify(postDoctorConfig)}\n`, "utf-8");
-    mockPostDoctorSnapshot(configPath, postDoctorConfig);
-    mockNoopPostUpdatePluginConvergence();
+    const preUpdateConfig = stableWhatsAppConfig();
+    const postDoctorConfig = stableConfig({ meta: { lastTouchedVersion: "2026.5.14" } });
+    await setupPostCoreConfigFixture({
+      preUpdateConfig,
+      backupConfig: postDoctorConfig,
+      postDoctorConfig,
+    });
 
     await runPostCoreUpdate();
 
@@ -6487,8 +6277,6 @@ describe("update-cli", () => {
   });
 
   it("restores pre-update channel model overrides when post-core resume restores a channel", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    const configPath = path.join(tempDir, "openclaw.json");
     const preUpdateConfig = {
       update: { channel: "stable" },
       channels: {
@@ -6520,11 +6308,7 @@ describe("update-cli", () => {
         },
       },
     } as OpenClawConfig;
-    await fs.mkdir(tempDir, { recursive: true });
-    await fs.writeFile(`${configPath}.pre-update`, `${JSON.stringify(preUpdateConfig)}\n`, "utf-8");
-    await fs.writeFile(configPath, `${JSON.stringify(postDoctorConfig)}\n`, "utf-8");
-    mockPostDoctorSnapshot(configPath, postDoctorConfig);
-    mockNoopPostUpdatePluginConvergence();
+    await setupPostCoreConfigFixture({ preUpdateConfig, postDoctorConfig });
 
     await runPostCoreUpdate();
 
@@ -6558,12 +6342,8 @@ describe("update-cli", () => {
     {
       name: "does not restore stale backup channels when current pre-update snapshot has none",
       prepare: async (configPath: string, preUpdateConfig: OpenClawConfig) => {
-        await fs.writeFile(
-          `${configPath}.pre-update`,
-          `${JSON.stringify({ update: { channel: "stable" } })}\n`,
-          "utf-8",
-        );
-        await fs.writeFile(`${configPath}.bak`, `${JSON.stringify(preUpdateConfig)}\n`, "utf-8");
+        await writeJsonFixture(`${configPath}.pre-update`, stableConfig());
+        await writeJsonFixture(`${configPath}.bak`, preUpdateConfig);
         return {};
       },
     },
@@ -6574,7 +6354,7 @@ describe("update-cli", () => {
         const staleTime = new Date(updateStartedAtMs - 60_000);
         for (const suffix of [".pre-update", ".bak"]) {
           const snapshotPath = `${configPath}${suffix}`;
-          await fs.writeFile(snapshotPath, `${JSON.stringify(preUpdateConfig)}\n`, "utf-8");
+          await writeJsonFixture(snapshotPath, preUpdateConfig);
           await fs.utimes(snapshotPath, staleTime, staleTime);
         }
         return { OPENCLAW_UPDATE_POST_CORE_STARTED_AT_MS: String(updateStartedAtMs) };
@@ -6584,11 +6364,7 @@ describe("update-cli", () => {
       name: "ignores disk fallback snapshots when the update attempt start is unknown",
       prepare: async (configPath: string, preUpdateConfig: OpenClawConfig) => {
         for (const suffix of [".pre-update", ".bak"]) {
-          await fs.writeFile(
-            `${configPath}${suffix}`,
-            `${JSON.stringify(preUpdateConfig)}\n`,
-            "utf-8",
-          );
+          await writeJsonFixture(`${configPath}${suffix}`, preUpdateConfig);
         }
         vi.mocked(runExec).mockRejectedValueOnce(new Error("ps unavailable"));
         return {};
@@ -6602,7 +6378,7 @@ describe("update-cli", () => {
           channels: { whatsapp: { enabled: true } },
         } as OpenClawConfig;
         const snapshotPath = `${configPath}.pre-update`;
-        await fs.writeFile(snapshotPath, `${JSON.stringify(staleConfig)}\n`, "utf-8");
+        await writeJsonFixture(snapshotPath, staleConfig);
         const staleTime = new Date(Date.now() - 7 * 60 * 60 * 1000);
         await fs.utimes(snapshotPath, staleTime, staleTime);
         return {};
@@ -6611,14 +6387,11 @@ describe("update-cli", () => {
   ])("$name", async ({ prepare, preserveParsed = false }) => {
     const tempDir = createCaseDir("openclaw-update");
     const configPath = path.join(tempDir, "openclaw.json");
-    const preUpdateConfig = {
-      update: { channel: "stable" },
-      channels: { whatsapp: { enabled: true, dmPolicy: "pairing" } },
-    } as OpenClawConfig;
-    const postDoctorConfig = { update: { channel: "stable" } } as OpenClawConfig;
+    const preUpdateConfig = stableWhatsAppConfig();
+    const postDoctorConfig = stableConfig();
     await fs.mkdir(tempDir, { recursive: true });
     const env = await prepare(configPath, preUpdateConfig);
-    await fs.writeFile(configPath, `${JSON.stringify(postDoctorConfig)}\n`, "utf-8");
+    await writeJsonFixture(configPath, postDoctorConfig);
     mockPostDoctorSnapshot(configPath, postDoctorConfig, { preserveParsed });
     mockNoopPostUpdatePluginConvergence();
 
@@ -6629,25 +6402,9 @@ describe("update-cli", () => {
   });
 
   it("uses the Windows parent process start time for old post-core parents", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    const configPath = path.join(tempDir, "openclaw.json");
-    const preUpdateConfig = {
-      update: { channel: "stable" },
-      channels: {
-        whatsapp: {
-          enabled: true,
-          dmPolicy: "pairing",
-        },
-      },
-    } as OpenClawConfig;
-    const postDoctorConfig = {
-      update: { channel: "stable" },
-    } as OpenClawConfig;
-    await fs.mkdir(tempDir, { recursive: true });
-    await fs.writeFile(`${configPath}.pre-update`, `${JSON.stringify(preUpdateConfig)}\n`, "utf-8");
-    await fs.writeFile(configPath, `${JSON.stringify(postDoctorConfig)}\n`, "utf-8");
-    mockPostDoctorSnapshot(configPath, postDoctorConfig);
-    mockNoopPostUpdatePluginConvergence();
+    const preUpdateConfig = stableWhatsAppConfig();
+    const postDoctorConfig = stableConfig();
+    await setupPostCoreConfigFixture({ preUpdateConfig, postDoctorConfig });
     vi.mocked(runExec).mockImplementationOnce(async (file, commandArgs) => {
       expect(file).toBe("powershell.exe");
       expect(commandArgs).toContain("-NonInteractive");
@@ -6702,14 +6459,10 @@ describe("update-cli", () => {
       meta: { lastTouchedVersion: "2026.5.14" },
     } as OpenClawConfig;
     await fs.mkdir(tempDir, { recursive: true });
-    await fs.writeFile(
-      sourceConfigPath,
-      `${JSON.stringify({
-        sourceConfig: resolvedPreUpdateConfig,
-        authoredConfig: authoredPreUpdateConfig,
-      })}\n`,
-      "utf-8",
-    );
+    await writeJsonFixture(sourceConfigPath, {
+      sourceConfig: resolvedPreUpdateConfig,
+      authoredConfig: authoredPreUpdateConfig,
+    });
     vi.mocked(readConfigFileSnapshot).mockResolvedValue({
       ...baseSnapshot,
       sourceConfig: postDoctorConfig,
@@ -6754,9 +6507,9 @@ describe("update-cli", () => {
       channels: {},
     } as OpenClawConfig;
     await fs.mkdir(tempDir, { recursive: true });
-    await fs.writeFile(channelsPath, `${JSON.stringify(includedChannels)}\n`, "utf-8");
-    await fs.writeFile(`${configPath}.bak`, `${JSON.stringify(preUpdateConfig)}\n`, "utf-8");
-    await fs.writeFile(configPath, `${JSON.stringify(postDoctorConfig)}\n`, "utf-8");
+    await writeJsonFixture(channelsPath, includedChannels);
+    await writeJsonFixture(`${configPath}.bak`, preUpdateConfig);
+    await writeJsonFixture(configPath, postDoctorConfig);
     mockPostDoctorSnapshot(configPath, postDoctorConfig);
     mockNoopPostUpdatePluginConvergence();
 
@@ -6777,8 +6530,7 @@ describe("update-cli", () => {
   });
 
   it("uses source config and plugin index records for post-update plugin sync", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     const pluginInstallRecords = {
       "lossless-claw": {
         source: "npm",
@@ -6826,8 +6578,7 @@ describe("update-cli", () => {
   });
 
   it("forwards ClawHub risk acknowledgement to post-update plugin work", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
 
     await updateCommand({
       channel: "beta",
@@ -6861,8 +6612,7 @@ describe("update-cli", () => {
       options: { channel: "beta", dryRun: true, restart: false },
     },
   ])("does not prompt for ClawHub risk when $name", async ({ stdoutTty, options }) => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     setTty(true);
     setStdoutTty(stdoutTty);
 
@@ -6999,12 +6749,7 @@ describe("update-cli", () => {
       name: "refreshes service env when already installed",
       run: async () => {
         mockOwnedGitService();
-        mockGitUpdateAfterMutation({
-          status: "ok",
-          mode: "git",
-          steps: [],
-          durationMs: 100,
-        } satisfies UpdateRunResult);
+        mockGitUpdateAfterMutation();
         vi.mocked(runDaemonInstall).mockResolvedValue(undefined);
         serviceLoaded.mockResolvedValue(true);
 
@@ -7083,8 +6828,7 @@ describe("update-cli", () => {
   ] as const)("updateCommand service refresh behavior: $name", runUpdateCliScenario);
 
   it("restores an unknown package service without rewriting its missing updated entrypoint", async () => {
-    const tempDir = createCaseDir("openclaw-update");
-    mockPackageInstallStatus(tempDir);
+    mockPackageInstallAtCaseDir();
     mockCurrentProcessFreshDoctor();
     serviceLoaded.mockResolvedValue(true);
     vi.mocked(runDaemonInstall).mockRejectedValueOnce(new Error("refresh failed"));
@@ -7118,12 +6862,6 @@ describe("update-cli", () => {
     const updatedRoot = createCaseDir("openclaw-updated-root");
     const updatedEntrypoint = path.join(updatedRoot, "dist", "entry.js");
     const updatedPackageJson = path.join(updatedRoot, "package.json");
-    await fs.mkdir(updatedRoot, { recursive: true });
-    await fs.writeFile(
-      updatedPackageJson,
-      JSON.stringify({ name: "openclaw", version: "2026.4.24" }),
-      "utf8",
-    );
     setupUpdatedRootRefresh({
       entrypoints: [updatedEntrypoint],
       gatewayUpdateImpl: async () =>
@@ -7158,22 +6896,6 @@ describe("update-cli", () => {
     const updatedEntrypoint = path.join(updatedRoot, "dist", "entry.js");
     const oldPackageJson = path.join(oldRoot, "package.json");
     const updatedPackageJson = path.join(updatedRoot, "package.json");
-    await Promise.all([
-      fs.mkdir(oldRoot, { recursive: true }),
-      fs.mkdir(updatedRoot, { recursive: true }),
-    ]);
-    await Promise.all([
-      fs.writeFile(
-        oldPackageJson,
-        JSON.stringify({ name: "openclaw", version: "2026.4.24" }),
-        "utf8",
-      ),
-      fs.writeFile(
-        updatedPackageJson,
-        JSON.stringify({ name: "openclaw", version: "2026.4.24" }),
-        "utf8",
-      ),
-    ]);
     setupUpdatedRootRefresh({
       entrypoints: [oldEntrypoint, updatedEntrypoint],
       gatewayUpdateImpl: async () =>
@@ -7864,14 +7586,10 @@ describe("update-cli", () => {
       hash: "post-doctor",
     });
     await fs.mkdir(tempDir, { recursive: true });
-    await fs.writeFile(
-      sourceConfigPath,
-      `${JSON.stringify({
-        sourceConfig: preUpdateConfig,
-        authoredConfig: preUpdateConfig,
-      })}\n`,
-      "utf-8",
-    );
+    await writeJsonFixture(sourceConfigPath, {
+      sourceConfig: preUpdateConfig,
+      authoredConfig: preUpdateConfig,
+    });
     vi.mocked(readConfigFileSnapshot).mockResolvedValue(postDoctorSnapshot);
 
     await withEnvAsync(
@@ -8046,12 +7764,7 @@ describe("update-cli", () => {
       });
       select.mockResolvedValue("dev");
       confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
-      vi.mocked(runGatewayUpdate).mockResolvedValue({
-        status: "ok",
-        mode: "git",
-        steps: [],
-        durationMs: 100,
-      });
+      vi.mocked(runGatewayUpdate).mockResolvedValue(makeOkUpdateResult());
 
       await updateWizardCommand({});
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -458,11 +458,6 @@ vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: mocks.readConfigFileSnapshot,
 }));
 
-vi.mock("../commands/doctor-gateway-health.js", () => ({
-  checkGatewayHealth: mocks.checkGatewayHealth,
-  probeGatewayMemoryStatus: mocks.probeGatewayMemoryStatus,
-}));
-
 vi.mock("../cli/daemon-cli/status.gather.js", () => ({
   gatherDaemonStatus: mocks.gatherDaemonStatus,
 }));
@@ -571,18 +566,6 @@ vi.mock("../cli/command-format.js", () => ({
   formatCliCommand: mocks.formatCliCommand,
 }));
 
-vi.mock("../commands/doctor-gateway-services.js", () => ({
-  maybeRepairGatewayServiceConfig: mocks.maybeRepairGatewayServiceConfig,
-  maybeScanExtraGatewayServices: mocks.maybeScanExtraGatewayServices,
-  maybeResolveDuelingSystemdGatewayScopes: mocks.maybeResolveDuelingSystemdGatewayScopes,
-}));
-
-vi.mock("../commands/doctor-platform-notes.js", () => ({
-  noteMacLaunchAgentOverrides: mocks.noteMacLaunchAgentOverrides,
-  noteMacLaunchctlGatewayEnvOverrides: mocks.noteMacLaunchctlGatewayEnvOverrides,
-  noteMacStaleOpenClawUpdateLaunchdJobs: mocks.noteMacStaleOpenClawUpdateLaunchdJobs,
-}));
-
 function requireDoctorContribution(id: string) {
   const contribution = resolveDoctorHealthContributions().find((entry) => entry.id === id);
   if (!contribution) {
@@ -614,6 +597,29 @@ function buildDoctorPrompter(shouldRepair: boolean): DoctorPrompter {
   };
 }
 
+function createDoctorContext({
+  shouldRepair = false,
+  ...overrides
+}: Parameters<typeof createDoctorHealthFlowContext>[0] & { shouldRepair?: boolean } = {}) {
+  return createDoctorHealthFlowContext({
+    configPath: "/tmp/fake-openclaw.json",
+    prompter: buildDoctorPrompter(shouldRepair),
+    ...overrides,
+  });
+}
+
+function createDoctorLintFixture(
+  cfg: OpenClawConfig | Record<string, unknown> = {},
+  overrides: Omit<Parameters<typeof createDoctorLintContext>[0], "cfg"> = {},
+) {
+  return createDoctorLintContext({
+    cfg: cfg as OpenClawConfig,
+    mode: "lint",
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    ...overrides,
+  });
+}
+
 describe("doctor health contributions", () => {
   async function withProcessPlatform<T>(
     platform: NodeJS.Platform,
@@ -635,69 +641,49 @@ describe("doctor health contributions", () => {
     mocks.maybeRunConfiguredPluginInstallReleaseStep.mockReset();
     mocks.registerBundledHealthChecks.mockReset();
     mocks.runDoctorHealthRepairs.mockReset();
-    mocks.maybeMigrateAuthProfileJsonStoresToSqlite.mockClear();
-    mocks.maybeMigrateAuthProfileJsonStoresToSqlite.mockResolvedValue(undefined);
-    mocks.maybeMigrateLegacyPluginModelCatalogs.mockClear();
-    mocks.maybeMigrateLegacyPluginModelCatalogs.mockResolvedValue({
+    mocks.maybeMigrateAuthProfileJsonStoresToSqlite.mockClear().mockResolvedValue(undefined);
+    mocks.maybeMigrateLegacyPluginModelCatalogs.mockClear().mockResolvedValue({
       detected: 0,
       migrated: 0,
       warnings: [],
     });
-    mocks.maybeRepairGatewayDaemon.mockClear();
-    mocks.maybeRepairGatewayDaemon.mockResolvedValue(undefined);
-    mocks.maybeRepairLegacyOAuthProfileIds.mockClear();
-    mocks.maybeRepairLegacyOAuthProfileIds.mockImplementation(async (cfg: unknown) => cfg);
-    mocks.collectLegacyPluginManifestContractMigrations.mockReset();
-    mocks.collectLegacyPluginManifestContractMigrations.mockReturnValue([]);
+    mocks.maybeRepairGatewayDaemon.mockClear().mockResolvedValue(undefined);
+    mocks.maybeRepairLegacyOAuthProfileIds
+      .mockClear()
+      .mockImplementation(async (cfg: unknown) => cfg);
+    mocks.collectLegacyPluginManifestContractMigrations.mockReset().mockReturnValue([]);
     mocks.legacyPluginManifestContractMigrationToHealthFinding.mockClear();
-    mocks.maybeRepairLegacyPluginManifestContracts.mockClear();
-    mocks.maybeRepairLegacyPluginManifestContracts.mockResolvedValue(undefined);
-    mocks.maybeRepairLegacyOAuthSidecarProfiles.mockClear();
-    mocks.maybeRepairLegacyOAuthSidecarProfiles.mockResolvedValue(undefined);
-    mocks.collectAuthProfileHealthFindings.mockClear();
-    mocks.collectAuthProfileHealthFindings.mockResolvedValue([]);
-    mocks.noteAuthProfileHealth.mockClear();
-    mocks.noteAuthProfileHealth.mockResolvedValue(undefined);
+    mocks.maybeRepairLegacyPluginManifestContracts.mockClear().mockResolvedValue(undefined);
+    mocks.maybeRepairLegacyOAuthSidecarProfiles.mockClear().mockResolvedValue(undefined);
+    mocks.collectAuthProfileHealthFindings.mockClear().mockResolvedValue([]);
+    mocks.noteAuthProfileHealth.mockClear().mockResolvedValue(undefined);
     mocks.noteLegacyCodexProviderOverride.mockClear();
     mocks.noteSharedAuthStoreStatus.mockClear();
-    mocks.noteMemorySearchHealth.mockClear();
-    mocks.noteMemorySearchHealth.mockResolvedValue(undefined);
-    mocks.noteWebFetchProxyDiagnostic.mockClear();
-    mocks.noteWebFetchProxyDiagnostic.mockResolvedValue(undefined);
-    mocks.buildGatewayConnectionDetails.mockClear();
-    mocks.buildGatewayConnectionDetails.mockReturnValue({ message: "gateway details" });
-    mocks.callGateway.mockReset();
-    mocks.callGateway.mockResolvedValue({});
+    mocks.noteMemorySearchHealth.mockClear().mockResolvedValue(undefined);
+    mocks.noteWebFetchProxyDiagnostic.mockClear().mockResolvedValue(undefined);
+    mocks.buildGatewayConnectionDetails.mockClear().mockReturnValue({ message: "gateway details" });
+    mocks.callGateway.mockReset().mockResolvedValue({});
     mocks.resolveSecretInputRef.mockClear();
-    mocks.resolveGatewayAuth.mockClear();
-    mocks.resolveGatewayAuth.mockReturnValue({ mode: "token", token: undefined });
-    mocks.resolveGatewayAuthToken.mockClear();
-    mocks.resolveGatewayAuthToken.mockResolvedValue({
+    mocks.resolveGatewayAuth.mockClear().mockReturnValue({ mode: "token", token: undefined });
+    mocks.resolveGatewayAuthToken.mockClear().mockResolvedValue({
       source: "unavailable",
       unresolvedRefReason: "exec provider failed",
     });
-    mocks.getSkippedExecRefStaticError.mockClear();
-    mocks.getSkippedExecRefStaticError.mockReturnValue(undefined);
-    mocks.maybeRepairGatewayServiceConfig.mockClear();
-    mocks.maybeRepairGatewayServiceConfig.mockResolvedValue(undefined);
-    mocks.maybeScanExtraGatewayServices.mockClear();
-    mocks.maybeScanExtraGatewayServices.mockResolvedValue(undefined);
+    mocks.getSkippedExecRefStaticError.mockClear().mockReturnValue(undefined);
+    mocks.maybeRepairGatewayServiceConfig.mockClear().mockResolvedValue(undefined);
+    mocks.maybeScanExtraGatewayServices.mockClear().mockResolvedValue(undefined);
     mocks.maybeResolveDuelingSystemdGatewayScopes.mockClear();
     mocks.noteMacLaunchAgentOverrides.mockClear();
     mocks.noteMacLaunchctlGatewayEnvOverrides.mockClear();
     mocks.noteMacStaleOpenClawUpdateLaunchdJobs.mockClear();
-    mocks.gatewaySecretInputPathCanWin.mockClear();
-    mocks.gatewaySecretInputPathCanWin.mockReset();
-    mocks.readGatewaySecretInputValue.mockClear();
-    mocks.readGatewaySecretInputValue.mockReset();
-    mocks.checkGatewayHealth.mockClear();
-    mocks.checkGatewayHealth.mockResolvedValue({
+    mocks.gatewaySecretInputPathCanWin.mockClear().mockReset();
+    mocks.readGatewaySecretInputValue.mockClear().mockReset();
+    mocks.checkGatewayHealth.mockClear().mockResolvedValue({
       authenticated: true,
       healthOk: true,
       status: { ok: true },
     });
-    mocks.probeGatewayMemoryStatus.mockClear();
-    mocks.probeGatewayMemoryStatus.mockResolvedValue({
+    mocks.probeGatewayMemoryStatus.mockClear().mockResolvedValue({
       checked: true,
       ready: true,
       skipped: false,
@@ -716,66 +702,57 @@ describe("doctor health contributions", () => {
       checksRepaired: 0,
       checksValidated: 0,
     }));
-    mocks.listHealthChecks.mockReset();
-    mocks.listHealthChecks.mockReturnValue([
+    mocks.listHealthChecks.mockReset().mockReturnValue([
       { id: "core/example/internal", kind: "core" },
       { id: "plugin/example/unrelated", kind: "plugin" },
     ]);
-    mocks.noteChromeMcpBrowserReadiness.mockReset();
-    mocks.noteChromeMcpBrowserReadiness.mockResolvedValue(undefined);
-    mocks.detectLegacyStateMigrations.mockReset();
-    mocks.detectLegacyStateMigrations.mockResolvedValue({ preview: [], warnings: [], notices: [] });
-    mocks.runLegacyStateMigrations.mockReset();
-    mocks.runLegacyStateMigrations.mockResolvedValue({ changes: [], warnings: [] });
-    mocks.detectLegacyClawdBrowserProfileResidue.mockReset();
-    mocks.detectLegacyClawdBrowserProfileResidue.mockReturnValue(null);
-    mocks.maybeArchiveLegacyClawdBrowserProfileResidue.mockReset();
-    mocks.maybeArchiveLegacyClawdBrowserProfileResidue.mockResolvedValue({
+    mocks.noteChromeMcpBrowserReadiness.mockReset().mockResolvedValue(undefined);
+    mocks.detectLegacyStateMigrations
+      .mockReset()
+      .mockResolvedValue({ preview: [], warnings: [], notices: [] });
+    mocks.runLegacyStateMigrations.mockReset().mockResolvedValue({ changes: [], warnings: [] });
+    mocks.detectLegacyClawdBrowserProfileResidue.mockReset().mockReturnValue(null);
+    mocks.maybeArchiveLegacyClawdBrowserProfileResidue.mockReset().mockResolvedValue({
       changes: [],
       warnings: [],
     });
-    mocks.resolveAgentWorkspaceDir.mockReset();
-    mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-workspace");
-    mocks.tryResolveConfiguredAgentWorkspaceDir.mockReset();
-    mocks.tryResolveConfiguredAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-workspace");
-    mocks.tryResolveSystemAgentWorkspaceDir.mockReset();
-    mocks.tryResolveSystemAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-workspace");
-    mocks.listAgentIds.mockReset();
-    mocks.listAgentIds.mockReturnValue(["default"]);
-    mocks.listAgentEntries.mockReset();
-    mocks.listAgentEntries.mockReturnValue([{ id: "default" }]);
-    mocks.tryResolveSoleAgentId.mockReset();
-    mocks.tryResolveSoleAgentId.mockReturnValue("default");
-    mocks.resolveDefaultAgentId.mockReset();
-    mocks.resolveDefaultAgentId.mockReturnValue("default");
-    mocks.resolveAgentContextLimits.mockReset();
-    mocks.resolveAgentContextLimits.mockImplementation(
-      (cfg: { agents?: { defaults?: { contextLimits?: unknown } } }) =>
-        cfg.agents?.defaults?.contextLimits ?? {},
-    );
+    mocks.resolveAgentWorkspaceDir.mockReset().mockReturnValue("/tmp/openclaw-workspace");
+    mocks.tryResolveConfiguredAgentWorkspaceDir
+      .mockReset()
+      .mockReturnValue("/tmp/openclaw-workspace");
+    mocks.tryResolveSystemAgentWorkspaceDir.mockReset().mockReturnValue("/tmp/openclaw-workspace");
+    mocks.listAgentIds.mockReset().mockReturnValue(["default"]);
+    mocks.listAgentEntries.mockReset().mockReturnValue([{ id: "default" }]);
+    mocks.tryResolveSoleAgentId.mockReset().mockReturnValue("default");
+    mocks.resolveDefaultAgentId.mockReset().mockReturnValue("default");
+    mocks.resolveAgentContextLimits
+      .mockReset()
+      .mockImplementation(
+        (cfg: { agents?: { defaults?: { contextLimits?: unknown } } }) =>
+          cfg.agents?.defaults?.contextLimits ?? {},
+      );
     mocks.note.mockReset();
-    mocks.collectActiveToolSchemaProjectionWarnings.mockReset();
-    mocks.collectActiveToolSchemaProjectionWarnings.mockResolvedValue([]);
-    mocks.loadModelCatalog.mockReset();
-    mocks.loadModelCatalog.mockResolvedValue([]);
-    mocks.findModelCatalogEntry.mockReset();
-    mocks.findModelCatalogEntry.mockReturnValue({ contextTokens: 200_000 });
-    mocks.getModelRefStatus.mockReset();
-    mocks.getModelRefStatus.mockReturnValue({
+    mocks.collectActiveToolSchemaProjectionWarnings.mockReset().mockResolvedValue([]);
+    mocks.loadModelCatalog.mockReset().mockResolvedValue([]);
+    mocks.findModelCatalogEntry.mockReset().mockReturnValue({ contextTokens: 200_000 });
+    mocks.getModelRefStatus.mockReset().mockReturnValue({
       allowed: true,
       inCatalog: true,
       key: "openai/gpt-5.5",
     });
-    mocks.resolveConfiguredModelRef.mockReset();
-    mocks.resolveConfiguredModelRef.mockReturnValue({ provider: "openai", model: "gpt-5.5" });
-    mocks.resolveDefaultModelForAgent.mockReset();
-    mocks.resolveDefaultModelForAgent.mockReturnValue({ provider: "openai", model: "gpt-5.5" });
-    mocks.resolveHooksGmailModel.mockReset();
-    mocks.resolveHooksGmailModel.mockReturnValue({ provider: "openai", model: "gpt-5.5" });
-    mocks.modelKey.mockReset();
-    mocks.modelKey.mockImplementation((provider: string, model: string) => `${provider}/${model}`);
-    mocks.readConfigFileSnapshot.mockReset();
-    mocks.readConfigFileSnapshot.mockResolvedValue({
+    mocks.resolveConfiguredModelRef
+      .mockReset()
+      .mockReturnValue({ provider: "openai", model: "gpt-5.5" });
+    mocks.resolveDefaultModelForAgent
+      .mockReset()
+      .mockReturnValue({ provider: "openai", model: "gpt-5.5" });
+    mocks.resolveHooksGmailModel
+      .mockReset()
+      .mockReturnValue({ provider: "openai", model: "gpt-5.5" });
+    mocks.modelKey
+      .mockReset()
+      .mockImplementation((provider: string, model: string) => `${provider}/${model}`);
+    mocks.readConfigFileSnapshot.mockReset().mockResolvedValue({
       exists: true,
       valid: true,
       config: {},
@@ -783,81 +760,58 @@ describe("doctor health contributions", () => {
     });
     mocks.checkGatewayHealth.mockReset();
     mocks.probeGatewayMemoryStatus.mockReset();
-    mocks.gatherDaemonStatus.mockReset();
-    mocks.gatherDaemonStatus.mockResolvedValue({});
+    mocks.gatherDaemonStatus.mockReset().mockResolvedValue({});
     mocks.noteWorkspaceStatus.mockReset();
-    mocks.resolveGatewayService.mockReset();
-    mocks.resolveGatewayService.mockReturnValue({ isLoaded: mocks.gatewayServiceIsLoaded });
-    mocks.gatewayServiceIsLoaded.mockReset();
-    mocks.gatewayServiceIsLoaded.mockResolvedValue(true);
-    mocks.collectWorkspaceStatusHealthFindings.mockReset();
-    mocks.collectWorkspaceStatusHealthFindings.mockResolvedValue([]);
-    mocks.collectDiskSpaceHealthFindings.mockReset();
-    mocks.collectDiskSpaceHealthFindings.mockReturnValue([]);
-    mocks.collectHeartbeatCadenceMigrationFindings.mockReset();
-    mocks.collectHeartbeatCadenceMigrationFindings.mockResolvedValue([]);
-    mocks.maybeMigrateHeartbeatCadenceToCron.mockReset();
-    mocks.maybeMigrateHeartbeatCadenceToCron.mockResolvedValue({ changes: [], warnings: [] });
-    mocks.collectHeartbeatScratchMigrationFindings.mockReset();
-    mocks.collectHeartbeatScratchMigrationFindings.mockResolvedValue([]);
-    mocks.maybeMigrateHeartbeatFilesToScratch.mockReset();
-    mocks.maybeMigrateHeartbeatFilesToScratch.mockResolvedValue({ changes: [], warnings: [] });
-    mocks.collectToolsMdMigrationFindings.mockReset();
-    mocks.collectToolsMdMigrationFindings.mockResolvedValue([]);
-    mocks.maybeMigrateToolsMd.mockReset();
-    mocks.maybeMigrateToolsMd.mockResolvedValue({ changes: [], warnings: [] });
-    mocks.collectHeartbeatTaskMigrationFindings.mockReset();
-    mocks.collectHeartbeatTaskMigrationFindings.mockResolvedValue([]);
-    mocks.maybeMigrateHeartbeatTasksToCron.mockReset();
-    mocks.maybeMigrateHeartbeatTasksToCron.mockResolvedValue({ changes: [], warnings: [] });
-    mocks.collectWhatsappResponsivenessHealthFindings.mockReset();
-    mocks.collectWhatsappResponsivenessHealthFindings.mockReturnValue([]);
-    mocks.noteWhatsappResponsivenessHealth.mockReset();
-    mocks.noteWhatsappResponsivenessHealth.mockResolvedValue(undefined);
-    mocks.collectDevicePairingHealthFindings.mockReset();
-    mocks.collectDevicePairingHealthFindings.mockResolvedValue([]);
-    mocks.collectLegacyCronStoreHealthFindings.mockReset();
-    mocks.collectLegacyCronStoreHealthFindings.mockResolvedValue([]);
-    mocks.collectLegacyWhatsAppCrontabHealthWarning.mockReset();
-    mocks.collectLegacyWhatsAppCrontabHealthWarning.mockResolvedValue(undefined);
-    mocks.maybeRepairLegacyCronStore.mockReset();
-    mocks.maybeRepairLegacyCronStore.mockResolvedValue(undefined);
-    mocks.repairCronCodexModelRefsAfterConfigWrite.mockReset();
-    mocks.repairCronCodexModelRefsAfterConfigWrite.mockResolvedValue({
+    mocks.resolveGatewayService
+      .mockReset()
+      .mockReturnValue({ isLoaded: mocks.gatewayServiceIsLoaded });
+    mocks.gatewayServiceIsLoaded.mockReset().mockResolvedValue(true);
+    mocks.collectWorkspaceStatusHealthFindings.mockReset().mockResolvedValue([]);
+    mocks.collectDiskSpaceHealthFindings.mockReset().mockReturnValue([]);
+    mocks.collectHeartbeatCadenceMigrationFindings.mockReset().mockResolvedValue([]);
+    mocks.maybeMigrateHeartbeatCadenceToCron
+      .mockReset()
+      .mockResolvedValue({ changes: [], warnings: [] });
+    mocks.collectHeartbeatScratchMigrationFindings.mockReset().mockResolvedValue([]);
+    mocks.maybeMigrateHeartbeatFilesToScratch
+      .mockReset()
+      .mockResolvedValue({ changes: [], warnings: [] });
+    mocks.collectToolsMdMigrationFindings.mockReset().mockResolvedValue([]);
+    mocks.maybeMigrateToolsMd.mockReset().mockResolvedValue({ changes: [], warnings: [] });
+    mocks.collectHeartbeatTaskMigrationFindings.mockReset().mockResolvedValue([]);
+    mocks.maybeMigrateHeartbeatTasksToCron
+      .mockReset()
+      .mockResolvedValue({ changes: [], warnings: [] });
+    mocks.collectWhatsappResponsivenessHealthFindings.mockReset().mockReturnValue([]);
+    mocks.noteWhatsappResponsivenessHealth.mockReset().mockResolvedValue(undefined);
+    mocks.collectDevicePairingHealthFindings.mockReset().mockResolvedValue([]);
+    mocks.collectLegacyCronStoreHealthFindings.mockReset().mockResolvedValue([]);
+    mocks.collectLegacyWhatsAppCrontabHealthWarning.mockReset().mockResolvedValue(undefined);
+    mocks.maybeRepairLegacyCronStore.mockReset().mockResolvedValue(undefined);
+    mocks.repairCronCodexModelRefsAfterConfigWrite.mockReset().mockResolvedValue({
       changes: [],
       warnings: [],
     });
-    mocks.noteLegacyWhatsAppCrontabHealthCheck.mockReset();
-    mocks.noteLegacyWhatsAppCrontabHealthCheck.mockResolvedValue(undefined);
-    mocks.scanConfiguredChannelPluginBlockers.mockReset();
-    mocks.scanConfiguredChannelPluginBlockers.mockReturnValue([]);
+    mocks.noteLegacyWhatsAppCrontabHealthCheck.mockReset().mockResolvedValue(undefined);
+    mocks.scanConfiguredChannelPluginBlockers.mockReset().mockReturnValue([]);
     mocks.channelPluginBlockerHitToHealthFinding.mockClear();
-    mocks.collectBundledChannelPackageStateLoadFailures.mockReset();
-    mocks.collectBundledChannelPackageStateLoadFailures.mockReturnValue([]);
-    mocks.collectStalePluginRuntimeSymlinkHealthFindings.mockReset();
-    mocks.collectStalePluginRuntimeSymlinkHealthFindings.mockResolvedValue([]);
-    mocks.collectChannelPreviewWarningHealthFindings.mockReset();
-    mocks.collectChannelPreviewWarningHealthFindings.mockResolvedValue([]);
-    mocks.isSystemdUserServiceAvailable.mockReset();
-    mocks.isSystemdUserServiceAvailable.mockResolvedValue(true);
-    mocks.readSystemdUserLingerStatus.mockReset();
-    mocks.readSystemdUserLingerStatus.mockResolvedValue({ user: "alice", linger: "no" });
-    mocks.resolveSystemdUserServiceAccount.mockReset();
-    mocks.resolveSystemdUserServiceAccount.mockReturnValue("alice");
-    mocks.replaceConfigFile.mockReset();
-    mocks.replaceConfigFile.mockResolvedValue(undefined);
-    mocks.applyWizardMetadata.mockReset();
-    mocks.applyWizardMetadata.mockImplementation((cfg: unknown) => cfg);
-    mocks.maybeRepairGatewayServiceConfig.mockReset();
-    mocks.maybeRepairGatewayServiceConfig.mockImplementation(async (cfg: unknown) => cfg);
-    mocks.maybeScanExtraGatewayServices.mockReset();
-    mocks.maybeScanExtraGatewayServices.mockResolvedValue(undefined);
-    mocks.noteMacLaunchAgentOverrides.mockReset();
-    mocks.noteMacLaunchAgentOverrides.mockResolvedValue(undefined);
-    mocks.noteMacLaunchctlGatewayEnvOverrides.mockReset();
-    mocks.noteMacLaunchctlGatewayEnvOverrides.mockResolvedValue(undefined);
-    mocks.noteMacStaleOpenClawUpdateLaunchdJobs.mockReset();
-    mocks.noteMacStaleOpenClawUpdateLaunchdJobs.mockResolvedValue(undefined);
+    mocks.collectBundledChannelPackageStateLoadFailures.mockReset().mockReturnValue([]);
+    mocks.collectStalePluginRuntimeSymlinkHealthFindings.mockReset().mockResolvedValue([]);
+    mocks.collectChannelPreviewWarningHealthFindings.mockReset().mockResolvedValue([]);
+    mocks.isSystemdUserServiceAvailable.mockReset().mockResolvedValue(true);
+    mocks.readSystemdUserLingerStatus
+      .mockReset()
+      .mockResolvedValue({ user: "alice", linger: "no" });
+    mocks.resolveSystemdUserServiceAccount.mockReset().mockReturnValue("alice");
+    mocks.replaceConfigFile.mockReset().mockResolvedValue(undefined);
+    mocks.applyWizardMetadata.mockReset().mockImplementation((cfg: unknown) => cfg);
+    mocks.maybeRepairGatewayServiceConfig
+      .mockReset()
+      .mockImplementation(async (cfg: unknown) => cfg);
+    mocks.maybeScanExtraGatewayServices.mockReset().mockResolvedValue(undefined);
+    mocks.noteMacLaunchAgentOverrides.mockReset().mockResolvedValue(undefined);
+    mocks.noteMacLaunchctlGatewayEnvOverrides.mockReset().mockResolvedValue(undefined);
+    mocks.noteMacStaleOpenClawUpdateLaunchdJobs.mockReset().mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -881,17 +835,13 @@ describe("doctor health contributions", () => {
         run: laterRun,
       }),
     ];
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
-    } as DoctorContributionRunContext;
+    });
 
     await runDoctorHealthContributionList(ctx, contributions);
 
@@ -905,17 +855,13 @@ describe("doctor health contributions", () => {
   it("rejects a failed initial config write before later work runs", async () => {
     const laterRun = vi.fn(async () => undefined);
     const cfg = { gateway: { mode: "invalid" } } as unknown as OpenClawConfig;
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg,
       cfgForPersistence: structuredClone(cfg),
       configResult: { cfg, shouldWriteConfig: true },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
-    } as DoctorContributionRunContext;
+    });
     mocks.replaceConfigFile.mockRejectedValueOnce(new Error("Config validation failed"));
 
     await expect(
@@ -947,11 +893,7 @@ describe("doctor health contributions", () => {
       changeLines: ["- moved tools to contracts.tools"],
     };
     mocks.collectLegacyPluginManifestContractMigrations.mockReturnValueOnce([migration]);
-    const ctx = {
-      cfg: { plugins: { load: { paths: ["/tmp/openclaw-plugin"] } } },
-      mode: "lint" as const,
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    };
+    const ctx = createDoctorLintFixture({ plugins: { load: { paths: ["/tmp/openclaw-plugin"] } } });
 
     await expect(runDoctorLintChecks(ctx, { checks: [check] })).resolves.toMatchObject({
       checksRun: 0,
@@ -1043,17 +985,13 @@ describe("doctor health contributions", () => {
 
   it("keeps a late runtime publication failure after committing config migrations", async () => {
     const cfg = { hooks: { gmail: { model: "openai/gpt-5.5" } } } as OpenClawConfig;
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg,
       cfgForPersistence: structuredClone(cfg),
       configResult: { cfg, shouldWriteConfig: true },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
-    } as DoctorContributionRunContext;
+    });
     const timeout = new Error("prepared model runtime publication timed out");
     mocks.collectActiveToolSchemaProjectionWarnings.mockResolvedValueOnce([
       `- agents.main: active tool schema validation could not resolve the runtime model context (${timeout.message}).`,
@@ -1078,17 +1016,13 @@ describe("doctor health contributions", () => {
     const cfg = {
       channels: { discord: { streaming: { mode: "partial" } } },
     } as OpenClawConfig;
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg,
       cfgForPersistence: structuredClone(cfg),
       configResult: { cfg, shouldWriteConfig: true },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
-    } as DoctorContributionRunContext;
+    });
 
     await requireDoctorContribution("doctor:write-config-migrations").run(ctx);
     await requireDoctorContribution("doctor:write-config").run(ctx);
@@ -1103,17 +1037,13 @@ describe("doctor health contributions", () => {
 
   it("does not mark an invalid migration durable when validation rejects the write", async () => {
     const cfg = { gateway: { mode: "invalid" } } as unknown as OpenClawConfig;
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg,
       cfgForPersistence: structuredClone(cfg),
       configResult: { cfg, shouldWriteConfig: true },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
-    } as DoctorContributionRunContext;
+    });
     mocks.replaceConfigFile.mockRejectedValueOnce(
       new Error(
         'Config validation failed: gateway.mode: Invalid input (allowed: "local", "remote")',
@@ -1136,7 +1066,7 @@ describe("doctor health contributions", () => {
     const cfg = {
       agents: { defaults: { heartbeat: { every: 5 } } },
     } as unknown as OpenClawConfig;
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg,
       cfgForPersistence: structuredClone(cfg),
       configResult: {
@@ -1144,13 +1074,10 @@ describe("doctor health contributions", () => {
         shouldWriteConfig: true,
         pendingChangePanels: ["- gatway"],
       },
-      configPath: "/tmp/fake-openclaw.json",
       sourceConfigValid: false,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
-    } as DoctorContributionRunContext;
+    });
     mocks.replaceConfigFile.mockRejectedValueOnce(
       Object.assign(
         new Error(
@@ -1208,17 +1135,13 @@ describe("doctor health contributions", () => {
     // First write pass commits; a later health repair then produces a candidate the
     // writer refuses. The warning must not claim the whole run wrote nothing.
     const cfg = { gateway: { mode: "local" } } as OpenClawConfig;
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg,
       cfgForPersistence: structuredClone(cfg),
       configResult: { cfg, shouldWriteConfig: true },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
-    } as DoctorContributionRunContext;
+    });
 
     await requireDoctorContribution("doctor:write-config-migrations").run(ctx);
     expect(ctx.configResultWriteCommitted).toBe(true);
@@ -1255,7 +1178,7 @@ describe("doctor health contributions", () => {
 
   it("prints held change panels as Doctor changes only after the write commits", async () => {
     const cfg = { gateway: { mode: "local" } } as OpenClawConfig;
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg,
       cfgForPersistence: structuredClone(cfg),
       configResult: {
@@ -1263,13 +1186,9 @@ describe("doctor health contributions", () => {
         shouldWriteConfig: true,
         pendingChangePanels: ["- gatway"],
       },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
-    } as DoctorContributionRunContext;
+    });
 
     await requireDoctorContribution("doctor:write-config-migrations").run(ctx);
 
@@ -1287,17 +1206,13 @@ describe("doctor health contributions", () => {
     const cfg = {
       agents: { ownership: "explicit", entries: { ops: {}, research: {} } },
     } as OpenClawConfig;
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg,
       cfgForPersistence: structuredClone(cfg),
       configResult: { cfg, shouldWriteConfig: true },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
-    } as DoctorContributionRunContext;
+    });
     mocks.replaceConfigFile.mockRejectedValueOnce(
       Object.assign(
         new Error(
@@ -1334,17 +1249,12 @@ describe("doctor health contributions", () => {
       status: { ok: true },
     });
     const contribution = requireDoctorContribution(DOCTOR_GATEWAY_HEALTH_ID);
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg: {},
       configResult: { cfg: {} },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
       cfgForPersistence: {},
-      configPath: "/tmp/fake-openclaw.json",
       env: {},
-    } as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await contribution.run(ctx);
 
@@ -1365,7 +1275,7 @@ describe("doctor health contributions", () => {
     );
     mocks.readGatewaySecretInputValue.mockReturnValue("exec-token");
     const contribution = requireDoctorContribution(DOCTOR_GATEWAY_HEALTH_ID);
-    const cfg = {
+    const cfg = createDoctorConfigFixture({
       gateway: {
         mode: "remote",
         remote: {
@@ -1381,18 +1291,8 @@ describe("doctor health contributions", () => {
           vault: { source: "exec", command: "/bin/false" },
         },
       },
-    };
-    const ctx = {
-      cfg,
-      configResult: { cfg },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
-      cfgForPersistence: cfg,
-      configPath: "/tmp/fake-openclaw.json",
-      env: {},
-    } as Parameters<(typeof contribution)["run"]>[0];
+    });
+    const ctx = createDoctorContext({ cfg, env: {} });
 
     await contribution.run(ctx);
 
@@ -1411,7 +1311,7 @@ describe("doctor health contributions", () => {
     );
     mocks.readGatewaySecretInputValue.mockReturnValue("exec-token");
     const contribution = requireDoctorContribution(DOCTOR_GATEWAY_HEALTH_ID);
-    const cfg = {
+    const cfg = createDoctorConfigFixture({
       gateway: {
         mode: "local",
         auth: {
@@ -1426,18 +1326,8 @@ describe("doctor health contributions", () => {
           vault: { source: "exec", command: "/bin/false" },
         },
       },
-    };
-    const ctx = {
-      cfg,
-      configResult: { cfg },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
-      cfgForPersistence: cfg,
-      configPath: "/tmp/fake-openclaw.json",
-      env: {},
-    } as Parameters<(typeof contribution)["run"]>[0];
+    });
+    const ctx = createDoctorContext({ cfg, env: {} });
 
     await contribution.run(ctx);
 
@@ -1506,15 +1396,11 @@ describe("doctor health contributions", () => {
       touchedConfig: true,
     });
     const contribution = requireDoctorContribution("doctor:release-configured-plugin-installs");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       configResult: { cfg: {}, sourceLastTouchedVersion: "2026.5.16-beta.4" },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
       cfgForPersistence: {},
-      configPath: "/tmp/fake-openclaw.json",
+      shouldRepair: true,
       env: {
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
@@ -1744,9 +1630,7 @@ describe("doctor health contributions", () => {
     const contribution = requireDoctorContribution("doctor:workspace-status");
     const cfg = { plugins: { entries: { codex: { enabled: true } } } };
 
-    await contribution.run(
-      createDoctorHealthFlowContext({ cfg, options: { nonInteractive: true } }),
-    );
+    await contribution.run(createDoctorContext({ cfg, options: { nonInteractive: true } }));
 
     expect(mocks.gatherDaemonStatus).not.toHaveBeenCalled();
     expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
@@ -1907,12 +1791,7 @@ describe("doctor health contributions", () => {
     const cfg = { agents: { defaults: { heartbeat: { every: "15m" } } } };
     const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-detector-state" };
 
-    await check!.detect({
-      mode: "lint",
-      cfg,
-      env,
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    });
+    await check!.detect(createDoctorLintFixture(cfg, { env }));
 
     expect(mocks.collectHeartbeatCadenceMigrationFindings).toHaveBeenCalledWith(cfg, env);
   });
@@ -1939,12 +1818,7 @@ describe("doctor health contributions", () => {
     const cfg = { agents: { defaults: { heartbeat: { every: "15m" } } } };
     const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-task-detector-state" };
 
-    await check!.detect({
-      mode: "lint",
-      cfg,
-      env,
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    });
+    await check!.detect(createDoctorLintFixture(cfg, { env }));
 
     expect(mocks.collectHeartbeatTaskMigrationFindings).toHaveBeenCalledWith(cfg, env);
   });
@@ -1966,8 +1840,8 @@ describe("doctor health contributions", () => {
     const check = contribution.healthChecks[0] as HealthCheck | undefined;
     expect(check).toMatchObject({ defaultEnabled: false });
 
-    const ctx = {
-      cfg: createDoctorConfigFixture({
+    const ctx = createDoctorLintFixture(
+      createDoctorConfigFixture({
         channels: {
           telegram: {
             accounts: {
@@ -1978,9 +1852,7 @@ describe("doctor health contributions", () => {
         },
         bindings: [{ agentId: "ops", match: { channel: "telegram" } }],
       }),
-      mode: "lint" as const,
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    };
+    );
 
     await expect(runDoctorLintChecks(ctx, { checks: [check!] })).resolves.toMatchObject({
       checksRun: 0,
@@ -2001,18 +1873,16 @@ describe("doctor health contributions", () => {
 
   it("preserves allow-exec Gateway SecretRef resolution in auth health", async () => {
     const contribution = requireDoctorContribution("doctor:gateway-auth");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {
         gateway: {
           mode: "local",
           auth: { mode: "token", token: "exec-token" },
         },
       },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { allowExec: true, nonInteractive: true },
       env: { OPENCLAW_TEST_GATEWAY_TOKEN: "1" },
+      configPath: "/tmp/openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -2035,13 +1905,12 @@ describe("doctor health contributions", () => {
 
   it("forwards allow-exec to Gateway service repair", async () => {
     const contribution = requireDoctorContribution("doctor:gateway-services");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: { gateway: { mode: "local" } },
       configResult: {},
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      shouldRepair: true,
       options: { allowExec: true },
+      configPath: "/tmp/openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -2058,7 +1927,7 @@ describe("doctor health contributions", () => {
   it("silently skips the host-service contribution in an externally managed container", async () => {
     mocks.isContainerEnvironment.mockReturnValue(true);
     const contribution = requireDoctorContribution("doctor:gateway-services");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: { gateway: { mode: "local" } },
       configResult: {},
       sourceConfigValid: true,
@@ -2077,14 +1946,11 @@ describe("doctor health contributions", () => {
 
   it("hints how to enable authenticated GitHub project search", async () => {
     const contribution = requireDoctorContribution("doctor:github-projects");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       configResult: {},
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
       env: {},
+      configPath: "/tmp/openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -2122,13 +1988,12 @@ describe("doctor health contributions", () => {
     const cfg = { session: { store: "/tmp/shared-sessions.json" } };
     const detected = { preview: ["legacy sessions"], warnings: [], notices: [] };
     mocks.detectLegacyStateMigrations.mockResolvedValue(detected);
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg,
       configResult: {},
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      shouldRepair: true,
       options: { nonInteractive: true },
+      configPath: "/tmp/openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -2174,14 +2039,10 @@ describe("doctor health contributions", () => {
       checksRepaired: 0,
       checksValidated: 1,
     }));
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       configResult: {},
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
-      configPath: "/tmp/fake-openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -2215,14 +2076,11 @@ describe("doctor health contributions", () => {
       checksRepaired: 1,
       checksValidated: 1,
     }));
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       configResult: {},
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      shouldRepair: true,
       options: { nonInteractive: true },
-      configPath: "/tmp/fake-openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -2237,13 +2095,12 @@ describe("doctor health contributions", () => {
     const cfg = { session: { store: "/tmp/shared-sessions.json" } };
     const detected = { preview: ["legacy sessions"], warnings: [], notices: [] };
     mocks.detectLegacyStateMigrations.mockResolvedValue(detected);
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg,
       configResult: {},
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      shouldRepair: true,
       options: { nonInteractive: true, repair: true },
+      configPath: "/tmp/openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -2278,13 +2135,12 @@ describe("doctor health contributions", () => {
       warnings: [],
       notices: ["Left reviewed legacy residue in place."],
     });
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       configResult: {},
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      shouldRepair: true,
       options: { nonInteractive: true },
+      configPath: "/tmp/openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -2301,17 +2157,15 @@ describe("doctor health contributions", () => {
       ({ path }: { path: string }) => path === "gateway.auth.token",
     );
     mocks.readGatewaySecretInputValue.mockReturnValue("exec-token");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {
         gateway: {
           mode: "local",
           auth: { mode: "token", token: "exec-token" },
         },
       },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
       options: { nonInteractive: true },
+      configPath: "/tmp/openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -2327,12 +2181,11 @@ describe("doctor health contributions", () => {
 
   it("runs the receipted auth migration after repairing OAuth sidecars", async () => {
     const contribution = requireDoctorContribution("doctor:auth-profiles");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      shouldRepair: true,
       options: { nonInteractive: true },
+      configPath: "/tmp/openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -2374,11 +2227,7 @@ describe("doctor health contributions", () => {
       throw new Error("expected split auth profile health check");
     }
 
-    await check.detect({
-      mode: "lint",
-      cfg: { auth: { profiles: {} } },
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    });
+    await check.detect(createDoctorLintFixture({ auth: { profiles: {} } }));
 
     expect(mocks.collectAuthProfileHealthFindings).toHaveBeenCalledWith({
       cfg: { auth: { profiles: {} } },
@@ -2388,16 +2237,15 @@ describe("doctor health contributions", () => {
 
   it("forwards skipped Gateway health to daemon repair", async () => {
     const contribution = requireDoctorContribution("doctor:gateway-daemon");
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg: {},
       gatewayDetails: { message: "gateway details" },
       gatewayHealthSkipped: true,
       healthOk: false,
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      shouldRepair: true,
       options: { nonInteractive: true },
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+      configPath: "/tmp/openclaw.json",
+    } as unknown as Parameters<typeof createDoctorContext>[0]);
 
     await contribution.run(ctx);
 
@@ -2459,11 +2307,7 @@ describe("doctor health contributions", () => {
     expect(systemdLingerCheck).toMatchObject({ defaultEnabled: false });
     expect(systemdLingerCheck).toBeDefined();
 
-    const ctx = {
-      cfg: { gateway: { mode: "local" } },
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture({ gateway: { mode: "local" } });
     const checks = [systemdLingerCheck!];
 
     await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
@@ -2495,11 +2339,7 @@ describe("doctor health contributions", () => {
     );
     expect(systemdLingerCheck).toBeDefined();
 
-    const ctx = {
-      cfg: { gateway: { mode: "local" } },
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture({ gateway: { mode: "local" } });
 
     await withProcessPlatform("linux", async () => {
       await expect(
@@ -2549,11 +2389,7 @@ describe("doctor health contributions", () => {
       (check) => check.id === "core/doctor/systemd-linger",
     );
     expect(systemdLingerCheck).toBeDefined();
-    const ctx = {
-      cfg: { gateway: { mode: "local" } },
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture({ gateway: { mode: "local" } });
 
     await withProcessPlatform("linux", async () => {
       await expect(
@@ -2589,11 +2425,7 @@ describe("doctor health contributions", () => {
       },
     ]);
 
-    const ctx = {
-      cfg: {},
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture();
 
     await expect(runDoctorLintChecks(ctx, { checks: [check!] })).resolves.toMatchObject({
       checksRun: 0,
@@ -2635,11 +2467,7 @@ describe("doctor health contributions", () => {
       expect(check).toMatchObject({ defaultEnabled: false });
       expect(check).toBeDefined();
 
-      const ctx = {
-        cfg: {},
-        mode: "lint",
-        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      } as const;
+      const ctx = createDoctorLintFixture();
 
       await expect(runDoctorLintChecks(ctx, { checks: [check!] })).resolves.toMatchObject({
         checksRun: 0,
@@ -2677,11 +2505,7 @@ describe("doctor health contributions", () => {
 
     const detect = vi.fn(async () => []);
 
-    const ctx = {
-      cfg: {},
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture();
     // Selection behavior does not need the real state-integrity filesystem scan.
     const checks = [{ ...stateIntegrityCheck!, detect }];
 
@@ -2720,11 +2544,7 @@ describe("doctor health contributions", () => {
       );
     });
 
-    const findings = await check.detect({
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      cfg: {},
-    });
+    const findings = await check.detect(createDoctorLintFixture());
 
     expect(contribution.healthCheckIds).toEqual(["core/doctor/memory-search"]);
     expect((check as HealthCheck & { defaultEnabled?: boolean }).defaultEnabled).toBe(false);
@@ -2755,11 +2575,7 @@ describe("doctor health contributions", () => {
       opts.noteFn("Memory search is explicitly disabled (enabled: false).", "Memory search");
     });
 
-    const findings = await check.detect({
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      cfg: {},
-    });
+    const findings = await check.detect(createDoctorLintFixture());
 
     expect(findings).toEqual([]);
   });
@@ -2775,11 +2591,7 @@ describe("doctor health contributions", () => {
       "Back up your workspace before major repair work.",
     );
 
-    const ctx = {
-      cfg: {},
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture();
     const checks = [workspaceSuggestionsCheck!];
 
     await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
@@ -2807,17 +2619,7 @@ describe("doctor health contributions", () => {
   it("labels normal workspace suggestions for secondary agents", async () => {
     const contribution = requireDoctorContribution("doctor:workspace-suggestions");
     const cfg = {} as OpenClawConfig;
-    const ctx = {
-      cfg,
-      cfgForPersistence: cfg,
-      configResult: { cfg },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
-      env: {},
-    } as DoctorContributionRunContext;
+    const ctx = createDoctorContext({ cfg, env: {} });
     mocks.listAgentIds.mockReturnValue(["default", "secondary"]);
     mocks.resolveAgentWorkspaceDir.mockImplementation((_cfg, agentId) => `/tmp/${agentId}`);
     mocks.collectWorkspaceBackupTip.mockImplementation((workspaceDir) =>
@@ -2843,17 +2645,7 @@ describe("doctor health contributions", () => {
   it("keeps single-agent workspace suggestion wording unchanged", async () => {
     const contribution = requireDoctorContribution("doctor:workspace-suggestions");
     const cfg = {} as OpenClawConfig;
-    const ctx = {
-      cfg,
-      cfgForPersistence: cfg,
-      configResult: { cfg },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
-      env: {},
-    } as DoctorContributionRunContext;
+    const ctx = createDoctorContext({ cfg, env: {} });
     mocks.collectWorkspaceBackupTip.mockReturnValue("- Back up this workspace.");
     mocks.shouldSuggestMemorySystem.mockResolvedValue(true);
 
@@ -2875,11 +2667,7 @@ describe("doctor health contributions", () => {
     expect(diskSpaceCheck).toMatchObject({ defaultEnabled: false });
     expect(diskSpaceCheck).toBeDefined();
 
-    const ctx = {
-      cfg: {},
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture();
     const checks = [diskSpaceCheck!];
 
     await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
@@ -2916,12 +2704,10 @@ describe("doctor health contributions", () => {
     expect(whatsappCheck).toMatchObject({ defaultEnabled: false });
     expect(whatsappCheck).toBeDefined();
 
-    const ctx = {
-      cfg: { channels: { whatsapp: { enabled: true } } },
-      mode: "lint",
-      allowExecSecretRefs: true,
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture(
+      { channels: { whatsapp: { enabled: true } } },
+      { allowExecSecretRefs: true },
+    );
     const checks = [whatsappCheck!];
 
     await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
@@ -3007,11 +2793,7 @@ describe("doctor health contributions", () => {
     mocks.gatewaySecretInputPathCanWin.mockReturnValue(true);
     mocks.readGatewaySecretInputValue.mockReturnValue("exec-token");
 
-    const ctx = {
-      cfg: { channels: { whatsapp: { enabled: true } } },
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture({ channels: { whatsapp: { enabled: true } } });
     const checks = [whatsappCheck!];
 
     await expect(
@@ -3036,11 +2818,7 @@ describe("doctor health contributions", () => {
     expect(devicePairingCheck).toMatchObject({ defaultEnabled: false });
     expect(devicePairingCheck).toBeDefined();
 
-    const ctx = {
-      cfg: { gateway: { mode: "local" } },
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture({ gateway: { mode: "local" } });
     const checks = [devicePairingCheck!];
     await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
       checksRun: 0,
@@ -3074,11 +2852,7 @@ describe("doctor health contributions", () => {
     expect(cronStoreCheck).toMatchObject({ defaultEnabled: false });
     expect(cronStoreCheck).toBeDefined();
 
-    const ctx = {
-      cfg: { cron: { store: "/tmp/openclaw-cron/jobs.json" } },
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as unknown as Parameters<typeof runDoctorLintChecks>[0];
+    const ctx = createDoctorLintFixture({ cron: { store: "/tmp/openclaw-cron/jobs.json" } });
     const checks = [cronStoreCheck!];
 
     await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
@@ -3114,11 +2888,7 @@ describe("doctor health contributions", () => {
     expect(crontabCheck).toMatchObject({ defaultEnabled: false });
     expect(crontabCheck).toBeDefined();
 
-    const ctx = {
-      cfg: {},
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture();
     const checks = [crontabCheck!];
 
     await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
@@ -3157,11 +2927,7 @@ describe("doctor health contributions", () => {
       { channelId: "discord", pluginId: "discord", reason: "missing explicit enablement" },
     ]);
 
-    const ctx = {
-      cfg: { channels: { discord: { enabled: true } } },
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture({ channels: { discord: { enabled: true } } });
     const checks = [blockerCheck!];
 
     await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
@@ -3201,11 +2967,7 @@ describe("doctor health contributions", () => {
       },
     ]);
 
-    const ctx = {
-      cfg: {},
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture();
 
     await expect(runDoctorLintChecks(ctx, { checks: [capabilityCheck!] })).resolves.toMatchObject({
       checksRun: 1,
@@ -3241,11 +3003,7 @@ describe("doctor health contributions", () => {
       },
     ]);
 
-    const ctx = {
-      cfg: { channels: { matrix: { enabled: true } } },
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    const ctx = createDoctorLintFixture({ channels: { matrix: { enabled: true } } });
     const checks = [previewWarningsCheck!];
 
     await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
@@ -3278,12 +3036,10 @@ describe("doctor health contributions", () => {
       (check) => check.id === "core/doctor/channel-preview-warnings",
     ) as HealthCheck | undefined;
     expect(previewWarningsCheck).toBeDefined();
-    const ctx = {
-      cfg: { channels: { matrix: { enabled: true } } },
-      mode: "lint",
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      allowExecSecretRefs: true,
-    } as const;
+    const ctx = createDoctorLintFixture(
+      { channels: { matrix: { enabled: true } } },
+      { allowExecSecretRefs: true },
+    );
 
     await previewWarningsCheck!.detect(ctx);
 
@@ -3305,15 +3061,11 @@ describe("doctor health contributions", () => {
       healthChecks,
       run: legacyRun,
     });
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
-      configPath: "/tmp/fake-openclaw.json",
+      shouldRepair: true,
     });
 
     await contribution.run(ctx);
@@ -3352,15 +3104,11 @@ describe("doctor health contributions", () => {
       label: "Test structured run",
       healthChecks,
     });
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
-      configPath: "/tmp/fake-openclaw.json",
+      shouldRepair: true,
     });
 
     await contribution.run(ctx);
@@ -3386,9 +3134,9 @@ describe("doctor health contributions", () => {
     ["sole-agent config", "default", "/tmp/openclaw-workspace"],
   ])("uses %s workspace scope for metadata and structured health", async (_, soleAgentId, cwd) => {
     mocks.tryResolveSoleAgentId.mockReturnValue(soleAgentId);
-    const runWithPluginMetadataSnapshot = vi.fn(
-      async (_scope: unknown, run: () => Promise<void>) => await run(),
-    );
+    const runWithPluginMetadataSnapshot = vi.fn((_scope: unknown, run: () => unknown) =>
+      run(),
+    ) as unknown as NonNullable<DoctorContributionRunContext["runWithPluginMetadataSnapshot"]>;
     const contribution = createDoctorHealthContribution({
       id: "doctor:test-workspace-scope",
       label: "Test workspace scope",
@@ -3397,18 +3145,14 @@ describe("doctor health contributions", () => {
         detect: vi.fn(async () => []),
       },
     });
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg: { agents: { ownership: "explicit" } },
       cfgForPersistence: {},
       configResult: { cfg: {} },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
-      configPath: "/tmp/fake-openclaw.json",
+      shouldRepair: true,
       env: {},
       runWithPluginMetadataSnapshot,
-    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+    });
 
     await runDoctorHealthContributionList(ctx, [contribution]);
 
@@ -3458,15 +3202,10 @@ describe("doctor health contributions", () => {
       label: "Test structured findings",
       healthChecks,
     });
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
-      configPath: "/tmp/fake-openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -3487,15 +3226,10 @@ describe("doctor health contributions", () => {
       label: "Test structured dry-run",
       healthChecks,
     });
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
-      configPath: "/tmp/fake-openclaw.json",
     });
 
     await contribution.run(ctx);
@@ -3549,15 +3283,11 @@ describe("doctor health contributions", () => {
       calls.push("note");
     });
     const contribution = requireDoctorContribution("doctor:browser");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       cfgForPersistence: {},
       configResult: { cfg: {} },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
-      configPath: "/tmp/fake-openclaw.json",
+      shouldRepair: true,
     });
 
     await contribution.run(ctx);
@@ -3579,15 +3309,11 @@ describe("doctor health contributions", () => {
 
   it("keeps core-kind repairs out of the extension repair pass", async () => {
     const contribution = requireDoctorContribution("doctor:structured-health-repairs");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       configResult: { cfg: {} },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
       cfgForPersistence: {},
-      configPath: "/tmp/fake-openclaw.json",
+      shouldRepair: true,
       env: {},
     });
 
@@ -3604,15 +3330,11 @@ describe("doctor health contributions", () => {
       { id: "core/doctor/shell-completion", kind: "plugin" },
     ]);
     const contribution = requireDoctorContribution("doctor:structured-health-repairs");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       configResult: { cfg: {} },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
       cfgForPersistence: {},
-      configPath: "/tmp/fake-openclaw.json",
+      shouldRepair: true,
       env: {},
     });
 
@@ -3628,15 +3350,11 @@ describe("doctor health contributions", () => {
       { id: "core/doctor/shell-completion", kind: "core" },
     ]);
     const contribution = requireDoctorContribution("doctor:structured-health-repairs");
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: {},
       configResult: { cfg: {} },
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
       cfgForPersistence: {},
-      configPath: "/tmp/fake-openclaw.json",
+      shouldRepair: true,
       env: {},
     });
 
@@ -3665,7 +3383,7 @@ describe("doctor health contributions", () => {
           checksValidated: 1,
         };
       });
-      const ctx = createDoctorHealthFlowContext({
+      const ctx = createDoctorContext({
         cfg: createDoctorConfigFixture({
           channels: {
             telegram: {
@@ -3678,12 +3396,8 @@ describe("doctor health contributions", () => {
           bindings: [{ agentId: "ops", match: { channel: "telegram" } }],
         }),
         configResult: { cfg: {} },
-        sourceConfigValid: true,
-        prompter: buildDoctorPrompter(shouldRepair),
-        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-        options: {},
         cfgForPersistence: {},
-        configPath: "/tmp/fake-openclaw.json",
+        shouldRepair,
         env: {},
       });
 
@@ -3715,12 +3429,7 @@ describe("doctor health contributions", () => {
       expect(writeConfigContribution.healthCheckIds).toEqual(["core/doctor/write-config"]);
       expect(check.defaultEnabled).toBe(false);
 
-      const ctx = {
-        cfg: {},
-        mode: "lint" as const,
-        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-        configPath: "/tmp/fake-openclaw.json",
-      };
+      const ctx = createDoctorLintFixture({}, { configPath: "/tmp/fake-openclaw.json" });
 
       await expect(runDoctorLintChecks(ctx, { checks: [check] })).resolves.toMatchObject({
         checksRun: 0,
@@ -3974,7 +3683,7 @@ describe("doctor health contributions", () => {
     };
     mocks.maybeRepairGatewayServiceConfig.mockResolvedValueOnce(repairedCfg);
 
-    const ctx = createDoctorHealthFlowContext({
+    const ctx = createDoctorContext({
       cfg: originalCfg,
       cfgForPersistence: originalCfg,
       configResult: {
@@ -3983,11 +3692,7 @@ describe("doctor health contributions", () => {
         shouldWriteConfig: true,
         skipPluginValidationOnWrite: true,
       },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
     });
 
@@ -4025,17 +3730,14 @@ describe("doctor health contributions", () => {
     const cfg = {};
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
-    await requireDoctorContribution("doctor:write-config").run({
-      cfg,
-      cfgForPersistence: cfg,
-      configResult: { cfg, shouldWriteConfig: false },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(false),
-      runtime,
-      options: {},
-      env: {},
-    } as DoctorContributionRunContext);
+    await requireDoctorContribution("doctor:write-config").run(
+      createDoctorContext({
+        cfg,
+        configResult: { cfg, shouldWriteConfig: false },
+        runtime,
+        env: {},
+      }),
+    );
 
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
     expect(runtime.log).not.toHaveBeenCalled();
@@ -4070,17 +3772,13 @@ describe("doctor health contributions", () => {
     expect(migrated.changes).toEqual([
       `Moved models.providers.clawrouter.apiKey ${legacyMarker} marker → structured env SecretRef.`,
     ]);
-    const ctx = {
+    const ctx = createDoctorContext({
       cfg: migrated.config,
       cfgForPersistence: legacyConfig,
       configResult: { cfg: migrated.config, shouldWriteConfig: true },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      options: {},
+      shouldRepair: true,
       env: {},
-    } as DoctorContributionRunContext;
+    });
     const writeConfigContribution = requireDoctorContribution("doctor:write-config");
 
     await writeConfigContribution.run(ctx);
@@ -4168,21 +3866,19 @@ describe("doctor health contributions", () => {
     const cfg = { mcp: { servers: { local: { command: "node", enabled: false } } } };
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
-    await requireDoctorContribution("doctor:write-config").run({
-      cfg,
-      cfgForPersistence: cfg,
-      configResult: {
+    await requireDoctorContribution("doctor:write-config").run(
+      createDoctorContext({
         cfg,
-        shouldWriteConfig: true,
-        skipWizardMetadataForIncludeWrite: true,
-      },
-      configPath: "/tmp/fake-openclaw.json",
-      sourceConfigValid: true,
-      prompter: buildDoctorPrompter(true),
-      runtime,
-      options: {},
-      env: {},
-    } as DoctorContributionRunContext);
+        configResult: {
+          cfg,
+          shouldWriteConfig: true,
+          skipWizardMetadataForIncludeWrite: true,
+        },
+        shouldRepair: true,
+        runtime,
+        env: {},
+      }),
+    );
 
     expect(mocks.applyWizardMetadata).not.toHaveBeenCalled();
     expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
@@ -4192,15 +3888,14 @@ describe("doctor health contributions", () => {
 
   describe("config size drops during update", () => {
     beforeEach(() => {
-      mocks.replaceConfigFile.mockReset();
-      mocks.replaceConfigFile.mockResolvedValue(undefined);
+      mocks.replaceConfigFile.mockReset().mockResolvedValue(undefined);
       mocks.applyWizardMetadata.mockImplementation((cfg: unknown) => cfg);
       vi.spyOn(fs, "existsSync").mockReturnValue(false);
     });
 
     function buildWriteConfigCtx(env: Record<string, string | undefined>) {
-      const cfg = { gateway: { mode: "local" } };
-      return {
+      const cfg: OpenClawConfig = { gateway: { mode: "local" } };
+      return createDoctorContext({
         cfg,
         cfgForPersistence: { gateway: { mode: "remote" } },
         configResult: {
@@ -4208,13 +3903,9 @@ describe("doctor health contributions", () => {
           shouldWriteConfig: true,
           skipPluginValidationOnWrite: false,
         },
-        configPath: "/tmp/fake-openclaw.json",
-        sourceConfigValid: true,
-        prompter: buildDoctorPrompter(true),
-        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-        options: {},
+        shouldRepair: true,
         env,
-      } as DoctorContributionRunContext;
+      });
     }
 
     const writeConfigContribution = resolveDoctorHealthContributions().find(
@@ -4390,19 +4081,17 @@ describe("doctor health contributions", () => {
     it("skips plugin schema validation for final validation during update doctor runs", async () => {
       const contribution = requireDoctorContribution("doctor:final-config-validation");
 
-      await contribution.run({
-        cfg: {},
-        cfgForPersistence: {},
-        configResult: { cfg: {} },
-        configPath: "/tmp/fake-openclaw.json",
-        sourceConfigValid: true,
-        prompter: buildDoctorPrompter(true),
-        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-        options: {},
-        env: {
-          OPENCLAW_UPDATE_IN_PROGRESS: "1",
-        },
-      } as DoctorContributionRunContext);
+      await contribution.run(
+        createDoctorContext({
+          cfg: {},
+          cfgForPersistence: {},
+          configResult: { cfg: {} },
+          shouldRepair: true,
+          env: {
+            OPENCLAW_UPDATE_IN_PROGRESS: "1",
+          },
+        }),
+      );
 
       expect(mocks.readConfigFileSnapshot).toHaveBeenCalledWith({
         skipPluginValidation: true,
@@ -4412,17 +4101,15 @@ describe("doctor health contributions", () => {
     it("keeps plugin schema validation for ordinary doctor final validation", async () => {
       const contribution = requireDoctorContribution("doctor:final-config-validation");
 
-      await contribution.run({
-        cfg: {},
-        cfgForPersistence: {},
-        configResult: { cfg: {} },
-        configPath: "/tmp/fake-openclaw.json",
-        sourceConfigValid: true,
-        prompter: buildDoctorPrompter(true),
-        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-        options: {},
-        env: {},
-      } as DoctorContributionRunContext);
+      await contribution.run(
+        createDoctorContext({
+          cfg: {},
+          cfgForPersistence: {},
+          configResult: { cfg: {} },
+          shouldRepair: true,
+          env: {},
+        }),
+      );
 
       expect(mocks.readConfigFileSnapshot).toHaveBeenCalledWith({
         skipPluginValidation: false,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../../agents/cron-creator-authority-context.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { onTrustedMessageAuditEvent } from "../../audit/message-audit-events.js";
-import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import { setReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { getTotalPendingReplies } from "../../auto-reply/reply/dispatcher-registry.js";
 import { markInboundContextLabel } from "../../auto-reply/reply/inbound-context-marker.js";
 import {
@@ -67,7 +67,16 @@ import type { GatewayRequestContext, RespondFn } from "./types.js";
 type ProjectedDispatchParams = Parameters<
   typeof import("../../auto-reply/dispatch.js").dispatchInboundMessageWithProjectedDispatcher
 >[0];
+type TestReplyDispatcher = ReturnType<
+  typeof import("../../auto-reply/reply/reply-dispatcher.js").createReplyDispatcher
+>;
+type TestDispatchParams = Omit<ProjectedDispatchParams, "dispatcherOptions"> & {
+  dispatcher: TestReplyDispatcher;
+};
 type RespondMock = ReturnType<typeof vi.fn<RespondFn>>;
+type TranscriptUpdate = Parameters<
+  typeof import("../../sessions/transcript-events.js").emitSessionTranscriptUpdate
+>[0];
 
 const TEST_TOOL_AUTHORITY_FINGERPRINT = "test-tool-authority";
 const TEST_TOOL_AUTHORITY_ROUTE = { provider: "openai", model: "gpt-5.6-sol" } as const;
@@ -81,122 +90,100 @@ const replyRunRegistry = {
   },
 };
 
-const mockState = vi.hoisted(() => ({
-  config: {} as Record<string, unknown>,
-  storePath: "",
-  transcriptPath: "",
-  sessionId: "sess-1",
-  mainSessionKey: "main",
-  finalText: "[[reply_to_current]]",
-  finalPayload: null as {
-    text?: string;
-    mediaUrl?: string;
-    mediaUrls?: string[];
-    channelData?: Record<string, unknown>;
-    spokenText?: string;
-    audioAsVoice?: boolean;
-    trustedLocalMedia?: boolean;
-    sensitiveMedia?: boolean;
-    replyToId?: string;
-    replyToCurrent?: boolean;
-    isReasoning?: boolean;
-    isError?: boolean;
-  } | null,
-  dispatchedReplies: [] as Array<{
-    kind: "tool" | "block" | "final";
-    payload: {
-      text?: string;
-      mediaUrl?: string;
-      mediaUrls?: string[];
-      channelData?: Record<string, unknown>;
-      spokenText?: string;
-      ttsSupplement?: { spokenText: string };
-      audioAsVoice?: boolean;
-      trustedLocalMedia?: boolean;
-      sensitiveMedia?: boolean;
-      replyToId?: string;
-      replyToCurrent?: boolean;
-      isReasoning?: boolean;
-      isStatusNotice?: boolean;
-      isError?: boolean;
-    };
-  }>,
-  dispatchError: null as Error | null,
-  dispatchWait: null as Promise<void> | null,
-  dispatchErrorAfterAgentRunStart: null as Error | null,
-  dispatchErrorAfterDelivery: null as Error | null,
-  sessionMetadataChanges: [] as Array<{
-    sessionKey: string;
-    agentId?: string;
-    reason: "command-metadata";
-  }>,
-  triggerAgentRunStart: false,
-  triggerUserMessagePersisted: false,
-  runtimeUserMessagePersistencePending: null as Promise<void> | null,
-  onAfterAgentRunStart: null as (() => void) | null,
-  agentRunId: "run-agent-1",
-  sessionEntry: {} as Record<string, unknown>,
-  sessionIdsByKey: new Map<string, string>(),
-  sessionMissing: false,
-  loadSessionEntryCalls: [] as Array<{ rawKey: string; opts?: { agentId?: string } }>,
-  lastDispatchCtx: undefined as MsgContext | undefined,
-  lastDispatchImages: undefined as Array<{ mimeType: string; data: string }> | undefined,
-  lastDispatchImageOrder: undefined as string[] | undefined,
-  lastDispatchThinkingLevelOverride: undefined as string | undefined,
-  lastDispatchOriginatingLeafEntryId: undefined as string | null | undefined,
-  lastTaskSuggestionDeliveryMode: undefined as "gateway" | undefined,
-  lastMessageInjectionDisposition: undefined as "none" | "accepted" | "rejected" | undefined,
-  lastDispatchUserTurnInput: undefined as unknown,
-  modelCatalog: null as ModelCatalogEntry[] | null,
-  emittedTranscriptUpdates: [] as Array<{
-    sessionFile?: string;
-    target?: { agentId: string; sessionId: string; sessionKey: string };
-    agentId?: string;
-    sessionId?: string;
-    sessionKey?: string;
-    message?: unknown;
-    messageId?: string;
-  }>,
-  savedMediaResults: [] as Array<{ id?: string; path: string; contentType?: string }>,
-  saveMediaError: null as Error | null,
-  savedMediaCalls: [] as Array<{ contentType?: string; subdir?: string; size: number }>,
-  saveMediaWait: null as Promise<void> | null,
-  activeSaveMediaCalls: 0,
-  maxActiveSaveMediaCalls: 0,
-  replyContextCalls: 0,
-  replyContextResult: null as {
-    ReplyToId?: string;
-    ReplyToBody?: string;
-    ReplyToSender?: string;
-  } | null,
-  replyContextWait: null as Promise<void> | null,
-  sandboxWorkspace: null as { workspaceDir: string; containerWorkdir?: string } | null,
-  stageSandboxMediaError: null as Error | null,
-  stagedRelativePaths: null as string[] | null,
-  hasBeforeAgentRunHooks: false,
-  hasMessageReceivedHooks: false,
-  messageReceivedCalls: [] as Array<{ event: unknown; context: unknown }>,
-  beforeMessageWriteBlock: false,
-  beforeMessageWriteContent: null as string | null,
-  beforeMessageWriteCalls: [] as Array<{ message: unknown; ctx: unknown }>,
-  dispatchBlockedByBeforeAgentRun: false,
-  disposedTranscriptWriteContext: false,
-  disposedTranscriptWriteAttempts: 0,
-  runtimeAssistantContentBeforeDelivery: null as Array<Record<string, unknown>> | null,
-  runtimeAssistantTextsBeforeDelivery: [] as string[],
-  cronAuthorityProbe: undefined as
-    | ((
-        runId: string | undefined,
-        capability: CronCreatorAuthorityCapability | undefined,
-      ) => Promise<void> | void)
-    | undefined,
-  // `unstagedSources` lets tests simulate partial staging failure: absolute
-  // source paths listed here are excluded from the returned `staged` map even
-  // though ctx still carries their rewritten paths. This mirrors how the real
-  // stageSandboxMedia silently skips over-cap files.
-  unstagedSources: null as string[] | null,
-  deleteMediaBufferCalls: [] as Array<{ id: string; subdir?: string }>,
-}));
+const mockState = vi.hoisted(() => {
+  const createTestState = () => ({
+    config: {} as Record<string, unknown>,
+    mainSessionKey: "main",
+    finalText: "[[reply_to_current]]",
+    finalPayload: null as ReplyPayload | null,
+    dispatchedReplies: [] as Array<{
+      kind: "tool" | "block" | "final";
+      payload: ReplyPayload;
+    }>,
+    dispatchError: null as Error | null,
+    dispatchWait: null as Promise<void> | null,
+    dispatchErrorAfterAgentRunStart: null as Error | null,
+    dispatchErrorAfterDelivery: null as Error | null,
+    sessionMetadataChanges: [] as Array<{
+      sessionKey: string;
+      agentId?: string;
+      reason: "command-metadata";
+    }>,
+    triggerAgentRunStart: false,
+    triggerUserMessagePersisted: false,
+    runtimeUserMessagePersistencePending: null as Promise<void> | null,
+    onAfterAgentRunStart: null as (() => void) | null,
+    agentRunId: "run-agent-1",
+    sessionEntry: {} as Record<string, unknown>,
+    sessionIdsByKey: new Map<string, string>(),
+    sessionMissing: false,
+    loadSessionEntryCalls: [] as Array<{ rawKey: string; opts?: { agentId?: string } }>,
+    lastDispatchCtx: undefined as MsgContext | undefined,
+    lastDispatchImages: undefined as Array<{ mimeType: string; data: string }> | undefined,
+    lastDispatchImageOrder: undefined as string[] | undefined,
+    lastDispatchThinkingLevelOverride: undefined as string | undefined,
+    lastDispatchOriginatingLeafEntryId: undefined as string | null | undefined,
+    lastTaskSuggestionDeliveryMode: undefined as "gateway" | undefined,
+    lastMessageInjectionDisposition: undefined as "none" | "accepted" | "rejected" | undefined,
+    lastDispatchUserTurnInput: undefined as unknown,
+    modelCatalog: null as ModelCatalogEntry[] | null,
+    emittedTranscriptUpdates: [] as TranscriptUpdate[],
+    savedMediaResults: [] as Array<{ id?: string; path: string; contentType?: string }>,
+    saveMediaError: null as Error | null,
+    savedMediaCalls: [] as Array<{ contentType?: string; subdir?: string; size: number }>,
+    saveMediaWait: null as Promise<void> | null,
+    activeSaveMediaCalls: 0,
+    maxActiveSaveMediaCalls: 0,
+    replyContextCalls: 0,
+    replyContextResult: null as {
+      ReplyToId?: string;
+      ReplyToBody?: string;
+      ReplyToSender?: string;
+    } | null,
+    replyContextWait: null as Promise<void> | null,
+    sandboxWorkspace: null as { workspaceDir: string; containerWorkdir?: string } | null,
+    stageSandboxMediaError: null as Error | null,
+    stagedRelativePaths: null as string[] | null,
+    hasBeforeAgentRunHooks: false,
+    hasMessageReceivedHooks: false,
+    messageReceivedCalls: [] as Array<{ event: unknown; context: unknown }>,
+    beforeMessageWriteBlock: false,
+    beforeMessageWriteContent: null as string | null,
+    beforeMessageWriteCalls: [] as Array<{ message: unknown; ctx: unknown }>,
+    dispatchBlockedByBeforeAgentRun: false,
+    disposedTranscriptWriteContext: false,
+    disposedTranscriptWriteAttempts: 0,
+    runtimeAssistantContentBeforeDelivery: null as Array<Record<string, unknown>> | null,
+    runtimeAssistantTextsBeforeDelivery: [] as string[],
+    cronAuthorityProbe: undefined as
+      | ((
+          runId: string | undefined,
+          capability: CronCreatorAuthorityCapability | undefined,
+        ) => Promise<void> | void)
+      | undefined,
+    // `unstagedSources` lets tests simulate partial staging failure: absolute
+    // source paths listed here are excluded from the returned `staged` map even
+    // though ctx still carries their rewritten paths. This mirrors how the real
+    // stageSandboxMedia silently skips over-cap files.
+    unstagedSources: null as string[] | null,
+    deleteMediaBufferCalls: [] as Array<{ id: string; subdir?: string }>,
+  });
+  const state = {
+    storePath: "",
+    transcriptPath: "",
+    sessionId: "sess-1",
+    ...createTestState(),
+  };
+  return Object.assign(state, {
+    reset: () => Object.assign(state, createTestState()),
+  });
+});
+
+type TestReply = (typeof mockState.dispatchedReplies)[number];
+type TestReplyPayload = TestReply["payload"];
+type SourceReplyTranscriptMirror = NonNullable<
+  Parameters<typeof setReplyPayloadMetadata>[1]["sourceReplyTranscriptMirror"]
+>;
 
 let suiteFixtureRoot = "";
 let suiteDatabasePath = "";
@@ -241,6 +228,12 @@ example
 
 const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+const INLINE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aYoYAAAAASUVORK5CYII=";
+const OFFLOAD_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+const TINY_JPEG_BASE64 =
+  "/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxAQEBUQEBAVFRUVFRUVFRUVFRUVFRUVFRUXFhUVFRUYHSggGBolHRUVITEhJSkrLi4uFx8zODMsNygtLisBCgoKDg0OGhAQGi0fICUtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIAAEAAQMBEQACEQEDEQH/xAAXAAADAQAAAAAAAAAAAAAAAAAAAQMC/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEAMQAAAB6AAAAP/EABQQAQAAAAAAAAAAAAAAAAAAACD/2gAIAQEAAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAACD/2gAIAQIBAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAACD/2gAIAQMBAT8Af//Z";
 
 vi.mock("../session-utils.js", async () => {
   const original =
@@ -307,189 +300,119 @@ vi.mock("../../auto-reply/dispatch.js", async () => {
 });
 
 dispatchInboundMessageMock.mockImplementation(
-  vi.fn(
-    async (params: {
-      ctx: MsgContext;
-      dispatcher: {
-        sendFinalReply: (payload: {
-          text?: string;
-          mediaUrl?: string;
-          mediaUrls?: string[];
-          spokenText?: string;
-          audioAsVoice?: boolean;
-          trustedLocalMedia?: boolean;
-          sensitiveMedia?: boolean;
-          replyToId?: string;
-          replyToCurrent?: boolean;
-          isReasoning?: boolean;
-          isError?: boolean;
-        }) => boolean;
-        sendBlockReply: (payload: {
-          text?: string;
-          mediaUrl?: string;
-          mediaUrls?: string[];
-          spokenText?: string;
-          audioAsVoice?: boolean;
-          trustedLocalMedia?: boolean;
-          replyToId?: string;
-          replyToCurrent?: boolean;
-          isReasoning?: boolean;
-          isError?: boolean;
-        }) => boolean;
-        sendToolResult: (payload: {
-          text?: string;
-          mediaUrl?: string;
-          mediaUrls?: string[];
-          spokenText?: string;
-          audioAsVoice?: boolean;
-          trustedLocalMedia?: boolean;
-          replyToId?: string;
-          replyToCurrent?: boolean;
-          isReasoning?: boolean;
-          isError?: boolean;
-        }) => boolean;
-        markComplete: () => void;
-        waitForIdle: () => Promise<void>;
-      };
-      onSessionMetadataChanges?: (
-        changes: Array<{
-          sessionKey: string;
-          agentId?: string;
-          reason: "command-metadata";
-        }>,
-      ) => void;
-      replyOptions?: {
-        runId?: string;
-        cronCreatorAuthorityCapability?: CronCreatorAuthorityCapability;
-        onAgentRunStart?: (runId: string) => void;
-        userTurnTranscriptRecorder?: {
-          message?: unknown;
-          resolveMessage?: () => Promise<unknown>;
-          markRuntimePersisted: (message: { role: "user"; content: string }) => void;
-          markRuntimePersistencePending: (pending: Promise<void>) => void;
-        };
-        images?: Array<{ mimeType: string; data: string }>;
-        imageOrder?: string[];
-        thinkingLevelOverride?: string;
-        taskSuggestionDeliveryMode?: "gateway";
-        messageInjectionDisposition?: "none" | "accepted" | "rejected";
-        turnAdoptionLifecycle?: {
-          originatingLeafEntryId?: string | null;
-        };
-      };
-    }) => {
-      mockState.lastDispatchCtx = params.ctx;
-      mockState.lastDispatchImages = params.replyOptions?.images;
-      mockState.lastDispatchImageOrder = params.replyOptions?.imageOrder;
-      mockState.lastDispatchThinkingLevelOverride = params.replyOptions?.thinkingLevelOverride;
-      mockState.lastDispatchOriginatingLeafEntryId =
-        params.replyOptions?.turnAdoptionLifecycle?.originatingLeafEntryId;
-      mockState.lastTaskSuggestionDeliveryMode = params.replyOptions?.taskSuggestionDeliveryMode;
-      mockState.lastMessageInjectionDisposition = params.replyOptions?.messageInjectionDisposition;
-      await mockState.cronAuthorityProbe?.(
-        params.replyOptions?.runId,
-        params.replyOptions?.cronCreatorAuthorityCapability,
+  vi.fn(async (params: TestDispatchParams) => {
+    mockState.lastDispatchCtx = params.ctx;
+    mockState.lastDispatchImages = params.replyOptions?.images;
+    mockState.lastDispatchImageOrder = params.replyOptions?.imageOrder;
+    mockState.lastDispatchThinkingLevelOverride = params.replyOptions?.thinkingLevelOverride;
+    mockState.lastDispatchOriginatingLeafEntryId =
+      params.replyOptions?.turnAdoptionLifecycle?.originatingLeafEntryId;
+    mockState.lastTaskSuggestionDeliveryMode = params.replyOptions?.taskSuggestionDeliveryMode;
+    mockState.lastMessageInjectionDisposition = params.replyOptions?.messageInjectionDisposition;
+    await mockState.cronAuthorityProbe?.(
+      params.replyOptions?.runId,
+      params.replyOptions?.cronCreatorAuthorityCapability,
+    );
+    const recorder = params.replyOptions?.userTurnTranscriptRecorder;
+    mockState.lastDispatchUserTurnInput = recorder?.resolveMessage
+      ? await recorder.resolveMessage()
+      : recorder?.message;
+    if (mockState.dispatchError) {
+      throw mockState.dispatchError;
+    }
+    if (mockState.dispatchWait) {
+      await mockState.dispatchWait;
+    }
+    if (mockState.triggerAgentRunStart) {
+      params.replyOptions?.onAgentRunStart?.(mockState.agentRunId);
+      mockState.onAfterAgentRunStart?.();
+    }
+    if (mockState.triggerUserMessagePersisted) {
+      params.replyOptions?.userTurnTranscriptRecorder?.markRuntimePersisted({
+        role: "user",
+        content: "persisted by runtime",
+        timestamp: Date.now(),
+      });
+    }
+    if (mockState.runtimeUserMessagePersistencePending) {
+      params.replyOptions?.userTurnTranscriptRecorder?.markRuntimePersistencePending(
+        mockState.runtimeUserMessagePersistencePending,
       );
-      const recorder = params.replyOptions?.userTurnTranscriptRecorder;
-      mockState.lastDispatchUserTurnInput = recorder?.resolveMessage
-        ? await recorder.resolveMessage()
-        : recorder?.message;
-      if (mockState.dispatchError) {
-        throw mockState.dispatchError;
-      }
-      if (mockState.dispatchWait) {
-        await mockState.dispatchWait;
-      }
-      if (mockState.triggerAgentRunStart) {
-        params.replyOptions?.onAgentRunStart?.(mockState.agentRunId);
-        mockState.onAfterAgentRunStart?.();
-      }
-      if (mockState.triggerUserMessagePersisted) {
-        params.replyOptions?.userTurnTranscriptRecorder?.markRuntimePersisted({
-          role: "user",
-          content: "persisted by runtime",
-        });
-      }
-      if (mockState.runtimeUserMessagePersistencePending) {
-        params.replyOptions?.userTurnTranscriptRecorder?.markRuntimePersistencePending(
-          mockState.runtimeUserMessagePersistencePending,
-        );
-      }
-      if (mockState.dispatchErrorAfterAgentRunStart) {
-        throw mockState.dispatchErrorAfterAgentRunStart;
-      }
-      if (mockState.runtimeAssistantContentBeforeDelivery) {
-        await appendSourceReplyMirrorEntry({
-          content: mockState.runtimeAssistantContentBeforeDelivery,
-          text: "",
-          provider: "openai",
-          model: "gpt-5.6-luna",
-          now: Date.now(),
-        });
-      }
-      for (const text of mockState.runtimeAssistantTextsBeforeDelivery) {
-        await appendSourceReplyMirrorEntry({
-          text,
-          provider: "openai",
-          model: "gpt-5.6-luna",
-          now: Date.now(),
-        });
-      }
-      if (mockState.sessionMetadataChanges.length > 0) {
-        params.onSessionMetadataChanges?.(mockState.sessionMetadataChanges);
-      }
-      const deliverReplies = async () => {
-        if (mockState.dispatchedReplies.length > 0) {
-          for (const reply of mockState.dispatchedReplies) {
-            if (reply.kind === "tool") {
-              params.dispatcher.sendToolResult(reply.payload);
-              continue;
-            }
-            if (reply.kind === "block") {
-              params.dispatcher.sendBlockReply(reply.payload);
-              continue;
-            }
-            params.dispatcher.sendFinalReply(reply.payload);
+    }
+    if (mockState.dispatchErrorAfterAgentRunStart) {
+      throw mockState.dispatchErrorAfterAgentRunStart;
+    }
+    if (mockState.runtimeAssistantContentBeforeDelivery) {
+      await appendSourceReplyMirrorEntry({
+        content: mockState.runtimeAssistantContentBeforeDelivery,
+        text: "",
+        provider: "openai",
+        model: "gpt-5.6-luna",
+        now: Date.now(),
+      });
+    }
+    for (const text of mockState.runtimeAssistantTextsBeforeDelivery) {
+      await appendSourceReplyMirrorEntry({
+        text,
+        provider: "openai",
+        model: "gpt-5.6-luna",
+        now: Date.now(),
+      });
+    }
+    if (mockState.sessionMetadataChanges.length > 0) {
+      params.onSessionMetadataChanges?.(mockState.sessionMetadataChanges);
+    }
+    const deliverReplies = async () => {
+      if (mockState.dispatchedReplies.length > 0) {
+        for (const reply of mockState.dispatchedReplies) {
+          if (reply.kind === "tool") {
+            params.dispatcher.sendToolResult(reply.payload);
+            continue;
           }
-        } else {
-          params.dispatcher.sendFinalReply(mockState.finalPayload ?? { text: mockState.finalText });
+          if (reply.kind === "block") {
+            params.dispatcher.sendBlockReply(reply.payload);
+            continue;
+          }
+          params.dispatcher.sendFinalReply(reply.payload);
         }
-        params.dispatcher.markComplete();
-        await params.dispatcher.waitForIdle();
-      };
-      if (mockState.disposedTranscriptWriteContext) {
-        const sessionKey = mockState.mainSessionKey;
-        const storePath = mockState.storePath;
-        await withOwnedSessionTranscriptWrites(
-          {
-            sessionKey,
-            sessionTarget: {
-              agentId: "main",
-              sessionId: mockState.sessionId,
-              sessionKey,
-              storePath,
-            },
-            withTranscriptWrite: async () => {
-              mockState.disposedTranscriptWriteAttempts += 1;
-              throw new Error("attempt disposed before transcript write");
-            },
-          },
-          deliverReplies,
-        );
       } else {
-        await deliverReplies();
+        params.dispatcher.sendFinalReply(mockState.finalPayload ?? { text: mockState.finalText });
       }
-      if (mockState.dispatchErrorAfterDelivery) {
-        throw mockState.dispatchErrorAfterDelivery;
-      }
-      return {
-        ok: true,
-        queuedFinal: true,
-        counts: { tool: 0, block: 0, final: 1 },
-        ...(mockState.dispatchBlockedByBeforeAgentRun ? { beforeAgentRunBlocked: true } : {}),
-      };
-    },
-  ),
+      params.dispatcher.markComplete();
+      await params.dispatcher.waitForIdle();
+    };
+    if (mockState.disposedTranscriptWriteContext) {
+      const sessionKey = mockState.mainSessionKey;
+      const storePath = mockState.storePath;
+      await withOwnedSessionTranscriptWrites(
+        {
+          sessionKey,
+          sessionTarget: {
+            agentId: "main",
+            sessionId: mockState.sessionId,
+            sessionKey,
+            storePath,
+          },
+          withTranscriptWrite: async () => {
+            mockState.disposedTranscriptWriteAttempts += 1;
+            throw new Error("attempt disposed before transcript write");
+          },
+        },
+        deliverReplies,
+      );
+    } else {
+      await deliverReplies();
+    }
+    if (mockState.dispatchErrorAfterDelivery) {
+      throw mockState.dispatchErrorAfterDelivery;
+    }
+    return {
+      ok: true,
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 1 },
+      ...(mockState.dispatchBlockedByBeforeAgentRun ? { beforeAgentRunBlocked: true } : {}),
+    };
+  }),
 );
 
 vi.mock("../../infra/outbound/session-binding-service.js", async () => {
@@ -560,19 +483,9 @@ vi.mock("../../sessions/transcript-events.js", async (importOriginal) => {
   return {
     attachSessionTranscriptRunId,
     resolveTerminalAssistantTranscriptRunId,
-    emitSessionTranscriptUpdate: vi.fn(
-      (update: {
-        sessionFile?: string;
-        target?: { agentId: string; sessionId: string; sessionKey: string };
-        agentId?: string;
-        sessionId?: string;
-        sessionKey?: string;
-        message?: unknown;
-        messageId?: string;
-      }) => {
-        mockState.emittedTranscriptUpdates.push(update);
-      },
-    ),
+    emitSessionTranscriptUpdate: vi.fn((update: TranscriptUpdate) => {
+      mockState.emittedTranscriptUpdates.push(update);
+    }),
   };
 });
 
@@ -1057,8 +970,12 @@ function createChatContext() {
 
 type ChatContext = ReturnType<typeof createChatContext>;
 
-function useChatTestModel(model: "vision-model" | "text-only") {
-  mockState.sessionEntry = { modelProvider: "test-provider", model };
+function useChatTestModel(model: "vision-model" | "text-only", configured = false) {
+  mockState.sessionEntry = {
+    modelProvider: "test-provider",
+    model,
+    ...(configured ? { providerOverride: "test-provider", modelOverride: model } : {}),
+  };
   mockState.modelCatalog = [
     {
       provider: "test-provider",
@@ -1067,6 +984,13 @@ function useChatTestModel(model: "vision-model" | "text-only") {
       input: model === "vision-model" ? ["text", "image"] : ["text"],
     },
   ];
+}
+
+function useGlobalSessionScope() {
+  mockState.config = {
+    agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+    session: { scope: "global" },
+  };
 }
 
 async function createReadyChatTranscript(prefix: string) {
@@ -1095,6 +1019,19 @@ function createChatRequestFixture() {
         context,
       }),
   };
+}
+
+async function sendNewChatRequest(
+  params: Omit<Parameters<typeof runNonStreamingChatSend>[0], "context" | "respond">,
+) {
+  const fixture = createChatRequestFixture();
+  const payload = await fixture.send(params);
+  return { ...fixture, payload };
+}
+
+async function createSqliteChatRequest(prefix: string) {
+  await createGatewayUserTurnSqliteFixture(prefix);
+  return createChatRequestFixture();
 }
 
 type NonStreamingChatSendWaitFor = "broadcast" | "dedupe" | "none";
@@ -1135,6 +1072,177 @@ function managedAudioBlocks(content: Array<Record<string, unknown>>) {
 function bindTestToolAuthority(operation: ReplyOperation) {
   operation.bindToolAuthorityProjector(() => TEST_TOOL_AUTHORITY_FINGERPRINT);
   operation.bindToolAuthorityRoute({ provider: "anthropic", model: "test-model" });
+}
+
+function beginActiveReplyOperation(params: {
+  backend?: Parameters<ReplyOperation["attachBackend"]>[0];
+  bindToolAuthority?: boolean;
+  originatingLeafEntryId?: string | null;
+  sessionId?: string;
+  sessionKey?: string;
+}) {
+  const operation = replyRunRegistry.begin({
+    sessionKey: params.sessionKey ?? "agent:main:main",
+    sessionId: params.sessionId ?? mockState.sessionId,
+    resetTriggered: false,
+    ...(params.originatingLeafEntryId !== undefined
+      ? { originatingLeafEntryId: params.originatingLeafEntryId }
+      : {}),
+  });
+  if (params.bindToolAuthority) {
+    bindTestToolAuthority(operation);
+  }
+  operation.setPhase("running");
+  if (params.backend) {
+    operation.attachBackend(params.backend);
+  }
+  return operation;
+}
+
+type TestReplyBackend = Parameters<ReplyOperation["attachBackend"]>[0];
+type TestQueueMessage = NonNullable<TestReplyBackend["queueMessage"]>;
+
+function beginMessageInjectionOperation(params: {
+  bindToolAuthority?: boolean;
+  cancel?: TestReplyBackend["cancel"];
+  isStopped?: TestReplyBackend["isStopped"];
+  isStreaming?: TestReplyBackend["isStreaming"];
+  legacy?: boolean;
+  originatingLeafEntryId?: string | null;
+  queueMessage: TestQueueMessage;
+  runId?: string;
+  supportsQueueMessageImages?: boolean;
+  taskSuggestionDeliveryMode?: "gateway";
+}) {
+  const backend = {
+    kind: "embedded" as const,
+    cancel: params.cancel ?? (() => {}),
+    runId: params.runId,
+    supportsQueueMessageImages: params.supportsQueueMessageImages,
+    taskSuggestionDeliveryMode: params.taskSuggestionDeliveryMode,
+    ...(params.legacy
+      ? {
+          queueMessage: params.queueMessage,
+          isStopped: params.isStopped,
+          isStreaming: params.isStreaming,
+        }
+      : {
+          messageInjection: { isAvailable: () => true, queueMessage: params.queueMessage },
+        }),
+  } satisfies TestReplyBackend;
+  return beginActiveReplyOperation({
+    bindToolAuthority: params.bindToolAuthority ?? true,
+    originatingLeafEntryId: params.originatingLeafEntryId,
+    backend,
+  });
+}
+
+async function appendTestTranscriptMessage(params: {
+  content: string;
+  display?: boolean;
+  eventId: string;
+  now: number;
+  parentId: string | null;
+  role: "assistant" | "user";
+}) {
+  await appendTranscriptMessage(transcriptScope(), {
+    eventId: params.eventId,
+    message: {
+      role: params.role,
+      content: params.content,
+      ...(params.display === undefined ? {} : { display: params.display }),
+    },
+    now: params.now,
+    parentId: params.parentId,
+  });
+}
+
+function createImageAttachment(
+  params: {
+    content?: string;
+    fileName?: string;
+    mimeType?: string;
+    type?: string;
+  } = {},
+) {
+  return {
+    ...(params.type ? { type: params.type } : {}),
+    mimeType: params.mimeType ?? "image/png",
+    ...(params.fileName ? { fileName: params.fileName } : {}),
+    content: params.content ?? TINY_PNG_BASE64,
+  };
+}
+
+function createFileAttachment(fileName: string, mimeType: string, content: string, type = "file") {
+  return {
+    type,
+    mimeType,
+    fileName,
+    content,
+  };
+}
+
+function createPngBuffer(size: number): Buffer {
+  const buffer = Buffer.alloc(size);
+  buffer.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  return buffer;
+}
+
+function writeSavedPng(fixtureDir: string, fileName: string): string {
+  const savedImagePath = path.join(fixtureDir, fileName);
+  fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+  mockState.savedMediaResults.push({ path: savedImagePath, contentType: "image/png" });
+  return savedImagePath;
+}
+
+function setSavedMediaResults(...results: Array<[path: string, contentType: string, id?: string]>) {
+  mockState.savedMediaResults = results.map(([pathValue, contentType, id]) => {
+    const result = { path: pathValue, contentType, id: undefined as string | undefined };
+    if (id) {
+      result.id = id;
+    }
+    return result;
+  });
+}
+
+async function createAudioTranscriptFixture(prefix: string, fileName = "tts.mp3") {
+  const transcriptDir = await createTranscriptFixture(prefix);
+  const audioPath = path.join(transcriptDir, fileName);
+  fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+  mockState.config = { agents: { defaults: { workspace: transcriptDir } } };
+  return { audioPath, transcriptDir };
+}
+
+function createSourceReply(
+  payload: TestReplyPayload,
+  sourceReplyTranscriptMirror: SourceReplyTranscriptMirror,
+): TestReply {
+  return {
+    kind: "final",
+    payload: setReplyPayloadMetadata(payload, { sourceReplyTranscriptMirror }),
+  };
+}
+
+function createMainSourceReply(params: {
+  idempotencyKey: string;
+  mediaUrls?: string[];
+  text?: string;
+}): TestReply {
+  const { idempotencyKey, mediaUrls, text } = params;
+  return createSourceReply(
+    { ...(text ? { text } : {}), ...(mediaUrls ? { mediaUrls } : {}) },
+    {
+      sessionKey: "main",
+      ...(text ? { text } : {}),
+      ...(mediaUrls ? { mediaUrls } : {}),
+      idempotencyKey,
+    },
+  );
+}
+
+function setAgentRunReplies(replies: TestReply[]) {
+  mockState.triggerAgentRunStart = true;
+  mockState.dispatchedReplies = replies;
 }
 
 function expectManagedAudioBlock(
@@ -1313,68 +1421,13 @@ afterAll(async () => {
 describe("chat directive tag stripping for non-streaming final payloads", () => {
   afterEach(() => {
     replyRunRegistryTesting.resetReplyRunRegistry();
-    mockState.config = {};
-    mockState.finalText = "[[reply_to_current]]";
-    mockState.finalPayload = null;
-    mockState.dispatchedReplies = [];
-    mockState.dispatchError = null;
-    mockState.dispatchWait = null;
-    mockState.dispatchErrorAfterAgentRunStart = null;
-    mockState.dispatchErrorAfterDelivery = null;
-    mockState.sessionMetadataChanges = [];
-    mockState.mainSessionKey = "main";
-    mockState.triggerAgentRunStart = false;
-    mockState.triggerUserMessagePersisted = false;
-    mockState.runtimeUserMessagePersistencePending = null;
-    mockState.onAfterAgentRunStart = null;
-    mockState.agentRunId = "run-agent-1";
-    mockState.sessionEntry = {};
-    mockState.sessionIdsByKey.clear();
-    mockState.sessionMissing = false;
-    mockState.loadSessionEntryCalls = [];
-    mockState.lastDispatchCtx = undefined;
-    mockState.lastDispatchImages = undefined;
-    mockState.lastDispatchImageOrder = undefined;
-    mockState.lastDispatchThinkingLevelOverride = undefined;
-    mockState.lastDispatchOriginatingLeafEntryId = undefined;
-    mockState.lastTaskSuggestionDeliveryMode = undefined;
-    mockState.lastMessageInjectionDisposition = undefined;
-    mockState.lastDispatchUserTurnInput = undefined;
-    mockState.modelCatalog = null;
-    mockState.emittedTranscriptUpdates = [];
-    mockState.savedMediaResults = [];
-    mockState.saveMediaError = null;
-    mockState.savedMediaCalls = [];
-    mockState.saveMediaWait = null;
-    mockState.activeSaveMediaCalls = 0;
-    mockState.maxActiveSaveMediaCalls = 0;
-    mockState.replyContextCalls = 0;
-    mockState.replyContextResult = null;
-    mockState.replyContextWait = null;
+    mockState.reset();
     bindingMocks.resolveByConversation.mockReset();
     bindingMocks.resolveByConversation.mockReturnValue(null);
-    mockState.sandboxWorkspace = null;
-    mockState.stageSandboxMediaError = null;
-    mockState.stagedRelativePaths = null;
-    mockState.unstagedSources = null;
-    mockState.deleteMediaBufferCalls = [];
-    mockState.hasBeforeAgentRunHooks = false;
-    mockState.hasMessageReceivedHooks = false;
-    mockState.messageReceivedCalls = [];
-    mockState.beforeMessageWriteBlock = false;
-    mockState.beforeMessageWriteContent = null;
-    mockState.beforeMessageWriteCalls = [];
-    mockState.dispatchBlockedByBeforeAgentRun = false;
-    mockState.disposedTranscriptWriteContext = false;
-    mockState.disposedTranscriptWriteAttempts = 0;
-    mockState.runtimeAssistantContentBeforeDelivery = null;
-    mockState.runtimeAssistantTextsBeforeDelivery = [];
-    mockState.cronAuthorityProbe = undefined;
   });
 
   it("carries an internal runtime tool cap into agent dispatch", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-runtime-tools-");
-    const { send } = createChatRequestFixture();
+    const { send } = await createSqliteChatRequest("openclaw-chat-send-runtime-tools-");
 
     await send({
       idempotencyKey: "idem-runtime-tools",
@@ -1392,15 +1445,17 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     ["stale", "previous-leaf"],
     ["empty", null],
   ])("rejects a %s expected active leaf before starting or writing", async (name, expectedLeaf) => {
-    await createGatewayUserTurnSqliteFixture(`openclaw-chat-send-${name}-leaf-`);
-    await appendTranscriptMessage(transcriptScope(), {
+    const { context, respond, send } = await createSqliteChatRequest(
+      `openclaw-chat-send-${name}-leaf-`,
+    );
+    await appendTestTranscriptMessage({
       eventId: "current-leaf",
-      message: { role: "user", content: "existing" },
+      role: "user",
+      content: "existing",
       now: 1,
       parentId: null,
     });
     const before = loadTranscriptEventsSync(transcriptScope());
-    const { context, respond, send } = createChatRequestFixture();
 
     await send({
       idempotencyKey: `idem-${name}-leaf`,
@@ -1430,16 +1485,21 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       accepted: false,
     },
   ])("$name", async ({ sessionId, accepted }) => {
-    await createGatewayUserTurnSqliteFixture(`openclaw-chat-send-active-ancestor-${sessionId}-`);
-    await appendTranscriptMessage(transcriptScope(), {
+    const { context, respond, send } = await createSqliteChatRequest(
+      `openclaw-chat-send-active-ancestor-${sessionId}-`,
+    );
+    await appendTestTranscriptMessage({
       eventId: "rendered-leaf",
-      message: { role: "assistant", content: "rendered" },
+      role: "assistant",
+      content: "rendered",
       now: 1,
       parentId: null,
     });
-    await appendTranscriptMessage(transcriptScope(), {
+    await appendTestTranscriptMessage({
       eventId: "memory-flush-user",
-      message: { role: "user", content: "maintenance prompt", display: false },
+      role: "user",
+      content: "maintenance prompt",
+      display: false,
       now: 2,
       parentId: "rendered-leaf",
     });
@@ -1452,14 +1512,15 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       firstKeptEntryId: "rendered-leaf",
       tokensBefore: 10,
     });
-    await appendTranscriptMessage(transcriptScope(), {
+    await appendTestTranscriptMessage({
       eventId: "background-leaf",
-      message: { role: "assistant", content: "background append", display: false },
+      role: "assistant",
+      content: "background append",
+      display: false,
       now: 3,
       parentId: "background-compaction",
     });
     const before = loadTranscriptEventsSync(transcriptScope());
-    const { context, respond, send } = createChatRequestFixture();
 
     await send({
       idempotencyKey: `idem-active-ancestor-${sessionId}`,
@@ -1487,22 +1548,27 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("rejects a copied exact leaf from the session before a branch switch", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-rotated-exact-leaf-");
-    await appendTranscriptMessage(transcriptScope(), {
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-rotated-exact-leaf-",
+    );
+    await appendTestTranscriptMessage({
       eventId: "branch-root",
-      message: { role: "user", content: "root" },
+      role: "user",
+      content: "root",
       now: 1,
       parentId: null,
     });
-    await appendTranscriptMessage(transcriptScope(), {
+    await appendTestTranscriptMessage({
       eventId: "copied-leaf",
-      message: { role: "assistant", content: "selected branch" },
+      role: "assistant",
+      content: "selected branch",
       now: 2,
       parentId: "branch-root",
     });
-    await appendTranscriptMessage(transcriptScope(), {
+    await appendTestTranscriptMessage({
       eventId: "active-sibling",
-      message: { role: "assistant", content: "active branch" },
+      role: "assistant",
+      content: "active branch",
       now: 3,
       parentId: "branch-root",
     });
@@ -1527,7 +1593,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.sessionId = switched.entry.sessionId;
     const before = loadTranscriptEventsSync(transcriptScope());
     expect(resolveSessionTranscriptActiveLeafEntryId(before)).toBe("copied-leaf");
-    const { context, respond, send } = createChatRequestFixture();
 
     await send({
       idempotencyKey: "idem-rotated-exact-leaf",
@@ -1549,22 +1614,27 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("rejects an expected sibling that is off the active path", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-off-path-sibling-");
-    await appendTranscriptMessage(transcriptScope(), {
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-off-path-sibling-",
+    );
+    await appendTestTranscriptMessage({
       eventId: "branch-root",
-      message: { role: "user", content: "root" },
+      role: "user",
+      content: "root",
       now: 1,
       parentId: null,
     });
-    await appendTranscriptMessage(transcriptScope(), {
+    await appendTestTranscriptMessage({
       eventId: "off-path-sibling",
-      message: { role: "assistant", content: "abandoned" },
+      role: "assistant",
+      content: "abandoned",
       now: 2,
       parentId: "branch-root",
     });
-    await appendTranscriptMessage(transcriptScope(), {
+    await appendTestTranscriptMessage({
       eventId: "active-sibling",
-      message: { role: "assistant", content: "active" },
+      role: "assistant",
+      content: "active",
       now: 3,
       parentId: "branch-root",
     });
@@ -1574,7 +1644,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       path: suiteDatabasePath,
     });
     const before = loadTranscriptEventsSync(transcriptScope());
-    const { context, respond, send } = createChatRequestFixture();
 
     await send({
       idempotencyKey: "idem-off-path-sibling",
@@ -1595,8 +1664,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("allows an expected empty leaf when the transcript is still empty", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-matching-empty-leaf-");
-    const { context, respond, send } = createChatRequestFixture();
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-matching-empty-leaf-",
+    );
 
     await send({
       idempotencyKey: "idem-matching-empty-leaf",
@@ -1617,14 +1687,16 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     ["matching", { expectedLeafEntryId: "current-leaf" }],
     ["absent", {}],
   ])("allows a %s expected active leaf", async (_name, requestParams) => {
-    await createGatewayUserTurnSqliteFixture(`openclaw-chat-send-${_name}-leaf-`);
-    await appendTranscriptMessage(transcriptScope(), {
+    const { context, respond, send } = await createSqliteChatRequest(
+      `openclaw-chat-send-${_name}-leaf-`,
+    );
+    await appendTestTranscriptMessage({
       eventId: "current-leaf",
-      message: { role: "user", content: "existing" },
+      role: "user",
+      content: "existing",
       now: 1,
       parentId: null,
     });
-    const { context, respond, send } = createChatRequestFixture();
 
     await send({
       idempotencyKey: `idem-${_name}-leaf`,
@@ -1641,14 +1713,16 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("starts one normal turn when steer admission finds no direct owner", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-stale-steer-no-owner-");
-    await appendTranscriptMessage(transcriptScope(), {
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-stale-steer-no-owner-",
+    );
+    await appendTestTranscriptMessage({
       eventId: "current-leaf",
-      message: { role: "assistant", content: "finished" },
+      role: "assistant",
+      content: "finished",
       now: 1,
       parentId: null,
     });
-    const { context, respond, send } = createChatRequestFixture();
 
     await send({
       idempotencyKey: "idem-stale-steer-no-owner",
@@ -1670,21 +1744,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("injects targetless steer into the exact direct owner without a client run id", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-targetless-no-leaf-");
-    const { context, respond, send } = createChatRequestFixture();
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-targetless-no-leaf-",
+    );
     const queueMessage = vi.fn(async () => {});
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
-    });
-    bindTestToolAuthority(operation);
-    operation.setPhase("running");
-    operation.attachBackend({
-      kind: "embedded",
-      cancel: () => {},
-      messageInjection: { isAvailable: () => true, queueMessage },
-    });
+    const operation = beginMessageInjectionOperation({ queueMessage });
 
     try {
       await send({
@@ -1713,14 +1777,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   ])(
     "starts the selected idle session despite %s activity",
     async (_name, activeSessionKey, slug) => {
-      await createGatewayUserTurnSqliteFixture(`openclaw-chat-send-idle-${slug}-`);
-      const { context, respond, send } = createChatRequestFixture();
-      const unrelated = replyRunRegistry.begin({
+      const { context, respond, send } = await createSqliteChatRequest(
+        `openclaw-chat-send-idle-${slug}-`,
+      );
+      const unrelated = beginActiveReplyOperation({
         sessionKey: activeSessionKey,
         sessionId: `${mockState.sessionId}-${slug}`,
-        resetTriggered: false,
       });
-      unrelated.setPhase("running");
 
       try {
         await send({
@@ -1744,15 +1807,12 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   );
 
   it("falls back visibly when the direct owner has a non-injectable CLI backend", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-cli-steer-fallback-");
-    const { context, respond, send } = createChatRequestFixture();
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-cli-steer-fallback-",
+    );
+    const operation = beginActiveReplyOperation({
+      backend: { kind: "cli", runId: "cli-run", cancel: vi.fn() },
     });
-    operation.setPhase("running");
-    operation.attachBackend({ kind: "cli", runId: "cli-run", cancel: vi.fn() });
 
     try {
       await send({
@@ -1775,21 +1835,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("deduplicates a retried targetless steer before a second injection", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-steer-idempotent-");
-    const { context, send } = createChatRequestFixture();
+    const { context, send } = await createSqliteChatRequest("openclaw-chat-send-steer-idempotent-");
     const queueMessage = vi.fn(async () => {});
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
-    });
-    bindTestToolAuthority(operation);
-    operation.setPhase("running");
-    operation.attachBackend({
-      kind: "embedded",
-      cancel: vi.fn(),
-      messageInjection: { isAvailable: () => true, queueMessage },
-    });
+    const operation = beginMessageInjectionOperation({ cancel: vi.fn(), queueMessage });
 
     try {
       await send({
@@ -1809,26 +1857,20 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("injects a matching leaf-bound targetless steer through the legacy backend seam", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-targetless-steer-");
-    await appendTranscriptMessage(transcriptScope(), {
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-targetless-steer-",
+    );
+    await appendTestTranscriptMessage({
       eventId: "current-leaf",
-      message: { role: "assistant", content: "working" },
+      role: "assistant",
+      content: "working",
       now: 1,
       parentId: null,
     });
-    const { context, respond, send } = createChatRequestFixture();
     const queueMessage = vi.fn(async () => {});
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
+    const operation = beginMessageInjectionOperation({
       originatingLeafEntryId: "current-leaf",
-    });
-    bindTestToolAuthority(operation);
-    operation.setPhase("running");
-    operation.attachBackend({
-      kind: "embedded",
-      cancel: () => {},
+      legacy: true,
       isStopped: () => false,
       queueMessage,
     });
@@ -1854,26 +1896,21 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("dispatches tool-bound input instead of injecting it into the active run", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-tool-bound-dispatch-");
-    await appendTranscriptMessage(transcriptScope(), {
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-tool-bound-dispatch-",
+    );
+    await appendTestTranscriptMessage({
       eventId: "current-leaf",
-      message: { role: "assistant", content: "working" },
+      role: "assistant",
+      content: "working",
       now: 1,
       parentId: null,
     });
-    const { context, respond, send } = createChatRequestFixture();
     const queueMessage = vi.fn(async () => {});
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
+    const operation = beginMessageInjectionOperation({
+      bindToolAuthority: false,
       originatingLeafEntryId: "current-leaf",
-    });
-    operation.setPhase("running");
-    operation.attachBackend({
-      kind: "embedded",
-      cancel: () => {},
-      messageInjection: { isAvailable: () => true, queueMessage },
+      queueMessage,
     });
     const toolBindings = { browser: { kind: "tab", tabId: 1, targetId: "target-1" } };
 
@@ -1920,30 +1957,23 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("falls back once without touching a successor when the captured owner ends", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-targetless-operation-aba-");
-    await appendTranscriptMessage(transcriptScope(), {
+    const { context, respond } = await createSqliteChatRequest(
+      "openclaw-chat-send-targetless-operation-aba-",
+    );
+    await appendTestTranscriptMessage({
       eventId: "current-leaf",
-      message: { role: "assistant", content: "working" },
+      role: "assistant",
+      content: "working",
       now: 1,
       parentId: null,
     });
-    const { context, respond } = createChatRequestFixture();
     const originalQueue = vi.fn(async () => {});
     const successorQueue = vi.fn(async () => {});
     const successorCancel = vi.fn();
     const dispatchCallsBefore = dispatchInboundMessageMock.mock.calls.length;
-    const original = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
+    const original = beginMessageInjectionOperation({
       originatingLeafEntryId: "current-leaf",
-    });
-    bindTestToolAuthority(original);
-    original.setPhase("running");
-    original.attachBackend({
-      kind: "embedded",
-      cancel: () => {},
-      messageInjection: { isAvailable: () => true, queueMessage: originalQueue },
+      queueMessage: originalQueue,
     });
     let successor: ReturnType<typeof replyRunRegistry.begin> | undefined;
 
@@ -1975,18 +2005,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
         async () => {
           original.complete();
-          successor = replyRunRegistry.begin({
-            sessionKey: "agent:main:main",
-            sessionId: mockState.sessionId,
-            resetTriggered: false,
+          successor = beginMessageInjectionOperation({
             originatingLeafEntryId: "current-leaf",
-          });
-          bindTestToolAuthority(successor);
-          successor.setPhase("running");
-          successor.attachBackend({
-            kind: "embedded",
             cancel: successorCancel,
-            messageInjection: { isAvailable: () => true, queueMessage: successorQueue },
+            queueMessage: successorQueue,
           });
           return true;
         },
@@ -2013,28 +2035,20 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("starts captured-operation injection before ACK and does not dispatch after owner clear", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-steer-before-ack-");
-    const { context, respond, send } = createChatRequestFixture();
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-steer-before-ack-",
+    );
     const delivery = createDeferred();
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
-      originatingLeafEntryId: null,
-    });
-    bindTestToolAuthority(operation);
-    operation.setPhase("running");
     let reportAcceptance: ((accepted: boolean) => void) | undefined;
     const queueMessage = vi.fn((_text: string, options?: ReplyBackendQueueMessageOptions) => {
       expect(respond).not.toHaveBeenCalled();
       reportAcceptance = options?.onQueueAccepted;
       return delivery.promise;
     });
-    operation.attachBackend({
-      kind: "embedded",
+    const operation = beginMessageInjectionOperation({
+      originatingLeafEntryId: null,
       runId: "active-run",
-      cancel: () => {},
-      messageInjection: { isAvailable: () => true, queueMessage },
+      queueMessage,
     });
 
     const pendingSend = send({
@@ -2066,32 +2080,22 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("records accepted steering once across transcript, hooks, audit, and finalization", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-steer-accounting-");
+    const { context, send } = await createSqliteChatRequest("openclaw-chat-send-steer-accounting-");
     mockState.hasMessageReceivedHooks = true;
-    mockState.savedMediaResults = [{ path: "/tmp/steer.png", contentType: "image/png" }];
+    setSavedMediaResults(["/tmp/steer.png", "image/png"]);
     const auditEvents: Array<{ reasonCode?: unknown; runId?: unknown }> = [];
     const disposeAudit = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
-    const { context, send } = createChatRequestFixture();
     const dispatchCallsBefore = dispatchInboundMessageMock.mock.calls.length;
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
-      originatingLeafEntryId: null,
-    });
-    bindTestToolAuthority(operation);
-    operation.setPhase("running");
     const queueMessage = vi.fn(async (_text: string, options?: ReplyBackendQueueMessageOptions) => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(dispatchCallsBefore);
       await options?.userTurnTranscriptRecorder?.persistApproved();
     });
-    operation.attachBackend({
-      kind: "embedded",
+    const operation = beginMessageInjectionOperation({
+      originatingLeafEntryId: null,
       runId: "active-run",
       supportsQueueMessageImages: true,
       taskSuggestionDeliveryMode: "gateway",
-      cancel: () => {},
-      messageInjection: { isAvailable: () => true, queueMessage },
+      queueMessage,
     });
 
     try {
@@ -2099,7 +2103,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         idempotencyKey: "idem-steer-accounting",
         requestParams: {
           queueMode: "steer",
-          attachments: [{ mimeType: "image/png", content: TINY_PNG_BASE64 }],
+          attachments: [createImageAttachment()],
         },
         client: {
           connect: {
@@ -2154,24 +2158,14 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("records the resolved run for accepted leaf-only steering", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-leaf-steer-provenance-");
-    const { send } = createChatRequestFixture();
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
-      originatingLeafEntryId: null,
-    });
-    bindTestToolAuthority(operation);
-    operation.setPhase("running");
+    const { send } = await createSqliteChatRequest("openclaw-chat-send-leaf-steer-provenance-");
     const queueMessage = vi.fn(async (_text: string, options?: ReplyBackendQueueMessageOptions) => {
       await options?.userTurnTranscriptRecorder?.persistApproved();
     });
-    operation.attachBackend({
-      kind: "embedded",
+    const operation = beginMessageInjectionOperation({
+      originatingLeafEntryId: null,
       runId: "active-run",
-      cancel: () => {},
-      messageInjection: { isAvailable: () => true, queueMessage },
+      queueMessage,
     });
 
     try {
@@ -2191,7 +2185,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("hydrates and accepts reply injection before ACK without waiting for delivery", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-reply-steer-");
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-reply-steer-",
+    );
     mockState.hasMessageReceivedHooks = true;
     const hydration = createDeferred();
     mockState.replyContextWait = hydration.promise;
@@ -2202,26 +2198,16 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     };
     const auditEvents: Array<{ reasonCode?: unknown }> = [];
     const disposeAudit = onTrustedMessageAuditEvent((event) => auditEvents.push(event));
-    const { context, respond, send } = createChatRequestFixture();
     const delivery = createDeferred();
     let reportAcceptance: ((accepted: boolean) => void) | undefined;
     const queueMessage = vi.fn((_text: string, options?: ReplyBackendQueueMessageOptions) => {
       reportAcceptance = options?.onQueueAccepted;
       return delivery.promise;
     });
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
+    const operation = beginMessageInjectionOperation({
       originatingLeafEntryId: "current-leaf",
-    });
-    bindTestToolAuthority(operation);
-    operation.setPhase("running");
-    operation.attachBackend({
-      kind: "embedded",
       runId: "run-a",
-      cancel: () => {},
-      messageInjection: { isAvailable: () => true, queueMessage },
+      queueMessage,
     });
 
     try {
@@ -2283,7 +2269,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("falls back once when reply hydration outlives its captured run", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-reply-steer-race-");
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-reply-steer-race-",
+    );
     const hydration = createDeferred();
     mockState.replyContextWait = hydration.promise;
     mockState.replyContextResult = {
@@ -2291,24 +2279,14 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       ReplyToBody: "quoted deployment status",
       ReplyToSender: "Alice",
     };
-    const { context, respond, send } = createChatRequestFixture();
     const dispatchCallsBefore = dispatchInboundMessageMock.mock.calls.length;
     const originalQueue = vi.fn(async () => {});
     const successorQueue = vi.fn(async () => {});
     const successorCancel = vi.fn();
-    const original = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
+    const original = beginMessageInjectionOperation({
       originatingLeafEntryId: "current-leaf",
-    });
-    bindTestToolAuthority(original);
-    original.setPhase("running");
-    original.attachBackend({
-      kind: "embedded",
       runId: "run-a",
-      cancel: () => {},
-      messageInjection: { isAvailable: () => true, queueMessage: originalQueue },
+      queueMessage: originalQueue,
     });
     let successor: ReturnType<typeof replyRunRegistry.begin> | undefined;
 
@@ -2325,19 +2303,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       expect(respond).not.toHaveBeenCalled();
       expect(originalQueue).not.toHaveBeenCalled();
       original.complete();
-      successor = replyRunRegistry.begin({
-        sessionKey: "agent:main:main",
-        sessionId: mockState.sessionId,
-        resetTriggered: false,
+      successor = beginMessageInjectionOperation({
         originatingLeafEntryId: "current-leaf",
-      });
-      bindTestToolAuthority(successor);
-      successor.setPhase("running");
-      successor.attachBackend({
-        kind: "embedded",
         runId: "run-b",
         cancel: successorCancel,
-        messageInjection: { isAvailable: () => true, queueMessage: successorQueue },
+        queueMessage: successorQueue,
       });
       hydration.resolve();
       await pendingSend;
@@ -2376,7 +2346,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps ordinary reply hydration after ACK when no injection target was captured", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-reply-no-steer-");
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-reply-no-steer-",
+    );
     const hydration = createDeferred();
     mockState.replyContextWait = hydration.promise;
     mockState.replyContextResult = {
@@ -2384,7 +2356,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       ReplyToBody: "quoted deployment status",
       ReplyToSender: "Alice",
     };
-    const { context, respond, send } = createChatRequestFixture();
 
     const pendingSend = send({
       idempotencyKey: "idem-reply-no-steer",
@@ -2421,28 +2392,20 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("falls back once when captured injection rejects acceptance", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-steer-reject-");
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-steer-reject-",
+    );
     mockState.finalText = "fallback reply";
-    const { context, respond, send } = createChatRequestFixture();
     const dispatchCallsBefore = dispatchInboundMessageMock.mock.calls.length;
     const delivery = createDeferred();
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
-      originatingLeafEntryId: null,
-    });
-    bindTestToolAuthority(operation);
-    operation.setPhase("running");
     const queueMessage = vi.fn((_text: string, options?: ReplyBackendQueueMessageOptions) => {
       options?.onQueueAccepted?.(false);
       return delivery.promise;
     });
-    operation.attachBackend({
-      kind: "embedded",
+    const operation = beginMessageInjectionOperation({
+      originatingLeafEntryId: null,
       runId: "active-run",
-      cancel: () => {},
-      messageInjection: { isAvailable: () => true, queueMessage },
+      queueMessage,
     });
 
     await send({
@@ -2471,30 +2434,23 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("never aborts or replays onto a successor after unconfirmed acceptance", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-steer-unconfirmed-");
-    const { context, send } = createChatRequestFixture();
+    const { context, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-steer-unconfirmed-",
+    );
     const delivery = createDeferred<{
       transcriptCommit: "unconfirmed";
       errorMessage: string;
     }>();
-    const first = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
-      originatingLeafEntryId: null,
-    });
-    bindTestToolAuthority(first);
-    first.setPhase("running");
     const queueMessage = vi.fn(async (_text: string, options?: ReplyBackendQueueMessageOptions) => {
       options?.onQueueAccepted?.(true);
       await options?.userTurnTranscriptRecorder?.persistApproved();
       return await delivery.promise;
     });
-    first.attachBackend({
-      kind: "embedded",
+    const first = beginMessageInjectionOperation({
+      originatingLeafEntryId: null,
       runId: "active-run",
       cancel: vi.fn(),
-      messageInjection: { isAvailable: () => true, queueMessage },
+      queueMessage,
     });
 
     await send({
@@ -2506,19 +2462,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(readPersistedUserMessages()[0]).not.toHaveProperty("__openclaw.steerTargetRunId");
     first.complete();
     const successorCancel = vi.fn();
-    const successor = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
+    const successor = beginMessageInjectionOperation({
       originatingLeafEntryId: null,
-    });
-    bindTestToolAuthority(successor);
-    successor.setPhase("running");
-    successor.attachBackend({
-      kind: "embedded",
       runId: "successor-run",
       cancel: successorCancel,
-      messageInjection: { isAvailable: () => true, queueMessage: vi.fn(async () => {}) },
+      queueMessage: vi.fn(async () => {}),
     });
     delivery.resolve({
       transcriptCommit: "unconfirmed",
@@ -2543,26 +2491,18 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("ACKs and dispatches once when captured injection throws synchronously", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-steer-sync-reject-");
-    const { respond, send } = createChatRequestFixture();
+    const { respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-steer-sync-reject-",
+    );
     const dispatchCallsBefore = dispatchInboundMessageMock.mock.calls.length;
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
-      originatingLeafEntryId: null,
-    });
-    bindTestToolAuthority(operation);
-    operation.setPhase("running");
     const queueMessage = vi.fn((): Promise<void> => {
       expect(respond).not.toHaveBeenCalled();
       throw new Error("synchronous rejection");
     });
-    operation.attachBackend({
-      kind: "embedded",
+    const operation = beginMessageInjectionOperation({
+      originatingLeafEntryId: null,
       runId: "active-run",
-      cancel: () => {},
-      messageInjection: { isAvailable: () => true, queueMessage },
+      queueMessage,
     });
 
     try {
@@ -2585,32 +2525,27 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("falls back once when captured owner evidence is stale", async () => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-steer-stale-owner-");
-    await appendTranscriptMessage(transcriptScope(), {
+    const { context, respond, send } = await createSqliteChatRequest(
+      "openclaw-chat-send-steer-stale-owner-",
+    );
+    await appendTestTranscriptMessage({
       eventId: "current-leaf",
-      message: { role: "assistant", content: "stale tool work" },
+      role: "assistant",
+      content: "stale tool work",
       now: 1,
       parentId: null,
     });
-    const { context, respond, send } = createChatRequestFixture();
     const dispatchCallsBefore = dispatchInboundMessageMock.mock.calls.length;
     vi.useFakeTimers({ toFake: ["Date"] });
-    const operation = replyRunRegistry.begin({
-      sessionKey: "agent:main:main",
-      sessionId: mockState.sessionId,
-      resetTriggered: false,
-      originatingLeafEntryId: "leaf-before-stale-run-output",
-    });
-    bindTestToolAuthority(operation);
-    operation.setPhase("running");
     const staleQueue = vi.fn(async () => {});
     const staleCancel = vi.fn();
-    operation.attachBackend({
-      kind: "embedded",
+    const operation = beginMessageInjectionOperation({
+      originatingLeafEntryId: "leaf-before-stale-run-output",
       runId: "active-run",
       cancel: staleCancel,
       isStreaming: () => false,
       isStopped: () => false,
+      legacy: true,
       queueMessage: staleQueue,
     });
 
@@ -2667,9 +2602,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         reason: "command-metadata",
       },
     ];
-    const { context, send } = createChatRequestFixture();
-
-    await send({
+    const { context } = await sendNewChatRequest({
       idempotencyKey: "idem-command-session-metadata",
       message: "/goal pause waiting",
       waitFor: "none",
@@ -2717,9 +2650,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
     ];
     mockState.dispatchErrorAfterDelivery = new Error("delivery failed after metadata");
-    const { context, send } = createChatRequestFixture();
-
-    await send({
+    const { context } = await sendNewChatRequest({
       idempotencyKey: "idem-command-session-metadata-error",
       message: "/goal pause waiting",
       expectBroadcast: false,
@@ -2739,9 +2670,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("persists non-agent delivery mirrors with the chat send idempotency key", async () => {
     await createTranscriptFixture("openclaw-chat-send-final-idem-");
     mockState.finalText = "mirror text";
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await sendNewChatRequest({
       idempotencyKey: "idem-final-mirror",
       expectBroadcast: false,
     });
@@ -2800,9 +2729,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     );
-    const { send } = createChatRequestFixture();
-
-    await send({
+    await sendNewChatRequest({
       idempotencyKey: "idem-plugin-binding-history",
       expectBroadcast: false,
     });
@@ -2830,9 +2757,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await createTranscriptFixture("openclaw-chat-send-managed-media-failure-");
     const source = "data:audio/mpeg;base64,not-valid!";
     mockState.finalPayload = { mediaUrl: source };
-    const { send } = createChatRequestFixture();
-
-    const payload = await send({ idempotencyKey: "idem-managed-media-failure" });
+    const { payload } = await sendNewChatRequest({
+      idempotencyKey: "idem-managed-media-failure",
+    });
 
     const serialized = JSON.stringify(payload?.message);
     expect(serialized).toContain(
@@ -2857,9 +2784,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     );
-    const { context, send } = createChatRequestFixture();
-
-    await send({
+    const { context } = await sendNewChatRequest({
       idempotencyKey: "idem-plugin-binding-rotation",
       expectBroadcast: false,
     });
@@ -2886,9 +2811,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     );
-    const { context, send } = createChatRequestFixture();
-
-    await send({
+    const { context } = await sendNewChatRequest({
       idempotencyKey: "idem-plugin-binding-blocked",
       expectBroadcast: false,
     });
@@ -2918,9 +2841,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       },
       { kind: "final", payload: { text: "derived reply without owner" } },
     ];
-    const { context, send } = createChatRequestFixture();
-
-    await send({
+    const { context } = await sendNewChatRequest({
       idempotencyKey: "idem-plugin-binding-partial",
       expectBroadcast: false,
     });
@@ -2947,9 +2868,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
     );
-    const { context, send } = createChatRequestFixture();
-
-    await send({
+    const { context } = await sendNewChatRequest({
       idempotencyKey: "idem-source-mirror-legacy",
       expectBroadcast: false,
     });
@@ -3003,10 +2922,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("registers default global tool-event recipients for unscoped global sends", async () => {
     await createTranscriptFixture("openclaw-chat-send-global-tool-events-");
-    mockState.config = {
-      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-      session: { scope: "global" },
-    };
+    useGlobalSessionScope();
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.agentRunId = "run-current-global";
@@ -3045,10 +2961,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("registers selected global alias tool-event recipients against the canonical run key", async () => {
     await createTranscriptFixture("openclaw-chat-send-global-alias-tool-events-");
-    mockState.config = {
-      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-      session: { scope: "global" },
-    };
+    useGlobalSessionScope();
     mockState.sessionEntry = { canonicalKey: "global" };
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
@@ -3088,10 +3001,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("scopes selected-agent global aliases before loading chat session state", async () => {
     await createTranscriptFixture("openclaw-chat-send-global-alias-load-");
-    mockState.config = {
-      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-      session: { scope: "global" },
-    };
+    useGlobalSessionScope();
     mockState.sessionEntry = { canonicalKey: "global" };
     const { send } = createChatRequestFixture();
 
@@ -3109,14 +3019,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("accepts selected-agent global main aliases before loading chat session state", async () => {
     await createTranscriptFixture("openclaw-chat-send-global-main-alias-load-");
-    mockState.config = {
-      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-      session: { scope: "global" },
-    };
+    useGlobalSessionScope();
     mockState.sessionEntry = { canonicalKey: "global" };
-    const { respond, send } = createChatRequestFixture();
-
-    await send({
+    const { respond } = await sendNewChatRequest({
       sessionKey: "main",
       requestParams: { agentId: "work" },
       idempotencyKey: "idem-global-main-alias-load",
@@ -3141,9 +3046,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       agents: { list: [{ id: "main", default: true }] },
       session: { scope: "per-sender" },
     };
-    const { respond, send } = createChatRequestFixture();
-
-    await send({
+    const { respond } = await sendNewChatRequest({
       sessionKey: "global",
       requestParams: { agentId: "main" },
       idempotencyKey: "idem-per-sender-global-alias",
@@ -3177,10 +3080,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("registers selected-agent global aliases under the canonical abort key", async () => {
     await createTranscriptFixture("openclaw-chat-send-global-alias-abort-key-");
-    mockState.config = {
-      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-      session: { scope: "global" },
-    };
+    useGlobalSessionScope();
     mockState.sessionEntry = { canonicalKey: "global" };
     let releaseDispatch: (() => void) | undefined;
     mockState.dispatchWait = new Promise((resolve) => {
@@ -3206,10 +3106,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("scopes chat history global aliases before loading session state", async () => {
     await createTranscriptFixture("openclaw-chat-history-global-alias-load-");
-    mockState.config = {
-      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-      session: { scope: "global" },
-    };
+    useGlobalSessionScope();
     mockState.sessionEntry = { canonicalKey: "global" };
     const { context, respond } = createChatRequestFixture();
     mockState.loadSessionEntryCalls = [];
@@ -3279,19 +3176,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("persists agent-run audio replies emitted as media-bearing block payloads", async () => {
-    await createTranscriptFixture("openclaw-chat-send-agent-audio-");
-    const transcriptDir = path.dirname(mockState.transcriptPath);
-    const audioPath = path.join(transcriptDir, "reply.mp3");
-    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.triggerAgentRunStart = true;
-    mockState.dispatchedReplies = [
+    const { audioPath } = await createAudioTranscriptFixture(
+      "openclaw-chat-send-agent-audio-",
+      "reply.mp3",
+    );
+    setAgentRunReplies([
       {
         kind: "block",
         payload: {
@@ -3300,7 +3189,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           trustedLocalMedia: true,
         },
       },
-    ];
+    ]);
     const { send } = createChatRequestFixture();
 
     await send({
@@ -3333,9 +3222,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("replaces a runtime-owned media reply instead of appending a duplicate assistant", async () => {
     await withTranscriptFixtureState("openclaw-chat-send-owned-media-", async (fixtureDir) => {
       const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-      const savedImagePath = path.join(fixtureDir, "reply.png");
-      fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-      mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+      writeSavedPng(fixtureDir, "reply.png");
       await appendSourceReplyMirrorEntry({
         idempotencyKey: "older-distinct-assistant",
         text: "A distinct earlier reply.",
@@ -3348,8 +3235,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         provider: "openai",
         model: "codex",
       });
-      mockState.triggerAgentRunStart = true;
-      mockState.dispatchedReplies = [
+      setAgentRunReplies([
         {
           kind: "final",
           payload: setReplyPayloadMetadata(
@@ -3364,7 +3250,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
             },
           ),
         },
-      ];
+      ]);
       const { send } = createChatRequestFixture();
 
       await send({
@@ -3392,10 +3278,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await withTranscriptFixtureState(
       "openclaw-chat-send-disposed-media-owner-",
       async (fixtureDir) => {
-        const savedImagePath = path.join(fixtureDir, "reply.png");
-        const mediaUrl = savedImagePath;
-        fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+        const mediaUrl = writeSavedPng(fixtureDir, "reply.png");
         await appendSourceReplyMirrorEntry({
           text: `Stale reply\nMEDIA:${mediaUrl}`,
           provider: "openai",
@@ -3470,20 +3353,14 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await withTranscriptFixtureState(
       "openclaw-chat-send-multiple-assistant-media-",
       async (fixtureDir) => {
-        const firstMediaUrl = path.join(fixtureDir, "first.png");
-        const secondMediaUrl = path.join(fixtureDir, "second.png");
-        fs.writeFileSync(firstMediaUrl, Buffer.from(TINY_PNG_BASE64, "base64"));
-        fs.writeFileSync(secondMediaUrl, Buffer.from(TINY_PNG_BASE64, "base64"));
+        const firstMediaUrl = writeSavedPng(fixtureDir, "first.png");
+        const secondMediaUrl = writeSavedPng(fixtureDir, "second.png");
         await appendSourceReplyMirrorEntry({
           text: "Older assistant reply",
           provider: "openai",
           model: "gpt-5.6-luna",
           now: Date.now(),
         });
-        mockState.savedMediaResults = [
-          { path: firstMediaUrl, contentType: "image/png" },
-          { path: secondMediaUrl, contentType: "image/png" },
-        ];
         mockState.triggerAgentRunStart = true;
         mockState.runtimeAssistantTextsBeforeDelivery = [
           `First image\nMEDIA:${firstMediaUrl}`,
@@ -3539,18 +3416,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("persists auto-TTS final media as audio-only so webchat does not duplicate assistant text", async () => {
-    const transcriptDir = await createTranscriptFixture("openclaw-chat-send-agent-tts-final-");
-    const audioPath = path.join(transcriptDir, "tts.mp3");
-    fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    mockState.config = {
-      agents: {
-        defaults: {
-          workspace: transcriptDir,
-        },
-      },
-    };
-    mockState.triggerAgentRunStart = true;
-    mockState.dispatchedReplies = [
+    const { audioPath } = await createAudioTranscriptFixture("openclaw-chat-send-agent-tts-final-");
+    setAgentRunReplies([
       {
         kind: "final",
         payload: {
@@ -3563,7 +3430,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           ttsSupplement: { spokenText: "This text is already in the model transcript." },
         },
       },
-    ];
+    ]);
     const { send } = createChatRequestFixture();
 
     await send({
@@ -3621,28 +3488,12 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: mirrorIdempotencyKey,
       text: "Codex source reply",
     });
-    mockState.triggerAgentRunStart = true;
-    const sourceReply = setReplyPayloadMetadata(
-      {
-        text: "Codex source reply",
-      },
-      {
-        sourceReplyTranscriptMirror: {
-          sessionKey: "main",
-          text: "Codex source reply",
-          idempotencyKey: mirrorIdempotencyKey,
-        },
-      },
-    );
-    mockState.dispatchedReplies = [
-      {
-        kind: "final",
-        payload: sourceReply,
-      },
-    ];
-    const { context, send } = createChatRequestFixture();
-
-    const broadcast = await send({
+    const sourceReply = createMainSourceReply({
+      idempotencyKey: mirrorIdempotencyKey,
+      text: "Codex source reply",
+    });
+    setAgentRunReplies([sourceReply]);
+    const { context, payload: broadcast } = await sendNewChatRequest({
       idempotencyKey: "idem-agent-source-reply",
       message: "hello from codex",
     });
@@ -3667,8 +3518,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("broadcasts agent-run status notices without source reply mirrors", async () => {
     await createTranscriptFixture("openclaw-chat-send-agent-status-notice-");
-    mockState.triggerAgentRunStart = true;
-    mockState.dispatchedReplies = [
+    setAgentRunReplies([
       {
         kind: "final",
         payload: {
@@ -3676,10 +3526,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           isStatusNotice: true,
         },
       },
-    ];
-    const { send } = createChatRequestFixture();
-
-    const broadcast = await send({
+    ]);
+    const { payload: broadcast } = await sendNewChatRequest({
       idempotencyKey: "idem-agent-status-notice",
       message: "/compact",
     });
@@ -3696,8 +3544,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("broadcasts a block status once while ignoring an ordinary agent final", async () => {
     await createTranscriptFixture("openclaw-chat-send-agent-block-status-notice-");
-    mockState.triggerAgentRunStart = true;
-    mockState.dispatchedReplies = [
+    setAgentRunReplies([
       {
         kind: "block",
         payload: {
@@ -3711,10 +3558,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           text: "ordinary provider final",
         },
       },
-    ];
-    const { context, send } = createChatRequestFixture();
-
-    const broadcast = await send({
+    ]);
+    const { context, payload: broadcast } = await sendNewChatRequest({
       idempotencyKey: "idem-agent-block-status-notice",
       message: "/model openai/gpt-5.5 keep going",
     });
@@ -3732,8 +3577,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("ignores non-status block and final payloads during source finalization", async () => {
     await createTranscriptFixture("openclaw-chat-send-agent-non-status-replies-");
-    mockState.triggerAgentRunStart = true;
-    mockState.dispatchedReplies = [
+    setAgentRunReplies([
       {
         kind: "block",
         payload: {
@@ -3746,10 +3590,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           text: "ordinary final",
         },
       },
-    ];
-    const { context, send } = createChatRequestFixture();
-
-    await send({
+    ]);
+    const { context } = await sendNewChatRequest({
       idempotencyKey: "idem-agent-non-status-replies",
       expectBroadcast: false,
       waitFor: "dedupe",
@@ -3765,9 +3607,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       "openclaw-chat-send-agent-source-reply-media-",
       async (fixtureDir) => {
         const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-        const savedImagePath = path.join(fixtureDir, "source-reply.png");
-        fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+        writeSavedPng(fixtureDir, "source-reply.png");
         const mirrorIdempotencyKey = "idem-agent-source-reply-media:internal-source-reply:0";
         const updatedAt = Date.parse("2026-05-18T11:00:00.000Z");
         const rewrittenAt = Date.parse("2026-05-18T11:05:00.000Z");
@@ -3780,27 +3620,12 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           idempotencyKey: mirrorIdempotencyKey,
           text: "Codex source reply with media",
         });
-        mockState.triggerAgentRunStart = true;
-        const sourceReply = setReplyPayloadMetadata(
-          {
-            text: "Codex source reply with media",
-            mediaUrls: [mediaUrl],
-          },
-          {
-            sourceReplyTranscriptMirror: {
-              sessionKey: "main",
-              text: "Codex source reply with media",
-              mediaUrls: [mediaUrl],
-              idempotencyKey: mirrorIdempotencyKey,
-            },
-          },
-        );
-        mockState.dispatchedReplies = [
-          {
-            kind: "final",
-            payload: sourceReply,
-          },
-        ];
+        const sourceReply = createMainSourceReply({
+          idempotencyKey: mirrorIdempotencyKey,
+          text: "Codex source reply with media",
+          mediaUrls: [mediaUrl],
+        });
+        setAgentRunReplies([sourceReply]);
         const { send } = createChatRequestFixture();
 
         vi.useFakeTimers({ toFake: ["Date"] });
@@ -3843,34 +3668,19 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       "openclaw-chat-send-agent-source-reply-sqlite-",
       async (fixtureDir) => {
         const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-        const savedImagePath = path.join(fixtureDir, "source-reply-sqlite.png");
-        fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+        writeSavedPng(fixtureDir, "source-reply-sqlite.png");
         const mirrorIdempotencyKey = "idem-source-reply-sqlite:internal-source-reply:0";
         await appendSourceReplyMirrorEntry({
           idempotencyKey: mirrorIdempotencyKey,
           text: "SQLite source reply with media",
         });
-        mockState.triggerAgentRunStart = true;
-        mockState.dispatchedReplies = [
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: "SQLite source reply with media",
-                mediaUrls: [mediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: "SQLite source reply with media",
-                  mediaUrls: [mediaUrl],
-                  idempotencyKey: mirrorIdempotencyKey,
-                },
-              },
-            ),
-          },
-        ];
+        setAgentRunReplies([
+          createMainSourceReply({
+            idempotencyKey: mirrorIdempotencyKey,
+            text: "SQLite source reply with media",
+            mediaUrls: [mediaUrl],
+          }),
+        ]);
         const { send } = createChatRequestFixture();
 
         await send({
@@ -3894,34 +3704,19 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       async (fixtureDir) => {
         const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
         const replyText = "Source reply with media";
-        const savedImagePath = path.join(fixtureDir, "source-reply-deduped.png");
-        fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+        writeSavedPng(fixtureDir, "source-reply-deduped.png");
         const mirrorIdempotencyKey = "idem-agent-source-reply-deduped:internal-source-reply:0";
         await appendSourceReplyMirrorEntry({
           text:
             resolveMirroredTranscriptText({ text: replyText, mediaUrls: [mediaUrl] }) ?? "media",
         });
-        mockState.triggerAgentRunStart = true;
-        mockState.dispatchedReplies = [
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: replyText,
-                mediaUrls: [mediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: replyText,
-                  mediaUrls: [mediaUrl],
-                  idempotencyKey: mirrorIdempotencyKey,
-                },
-              },
-            ),
-          },
-        ];
+        setAgentRunReplies([
+          createMainSourceReply({
+            idempotencyKey: mirrorIdempotencyKey,
+            text: replyText,
+            mediaUrls: [mediaUrl],
+          }),
+        ]);
         const { send } = createChatRequestFixture();
 
         const broadcast = await send({
@@ -3948,14 +3743,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       async (fixtureDir) => {
         const firstMediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
         const secondMediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-        const firstSavedImagePath = path.join(fixtureDir, "source-reply-1.png");
-        const secondSavedImagePath = path.join(fixtureDir, "source-reply-2.png");
-        fs.writeFileSync(firstSavedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        fs.writeFileSync(secondSavedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [
-          { path: firstSavedImagePath, contentType: "image/png" },
-          { path: secondSavedImagePath, contentType: "image/png" },
-        ];
+        writeSavedPng(fixtureDir, "source-reply-1.png");
+        writeSavedPng(fixtureDir, "source-reply-2.png");
         const firstMirrorKey = "idem-agent-source-reply-multi:internal-source-reply:0";
         const secondMirrorKey = "idem-agent-source-reply-multi:internal-source-reply:1";
         await appendSourceReplyMirrorEntry({
@@ -3966,43 +3755,18 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           idempotencyKey: secondMirrorKey,
           text: "Second source reply",
         });
-        mockState.triggerAgentRunStart = true;
-        mockState.dispatchedReplies = [
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: "First source reply",
-                mediaUrls: [firstMediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: "First source reply",
-                  mediaUrls: [firstMediaUrl],
-                  idempotencyKey: firstMirrorKey,
-                },
-              },
-            ),
-          },
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: "Second source reply",
-                mediaUrls: [secondMediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: "Second source reply",
-                  mediaUrls: [secondMediaUrl],
-                  idempotencyKey: secondMirrorKey,
-                },
-              },
-            ),
-          },
-        ];
+        setAgentRunReplies([
+          createMainSourceReply({
+            idempotencyKey: firstMirrorKey,
+            text: "First source reply",
+            mediaUrls: [firstMediaUrl],
+          }),
+          createMainSourceReply({
+            idempotencyKey: secondMirrorKey,
+            text: "Second source reply",
+            mediaUrls: [secondMediaUrl],
+          }),
+        ]);
         const { send } = createChatRequestFixture();
 
         const broadcast = await send({
@@ -4032,57 +3796,26 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       async (fixtureDir) => {
         const firstMediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
         const secondMediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-        const firstSavedImagePath = path.join(fixtureDir, "source-reply-backed.png");
-        const secondSavedImagePath = path.join(fixtureDir, "source-reply-missing.png");
-        fs.writeFileSync(firstSavedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        fs.writeFileSync(secondSavedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [
-          { path: firstSavedImagePath, contentType: "image/png" },
-          { path: secondSavedImagePath, contentType: "image/png" },
-        ];
+        writeSavedPng(fixtureDir, "source-reply-backed.png");
+        writeSavedPng(fixtureDir, "source-reply-missing.png");
         const backedMirrorKey = "idem-agent-source-reply-partial:internal-source-reply:0";
         const missingMirrorKey = "idem-agent-source-reply-partial:internal-source-reply:1";
         await appendSourceReplyMirrorEntry({
           idempotencyKey: backedMirrorKey,
           text: "Backed source reply",
         });
-        mockState.triggerAgentRunStart = true;
-        mockState.dispatchedReplies = [
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: "Backed source reply",
-                mediaUrls: [firstMediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: "Backed source reply",
-                  mediaUrls: [firstMediaUrl],
-                  idempotencyKey: backedMirrorKey,
-                },
-              },
-            ),
-          },
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: "Missing mirror source reply",
-                mediaUrls: [secondMediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: "Missing mirror source reply",
-                  mediaUrls: [secondMediaUrl],
-                  idempotencyKey: missingMirrorKey,
-                },
-              },
-            ),
-          },
-        ];
+        setAgentRunReplies([
+          createMainSourceReply({
+            idempotencyKey: backedMirrorKey,
+            text: "Backed source reply",
+            mediaUrls: [firstMediaUrl],
+          }),
+          createMainSourceReply({
+            idempotencyKey: missingMirrorKey,
+            text: "Missing mirror source reply",
+            mediaUrls: [secondMediaUrl],
+          }),
+        ]);
         const { send } = createChatRequestFixture();
 
         const broadcast = await send({
@@ -4109,9 +3842,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       "openclaw-chat-send-agent-source-reply-text-tail-",
       async (fixtureDir) => {
         const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-        const savedImagePath = path.join(fixtureDir, "source-reply-text-tail.png");
-        fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+        writeSavedPng(fixtureDir, "source-reply-text-tail.png");
         const mediaMirrorKey = "idem-agent-source-reply-text-tail:internal-source-reply:0";
         const textMirrorKey = "idem-agent-source-reply-text-tail:internal-source-reply:1";
         await appendSourceReplyMirrorEntry({
@@ -4122,41 +3853,17 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           idempotencyKey: textMirrorKey,
           text: "Text-only source reply",
         });
-        mockState.triggerAgentRunStart = true;
-        mockState.dispatchedReplies = [
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: "Media source reply",
-                mediaUrls: [mediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: "Media source reply",
-                  mediaUrls: [mediaUrl],
-                  idempotencyKey: mediaMirrorKey,
-                },
-              },
-            ),
-          },
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: "Text-only source reply",
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: "Text-only source reply",
-                  idempotencyKey: textMirrorKey,
-                },
-              },
-            ),
-          },
-        ];
+        setAgentRunReplies([
+          createMainSourceReply({
+            idempotencyKey: mediaMirrorKey,
+            text: "Media source reply",
+            mediaUrls: [mediaUrl],
+          }),
+          createMainSourceReply({
+            idempotencyKey: textMirrorKey,
+            text: "Text-only source reply",
+          }),
+        ]);
         const { send } = createChatRequestFixture();
 
         const broadcast = await send({
@@ -4183,35 +3890,20 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       "openclaw-chat-send-agent-source-reply-collision-",
       async (fixtureDir) => {
         const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-        const savedImagePath = path.join(fixtureDir, "source-reply-collision.png");
-        fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+        writeSavedPng(fixtureDir, "source-reply-collision.png");
         const collidingMirrorKey = "idem-agent-source-reply-collision:internal-source-reply:0";
         await appendSourceReplyMirrorEntry({
           idempotencyKey: collidingMirrorKey,
           text: "Existing assistant content",
           model: "gateway-injected",
         });
-        mockState.triggerAgentRunStart = true;
-        mockState.dispatchedReplies = [
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: "Source reply with media",
-                mediaUrls: [mediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: "Source reply with media",
-                  mediaUrls: [mediaUrl],
-                  idempotencyKey: collidingMirrorKey,
-                },
-              },
-            ),
-          },
-        ];
+        setAgentRunReplies([
+          createMainSourceReply({
+            idempotencyKey: collidingMirrorKey,
+            text: "Source reply with media",
+            mediaUrls: [mediaUrl],
+          }),
+        ]);
         const { send } = createChatRequestFixture();
 
         const broadcast = await send({
@@ -4237,28 +3929,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       "openclaw-chat-send-agent-source-reply-media-only-",
       async (fixtureDir) => {
         const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-        const savedImagePath = path.join(fixtureDir, "source-reply-media-only.png");
-        fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+        writeSavedPng(fixtureDir, "source-reply-media-only.png");
         const missingMirrorKey = "idem-agent-source-reply-media-only:internal-source-reply:0";
-        mockState.triggerAgentRunStart = true;
-        mockState.dispatchedReplies = [
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                mediaUrls: [mediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  mediaUrls: [mediaUrl],
-                  idempotencyKey: missingMirrorKey,
-                },
-              },
-            ),
-          },
-        ];
+        setAgentRunReplies([
+          createMainSourceReply({ idempotencyKey: missingMirrorKey, mediaUrls: [mediaUrl] }),
+        ]);
         const { send } = createChatRequestFixture();
 
         const broadcast = await send({
@@ -4281,9 +3956,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       "openclaw-chat-send-agent-source-reply-media-only-sibling-",
       async (fixtureDir) => {
         const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-        const savedImagePath = path.join(fixtureDir, "source-reply-media-only-sibling.png");
-        fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+        writeSavedPng(fixtureDir, "source-reply-media-only-sibling.png");
         const textMirrorKey = "idem-agent-source-reply-media-only-sibling:internal-source-reply:0";
         const missingMirrorKey =
           "idem-agent-source-reply-media-only-sibling:internal-source-reply:1";
@@ -4291,39 +3964,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           idempotencyKey: textMirrorKey,
           text: "Text source reply",
         });
-        mockState.triggerAgentRunStart = true;
-        mockState.dispatchedReplies = [
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: "Text source reply",
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: "Text source reply",
-                  idempotencyKey: textMirrorKey,
-                },
-              },
-            ),
-          },
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                mediaUrls: [mediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  mediaUrls: [mediaUrl],
-                  idempotencyKey: missingMirrorKey,
-                },
-              },
-            ),
-          },
-        ];
+        setAgentRunReplies([
+          createMainSourceReply({ idempotencyKey: textMirrorKey, text: "Text source reply" }),
+          createMainSourceReply({ idempotencyKey: missingMirrorKey, mediaUrls: [mediaUrl] }),
+        ]);
         const { send } = createChatRequestFixture();
 
         const broadcast = await send({
@@ -4350,9 +3994,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       "openclaw-chat-send-agent-source-reply-later-",
       async (fixtureDir) => {
         const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
-        const savedImagePath = path.join(fixtureDir, "source-reply-later.png");
-        fs.writeFileSync(savedImagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
-        mockState.savedMediaResults = [{ path: savedImagePath, contentType: "image/png" }];
+        writeSavedPng(fixtureDir, "source-reply-later.png");
         const mirrorKey = "idem-agent-source-reply-later:internal-source-reply:0";
         await appendSourceReplyMirrorEntry({
           idempotencyKey: mirrorKey,
@@ -4363,26 +4005,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           text: "Later assistant content",
           model: "gateway-injected",
         });
-        mockState.triggerAgentRunStart = true;
-        mockState.dispatchedReplies = [
-          {
-            kind: "final",
-            payload: setReplyPayloadMetadata(
-              {
-                text: "Source reply with media",
-                mediaUrls: [mediaUrl],
-              },
-              {
-                sourceReplyTranscriptMirror: {
-                  sessionKey: "main",
-                  text: "Source reply with media",
-                  mediaUrls: [mediaUrl],
-                  idempotencyKey: mirrorKey,
-                },
-              },
-            ),
-          },
-        ];
+        setAgentRunReplies([
+          createMainSourceReply({
+            idempotencyKey: mirrorKey,
+            text: "Source reply with media",
+            mediaUrls: [mediaUrl],
+          }),
+        ]);
         const { send } = createChatRequestFixture();
 
         const broadcast = await send({
@@ -4410,24 +4039,12 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("does not broadcast an error terminal after an internal-ui source reply final", async () => {
     await createTranscriptFixture("openclaw-chat-send-agent-source-reply-error-");
-    mockState.triggerAgentRunStart = true;
-    const sourceReply = setReplyPayloadMetadata(
-      {
-        text: "Codex source reply",
-      },
-      {
-        sourceReplyTranscriptMirror: {
-          sessionKey: "main",
-          text: "Codex source reply",
-          idempotencyKey: "idem-agent-source-reply-error:internal-source-reply:0",
-        },
-      },
-    );
-    mockState.dispatchedReplies = [
-      {
-        kind: "final",
-        payload: sourceReply,
-      },
+    const sourceReply = createMainSourceReply({
+      idempotencyKey: "idem-agent-source-reply-error:internal-source-reply:0",
+      text: "Codex source reply",
+    });
+    setAgentRunReplies([
+      sourceReply,
       {
         kind: "final",
         payload: {
@@ -4435,7 +4052,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           isError: true,
         },
       },
-    ];
+    ]);
     const { context, send } = createChatRequestFixture();
 
     const broadcast = await send({
@@ -5413,10 +5030,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       agentId: "work",
       sessionKey: "agent:work:global",
     });
-    mockState.config = {
-      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
-      session: { scope: "global" },
-    };
+    useGlobalSessionScope();
     mockState.sessionEntry = { canonicalKey: "global" };
     const { context, respond, inject } = createChatRequestFixture();
 
@@ -6069,18 +5683,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("prepares managed image claims for Pi user-turn persistence", async () => {
     await createReadyChatTranscript("openclaw-chat-send-user-transcript-images-");
     mockState.triggerAgentRunStart = true;
-    mockState.savedMediaResults = [
-      {
-        id: "chat-send-image-a.png",
-        path: "/tmp/chat-send-image-a.png",
-        contentType: "image/png",
-      },
-      {
-        id: "chat-send-image-b.jpg",
-        path: "/tmp/chat-send-image-b.jpg",
-        contentType: "image/jpeg",
-      },
-    ];
+    setSavedMediaResults(
+      ["/tmp/chat-send-image-a.png", "image/png", "chat-send-image-a.png"],
+      ["/tmp/chat-send-image-b.jpg", "image/jpeg", "chat-send-image-b.jpg"],
+    );
     const { send } = createChatRequestFixture();
 
     await send({
@@ -6088,16 +5694,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       message: "edit these",
       requestParams: {
         attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aYoYAAAAASUVORK5CYII=",
-          },
-          {
-            mimeType: "image/jpeg",
-            content:
-              "/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxAQEBUQEBAVFRUVFRUVFRUVFRUVFRUVFRUXFhUVFRUYHSggGBolHRUVITEhJSkrLi4uFx8zODMsNygtLisBCgoKDg0OGhAQGi0fICUtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIAAEAAQMBEQACEQEDEQH/xAAXAAADAQAAAAAAAAAAAAAAAAAAAQMC/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEAMQAAAB6AAAAP/EABQQAQAAAAAAAAAAAAAAAAAAACD/2gAIAQEAAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAACD/2gAIAQIBAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAACD/2gAIAQMBAT8Af//Z",
-          },
+          createImageAttachment({ content: INLINE_PNG_BASE64 }),
+          createImageAttachment({ content: TINY_JPEG_BASE64, mimeType: "image/jpeg" }),
         ],
       },
       expectBroadcast: false,
@@ -6151,9 +5749,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("prepares non-image chat.send attachments as claim-only media refs without dispatch images", async () => {
     await createReadyChatTranscript("openclaw-chat-send-user-transcript-file-");
     mockState.triggerAgentRunStart = true;
-    mockState.savedMediaResults = [
-      { path: "/tmp/chat-send-brief.pdf", contentType: "application/pdf" },
-    ];
+    setSavedMediaResults(["/tmp/chat-send-brief.pdf", "application/pdf"]);
     const { send } = createChatRequestFixture();
 
     await send({
@@ -6161,12 +5757,11 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       message: "summarize this",
       requestParams: {
         attachments: [
-          {
-            type: "file",
-            mimeType: "application/pdf",
-            fileName: "brief.pdf",
-            content: Buffer.from("%PDF-1.4\n").toString("base64"),
-          },
+          createFileAttachment(
+            "brief.pdf",
+            "application/pdf",
+            Buffer.from("%PDF-1.4\n").toString("base64"),
+          ),
         ],
       },
       expectBroadcast: false,
@@ -6207,50 +5802,21 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("preserves managed attachment claims in transcript order", async () => {
     await createReadyChatTranscript("openclaw-chat-send-user-transcript-offloaded-");
     mockState.triggerAgentRunStart = true;
-    mockState.sessionEntry = {
-      modelProvider: "test-provider",
-      model: "vision-model",
-      providerOverride: "test-provider",
-      modelOverride: "vision-model",
-    };
-    mockState.modelCatalog = [
-      {
-        provider: "test-provider",
-        id: "vision-model",
-        name: "Vision model",
-        input: ["text", "image"],
-      },
-    ];
-    mockState.savedMediaResults = [
-      {
-        id: "offloaded-big.png",
-        path: "/tmp/offloaded-big.png",
-        contentType: "image/png",
-      },
-      {
-        id: "chat-send-inline.png",
-        path: "/tmp/chat-send-inline.png",
-        contentType: "image/png",
-      },
-    ];
+    useChatTestModel("vision-model", true);
+    setSavedMediaResults(
+      ["/tmp/offloaded-big.png", "image/png", "offloaded-big.png"],
+      ["/tmp/chat-send-inline.png", "image/png", "chat-send-inline.png"],
+    );
     const { send } = createChatRequestFixture();
-    const bigPng = Buffer.alloc(2_100_000);
-    bigPng.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    const bigPng = createPngBuffer(2_100_000);
 
     await send({
       idempotencyKey: "idem-user-transcript-offloaded",
       message: "edit both",
       requestParams: {
         attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aYoYAAAAASUVORK5CYII=",
-          },
-          {
-            mimeType: "image/png",
-            content: bigPng.toString("base64"),
-          },
+          createImageAttachment({ content: INLINE_PNG_BASE64 }),
+          createImageAttachment({ content: bigPng.toString("base64") }),
         ],
       },
       expectBroadcast: false,
@@ -6286,9 +5852,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("leaves ACP bridge user persistence to the agent runtime", async () => {
     await createReadyChatTranscript("openclaw-chat-send-user-transcript-acp-images-");
     mockState.triggerAgentRunStart = true;
-    mockState.savedMediaResults = [
-      { path: "/tmp/should-not-be-used.png", contentType: "image/png" },
-    ];
+    setSavedMediaResults(["/tmp/should-not-be-used.png", "image/png"]);
     const { send } = createChatRequestFixture();
 
     await send({
@@ -6305,13 +5869,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         },
       },
       requestParams: {
-        attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aYoYAAAAASUVORK5CYII=",
-          },
-        ],
+        attachments: [createImageAttachment({ content: INLINE_PNG_BASE64 })],
       },
       expectBroadcast: false,
     });
@@ -6331,9 +5889,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("waits for the user transcript update before final broadcast on non-agent attachment sends", async () => {
     await createGatewayUserTurnSqliteFixture("openclaw-chat-send-no-agent-images-order-");
     mockState.finalText = "ok";
-    mockState.savedMediaResults = [
-      { path: "/tmp/chat-send-image-a.png", contentType: "image/png" },
-    ];
+    setSavedMediaResults(["/tmp/chat-send-image-a.png", "image/png"]);
     let releaseSave = () => {};
     mockState.saveMediaWait = new Promise<void>((resolve) => {
       releaseSave = resolve;
@@ -6344,13 +5900,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-no-agent-images-order",
       message: "quick command",
       requestParams: {
-        attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aYoYAAAAASUVORK5CYII=",
-          },
-        ],
+        attachments: [createImageAttachment({ content: INLINE_PNG_BASE64 })],
       },
       expectBroadcast: false,
       waitForCompletion: false,
@@ -6507,13 +6057,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-text-only-attachments",
       message: "describe image",
       requestParams: {
-        attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
-          },
-        ],
+        attachments: [createImageAttachment({ content: OFFLOAD_PNG_BASE64 })],
       },
       expectBroadcast: false,
       waitFor: "none",
@@ -6564,13 +6108,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-configured-custom-vision",
       message: "describe image",
       requestParams: {
-        attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
-          },
-        ],
+        attachments: [createImageAttachment({ content: OFFLOAD_PNG_BASE64 })],
       },
       expectBroadcast: false,
     });
@@ -6604,13 +6142,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         originatingChannel: "slack",
         originatingTo: "user:U123",
         originatingAccountId: "default",
-        attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
-          },
-        ],
+        attachments: [createImageAttachment({ content: OFFLOAD_PNG_BASE64 })],
       },
       expectBroadcast: false,
     });
@@ -6662,13 +6194,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-agent-scoped-text-only-attachments",
       message: "describe image",
       requestParams: {
-        attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
-          },
-        ],
+        attachments: [createImageAttachment({ content: OFFLOAD_PNG_BASE64 })],
       },
       expectBroadcast: false,
       waitFor: "none",
@@ -6700,9 +6226,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("routes non-image offloaded refs into media facts for chat.send", async () => {
     await createReadyChatTranscript("openclaw-chat-send-non-image-ctx-media-paths-");
     useChatTestModel("vision-model");
-    mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
-    ];
+    setSavedMediaResults(["/home/user/.openclaw/media/inbound/report.pdf", "application/pdf"]);
     const { send } = createChatRequestFixture();
     const pdf = Buffer.from("%PDF-1.4\n%µ¶\n1 0 obj\n<<>>\nendobj\n").toString("base64");
 
@@ -6710,14 +6234,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-non-image-ctx-media",
       message: "read this",
       requestParams: {
-        attachments: [
-          {
-            type: "file",
-            mimeType: "application/pdf",
-            fileName: "report.pdf",
-            content: pdf,
-          },
-        ],
+        attachments: [createFileAttachment("report.pdf", "application/pdf", pdf)],
       },
       expectBroadcast: false,
     });
@@ -6744,9 +6261,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("routes image-named generic container bytes as non-image media paths for chat.send", async () => {
     await createReadyChatTranscript("openclaw-chat-send-spoofed-image-container-");
     useChatTestModel("vision-model");
-    mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/fake.zip", contentType: "application/zip" },
-    ];
+    setSavedMediaResults(["/home/user/.openclaw/media/inbound/fake.zip", "application/zip"]);
     const { send } = createChatRequestFixture();
     const zip = Buffer.from("PK\u0003\u0004zip-archive-bytes").toString("base64");
 
@@ -6754,14 +6269,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-spoofed-image-container",
       message: "inspect this",
       requestParams: {
-        attachments: [
-          {
-            type: "image",
-            mimeType: "image/png",
-            fileName: "fake.png",
-            content: zip,
-          },
-        ],
+        attachments: [createFileAttachment("fake.png", "image/png", zip, "image")],
       },
       expectBroadcast: false,
     });
@@ -6789,9 +6297,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   it("preserves sandbox-relative fact paths and workspace context for media-understanding", async () => {
     await createReadyChatTranscript("openclaw-chat-send-non-image-absolutize-");
     useChatTestModel("vision-model");
-    mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
-    ];
+    setSavedMediaResults(["/home/user/.openclaw/media/inbound/report.pdf", "application/pdf"]);
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     mockState.stagedRelativePaths = ["media/inbound/report.pdf"];
     const { send } = createChatRequestFixture();
@@ -6801,14 +6307,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-non-image-absolutize",
       message: "read this",
       requestParams: {
-        attachments: [
-          {
-            type: "file",
-            mimeType: "application/pdf",
-            fileName: "report.pdf",
-            content: pdf,
-          },
-        ],
+        attachments: [createFileAttachment("report.pdf", "application/pdf", pdf)],
       },
       expectBroadcast: false,
     });
@@ -6832,10 +6331,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         pluginRoot: "/plugins/demo-plugin",
       },
     });
-    mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
-      { path: "/home/user/.openclaw/media/inbound/screenshot.png", contentType: "image/png" },
-    ];
+    setSavedMediaResults(
+      ["/home/user/.openclaw/media/inbound/report.pdf", "application/pdf"],
+      ["/home/user/.openclaw/media/inbound/screenshot.png", "image/png"],
+    );
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     mockState.stagedRelativePaths = ["media/inbound/report.pdf"];
     const { send } = createChatRequestFixture();
@@ -6850,18 +6349,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         originatingTo: "user:U123",
         originatingAccountId: "default",
         attachments: [
-          {
-            type: "image",
-            mimeType: "image/png",
-            fileName: "screenshot.png",
-            content: TINY_PNG_BASE64,
-          },
-          {
-            type: "file",
-            mimeType: "application/pdf",
-            fileName: "report.pdf",
-            content: pdf,
-          },
+          createFileAttachment("screenshot.png", "image/png", TINY_PNG_BASE64, "image"),
+          createFileAttachment("report.pdf", "application/pdf", pdf),
         ],
       },
       expectBroadcast: false,
@@ -6889,12 +6378,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // the staging-throw fallback test below.) #90097
     await createReadyChatTranscript("openclaw-chat-send-stage-unavailable-");
     useChatTestModel("vision-model");
-    mockState.savedMediaResults = [
-      {
-        path: "/home/user/.openclaw/media/inbound/report.bin",
-        contentType: "application/octet-stream",
-      },
-    ];
+    setSavedMediaResults([
+      "/home/user/.openclaw/media/inbound/report.bin",
+      "application/octet-stream",
+    ]);
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     const stageError = Object.assign(new Error("ENOSPC: no space left on device"), {
       code: "ENOSPC",
@@ -6909,14 +6396,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-stage-unavailable",
       message: "read this",
       requestParams: {
-        attachments: [
-          {
-            type: "file",
-            mimeType: "application/octet-stream",
-            fileName: "report.bin",
-            content: binPayload,
-          },
-        ],
+        attachments: [createFileAttachment("report.bin", "application/octet-stream", binPayload)],
       },
       expectBroadcast: false,
       waitFor: "none",
@@ -6954,14 +6434,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-chat-send-attachment-parse-stack",
       message: "inspect this",
       requestParams: {
-        attachments: [
-          {
-            type: "file",
-            mimeType: "image/png",
-            fileName: "broken.png",
-            content: "not-base64",
-          },
-        ],
+        attachments: [createFileAttachment("broken.png", "image/png", "not-base64")],
       },
       expectBroadcast: false,
       waitFor: "none",
@@ -6998,16 +6471,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // fall back instead — see the staging-skip fallback test below.) #90097
     await createReadyChatTranscript("openclaw-chat-send-partial-stage-");
     useChatTestModel("vision-model");
-    mockState.savedMediaResults = [
-      {
-        path: "/home/user/.openclaw/media/inbound/report.bin",
-        contentType: "application/octet-stream",
-      },
-      {
-        path: "/home/user/.openclaw/media/inbound/data.bin",
-        contentType: "application/octet-stream",
-      },
-    ];
+    setSavedMediaResults(
+      ["/home/user/.openclaw/media/inbound/report.bin", "application/octet-stream"],
+      ["/home/user/.openclaw/media/inbound/data.bin", "application/octet-stream"],
+    );
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     mockState.stagedRelativePaths = ["media/inbound/report.bin", "media/inbound/data.bin"];
     mockState.unstagedSources = ["/home/user/.openclaw/media/inbound/data.bin"];
@@ -7019,18 +6486,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       message: "read these",
       requestParams: {
         attachments: [
-          {
-            type: "file",
-            mimeType: "application/octet-stream",
-            fileName: "report.bin",
-            content: binPayload,
-          },
-          {
-            type: "file",
-            mimeType: "application/octet-stream",
-            fileName: "data.bin",
-            content: binPayload,
-          },
+          createFileAttachment("report.bin", "application/octet-stream", binPayload),
+          createFileAttachment("data.bin", "application/octet-stream", binPayload),
         ],
       },
       expectBroadcast: false,
@@ -7057,9 +6514,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // it must reach dispatch with its managed media path instead of a 4xx.
     await createReadyChatTranscript("openclaw-chat-send-managed-pdf-pass-through-");
     useChatTestModel("vision-model");
-    mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/huge.pdf", contentType: "application/pdf" },
-    ];
+    setSavedMediaResults(["/home/user/.openclaw/media/inbound/huge.pdf", "application/pdf"]);
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     const { send } = createChatRequestFixture();
     // 6MB PDF — above STAGED_MEDIA_MAX_BYTES (5MB) but below the 20MB parse cap.
@@ -7071,12 +6526,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       message: "read this",
       requestParams: {
         attachments: [
-          {
-            type: "file",
-            mimeType: "application/pdf",
-            fileName: "huge.pdf",
-            content: oversized.toString("base64"),
-          },
+          createFileAttachment("huge.pdf", "application/pdf", oversized.toString("base64")),
         ],
       },
       expectBroadcast: false,
@@ -7102,9 +6552,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // the media-store root.
     await createReadyChatTranscript("openclaw-chat-send-managed-pdf-stage-throw-");
     useChatTestModel("vision-model");
-    mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
-    ];
+    setSavedMediaResults(["/home/user/.openclaw/media/inbound/report.pdf", "application/pdf"]);
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     mockState.stageSandboxMediaError = Object.assign(new Error("ENOSPC: no space left on device"), {
       code: "ENOSPC",
@@ -7118,9 +6566,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-managed-pdf-stage-throw",
       message: "read this",
       requestParams: {
-        attachments: [
-          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
-        ],
+        attachments: [createFileAttachment("report.pdf", "application/pdf", pdf)],
       },
       expectBroadcast: false,
     });
@@ -7144,9 +6590,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // send; the staged workspace dir is still carried for any files that landed.
     await createReadyChatTranscript("openclaw-chat-send-managed-pdf-stage-skip-");
     useChatTestModel("vision-model");
-    mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
-    ];
+    setSavedMediaResults(["/home/user/.openclaw/media/inbound/report.pdf", "application/pdf"]);
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     // No stagedRelativePaths → staged map is empty and the fact keeps the
     // absolute path, mirroring stageSandboxMedia silently skipping the file.
@@ -7157,9 +6601,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-managed-pdf-stage-skip",
       message: "read this",
       requestParams: {
-        attachments: [
-          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
-        ],
+        attachments: [createFileAttachment("report.pdf", "application/pdf", pdf)],
       },
       expectBroadcast: false,
     });
@@ -7180,13 +6622,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // still surface a retryable 5xx and clean up every offloaded entry.
     await createReadyChatTranscript("openclaw-chat-send-mixed-stage-skip-");
     useChatTestModel("vision-model");
-    mockState.savedMediaResults = [
-      { path: "/home/user/.openclaw/media/inbound/report.pdf", contentType: "application/pdf" },
-      {
-        path: "/home/user/.openclaw/media/inbound/data.bin",
-        contentType: "application/octet-stream",
-      },
-    ];
+    setSavedMediaResults(
+      ["/home/user/.openclaw/media/inbound/report.pdf", "application/pdf"],
+      ["/home/user/.openclaw/media/inbound/data.bin", "application/octet-stream"],
+    );
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     mockState.stagedRelativePaths = ["media/inbound/report.pdf", "media/inbound/data.bin"];
     mockState.unstagedSources = ["/home/user/.openclaw/media/inbound/data.bin"];
@@ -7199,13 +6638,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       message: "read these",
       requestParams: {
         attachments: [
-          { type: "file", mimeType: "application/pdf", fileName: "report.pdf", content: pdf },
-          {
-            type: "file",
-            mimeType: "application/octet-stream",
-            fileName: "data.bin",
-            content: bin,
-          },
+          createFileAttachment("report.pdf", "application/pdf", pdf),
+          createFileAttachment("data.bin", "application/octet-stream", bin),
         ],
       },
       expectBroadcast: false,
@@ -7237,12 +6671,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // other oversized non-image files must still be rejected.
     await createReadyChatTranscript("openclaw-chat-send-sandbox-oversize-");
     useChatTestModel("vision-model");
-    mockState.savedMediaResults = [
-      {
-        path: "/home/user/.openclaw/media/inbound/huge.bin",
-        contentType: "application/octet-stream",
-      },
-    ];
+    setSavedMediaResults([
+      "/home/user/.openclaw/media/inbound/huge.bin",
+      "application/octet-stream",
+    ]);
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
     const { respond, send } = createChatRequestFixture();
     // 6MB buffer — above STAGED_MEDIA_MAX_BYTES (5MB) but below the 20MB parse cap.
@@ -7255,12 +6687,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       message: "read this",
       requestParams: {
         attachments: [
-          {
-            type: "file",
-            mimeType: "application/octet-stream",
-            fileName: "huge.bin",
-            content: oversizedPayload,
-          },
+          createFileAttachment("huge.bin", "application/octet-stream", oversizedPayload),
         ],
       },
       expectBroadcast: false,
@@ -7282,39 +6709,18 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("passes imageOrder for mixed inline and offloaded chat.send attachments", async () => {
     await createReadyChatTranscript("openclaw-chat-send-image-order-");
-    mockState.sessionEntry = {
-      modelProvider: "test-provider",
-      model: "vision-model",
-      providerOverride: "test-provider",
-      modelOverride: "vision-model",
-    };
-    mockState.modelCatalog = [
-      {
-        provider: "test-provider",
-        id: "vision-model",
-        name: "Vision model",
-        input: ["text", "image"],
-      },
-    ];
-    mockState.savedMediaResults = [{ path: "/tmp/offloaded-big.png", contentType: "image/png" }];
+    useChatTestModel("vision-model", true);
+    setSavedMediaResults(["/tmp/offloaded-big.png", "image/png"]);
     const { send } = createChatRequestFixture();
-    const bigPng = Buffer.alloc(2_100_000);
-    bigPng.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    const bigPng = createPngBuffer(2_100_000);
 
     await send({
       idempotencyKey: "idem-image-order",
       message: "describe both",
       requestParams: {
         attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
-          },
-          {
-            mimeType: "image/png",
-            content: bigPng.toString("base64"),
-          },
+          createImageAttachment({ content: OFFLOAD_PNG_BASE64 }),
+          createImageAttachment({ content: bigPng.toString("base64") }),
         ],
       },
       expectBroadcast: false,
@@ -7329,19 +6735,13 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     useChatTestModel("vision-model");
     mockState.saveMediaError = new Error("disk full");
     const { respond, send } = createChatRequestFixture();
-    const bigPng = Buffer.alloc(2_100_000);
-    bigPng.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    const bigPng = createPngBuffer(2_100_000);
 
     await send({
       idempotencyKey: "idem-media-offload-error",
       message: "describe image",
       requestParams: {
-        attachments: [
-          {
-            mimeType: "image/png",
-            content: bigPng.toString("base64"),
-          },
-        ],
+        attachments: [createImageAttachment({ content: bigPng.toString("base64") })],
       },
       waitFor: "none",
     });
@@ -7354,10 +6754,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("persists chat.send attachments one at a time", async () => {
     await createReadyChatTranscript("openclaw-chat-send-image-serial-save-");
-    mockState.savedMediaResults = [
-      { path: "/tmp/chat-send-image-a.png", contentType: "image/png" },
-      { path: "/tmp/chat-send-image-b.jpg", contentType: "image/jpeg" },
-    ];
+    setSavedMediaResults(
+      ["/tmp/chat-send-image-a.png", "image/png"],
+      ["/tmp/chat-send-image-b.jpg", "image/jpeg"],
+    );
     let releaseSave = () => {};
     mockState.saveMediaWait = new Promise<void>((resolve) => {
       releaseSave = resolve;
@@ -7369,16 +6769,8 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       message: "serial please",
       requestParams: {
         attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aYoYAAAAASUVORK5CYII=",
-          },
-          {
-            mimeType: "image/jpeg",
-            content:
-              "/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxAQEBUQEBAVFRUVFRUVFRUVFRUVFRUVFRUXFhUVFRUYHSggGBolHRUVITEhJSkrLi4uFx8zODMsNygtLisBCgoKDg0OGhAQGi0fICUtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIAAEAAQMBEQACEQEDEQH/xAAXAAADAQAAAAAAAAAAAAAAAAAAAQMC/8QAFBABAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEAMQAAAB6AAAAP/EABQQAQAAAAAAAAAAAAAAAAAAACD/2gAIAQEAAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAACD/2gAIAQIBAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAACD/2gAIAQMBAT8Af//Z",
-          },
+          createImageAttachment({ content: INLINE_PNG_BASE64 }),
+          createImageAttachment({ content: TINY_JPEG_BASE64, mimeType: "image/jpeg" }),
         ],
       },
       expectBroadcast: false,
@@ -7399,7 +6791,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
   it("does not parse or offload attachments for stop commands", async () => {
     await createTranscriptFixture("openclaw-chat-send-stop-command-attachments-");
-    mockState.savedMediaResults = [{ path: "/tmp/should-not-exist.png", contentType: "image/png" }];
+    setSavedMediaResults(["/tmp/should-not-exist.png", "image/png"]);
     const { context, respond, send } = createChatRequestFixture();
     context.chatAbortControllers.set("run-same-session", {
       controller: new AbortController(),
@@ -7413,13 +6805,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-stop-command-attachments",
       message: "/stop",
       requestParams: {
-        attachments: [
-          {
-            mimeType: "image/png",
-            content:
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
-          },
-        ],
+        attachments: [createImageAttachment({ content: OFFLOAD_PNG_BASE64 })],
       },
       expectBroadcast: false,
       waitFor: "none",


### PR DESCRIPTION
## Summary

- consolidate repetitive fixture setup in the agent loop, update CLI, doctor health, and gateway chat suites
- preserve the existing titles, assertions, hooks, and behavior coverage while reducing test-only maintenance surface
- align the gateway proof with the current canonical gateway-methods project after removal of the historical duplicate project overlap

## Verification

- AgentCore owner suite: 67/67
- doctor health contributions: 115/115
- update CLI: 247/247
- gateway chat directives: canonical owner suite 202/202
- independent combined proof: 631 tests passed
- format, lint, diff, scope, AST inventory, and accepted-file hash checks passed
- mandatory isolated review and secret scan completed clean with no actionable findings
- exact reviewed binary diff: `e55444d08fcb4d0cbc640cbffce63334a2270c5636c6ca67cf38377fc3c4550f`

This is test-only: +1763/-3328, net -1565. No production, API, configuration, schema, migration, security, or documented behavior changes.

Changelog: not required for test-only cleanup.
