### PR TITLE
refactor(config): simplify allowed-value formatting

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2658,7 +2658,7 @@ src/commands/tasks.ts	2
 src/commands/telemetry-exporter-summary.ts	3
 src/commands/test-runtime-config-helpers.ts	3
 src/config/agent-dirs.ts	1
-src/config/allowed-values.ts	2
+src/config/allowed-values.ts	1
 src/config/bundled-channel-config-metadata.generated.ts	1
 src/config/channel-alias-migration.ts	2
 src/config/channel-capabilities.ts	2

--- a/src/config/allowed-values.ts
+++ b/src/config/allowed-values.ts
@@ -44,22 +44,13 @@ function toAllowedValueLabel(value: unknown): string {
 }
 
 function toAllowedValueValue(value: unknown): string {
-  if (typeof value === "string") {
-    return value;
-  }
-  return safeStringify(value);
+  return typeof value === "string" ? value : safeStringify(value);
 }
 
 function toAllowedValueDedupKey(value: unknown): string {
-  if (value === null) {
-    return "null:null";
-  }
-  const kind = typeof value;
+  const kind = value === null ? "null" : typeof value;
   // Preserve schema distinctions such as numeric 1 vs string "1" even when labels match.
-  if (kind === "string") {
-    return `string:${value as string}`;
-  }
-  return `${kind}:${safeStringify(value)}`;
+  return `${kind}:${toAllowedValueValue(value)}`;
 }
 
 /** Summarizes enum/allowed-value candidates for compact validation error hints. */
@@ -97,14 +88,10 @@ export function summarizeAllowedValues(
   };
 }
 
-function messageAlreadyIncludesAllowedValues(message: string): boolean {
-  const lower = normalizeLowercaseStringOrEmpty(message);
-  return lower.includes("(allowed:") || lower.includes("expected one of");
-}
-
 /** Appends an allowed-values hint unless the validation message already includes one. */
 export function appendAllowedValuesHint(message: string, summary: AllowedValuesSummary): string {
-  if (messageAlreadyIncludesAllowedValues(message)) {
+  const lower = normalizeLowercaseStringOrEmpty(message);
+  if (lower.includes("(allowed:") || lower.includes("expected one of")) {
     return message;
   }
   return `${message} (allowed: ${summary.formatted})`;


### PR DESCRIPTION
## Summary

- Simplify the existing allowed-value formatting owner by removing duplicated private formatting and deduplication logic.
- Preserve both public exports, null-versus-object handling, six mixed-type distinctions, UTF-16 truncation, the 12-value cap, exact stringify side effects, and duplicate warning suppression.
- Remove 13 production lines without changing configuration contracts, schemas, public APIs, or tests.

## Verification

- Four real owner, Zod, TypeBox, and configuration-plugin suites passed: 133 tests.
- Exported-boundary differential proof covered 17 hostile input families, mixed types, UTF-16 limits, the cap, and exactly three custom stringify calls.
- Focused formatting, direct owner lint, and whitespace checks passed.
- Independent source review and fresh structured autoreview reported no actionable findings.
