### PR TITLE
refactor(i18n): share canonical native app locales

### DIFF
--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -1,35 +1,11 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { NATIVE_I18N_LOCALES } from "./native-i18n-locales.ts";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "..");
-// Keep this script independent from the translation client loaded by native-app-i18n.
-// Artifact locale assertions below make drift fail instead of silently dropping a language.
-export const APPLE_I18N_LOCALES = [
-  "zh-CN",
-  "zh-TW",
-  "pt-BR",
-  "de",
-  "es",
-  "ja-JP",
-  "ko",
-  "fr",
-  "hi",
-  "ar",
-  "it",
-  "tr",
-  "uk",
-  "id",
-  "pl",
-  "th",
-  "vi",
-  "nl",
-  "fa",
-  "ru",
-  "sv",
-] as const;
-const REQUIRED_LOCALES = ["en", ...APPLE_I18N_LOCALES];
+const REQUIRED_LOCALES = ["en", ...NATIVE_I18N_LOCALES];
 const FORMAT_RE = /%(?:%|(?:\d+\$)?(?:lld|ld|[@a-z]))/giu;
 const INFLECTED_COUNT_INTERPOLATION_RE = /\\\([A-Za-z_][A-Za-z0-9_]*\)/gu;
 const INFLECTED_COUNT_INTERPOLATION_EXACT_RE = /^\\\([A-Za-z_][A-Za-z0-9_]*\)$/u;
@@ -783,7 +759,7 @@ async function validateRuntimeInterpolationPaths(): Promise<void> {
 }
 
 async function readNativeTranslations(): Promise<NativeTranslationArtifact[]> {
-  const expectedFiles = APPLE_I18N_LOCALES.map((locale) => `${locale}.json`).toSorted();
+  const expectedFiles = NATIVE_I18N_LOCALES.map((locale) => `${locale}.json`).toSorted();
   const actualFiles = (
     await readdir(path.join(ROOT, NATIVE_TRANSLATIONS_DIR), {
       withFileTypes: true,
@@ -798,7 +774,7 @@ async function readNativeTranslations(): Promise<NativeTranslationArtifact[]> {
     );
   }
   return Promise.all(
-    APPLE_I18N_LOCALES.map(async (locale) => {
+    NATIVE_I18N_LOCALES.map(async (locale) => {
       const artifact = JSON.parse(
         await readFile(path.join(ROOT, NATIVE_TRANSLATIONS_DIR, `${locale}.json`), "utf8"),
       ) as NativeTranslationArtifact;
@@ -876,7 +852,7 @@ async function syncIosInfoPlist(write: boolean): Promise<number> {
     const sourceEntries = parseInfoPlistStrings(
       await readFile(path.join(ROOT, target.sourcePath), "utf8"),
     );
-    for (const locale of APPLE_I18N_LOCALES) {
+    for (const locale of NATIVE_I18N_LOCALES) {
       const localeDir = APPLE_LOCALE_DIRECTORIES[locale] ?? locale;
       const outputPath = path.join(
         ROOT,
@@ -1007,7 +983,7 @@ export async function checkAppleAppI18n() {
       `infoPlistFiles=${infoPlistFiles}`,
       `translationContradictions=${iosBuild.contradictions.length}`,
       `macosTranslationContradictions=${macosBuild.contradictions.length}`,
-      `locales=${APPLE_I18N_LOCALES.join(",")}`,
+      `locales=${NATIVE_I18N_LOCALES.join(",")}`,
       "\n",
     ].join(" "),
   );

--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-  APPLE_I18N_LOCALES,
   assertMacosCatalogCurrent,
   buildIosCatalog,
   buildMacosCatalog,
@@ -13,7 +12,7 @@ import {
   selectInfoPlistTranslation,
   verifyAppleAppI18n,
 } from "../../scripts/apple-app-i18n.ts";
-import { NATIVE_I18N_LOCALES } from "../../scripts/native-app-i18n.ts";
+import { NATIVE_I18N_LOCALES } from "../../scripts/native-i18n-locales.ts";
 
 describe("Apple app i18n catalogs", () => {
   it("keeps source-owned runtime coverage complete", async () => {
@@ -50,7 +49,7 @@ describe("Apple app i18n catalogs", () => {
       const entry = catalog.strings[key];
       expect(entry, key).toBeDefined();
       const localizedValues: string[] = [];
-      for (const locale of ["en", ...APPLE_I18N_LOCALES]) {
+      for (const locale of ["en", ...NATIVE_I18N_LOCALES]) {
         const unit = entry?.localizations?.[locale]?.stringUnit;
         expect(unit?.value, `${key}:${locale}`).toBeTruthy();
         if (locale !== "en" && unit?.value) {
@@ -62,10 +61,6 @@ describe("Apple app i18n catalogs", () => {
         key,
       ).toBe(true);
     }
-  });
-
-  it("keeps the Apple and native shipped locale sets identical", () => {
-    expect(APPLE_I18N_LOCALES).toEqual(NATIVE_I18N_LOCALES);
   });
 
   it("derives shared discovery status coverage into the iOS catalog", async () => {
@@ -440,7 +435,7 @@ describe("Apple app i18n catalogs", () => {
       const localeDirs = (await readdir(root, { withFileTypes: true })).filter(
         (entry) => entry.isDirectory() && entry.name.endsWith(".lproj"),
       );
-      expect(localeDirs).toHaveLength(APPLE_I18N_LOCALES.length);
+      expect(localeDirs).toHaveLength(NATIVE_I18N_LOCALES.length);
       for (const localeDir of localeDirs) {
         const localizedPlist = await readFile(
           path.join(root, localeDir.name, "InfoPlist.strings"),
@@ -552,7 +547,7 @@ describe("Apple app i18n catalogs", () => {
             }
           }),
       );
-      expect(infoPlistFiles.filter(Boolean)).toHaveLength(APPLE_I18N_LOCALES.length);
+      expect(infoPlistFiles.filter(Boolean)).toHaveLength(NATIVE_I18N_LOCALES.length);
     } finally {
       await rm(outputDir, { force: true, recursive: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Apple app localization maintained a second, independently editable copy of the 21 native locales already owned by the shared native-app locale catalog. Adding or reordering a native locale therefore required duplicate Apple maintenance and could leave generated Apple catalogs or InfoPlist translations out of sync with Android.

## Why This Change Was Made

Maintainer-requested refactor: the Apple generator and its behavior tests now import the existing dependency-free native locale owner directly, as the Android generator already does. This removes the duplicate Apple-only list, its test-only export, and the parity assertion that becomes tautological once there is one source of truth. The generator remains independent of the native translation client and CLI.

## User Impact

No user-visible behavior changes. The same 21 locales, locale ordering, iOS and macOS catalogs, Android resources, and InfoPlist outputs are preserved. Future native locale changes have one canonical owner. Production tooling: +6/-30 lines (net -24); tests: +4/-9 lines (net -5).

## Evidence

- `node scripts/run-vitest.mjs test/scripts/apple-app-i18n.test.ts test/scripts/android-app-i18n.test.ts test/scripts/native-app-i18n.test.ts` — 3 test files, 54 tests passed.
- `node --import tsx scripts/apple-app-i18n.ts check` — 1,629 iOS keys, 1,287 macOS keys, 84 InfoPlist files, 21 locales, and zero translation contradictions; identical to the pre-change run.
- `node --import tsx scripts/android-app-i18n.ts check` — 1,632 app keys, 4 third-party keys, 122 Wear keys, and the same 21 ordered locales; identical to the pre-change run.
- `node --import tsx scripts/native-app-i18n.ts verify` — 4,239 native entries, unchanged inventory, plus Apple and Android source verification.
- `node scripts/check-changed.mjs -- scripts/apple-app-i18n.ts test/scripts/apple-app-i18n.test.ts` — all formatting, script/root-test typechecking, erasability, lint, and repository guards passed.
- `node --import tsx scripts/check-deadcode-exports.mts` — production, full-tree, and script unused-export scans all passed with zero findings.
- Fresh automated code review and separate independent source review: clean. AI-assisted, maintainer-directed change.

Pre-existing follow-up: native locale-owner changes are not currently included in the native locale-refresh trigger/invalidation paths or native CI scope classification. This focused generator refactor intentionally does not change workflow or CI ownership.
