### PR TITLE
fix(plugins): inspection loads the wrong plugin when names collide

### DIFF
--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -889,9 +889,12 @@ describe("plugins cli list", () => {
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("broken (unsupported transport)");
   });
 
-  it("runtime-inspects without repairing deps", async () => {
+  it("runtime-inspects exact plugin ids and display names without repairing deps", async () => {
     buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [createPluginRecord({ id: "openclaw-mem0", name: "Mem0" })],
+      plugins: [
+        createPluginRecord({ id: "unrelated-plugin", name: "openclaw-mem0" }),
+        createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
+      ],
       diagnostics: [],
     });
     buildPluginInspectReportMock.mockReturnValue({
@@ -921,12 +924,13 @@ describe("plugins cli list", () => {
       compatibility: [],
     });
 
-    await runPluginsCommand(["plugins", "inspect", "openclaw-mem0", "--runtime"]);
-
-    expect(buildPluginDiagnosticsReportMock).toHaveBeenCalledWith({
-      config: {},
-      onlyPluginIds: ["openclaw-mem0"],
-    });
+    for (const selector of ["openclaw-mem0", "Mem0"]) {
+      await runPluginsCommand(["plugins", "inspect", selector, "--runtime"]);
+      expect(buildPluginDiagnosticsReportMock).toHaveBeenLastCalledWith({
+        config: {},
+        onlyPluginIds: ["openclaw-mem0"],
+      });
+    }
   });
 
   it("does not runtime-load plugins when inspect target is missing", async () => {

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -235,7 +235,9 @@ export async function runPluginsInspectCommand(
       }),
     { command: "inspect" },
   );
-  const targetPlugin = snapshotReport.plugins.find((entry) => entry.id === id || entry.name === id);
+  const targetPlugin =
+    snapshotReport.plugins.find((entry) => entry.id === id) ??
+    snapshotReport.plugins.find((entry) => entry.name === id);
   if (!targetPlugin) {
     if (id === "skill-workshop") {
       const { detectSkillWorkshopToolPolicyDiagnostic } =

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -722,12 +722,12 @@ describe("plugin status reports", () => {
     ]);
   });
 
-  it("builds inspect reports for every loaded plugin", () => {
+  it("prefers exact plugin ids over display names in individual and all inspect reports", () => {
     setPluginLoadResult({
       plugins: [
         createPluginRecord({
           id: "lca",
-          name: "LCA",
+          name: "microsoft",
           description: "Legacy hook plugin",
           hookCount: 1,
         }),
@@ -742,6 +742,9 @@ describe("plugin status reports", () => {
       ],
       hooks: [createCustomHook({ pluginId: "lca", events: ["message"] })],
     });
+
+    expect(expectInspectReport("microsoft").plugin.id).toBe("microsoft");
+    expect(expectInspectReport("Microsoft").plugin.id).toBe("microsoft");
 
     const inspect = buildAllPluginInspectReports();
 

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -363,7 +363,9 @@ export function buildPluginInspectReport(params: {
       workspaceDir: params.workspaceDir,
       env: params.env,
     });
-  const plugin = report.plugins.find((entry) => entry.id === params.id || entry.name === params.id);
+  const plugin =
+    report.plugins.find((entry) => entry.id === params.id) ??
+    report.plugins.find((entry) => entry.name === params.id);
   if (!plugin) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where inspecting a plugin by its exact ID could display or load an entirely different plugin when an earlier plugin used that ID as its display name. Inspecting all plugins could consequently repeat one plugin and omit another.

## Why This Change Was Made

Give exact plugin IDs precedence at both authoritative inspection lookup boundaries, while preserving the display-name lookup compatibility that already ships in stable releases. This matches the exact-ID precedence already used by plugin uninstall selection.

## User Impact

Plugin inspection, runtime inspection, complete plugin inventories, and compatibility diagnostics now consistently refer to the plugin requested by its exact ID; existing display-name aliases still work.

## Evidence

- Before the fix, owner-level inspection selected a colliding display-name plugin, and real CLI runtime inspection attempted to load the wrong plugin.
- After the fix, `node scripts/run-vitest.mjs src/plugins/status.test.ts src/cli/plugins-cli.list.test.ts src/cli/plugins-uninstall-selection.test.ts src/auto-reply/reply/commands-plugins.test.ts` passes all 81 tests.
- Focused formatting, lint, independent owner-boundary review, and structured review are clean. Four production lines are required to preserve the stable display-name contract across both independent lookup boundaries.
