### PR TITLE
fix(agents): preserve channel-owned messaging thread identity

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
@@ -3,7 +3,6 @@ import {
   HEARTBEAT_RESPONSE_TOOL_NAME,
   normalizeHeartbeatToolResponse,
 } from "../auto-reply/heartbeat-tool-response.js";
-import { parseSessionThreadInfoFast } from "../config/sessions/thread-info.js";
 import {
   emitAgentActivityEvent,
   type AgentCommandOutputEventData,
@@ -290,8 +289,7 @@ export async function handleToolExecutionEnd(
         config: ctx.params.config,
         currentChannelId: ctx.params.currentChannelId,
         currentMessagingTarget: ctx.params.currentMessagingTarget,
-        currentThreadId:
-          ctx.params.currentThreadId ?? parseSessionThreadInfoFast(ctx.params.sessionKey).threadId,
+        currentThreadId: ctx.params.currentThreadId,
         currentMessageId: ctx.params.currentMessageId,
         replyToMode: ctx.params.replyToMode,
         hasRepliedRef: startData?.hasRepliedRef,
@@ -319,8 +317,7 @@ export async function handleToolExecutionEnd(
         currentAccountId: ctx.params.currentAccountId,
         currentChannelId: ctx.params.currentChannelId,
         currentMessagingTarget: ctx.params.currentMessagingTarget,
-        currentThreadId:
-          ctx.params.currentThreadId ?? parseSessionThreadInfoFast(ctx.params.sessionKey).threadId,
+        currentThreadId: ctx.params.currentThreadId,
         sessionKey: ctx.params.sessionKey,
         deliveredPayload: extractionResult,
       }),

--- a/src/agents/embedded-agent-subscribe.handlers.tools.start.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.start.ts
@@ -4,7 +4,6 @@ import {
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { parseSessionThreadInfoFast } from "../config/sessions/thread-info.js";
 import { emitAgentActivityEvent, type AgentItemEventData } from "../infra/agent-activity-events.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { REQUIRED_PARAM_GROUPS, type RequiredParamGroup } from "./agent-tools.params.js";
@@ -561,9 +560,7 @@ export function handleToolExecutionStart(
           config: ctx.params.config,
           currentChannelId: ctx.params.currentChannelId,
           currentMessagingTarget: ctx.params.currentMessagingTarget,
-          currentThreadId:
-            ctx.params.currentThreadId ??
-            parseSessionThreadInfoFast(ctx.params.sessionKey).threadId,
+          currentThreadId: ctx.params.currentThreadId,
           currentMessageId: ctx.params.currentMessageId,
           replyToMode: ctx.params.replyToMode,
           hasRepliedRef: ctx.params.hasRepliedRef,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -3363,6 +3363,57 @@ describe("messaging tool media URL tracking", () => {
     });
   });
 
+  it.each([
+    { label: "suppressed adapter thread", currentThreadId: undefined },
+    { label: "prepared native topic", currentThreadId: "42" },
+  ])("keeps the $label independent from scoped session identity", async ({ currentThreadId }) => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "telegram" }),
+            threading: {
+              resolveAutoThreadId: ({
+                toolContext,
+              }: {
+                toolContext?: { currentThreadTs?: string };
+              }) => toolContext?.currentThreadTs,
+            },
+          },
+          source: "test",
+        },
+      ]),
+    );
+    const { ctx } = createTestContext();
+    Object.assign(ctx.params, {
+      sessionKey: "agent:main:main:thread:1234:42",
+      messageChannel: "telegram",
+      currentChannelId: "1234",
+      currentMessagingTarget: "1234",
+      currentThreadId,
+      replyToMode: "all",
+    });
+    const toolCallId = `tool-message-scoped-thread-${currentThreadId ?? "none"}`;
+
+    await startTool(ctx, {
+      toolName: "message",
+      toolCallId,
+      args: { action: "send", to: "1234", message: "thread ownership" },
+    });
+
+    expect(ctx.state.pendingMessagingTargets.get(toolCallId)?.threadId).toBe(currentThreadId);
+
+    await endTool(ctx, {
+      toolName: "message",
+      toolCallId,
+      isError: false,
+      result: { details: { messageId: "message-scoped-thread" } },
+    });
+
+    expect(requireSingleMessagingTarget(ctx).threadId).toBe(currentThreadId);
+  });
+
   it("preserves the pre-send reply state when committing implicit thread evidence", async () => {
     setActivePluginRegistry(
       createTestRegistry([

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -26,7 +26,7 @@ const state = setupAgentRunnerExecutionTestState();
 afterEach(resetGeneratedMediaTaskActivityForTests);
 
 describe("executeAgentTurn: CLI session routing", () => {
-  it("carries prepared model context facts into CLI execution", async () => {
+  it("carries prepared model and thread context facts into CLI execution", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
       result: await params.run("claude-cli", "claude-sonnet-4-6"),
@@ -39,6 +39,7 @@ describe("executeAgentTurn: CLI session routing", () => {
       meta: {},
     });
     const followupRun = createFollowupRun();
+    followupRun.originatingThreadId = 42;
     followupRun.run.provider = "claude-cli";
     followupRun.run.model = "claude-sonnet-4-6";
     followupRun.run.thinkingCatalog = [
@@ -57,6 +58,7 @@ describe("executeAgentTurn: CLI session routing", () => {
         sessionCtx: {
           Provider: "telegram",
           MessageSid: "msg",
+          MessageThreadId: "stale-topic",
         } as unknown as TemplateContext,
       }),
     );
@@ -65,6 +67,7 @@ describe("executeAgentTurn: CLI session routing", () => {
     expectMockCallArgFields(state.runCliAgentMock, 0, "CLI run params", {
       modelContextWindow: 400_000,
       modelContextTokens: 321_000,
+      currentThreadTs: "42",
     });
   });
 

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -545,8 +545,6 @@ export async function runReplyAgent(
       activeSessionEntry,
       activeSessionStore,
       storePath,
-      messageThreadId:
-        typeof sessionCtx.MessageThreadId === "string" ? sessionCtx.MessageThreadId : undefined,
       followupRun,
       onActiveSessionEntry: (nextEntry) => {
         activeSessionEntry = nextEntry;

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -57,7 +57,6 @@ export async function resetReplyRunSession(params: {
   activeSessionEntry?: SessionEntry;
   activeSessionStore?: Record<string, SessionEntry>;
   storePath?: string;
-  messageThreadId?: string;
   followupRun: FollowupRun;
   onActiveSessionEntry: (entry: SessionEntry) => void;
   onNewSession: (newSessionId: string, nextSessionFile: string) => void;

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -410,10 +410,17 @@ describe("agent-runner-utils", () => {
           context,
         }: {
           accountId?: string | null;
-          context: { ChatType?: string; NativeChannelId?: string; To?: string };
+          context: {
+            ChatType?: string;
+            MessageThreadId?: string | number;
+            NativeChannelId?: string;
+            To?: string;
+          };
         }) => ({
           currentChannelId: context.NativeChannelId ?? context.To,
           currentMessagingTarget: context.To,
+          currentThreadTs:
+            context.MessageThreadId != null ? String(context.MessageThreadId) : undefined,
           replyToMode: accountId === "work" && context.ChatType === "direct" ? "off" : "all",
         }),
       },
@@ -425,12 +432,15 @@ describe("agent-runner-utils", () => {
       sessionCtx: {
         Provider: "cron-event",
         NativeChannelId: "D1",
+        SessionKey: "agent:main:main:thread:1234:42",
+        MessageThreadId: "stale-topic",
       },
       replyRoute: {
         originatingChannel: "slack",
         originatingTo: "user:U1",
         originatingAccountId: "work",
         originatingChatType: "direct",
+        originatingThreadId: 42,
       },
       hasRepliedRef: undefined,
       provider: "openai",
@@ -442,6 +452,8 @@ describe("agent-runner-utils", () => {
     expect(resolved.embeddedContext.messageTo).toBe("user:U1");
     expect(resolved.embeddedContext.currentChannelId).toBe("D1");
     expect(resolved.embeddedContext.currentMessagingTarget).toBe("user:U1");
+    expect(resolved.embeddedContext.messageThreadId).toBe(42);
+    expect(resolved.embeddedContext.currentThreadTs).toBe("42");
     expect(resolved.embeddedContext.agentAccountId).toBe("work");
     expect(resolved.embeddedContext.chatType).toBe("direct");
     expect(resolved.embeddedContext.replyToMode).toBe("off");

--- a/src/auto-reply/reply/followup-turn-execution.test.ts
+++ b/src/auto-reply/reply/followup-turn-execution.test.ts
@@ -771,26 +771,6 @@ describe("executeFollowupTurn", () => {
     await expect(result.progress.drain()).rejects.toBe(failure);
   });
 
-  it("preserves numeric thread ids during canonical role-ordering recovery", async () => {
-    const turn = createTurn({
-      queued: { ...createTurn().queued, originatingThreadId: 42 },
-    });
-    state.reset.mockResolvedValue(true);
-    state.execute.mockImplementation(async (params: AgentTurnParams) => {
-      await params.resetSessionAfterRoleOrderingConflict("invalid history");
-      return { runId: "run-1", outcome: { kind: "rejected", payload: { text: "done" } } };
-    });
-
-    await executeFollowupTurn({
-      turn,
-      defaults: { typing: createTypingController(), typingMode: "never", defaultModel: "claude" },
-      onToolResult: vi.fn(async () => {}),
-      onCompactionNoticePayload: vi.fn(async () => {}),
-    });
-
-    expect(state.reset).toHaveBeenCalledWith(expect.objectContaining({ messageThreadId: "42" }));
-  });
-
   it("updates the reply operation after role-ordering recovery rotates the session", async () => {
     const updateSessionId = vi.fn();
     const turn = createTurn({

--- a/src/auto-reply/reply/followup-turn-execution.ts
+++ b/src/auto-reply/reply/followup-turn-execution.ts
@@ -350,8 +350,6 @@ export async function executeFollowupTurn(params: {
             activeSessionEntry: session.current(),
             activeSessionStore: turn.sessionStore,
             storePath: session.storePath,
-            messageThreadId:
-              sessionCtx.MessageThreadId != null ? String(sessionCtx.MessageThreadId) : undefined,
             followupRun: turn.queued,
             onActiveSessionEntry: (entry) => {
               session.adopt(entry);


### PR DESCRIPTION
## Summary

Follow-up to #128896 and #128866. Keep transport thread identity owned by the prepared delivery route and its channel adapter instead of reconstructing it from an opaque session key.

- Remove the three embedded messaging-tool fallbacks that treated a scoped session suffix such as `1234:42` as a real transport thread.
- Preserve the existing canonical `FollowupRun.originatingThreadId` flow through embedded, queued, and CLI execution; channel adapters remain free to suppress or replace their own thread context.
- Delete the SQLite-era dead session-reset `messageThreadId` parameter, both production callers, and the implementation-coupled test that asserted an argument the reset owner never read.
- Extend existing coverage for prepared numeric Telegram topics, adapter-suppressed threads, queued adapter hydration, CLI runtime parity, and cross-channel threading contracts.

## Root cause and proof

Before the fix, a failing-first messaging-tool lifecycle regression expected no thread when its channel adapter supplied none, but the subscriber fabricated the scoped session suffix `1234:42` as the outbound transport thread. The prepared native topic `42` already reaches both runtimes through the existing follow-up route, so the owner-boundary repair is deletion rather than a new fallback or compatibility layer.

The obsolete reset argument lost its only real consumer in SQLite migration #98236; a later mock-only assertion in #114599 preserved the dead interface without protecting observable behavior.

Verified locally:

- 322 focused owner, sibling, reset, CLI, channel-adapter, and Telegram transport tests.
- 33 SQLite-backed reply/restart recovery lifecycle scenarios, including scoped Telegram topic recovery and the next inbound turn.
- Full changed-code gate across core production and tests.
- Fresh independent Codex review with no accepted/actionable findings.
- Real-user Telegram Desktop proof: https://github.com/openclaw/openclaw/actions/runs/32822380074.

The real leased Telegram user exercised ordinary same-topic replies, explicit messaging-tool sends, and Gateway restart during an in-flight turn. Desktop recordings, Bot API payloads, and SQLite rows verify the same canonical numeric forum topic throughout. Both current main and the candidate are expected to pass: this follow-up preserves existing Telegram behavior while removing an invalid owner fallback demonstrated by the fail-first adapter-suppression regression.

Named proof-harness follow-up: expose validated `--thread-id` on the trusted Mantis lane's user-send/turn primitive, and pass the existing user-driver `probe --thread-id` through its outbound send. Until then, a real approved forum topic provides executable thread-ownership proof; the runner cannot drive a bot-private topic directly.

Production code is net-negative (-11 lines); no schema, protocol, configuration, plugin contract, or persistence format changes.
