### PR TITLE
fix(cli): failing one-shot commands incorrectly exit successfully

### DIFF
--- a/src/cli/one-shot-exit.test.ts
+++ b/src/cli/one-shot-exit.test.ts
@@ -119,6 +119,59 @@ describe("one-shot CLI exit", () => {
     }
   });
 
+  it.each([
+    { name: "successful completion", processExitCode: undefined, expectedExitCode: 0 },
+    { name: "recorded command failure", processExitCode: 1, expectedExitCode: 1 },
+    { name: "integer-string command failure", processExitCode: "9", expectedExitCode: 9 },
+  ])(
+    "preserves the final process outcome for $name",
+    async ({ processExitCode, expectedExitCode }) => {
+      const previousExitCode = process.exitCode;
+      const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+
+      try {
+        process.exitCode = undefined;
+        await runCliWithExitFinalization({
+          run: async () => {
+            requestExitAfterOneShotOutput(defaultRuntime);
+            process.exitCode = processExitCode;
+          },
+          onError: ignoreError,
+          env: {},
+          execArgv: [],
+          platform: "linux",
+          markers: {},
+        });
+
+        await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(expectedExitCode));
+      } finally {
+        process.exitCode = previousExitCode;
+      }
+    },
+  );
+
+  it.each([0, 7])("preserves an explicit exit override of %i", async (requestedExitCode) => {
+    const previousExitCode = process.exitCode;
+    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+
+    try {
+      process.exitCode = 9;
+      requestExitAfterOneShotOutput(defaultRuntime, requestedExitCode);
+      await runCliWithExitFinalization({
+        run: successfulRun,
+        onError: ignoreError,
+        env: {},
+        execArgv: [],
+        platform: "linux",
+        markers: {},
+      });
+
+      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(requestedExitCode));
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
   it("normalizes a Node integer-string process exit code", async () => {
     const previousExitCode = process.exitCode;
     const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
@@ -324,6 +377,98 @@ describe("one-shot CLI exit", () => {
     expect(result.signal).toBeNull();
     expect(result.stderr).toBe("");
     expect(result.stdout).toHaveLength(payloadBytes);
+  });
+
+  it.each([
+    {
+      name: "long help spelling consumed as a proxy URL",
+      args: ["--proxy-url", "--help", "--json"],
+      exitCode: 1,
+      failure: true,
+    },
+    {
+      name: "short help spelling consumed as a proxy URL",
+      args: ["--proxy-url", "-h", "--json"],
+      exitCode: 1,
+      failure: true,
+    },
+    {
+      name: "ordinary invalid proxy URL",
+      args: ["--proxy-url", "invalid", "--json"],
+      exitCode: 1,
+      failure: true,
+    },
+    {
+      name: "genuine command help after a boolean option",
+      args: ["--json", "--help"],
+      exitCode: 0,
+      failure: false,
+    },
+  ])("keeps the real proxy command exit truthful for $name", ({ args, exitCode, failure }) => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: "/dev/null",
+      OPENCLAW_CONFIG_PATH: "/dev/null",
+      TSX_DISABLE_CACHE: "1",
+      NODE_DISABLE_COMPILE_CACHE: "1",
+    };
+    delete env.VITEST;
+    delete env.VITEST_POOL_ID;
+    delete env.VITEST_WORKER_ID;
+    const oneShotExitUrl = new URL("./one-shot-exit.ts", import.meta.url).href;
+    const runtimeSnapshotUrl = new URL("../config/runtime-snapshot.ts", import.meta.url).href;
+    const argvInvocationUrl = new URL("./argv-invocation.ts", import.meta.url).href;
+    const proxyCliUrl = new URL("./proxy-cli.ts", import.meta.url).href;
+    const script = `
+      import { Command, CommanderError } from "commander";
+      import { setRuntimeConfigSnapshot } from ${JSON.stringify(runtimeSnapshotUrl)};
+      import { resolveCliArgvInvocation } from ${JSON.stringify(argvInvocationUrl)};
+      import { registerProxyCli } from ${JSON.stringify(proxyCliUrl)};
+      import { requestExitAfterOneShotOutput, runCliWithExitFinalization } from ${JSON.stringify(oneShotExitUrl)};
+
+      setRuntimeConfigSnapshot({});
+      const argv = ["node", "openclaw", "proxy", "validate", ...${JSON.stringify(args)}];
+      await runCliWithExitFinalization({
+        run: async () => {
+          const program = new Command().enablePositionalOptions().exitOverride();
+          registerProxyCli(program);
+          try {
+            await program.parseAsync(argv);
+          } catch (error) {
+            if (!(error instanceof CommanderError) || error.exitCode !== 0) {
+              throw error;
+            }
+            process.exitCode = error.exitCode;
+          }
+          if (resolveCliArgvInvocation(argv).hasHelpOrVersion) {
+            requestExitAfterOneShotOutput();
+          }
+        },
+        onError: (error) => { throw error; },
+      });
+    `;
+
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", script],
+      { encoding: "utf8", env, timeout: 30_000 },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(exitCode);
+    if (failure) {
+      expect(JSON.parse(result.stdout)).toEqual(
+        expect.objectContaining({
+          ok: false,
+          config: expect.objectContaining({
+            errors: ["proxyUrl must use http:// or https://"],
+          }),
+        }),
+      );
+    } else {
+      expect(result.stdout).toContain("Usage: openclaw proxy validate");
+    }
   });
 
   it.each([

--- a/src/cli/one-shot-exit.ts
+++ b/src/cli/one-shot-exit.ts
@@ -112,12 +112,12 @@ export async function runCliWithExitFinalization(params: {
 
 export function requestExitAfterOneShotOutput(
   runtime: RuntimeEnv = defaultRuntime,
-  exitCode = 0,
+  exitCode?: number,
 ): boolean {
   if (runtime !== defaultRuntime) {
     return false;
   }
-  requestedExitCode = exitCode;
+  requestedExitCode = exitCode ?? "process";
   return true;
 }
 

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -122,10 +122,7 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/agent", "docs.openclaw.ai/cli/age
       await runCommandWithRuntime(defaultRuntime, async () => {
         setVerbose(verboseLevel === "on");
         await agentCliCommand(opts, defaultRuntime);
-        requestExitAfterOneShotOutput(
-          defaultRuntime,
-          typeof process.exitCode === "number" ? process.exitCode : 0,
-        );
+        requestExitAfterOneShotOutput(defaultRuntime);
       });
     });
 

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -180,12 +180,22 @@ describe("agent command registration", () => {
     expect(deps).toBeUndefined();
   });
 
-  it("keeps bare agent on the existing parent action", async () => {
-    await runCli(["agent", "--message", "hi", "--agent", "ops"]);
+  it.each([0, 1])("keeps bare agent on the parent action with exit code %i", async (exitCode) => {
+    const previousExitCode = process.exitCode;
+    agentCliCommandMock.mockImplementationOnce(async () => {
+      process.exitCode = exitCode;
+    });
 
-    expect(agentCliCommandMock).toHaveBeenCalledTimes(1);
-    expect(agentExecCommandMock).not.toHaveBeenCalled();
-    expect(requestExitAfterOneShotOutputMock).toHaveBeenCalledWith(runtime, 0);
+    try {
+      await runCli(["agent", "--message", "hi", "--agent", "ops"]);
+
+      expect(agentCliCommandMock).toHaveBeenCalledTimes(1);
+      expect(agentExecCommandMock).not.toHaveBeenCalled();
+      expect(requestExitAfterOneShotOutputMock).toHaveBeenCalledWith(runtime);
+      expect(process.exitCode).toBe(exitCode);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
   });
 
   it("keeps an exec-valued parent message on the existing parent action", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running a failing one-shot CLI command could receive a successful operating-system exit code when the command's arguments also looked like a help invocation. For example, both `openclaw proxy validate --proxy-url --help --json` and the equivalent `-h` form produced a failure JSON envelope but exited `0` instead of `1`.

Related: #125557

## Why This Change Was Made

The shared one-shot finalization owner eagerly captured an omitted exit override as `0`, so a later help-completion exit request erased the real `process.exitCode` recorded by the command. Reuse the owner's existing deferred `"process"` mode for omitted overrides, resolve the authoritative process outcome only after shared cleanup and stream drainage, and remove the redundant agent-command workaround introduced by #125557. Explicit exit overrides, ordinary successful help, macOS system-CA finalization, custom runtimes, and nested agent execution retain their existing contracts.

## User Impact

Shell scripts, CI jobs, automation, and operators now reliably see a nonzero exit status when one-shot commands fail, even when an option consumes `--help` or `-h` as its value. Successful commands and real help continue to exit successfully, and structured stdout is fully drained before termination.

## Evidence

- Reviewed head: `2a9caefc7cb5c4d0e2324bdd3bafa4af82870340`.
- Before: real spawned Commander proxy-validation commands with `--proxy-url --help --json` and `--proxy-url -h --json` emitted `{ "ok": false }` but terminated with operating-system exit `0`.
- After: both real spawned commands retain their failure JSON and terminate with exit `1`; ordinary invalid input also exits `1`, while genuine `--json --help` remains exit `0`.
- Focused verification: `node scripts/run-vitest.mjs src/cli/one-shot-exit.test.ts src/cli/program/register.agent.test.ts` — **2 files, 58 tests passed**, including real child-process exit status, numeric and integer-string process outcomes, explicit `0`/`7` overrides, embedded runtimes, macOS system-CA finalization, stdout/stderr drainage, and agent-command sibling behavior.
- Independent owner/sibling verification: **162 broader CLI tests passed**.
- Formatting: `node_modules/.bin/oxfmt --check src/cli/one-shot-exit.ts src/cli/one-shot-exit.test.ts src/cli/program/register.agent-turn.ts src/cli/program/register.agent.test.ts` — all four files clean.
- `git diff --check` passes.
- Production LOC: `+3/-6` (**net -3**); regression tests: `+161/-6`.
- Independent full-commit authenticated Codex review: clean; no actionable findings.
- No new configuration, persistence, public API, dependency, authentication, or protocol surface.
