### PR TITLE
fix(slack): explicit replies land in the requested thread

### DIFF
--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -644,6 +644,26 @@ describe("handleSlackMessageAction", () => {
 
   it.each([
     {
+      name: "prefers an explicit reply target over an inherited Slack thread",
+      params: {
+        to: "channel:C1",
+        message: "Reply to the requested message",
+        threadId: "111.222",
+        replyTo: "999.000",
+      },
+      expected: { content: "Reply to the requested message", threadTs: "999.000" },
+    },
+    {
+      name: "falls back to the Slack thread when the reply target is not a timestamp",
+      params: {
+        to: "channel:C1",
+        message: "Reply in the current thread",
+        threadId: "111.222",
+        replyTo: "msg-internal-1",
+      },
+      expected: { content: "Reply in the current thread", threadTs: "111.222" },
+    },
+    {
       name: "passes replyBroadcast through for Slack thread sends",
       params: {
         to: "channel:C1",

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -23,6 +23,7 @@ import {
   resolveSlackReplyDeliveryMessages,
   type SlackReplyDeliveryMessage,
 } from "./reply-blocks.js";
+import { resolveSlackThreadTsValue } from "./thread-ts.js";
 import { countSlackTextUtf8Bytes } from "./truncate.js";
 
 type SlackActionInvoke = (
@@ -139,7 +140,7 @@ export async function handleSlackMessageAction(params: {
         mediaUrl: mediaUrl ?? undefined,
         ...(readSlackForceDocument(actionParams) ? { forceDocument: true } : {}),
         accountId,
-        threadTs: threadId ?? replyTo ?? undefined,
+        threadTs: resolveSlackThreadTsValue({ replyToId: replyTo, threadId }),
         ...(topLevel ? { topLevel: true } : {}),
         ...(replyBroadcast ? { replyBroadcast } : {}),
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack replies were posted to the inherited conversation thread instead of the message explicitly selected as the reply target when both thread values were present.

## Why This Change Was Made

Slack's message-action dispatcher now uses the same canonical thread-timestamp resolver as Slack send telemetry and outbound delivery. This keeps explicit valid reply targets authoritative while falling back to the inherited thread when a reply identifier is not a Slack timestamp. Upload actions intentionally retain their existing thread-first behavior.

## User Impact

Explicit Slack replies reach the requested thread, and internal or otherwise invalid reply identifiers no longer break an already-valid inherited thread.

## Evidence

- Existing dispatcher regression before the repair: 47 passing, one failing; expected explicit thread `999.000`, received inherited thread `111.222`.
- Dispatcher regression after the repair: 48 passing, including explicit-reply precedence and invalid-reply fallback.
- Six Slack dispatcher, timestamp-normalization, channel, message-adapter, and outbound sibling suites: 140 passing.
- Plugin normalization-core and package-relative boundary ratchets both pass; formatting and staged whitespace checks pass.
- Independent source review and mandatory Codex autoreview both report no actionable findings.
- Production delta: +2/-1 (net +1, the required import of the existing canonical resolver); regression tests: +20/-0.
