### PR TITLE
test(google): isolate Vertex streams from ambient ADC

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -186,6 +186,7 @@ async function useGoogleAuthorizedUserCredentials(
 async function useGoogleAuthLibraryCredentials(label: string, token?: string): Promise<void> {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), `openclaw-google-vertex-${label}-`));
   vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+  vi.stubEnv("CLOUDSDK_CONFIG", "");
   vi.stubEnv("HOME", path.join(tempDir, "home"));
   vi.stubEnv("APPDATA", "");
   if (token !== undefined) {
@@ -906,7 +907,7 @@ describe("google transport stream", () => {
       if (provider === "google-vertex") {
         vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
         vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
-        googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+        await useGoogleAuthLibraryCredentials("blocked", "ya29.vertex-token");
       }
 
       const result =
@@ -933,7 +934,7 @@ describe("google transport stream", () => {
       if (provider === "google-vertex") {
         vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
         vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
-        googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.vertex-token");
+        await useGoogleAuthLibraryCredentials("unfinished", "ya29.vertex-token");
       }
 
       const result =
@@ -2020,12 +2021,9 @@ describe("google transport stream", () => {
   );
 
   it("strips redundant google provider prefixes from Google Vertex model paths", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-prefix-"));
-    vi.stubEnv("HOME", path.join(tempDir, "home"));
-    vi.stubEnv("APPDATA", "");
     vi.stubEnv("GOOGLE_CLOUD_PROJECT", "vertex-project");
     vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
-    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.transport-token");
+    await useGoogleAuthLibraryCredentials("prefix", "ya29.transport-token");
     const tokenFetchMock = vi.fn();
     mockGoogleTextResponse();
 


### PR DESCRIPTION
## Summary

Keep Google Vertex transport regressions independent of a developer's ambient Application Default Credentials. Four existing provider-owned streaming tests incorrectly discovered local credentials before reaching their mocked auth-library transport: two blocked-prompt cases, incomplete-stream handling, and canonical Vertex model paths.

Reuse the existing isolated auth-library fixture for each affected case and clear `CLOUDSDK_CONFIG` in that shared fixture alongside `GOOGLE_APPLICATION_CREDENTIALS`, `HOME`, and `APPDATA`. Explicit credential-precedence tests remain unchanged. Production code is untouched, and the test-only diff removes two lines overall.

## Validation

- Exact current-main reproduction with locally present application-default credentials: all four selected Vertex cases failed before the fix.
- Full Google transport owner suite after the fix: **135 passed, 0 failed**.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-vertex-isolation OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs --configLoader runner extensions/google/transport-stream.test.ts`
- Focused formatter, focused extension lint, and `git diff --check` all passed.
- Independent maintainer review and structured autoreview found no actionable issues.
- Hosted CI can already be green without developer ADC: the earlier QA baseline completed successfully in https://github.com/openclaw/openclaw/actions/runs/32810944276 while the identical commit failed locally.
