### PR TITLE
refactor(agents): consolidate aborted attempt settlement

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts
@@ -5,13 +5,10 @@ import type { SessionManager } from "../../sessions/index.js";
  * Handles sessions-yield interruption, persistence, and artifact cleanup.
  */
 import { isRunnerAbortError } from "../abort.js";
-import { log } from "../logger.js";
-import { resolveEmbeddedAbortSettleTimeoutMs } from "./attempt-finalize.js";
+import { waitForEmbeddedAbortSettle } from "./attempt-subscription-cleanup.js";
 
 const SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE = "openclaw.sessions_yield_interrupt";
 const SESSIONS_YIELD_CONTEXT_CUSTOM_TYPE = "openclaw.sessions_yield";
-
-const SESSIONS_YIELD_ABORT_SETTLE_TIMEOUT_MS = resolveEmbeddedAbortSettleTimeoutMs();
 
 // Persist a hidden context reminder so the next turn knows why the runner stopped.
 function buildSessionsYieldContextMessage(message: string): string {
@@ -23,32 +20,12 @@ export async function waitForSessionsYieldAbortSettle(params: {
   runId: string;
   sessionId: string;
 }): Promise<void> {
-  if (!params.settlePromise) {
-    return;
-  }
-
-  let timeout: NodeJS.Timeout | undefined;
-  const outcome = await Promise.race([
-    params.settlePromise
-      .then(() => "settled" as const)
-      .catch((err: unknown) => {
-        log.warn(
-          `sessions_yield abort settle failed: runId=${params.runId} sessionId=${params.sessionId} err=${String(err)}`,
-        );
-        return "errored" as const;
-      }),
-    new Promise<"timed_out">((resolve) => {
-      timeout = setTimeout(() => resolve("timed_out"), SESSIONS_YIELD_ABORT_SETTLE_TIMEOUT_MS);
-    }),
-  ]);
-  if (timeout) {
-    clearTimeout(timeout);
-  }
-  if (outcome === "timed_out") {
-    log.warn(
-      `sessions_yield abort settle timed out: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${SESSIONS_YIELD_ABORT_SETTLE_TIMEOUT_MS}`,
-    );
-  }
+  await waitForEmbeddedAbortSettle({
+    promise: params.settlePromise,
+    runId: params.runId,
+    sessionId: params.sessionId,
+    reason: "sessions_yield",
+  });
 }
 
 // Return a synthetic aborted response so agent runtime unwinds without a real provider call.

--- a/src/agents/embedded-agent-runner/run/attempt-subscription-cleanup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-subscription-cleanup.ts
@@ -14,15 +14,17 @@ type ToolResultFlushManager = {
   clearPendingToolResults?: (() => void) | undefined;
 };
 
-async function waitForEmbeddedAbortSettle(params: {
+export async function waitForEmbeddedAbortSettle(params: {
   promise: Promise<unknown> | null | undefined;
   runId: string;
   sessionId: string;
+  reason?: "embedded" | "sessions_yield";
 }): Promise<void> {
   if (!params.promise) {
     return;
   }
 
+  const reason = params.reason ?? "embedded";
   let timeout: NodeJS.Timeout | undefined;
   // Abort settlement is advisory cleanup; timeout or errors are logged but do
   // not block disposing attempt-owned resources.
@@ -31,7 +33,7 @@ async function waitForEmbeddedAbortSettle(params: {
       .then(() => "settled" as const)
       .catch((err: unknown) => {
         log.warn(
-          `embedded abort settle failed: runId=${params.runId} sessionId=${params.sessionId} err=${String(err)}`,
+          `${reason} abort settle failed: runId=${params.runId} sessionId=${params.sessionId} err=${String(err)}`,
         );
         return "errored" as const;
       }),
@@ -44,7 +46,7 @@ async function waitForEmbeddedAbortSettle(params: {
   }
   if (outcome === "timed_out") {
     log.warn(
-      `embedded abort settle timed out: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${EMBEDDED_ABORT_SETTLE_TIMEOUT_MS}`,
+      `${reason} abort settle timed out: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${EMBEDDED_ABORT_SETTLE_TIMEOUT_MS}`,
     );
   }
 }

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "../../../llm/types.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { SessionManager } from "../../sessions/session-manager.js";
-import { stripSessionsYieldArtifacts } from "./attempt-sessions-yield.js";
+import { log } from "../logger.js";
+import { resolveEmbeddedAbortSettleTimeoutMs } from "./attempt-finalize.js";
+import {
+  stripSessionsYieldArtifacts,
+  waitForSessionsYieldAbortSettle,
+} from "./attempt-sessions-yield.js";
 
 const SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE = "openclaw.sessions_yield_interrupt";
 
@@ -64,6 +69,60 @@ function buildSession(messages: AgentMessage[], sessionManager = SessionManager.
     sessionManager,
   };
 }
+
+describe("waitForSessionsYieldAbortSettle", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("logs the yield-specific warning and clears its timer after timeout", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(log, "warn").mockImplementation(() => {});
+    const timeoutMs = resolveEmbeddedAbortSettleTimeoutMs();
+    const wait = waitForSessionsYieldAbortSettle({
+      settlePromise: new Promise(() => {}),
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    await vi.advanceTimersByTimeAsync(timeoutMs);
+    await wait;
+
+    expect(log.warn).toHaveBeenCalledWith(
+      `sessions_yield abort settle timed out: runId=run-1 sessionId=session-1 timeoutMs=${timeoutMs}`,
+    );
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("logs rejected settlement and clears its pending timer", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(log, "warn").mockImplementation(() => {});
+
+    await waitForSessionsYieldAbortSettle({
+      settlePromise: Promise.reject(new Error("settle failed")),
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "sessions_yield abort settle failed: runId=run-1 sessionId=session-1 err=Error: settle failed",
+    );
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("skips missing settlement without scheduling a timer", async () => {
+    vi.useFakeTimers();
+
+    await waitForSessionsYieldAbortSettle({
+      settlePromise: null,
+      runId: "run-1",
+      sessionId: "session-1",
+    });
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});
 
 describe("stripSessionsYieldArtifacts", () => {
   it("removes the full non-continuable yield suffix", () => {

--- a/src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.test.ts
@@ -77,6 +77,9 @@ describe("cleanupEmbeddedAttemptResources", () => {
     await cleanupPromise;
 
     expect(order).toEqual(["flush", "dispose"]);
+    expect(log.warn).toHaveBeenCalledWith(
+      `embedded abort settle timed out: runId=run-1 sessionId=session-1 timeoutMs=${abortSettleTimeoutMs}`,
+    );
   });
 
   it("disposes the session before runtime teardown can hang", async () => {


### PR DESCRIPTION
Related: #105907

## What Problem This Solves

Embedded agent shutdown and sessions-yield handoff maintained separate copies of the same abort-settlement timeout, timer cleanup, and diagnostic behavior. Those parallel implementations could drift whenever lifecycle cleanup changed.

## Why This Change Was Made

Route both settlement paths through the existing embedded cleanup owner, retaining the same configured timeout, cleanup ordering, rejection handling, missing-promise behavior, timer disposal, and distinct diagnostics. This removes 21 lines of production code without adding a new abstraction or dependency.

## User Impact

No intended user-visible behavior change. Agent shutdown and sessions-yield handoff keep their existing behavior while sharing one lifecycle implementation.

## Evidence

- Baseline: four focused test files, 19 passing tests.
- Updated: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.test.ts src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts src/agents/embedded-agent-runner/run/attempt-prompt-error.test.ts src/agents/embedded-agent-runner/run/attempt.abort-settle-timeout.test.ts` — four files, 22 passing tests across two Vitest shards.
- New direct yield-path coverage proves timeout warnings, rejected-settlement warnings, absent promises, and cleared timers; existing cleanup coverage now verifies its exact diagnostic independently.
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/run/attempt-subscription-cleanup.ts src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.test.ts src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts` — passed; the omitted dead-export scan had already passed separately on the same unchanged head before correcting isolated-worktree dependency resolution.
- `git diff --check`; production +12/-33 (net -21), tests +64/-2.
- Fresh automated review plus independent source and exact-head read-only reviews: no actionable findings.
