### PR TITLE
fix(gateway): preserve portal retry page on target port collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Gateway portal proxy allocation:** prevent an ephemeral portal listener from claiming its own target port and proxying back into its authorization boundary, preserving the retry page when the target is unavailable.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Gateway portal proxy allocation:** prevent an ephemeral portal listener from claiming its own target port and proxying back into its authorization boundary, preserving the retry page when the target is unavailable.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/src/gateway/portals/portal-service.test.ts
+++ b/src/gateway/portals/portal-service.test.ts
@@ -1,4 +1,4 @@
-import { request } from "node:http";
+import { request, type Server } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getFreePort } from "../../test-utils/ports.js";
 import * as httpListen from "../server/http-listen.js";
@@ -82,6 +82,7 @@ describe("gateway portal service", () => {
     ]);
     expect(httpServers).toHaveLength(2);
     expect(httpServers.every((server) => server.listening)).toBe(true);
+    expect(await getStatus("127.0.0.1", portal.listenPort, `/?${portal.tokenQuery}`)).toBe(502);
 
     const ownedServers = [...httpServers];
     await service.closeAll();
@@ -89,6 +90,30 @@ describe("gateway portal service", () => {
     expect(ownedServers.every((server) => !server.listening && server.address() === null)).toBe(
       true,
     );
+  });
+
+  it("cleans up when every allocation collides with the target port", async () => {
+    const targetPort = await getFreePort();
+    const actualListen = httpListen.listenGatewayHttpServer;
+    const attemptedServers = new Set<Server>();
+    const listen = vi
+      .spyOn(httpListen, "listenGatewayHttpServer")
+      .mockImplementation(async (params) => {
+        attemptedServers.add(params.httpServer);
+        await actualListen({ ...params, port: targetPort });
+      });
+    const { service, httpServers } = makeService(["127.0.0.1"]);
+
+    await expect(service.open({ targetPort })).rejects.toThrow(
+      `Portal listener repeatedly allocated target port ${targetPort}`,
+    );
+
+    expect(listen).toHaveBeenCalledTimes(10);
+    expect(attemptedServers.size).toBe(1);
+    expect(httpServers).toEqual([]);
+    const [primaryServer] = attemptedServers;
+    expect(primaryServer?.listening).toBe(false);
+    expect(primaryServer?.address()).toBeNull();
   });
 
   it("updates an existing target without replacing its listener or token", async () => {

--- a/src/gateway/portals/portal-service.test.ts
+++ b/src/gateway/portals/portal-service.test.ts
@@ -1,10 +1,13 @@
 import { request } from "node:http";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getFreePort } from "../../test-utils/ports.js";
+import * as httpListen from "../server/http-listen.js";
 import { createGatewayPortalService, type GatewayPortalService } from "./portal-service.js";
 
 const services = new Set<GatewayPortalService>();
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all([...services].map((service) => service.closeAll()));
   services.clear();
 });
@@ -27,6 +30,16 @@ async function getStatus(host: string, port: number, path: string): Promise<numb
   });
 }
 
+async function getDistinctFreePort(excluded: number): Promise<number> {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const port = await getFreePort();
+    if (port !== excluded) {
+      return port;
+    }
+  }
+  throw new Error("Failed to reserve a distinct test port");
+}
+
 describe("gateway portal service", () => {
   it("allocates one port across every frozen bind host", async () => {
     const { service, httpServers } = makeService(["127.0.0.1", "::1"]);
@@ -37,6 +50,45 @@ describe("gateway portal service", () => {
     expect(httpServers).toHaveLength(2);
     expect(await getStatus("127.0.0.1", portal.listenPort, "/")).toBe(401);
     expect(await getStatus("::1", portal.listenPort, "/")).toBe(401);
+  });
+
+  it("retries a target-port collision before binding sibling hosts", async () => {
+    const targetPort = await getFreePort();
+    const acceptedPort = await getDistinctFreePort(targetPort);
+    const actualListen = httpListen.listenGatewayHttpServer;
+    const calls: Array<{ host: string; port: number }> = [];
+    let primaryAttempt = 0;
+    vi.spyOn(httpListen, "listenGatewayHttpServer").mockImplementation(async (params) => {
+      calls.push({ host: params.bindHost, port: params.port });
+      if (params.bindHost === "127.0.0.1" && params.port === 0) {
+        primaryAttempt += 1;
+        await actualListen({
+          ...params,
+          port: primaryAttempt === 1 ? targetPort : acceptedPort,
+        });
+        return;
+      }
+      await actualListen(params);
+    });
+    const { service, httpServers } = makeService(["127.0.0.1", "::1"]);
+
+    const portal = await service.open({ targetPort });
+
+    expect(portal.listenPort).toBe(acceptedPort);
+    expect(calls).toEqual([
+      { host: "127.0.0.1", port: 0 },
+      { host: "127.0.0.1", port: 0 },
+      { host: "::1", port: acceptedPort },
+    ]);
+    expect(httpServers).toHaveLength(2);
+    expect(httpServers.every((server) => server.listening)).toBe(true);
+
+    const ownedServers = [...httpServers];
+    await service.closeAll();
+    expect(httpServers).toEqual([]);
+    expect(ownedServers.every((server) => !server.listening && server.address() === null)).toBe(
+      true,
+    );
   });
 
   it("updates an existing target without replacing its listener or token", async () => {

--- a/src/gateway/portals/portal-service.ts
+++ b/src/gateway/portals/portal-service.ts
@@ -11,6 +11,8 @@ import type {
 import { listenGatewayHttpServer } from "../server/http-listen.js";
 import { handlePortalProxyRequest, handlePortalProxyUpgrade } from "./portal-http-proxy.js";
 
+const PORTAL_PORT_ALLOCATION_ATTEMPTS = 10;
+
 type PortalEntry = {
   id: string;
   title: string;
@@ -189,7 +191,40 @@ export function createGatewayPortalService(params: {
         // Registration precedes every bind so whole-gateway cleanup owns partial startup.
         params.httpServers.push(...servers);
         try {
+          const primaryServer = servers[0];
+          const primaryHost = params.httpBindHosts[0];
+          if (!primaryServer || !primaryHost) {
+            throw new Error("Missing primary portal HTTP server");
+          }
+          for (let attempt = 0; attempt < PORTAL_PORT_ALLOCATION_ATTEMPTS; attempt += 1) {
+            await listenGatewayHttpServer({
+              httpServer: primaryServer,
+              bindHost: primaryHost,
+              port: 0,
+              retryEaddrinuse: false,
+              serviceName: "portal",
+              endpointScheme: params.tlsOptions ? "https" : "http",
+            });
+            const address = primaryServer.address() as AddressInfo | null;
+            if (!address || typeof address === "string") {
+              throw new Error("Portal listener failed to resolve its port");
+            }
+            if (address.port !== portal.targetPort) {
+              portal.listenPort = address.port;
+              break;
+            }
+            // A proxy cannot share its target port: it would dial itself and fail auth.
+            await closeServers([primaryServer]);
+          }
+          if (portal.listenPort === 0) {
+            throw new Error(
+              `Portal listener repeatedly allocated target port ${portal.targetPort}`,
+            );
+          }
           for (const [index, host] of params.httpBindHosts.entries()) {
+            if (index === 0) {
+              continue;
+            }
             const server = servers[index];
             if (!server) {
               throw new Error(`Missing portal HTTP server for bind host ${host}`);
@@ -197,18 +232,11 @@ export function createGatewayPortalService(params: {
             await listenGatewayHttpServer({
               httpServer: server,
               bindHost: host,
-              port: index === 0 ? 0 : portal.listenPort,
+              port: portal.listenPort,
               retryEaddrinuse: false,
               serviceName: "portal",
               endpointScheme: params.tlsOptions ? "https" : "http",
             });
-            if (index === 0) {
-              const address = server.address() as AddressInfo | null;
-              if (!address || typeof address === "string") {
-                throw new Error("Portal listener failed to resolve its port");
-              }
-              portal.listenPort = address.port;
-            }
           }
         } catch (error) {
           removeServers(params.httpServers, servers);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a portal for an unavailable local app could receive the portal's private 401 page instead of the expected retrying 502 page when the OS reassigned the app's just-released port to the portal listener.

## Why This Change Was Made

The portal service now owns this allocation invariant: its primary proxy listener may never use the target port. It reuses the already-registered primary server for up to 10 immediate ephemeral allocations, accepts the first distinct port, then binds sibling hosts to that accepted port. Existing authorization, localhost dual-stack target dialing, WebSocket handling, and whole-gateway cleanup remain unchanged.

The regression test forces the first ephemeral allocation to equal the target port, proves the primary listener retries before any sibling bind, makes an authenticated request through the accepted listener, and verifies shutdown removes and closes both listeners. A separate exhaustion case proves ten consecutive collisions leave neither a registered nor listening server.

Production LOC: +36/-8 (net +28), justified by enforcing the listener-allocation ownership boundary before the proxy can self-dial.

Tests: +79/-2.

## User Impact

Portal users consistently see the auto-refreshing "Waiting for app" page while a target is down, including the rare target-port reuse race, instead of being sent into the portal authentication boundary.

## Evidence

- Hosted failure reproduced the symptom: expected 502, received 401 in `portal-http-proxy.test.ts`: https://github.com/openclaw/openclaw/actions/runs/32814880297
- Exact-head focused portal service + HTTP proxy suites: 18/18 passing.
- Bounded combined repeat: 10/10 iterations passing, 180 assertions total.
- Authenticated collision trace, bearer redacted: `GET http://127.0.0.1:<portal-listen-port>/?openclaw_portal=<redacted> -> 502`. The test builds the query from `portal.tokenQuery`; the token is never logged.
- Exhaustion cleanup: ten forced target-port allocations produce the bounded allocation error, empty the shared listener registry, and leave the reused primary server closed with a null address.
- `git diff --check`: passing.
- Targeted `oxfmt --check`: passing.
- `check-changed`: conflict markers, ratchets, changelog attribution, dependency pins, formatting, deprecated API, plugin boundaries, wrapper shadowing, package patch guards, and all three dead-export scans passed. Core typecheck then reported unrelated stale shared-dependency errors in Google AI, markdown-it, and pi-tui surfaces; no error referenced the portal files.
- Autoreview preflight ran TruffleHog clean. The Codex reviewer could not start because the standalone CLI is absent on this host; the supported Claude fallback could not refresh its expired OAuth session. Exact-head ClawSweeper review and hosted CI provide the external review/type gates.

AI-assisted: yes. The implementation and tests were reviewed against the portal service owner, proxy caller/callee path, gateway lifecycle cleanup, Node `net.Server.listen` retry contract, and the original feature history.
