### PR TITLE
fix(agents): preserve setup CLI model resolution

### DIFF
--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -205,9 +205,14 @@ describe("resolveCliBackendConfig", () => {
 
   it("falls back to setup registration before runtime activation", () => {
     const parseJsonlEvent = vi.fn();
+    const resolveModelId = vi.fn(
+      ({ modelId, contextWindow }: { modelId: string; contextWindow?: string }) =>
+        contextWindow === "1m" ? `${modelId}[1m]` : modelId,
+    );
     const entry = setupEntry({
       config: { command: "setup-acme", args: ["run"] },
       parseJsonlEvent,
+      resolveModelId,
     });
     cliBackendsTesting.setDepsForTest({
       resolveRuntimeCliBackends: () => [],
@@ -220,6 +225,9 @@ describe("resolveCliBackendConfig", () => {
     expect(resolved.config).toEqual({ command: "setup-acme", args: ["run"] });
     expect(resolved.runtimeArtifact).toEqual(runtimeArtifact);
     expect(resolved.parseJsonlEvent).toBe(parseJsonlEvent);
+    expect(resolved.resolveModelId?.({ modelId: "acme-large", contextWindow: "1m" })).toBe(
+      "acme-large[1m]",
+    );
   });
 
   it("returns null when no plugin owns the backend", () => {

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -81,35 +81,6 @@ type CliRuntimeModelBackendBinding = {
   pluginId?: string;
 };
 
-type FallbackCliBackendPolicy = {
-  modelProvider?: string;
-  bundleMcp: boolean;
-  bundleMcpMode?: CliBundleMcpMode;
-  baseConfig?: CliBackendConfig;
-  normalizeConfig?: (
-    config: CliBackendConfig,
-    context?: CliBackendNormalizeConfigContext,
-  ) => CliBackendConfig;
-  transformSystemPrompt?: CliBackendPlugin["transformSystemPrompt"];
-  textTransforms?: PluginTextTransforms;
-  defaultAuthProfileId?: string;
-  authEpochMode?: CliBackendAuthEpochMode;
-  autoSelectAuthProfile?: boolean;
-  contextEngineHostCapabilities?: readonly ContextEngineHostCapability[];
-  ownsNativeCompaction?: boolean;
-  manualCompaction?: CliBackendPlugin["manualCompaction"];
-  prepareExecution?: CliBackendPlugin["prepareExecution"];
-  resolveExecutionArgs?: CliBackendPlugin["resolveExecutionArgs"];
-  resolveModelId?: CliBackendPlugin["resolveModelId"];
-  parseJsonlEvent?: CliBackendPlugin["parseJsonlEvent"];
-  toolAvailabilityEnforcement?: CliBackendToolAvailabilityEnforcement;
-  nativeToolMode?: CliBackendNativeToolMode;
-  sideQuestionToolMode?: CliBackendSideQuestionToolMode;
-  runtimeArtifact?: CliBackendRuntimeArtifactPolicy;
-};
-
-const FALLBACK_CLI_BACKEND_POLICIES: Record<string, FallbackCliBackendPolicy> = {};
-
 function normalizeBundleMcpMode(
   mode: CliBundleMcpMode | undefined,
   enabled: boolean,
@@ -118,46 +89,6 @@ function normalizeBundleMcpMode(
     return undefined;
   }
   return mode ?? "claude-config-file";
-}
-
-function resolveSetupCliBackendPolicy(provider: string): FallbackCliBackendPolicy | undefined {
-  const entry = cliBackendsDeps.resolvePluginSetupCliBackend({
-    backend: provider,
-  });
-  if (!entry) {
-    return undefined;
-  }
-  return {
-    // Setup-registered backends keep narrow CLI paths generic even when the
-    // runtime plugin registry has not booted yet.
-    bundleMcp: entry.backend.bundleMcp === true,
-    modelProvider: resolveCliBackendModelProvider(entry.backend),
-    bundleMcpMode: normalizeBundleMcpMode(
-      entry.backend.bundleMcpMode,
-      entry.backend.bundleMcp === true,
-    ),
-    baseConfig: entry.backend.config,
-    normalizeConfig: entry.backend.normalizeConfig,
-    transformSystemPrompt: entry.backend.transformSystemPrompt,
-    textTransforms: entry.backend.textTransforms,
-    defaultAuthProfileId: entry.backend.defaultAuthProfileId,
-    authEpochMode: entry.backend.authEpochMode,
-    autoSelectAuthProfile: entry.backend.autoSelectAuthProfile,
-    contextEngineHostCapabilities: entry.backend.contextEngineHostCapabilities,
-    ownsNativeCompaction: entry.backend.ownsNativeCompaction,
-    manualCompaction: entry.backend.manualCompaction,
-    prepareExecution: entry.backend.prepareExecution,
-    resolveExecutionArgs: entry.backend.resolveExecutionArgs,
-    parseJsonlEvent: entry.backend.parseJsonlEvent,
-    toolAvailabilityEnforcement: entry.backend.toolAvailabilityEnforcement,
-    nativeToolMode: entry.backend.nativeToolMode,
-    sideQuestionToolMode: entry.backend.sideQuestionToolMode,
-    runtimeArtifact: entry.backend.runtimeArtifact,
-  };
-}
-
-function resolveFallbackCliBackendPolicy(provider: string): FallbackCliBackendPolicy | undefined {
-  return FALLBACK_CLI_BACKEND_POLICIES[provider] ?? resolveSetupCliBackendPolicy(provider);
 }
 
 function normalizeBackendKey(key: string): string {
@@ -360,79 +291,44 @@ export function resolveCliBackendConfig(
   };
   const runtimeTextTransforms = resolveRuntimeTextTransforms();
   const registered = resolveRegisteredBackend(normalized);
-  if (registered) {
-    const registeredConfig = { ...registered.config };
-    const config = registered.normalizeConfig
-      ? registered.normalizeConfig(registeredConfig, normalizeContext)
-      : registeredConfig;
-    const command = config.command?.trim();
-    if (!command) {
-      return null;
-    }
-    return {
-      id: normalized,
-      ...(registered.modelProvider
-        ? { modelProvider: normalizeProviderId(registered.modelProvider) }
-        : {}),
-      config: { ...config, command },
-      bundleMcp: registered.bundleMcp === true,
-      bundleMcpMode: normalizeBundleMcpMode(
-        registered.bundleMcpMode,
-        registered.bundleMcp === true,
-      ),
-      pluginId: registered.pluginId,
-      transformSystemPrompt: registered.transformSystemPrompt,
-      textTransforms: mergePluginTextTransforms(runtimeTextTransforms, registered.textTransforms),
-      defaultAuthProfileId: registered.defaultAuthProfileId,
-      authEpochMode: registered.authEpochMode,
-      autoSelectAuthProfile: registered.autoSelectAuthProfile,
-      contextEngineHostCapabilities: registered.contextEngineHostCapabilities,
-      ownsNativeCompaction: registered.ownsNativeCompaction,
-      manualCompaction: registered.manualCompaction,
-      prepareExecution: registered.prepareExecution,
-      resolveExecutionArgs: registered.resolveExecutionArgs,
-      resolveModelId: registered.resolveModelId,
-      parseJsonlEvent: registered.parseJsonlEvent,
-      toolAvailabilityEnforcement: registered.toolAvailabilityEnforcement,
-      nativeToolMode: registered.nativeToolMode,
-      sideQuestionToolMode: registered.sideQuestionToolMode,
-      runtimeArtifact: registered.runtimeArtifact,
-    };
-  }
-
-  const fallbackPolicy = resolveFallbackCliBackendPolicy(normalized);
-  if (!fallbackPolicy?.baseConfig) {
+  const backend =
+    registered ?? cliBackendsDeps.resolvePluginSetupCliBackend({ backend: normalized })?.backend;
+  if (!backend) {
     return null;
   }
-  const config = fallbackPolicy.normalizeConfig
-    ? fallbackPolicy.normalizeConfig(fallbackPolicy.baseConfig, normalizeContext)
-    : fallbackPolicy.baseConfig;
+  const baseConfig = registered ? { ...backend.config } : backend.config;
+  const config = backend.normalizeConfig
+    ? backend.normalizeConfig(baseConfig, normalizeContext)
+    : baseConfig;
   const command = config.command?.trim();
   if (!command) {
     return null;
   }
+  const modelProvider = resolveCliBackendModelProvider(backend);
+  const bundleMcp = backend.bundleMcp === true;
   return {
     id: normalized,
-    ...(fallbackPolicy.modelProvider ? { modelProvider: fallbackPolicy.modelProvider } : {}),
+    ...(modelProvider ? { modelProvider } : {}),
     config: { ...config, command },
-    bundleMcp: fallbackPolicy.bundleMcp,
-    bundleMcpMode: fallbackPolicy.bundleMcpMode,
-    transformSystemPrompt: fallbackPolicy.transformSystemPrompt,
-    textTransforms: mergePluginTextTransforms(runtimeTextTransforms, fallbackPolicy.textTransforms),
-    defaultAuthProfileId: fallbackPolicy.defaultAuthProfileId,
-    authEpochMode: fallbackPolicy.authEpochMode,
-    autoSelectAuthProfile: fallbackPolicy.autoSelectAuthProfile,
-    contextEngineHostCapabilities: fallbackPolicy.contextEngineHostCapabilities,
-    ownsNativeCompaction: fallbackPolicy.ownsNativeCompaction,
-    manualCompaction: fallbackPolicy.manualCompaction,
-    prepareExecution: fallbackPolicy.prepareExecution,
-    resolveExecutionArgs: fallbackPolicy.resolveExecutionArgs,
-    resolveModelId: fallbackPolicy.resolveModelId,
-    parseJsonlEvent: fallbackPolicy.parseJsonlEvent,
-    toolAvailabilityEnforcement: fallbackPolicy.toolAvailabilityEnforcement,
-    nativeToolMode: fallbackPolicy.nativeToolMode,
-    sideQuestionToolMode: fallbackPolicy.sideQuestionToolMode,
-    runtimeArtifact: fallbackPolicy.runtimeArtifact,
+    bundleMcp,
+    bundleMcpMode: normalizeBundleMcpMode(backend.bundleMcpMode, bundleMcp),
+    ...(registered ? { pluginId: registered.pluginId } : {}),
+    transformSystemPrompt: backend.transformSystemPrompt,
+    textTransforms: mergePluginTextTransforms(runtimeTextTransforms, backend.textTransforms),
+    defaultAuthProfileId: backend.defaultAuthProfileId,
+    authEpochMode: backend.authEpochMode,
+    autoSelectAuthProfile: backend.autoSelectAuthProfile,
+    contextEngineHostCapabilities: backend.contextEngineHostCapabilities,
+    ownsNativeCompaction: backend.ownsNativeCompaction,
+    manualCompaction: backend.manualCompaction,
+    prepareExecution: backend.prepareExecution,
+    resolveExecutionArgs: backend.resolveExecutionArgs,
+    resolveModelId: backend.resolveModelId,
+    parseJsonlEvent: backend.parseJsonlEvent,
+    toolAvailabilityEnforcement: backend.toolAvailabilityEnforcement,
+    nativeToolMode: backend.nativeToolMode,
+    sideQuestionToolMode: backend.sideQuestionToolMode,
+    runtimeArtifact: backend.runtimeArtifact,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where CLI backends resolved from setup registration before runtime activation would lose their backend-owned model-ID resolver. A selectable native model variant such as Claude CLI's explicit 1M context-window model could therefore remain on the unmodified model ID on that path.

## Why This Change Was Made

The setup path projected `CliBackendPlugin` into an otherwise empty fallback-policy abstraction, while the runtime path projected the same fields separately. Those lists drifted when `resolveModelId` was added. This removes the empty fallback policy and resolves both registry sources through one `CliBackendPlugin` normalization path, preserving runtime-only plugin identity and existing config-normalizer copy semantics.

## User Impact

CLI model selections now retain backend-owned model-ID mapping even when the backend is available only through setup registration. Runtime-registered backends keep their existing behavior.

## Evidence

- Regression proof before the production change: `node scripts/run-vitest.mjs src/agents/cli-backends.test.ts` failed the setup-registration case with expected `acme-large[1m]`, received `undefined`.
- Focused test after the change: `node scripts/run-vitest.mjs src/agents/cli-backends.test.ts` — 12/12 passed.
- Focused test typecheck: `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.agents-root.json --builders 1` — passed.
- Focused lint: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/cli-backends.test.ts src/agents/cli-backends.ts` — 0 warnings/errors.
- `node scripts/check-changed.mjs -- src/agents/cli-backends.ts src/agents/cli-backends.test.ts` passed all gates through core production typecheck; the core-test aggregate then stopped on the existing `ui/vite.config.ts` missing declaration for `pako`, reproduced on an unmodified clean `origin/main` worktree with both UI typecheck shards.
- LOC: production +29/−133 (net −104); tests +8/−0; total net −96.
- Deslop/test-audit: clean; the regression extends the existing setup-resolution behavior case, required no production test seam, and failed pre-fix for the intended omission.
- Structured autoreview: clean, patch correct, no actionable findings.
- Separate exact-head read-only Codex review: PASS, no concrete actionable defects.

AI-assisted: yes. I understand the change and verified the owner path, callers, history, and focused behavior.
- Live proof gap: no real Claude CLI process was launched because reproducing the setup-only pre-runtime registry state requires an authenticated local Claude CLI lifecycle unavailable in the isolated orb; the generic owner-boundary regression directly exercises that state, and exact-head CI covers the full repository suite.