### PR TITLE
chore: remove duplicate media registry tests

### DIFF
--- a/src/media-generation/registry.test.ts
+++ b/src/media-generation/registry.test.ts
@@ -122,16 +122,6 @@ describe("image-generation provider registry", () => {
 });
 
 describe("video-generation provider registry", () => {
-  it("delegates provider resolution to the capability provider boundary", async () => {
-    const { listVideoGenerationProviders } = await loadProviderRegistry();
-
-    expect(listVideoGenerationProviders()).toStrictEqual([]);
-    expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
-      key: "videoGenerationProviders",
-      cfg: undefined,
-    });
-  });
-
   it("uses active plugin providers without loading from disk", async () => {
     resolvePluginCapabilityProvidersMock.mockReturnValue([
       createVideoProvider({ id: "custom-video" }),


### PR DESCRIPTION
## What Problem This Solves

The video-generation registry suite repeated the same resolver key and `cfg: undefined` call-shape assertion already covered by its stronger active-provider lookup test. The duplicate added maintenance cost and refactor-sensitive failure noise without protecting an independent behavior or contract.

## Why This Change Was Made

Remove only the video delegation-only case. The image delegation test remains because it uniquely proves that a non-empty `OpenClawConfig` reaches the resolver, which is observable through runtime provider selection and the Plugin SDK. Provider lookup and prototype-like provider ID security coverage also remain unchanged.

This PR is AI-assisted and was produced from a maintainer-requested test audit.

## User Impact

No user-visible behavior changes. Maintainers get a smaller, behavior-focused media registry test suite without weakening config, runtime, SDK, or security contract coverage.

## Evidence

- `node scripts/run-vitest.mjs src/media-generation/registry.test.ts` — 5 tests passed on the final narrowed diff.
- `node scripts/check-changed.mjs -- src/media-generation/registry.test.ts` — required changed-file gates passed on the final diff, including test typecheck and lint.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted ...` — final narrowed diff clean, no accepted/actionable findings; patch correctness 0.99.

Production LOC: +0/-0 | Tests: +0/-10
