### PR TITLE
fix(reply): rich replies disappear beside silent-response markers

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -5889,7 +5889,12 @@ describe("deliverOutboundPayloads", () => {
     expect(pinOptions?.messageId).toBe("mx-1");
   });
 
-  it("preserves channelData-only payloads with empty text for sendPayload channels", async () => {
+  it.each([
+    { name: "empty text", text: " \n\t " },
+    { name: "a silent token", text: "NO_REPLY" },
+    { name: "a silent JSON action", text: '{"action":"NO_REPLY"}' },
+    { name: "a relay status placeholder", text: "No channel reply." },
+  ])("delivers channelData-only payloads with $name", async ({ text }) => {
     const sendPayload = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-1" });
     const sendText = vi.fn();
     const sendMedia = vi.fn();
@@ -5899,7 +5904,7 @@ describe("deliverOutboundPayloads", () => {
       cfg: {},
       channel: "line",
       to: "U123",
-      payloads: [{ text: " \n\t ", channelData: { mode: "flex" } }],
+      payloads: [{ text, channelData: { mode: "flex" } }],
     });
 
     expect(sendPayload).toHaveBeenCalledTimes(1);

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -253,6 +253,49 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ]);
   });
 
+  it.each(
+    typedCases<{ name: string; content: ReplyPayload }>([
+      { name: "media", content: { mediaUrl: "https://x.test/one.png" } },
+      {
+        name: "voice media",
+        content: { mediaUrl: "https://x.test/voice.ogg", audioAsVoice: true },
+      },
+      {
+        name: "presentation",
+        content: { presentation: { blocks: [{ type: "text", text: "Visible card" }] } },
+      },
+      {
+        name: "interactive blocks",
+        content: { interactive: { blocks: [{ type: "text", text: "Visible controls" }] } },
+      },
+      { name: "channel data", content: { channelData: { mode: "flex" } } },
+      { name: "location", content: { location: { latitude: 1, longitude: 2 } } },
+    ]),
+  )("preserves $name without exposing suppressed reply text", ({ content }) => {
+    for (const text of [
+      "NO_REPLY",
+      '{"action":"NO_REPLY"}',
+      "No channel reply.",
+      "Replied in-thread.",
+    ]) {
+      const [normalized] = normalizeReplyPayloadsForDelivery([{ ...content, text }]);
+      expect(normalized, text).toMatchObject({ ...content, text: "" });
+    }
+  });
+
+  it.each(["NO_REPLY", '{"action":"NO_REPLY"}', "No channel reply.", "Replied in-thread."])(
+    "suppresses %s when an audio-as-voice marker has no media",
+    (text) => {
+      expect(normalizeReplyPayloadsForDelivery([{ text, audioAsVoice: true }])).toStrictEqual([]);
+    },
+  );
+
+  it("preserves empty audio-as-voice markers used for delivery tracking", () => {
+    expect(normalizeReplyPayloadsForDelivery([{ audioAsVoice: true }])).toMatchObject([
+      { text: "", audioAsVoice: true },
+    ]);
+  });
+
   it("drops bare silent replies for direct conversations", () => {
     expect(
       projectOutboundPayloadPlanForDelivery(

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -230,12 +230,7 @@ function createOutboundPayloadPlanEntry(
   const strippedParsed =
     strippedText === (parsed.text ?? "") ? parsed : parseReplyDirectives(strippedText);
   const parsedText = strippedParsed.text ?? "";
-  if (
-    (strippedParsed.isSilent || isSuppressedRelayStatusText(parsedText)) &&
-    mergedMedia.length === 0
-  ) {
-    return null;
-  }
+  const suppressedText = strippedParsed.isSilent || isSuppressedRelayStatusText(parsedText);
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
   const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
   const normalizedPayload: ReplyPayload = {
@@ -243,7 +238,7 @@ function createOutboundPayloadPlanEntry(
     text:
       formatBtwTextForExternalDelivery({
         ...payload,
-        text: parsedText,
+        text: suppressedText ? "" : parsedText,
       }) ?? "",
     mediaUrls: mergedMedia.length ? mergedMedia : undefined,
     mediaUrl: resolvedMediaUrl,
@@ -252,7 +247,10 @@ function createOutboundPayloadPlanEntry(
     replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
     audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
   };
-  if (!isRenderablePayload(normalizedPayload)) {
+  const hasRenderableContent = suppressedText
+    ? hasReplyPayloadContent(normalizedPayload)
+    : isRenderablePayload(normalizedPayload);
+  if (!hasRenderableContent) {
     return null;
   }
   const hasChannelData = hasReplyChannelData(normalizedPayload.channelData);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users expecting an interactive card, buttons, channel-native content, location, or media could receive no reply when the model paired that visible content with a silent-reply marker. Relay housekeeping text could also leak into an otherwise valid media caption.

## Why This Change Was Made

Normalize silent and relay-control text in the shared outbound payload owner, then let its existing content-aware renderability decision preserve every supported visible payload shape. This removes the earlier media-only suppression branch instead of adding channel-specific exceptions.

## User Impact

Rich replies and attachments are delivered across channels without exposing internal silent-reply markers or relay status. Truly empty silent replies remain suppressed.

## Evidence

- Before the fix, five outbound-payload regressions and three real outbound-adapter regressions failed: media leaked relay text, while presentations, interactive blocks, channel-native payloads, and locations disappeared.
- Independent review additionally found and reproduced four phantom voice-only deliveries; the final owner repair suppresses those genuine silent payloads while preserving legitimate voice-tracking markers and real voice media.
- After the fix, `node scripts/run-vitest.mjs src/infra/outbound/payloads.test.ts src/infra/outbound/deliver.test.ts src/infra/outbound/deliver-payload.presentation.test.ts src/interactive/payload.test.ts src/auto-reply/reply/reply-delivery.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/block-reply-pipeline.test.ts` passes all 398 tests.
- Focused formatting and lint checks pass; production code decreases by two lines. No configuration, persistence, protocol, plugin contract, or external-service behavior is changed.
