### PR TITLE
refactor(cli): simplify message command action registration

### DIFF
--- a/src/cli/program/message/register.broadcast.ts
+++ b/src/cli/program/message/register.broadcast.ts
@@ -12,7 +12,5 @@ export function registerMessageBroadcastCommand(message: Command, helpers: Messa
     .requiredOption("--targets <target...>", CHANNEL_TARGETS_DESCRIPTION)
     .option("--message <text>", "Message to send")
     .option("--media <url>", "Media URL")
-    .action(async (options: Record<string, unknown>) => {
-      await helpers.runMessageAction("broadcast", options);
-    });
+    .action((options: Record<string, unknown>) => helpers.runMessageAction("broadcast", options));
 }

--- a/src/cli/program/message/register.discord-admin.ts
+++ b/src/cli/program/message/register.discord-admin.ts
@@ -9,9 +9,7 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
     .withMessageBase(
       role.command("info").description("List roles").requiredOption("--guild-id <id>", "Guild id"),
     )
-    .action(async (opts) => {
-      await helpers.runMessageAction("role-info", opts);
-    });
+    .action((opts) => helpers.runMessageAction("role-info", opts));
 
   helpers
     .withMessageBase(
@@ -22,9 +20,7 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
         .requiredOption("--user-id <id>", "User id")
         .requiredOption("--role-id <id>", "Role id"),
     )
-    .action(async (opts) => {
-      await helpers.runMessageAction("role-add", opts);
-    });
+    .action((opts) => helpers.runMessageAction("role-add", opts));
 
   helpers
     .withMessageBase(
@@ -35,18 +31,14 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
         .requiredOption("--user-id <id>", "User id")
         .requiredOption("--role-id <id>", "Role id"),
     )
-    .action(async (opts) => {
-      await helpers.runMessageAction("role-remove", opts);
-    });
+    .action((opts) => helpers.runMessageAction("role-remove", opts));
 
   const channel = message.command("channel").description("Channel actions");
   helpers
     .withMessageBase(
       helpers.withRequiredMessageTarget(channel.command("info").description("Fetch channel info")),
     )
-    .action(async (opts) => {
-      await helpers.runMessageAction("channel-info", opts);
-    });
+    .action((opts) => helpers.runMessageAction("channel-info", opts));
 
   helpers
     .withMessageBase(
@@ -55,9 +47,7 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
         .description("List channels")
         .requiredOption("--guild-id <id>", "Guild id"),
     )
-    .action(async (opts) => {
-      await helpers.runMessageAction("channel-list", opts);
-    });
+    .action((opts) => helpers.runMessageAction("channel-list", opts));
 
   const member = message.command("member").description("Member actions");
   helpers
@@ -68,9 +58,7 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
         .requiredOption("--user-id <id>", "User id"),
     )
     .option("--guild-id <id>", "Guild id (Discord)")
-    .action(async (opts) => {
-      await helpers.runMessageAction("member-info", opts);
-    });
+    .action((opts) => helpers.runMessageAction("member-info", opts));
 
   const voice = message.command("voice").description("Voice actions");
   helpers
@@ -81,9 +69,7 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
         .requiredOption("--guild-id <id>", "Guild id")
         .requiredOption("--user-id <id>", "User id"),
     )
-    .action(async (opts) => {
-      await helpers.runMessageAction("voice-status", opts);
-    });
+    .action((opts) => helpers.runMessageAction("voice-status", opts));
 
   const event = message.command("event").description("Event actions");
   helpers
@@ -93,9 +79,7 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
         .description("List scheduled events")
         .requiredOption("--guild-id <id>", "Guild id"),
     )
-    .action(async (opts) => {
-      await helpers.runMessageAction("event-list", opts);
-    });
+    .action((opts) => helpers.runMessageAction("event-list", opts));
 
   helpers
     .withMessageBase(
@@ -112,9 +96,7 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
     .option("--location <text>", "Event location")
     .option("--event-type <stage|external|voice>", "Event type")
     .option("--image <url>", "Cover image URL or local file path")
-    .action(async (opts) => {
-      await helpers.runMessageAction("event-create", opts);
-    });
+    .action((opts) => helpers.runMessageAction("event-create", opts));
 
   helpers
     .withMessageBase(
@@ -127,9 +109,7 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
     .option("--duration-min <n>", "Timeout duration minutes")
     .option("--until <iso>", "Timeout until")
     .option("--reason <text>", "Moderation reason")
-    .action(async (opts) => {
-      await helpers.runMessageAction("timeout", opts);
-    });
+    .action((opts) => helpers.runMessageAction("timeout", opts));
 
   helpers
     .withMessageBase(
@@ -140,9 +120,7 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
         .requiredOption("--user-id <id>", "User id"),
     )
     .option("--reason <text>", "Moderation reason")
-    .action(async (opts) => {
-      await helpers.runMessageAction("kick", opts);
-    });
+    .action((opts) => helpers.runMessageAction("kick", opts));
 
   helpers
     .withMessageBase(
@@ -154,7 +132,5 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
     )
     .option("--reason <text>", "Moderation reason")
     .option("--delete-days <n>", "Ban delete message days")
-    .action(async (opts) => {
-      await helpers.runMessageAction("ban", opts);
-    });
+    .action((opts) => helpers.runMessageAction("ban", opts));
 }

--- a/src/cli/program/message/register.emoji-sticker.ts
+++ b/src/cli/program/message/register.emoji-sticker.ts
@@ -10,9 +10,7 @@ export function registerMessageEmojiCommands(message: Command, helpers: MessageC
   helpers
     .withMessageBase(emoji.command("list").description("List emojis"))
     .option("--guild-id <id>", "Guild id (Discord)")
-    .action(async (opts) => {
-      await helpers.runMessageAction("emoji-list", opts);
-    });
+    .action((opts) => helpers.runMessageAction("emoji-list", opts));
 
   helpers
     .withMessageBase(
@@ -24,9 +22,7 @@ export function registerMessageEmojiCommands(message: Command, helpers: MessageC
     .requiredOption("--emoji-name <name>", "Emoji name")
     .requiredOption("--media <path-or-url>", "Emoji media (path or URL)")
     .option("--role-ids <id>", "Role id (repeat)", collectOption, [] as string[])
-    .action(async (opts) => {
-      await helpers.runMessageAction("emoji-upload", opts);
-    });
+    .action((opts) => helpers.runMessageAction("emoji-upload", opts));
 }
 
 /** Register sticker send/upload commands. */
@@ -39,9 +35,7 @@ export function registerMessageStickerCommands(message: Command, helpers: Messag
     )
     .requiredOption("--sticker-id <id>", "Sticker id (repeat)", collectOption)
     .option("-m, --message <text>", "Optional message body")
-    .action(async (opts) => {
-      await helpers.runMessageAction("sticker", opts);
-    });
+    .action((opts) => helpers.runMessageAction("sticker", opts));
 
   helpers
     .withMessageBase(
@@ -54,7 +48,5 @@ export function registerMessageStickerCommands(message: Command, helpers: Messag
     .requiredOption("--sticker-desc <text>", "Sticker description")
     .requiredOption("--sticker-tags <tags>", "Sticker tags")
     .requiredOption("--media <path-or-url>", "Sticker media (path or URL)")
-    .action(async (opts) => {
-      await helpers.runMessageAction("sticker-upload", opts);
-    });
+    .action((opts) => helpers.runMessageAction("sticker-upload", opts));
 }

--- a/src/cli/program/message/register.permissions-search.ts
+++ b/src/cli/program/message/register.permissions-search.ts
@@ -11,9 +11,7 @@ export function registerMessagePermissionsCommand(message: Command, helpers: Mes
         message.command("permissions").description("Fetch channel permissions"),
       ),
     )
-    .action(async (opts) => {
-      await helpers.runMessageAction("permissions", opts);
-    });
+    .action((opts) => helpers.runMessageAction("permissions", opts));
 }
 
 /** Register Discord message search command and repeatable filters. */
@@ -27,7 +25,5 @@ export function registerMessageSearchCommand(message: Command, helpers: MessageC
     .option("--author-id <id>", "Author id")
     .option("--author-ids <id>", "Author id (repeat)", collectOption, [] as string[])
     .option("--limit <n>", "Result limit")
-    .action(async (opts) => {
-      await helpers.runMessageAction("search", opts);
-    });
+    .action((opts) => helpers.runMessageAction("search", opts));
 }

--- a/src/cli/program/message/register.pins.ts
+++ b/src/cli/program/message/register.pins.ts
@@ -4,38 +4,30 @@ import type { MessageCliHelpers } from "./helpers.js";
 
 /** Register message pin management commands. */
 export function registerMessagePinCommands(message: Command, helpers: MessageCliHelpers) {
-  const pins = [
-    helpers
-      .withMessageBase(
-        helpers.withRequiredMessageTarget(message.command("pin").description("Pin a message")),
-      )
-      .requiredOption("--message-id <id>", "Message id")
-      .action(async (opts) => {
-        await helpers.runMessageAction("pin", opts);
-      }),
-    helpers
-      .withMessageBase(
-        helpers.withRequiredMessageTarget(message.command("unpin").description("Unpin a message")),
-      )
-      .requiredOption("--message-id <id>", "Message id (or pinned message resource id for MSTeams)")
-      .option(
-        "--pinned-message-id <id>",
-        "Pinned message resource id (MSTeams: from pin or list-pins, not the chat message id)",
-      )
-      .action(async (opts) => {
-        await helpers.runMessageAction("unpin", opts);
-      }),
-    helpers
-      .withMessageBase(
-        helpers.withRequiredMessageTarget(
-          message.command("pins").description("List pinned messages"),
-        ),
-      )
-      .option("--limit <n>", "Result limit")
-      .action(async (opts) => {
-        await helpers.runMessageAction("list-pins", opts);
-      }),
-  ] as const;
+  helpers
+    .withMessageBase(
+      helpers.withRequiredMessageTarget(message.command("pin").description("Pin a message")),
+    )
+    .requiredOption("--message-id <id>", "Message id")
+    .action((opts) => helpers.runMessageAction("pin", opts));
 
-  void pins;
+  helpers
+    .withMessageBase(
+      helpers.withRequiredMessageTarget(message.command("unpin").description("Unpin a message")),
+    )
+    .requiredOption("--message-id <id>", "Message id (or pinned message resource id for MSTeams)")
+    .option(
+      "--pinned-message-id <id>",
+      "Pinned message resource id (MSTeams: from pin or list-pins, not the chat message id)",
+    )
+    .action((opts) => helpers.runMessageAction("unpin", opts));
+
+  helpers
+    .withMessageBase(
+      helpers.withRequiredMessageTarget(
+        message.command("pins").description("List pinned messages"),
+      ),
+    )
+    .option("--limit <n>", "Result limit")
+    .action((opts) => helpers.runMessageAction("list-pins", opts));
 }

--- a/src/cli/program/message/register.poll.ts
+++ b/src/cli/program/message/register.poll.ts
@@ -28,7 +28,5 @@ export function registerMessagePollCommand(message: Command, helpers: MessageCli
       false,
     )
     .option("--thread-id <id>", "Thread id (Telegram forum topic / Slack thread ts)")
-    .action(async (opts) => {
-      await helpers.runMessageAction("poll", opts);
-    });
+    .action((opts) => helpers.runMessageAction("poll", opts));
 }

--- a/src/cli/program/message/register.reactions.ts
+++ b/src/cli/program/message/register.reactions.ts
@@ -17,9 +17,7 @@ export function registerMessageReactionsCommands(message: Command, helpers: Mess
     .option("--from-me", "WhatsApp reaction fromMe", false)
     .option("--target-author <id>", "Signal reaction target author (uuid or phone)")
     .option("--target-author-uuid <uuid>", "Signal reaction target author uuid")
-    .action(async (opts) => {
-      await helpers.runMessageAction("react", opts);
-    });
+    .action((opts) => helpers.runMessageAction("react", opts));
 
   helpers
     .withMessageBase(
@@ -29,7 +27,5 @@ export function registerMessageReactionsCommands(message: Command, helpers: Mess
     )
     .requiredOption("--message-id <id>", "Message id")
     .option("--limit <n>", "Result limit")
-    .action(async (opts) => {
-      await helpers.runMessageAction("reactions", opts);
-    });
+    .action((opts) => helpers.runMessageAction("reactions", opts));
 }

--- a/src/cli/program/message/register.read-edit-delete.ts
+++ b/src/cli/program/message/register.read-edit-delete.ts
@@ -20,9 +20,7 @@ export function registerMessageReadEditDeleteCommands(
     .option("--around <id>", "Read around id")
     .option("--thread-id <id>", "Thread id (Slack thread timestamp)")
     .option("--include-thread", "Include thread replies (Discord)", false)
-    .action(async (opts) => {
-      await helpers.runMessageAction("read", opts);
-    });
+    .action((opts) => helpers.runMessageAction("read", opts));
 
   helpers
     .withMessageBase(
@@ -35,9 +33,7 @@ export function registerMessageReadEditDeleteCommands(
       ),
     )
     .option("--thread-id <id>", "Thread id (Telegram forum thread)")
-    .action(async (opts) => {
-      await helpers.runMessageAction("edit", opts);
-    });
+    .action((opts) => helpers.runMessageAction("edit", opts));
 
   helpers
     .withMessageBase(
@@ -48,7 +44,5 @@ export function registerMessageReadEditDeleteCommands(
           .requiredOption("--message-id <id>", "Message id"),
       ),
     )
-    .action(async (opts) => {
-      await helpers.runMessageAction("delete", opts);
-    });
+    .action((opts) => helpers.runMessageAction("delete", opts));
 }

--- a/src/cli/program/message/register.send.ts
+++ b/src/cli/program/message/register.send.ts
@@ -40,7 +40,5 @@ export function registerMessageSendCommand(message: Command, helpers: MessageCli
           false,
         ),
     )
-    .action(async (opts) => {
-      await helpers.runMessageAction("send", opts);
-    });
+    .action((opts) => helpers.runMessageAction("send", opts));
 }

--- a/src/cli/program/message/register.thread.ts
+++ b/src/cli/program/message/register.thread.ts
@@ -57,9 +57,7 @@ export function registerMessageThreadCommands(message: Command, helpers: Message
     .option("--include-archived", "Include archived threads", false)
     .option("--before <id>", "Read/search before id")
     .option("--limit <n>", "Result limit")
-    .action(async (opts) => {
-      await helpers.runMessageAction("thread-list", opts);
-    });
+    .action((opts) => helpers.runMessageAction("thread-list", opts));
 
   helpers
     .withMessageBase(
@@ -75,7 +73,5 @@ export function registerMessageThreadCommands(message: Command, helpers: Message
       "Attach media (image/audio/video/document). Accepts local paths or URLs.",
     )
     .option("--reply-to <id>", "Reply-to message id")
-    .action(async (opts) => {
-      await helpers.runMessageAction("thread-reply", opts);
-    });
+    .action((opts) => helpers.runMessageAction("thread-reply", opts));
 }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup: message command registration repeated the same redundant async wrapper for nearly every subcommand, while pin registration built and discarded an unused array. The extra ceremony made the command family noisier without owning any distinct behavior.

## Why This Change Was Made

Return the existing canonical message-action Promise directly from 31 Commander action callbacks and register the three pin commands directly. Preserve the meaningful thread-create normalization boundary, every command option/action mapping, execution order, and failure behavior. Production code decreases by 64 lines without adding an abstraction.

## User Impact

No user-visible behavior change. Message commands, options, asynchronous completion, errors, and post-action hooks retain their existing behavior.

## Evidence

- Focused existing coverage: `node scripts/run-vitest.mjs src/cli/program/message/helpers.test.ts src/cli/program/message/register.thread.test.ts src/cli/program/register.message.test.ts src/cli/program/command-tree.test.ts src/cli/program/root-command-descriptions.test.ts src/commands/message.test.ts` — six files, 74 passing tests.
- Full applicable core/core-test changed gate passed: `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 node scripts/check-changed.mjs -- src/cli/program/message/register.broadcast.ts src/cli/program/message/register.discord-admin.ts src/cli/program/message/register.emoji-sticker.ts src/cli/program/message/register.permissions-search.ts src/cli/program/message/register.pins.ts src/cli/program/message/register.poll.ts src/cli/program/message/register.reactions.ts src/cli/program/message/register.read-edit-delete.ts src/cli/program/message/register.send.ts src/cli/program/message/register.thread.ts`. The identical unchanged patch had already passed the production, full-tree, and script dead-export scans separately.
- Actual Commander 15 parser exercised all 32 message leaf commands before and after the change with identical action mappings; delayed Promise actions completed before post-action hooks, and rejected Promises/synchronous failures propagated identically without running post-action hooks.
- Commander source and TypeScript declarations directly confirm action callbacks may return Promises and that `parseAsync` awaits the action chain.
- Independent source review and automated precommit Codex review reported no actionable findings.

AI-assisted maintainer-requested refactor.
