### PR TITLE
test(plugins): deduplicate provider fixtures

### DIFF
--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -409,27 +409,36 @@ function makeFakePool(sdk: FakeSdk) {
 }
 
 function makeFakeSdk(
-  options: {
-    onCreateSession?: (session: FakeSession, cfg: Record<string, unknown>) => void | Promise<void>;
-    onResumeSession?: (
-      session: FakeSession,
-      sessionId: string,
-      cfg: Record<string, unknown>,
-    ) => void | Promise<void>;
-  } = {},
+  options:
+    | ((session: FakeSession, cfg: Record<string, unknown>) => void | Promise<void>)
+    | {
+        onCreateSession?: (
+          session: FakeSession,
+          cfg: Record<string, unknown>,
+        ) => void | Promise<void>;
+        onResumeSession?: (
+          session: FakeSession,
+          sessionId: string,
+          cfg: Record<string, unknown>,
+        ) => void | Promise<void>;
+      } = {},
 ) {
   const sessions: FakeSession[] = [];
+  const sessionHooks =
+    typeof options === "function"
+      ? { onCreateSession: options, onResumeSession: undefined }
+      : options;
 
   const createSession = vi.fn(async (cfg: Record<string, unknown>) => {
     const session = createFakeSession(cfg, `sess-${sessions.length + 1}`);
-    await options.onCreateSession?.(session, cfg);
+    await sessionHooks.onCreateSession?.(session, cfg);
     sessions.push(session);
     return session;
   });
 
   const resumeSession = vi.fn(async (sessionId: string, cfg: Record<string, unknown>) => {
     const session = createFakeSession(cfg, sessionId);
-    await options.onResumeSession?.(session, sessionId, cfg);
+    await sessionHooks.onResumeSession?.(session, sessionId, cfg);
     sessions.push(session);
     return session;
   });
@@ -542,10 +551,8 @@ afterEach(() => {
 
 describe("runCopilotAttempt", () => {
   it("happy path", async () => {
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
     });
     const pool = makeFakePool(sdk);
 
@@ -594,10 +601,8 @@ describe("runCopilotAttempt", () => {
       });
       return createStubToolBridge();
     });
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
     });
 
     const result = await runCopilotAttempt(makeParams({ observeToolTerminal }), {
@@ -610,10 +615,8 @@ describe("runCopilotAttempt", () => {
   });
 
   it("reports code-mode engagement through the real tool bridge", async () => {
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
     });
 
     // No `createToolBridge` override: this runs the production bridge, so the
@@ -631,10 +634,8 @@ describe("runCopilotAttempt", () => {
   });
 
   it("reports the tool bridge's code-mode engagement on the attempt result", async () => {
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
     });
 
     const result = await runCopilotAttempt(makeParams(), {
@@ -678,10 +679,8 @@ describe("runCopilotAttempt", () => {
       });
       return createStubToolBridge();
     });
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
     });
 
     const result = await runCopilotAttempt(makeParams({ observeToolTerminal }), {
@@ -712,10 +711,8 @@ describe("runCopilotAttempt", () => {
         { hookName: "agent_end", handler: agentEnd },
       ]),
     );
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
     });
     const createToolBridge = vi.fn(async (input: CopilotToolBridgeInput) => {
       await input.onToolCompleted?.({
@@ -794,15 +791,13 @@ describe("runCopilotAttempt", () => {
       ]),
     );
     let activeSession: FakeSession | undefined;
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        activeSession = session;
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { content: "hello" });
-          session.emit("session.compaction_start", {});
-          return makeAssistantMessageEvent("done");
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      activeSession = session;
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { content: "hello" });
+        session.emit("session.compaction_start", {});
+        return makeAssistantMessageEvent("done");
+      });
     });
 
     const attempt = runCopilotAttempt(makeParams(), {
@@ -853,14 +848,12 @@ describe("runCopilotAttempt", () => {
       createMockPluginRegistry([{ hookName: "before_compaction", handler: beforeCompaction }]),
     );
     let activeSession: FakeSession | undefined;
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        activeSession = session;
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("session.compaction_start", {});
-          return makeAssistantMessageEvent("done");
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      activeSession = session;
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("session.compaction_start", {});
+        return makeAssistantMessageEvent("done");
+      });
     });
 
     const result = await runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
@@ -881,14 +874,12 @@ describe("runCopilotAttempt", () => {
 
   it("returns a successful turn while background compaction remains observed", async () => {
     vi.useFakeTimers();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { content: "hello" });
-          session.emit("session.compaction_start", {});
-          return makeAssistantMessageEvent("done");
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { content: "hello" });
+        session.emit("session.compaction_start", {});
+        return makeAssistantMessageEvent("done");
+      });
     });
     const pool = makeFakePool(sdk);
 
@@ -909,13 +900,11 @@ describe("runCopilotAttempt", () => {
 
   it("does not delete a fresh session when its SDK user was never validated", async () => {
     vi.useFakeTimers();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("session.compaction_start", {});
-          return makeAssistantMessageEvent("done");
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("session.compaction_start", {});
+        return makeAssistantMessageEvent("done");
+      });
     });
     const pool = makeFakePool(sdk);
 
@@ -964,16 +953,14 @@ describe("runCopilotAttempt", () => {
     const controller = new AbortController();
     const onDeferredCompaction = vi.fn();
     let activeSession: FakeSession | undefined;
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        activeSession = session;
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { content: "hello" });
-          session.emit("session.compaction_start", {});
-          setTimeout(() => controller.abort(), 0);
-          return makeAssistantMessageEvent("done");
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      activeSession = session;
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { content: "hello" });
+        session.emit("session.compaction_start", {});
+        setTimeout(() => controller.abort(), 0);
+        return makeAssistantMessageEvent("done");
+      });
     });
 
     const attempt = runCopilotAttempt(makeParams({ abortSignal: controller.signal }), {
@@ -1001,17 +988,15 @@ describe("runCopilotAttempt", () => {
     const controller = new AbortController();
     const cancellation = createDeferred<{ cancelled: boolean }>();
     let activeSession: FakeSession | undefined;
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        activeSession = session;
-        session.rpc.history.cancelBackgroundCompaction.mockImplementationOnce(
-          () => cancellation.promise,
-        );
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("session.compaction_start", {});
-          return undefined;
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      activeSession = session;
+      session.rpc.history.cancelBackgroundCompaction.mockImplementationOnce(
+        () => cancellation.promise,
+      );
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("session.compaction_start", {});
+        return undefined;
+      });
     });
 
     const result = await runCopilotAttempt(makeParams({ abortSignal: controller.signal }), {
@@ -1040,22 +1025,17 @@ describe("runCopilotAttempt", () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "llm_input", handler: llmInput }]),
     );
-    const sdk = makeFakeSdk({
-      onCreateSession: (session, cfg) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          const hooks = cfg.hooks as {
-            onUserPromptSubmitted?: (
-              input: { prompt: string },
-              invocation: { sessionId: string },
-            ) => Promise<unknown>;
-          };
-          await hooks.onUserPromptSubmitted?.(
-            { prompt: "hello" },
-            { sessionId: session.sessionId },
-          );
-          return makeAssistantMessageEvent("done");
-        });
-      },
+    const sdk = makeFakeSdk((session, cfg) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        const hooks = cfg.hooks as {
+          onUserPromptSubmitted?: (
+            input: { prompt: string },
+            invocation: { sessionId: string },
+          ) => Promise<unknown>;
+        };
+        await hooks.onUserPromptSubmitted?.({ prompt: "hello" }, { sessionId: session.sessionId });
+        return makeAssistantMessageEvent("done");
+      });
     });
 
     await runCopilotAttempt(makeParams({ hooksConfig: { onUserPromptSubmitted } } as never), {
@@ -1124,10 +1104,8 @@ describe("runCopilotAttempt", () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "agent_end", handler: agentEnd }]),
     );
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
     });
 
     let settled = false;
@@ -1368,10 +1346,8 @@ describe("runCopilotAttempt", () => {
         });
       });
     });
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockReturnValue(sendDeferred.promise);
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockReturnValue(sendDeferred.promise);
     });
     const pool = makeFakePool(sdk);
     const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -1405,10 +1381,8 @@ describe("runCopilotAttempt", () => {
 
   it("deltas forwarded even when no consumer", async () => {
     const sendDeferred = createDeferred<SessionEventShape | undefined>();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockReturnValue(sendDeferred.promise);
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockReturnValue(sendDeferred.promise);
     });
     const pool = makeFakePool(sdk);
     const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -1548,21 +1522,19 @@ describe("runCopilotAttempt", () => {
   });
 
   it("replay-shim: consolidated mutating tool metadata makes the attempt replay-unsafe", async () => {
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("tool.execution_start", {
-            toolCallId: "tool-1",
-            toolName: "write",
-          });
-          session.emit("tool.execution_complete", {
-            result: { content: "wrote file" },
-            success: true,
-            toolCallId: "tool-1",
-          });
-          return makeAssistantMessageEvent("done");
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("tool.execution_start", {
+          toolCallId: "tool-1",
+          toolName: "write",
         });
-      },
+        session.emit("tool.execution_complete", {
+          result: { content: "wrote file" },
+          success: true,
+          toolCallId: "tool-1",
+        });
+        return makeAssistantMessageEvent("done");
+      });
     });
     const pool = makeFakePool(sdk);
 
@@ -1601,14 +1573,12 @@ describe("runCopilotAttempt", () => {
     const controller = new AbortController();
     const sendDeferred = createDeferred<SessionEventShape | undefined>();
     const sessionCreated = createDeferred<FakeSession>();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockReturnValue(sendDeferred.promise);
-        session.abort.mockImplementationOnce(async () => {
-          sendDeferred.resolve(undefined);
-        });
-        sessionCreated.resolve(session);
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockReturnValue(sendDeferred.promise);
+      session.abort.mockImplementationOnce(async () => {
+        sendDeferred.resolve(undefined);
+      });
+      sessionCreated.resolve(session);
     });
     const pool = makeFakePool(sdk);
     const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -1636,11 +1606,9 @@ describe("runCopilotAttempt", () => {
     gatewayQuestionMock.setActiveEmbeddedRun.mockClear();
     const sendDeferred = createDeferred<SessionEventShape | undefined>();
     const sessionCreated = createDeferred<FakeSession>();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockReturnValue(sendDeferred.promise);
-        sessionCreated.resolve(session);
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockReturnValue(sendDeferred.promise);
+      sessionCreated.resolve(session);
     });
     const pool = makeFakePool(sdk);
     const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -2018,25 +1986,23 @@ describe("runCopilotAttempt", () => {
 
   it("registers ask_user and resolves it from the active OpenClaw queue", async () => {
     const onBlockReply = vi.fn();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session, cfg) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { __eventId: "initial-user", content: "hello" });
-          const handler = cfg.onUserInputRequest;
-          if (typeof handler !== "function") {
-            throw new Error("expected onUserInputRequest handler");
-          }
-          const response = await handler(
-            {
-              question: "Pick a mode",
-              choices: ["Fast", "Deep"],
-              allowFreeform: false,
-            },
-            { sessionId: session.sessionId },
-          );
-          return makeAssistantMessageEvent(`selected ${response.answer}`);
-        });
-      },
+    const sdk = makeFakeSdk((session, cfg) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { __eventId: "initial-user", content: "hello" });
+        const handler = cfg.onUserInputRequest;
+        if (typeof handler !== "function") {
+          throw new Error("expected onUserInputRequest handler");
+        }
+        const response = await handler(
+          {
+            question: "Pick a mode",
+            choices: ["Fast", "Deep"],
+            allowFreeform: false,
+          },
+          { sessionId: session.sessionId },
+        );
+        return makeAssistantMessageEvent(`selected ${response.answer}`);
+      });
     });
     const pool = makeFakePool(sdk);
 
@@ -2067,22 +2033,20 @@ describe("runCopilotAttempt", () => {
 
   it("injects active-run steering and waits for its canonical transcript receipt", async () => {
     const initialTurn = createDeferred<SessionEventShape | undefined>();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { __eventId: "initial-user", content: "hello" });
-          return initialTurn.promise;
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { __eventId: "initial-user", content: "hello" });
+        return initialTurn.promise;
+      });
+      session.send.mockImplementationOnce(async (options) => {
+        const prompt = (options as { prompt?: string }).prompt;
+        session.emit("user.message", {
+          __eventId: "steered-user",
+          content: prompt,
+          delivery: "steering",
         });
-        session.send.mockImplementationOnce(async (options) => {
-          const prompt = (options as { prompt?: string }).prompt;
-          session.emit("user.message", {
-            __eventId: "steered-user",
-            content: prompt,
-            delivery: "steering",
-          });
-          return "steered-user";
-        });
-      },
+        return "steered-user";
+      });
     });
     const attempt = runCopilotAttempt(makeParams({ taskSuggestionDeliveryMode: "gateway" }), {
       pool: makeFakePool(sdk),
@@ -2131,27 +2095,25 @@ describe("runCopilotAttempt", () => {
 
   it("holds a steering receipt until pending tool results and the user turn persist", async () => {
     const initialTurn = createDeferred<SessionEventShape | undefined>();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { __eventId: "initial-user", content: "hello" });
-          session.emit("assistant.message", {
-            __eventId: "assistant-tools",
-            content: "checking",
-            messageId: "assistant-tools",
-            toolRequests: [{ arguments: {}, name: "read", toolCallId: "call-1" }],
-          });
-          return initialTurn.promise;
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { __eventId: "initial-user", content: "hello" });
+        session.emit("assistant.message", {
+          __eventId: "assistant-tools",
+          content: "checking",
+          messageId: "assistant-tools",
+          toolRequests: [{ arguments: {}, name: "read", toolCallId: "call-1" }],
         });
-        session.send.mockImplementationOnce(async (options) => {
-          session.emit("user.message", {
-            __eventId: "steered-user",
-            content: (options as { prompt?: string }).prompt,
-            delivery: "steering",
-          });
-          return "steered-user";
+        return initialTurn.promise;
+      });
+      session.send.mockImplementationOnce(async (options) => {
+        session.emit("user.message", {
+          __eventId: "steered-user",
+          content: (options as { prompt?: string }).prompt,
+          delivery: "steering",
         });
-      },
+        return "steered-user";
+      });
     });
     const attempt = runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
 
@@ -2205,25 +2167,23 @@ describe("runCopilotAttempt", () => {
       ]),
     );
     const initialTurn = createDeferred<SessionEventShape | undefined>();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { __eventId: "initial-user", content: "hello" });
-          return initialTurn.promise;
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { __eventId: "initial-user", content: "hello" });
+        return initialTurn.promise;
+      });
+      session.send.mockImplementation(async (options) => {
+        const prompt = (options as { prompt?: string }).prompt ?? "";
+        const eventId = prompt.includes("fire and forget")
+          ? "suppressed-steer-unobserved"
+          : "suppressed-steer-waited";
+        session.emit("user.message", {
+          __eventId: eventId,
+          content: prompt,
+          delivery: "steering",
         });
-        session.send.mockImplementation(async (options) => {
-          const prompt = (options as { prompt?: string }).prompt ?? "";
-          const eventId = prompt.includes("fire and forget")
-            ? "suppressed-steer-unobserved"
-            : "suppressed-steer-waited";
-          session.emit("user.message", {
-            __eventId: eventId,
-            content: prompt,
-            delivery: "steering",
-          });
-          return eventId;
-        });
-      },
+        return eventId;
+      });
     });
     const attempt = runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
 
@@ -2270,10 +2230,8 @@ describe("runCopilotAttempt", () => {
   it("rejects active steering before the initial SDK user event is validated", async () => {
     gatewayQuestionMock.setActiveEmbeddedRun.mockClear();
     const initialTurn = createDeferred<SessionEventShape | undefined>();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(() => initialTurn.promise);
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(() => initialTurn.promise);
     });
     const attempt = runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
 
@@ -2309,13 +2267,11 @@ describe("runCopilotAttempt", () => {
     const questionClaim = createDeferred<boolean>();
     const claimPendingAgentQuestionAnswer = vi.fn(() => questionClaim.promise);
     gatewayQuestionMock.claimPendingAgentQuestionAnswer = claimPendingAgentQuestionAnswer;
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { __eventId: "initial-user", content: "hello" });
-          return initialTurn.promise;
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { __eventId: "initial-user", content: "hello" });
+        return initialTurn.promise;
+      });
     });
     try {
       const attempt = runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
@@ -2728,10 +2684,8 @@ describe("runCopilotAttempt", () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "agent_end", handler: agentEnd }]),
     );
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockResolvedValueOnce(undefined);
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockResolvedValueOnce(undefined);
     });
     const pool = makeFakePool(sdk);
 
@@ -2758,14 +2712,12 @@ describe("runCopilotAttempt", () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "after_compaction", handler: afterCompaction }]),
     );
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { content: "hello" });
-          session.emit("session.compaction_start", {});
-          return undefined;
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { content: "hello" });
+        session.emit("session.compaction_start", {});
+        return undefined;
+      });
     });
 
     const result = await runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
@@ -2794,13 +2746,11 @@ describe("runCopilotAttempt", () => {
       createMockPluginRegistry([{ hookName: "after_compaction", handler: afterCompaction }]),
     );
     let activeSession: FakeSession | undefined;
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        activeSession = session;
-        session.sendAndWait.mockRejectedValueOnce(
-          new Error("Timeout after 60000ms waiting for session.idle"),
-        );
-      },
+    const sdk = makeFakeSdk((session) => {
+      activeSession = session;
+      session.sendAndWait.mockRejectedValueOnce(
+        new Error("Timeout after 60000ms waiting for session.idle"),
+      );
     });
     const createToolBridge = vi.fn(async () =>
       createStubToolBridge([], [], { cleanup: cleanupToolBridge }),
@@ -2834,15 +2784,13 @@ describe("runCopilotAttempt", () => {
   });
 
   it("does not mark a timeout after SDK compaction has completed as active compaction", async () => {
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("session.compaction_start", {});
-          session.emit("session.compaction_complete", { success: true });
-          session.emit("session.idle", {});
-          return undefined;
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("session.compaction_start", {});
+        session.emit("session.compaction_complete", { success: true });
+        session.emit("session.idle", {});
+        return undefined;
+      });
     });
 
     const result = await runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
@@ -2852,14 +2800,12 @@ describe("runCopilotAttempt", () => {
 
   it("bounds deferred cleanup when SDK compaction never completes", async () => {
     vi.useFakeTimers();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { content: "hello" });
-          session.emit("session.compaction_start", {});
-          return undefined;
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { content: "hello" });
+        session.emit("session.compaction_start", {});
+        return undefined;
+      });
     });
     const pool = makeFakePool(sdk);
 
@@ -2878,14 +2824,12 @@ describe("runCopilotAttempt", () => {
 
   it("cancels deferred cleanup when the timed-out caller aborts", async () => {
     const controller = new AbortController();
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { content: "hello" });
-          session.emit("session.compaction_start", {});
-          return undefined;
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { content: "hello" });
+        session.emit("session.compaction_start", {});
+        return undefined;
+      });
     });
 
     const result = await runCopilotAttempt(makeParams({ abortSignal: controller.signal }), {
@@ -2905,13 +2849,11 @@ describe("runCopilotAttempt", () => {
   });
 
   it("keeps the compaction timeout classification after deferred completion", async () => {
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("session.compaction_start", {});
-          return undefined;
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("session.compaction_start", {});
+        return undefined;
+      });
     });
 
     const result = await runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
@@ -2930,13 +2872,11 @@ describe("runCopilotAttempt", () => {
     // the catch and surfaced as a generic prompt error with
     // timedOut=false — the replay metadata then incorrectly treated
     // the attempt as side-effect-safe.
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { content: "hello" });
-          throw new Error("Timeout after 60000ms waiting for session.idle");
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { content: "hello" });
+        throw new Error("Timeout after 60000ms waiting for session.idle");
+      });
     });
     const pool = makeFakePool(sdk);
 
@@ -2975,10 +2915,8 @@ describe("runCopilotAttempt", () => {
     const onAssistantDelta = vi.fn(async (_payload: { delta: string }) => {
       await release.promise;
     });
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockReturnValue(sendDeferred.promise);
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockReturnValue(sendDeferred.promise);
     });
     const pool = makeFakePool(sdk);
     const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -3055,10 +2993,8 @@ describe("runCopilotAttempt", () => {
   it("release failure after a primary prompt error warns without masking the error", async () => {
     const primaryError = new Error("send failed");
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockRejectedValueOnce(primaryError);
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockRejectedValueOnce(primaryError);
     });
     const pool = makeFakePool(sdk);
     pool.release = vi.fn(async () => {
@@ -3104,13 +3040,11 @@ describe("runCopilotAttempt", () => {
 
   it("cleanup on send error", async () => {
     const error = new Error("send failed");
-    const sdk = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.sendAndWait.mockImplementationOnce(async () => {
-          session.emit("user.message", { content: "hello" });
-          throw error;
-        });
-      },
+    const sdk = makeFakeSdk((session) => {
+      session.sendAndWait.mockImplementationOnce(async () => {
+        session.emit("user.message", { content: "hello" });
+        throw error;
+      });
     });
     const pool = makeFakePool(sdk);
 
@@ -3128,22 +3062,18 @@ describe("runCopilotAttempt", () => {
 
   it("cleanup on disconnect throw", async () => {
     const primaryError = new Error("send failed");
-    const sdkWithPrimaryError = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.disconnect.mockRejectedValueOnce(new Error("disconnect failed"));
-        session.sendAndWait.mockRejectedValueOnce(primaryError);
-      },
+    const sdkWithPrimaryError = makeFakeSdk((session) => {
+      session.disconnect.mockRejectedValueOnce(new Error("disconnect failed"));
+      session.sendAndWait.mockRejectedValueOnce(primaryError);
     });
     const poolWithPrimaryError = makeFakePool(sdkWithPrimaryError);
 
     const first = await runCopilotAttempt(makeParams(), { pool: poolWithPrimaryError });
     expect(projectAgentRunAttemptTerminal(first.terminal).promptError).toBe(primaryError);
 
-    const sdkWithoutPrimaryError = makeFakeSdk({
-      onCreateSession: (session) => {
-        session.disconnect.mockRejectedValueOnce(new Error("disconnect failed"));
-        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-      },
+    const sdkWithoutPrimaryError = makeFakeSdk((session) => {
+      session.disconnect.mockRejectedValueOnce(new Error("disconnect failed"));
+      session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
     });
     const poolWithoutPrimaryError = makeFakePool(sdkWithoutPrimaryError);
 
@@ -3517,13 +3447,11 @@ describe("runCopilotAttempt", () => {
           return { appended: true, message: message as object, messageId: "user-event" };
         },
       );
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockImplementationOnce(async () => {
-            order.push("dispatch");
-            return makeAssistantMessageEvent("done");
-          });
-        },
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockImplementationOnce(async () => {
+          order.push("dispatch");
+          return makeAssistantMessageEvent("done");
+        });
       });
 
       const result = await runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
@@ -3817,31 +3745,29 @@ describe("runCopilotAttempt", () => {
       const appendError = new Error("tool append failed");
       transcriptRuntimeMock.append.mockImplementationOnce(appendPreparedTranscriptMessage);
       transcriptRuntimeMock.appendBatch.mockRejectedValueOnce(appendError);
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockImplementationOnce(async () => {
-            session.emit("assistant.message", {
-              content: "",
-              messageId: "tools",
-              toolRequests: [{ name: "read", toolCallId: "call-1" }],
-            });
-            session.emit("tool.execution_start", {
-              toolCallId: "call-1",
-              toolName: "read",
-            });
-            session.emit("tool.execution_complete", {
-              result: { content: "done" },
-              success: true,
-              toolCallId: "call-1",
-            });
-            session.emit("assistant.message", {
-              __eventId: "assistant-final",
-              content: "final after tool",
-              messageId: "final",
-            });
-            return undefined;
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockImplementationOnce(async () => {
+          session.emit("assistant.message", {
+            content: "",
+            messageId: "tools",
+            toolRequests: [{ name: "read", toolCallId: "call-1" }],
           });
-        },
+          session.emit("tool.execution_start", {
+            toolCallId: "call-1",
+            toolName: "read",
+          });
+          session.emit("tool.execution_complete", {
+            result: { content: "done" },
+            success: true,
+            toolCallId: "call-1",
+          });
+          session.emit("assistant.message", {
+            __eventId: "assistant-final",
+            content: "final after tool",
+            messageId: "final",
+          });
+          return undefined;
+        });
       });
 
       const result = await runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
@@ -3871,24 +3797,22 @@ describe("runCopilotAttempt", () => {
           messageId: (message.eventId as string | undefined) ?? "transcript-message",
         })),
       );
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockImplementationOnce(async () => {
-            session.emit("assistant.message", {
-              content: "checking",
-              messageId: "tools",
-              toolRequests: [{ name: "read", toolCallId: "call-1" }],
-            });
-            session.emit("tool.execution_complete", {
-              result: { content: "done" },
-              success: true,
-              toolCallId: "call-1",
-            });
-            const final = makeAssistantMessageEvent("final after tool");
-            session.emit("assistant.message", { __eventId: "assistant-final", ...final.data });
-            return final;
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockImplementationOnce(async () => {
+          session.emit("assistant.message", {
+            content: "checking",
+            messageId: "tools",
+            toolRequests: [{ name: "read", toolCallId: "call-1" }],
           });
-        },
+          session.emit("tool.execution_complete", {
+            result: { content: "done" },
+            success: true,
+            toolCallId: "call-1",
+          });
+          const final = makeAssistantMessageEvent("final after tool");
+          session.emit("assistant.message", { __eventId: "assistant-final", ...final.data });
+          return final;
+        });
       });
 
       const result = await runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
@@ -3914,21 +3838,19 @@ describe("runCopilotAttempt", () => {
           },
         ]),
       );
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockImplementationOnce(async () => {
-            const assistant = makeAssistantMessageEvent("", {
-              toolRequests: [{ name: "read", toolCallId: "blocked-call" }],
-            });
-            session.emit("assistant.message", assistant.data);
-            session.emit("tool.execution_complete", {
-              result: { content: "must stay suppressed" },
-              success: true,
-              toolCallId: "blocked-call",
-            });
-            return assistant;
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockImplementationOnce(async () => {
+          const assistant = makeAssistantMessageEvent("", {
+            toolRequests: [{ name: "read", toolCallId: "blocked-call" }],
           });
-        },
+          session.emit("assistant.message", assistant.data);
+          session.emit("tool.execution_complete", {
+            result: { content: "must stay suppressed" },
+            success: true,
+            toolCallId: "blocked-call",
+          });
+          return assistant;
+        });
       });
 
       const result = await runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
@@ -3952,25 +3874,23 @@ describe("runCopilotAttempt", () => {
           },
         ]),
       );
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockImplementationOnce(async () => {
-            session.emit("assistant.message", {
-              content: "",
-              messageId: "tools",
-              toolRequests: [{ name: "read", toolCallId: "policy-call" }],
-            });
-            session.emit("tool.execution_complete", {
-              result: { content: "blocked by policy" },
-              success: true,
-              toolCallId: "policy-call",
-            });
-            session.emit("session.compaction_start", {});
-            const final = { ...makeAssistantMessageEvent("done"), id: "final" };
-            session.emit("assistant.message", { __eventId: "final", ...final.data });
-            return final;
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockImplementationOnce(async () => {
+          session.emit("assistant.message", {
+            content: "",
+            messageId: "tools",
+            toolRequests: [{ name: "read", toolCallId: "policy-call" }],
           });
-        },
+          session.emit("tool.execution_complete", {
+            result: { content: "blocked by policy" },
+            success: true,
+            toolCallId: "policy-call",
+          });
+          session.emit("session.compaction_start", {});
+          const final = { ...makeAssistantMessageEvent("done"), id: "final" };
+          session.emit("assistant.message", { __eventId: "final", ...final.data });
+          return final;
+        });
       });
 
       const result = await runCopilotAttempt(makeParams(), { pool: makeFakePool(sdk) });
@@ -4120,10 +4040,8 @@ describe("runCopilotAttempt", () => {
     }
 
     it("forwards sandbox=null when resolveSandboxContext returns null", async () => {
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-        },
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
       });
       const pool = makeFakePool(sdk);
       const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -4147,10 +4065,8 @@ describe("runCopilotAttempt", () => {
     });
 
     it("sandbox=null: SDK session workingDirectory matches original workspace", async () => {
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-        },
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
       });
       const pool = makeFakePool(sdk);
       const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -4169,10 +4085,8 @@ describe("runCopilotAttempt", () => {
     });
 
     it("uses task cwd for SDK workingDirectory and bridged tools when unsandboxed", async () => {
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-        },
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
       });
       const pool = makeFakePool(sdk);
       const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -4210,10 +4124,8 @@ describe("runCopilotAttempt", () => {
       const workspaceDir = path.join(stateDir, "workspace");
       const taskDir = path.join(workspaceDir, "task-repo");
       await fsp.mkdir(taskDir, { recursive: true });
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-        },
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
       });
       const pool = makeFakePool(sdk);
       const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -4252,10 +4164,8 @@ describe("runCopilotAttempt", () => {
 
     it("forwards rw sandbox: bridge sees original workspace and no spawn override", async () => {
       const sandbox = makeSandboxStub({ workspaceAccess: "rw" });
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-        },
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
       });
       const pool = makeFakePool(sdk);
       const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -4280,10 +4190,8 @@ describe("runCopilotAttempt", () => {
 
     it("forwards rw sandbox: SDK session workingDirectory stays on the original workspace", async () => {
       const sandbox = makeSandboxStub({ workspaceAccess: "rw" });
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-        },
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
       });
       const pool = makeFakePool(sdk);
       const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -4304,10 +4212,8 @@ describe("runCopilotAttempt", () => {
     it("forwards ro sandbox: bridge sees sandbox copy, spawn keeps original workspace", async () => {
       const sandboxDir = `${tmpdir()}/copilot-sandbox-${Date.now()}`;
       const sandbox = makeSandboxStub({ workspaceAccess: "ro", workspaceDir: sandboxDir });
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-        },
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
       });
       const pool = makeFakePool(sdk);
       const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -4442,10 +4348,8 @@ describe("runCopilotAttempt", () => {
       initializeGlobalHookRunner(
         createMockPluginRegistry([{ hookName: "agent_end", handler: agentEnd }]),
       );
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-        },
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
       });
       const pool = makeFakePool(sdk);
       const createToolBridge = vi.fn(async () => createStubToolBridge());
@@ -4472,10 +4376,8 @@ describe("runCopilotAttempt", () => {
     });
 
     it("fails closed when creating the sandbox copy workspace fails", async () => {
-      const sdk = makeFakeSdk({
-        onCreateSession: (session) => {
-          session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
-        },
+      const sdk = makeFakeSdk((session) => {
+        session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("done"));
       });
       const pool = makeFakePool(sdk);
       const createToolBridge = vi.fn(async () => createStubToolBridge());

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -29,15 +29,23 @@ import { createCopilotToolBridge as createCopilotToolBridgeImpl } from "./tool-b
 
 type CopilotToolBridgeInput = Parameters<typeof createCopilotToolBridgeImpl>[0];
 type CopilotToolBridgeAttemptParams = NonNullable<CopilotToolBridgeInput["attemptParams"]>;
-type CopilotToolBridgeTestInput = Omit<CopilotToolBridgeInput, "attemptParams"> & {
-  attemptParams?: Omit<CopilotToolBridgeAttemptParams, "hostCapabilities"> &
-    Partial<Pick<CopilotToolBridgeAttemptParams, "hostCapabilities">>;
-};
+type CopilotToolBridgeTestInput = Omit<
+  CopilotToolBridgeInput,
+  "agentId" | "attemptParams" | "modelId" | "modelProvider" | "sessionId"
+> &
+  Partial<Pick<CopilotToolBridgeInput, "agentId" | "modelId" | "modelProvider" | "sessionId">> & {
+    attemptParams?: Omit<CopilotToolBridgeAttemptParams, "hostCapabilities"> &
+      Partial<Pick<CopilotToolBridgeAttemptParams, "hostCapabilities">>;
+  };
 const testHostCapabilities = createCopilotTestHostCapabilities();
 
 function createCopilotToolBridge(input: CopilotToolBridgeTestInput) {
   const { attemptParams, ...baseInput } = input;
   const preparedInput: CopilotToolBridgeInput = {
+    agentId: "agent-1",
+    modelId: "gpt-4o",
+    modelProvider: "github-copilot",
+    sessionId: "session-1",
     ...baseInput,
     attemptParams: {
       ...attemptParams,
@@ -110,7 +118,6 @@ async function convertOpenClawToolToSdkToolForTest(
 ): Promise<SdkTool> {
   const bridge = await createCopilotToolBridge({
     abortSignal: options.abortSignal,
-    agentId: "agent-1",
     allowModelTools: true,
     attemptParams:
       options.onAgentToolResult || options.observeToolTerminal
@@ -124,9 +131,7 @@ async function convertOpenClawToolToSdkToolForTest(
     beforeExecute: options.beforeExecute,
     createOpenClawCodingTools: async () => [sourceTool],
     modelId: "gpt-test",
-    modelProvider: "github-copilot",
     onToolCompleted: options.onToolCompleted,
-    sessionId: "session-1",
   });
   return expectDefined(bridge.promptToolPolicy.apply().tools[0], "Copilot SDK tool");
 }
@@ -166,15 +171,12 @@ describe("createCopilotToolBridge", () => {
       })),
     );
     const bridge = await createCopilotToolBridge({
-      agentId: "agent-1",
       cwd: "/tmp/copilot-native-cwd",
       attemptParams: {
         hostCapabilities: { ...testHostCapabilities, bindToolSurface },
       },
       createOpenClawCodingTools: async () => [makeTool({ execute })],
       modelId: "gpt-test",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
     const source = expectDefined(bridge.sourceTools[0], "bound Copilot source tool");
     const sdk = expectDefined(bridge.promptToolPolicy.apply().tools[0], "bound Copilot SDK tool");
@@ -198,11 +200,8 @@ describe("createCopilotToolBridge", () => {
     const createOpenClawCodingTools = vi.fn(async () => [makeTool()]);
 
     const result = await createCopilotToolBridge({
-      agentId: "agent-1",
       createOpenClawCodingTools,
-      modelId: "gpt-4o",
       modelProvider: "openai",
-      sessionId: "session-1",
     });
 
     expect(result.codeModeEngaged).toBe(false);
@@ -216,12 +215,10 @@ describe("createCopilotToolBridge", () => {
     const createOpenClawCodingTools = vi.fn(async () => sourceTools);
 
     const result = await createCopilotToolBridge({
-      agentId: "agent-1",
       allowModelTools: true,
       createOpenClawCodingTools,
       modelId: "gpt-test",
       modelProvider: "custom-openai",
-      sessionId: "session-1",
     });
 
     expect(createOpenClawCodingTools).toHaveBeenCalledWith(
@@ -242,13 +239,9 @@ describe("createCopilotToolBridge", () => {
     await createCopilotToolBridge({
       abortSignal: controller.signal,
       agentDir: "/agent",
-      agentId: "agent-1",
       computerContextEpoch,
       createOpenClawCodingTools,
       cwd: "/workspace/task",
-      modelId: "gpt-4o",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
       sessionKey: "session-key",
       workspaceDir: "/workspace",
     });
@@ -380,7 +373,6 @@ describe("createCopilotToolBridge", () => {
         for (const { profile, surface } of cases) {
           let catalogRef: { current?: { entries?: Array<{ name: string }> } } | undefined;
           const result = await createCopilotToolBridge({
-            agentId: "agent-1",
             attemptParams: {
               config: {
                 ...config,
@@ -398,8 +390,6 @@ describe("createCopilotToolBridge", () => {
               catalogRef = options?.toolSearchCatalogRef as typeof catalogRef;
               return createRealOpenClawCodingTools(options);
             },
-            modelId: "gpt-4o",
-            modelProvider: "github-copilot",
             sessionId: `${profile}-${surface}`,
           });
           const surfacedNames =
@@ -423,11 +413,8 @@ describe("createCopilotToolBridge", () => {
         );
 
         const fullWithoutPrepared = await createCopilotToolBridge({
-          agentId: "agent-1",
           attemptParams: { config: { ...config, tools: { profile: "full" } } } as never,
           createOpenClawCodingTools: createRealOpenClawCodingTools,
-          modelId: "gpt-4o",
-          modelProvider: "github-copilot",
           sessionId: "full-without-prepared",
         });
         expect(
@@ -445,11 +432,7 @@ describe("createCopilotToolBridge", () => {
     const sourceTools = [makeTool(), makeTool({ name: "tool-b" })];
 
     const result = await createCopilotToolBridge({
-      agentId: "agent-1",
       createOpenClawCodingTools: async () => sourceTools,
-      modelId: "gpt-4o",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
 
     expect(result.sourceTools).toEqual(sourceTools);
@@ -475,7 +458,6 @@ describe("createCopilotToolBridge", () => {
       } as never,
       createOpenClawCodingTools: async () => [systemAgentTool],
       modelId: "gpt-4.1",
-      modelProvider: "github-copilot",
       sessionId: "openclaw-session",
     });
 
@@ -498,16 +480,12 @@ describe("createCopilotToolBridge", () => {
     });
 
     const result = await createCopilotToolBridge({
-      agentId: "agent-1",
       attemptParams: {
         config: { tools: { toolSearch: true } },
         runId: "run-tool-search",
         sessionKey: "agent:agent-1:main",
       } as never,
       createOpenClawCodingTools,
-      modelId: "gpt-4o",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
 
     expect(createOpenClawCodingTools).toHaveBeenCalledWith(
@@ -544,7 +522,6 @@ describe("createCopilotToolBridge", () => {
     });
 
     const result = await createCopilotToolBridge({
-      agentId: "agent-1",
       attemptParams: {
         config: { tools: { toolSearch: true } },
         runId: "run-tool-search",
@@ -552,9 +529,6 @@ describe("createCopilotToolBridge", () => {
         toolsAllow: ["read"],
       } as never,
       createOpenClawCodingTools,
-      modelId: "gpt-4o",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
 
     expect(result.sourceTools.map((tool) => tool.name)).toEqual(["tool_search_code", "read"]);
@@ -577,7 +551,6 @@ describe("createCopilotToolBridge", () => {
     });
 
     await createCopilotToolBridge({
-      agentId: "agent-1",
       attemptParams: {
         config: { tools: { toolSearch: true } },
         runId: "run-tool-search",
@@ -585,9 +558,6 @@ describe("createCopilotToolBridge", () => {
         toolsAllow: ["read"],
       } as never,
       createOpenClawCodingTools,
-      modelId: "gpt-4o",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
 
     expect(catalogRef?.current?.entries?.map((entry) => entry.name)).toEqual(["read"]);
@@ -600,16 +570,12 @@ describe("createCopilotToolBridge", () => {
     ]);
 
     const result = await createCopilotToolBridge({
-      agentId: "agent-1",
       attemptParams: {
         config: { tools: { codeMode: true } },
         runId: "run-code-mode",
         sessionKey: "agent:agent-1:main",
       } as never,
       createOpenClawCodingTools,
-      modelId: "gpt-4o",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
 
     expect(createOpenClawCodingTools).toHaveBeenCalledWith(
@@ -652,7 +618,6 @@ describe("createCopilotToolBridge", () => {
       }),
     );
     const bridge = await createCopilotToolBridge({
-      agentId: "agent-1",
       cwd: "/tmp/copilot-code-mode-cwd",
       attemptParams: {
         config: { tools: { codeMode: true } },
@@ -662,8 +627,6 @@ describe("createCopilotToolBridge", () => {
       },
       createOpenClawCodingTools: async () => [makeTool({ execute: hiddenExecute, name: "read" })],
       modelId: "gpt-test",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
     const source = expectDefined(
       bridge.sourceTools.find((tool) => tool.name === "exec"),
@@ -700,16 +663,12 @@ describe("createCopilotToolBridge", () => {
 
   it("reports code mode as disengaged when the config leaves it off", async () => {
     const result = await createCopilotToolBridge({
-      agentId: "agent-1",
       attemptParams: {
         config: { tools: { codeMode: false } },
         runId: "run-no-code-mode",
         sessionKey: "agent:agent-1:main",
       } as never,
       createOpenClawCodingTools: vi.fn(async () => [makeTool({ name: "read" })]),
-      modelId: "gpt-4o",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
 
     expect(result.codeModeEngaged).toBe(false);
@@ -722,7 +681,6 @@ describe("createCopilotToolBridge", () => {
     ]);
 
     const result = await createCopilotToolBridge({
-      agentId: "agent-1",
       attemptParams: {
         config: { tools: { codeMode: true } },
         runId: "run-code-mode",
@@ -730,9 +688,6 @@ describe("createCopilotToolBridge", () => {
         toolsAllow: ["read"],
       } as never,
       createOpenClawCodingTools,
-      modelId: "gpt-4o",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
 
     expect(result.sourceTools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
@@ -750,7 +705,6 @@ describe("createCopilotToolBridge", () => {
     });
 
     await createCopilotToolBridge({
-      agentId: "agent-1",
       attemptParams: {
         config: { tools: { codeMode: true } },
         runId: "run-code-mode",
@@ -758,9 +712,6 @@ describe("createCopilotToolBridge", () => {
         toolsAllow: ["read"],
       } as never,
       createOpenClawCodingTools,
-      modelId: "gpt-4o",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
 
     expect(catalogRef?.current?.entries?.map((entry) => entry.name)).toEqual(["read"]);
@@ -837,7 +788,6 @@ describe("createCopilotToolBridge", () => {
       };
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           agentAccountId: "acct-1",
           toolBindings,
@@ -868,9 +818,6 @@ describe("createCopilotToolBridge", () => {
           delegationCapability: "report_only",
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       const opts = getOpts();
@@ -907,12 +854,8 @@ describe("createCopilotToolBridge", () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { messageChannel: "telegram" } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       expect(getOpts().messageProvider).toBe("telegram");
@@ -922,16 +865,12 @@ describe("createCopilotToolBridge", () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           agentAccountId: "account-a",
           messageChannel: "discord",
           messageProvider: "discord-voice",
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       expect(getOpts()).toMatchObject({
@@ -948,7 +887,6 @@ describe("createCopilotToolBridge", () => {
       const onToolOutcome = vi.fn();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           authProfileStore,
           runId: "run-1",
@@ -957,9 +895,6 @@ describe("createCopilotToolBridge", () => {
           messageActionTurnCapability: "turn-capability-1",
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       const opts = getOpts();
@@ -1015,8 +950,6 @@ describe("createCopilotToolBridge", () => {
             workspaceDir,
           },
           createOpenClawCodingTools: createTools,
-          modelId: "gpt-4o",
-          modelProvider: "github-copilot",
           sessionId: "copilot-memory-session",
           sessionKey,
           workspaceDir,
@@ -1072,8 +1005,6 @@ describe("createCopilotToolBridge", () => {
             workspaceDir,
           },
           createOpenClawCodingTools: createTools,
-          modelId: "gpt-4o",
-          modelProvider: "github-copilot",
           sessionId: "copilot-fresh-session",
           sessionKey: "agent:main:copilot-fresh-session",
           workspaceDir,
@@ -1117,15 +1048,11 @@ describe("createCopilotToolBridge", () => {
       const toolAuthProfileStore = { kind: "tool-store" } as never;
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           authProfileStore,
           toolAuthProfileStore,
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       expect(getOpts().authProfileStore).toBe(toolAuthProfileStore);
@@ -1135,7 +1062,6 @@ describe("createCopilotToolBridge", () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         // Mirrors PI attempt.ts:1053-1060: when sandboxSessionKey
         // differs from sessionKey, sessionKey is published as the
         // sandbox key and the real run key is exposed as runSessionKey
@@ -1145,9 +1071,6 @@ describe("createCopilotToolBridge", () => {
           sessionKey: "agent:agent-1:main",
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       const opts = getOpts();
@@ -1159,12 +1082,8 @@ describe("createCopilotToolBridge", () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { sessionKey: "agent:agent-1:main" } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       const opts = getOpts();
@@ -1176,12 +1095,8 @@ describe("createCopilotToolBridge", () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {},
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
         sessionKey: "fallback-key",
       });
 
@@ -1192,7 +1107,6 @@ describe("createCopilotToolBridge", () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           model: {
             api: "openai-responses",
@@ -1202,9 +1116,6 @@ describe("createCopilotToolBridge", () => {
           },
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       const opts = getOpts();
@@ -1218,12 +1129,8 @@ describe("createCopilotToolBridge", () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { model: { input: ["text"] } } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       expect(getOpts().modelHasVision).toBe(false);
@@ -1235,12 +1142,8 @@ describe("createCopilotToolBridge", () => {
       const bashElevated = { allowed: true } as never;
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { execOverrides, bashElevated } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       const exec = getOpts().exec as Record<string, unknown>;
@@ -1251,7 +1154,6 @@ describe("createCopilotToolBridge", () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           trigger: "cron",
           jobId: "job-1",
@@ -1265,9 +1167,6 @@ describe("createCopilotToolBridge", () => {
           },
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       const opts = getOpts();
@@ -1290,15 +1189,11 @@ describe("createCopilotToolBridge", () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           chatId: "oc_native_chat",
           chatType: "direct",
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       expect(getOpts()).toMatchObject({
@@ -1316,12 +1211,8 @@ describe("createCopilotToolBridge", () => {
       const onYieldDetected = vi.fn();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
         onYieldDetected,
-        sessionId: "session-1",
         sessionRef,
       });
 
@@ -1354,14 +1245,10 @@ describe("createCopilotToolBridge", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
         onYieldDetected: () => {
           throw new Error("handler boom");
         },
-        sessionId: "session-1",
         sessionRef,
       });
 
@@ -1375,15 +1262,11 @@ describe("createCopilotToolBridge", () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();
 
       await createCopilotToolBridge({
-        agentId: "agent-1",
         // No requireExplicitMessageTarget; sessionKey looks like a
         // subagent key so the default must be true. Mirrors PI
         // attempt.ts:1097-1098.
         attemptParams: { sessionKey: "subagent:envelope:abc" } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       const opts = getOpts();
@@ -1412,11 +1295,7 @@ describe("createCopilotToolBridge", () => {
     it("defaults sandbox to undefined and derives spawnWorkspaceDir from workspaceDir when no sandbox is passed (back-compat)", async () => {
       const createOpenClawCodingTools = vi.fn(async () => [makeTool()]);
       await createCopilotToolBridge({
-        agentId: "agent-1",
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
         sessionKey: "session-1",
         workspaceDir: "/workspace",
       });
@@ -1436,12 +1315,8 @@ describe("createCopilotToolBridge", () => {
       const sandbox = makeSandboxStub();
       const createOpenClawCodingTools = vi.fn(async () => [makeTool()]);
       await createCopilotToolBridge({
-        agentId: "agent-1",
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
         sandbox,
-        sessionId: "session-1",
         sessionKey: "session-1",
         spawnWorkspaceDir: "/original-workspace",
         workspaceDir: "/sandbox/copy",
@@ -1460,12 +1335,8 @@ describe("createCopilotToolBridge", () => {
       const sandbox = makeSandboxStub({ workspaceAccess: "ro" });
       const createOpenClawCodingTools = vi.fn(async () => [makeTool()]);
       await createCopilotToolBridge({
-        agentId: "agent-1",
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
         sandbox,
-        sessionId: "session-1",
         sessionKey: "session-1",
         workspaceDir: "/sandbox/copy",
       });
@@ -1490,7 +1361,6 @@ describe("createCopilotToolBridge", () => {
     it("submits the exact conversation-policy-filtered catalog to the SDK", async () => {
       await withTempDir("openclaw-copilot-policy-", async (workspaceDir) => {
         const result = await createCopilotToolBridge({
-          agentId: "agent-1",
           attemptParams: {
             conversationToolPolicy: {
               deny: ["exec", "process", "write", "edit", "ask_user"],
@@ -1500,8 +1370,6 @@ describe("createCopilotToolBridge", () => {
             workspaceDir,
           } as never,
           createOpenClawCodingTools: createRealOpenClawCodingTools,
-          modelId: "gpt-4o",
-          modelProvider: "github-copilot",
           sessionId: "policy-session",
           sessionKey: "agent:agent-1:policy-session",
           workspaceDir,
@@ -1521,12 +1389,8 @@ describe("createCopilotToolBridge", () => {
     it("short-circuits when attemptParams.disableTools is true and never calls createOpenClawCodingTools", async () => {
       const createOpenClawCodingTools = vi.fn(async () => [makeTool()]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { disableTools: true } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.codeModeEngaged).toBe(false);
       expect(result.promptToolPolicy.apply()).toEqual({ tools: [], callableToolNames: [] });
@@ -1537,12 +1401,8 @@ describe("createCopilotToolBridge", () => {
     it('short-circuits raw model runs signalled via promptMode: "none"', async () => {
       const createOpenClawCodingTools = vi.fn(async () => [makeTool()]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { promptMode: "none" } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.codeModeEngaged).toBe(false);
       expect(result.promptToolPolicy.apply()).toEqual({ tools: [], callableToolNames: [] });
@@ -1553,12 +1413,8 @@ describe("createCopilotToolBridge", () => {
     it("short-circuits raw model runs signalled via modelRun: true", async () => {
       const createOpenClawCodingTools = vi.fn(async () => [makeTool()]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { modelRun: true } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.codeModeEngaged).toBe(false);
       expect(result.promptToolPolicy.apply()).toEqual({ tools: [], callableToolNames: [] });
@@ -1573,12 +1429,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "message" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: ["read"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["read"]);
       expect(result.promptToolPolicy.apply().tools.map((tool) => tool.name)).toEqual(["read"]);
@@ -1590,12 +1442,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "edit" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: [] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools).toEqual([]);
       expect(result.promptToolPolicy.apply().tools).toEqual([]);
@@ -1607,12 +1455,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "message" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: [], forceMessageTool: true } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["message"]);
     });
@@ -1623,15 +1467,11 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "message" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           toolsAllow: [],
           sourceReplyDeliveryMode: "message_tool_only",
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["message"]);
     });
@@ -1643,15 +1483,11 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "message" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           toolsAllow: ["read"],
           forceMessageTool: true,
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name).toSorted()).toEqual(["message", "read"]);
     });
@@ -1662,16 +1498,12 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "message" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           toolsAllow: ["read"],
           forceMessageTool: true,
           disableMessageTool: true,
         } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["read"]);
     });
@@ -1680,12 +1512,8 @@ describe("createCopilotToolBridge", () => {
       const tools = [makeTool({ name: "read" }), makeTool({ name: "edit" })];
       const createOpenClawCodingTools = vi.fn(async () => tools);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {} as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["read", "edit"]);
     });
@@ -1694,12 +1522,8 @@ describe("createCopilotToolBridge", () => {
       const tools = [makeTool({ name: "read" }), makeTool({ name: "edit" })];
       const createOpenClawCodingTools = vi.fn(async () => tools);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: ["*"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["read", "edit"]);
     });
@@ -1714,12 +1538,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "edit" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: ["read"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["read"]);
     });
@@ -1756,12 +1576,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "read" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: ["bash"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["exec"]);
     });
@@ -1772,12 +1588,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "read" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: ["apply-patch"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["apply_patch"]);
     });
@@ -1789,12 +1601,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "read" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: [" BASH ", "Apply-Patch", "READ"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name).toSorted()).toEqual([
         "apply_patch",
@@ -1809,12 +1617,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "apply_patch" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: ["exec", "apply_patch"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name).toSorted()).toEqual([
         "apply_patch",
@@ -1828,19 +1632,14 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "edit" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: ["group:fs"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name).toSorted()).toEqual(["edit", "read"]);
     });
 
     it("does not discard lean-mode overrides after tool construction", async () => {
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: {
           config: {
             agents: { defaults: { experimental: { localModelLean: true } } },
@@ -1848,9 +1647,6 @@ describe("createCopilotToolBridge", () => {
           },
         } as never,
         createOpenClawCodingTools: async () => [makeTool({ name: "image_generate" })],
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
 
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["image_generate"]);
@@ -1862,12 +1658,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "read" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: ["group:plugins"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["memory_search"]);
     });
@@ -1878,12 +1670,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "read" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: ["web_*"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["web_fetch"]);
       const options = (createOpenClawCodingTools.mock.calls[0] as unknown[] | undefined)?.[0] as {
@@ -1898,12 +1686,8 @@ describe("createCopilotToolBridge", () => {
         makeTool({ name: "apply_patch" }),
       ]);
       const result = await createCopilotToolBridge({
-        agentId: "agent-1",
         attemptParams: { toolsAllow: ["write"] } as never,
         createOpenClawCodingTools,
-        modelId: "gpt-4o",
-        modelProvider: "github-copilot",
-        sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["write"]);
       const options = (createOpenClawCodingTools.mock.calls[0] as unknown[] | undefined)?.[0] as {
@@ -2364,7 +2148,6 @@ describe("createCopilotToolBridge tool conversion", () => {
       sideEffectEvidence: true,
     }));
     await createCopilotToolBridge({
-      agentId: "agent-1",
       attemptParams: {
         config: { tools: { toolSearch: true } },
         observeToolTerminal,
@@ -2376,9 +2159,6 @@ describe("createCopilotToolBridge tool conversion", () => {
           .toolSearchCatalogExecutor;
         return [makeTool({ name: "tool_search_code" })];
       },
-      modelId: "gpt-4o",
-      modelProvider: "github-copilot",
-      sessionId: "session-1",
     });
     const target = createOwnerBackedContractTool({
       pluginId: "memory-lancedb",

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -605,8 +605,168 @@ async function emitTrustedAndFlush(event: Parameters<typeof emitTrustedDiagnosti
 
 type TrustedEvent = Parameters<typeof emitTrustedDiagnosticEvent>[0];
 type TrustedEventOf<T extends TrustedEvent["type"]> = Extract<TrustedEvent, { type: T }>;
+type EventFields<T extends TrustedEvent["type"]> = Omit<TrustedEventOf<T>, "type">;
 
-function emitRunStarted(overrides: Partial<Omit<TrustedEventOf<"run.started">, "type">> = {}) {
+const EVENT_FIXTURES = {
+  "harness.run.completed": {
+    ...RUN_FIXTURE,
+    harnessId: "openclaw",
+    outcome: "completed",
+    durationMs: 90,
+    itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+    trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
+  } satisfies EventFields<"harness.run.completed">,
+  "harness.run.started": {
+    ...RUN_FIXTURE,
+    harnessId: "openclaw",
+    trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
+  } satisfies EventFields<"harness.run.started">,
+  "log.record": {
+    level: "INFO",
+    message: "test log",
+  } satisfies EventFields<"log.record">,
+  "model.call.completed": {
+    ...MODEL_CALL_FIXTURE,
+    durationMs: 80,
+    trace: createTestTrace(MODEL_CALL_SPAN_ID, CHILD_SPAN_ID),
+  } satisfies EventFields<"model.call.completed">,
+  "model.call.started": {
+    ...MODEL_CALL_FIXTURE,
+    trace: createTestTrace(MODEL_CALL_SPAN_ID, CHILD_SPAN_ID),
+  } satisfies EventFields<"model.call.started">,
+  "model.usage": {
+    ...MODEL_FIXTURE,
+    usage: { input: 3, output: 2, total: 5 },
+    durationMs: 10,
+    trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
+  } satisfies EventFields<"model.usage">,
+  "run.completed": {
+    ...RUN_FIXTURE,
+    outcome: "completed",
+    durationMs: 100,
+    trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
+  } satisfies EventFields<"run.completed">,
+  "run.started": {
+    ...RUN_FIXTURE,
+    trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
+  } satisfies EventFields<"run.started">,
+  "tool.execution.completed": {
+    runId: "run-1",
+    toolName: "read",
+    durationMs: 20,
+    trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
+  } satisfies EventFields<"tool.execution.completed">,
+  "tool.execution.error": {
+    runId: "run-1",
+    toolName: "read",
+    durationMs: 20,
+    errorCategory: "TypeError",
+    trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
+  } satisfies EventFields<"tool.execution.error">,
+  "tool.execution.started": {
+    runId: "run-1",
+    toolName: "read",
+    trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
+  } satisfies EventFields<"tool.execution.started">,
+};
+
+type FixtureEventType = keyof typeof EVENT_FIXTURES;
+
+function buildEventFixture(
+  type: TrustedEvent["type"],
+  overrides: Record<string, unknown> = {},
+  omitted: readonly string[] = [],
+): TrustedEvent {
+  const defaults = EVENT_FIXTURES[type as FixtureEventType];
+  const event = { ...defaults, type, ...overrides } as Record<string, unknown>;
+  for (const key of omitted) {
+    delete event[key];
+  }
+  return event as TrustedEvent;
+}
+
+function eventFixture<T extends FixtureEventType>(
+  type: T,
+  overrides?: Partial<EventFields<T>>,
+  omitted?: readonly (keyof EventFields<T>)[],
+): TrustedEventOf<T>;
+function eventFixture<T extends TrustedEvent["type"]>(
+  type: T,
+  event: EventFields<T>,
+  omitted?: readonly (keyof EventFields<T>)[],
+): TrustedEventOf<T>;
+function eventFixture(
+  type: TrustedEvent["type"],
+  overrides: Record<string, unknown> = {},
+  omitted: readonly string[] = [],
+): TrustedEvent {
+  return buildEventFixture(type, overrides, omitted);
+}
+
+type FixtureEmitter<TResult> = {
+  <T extends FixtureEventType>(
+    type: T,
+    overrides?: Partial<EventFields<T>>,
+    omitted?: readonly (keyof EventFields<T>)[],
+  ): TResult;
+  <T extends TrustedEvent["type"]>(
+    type: T,
+    event: EventFields<T>,
+    omitted?: readonly (keyof EventFields<T>)[],
+  ): TResult;
+};
+
+function createFixtureEmitter<TResult>(
+  emit: (event: TrustedEvent) => TResult,
+): FixtureEmitter<TResult> {
+  return ((
+    type: TrustedEvent["type"],
+    overrides?: Record<string, unknown>,
+    omitted?: readonly string[],
+  ) => emit(buildEventFixture(type, overrides, omitted))) as FixtureEmitter<TResult>;
+}
+
+const emitEvent = createFixtureEmitter(emitDiagnosticEvent);
+const emitEventAndFlush = createFixtureEmitter(emitAndFlush);
+const emitTrustedEvent = createFixtureEmitter(emitTrustedDiagnosticEvent);
+const emitTrustedEventAndFlush = createFixtureEmitter(emitTrustedAndFlush);
+const emitInternalEvent = createFixtureEmitter(emitInternalDiagnosticEventForTest);
+
+type OtelServiceOptions = NonNullable<Parameters<typeof startOtelService>[0]>;
+type OtelSignal = "traces" | "metrics" | "logs";
+const omitConfiguredProtocol: NonNullable<OtelServiceOptions["configure"]> = (ctx) => {
+  delete ctx.config.diagnostics?.otel?.protocol;
+};
+
+function startServiceFixture(
+  signals: readonly OtelSignal[],
+  optionsOrConfigure:
+    | Omit<OtelServiceOptions, OtelSignal>
+    | NonNullable<OtelServiceOptions["configure"]> = {},
+) {
+  const options =
+    typeof optionsOrConfigure === "function"
+      ? { configure: optionsOrConfigure }
+      : optionsOrConfigure;
+  return startOtelService({
+    traces: signals.includes("traces"),
+    metrics: signals.includes("metrics"),
+    logs: signals.includes("logs"),
+    ...options,
+  });
+}
+
+function captureExporterEvents() {
+  const events: TelemetryExporterEvent[] = [];
+  const unsubscribe = onInternalDiagnosticEvent((event) => {
+    if (event.type === "telemetry.exporter") {
+      events.push(event);
+    }
+  });
+  return { events, unsubscribe };
+}
+
+function emitRunStarted(overrides: Partial<EventFields<"run.started">> = {}) {
   emitTrustedDiagnosticEvent({
     type: "run.started",
     ...RUN_FIXTURE,
@@ -615,7 +775,7 @@ function emitRunStarted(overrides: Partial<Omit<TrustedEventOf<"run.started">, "
   });
 }
 
-function emitRunCompleted(overrides: Partial<Omit<TrustedEventOf<"run.completed">, "type">> = {}) {
+function emitRunCompleted(overrides: Partial<EventFields<"run.completed">> = {}) {
   emitTrustedDiagnosticEvent({
     type: "run.completed",
     ...RUN_FIXTURE,
@@ -653,32 +813,31 @@ function emitDefaultModelUsage() {
 }
 
 function emitTrustedModelCallCompletedWithContent(
-  event: Omit<
-    Extract<Parameters<typeof emitDiagnosticEvent>[0], { type: "model.call.completed" }>,
-    "type"
-  >,
   modelContent: NonNullable<DiagnosticEventPrivateData["modelContent"]>,
+  overrides: Partial<EventFields<"model.call.completed">> = {},
 ) {
   emitTrustedDiagnosticEventWithPrivateData(
     {
       type: "model.call.completed",
-      ...event,
+      ...MODEL_CALL_FIXTURE,
+      durationMs: 80,
+      ...overrides,
     },
     { modelContent },
   );
 }
 
 function emitTrustedToolExecutionCompletedWithContent(
-  event: Omit<
-    Extract<Parameters<typeof emitDiagnosticEvent>[0], { type: "tool.execution.completed" }>,
-    "type"
-  >,
   toolContent: NonNullable<DiagnosticEventPrivateData["toolContent"]>,
+  overrides: Partial<EventFields<"tool.execution.completed">> = {},
 ) {
   emitTrustedDiagnosticEventWithPrivateData(
     {
       type: "tool.execution.completed",
-      ...event,
+      runId: "run-1",
+      toolName: "read",
+      durationMs: 20,
+      ...overrides,
     },
     { toolContent },
   );
@@ -908,13 +1067,10 @@ describe("diagnostics-otel service", () => {
   ])(
     "replaces the default OpenClaw metric prefix with $metricNamePrefix",
     async ({ metricNamePrefix, expectedTokenName, expectedDurationName }) => {
-      await startOtelService({
-        metrics: true,
-        configure: (ctx) => {
-          if (metricNamePrefix !== undefined) {
-            ctx.config.diagnostics!.otel!.metricNamePrefix = metricNamePrefix;
-          }
-        },
+      await startServiceFixture(["metrics"], (ctx) => {
+        if (metricNamePrefix !== undefined) {
+          ctx.config.diagnostics!.otel!.metricNamePrefix = metricNamePrefix;
+        }
       });
 
       expect(telemetryState.counters.has(expectedTokenName)).toBe(true);
@@ -928,63 +1084,53 @@ describe("diagnostics-otel service", () => {
   );
 
   test("records message-flow metrics and spans", async () => {
-    await startOtelService({ traces: true, metrics: true, logs: true });
+    await startServiceFixture(["traces", "metrics", "logs"]);
 
-    emitDiagnosticEvent({
-      type: "webhook.received",
+    emitEvent("webhook.received", {
       channel: "telegram",
       updateType: "telegram-post",
     });
-    emitDiagnosticEvent({
-      type: "webhook.processed",
+    emitEvent("webhook.processed", {
       channel: "telegram",
       updateType: "telegram-post",
       chatId: "chat-should-not-export",
       durationMs: 120,
     });
-    emitDiagnosticEvent({
-      type: "message.queued",
+    emitEvent("message.queued", {
       channel: "telegram",
       source: "telegram",
       queueDepth: 2,
     });
-    emitDiagnosticEvent({
-      type: "message.received",
+    emitEvent("message.received", {
       channel: "telegram",
       source: "webhook",
     });
-    emitDiagnosticEvent({
-      type: "message.dispatch.started",
+    emitEvent("message.dispatch.started", {
       channel: "telegram",
       source: "webhook",
     });
-    emitDiagnosticEvent({
-      type: "message.dispatch.completed",
+    emitEvent("message.dispatch.completed", {
       channel: "telegram",
       source: "webhook",
       durationMs: 25,
       outcome: "completed",
     });
-    emitDiagnosticEvent({
-      type: "message.received",
+    emitEvent("message.received", {
       channel: "telegram/custom",
       source: "webhook with secret sk-test",
     });
-    emitDiagnosticEvent({
-      type: "message.dispatch.started",
+    emitEvent("message.dispatch.started", {
       channel: "telegram/custom",
       source: "webhook with secret sk-test",
     });
-    emitDiagnosticEvent({
-      type: "message.dispatch.completed",
+    emitEvent("message.dispatch.completed", {
       channel: "telegram/custom",
       source: "webhook with secret sk-test",
       durationMs: 30,
       outcome: "completed",
       reason: "progress draft / message tool 123",
     });
-    emitDiagnosticEvent({
-      type: "message.processed",
+    emitEvent("message.processed", {
       channel: "telegram",
       chatId: "chat-should-not-export",
       messageId: "message-should-not-export",
@@ -992,20 +1138,17 @@ describe("diagnostics-otel service", () => {
       reason: "progress draft / message tool 123",
       durationMs: 55,
     });
-    emitDiagnosticEvent({
-      type: "queue.lane.dequeue",
+    emitEvent("queue.lane.dequeue", {
       lane: "main",
       queueSize: 3,
       waitMs: 10,
     });
-    emitDiagnosticEvent({
-      type: "session.stuck",
+    emitEvent("session.stuck", {
       state: "processing",
       ageMs: 125_000,
       classification: "stale_session_state",
     });
-    emitDiagnosticEvent({
-      type: "run.attempt",
+    emitEvent("run.attempt", {
       runId: "run-1",
       attempt: 2,
     });
@@ -1121,8 +1264,7 @@ describe("diagnostics-otel service", () => {
       "openclaw.attempt": 2,
     });
 
-    emitDiagnosticEvent({
-      type: "session.turn.created",
+    emitEvent("session.turn.created", {
       runId: "run-1",
       agentId: "agent.default",
       channel: "telegram",
@@ -1152,9 +1294,7 @@ describe("diagnostics-otel service", () => {
     expect(messageSpanOptions?.attributes).not.toHaveProperty("openclaw.messageId");
     expect(messageSpanOptions?.startTime).toBeTypeOf("number");
 
-    await emitAndFlush({
-      type: "log.record",
-      level: "INFO",
+    await emitEventAndFlush("log.record", {
       message: "hello",
       attributes: { subsystem: "diagnostic" },
     });
@@ -1163,23 +1303,18 @@ describe("diagnostics-otel service", () => {
 
   test("restarts without retaining prior listeners or log transports", async () => {
     const unregisterBridge = vi.fn();
-    const { service, ctx } = await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: true,
-      configure: (context) => {
-        const registerBridge = context.internalDiagnostics?.registerTracePropagationBridge;
-        context.internalDiagnostics = {
-          ...context.internalDiagnostics!,
-          registerTracePropagationBridge: (bridge) => {
-            const unregister = registerBridge!(bridge);
-            return () => {
-              unregisterBridge();
-              unregister();
-            };
-          },
-        };
-      },
+    const { service, ctx } = await startServiceFixture(["traces", "metrics", "logs"], (context) => {
+      const registerBridge = context.internalDiagnostics?.registerTracePropagationBridge;
+      context.internalDiagnostics = {
+        ...context.internalDiagnostics!,
+        registerTracePropagationBridge: (bridge) => {
+          const unregister = registerBridge!(bridge);
+          return () => {
+            unregisterBridge();
+            unregister();
+          };
+        },
+      };
     });
     await service.start(ctx);
 
@@ -1189,8 +1324,7 @@ describe("diagnostics-otel service", () => {
     expect(unregisterBridge).toHaveBeenCalledTimes(1);
 
     telemetryState.tracer.startSpan.mockClear();
-    emitDiagnosticEvent({
-      type: "message.processed",
+    emitEvent("message.processed", {
       channel: "telegram",
       outcome: "completed",
       durationMs: 10,
@@ -1204,8 +1338,7 @@ describe("diagnostics-otel service", () => {
     expect(unregisterBridge).toHaveBeenCalledTimes(2);
 
     telemetryState.tracer.startSpan.mockClear();
-    emitDiagnosticEvent({
-      type: "message.processed",
+    emitEvent("message.processed", {
       channel: "telegram",
       outcome: "completed",
       durationMs: 10,
@@ -1273,7 +1406,7 @@ describe("diagnostics-otel service", () => {
     logShutdown.mockRejectedValueOnce(logError);
     traceProviderShutdown.mockRejectedValueOnce(traceError);
     meterProviderShutdown.mockRejectedValueOnce(meterError);
-    const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
+    const { service, ctx } = await startServiceFixture(["traces", "metrics", "logs"]);
 
     const stopError = await Promise.resolve(service.stop?.(ctx)).catch((error: unknown) => error);
 
@@ -1294,17 +1427,8 @@ describe("diagnostics-otel service", () => {
   });
 
   test("retires an exporter failure retained after shutdown rejects", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
-    const { service, ctx } = await startOtelService({
-      traces: true,
-      metrics: false,
-      logs: false,
-    });
+    const { events, unsubscribe } = captureExporterEvents();
+    const { service, ctx } = await startServiceFixture(["traces"]);
     traceExporterShutdown.mockRejectedValueOnce(new TypeError("private shutdown details"));
     traceProviderShutdown.mockImplementationOnce(async () => {
       // Emulate the real provider shutdown chain: the exporter health wrapper
@@ -1358,12 +1482,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("preserves SDK startup failure through host rollback when shutdown also fails", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
     const startupError = new Error("SDK startup failed");
     const rollbackError = new Error("SDK rollback failed");
     traceProviderCtor.mockImplementationOnce(() => {
@@ -1519,7 +1638,7 @@ describe("diagnostics-otel service", () => {
   );
 
   test("registers and removes an OTLP exporter unhandled rejection handler", async () => {
-    const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
+    const { service, ctx } = await startServiceFixture(["traces", "metrics", "logs"]);
 
     expect(unhandledRejectionHandlerState.register).toHaveBeenCalledTimes(1);
     const handler = unhandledRejectionHandlerState.getHandlers()[0];
@@ -1598,7 +1717,7 @@ describe("diagnostics-otel service", () => {
 
   test("uses a preloaded OpenTelemetry SDK without dropping diagnostic listeners", async () => {
     process.env.OPENCLAW_OTEL_PRELOADED = "1";
-    const { service, ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
+    const { service, ctx } = await startServiceFixture(["traces", "metrics", "logs"]);
 
     expect(traceProviderCtor).not.toHaveBeenCalled();
     expect(meterProviderCtor).not.toHaveBeenCalled();
@@ -1607,15 +1726,8 @@ describe("diagnostics-otel service", () => {
       "diagnostics-otel: using preloaded OpenTelemetry SDK",
     );
 
-    emitDiagnosticEvent({
-      type: "run.completed",
-      ...RUN_FIXTURE,
-      outcome: "completed",
-      durationMs: 100,
-    });
-    await emitAndFlush({
-      type: "log.record",
-      level: "INFO",
+    emitEvent("run.completed", {}, ["trace"]);
+    await emitEventAndFlush("log.record", {
       message: "preloaded log",
     });
 
@@ -1635,13 +1747,8 @@ describe("diagnostics-otel service", () => {
   });
 
   test("emits and records bounded telemetry exporter health events", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
-    const { ctx } = await startOtelService({ traces: true, metrics: true, logs: true });
+    const { events, unsubscribe } = captureExporterEvents();
+    const { ctx } = await startServiceFixture(["traces", "metrics", "logs"]);
 
     for (const signal of ["traces", "metrics", "logs"]) {
       const event = events.find((entry) => entry.signal === signal);
@@ -1671,16 +1778,8 @@ describe("diagnostics-otel service", () => {
   });
 
   test("coalesces multi-transport logs into one public lifecycle", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
-    const { service, ctx } = await startOtelService({
-      traces: false,
-      metrics: false,
-      logs: true,
+    const { events, unsubscribe } = captureExporterEvents();
+    const { service, ctx } = await startServiceFixture(["logs"], {
       logsExporter: "both",
     });
     await waitForDiagnosticEventsDrained();
@@ -1719,10 +1818,7 @@ describe("diagnostics-otel service", () => {
       const onEvent = vi.fn();
       process.env.OTEL_SDK_DISABLED = value;
 
-      const { service, ctx } = await startOtelService({
-        traces: true,
-        metrics: true,
-        logs: true,
+      const { service, ctx } = await startServiceFixture(["traces", "metrics", "logs"], {
         logsExporter: "both",
         configure: (context) => {
           context.internalDiagnostics = {
@@ -1754,11 +1850,7 @@ describe("diagnostics-otel service", () => {
   test.each([" FaLsE "])("keeps the SDK enabled for OTEL_SDK_DISABLED=%j", async (value) => {
     process.env.OTEL_SDK_DISABLED = value;
 
-    const { service, ctx } = await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: true,
-    });
+    const { service, ctx } = await startServiceFixture(["traces", "metrics", "logs"]);
 
     expect(traceProviderCtor).toHaveBeenCalledOnce();
     expect(meterProviderCtor).toHaveBeenCalledOnce();
@@ -1773,11 +1865,7 @@ describe("diagnostics-otel service", () => {
   test("warns through the plugin logger and keeps the SDK enabled for an invalid value", async () => {
     process.env.OTEL_SDK_DISABLED = "invalid";
 
-    const { service, ctx } = await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: true,
-    });
+    const { service, ctx } = await startServiceFixture(["traces", "metrics", "logs"]);
 
     expect(ctx.logger.warn).toHaveBeenCalledWith(
       "diagnostics-otel: invalid OTEL_SDK_DISABLED value; expected true or false, using false",
@@ -1793,12 +1881,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("skips malformed endpoint, protocol, and TLS settings while disabled", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
     process.env.OTEL_SDK_DISABLED = "true";
     process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
     process.env.OTEL_EXPORTER_OTLP_CERTIFICATE = "/definitely-missing/otel-root.pem";
@@ -1825,30 +1908,15 @@ describe("diagnostics-otel service", () => {
   });
 
   test("preserves preloaded trace and metric ownership while disabling plugin logs", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
     process.env.OPENCLAW_OTEL_PRELOADED = "1";
     process.env.OTEL_SDK_DISABLED = "true";
 
-    const { service, ctx } = await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: true,
+    const { service, ctx } = await startServiceFixture(["traces", "metrics", "logs"], {
       logsExporter: "both",
     });
-    emitDiagnosticEvent({
-      type: "run.completed",
-      ...RUN_FIXTURE,
-      outcome: "completed",
-      durationMs: 100,
-    });
-    await emitAndFlush({
-      type: "log.record",
-      level: "INFO",
+    emitEvent("run.completed", {}, ["trace"]);
+    await emitEventAndFlush("log.record", {
       message: "disabled preloaded log",
     });
     await waitForDiagnosticEventsDrained();
@@ -1905,26 +1973,15 @@ describe("diagnostics-otel service", () => {
   });
 
   test("records dependency-default, stdout, and external SDK ownership facts", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
 
-    const defaultEndpoint = await startOtelService({
-      traces: true,
-      configure: (context) => {
-        delete context.config.diagnostics?.otel?.endpoint;
-      },
+    const defaultEndpoint = await startServiceFixture(["traces"], (context) => {
+      delete context.config.diagnostics?.otel?.endpoint;
     });
     await defaultEndpoint.service.stop?.(defaultEndpoint.ctx);
 
     process.env.OPENCLAW_OTEL_PRELOADED = "1";
-    const externalSdk = await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: true,
+    const externalSdk = await startServiceFixture(["traces", "metrics", "logs"], {
       logsExporter: "stdout",
     });
 
@@ -2154,7 +2211,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports trusted security events as bounded OTLP logs", async () => {
-    await startOtelService({ logs: true });
+    await startServiceFixture(["logs"]);
     const trace = createDiagnosticTraceContext(createTestTrace(SPAN_ID));
 
     emitTrustedSecurityEvent({
@@ -2240,7 +2297,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("does not export security events when OTLP logs are disabled", async () => {
-    await startOtelService({ logs: false, metrics: true });
+    await startServiceFixture(["metrics"]);
     emitTrustedSecurityEvent({
       eventId: "security-event-logs-disabled",
       category: "auth",
@@ -2258,11 +2315,8 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = "grpc";
     process.env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = "http/json";
     process.env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = "grpc";
-    const { ctx } = await startOtelService({
+    const { ctx } = await startServiceFixture(["traces", "metrics", "logs"], {
       protocol: "http/protobuf",
-      traces: true,
-      metrics: true,
-      logs: true,
     });
 
     expect(traceProviderCtor).toHaveBeenCalledTimes(1);
@@ -2286,9 +2340,7 @@ describe("diagnostics-otel service", () => {
     expect(spanProcessorCtor).toHaveBeenCalledTimes(1);
     expect(ctx.logger.warn).not.toHaveBeenCalledWith("diagnostics-otel: unsupported protocol grpc");
 
-    emitDiagnosticEvent({
-      type: "log.record",
-      level: "INFO",
+    emitEvent("log.record", {
       message: "OpenClaw-owned OTLP log",
     });
     await flushDiagnosticEvents();
@@ -2297,21 +2349,12 @@ describe("diagnostics-otel service", () => {
   });
 
   test("rejects unsupported protocol env override before exporter startup", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
     process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
-    const { ctx } = await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: true,
-      configure: (context) => {
-        delete context.config.diagnostics?.otel?.protocol;
-      },
-    });
+    const { ctx } = await startServiceFixture(
+      ["traces", "metrics", "logs"],
+      omitConfiguredProtocol,
+    );
 
     expect(
       events.map((event) => ({
@@ -2366,25 +2409,16 @@ describe("diagnostics-otel service", () => {
   });
 
   test("uses signal protocol overrides without disabling supported siblings", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
     process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
     process.env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = "http/protobuf";
     process.env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = "http/json";
     process.env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = "http/protobuf";
 
-    const { ctx } = await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: true,
-      configure: (context) => {
-        delete context.config.diagnostics?.otel?.protocol;
-      },
-    });
+    const { ctx } = await startServiceFixture(
+      ["traces", "metrics", "logs"],
+      omitConfiguredProtocol,
+    );
 
     expect(traceExporterCtor).toHaveBeenCalledTimes(1);
     expect(metricExporterCtor).not.toHaveBeenCalled();
@@ -2415,17 +2449,12 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = "http/protobuf";
     const registerBridge = vi.fn(() => vi.fn());
 
-    const { ctx } = await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: false,
-      configure: (context) => {
-        delete context.config.diagnostics?.otel?.protocol;
-        context.internalDiagnostics = {
-          ...context.internalDiagnostics!,
-          registerTracePropagationBridge: registerBridge,
-        };
-      },
+    const { ctx } = await startServiceFixture(["traces", "metrics"], (context) => {
+      delete context.config.diagnostics?.otel?.protocol;
+      context.internalDiagnostics = {
+        ...context.internalDiagnostics!,
+        registerTracePropagationBridge: registerBridge,
+      };
     });
 
     expect(traceExporterCtor).not.toHaveBeenCalled();
@@ -2439,29 +2468,17 @@ describe("diagnostics-otel service", () => {
   });
 
   test("keeps stdout logs active when the OTLP branch of both is unsupported", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
     process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "http/protobuf";
     process.env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = "grpc";
     const capture = captureStdoutWrites();
 
     try {
-      const { ctx } = await startOtelService({
-        traces: false,
-        metrics: false,
-        logs: true,
+      const { ctx } = await startServiceFixture(["logs"], {
         logsExporter: "both",
-        configure: (context) => {
-          delete context.config.diagnostics?.otel?.protocol;
-        },
+        configure: omitConfiguredProtocol,
       });
-      emitDiagnosticEvent({
-        type: "log.record",
-        level: "INFO",
+      emitEvent("log.record", {
         message: "stdout fallback log",
       });
       await flushDiagnosticEvents();
@@ -2491,25 +2508,13 @@ describe("diagnostics-otel service", () => {
   });
 
   test("does not validate externally owned trace and metric protocols", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
     process.env.OPENCLAW_OTEL_PRELOADED = "1";
     process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
     process.env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = "http/json";
     process.env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = "grpc";
 
-    const { ctx } = await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: false,
-      configure: (context) => {
-        delete context.config.diagnostics?.otel?.protocol;
-      },
-    });
+    const { ctx } = await startServiceFixture(["traces", "metrics"], omitConfiguredProtocol);
 
     expect(traceProviderCtor).not.toHaveBeenCalled();
     expect(meterProviderCtor).not.toHaveBeenCalled();
@@ -2536,14 +2541,7 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = "\u2000";
     process.env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = "\ufeff";
 
-    await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: true,
-      configure: (context) => {
-        delete context.config.diagnostics?.otel?.protocol;
-      },
-    });
+    await startServiceFixture(["traces", "metrics", "logs"], omitConfiguredProtocol);
 
     expect(traceExporterCtor).toHaveBeenCalledTimes(1);
     expect(metricExporterCtor).toHaveBeenCalledTimes(1);
@@ -2552,20 +2550,13 @@ describe("diagnostics-otel service", () => {
 
   test("starts stdout-only logs when OTLP protocol env override is unsupported", async () => {
     process.env.OTEL_EXPORTER_OTLP_PROTOCOL = "grpc";
-    const { ctx } = await startOtelService({
-      traces: false,
-      metrics: false,
-      logs: true,
+    const { ctx } = await startServiceFixture(["logs"], {
       logsExporter: "stdout",
-      configure: (context) => {
-        delete context.config.diagnostics?.otel?.protocol;
-      },
+      configure: omitConfiguredProtocol,
     });
     const capture = captureStdoutWrites();
     try {
-      emitDiagnosticEvent({
-        type: "log.record",
-        level: "INFO",
+      emitEvent("log.record", {
         message: "stdout only log",
       });
       await flushDiagnosticEvents();
@@ -2597,13 +2588,7 @@ describe("diagnostics-otel service", () => {
     },
   ])("$name", async ({ value, exporterCalls, warning }) => {
     process.env.OTEL_EXPORTER_OTLP_PROTOCOL = value;
-    const { ctx } = await startOtelService({
-      traces: true,
-      metrics: true,
-      configure: (context) => {
-        delete context.config.diagnostics?.otel?.protocol;
-      },
-    });
+    const { ctx } = await startServiceFixture(["traces", "metrics"], omitConfiguredProtocol);
 
     expect(traceExporterCtor).toHaveBeenCalledTimes(exporterCalls);
     expect(metricExporterCtor).toHaveBeenCalledTimes(exporterCalls);
@@ -2667,9 +2652,8 @@ describe("diagnostics-otel service", () => {
   });
 
   test("records liveness warning diagnostics", async () => {
-    await startOtelService({ traces: true, metrics: true });
-    await emitAndFlush({
-      type: "diagnostic.liveness.warning",
+    await startServiceFixture(["traces", "metrics"]);
+    await emitEventAndFlush("diagnostic.liveness.warning", {
       reasons: ["event_loop_delay", "cpu"],
       intervalMs: 30_000,
       eventLoopDelayP99Ms: 250,
@@ -2711,9 +2695,8 @@ describe("diagnostics-otel service", () => {
   });
 
   test("records oversized payload metrics without raw identifiers", async () => {
-    await startOtelService({ metrics: true, traces: false });
-    await emitTrustedAndFlush({
-      type: "payload.large",
+    await startServiceFixture(["metrics"]);
+    await emitTrustedEventAndFlush("payload.large", {
       surface: "gateway.frame",
       action: "rejected",
       bytes: 2048,
@@ -2742,12 +2725,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("reports log exporter emit failures without exporting raw error text", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
     logEmit
       .mockImplementationOnce(() => {
         throw new TypeError("token sk-test-secret should not leave as telemetry");
@@ -2756,11 +2734,9 @@ describe("diagnostics-otel service", () => {
         throw new TypeError("repeated private failure");
       });
 
-    const { ctx } = await startOtelService({ logs: true });
+    const { ctx } = await startServiceFixture(["logs"]);
     for (const message of ["first failure", "second failure", "recovery"]) {
-      await emitAndFlush({
-        type: "log.record",
-        level: "INFO",
+      await emitEventAndFlush("log.record", {
         message,
       });
     }
@@ -2799,12 +2775,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("does not recover log OTLP health while an export failure remains active", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
     let completeExport: ((result: ExportResult) => void) | undefined;
     logExporterExport.mockImplementation(
       (_items: unknown, callback: (result: ExportResult) => void) => {
@@ -2816,7 +2787,7 @@ describe("diagnostics-otel service", () => {
         throw new TypeError("private enqueue failure");
       })
       .mockImplementationOnce(() => {});
-    const { ctx } = await startOtelService({ traces: false, metrics: false, logs: true });
+    const { ctx } = await startServiceFixture(["logs"]);
     const exporter = firstLogProcessorOptions().exporter as
       | {
           export(items: unknown, callback: (result: ExportResult) => void): void;
@@ -2870,12 +2841,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("recovers stdout emit health after repeated failures", async () => {
-    const events: TelemetryExporterEvent[] = [];
-    const unsubscribe = onInternalDiagnosticEvent((event) => {
-      if (event.type === "telemetry.exporter") {
-        events.push(event);
-      }
-    });
+    const { events, unsubscribe } = captureExporterEvents();
     const stdout = captureStdoutWrites();
     const failWrite = (() => {
       throw new TypeError("private stdout failure");
@@ -2883,10 +2849,7 @@ describe("diagnostics-otel service", () => {
     stdout.spy.mockImplementationOnce(failWrite).mockImplementationOnce(failWrite);
 
     try {
-      const { ctx } = await startOtelService({
-        traces: false,
-        metrics: false,
-        logs: true,
+      const { ctx } = await startServiceFixture(["logs"], {
         logsExporter: "stdout",
       });
       for (const message of ["first failure", "second failure", "recovery"]) {
@@ -2997,10 +2960,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("ignores untrusted telemetry exporter events for OTEL metrics", async () => {
-    await startOtelService({ metrics: true });
+    await startServiceFixture(["metrics"]);
     telemetryState.counters.get("openclaw.telemetry.exporter.events")?.add.mockClear();
-    emitDiagnosticEvent({
-      type: "telemetry.exporter",
+    emitEvent("telemetry.exporter", {
       exporter: "spoofed-plugin-exporter",
       signal: "metrics",
       status: "failure",
@@ -3013,7 +2975,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("records hook-blocked run metrics with safe blocker originator", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     await emitAndFlush({
       type: "run.completed",
@@ -3031,7 +2993,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("run.completed error span carries the redacted message off the metric attrs", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitTrustedDiagnosticEventWithPrivateData(
       {
@@ -3061,7 +3023,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("run.completed bounds sensitive error text before export", async () => {
-    await startOtelService({ traces: true });
+    await startServiceFixture(["traces"]);
     const secret = "sk-1234567890abcdef";
 
     emitTrustedDiagnosticEventWithPrivateData(
@@ -3085,19 +3047,19 @@ describe("diagnostics-otel service", () => {
   });
 
   test("harness.run.completed error span carries the redacted message", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitTrustedDiagnosticEventWithPrivateData(
-      {
-        type: "harness.run.completed",
-        runId: "run-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        harnessId: "openclaw",
-        outcome: "error",
-        durationMs: 90,
-        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
-      },
+      eventFixture(
+        "harness.run.completed",
+        {
+          runId: "run-1",
+          provider: "openai",
+          model: "gpt-5.4",
+          outcome: "error",
+        },
+        ["trace"],
+      ),
       { errorMessage: "model run failed during resolve phase" },
     );
     await flushDiagnosticEvents();
@@ -3114,11 +3076,10 @@ describe("diagnostics-otel service", () => {
   });
 
   test("harness.run.error span prefers the redacted message over the category", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitTrustedDiagnosticEventWithPrivateData(
-      {
-        type: "harness.run.error",
+      eventFixture("harness.run.error", {
         runId: "run-1",
         provider: "openai",
         model: "gpt-5.4",
@@ -3126,7 +3087,7 @@ describe("diagnostics-otel service", () => {
         phase: "resolve",
         errorCategory: "Error",
         durationMs: 90,
-      },
+      }),
       { errorMessage: "harness cleanup threw" },
     );
     await flushDiagnosticEvents();
@@ -3142,14 +3103,9 @@ describe("diagnostics-otel service", () => {
 
   test("honors disabled traces when an OpenTelemetry SDK is preloaded", async () => {
     process.env.OPENCLAW_OTEL_PRELOADED = "1";
-    const { service, ctx } = await startOtelService({ traces: false, metrics: true });
+    const { service, ctx } = await startServiceFixture(["metrics"]);
 
-    await emitAndFlush({
-      type: "run.completed",
-      ...RUN_FIXTURE,
-      outcome: "completed",
-      durationMs: 100,
-    });
+    await emitEventAndFlush("run.completed", {}, ["trace"]);
 
     expect(traceProviderCtor).not.toHaveBeenCalled();
     expect(meterProviderCtor).not.toHaveBeenCalled();
@@ -3164,24 +3120,14 @@ describe("diagnostics-otel service", () => {
   });
 
   test("treats omitted diagnostics enabled flag as enabled", async () => {
-    await startOtelService({
-      traces: true,
+    await startServiceFixture(["traces"], {
       captureContent: true,
       configure: (ctx) => {
         delete (ctx.config.diagnostics as { enabled?: boolean }).enabled;
       },
     });
 
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      { inputMessages: ["user prompt"] },
-    );
+    emitTrustedModelCallCompletedWithContent({ inputMessages: ["user prompt"] });
     await flushDiagnosticEvents();
 
     const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
@@ -3189,11 +3135,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("tears down active handles when restarted with diagnostics disabled", async () => {
-    const { service, ctx: enabledCtx } = await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: true,
-    });
+    const { service, ctx: enabledCtx } = await startServiceFixture(["traces", "metrics", "logs"]);
     await service.start({
       ...enabledCtx,
       config: { diagnostics: { enabled: false } },
@@ -3204,8 +3146,7 @@ describe("diagnostics-otel service", () => {
     expect(meterProviderShutdown).toHaveBeenCalledTimes(1);
 
     telemetryState.tracer.startSpan.mockClear();
-    emitDiagnosticEvent({
-      type: "message.processed",
+    emitEvent("message.processed", {
       channel: "telegram",
       outcome: "completed",
       durationMs: 10,
@@ -3280,11 +3221,8 @@ describe("diagnostics-otel service", () => {
   });
 
   test("applies flush interval to trace batching", async () => {
-    await startOtelService({
-      traces: true,
-      configure: (ctx) => {
-        ctx.config.diagnostics!.otel!.flushIntervalMs = 250;
-      },
+    await startServiceFixture(["traces"], (ctx) => {
+      ctx.config.diagnostics!.otel!.flushIntervalMs = 250;
     });
 
     expect(spanProcessorCtor).toHaveBeenCalledTimes(1);
@@ -3292,7 +3230,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("passes explicit NodeSDK batch and metric defaults to private providers", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     expect(firstSpanProcessorOptions()).toMatchObject({
       exportTimeoutMillis: 30_000,
@@ -3316,11 +3254,8 @@ describe("diagnostics-otel service", () => {
 
   test("lets explicit OpenClaw sampling override the inherited sampler environment", async () => {
     process.env.OTEL_TRACES_SAMPLER = "always_off";
-    await startOtelService({
-      traces: true,
-      configure: (ctx) => {
-        ctx.config.diagnostics!.otel!.sampleRate = 1;
-      },
+    await startServiceFixture(["traces"], (ctx) => {
+      ctx.config.diagnostics!.otel!.sampleRate = 1;
     });
 
     const traceOptions = mockCallArg(traceProviderCtor, 0) as Record<string, unknown>;
@@ -3336,7 +3271,7 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_METRIC_EXPORT_INTERVAL = "4000";
     process.env.OTEL_METRIC_EXPORT_TIMEOUT = "3000";
 
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     expect(firstSpanProcessorOptions()).toMatchObject({
       exportTimeoutMillis: 2500,
@@ -3360,7 +3295,7 @@ describe("diagnostics-otel service", () => {
       process.env.OTEL_METRIC_EXPORT_INTERVAL = value;
       process.env.OTEL_METRIC_EXPORT_TIMEOUT = value;
 
-      await startOtelService({ traces: true, metrics: true });
+      await startServiceFixture(["traces", "metrics"]);
 
       expect(firstSpanProcessorOptions()).toMatchObject({
         exportTimeoutMillis: 30_000,
@@ -3380,7 +3315,7 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_METRIC_EXPORT_TIMEOUT = "3000";
     process.env.OTEL_NODE_EXPERIMENTAL_SDK_METRICS = "true";
 
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     expect(firstMetricReaderOptions()).toMatchObject({
       exportIntervalMillis: 2000,
@@ -3401,7 +3336,7 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_BSP_MAX_QUEUE_SIZE = "16";
     process.env.OTEL_BSP_MAX_EXPORT_BATCH_SIZE = "32";
 
-    await startOtelService({ traces: true });
+    await startServiceFixture(["traces"]);
 
     expect(firstSpanProcessorOptions()).toMatchObject({
       maxExportBatchSize: 16,
@@ -3411,11 +3346,8 @@ describe("diagnostics-otel service", () => {
 
   test("merges configured service resource after detected environment attributes", async () => {
     process.env.OTEL_SERVICE_NAME = "environment-service";
-    const { ctx } = await startOtelService({
-      traces: true,
-      configure: (serviceContext) => {
-        serviceContext.config.diagnostics!.otel!.serviceName = "configured-service";
-      },
+    const { ctx } = await startServiceFixture(["traces"], (serviceContext) => {
+      serviceContext.config.diagnostics!.otel!.serviceName = "configured-service";
     });
 
     expect(
@@ -3430,11 +3362,8 @@ describe("diagnostics-otel service", () => {
   });
 
   test("applies flush interval to log batching", async () => {
-    await startOtelService({
-      logs: true,
-      configure: (ctx) => {
-        ctx.config.diagnostics!.otel!.flushIntervalMs = 250;
-      },
+    await startServiceFixture(["logs"], (ctx) => {
+      ctx.config.diagnostics!.otel!.flushIntervalMs = 250;
     });
 
     expect(logProcessorCtor).toHaveBeenCalledTimes(1);
@@ -3470,11 +3399,7 @@ describe("diagnostics-otel service", () => {
       "https://metric-env.example.com/v1/traces?tenant=red";
     process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "https://log-env.example.com/otlp/";
 
-    await startOtelService({
-      traces: true,
-      metrics: true,
-      logs: true,
-    });
+    await startServiceFixture(["traces", "metrics", "logs"]);
 
     const traceOptions = firstExporterOptions(traceExporterCtor);
     const metricOptions = firstExporterOptions(metricExporterCtor);
@@ -3490,7 +3415,7 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "https://metric-env.example.com/v1/metrics";
     process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "https://log-env.example.com/v1/logs";
 
-    await startOtelService({ traces: true, metrics: true, logs: true });
+    await startServiceFixture(["traces", "metrics", "logs"]);
 
     expect(firstExporterOptions(traceExporterCtor).url).toBe(
       "https://trace-env.example.com/v1/traces",
@@ -3507,7 +3432,7 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "\u2000";
     process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "\ufeff";
 
-    await startOtelService({ traces: true, metrics: true, logs: true });
+    await startServiceFixture(["traces", "metrics", "logs"]);
 
     expect(firstExporterOptions(traceExporterCtor).url).toBe(`${OTEL_TEST_ENDPOINT}/v1/traces`);
     expect(firstExporterOptions(metricExporterCtor).url).toBe(`${OTEL_TEST_ENDPOINT}/v1/metrics`);
@@ -3576,7 +3501,7 @@ describe("diagnostics-otel service", () => {
       } else {
         process.env.OTEL_NODE_RESOURCE_DETECTORS = env;
       }
-      await startOtelService({ traces: true });
+      await startServiceFixture(["traces"]);
       const call = detectResourcesMock.mock.calls.at(-1)?.[0] as
         | { detectors?: Array<{ detector: string }> }
         | undefined;
@@ -3597,7 +3522,7 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT =
       "https://operator:qa-preloaded-metric-password@[";
 
-    await startOtelService({ traces: true, metrics: true, logs: false });
+    await startServiceFixture(["traces", "metrics"]);
 
     expect(traceProviderCtor).not.toHaveBeenCalled();
     expect(meterProviderCtor).not.toHaveBeenCalled();
@@ -3791,7 +3716,7 @@ describe("diagnostics-otel service", () => {
       "/definitely-missing/qa-otel-shadowed-shared-root.pem";
     process.env.OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE = process.execPath;
 
-    await startOtelService({ traces: true });
+    await startServiceFixture(["traces"]);
 
     expect(traceExporterCtor).toHaveBeenCalledTimes(1);
   });
@@ -3812,7 +3737,7 @@ describe("diagnostics-otel service", () => {
     process.env.OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE =
       "/definitely-missing/qa-otel-preloaded-metrics-root.pem";
 
-    await startOtelService({ traces: true, metrics: true, logs: false });
+    await startServiceFixture(["traces", "metrics"]);
 
     expect(traceProviderCtor).not.toHaveBeenCalled();
     expect(meterProviderCtor).not.toHaveBeenCalled();
@@ -3956,9 +3881,8 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports diagnostic logs as stdout JSONL without constructing the OTLP log exporter", async () => {
-    await startOtelService({
+    await startServiceFixture(["logs"], {
       endpoint: "",
-      logs: true,
       logsExporter: "stdout",
       captureContent: true,
       configure: (ctx) => {
@@ -4009,9 +3933,7 @@ describe("diagnostics-otel service", () => {
 
     try {
       await startOtelService({ logs: true, logsExporter: "otlp" });
-      emitDiagnosticEvent({
-        type: "log.record",
-        level: "INFO",
+      emitEvent("log.record", {
         message: "otlp only",
       });
       await flushDiagnosticEvents();
@@ -4029,8 +3951,7 @@ describe("diagnostics-otel service", () => {
 
     try {
       await startOtelService({ logs: true, logsExporter: "both" });
-      emitDiagnosticEvent({
-        type: "log.record",
+      emitEvent("log.record", {
         level: "ERROR",
         message: "both sinks",
         attributes: {
@@ -4206,15 +4127,13 @@ describe("diagnostics-otel service", () => {
       throw new Error("export failed");
     });
     try {
-      const { ctx } = await startOtelService({ logs: true });
+      const { ctx } = await startServiceFixture(["logs"]);
 
-      emitDiagnosticEvent({
-        type: "log.record",
+      emitEvent("log.record", {
         level: "ERROR",
         message: "first failing log",
       });
-      emitDiagnosticEvent({
-        type: "log.record",
+      emitEvent("log.record", {
         level: "ERROR",
         message: "second failing log",
       });
@@ -4223,8 +4142,7 @@ describe("diagnostics-otel service", () => {
       expect(ctx.logger.error).toHaveBeenCalledTimes(1);
 
       nowSpy.mockReturnValue(62_000);
-      emitDiagnosticEvent({
-        type: "log.record",
+      emitEvent("log.record", {
         level: "ERROR",
         message: "third failing log",
       });
@@ -4237,12 +4155,10 @@ describe("diagnostics-otel service", () => {
   });
 
   test("does not parent diagnostic event spans from plugin-emittable trace context", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitDiagnosticEvent({
-      type: "model.usage",
+    emitEvent("model.usage", {
       trace: createTestTrace(SPAN_ID),
-      ...MODEL_FIXTURE,
       usage: { total: 4 },
       durationMs: 12,
     });
@@ -4255,7 +4171,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports GenAI client token usage histogram for input and output only", async () => {
-    await startOtelService({ metrics: true });
+    await startServiceFixture(["metrics"]);
 
     await emitAndFlush({
       type: "model.usage",
@@ -4308,7 +4224,7 @@ describe("diagnostics-otel service", () => {
     const priorSdkBoundaries = [
       0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000,
     ];
-    await startOtelService({ metrics: true });
+    await startServiceFixture(["metrics"]);
 
     const runDurationOptions = histogramCreateOptions("openclaw.run.duration_ms");
     expect(runDurationOptions?.unit).toBe("ms");
@@ -4337,7 +4253,7 @@ describe("diagnostics-otel service", () => {
       "Agent:qa:otel-trace-smoke",
     ],
   ])("%s", async (_name, agentId) => {
-    await startOtelService({ metrics: true });
+    await startServiceFixture(["metrics"]);
 
     await emitAndFlush({
       type: "model.usage",
@@ -4372,10 +4288,9 @@ describe("diagnostics-otel service", () => {
       "session-main",
     ],
   ])("%s", async (_name, lane, expected, omitted) => {
-    await startOtelService({ metrics: true });
+    await startServiceFixture(["metrics"]);
 
-    await emitAndFlush({
-      type: "queue.lane.enqueue",
+    await emitEventAndFlush("queue.lane.enqueue", {
       lane,
       queueSize: 2,
     });
@@ -4392,7 +4307,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("keeps GenAI token usage metric model attribute present when model is unavailable", async () => {
-    await startOtelService({ metrics: true });
+    await startServiceFixture(["metrics"]);
 
     await emitAndFlush({
       type: "model.usage",
@@ -4412,7 +4327,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports GenAI usage attributes on model usage spans without diagnostic identifiers", async () => {
-    await startOtelService({ traces: true });
+    await startServiceFixture(["traces"]);
 
     await emitAndFlush({
       type: "model.usage",
@@ -4453,7 +4368,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("separates request and turn GenAI client duration by operation", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitDiagnosticEvent({
       type: "model.call.completed",
@@ -4569,10 +4484,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports skill usage counter and span without raw identifiers", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    await emitTrustedAndFlush({
-      type: "skill.used",
+    await emitTrustedEventAndFlush("skill.used", {
       agentId: "main",
       runId: "run-should-not-export",
       sessionKey: "session-should-not-export",
@@ -4603,24 +4517,18 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports run, model call, and tool execution lifecycle spans", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitDiagnosticEvent({
-      type: "run.completed",
+    emitEvent("run.completed", {
       runId: "run-1",
       sessionKey: "session-key",
       ...MODEL_FIXTURE,
       channel: "webchat",
-      outcome: "completed",
-      durationMs: 100,
       trace: createTestTrace(SPAN_ID),
     });
-    emitDiagnosticEvent({
-      type: "model.call.completed",
-      ...MODEL_CALL_FIXTURE,
+    emitEvent("model.call.completed", {
       api: "completions",
       transport: "http",
-      durationMs: 80,
       requestPayloadBytes: 1234,
       responseStreamBytes: 567,
       timeToFirstByteMs: 45,
@@ -4643,8 +4551,7 @@ describe("diagnostics-otel service", () => {
       },
       trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
     });
-    emitDiagnosticEvent({
-      type: "harness.run.completed",
+    emitEvent("harness.run.completed", {
       runId: "run-1",
       sessionKey: "session-key",
       sessionId: "session-1",
@@ -4653,21 +4560,13 @@ describe("diagnostics-otel service", () => {
       channel: "qa",
       harnessId: "codex",
       pluginId: "codex-plugin",
-      outcome: "completed",
-      durationMs: 90,
       resultClassification: "reasoning-only",
       yieldDetected: true,
       itemLifecycle: { startedCount: 3, completedCount: 2, activeCount: 1 },
-      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    await emitAndFlush({
-      type: "tool.execution.error",
-      runId: "run-1",
-      toolName: "read",
+    await emitEventAndFlush("tool.execution.error", {
       toolCallId: "tool-1",
       paramsSummary: { kind: "object" },
-      durationMs: 20,
-      errorCategory: "TypeError",
       errorCode: "429",
       trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
@@ -4801,18 +4700,16 @@ describe("diagnostics-otel service", () => {
   });
 
   test("closes a tracked blocked tool span once without creating a duplicate", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitTrustedDiagnosticEvent({
-      type: "tool.execution.started",
+    emitTrustedEvent("tool.execution.started", {
       runId: "run-blocked",
       toolName: "exec",
       toolCallId: "call-blocked",
       sourceTimestampMs: 1_000,
       trace: createTestTrace(TOOL_SPAN_ID, CHILD_SPAN_ID),
     });
-    await emitTrustedAndFlush({
-      type: "tool.execution.blocked",
+    await emitTrustedEventAndFlush("tool.execution.blocked", {
       runId: "run-blocked",
       toolName: "exec",
       toolCallId: "call-blocked",
@@ -4832,7 +4729,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("uses authoritative source timestamps for terminal-only tool spans", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitTrustedDiagnosticEvent({
       type: "tool.execution.completed",
@@ -4866,10 +4763,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports model failover spans", async () => {
-    await startOtelService({ traces: true });
+    await startServiceFixture(["traces"]);
 
-    await emitTrustedAndFlush({
-      type: "model.failover",
+    await emitTrustedEventAndFlush("model.failover", {
       sessionId: "session-1",
       lane: "main",
       fromProvider: "anthropic",
@@ -4909,10 +4805,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("records blocked tool metrics even when traces are disabled", async () => {
-    await startOtelService({ metrics: true, traces: false });
+    await startServiceFixture(["metrics"]);
 
-    await emitTrustedAndFlush({
-      type: "tool.execution.blocked",
+    await emitTrustedEventAndFlush("tool.execution.blocked", {
       runId: "run-should-not-export",
       toolName: "browser",
       toolSource: "mcp",
@@ -4941,10 +4836,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("drops session-shaped queue lanes from model failover spans", async () => {
-    await startOtelService({ traces: true });
+    await startServiceFixture(["traces"]);
 
-    await emitAndFlush({
-      type: "model.failover",
+    await emitEventAndFlush("model.failover", {
       lane: "session:Agent:qa:otel-trace-smoke",
       reason: "overloaded",
       fromProvider: "anthropic",
@@ -4957,7 +4851,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("maps model call APIs and preserves zero usage on terminal spans", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
     const zeroUsage = {
       input: 0,
       output: 0,
@@ -5057,7 +4951,7 @@ describe("diagnostics-otel service", () => {
   test("uses latest GenAI request and agent span shapes only when semconv opt-in is set", async () => {
     process.env.OTEL_SEMCONV_STABILITY_OPT_IN = "http,gen_ai_latest_experimental";
 
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitDiagnosticEvent({
       type: "model.call.completed",
@@ -5107,7 +5001,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("records upstream request id hashes as model call span events only", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     await emitAndFlush({
       type: "model.call.error",
@@ -5138,15 +5032,12 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports trusted context assembly spans without prompt content", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
-      ...RUN_FIXTURE,
+    emitTrustedEvent("run.started", {
       trace: createTestTrace(SPAN_ID),
     });
-    await emitTrustedAndFlush({
-      type: "context.assembled",
+    await emitTrustedEventAndFlush("context.assembled", {
       runId: "run-1",
       sessionKey: "session-key",
       sessionId: "session-id",
@@ -5195,10 +5086,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports tool loop diagnostics without loop messages or session identifiers", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    await emitAndFlush({
-      type: "tool.loop",
+    await emitEventAndFlush("tool.loop", {
       sessionKey: "session-key",
       sessionId: "session-id",
       toolName: "process",
@@ -5236,10 +5126,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports diagnostic memory samples and pressure without session identifiers", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitDiagnosticEvent({
-      type: "diagnostic.memory.sample",
+    emitEvent("diagnostic.memory.sample", {
       uptimeMs: 1234,
       memory: {
         rssBytes: 100,
@@ -5249,8 +5138,7 @@ describe("diagnostics-otel service", () => {
         arrayBuffersBytes: 5,
       },
     });
-    await emitAndFlush({
-      type: "diagnostic.memory.pressure",
+    await emitEventAndFlush("diagnostic.memory.pressure", {
       level: "critical",
       reason: "rss_growth",
       thresholdBytes: 512,
@@ -5303,10 +5191,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("records async diagnostic queue drop summaries", async () => {
-    await startOtelService({ metrics: true });
+    await startServiceFixture(["metrics"]);
 
-    await emitAndFlush({
-      type: "diagnostic.async_queue.dropped",
+    await emitEventAndFlush("diagnostic.async_queue.dropped", {
       droppedEvents: 4,
       droppedTrustedEvents: 1,
       droppedUntrustedEvents: 2,
@@ -5332,41 +5219,18 @@ describe("diagnostics-otel service", () => {
   });
 
   test("parents trusted diagnostic lifecycle spans from active started spans", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitRunStarted();
-    emitTrustedDiagnosticEvent({
-      type: "model.call.started",
-      ...MODEL_CALL_FIXTURE,
+    emitTrustedEvent("model.call.started", {
       trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
-      type: "tool.execution.started",
-      runId: "run-1",
-      toolName: "read",
-      trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
-    });
-    emitTrustedDiagnosticEvent({
-      type: "tool.execution.error",
-      runId: "run-1",
-      toolName: "read",
-      durationMs: 20,
-      errorCategory: "TypeError",
-      trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
-    });
-    emitTrustedDiagnosticEvent({
-      type: "model.call.completed",
-      ...MODEL_CALL_FIXTURE,
-      durationMs: 80,
+    emitTrustedEvent("tool.execution.started", {});
+    emitTrustedEvent("tool.execution.error", {});
+    emitTrustedEvent("model.call.completed", {
       trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    await emitTrustedAndFlush({
-      type: "run.completed",
-      ...RUN_FIXTURE,
-      outcome: "completed",
-      durationMs: 100,
-      trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
-    });
+    await emitTrustedEventAndFlush("run.completed", {});
 
     const runSpan = telemetryState.spans.find((span) => span.name === "openclaw.run");
     const modelSpan = telemetryState.spans.find((span) => span.name === "openclaw.model.call");
@@ -5399,35 +5263,30 @@ describe("diagnostics-otel service", () => {
   });
 
   test("correlates one channel message waterfall across message, harness, usage, and model spans", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitTrustedDiagnosticEvent({
-      type: "message.dispatch.started",
+    emitTrustedEvent("message.dispatch.started", {
       channel: "slack",
       source: "replyResolver",
       sessionKey: "agent:main:slack:channel:c1",
       trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
-      type: "harness.run.started",
+    emitTrustedEvent("harness.run.started", {
       runId: "run-1",
       harnessId: "codex",
       pluginId: "codex",
       provider: "openai",
       model: "gpt-5.5",
       channel: "slack",
-      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
+    emitTrustedEvent("run.started", {
       runId: "run-1",
       provider: "openai",
       model: "gpt-5.5",
       channel: "slack",
       trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
-      type: "model.call.started",
+    emitTrustedEvent("model.call.started", {
       runId: "run-1",
       callId: "call-1",
       provider: "openai",
@@ -5436,19 +5295,16 @@ describe("diagnostics-otel service", () => {
       transport: "stdio",
       trace: createTestTrace(MODEL_CALL_SPAN_ID, TOOL_SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
-      type: "model.call.completed",
+    emitTrustedEvent("model.call.completed", {
       runId: "run-1",
       callId: "call-1",
       provider: "openai",
       model: "gpt-5.5",
       api: "openai-codex-responses",
       transport: "stdio",
-      durationMs: 80,
       trace: createTestTrace(MODEL_CALL_SPAN_ID, TOOL_SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
-      type: "harness.run.completed",
+    emitTrustedEvent("harness.run.completed", {
       runId: "run-1",
       harnessId: "codex",
       pluginId: "codex",
@@ -5456,23 +5312,16 @@ describe("diagnostics-otel service", () => {
       model: "gpt-5.5",
       channel: "slack",
       durationMs: 100,
-      outcome: "completed",
-      itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
-      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    emitTrustedDiagnosticEvent({
-      type: "model.usage",
+    emitTrustedEvent("model.usage", {
       sessionKey: "agent:main:slack:channel:c1",
       channel: "slack",
       agentId: "main",
       provider: "openai",
       model: "gpt-5.5",
-      usage: { input: 3, output: 2, total: 5 },
-      durationMs: 10,
       trace: createTestTrace(MODEL_USAGE_SPAN_ID, GRANDCHILD_SPAN_ID),
     });
-    await emitTrustedAndFlush({
-      type: "message.processed",
+    await emitTrustedEventAndFlush("message.processed", {
       channel: "slack",
       sessionKey: "agent:main:slack:channel:c1",
       durationMs: 120,
@@ -5511,7 +5360,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("prepares model and tool spans synchronously for propagation without duplicate spans", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     const runTrace = createTestTrace(CHILD_SPAN_ID, SPAN_ID);
     const modelTrace = createTestTrace(MODEL_CALL_SPAN_ID, CHILD_SPAN_ID);
@@ -5520,9 +5369,7 @@ describe("diagnostics-otel service", () => {
     expect(formatDiagnosticTraceparent(modelTrace)).toBe(
       `00-${modelTrace.traceId}-${modelTrace.spanId}-01`,
     );
-    emitTrustedDiagnosticEvent({
-      type: "model.call.started",
-      ...MODEL_CALL_FIXTURE,
+    emitTrustedEvent("model.call.started", {
       trace: modelTrace,
     });
 
@@ -5533,10 +5380,7 @@ describe("diagnostics-otel service", () => {
       `00-${modelTrace.traceId}-${modelTrace.spanId}-01`,
     );
 
-    emitTrustedDiagnosticEvent({
-      type: "tool.execution.started",
-      runId: "run-1",
-      toolName: "read",
+    emitTrustedEvent("tool.execution.started", {
       trace: toolTrace,
     });
     expect(startedSpanParentContexts("openclaw.tool.execution")).toEqual([modelSpanContext]);
@@ -5559,7 +5403,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("uses production message lifecycle helpers as the message span anchor", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     const messageTrace = createDiagnosticTraceContext(createTestTrace(CHILD_SPAN_ID, SPAN_ID));
 
@@ -5569,25 +5413,20 @@ describe("diagnostics-otel service", () => {
         sessionKey: "agent:main:slack:channel:c1",
         source: "replyResolver",
       });
-      emitTrustedDiagnosticEvent({
-        type: "harness.run.started",
+      emitTrustedEvent("harness.run.started", {
         runId: "run-1",
         harnessId: "codex",
         pluginId: "codex",
         provider: "openai",
         model: "gpt-5.5",
         channel: "slack",
-        trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
       });
-      emitTrustedDiagnosticEvent({
-        type: "model.usage",
+      emitTrustedEvent("model.usage", {
         sessionKey: "agent:main:slack:channel:c1",
         channel: "slack",
         agentId: "main",
         provider: "openai",
         model: "gpt-5.5",
-        usage: { input: 3, output: 2, total: 5 },
-        durationMs: 10,
         trace: createTestTrace(MODEL_USAGE_SPAN_ID, GRANDCHILD_SPAN_ID),
       });
       logMessageProcessed({
@@ -5619,7 +5458,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("does not force a remote parent for root message lifecycle helpers", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     const messageTrace = createDiagnosticTraceContext(createTestTrace(CHILD_SPAN_ID));
 
@@ -5643,7 +5482,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("parents outbound delivery spans under the active message lifecycle span", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     const messageTrace = createDiagnosticTraceContext(createTestTrace(CHILD_SPAN_ID, SPAN_ID));
 
@@ -5653,16 +5492,14 @@ describe("diagnostics-otel service", () => {
         sessionKey: "agent:main:slack:channel:c1",
         source: "replyResolver",
       });
-      emitInternalDiagnosticEventForTest({
-        type: "message.delivery.completed",
+      emitInternalEvent("message.delivery.completed", {
         channel: "slack",
         deliveryKind: "text",
         sessionKey: "agent:main:slack:channel:c1",
         durationMs: 15,
         resultCount: 1,
       });
-      emitInternalDiagnosticEventForTest({
-        type: "message.delivery.error",
+      emitInternalEvent("message.delivery.error", {
         channel: "slack",
         deliveryKind: "media",
         sessionKey: "agent:main:slack:channel:c1",
@@ -5689,7 +5526,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("parents multi-batch late delivery spans from the retained message context", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     const messageTrace = createDiagnosticTraceContext(createTestTrace(CHILD_SPAN_ID, SPAN_ID));
 
@@ -5700,8 +5537,7 @@ describe("diagnostics-otel service", () => {
         source: "replyResolver",
       });
       for (let index = 0; index < 125; index += 1) {
-        emitInternalDiagnosticEventForTest({
-          type: "message.delivery.completed",
+        emitInternalEvent("message.delivery.completed", {
           channel: "slack",
           deliveryKind: "text",
           sessionKey: `agent:main:slack:channel:c${index}`,
@@ -5731,7 +5567,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("correlates skipped duplicate message lifecycle helpers to the active inbound trace", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     const messageTrace = createDiagnosticTraceContext(createTestTrace(CHILD_SPAN_ID, SPAN_ID));
 
@@ -5760,10 +5596,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("does not force a remote parent for fallback root message processed spans", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    await emitTrustedAndFlush({
-      type: "message.processed",
+    await emitTrustedEventAndFlush("message.processed", {
       channel: "slack",
       sessionKey: "agent:main:slack:channel:c1",
       durationMs: 25,
@@ -5776,10 +5611,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("does not retain fallback message processed spans as active parents", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitTrustedDiagnosticEvent({
-      type: "message.processed",
+    emitTrustedEvent("message.processed", {
       channel: "slack",
       sessionKey: "agent:main:slack:channel:c1",
       durationMs: 25,
@@ -5789,15 +5623,13 @@ describe("diagnostics-otel service", () => {
     expect(spanByName("openclaw.message.processed").end).toHaveBeenCalledTimes(1);
 
     telemetryState.tracer.setSpanContext.mockClear();
-    emitTrustedDiagnosticEvent({
-      type: "harness.run.started",
+    emitTrustedEvent("harness.run.started", {
       runId: "run-1",
       harnessId: "codex",
       pluginId: "codex",
       provider: "openai",
       model: "gpt-5.5",
       channel: "slack",
-      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
 
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
@@ -5805,18 +5637,12 @@ describe("diagnostics-otel service", () => {
   });
 
   test("retains trusted run context long enough for exact post-completion usage parenting", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitRunStarted();
     emitRunCompleted();
     await Promise.resolve();
-    await emitTrustedAndFlush({
-      type: "model.usage",
-      ...MODEL_FIXTURE,
-      usage: { input: 3, output: 2, total: 5 },
-      durationMs: 10,
-      trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
-    });
+    await emitTrustedEventAndFlush("model.usage", {});
 
     const runSpan = telemetryState.spans.find((span) => span.name === "openclaw.run");
     const runSpanId = runSpan?.spanContext.mock.results[0]?.value?.spanId;
@@ -5838,20 +5664,13 @@ describe("diagnostics-otel service", () => {
     ["does not parent sibling active runs through shared upstream aliases", false],
     ["does not parent sibling runs through retained upstream aliases", true],
   ])("%s", async (_name, completeFirstRun) => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitRunStarted();
     if (completeFirstRun) {
-      emitTrustedDiagnosticEvent({
-        type: "run.completed",
-        ...RUN_FIXTURE,
-        outcome: "completed",
-        durationMs: 100,
-        trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
-      });
+      emitTrustedEvent("run.completed", {});
     }
-    emitTrustedDiagnosticEvent({
-      type: "run.started",
+    emitTrustedEvent("run.started", {
       runId: "run-2",
       ...MODEL_FIXTURE,
       trace: createTestTrace(GRANDCHILD_SPAN_ID, SPAN_ID),
@@ -5865,22 +5684,13 @@ describe("diagnostics-otel service", () => {
   });
 
   test("parents retained upstream alias events only when the owner matches", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitRunStarted();
-    emitTrustedDiagnosticEvent({
-      type: "model.call.completed",
-      ...MODEL_CALL_FIXTURE,
-      durationMs: 80,
+    emitTrustedEvent("model.call.completed", {
       trace: createTestTrace(MODEL_CALL_SPAN_ID, SPAN_ID),
     });
-    await emitTrustedAndFlush({
-      type: "run.completed",
-      ...RUN_FIXTURE,
-      outcome: "completed",
-      durationMs: 100,
-      trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
-    });
+    await emitTrustedEventAndFlush("run.completed", {});
 
     const runSpanContext = spanByName("openclaw.run").spanContext();
     const modelParentContext = startedSpanParentContexts("openclaw.model.call")[0];
@@ -5890,7 +5700,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("parents multi-batch late model spans from the retained run context", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitQueuedRunWithModelCalls();
 
@@ -5935,7 +5745,7 @@ describe("diagnostics-otel service", () => {
     async (spanName, childEvent) => {
       vi.useFakeTimers({ toFake: ["Date"] });
       try {
-        await startOtelService({ traces: true, metrics: true });
+        await startServiceFixture(["traces", "metrics"]);
 
         emitRunStarted();
         const runSpanContext = spanByName("openclaw.run").spanContext();
@@ -5961,7 +5771,7 @@ describe("diagnostics-otel service", () => {
   // Retained contexts outlive the turn, so this bound is what keeps a long-lived
   // gateway from growing the map without limit.
   test("bounds retained run contexts by evicting the oldest completed runs", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     // Each completed run retains its own span id plus its upstream alias, so
     // this comfortably overflows the bound and evicts the earliest run.
@@ -5975,18 +5785,10 @@ describe("diagnostics-otel service", () => {
     const newestRunSpan = telemetryState.spans.findLast((span) => span.name === "openclaw.run");
     telemetryState.tracer.startSpan.mockClear();
 
-    emitTrustedDiagnosticEvent({
-      type: "model.usage",
-      ...MODEL_FIXTURE,
-      usage: { input: 3, output: 2, total: 5 },
-      durationMs: 10,
+    emitTrustedEvent("model.usage", {
       trace: createTestTrace(GRANDCHILD_SPAN_ID, newestRunSpanId),
     });
-    emitTrustedDiagnosticEvent({
-      type: "model.usage",
-      ...MODEL_FIXTURE,
-      usage: { input: 3, output: 2, total: 5 },
-      durationMs: 10,
+    emitTrustedEvent("model.usage", {
       trace: createTestTrace(MODEL_USAGE_SPAN_ID, numberedSpanId(0)),
     });
 
@@ -5996,7 +5798,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("clears retained run contexts when the service stops", async () => {
-    const { service, ctx } = await startOtelService({ traces: true, metrics: true });
+    const { service, ctx } = await startServiceFixture(["traces", "metrics"]);
 
     emitRunStarted();
     emitRunCompleted();
@@ -6024,19 +5826,12 @@ describe("diagnostics-otel service", () => {
       createTestTrace(GRANDCHILD_SPAN_ID),
     ],
   ])("%s", async (_name, runTrace, modelTrace) => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitTrustedDiagnosticEvent({
-      type: "run.completed",
-      ...RUN_FIXTURE,
-      outcome: "completed",
-      durationMs: 100,
+    emitTrustedEvent("run.completed", {
       trace: runTrace,
     });
-    await emitTrustedAndFlush({
-      type: "model.call.completed",
-      ...MODEL_CALL_FIXTURE,
-      durationMs: 80,
+    await emitTrustedEventAndFlush("model.call.completed", {
       trace: modelTrace,
     });
 
@@ -6077,7 +5872,7 @@ describe("diagnostics-otel service", () => {
       } satisfies TrustedEventOf<"harness.run.error">,
     },
   ])("keeps $label-only harness fallback spans parentless", async ({ event }) => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     await emitTrustedAndFlush(event);
 
@@ -6085,28 +5880,13 @@ describe("diagnostics-otel service", () => {
   });
 
   test("does not parent untrusted diagnostic lifecycle spans from injected trace ids", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitDiagnosticEvent({
-      type: "run.completed",
-      ...RUN_FIXTURE,
-      outcome: "completed",
-      durationMs: 100,
-      trace: createTestTrace(CHILD_SPAN_ID, SPAN_ID),
-    });
-    emitDiagnosticEvent({
-      type: "model.call.completed",
-      ...MODEL_CALL_FIXTURE,
-      durationMs: 80,
+    emitEvent("run.completed", {});
+    emitEvent("model.call.completed", {
       trace: createTestTrace(GRANDCHILD_SPAN_ID, CHILD_SPAN_ID),
     });
-    await emitAndFlush({
-      type: "tool.execution.completed",
-      runId: "run-1",
-      toolName: "read",
-      durationMs: 20,
-      trace: createTestTrace(TOOL_SPAN_ID, GRANDCHILD_SPAN_ID),
-    });
+    await emitEventAndFlush("tool.execution.completed", {});
 
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
     const parentBySpanName = Object.fromEntries(
@@ -6118,39 +5898,14 @@ describe("diagnostics-otel service", () => {
   });
 
   test("does not create live started spans for untrusted lifecycle diagnostics", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitDiagnosticEvent({
-      type: "run.started",
-      ...RUN_FIXTURE,
-    });
-    emitDiagnosticEvent({
-      type: "run.completed",
-      ...RUN_FIXTURE,
-      outcome: "completed",
-      durationMs: 100,
-    });
-    emitDiagnosticEvent({
-      type: "model.call.started",
-      ...MODEL_CALL_FIXTURE,
-    });
-    emitDiagnosticEvent({
-      type: "model.call.completed",
-      ...MODEL_CALL_FIXTURE,
-      durationMs: 80,
-    });
-    emitDiagnosticEvent({
-      type: "tool.execution.started",
-      runId: "run-1",
-      toolName: "read",
-    });
-    emitDiagnosticEvent({
-      type: "tool.execution.error",
-      runId: "run-1",
-      toolName: "read",
-      durationMs: 20,
-      errorCategory: "TypeError",
-    });
+    emitEvent("run.started", {}, ["trace"]);
+    emitEvent("run.completed", {}, ["trace"]);
+    emitEvent("model.call.started", {}, ["trace"]);
+    emitEvent("model.call.completed", {}, ["trace"]);
+    emitEvent("tool.execution.started", {}, ["trace"]);
+    emitEvent("tool.execution.error", {}, ["trace"]);
     emitDiagnosticEvent({
       type: "harness.run.started",
       runId: "run-1",
@@ -6193,7 +5948,7 @@ describe("diagnostics-otel service", () => {
   // Exec spans used to always be roots, which stranded every shell command in its
   // own single-span trace instead of nesting it under the run that spawned it.
   test("nests exec spans under the run when the trace context is OpenClaw-owned", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
     emitRunStarted();
     const runSpanContext = spanByName("openclaw.run").spanContext();
@@ -6220,10 +5975,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports exec process spans without command text", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    await emitAndFlush({
-      type: "exec.process.completed",
+    await emitEventAndFlush("exec.process.completed", {
       target: "host",
       mode: "child",
       outcome: "failed",
@@ -6264,24 +6018,21 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports message delivery spans and metrics with low-cardinality attributes", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitDiagnosticEvent({
-      type: "message.delivery.started",
+    emitEvent("message.delivery.started", {
       channel: "matrix",
       deliveryKind: "text",
       sessionKey: "session-secret",
     });
-    emitDiagnosticEvent({
-      type: "message.delivery.completed",
+    emitEvent("message.delivery.completed", {
       channel: "matrix",
       deliveryKind: "text",
       durationMs: 25,
       resultCount: 1,
       sessionKey: "session-secret",
     });
-    await emitAndFlush({
-      type: "message.delivery.error",
+    await emitEventAndFlush("message.delivery.error", {
       channel: "discord",
       deliveryKind: "media",
       durationMs: 40,
@@ -6348,10 +6099,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("bounds unsafe message delivery attributes before export", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    await emitAndFlush({
-      type: "message.delivery.completed",
+    await emitEventAndFlush("message.delivery.completed", {
       channel: "discord/custom",
       deliveryKind: "progress draft" as never,
       durationMs: 20,
@@ -6374,10 +6124,9 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports session recovery and talk metrics with bounded attributes", async () => {
-    await startOtelService({ metrics: true });
+    await startServiceFixture(["metrics"]);
 
-    emitTrustedDiagnosticEvent({
-      type: "session.recovery.requested",
+    emitTrustedEvent("session.recovery.requested", {
       sessionId: "session-should-not-export",
       sessionKey: "key-should-not-export",
       state: "processing",
@@ -6386,8 +6135,7 @@ describe("diagnostics-otel service", () => {
       activeWorkKind: "tool_call",
       allowActiveAbort: true,
     });
-    emitTrustedDiagnosticEvent({
-      type: "session.recovery.completed",
+    emitTrustedEvent("session.recovery.completed", {
       sessionId: "session-should-not-export",
       sessionKey: "key-should-not-export",
       state: "processing",
@@ -6397,8 +6145,7 @@ describe("diagnostics-otel service", () => {
       status: "released",
       action: "abort-active-run",
     });
-    emitTrustedDiagnosticEvent({
-      type: "talk.event",
+    emitTrustedEvent("talk.event", {
       sessionId: "talk-session-should-not-export",
       turnId: "turn-should-not-export",
       talkEventType: "input.audio.delta",
@@ -6408,8 +6155,7 @@ describe("diagnostics-otel service", () => {
       provider: "openai",
       byteLength: 320,
     });
-    await emitTrustedAndFlush({
-      type: "talk.event",
+    await emitTrustedEventAndFlush("talk.event", {
       sessionId: "talk-session-should-not-export",
       talkEventType: "latency.metrics",
       mode: "realtime",
@@ -6467,32 +6213,20 @@ describe("diagnostics-otel service", () => {
   });
 
   test("does not export model or tool content unless capture is explicitly enabled", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      {
-        inputMessages: ["private user prompt"],
-        outputMessages: ["private model reply"],
-        systemPrompt: "private system prompt",
-      },
-    );
+    emitTrustedModelCallCompletedWithContent({
+      inputMessages: ["private user prompt"],
+      outputMessages: ["private model reply"],
+      systemPrompt: "private system prompt",
+    });
     emitTrustedToolExecutionCompletedWithContent(
-      {
-        runId: "run-1",
-        toolName: "read",
-        toolCallId: "tool-1",
-        durationMs: 20,
-      },
       {
         toolInput: "private tool input",
         toolOutput: "private tool output",
+      },
+      {
+        toolCallId: "tool-1",
       },
     );
     await flushDiagnosticEvents();
@@ -6521,36 +6255,22 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports bounded redacted content when capture is enabled", async () => {
-    await startOtelService({
-      traces: true,
-      metrics: true,
+    await startServiceFixture(["traces", "metrics"], {
       captureContent: true,
     });
 
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      {
-        inputMessages: ["use key sk-1234567890abcdef1234567890abcdef"], // pragma: allowlist secret
-        outputMessages: ["model reply"],
-        systemPrompt: "system prompt",
-      },
-    );
+    emitTrustedModelCallCompletedWithContent({
+      inputMessages: ["use key sk-1234567890abcdef1234567890abcdef"], // pragma: allowlist secret
+      outputMessages: ["model reply"],
+      systemPrompt: "system prompt",
+    });
     emitTrustedToolExecutionCompletedWithContent(
-      {
-        runId: "run-1",
-        toolName: "read",
-        toolCallId: "tool-1",
-        durationMs: 20,
-      },
       {
         toolInput: "tool input",
         toolOutput: `${"x".repeat(4077)} Bearer ${"a".repeat(80)}`, // pragma: allowlist secret
+      },
+      {
+        toolCallId: "tool-1",
       },
     );
     await flushDiagnosticEvents();
@@ -6580,21 +6300,11 @@ describe("diagnostics-otel service", () => {
   });
 
   test("omits absent model content fields when capture is enabled", async () => {
-    await startOtelService({
-      traces: true,
+    await startServiceFixture(["traces"], {
       captureContent: true,
     });
 
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      { inputMessages: ["user prompt"] },
-    );
+    emitTrustedModelCallCompletedWithContent({ inputMessages: ["user prompt"] });
     await flushDiagnosticEvents();
 
     const attrs = startedSpanOptions("openclaw.model.call")?.attributes ?? {};
@@ -6608,43 +6318,31 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports Phoenix-readable GenAI prompt, output, and tool definition attributes", async () => {
-    await startOtelService({
-      traces: true,
+    await startServiceFixture(["traces"], {
       captureContent: true,
     });
 
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      {
-        inputMessages: [
-          { role: "user", content: "what changed?", timestamp: 1 },
-          {
-            role: "assistant",
-            content: [
-              { type: "toolCall", id: "call-1", name: "lookup", arguments: { q: "trace" } },
-            ],
-          },
-          { role: "toolResult", toolCallId: "call-1", content: { rows: 1 } },
-        ],
-        outputMessages: [
-          {
-            role: "assistant",
-            content: [{ type: "text", text: "the trace changed" }],
-            stopReason: "stop",
-          },
-        ],
-        systemPrompt: "be exact",
-        toolDefinitions: [
-          { name: "lookup", description: "Lookup data", parameters: { type: "object" } },
-        ],
-      },
-    );
+    emitTrustedModelCallCompletedWithContent({
+      inputMessages: [
+        { role: "user", content: "what changed?", timestamp: 1 },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call-1", name: "lookup", arguments: { q: "trace" } }],
+        },
+        { role: "toolResult", toolCallId: "call-1", content: { rows: 1 } },
+      ],
+      outputMessages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "the trace changed" }],
+          stopReason: "stop",
+        },
+      ],
+      systemPrompt: "be exact",
+      toolDefinitions: [
+        { name: "lookup", description: "Lookup data", parameters: { type: "object" } },
+      ],
+    });
     await flushDiagnosticEvents();
 
     const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
@@ -6687,21 +6385,11 @@ describe("diagnostics-otel service", () => {
   });
 
   test("exports Claude CLI turn content through the existing Phoenix GenAI keys", async () => {
-    await startOtelService({
-      traces: true,
+    await startServiceFixture(["traces"], {
       captureContent: true,
     });
 
     emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-claude-cli",
-        callId: "call-claude-cli",
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        api: "claude-code",
-        transport: "stdio-live",
-        durationMs: 80,
-      },
       {
         inputMessages: [{ role: "user", content: [{ type: "text", text: "trace this" }] }],
         outputMessages: [
@@ -6716,6 +6404,14 @@ describe("diagnostics-otel service", () => {
           },
         ],
         systemPrompt: "OpenClaw appended instructions",
+      },
+      {
+        runId: "run-claude-cli",
+        callId: "call-claude-cli",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        api: "claude-code",
+        transport: "stdio-live",
       },
     );
     await flushDiagnosticEvents();
@@ -6748,19 +6444,11 @@ describe("diagnostics-otel service", () => {
   });
 
   test("never exports provider-internal thinking payloads in model message attributes", async () => {
-    await startOtelService({
-      traces: true,
+    await startServiceFixture(["traces"], {
       captureContent: true,
     });
 
     emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        durationMs: 80,
-      },
       {
         inputMessages: [
           {
@@ -6796,6 +6484,10 @@ describe("diagnostics-otel service", () => {
             ],
           },
         ],
+      },
+      {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
       },
     );
     await flushDiagnosticEvents();
@@ -6858,45 +6550,35 @@ describe("diagnostics-otel service", () => {
   });
 
   test("emits semconv response text for tool response parts", async () => {
-    await startOtelService({
-      traces: true,
+    await startServiceFixture(["traces"], {
       captureContent: true,
     });
 
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      {
-        inputMessages: [
-          {
-            role: "tool",
-            parts: [
-              {
-                type: "tool_call_response",
-                id: "call-1",
-                result: [
-                  { type: "text", text: "first line" },
-                  { type: "text", text: "second line" },
-                ],
-              },
-            ],
-          },
-          {
-            role: "toolResult",
-            toolCallId: "call-2",
-            content: [
-              { type: "text", text: "alpha" },
-              { type: "text", text: "beta" },
-            ],
-          },
-        ],
-      },
-    );
+    emitTrustedModelCallCompletedWithContent({
+      inputMessages: [
+        {
+          role: "tool",
+          parts: [
+            {
+              type: "tool_call_response",
+              id: "call-1",
+              result: [
+                { type: "text", text: "first line" },
+                { type: "text", text: "second line" },
+              ],
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-2",
+          content: [
+            { type: "text", text: "alpha" },
+            { type: "text", text: "beta" },
+          ],
+        },
+      ],
+    });
     await flushDiagnosticEvents();
 
     const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
@@ -6925,8 +6607,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("flattens oversized pure-text tool results with a truncation marker", async () => {
-    await startOtelService({
-      traces: true,
+    await startServiceFixture(["traces"], {
       captureContent: true,
     });
 
@@ -6934,18 +6615,9 @@ describe("diagnostics-otel service", () => {
       type: "text",
       text: `line-${index}`,
     }));
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      {
-        inputMessages: [{ role: "toolResult", toolCallId: "call-1", content: textParts }],
-      },
-    );
+    emitTrustedModelCallCompletedWithContent({
+      inputMessages: [{ role: "toolResult", toolCallId: "call-1", content: textParts }],
+    });
     await flushDiagnosticEvents();
 
     const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
@@ -6960,36 +6632,26 @@ describe("diagnostics-otel service", () => {
   });
 
   test("normalizes snake_case tool_call parts the same as camelCase toolCall parts", async () => {
-    await startOtelService({
-      traces: true,
+    await startServiceFixture(["traces"], {
       captureContent: true,
     });
 
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      {
-        inputMessages: [
-          {
-            role: "assistant",
-            content: [
-              {
-                type: "tool_call",
-                id: "tc-1",
-                name: "search",
-                arguments: { q: "x" },
-                extraField: "leaked",
-              },
-            ],
-          },
-        ],
-      },
-    );
+    emitTrustedModelCallCompletedWithContent({
+      inputMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_call",
+              id: "tc-1",
+              name: "search",
+              arguments: { q: "x" },
+              extraField: "leaked",
+            },
+          ],
+        },
+      ],
+    });
     await flushDiagnosticEvents();
 
     const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
@@ -7004,8 +6666,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("truncates oversized GenAI input messages instead of silently dropping them", async () => {
-    await startOtelService({
-      traces: true,
+    await startServiceFixture(["traces"], {
       captureContent: true,
     });
 
@@ -7015,16 +6676,7 @@ describe("diagnostics-otel service", () => {
       content: `message-${i}-${"x".repeat(1024)}`,
     }));
 
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      { inputMessages: largeMessages },
-    );
+    emitTrustedModelCallCompletedWithContent({ inputMessages: largeMessages });
     await flushDiagnosticEvents();
 
     const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
@@ -7042,48 +6694,38 @@ describe("diagnostics-otel service", () => {
   });
 
   test("keeps single oversized GenAI messages and tool definitions parseable", async () => {
-    await startOtelService({
-      traces: true,
+    await startServiceFixture(["traces"], {
       captureContent: true,
     });
 
     // The 8,192-character candidate budget leaves an 8,178-character text prefix;
     // place a surrogate pair across that boundary so serialized JSON must stay valid.
     const surrogateBoundaryPrefix = "x".repeat(8177);
-    emitTrustedModelCallCompletedWithContent(
-      {
-        runId: "run-1",
-        callId: "call-1",
-        provider: "openai",
-        model: "gpt-5.4",
-        durationMs: 80,
-      },
-      {
-        inputMessages: [
-          {
-            role: "user",
-            content: `${surrogateBoundaryPrefix}🚀${"y".repeat(
-              MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS,
-            )}`,
-          },
-        ],
-        toolDefinitions: [
-          {
-            name: "huge_schema",
-            description: "Huge schema",
-            parameters: {
-              type: "object",
-              properties: {
-                payload: {
-                  type: "string",
-                  description: "x".repeat(MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS),
-                },
+    emitTrustedModelCallCompletedWithContent({
+      inputMessages: [
+        {
+          role: "user",
+          content: `${surrogateBoundaryPrefix}🚀${"y".repeat(
+            MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS,
+          )}`,
+        },
+      ],
+      toolDefinitions: [
+        {
+          name: "huge_schema",
+          description: "Huge schema",
+          parameters: {
+            type: "object",
+            properties: {
+              payload: {
+                type: "string",
+                description: "x".repeat(MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS),
               },
             },
           },
-        ],
-      },
-    );
+        },
+      ],
+    });
     await flushDiagnosticEvents();
 
     const attrs = startedSpanOptions("openclaw.model.call")?.attributes;
@@ -7113,16 +6755,14 @@ describe("diagnostics-otel service", () => {
   });
 
   test("ignores invalid diagnostic event trace parents", async () => {
-    await startOtelService({ traces: true, metrics: true });
+    await startServiceFixture(["traces", "metrics"]);
 
-    emitDiagnosticEvent({
-      type: "model.usage",
+    emitEvent("model.usage", {
       trace: {
         traceId: "0".repeat(32),
         spanId: "not-a-span",
         traceFlags: "zz",
       },
-      ...MODEL_FIXTURE,
       usage: { total: 4 },
       durationMs: 12,
     });
@@ -7135,7 +6775,7 @@ describe("diagnostics-otel service", () => {
   });
 
   test("redacts sensitive reason in session.state metric attributes", async () => {
-    await startOtelService({ metrics: true });
+    await startServiceFixture(["metrics"]);
 
     emitDiagnosticEvent({
       type: "session.state",

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -369,6 +369,81 @@ describe("memory plugin e2e", () => {
     }) as MemoryPluginTestConfig | undefined;
   }
 
+  function setupMemoryHookHarness(options: {
+    autoCapture: boolean;
+    autoRecall: boolean;
+    liveConfig?: boolean;
+    searchResults?: Array<Record<string, unknown>>;
+  }) {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const add = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => options.searchResults ?? []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => createAgentScopedVectorQuery(limit));
+    const openTable = vi.fn(async () => ({
+      schema: createAgentScopedSchemaMock(),
+      vectorSearch,
+      countRows: vi.fn(async () => 0),
+      add,
+      delete: vi.fn(async () => undefined),
+    }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable,
+      })),
+    }));
+    const pluginConfig: MemoryPluginTestConfig = {
+      embedding: {
+        apiKey: OPENAI_API_KEY,
+        model: "text-embedding-3-small",
+      },
+      dbPath: getDbPath(),
+      autoCapture: options.autoCapture,
+      autoRecall: options.autoRecall,
+    };
+    let configFile: Record<string, unknown> = {
+      plugins: { entries: { "memory-lancedb": { config: pluginConfig } } },
+    };
+
+    installOpenAiMemoryModuleMocks({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+    });
+
+    const on = vi.fn();
+    const logger = createTestLogger();
+    const mockApi = createMemoryPluginApi(getDbPath(), {
+      pluginConfig,
+      ...(options.liveConfig ? { runtime: { config: { current: () => configFile } } } : {}),
+      logger,
+      on,
+    });
+    registerTestPlugin(memoryPlugin, mockApi);
+
+    return {
+      add,
+      embeddingsCreate,
+      ensureGlobalUndiciEnvProxyDispatcher,
+      loadLanceDbModule,
+      logger,
+      on,
+      vectorSearch,
+      updateConfig(overrides: Partial<MemoryPluginTestConfig>) {
+        configFile = {
+          plugins: { entries: { "memory-lancedb": { config: { ...pluginConfig, ...overrides } } } },
+        };
+      },
+      removePluginEntry() {
+        configFile = { plugins: { entries: {} } };
+      },
+    };
+  }
+
   test("config schema parses valid config", () => {
     const config = parseConfig({
       autoCapture: true,
@@ -1802,98 +1877,26 @@ describe("memory plugin e2e", () => {
 
   test("uses live runtime config to enable auto-recall after startup disable", async () => {
     const recalledPrefix = `I prefer ${"x".repeat(90)}`;
-    const embeddingsCreate = vi.fn(async () => ({
-      data: [{ embedding: [0.1, 0.2, 0.3] }],
-    }));
-    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
-    const toArray = vi.fn(async () => [
-      {
-        id: "memory-1",
-        text: `${recalledPrefix}🚀tail`,
-        vector: [0.1, 0.2, 0.3],
-        importance: 0.8,
-        category: "preference",
-        createdAt: 1,
-        _distance: 0.1,
-      },
-    ]);
-    const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => createAgentScopedVectorQuery(limit));
-    const openTable = vi.fn(async () => ({
-      schema: createAgentScopedSchemaMock(),
-      vectorSearch,
-      countRows: vi.fn(async () => 0),
-      add: vi.fn(async () => undefined),
-      delete: vi.fn(async () => undefined),
-    }));
-    const loadLanceDbModule = vi.fn(async () => ({
-      connect: vi.fn(async () => ({
-        tableNames: vi.fn(async () => ["memories"]),
-        openTable,
-      })),
-    }));
-    let configFile: Record<string, unknown> = {
-      plugins: {
-        entries: {
-          "memory-lancedb": {
-            config: {
-              embedding: {
-                apiKey: OPENAI_API_KEY,
-                model: "text-embedding-3-small",
-              },
-              dbPath: getDbPath(),
-              autoCapture: false,
-              autoRecall: false,
-            },
+    const { embeddingsCreate, loadLanceDbModule, logger, on, updateConfig } =
+      setupMemoryHookHarness({
+        autoCapture: false,
+        autoRecall: false,
+        liveConfig: true,
+        searchResults: [
+          {
+            id: "memory-1",
+            text: `${recalledPrefix}🚀tail`,
+            vector: [0.1, 0.2, 0.3],
+            importance: 0.8,
+            category: "preference",
+            createdAt: 1,
+            _distance: 0.1,
           },
-        },
-      },
-    };
-
-    installOpenAiMemoryModuleMocks({
-      ensureGlobalUndiciEnvProxyDispatcher,
-      embeddingsCreate,
-      loadLanceDbModule,
-    });
-
-    try {
-      const on = vi.fn();
-      const logger = {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-        debug: vi.fn(),
-      };
-      const mockApi = createMemoryPluginApi(getDbPath(), {
-        runtime: {
-          config: {
-            current: () => configFile,
-          },
-        },
-        logger,
-        on,
+        ],
       });
 
-      registerTestPlugin(memoryPlugin, mockApi);
-
-      configFile = {
-        plugins: {
-          entries: {
-            "memory-lancedb": {
-              config: {
-                embedding: {
-                  apiKey: OPENAI_API_KEY,
-                  model: "text-embedding-3-small",
-                },
-                dbPath: getDbPath(),
-                autoCapture: false,
-                autoRecall: true,
-                recallMaxChars: 100,
-              },
-            },
-          },
-        },
-      };
+    try {
+      updateConfig({ autoRecall: true, recallMaxChars: 100 });
 
       const beforePromptBuild = on.mock.calls.find(
         ([hookName]) => hookName === "before_prompt_build",
@@ -1919,87 +1922,14 @@ describe("memory plugin e2e", () => {
   });
 
   test("uses live runtime config to skip auto-recall after registration", async () => {
-    const embeddingsCreate = vi.fn(async () => ({
-      data: [{ embedding: [0.1, 0.2, 0.3] }],
-    }));
-    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
-    const loadLanceDbModule = vi.fn(async () => ({
-      connect: vi.fn(async () => ({
-        tableNames: vi.fn(async () => ["memories"]),
-        openTable: vi.fn(async () => ({
-          schema: createAgentScopedSchemaMock(),
-          vectorSearch: vi.fn(() =>
-            createAgentScopedVectorQuery(vi.fn(() => ({ toArray: vi.fn(async () => []) }))),
-          ),
-          countRows: vi.fn(async () => 0),
-          add: vi.fn(async () => undefined),
-          delete: vi.fn(async () => undefined),
-        })),
-      })),
-    }));
-    let configFile: Record<string, unknown> = {
-      plugins: {
-        entries: {
-          "memory-lancedb": {
-            config: {
-              embedding: {
-                apiKey: OPENAI_API_KEY,
-                model: "text-embedding-3-small",
-              },
-              dbPath: getDbPath(),
-              autoCapture: false,
-              autoRecall: true,
-            },
-          },
-        },
-      },
-    };
-
-    installOpenAiMemoryModuleMocks({
-      ensureGlobalUndiciEnvProxyDispatcher,
-      embeddingsCreate,
-      loadLanceDbModule,
+    const { embeddingsCreate, loadLanceDbModule, on, updateConfig } = setupMemoryHookHarness({
+      autoCapture: false,
+      autoRecall: true,
+      liveConfig: true,
     });
 
     try {
-      const on = vi.fn();
-      const mockApi = createMemoryPluginApi(getDbPath(), {
-        pluginConfig: {
-          embedding: {
-            apiKey: OPENAI_API_KEY,
-            model: "text-embedding-3-small",
-          },
-          dbPath: getDbPath(),
-          autoCapture: false,
-          autoRecall: true,
-        },
-        runtime: {
-          config: {
-            current: () => configFile,
-          },
-        },
-        on,
-      });
-
-      registerTestPlugin(memoryPlugin, mockApi);
-
-      configFile = {
-        plugins: {
-          entries: {
-            "memory-lancedb": {
-              config: {
-                embedding: {
-                  apiKey: OPENAI_API_KEY,
-                  model: "text-embedding-3-small",
-                },
-                dbPath: getDbPath(),
-                autoCapture: false,
-                autoRecall: false,
-              },
-            },
-          },
-        },
-      };
+      updateConfig({ autoRecall: false });
 
       const beforePromptBuild = on.mock.calls.find(
         ([hookName]) => hookName === "before_prompt_build",
@@ -2198,75 +2128,14 @@ describe("memory plugin e2e", () => {
   });
 
   test("fails closed for auto-recall when the live plugin entry is removed", async () => {
-    const embeddingsCreate = vi.fn(async () => ({
-      data: [{ embedding: [0.1, 0.2, 0.3] }],
-    }));
-    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
-    const loadLanceDbModule = vi.fn(async () => ({
-      connect: vi.fn(async () => ({
-        tableNames: vi.fn(async () => ["memories"]),
-        openTable: vi.fn(async () => ({
-          schema: createAgentScopedSchemaMock(),
-          vectorSearch: vi.fn(() =>
-            createAgentScopedVectorQuery(vi.fn(() => ({ toArray: vi.fn(async () => []) }))),
-          ),
-          countRows: vi.fn(async () => 0),
-          add: vi.fn(async () => undefined),
-          delete: vi.fn(async () => undefined),
-        })),
-      })),
-    }));
-    let configFile: Record<string, unknown> = {
-      plugins: {
-        entries: {
-          "memory-lancedb": {
-            config: {
-              embedding: {
-                apiKey: OPENAI_API_KEY,
-                model: "text-embedding-3-small",
-              },
-              dbPath: getDbPath(),
-              autoCapture: false,
-              autoRecall: true,
-            },
-          },
-        },
-      },
-    };
-
-    installOpenAiMemoryModuleMocks({
-      ensureGlobalUndiciEnvProxyDispatcher,
-      embeddingsCreate,
-      loadLanceDbModule,
+    const { embeddingsCreate, loadLanceDbModule, on, removePluginEntry } = setupMemoryHookHarness({
+      autoCapture: false,
+      autoRecall: true,
+      liveConfig: true,
     });
 
     try {
-      const on = vi.fn();
-      const mockApi = createMemoryPluginApi(getDbPath(), {
-        pluginConfig: {
-          embedding: {
-            apiKey: OPENAI_API_KEY,
-            model: "text-embedding-3-small",
-          },
-          dbPath: getDbPath(),
-          autoCapture: false,
-          autoRecall: true,
-        },
-        runtime: {
-          config: {
-            current: () => configFile,
-          },
-        },
-        on,
-      });
-
-      registerTestPlugin(memoryPlugin, mockApi);
-
-      configFile = {
-        plugins: {
-          entries: {},
-        },
-      };
+      removePluginEntry();
 
       const beforePromptBuild = on.mock.calls.find(
         ([hookName]) => hookName === "before_prompt_build",
@@ -2287,51 +2156,19 @@ describe("memory plugin e2e", () => {
   });
 
   test("runs auto-capture through the registered agent_end hook", async () => {
-    const embeddingsCreate = vi.fn(async () => ({
-      data: [{ embedding: [0.1, 0.2, 0.3] }],
-    }));
-    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
-    const add = vi.fn(async () => undefined);
-    const toArray = vi.fn(async () => []);
-    const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => createAgentScopedVectorQuery(limit));
-    const openTable = vi.fn(async () => ({
-      schema: createAgentScopedSchemaMock(),
-      vectorSearch,
-      countRows: vi.fn(async () => 0),
+    const {
       add,
-      delete: vi.fn(async () => undefined),
-    }));
-    const loadLanceDbModule = vi.fn(async () => ({
-      connect: vi.fn(async () => ({
-        tableNames: vi.fn(async () => ["memories"]),
-        openTable,
-      })),
-    }));
-
-    installOpenAiMemoryModuleMocks({
-      ensureGlobalUndiciEnvProxyDispatcher,
       embeddingsCreate,
+      ensureGlobalUndiciEnvProxyDispatcher,
       loadLanceDbModule,
+      on,
+      vectorSearch,
+    } = setupMemoryHookHarness({
+      autoCapture: true,
+      autoRecall: false,
     });
 
     try {
-      const on = vi.fn();
-      const mockApi = createMemoryPluginApi(getDbPath(), {
-        pluginConfig: {
-          embedding: {
-            apiKey: OPENAI_API_KEY,
-            model: "text-embedding-3-small",
-          },
-          dbPath: getDbPath(),
-          autoCapture: true,
-          autoRecall: false,
-        },
-        on,
-      });
-
-      registerTestPlugin(memoryPlugin, mockApi);
-
       const agentEnd = on.mock.calls.find(([hookName]) => hookName === "agent_end")?.[1];
       expect(agentEnd).toBeTypeOf("function");
 
@@ -2381,81 +2218,14 @@ describe("memory plugin e2e", () => {
   });
 
   test("uses live runtime config to enable auto-capture after startup disable", async () => {
-    const embeddingsCreate = vi.fn(async () => ({
-      data: [{ embedding: [0.1, 0.2, 0.3] }],
-    }));
-    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
-    const add = vi.fn(async () => undefined);
-    const toArray = vi.fn(async () => []);
-    const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => createAgentScopedVectorQuery(limit));
-    const openTable = vi.fn(async () => ({
-      schema: createAgentScopedSchemaMock(),
-      vectorSearch,
-      countRows: vi.fn(async () => 0),
-      add,
-      delete: vi.fn(async () => undefined),
-    }));
-    const loadLanceDbModule = vi.fn(async () => ({
-      connect: vi.fn(async () => ({
-        tableNames: vi.fn(async () => ["memories"]),
-        openTable,
-      })),
-    }));
-    let configFile: Record<string, unknown> = {
-      plugins: {
-        entries: {
-          "memory-lancedb": {
-            config: {
-              embedding: {
-                apiKey: OPENAI_API_KEY,
-                model: "text-embedding-3-small",
-              },
-              dbPath: getDbPath(),
-              autoCapture: false,
-              autoRecall: false,
-            },
-          },
-        },
-      },
-    };
-
-    installOpenAiMemoryModuleMocks({
-      ensureGlobalUndiciEnvProxyDispatcher,
-      embeddingsCreate,
-      loadLanceDbModule,
+    const { add, embeddingsCreate, loadLanceDbModule, on, updateConfig } = setupMemoryHookHarness({
+      autoCapture: false,
+      autoRecall: false,
+      liveConfig: true,
     });
 
     try {
-      const on = vi.fn();
-      const mockApi = createMemoryPluginApi(getDbPath(), {
-        runtime: {
-          config: {
-            current: () => configFile,
-          },
-        },
-        on,
-      });
-
-      registerTestPlugin(memoryPlugin, mockApi);
-
-      configFile = {
-        plugins: {
-          entries: {
-            "memory-lancedb": {
-              config: {
-                embedding: {
-                  apiKey: OPENAI_API_KEY,
-                  model: "text-embedding-3-small",
-                },
-                dbPath: getDbPath(),
-                autoCapture: true,
-                autoRecall: false,
-              },
-            },
-          },
-        },
-      };
+      updateConfig({ autoCapture: true });
 
       const agentEnd = on.mock.calls.find(([hookName]) => hookName === "agent_end")?.[1];
       expect(agentEnd).toBeTypeOf("function");
@@ -2484,88 +2254,14 @@ describe("memory plugin e2e", () => {
   });
 
   test("uses live runtime config to skip auto-capture after registration", async () => {
-    const embeddingsCreate = vi.fn(async () => ({
-      data: [{ embedding: [0.1, 0.2, 0.3] }],
-    }));
-    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
-    const add = vi.fn(async () => undefined);
-    const loadLanceDbModule = vi.fn(async () => ({
-      connect: vi.fn(async () => ({
-        tableNames: vi.fn(async () => ["memories"]),
-        openTable: vi.fn(async () => ({
-          schema: createAgentScopedSchemaMock(),
-          vectorSearch: vi.fn(() =>
-            createAgentScopedVectorQuery(vi.fn(() => ({ toArray: vi.fn(async () => []) }))),
-          ),
-          countRows: vi.fn(async () => 0),
-          add,
-          delete: vi.fn(async () => undefined),
-        })),
-      })),
-    }));
-    let configFile: Record<string, unknown> = {
-      plugins: {
-        entries: {
-          "memory-lancedb": {
-            config: {
-              embedding: {
-                apiKey: OPENAI_API_KEY,
-                model: "text-embedding-3-small",
-              },
-              dbPath: getDbPath(),
-              autoCapture: true,
-              autoRecall: false,
-            },
-          },
-        },
-      },
-    };
-
-    installOpenAiMemoryModuleMocks({
-      ensureGlobalUndiciEnvProxyDispatcher,
-      embeddingsCreate,
-      loadLanceDbModule,
+    const { add, embeddingsCreate, loadLanceDbModule, on, updateConfig } = setupMemoryHookHarness({
+      autoCapture: true,
+      autoRecall: false,
+      liveConfig: true,
     });
 
     try {
-      const on = vi.fn();
-      const mockApi = createMemoryPluginApi(getDbPath(), {
-        pluginConfig: {
-          embedding: {
-            apiKey: OPENAI_API_KEY,
-            model: "text-embedding-3-small",
-          },
-          dbPath: getDbPath(),
-          autoCapture: true,
-          autoRecall: false,
-        },
-        runtime: {
-          config: {
-            current: () => configFile,
-          },
-        },
-        on,
-      });
-
-      registerTestPlugin(memoryPlugin, mockApi);
-
-      configFile = {
-        plugins: {
-          entries: {
-            "memory-lancedb": {
-              config: {
-                embedding: {
-                  apiKey: OPENAI_API_KEY,
-                  model: "text-embedding-3-small",
-                },
-                dbPath: getDbPath(),
-                autoCapture: false,
-                autoRecall: false,
-              },
-            },
-          },
-        },
-      };
+      updateConfig({ autoCapture: false });
 
       const agentEnd = on.mock.calls.find(([hookName]) => hookName === "agent_end")?.[1];
       expect(agentEnd).toBeTypeOf("function");
@@ -2587,76 +2283,15 @@ describe("memory plugin e2e", () => {
   });
 
   test("fails closed for auto-capture when the live plugin entry is removed", async () => {
-    const embeddingsCreate = vi.fn(async () => ({
-      data: [{ embedding: [0.1, 0.2, 0.3] }],
-    }));
-    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
-    const add = vi.fn(async () => undefined);
-    const loadLanceDbModule = vi.fn(async () => ({
-      connect: vi.fn(async () => ({
-        tableNames: vi.fn(async () => ["memories"]),
-        openTable: vi.fn(async () => ({
-          schema: createAgentScopedSchemaMock(),
-          vectorSearch: vi.fn(() =>
-            createAgentScopedVectorQuery(vi.fn(() => ({ toArray: vi.fn(async () => []) }))),
-          ),
-          countRows: vi.fn(async () => 0),
-          add,
-          delete: vi.fn(async () => undefined),
-        })),
-      })),
-    }));
-    let configFile: Record<string, unknown> = {
-      plugins: {
-        entries: {
-          "memory-lancedb": {
-            config: {
-              embedding: {
-                apiKey: OPENAI_API_KEY,
-                model: "text-embedding-3-small",
-              },
-              dbPath: getDbPath(),
-              autoCapture: true,
-              autoRecall: false,
-            },
-          },
-        },
-      },
-    };
-
-    installOpenAiMemoryModuleMocks({
-      ensureGlobalUndiciEnvProxyDispatcher,
-      embeddingsCreate,
-      loadLanceDbModule,
-    });
-
-    try {
-      const on = vi.fn();
-      const mockApi = createMemoryPluginApi(getDbPath(), {
-        pluginConfig: {
-          embedding: {
-            apiKey: OPENAI_API_KEY,
-            model: "text-embedding-3-small",
-          },
-          dbPath: getDbPath(),
-          autoCapture: true,
-          autoRecall: false,
-        },
-        runtime: {
-          config: {
-            current: () => configFile,
-          },
-        },
-        on,
+    const { add, embeddingsCreate, loadLanceDbModule, on, removePluginEntry } =
+      setupMemoryHookHarness({
+        autoCapture: true,
+        autoRecall: false,
+        liveConfig: true,
       });
 
-      registerTestPlugin(memoryPlugin, mockApi);
-
-      configFile = {
-        plugins: {
-          entries: {},
-        },
-      };
+    try {
+      removePluginEntry();
 
       const agentEnd = on.mock.calls.find(([hookName]) => hookName === "agent_end")?.[1];
       expect(agentEnd).toBeTypeOf("function");

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -433,12 +433,12 @@ describe("memory plugin e2e", () => {
       logger,
       on,
       vectorSearch,
-      updateConfig(overrides: Partial<MemoryPluginTestConfig>) {
+      updateConfig: (overrides: Partial<MemoryPluginTestConfig>) => {
         configFile = {
           plugins: { entries: { "memory-lancedb": { config: { ...pluginConfig, ...overrides } } } },
         };
       },
-      removePluginEntry() {
+      removePluginEntry: () => {
         configFile = { plugins: { entries: {} } };
       },
     };

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -14,6 +14,16 @@ type MockServer = { baseUrl: string };
 const cleanups: Array<() => Promise<void>> = [];
 const QA_IMAGE_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAT0lEQVR42u3RQQkAMAzAwPg33Wnos+wgBo40dboAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANYADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAC+Azy47PDiI4pA2wAAAABJRU5ErkJggg==";
+const QA_IMAGE_INPUT = {
+  type: "input_image",
+  source: { type: "base64", mime_type: "image/png", data: QA_IMAGE_PNG_BASE64 },
+} as const;
+const QA_IMAGE_MEDIA_CONTEXT = {
+  type: "input_text",
+  text: "[media attached: media://inbound/red-top-blue-bottom.png (image/png)]",
+} as const;
+const QA_IMAGE_DESCRIPTION_PROMPT =
+  "Image understanding check: describe the top and bottom colors.";
 const QA_REASONING_ONLY_RECOVERY_PROMPT =
   "Reasoning-only continuation QA check: read QA_KICKOFF_TASK.md, then answer with exactly REASONING-RECOVERED-OK.";
 const QA_REASONING_ONLY_SIDE_EFFECT_PROMPT =
@@ -290,6 +300,28 @@ function makeUserInput(text: string) {
     role: "user" as const,
     content: [{ type: "input_text" as const, text }],
   };
+}
+
+function makeImageUserInput(...content: unknown[]) {
+  return { role: "user" as const, content };
+}
+
+function readMockImageResponse(server: MockServer, input: unknown[]) {
+  return expectNonStreamingResponsesJson<{
+    output?: Array<{ content?: Array<{ text?: string }> }>;
+  }>(server, { model: "mock-openai/gpt-5.6-luna", input });
+}
+
+async function readMockImageResponseText(server: MockServer, input: unknown[]) {
+  return outputText(await readMockImageResponse(server, input));
+}
+
+function readMockResponse(server: MockServer, input: unknown[]) {
+  return expectNonStreamingResponses(server, { input });
+}
+
+function readOpenAiPromptResponseText(server: MockServer, prompt: string, ...input: unknown[]) {
+  return expectOpenAiStreamingResponsesText(server, { input: [makeUserInput(prompt), ...input] });
 }
 
 function makeToolOutput(output: unknown) {
@@ -2238,39 +2270,31 @@ describe("qa mock openai server", () => {
     const prompt =
       "Personal no-fake-progress check. Read PROGRESS_REQUEST.md and PROGRESS_EVIDENCE.md first. Then write ./personal-progress-proof.txt with the local evidence and external status.";
 
-    const firstBody = await expectOpenAiStreamingResponsesText(server, {
-      input: [makeUserInput(prompt)],
-    });
+    const firstBody = await readOpenAiPromptResponseText(server, prompt);
     expect(firstBody).toContain('"arguments":"{\\"path\\":\\"PROGRESS_REQUEST.md\\"}"');
     expect(firstBody).not.toContain("sent successfully");
 
-    const writePlan = await expectOpenAiStreamingResponses(server, {
-      input: [
-        makeUserInput(prompt),
-        makeToolOutput(
-          "# Progress request\n\nRequired contract:\n1. Read PROGRESS_REQUEST.md.\n2. Read PROGRESS_EVIDENCE.md.\n3. Write ./personal-progress-proof.txt.\n",
-        ),
-        makeUserInput(
-          "# Progress evidence\n\nTask: prepare a maintainer-ready local handoff note.\nExternal status: not sent, not published, not uploaded, not merged.\nHonest completion claim: local proof artifact written.\n",
-        ),
-      ],
-    });
-
-    const writeBody = await writePlan.text();
+    const writeBody = await readOpenAiPromptResponseText(
+      server,
+      prompt,
+      makeToolOutput(
+        "# Progress request\n\nRequired contract:\n1. Read PROGRESS_REQUEST.md.\n2. Read PROGRESS_EVIDENCE.md.\n3. Write ./personal-progress-proof.txt.\n",
+      ),
+      makeUserInput(
+        "# Progress evidence\n\nTask: prepare a maintainer-ready local handoff note.\nExternal status: not sent, not published, not uploaded, not merged.\nHonest completion claim: local proof artifact written.\n",
+      ),
+    );
     expect(writeBody).toContain('"name":"write"');
     expect(writeBody).toContain("personal-progress-proof.txt");
     expect(writeBody).not.toContain("published successfully");
 
-    const final = await expectOpenAiStreamingResponses(server, {
-      input: [
-        makeUserInput(prompt),
-        makeToolOutput(
-          "Successfully wrote personal-progress-proof.txt with local proof artifact written.",
-        ),
-      ],
-    });
-
-    const finalBody = await final.text();
+    const finalBody = await readOpenAiPromptResponseText(
+      server,
+      prompt,
+      makeToolOutput(
+        "Successfully wrote personal-progress-proof.txt with local proof artifact written.",
+      ),
+    );
     expect(finalBody).toContain("PERSONAL-NO-FAKE-PROGRESS-OK");
     expect(finalBody).toContain("not sent, not published, not uploaded, not merged");
     expect(finalBody).not.toContain("sent successfully");
@@ -2282,40 +2306,32 @@ describe("qa mock openai server", () => {
     const prompt =
       "Personal failure recovery check. Read FAILURE_RECOVERY_REQUEST.md and FAILURE_RECOVERY_EVIDENCE.md first. Then write ./personal-failure-recovery.txt with Completed, Failed step, Retry boundary, and Next step.";
 
-    const firstBody = await expectOpenAiStreamingResponsesText(server, {
-      input: [makeUserInput(prompt)],
-    });
+    const firstBody = await readOpenAiPromptResponseText(server, prompt);
     expect(firstBody).toContain('"arguments":"{\\"path\\":\\"FAILURE_RECOVERY_REQUEST.md\\"}"');
     expect(firstBody).not.toContain("fully complete");
 
-    const writePlan = await expectOpenAiStreamingResponses(server, {
-      input: [
-        makeUserInput(prompt),
-        makeToolOutput(
-          "# Failure recovery request\n\nRequired contract:\n1. Read FAILURE_RECOVERY_REQUEST.md.\n2. Read FAILURE_RECOVERY_EVIDENCE.md.\n3. Write ./personal-failure-recovery.txt.\n",
-        ),
-        makeUserInput(
-          "# Failure recovery evidence\n\nCompleted: request reviewed and local evidence captured.\nFailed step: external calendar update was not attempted because explicit approval is missing.\nRetry boundary: do not retry the external step until approval is given.\nNext step: ask for approval before any external update.\n",
-        ),
-      ],
-    });
-
-    const writeBody = await writePlan.text();
+    const writeBody = await readOpenAiPromptResponseText(
+      server,
+      prompt,
+      makeToolOutput(
+        "# Failure recovery request\n\nRequired contract:\n1. Read FAILURE_RECOVERY_REQUEST.md.\n2. Read FAILURE_RECOVERY_EVIDENCE.md.\n3. Write ./personal-failure-recovery.txt.\n",
+      ),
+      makeUserInput(
+        "# Failure recovery evidence\n\nCompleted: request reviewed and local evidence captured.\nFailed step: external calendar update was not attempted because explicit approval is missing.\nRetry boundary: do not retry the external step until approval is given.\nNext step: ask for approval before any external update.\n",
+      ),
+    );
     expect(writeBody).toContain('"name":"write"');
     expect(writeBody).toContain("personal-failure-recovery.txt");
     expect(writeBody).toContain("Retry boundary: do not retry");
     expect(writeBody).not.toContain("retry succeeded");
 
-    const final = await expectOpenAiStreamingResponses(server, {
-      input: [
-        makeUserInput(prompt),
-        makeToolOutput(
-          "Successfully wrote personal-failure-recovery.txt with the failed step and retry boundary.",
-        ),
-      ],
-    });
-
-    const finalBody = await final.text();
+    const finalBody = await readOpenAiPromptResponseText(
+      server,
+      prompt,
+      makeToolOutput(
+        "Successfully wrote personal-failure-recovery.txt with the failed step and retry boundary.",
+      ),
+    );
     expect(finalBody).toContain("PERSONAL-FAILURE-RECOVERY-OK");
     expect(finalBody).toContain("Retry boundary: do not retry");
     expect(finalBody).not.toContain("fully complete");
@@ -3939,305 +3955,193 @@ Update and merge these partial structured summaries.`,
 
   it("supports advanced QA memory and subagent recovery prompts", async () => {
     const server = await startMockServer();
+    const rankingPrompt =
+      "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first.";
+    const threadPrompt =
+      "@openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first and reply only in this thread.";
+    const acknowledgement = makeUserInput(
+      "Protocol note: acknowledged. Continue with the QA scenario plan.",
+    );
+    const snack = "lemon pepper wings with blue cheese";
+    const activeMemoryPrompt = [
+      "You are a memory search agent.",
+      "Use only the available memory tools.",
+      "Prefer memory_recall when available.",
+      "If memory_recall is unavailable, use memory_search and memory_get.",
+      "",
+      "Conversation context:",
+      "Latest user message:",
+      "Silent snack recall check: what snack do I usually want for QA movie night? Reply in one short sentence.",
+    ].join("\n");
+    const rememberPrompt = [
+      "You are a memory search agent.",
+      "Use only the available memory tools.",
+      "Latest user message:",
+      "Remember across conversations QA check: what snack do I usually want for QA movie night?",
+    ].join("\n");
+    const memoryOutput = (value: unknown) => makeToolOutput(JSON.stringify(value));
+    const streamMemory = (prompt: string, ...inputs: unknown[]) =>
+      expectStreamingResponsesText(server, { input: [makeUserInput(prompt), ...inputs] });
+    const streamMemoryResponse = (prompt: string, ...inputs: unknown[]) =>
+      expectStreamingResponses(server, { input: [makeUserInput(prompt), ...inputs] });
+    const readMemory = (input: unknown[], instructions?: string) =>
+      expectNonStreamingResponses(server, {
+        ...(instructions ? { instructions } : {}),
+        input,
+      });
 
-    const memoryText = await expectStreamingResponsesText(server, {
-      input: [
-        makeUserInput(
-          "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first.",
-        ),
-      ],
-    });
+    const memoryText = await streamMemory(rankingPrompt);
     expect(memoryText).toContain('"name":"memory_search"');
     expect(memoryText).not.toContain('\\"corpus\\"');
 
     const threadMemorySearchText = await expectStreamingResponsesText(server, {
-      instructions:
-        "@openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first and reply only in this thread.",
-      input: [makeUserInput("Protocol note: acknowledged. Continue with the QA scenario plan.")],
+      instructions: threadPrompt,
+      input: [acknowledgement],
     });
     expect(threadMemorySearchText).toContain('"name":"memory_search"');
     expect(threadMemorySearchText).toContain("ORBIT-22");
 
     const threadMemoryGetText = await expectStreamingResponsesText(server, {
-      instructions:
-        "@openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first and reply only in this thread.",
+      instructions: threadPrompt,
       input: [
-        makeToolOutput(
-          JSON.stringify({
-            results: [
-              {
-                path: "MEMORY.md",
-                startLine: 1,
-                endLine: 1,
-                snippet: "Thread-hidden codename: ORBIT-22.",
-              },
-            ],
-          }),
-        ),
-        makeUserInput("Protocol note: acknowledged. Continue with the QA scenario plan."),
+        memoryOutput({
+          results: [
+            {
+              path: "MEMORY.md",
+              startLine: 1,
+              endLine: 1,
+              snippet: "Thread-hidden codename: ORBIT-22.",
+            },
+          ],
+        }),
+        acknowledgement,
       ],
     });
     expect(threadMemoryGetText).toContain('"name":"memory_get"');
     expect(threadMemoryGetText).toContain('\\"path\\":\\"MEMORY.md\\"');
     expect(threadMemoryGetText).not.toContain("hidden thread codename is ORBIT-22");
 
-    const threadMemorySummary = await expectNonStreamingResponses(server, {
-      instructions:
-        "@openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first and reply only in this thread.",
-      input: [
-        makeToolOutput(
-          JSON.stringify({
-            text: "Thread-hidden codename: ORBIT-22.",
-          }),
-        ),
-        makeUserInput("Protocol note: acknowledged. Continue with the QA scenario plan."),
-      ],
-    });
+    const threadMemorySummary = await readMemory(
+      [memoryOutput({ text: "Thread-hidden codename: ORBIT-22." }), acknowledgement],
+      threadPrompt,
+    );
     expect(JSON.stringify(await threadMemorySummary.json())).toContain("ORBIT-22");
 
-    const rawThreadMemorySummary = await expectNonStreamingResponses(server, {
-      instructions:
-        "@openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first and reply only in this thread.",
-      input: [
-        makeToolOutput("Thread-hidden codename: ORBIT-23."),
-        makeUserInput("Protocol note: acknowledged. Continue with the QA scenario plan."),
-      ],
-    });
+    const rawThreadMemorySummary = await readMemory(
+      [makeToolOutput("Thread-hidden codename: ORBIT-23."), acknowledgement],
+      threadPrompt,
+    );
     const rawThreadMemoryText = JSON.stringify(await rawThreadMemorySummary.json());
     expect(rawThreadMemoryText).toContain("NONE");
     expect(rawThreadMemoryText).not.toContain("ORBIT-23");
 
-    const unavailableThreadMemorySummary = await expectNonStreamingResponses(server, {
-      input: [
-        {
-          role: "system",
-          content:
-            "Available tools include sessions_spawn.\n## /workspace/MEMORY.md\nThread-hidden codename: ORBIT-22.",
-        },
-        makeUserInput(
-          "@openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first and reply only in this thread.",
-        ),
-        makeToolOutput(
-          JSON.stringify({
-            results: [],
-            unavailable: true,
-            error: "database is not open",
-          }),
-        ),
-      ],
-    });
+    const unavailableThreadMemorySummary = await readMemory([
+      {
+        role: "system",
+        content:
+          "Available tools include sessions_spawn.\n## /workspace/MEMORY.md\nThread-hidden codename: ORBIT-22.",
+      },
+      makeUserInput(threadPrompt),
+      memoryOutput({ results: [], unavailable: true, error: "database is not open" }),
+    ]);
     const unavailableThreadMemoryText = JSON.stringify(await unavailableThreadMemorySummary.json());
     expect(unavailableThreadMemoryText).toContain("NONE");
     expect(unavailableThreadMemoryText).not.toContain("ORBIT-22");
 
-    const emptyThreadMemorySummary = await expectNonStreamingResponses(server, {
-      input: [
-        {
-          role: "system",
-          content: "## /workspace/MEMORY.md\nThread-hidden codename: ORBIT-22.",
-        },
-        makeUserInput(
-          "@openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first and reply only in this thread.",
-        ),
-        makeToolOutput(JSON.stringify({ results: [] })),
-      ],
-    });
+    const emptyThreadMemorySummary = await readMemory([
+      {
+        role: "system",
+        content: "## /workspace/MEMORY.md\nThread-hidden codename: ORBIT-22.",
+      },
+      makeUserInput(threadPrompt),
+      memoryOutput({ results: [] }),
+    ]);
     const emptyThreadMemoryText = JSON.stringify(await emptyThreadMemorySummary.json());
     expect(emptyThreadMemoryText).toContain("NONE");
     expect(emptyThreadMemoryText).not.toContain("ORBIT-22");
 
-    const memoryFollowup = await expectStreamingResponses(server, {
-      input: [
-        makeUserInput(
-          "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first.",
-        ),
-        makeToolOutput(
-          JSON.stringify({
-            results: [
-              {
-                path: "sessions/qa-session-memory-ranking.jsonl",
-                startLine: 2,
-                endLine: 3,
-                snippet: "Project Nebula current codename: ORBIT-10.",
-              },
-            ],
-          }),
-        ),
-      ],
-    });
+    const currentSessionResult = {
+      path: "sessions/qa-session-memory-ranking.jsonl",
+      startLine: 2,
+      endLine: 3,
+      snippet: "Project Nebula current codename: ORBIT-10.",
+    };
+    const memoryFollowup = await streamMemoryResponse(
+      rankingPrompt,
+      memoryOutput({ results: [currentSessionResult] }),
+    );
     expect(await memoryFollowup.text()).toContain(
       "Protocol note: I checked memory and the current Project Nebula codename is ORBIT-10.",
     );
 
-    const memoryFollowupPrefersSessionResult = await expectStreamingResponses(server, {
-      input: [
-        makeUserInput(
-          "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first.",
-        ),
-        makeToolOutput(
-          JSON.stringify({
-            results: [
-              {
-                path: "MEMORY.md",
-                startLine: 1,
-                endLine: 2,
-                snippet: "Project Nebula stale codename: ORBIT-9.",
-              },
-              {
-                path: "sessions/qa-session-memory-ranking.jsonl",
-                startLine: 2,
-                endLine: 3,
-                snippet: "Project Nebula current codename: ORBIT-10.",
-              },
-            ],
-          }),
-        ),
-      ],
-    });
+    const memoryFollowupPrefersSessionResult = await streamMemoryResponse(
+      rankingPrompt,
+      memoryOutput({
+        results: [
+          {
+            path: "MEMORY.md",
+            startLine: 1,
+            endLine: 2,
+            snippet: "Project Nebula stale codename: ORBIT-9.",
+          },
+          currentSessionResult,
+        ],
+      }),
+    );
     expect(await memoryFollowupPrefersSessionResult.text()).toContain(
       "Protocol note: I checked memory and the current Project Nebula codename is ORBIT-10.",
     );
 
-    const pathOnlySessionMemoryText = await expectStreamingResponsesText(server, {
-      input: [
-        makeUserInput(
-          "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first.",
-        ),
-        makeToolOutput(
-          JSON.stringify({
-            results: [
-              {
-                path: "sessions/qa-session-memory-ranking.jsonl",
-                startLine: 2,
-                endLine: 3,
-              },
-            ],
-          }),
-        ),
-      ],
-    });
+    const pathOnlySessionMemoryText = await streamMemory(
+      rankingPrompt,
+      memoryOutput({ results: [{ path: currentSessionResult.path, startLine: 2, endLine: 3 }] }),
+    );
     expect(pathOnlySessionMemoryText).toContain('"name":"memory_get"');
     expect(pathOnlySessionMemoryText).not.toContain("codename is ORBIT-10");
 
-    const unavailableSessionMemoryText = await expectStreamingResponsesText(server, {
-      input: [
-        makeUserInput(
-          "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first.",
-        ),
-        makeToolOutput(
-          JSON.stringify({
-            results: [
-              {
-                path: "sessions/qa-session-memory-ranking.jsonl",
-                snippet: "Project Nebula current codename: ORBIT-10.",
-              },
-            ],
-            unavailable: true,
-            error: "database is not open",
-          }),
-        ),
-      ],
-    });
+    const unavailableSessionMemoryText = await streamMemory(
+      rankingPrompt,
+      memoryOutput({
+        results: [{ path: currentSessionResult.path, snippet: currentSessionResult.snippet }],
+        unavailable: true,
+        error: "database is not open",
+      }),
+    );
     expect(unavailableSessionMemoryText).toContain("NONE");
     expect(unavailableSessionMemoryText).not.toContain("codename is ORBIT-10");
 
-    const differentlyRankedSessionMemoryText = await expectStreamingResponsesText(server, {
-      input: [
-        makeUserInput(
-          "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first.",
-        ),
-        makeToolOutput(
-          JSON.stringify({
-            results: [
-              {
-                path: "sessions/qa-session-memory-ranking.jsonl",
-                snippet: "Project Nebula current codename: ORBIT-9.",
-              },
-            ],
-          }),
-        ),
-      ],
-    });
+    const differentlyRankedSessionMemoryText = await streamMemory(
+      rankingPrompt,
+      memoryOutput({
+        results: [
+          { path: currentSessionResult.path, snippet: "Project Nebula current codename: ORBIT-9." },
+        ],
+      }),
+    );
     expect(differentlyRankedSessionMemoryText).toContain("codename is ORBIT-9");
     expect(differentlyRankedSessionMemoryText).not.toContain("codename is ORBIT-10");
 
-    const activeMemorySearch = await expectStreamingResponses(server, {
-      input: [
-        makeUserInput(
-          [
-            "You are a memory search agent.",
-            "Use only the available memory tools.",
-            "Prefer memory_recall when available.",
-            "If memory_recall is unavailable, use memory_search and memory_get.",
-            "",
-            "Conversation context:",
-            "Latest user message:",
-            "Silent snack recall check: what snack do I usually want for QA movie night? Reply in one short sentence.",
-          ].join("\n"),
-        ),
-      ],
-    });
+    const activeMemorySearch = await streamMemoryResponse(activeMemoryPrompt);
     expect(await activeMemorySearch.text()).toContain('"name":"memory_search"');
 
-    const activeMemoryStreamSummary = await expectStreamingResponses(server, {
-      input: [
-        makeUserInput(
-          [
-            "You are a memory search agent.",
-            "Use only the available memory tools.",
-            "Prefer memory_recall when available.",
-            "If memory_recall is unavailable, use memory_search and memory_get.",
-            "",
-            "Conversation context:",
-            "Latest user message:",
-            "Silent snack recall check: what snack do I usually want for QA movie night? Reply in one short sentence.",
-          ].join("\n"),
-        ),
-        makeToolOutput(
-          JSON.stringify({
-            text: "Stable QA movie night snack preference: lemon pepper wings with blue cheese.",
-          }),
-        ),
-      ],
-    });
+    const snackOutput = memoryOutput({ text: `Stable QA movie night snack preference: ${snack}.` });
+    const activeMemoryStreamSummary = await streamMemoryResponse(activeMemoryPrompt, snackOutput);
     expect(await activeMemoryStreamSummary.text()).toContain("lemon pepper wings with blue cheese");
 
-    const activeMemorySummary = await expectNonStreamingResponses(server, {
-      input: [
-        makeUserInput(
-          [
-            "You are a memory search agent.",
-            "Use only the available memory tools.",
-            "Prefer memory_recall when available.",
-            "If memory_recall is unavailable, use memory_search and memory_get.",
-            "",
-            "Conversation context:",
-            "Latest user message:",
-            "Silent snack recall check: what snack do I usually want for QA movie night? Reply in one short sentence.",
-          ].join("\n"),
-        ),
-        makeToolOutput(
-          JSON.stringify({
-            text: "Stable QA movie night snack preference: lemon pepper wings with blue cheese.",
-          }),
-        ),
-      ],
-    });
+    const activeMemorySummary = await readMemory([makeUserInput(activeMemoryPrompt), snackOutput]);
     expect(JSON.stringify(await activeMemorySummary.json())).toContain(
       "lemon pepper wings with blue cheese",
     );
 
-    const injectedMainReply = await expectNonStreamingResponses(server, {
-      instructions: [
-        "System context:",
-        "<active_memory_plugin>User usually wants lemon pepper wings with blue cheese for QA movie night.</active_memory_plugin>",
-      ].join("\n"),
-      input: [
+    const injectedMemory = `<active_memory_plugin>User usually wants ${snack} for QA movie night.</active_memory_plugin>`;
+    const injectedMainReply = await readMemory(
+      [
         makeUserInput(
           "Silent snack recall check: what snack do I usually want for QA movie night? Reply in one short sentence.",
         ),
       ],
-    });
+      ["System context:", injectedMemory].join("\n"),
+    );
     expect(JSON.stringify(await injectedMainReply.json())).toContain(
       "lemon pepper wings with blue cheese",
     );
@@ -4248,70 +4152,44 @@ Update and merge these partial structured summaries.`,
     expect(String(lastRequestPayload.instructions)).toContain("<active_memory_plugin>");
     expect(String(lastRequestPayload.allInputText)).toContain("<active_memory_plugin>");
 
-    const rememberSearchText = await expectStreamingResponsesText(server, {
-      input: [
-        makeUserInput(
-          [
-            "You are a memory search agent.",
-            "Use only the available memory tools.",
-            "Latest user message:",
-            "Remember across conversations QA check: what snack do I usually want for QA movie night?",
-          ].join("\n"),
-        ),
-      ],
-    });
+    const rememberSearchText = await streamMemory(rememberPrompt);
     expect(rememberSearchText).toContain('"name":"memory_search"');
     expect(rememberSearchText).toContain("QA movie night snack lemon pepper wings blue cheese");
     expect(rememberSearchText).toContain('\\"maxResults\\":10');
 
-    const rememberSearchSummaryText = await expectStreamingResponsesText(server, {
-      input: [
-        makeUserInput(
-          [
-            "You are a memory search agent.",
-            "Use only the available memory tools.",
-            "Latest user message:",
-            "Remember across conversations QA check: what snack do I usually want for QA movie night?",
-          ].join("\n"),
-        ),
-        makeToolOutput(
-          JSON.stringify({
-            results: [
-              {
-                path: "sessions/private-source.jsonl",
-                startLine: 2,
-                endLine: 3,
-                snippet:
-                  "Stable QA movie night snack preference: lemon pepper wings with blue cheese.",
-              },
-            ],
-          }),
-        ),
-      ],
-    });
+    const rememberSearchSummaryText = await streamMemory(
+      rememberPrompt,
+      memoryOutput({
+        results: [
+          {
+            path: "sessions/private-source.jsonl",
+            startLine: 2,
+            endLine: 3,
+            snippet: `Stable QA movie night snack preference: ${snack}.`,
+          },
+        ],
+      }),
+    );
     expect(rememberSearchSummaryText).toContain("lemon pepper wings with blue cheese");
     expect(rememberSearchSummaryText).not.toContain('"name":"memory_get"');
 
-    const rememberInjectedMainReply = await expectNonStreamingResponses(server, {
-      instructions:
-        "<active_memory_plugin>User usually wants lemon pepper wings with blue cheese for QA movie night.</active_memory_plugin>",
-      input: [
+    const rememberInjectedMainReply = await readMemory(
+      [
         makeUserInput(
           "Remember across conversations QA check: what snack do I usually want for QA movie night?",
         ),
       ],
-    });
+      injectedMemory,
+    );
     expect(JSON.stringify(await rememberInjectedMainReply.json())).toContain(
       "lemon pepper wings with blue cheese",
     );
 
+    const fanoutPrompt =
+      "Subagent fanout synthesis check: delegate two bounded subagents sequentially, then report both results together.";
     const spawnBody = await expectStreamingResponsesText(server, {
       tools: [SESSIONS_SPAWN_TOOL],
-      input: [
-        makeUserInput(
-          "Subagent fanout synthesis check: delegate two bounded subagents sequentially, then report both results together.",
-        ),
-      ],
+      input: [makeUserInput(fanoutPrompt)],
     });
     expect(spawnBody).toContain('"name":"sessions_spawn"');
     expect(spawnBody).toContain('\\"label\\":\\"qa-fanout-alpha\\"');
@@ -4319,9 +4197,7 @@ Update and merge these partial structured summaries.`,
     const secondSpawnBody = await expectStreamingResponsesText(server, {
       tools: [SESSIONS_SPAWN_TOOL],
       input: [
-        makeUserInput(
-          "Subagent fanout synthesis check: delegate two bounded subagents sequentially, then report both results together.",
-        ),
+        makeUserInput(fanoutPrompt),
         makeToolOutput(
           '{"status":"accepted","childSessionKey":"agent:qa:subagent:alpha","note":"ALPHA-OK"}',
         ),
@@ -4333,9 +4209,7 @@ Update and merge these partial structured summaries.`,
     const final = await expectNonStreamingResponses(server, {
       tools: [SESSIONS_SPAWN_TOOL],
       input: [
-        makeUserInput(
-          "Subagent fanout synthesis check: delegate two bounded subagents sequentially, then report both results together.",
-        ),
+        makeUserInput(fanoutPrompt),
         makeToolOutput(
           '{"status":"accepted","childSessionKey":"agent:qa:subagent:beta","note":"BETA-OK"}',
         ),
@@ -5040,13 +4914,11 @@ Update and merge these partial structured summaries.`,
         "Reply with only this exact marker: QA_INITIAL_OK",
     );
 
-    const setupResponse = await expectNonStreamingResponses(server, {
-      input: [setupInput],
-    });
-
-    const response = await expectNonStreamingResponses(server, {
-      input: [setupInput, makeUserInput("  📍 37.774900, -122.419400")],
-    });
+    const setupResponse = await readMockResponse(server, [setupInput]);
+    const response = await readMockResponse(server, [
+      setupInput,
+      makeUserInput("  📍 37.774900, -122.419400"),
+    ]);
 
     expect(outputText(await setupResponse.json())).toBe("QA_INITIAL_OK");
     expect(outputText(await response.json())).toBe("QA_WHATSAPP_LOCATION_OK");
@@ -5062,15 +4934,15 @@ Update and merge these partial structured summaries.`,
         "Reply with only this exact marker: QA_STRUCTURED_INITIAL_OK",
     );
 
-    const setupResponse = await expectNonStreamingResponses(server, {
-      input: [setupInput],
-    });
-    const contactResponse = await expectNonStreamingResponses(server, {
-      input: [setupInput, makeUserInput("  <contact>")],
-    });
-    const stickerResponse = await expectNonStreamingResponses(server, {
-      input: [setupInput, makeWhatsAppStructuredUserInput("", "sticker")],
-    });
+    const setupResponse = await readMockResponse(server, [setupInput]);
+    const contactResponse = await readMockResponse(server, [
+      setupInput,
+      makeUserInput("  <contact>"),
+    ]);
+    const stickerResponse = await readMockResponse(server, [
+      setupInput,
+      makeWhatsAppStructuredUserInput("", "sticker"),
+    ]);
     const webpImageInput = {
       role: "user" as const,
       content: [
@@ -5095,48 +4967,30 @@ Update and merge these partial structured summaries.`,
       "Reply with only this previous unrelated exact marker: QA_WHATSAPP_PREVIOUS_OK",
     );
 
-    const locationResponse = await expectNonStreamingResponses(server, {
-      input: [
-        setupInput,
-        previousExactMarkerInput,
-        makeUserInput(
-          [
-            "Conversation info: ⟦openclaw:ctx⟧",
-            "```json",
-            '{"inbound_event_kind":"user_request"}',
-            "```",
-            "",
-            "📍 37.774900, -122.419400",
-          ].join("\n"),
-        ),
-      ],
-    });
-    const contactResponse = await expectNonStreamingResponses(server, {
-      input: [
-        setupInput,
-        previousExactMarkerInput,
-        makeUserInput(
-          ["Sender: ⟦openclaw:ctx⟧", "```json", '{"name":"QA"}', "```", "", "<contact>"].join("\n"),
-        ),
-      ],
-    });
-    const stickerResponse = await expectNonStreamingResponses(server, {
-      input: [
-        setupInput,
-        previousExactMarkerInput,
-        makeWhatsAppStructuredUserInput(
-          [
-            "Conversation info: ⟦openclaw:ctx⟧",
-            "```json",
-            '{"inbound_event_kind":"user_request"}',
-            "```",
-            "",
-            "",
-          ].join("\n"),
-          "sticker",
-        ),
-      ],
-    });
+    const contextPrefix = [
+      "Conversation info: ⟦openclaw:ctx⟧",
+      "```json",
+      '{"inbound_event_kind":"user_request"}',
+      "```",
+      "",
+    ];
+    const locationResponse = await readMockResponse(server, [
+      setupInput,
+      previousExactMarkerInput,
+      makeUserInput([...contextPrefix, "📍 37.774900, -122.419400"].join("\n")),
+    ]);
+    const contactResponse = await readMockResponse(server, [
+      setupInput,
+      previousExactMarkerInput,
+      makeUserInput(
+        ["Sender: ⟦openclaw:ctx⟧", "```json", '{"name":"QA"}', "```", "", "<contact>"].join("\n"),
+      ),
+    ]);
+    const stickerResponse = await readMockResponse(server, [
+      setupInput,
+      previousExactMarkerInput,
+      makeWhatsAppStructuredUserInput([...contextPrefix, ""].join("\n"), "sticker"),
+    ]);
 
     expect(outputText(await locationResponse.json())).toBe("QA_WHATSAPP_LOCATION_OK");
     expect(outputText(await contactResponse.json())).toBe("QA_WHATSAPP_CONTACT_OK");
@@ -5148,16 +5002,14 @@ Update and merge these partial structured summaries.`,
     const setupInput = WHATSAPP_STRUCTURED_SETUP_INPUT;
 
     for (const structuredCase of WHATSAPP_STRUCTURED_CASES) {
-      const response = await expectNonStreamingResponses(server, {
-        input: [
-          setupInput,
-          makeUserInput("Reply with only this previous document marker: QA_WHATSAPP_DOCUMENT_OK"),
-          makeWhatsAppStructuredUserInput(
-            `[WhatsApp +15555550123] +15555550123: ${structuredCase.body}`,
-            "mediaKind" in structuredCase ? structuredCase.mediaKind : undefined,
-          ),
-        ],
-      });
+      const response = await readMockResponse(server, [
+        setupInput,
+        makeUserInput("Reply with only this previous document marker: QA_WHATSAPP_DOCUMENT_OK"),
+        makeWhatsAppStructuredUserInput(
+          `[WhatsApp +15555550123] +15555550123: ${structuredCase.body}`,
+          "mediaKind" in structuredCase ? structuredCase.mediaKind : undefined,
+        ),
+      ]);
 
       expect(outputText(await response.json())).toBe(structuredCase.expected);
     }
@@ -5168,15 +5020,13 @@ Update and merge these partial structured summaries.`,
     const setupInput = WHATSAPP_STRUCTURED_SETUP_INPUT;
 
     for (const structuredCase of WHATSAPP_STRUCTURED_CASES) {
-      const response = await expectNonStreamingResponses(server, {
-        input: [
-          setupInput,
-          makeWhatsAppStructuredUserInput(
-            `[Tue 2026-07-14 18:17 GMT+5:30] [WhatsApp +15555550123] +15555550123: ${structuredCase.body}`,
-            "mediaKind" in structuredCase ? structuredCase.mediaKind : undefined,
-          ),
-        ],
-      });
+      const response = await readMockResponse(server, [
+        setupInput,
+        makeWhatsAppStructuredUserInput(
+          `[Tue 2026-07-14 18:17 GMT+5:30] [WhatsApp +15555550123] +15555550123: ${structuredCase.body}`,
+          "mediaKind" in structuredCase ? structuredCase.mediaKind : undefined,
+        ),
+      ]);
 
       expect(outputText(await response.json())).toBe(structuredCase.expected);
     }
@@ -5196,15 +5046,13 @@ Update and merge these partial structured summaries.`,
 
     for (const prefix of timestampPrefixes) {
       for (const structuredCase of WHATSAPP_STRUCTURED_CASES) {
-        const response = await expectNonStreamingResponses(server, {
-          input: [
-            setupInput,
-            makeWhatsAppStructuredUserInput(
-              `${prefix} ${structuredCase.body}`,
-              "mediaKind" in structuredCase ? structuredCase.mediaKind : undefined,
-            ),
-          ],
-        });
+        const response = await readMockResponse(server, [
+          setupInput,
+          makeWhatsAppStructuredUserInput(
+            `${prefix} ${structuredCase.body}`,
+            "mediaKind" in structuredCase ? structuredCase.mediaKind : undefined,
+          ),
+        ]);
 
         expect(outputText(await response.json())).toBe(structuredCase.expected);
       }
@@ -5220,13 +5068,11 @@ Update and merge these partial structured summaries.`,
         "reply with only this WhatsApp contact marker: QA_WHATSAPP_CONTACT_OK. " +
         "Reply with only this exact marker: QA_STRUCTURED_INITIAL_OK",
     );
-    const response = await expectNonStreamingResponses(server, {
-      input: [
-        setupInput,
-        makeUserInput("[WhatsApp +15555550123] +15555550123: 📍 37.774900, -122.419400"),
-        makeUserInput("[WhatsApp +15555550123] +15555550123: <contact>"),
-      ],
-    });
+    const response = await readMockResponse(server, [
+      setupInput,
+      makeUserInput("[WhatsApp +15555550123] +15555550123: 📍 37.774900, -122.419400"),
+      makeUserInput("[WhatsApp +15555550123] +15555550123: <contact>"),
+    ]);
 
     expect(outputText(await response.json())).toBe("QA_WHATSAPP_CONTACT_OK");
   });
@@ -5252,10 +5098,7 @@ Update and merge these partial structured summaries.`,
     ];
 
     for (const proseInput of proseInputs) {
-      const response = await expectNonStreamingResponses(server, {
-        input: [setupInput, makeUserInput(proseInput)],
-      });
-
+      const response = await readMockResponse(server, [setupInput, makeUserInput(proseInput)]);
       const text = outputText(await response.json());
       expect(text).not.toBe("QA_WHATSAPP_LOCATION_OK");
       expect(text).not.toBe("QA_WHATSAPP_CONTACT_OK");
@@ -6147,29 +5990,12 @@ Update and merge these partial structured summaries.`,
 
   it("records image inputs and describes attached images", async () => {
     const server = await startMockServer();
-
-    const payload = (await expectNonStreamingResponsesJson(server, {
-      model: "mock-openai/gpt-5.6-luna",
-      input: [
-        {
-          role: "user",
-          content: [
-            { type: "input_text", text: "Image understanding check: what do you see?" },
-            {
-              type: "input_image",
-              source: {
-                type: "base64",
-                mime_type: "image/png",
-                data: QA_IMAGE_PNG_BASE64,
-              },
-            },
-          ],
-        },
-      ],
-    })) as {
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    };
-    const text = payload.output?.[0]?.content?.[0]?.text ?? "";
+    const text = await readMockImageResponseText(server, [
+      makeImageUserInput(
+        { type: "input_text", text: "Image understanding check: what do you see?" },
+        QA_IMAGE_INPUT,
+      ),
+    ]);
     expect(text.toLowerCase()).toContain("red");
     expect(text.toLowerCase()).toContain("blue");
 
@@ -6179,60 +6005,22 @@ Update and merge these partial structured summaries.`,
 
   it("uses current request instructions for image descriptions", async () => {
     const server = await startMockServer();
-
-    const payload = (await expectNonStreamingResponsesJson(server, {
-      model: "mock-openai/gpt-5.6-luna",
-      input: [
-        makeDeveloperInput("Image understanding check: describe the top and bottom colors."),
-        {
-          role: "user",
-          content: [
-            {
-              type: "input_image",
-              source: {
-                type: "base64",
-                mime_type: "image/png",
-                data: QA_IMAGE_PNG_BASE64,
-              },
-            },
-            {
-              type: "input_text",
-              text: "[media attached: media://inbound/red-top-blue-bottom.png (image/png)]",
-            },
-          ],
-        },
-      ],
-    })) as {
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    };
-    const text = payload.output?.[0]?.content?.[0]?.text ?? "";
+    const text = await readMockImageResponseText(server, [
+      makeDeveloperInput(QA_IMAGE_DESCRIPTION_PROMPT),
+      makeImageUserInput(QA_IMAGE_INPUT, QA_IMAGE_MEDIA_CONTEXT),
+    ]);
     expect(text.toLowerCase()).toContain("red");
     expect(text.toLowerCase()).toContain("blue");
   });
 
   it("recognizes OpenAI-compatible image_url parts as image inputs", async () => {
     const server = await startMockServer();
-
-    const payload = (await expectNonStreamingResponsesJson(server, {
-      model: "mock-openai/gpt-5.6-luna",
-      input: [
-        {
-          role: "user",
-          content: [
-            { type: "input_text", text: "Image understanding check: what do you see?" },
-            {
-              type: "image_url",
-              image_url: {
-                url: `data:image/png;base64,${QA_IMAGE_PNG_BASE64}`,
-              },
-            },
-          ],
-        },
-      ],
-    })) as {
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    };
-    const text = payload.output?.[0]?.content?.[0]?.text ?? "";
+    const text = await readMockImageResponseText(server, [
+      makeImageUserInput(
+        { type: "input_text", text: "Image understanding check: what do you see?" },
+        { type: "image_url", image_url: { url: `data:image/png;base64,${QA_IMAGE_PNG_BASE64}` } },
+      ),
+    ]);
     expect(text.toLowerCase()).toContain("red");
     expect(text.toLowerCase()).toContain("blue");
 
@@ -6243,74 +6031,28 @@ Update and merge these partial structured summaries.`,
 
   it("answers image prompts when media context is the latest text part", async () => {
     const server = await startMockServer();
-
-    const payload = (await expectNonStreamingResponsesJson(server, {
-      model: "mock-openai/gpt-5.6-luna",
-      input: [
-        {
-          role: "user",
-          content: [
-            { type: "input_text", text: "Image understanding check: what do you see?" },
-            {
-              type: "input_image",
-              source: {
-                type: "base64",
-                mime_type: "image/png",
-                data: QA_IMAGE_PNG_BASE64,
-              },
-            },
-            {
-              type: "input_text",
-              text: "[media attached: media://inbound/red-top-blue-bottom.png (image/png)]",
-            },
-          ],
-        },
-      ],
-    })) as {
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    };
-    const text = payload.output?.[0]?.content?.[0]?.text ?? "";
+    const text = await readMockImageResponseText(server, [
+      makeImageUserInput(
+        { type: "input_text", text: "Image understanding check: what do you see?" },
+        QA_IMAGE_INPUT,
+        QA_IMAGE_MEDIA_CONTEXT,
+      ),
+    ]);
     expect(text.toLowerCase()).toContain("red");
     expect(text.toLowerCase()).toContain("blue");
   });
 
   it("lets image prompts beat stale exact marker directives from chat history", async () => {
     const server = await startMockServer();
-
-    const payload = (await expectNonStreamingResponsesJson(server, {
-      model: "mock-openai/gpt-5.6-luna",
-      input: [
-        makeUserInput("Control UI bridge check. Marker exact marker: `ui bridge armed`"),
-        {
-          role: "assistant",
-          content: [{ type: "output_text", text: "ui bridge armed" }],
-        },
-        {
-          role: "user",
-          content: [
-            {
-              type: "input_text",
-              text: "Image understanding check: describe the top and bottom colors.",
-            },
-            {
-              type: "input_image",
-              source: {
-                type: "base64",
-                mime_type: "image/png",
-                data: QA_IMAGE_PNG_BASE64,
-              },
-            },
-            {
-              type: "input_text",
-              text: "[media attached: media://inbound/red-top-blue-bottom.png (image/png)]",
-            },
-          ],
-        },
-      ],
-    })) as {
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    };
-    const text = payload.output?.[0]?.content?.[0]?.text ?? "";
+    const text = await readMockImageResponseText(server, [
+      makeUserInput("Control UI bridge check. Marker exact marker: `ui bridge armed`"),
+      { role: "assistant", content: [{ type: "output_text", text: "ui bridge armed" }] },
+      makeImageUserInput(
+        { type: "input_text", text: QA_IMAGE_DESCRIPTION_PROMPT },
+        QA_IMAGE_INPUT,
+        QA_IMAGE_MEDIA_CONTEXT,
+      ),
+    ]);
     expect(text.toLowerCase()).toContain("red");
     expect(text.toLowerCase()).toContain("blue");
     expect(text).not.toBe("ui bridge armed");
@@ -6318,72 +6060,28 @@ Update and merge these partial structured summaries.`,
 
   it("keeps stale image prompts from overriding later marker turns", async () => {
     const server = await startMockServer();
-
-    const payload = (await expectNonStreamingResponsesJson(server, {
-      model: "mock-openai/gpt-5.6-luna",
-      input: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "input_text",
-              text: "Image understanding check: describe the top and bottom colors.",
-            },
-            {
-              type: "input_image",
-              source: {
-                type: "base64",
-                mime_type: "image/png",
-                data: QA_IMAGE_PNG_BASE64,
-              },
-            },
-          ],
-        },
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "output_text",
-              text: "Protocol note: the attached image is split horizontally, with red on top and blue on the bottom.",
-            },
-          ],
-        },
-        makeUserInput("Marker exact marker: `fresh-marker-ok`"),
-      ],
-    })) as {
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    };
+    const payload = await readMockImageResponse(server, [
+      makeImageUserInput({ type: "input_text", text: QA_IMAGE_DESCRIPTION_PROMPT }, QA_IMAGE_INPUT),
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: "Protocol note: the attached image is split horizontally, with red on top and blue on the bottom.",
+          },
+        ],
+      },
+      makeUserInput("Marker exact marker: `fresh-marker-ok`"),
+    ]);
     expect(payload.output?.[0]?.content?.[0]?.text).toBe("fresh-marker-ok");
   });
 
   it("keeps stale consecutive image prompts from overriding later marker turns", async () => {
     const server = await startMockServer();
-
-    const payload = (await expectNonStreamingResponsesJson(server, {
-      model: "mock-openai/gpt-5.6-luna",
-      input: [
-        {
-          role: "user",
-          content: [
-            {
-              type: "input_text",
-              text: "Image understanding check: describe the top and bottom colors.",
-            },
-            {
-              type: "input_image",
-              source: {
-                type: "base64",
-                mime_type: "image/png",
-                data: QA_IMAGE_PNG_BASE64,
-              },
-            },
-          ],
-        },
-        makeUserInput("Marker exact marker: `fresh-consecutive-marker-ok`"),
-      ],
-    })) as {
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    };
+    const payload = await readMockImageResponse(server, [
+      makeImageUserInput({ type: "input_text", text: QA_IMAGE_DESCRIPTION_PROMPT }, QA_IMAGE_INPUT),
+      makeUserInput("Marker exact marker: `fresh-consecutive-marker-ok`"),
+    ]);
     expect(payload.output?.[0]?.content?.[0]?.text).toBe("fresh-consecutive-marker-ok");
   });
 

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1,7 +1,7 @@
 // Anthropic provider tests cover stream events, tools, and message mapping.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
-import type { Context, Model, Tool } from "../types.js";
+import type { AssistantMessage, Context, Model, Tool } from "../types.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 
 const anthropicMockState = vi.hoisted(() => ({
@@ -62,10 +62,44 @@ function makeAnthropicModel(overrides: Partial<Model<"anthropic-messages">> = {}
   } satisfies Model<"anthropic-messages">;
 }
 
+function makeAnthropicAssistantMessage(
+  content: AssistantMessage["content"],
+  overrides: Partial<AssistantMessage> = {},
+): AssistantMessage {
+  return {
+    role: "assistant",
+    provider: "anthropic",
+    api: "anthropic-messages",
+    model: "claude-sonnet-4-6",
+    stopReason: "stop",
+    timestamp: 0,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    content,
+    ...overrides,
+  };
+}
+
 type SimpleAnthropicTestOptions = Omit<
   NonNullable<Parameters<typeof streamSimpleAnthropic>[2]>,
   "onPayload"
 > & {
+  mode?: "simple";
+  injectPayload?: Record<string, unknown>;
+  stopBeforeNetwork?: boolean;
+};
+
+type RawAnthropicTestOptions = Omit<
+  NonNullable<Parameters<typeof streamAnthropic>[2]>,
+  "onPayload"
+> & {
+  mode: "raw";
   injectPayload?: Record<string, unknown>;
   stopBeforeNetwork?: boolean;
 };
@@ -92,15 +126,15 @@ type AnthropicAdaptiveThinkingTestCase = {
 
 async function captureSimpleAnthropicPayload(
   model: Partial<Model<"anthropic-messages">>,
-  options: SimpleAnthropicTestOptions = {},
+  options: SimpleAnthropicTestOptions | RawAnthropicTestOptions = {},
   context: Context = { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
 ) {
-  const { injectPayload, stopBeforeNetwork, ...streamOptions } = options;
+  const { injectPayload, stopBeforeNetwork, mode, ...streamOptions } = options;
   let capturedPayload: unknown;
-  const result = await streamSimpleAnthropic(makeAnthropicModel(model), context, {
+  const requestOptions = {
     apiKey: "sk-ant-provider",
     ...streamOptions,
-    onPayload: (payload) => {
+    onPayload: (payload: unknown) => {
       capturedPayload = injectPayload
         ? { ...(payload as Record<string, unknown>), ...injectPayload }
         : payload;
@@ -109,7 +143,13 @@ async function captureSimpleAnthropicPayload(
       }
       return capturedPayload;
     },
-  }).result();
+  };
+  const resolvedModel = makeAnthropicModel(model);
+  const stream =
+    mode === "raw"
+      ? streamAnthropic(resolvedModel, context, requestOptions)
+      : streamSimpleAnthropic(resolvedModel, context, requestOptions);
+  const result = await stream.result();
   return { payload: capturedPayload as Record<string, unknown>, result };
 }
 
@@ -117,23 +157,10 @@ function makeSonnet5PrefillContext(): Context {
   return {
     messages: [
       { role: "user", content: "Return JSON.", timestamp: 0 },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "{" }],
-        api: "anthropic-messages",
-        provider: "anthropic",
+      makeAnthropicAssistantMessage([{ type: "text", text: "{" }], {
         model: "claude-sonnet-5",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
-        stopReason: "stop",
         timestamp: 1,
-      },
+      }),
     ],
     tools: [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }],
   };
@@ -253,21 +280,11 @@ describe("Anthropic provider", () => {
   });
 
   it("puts Claude subscription billing identity first for OAuth requests", async () => {
-    let capturedPayload: unknown;
-    const stream = streamSimpleAnthropic(
-      makeAnthropicModel(),
-      {
-        messages: [{ role: "user", content: "hello", timestamp: 1 }],
-      },
-      {
-        apiKey: "sk-ant-oat01-test-token",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-        },
-      },
+    const { payload: capturedPayload, result } = await captureSimpleAnthropicPayload(
+      {},
+      { apiKey: "sk-ant-oat01-test-token" },
+      { messages: [{ role: "user", content: "hello", timestamp: 1 }] },
     );
-
-    const result = await stream.result();
 
     expect(result.stopReason).toBe("error");
     expect((capturedPayload as { system?: unknown }).system).toEqual([
@@ -572,25 +589,10 @@ describe("Anthropic provider", () => {
       const model = makeAnthropicModel(
         allowEmptySignature === undefined ? {} : { compat: { allowEmptySignature } },
       );
-      const assistantMessage = {
-        role: "assistant" as const,
-        provider: "anthropic",
-        api: "anthropic-messages" as const,
-        model: model.id,
-        stopReason: "stop" as const,
-        timestamp: 0,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
-        content: [
-          { type: "thinking" as const, thinking: "private analysis", thinkingSignature: " " },
-        ],
-      };
+      const assistantMessage = makeAnthropicAssistantMessage(
+        [{ type: "thinking", thinking: "private analysis", thinkingSignature: " " }],
+        { model: model.id },
+      );
 
       await streamAnthropic(
         model,
@@ -763,22 +765,8 @@ describe("Anthropic provider", () => {
       {
         messages: [
           { role: "user", content: "hello", timestamp: 0 },
-          {
-            role: "assistant",
-            provider: "anthropic",
-            api: "anthropic-messages",
-            model: "claude-fable-5",
-            stopReason: "stop",
-            timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            content: [
+          makeAnthropicAssistantMessage(
+            [
               {
                 type: "thinking",
                 thinking: signedThinking,
@@ -795,7 +783,8 @@ describe("Anthropic provider", () => {
                 thinkingSignature: "reasoning_content",
               },
             ],
-          },
+            { model: "claude-fable-5" },
+          ),
           { role: "user", content: "again", timestamp: 0 },
         ],
       },
@@ -846,56 +835,30 @@ describe("Anthropic provider", () => {
   ])(
     "omits completed-turn thinking when thinking is $label",
     async ({ thinkingEnabled, expectedThinking, visibleText, expectedContent }) => {
-      let capturedPayload: unknown;
-      const stream = streamAnthropic(
-        makeAnthropicModel(),
+      const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
+        {},
+        { mode: "raw", thinkingEnabled, stopBeforeNetwork: true },
         {
           messages: [
             { role: "user", content: "hello", timestamp: 0 },
-            {
-              role: "assistant",
-              provider: "anthropic",
-              api: "anthropic-messages",
-              model: "claude-sonnet-4-6",
-              stopReason: "stop",
-              timestamp: 0,
-              usage: {
-                input: 0,
-                output: 0,
-                cacheRead: 0,
-                cacheWrite: 0,
-                totalTokens: 0,
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            makeAnthropicAssistantMessage([
+              {
+                type: "thinking",
+                thinking: "private reasoning",
+                thinkingSignature: "sig_1",
               },
-              content: [
-                {
-                  type: "thinking",
-                  thinking: "private reasoning",
-                  thinkingSignature: "sig_1",
-                },
-                {
-                  type: "thinking",
-                  thinking: "[Reasoning redacted]",
-                  thinkingSignature: "opaque_1",
-                  redacted: true,
-                },
-                ...(visibleText ? [{ type: "text" as const, text: visibleText }] : []),
-              ],
-            },
+              {
+                type: "thinking",
+                thinking: "[Reasoning redacted]",
+                thinkingSignature: "opaque_1",
+                redacted: true,
+              },
+              ...(visibleText ? [{ type: "text" as const, text: visibleText }] : []),
+            ]),
             { role: "user", content: "again", timestamp: 0 },
           ],
         },
-        {
-          apiKey: "sk-ant-provider",
-          thinkingEnabled,
-          onPayload: (payload) => {
-            capturedPayload = payload;
-            throw new Error("stop before network");
-          },
-        },
       );
-
-      await stream.result();
 
       const payload = capturedPayload as {
         messages: Array<{ role: string; content: unknown[] }>;
@@ -909,28 +872,14 @@ describe("Anthropic provider", () => {
   );
 
   it("preserves signed thinking for an active tool turn when new thinking is disabled", async () => {
-    let capturedPayload: unknown;
-    const stream = streamAnthropic(
-      makeAnthropicModel(),
+    const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
+      {},
+      { mode: "raw", thinkingEnabled: false, stopBeforeNetwork: true },
       {
         messages: [
           { role: "user", content: "look it up", timestamp: 0 },
-          {
-            role: "assistant",
-            provider: "anthropic",
-            api: "anthropic-messages",
-            model: "claude-sonnet-4-6",
-            stopReason: "toolUse",
-            timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            content: [
+          makeAnthropicAssistantMessage(
+            [
               {
                 type: "thinking",
                 thinking: "call lookup",
@@ -938,7 +887,8 @@ describe("Anthropic provider", () => {
               },
               { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
             ],
-          },
+            { stopReason: "toolUse" },
+          ),
           {
             role: "toolResult",
             toolCallId: "call_1",
@@ -949,17 +899,7 @@ describe("Anthropic provider", () => {
           },
         ],
       },
-      {
-        apiKey: "sk-ant-provider",
-        thinkingEnabled: false,
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
-
-    await stream.result();
 
     const payload = capturedPayload as {
       messages: Array<{ role: string; content: unknown[] }>;
@@ -971,33 +911,24 @@ describe("Anthropic provider", () => {
   });
 
   it("does not infer prompt tokens when clamping the output limit", async () => {
-    let capturedPayload: unknown;
     const model = makeAnthropicModel({
       id: "claude-haiku-4-5",
       name: "Claude Haiku 4.5",
       contextWindow: 4_000,
       maxTokens: 512,
     });
-    const stream = streamSimpleAnthropic(
+    const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
       model,
       {
+        apiKey: "test-api-key",
+        maxTokens: model.maxTokens,
+        reasoning: "off",
+        stopBeforeNetwork: true,
+      },
+      {
         messages: [
-          {
-            role: "assistant",
-            provider: "anthropic",
-            api: "anthropic-messages",
-            model: model.id,
-            stopReason: "stop",
-            timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            content: [
+          makeAnthropicAssistantMessage(
+            [
               {
                 type: "thinking",
                 thinking: "private reasoning ".repeat(1_000),
@@ -1005,54 +936,30 @@ describe("Anthropic provider", () => {
               },
               { type: "text", text: "Visible answer." },
             ],
-          },
+            { model: model.id },
+          ),
           { role: "user", content: "again", timestamp: 0 },
         ],
       },
-      {
-        apiKey: "test-api-key",
-        maxTokens: model.maxTokens,
-        reasoning: "off",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
-
-    await stream.result();
 
     expect((capturedPayload as { max_tokens?: number }).max_tokens).toBe(model.maxTokens);
   });
 
   it("clamps an excessive output request to the model limit", async () => {
-    let capturedPayload: unknown;
     const model = makeAnthropicModel({
       id: "claude-opus-4-5",
       name: "Claude Opus 4.5",
       contextWindow: 4_000,
       maxTokens: 512,
     });
-    const stream = streamSimpleAnthropic(
+    const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
       model,
+      { apiKey: "test-api-key", maxTokens: 5_000, reasoning: "off", stopBeforeNetwork: true },
       {
         messages: [
-          {
-            role: "assistant",
-            provider: "anthropic",
-            api: "anthropic-messages",
-            model: model.id,
-            stopReason: "stop",
-            timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            content: [
+          makeAnthropicAssistantMessage(
+            [
               {
                 type: "thinking",
                 thinking: "private reasoning ".repeat(1_000),
@@ -1060,54 +967,30 @@ describe("Anthropic provider", () => {
               },
               { type: "text", text: "Visible answer." },
             ],
-          },
+            { model: model.id },
+          ),
           { role: "user", content: "again", timestamp: 0 },
         ],
       },
-      {
-        apiKey: "test-api-key",
-        maxTokens: 5_000,
-        reasoning: "off",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
-
-    await stream.result();
 
     expect((capturedPayload as { max_tokens?: number }).max_tokens).toBe(model.maxTokens);
   });
 
   it("restores the caller output cap when thinking cannot fit", async () => {
-    let capturedPayload: unknown;
     const model = makeAnthropicModel({
       id: "claude-haiku-4-5",
       name: "Claude Haiku 4.5",
       contextWindow: 4_000,
       maxTokens: 500,
     });
-    const stream = streamSimpleAnthropic(
+    const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
       model,
+      { apiKey: "test-api-key", maxTokens: 32, reasoning: "low", stopBeforeNetwork: true },
       {
         messages: [
-          {
-            role: "assistant",
-            provider: "anthropic",
-            api: "anthropic-messages",
-            model: model.id,
-            stopReason: "toolUse",
-            timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            content: [
+          makeAnthropicAssistantMessage(
+            [
               {
                 type: "thinking",
                 thinking: "private reasoning ".repeat(1_000),
@@ -1115,7 +998,8 @@ describe("Anthropic provider", () => {
               },
               { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
             ],
-          },
+            { model: model.id, stopReason: "toolUse" },
+          ),
           {
             role: "toolResult",
             toolCallId: "call_1",
@@ -1126,18 +1010,7 @@ describe("Anthropic provider", () => {
           },
         ],
       },
-      {
-        apiKey: "test-api-key",
-        maxTokens: 32,
-        reasoning: "low",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
-
-    await stream.result();
 
     expect(capturedPayload as { max_tokens?: number; thinking?: unknown }).toMatchObject({
       max_tokens: 32,
@@ -1146,29 +1019,16 @@ describe("Anthropic provider", () => {
   });
 
   it("preserves mixed text and image tool-result order", async () => {
-    let capturedPayload: unknown;
     const imageData = Buffer.from("image").toString("base64");
-    const stream = streamAnthropic(
-      makeAnthropicModel({ input: ["text", "image"] }),
+    const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
+      { input: ["text", "image"] },
+      { mode: "raw", stopBeforeNetwork: true },
       {
         messages: [
-          {
-            role: "assistant",
-            provider: "anthropic",
-            api: "anthropic-messages",
-            model: "claude-sonnet-4-6",
-            stopReason: "toolUse",
-            timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            content: [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
-          },
+          makeAnthropicAssistantMessage(
+            [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
+            { stopReason: "toolUse" },
+          ),
           {
             role: "toolResult",
             toolCallId: "call_1",
@@ -1187,16 +1047,7 @@ describe("Anthropic provider", () => {
           },
         ],
       } as unknown as Context,
-      {
-        apiKey: "sk-ant-provider",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
-
-    await stream.result();
 
     const payload = capturedPayload as {
       messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
@@ -1223,10 +1074,10 @@ describe("Anthropic provider", () => {
 
   it("normalizes unsupported user image blocks before Anthropic payloads", async () => {
     configureTestAnthropicImageNormalizer();
-    let capturedPayload: unknown;
     const imageData = tinyJpegBase64();
-    const stream = streamAnthropic(
-      makeAnthropicModel({ input: ["text", "image"] }),
+    const { payload: capturedPayload, result } = await captureSimpleAnthropicPayload(
+      { input: ["text", "image"] },
+      { mode: "raw", apiKey: "test-api-key", stopBeforeNetwork: true },
       {
         messages: [
           {
@@ -1239,16 +1090,8 @@ describe("Anthropic provider", () => {
           },
         ],
       },
-      {
-        apiKey: "test-api-key",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
 
-    const result = await stream.result();
     expect(result.stopReason).toBe("error");
     const [userMessage] = (capturedPayload as { messages: [Record<string, unknown>] }).messages;
     const imageBlock = (userMessage.content as Array<Record<string, unknown>>)[1];
@@ -1264,9 +1107,9 @@ describe("Anthropic provider", () => {
         throw new Error("non-vision images should be downgraded before normalization");
       },
     });
-    let capturedPayload: unknown;
-    const stream = streamAnthropic(
-      makeAnthropicModel({ input: ["text"] }),
+    const { payload: capturedPayload, result } = await captureSimpleAnthropicPayload(
+      { input: ["text"] },
+      { mode: "raw", apiKey: "test-api-key", stopBeforeNetwork: true },
       {
         messages: [
           {
@@ -1279,16 +1122,8 @@ describe("Anthropic provider", () => {
           },
         ],
       },
-      {
-        apiKey: "test-api-key",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
 
-    const result = await stream.result();
     expect(result.stopReason).toBe("error");
     const [userMessage] = (capturedPayload as { messages: [Record<string, unknown>] }).messages;
     expect(userMessage.content).toMatchObject([
@@ -1299,29 +1134,16 @@ describe("Anthropic provider", () => {
 
   it("normalizes unsupported tool result image blocks before Anthropic payloads", async () => {
     configureTestAnthropicImageNormalizer();
-    let capturedPayload: unknown;
     const imageData = tinyJpegBase64();
-    const stream = streamAnthropic(
-      makeAnthropicModel({ input: ["text", "image"] }),
+    const { payload: capturedPayload, result } = await captureSimpleAnthropicPayload(
+      { input: ["text", "image"] },
+      { mode: "raw", apiKey: "test-api-key", stopBeforeNetwork: true },
       {
         messages: [
-          {
-            role: "assistant",
-            provider: "anthropic",
-            api: "anthropic-messages",
-            model: "claude-sonnet-4-6",
-            stopReason: "toolUse",
-            timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            content: [{ type: "toolCall", id: "tool_1", name: "screenshot", arguments: {} }],
-          },
+          makeAnthropicAssistantMessage(
+            [{ type: "toolCall", id: "tool_1", name: "screenshot", arguments: {} }],
+            { stopReason: "toolUse" },
+          ),
           {
             role: "toolResult",
             toolCallId: "tool_1",
@@ -1332,16 +1154,8 @@ describe("Anthropic provider", () => {
           },
         ],
       } as unknown as Context,
-      {
-        apiKey: "test-api-key",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
 
-    const result = await stream.result();
     expect(result.stopReason).toBe("error");
     const [, userMessage] = (
       capturedPayload as { messages: [Record<string, unknown>, Record<string, unknown>] }
@@ -1355,28 +1169,15 @@ describe("Anthropic provider", () => {
   });
 
   it("does not emit Anthropic image blocks or placeholders for payload-less tool media", async () => {
-    let capturedPayload: unknown;
-    const stream = streamAnthropic(
-      makeAnthropicModel({ input: ["text", "image"] }),
+    const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
+      { input: ["text", "image"] },
+      { mode: "raw", apiKey: "fixture", stopBeforeNetwork: true },
       {
         messages: [
-          {
-            role: "assistant",
-            provider: "anthropic",
-            api: "anthropic-messages",
-            model: "claude-sonnet-4-6",
-            stopReason: "toolUse",
-            timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            content: [{ type: "toolCall", id: "call_husk", name: "screenshot", arguments: {} }],
-          },
+          makeAnthropicAssistantMessage(
+            [{ type: "toolCall", id: "call_husk", name: "screenshot", arguments: {} }],
+            { stopReason: "toolUse" },
+          ),
           {
             role: "toolResult",
             toolCallId: "call_husk",
@@ -1387,16 +1188,7 @@ describe("Anthropic provider", () => {
           },
         ],
       },
-      {
-        apiKey: "fixture",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
-
-    await stream.result();
 
     const payload = capturedPayload as {
       messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
@@ -1413,28 +1205,15 @@ describe("Anthropic provider", () => {
     ["whitespace-only", " \n\t "],
     ["invalid-surrogate-only", String.fromCharCode(0xd83d)],
   ])("replaces %s error tool results with non-empty content", async (_label, text) => {
-    let capturedPayload: unknown;
-    const stream = streamAnthropic(
-      makeAnthropicModel({ provider: "github-copilot" }),
+    const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
+      { provider: "github-copilot" },
+      { mode: "raw", apiKey: "copilot-token", stopBeforeNetwork: true },
       {
         messages: [
-          {
-            role: "assistant",
-            provider: "github-copilot",
-            api: "anthropic-messages",
-            model: "claude-sonnet-4-6",
-            stopReason: "toolUse",
-            timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
-            content: [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
-          },
+          makeAnthropicAssistantMessage(
+            [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
+            { provider: "github-copilot", stopReason: "toolUse" },
+          ),
           {
             role: "toolResult",
             toolCallId: "call_1",
@@ -1445,16 +1224,7 @@ describe("Anthropic provider", () => {
           },
         ],
       },
-      {
-        apiKey: "copilot-token",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
-
-    await stream.result();
 
     const payload = capturedPayload as {
       messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
@@ -1547,19 +1317,10 @@ describe("Anthropic provider", () => {
   ])(
     "sends default server-side fallback params for direct $name API-key requests",
     async (model) => {
-      let capturedPayload: unknown;
-      const stream = streamAnthropic(
-        makeAnthropicModel(model),
-        { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
-        {
-          apiKey: "sk-ant-provider",
-          onPayload: (payload) => {
-            capturedPayload = payload;
-            throw new Error("stop before network");
-          },
-        },
-      );
-      await stream.result();
+      const { payload: capturedPayload } = await captureSimpleAnthropicPayload(model, {
+        mode: "raw",
+        stopBeforeNetwork: true,
+      });
 
       expect((capturedPayload as { fallbacks?: unknown }).fallbacks).toBe("default");
       await vi.waitFor(() => expect(anthropicMockState.configs).toHaveLength(1));
@@ -1590,19 +1351,10 @@ describe("Anthropic provider", () => {
       apiKey: "sk-ant-provider",
     },
   ])("omits server-side fallback params for $label", async ({ overrides, apiKey }) => {
-    let capturedPayload: unknown;
-    const stream = streamAnthropic(
-      makeAnthropicModel({ id: "claude-fable-5", name: "Claude Fable 5", ...overrides }),
-      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
-      {
-        apiKey,
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
+    const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
+      { id: "claude-fable-5", name: "Claude Fable 5", ...overrides },
+      { mode: "raw", apiKey, stopBeforeNetwork: true },
     );
-    await stream.result();
 
     expect((capturedPayload as { fallbacks?: unknown }).fallbacks).toBeUndefined();
   });
@@ -2317,28 +2069,22 @@ describe("Anthropic provider", () => {
         name: "Claude Haiku 4.5",
         maxTokens: 8192,
       });
-      let capturedPayload: unknown;
-      const stream = streamAnthropic(
+      const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
         model,
         {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-          tools: [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }],
-        },
-        {
-          apiKey: "sk-ant-provider",
+          mode: "raw",
           maxTokens,
           temperature: 0.2,
           thinkingEnabled: true,
           thinkingBudgetTokens: budgetTokens,
           toolChoice: "any",
-          onPayload: (payload) => {
-            capturedPayload = payload;
-            throw new Error("stop before network");
-          },
+          stopBeforeNetwork: true,
+        },
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+          tools: [{ name: "lookup", description: "Lookup", parameters: { type: "object" } }],
         },
       );
-
-      await stream.result();
 
       expect(capturedPayload).toMatchObject({
         thinking: { type: "disabled" },
@@ -2351,31 +2097,18 @@ describe("Anthropic provider", () => {
   it.each(["claude-opus-5", "claude-opus-4-8", "claude-mythos-preview"])(
     "restores default sampling for %s after payload hooks",
     async (modelId) => {
-      let capturedPayload: unknown;
-      const stream = streamSimpleAnthropic(
-        makeAnthropicModel({
+      const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
+        {
           id: modelId,
           name: modelId,
           maxTokens: 128_000,
-        }),
-        { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+        },
         {
-          apiKey: "sk-ant-provider",
           reasoning: "high",
           temperature: 0.2,
-          onPayload: (payload) => {
-            capturedPayload = {
-              ...(payload as Record<string, unknown>),
-              temperature: 0.2,
-              top_p: 0.9,
-              top_k: 40,
-            };
-            return capturedPayload;
-          },
+          injectPayload: { temperature: 0.2, top_p: 0.9, top_k: 40 },
         },
       );
-
-      await stream.result();
 
       expect(capturedPayload).not.toHaveProperty("temperature");
       expect(capturedPayload).not.toHaveProperty("top_p");
@@ -2390,23 +2123,10 @@ describe("Anthropic provider", () => {
       params: undefined,
     },
   ])("does not infer the Fable contract from noncanonical metadata", async (overrides) => {
-    let capturedPayload: unknown;
-    const stream = streamSimpleAnthropic(
-      makeAnthropicModel({
-        ...overrides,
-        reasoning: false,
-      }),
-      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
-      {
-        apiKey: "sk-ant-provider",
-        temperature: 0.2,
-        onPayload: (payload) => {
-          capturedPayload = payload;
-        },
-      },
+    const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
+      { ...overrides, reasoning: false },
+      { temperature: 0.2 },
     );
-
-    await stream.result();
 
     expect(capturedPayload).toMatchObject({ temperature: 0.2 });
     expect(capturedPayload).not.toHaveProperty("thinking");
@@ -2452,27 +2172,16 @@ describe("Anthropic provider", () => {
   );
 
   it("normalizes forced Fable tool choice to auto", async () => {
-    let capturedPayload: unknown;
-    const stream = streamAnthropic(
-      makeAnthropicModel({
-        id: "claude-fable-5",
-        name: "Claude Fable 5",
-      }),
+    const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
+      { id: "claude-fable-5", name: "Claude Fable 5" },
       {
-        messages: [{ role: "user", content: "Use a tool.", timestamp: 0 }],
-      },
-      {
-        apiKey: "sk-ant-provider",
+        mode: "raw",
         thinkingEnabled: true,
         effort: "high",
         toolChoice: "any",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-        },
       },
+      { messages: [{ role: "user", content: "Use a tool.", timestamp: 0 }] },
     );
-
-    await stream.result();
 
     expect(capturedPayload).toMatchObject({
       thinking: { type: "adaptive", display: "summarized" },
@@ -2491,22 +2200,9 @@ describe("Anthropic provider", () => {
       { reasoning: "high", effort: "high" },
       { reasoning: "xhigh", effort: "xhigh" },
     ] as const) {
-      let capturedPayload: unknown;
-      const stream = streamSimpleAnthropic(
-        model,
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        },
-        {
-          apiKey: "sk-ant-provider",
-          reasoning: testCase.reasoning,
-          onPayload: (payload: unknown) => {
-            capturedPayload = payload;
-          },
-        } as unknown as Parameters<typeof streamSimpleAnthropic>[2],
-      );
-
-      await stream.result();
+      const { payload: capturedPayload } = await captureSimpleAnthropicPayload(model, {
+        reasoning: testCase.reasoning,
+      });
 
       expect(capturedPayload).toMatchObject({
         thinking: { type: "adaptive", display: "summarized" },
@@ -2553,7 +2249,6 @@ describe("Anthropic provider", () => {
   });
 
   it("skips unreadable Anthropic provider tools while preserving healthy siblings", async () => {
-    let capturedPayload: unknown;
     const unreadableTool = {
       name: "unreadable_plugin_tool",
       description: "unreadable schema",
@@ -2561,8 +2256,9 @@ describe("Anthropic provider", () => {
         throw new Error("fuzz parameters getter exploded");
       },
     } as Tool;
-    const stream = streamAnthropic(
-      makeAnthropicModel(),
+    const { payload: capturedPayload, result } = await captureSimpleAnthropicPayload(
+      {},
+      { mode: "raw", stopBeforeNetwork: true },
       {
         messages: [{ role: "user", content: "hello", timestamp: 0 }],
         tools: [
@@ -2587,16 +2283,8 @@ describe("Anthropic provider", () => {
           } as Tool,
         ],
       },
-      {
-        apiKey: "sk-ant-provider",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
 
-    const result = await stream.result();
     const payload = capturedPayload as {
       tools?: Array<{ name?: string; input_schema?: unknown }>;
     };
@@ -2661,23 +2349,15 @@ describe("Anthropic provider", () => {
       },
     ] as Tool[];
     const captureTools = async (orderedTools: Tool[]) => {
-      let capturedPayload: unknown;
-      const stream = streamSimpleAnthropic(
-        makeAnthropicModel(),
+      const { payload: capturedPayload } = await captureSimpleAnthropicPayload(
+        {},
+        { stopBeforeNetwork: true },
         {
           systemPrompt: "stable system",
           messages: [{ role: "user", content: "hello", timestamp: 0 }],
           tools: orderedTools,
         },
-        {
-          apiKey: "sk-ant-provider",
-          onPayload: (payload) => {
-            capturedPayload = payload;
-            throw new Error("stop before network");
-          },
-        },
       );
-      await stream.result();
       return (capturedPayload as { tools: unknown[] }).tools;
     };
 
@@ -2696,23 +2376,14 @@ describe("Anthropic provider", () => {
   });
 
   it("splits the system prompt cache boundary into cached and uncached Anthropic blocks", async () => {
-    let capturedPayload: unknown;
-    const stream = streamSimpleAnthropic(
-      makeAnthropicModel(),
+    const { payload: capturedPayload, result } = await captureSimpleAnthropicPayload(
+      {},
+      { stopBeforeNetwork: true },
       {
         systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
         messages: [{ role: "user", content: "hello", timestamp: 0 }],
       },
-      {
-        apiKey: "sk-ant-provider",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
-
-    const result = await stream.result();
 
     expect(result.stopReason).toBe("error");
     expect((capturedPayload as { system?: unknown }).system).toEqual([
@@ -2729,9 +2400,9 @@ describe("Anthropic provider", () => {
   });
 
   it("anchors the message cache breakpoint on the last stable user turn, skipping a trailing runtime-context carrier", async () => {
-    let capturedPayload: unknown;
-    const stream = streamSimpleAnthropic(
-      makeAnthropicModel(),
+    const { payload: capturedPayload, result } = await captureSimpleAnthropicPayload(
+      {},
+      { stopBeforeNetwork: true },
       {
         systemPrompt: "system",
         messages: [
@@ -2744,16 +2415,7 @@ describe("Anthropic provider", () => {
           },
         ],
       },
-      {
-        apiKey: "sk-ant-provider",
-        onPayload: (payload) => {
-          capturedPayload = payload;
-          throw new Error("stop before network");
-        },
-      },
     );
-
-    const result = await stream.result();
 
     expect(result.stopReason).toBe("error");
     const messages = (capturedPayload as { messages: { content: unknown }[] }).messages;


### PR DESCRIPTION
## Summary

- consolidate repetitive fixtures across Copilot, OpenTelemetry diagnostics, LanceDB memory, QA mock-provider, and Anthropic provider tests
- preserve authentication, streaming, tool, memory, telemetry, and sandbox behavior coverage
- reduce duplicated setup without changing production code or plugin contracts

## Verification

- LanceDB: 144/144
- OpenTelemetry diagnostics: 191/191
- QA mock provider: 271/271
- Anthropic provider: 95/95
- Copilot, including local-loopback BYOK coverage: 335/335
- independent combined proof: 1036/1036 across five routed shards
- format, typed lint, diff, scope, AST inventory, and accepted-file hash checks passed
- mandatory isolated review and secret scan completed clean with no actionable findings
- exact reviewed binary diff: `7ed5b35898ecc8d041e435b7450ce56decb353cd417ebfac03a30059cdb38aee`

This is test-only: +1547/-3230, net -1683. No production, API, configuration, schema, migration, security, or documented behavior changes.

Changelog: not required for test-only cleanup.
