### PR TITLE
fix(cli): render Gateway health JSON failures

### DIFF
--- a/src/cli/gateway-cli/health-route.test.ts
+++ b/src/cli/gateway-cli/health-route.test.ts
@@ -80,29 +80,31 @@ describe("runGatewayHealthJsonRoute", () => {
     );
   });
 
-  it("formats local config resolution failures", async () => {
+  it("leaves local config resolution failures to the root CLI renderer", async () => {
     const runtime = createRuntime();
     const error = new Error("config unavailable");
     const callGateway = vi.fn();
 
-    await runGatewayHealthJsonRoute(
-      {
-        rpc: { json: true, timeout: "10000" },
-        localPortOverride: 19083,
-      },
-      runtime as never,
-      {
-        callGateway,
-        readNonObservingHealthConfig: vi.fn(async () => {
-          throw error;
-        }),
-      },
-    );
+    await expect(
+      runGatewayHealthJsonRoute(
+        {
+          rpc: { json: true, timeout: "10000" },
+          localPortOverride: 19083,
+        },
+        runtime as never,
+        {
+          callGateway,
+          readNonObservingHealthConfig: vi.fn(async () => {
+            throw error;
+          }),
+        },
+      ),
+    ).rejects.toBe(error);
 
     expect(callGateway).not.toHaveBeenCalled();
     expect(runtime.writeJson).not.toHaveBeenCalled();
-    expect(runtime.error).toHaveBeenCalledWith(error.message);
-    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
   });
 
   it("preserves structured transport errors", async () => {

--- a/src/cli/gateway-cli/health-route.ts
+++ b/src/cli/gateway-cli/health-route.ts
@@ -1,5 +1,4 @@
 // Route-first machine-readable Gateway health command.
-import { formatErrorMessage } from "../../infra/errors.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 
 type GatewayHealthRpcOpts = Parameters<
@@ -65,9 +64,7 @@ export async function runGatewayHealthJsonRoute(
     );
   } catch (error) {
     if (!rpc) {
-      runtime.error(formatErrorMessage(error));
-      runtime.exit(1);
-      return;
+      throw error;
     }
     const [healthModule, callModule] = await Promise.all([
       deps.emitReachableGatewayAuthDiagnostic && deps.readNonObservingHealthConfig

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -212,6 +212,33 @@ describe("cli json stdout contract", () => {
       tty: true,
     },
     {
+      name: "routed Gateway health config failure in JSON mode",
+      args: ["gateway", "health", "--port", "29793", "--json"],
+      message: "AUTOQA_ROUTE_CONFIG_READ_FAILURE",
+      configReadFailure: true,
+    },
+    {
+      name: "Gateway health config failure in human mode",
+      args: ["gateway", "health", "--port", "29793"],
+      message: "AUTOQA_ROUTE_CONFIG_READ_FAILURE",
+      configReadFailure: true,
+      human: true,
+    },
+    {
+      name: "Gateway health config failure through forced Commander",
+      args: ["gateway", "health", "--port", "29793", "--json"],
+      message: "AUTOQA_ROUTE_CONFIG_READ_FAILURE",
+      configReadFailure: true,
+      commander: true,
+    },
+    {
+      name: "routed Gateway health config failure with dual TTYs",
+      args: ["gateway", "health", "--port", "29793", "--json"],
+      message: "AUTOQA_ROUTE_CONFIG_READ_FAILURE",
+      configReadFailure: true,
+      tty: true,
+    },
+    {
       name: "specialized explicit Gateway authentication failure",
       args: ["gateway", "call", "system-presence", "--url", "ws://127.0.0.1:29793", "--json"],
       specializedAuth: true,
@@ -226,6 +253,18 @@ describe("cli json stdout contract", () => {
           [
             'import net from "node:net";',
             `net.Socket.prototype.connect = function () { throw new Error(${JSON.stringify(gatewayError)}); };`,
+            ...("configReadFailure" in testCase
+              ? [
+                  'import fs from "node:fs";',
+                  "const originalExistsSync = fs.existsSync;",
+                  "fs.existsSync = function (target, ...args) {",
+                  '  if (String(target) === process.env.OPENCLAW_CONFIG_PATH && new Error().stack?.includes("readNonObservingHealthConfig")) {',
+                  `    throw new Error(${JSON.stringify(testCase.message)});`,
+                  "  }",
+                  "  return originalExistsSync.call(this, target, ...args);",
+                  "};",
+                ]
+              : []),
             ...("tty" in testCase
               ? [
                   'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });',
@@ -269,7 +308,11 @@ describe("cli json stdout contract", () => {
             ok: false,
             error: { type: "cli_error", message: testCase.message },
           });
-          expect(result.stderr).not.toContain(testCase.message);
+          if ("configReadFailure" in testCase && !("commander" in testCase)) {
+            expect(result.stderr).toContain(testCase.message);
+          } else {
+            expect(result.stderr).not.toContain(testCase.message);
+          }
         }
         if ("tty" in testCase) {
           expect(result.stderr).toContain("\u001B[?25h");


### PR DESCRIPTION
## What Problem This Solves

Route-first `gateway health --port ... --json` returned empty stdout when local config resolution failed before RPC setup, while forced Commander correctly emitted a canonical JSON failure.

Fixes https://github.com/openclaw/openclaw/issues/129105.

## Why This Change Was Made

The health fast route now rethrows failures that occur before RPC options are resolved, allowing the existing root renderer to own JSON/human output and terminal finalization. The post-RPC specialized Gateway diagnostic/formatter path remains unchanged.

Production delta: +1/-4, net -3 lines. Tests: +62/-17, net +45 lines.

## User Impact

Routed Gateway health failures now produce parseable JSON consistent with Commander. Target selection, read-only RPC behavior, specialized Gateway payloads, and human output remain unchanged.

## Evidence

- Pre-fix routed JSON regression reproduced empty stdout; forced Commander was already correct.
- Focused owner/sibling proof: 61 tests passed.
- Built-process proof: 13 Gateway query/health cases passed across routed JSON, human, Commander, dual TTY, no-connection/no-state, and specialized payload paths.
- CLI startup build and complete changed-file gates passed.
- Fresh final P1 autoreview: no actionable findings.
- `git diff --check`: passed.

Malformed shared configuration behavior remains tracked in #128606.
