### PR TITLE
fix(reply): prevent deduplicated follow-ups from losing threaded replies

### DIFF
--- a/src/auto-reply/reply/followup-delivery-payloads.ts
+++ b/src/auto-reply/reply/followup-delivery-payloads.ts
@@ -11,8 +11,13 @@ import {
   resolveOriginMessageProvider,
   resolveOriginMessageTo,
 } from "./origin-routing.js";
-import { applyReplyThreading, filterMessagingToolReplyPayload } from "./reply-payloads.js";
-import { createReplyDeliveryContext, resolveReplyToMode } from "./reply-threading.js";
+import { applyReplyTagsToPayload, isRenderablePayload } from "./reply-payloads-base.js";
+import { filterMessagingToolReplyPayload } from "./reply-payloads.js";
+import {
+  createReplyDeliveryContext,
+  createReplyToModeFilterForChannel,
+  resolveReplyToMode,
+} from "./reply-threading.js";
 
 /** Strips empty/heartbeat payloads, applies threading, and dedupes message-tool sends. */
 export function resolveFollowupDeliveryPayloads(params: {
@@ -75,22 +80,18 @@ export function resolveFollowupDeliveryPayloads(params: {
       sanitizedPayloads.push(sanitized);
     }
   }
-  const replyTaggedPayloads = applyReplyThreading({
-    payloads: sanitizedPayloads,
-    replyToMode,
-    replyToChannel,
-  }).map((payload) =>
-    setReplyPayloadMetadata(payload, {
-      replyDelivery,
-      ...(replyDeliverySource ? { replyDeliverySource } : {}),
-    }),
-  );
   const originatingTo = resolveOriginMessageTo({
     originatingTo: params.originatingTo,
   });
-  return replyTaggedPayloads.flatMap((payload) =>
+  const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
+  return sanitizedPayloads.flatMap((payload) =>
     filterMessagingToolReplyPayload({
-      payload,
+      payload: applyReplyToMode.preview(
+        setReplyPayloadMetadata(applyReplyTagsToPayload(payload), {
+          replyDelivery,
+          ...(replyDeliverySource ? { replyDeliverySource } : {}),
+        }),
+      ),
       config: params.cfg,
       messageProvider: replyMessageProvider,
       messagingToolSentTargets: params.sentTargets,
@@ -99,6 +100,8 @@ export function resolveFollowupDeliveryPayloads(params: {
       accountId,
       sentMediaUrls: params.sentMediaUrls,
       sentTexts: params.sentTexts,
-    }),
+    })
+      .filter(isRenderablePayload)
+      .map(applyReplyToMode),
   );
 }

--- a/src/auto-reply/reply/followup-delivery.channel.test.ts
+++ b/src/auto-reply/reply/followup-delivery.channel.test.ts
@@ -170,7 +170,7 @@ describe("follow-up delivery channel boundary", () => {
     slack.threading = {
       resolveReplyTransport: ({ threadId, replyToId, replyToIsExplicit }) => ({
         threadId: null,
-        replyToId: replyToIsExplicit ? replyToId : threadId,
+        replyToId: replyToIsExplicit ? replyToId : threadId == null ? undefined : String(threadId),
       }),
     };
     setActivePluginRegistry(

--- a/src/auto-reply/reply/followup-delivery.channel.test.ts
+++ b/src/auto-reply/reply/followup-delivery.channel.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
+import { resolveFollowupDeliveryPayloads } from "./followup-delivery-payloads.js";
 import { deliverFollowupDecision } from "./followup-delivery.js";
 import type { AdmittedFollowupTurn } from "./followup-turn-admission.js";
 
@@ -138,6 +139,70 @@ afterEach(() => {
 });
 
 describe("follow-up delivery channel boundary", () => {
+  it.each([
+    { mode: "first", duplicate: "media" },
+    { mode: "batched", duplicate: "media" },
+    { mode: "first", duplicate: "text" },
+    { mode: "batched", duplicate: "text" },
+  ] as const)(
+    "preserves the $mode reply slot when earlier $duplicate was already sent",
+    ({ mode, duplicate }) => {
+      const duplicatePayload =
+        duplicate === "media"
+          ? { mediaUrl: "/tmp/already-sent.png", replyToId: "parent" }
+          : { text: "already sent", replyToId: "parent" };
+
+      expect(
+        resolveFollowupDeliveryPayloads({
+          cfg: {},
+          payloads: [duplicatePayload, { text: "actual answer", replyToId: "parent" }],
+          originatingChannel: "discord",
+          originatingReplyToMode: mode,
+          sentMediaUrls: ["/tmp/already-sent.png"],
+          sentTexts: ["already sent"],
+        }),
+      ).toEqual([{ text: "actual answer", replyToId: "parent" }]);
+    },
+  );
+
+  it("dedupes later Slack replies against their actual first-mode transport thread", () => {
+    const slack = createChannelPlugin("slack");
+    slack.threading = {
+      resolveReplyTransport: ({ threadId, replyToId, replyToIsExplicit }) => ({
+        threadId: null,
+        replyToId: replyToIsExplicit ? replyToId : threadId,
+      }),
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "slack", plugin: slack, source: "test" }]),
+    );
+
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: {},
+        payloads: [
+          { text: "first answer", replyToId: "111.000" },
+          { text: "already sent", replyToId: "222.000" },
+        ],
+        messageProvider: "slack",
+        originatingChannel: "slack",
+        originatingReplyToMode: "first",
+        originatingTo: "channel:C1",
+        originatingThreadId: "111.000",
+        sentTexts: ["already sent"],
+        sentTargets: [
+          {
+            tool: "slack",
+            provider: "slack",
+            to: "channel:C1",
+            threadId: "111.000",
+            text: "already sent",
+          },
+        ],
+      }),
+    ).toEqual([{ text: "first answer", replyToId: "111.000" }]);
+  });
+
   it("emits one safe cross-channel error when a terminal payload fails after status delivery", async () => {
     const onBlockReply = await deliverBatch({
       messageProvider: "discord",

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -162,7 +162,7 @@ describe("resolveFollowupDeliveryPayloads", () => {
         payloads: [{ mediaUrl: "/tmp/img.png" }],
         sentMediaUrls: ["/tmp/img.png"],
       }),
-    ).toEqual([{ mediaUrl: undefined, mediaUrls: undefined }]);
+    ).toEqual([]);
   });
 
   it("does not dedupe text sent via messaging tool to another target", () => {
@@ -685,6 +685,28 @@ describe("resolveFollowupDeliveryDecision", () => {
         }),
       ).toMatchObject({ kind: "retry-source-delivery" });
     }
+  });
+
+  it("recovers a substantive final after an explicitly allowed media payload is deduplicated", () => {
+    const substantiveFinal =
+      "This is a substantive private answer that missed the message tool. It must trigger recovery after its only marked media was already delivered.";
+    const turn = createTurn();
+    turn.queued.run.sourceReplyDeliveryMode = "message_tool_only";
+    const mediaUrl = "file:///tmp/already-sent.png";
+    const execution = createSettledExecution(substantiveFinal);
+    if (execution.outcome.kind === "settled") {
+      execution.outcome.result.messagingToolSentMediaUrls = [mediaUrl];
+    }
+
+    expect(
+      resolveFollowupDeliveryDecision({
+        turn,
+        execution,
+        accounting: createAccounting([
+          setReplyPayloadMetadata({ mediaUrl }, { deliverDespiteSourceReplySuppression: true }),
+        ]),
+      }),
+    ).toMatchObject({ kind: "retry-source-delivery" });
   });
 
   it("routes settled delivery with the actual runtime provider", () => {

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -1,7 +1,6 @@
 // Re-exports reply payload metadata helpers used by agent delivery code.
 export {
   applyReplyTagsToPayload,
-  applyReplyThreading,
   formatBtwTextForExternalDelivery,
   isRenderablePayload,
   shouldSuppressReasoningPayload,

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import type { TemplateContext } from "../templating.js";
 import { buildThreadingToolContext } from "./agent-runner-utils.js";
-import { applyReplyThreading } from "./reply-payloads.js";
+import { applyReplyThreading } from "./reply-payloads-base.js";
 import { formatRunLabel, resolveSubagentLabel, sortSubagentRuns } from "./subagents-utils.js";
 
 function createSlackThreadingPlugin(): ChannelPlugin {

--- a/src/auto-reply/reply/reply-threading.test.ts
+++ b/src/auto-reply/reply/reply-threading.test.ts
@@ -145,6 +145,19 @@ describe("createReplyToModeFilterForChannel", () => {
     setActivePluginRegistry(createTestRegistry());
   });
 
+  it.each(["first", "batched"] as const)(
+    "previews the %s transport without consuming its single reply slot",
+    (mode) => {
+      const filter = createReplyToModeFilterForChannel(mode, "discord");
+      const first = { text: "discarded", replyToId: "parent" };
+      const actual = { text: "actual", replyToId: "parent" };
+
+      expect(filter.preview(first).replyToId).toBe("parent");
+      expect(filter(actual).replyToId).toBe("parent");
+      expect(filter.preview({ text: "later", replyToId: "other" }).replyToId).toBeUndefined();
+    },
+  );
+
   it("strips explicit Slack reply tags upstream when replyToMode is off", () => {
     setActivePluginRegistry(
       createTestRegistry([

--- a/src/auto-reply/reply/reply-threading.ts
+++ b/src/auto-reply/reply/reply-threading.ts
@@ -146,7 +146,7 @@ function createReplyToModeFilter(
   opts: { allowExplicitReplyTagsWhenOff?: boolean } = {},
 ) {
   let hasThreaded = false;
-  return (payload: ReplyPayload): ReplyPayload => {
+  const apply = (payload: ReplyPayload, preview = false): ReplyPayload => {
     const isStatusNotice = isReplyPayloadStatusNotice(payload);
     if (!payload.replyToId) {
       return payload;
@@ -179,11 +179,15 @@ function createReplyToModeFilter(
     // threaded (so they appear in-context), but they must not consume the
     // "first" slot of the replyToMode=first|batched filter.  Skip advancing
     // hasThreaded so the real assistant reply still gets replyToId.
-    if (isSingleUseReplyToMode(mode) && !isStatusNotice) {
+    if (isSingleUseReplyToMode(mode) && !isStatusNotice && !preview) {
       hasThreaded = true;
     }
     return payload;
   };
+  // Dedupe must inspect the actual transport route without spending a first-reply slot.
+  return Object.assign((payload: ReplyPayload) => apply(payload), {
+    preview: (payload: ReplyPayload) => apply(payload, true),
+  });
 }
 
 /** Resolve whether implicit current-message replies are allowed under threading policy. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users would receive no reply, lose the expected threaded reply, or receive a duplicate Slack reply when a messaging tool had already delivered media or text during a queued follow-up.

## Why This Change Was Made

Follow-up delivery applied stateful first/batched reply threading before message-tool deduplication. Duplicate payloads consequently consumed the single-use reply slot, deduplicated media survived as an empty but explicitly deliverable reply, and empty replies blocked recovery of a substantive assistant final. Naively reversing the order also changed Slack's actual thread destination, so the canonical threading owner now supports a side-effect-free route preview: deduplication sees the eventual transport destination, while the reply slot is committed only after a visible payload survives.

Production delta: +24/-18 (net +6), justified by the new owner-level preview/commit boundary that preserves actual channel routing while preventing discarded payloads from consuming state; the obsolete threading barrel export was removed. Tests: +102/-2.

## User Impact

Previously sent media never suppresses a real assistant answer, duplicate media or text never steals the first threaded reply, substantive message-tool-only answers recover normally, and Slack replies are deduplicated against their actual transport thread.

## Evidence

- Authentic pre-fix owner regressions: already-sent media returned an empty payload; duplicate media/text consumed both first and batched threading slots; a substantive final returned an empty `deliver` decision instead of `retry-source-delivery`.
- Independent review caught and reproduced an additional real Slack route regression in the initial naive reorder; the final change preserves the registered Slack threading adapter's actual destination and suppresses its already-sent cross-thread duplicate.
- `node scripts/run-vitest.mjs src/auto-reply/reply/followup-delivery.test.ts src/auto-reply/reply/followup-delivery.channel.test.ts src/auto-reply/reply/reply-payloads.test.ts src/auto-reply/reply/reply-threading.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-plumbing.test.ts`: 212 passed, 1 existing skipped.
- Focused lint, production/full-tree unused-export checks, assertion-safety ratchet, max-lines ratchet, and final fresh independent source-aware owner/sibling review all pass.
