### PR TITLE
fix(sessions): history pagination skips projected messages or stops advancing

### DIFF
--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -481,6 +481,55 @@ describe("sessions_history redaction", () => {
     });
   });
 
+  it("preserves the Gateway replay cursor for projected siblings from the same row", async () => {
+    const tool = createSessionsHistoryTool({
+      config: {},
+      callGateway: async <T = Record<string, unknown>>(): Promise<T> =>
+        ({
+          messages: [
+            { role: "assistant", content: "projected sibling", __openclaw: { seq: 8 } },
+            { role: "assistant", content: "latest", __openclaw: { seq: 9 } },
+          ],
+          offset: 0,
+          nextOffset: 2,
+          hasMore: true,
+          totalMessages: 10,
+        }) as T,
+    });
+
+    const result = await tool.execute("projected-replay", { sessionKey: "main", offset: 0 });
+
+    expect(result.details).toMatchObject({
+      offset: 0,
+      nextOffset: 2,
+      hasMore: true,
+      totalMessages: 10,
+    });
+  });
+
+  it("keeps history pagination advancing past an already-returned row", async () => {
+    const tool = createSessionsHistoryTool({
+      config: {},
+      callGateway: async <T = Record<string, unknown>>(): Promise<T> =>
+        ({
+          messages: [{ role: "assistant", content: "visible", __openclaw: { seq: 7 } }],
+          offset: 4,
+          nextOffset: 5,
+          hasMore: true,
+          totalMessages: 10,
+        }) as T,
+    });
+
+    const result = await tool.execute("cursor-progress", { sessionKey: "main", offset: 4 });
+
+    expect(result.details).toMatchObject({
+      offset: 4,
+      nextOffset: 5,
+      hasMore: true,
+      totalMessages: 10,
+    });
+  });
+
   it("honors a scoped incarnation grant through the sandbox visibility clamp", async () => {
     const requesterSessionKey = "agent:main:clickclack:discussion-proof";
     const targetSessionKey = "agent:main:main";

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -338,17 +338,15 @@ function resolveSessionsHistoryPaginationMetadata(params: {
     };
   }
 
-  // Gateway offsets count newest transcript rows already returned. Recompute
-  // from the oldest surviving seq after this tool's own filter/cap passes.
-  const oldestSeq = params.messages
+  // Respect Gateway replay cursors and this tool's own byte cap while always advancing.
+  const seq = params.messages
     .map((message) => readHistoryMessageSeq(message))
     .find((seq): seq is number => typeof seq === "number");
+  const gatewayOffset = result?.nextOffset;
   const nextOffset =
-    oldestSeq !== undefined
-      ? Math.max(offset, totalMessages - oldestSeq + 1)
-      : typeof result?.nextOffset === "number"
-        ? result.nextOffset
-        : undefined;
+    seq === undefined
+      ? gatewayOffset
+      : Math.max(offset + 1, Math.min(gatewayOffset ?? totalMessages, totalMessages - seq + 1));
   const hasMore =
     nextOffset !== undefined
       ? nextOffset < totalMessages

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -341,7 +341,7 @@ function resolveSessionsHistoryPaginationMetadata(params: {
   // Respect Gateway replay cursors and this tool's own byte cap while always advancing.
   const seq = params.messages
     .map((message) => readHistoryMessageSeq(message))
-    .find((seq): seq is number => typeof seq === "number");
+    .find((value): value is number => typeof value === "number");
   const gatewayOffset = result?.nextOffset;
   const nextOffset =
     seq === undefined


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents paginating session history could silently skip projected messages from the same transcript row or repeatedly request the same page without ever reaching older messages.

## Why This Change Was Made

The Gateway owns transcript-row pagination and sometimes returns a deliberately earlier replay cursor so every projected sibling remains reachable. The agent-facing session-history tool recomputed that cursor from the oldest visible sequence, overwriting the Gateway's replay decision and permitting a cursor equal to the current offset. The tool now combines the authoritative Gateway cursor with its own stricter byte-cap cursor while requiring every continuation to advance. Existing filtering, redaction, session visibility, anchored reads, final pages, and byte limits remain unchanged.

## User Impact

Agents can read all visible session-history messages across page boundaries, including multiple projected messages belonging to one transcript row, without skipping history or getting stuck in pagination loops.

## Evidence

- Both new actual tool-boundary regressions failed on the original code: the projected-sibling replay cursor was `3` instead of `2`, and the progress cursor repeated `4` instead of advancing to `5`.
- After the owner-boundary repair, all **65 history, session-list, and session-send tests pass** across three existing suites.
- The pre-existing real Gateway integration test `chat.history advances past a replay boundary that cannot fit all projected siblings` independently establishes the authoritative producer contract.
- Max-lines and assertion-safety ratchets both pass; all changed files pass the repository formatter and `git diff --check`.
- Independent code review and the mandatory authenticated Codex autoreview both reported no actionable findings.
- Production: `+7/-9` (**net -2 lines**); regression tests: `+49/-0`.
- Reviewed head: `839c745ba27c8873ff3c2efe30d7ce7ba747a3ef`.
