### PR TITLE
refactor(apple): share native chat payload normalization

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatEventText.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatEventText.swift
@@ -12,7 +12,7 @@ public enum OpenClawChatEventText {
 
     private static func assistantText(fromValue value: Any) -> String? {
         if let text = value as? String {
-            return self.trimmed(text)
+            return ChatPayloadDecoding.trimmedNonEmptyString(text)
         }
 
         guard let object = self.dictionary(from: value) else { return nil }
@@ -29,7 +29,7 @@ public enum OpenClawChatEventText {
 
     private static func textContent(from value: Any) -> String? {
         if let text = value as? String {
-            return self.trimmed(text)
+            return ChatPayloadDecoding.trimmedNonEmptyString(text)
         }
 
         let parts: [String] = if let array = value as? [AnyCodable] {
@@ -40,19 +40,19 @@ public enum OpenClawChatEventText {
             self.textContentPart(from: value).map { [$0] } ?? []
         }
 
-        return self.trimmed(parts.joined(separator: "\n"))
+        return ChatPayloadDecoding.trimmedNonEmptyString(parts.joined(separator: "\n"))
     }
 
     private static func textContentPart(from value: Any) -> String? {
         if let text = value as? String {
-            return self.trimmed(text)
+            return ChatPayloadDecoding.trimmedNonEmptyString(text)
         }
         guard let object = self.dictionary(from: value) else { return nil }
         guard ChatMessageVisibleText.isVisibleContentType(
             self.stringValue(object["type"]),
             role: "assistant")
         else { return nil }
-        return self.trimmed(self.stringValue(object["text"]) ?? "")
+        return ChatPayloadDecoding.trimmedNonEmptyString(self.stringValue(object["text"]))
     }
 
     private static func dictionary(from value: Any) -> [String: Any]? {
@@ -71,10 +71,5 @@ public enum OpenClawChatEventText {
             return self.stringValue(wrapped.value)
         }
         return nil
-    }
-
-    private static func trimmed(_ text: String) -> String? {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatPayloadDecoding.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatPayloadDecoding.swift
@@ -6,4 +6,9 @@ enum ChatPayloadDecoding {
         let data = try JSONEncoder().encode(payload)
         return try JSONDecoder().decode(T.self, from: data)
     }
+
+    static func trimmedNonEmptyString(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSubagentActivity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSubagentActivity.swift
@@ -47,7 +47,10 @@ struct ChatSubagentActivityState: Equatable, Sendable {
         else { return }
         let previous = self.activitiesByID[task.id]
         let fallbackSnippet = Self.firstNonBlank(task.lastactivity, task.progresssummary, task.lasttoolname)
-        let snippet = if !status.isWorking, previous != nil, Self.nonBlank(task.lastactivity) == nil {
+        let snippet = if !status.isWorking,
+                         previous != nil,
+                         ChatPayloadDecoding.trimmedNonEmptyString(task.lastactivity) == nil
+        {
             previous?.snippet
         } else {
             fallbackSnippet ?? previous?.snippet
@@ -71,7 +74,8 @@ struct ChatSubagentActivityState: Equatable, Sendable {
             diffStat: Self.diffStat(task.diffstat) ?? previous?.diffStat,
             updatedAt: updatedAt,
             terminalObservedAt: terminalObservedAt,
-            terminalSummary: Self.nonBlank(task.terminalsummary) ?? previous?.terminalSummary)
+            terminalSummary: ChatPayloadDecoding.trimmedNonEmptyString(task.terminalsummary)
+                ?? previous?.terminalSummary)
     }
 
     mutating func remove(taskID: String) {
@@ -144,12 +148,7 @@ struct ChatSubagentActivityState: Equatable, Sendable {
     }
 
     private static func firstNonBlank(_ values: String?...) -> String? {
-        values.lazy.compactMap(self.nonBlank).first
-    }
-
-    private static func nonBlank(_ value: String?) -> String? {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed?.isEmpty == false ? trimmed : nil
+        values.lazy.compactMap(ChatPayloadDecoding.trimmedNonEmptyString).first
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/Swarm.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/Swarm.swift
@@ -17,9 +17,9 @@ struct OpenClawChatSwarmActivityState: Equatable {
     }
 
     mutating func observe(_ event: OpenClawChatSessionsChangedEvent) -> Bool {
-        guard let groupID = Self.normalized(event.swarmGroupId) else { return false }
-        let kind = Self.normalized(event.kind)
-        let text = Self.normalized(event.text)
+        guard let groupID = ChatPayloadDecoding.trimmedNonEmptyString(event.swarmGroupId) else { return false }
+        let kind = ChatPayloadDecoding.trimmedNonEmptyString(event.kind)
+        let text = ChatPayloadDecoding.trimmedNonEmptyString(event.text)
         if let text, kind == "phase" || kind == "log" {
             if kind == "phase" {
                 let rankKey = Self.phaseRankKey(groupID: groupID, phase: text)
@@ -46,8 +46,8 @@ struct OpenClawChatSwarmActivityState: Equatable {
             return true
         }
 
-        guard let childKey = Self.normalized(event.sessionKey) else { return true }
-        if let phase = Self.normalized(event.swarmPhase) {
+        guard let childKey = ChatPayloadDecoding.trimmedNonEmptyString(event.sessionKey) else { return true }
+        if let phase = ChatPayloadDecoding.trimmedNonEmptyString(event.swarmPhase) {
             Self.setBounded(
                 &self.phaseByChild,
                 key: childKey,
@@ -70,7 +70,7 @@ struct OpenClawChatSwarmActivityState: Equatable {
 
     func decorate(_ sessions: [OpenClawChatSessionEntry]) -> [OpenClawChatSessionEntry] {
         sessions.map { row in
-            guard let groupID = Self.normalized(row.swarmGroupId) else { return row }
+            guard let groupID = ChatPayloadDecoding.trimmedNonEmptyString(row.swarmGroupId) else { return row }
             let phase = self.phaseByChild[row.key] ?? row.swarmPhase
             let rank = phase.flatMap { self.phaseRankByGroupPhase[Self.phaseRankKey(groupID: groupID, phase: $0)] }
                 ?? row.swarmPhaseRank
@@ -81,11 +81,6 @@ struct OpenClawChatSwarmActivityState: Equatable {
             decorated.swarmLog = log
             return decorated
         }
-    }
-
-    private static func normalized(_ value: String?) -> String? {
-        let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return normalized?.isEmpty == false ? normalized : nil
     }
 
     private static func phaseRankKey(groupID: String, phase: String) -> String {
@@ -253,7 +248,7 @@ enum SelfContainedSwarmHelpers {
     }
 
     static func isActivityNote(_ event: OpenClawChatSessionsChangedEvent) -> Bool {
-        let kind = self.normalized(event.kind)
+        let kind = ChatPayloadDecoding.trimmedNonEmptyString(event.kind)
         return kind == "phase" || kind == "log"
     }
 
@@ -261,15 +256,17 @@ enum SelfContainedSwarmHelpers {
         _ event: OpenClawChatSessionsChangedEvent,
         matchesParent: (String) -> Bool) -> Bool
     {
-        if let parent = normalized(event.parentSessionKey) ?? normalized(event.spawnedBy) {
+        if let parent = ChatPayloadDecoding.trimmedNonEmptyString(event.parentSessionKey)
+            ?? ChatPayloadDecoding.trimmedNonEmptyString(event.spawnedBy)
+        {
             return matchesParent(parent)
         }
-        let kind = self.normalized(event.kind)
+        let kind = ChatPayloadDecoding.trimmedNonEmptyString(event.kind)
         if kind == "phase" || kind == "log" {
-            guard let sessionKey = normalized(event.sessionKey) else { return false }
+            guard let sessionKey = ChatPayloadDecoding.trimmedNonEmptyString(event.sessionKey) else { return false }
             return matchesParent(sessionKey)
         }
-        guard let groupID = normalized(event.swarmGroupId) else { return false }
+        guard let groupID = ChatPayloadDecoding.trimmedNonEmptyString(event.swarmGroupId) else { return false }
         return self.generatedGroupBelongsToParent(groupID, matchesParent: matchesParent)
     }
 
@@ -280,11 +277,6 @@ enum SelfContainedSwarmHelpers {
         let parts = groupID.split(separator: ":", omittingEmptySubsequences: false)
         guard parts.first == "swarm", parts.count > 2 else { return false }
         return matchesParent(parts.dropFirst().dropLast().joined(separator: ":"))
-    }
-
-    private static func normalized(_ value: String?) -> String? {
-        let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines)
-        return normalized?.isEmpty == false ? normalized : nil
     }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Native chat event processing independently owned four equivalent string-normalization helpers. Each trimmed `whitespacesAndNewlines` and converted nil or empty results to nil, leaving identical behavior duplicated across event text, subagent activity, and two Swarm paths.

## Why This Change Was Made

This moves the shared internal contract to `ChatPayloadDecoding.trimmedNonEmptyString` and removes the four private implementations. It deliberately excludes outbound request normalization and session/sidebar normalization because those ownership paths are under active PRs #112004, #112227, and #128286.

Rejected alternatives: a new utility file would add a source path and project-metadata burden; a module-wide generic `String` extension would broaden the API surface beyond this payload boundary.

Production LOC: +30/-39 (net -9) | Tests: +0/-0

## User Impact

No user-visible behavior or compatibility change. Native chat payload normalization now has one owner instead of four, reducing future drift risk.

## Evidence

Exact head: `9bac5c66ec55e80cd7efb329e325244728b5b6d0`

- `node scripts/check-changed.mjs -- apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatPayloadDecoding.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSubagentActivity.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatEventText.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/Swarm.swift` — passed all guards and 7 routed Vitest shards (357 passed, 131 skipped).
- `git diff --check origin/main...HEAD` — passed.
- Deslop: clean; no comments, defensive branches, type laundering, compatibility shims, or style drift introduced.
- Structured autoreview (`.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`) — clean, no accepted/actionable findings.
- Separate exact-head read-only Codex review — clean, no concrete P0–P2 findings; the shared payload owner is the narrowest behavior-neutral fix.
- Exact-head hosted CI run [32831487295](https://github.com/openclaw/openclaw/actions/runs/32831487295) — passed, including `macos-swift` (Swift compilation/format/lint), `ios-build`, both iOS screenshot jobs, and `openclaw/ci-gate`.
