### PR TITLE
fix(slack): prevent duplicate files across direct and forwarded attachments

### DIFF
--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1265,14 +1265,15 @@ describe("Slack message file intake", () => {
   });
 
   it("keeps forwarded images before their files without letting failures shift later attachments", async () => {
-    mockFetch.mockImplementation(async (input) =>
-      String(input).includes("FFAILED")
+    mockFetch.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      return url.includes("FFAILED")
         ? new Response("unavailable", { status: 500 })
         : new Response(Buffer.from("file contents"), {
             status: 200,
             headers: { "content-type": "image/png" },
-          }),
-    );
+          });
+    });
 
     const result = await resolveMessageFiles({
       direct: [file("FDIRECT")],

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -9,11 +9,13 @@ import {
 } from "openclaw/plugin-sdk/ssrf-runtime";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SlackFile } from "../types.js";
 import {
   resolveSlackAttachmentContent,
   resolveSlackMedia,
   SLACK_MEDIA_READ_IDLE_TIMEOUT_MS,
 } from "./media.js";
+import { resolveSlackMessageContent } from "./message-handler/prepare-content.js";
 import { resolveSlackThreadHistory, resolveSlackThreadStarter } from "./thread.js";
 import { logVerbose } from "./thread.runtime.js";
 
@@ -1145,6 +1147,197 @@ describe("Slack media SSRF policy", () => {
       expect(lookupFn).toHaveBeenCalledWith(fileHostname, { all: true });
     },
   );
+});
+
+describe("Slack message file intake", () => {
+  beforeEach(() => {
+    mockFetch = vi.fn(
+      async () =>
+        new Response(Buffer.from("file contents"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  const file = (id: string): SlackFile => ({
+    id,
+    name: `${id.trim()}.png`,
+    mimetype: "image/png",
+    url_private_download: `https://files.slack.com/${id.trim()}.png`,
+  });
+
+  async function resolveMessageFiles(params: {
+    direct?: SlackFile[];
+    forwarded?: SlackFile[][];
+    attachments?: Array<{ is_share?: boolean; files?: SlackFile[]; image_url?: string }>;
+    preloadedMedia?: ReadonlyMap<SlackFile, SlackMediaResult[number]>;
+  }) {
+    return await resolveSlackMessageContent({
+      message: {
+        type: "message",
+        channel: "C123",
+        text: "Attached files",
+        files: params.direct,
+        attachments:
+          params.attachments ??
+          params.forwarded?.map((files) => ({ is_share: true as const, files })),
+      },
+      isThreadReply: false,
+      threadStarter: null,
+      isBotMessage: false,
+      botToken: "xoxb-test-token",
+      mediaMaxBytes: 1024,
+      preloadedMedia: params.preloadedMedia,
+    });
+  }
+
+  it.each([
+    {
+      name: "direct and forwarded copies",
+      direct: [file("FSHARED")],
+      forwarded: [[file("FSHARED")]],
+    },
+    {
+      name: "repeated direct copies",
+      direct: [file("FSHARED"), file(" FSHARED ")],
+      forwarded: [],
+    },
+    {
+      name: "copies across multiple forwarded attachments",
+      direct: [],
+      forwarded: [[file("FSHARED")], [file("FSHARED")]],
+    },
+  ])("downloads $name once and exposes one agent attachment", async ({ direct, forwarded }) => {
+    const result = await resolveMessageFiles({ direct, forwarded });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(result?.effectiveDirectMedia).toHaveLength(1);
+    expect(result?.rawBody.match(/fileId: FSHARED/g)).toHaveLength(1);
+  });
+
+  it("keeps richer forwarded metadata when the matching direct file has no download URL", async () => {
+    const result = await resolveMessageFiles({
+      direct: [{ id: "FRICH" }],
+      forwarded: [[file("FRICH")]],
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(result?.effectiveDirectMedia).toHaveLength(1);
+    expect(result?.rawBody).toContain("FRICH.png (image/png, fileId: FRICH)");
+  });
+
+  it("reuses the exact preloaded voice-file object across forwarded duplicates", async () => {
+    const voice = file("FVOICE");
+    const preloaded = {
+      path: "/tmp/preloaded-voice.ogg",
+      contentType: "audio/ogg",
+      placeholder: "[Slack file: voice.ogg (fileId: FVOICE)]",
+    };
+
+    const result = await resolveMessageFiles({
+      direct: [voice],
+      forwarded: [[file("FVOICE")]],
+      preloadedMedia: new Map([[voice, preloaded]]),
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.effectiveDirectMedia).toEqual([preloaded]);
+    expect(result?.effectiveDirectMedia?.[0]).toBe(preloaded);
+  });
+
+  it("applies Slack's eight-file budget once across direct and forwarded sources", async () => {
+    const result = await resolveMessageFiles({
+      direct: Array.from({ length: 8 }, (_, index) => file(`FDIRECT${index}`)),
+      forwarded: [Array.from({ length: 8 }, (_, index) => file(`FFORWARDED${index}`))],
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(8);
+    expect(result?.effectiveDirectMedia).toHaveLength(8);
+    expect(result?.rawBody).toContain("FDIRECT0.png");
+    expect(result?.rawBody).not.toContain("FFORWARDED0.png");
+  });
+
+  it("keeps forwarded images before their files without letting failures shift later attachments", async () => {
+    mockFetch.mockImplementation(async (input) =>
+      String(input).includes("FFAILED")
+        ? new Response("unavailable", { status: 500 })
+        : new Response(Buffer.from("file contents"), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          }),
+    );
+
+    const result = await resolveMessageFiles({
+      direct: [file("FDIRECT")],
+      attachments: [
+        {
+          is_share: true,
+          image_url: "https://files.slack.com/first-image.png",
+          files: [file("FFAILED"), file("FFIRST")],
+        },
+        {
+          is_share: true,
+          image_url: "https://files.slack.com/second-image.png",
+          files: [file("FDIRECT"), file("FSECOND")],
+        },
+      ],
+    });
+
+    expect(result?.effectiveDirectMedia?.map((item) => item.placeholder)).toEqual([
+      "[Slack file: FDIRECT.png (image/png, fileId: FDIRECT)]",
+      "[Forwarded image: first-image.png]",
+      "[Slack file: FFIRST.png (image/png, fileId: FFIRST)]",
+      "[Forwarded image: second-image.png]",
+      "[Slack file: FSECOND.png (image/png, fileId: FSECOND)]",
+    ]);
+    expect(result?.rawBody).toContain(
+      "FDIRECT)] [Forwarded image: first-image.png] [Slack file: FFIRST",
+    );
+  });
+
+  it("preserves distinct files without Slack file identifiers", async () => {
+    const first = { ...file("FIRST"), id: undefined };
+    const second = { ...file("SECOND"), id: undefined };
+
+    const result = await resolveMessageFiles({ direct: [first], forwarded: [[second]] });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result?.effectiveDirectMedia).toHaveLength(2);
+    expect(result?.rawBody).toContain("FIRST.png");
+    expect(result?.rawBody).toContain("SECOND.png");
+  });
+
+  it("does not accept richer file metadata from untrusted forwarded attachments", async () => {
+    const result = await resolveMessageFiles({
+      direct: [{ id: "FUNTRUSTED" }],
+      attachments: [{ is_share: false, files: [file("FUNTRUSTED")] }],
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.effectiveDirectMedia).toBeNull();
+    expect(result?.rawBody).toBe("Attached files\n[Slack file: file (fileId: FUNTRUSTED)]");
+  });
+
+  it("ignores richer metadata beyond the existing forwarded-attachment trust limit", async () => {
+    const result = await resolveMessageFiles({
+      direct: [{ id: "FLATE" }],
+      attachments: [
+        ...Array.from({ length: 8 }, () => ({ is_share: true })),
+        { is_share: true, files: [file("FLATE")] },
+      ],
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.effectiveDirectMedia).toBeNull();
+    expect(result?.rawBody).toBe("Attached files\n[Slack file: file (fileId: FLATE)]");
+  });
 });
 
 describe("resolveSlackAttachmentContent", () => {

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -7,6 +7,7 @@ import { normalizeHostname } from "openclaw/plugin-sdk/host-runtime";
 import { resolveRequestUrl } from "openclaw/plugin-sdk/request-url";
 import {
   normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
   normalizeOptionalLowercaseString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatSlackFileReference } from "../file-reference.js";
@@ -386,6 +387,7 @@ export async function resolveSlackMedia(params: {
 
 /** Extracts text and media from forwarded-message attachments. Returns null when empty. */
 export async function resolveSlackAttachmentContent(params: {
+  files?: SlackFile[];
   attachments?: SlackAttachment[];
   client?: SlackWebClient;
   token: string;
@@ -393,27 +395,71 @@ export async function resolveSlackAttachmentContent(params: {
   readIdleTimeoutMs?: number;
   totalTimeoutMs?: number;
   abortSignal?: AbortSignal;
+  preloadedMedia?: ReadonlyMap<SlackFile, SlackMediaResult>;
 }): Promise<{
   text: string;
   media: SlackMediaResult[];
   files?: SlackFile[];
   unavailableImageCount: number;
 } | null> {
-  const attachments = params.attachments;
-  if (!attachments || attachments.length === 0) {
-    return null;
-  }
-
-  const forwardedAttachments = attachments
+  const forwardedAttachments = (params.attachments ?? [])
     .filter((attachment) => isForwardedSlackAttachment(attachment))
     .slice(0, MAX_SLACK_FORWARDED_ATTACHMENTS);
-  if (forwardedAttachments.length === 0) {
+  const candidates = [
+    ...(params.files ?? []),
+    ...forwardedAttachments.flatMap((attachment) => attachment.files ?? []),
+  ];
+  if (forwardedAttachments.length === 0 && candidates.length === 0) {
     return null;
   }
 
+  const fileIds = new Set<string>();
+  const allFiles = candidates
+    .filter((file) => {
+      const fileId = normalizeOptionalString(file.id);
+      if (!fileId) {
+        return true;
+      }
+      if (fileIds.has(fileId)) {
+        return false;
+      }
+      fileIds.add(fileId);
+      return true;
+    })
+    .slice(0, MAX_SLACK_MEDIA_FILES)
+    .map((file) => {
+      const fileId = normalizeOptionalString(file.id);
+      if (
+        !fileId ||
+        params.preloadedMedia?.has(file) ||
+        file.url_private_download ||
+        file.url_private
+      ) {
+        return file;
+      }
+      const downloadable = candidates.find(
+        (candidate) =>
+          normalizeOptionalString(candidate.id) === fileId &&
+          (candidate.url_private_download || candidate.url_private),
+      );
+      return downloadable ? Object.assign({}, file, downloadable) : file;
+    });
+  const pendingFiles = new Map<SlackFile | string, SlackFile>(
+    allFiles.map((file) => [normalizeOptionalString(file.id) ?? file, file]),
+  );
+  const resolveFiles = (files?: SlackFile[]) =>
+    resolveSlackMedia({
+      ...params,
+      files: files?.flatMap((file) => {
+        const key = normalizeOptionalString(file.id) ?? file;
+        const selected = pendingFiles.get(key);
+        pendingFiles.delete(key);
+        return selected ? [selected] : [];
+      }),
+    });
+  const directMediaPromise = resolveFiles(params.files);
   const textBlocks: string[] = [];
-  const allMedia: SlackMediaResult[] = [];
-  const allFiles = forwardedAttachments.flatMap((attachment) => attachment.files ?? []);
+  const attachmentMedia: SlackMediaResult[] = [];
   let unavailableImageCount = 0;
   const govSlack = isGovSlackClient(params.client);
 
@@ -447,7 +493,7 @@ export async function resolveSlackAttachmentContent(params: {
           abortSignal: params.abortSignal,
         });
         const label = saved.fileName ?? "forwarded image";
-        allMedia.push({
+        attachmentMedia.push({
           path: saved.path,
           contentType: saved.contentType,
           placeholder: `[Forwarded image: ${label}]`,
@@ -456,23 +502,10 @@ export async function resolveSlackAttachmentContent(params: {
         unavailableImageCount += 1;
       }
     }
-
-    if (att.files && att.files.length > 0) {
-      const fileMedia = await resolveSlackMedia({
-        files: att.files,
-        client: params.client,
-        token: params.token,
-        maxBytes: params.maxBytes,
-        readIdleTimeoutMs: params.readIdleTimeoutMs,
-        totalTimeoutMs: params.totalTimeoutMs,
-        abortSignal: params.abortSignal,
-      });
-      if (fileMedia) {
-        allMedia.push(...fileMedia);
-      }
-    }
+    attachmentMedia.push(...((await resolveFiles(att.files)) ?? []));
   }
 
+  const allMedia = [...((await directMediaPromise) ?? []), ...attachmentMedia];
   const combinedText = textBlocks.join("\n\n");
   if (
     !combinedText &&

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -8,7 +8,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import { formatSlackFileReference } from "../../file-reference.js";
 import type { SlackFile, SlackMessageEvent } from "../../types.js";
 import { resolveSlackMessageText } from "../block-text.js";
-import { MAX_SLACK_MEDIA_FILES, type SlackMediaResult } from "../media-types.js";
+import type { SlackMediaResult } from "../media-types.js";
 import type { SlackThreadStarter } from "../thread.js";
 
 type SlackResolvedMessageContent = {
@@ -98,11 +98,12 @@ export async function resolveSlackMessageContent(params: {
     threadStarter: params.threadStarter,
   });
 
-  const mediaPromise =
-    ownFiles && ownFiles.length > 0
-      ? loadSlackMediaModule().then(({ resolveSlackMedia }) =>
-          resolveSlackMedia({
+  const attachmentContent =
+    ownFiles?.length || params.message.attachments?.length
+      ? await loadSlackMediaModule().then(({ resolveSlackAttachmentContent }) =>
+          resolveSlackAttachmentContent({
             files: ownFiles,
+            attachments: params.message.attachments,
             client: params.client,
             token: params.botToken,
             maxBytes: params.mediaMaxBytes,
@@ -112,51 +113,17 @@ export async function resolveSlackMessageContent(params: {
             preloadedMedia: params.preloadedMedia,
           }),
         )
-      : Promise.resolve(null);
+      : null;
 
-  const attachmentContentPromise =
-    params.message.attachments && params.message.attachments.length > 0
-      ? loadSlackMediaModule().then(({ resolveSlackAttachmentContent }) =>
-          resolveSlackAttachmentContent({
-            attachments: params.message.attachments,
-            client: params.client,
-            token: params.botToken,
-            maxBytes: params.mediaMaxBytes,
-            readIdleTimeoutMs: params.mediaReadIdleTimeoutMs,
-            totalTimeoutMs: params.mediaTotalTimeoutMs,
-            abortSignal: params.abortSignal,
-          }),
-        )
-      : Promise.resolve(null);
-
-  const [media, attachmentContent] = await Promise.all([mediaPromise, attachmentContentPromise]);
-
-  const mergedMedia = [...(media ?? []), ...(attachmentContent?.media ?? [])];
-  const effectiveDirectMedia = mergedMedia.length > 0 ? mergedMedia : null;
+  const effectiveDirectMedia = attachmentContent?.media.length ? attachmentContent.media : null;
   const mediaPlaceholder = effectiveDirectMedia
     ? effectiveDirectMedia.map((item) => item.placeholder).join(" ")
     : undefined;
 
-  const fallbackFileIds = new Set<string>();
-  const fallbackFiles = [...(ownFiles ?? []), ...(attachmentContent?.files ?? [])].filter(
-    (file) => {
-      const fileId = normalizeOptionalString(file.id);
-      if (!fileId) {
-        return true;
-      }
-      if (fallbackFileIds.has(fileId)) {
-        return false;
-      }
-      fallbackFileIds.add(fileId);
-      return true;
-    },
-  );
+  const fallbackFiles = attachmentContent?.files ?? [];
   const fileOnlyFallback =
     !mediaPlaceholder && fallbackFiles.length > 0
-      ? fallbackFiles
-          .slice(0, MAX_SLACK_MEDIA_FILES)
-          .map((file) => formatSlackFileReference(file))
-          .join(", ")
+      ? fallbackFiles.map((file) => formatSlackFileReference(file)).join(", ")
       : undefined;
   const fileOnlyPlaceholder = fileOnlyFallback ? `[Slack file: ${fileOnlyFallback}]` : undefined;
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending Slack messages with direct files and forwarded attachments would see duplicate files, exceed the existing eight-file limit, lose richer attachment metadata, or receive images and files in the wrong order when the same Slack file appeared through multiple message surfaces.

## Why This Change Was Made

Slack previously downloaded direct message files and forwarded attachment files through separate admission paths, so neither owner had the complete message-level file inventory before downloads started. Move file admission, normalized-ID deduplication, richer metadata selection, and the existing eight-file budget into the Slack attachment-content owner, then let message preparation consume that single canonical result. Keep the original preloaded voice-file object, distinguish files without IDs, retain forwarded image/file ordering, and preserve existing trusted-share, attachment-limit, GovSlack, authentication, and SSRF boundaries.

A downstream result filter would still perform duplicate authenticated downloads and would not enforce the existing budget before work starts. Independent per-source limits would continue admitting up to twice the existing cap. The owner-boundary refactor fixes the shared invariant without adding production code: production +68/-68, net zero; focused regression coverage +193 lines.

## User Impact

Slack messages deliver each attached file to the agent exactly once, preserve direct files and forwarded images/files in their original visible order, honor the existing eight-file limit across the whole message, and reuse already-downloaded voice attachments without downloading them again. Sparse direct-file metadata is completed only from trusted forwarded copies that are already within the existing admission boundary.

## Evidence

- Exact reviewed commit: `82ec16bc5a2ec3ae12a74fb71fd581b6d04c0aa5`.
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/media.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/preflight-audio.test.ts`: **238 tests passed across 3 files**.
- Regressions exercise direct/forwarded duplicate IDs, repeated direct IDs, duplicates across forwarded attachments, richer sparse metadata, original-object voice preloads, the shared eight-file cap, forwarded image/file ordering around failures, distinct ID-less files, untrusted attachments, and out-of-budget forwarded attachment metadata.
- `node_modules/.bin/oxfmt --check extensions/slack/src/monitor/media.ts extensions/slack/src/monitor/media.test.ts extensions/slack/src/monitor/message-handler/prepare-content.ts`: passed.
- `git diff --check 82ec16bc5a2ec3ae12a74fb71fd581b6d04c0aa5^ 82ec16bc5a2ec3ae12a74fb71fd581b6d04c0aa5`: passed.
- Fresh authenticated review and a separate independent owner/sibling review found no actionable issues on the exact commit. Previous independent proof additionally passed the broader 265-test Slack owner/sibling set.
- The message-entry regression uses the production message preparation and attachment-download path against a mocked Slack HTTP boundary; no authenticated live Slack message was sent.
- Scope: Slack plugin-private message intake only; no configuration, public SDK, protocol, dependencies, persistence, or authentication-policy changes.
