### PR TITLE
fix(nodes): keep starting containers out of the exited state

### DIFF
--- a/src/node-host/node-worker-container-engine.ts
+++ b/src/node-host/node-worker-container-engine.ts
@@ -34,6 +34,18 @@ const CONTAINER_NODE_EXECUTABLE = "node";
 const CONTAINER_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const CONTAINER_ID_PATTERN = /^[a-f0-9]{64}$/u;
 const ENCODED_LAUNCH_PATTERN = /^[A-Za-z0-9_-]+$/u;
+// `.State.Running` is false both before a container starts and after it exits.
+// A created or initialized container still owns an admitted workload, so its
+// launch must never be finalized or fenced as if the worker had already ended.
+const OWNED_CONTAINER_STATUSES = new Set([
+  "created",
+  "initialized",
+  "running",
+  "paused",
+  "restarting",
+  "stopping",
+]);
+const ENDED_CONTAINER_STATUSES = new Set(["exited", "stopped", "dead", "removing"]);
 
 function hostNamespace(bundleRoot: string): string {
   return createHash("sha256").update(path.resolve(bundleRoot)).digest("hex").slice(0, 32);
@@ -343,8 +355,8 @@ export async function inspectNodeWorkerContainer(
 ): Promise<"live" | "dead" | "reused" | "unknown"> {
   try {
     const format = expected
-      ? `{{.State.Running}}\t{{index .Config.Labels "${HOST_LABEL}"}}\t{{index .Config.Labels "${GATEWAY_LABEL}"}}\t{{index .Config.Labels "${LAUNCH_LABEL}"}}`
-      : "{{.State.Running}}";
+      ? `{{.State.Status}}\t{{index .Config.Labels "${HOST_LABEL}"}}\t{{index .Config.Labels "${GATEWAY_LABEL}"}}\t{{index .Config.Labels "${LAUNCH_LABEL}"}}`
+      : "{{.State.Status}}";
     const state = await runContainerCommand(engine, [
       "inspect",
       "--type",
@@ -353,7 +365,7 @@ export async function inspectNodeWorkerContainer(
       format,
       containerId,
     ]);
-    const [running, owner, gateway, launch, extra] = state.split("\t");
+    const [status = "", owner, gateway, launch, extra] = state.split("\t");
     if (expected) {
       if (
         extra !== undefined ||
@@ -366,7 +378,11 @@ export async function inspectNodeWorkerContainer(
     } else if (owner !== undefined) {
       return "unknown";
     }
-    return running === "true" ? "live" : running === "false" ? "dead" : "unknown";
+    return OWNED_CONTAINER_STATUSES.has(status)
+      ? "live"
+      : ENDED_CONTAINER_STATUSES.has(status)
+        ? "dead"
+        : "unknown";
   } catch (error) {
     return missingContainer(error) ? "dead" : "unknown";
   }

--- a/src/node-host/node-worker-supervisor.container.test.ts
+++ b/src/node-host/node-worker-supervisor.container.test.ts
@@ -147,7 +147,7 @@ if (command === "version") {
   }
   const entry = args.at(-1);
   const image = args.at(-2);
-  const container = { id, labels, env, mounts, image, entry, running: false, pid: null };
+  const container = { id, labels, env, mounts, image, entry, status: "created", pid: null };
   save(container);
   record({ argv: args, container, journal: journalState(launchIdFor(container)) });
   releaseAfterMarker("hold-create", () => process.stdout.write(id + "\n"));
@@ -167,12 +167,15 @@ if (command === "version") {
       process.stderr.write("container worker executed before its exact identity was journaled\n");
       process.exit(67);
     }
+    // A real engine leaves the container "created" until its start request lands,
+    // so the marker lets a test hold the launch inside that startup window.
+    await new Promise((resolve) => releaseAfterMarker("hold-start", resolve));
     const child = spawn(process.execPath, [container.entry], {
       detached: process.platform !== "win32",
       env: container.env,
       stdio: ["pipe", "inherit", "inherit"],
     });
-    container.running = true;
+    container.status = "running";
     container.pid = child.pid;
     save(container);
     child.stdin.end(descriptor);
@@ -183,7 +186,7 @@ if (command === "version") {
     child.once("exit", (code, signal) => {
       if (fs.existsSync(statePath(container.id))) {
         const current = load(container.id);
-        current.running = false;
+        current.status = "exited";
         current.pid = null;
         save(current);
       }
@@ -198,7 +201,11 @@ if (command === "version") {
   record({ argv: args });
   const container = readContainer(id);
   const format = args[args.indexOf("--format") + 1];
-  const columns = [String(container.running)];
+  const columns = [container.status];
+  // Releasing the startup hold here proves the supervisor observed the container
+  // while it was still created: the launch only proceeds after that observation.
+  const startHold = path.join(engineRoot, "hold-start");
+  if (fs.existsSync(startHold)) fs.unlinkSync(startHold);
   if (format.includes("openclaw.node-worker.host")) {
     columns.push(
       container.labels["openclaw.node-worker.host"] ?? "",
@@ -210,11 +217,11 @@ if (command === "version") {
 } else if (command === "kill") {
   const container = readContainer(args.at(-1));
   record({ argv: args, journal: journalState(launchIdFor(container)) });
-  if (!container.running) {
+  if (container.status !== "running") {
     process.stderr.write("container is not running\n");
     process.exit(1);
   }
-  container.running = false;
+  container.status = "exited";
   save(container);
   if (container.pid) {
     try {
@@ -263,7 +270,7 @@ type FakeContainer = {
   mounts: string[];
   image: string;
   entry: string;
-  running: boolean;
+  status: "created" | "running" | "exited";
   pid: number | null;
 };
 
@@ -339,7 +346,12 @@ function containerFixture(
         .split("\n")
         .map((line) => JSON.parse(line) as EngineEvent);
     },
-    seed(params: { id: string; launchId: string; owner?: string; running?: boolean }) {
+    seed(params: {
+      id: string;
+      launchId: string;
+      owner?: string;
+      status?: FakeContainer["status"];
+    }) {
       const container: FakeContainer = {
         id: params.id,
         labels: {
@@ -351,7 +363,7 @@ function containerFixture(
         mounts: [],
         image: "node:22-slim",
         entry: bundleEntry,
-        running: params.running ?? true,
+        status: params.status ?? "running",
         pid: null,
       };
       fs.writeFileSync(
@@ -435,7 +447,7 @@ describe("node worker supervisor container isolation", () => {
         },
       });
       const completed = await waitForTerminal(fixture.supervisor, input.launchId);
-      expect(completed?.state).toBe("completed");
+      expect(completed).toMatchObject({ state: "completed" });
       expect(JSON.parse(completed?.resultJson ?? "null")).toEqual({
         status: "completed",
         argv: [],
@@ -480,6 +492,32 @@ describe("node worker supervisor container isolation", () => {
         container_json: JSON.stringify(running.container),
       });
     } finally {
+      await fixture.supervisor.close();
+    }
+  });
+
+  it("keeps a launch running while its container is still starting", async () => {
+    const fixture = containerFixture();
+    const input = testWorkerLaunchInput(fixture.workspaceDir, "container-startup-poll");
+    const startMarker = path.join(fixture.engineRoot, "hold-start");
+    fs.writeFileSync(startMarker, "hold");
+
+    try {
+      const running = await fixture.supervisor.launch(input, endpoint);
+
+      // The fake engine keeps the container created until this poll inspects it,
+      // so the supervisor must not read startup as an exited worker.
+      expect(await fixture.supervisor.status(input.launchId)).toMatchObject({
+        state: "running",
+        container: running.container,
+      });
+      expect(await waitForTerminal(fixture.supervisor, input.launchId)).toMatchObject({
+        state: "completed",
+      });
+    } finally {
+      if (fs.existsSync(startMarker)) {
+        fs.unlinkSync(startMarker);
+      }
       await fixture.supervisor.close();
     }
   });
@@ -667,7 +705,7 @@ describe("node worker supervisor container isolation", () => {
   it("interrupts a stale running journal after verifying its dead container identity", async () => {
     const fixture = containerFixture();
     const launchId = "container-dead-recovery";
-    const container = fixture.seed({ id: "c".repeat(64), launchId, running: false });
+    const container = fixture.seed({ id: "c".repeat(64), launchId, status: "exited" });
     claimFixtureLaunch(fixture, launchId, container.id);
 
     try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running node-hosted worker sessions with `nodeHost.workerRuns.isolation=container` would have a healthy worker killed mid-run when anything asked for its status during container startup. The launch ends as `failed` with `node worker failed with exit code 137`, and the session dies for no reason the operator can see.

The same defect makes `src/node-host/node-worker-supervisor.container.test.ts` flaky on CI. It has been failing on loaded Blacksmith shards since #128447 landed, e.g. [run 32706072003](https://github.com/openclaw/openclaw/actions/runs/32706072003/job/97367492561) and [run 32789084018](https://github.com/openclaw/openclaw/actions/runs/32789084018/job/97627125376), always as `expected 'failed' to be 'completed'`.

## Why This Change Was Made

`inspectNodeWorkerContainer` asked the engine for `{{.State.Running}}`, which is `false` in two unrelated situations: a container that already exited, and one that was created but has not started yet. `NodeWorkerSupervisor.status()` treats `dead` as proof the workload ended, so it force-removes the container and finalizes the launch. Because the launch path returns as soon as the start client is spawned and the journal is written, any status poll in the startup window destroys a live worker.

The fix classifies the engine's `{{.State.Status}}` instead of a boolean: statuses that still own a workload (`created`, `initialized`, `running`, `paused`, `restarting`, `stopping`) stay `live`, finished ones (`exited`, `stopped`, `dead`, `removing`) report `dead`, and anything else remains `unknown`. The set members come from Docker's documented container states and Podman's upstream `ContainerStatus` values, since both engines are supported. As a side effect, `killNodeWorkerContainer`'s post-removal verification no longer accepts a surviving `created` container as successfully removed.

Non-goal: no retry, timeout bump, or test-side sleep. The startup window is real and the supervisor now reads it correctly.

## User Impact

Container-isolated worker sessions no longer die at random during startup. A status call arriving while the container is still starting returns `running` instead of killing the worker and recording a bogus `failed` receipt.

## Evidence

**Real engine, not just the test double.** Docker 29.4.0 reports the created state as not-running, and the window persists after the start client is spawned:

```
$ docker inspect --type container --format '{{.State.Status}}|{{.State.Running}}' "$CID"
created|false

$ docker start --attach --interactive "$CID" &   # then poll
 60ms after spawn: created|false
120ms after spawn: running|true
```

Pre-fix, that first sample is classified `dead` and the supervisor kills the container.

**Deterministic reproduction.** Widening the startup window by 40ms in the fake engine made the existing test fail with the exact CI signature, and a probe on the terminal receipt showed the self-inflicted kill:

```
[probe] status inspect => dead
[probe] terminal {"state":"failed","errorText":"node worker failed with exit code 137"}
AssertionError: expected 'failed' to be 'completed'
```

With the fix in place, that same 40ms window passes 3/3.

**Regression test.** `keeps a launch running while its container is still starting` holds the container in `created` until the supervisor's own inspect observes it, then asserts the launch is still `running` and completes. Against the old classification it is the only failing test in the file (13 passed, 1 failed); with the fix the file is 14/14. The fake engine now models engine status rather than a boolean, matching what a real engine reports.

**Diagnosability.** The original assertion compared only `state`, so CI printed `expected 'failed' to be 'completed'` and discarded the receipt's `errorText`, which named the cause. It now uses `toMatchObject`, so the next failure prints it.

**Local validation** (branch base `49c5bb21c3b`):

- `node scripts/run-vitest.mjs src/node-host` — 41 files, 561 passed, 2 skipped
- `node scripts/check-changed.mjs` — green
- container suite run 8x consecutively — 8/8 green
- Codex autoreview (`gpt-5.6-sol`, xhigh) — clean, no accepted findings

**Size.** Production LOC: +20/-4 (net +16) | Tests: +49/-11. The production growth is the closed status classification and the comment explaining why `.State.Running` is not a liveness signal; it encodes an engine contract that cannot be expressed more simply.

**Not covered.** No live proof against Podman; its status strings were verified from upstream `libpod/define/containerstate.go` rather than a running daemon.

Prior repair for context: #128788 fixed a different cause of the same assertion (partial JSON reads of the fake engine's state file) on 2026-08-24. Sampling failed vitest shard jobs in three one-hour windows after that landed still found 4 hits of this signature out of 25, so this race is the surviving cause.
