### PR TITLE
fix(agents): preserve survivor-owned databases offline

### DIFF
--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -5,12 +5,16 @@ import {
   formatSharedAuthStoreOwnerDeleteError,
   isSharedAuthStoreOwner,
 } from "../agents/agent-delete-safety.js";
-import { normalizeAgentDirRegistryPath } from "../agents/agent-dir-registry.js";
+import {
+  isPathOwnedByAnotherRegisteredAgent,
+  normalizeAgentDirRegistryPath,
+} from "../agents/agent-dir-registry.js";
 import {
   beginAgentDeletion,
   claimCompletedAgentDeletion,
 } from "../agents/agent-lifecycle-registry.js";
 import {
+  listAgentIds,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   tryResolveSoleAgentId,
@@ -358,6 +362,11 @@ export async function agentsDeleteCommand(
     }
   }
   if (deleteFiles) {
+    // Directory ownership is process-local; prepare every survivor before filtering journal paths,
+    // or a deleted agent's database nested beneath a survivor's agentDir could be trashed.
+    for (const survivingAgentId of listAgentIds(result.config)) {
+      resolveAgentDir(result.config, survivingAgentId);
+    }
     const canonicalAgentDir = normalizeAgentDirRegistryPath(agentDir);
     const survivingDatabasePaths = new Set(
       listOpenClawRegisteredAgentDatabases()
@@ -370,6 +379,7 @@ export async function agentsDeleteCommand(
       return (
         !isPathInside(canonicalAgentDir, canonicalPath) &&
         !survivingDatabasePaths.has(canonicalPath) &&
+        !isPathOwnedByAnotherRegisteredAgent({ agentId, pathname }) &&
         findOverlappingWorkspaceAgentIds(result.config, agentId, canonicalPath).length === 0
       );
     });

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -675,10 +675,15 @@ describe("agents delete command", () => {
 
   it("deregisters the agent database after offline deletion", async () => {
     await withStateDirEnv("openclaw-agents-delete-registry-", async ({ tempRoot, stateDir }) => {
+      const mainAgentDir = path.join(tempRoot, "main-agent");
       const cfg: OpenClawConfig = {
         agents: {
           list: [
-            { id: "main", workspace: path.join(stateDir, "workspace-main") },
+            {
+              id: "main",
+              agentDir: mainAgentDir,
+              workspace: path.join(stateDir, "workspace-main"),
+            },
             { id: "ops", workspace: path.join(stateDir, "workspace-ops") },
           ],
         },
@@ -687,8 +692,10 @@ describe("agents delete command", () => {
       const databasePath = path.join(stateDir, "agents", "ops", "agent", "openclaw-agent.sqlite");
       const externalDatabaseDir = path.join(tempRoot, "external-databases");
       await fs.mkdir(externalDatabaseDir);
+      await fs.mkdir(mainAgentDir);
       const externalDatabasePath = path.join(externalDatabaseDir, "ops.sqlite");
       const sharedDatabasePath = path.join(externalDatabaseDir, "shared.sqlite");
+      const survivorOwnedDatabasePath = path.join(mainAgentDir, "ops.sqlite");
       const externalDatabasePaths = [
         externalDatabasePath,
         `${externalDatabasePath}-wal`,
@@ -696,14 +703,16 @@ describe("agents delete command", () => {
         `${externalDatabasePath}-journal`,
       ];
       await Promise.all(
-        [...externalDatabasePaths, sharedDatabasePath].map((sqlitePath) =>
-          fs.writeFile(sqlitePath, ""),
+        [...externalDatabasePaths, sharedDatabasePath, survivorOwnedDatabasePath].map(
+          (sqlitePath) => fs.writeFile(sqlitePath, ""),
         ),
       );
       const canonicalExternalDatabaseDir = await fs.realpath(externalDatabaseDir);
+      const canonicalMainAgentDir = await fs.realpath(mainAgentDir);
       registerOpenClawAgentDatabase({ agentId: "ops", path: databasePath });
       registerOpenClawAgentDatabase({ agentId: "ops", path: externalDatabasePath });
       registerOpenClawAgentDatabase({ agentId: "ops", path: sharedDatabasePath });
+      registerOpenClawAgentDatabase({ agentId: "ops", path: survivorOwnedDatabasePath });
       registerOpenClawAgentDatabase({ agentId: "main", path: sharedDatabasePath });
       recordAgentProvenance("ops", { createdVia: "operator" });
       recordAgentProvenance("child", { createdVia: "agent", creatorAgentId: "ops" });
@@ -726,6 +735,11 @@ describe("agents delete command", () => {
         path.join(canonicalExternalDatabaseDir, path.basename(sharedDatabasePath)),
         expect.anything(),
       );
+      expect(fsSafeMocks.movePathToTrash).not.toHaveBeenCalledWith(
+        path.join(canonicalMainAgentDir, path.basename(survivorOwnedDatabasePath)),
+        expect.anything(),
+      );
+      expect((await fs.stat(survivorOwnedDatabasePath)).isFile()).toBe(true);
       const registeredDatabases = listOpenClawRegisteredAgentDatabases();
       expect(registeredDatabases.map((entry) => entry.agentId)).not.toContain("ops");
       expect(registeredDatabases).toEqual(


### PR DESCRIPTION
Closes #129014

Follow-up to #129017.

## What Problem This Solves

Fixes the remaining ownership gap in offline agent deletion: a database journaled for the deleted agent could be physically located beneath another configured agent's `agentDir`. The first repair protected exact surviving database registrations and workspaces, but could still move this survivor-directory-owned file to Trash.

## Why This Change Was Made

Offline deletion now prepares every surviving configured agent directory in the existing process-local agent-directory registry before evaluating journaled database paths. It then applies the same `isPathOwnedByAnotherRegisteredAgent` boundary used by Gateway deletion, so a path inside or overlapping a surviving agent directory is preserved.

This is the focused correction requested by ClawSweeper's completed review of #129017. It does not change the journal schema, Gateway flow, or plugin-owned binding cleanup.

## User Impact

Operators can delete agents offline without risking a database file stored under another surviving agent's state directory. Eligible external database files are still removed, while registry cleanup and journal completion retain the behavior landed in #129017.

Production LOC: +11/-1 (net +10) | Tests: +17/-3 (net +14)

## Evidence

- Pre-fix regression: the offline path attempted to Trash `main`'s directory-contained `ops.sqlite`.
- The regression now verifies the survivor-owned file never reaches Trash, remains on disk, and the deleted agent's registry row is still released.
- `node scripts/run-vitest.mjs src/commands/agents.delete.test.ts` — 17 passed.
- `node scripts/run-vitest.mjs src/commands/agents.delete.workspace.test.ts` — 10 passed.
- Focused Gateway survivor ownership scenarios — 3 passed before publication.
- `node scripts/check-changed.mjs -- src/commands/agents.commands.delete.ts src/commands/agents.delete.test.ts` — passed after rebasing onto current `main`.
- Mandatory Codex autoreview — no accepted/actionable findings; correctness confidence 0.99.

A separate live CLI deletion was not run because the terminal action moves real host paths into Trash. The regression exercises isolated config, state SQLite, database registry, deletion journal, configured agent directories, and filesystem paths while mocking only Gateway reachability and the final Trash transport.

- [x] AI-assisted
- [x] I understand the change and verified the ownership boundary
