### PR TITLE
fix(plugins): list silently hides discovery and registry failures

### DIFF
--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -105,11 +105,72 @@ describe("plugins cli list", () => {
     expect(output).toContain("Disabled plugin description");
   });
 
+  it.each([
+    { label: "default", args: [], visibleError: true },
+    { label: "verbose", args: ["--verbose"], visibleError: true },
+    { label: "enabled-only", args: ["--enabled"], visibleError: false },
+  ])(
+    "surfaces plugin discovery and stale-registry diagnostics in the $label list",
+    async ({ args, visibleError }) => {
+      const refreshMessage =
+        "Persisted plugin registry is stale. Run `openclaw plugins registry --refresh`.";
+      const dependencyError = "Plugin dependency example-package could not be resolved.";
+      buildPluginRegistrySnapshotReportMock.mockReturnValue({
+        workspaceDir: "/workspace",
+        registrySource: "derived",
+        registryDiagnostics: [
+          {
+            level: "info",
+            code: "persisted-registry-missing",
+            message: "Persisted plugin registry is missing; using the derived index.",
+          },
+          {
+            level: "warn",
+            code: "persisted-registry-stale-source",
+            message: refreshMessage,
+          },
+        ],
+        plugins: [
+          createPluginRecord({ id: "healthy", description: "Healthy plugin" }),
+          createPluginRecord({
+            id: "broken",
+            enabled: visibleError,
+            status: "error",
+            error: dependencyError,
+          }),
+        ],
+        diagnostics: [
+          { level: "warn", message: "Duplicate plugin ID shadows an installed plugin." },
+          { level: "error", message: "Plugin manifest could not be loaded." },
+          { level: "error", pluginId: "broken", message: dependencyError },
+        ],
+      });
+
+      await runPluginsCommand(["plugins", "list", ...args]);
+
+      const output = pluginsCliRuntimeLogs.join("\n");
+      expect(output).toContain("Warning: Duplicate plugin ID shadows an installed plugin.");
+      expect(output).toContain("Error: Plugin manifest could not be loaded.");
+      expect(output).toContain(`Warning: ${refreshMessage}`);
+      expect(output).not.toContain("Persisted plugin registry is missing");
+      expect(output.split(dependencyError)).toHaveLength(2);
+      expect(output.includes(`Error: ${dependencyError}`)).toBe(!visibleError);
+    },
+  );
+
   it("includes imported state in JSON output", async () => {
+    const registryDiagnostics = [
+      {
+        level: "info",
+        code: "persisted-registry-missing",
+        message: "Persisted plugin registry is missing; using the derived index.",
+      },
+    ];
+    const diagnostics = [{ level: "warn", message: "Plugin discovery needs attention." }];
     buildPluginRegistrySnapshotReportMock.mockReturnValue({
       workspaceDir: "/workspace",
       registrySource: "persisted",
-      registryDiagnostics: [],
+      registryDiagnostics,
       plugins: [
         createPluginRecord({
           id: "demo",
@@ -118,7 +179,7 @@ describe("plugins cli list", () => {
           explicitlyEnabled: true,
         }),
       ],
-      diagnostics: [],
+      diagnostics,
     });
 
     await runPluginsCommand(["plugins", "list", "--json"]);
@@ -148,13 +209,13 @@ describe("plugins cli list", () => {
     };
     expect(output.workspaceDir).toBe("/workspace");
     expect(output.registry?.source).toBe("persisted");
-    expect(output.registry?.diagnostics).toEqual([]);
+    expect(output.registry?.diagnostics).toEqual(registryDiagnostics);
     expect(output.plugins).toHaveLength(1);
     expect(output.plugins?.[0]?.id).toBe("demo");
     expect(output.plugins?.[0]?.imported).toBe(true);
     expect(output.plugins?.[0]?.activated).toBe(true);
     expect(output.plugins?.[0]?.explicitlyEnabled).toBe(true);
-    expect(output.diagnostics).toEqual([]);
+    expect(output.diagnostics).toEqual(diagnostics);
   });
 
   it("keeps doctor on a module-loading snapshot", async () => {

--- a/src/cli/plugins-list-command.ts
+++ b/src/cli/plugins-list-command.ts
@@ -77,11 +77,17 @@ export async function runPluginsListCommand(
     theme,
   } = await loadHumanListModules();
 
-  const workspaceScopeDiagnostic = report.diagnostics.find(
-    (diagnostic) => diagnostic.code === "workspace-scope-omitted",
+  const diagnostics = [...report.diagnostics, ...report.registryDiagnostics].filter(
+    (diagnostic) =>
+      diagnostic.level !== "info" &&
+      (diagnostic.level !== "error" ||
+        !list.some((plugin) => plugin.status === "error" && plugin.error === diagnostic.message)),
   );
-  if (workspaceScopeDiagnostic) {
-    runtime.log(theme.warn(`Warning: ${workspaceScopeDiagnostic.message}`));
+  for (const { level, message } of diagnostics) {
+    const format = level === "error" ? theme.error : theme.warn;
+    runtime.log(format(`${level === "error" ? "Error" : "Warning"}: ${message}`));
+  }
+  if (diagnostics.length > 0) {
     runtime.log("");
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw plugins list` silently hid plugin-discovery errors and actionable stale-registry warnings, potentially suggesting that no plugins existed when inventory scanning had actually failed.

## Why This Change Was Made

Display warning and error diagnostics already produced by plugin discovery and registry inventory in their existing human-output owner. Routine informational registry notices remain quiet, and structured JSON output keeps its unchanged complete diagnostic arrays.

## User Impact

Operators now see actionable discovery failures and registry repair guidance in ordinary and verbose plugin listings without extra informational noise.

## Evidence

- Two real CLI regressions failed before the fix: ordinary and verbose listings omitted both discovery failures and actionable registry warnings.
- Independent review additionally reproduced dependency errors already shown in their plugin row; the final output owner avoids printing those exact visible errors twice while retaining diagnostics for filtered-out plugins.
- After the fix, `node scripts/run-vitest.mjs src/cli/plugins-cli.list.test.ts src/cli/plugins-list-command.test.ts src/cli/plugins-list-format.test.ts src/plugins/status.registry-snapshot.test.ts src/plugins/plugin-registry.test.ts` passes all 87 tests.
- Existing workspace warnings and JSON diagnostic arrays remain intact; formatting, lint, independent review, and structured review pass.
