### PR TITLE
fix(telegram): describe reaction emoji syntax

### DIFF
--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -498,6 +498,53 @@ describe("telegramMessageActions", () => {
     });
   });
 
+  it("advertises Telegram reaction syntax and emoji discovery in message tool schema", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "tok",
+          actions: { reactions: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    const discovery = telegramMessageActions.describeMessageTool?.({ cfg });
+    const contributions = Array.isArray(discovery?.schema)
+      ? discovery.schema
+      : discovery?.schema
+        ? [discovery.schema]
+        : [];
+    const reactionSchema = contributions.find((entry) => entry.actions?.includes("react"));
+    const emojiDescription = (
+      reactionSchema?.properties.emoji as { description?: string } | undefined
+    )?.description;
+
+    expect(reactionSchema?.actions).toEqual(["react"]);
+    expect(reactionSchema?.properties.emoji).toMatchObject({
+      type: "string",
+      description: expect.stringContaining("custom_emoji_id"),
+    });
+    expect(emojiDescription).toContain('action:"emoji-list"');
+    expect(emojiDescription).toContain("arbitrary Unicode may be rejected");
+
+    const disabledDiscovery = telegramMessageActions.describeMessageTool?.({
+      cfg: {
+        channels: {
+          telegram: {
+            botToken: "tok",
+            actions: { reactions: false },
+          },
+        },
+      } as OpenClawConfig,
+    });
+    const disabledContributions = Array.isArray(disabledDiscovery?.schema)
+      ? disabledDiscovery.schema
+      : disabledDiscovery?.schema
+        ? [disabledDiscovery.schema]
+        : [];
+    expect(disabledContributions.find((entry) => entry.actions?.includes("react"))).toBeUndefined();
+  });
+
   it("matches runtime account-key normalization during SecretRef-tolerant discovery", () => {
     const cfg = {
       channels: {

--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -514,12 +514,12 @@ describe("telegramMessageActions", () => {
       : discovery?.schema
         ? [discovery.schema]
         : [];
-    const reactionSchema = contributions.find((entry) => entry.actions?.includes("react"));
+    const reactionSchema = contributions.find((entry) => "emoji" in entry.properties);
     const emojiDescription = (
       reactionSchema?.properties.emoji as { description?: string } | undefined
     )?.description;
 
-    expect(reactionSchema?.actions).toEqual(["react"]);
+    expect(reactionSchema?.actions).toEqual([]);
     expect(reactionSchema?.properties.emoji).toMatchObject({
       type: "string",
       description: expect.stringContaining("custom_emoji_id"),

--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -519,6 +519,7 @@ describe("telegramMessageActions", () => {
       reactionSchema?.properties.emoji as { description?: string } | undefined
     )?.description;
 
+    expect(discovery?.actions).toEqual(expect.arrayContaining(["react", "emoji-list"]));
     expect(reactionSchema?.actions).toEqual([]);
     expect(reactionSchema?.properties.emoji).toMatchObject({
       type: "string",
@@ -542,7 +543,9 @@ describe("telegramMessageActions", () => {
       : disabledDiscovery?.schema
         ? [disabledDiscovery.schema]
         : [];
-    expect(disabledContributions.find((entry) => entry.actions?.includes("react"))).toBeUndefined();
+    expect(disabledDiscovery?.actions).not.toContain("react");
+    expect(disabledDiscovery?.actions).not.toContain("emoji-list");
+    expect(disabledContributions.find((entry) => "emoji" in entry.properties)).toBeUndefined();
   });
 
   it("matches runtime account-key normalization during SecretRef-tolerant discovery", () => {

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -24,6 +24,7 @@ import {
 import { isTelegramInlineButtonsEnabled } from "./inline-buttons.js";
 import {
   createTelegramPollExtraToolSchemas,
+  createTelegramReactionEmojiSchema,
   createTelegramRichSendExtraToolSchemas,
 } from "./message-tool-schema.js";
 import { rejectTelegramNativeButtonParams } from "./native-button-params.js";
@@ -202,6 +203,12 @@ function describeTelegramMessageTool({
     schema.push({
       properties: createTelegramPollExtraToolSchemas(),
       visibility: "all-configured",
+    });
+  }
+  if (discovery.isEnabled("reactions")) {
+    schema.push({
+      properties: createTelegramReactionEmojiSchema(),
+      actions: ["react"],
     });
   }
   if (discovery.isEnabled("sendMessage")) {

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -208,7 +208,9 @@ function describeTelegramMessageTool({
   if (discovery.isEnabled("reactions")) {
     schema.push({
       properties: createTelegramReactionEmojiSchema(),
-      actions: ["react"],
+      // The shared emoji parameter keeps react valid across channels; this
+      // contribution only adds Telegram-specific guidance for that parameter.
+      actions: [],
     });
   }
   if (discovery.isEnabled("sendMessage")) {

--- a/extensions/telegram/src/message-tool-schema.ts
+++ b/extensions/telegram/src/message-tool-schema.ts
@@ -20,6 +20,19 @@ export function createTelegramPollExtraToolSchemas() {
   };
 }
 
+/** Schema additions for Telegram reactions through the existing react action. */
+export function createTelegramReactionEmojiSchema() {
+  return {
+    emoji: Type.Optional(
+      Type.String({
+        description:
+          'Telegram reaction emoji: use a supported Unicode reaction, or pass the numeric custom_emoji_id identifier returned by action:"emoji-list" directly as emoji. ' +
+          'Use action:"emoji-list" to inspect reactions allowed in the current chat; arbitrary Unicode may be rejected by Telegram.',
+      }),
+    ),
+  };
+}
+
 /** Schema additions for Telegram-native rich sends through the existing send action. */
 export function createTelegramRichSendExtraToolSchemas() {
   return {

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -4176,6 +4176,48 @@ describe("message tool description", () => {
     expect(tool.description).not.toContain("telegram (");
   });
 
+  it("keeps cross-channel Telegram reactions available when emoji schema is metadata-only", () => {
+    const signalPlugin = createChannelPlugin({
+      id: "signal",
+      label: "Signal",
+      docsPath: "/channels/signal",
+      blurb: "Signal test plugin.",
+      actions: ["send"],
+    });
+    const telegramPlugin = createChannelPlugin({
+      id: "telegram",
+      label: "Telegram",
+      docsPath: "/channels/telegram",
+      blurb: "Telegram test plugin.",
+      actions: ["send", "react"],
+      toolSchema: {
+        actions: [],
+        properties: {
+          emoji: Type.Optional(Type.String()),
+        },
+      },
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "signal", source: "test", plugin: signalPlugin },
+        { pluginId: "telegram", source: "test", plugin: telegramPlugin },
+      ]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "signal",
+    });
+
+    const properties = getToolProperties(tool);
+    expect(getActionEnum(properties)).toContain("react");
+    expect(properties.emoji).toMatchObject({ type: "string" });
+    expect((properties.emoji as { description?: string }).description).not.toContain(
+      "custom_emoji_id",
+    );
+  });
+
   it("does not advertise cross-channel actions whose params are hidden by current-channel schema", () => {
     const signalPlugin = createChannelPlugin({
       id: "signal",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents reacting in Telegram could get `REACTION_INVALID` because the shared message-tool schema did not explain Telegram's numeric custom emoji identifiers or chat-scoped allowed Unicode reactions.

Fixes #128935

## Why This Change Was Made

Telegram contributes a channel-scoped `emoji` description for `react` when reactions are enabled. The contribution is metadata-only (`actions: []`), so the shared `emoji` parameter remains valid for cross-channel reactions while Telegram still explains `emoji-list` and numeric custom-emoji identifiers. This follows the merged channel-owned discovery precedent in #128435.

## User Impact

Agents can discover Telegram's current reaction choices and format custom emoji reactions correctly without losing cross-channel reaction support.

## Evidence

- Base (`0a79ae5fd040`): the real `telegramMessageActions.describeMessageTool` adapter exposed `react` and `emoji-list` but emitted no Telegram `emoji` description.
- Head (`692ff1c0645e1dca76e06c67b20e863b368204ae`): the same production adapter emits a metadata-only Telegram `emoji` contribution; cross-channel message-tool discovery keeps `react`, and the reactions-disabled negative control emits no reaction schema.
- `pnpm test extensions/telegram/src/channel-actions.test.ts` — 16 tests passed, including schema guidance and the reactions-disabled negative control.
- `pnpm test src/agents/tools/message-tool.test.ts` — 236 tests passed, including cross-channel `react` discovery and Telegram metadata isolation.
- `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test`, and `pnpm tsgo:core:test` — passed.

```text
head (`692ff1c0645e1dca76e06c67b20e863b368204ae`), `$ pnpm exec tsx proof-live.ts`
sha: 692ff1c0645e1dca76e06c67b20e863b368204ae
configured: {"reactionActions":[],"hasReactionSchema":true,"emojiDescription":"Telegram reaction emoji: use a supported Unicode reaction, or pass the numeric custom_emoji_id identifier returned by action:\"emoji-list\" directly as emoji. Use action:\"emoji-list\" to inspect reactions allowed in the current chat; arbitrary Unicode may be rejected by Telegram."}
negative-control: {"hasReactionSchema":false}
```

<details>
<summary>proof-live.ts</summary>

```ts
import { execFileSync } from "node:child_process";
import { telegramMessageActions } from "./extensions/telegram/src/channel-actions.ts";

function describe(cfg: unknown) {
  const discovery = telegramMessageActions.describeMessageTool?.({ cfg: cfg as never });
  const contributions = Array.isArray(discovery?.schema)
    ? discovery.schema
    : discovery?.schema
      ? [discovery.schema]
      : [];
  const reaction = contributions.find((entry) => "emoji" in entry.properties);
  const emoji = reaction?.properties.emoji as { description?: string } | undefined;
  return {
    reactionActions: reaction?.actions,
    hasReactionSchema: Boolean(reaction),
    emojiDescription: emoji?.description,
  };
}

console.log(`sha: ${execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim()}`);
console.log(
  `configured: ${JSON.stringify(
    describe({ channels: { telegram: { botToken: "redacted" } } }),
  )}`,
);
console.log(
  `negative-control: ${JSON.stringify(
    describe({
      channels: { telegram: { botToken: "redacted", actions: { reactions: false } } },
    }),
  )}`,
);
```

</details>

AI-assisted: built with Codex
