### PR TITLE
fix(gateway): prevent assistant commentary leaking into session history

### DIFF
--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -220,7 +220,7 @@ function sanitizeAssistantPhasedContentBlocks(content: unknown[]): {
       return false;
     }
     const entry = block as { type?: unknown; textSignature?: unknown };
-    return entry.type === "text" && Boolean(parseAssistantTextSignature(entry)?.phase);
+    return isAssistantTextContentType(entry.type) && parseAssistantTextSignature(entry)?.phase;
   });
   if (!hasExplicitPhasedText) {
     return { content, changed: false };
@@ -230,7 +230,7 @@ function sanitizeAssistantPhasedContentBlocks(content: unknown[]): {
       return true;
     }
     const entry = block as { type?: unknown; textSignature?: unknown };
-    if (entry.type !== "text") {
+    if (!isAssistantTextContentType(entry.type)) {
       return true;
     }
     return parseAssistantTextSignature(entry)?.phase === "final_answer";

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -1457,36 +1457,40 @@ describe("session history HTTP endpoints", () => {
       });
 
       await withGatewayHarness(async (harness) => {
-        const hidden = await appendAssistantMessageToSessionTranscript({
-          sessionKey: "agent:main:main",
-          text: "NO_REPLY",
-          storePath,
-        });
-        expect(hidden.ok).toBe(true);
-
-        if (!hidden.ok) {
-          throw new Error(`append failed: ${hidden.reason}`);
-        }
-        const visibleMessageId = await appendTranscriptMessage({
-          sessionKey: "agent:main:main",
-          storePath,
-          message: makeTranscriptAssistantMessage({
-            text: "Done.",
-            content: [
-              {
-                type: blockType,
-                text: "internal reasoning",
-                textSignature: JSON.stringify({ v: 1, id: "item_commentary", phase: "commentary" }),
+        const visibleMessageId = "visible-phased-assistant";
+        await replaceTranscriptEvents(
+          { agentId: AGENT_ID, sessionId: "sess-main", sessionKey: "agent:main:main", storePath },
+          [
+            { type: "session", version: 1, id: "sess-main" },
+            { id: "hidden-control", message: makeTranscriptAssistantMessage({ text: "NO_REPLY" }) },
+            {
+              id: visibleMessageId,
+              message: {
+                ...makeTranscriptAssistantMessage({ text: "Done." }),
+                content: [
+                  {
+                    type: blockType,
+                    text: "internal reasoning",
+                    textSignature: JSON.stringify({
+                      v: 1,
+                      id: "item_commentary",
+                      phase: "commentary",
+                    }),
+                  },
+                  {
+                    type: blockType,
+                    text: "Done.",
+                    textSignature: JSON.stringify({
+                      v: 1,
+                      id: "item_final",
+                      phase: "final_answer",
+                    }),
+                  },
+                ],
               },
-              {
-                type: blockType,
-                text: "Done.",
-                textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
-              },
-            ],
-          }),
-          emitInlineMessage: false,
-        });
+            },
+          ],
+        );
 
         const historyRes = await fetchSessionHistory(harness.port, "agent:main:main");
         expect(historyRes.status).toBe(200);

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -1442,77 +1442,80 @@ describe("session history HTTP endpoints", () => {
     });
   });
 
-  test("sanitizes phased assistant history entries before returning them", async () => {
-    const storePath = await createSessionStoreFile();
-    await writeSessionStore({
-      entries: {
-        main: {
-          sessionId: "sess-main",
-          updatedAt: Date.now(),
+  test.each(["text", "output_text", "input_text"])(
+    "sanitizes phased %s assistant history entries before returning them",
+    async (blockType) => {
+      const storePath = await createSessionStoreFile();
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            updatedAt: Date.now(),
+          },
         },
-      },
-      storePath,
-    });
-
-    await withGatewayHarness(async (harness) => {
-      const hidden = await appendAssistantMessageToSessionTranscript({
-        sessionKey: "agent:main:main",
-        text: "NO_REPLY",
         storePath,
       });
-      expect(hidden.ok).toBe(true);
 
-      if (!hidden.ok) {
-        throw new Error(`append failed: ${hidden.reason}`);
-      }
-      const visibleMessageId = await appendTranscriptMessage({
-        sessionKey: "agent:main:main",
-        storePath,
-        message: makeTranscriptAssistantMessage({
-          text: "Done.",
-          content: [
-            {
-              type: "text",
-              text: "internal reasoning",
-              textSignature: JSON.stringify({ v: 1, id: "item_commentary", phase: "commentary" }),
-            },
-            {
-              type: "text",
-              text: "Done.",
-              textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
-            },
-          ],
-        }),
-        emitInlineMessage: false,
-      });
+      await withGatewayHarness(async (harness) => {
+        const hidden = await appendAssistantMessageToSessionTranscript({
+          sessionKey: "agent:main:main",
+          text: "NO_REPLY",
+          storePath,
+        });
+        expect(hidden.ok).toBe(true);
 
-      const historyRes = await fetchSessionHistory(harness.port, "agent:main:main");
-      expect(historyRes.status).toBe(200);
-      const body = (await historyRes.json()) as {
-        sessionKey?: string;
-        messages?: Array<{
-          content?: Array<{ text?: string }>;
-          openclawStreamFallback?: { itemId?: string; replacementText?: string; source?: string };
-          __openclaw?: { id?: string; seq?: number };
-        }>;
-      };
-      expect(body.sessionKey).toBe("agent:main:main");
-      expect(body.messages).toHaveLength(2);
-      expect(body.messages?.[0]).toMatchObject({
-        content: [{ type: "text", text: "internal reasoning" }],
-        openclawStreamFallback: {
-          itemId: "item_commentary",
-          replacementText: "internal reasoning",
-          source: "segment",
-        },
+        if (!hidden.ok) {
+          throw new Error(`append failed: ${hidden.reason}`);
+        }
+        const visibleMessageId = await appendTranscriptMessage({
+          sessionKey: "agent:main:main",
+          storePath,
+          message: makeTranscriptAssistantMessage({
+            text: "Done.",
+            content: [
+              {
+                type: blockType,
+                text: "internal reasoning",
+                textSignature: JSON.stringify({ v: 1, id: "item_commentary", phase: "commentary" }),
+              },
+              {
+                type: blockType,
+                text: "Done.",
+                textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+              },
+            ],
+          }),
+          emitInlineMessage: false,
+        });
+
+        const historyRes = await fetchSessionHistory(harness.port, "agent:main:main");
+        expect(historyRes.status).toBe(200);
+        const body = (await historyRes.json()) as {
+          sessionKey?: string;
+          messages?: Array<{
+            content?: Array<{ text?: string }>;
+            openclawStreamFallback?: { itemId?: string; replacementText?: string; source?: string };
+            __openclaw?: { id?: string; seq?: number };
+          }>;
+        };
+        expect(body.sessionKey).toBe("agent:main:main");
+        expect(body.messages).toHaveLength(2);
+        expect(body.messages?.[0]).toMatchObject({
+          content: [{ type: "text", text: "internal reasoning" }],
+          openclawStreamFallback: {
+            itemId: "item_commentary",
+            replacementText: "internal reasoning",
+            source: "segment",
+          },
+        });
+        expect(body.messages?.[1]?.content?.map((block) => block.text)).toEqual(["Done."]);
+        expectOpenClawMetadata(body.messages?.[1]?.["__openclaw"], {
+          id: visibleMessageId,
+          seq: 2,
+        });
       });
-      expect(body.messages?.[1]?.content?.[0]?.text).toBe("Done.");
-      expectOpenClawMetadata(body.messages?.[1]?.["__openclaw"], {
-        id: visibleMessageId,
-        seq: 2,
-      });
-    });
-  });
+    },
+  );
 
   test("streams session history updates over SSE", async () => {
     const { storePath } = await seedSession({ text: "first message" });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing assistant session history would see internal commentary mixed into the final answer when a provider persisted phased `output_text` or `input_text` blocks instead of plain `text` blocks.

## Why This Change Was Made

The shared Gateway history projection already owns a canonical classifier for all three assistant text-block formats, but its phase filter independently recognized only plain `text`. Reuse the existing classifier for both phase detection and filtering so REST, server-sent events, and WebSocket projections share the same final-answer invariant while intentionally separate commentary progress remains available.

Production delta: +2/-2 (net zero). Tests: +69/-62 (net +7).

## User Impact

Assistant history consistently displays only the final answer in its final-answer message regardless of provider text-block format, without losing separately projected commentary progress, transcript metadata, or structured non-text content.

## Evidence

- Before the fix, the real Gateway HTTP regression passed for `text` and failed for both `output_text` and `input_text`: expected `Done.`, received `internal reasoning`.
- After the fix, all 88 real Gateway HTTP/SSE tests passed, along with all 27 Gateway projection tests and all 17 shared-content tests (132 total): `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/gateway/sessions-history-http.test.ts src/gateway/chat-display-projection.test.ts src/shared/chat-message-content.test.ts`. The skip flag avoids a redundant CLI build in a linked checkout with preexisting stale shared dependencies; the actual HTTP/SSE Gateway servers still run.
- Focused lint and both assertion-safety and max-lines ratchets passed.
- Fresh independent source-aware review: clean, including HTTP/SSE/WebSocket sibling paths, intentional commentary progress fallback, metadata preservation, all three canonical text formats, and the raw persisted-transcript fixture boundary. The first hosted run exposed that the typed internal assistant constructor cannot represent provider-persisted text variants; the regression now uses the existing raw transcript fixture without unsafe casts or weakened public types.
