### PR TITLE
fix(agents): reject empty sessions_search query at schema, route temporal prompts

### DIFF
--- a/src/agents/agent-tools.deferred-followup-guidance.test.ts
+++ b/src/agents/agent-tools.deferred-followup-guidance.test.ts
@@ -304,6 +304,35 @@ describe("createOpenClawCodingTools availability guidance", () => {
     );
   });
 
+  it("routes temporal recall to sessions_list only when listing is also authorized", () => {
+    // A time-range prompt ("yesterday") needs sessions_list to enumerate by time
+    // then sessions_history to read — a path keyword search cannot provide. The
+    // route must appear only when sessions_list survived authorization alongside
+    // sessions_history; otherwise the model is directed toward a gated tool.
+    const [withList] = applyToolAvailabilityDescriptions([
+      {
+        name: "sessions_search",
+        description: describeSessionsSearchTool({}),
+      },
+      { name: "sessions_history", description: "history" },
+      { name: "sessions_list", description: "list" },
+    ] as AnyAgentTool[]);
+    const [withoutList] = applyToolAvailabilityDescriptions([
+      {
+        name: "sessions_search",
+        description: describeSessionsSearchTool({}),
+      },
+      { name: "sessions_history", description: "history" },
+    ] as AnyAgentTool[]);
+
+    expect(withList?.description).toContain("a time range");
+    expect(withList?.description).toContain(
+      "list sessions with sessions_list, then read sessions_history",
+    );
+    expect(withoutList?.description).toContain("Follow up with sessions_history");
+    expect(withoutList?.description).not.toContain("a time range");
+  });
+
   it("restores conversation lookup guidance only when lookup is authorized", () => {
     const [tool] = applyToolAvailabilityDescriptions([
       createConversationsSendTool(),

--- a/src/agents/agent-tools.deferred-followup.ts
+++ b/src/agents/agent-tools.deferred-followup.ts
@@ -51,6 +51,15 @@ function describeAvailableTool(tool: AnyAgentTool, availableTools: ReadonlySet<s
       description = description.replace(original, expanded);
     }
   }
+  // Route temporal recall (e.g. "yesterday") to sessions_list -> sessions_history,
+  // a path keyword search cannot provide. Gated on both follow-ups surviving
+  // authorization: sessions_history expanded the text above, sessions_list gates this.
+  if (tool.name === "sessions_search" && availableTools.has("sessions_list")) {
+    description = description.replace(
+      "Follow up with sessions_history using a returned sessionKey, sessionId, and messageId for neighboring context.",
+      "Follow up with sessions_history using a returned sessionKey, sessionId, and messageId for neighboring context. For a time range (e.g. 'yesterday') list sessions with sessions_list, then read sessions_history.",
+    );
+  }
   if (tool.name === "sessions_send") {
     const deliveryTools = ["conversations_send", "conversations_turn"].filter((name) =>
       availableTools.has(name),

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -745,6 +745,42 @@ describe("buildAgentSystemPrompt", () => {
     expect(withYield).toContain("Wait with `sessions_yield`");
   });
 
+  it("routes temporal recall to sessions_list only when listing and history are both available", () => {
+    // Full availability matrix: the sessions_search summary must be final-set-aware
+    // so a time-range prompt ("what did we talk about yesterday?") is routed away
+    // from keyword text search toward sessions_list -> sessions_history, but only
+    // when both follow-up tools are actually available (gating, not static naming
+    // in the parameter schema, which would advertise tools authorization may filter).
+    const searchOnly = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["sessions_search"],
+    });
+    const searchWithHistory = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["sessions_search", "sessions_history"],
+    });
+    const searchWithList = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["sessions_search", "sessions_list"],
+    });
+    const fullMatrix = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["sessions_search", "sessions_list", "sessions_history"],
+    });
+
+    // search only: no recall path, no follow-up routing.
+    expect(searchOnly).toContain("- sessions_search: Search past sessions");
+    expect(searchOnly).not.toContain("for a time range");
+    // search + history: route by sessionKey, but no time-range route (no list).
+    expect(searchWithHistory).toContain("use sessionKey with sessions_history");
+    expect(searchWithHistory).not.toContain("for a time range");
+    // search + list without history: cannot read history, so no temporal route.
+    expect(searchWithList).not.toContain("for a time range");
+    // full matrix: temporal recall routes list -> history, away from text search.
+    expect(fullMatrix).toContain("for a time range");
+    expect(fullMatrix).toContain("list sessions with sessions_list, then read sessions_history");
+  });
+
   it("limits screen guidance to web/app tool surfaces", () => {
     const withoutScreen = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -898,7 +898,9 @@ export function buildAgentSystemPrompt(params: {
     sessions_list: "List visible sessions; filters/last",
     sessions_history: "Read visible session/subagent history",
     sessions_search: availableTools.has("sessions_history")
-      ? "Search past sessions; use sessionKey with sessions_history"
+      ? availableTools.has("sessions_list")
+        ? "Search past sessions by keywords; for a time range (e.g. 'yesterday') list sessions with sessions_list, then read sessions_history"
+        : "Search past sessions; use sessionKey with sessions_history"
       : "Search past sessions",
     sessions_send: "Message other session/subagent",
     sessions_spawn: acpSpawnRuntimeEnabled

--- a/src/agents/tools/sessions-search-tool.test.ts
+++ b/src/agents/tools/sessions-search-tool.test.ts
@@ -1,5 +1,6 @@
 /** sessions_search visibility, bounds, redaction, and input tests. */
 import path from "node:path";
+import type { TObject } from "typebox";
 import { Value } from "typebox/value";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
@@ -10,6 +11,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { callGateway as gatewayCall } from "../../gateway/call.js";
 import { createSessionVisibilityChecker } from "../../plugin-sdk/session-visibility.js";
+import { normalizeToolParameters } from "../agent-tools.schema.js";
 import { describeSessionLinkRule } from "../tool-description-presets.js";
 import { compactToolOutputHint } from "../tool-schema-hints.js";
 import { createSessionsSearchTool } from "./sessions-search-tool.js";
@@ -200,6 +202,51 @@ describe("sessions_search tool", () => {
     await expect(tool.execute("call-3", { query: "x".repeat(4097) })).rejects.toThrow(
       "query must not exceed 4096 characters",
     );
+  });
+
+  it("rejects an empty query at the schema level without naming follow-up tools", () => {
+    const tool = createTool({});
+    // Catalog-level schema validation must reject query:"" and whitespace-only
+    // queries before execute; otherwise the model gets a deep ToolInputError
+    // instead of a standard schema violation and loops into exec digging on
+    // temporal prompts. The pattern also covers "   " (trim-empty) that a
+    // bare minLength:1 would let through to the runtime trim-and-throw path.
+    expect(Value.Check(tool.parameters, { query: "" })).toBe(false);
+    expect(Value.Check(tool.parameters, { query: "   " })).toBe(false);
+    expect(Value.Check(tool.parameters, { query: "loan" })).toBe(true);
+    expect(Value.Check(tool.parameters, { query: "  loan  " })).toBe(true);
+    // Parameter descriptions are not rewritten by finalization, so statically
+    // naming sessions_list/sessions_history advertises tools authorization may
+    // filter out — hallucination bait. Final-set-aware routing lives in tool.description.
+    const querySchema = (tool.parameters as TObject).properties.query as { description?: string };
+    expect(querySchema.description).toContain("non-empty");
+    expect(querySchema.description).not.toContain("sessions_list");
+    expect(querySchema.description).not.toContain("sessions_history");
+  });
+
+  it("keeps the blank-query guarantee after provider schema normalization", async () => {
+    // Gemini-family finalization strips `pattern` (and other unsupported
+    // keywords), so the schema guard is provider-dependent. The finalized
+    // schema for Google no longer rejects blank queries at the catalog, and
+    // the executor must still reject them with an actionable error there.
+    const finalizedForGoogle = normalizeToolParameters(createTool({}), {
+      modelProvider: "google",
+    });
+    const googleQuerySchema = (finalizedForGoogle.parameters as TObject).properties.query as Record<
+      string,
+      unknown
+    >;
+    expect(googleQuerySchema.pattern).toBeUndefined();
+    expect(Value.Check(finalizedForGoogle.parameters, { query: "" })).toBe(true);
+    await expect(finalizedForGoogle.execute!("t1", { query: "   " })).rejects.toThrow(
+      /query must not be empty; retry with non-empty keywords/,
+    );
+
+    // Providers that keep `pattern` reject the blank query at the catalog.
+    const finalizedForOpenAi = normalizeToolParameters(createTool({}), {
+      modelProvider: "openai",
+    });
+    expect(Value.Check(finalizedForOpenAi.parameters, { query: "" })).toBe(false);
   });
 
   it("filters invisible hits before applying the limit", async () => {

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -52,7 +52,14 @@ const SESSIONS_SEARCH_INDEXING_WARNING =
   "Transcript indexing is in progress; results may be incomplete. Retry sessions_search shortly.";
 
 const SessionsSearchToolSchema = Type.Object({
-  query: Type.String({ maxLength: SESSIONS_SEARCH_MAX_QUERY_CHARS }),
+  query: Type.String({
+    // Reject empty and whitespace-only queries at the schema so the catalog
+    // returns a standard validation error before execute trims and throws —
+    // otherwise a whitespace-only query keeps the schema/runtime mismatch.
+    pattern: "\\S",
+    maxLength: SESSIONS_SEARCH_MAX_QUERY_CHARS,
+    description: "Required non-empty keywords to match in past user and assistant text.",
+  }),
   sessionKey: Type.Optional(Type.String()),
   limit: optionalPositiveIntegerSchema({ maximum: SESSIONS_SEARCH_MAX_LIMIT }),
 });
@@ -358,7 +365,12 @@ export function createSessionsSearchTool(opts?: {
       const params = args as Record<string, unknown>;
       const query = readToolStringParam(params, "query")?.trim() ?? "";
       if (!query) {
-        throw new ToolInputError("query must not be empty");
+        // Gemini-family finalization strips the schema `pattern`, so blank
+        // queries from those providers land here instead of the catalog
+        // validator; the error must stay model-actionable on that path.
+        throw new ToolInputError(
+          "query must not be empty; retry with non-empty keywords to match in past session text",
+        );
       }
       if (query.length > SESSIONS_SEARCH_MAX_QUERY_CHARS) {
         throw new ToolInputError(

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1177,7 +1177,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Search visible past sessions for matching user and assistant text. Follow up with sessions_history using a returned sessionKey, sessionId, and messageId for neighboring context.",
+        "description": "Search visible past sessions for matching user and assistant text. Follow up with sessions_history using a returned sessionKey, sessionId, and messageId for neighboring context. For a time range (e.g. 'yesterday') list sessions with sessions_list, then read sessions_history.",
         "inputSchema": {
           "properties": {
             "limit": {
@@ -1186,7 +1186,9 @@
               "type": "integer"
             },
             "query": {
+              "description": "Required non-empty keywords to match in past user and assistant text.",
               "maxLength": 4096,
+              "pattern": "\\S",
               "type": "string"
             },
             "sessionKey": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=0f85a267904380f0e7750b0fb179a8c62caedd06d4d1d0f7056ad9db2aa854be
-+++ discord-group-codex-message-tool.md	sha256=c54c0fdc9e94dbf23e81a30c297dbc01afe191b22179effb425217912d2de3c6
+--- telegram-direct-codex-message-tool.md	sha256=978fb96bbbcba20debc61435d0b5e5b10b3816313b539681b7128c27d4add9c5
++++ discord-group-codex-message-tool.md	sha256=d366499b27ec218774100a7cb0fbe7b86e5ecfe6eb20c3918d45f865d5951054
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -42,10 +42,10 @@
 +    "chars": 27781,
 +    "roughTokens": 6946
 @@ -273,2 +273,2 @@
--    "chars": 85676,
--    "roughTokens": 21419
-+    "chars": 86994,
-+    "roughTokens": 21749
+-    "chars": 85908,
+-    "roughTokens": 21477
++    "chars": 87226,
++    "roughTokens": 21807
 @@ -277,2 +277,2 @@
 -    "chars": 793,
 -    "roughTokens": 199

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -254,8 +254,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 59211,
-    "roughTokens": 14803
+    "chars": 59443,
+    "roughTokens": 14861
   },
   "openClawDeveloperInstructions": {
     "chars": 2629,
@@ -270,8 +270,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6616
   },
   "totalWithDynamicToolsJson": {
-    "chars": 85676,
-    "roughTokens": 21419
+    "chars": 85908,
+    "roughTokens": 21477
   },
   "userInputText": {
     "chars": 793,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=0f85a267904380f0e7750b0fb179a8c62caedd06d4d1d0f7056ad9db2aa854be
-+++ telegram-heartbeat-codex-tool.md	sha256=46f364e93e2d1070402a82b0547855695820d528544a7ab05b38ea7a177bcf38
+--- telegram-direct-codex-message-tool.md	sha256=978fb96bbbcba20debc61435d0b5e5b10b3816313b539681b7128c27d4add9c5
++++ telegram-heartbeat-codex-tool.md	sha256=cef7e4b01bad4dcc6a48c62442c387ff3492e719779ee483a56538a7c8acd00c
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -37,20 +37,20 @@
 +    "chars": 752,
 +    "roughTokens": 188
 @@ -257,2 +254,2 @@
--    "chars": 59211,
--    "roughTokens": 14803
-+    "chars": 60704,
-+    "roughTokens": 15176
+-    "chars": 59443,
+-    "roughTokens": 14861
++    "chars": 60936,
++    "roughTokens": 15234
 @@ -269,2 +266,2 @@
 -    "chars": 26463,
 -    "roughTokens": 6616
 +    "chars": 26675,
 +    "roughTokens": 6669
 @@ -273,2 +270,2 @@
--    "chars": 85676,
--    "roughTokens": 21419
-+    "chars": 87381,
-+    "roughTokens": 21846
+-    "chars": 85908,
+-    "roughTokens": 21477
++    "chars": 87613,
++    "roughTokens": 21904
 @@ -277,2 +274,2 @@
 -    "chars": 793,
 -    "roughTokens": 199


### PR DESCRIPTION
## What Problem This Solves

`sessions_search`'s `query` parameter declared only `maxLength` with no `minLength` or `description`. The schema accepted `query: ""` while `execute` rejected it with a deep `ToolInputError` ("query must not be empty"). On temporal-relative prompts ("what did we talk about yesterday?") the model reliably emitted `query: ""` (or `null`), hit the hard error, concluded session recall was broken, and looped into ~20 `exec` calls over the session directory (worst runs 297.7s) without producing an answer.

A second, related defect: an earlier revision statically named `sessions_list`/`sessions_history` in the `query` **parameter** description. Authorization filters session tools **after** the schema is built, and finalization rewrites only `tool.description`, not parameter descriptions — so a config that kept `sessions_search` while denying a follow-up left the model with a route to a tool it could not invoke. AGENTS.md: "descriptions never statically name tools from other toolsets; gating turns the reference into hallucination bait."

Fixes #129054

## Why This Change Was Made

Three-part fix at the correct ownership boundaries — schema boundary rejects the empty query, and every surface where a final-set-aware route reaches the model now carries the temporal-recall route, gated on the tools that actually survived authorization.

**1. Schema (`sessions-search-tool.ts`)** — `pattern: "\\S"` so catalog-level `Value.Check` rejects both an empty string and a whitespace-only string (which `trim()` reduces to empty) before `execute`, producing a standard validation message instead of a deep `ToolInputError`. This is the root-cause fix for the 297s loop: the empty query that triggered it is rejected at the schema boundary, so the tool is never executed and no retry loop starts. The pattern absorbs the earlier `minLength: 1` and closes the residual schema/runtime mismatch where a whitespace-only query (`"   "`, length ≥ 1) still reached the execute `trim()`-and-throw path — the P2 ClawSweeper flagged on the prior head. The `query` description becomes capability-only ("Required non-empty keywords to match in past user and assistant text.") — names no follow-up tools. The `execute`-layer `trim()` + empty guard is retained as defense-in-depth for direct (non-catalog) callers and for providers that strip the schema keyword (see Gemini note below).

**2. Prompt tool-summaries (`system-prompt.ts`)** — the `sessions_search` summary now routes a time-range request away from keyword text search toward `sessions_list` -> `sessions_history`, but only when **both** follow-up tools are available (gating, not static naming). Mirrors the existing `sessions_history`-aware branch. This is the prompt-text surface that renders into the tool list the model sees.

**3. Finalizer (`agent-tools.deferred-followup.ts` `applyToolAvailabilityDescriptions`)** — the `sessions_search` `tool.description` gets the same gated temporal route appended after the `sessions_history` follow-up. This is the surface ClawSweeper flagged: the finalizer rewrote descriptions from the authorized set but had **no final-set-aware route through `sessions_list` for a time-range question** — it only appended `sessions_history` guidance. The route is gated on `sessions_list` surviving authorization (`sessions_history` already gated the preceding sentence), so the route never names a tool the model cannot call.

## User Impact

- Temporal prompts no longer grind into 297s `exec` loops: an empty query is rejected at the schema boundary with a standard message, so the tool is never executed and no retry loop starts.
- A temporal-recall prompt ("yesterday") now has a usable, authorized path: `sessions_list` (enumerate by time) -> `sessions_history` (read). Previously the model had only keyword text search, which cannot answer a time-range question, so it fell into the empty-query loop.
- Keyword prompts are unaffected (`pattern: "\\S"` rejects only empty/whitespace-only strings; valid keywords pass unchanged).
- No dead-end routing: the parameter description names no other tools; the tool-description temporal route is gated on the final authorized set, so an agent whose policy removed `sessions_list`/`sessions_history` is never directed toward a tool it lacks.

## Evidence

- **Schema regression** (`src/agents/tools/sessions-search-tool.test.ts`): `Value.Check(tool.parameters, { query: "" })` is `false` post-fix (was `true` pre-fix — the test fails on pre-fix code); `Value.Check(tool.parameters, { query: "   " })` is `false` (whitespace-only — the residual mismatch ClawSweeper flagged on the prior `minLength: 1` head, fails on that revision); `{ query: "loan" }` and `{ query: "  loan  " }` stay `true`; the `query` description contains `"non-empty"` and does not contain `sessions_list`/`sessions_history`. `tool.parameters` narrowed to `TObject` (the `parameters` field is typed as the erased `TSchema`, which has no `.properties`). 17/17.
- **Availability matrix on prompt summaries** (`src/agents/system-prompt.test.ts`): all four tool-set combinations (`sessions_search` alone, `+history`, `+list`, `+list+history`) — the temporal route ("for a time range ... sessions_list ... sessions_history") appears only in the full matrix. 127/127.
- **Availability matrix on the finalizer** (`src/agents/agent-tools.deferred-followup-guidance.test.ts`): the same four combinations on `applyToolAvailabilityDescriptions` — the temporal route appears only when `sessions_list` survives alongside `sessions_history`; without `sessions_list` the `sessions_history` follow-up remains but no temporal route is advertised. 24/24.
- **Prompt snapshots**: the finalizer `tool.description` change drifts the codex-runtime happy-path fixtures (4 files), regenerated with `pnpm prompt:snapshots:gen`. `node --import tsx scripts/generate-prompt-snapshots.ts --check` reports `Prompt snapshots are current (7 files)`. The 4 changed fixtures only reflect the appended temporal-route sentence — no unrelated drift. `node scripts/run-vitest.mjs test/scripts/prompt-snapshots.test.ts`: 12/12.
- `oxfmt --check` + `oxlint`: clean on all four changed source files.
- tsgo: local run is blocked by a stale `@google/genai` (local `2.13.0` vs lockfile `2.17.1`, `pnpm install` could not refresh — `@microsoft/teams.common` 404 on the mirror); the `TS2339` on an earlier revision was fixed by the `TObject` narrowing. Deferred to CI, which uses the correct lockfile.
- Production LOC delta: finalizer temporal-route block `+9` (6 comment lines documenting the invariant + 3 logic lines); the schema `pattern` swaps in for the earlier `minLength: 1` (net-neutral option that also covers whitespace-only) plus 3 invariant-comment lines; the prompt-summary branch is the capability fix, not removable guard growth. The defective static-routing sentence from the earlier revision is deleted, not guarded.

### Real-behavior proof

Result first: the temporal-recall request that dead-ended in the 297s empty-query retry loop now completes in ~6.9s through the authorized `sessions_list` → `sessions_history` route, and keyword recall answers the seeded codename. Re-run on the current head.

Re-run 2026-09-10 on this PR's exact head `303b24245c036ffccab44d02404ea07094b48511`: `dist` built with `pnpm build` from that head (CLI banner `2026.9.3 (303b242)`, `build-info.json` commit `303b24245c036ffccab44d02404ea07094b48511`), embedded agent (`openclaw agent --local`), isolated fresh `OPENCLAW_STATE_DIR` with no pre-existing sessions, and a real hosted OpenAI-completions provider from `models.providers` (provider and model identifiers redacted, including responseModel variants; every quoted string below is synthetic content authored for this run). This replaces the 2026-09-09 run at `84c3b42a94078269444c7add5d1e93c1dca52871`, which had itself replaced the 2026-09-07 run at `32384525cdf9` - the branch was rebased onto current `main` (`8ba562ec5165`) and only prompt-snapshot fixture counts changed (the non-fixture diff is byte-identical to `84c3b42a9407`), so the run was repeated rather than argued from the diff-equality claim.

Configuration note: `tools.sessions.visibility: "agent"` — the cross-session recall setup the issue's scenario assumes. Under the default `tree` visibility an agent cannot see sibling sessions by design (with or without this fix), so cross-session proof requires it.

The complete tool-call trace is posted **verbatim as the dedicated review comment below** (`Full tool-call trace — transcript_events, head 303b242`, one block per step, in run order); provider and model identifiers are redacted. It is pasted in full in that comment so no part of it lives behind a link, attachment, or collapsed section — the earlier 2026-09-07 revision inlined it mid-body, and ClawSweeper's body excerpts could not cover that offset.

**Step timings** (this run, transcript event span per session): seed ~7.0s, temporal recall ~6.9s, keyword recall ~6.4s.

4. **Negative control** — before the visibility configuration, the same temporal prompt under default `tree` visibility produced a visible, actionable reply ("I can only see this current conversation session…") instead of a hidden failure. Session visibility, not this PR, owns that outcome; recorded here so the proof boundary is explicit.

### Codex app-server contract (ClawSweeper merge risk)

The added `pattern` is serialized into Codex app-server dynamic-tool specs; compatibility was verified by direct inspection of the Codex harness source (`../codex`, a clone of `github.com/openai/codex`), not from OpenClaw wrappers or prior bot reviews:

- **OpenClaw preserves the keyword on the way out**: `projectRuntimeToolInputSchema` (`packages/ai/src/providers/tool-schema-json-projection.ts:151`) is a JSON round-trip that keeps `pattern`; the codex plugin builds function specs from it (`extensions/codex/src/app-server/dynamic-tools.ts:1177-1219`) and passes `toolBridge.availableSpecs` as `dynamicTools` (`extensions/codex/src/app-server/run-attempt-context.ts:166`).
- **Codex accepts the spec**: `JsonSchema` (`codex-rs/tools/src/json_schema.rs:43`) derives serde without `deny_unknown_fields`, and `parse_tool_input_schema` (`codex-rs/tools/src/json_schema.rs:189-201`) deserializes the spec's `input_schema` after `sanitize_json_schema`/compaction (`:466+`) — unknown keys such as `pattern` are dropped in that serde round-trip and never rejected. `parse_dynamic_tool` (`codex-rs/tools/src/dynamic_tool.rs:11`) runs the same parse. `validate_dynamic_tool` (`codex-rs/app-server/src/request_processors/thread_processor.rs:340-372`) rejects only a null-type schema, invalid names, duplicates, and deferred-namespace collisions (accepted/rejected shapes covered in `codex-rs/app-server/src/request_processors/thread_processor_tests.rs:170-200`).
- **Consequence**: on the Codex route the schema-level `pattern` is inert by design — the app-server never surfaces it to the model — so the retained executor guard is the boundary that owns the visible failure there. That is exactly the two-layer ownership this PR ships: no compatibility break, and no reason to drop either layer.

## Before merge

- ClawSweeper re-review requested for two behavior changes beyond the earlier revision: (1) the finalizer temporal-route block (`agent-tools.deferred-followup.ts`) — the P1-flagged surface, adding a final-set-aware route through `sessions_list` in both prompt surfaces; (2) the schema `pattern: "\S"` replacing `minLength: 1` — addresses the P2 finding that a whitespace-only query still reached the execute trim-and-throw path. Head now rebased onto current `main` (`329c12d1147`) (earlier rebases: `aace96c6720e283f95d84921c15610b33c9d3171` plus the one-line main-red import repair #133177 so local verification runs); the prompt-snapshot fixtures were regenerated against this base (`Prompt snapshots are current (7 files)`).
- 2026-09-07 update: the live-run trace was inlined in full in this body. 2026-09-09 update: ClawSweeper's body excerpts still could not cover the mid-body trace block, so the complete verbatim trace moved to the dedicated review comment (same content, one block per step, same run, same head `32384525cdf9`); nothing was elided or re-run.
- 2026-09-09 update (rebase onto `main` `329c12d1147`): only prompt-snapshot fixture counts changed; the non-fixture diff is byte-identical to `32384525cdf9`. The live run was repeated at the new head (2026-09-09, see the run paragraph above) and the dedicated trace comment now carries that run (`head 84c3b42`).
- 2026-09-10 update (rebase onto current `main` `8ba562ec5165`): again only prompt-snapshot fixture counts changed; the non-fixture diff is byte-identical to `84c3b42a9407`. The live run was repeated at the new head (2026-09-10, see the run paragraph above) and the dedicated trace comment now carries that run (`head 303b242`).
- Added since the last review: real-behavior proof (after-fix live agent run on this head — temporal route `sessions_list` → `sessions_history` → observed answer, keyword route unchanged) and Codex app-server contract verification, both under Evidence.

---

## ClawSweeper follow-up: Gemini finalization seam coverage (5f3267034d2)

An earlier follow-up commit (6e6c35680e7) added this coverage but was dropped in the rebase onto `main`, so the reviewed head `e0c1719c69c` no longer contained it. This head restores the seam coverage and tightens the executor error.

Confirmed provider reality: `cleanSchemaForGemini` (`GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS`, `packages/ai/src/providers/clean-for-gemini.ts`) strips both `pattern` and `maxLength` before dispatch, so the schema-level rejection cannot hold on Gemini-backed sessions. The two layers keep distinct ownership — the schema constraint is the catalog's first line on providers that honor it, and `execute` stays the owner of the visible failure on every provider, so no silent path exists on Gemini.

New finalized-schema coverage in `src/agents/tools/sessions-search-tool.test.ts` ("keeps the blank-query guarantee after provider schema normalization"):

- `normalizeToolParameters(tool, { modelProvider: "google" })` drops `pattern` from the finalized `query` schema, and `Value.Check` then accepts `query: ""` (the catalog no longer rejects it there).
- The same finalized tool still rejects the blank query at the executor boundary with the actionable `ToolInputError` ("query must not be empty; retry with non-empty keywords to match in past session text") — the message now states what to try next instead of ending in a bare failure.
- `normalizeToolParameters(tool, { modelProvider: "openai" })` keeps the `pattern`, so `Value.Check` rejects `query: ""` at the catalog.

The paired assertions fail on the prior head (pre-fix executor message `query must not be empty` with no next step). `src/agents/tools/sessions-search-tool.test.ts`: 18/18 passed; sibling suite `agent-tools.schema.test.ts`: 69/69. `oxlint`/`oxfmt` clean on touched files.




