### PR TITLE
fix(plugins): doctor reports supported hook-only plugins as unhealthy

### DIFF
--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -143,7 +143,7 @@ export const buildPluginRegistrySnapshotReportMock: UnknownMock = vi.fn();
 export const buildPluginInspectReportMock: UnknownMock = vi.fn();
 const buildAllPluginInspectReports: UnknownMock = vi.fn();
 export const buildPluginDiagnosticsReportMock: UnknownMock = vi.fn();
-const buildPluginCompatibilityNotices: UnknownMock = vi.fn();
+export const buildPluginCompatibilityNoticesMock: UnknownMock = vi.fn();
 export const inspectPluginRegistryMock: AsyncUnknownMock = vi.fn();
 export const refreshPluginRegistryMock: AsyncUnknownMock = vi.fn();
 export const notifyGatewayPluginMetadataChangedMock: AsyncUnknownMock = vi.fn();
@@ -486,7 +486,7 @@ vi.mock("../plugins/status.js", () => ({
       Parameters<(typeof import("../plugins/status.js"))["buildPluginCompatibilityNotices"]>,
       ReturnType<(typeof import("../plugins/status.js"))["buildPluginCompatibilityNotices"]>
     >(
-      buildPluginCompatibilityNotices,
+      buildPluginCompatibilityNoticesMock,
       ...args,
     )) as (typeof import("../plugins/status.js"))["buildPluginCompatibilityNotices"],
   formatPluginCompatibilityNotice: (entry: { message: string }) => entry.message,
@@ -853,7 +853,7 @@ export function resetPluginsCliTestState() {
   buildPluginRegistrySnapshotReportMock.mockReset();
   buildPluginInspectReportMock.mockReset();
   buildPluginDiagnosticsReportMock.mockReset();
-  buildPluginCompatibilityNotices.mockReset();
+  buildPluginCompatibilityNoticesMock.mockReset();
   inspectPluginRegistryMock.mockReset();
   refreshPluginRegistryMock.mockReset();
   notifyGatewayPluginMetadataChangedMock.mockReset();
@@ -993,7 +993,7 @@ export function resetPluginsCliTestState() {
     registryDiagnostics: [],
   });
   buildPluginDiagnosticsReportMock.mockReturnValue(defaultPluginReport);
-  buildPluginCompatibilityNotices.mockReturnValue([]);
+  buildPluginCompatibilityNoticesMock.mockReturnValue([]);
   const defaultRegistryIndex = {
     version: 1,
     hostContractVersion: "2026.4.25",

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -195,7 +195,7 @@ describe("plugins cli list", () => {
 
       await runPluginsCommand(["plugins", "doctor", ...args]);
 
-      if (args.includes("--json")) {
+      if (args.length > 0) {
         expect(JSON.parse(pluginsCliRuntimeLogs[0] ?? "null")).toMatchObject({
           ok: healthy,
           compatibility: [notice],

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -5,9 +5,10 @@ import type {
   ConfigValidationIssue,
   OpenClawConfig,
 } from "../config/types.openclaw.js";
-import { createPluginRecord } from "../plugins/status.test-fixtures.js";
+import { createCompatibilityNotice, createPluginRecord } from "../plugins/status.test-fixtures.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
+  buildPluginCompatibilityNoticesMock,
   buildPluginDiagnosticsReportMock,
   buildPluginInspectReportMock,
   buildPluginRegistrySnapshotReportMock,
@@ -171,6 +172,50 @@ describe("plugins cli list", () => {
     });
     expect(pluginsCliRuntimeLogs).toContain(cleanDoctorMessage);
   });
+
+  it.each([
+    { severity: "info", code: "hook-only", healthy: true, args: [] },
+    { severity: "info", code: "hook-only", healthy: true, args: ["--json"] },
+    { severity: "warn", code: "removed-session-transcript-file-api", healthy: false, args: [] },
+    {
+      severity: "warn",
+      code: "removed-session-transcript-file-api",
+      healthy: false,
+      args: ["--json"],
+    },
+  ] as const)(
+    "keeps $severity compatibility notices visible while reporting healthy=$healthy ($args)",
+    async ({ code, healthy, args }) => {
+      const notice = createCompatibilityNotice({ pluginId: "compatible-plugin", code });
+      buildPluginDiagnosticsReportMock.mockReturnValue({
+        plugins: [createPluginRecord({ id: "compatible-plugin" })],
+        diagnostics: [],
+      });
+      buildPluginCompatibilityNoticesMock.mockReturnValue([notice]);
+
+      await runPluginsCommand(["plugins", "doctor", ...args]);
+
+      if (args.includes("--json")) {
+        expect(JSON.parse(pluginsCliRuntimeLogs[0] ?? "null")).toMatchObject({
+          ok: healthy,
+          compatibility: [notice],
+          pluginErrors: [],
+          diagnostics: [],
+          configurationWarnings: [],
+        });
+        return;
+      }
+
+      const output = pluginsCliRuntimeLogs.join("\n");
+      expect(output).toContain(notice.message);
+      expect(output).toContain(`[${notice.severity}]`);
+      if (healthy) {
+        expect(output).toContain(cleanDoctorMessage);
+      } else {
+        expect(output).not.toContain(cleanDoctorMessage);
+      }
+    },
+  );
 
   it.each([
     { format: "human", args: [] },

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -396,7 +396,8 @@ export async function runPluginsDoctorCommand(opts: PluginDoctorOptions = {}): P
     ...collectConfiguredRuntimePluginWarnings({ cfg: sourceCfg, plugins: report.plugins }),
   ]);
   const hasInstallTreeIssues =
-    errors.length > 0 || diags.length > 0 || shadowed.length > 0 || compatibility.length > 0;
+    [errors, diags, shadowed].some(({ length }) => length > 0) ||
+    compatibility.some(({ severity }) => severity === "warn");
 
   if (opts.json) {
     defaultRuntime.writeJson({
@@ -446,11 +447,11 @@ export async function runPluginsDoctorCommand(opts: PluginDoctorOptions = {}): P
     return;
   }
 
-  if (!hasInstallTreeIssues && pluginConfigWarnings.size === 0) {
-    defaultRuntime.log(
-      "Plugin discovery, module loading, compatibility, and configuration checks passed. " +
-        'Run "openclaw health" to check the running Gateway, including runtime quarantines and fallbacks.',
-    );
+  const healthyMessage =
+    "Plugin discovery, module loading, compatibility, and configuration checks passed. " +
+    'Run "openclaw health" to check the running Gateway, including runtime quarantines and fallbacks.';
+  if (!hasInstallTreeIssues && pluginConfigWarnings.size === 0 && compatibility.length === 0) {
+    defaultRuntime.log(healthyMessage);
     return;
   }
 
@@ -511,14 +512,13 @@ export async function runPluginsDoctorCommand(opts: PluginDoctorOptions = {}): P
     if (lines.length > 0) {
       lines.push("");
     }
-    lines.push(theme.warn("Plugin configuration:"));
-    lines.push(...pluginConfigWarnings);
+    lines.push(theme.warn("Plugin configuration:"), ...pluginConfigWarnings);
   }
-  if (!hasInstallTreeIssues && pluginConfigWarnings.size > 0) {
-    if (lines.length > 0) {
-      lines.push("");
-    }
-    lines.push("No plugin install-tree issues detected; configuration warnings remain.");
+  if (!hasInstallTreeIssues) {
+    const summary = pluginConfigWarnings.size
+      ? "No plugin install-tree issues detected; configuration warnings remain."
+      : healthyMessage;
+    lines.push("", summary);
   }
   const docs = formatDocsLink("/plugin", "docs.openclaw.ai/plugin");
   lines.push("");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw plugins doctor` could see a healthy, supported plugin installation reported as unhealthy solely because a hook-only plugin emitted an informational compatibility notice.

## Why This Change Was Made

Classify compatibility notices by their existing authoritative severity at the plugin doctor owner: actionable warnings remain unhealthy, while supported informational notices remain visible without becoming failures.

## User Impact

Plugin doctor now accurately reports supported hook-only plugins as healthy in both human-readable and JSON output while continuing to show their informational notices and flag real plugin warnings, errors, and configuration problems.

## Evidence

- Before the fix, real CLI owner regressions showed an informational notice suppressing the healthy human summary and incorrectly producing `ok: false` in JSON.
- After the fix, `node scripts/run-vitest.mjs src/cli/plugins-cli.list.test.ts` passes all 36 focused cases, including informational and warning notices in both output modes.
- Formatting, lint, independent owner-boundary review, and structured review pass. Production additions and removals are balanced: zero net production-code growth.
