### PR TITLE
fix(agents): child tasks lose findings and actionable failure causes

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-output.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-output.test.ts
@@ -517,6 +517,36 @@ describe("readSubagentOutput", () => {
 });
 
 describe("buildChildCompletionFindings", () => {
+  it.each([
+    {
+      name: "timeout with its preserved failure cause",
+      outcome: { status: "timeout", error: "  provider rejected the request  " },
+      expected: "timeout: provider rejected the request",
+    },
+    {
+      name: "timeout without a failure cause",
+      outcome: { status: "timeout" },
+      expected: "timeout",
+    },
+    {
+      name: "ordinary failure with its cause",
+      outcome: { status: "error", error: "  provider rejected the request  " },
+      expected: "error: provider rejected the request",
+    },
+  ] as const)("describes a $name in parent-visible findings", ({ outcome, expected }) => {
+    const findings = buildChildCompletionFindings([
+      {
+        childSessionKey: "agent:main:subagent:child",
+        task: "child task",
+        createdAt: 1,
+        completion: { resultText: "captured findings" },
+        execution: { outcome },
+      },
+    ]);
+
+    expect(findings).toContain(`status: ${expected}`);
+  });
+
   it("hard-bounds each child result and the aggregate parent prompt", () => {
     const findings = buildChildCompletionFindings(
       Array.from({ length: 8 }, (_, index) => ({
@@ -711,21 +741,27 @@ describe("buildChildCompletionFindings", () => {
     expect(findings).toContain("(no output)");
   });
 
-  it("uses captured fallback output when a resumed completion returns NO_REPLY", () => {
+  it.each([
+    { name: "successful NO_REPLY", status: "ok", resultText: "NO_REPLY" },
+    { name: "blank failed", status: "error", resultText: "" },
+    { name: "whitespace timed-out", status: "timeout", resultText: " \n\t " },
+    { name: "blank unknown", status: "unknown", resultText: "" },
+  ] as const)("uses captured fallback output for a $name completion", ({ status, resultText }) => {
     const findings = buildChildCompletionFindings([
       {
         childSessionKey: "agent:main:subagent:child",
         task: "child task",
         createdAt: 1,
         completion: {
-          resultText: "NO_REPLY",
+          resultText,
           fallbackResultText: "findings captured before the wake",
         },
-        execution: { outcome: { status: "ok" } },
+        execution: { outcome: { status } },
       },
     ]);
 
     expect(findings).toContain("findings captured before the wake");
+    expect(findings).not.toContain("(no output)");
     expect(findings).not.toContain("NO_REPLY");
   });
 

--- a/src/agents/subagents/announce/subagent-announce-output.ts
+++ b/src/agents/subagents/announce/subagent-announce-output.ts
@@ -397,11 +397,9 @@ function describeSubagentOutcome(outcome?: SubagentRunOutcome): string {
   if (outcome.status === "ok") {
     return "ok";
   }
-  if (outcome.status === "timeout") {
-    return "timeout";
-  }
-  if (outcome.status === "error") {
-    return outcome.error?.trim() ? `error: ${outcome.error.trim()}` : "error";
+  if (outcome.status === "timeout" || outcome.status === "error") {
+    const error = outcome.error?.trim();
+    return error ? `${outcome.status}: ${error}` : outcome.status;
   }
   return "unknown";
 }

--- a/src/agents/subagents/completion/subagent-completion-result.test.ts
+++ b/src/agents/subagents/completion/subagent-completion-result.test.ts
@@ -47,4 +47,26 @@ describe("resolveSubagentCompletionResultText", () => {
       }),
     ).toBe("legacy fallback");
   });
+
+  it.each([
+    { status: "error", resultText: "" },
+    { status: "error", resultText: " \n\t " },
+    { status: "timeout", resultText: "" },
+    { status: "timeout", resultText: " \n\t " },
+    { status: "unknown", resultText: "" },
+    { status: "unknown", resultText: " \n\t " },
+  ] as const)(
+    "preserves captured findings when a $status completion has blank primary text ($#)",
+    ({ status, resultText }) => {
+      expect(
+        resolveSubagentCompletionResultText({
+          completion: {
+            resultText,
+            fallbackResultText: "  actionable captured findings  ",
+          },
+          execution: { status: "terminal", outcome: { status } },
+        }),
+      ).toBe("actionable captured findings");
+    },
+  );
 });

--- a/src/agents/subagents/completion/subagent-completion-result.ts
+++ b/src/agents/subagents/completion/subagent-completion-result.ts
@@ -25,5 +25,5 @@ export function resolveSubagentCompletionResultText(entry: {
   if (entry.execution.outcome?.status === "ok") {
     return selectDeliverableSessionsReply(primary, fallback);
   }
-  return (primary ?? fallback)?.trim() || undefined;
+  return primary?.trim() || fallback?.trim() || undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where parent agents could receive `(no output)` after a failed or timed-out child had already captured useful findings. Batched child-completion summaries also omitted the actionable cause of failures initially reported as pending-error timeouts.

## Why This Change Was Made

Select non-empty captured output in the canonical child-completion result owner, and preserve authoritative timeout failure causes in the existing parent-facing outcome formatter. Explicit terminal-reply decisions and successful-run silent-reply handling retain their existing precedence.

## User Impact

Parent agents now receive the findings and actionable failure details needed to continue their work, while ordinary timeouts and intentionally silent child completions retain their existing behavior.

## Evidence

- Before the fix, six owner-boundary cases failed for blank and whitespace primary results across failed, timed-out, and unknown child outcomes; four parent-facing completion cases also failed.
- Focused child-completion, parent-findings, admission, and registry sibling suites pass all 94 tests.
- Focused formatting, lint, and existing sibling-contract checks pass. Production code decreases by two lines; no persistence, protocol, configuration, provider, or public-contract behavior is changed.
