### PR TITLE
fix(codex): preserve native subagent gateway delivery

### DIFF
--- a/scripts/test-live-codex-harness-docker.sh
+++ b/scripts/test-live-codex-harness-docker.sh
@@ -191,16 +191,13 @@ tmp_dir="$(mktemp -d)"
 openclaw_live_stage_source_tree "$tmp_dir"
 openclaw_live_stage_node_modules "$tmp_dir"
 openclaw_live_link_runtime_tree "$tmp_dir"
-if [ -d /app/dist-runtime/extensions/codex ]; then
-  export OPENCLAW_BUNDLED_PLUGINS_DIR=/app/dist-runtime/extensions
-elif [ -d /app/dist/extensions/codex ]; then
-  export OPENCLAW_BUNDLED_PLUGINS_DIR=/app/dist/extensions
-elif [ -f "$tmp_dir/extensions/codex/openclaw.plugin.json" ]; then
-  export OPENCLAW_BUNDLED_PLUGINS_DIR="$tmp_dir/extensions"
-else
+if [ ! -f "$tmp_dir/extensions/codex/openclaw.plugin.json" ]; then
   echo "ERROR: staged Codex plugin not found for live harness." >&2
   exit 1
 fi
+# Source Gateway and plugin must share one prepared-runtime owner; built artifacts own a
+# separate lifecycle and are validated by the packaged-plugin Docker lane instead.
+export OPENCLAW_BUNDLED_PLUGINS_DIR="$tmp_dir/extensions"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 if [ -n "${OPENCLAW_LIVE_CODEX_TRUSTED_HARNESS_DIR:-}" ] && [ -d "$OPENCLAW_LIVE_CODEX_TRUSTED_HARNESS_DIR" ]; then
   for harness_file in src/gateway/gateway-codex-harness.live-helpers.ts; do

--- a/src/plugins/runtime/gateway-request-scope.test.ts
+++ b/src/plugins/runtime/gateway-request-scope.test.ts
@@ -82,6 +82,23 @@ describe("gateway request scope", () => {
     });
   });
 
+  it("preserves host-issued Gateway resolver bindings across reloaded modules", async () => {
+    const first = await importGatewayRequestScopeModule();
+    const owner = {};
+    const resolver = vi.fn(() => TEST_SCOPE.context!);
+    first.bindGatewayContextResolver(owner, resolver);
+
+    vi.resetModules();
+    const second = await importGatewayRequestScopeModule();
+
+    expect(second.getGatewayContextResolver(owner)).toBe(resolver);
+    expect(second.getSharedGatewayContextResolver([owner])).toBe(resolver);
+    expect(second.getGatewayContextResolver({})).toBeUndefined();
+
+    second.clearGatewayContextResolver(owner);
+    expect(first.getGatewayContextResolver(owner)).toBeUndefined();
+  });
+
   it("attaches plugin id to the active scope", async () => {
     await expectPluginIdScopedGatewayScope("voice-call");
   });

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -32,6 +32,7 @@ type PluginRuntimePluginScope = {
 const PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY: unique symbol = Symbol.for(
   "openclaw.pluginRuntimeGatewayRequestScope",
 );
+const GATEWAY_CONTEXT_RESOLVERS_KEY: unique symbol = Symbol.for("openclaw.gatewayContextResolvers");
 
 const pluginRuntimeGatewayRequestScope = resolveGlobalSingleton<
   AsyncLocalStorage<PluginRuntimeGatewayRequestScope>
@@ -39,7 +40,11 @@ const pluginRuntimeGatewayRequestScope = resolveGlobalSingleton<
   PLUGIN_RUNTIME_GATEWAY_REQUEST_SCOPE_KEY,
   () => new AsyncLocalStorage<PluginRuntimeGatewayRequestScope>(),
 );
-const gatewayContextResolvers = new WeakMap<object, GatewayContextResolver>();
+// Built plugin chunks and source Gateway code must redeem the same host-issued owner bindings.
+const gatewayContextResolvers = resolveGlobalSingleton<WeakMap<object, GatewayContextResolver>>(
+  GATEWAY_CONTEXT_RESOLVERS_KEY,
+  () => new WeakMap(),
+);
 
 export function bindGatewayContextResolver(
   owner: object,

--- a/test/scripts/test-live-codex-harness-docker.test.ts
+++ b/test/scripts/test-live-codex-harness-docker.test.ts
@@ -165,6 +165,43 @@ describe("scripts/test-live-codex-harness-docker.sh", () => {
     expect(script).not.toContain("run_setup_command npm install -g @openai/codex");
   });
 
+  it("keeps the staged Gateway and Codex plugin on the same source module graph", () => {
+    const script = fs.readFileSync(SCRIPT_PATH, "utf8");
+    const selection = script
+      .split('openclaw_live_link_runtime_tree "$tmp_dir"\n')[1]
+      ?.split('openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"')[0];
+    expect(selection).toBeDefined();
+
+    const root = fs.mkdtempSync(
+      path.join(process.env.TMPDIR ?? "/tmp", "openclaw-codex-plugin-roots-"),
+    );
+    try {
+      const stagedRoot = path.join(root, "staged");
+      const stagedPlugin = path.join(stagedRoot, "extensions", "codex");
+      fs.mkdirSync(stagedPlugin, { recursive: true });
+      fs.writeFileSync(path.join(stagedPlugin, "openclaw.plugin.json"), "{}");
+      fs.mkdirSync(path.join(root, "dist-runtime", "extensions", "codex"), {
+        recursive: true,
+      });
+      const executableSelection = selection!
+        .replaceAll("/app/dist-runtime", path.join(root, "dist-runtime"))
+        .replaceAll("/app/dist", path.join(root, "dist"));
+      const result = spawnSync(
+        "bash",
+        ["-c", `${executableSelection}\nprintf '%s' "$OPENCLAW_BUNDLED_PLUGINS_DIR"`],
+        {
+          encoding: "utf8",
+          env: { ...process.env, tmp_dir: stagedRoot },
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe(path.join(stagedRoot, "extensions"));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("fails instead of skipping when Codex auth cannot identify an account", () => {
     const script = fs.readFileSync(SCRIPT_PATH, "utf8");
 


### PR DESCRIPTION
## Summary

Fix the real Codex native-subagent delivery failure reproduced by the authenticated Docker live harness: the child completed successfully, but its task stayed pending because the staged source Gateway loaded a built Codex plugin and entered a second, uninitialized Gateway runtime.

- Keep the source-based live Gateway and bundled Codex plugin on the same staged source module graph; packaged plugins remain covered by the dedicated npm-plugin and package/install lanes.
- Share host-issued Gateway context resolver bindings across duplicate module copies through the existing process singleton, preserving exact owner identity and cross-copy revocation.
- Add executable plugin-root selection coverage and a duplicate-module Gateway resolver regression; both tests were demonstrated failing before their respective fixes.

## Root cause and ownership

The Docker live helper staged source Gateway code but preferred the built plugin tree. The built Codex plugin imported its own compiled task SDK, Gateway agent executor, and prepared runtime, so native completion saw a separate inactive Gateway lifecycle. The owner fix keeps source execution on one canonical graph. Independently, the adjacent Gateway resolver WeakMap was module-local while its AsyncLocalStorage was already shared, so a legitimate host-issued resolver was lost across module copies; that owner registry now uses the same existing shared-singleton abstraction.

## Verification

- Reproduced the original real API-key Docker failure: https://github.com/openclaw/openclaw/actions/runs/32818853016
- Verified real authenticated source-Gateway Codex 0.149.1 native subagent spawn and delivered completion on current main.
- Five owner and sibling suites passed: 103 tests across Gateway request scope, subagent context binding, task SDK completion, Codex native monitoring, and executable Docker plugin-root selection.
- Independent Codex autoreview passed with no accepted or actionable findings.
- Formatting, shell syntax, focused type-aware lint, whitespace validation, and the changed-file gate through its first 17 checks passed. Full local typechecking encountered unrelated baseline errors from intentionally reused stale shared worktree dependencies; exact-head hosted CI validates against the canonical lockfile.
- Production LOC: +10/-8 (net +2); tests: +54/-0.

Related: #127026, #127714, #127724, #128370.
