### PR TITLE
fix(cli): nested command help stalls while loading routed commands

### DIFF
--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -614,7 +614,6 @@ describe("runCli exit behavior", () => {
   });
 
   it("does not load inactive provider cleanup modules for cold help", async () => {
-    tryRouteCliMock.mockResolvedValueOnce(false);
     const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
     buildProgramMock.mockReturnValueOnce({
       commands: [{ name: () => "nodes", aliases: () => [] }],
@@ -2277,6 +2276,26 @@ describe("runCli exit behavior", () => {
     expect(tryRouteCliMock).not.toHaveBeenCalled();
     expect(buildProgramMock).not.toHaveBeenCalled();
     expect(closeActiveMemorySearchManagersMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["plugins install", ["plugins", "install", "--help"]],
+    ["plugins list", ["plugins", "list", "--help"]],
+    ["gateway status", ["gateway", "status", "--help"]],
+  ])("renders %s help without importing the command router", async (_name, args) => {
+    const argv = ["node", "openclaw", ...args];
+    const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
+    const program = {
+      commands: [{ name: () => args[0], aliases: () => [] }],
+      parseAsync,
+    };
+    buildProgramMock.mockReturnValueOnce(program);
+
+    await runCli(argv);
+
+    expect(tryRouteCliMock).not.toHaveBeenCalled();
+    expect(registerSubCliByNameMock).toHaveBeenCalledWith(program, args[0], argv);
+    expect(parseAsync).toHaveBeenCalledWith(argv);
   });
 
   it("propagates precomputed help metadata failures", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1497,17 +1497,19 @@ async function runCliWithPreparedOutputMode(
       return;
     }
 
-    const { tryRouteCli } = await startupTrace.measure("route-import", () => import("./route.js"));
-    const routed = await startupTrace.measure(
-      "route",
-      () =>
-        options.builtInMachineOutput
-          ? tryRouteCli(normalizedArgv, { machineOutput: true })
-          : tryRouteCli(normalizedArgv),
-      { timeline: false },
-    );
-    if (routed) {
-      return;
+    if (!isHelpOrVersionInvocation) {
+      const route = await startupTrace.measure("route-import", () => import("./route.js"));
+      const routed = await startupTrace.measure(
+        "route",
+        () =>
+          options.builtInMachineOutput
+            ? route.tryRouteCli(normalizedArgv, { machineOutput: true })
+            : route.tryRouteCli(normalizedArgv),
+        { timeline: false },
+      );
+      if (routed) {
+        return;
+      }
     }
 
     let parseArgv = normalizeGeneratedHelpCommandArgv(normalizedArgv);


### PR DESCRIPTION
Closes #128821

## What Problem This Solves

Fixes an issue where users asking for nested command help, including `openclaw plugins install --help` and `openclaw plugins list --help`, would load the entire route-first command graph before Commander could display the requested help. On resource-constrained installations, this needless bootstrap can remain CPU-bound without producing any output.

## Why This Change Was Made

The CLI dispatcher already computes whether an invocation requests help or a version, and the route-first owner immediately rejects those exact invocations using the same classification. Gate the route-module import at the dispatcher so every help/version command goes directly to its existing Commander registration and parsing path. This preserves exact leaf-specific help, root options, container dispatch, unknown-command validation, and ordinary routed commands without adding generated metadata, configuration, fallback paths, or plugin-specific special cases.

Production delta: +13/-11 lines (net +2); regression tests: +20/-1 lines. The removed test setup was an obsolete queued router response for help, which otherwise leaked into later tests once help correctly stopped routing.

## User Impact

Nested plugin, gateway, and other command help renders promptly with the correct command-specific usage and options, even when loading the unnecessary route graph would otherwise stall the CLI.

## Evidence

Exact reviewed head: `574d03ca6ee39b6a93fa7c57bc6dece39ad14f9b`.

Before the fix, the new owner-boundary regression failed for all three commands because each invoked the router despite the router rejecting help requests:

```text
plugins install --help: router called unexpectedly
plugins list --help: router called unexpectedly
gateway status --help: router called unexpectedly
```

After the fix, focused owner and sibling coverage passed:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/cli/run-main.exit.test.ts \
  src/cli/route.test.ts \
  src/cli/precomputed-help.test.ts \
  src/cli/argv-invocation.test.ts \
  src/cli/plugins-cli.lazy.test.ts

Test Files: 5 passed
Tests: 281 passed
```

The built distributable was also exercised through its actual `openclaw.mjs` launcher with an isolated state directory:

```text
openclaw plugins install --help: exit 0, 0.545s
Usage: openclaw plugins install [options] <path-or-spec-or-plugin>

openclaw plugins list --help: exit 0, 0.393s
Usage: openclaw plugins list [options]

openclaw gateway status --help: exit 0, 0.536s
Usage: openclaw gateway status [options]
```

The previous built CLI emitted `cli.main.route-import` and `cli.main.route` in its gateway startup trace; the repaired built CLI emitted neither phase and still reached `build-program`, `register-primary`, and `parse` with the correct command-specific output.

Targeted oxlint, formatting, and `git diff --check` passed. A full local build was intentionally stopped under unrelated host CPU pressure after it had already emitted the tested distributable; hosted exact-head CI owns the remaining broad build/check coverage. Structured autoreview found no actionable issues, and an independent verifier personally repeated the distributable CLI checks. AI-assisted.
