### PR TITLE
refactor(channels): reuse wildcard model matcher

### DIFF
--- a/src/channels/model-overrides.ts
+++ b/src/channels/model-overrides.ts
@@ -222,19 +222,6 @@ export function resolveChannelModelOverride(
   }
 
   const { keys, parentKeys } = buildChannelCandidates(params);
-  if (keys.length === 0 && parentKeys.length === 0) {
-    const wildcardModel = normalizeOptionalString(providerEntries["*"]);
-    if (wildcardModel) {
-      return {
-        channel:
-          normalizeMessageChannel(channel) ?? normalizeOptionalLowercaseString(channel) ?? "",
-        model: wildcardModel,
-        matchKey: "*",
-        matchSource: "wildcard",
-      };
-    }
-    return null;
-  }
   const match = resolveChannelEntryMatchWithFallback({
     entries: providerEntries,
     keys,


### PR DESCRIPTION
## What Problem This Solves

`channels.modelByChannel` wildcard fallback had a second, hand-written resolution branch when a conversation produced no direct or parent candidates. That duplicated wildcard-selection policy already owned by the shared channel-entry matcher and created an unnecessary drift point in channel model routing.

## Why This Change Was Made

The stale early return is deleted so empty candidate lists flow through `resolveChannelEntryMatchWithFallback`, the canonical direct/parent/wildcard matcher. That matcher already returns the wildcard entry with `matchKey: "*"` and `matchSource: "wildcard"`; model and channel normalization continue through the existing common result path.

Rejected alternatives: adding a result-builder abstraction would add production code for the same behavior, while changing direct-match resolution would widen the routing-policy surface. This deletion keeps precedence, plugin-owned candidate construction, config shape, and provider behavior unchanged.

Production LOC: **−13** (`+0/−13`). Test LOC: **0**. No new test was added because the retained `applies provider wildcard model overrides to direct chats` regression already exercises the exact no-candidate wildcard boundary.

## User Impact

No user-visible behavior or compatibility change. Operators retain identical direct, group, parent-session, plugin-owned, and wildcard model override behavior with one fewer duplicate routing branch.

## Evidence

Exact reviewed head: `481ab0110e7bf3d8a40cd8575e6a64e7423a33fb`

- `node scripts/run-vitest.mjs src/channels/model-overrides.test.ts` — 19/19 passed.
- `node scripts/check-changed.mjs -- src/channels/model-overrides.ts` — all selected production, typecheck, lint, architecture, and guard lanes passed.
- `git diff --check` and targeted `oxfmt --check` — passed.
- Deslop — clean; final diff is deletion-only.
- Autoreview (Codex, high) — clean, patch correct (0.99), no accepted/actionable findings.
- Independent Codex review of the frozen head — PASS, no findings.
- Open issue/PR and history checks found no active overlap on `src/channels/model-overrides.ts`; related session/model PRs own different files and behavior.
- Hosted CI: pending on this draft head; exact-head results will be verified before landing.

Credit: investigation and patch authored by Amp for @steipete.
