### PR TITLE
fix(tui): clear private session state before switching agents

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -35,7 +35,7 @@ type SelectableOverlay = {
   onSelect?: (item: { value: string; label?: string; description?: string }) => void;
 };
 type SetActivityStatusMock = ReturnType<typeof vi.fn> & ((text: string) => void);
-type SetSessionMock = ReturnType<typeof vi.fn> & ((key: string) => Promise<void>);
+type SetSessionMock = ReturnType<typeof vi.fn> & ((key: string, agentId?: string) => Promise<void>);
 type ConsumeCompletedRunMock = ReturnType<typeof vi.fn> & ((runId: string) => boolean);
 type FlushPendingHistoryRefreshMock = ReturnType<typeof vi.fn> & (() => void);
 type RefreshAgentsMock = ReturnType<typeof vi.fn> & (() => Promise<Result<void, string>>);
@@ -149,7 +149,13 @@ function createHarness(params?: {
     params?.runUsageCostCommand === null
       ? undefined
       : (params?.runUsageCostCommand ?? vi.fn().mockResolvedValue({ text: "💸 Usage cost" }));
-  const setSession = params?.setSession ?? (vi.fn().mockResolvedValue(undefined) as SetSessionMock);
+  const setSession =
+    params?.setSession ??
+    (vi.fn(async (_key: string, agentId?: string) => {
+      if (agentId) {
+        state.currentAgentId = agentId;
+      }
+    }) as SetSessionMock);
   const addUser = vi.fn();
   const addPendingUser = vi.fn();
   const dropPendingUser = vi.fn();
@@ -484,7 +490,10 @@ describe("tui command handlers", () => {
       selector.onSelect?.({ value });
       await flushAsyncSelect();
 
-      expect(harness.setSession).toHaveBeenCalledExactlyOnceWith(session);
+      expect(harness.setSession).toHaveBeenCalledExactlyOnceWith(
+        session,
+        ...(command === "/agents" ? [value] : []),
+      );
       expect(harness.closeOverlay).toHaveBeenCalledExactlyOnceWith(harness.overlayHandle);
     },
   );
@@ -1003,8 +1012,30 @@ describe("tui command handlers", () => {
     await handleCommand("/agent Work");
 
     expect(state.currentAgentId).toBe("work");
-    expect(setSession).toHaveBeenCalledWith("");
+    expect(setSession).toHaveBeenCalledWith("", "work");
     expect(addSystem).toHaveBeenCalledWith("agent set to work; use /openclaw to return");
+  });
+
+  it("lets the session owner observe the previous agent before switching a global session", async () => {
+    let ownerBeforeSelection: string | undefined;
+    const setSession = vi.fn(async (_key: string, agentId?: string) => {
+      ownerBeforeSelection = harness.state.currentAgentId;
+      if (agentId) {
+        harness.state.currentAgentId = agentId;
+      }
+    }) as SetSessionMock;
+    const harness = createHarness({
+      currentAgentId: "research",
+      currentSessionKey: "global",
+      setSession,
+    });
+
+    await harness.handleCommand("/agent OPS");
+
+    expect(ownerBeforeSelection).toBe("research");
+    expect(setSession).toHaveBeenCalledExactlyOnceWith("", "ops");
+    expect(harness.state.currentAgentId).toBe("ops");
+    expect(harness.addSystem).toHaveBeenCalledWith("agent set to ops; use /openclaw to return");
   });
 
   it("marks the generated runId as local before gateway events arrive", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -76,7 +76,7 @@ type CommandHandlerContext = {
   closeOverlay: (handle?: OverlayHandle) => void;
   refreshSessionInfo: () => Promise<void>;
   loadHistory: () => Promise<unknown>;
-  setSession: (key: string) => Promise<void>;
+  setSession: (key: string, agentId?: string) => Promise<void>;
   refreshAgents: (ownsRefresh?: () => boolean) => Promise<Result<void, string>>;
   abortActive: (params?: { preferActive?: boolean }) => Promise<void>;
   setActivityStatus: (text: string) => void;
@@ -219,8 +219,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   };
 
   const setAgent = async (id: string) => {
-    state.currentAgentId = normalizeAgentId(id);
-    await setSession("");
+    await setSession("", normalizeAgentId(id));
     chatLog.addSystem(`agent set to ${state.currentAgentId}; use /openclaw to return`);
   };
 

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -192,6 +192,58 @@ describe("tui session actions", () => {
     );
   });
 
+  it("retires the previous global agent before replacement history resolves", async () => {
+    const state = createBaseState({
+      currentAgentId: "research",
+      currentSessionKey: "global",
+      currentSessionId: "research-session",
+      activeChatRunId: "research-run",
+      pendingSubmit: acceptedSubmit("research-pending", "private draft"),
+      historyLoaded: true,
+      sessionInfo: { displayName: "Research secret", updatedAt: 100, verboseLevel: "full" },
+    });
+    sendPendingUser(state, "research-pending", "private draft");
+    const chatLog = new ChatLog();
+    chatLog.addUser("PRIVATE RESEARCH HISTORY");
+    const history = createDeferred<{
+      messages: unknown[];
+      sessionInfo: { sessionId: string };
+    }>();
+    const loadHistory = vi.fn(() => history.promise);
+    const invalidateRunOwnership = vi.fn();
+    const clearLocalRunIds = vi.fn();
+    const { setSession } = createTestSessionActions({
+      client: makeTuiBackend({ loadHistory }),
+      chatLog,
+      state,
+      invalidateRunOwnership,
+      clearLocalRunIds,
+      resolveSessionSelection: vi.fn((_raw?: string, agentId = state.currentAgentId) => ({
+        key: "global",
+        agentId,
+      })),
+    });
+
+    const switching = setSession("", "ops");
+
+    expect(state.currentAgentId).toBe("ops");
+    expect(state.currentSessionKey).toBe("global");
+    expect(state.currentSessionId).toBeNull();
+    expect(state.sessionInfo.displayName).toBeUndefined();
+    expect(state.activeChatRunId).toBeNull();
+    expect(state.pendingSubmit).toBeNull();
+    expect(state.historyLoaded).toBe(false);
+    expect(state.sessionProjection?.entries).toEqual([]);
+    expect(chatLog.render(120).join("\n")).not.toContain("PRIVATE RESEARCH HISTORY");
+    expect(invalidateRunOwnership).toHaveBeenCalledOnce();
+    expect(clearLocalRunIds).toHaveBeenCalledOnce();
+    expect(loadHistory).toHaveBeenCalledWith({ sessionKey: "global", agentId: "ops", limit: 200 });
+
+    history.resolve({ messages: [], sessionInfo: { sessionId: "ops-session" } });
+    await switching;
+    expect(state.currentSessionId).toBe("ops-session");
+  });
+
   it("returns success after applying a normalized fresh agent roster", async () => {
     const state = createBaseState({
       agents: [{ id: "cached", name: "Cached Agent" }],

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -642,8 +642,8 @@ export function createSessionActions(context: SessionActionContext) {
     }
   };
 
-  const setSession = async (rawKey: string) => {
-    applySessionSelection(resolveSessionSelection(rawKey));
+  const setSession = async (rawKey: string, agentId?: string) => {
+    applySessionSelection(resolveSessionSelection(rawKey, agentId));
     await loadHistory();
   };
 


### PR DESCRIPTION
Follows #129032.

## What Problem This Solves

Fixes an issue where users switching agents in a globally scoped TUI session would briefly see the previous agent's private conversation and session metadata while the new agent's history was loading. Because globally scoped agents share the literal `global` session key, the old agent's session ID, display name, visible transcript, and run ownership were not retired when `/agent` selected its replacement.

## Why This Change Was Made

The agent-switch producer now passes the normalized destination agent into the existing canonical session-selection owner instead of mutating the current agent first. That owner can compare the complete old and new agent/session identities, synchronously clear the previous agent's private transcript and run state, and only then request destination-agent history. The production change removes one line overall and introduces no fallback or compatibility branch.

## User Impact

Changing agents no longer exposes a previous agent's private global-session conversation, stale session display name, pending prompt, or run state while replacement history loads. Normal agent-scoped sessions, agent/session pickers, queued-session isolation, and globally scoped history requests continue to work.

## Evidence

- Untouched-current-main RED through the real pinned pi-tui `0.84.2` screen, actual `ChatLog`, and both production command/session owners: `/agent ops` left `PRIVATE RESEARCH HISTORY` visible with `currentSessionId: "research-session"`, `displayName: "Research secret"`, and zero run-ownership invalidations while requesting history for `ops`.
- Two regression tests failed on untouched production: the producer had already overwritten `research` with `ops` before the selection owner ran, and the owner ignored the explicit destination agent for the colliding `global` key.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-tui-global-agent-switch-vitest-cache node scripts/run-vitest.mjs run --configLoader runner --no-cache --maxWorkers 1 src/tui/tui-command-handlers.test.ts src/tui/tui-session-actions.test.ts` — **263 passed**.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-tui-global-agent-switch-pty-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner --no-cache --maxWorkers 1 src/tui/tui-pty-harness.e2e.test.ts src/tui/tui-session-identity-pty.e2e.test.ts -t 'selects model and session pickers through authenticated real PTY frames|ignores delayed aborts and streamed events from the previously selected session|restores a remembered global session'` — **3 actual PTY scenarios passed**.
- Real `TuiMainScreen` + `ChatLog` + production command/session owners + session projection passed both agent-scoped and global-session `/agent` transitions: before replacement history resolves, the old transcript, display name, session ID, active run, pending submit, and pending projection are cleared; the old run owner is invalidated exactly once and the new history request targets the correct agent.
- `node_modules/.bin/oxlint --type-aware --type-check src/tui/tui-command-handlers.ts src/tui/tui-command-handlers.test.ts src/tui/tui-session-actions.ts src/tui/tui-session-actions.test.ts` and `git diff --check` passed.
- Two independent exact-diff owner-boundary reviews reported no actionable findings.

