### PR TITLE
fix(lmstudio): preserve embedding index across API key rotation

### DIFF
--- a/extensions/lmstudio/memory-embedding-adapter.ts
+++ b/extensions/lmstudio/memory-embedding-adapter.ts
@@ -30,7 +30,7 @@ export const lmstudioMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdap
           provider: providerId,
           baseUrl: client.baseUrl,
           model: client.model,
-          headers: sanitizeEmbeddingCacheHeaders(client.headers, ["authorization"]),
+          headers: sanitizeEmbeddingCacheHeaders(client.headers, ["authorization", "x-api-key"]),
         },
       },
     };

--- a/extensions/lmstudio/src/embedding-provider.test.ts
+++ b/extensions/lmstudio/src/embedding-provider.test.ts
@@ -455,4 +455,48 @@ describe("createLmstudioEmbeddingProvider preload context length", () => {
       model: EMBEDDING_MODEL,
     });
   });
+
+  it("keeps API key rotation out of memory identity without dropping tenant headers", async () => {
+    const readIdentity = async (headers: Record<string, string>) =>
+      (
+        await lmstudioMemoryEmbeddingProviderAdapter.create({
+          config: buildConfig({ provider: { params: { preload: false } } }),
+          provider: "lmstudio",
+          model: EMBEDDING_MODEL,
+          fallback: "none",
+          remote: { headers },
+        })
+      ).runtime?.cacheKeyData;
+
+    const defaultIdentity = await readIdentity({});
+    const firstTenant = await readIdentity({
+      Authorization: "Bearer synthetic-before",
+      "X-API-KEY": "synthetic-key-before",
+      "X-Tenant": "tenant-a",
+    });
+    const rotatedTenant = await readIdentity({
+      Authorization: "Bearer synthetic-after",
+      "x-Api-Key": "synthetic-key-after",
+      "X-Tenant": "tenant-a",
+    });
+    const otherTenant = await readIdentity({
+      "X-Api-Key": "synthetic-key-after",
+      "X-Tenant": "tenant-b",
+    });
+
+    expect(defaultIdentity).toEqual({
+      provider: "lmstudio",
+      baseUrl: "http://localhost:1234/v1",
+      model: EMBEDDING_MODEL,
+      headers: [["Content-Type", "application/json"]],
+    });
+    expect(firstTenant).toEqual(rotatedTenant);
+    expect(firstTenant).not.toEqual(otherTenant);
+    expect(firstTenant).toMatchObject({
+      headers: [
+        ["Content-Type", "application/json"],
+        ["X-Tenant", "tenant-a"],
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Keep LM Studio memory index identity stable when operators rotate an `X-Api-Key` header. The LM Studio embedding adapter already excludes `Authorization`; applying the existing case-insensitive cache-header sanitizer to `X-Api-Key` as well matches the Ollama adapter without changing the provider, endpoint, model, tenant, or ordinary headerless identity.

The production change replaces one existing line and adds no production lines. The owner-boundary regression first failed on current main because rotating mixed-case API-key headers changed the index identity, then passed after the fix. It also proves authorization rotation is ignored, tenant changes remain isolated, and the existing `Content-Type` identity of ordinary LM Studio installations is preserved.

## Upgrade impact

Existing LM Studio installations that already configured an explicit `X-Api-Key` header will see a one-time embedding-index identity change when upgrading. If vector search reports an index identity mismatch, rebuild the affected agent once:

```bash
openclaw memory index --force --agent <id>
```

Ordinary LM Studio installations without an `X-Api-Key` header keep exactly the same index identity and do not need a rebuild.

## Validation

- Existing owner regression: 14 passed and 1 failed on current main before the fix; all 15 passed after the one-line repair.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-lmstudio-cache-identity-vitest OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/lmstudio/src/embedding-provider.test.ts --configLoader runner`
- `node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/lmstudio/memory-embedding-adapter.ts extensions/lmstudio/src/embedding-provider.test.ts`
- Focused formatting check, `git diff --check`, two independent maintainer reviews, and structured autoreview all passed.
- The broad local extension lint wrapper encountered existing dependency/type mismatches in unrelated Google, Markdown, and TUI packages; exact-head hosted CI provides the authoritative clean-install boundary checks.
