### PR TITLE
fix(android): prevent unavailable SMS from reopening onboarding approval

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -3222,6 +3222,7 @@ private fun rememberPermissionState(
         }
       motionGranted = permissions[Manifest.permission.ACTIVITY_RECOGNITION] ?: motionGranted
       smsGranted =
+        !smsAvailable ||
         mergedRequiredPermissionGrantState(
           permissions = permissions,
           requiredPermissions = listOf(Manifest.permission.SEND_SMS, Manifest.permission.READ_SMS),

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -219,6 +219,8 @@ class OnboardingFlowLogicTest {
       PermissionApprovalCase(expected = true, requestedCameraEnabled = true),
       PermissionApprovalCase(expected = true, requestedLocationMode = LocationMode.WhileUsing),
       PermissionApprovalCase(expected = true, currentSmsGranted = false),
+      PermissionApprovalCase(expected = true, requestedSmsGranted = false),
+      PermissionApprovalCase(expected = false),
       PermissionApprovalCase(
         expected = false,
         currentCameraEnabled = true,
@@ -235,7 +237,7 @@ class OnboardingFlowLogicTest {
           currentLocationMode = case.currentLocationMode,
           requestedLocationMode = case.requestedLocationMode,
           currentSmsGranted = case.currentSmsGranted,
-          requestedSmsGranted = true,
+          requestedSmsGranted = case.requestedSmsGranted,
         ),
       )
     }
@@ -347,6 +349,22 @@ class OnboardingFlowLogicTest {
         currentlyGranted = { true },
       )
     assertFalse(deniedRead)
+
+    val afterUnrelatedPermission =
+      mergedRequiredPermissionGrantState(
+        permissions = mapOf(Manifest.permission.RECORD_AUDIO to true),
+        requiredPermissions = requiredPermissions,
+        currentlyGranted = { true },
+      )
+    assertTrue(afterUnrelatedPermission)
+
+    val afterUnrelatedPermissionWithSmsDenied =
+      mergedRequiredPermissionGrantState(
+        permissions = mapOf(Manifest.permission.RECORD_AUDIO to true),
+        requiredPermissions = requiredPermissions,
+        currentlyGranted = { false },
+      )
+    assertFalse(afterUnrelatedPermissionWithSmsDenied)
   }
 
   @Test
@@ -912,6 +930,7 @@ class OnboardingFlowLogicTest {
     val currentLocationMode: LocationMode = LocationMode.Off,
     val requestedLocationMode: LocationMode = LocationMode.Off,
     val currentSmsGranted: Boolean = true,
+    val requestedSmsGranted: Boolean = true,
   )
 
   private data class GatewayContinueCase(


### PR DESCRIPTION
## What Problem This Solves

The default Google Play Android build can send an already-approved device back to **Approve node access** after the user grants an unrelated permission during onboarding. In a real Play app, tapping Voice, accepting Android's microphone permission dialog, and pressing Continue incorrectly leaves onboarding unfinished and asks the operator to approve the node again.

Play intentionally has no SMS capability. Its onboarding state correctly initializes unavailable SMS as already satisfied, but every unrelated runtime-permission callback was recomputing nonexistent `SEND_SMS` and `READ_SMS` grants as false. That fabricated true-to-false capability change triggered node reapproval even though the device's actual advertised SMS surface never existed.

## Why This Change Was Made

Preserve the existing unavailable-capability sentinel at its producer: the onboarding permission callback now keeps SMS satisfied whenever the SMS feature or telephony capability is unavailable. Real SMS grants in the enabled third-party build continue to use the existing dual-permission merge and still trigger node reapproval when their authority changes. No permission, product capability, settings, protocol, helper, or fallback surface is added.

The production change is exactly **one added line**. Existing owner-level logic coverage additionally verifies unchanged unavailable capability state, both real SMS grant transitions, and unrelated microphone callbacks with SMS granted or denied.

## Evidence

- Real Android 36 **Play** app, actual approved screenshot-fixture gateway, real Compose onboarding, real Google Android `RECORD_AUDIO` permission dialog and Allow action, real Activity Result callback, and real Continue button.
- Unchanged baseline: the same actual device shows **Approve node access**, with `onboardingCompleted=false`, `microphoneGranted=true`, and `smsEnabled=false`.
- Fixed app: the same real permission-dialog flow completes onboarding into **Chat**, with `onboardingCompleted=true`, `microphoneGranted=true`, and `smsEnabled=false`. The same Android UI instrumentation passed before and after against their expected visible outcomes.
- Play owner suite: `:app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest` — **63 passed**.
- Third-party sibling owner suite: `:app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest` — **63 passed**, including real enabled-SMS reapproval controls.
- Exact hosted Android formatting lane: `:app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck` — **passed**; combined validation finished `BUILD SUCCESSFUL` with 126 tasks.
- Fresh independent structured review reported no actionable findings.
- The full real Android permission/callback/UI before-and-after is the actual fail-first owner regression; the pure approval and permission-merge tables are additional boundary coverage.

### Before: Play onboarding incorrectly demands node approval

![Actual Android Play build incorrectly requesting node reapproval after microphone permission](https://github.com/user-attachments/assets/a7eab601-6d34-45e8-bf07-d88e2c96f414)

### After: the same real permission flow finishes onboarding

![Actual Android Play build completing onboarding into Chat after the same microphone permission](https://github.com/user-attachments/assets/dd4930a7-40bd-4dbf-ab18-8f779d4287d6)
