### PR TITLE
fix: streamed replies rescan the whole accumulated buffer on every delta to test an 8-character silent-reply token

### DIFF
--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -308,10 +308,8 @@ export function isSilentReplyPrefixText(
   }
   const tokenUpper = token.toUpperCase();
   const trimmed = text.trimStart();
-  // The `tokenUpper.startsWith(normalized)` test below can only hold for a
-  // candidate no longer than the token, and Unicode upper-casing never shortens
-  // a string, so reject over-long input before scanning it. Without this the
-  // per-delta typing check walks the whole accumulated reply buffer.
+  // Uppercasing never shortens text, so overlong candidates cannot match.
+  // Reject before scanning each streamed reply's growing buffer.
   if (!trimmed || trimmed.length > tokenUpper.length) {
     return false;
   }

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -306,23 +306,24 @@ export function isSilentReplyPrefixText(
   if (!text) {
     return false;
   }
+  const tokenUpper = token.toUpperCase();
   const trimmed = text.trimStart();
-  if (!trimmed) {
-    return false;
-  }
-  // Guard against suppressing natural-language "No..." text while still
-  // catching uppercase lead fragments like "NO" from streamed NO_REPLY.
-  if (trimmed !== trimmed.toUpperCase()) {
+  // The `tokenUpper.startsWith(normalized)` test below can only hold for a
+  // candidate no longer than the token, and Unicode upper-casing never shortens
+  // a string, so reject over-long input before scanning it. Without this the
+  // per-delta typing check walks the whole accumulated reply buffer.
+  if (!trimmed || trimmed.length > tokenUpper.length) {
     return false;
   }
   const normalized = trimmed.toUpperCase();
-  if (!normalized) {
+  // Guard against suppressing natural-language "No..." text while still
+  // catching uppercase lead fragments like "NO" from streamed NO_REPLY.
+  if (trimmed !== normalized) {
     return false;
   }
   if (normalized.length < 2) {
     return false;
   }
-  const tokenUpper = token.toUpperCase();
   if (!tokenUpper.startsWith(normalized)) {
     return false;
   }


### PR DESCRIPTION
## What Problem This Solves

Every streamed partial reply pays a full scan of the entire accumulated reply buffer just to test whether it might be the 8-character `NO_REPLY` sentinel.

`isSilentReplyPrefixText` (`src/auto-reply/tokens.ts`) ran `trimStart()` and then **two** whole-string `toUpperCase()` passes before reaching `tokenUpper.startsWith(normalized)` — the first test whose outcome can depend on length. Its hot caller is `startTypingOnText` (`src/auto-reply/reply/typing.ts:234-246`), reached per streamed partial from `signalTextDelta` (`src/auto-reply/reply/typing-mode.ts:121`) with the **accumulated** text, not the delta. That makes the check O(n) per delta and O(n²) over a reply, and the cost lands on the gateway main thread while replies are streaming.

Closes #129073

## Why This Change Was Made

The wasted work is provable, not estimated. `tokenUpper.startsWith(normalized)` can only be true when `normalized.length <= tokenUpper.length`. Unicode full case mapping never *shortens* a string under `toUpperCase` — the growth cases (`ß`→`SS`, `ﬁ`→`FI`) are the only length changes — so `trimmed.length <= normalized.length` always holds. Therefore `trimmed.length > tokenUpper.length` already implies the `startsWith` test fails, and every buffer scan performed for such a candidate was guaranteed-useless before it started. That is essentially every delta past the first few characters of a reply.

So the fix is to hoist `tokenUpper` and reject over-long candidates first. Reusing the already-computed `normalized` for the mixed-case guard folds the duplicate `toUpperCase()` at the same time. Net −7/+8 lines in one function, no new helper, no new file.

The change is deliberately scoped to the ordering. No matching rule is touched: the token-prefix logic, the `_` short-circuit, the non-letter custom-token rule (#100007) and the `NO` special case are all byte-for-byte unchanged and still run in the same order relative to each other.

## User Impact

Streaming replies stop spending main-thread time proportional to reply length on a constant-size sentinel check. No user-visible behavior changes: the same inputs produce the same silent/not-silent classification, so nothing about `NO_REPLY` suppression, typing indicators, or custom silent tokens moves.

## Evidence

**Provenance caveat, stated up front.** The CPU-profile percentage below was measured on the compiled `dist` of `v2026.7.1-2` under a 16-agent load rig, and has **not** been re-measured against `main`. What was verified against current `main` (`0a79ae5fd04`) is that the code path is unchanged — the two `toUpperCase()` calls and the late `tokenUpper` derivation are exactly as described. The equivalence corpus below **was** run fresh against the code in this PR.

**Semantics — equivalence corpus, run on this diff.** Stock and patched implementations were evaluated over **6,123 cases × 10 tokens = 61,230 evaluations**, and the packed result bitstrings hash identically:

```
cases=6123 tokens=10 evaluations=61230 diffs=0
stock   sha256=fec9a147f880ddd016acf21dd8c5300aaa31f545fa44cd6130e9819fef869ef8
patched sha256=fec9a147f880ddd016acf21dd8c5300aaa31f545fa44cd6130e9819fef869ef8
IDENTICAL
```

The corpus covers: every prefix of `NO_REPLY` crossed with lower-case, leading/trailing whitespace, newline and tab padding, punctuation suffixes, spaced-out variants and long trailing text; the full token with seven suffixes; the case-growth characters `ß`/`SS`, `ﬁ`/`FI` and dotted-`İ`; 4,000 pseudorandom strings over an alphabet including `_ - . ! \n \t ß ﬁ İ`; and 2,000 single-character mutations of the token truncated to random lengths. Tokens exercised: `NO_REPLY`, `no_reply`, `HELP-QUIET`, `Q7`, `ß`, `ﬁx`, `SILENT`, `A_B_C`, `STOP1`, `İ` — i.e. both the growth-under-uppercase tokens and the non-letter custom tokens from #100007.

**Measured cost on `v2026.7.1-2`.** `isSilentReplyPrefixText` and its `toUpperCase` children accounted for **3.7% of the pegged gateway main thread** during a sustained 16-agent run with multi-KB replies.

**Validation run locally on this branch** (Node 22.22.3 — 24.15 was not available on this machine; 22.22.3+ is supported):

| Command | Result |
|---|---|
| `node scripts/run-vitest.mjs src/auto-reply/tokens.test.ts` | **82 passed / 82** |
| `node scripts/run-tsgo.mjs -p tsconfig.core.json` | **exit 0** |
| `node scripts/check-changed.mjs` (lint + oxlint core/extensions/scripts + import cycles) | **exit 0**, 0 runtime value cycles |
| `node_modules/.bin/oxfmt --check src/auto-reply/tokens.ts` | **clean** |
| `node scripts/run-vitest.mjs src/auto-reply` (274 files) | 268 passed, **5 files / 15 tests failed** |

Those 15 failures are **pre-existing and unrelated**. They are in `model-selection.test.ts`, `commands-status.test.ts`, `commands-models.test.ts`, `directive-handling.model.test.ts` and `agent-runner-memory.preflight-stale-tokens.test.ts`, all asserting on local Codex/OpenAI auth-profile labelling. I confirmed the baseline by reverting `src/auto-reply/tokens.ts` to `origin/main` and re-running exactly those five files: **the same 15 tests fail, 252 pass**. `pnpm build` was not run — this change alters no module boundary, dynamic import, packaging surface or exported signature.

**Interaction with open #122508.** That PR edits the same function (relaxing the `normalized.length < 2` floor to allow a lone `N`, per #122476). I verified composition empirically rather than by inspection: fetching `refs/pull/122508/head` and merging it into this branch, **`src/auto-reply/tokens.ts` auto-merges with no conflict** and the two changes compose correctly — the length guard sits above, #122508's relaxed floor and lone-`N` case sit below, and a lone `N` (length 1 ≤ 8) passes the new guard unaffected. The merge does report one conflict, but it is unrelated to this PR and pre-existing: #122508 modifies `src/agents/embedded-agent-subscribe.handlers.messages.test.ts`, which `main` has since deleted. Whichever of the two lands first, the other rebases cleanly over this file.

---

*AI-assisted: this change was authored by an agent. It read current `main`, derived and checked the Unicode length argument, wrote and ran the equivalence corpus above, ran the listed validation, and baselined the unrelated failures. The 3.7% profile figure comes from a human-run load rig on `v2026.7.1-2`, as flagged above. I understand the code and the argument it rests on.*
