### PR TITLE
refactor(plugins): consolidate provider registration flows

### DIFF
--- a/src/plugins/registry-registrars-providers.ts
+++ b/src/plugins/registry-registrars-providers.ts
@@ -6,22 +6,7 @@ import { normalizeRegisteredProvider } from "./provider-validation.js";
 import { canClaimReservedCommandOwnership } from "./registry-registrars-operations.js";
 import type { PluginRegistryState } from "./registry-state.js";
 import type { PluginRecord, PluginTextTransformsRegistration } from "./registry-types.js";
-import type {
-  CliBackendPlugin,
-  ImageGenerationProviderPlugin,
-  MediaUnderstandingProviderPlugin,
-  MigrationProviderPlugin,
-  MusicGenerationProviderPlugin,
-  ProviderPlugin,
-  RealtimeTranscriptionProviderPlugin,
-  RealtimeVoiceProviderPlugin,
-  SpeechProviderPlugin,
-  TranscriptSourceProvider,
-  VideoGenerationProviderPlugin,
-  WebFetchProviderPlugin,
-  WebSearchProviderPlugin,
-  WorkerProvider,
-} from "./types.js";
+import type { CliBackendPlugin, ProviderPlugin, WorkerProvider } from "./types.js";
 import { validateWorkerProviderContract } from "./worker-provider-registry.js";
 
 type PluginOwnedProviderRegistration<T extends { id: string }> = {
@@ -254,46 +239,52 @@ export function createProviderRegistrars(state: PluginRegistryState) {
     }
   };
 
-  const registerUniqueProviderLike = <T extends { id: string }>(params: {
-    record: PluginRecord;
-    provider: T;
-    kindLabel: string;
-    registrations: Array<PluginOwnedProviderRegistration<T>>;
-    ownedIds: string[];
-  }): boolean => {
-    const id = params.provider.id.trim();
-    const { record, kindLabel } = params;
-    if (!id) {
-      pushDiagnostic({
-        level: "error",
+  const createProviderLikeRegistrar =
+    <T extends { id: string }>(params: {
+      kindLabel: string;
+      registrations: Array<PluginOwnedProviderRegistration<T>>;
+      ownedIds: (record: PluginRecord) => string[];
+      onRegister?: (record: PluginRecord, provider: T) => void;
+    }) =>
+    (record: PluginRecord, provider: T): boolean | void => {
+      const id = provider.id.trim();
+      const { kindLabel } = params;
+      if (!id) {
+        pushDiagnostic({
+          level: "error",
+          pluginId: record.id,
+          source: record.source,
+          message: `${kindLabel} registration missing id`,
+        });
+        return params.onRegister ? undefined : false;
+      }
+      const existing = params.registrations.find((entry) => entry.provider.id === id);
+      if (existing) {
+        pushDiagnostic({
+          level: "error",
+          pluginId: record.id,
+          source: record.source,
+          message: `${kindLabel} already registered: ${id} (${existing.pluginId})`,
+        });
+        return params.onRegister ? undefined : false;
+      }
+      const ownedIds = params.ownedIds(record);
+      if (!ownedIds.includes(id)) {
+        ownedIds.push(id);
+      }
+      params.registrations.push({
         pluginId: record.id,
+        pluginName: record.name,
+        provider,
         source: record.source,
-        message: `${kindLabel} registration missing id`,
+        rootDir: record.rootDir,
       });
-      return false;
-    }
-    const existing = params.registrations.find((entry) => entry.provider.id === id);
-    if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `${kindLabel} already registered: ${id} (${existing.pluginId})`,
-      });
-      return false;
-    }
-    if (!params.ownedIds.includes(id)) {
-      params.ownedIds.push(id);
-    }
-    params.registrations.push({
-      pluginId: record.id,
-      pluginName: record.name,
-      provider: params.provider,
-      source: record.source,
-      rootDir: record.rootDir,
-    });
-    return true;
-  };
+      if (params.onRegister) {
+        params.onRegister(record, provider);
+        return;
+      }
+      return true;
+    };
 
   const registerWorkerProvider = (record: PluginRecord, provider: WorkerProvider) => {
     const reject = (message: string) =>
@@ -321,170 +312,98 @@ export function createProviderRegistrars(state: PluginRegistryState) {
     });
   };
 
-  const registerSpeechProvider = (record: PluginRecord, provider: SpeechProviderPlugin) => {
-    if (
-      registerUniqueProviderLike({
-        record,
-        provider,
-        kindLabel: "speech provider",
-        registrations: registry.speechProviders,
-        ownedIds: record.speechProviderIds,
-      })
-    ) {
+  const registerSpeechProvider = createProviderLikeRegistrar({
+    kindLabel: "speech provider",
+    registrations: registry.speechProviders,
+    ownedIds: (record) => record.speechProviderIds,
+    onRegister: (record, provider) =>
       registerSynthesizedVoiceModelCatalogProvider({
         record,
         provider,
         capabilities: { tts: true },
         modes: ["tts"],
-      });
-    }
-  };
+      }),
+  });
 
-  const registerRealtimeTranscriptionProvider = (
-    record: PluginRecord,
-    provider: RealtimeTranscriptionProviderPlugin,
-  ) => {
-    if (
-      registerUniqueProviderLike({
-        record,
-        provider,
-        kindLabel: "realtime transcription provider",
-        registrations: registry.realtimeTranscriptionProviders,
-        ownedIds: record.realtimeTranscriptionProviderIds,
-      })
-    ) {
+  const registerRealtimeTranscriptionProvider = createProviderLikeRegistrar({
+    kindLabel: "realtime transcription provider",
+    registrations: registry.realtimeTranscriptionProviders,
+    ownedIds: (record) => record.realtimeTranscriptionProviderIds,
+    onRegister: (record, provider) =>
       registerSynthesizedVoiceModelCatalogProvider({
         record,
         provider,
         capabilities: { realtime_transcription: true },
         modes: ["realtime_transcription"],
-      });
-    }
-  };
+      }),
+  });
 
-  const registerRealtimeVoiceProvider = (
-    record: PluginRecord,
-    provider: RealtimeVoiceProviderPlugin,
-  ) => {
-    if (
-      registerUniqueProviderLike({
-        record,
-        provider,
-        kindLabel: "realtime voice provider",
-        registrations: registry.realtimeVoiceProviders,
-        ownedIds: record.realtimeVoiceProviderIds,
-      })
-    ) {
+  const registerRealtimeVoiceProvider = createProviderLikeRegistrar({
+    kindLabel: "realtime voice provider",
+    registrations: registry.realtimeVoiceProviders,
+    ownedIds: (record) => record.realtimeVoiceProviderIds,
+    onRegister: (record, provider) =>
       registerSynthesizedVoiceModelCatalogProvider({
         record,
         provider,
         capabilities: { realtime_voice: true },
         modes: ["realtime_voice"],
-      });
-    }
-  };
+      }),
+  });
 
-  const registerMediaUnderstandingProvider = (
-    record: PluginRecord,
-    provider: MediaUnderstandingProviderPlugin,
-  ) =>
-    registerUniqueProviderLike({
-      record,
-      provider,
-      kindLabel: "media provider",
-      registrations: registry.mediaUnderstandingProviders,
-      ownedIds: record.mediaUnderstandingProviderIds,
-    });
+  const registerMediaUnderstandingProvider = createProviderLikeRegistrar({
+    kindLabel: "media provider",
+    registrations: registry.mediaUnderstandingProviders,
+    ownedIds: (record) => record.mediaUnderstandingProviderIds,
+  });
 
-  const registerTranscriptSourceProvider = (
-    record: PluginRecord,
-    provider: TranscriptSourceProvider,
-  ) =>
-    registerUniqueProviderLike({
-      record,
-      provider,
-      kindLabel: "transcripts source provider",
-      registrations: registry.transcriptSourceProviders,
-      ownedIds: record.transcriptSourceProviderIds,
-    });
+  const registerTranscriptSourceProvider = createProviderLikeRegistrar({
+    kindLabel: "transcripts source provider",
+    registrations: registry.transcriptSourceProviders,
+    ownedIds: (record) => record.transcriptSourceProviderIds,
+  });
 
-  const registerImageGenerationProvider = (
-    record: PluginRecord,
-    provider: ImageGenerationProviderPlugin,
-  ) => {
-    if (
-      registerUniqueProviderLike({
-        record,
-        provider,
-        kindLabel: "image-generation provider",
-        registrations: registry.imageGenerationProviders,
-        ownedIds: record.imageGenerationProviderIds,
-      })
-    ) {
-      registerSynthesizedMediaModelCatalogProvider({ record, kind: "image_generation", provider });
-    }
-  };
+  const registerImageGenerationProvider = createProviderLikeRegistrar({
+    kindLabel: "image-generation provider",
+    registrations: registry.imageGenerationProviders,
+    ownedIds: (record) => record.imageGenerationProviderIds,
+    onRegister: (record, provider) =>
+      registerSynthesizedMediaModelCatalogProvider({ record, kind: "image_generation", provider }),
+  });
 
-  const registerVideoGenerationProvider = (
-    record: PluginRecord,
-    provider: VideoGenerationProviderPlugin,
-  ) => {
-    if (
-      registerUniqueProviderLike({
-        record,
-        provider,
-        kindLabel: "video-generation provider",
-        registrations: registry.videoGenerationProviders,
-        ownedIds: record.videoGenerationProviderIds,
-      })
-    ) {
-      registerSynthesizedMediaModelCatalogProvider({ record, kind: "video_generation", provider });
-    }
-  };
+  const registerVideoGenerationProvider = createProviderLikeRegistrar({
+    kindLabel: "video-generation provider",
+    registrations: registry.videoGenerationProviders,
+    ownedIds: (record) => record.videoGenerationProviderIds,
+    onRegister: (record, provider) =>
+      registerSynthesizedMediaModelCatalogProvider({ record, kind: "video_generation", provider }),
+  });
 
-  const registerMusicGenerationProvider = (
-    record: PluginRecord,
-    provider: MusicGenerationProviderPlugin,
-  ) => {
-    if (
-      registerUniqueProviderLike({
-        record,
-        provider,
-        kindLabel: "music-generation provider",
-        registrations: registry.musicGenerationProviders,
-        ownedIds: record.musicGenerationProviderIds,
-      })
-    ) {
-      registerSynthesizedMediaModelCatalogProvider({ record, kind: "music_generation", provider });
-    }
-  };
+  const registerMusicGenerationProvider = createProviderLikeRegistrar({
+    kindLabel: "music-generation provider",
+    registrations: registry.musicGenerationProviders,
+    ownedIds: (record) => record.musicGenerationProviderIds,
+    onRegister: (record, provider) =>
+      registerSynthesizedMediaModelCatalogProvider({ record, kind: "music_generation", provider }),
+  });
 
-  const registerWebFetchProvider = (record: PluginRecord, provider: WebFetchProviderPlugin) =>
-    registerUniqueProviderLike({
-      record,
-      provider,
-      kindLabel: "web fetch provider",
-      registrations: registry.webFetchProviders,
-      ownedIds: record.webFetchProviderIds,
-    });
+  const registerWebFetchProvider = createProviderLikeRegistrar({
+    kindLabel: "web fetch provider",
+    registrations: registry.webFetchProviders,
+    ownedIds: (record) => record.webFetchProviderIds,
+  });
 
-  const registerWebSearchProvider = (record: PluginRecord, provider: WebSearchProviderPlugin) =>
-    registerUniqueProviderLike({
-      record,
-      provider,
-      kindLabel: "web search provider",
-      registrations: registry.webSearchProviders,
-      ownedIds: record.webSearchProviderIds,
-    });
+  const registerWebSearchProvider = createProviderLikeRegistrar({
+    kindLabel: "web search provider",
+    registrations: registry.webSearchProviders,
+    ownedIds: (record) => record.webSearchProviderIds,
+  });
 
-  const registerMigrationProvider = (record: PluginRecord, provider: MigrationProviderPlugin) =>
-    registerUniqueProviderLike({
-      record,
-      provider,
-      kindLabel: "migration provider",
-      registrations: registry.migrationProviders,
-      ownedIds: record.migrationProviderIds,
-    });
+  const registerMigrationProvider = createProviderLikeRegistrar({
+    kindLabel: "migration provider",
+    registrations: registry.migrationProviders,
+    ownedIds: (record) => record.migrationProviderIds,
+  });
 
   return {
     registerProvider,


### PR DESCRIPTION
## What Problem This Solves

The plugin registry repeated the same provider-registration ceremony across eleven capability families, making ownership bookkeeping, duplicate diagnostics, and synthesized catalog side effects unnecessarily expensive to maintain consistently.

## Why This Change Was Made

Replace the eleven near-identical internal wrappers with one strongly typed registrar factory. Each family still owns the same registry bucket, plugin-owned identifier list, diagnostic wording, return values, and success-only voice or media catalog hook; public plugin APIs and provider behavior do not change.

## User Impact

No user-visible behavior changes. Plugin developers keep every existing registration method and contract, while the internal implementation shrinks by 81 production lines (+111/-192) without adding abstractions, configuration, dependencies, or tests.

## Evidence

- Existing owner, public registration-capture, and bundled plugin contract suites pass unchanged: `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/plugins/registry.provider-like.test.ts src/plugins/captured-registration.test.ts src/plugins/contracts/registry.contract.test.ts` (39 tests across three Vitest shards).
- Changed-file gates pass: `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 node scripts/check-changed.mjs -- src/plugins/registry-registrars-providers.ts` (production and test typechecks, formatting, lint, plugin boundaries, database-first and runtime-loader guards, import cycles, and auth guards).
- Production, full-tree, and script dead-export scans also passed on the identical reviewed source in the initial changed-file run; the rerun skipped only that already-proven scan after fixing linked-worktree UI dependency resolution.
- Fresh structured Codex autoreview found no actionable findings; independent source review verified all eleven family mappings, exact diagnostics/return values, and synthesized catalog ordering.
