### PR TITLE
fix(android): preserve gateway context paths in control pages

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -8328,10 +8328,10 @@ internal fun gatewayRegistryEntry(
     )
   }
 
-/** HTTP(S) origin serving the connected gateway's Control UI pages. */
+/** HTTP(S) base URL serving the connected gateway's Control UI pages. */
 internal fun gatewayControlPageBaseUrl(endpoint: GatewayEndpoint): String {
   val scheme = if (endpoint.tlsEnabled) "https" else "http"
-  return "$scheme://${formatGatewayAuthority(endpoint.host, endpoint.port)}"
+  return "$scheme://${formatGatewayAuthority(endpoint.host, endpoint.port)}${endpoint.contextPath}"
 }
 
 data class GatewayModelSummary(

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayFleetSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayFleetSelectionTest.kt
@@ -3,9 +3,16 @@ package ai.openclaw.app
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewayRegistryEntry
 import ai.openclaw.app.gateway.GatewayRegistryEntryKind
+import ai.openclaw.app.ui.controlUiOriginRule
+import ai.openclaw.app.ui.desktopUrl
+import ai.openclaw.app.ui.sessionDashboardUrl
+import ai.openclaw.app.ui.terminalUrl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 class GatewayFleetSelectionTest {
   @Test
@@ -106,4 +113,51 @@ class GatewayFleetSelectionTest {
       kind = GatewayRegistryEntryKind.DISCOVERED,
       name = stableId,
     )
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class GatewayControlPageContextPathTest {
+  @Test
+  fun controlPageBasePreservesNormalizedGatewayContextPaths() {
+    val cases =
+      listOf(
+        GatewayEndpoint.manual("gateway.example", 443, true, "openclaw-gw") to
+          "https://gateway.example:443/openclaw-gw",
+        GatewayEndpoint.manual("gateway.example", 443, true, "/tenant%2Fgateway%20west") to
+          "https://gateway.example:443/tenant%2Fgateway%20west",
+        GatewayEndpoint.manual("gateway.example", 443, true, "//openclaw") to
+          "https://gateway.example:443//openclaw",
+        GatewayEndpoint.manual("gateway.example", 443, true, "/") to
+          "https://gateway.example:443",
+        GatewayEndpoint.manual("::1", 18789, false, "/gateway") to
+          "http://[::1]:18789/gateway",
+      )
+
+    cases.forEach { (endpoint, expected) ->
+      assertEquals(endpoint.contextPath, expected, gatewayControlPageBaseUrl(endpoint))
+    }
+  }
+
+  @Test
+  fun everyControlPagePreservesEncodedGatewayContextPathAndOrigin() {
+    val baseUrl =
+      gatewayControlPageBaseUrl(
+        GatewayEndpoint.manual("gateway.example", 443, true, "/tenant%2Fgateway%20west"),
+      )
+
+    assertEquals(
+      "https://gateway.example:443/tenant%2Fgateway%20west/focus/terminal",
+      terminalUrl(baseUrl),
+    )
+    assertEquals(
+      "https://gateway.example:443/tenant%2Fgateway%20west/focus/desktop",
+      desktopUrl(baseUrl),
+    )
+    assertEquals(
+      "https://gateway.example:443/tenant%2Fgateway%20west/chat?session=agent%3Amain%3Aqa&face=dashboard",
+      sessionDashboardUrl(baseUrl, "agent:main:qa"),
+    )
+    assertEquals("https://gateway.example:443", controlUiOriginRule(baseUrl))
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Android successfully connects to a gateway configured with a reverse-proxy context path, but Terminal, Desktop, and Dashboard then open the unprefixed root. The WebSocket connection already preserves the validated endpoint path; the single Control UI base-URL producer discarded it. Consequently, all three embedded routes can return HTTP 404 despite an otherwise healthy gateway connection.

## What Changed

Preserve the already-normalized `GatewayEndpoint.contextPath` in the existing Control UI base-URL producer. Terminal, Desktop, Dashboard, and their gateway WebSocket bootstrap now inherit the same configured path without changing schemes, authorities, authentication origins, TLS, credentials, or route ownership. Clarify the producer's existing documentation: its result is a base URL, not an origin.

Production delta: **+2/-2 (net zero)**. Regression coverage: **+54 test lines**. No compatibility branch, configuration surface, dependency, or production-only test hook.

## Evidence

- Before the fix, the new owner regressions failed exactly because `/openclaw-gw` and encoded `/tenant%2Fgateway%20west` were missing; four existing owner controls passed.
- After the fix, **11 owner and sibling tests passed**, including normalized and root paths, preserved encoded delimiters and spaces, repeated slashes, IPv6, TLS/plaintext, all three actual route builders, and the unchanged authentication origin.
- All four Android module lint checks passed: app, benchmark, wear, and wear-shared.
- A real Android API 36 Chromium WebView mounted on the actual app activity loaded URLs from the production gateway URL producer and all three production route builders against an in-app loopback HTTP server. Before the fix, Terminal, Desktop, and Dashboard requested unprefixed URLs and rendered real HTTP 404 responses. After the fix, all three requested their `/tenant/gw`-prefixed URLs and rendered real HTTP 200 responses. Dashboard's session/face query, same-origin authentication, and TLS controls remained intact.
- The visual proof waits for Chromium compositor frames and rejects blank screenshots by checking the actual screenshot pixels. The images below show the same Desktop route before and after the owner-boundary repair.

### Before: the configured gateway path is lost

![Android Desktop route before the fix: visible 404 ROOT ROUTE FAILED](https://github.com/user-attachments/assets/61f837eb-0953-4789-8d3c-14406b3cd982)

### After: the configured gateway path reaches the real Desktop route

![Android Desktop route after the fix: visible 200 TENANT DESKTOP OK](https://github.com/user-attachments/assets/6f4a2174-2738-4f0a-98c1-c9472334289d)
