### PR TITLE
fix(reef): stop exposing retired account runtime

### DIFF
--- a/extensions/reef/runtime-api.ts
+++ b/extensions/reef/runtime-api.ts
@@ -1,1 +1,1 @@
-export { setReefRuntime, getReefRuntime, setActiveReef, getActiveReef } from "./src/runtime.js";
+export { setReefRuntime, getReefRuntime, getActiveReef } from "./src/runtime.js";

--- a/extensions/reef/src/channel.test.ts
+++ b/extensions/reef/src/channel.test.ts
@@ -3,6 +3,7 @@ import http from "node:http";
 import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { createStartAccountContext } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateSyncKeyedStoreForTests,
@@ -10,16 +11,23 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { defaultRuntime } from "openclaw/plugin-sdk/runtime";
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { generateIdentity } from "../protocol/index.js";
 import { runReefChannelLifecycle } from "./channel-lifecycle.js";
 import { reefPlugin } from "./channel.js";
+import { handleReefCommand } from "./commands.js";
 import { resolveReefConfig } from "./config-schema.js";
 import { reefKeys } from "./flow.test-helpers.js";
 import { ReefFriendManager } from "./friends.js";
 import { resolveReefInboundDispatchContent } from "./inbound.js";
-import { setReefRuntime } from "./runtime.js";
-import { ReefTransportClient } from "./transport.js";
+import { getActiveReef, setReefRuntime } from "./runtime.js";
+import {
+  finalizeReefIdentityBinding,
+  generateAndStoreKeys,
+  reserveReefIdentityBinding,
+} from "./state.js";
+import { ReefInboxConnection, ReefTransportClient } from "./transport.js";
 import { openReefTrustStore } from "./trust-store.js";
 
 function deferred() {
@@ -197,6 +205,221 @@ describe("Reef channel status", () => {
     });
 
     expect(snapshot).toMatchObject({ lifecycle: "recovering" });
+  });
+});
+
+describe("Reef gateway account ownership", () => {
+  const reefRuntimeSlot = createPluginRuntimeStore<unknown>({
+    pluginId: "reef",
+    errorMessage: "test",
+  });
+  const activeReefSlot = createPluginRuntimeStore<unknown>({
+    key: "plugin-runtime:reef:active",
+    errorMessage: "test",
+  });
+  const cfg = {
+    channels: {
+      reef: {
+        handle: "clawd",
+        email: "clawd@example.com",
+        guard: {
+          provider: "openai" as const,
+          pinnedModel: "gpt-5.6-luna",
+          apiKeyEnv: "REEF_TEST_GUARD_KEY",
+          policyVersion: "v1",
+          timeoutMs: 1_000,
+        },
+      },
+    },
+  };
+  const controllers: AbortController[] = [];
+  const inboxDrains: ReturnType<typeof deferred>[] = [];
+  const accountTasks: Promise<unknown>[] = [];
+  let stateDir = "";
+
+  beforeEach(async () => {
+    resetPluginStateStoreForTests();
+    activeReefSlot.clearRuntime();
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "reef-account-ownership-"));
+    vi.stubEnv("REEF_TEST_GUARD_KEY", "test-only-credential");
+    const runtime = createPluginRuntimeMock();
+    runtime.state.openSyncKeyedStore = <T>(options: OpenKeyedStoreOptions) =>
+      createPluginStateSyncKeyedStoreForTests<T>("reef", {
+        ...options,
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      });
+    runtime.state.resolveStateDir = () => stateDir;
+    await generateAndStoreKeys(runtime);
+    finalizeReefIdentityBinding(
+      runtime,
+      reserveReefIdentityBinding(runtime, {
+        handle: cfg.channels.reef.handle,
+        relayUrl: "https://reefwire.ai",
+      }),
+    );
+    setReefRuntime(runtime);
+    vi.spyOn(ReefTransportClient.prototype, "listFriends").mockResolvedValue({ friendships: [] });
+    vi.spyOn(ReefInboxConnection.prototype, "start").mockImplementation(() => {
+      const drain = deferred();
+      inboxDrains.push(drain);
+      return drain.promise;
+    });
+  });
+
+  afterEach(async () => {
+    for (const controller of controllers.splice(0)) {
+      controller.abort();
+    }
+    for (const drain of inboxDrains.splice(0)) {
+      drain.resolve();
+    }
+    await Promise.allSettled(accountTasks.splice(0));
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    activeReefSlot.clearRuntime();
+    reefRuntimeSlot.clearRuntime();
+    resetPluginStateStoreForTests();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  function startAccount() {
+    const abort = new AbortController();
+    controllers.push(abort);
+    const start = reefPlugin.gateway?.startAccount;
+    if (!start) {
+      throw new Error("expected Reef gateway account starter");
+    }
+    const account = start(
+      createStartAccountContext({
+        account: reefPlugin.config.resolveAccount(cfg),
+        cfg,
+        abortSignal: abort.signal,
+      }),
+    );
+    accountTasks.push(account);
+    return { abort, account };
+  }
+
+  function sendOutbound(text: string) {
+    const send = reefPlugin.outbound?.sendText;
+    if (!send) {
+      throw new Error("expected Reef outbound sender");
+    }
+    return send({ cfg, accountId: "default", to: "@molty", text });
+  }
+
+  it("retires outbound, command, and pairing authority before account shutdown drains", async () => {
+    const account = startAccount();
+    await vi.waitFor(() => {
+      expect(inboxDrains).toHaveLength(1);
+    });
+    const active = getActiveReef();
+    const send = vi.spyOn(active.flow, "send").mockResolvedValue("account-a-message");
+    const listFriends = vi.spyOn(active.friends, "list").mockResolvedValue([]);
+    const reconcileFriends = vi.spyOn(active.friends, "reconcile");
+    const listReviews = vi.spyOn(active.reviews, "list");
+    let settled = false;
+    void account.account.then(() => {
+      settled = true;
+    });
+
+    account.abort.abort();
+
+    expect(() => getActiveReef()).toThrow("Reef channel is not running");
+    await expect(sendOutbound("stopped account")).rejects.toThrow("Reef channel is not running");
+    await expect(handleReefCommand({ args: "friend list" })).rejects.toThrow(
+      "Reef channel is not running",
+    );
+    await expect(handleReefCommand({ args: "review list" })).rejects.toThrow(
+      "Reef channel is not running",
+    );
+    await expect(reefPlugin.pairing?.notifyApproval?.({ cfg, id: "molty" })).rejects.toThrow(
+      "Reef channel is not running",
+    );
+    expect(settled).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+    expect(listFriends).not.toHaveBeenCalled();
+    expect(reconcileFriends).not.toHaveBeenCalled();
+    expect(listReviews).not.toHaveBeenCalled();
+
+    inboxDrains[0]!.resolve();
+    await account.account;
+
+    expect(settled).toBe(true);
+    expect(() => getActiveReef()).toThrow("Reef channel is not running");
+    await expect(sendOutbound("settled account")).rejects.toThrow("Reef channel is not running");
+    await expect(handleReefCommand({ args: "friend list" })).rejects.toThrow(
+      "Reef channel is not running",
+    );
+    expect(send).not.toHaveBeenCalled();
+    expect(listFriends).not.toHaveBeenCalled();
+  });
+
+  it("keeps the replacement account authoritative through stale and failed account teardown", async () => {
+    const first = startAccount();
+    await vi.waitFor(() => {
+      expect(inboxDrains).toHaveLength(1);
+    });
+    const firstActive = getActiveReef();
+    const firstSend = vi.spyOn(firstActive.flow, "send").mockResolvedValue("account-a-message");
+    const firstList = vi.spyOn(firstActive.friends, "list").mockResolvedValue([]);
+
+    first.abort.abort();
+    const replacement = startAccount();
+    await vi.waitFor(() => {
+      expect(inboxDrains).toHaveLength(2);
+    });
+    const replacementActive = getActiveReef();
+    expect(replacementActive).not.toBe(firstActive);
+    const replacementSend = vi
+      .spyOn(replacementActive.flow, "send")
+      .mockResolvedValue("account-b-message");
+    const replacementList = vi.spyOn(replacementActive.friends, "list").mockResolvedValue([]);
+
+    await expect(sendOutbound("while predecessor drains")).resolves.toMatchObject({
+      messageId: "account-b-message",
+    });
+    await expect(handleReefCommand({ args: "friend list" })).resolves.toEqual({
+      text: "No Reef friends.",
+    });
+    expect(firstSend).not.toHaveBeenCalled();
+    expect(firstList).not.toHaveBeenCalled();
+    expect(replacementSend).toHaveBeenCalledOnce();
+    expect(replacementList).toHaveBeenCalledOnce();
+
+    inboxDrains[0]!.resolve();
+    await first.account;
+
+    expect(getActiveReef()).toBe(replacementActive);
+    await expect(sendOutbound("after predecessor settles")).resolves.toMatchObject({
+      messageId: "account-b-message",
+    });
+    await expect(handleReefCommand({ args: "friend list" })).resolves.toEqual({
+      text: "No Reef friends.",
+    });
+
+    vi.spyOn(ReefTransportClient.prototype, "listFriends").mockRejectedValueOnce(
+      new Error("startup reconcile failed"),
+    );
+    const neverActivated = startAccount();
+    await expect(neverActivated.account).rejects.toThrow("startup reconcile failed");
+
+    expect(getActiveReef()).toBe(replacementActive);
+    await expect(sendOutbound("after failed replacement")).resolves.toMatchObject({
+      messageId: "account-b-message",
+    });
+    await expect(handleReefCommand({ args: "friend list" })).resolves.toEqual({
+      text: "No Reef friends.",
+    });
+    expect(firstSend).not.toHaveBeenCalled();
+    expect(firstList).not.toHaveBeenCalled();
+    expect(replacementSend).toHaveBeenCalledTimes(3);
+    expect(replacementList).toHaveBeenCalledTimes(3);
+
+    replacement.abort.abort();
+    inboxDrains[1]!.resolve();
+    await replacement.account;
+    expect(() => getActiveReef()).toThrow("Reef channel is not running");
   });
 });
 

--- a/extensions/reef/src/channel.test.ts
+++ b/extensions/reef/src/channel.test.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { createStartAccountContext } from "openclaw/plugin-sdk/channel-test-helpers";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateSyncKeyedStoreForTests,
@@ -29,16 +30,6 @@ import {
 } from "./state.js";
 import { ReefInboxConnection, ReefTransportClient } from "./transport.js";
 import { openReefTrustStore } from "./trust-store.js";
-
-function deferred() {
-  let resolve!: () => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
 
 describe("Reef inbound dispatch content", () => {
   it("keeps provenance model-visible without storing it in the transcript body", () => {
@@ -233,7 +224,7 @@ describe("Reef gateway account ownership", () => {
     },
   };
   const controllers: AbortController[] = [];
-  const inboxDrains: ReturnType<typeof deferred>[] = [];
+  const inboxDrains: ReturnType<typeof createDeferred<void>>[] = [];
   const accountTasks: Promise<unknown>[] = [];
   let stateDir = "";
 
@@ -260,7 +251,7 @@ describe("Reef gateway account ownership", () => {
     setReefRuntime(runtime);
     vi.spyOn(ReefTransportClient.prototype, "listFriends").mockResolvedValue({ friendships: [] });
     vi.spyOn(ReefInboxConnection.prototype, "start").mockImplementation(() => {
-      const drain = deferred();
+      const drain = createDeferred<void>();
       inboxDrains.push(drain);
       return drain.promise;
     });
@@ -353,6 +344,53 @@ describe("Reef gateway account ownership", () => {
     );
     expect(send).not.toHaveBeenCalled();
     expect(listFriends).not.toHaveBeenCalled();
+  });
+
+  it("revokes borrowed pairing approval before a paused reconcile reaches the replaced flow", async () => {
+    startAccount();
+    await vi.waitFor(() => expect(inboxDrains).toHaveLength(1));
+    const firstActive = getActiveReef();
+    const reconcilePaused = createDeferred<void>();
+    const firstList = vi.fn(async () => {
+      await reconcilePaused.promise;
+      return { friendships: [] };
+    });
+    firstActive.friends.transport.listFriends = firstList;
+    const firstSend = vi.spyOn(firstActive.flow, "send").mockResolvedValue("account-a-message");
+    const stale = reefPlugin.pairing!.notifyApproval!({ cfg, id: "molty" });
+    await vi.waitFor(() => expect(firstList).toHaveBeenCalledOnce());
+
+    startAccount();
+    await vi.waitFor(() => expect(inboxDrains).toHaveLength(2));
+    const replacementActive = getActiveReef();
+
+    reconcilePaused.resolve();
+    const staleResult = await stale.catch((error: unknown) => error);
+
+    expect(firstSend).not.toHaveBeenCalled();
+    expect(staleResult).toBeInstanceOf(Error);
+    expect(getActiveReef()).toBe(replacementActive);
+  });
+
+  it("rejects a borrowed Reef command when shutdown interrupts its friend lookup", async () => {
+    const account = startAccount();
+    await vi.waitFor(() => expect(inboxDrains).toHaveLength(1));
+    const active = getActiveReef();
+    const listPaused = createDeferred<void>();
+    const listFriends = vi.fn(async () => {
+      await listPaused.promise;
+      return { friendships: [] };
+    });
+    active.friends.transport.listFriends = listFriends;
+    const command = handleReefCommand({ args: "friend list" });
+    await vi.waitFor(() => expect(listFriends).toHaveBeenCalledOnce());
+
+    account.abort.abort();
+    listPaused.resolve();
+
+    await expect(command).rejects.toBeInstanceOf(Error);
+    inboxDrains[0]!.resolve();
+    await account.account;
   });
 
   it("keeps the replacement account authoritative through stale and failed account teardown", async () => {
@@ -533,8 +571,8 @@ describe("Reef channel lifecycle", () => {
   it("does not activate when the parent aborts during startup reconcile", async () => {
     const parent = new AbortController();
     const inbox = hangingInbox();
-    const reconcileStarted = deferred();
-    const finishReconcile = deferred();
+    const reconcileStarted = createDeferred<void>();
+    const finishReconcile = createDeferred<void>();
     const onReady = vi.fn(async () => {});
     const lifecycle = runReefChannelLifecycle({
       parentSignal: parent.signal,
@@ -557,8 +595,8 @@ describe("Reef channel lifecycle", () => {
   it("does not reject when startup reconcile fails after the parent aborts", async () => {
     const parent = new AbortController();
     const inbox = hangingInbox();
-    const reconcileStarted = deferred();
-    const finishReconcile = deferred();
+    const reconcileStarted = createDeferred<void>();
+    const finishReconcile = createDeferred<void>();
     const onReady = vi.fn(async () => {});
     const lifecycle = runReefChannelLifecycle({
       parentSignal: parent.signal,
@@ -582,7 +620,7 @@ describe("Reef channel lifecycle", () => {
     { phase: "friend reconciliation", completedRequests: 0 },
     { phase: "pairing-candidate surfacing", completedRequests: 1 },
   ])("promptly aborts a stalled $phase request", async ({ completedRequests }) => {
-    const requestStarted = deferred();
+    const requestStarted = createDeferred<void>();
     let requests = 0;
     const server = http.createServer((_request, response) => {
       if (requests++ < completedRequests) {
@@ -644,8 +682,8 @@ describe("Reef channel lifecycle", () => {
   it("does not start the inbox when the parent aborts during activation", async () => {
     const parent = new AbortController();
     const inbox = hangingInbox();
-    const activationStarted = deferred();
-    const finishActivation = deferred();
+    const activationStarted = createDeferred<void>();
+    const finishActivation = createDeferred<void>();
     const lifecycle = runReefChannelLifecycle({
       parentSignal: parent.signal,
       startInbox: inbox.startInbox,

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -32,7 +32,12 @@ import {
   ReefReceiptNotifier,
 } from "./owner-notice.js";
 import { isRephrasedReefResend } from "./rejection-resend.js";
-import { getActiveReef, getOptionalReefRuntime, getReefRuntime, setActiveReef } from "./runtime.js";
+import {
+  createReefRuntimeAuthority,
+  getActiveReef,
+  getOptionalReefRuntime,
+  getReefRuntime,
+} from "./runtime.js";
 import { reefSetupContract, reefSetupWizard } from "./setup.js";
 import { assertReefIdentityBinding, loadKeys, openStores, ReefInboxCursorStore } from "./state.js";
 import {
@@ -255,12 +260,13 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         relayUrl: parseReefRelayUrl(ctx.account.config.relayUrl),
       };
       assertReefIdentityBinding(runtime, identityBinding);
+      const authority = createReefRuntimeAuthority(ctx.abortSignal);
       const transport = new ReefTransportClient(
         ctx.account.config.relayUrl,
         ctx.account.config.handle!,
         keys,
       );
-      const stores = openStores(runtime, keys);
+      const stores = openStores(runtime, keys, { authoritySignal: authority.signal });
       const inboxCursor = new ReefInboxCursorStore(runtime, identityBinding);
       const reviews = stores.reviews;
       const pairing = createChannelPairingController({
@@ -269,12 +275,15 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         accountId: "default",
       });
       const trust = openReefTrustStore(runtime, ctx.account.config);
-      const friends = new ReefFriendManager(transport, trust, {
-        list: pairing.readAllowFromStore,
-        remove: async (peer) => {
-          return (await pairing.removeAllowFromStoreEntry(peer)).changed;
+      const friends = new ReefFriendManager(
+        transport,
+        trust,
+        {
+          list: pairing.readAllowFromStore,
+          remove: async (peer) => (await pairing.removeAllowFromStoreEntry(peer)).changed,
         },
-      });
+        authority.signal,
+      );
       const onIngress = async (message: ReefIngressMessage) => {
         const dispatchContent = resolveReefInboundDispatchContent(message);
         const budget = autonomyBudget(message.autonomy);
@@ -341,6 +350,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
         replay: stores.replay,
         reviews,
         delivered: stores.delivered,
+        authoritySignal: authority.signal,
         onIngress,
         onOwnerNotice: async (text) =>
           ownerNotice({
@@ -440,19 +450,12 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
       // Attempt the peer-key refresh before recovery can dispatch an agent
       // turn. The lifecycle activates only after that attempt is classified.
       // The lifecycle owns both the ordering and the reconcile failure policy.
-      let releaseActiveReef: (() => void) | undefined;
-      const retireActiveReef = () => releaseActiveReef?.();
       const activate = async () => {
         await receiptNotifier.notifyRejections(trust.pendingOutboundRejections());
         if (ctx.abortSignal.aborted) {
           return;
         }
-        releaseActiveReef = setActiveReef({ flow, friends, reviews });
-        ctx.abortSignal.addEventListener("abort", retireActiveReef, { once: true });
-        if (ctx.abortSignal.aborted) {
-          retireActiveReef();
-          return;
-        }
+        authority.activate({ flow, friends, reviews });
         ctx.setStatus({ accountId: "default", running: true, connected: false });
       };
       const inbox = new ReefInboxConnection(
@@ -517,8 +520,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           onReady: activate,
         });
       } finally {
-        ctx.abortSignal.removeEventListener("abort", retireActiveReef);
-        retireActiveReef();
+        authority.release();
         ctx.setStatus({ accountId: "default", running: false, connected: false });
       }
     },

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -440,12 +440,19 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
       // Attempt the peer-key refresh before recovery can dispatch an agent
       // turn. The lifecycle activates only after that attempt is classified.
       // The lifecycle owns both the ordering and the reconcile failure policy.
+      let releaseActiveReef: (() => void) | undefined;
+      const retireActiveReef = () => releaseActiveReef?.();
       const activate = async () => {
         await receiptNotifier.notifyRejections(trust.pendingOutboundRejections());
         if (ctx.abortSignal.aborted) {
           return;
         }
-        setActiveReef({ flow, friends, reviews });
+        releaseActiveReef = setActiveReef({ flow, friends, reviews });
+        ctx.abortSignal.addEventListener("abort", retireActiveReef, { once: true });
+        if (ctx.abortSignal.aborted) {
+          retireActiveReef();
+          return;
+        }
         ctx.setStatus({ accountId: "default", running: true, connected: false });
       };
       const inbox = new ReefInboxConnection(
@@ -510,6 +517,8 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           onReady: activate,
         });
       } finally {
+        ctx.abortSignal.removeEventListener("abort", retireActiveReef);
+        retireActiveReef();
         ctx.setStatus({ accountId: "default", running: false, connected: false });
       }
     },

--- a/extensions/reef/src/config-schema.test.ts
+++ b/extensions/reef/src/config-schema.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import reefChannelEntry from "../index.js";
 import { reefPlugin } from "./channel.js";
 import { autonomyBudget, parseReefRelayUrl, ReefChannelConfigSchema } from "./config-schema.js";
-import { setActiveReef } from "./runtime.js";
+import { createReefRuntimeAuthority } from "./runtime.js";
 
 describe("Reef configuration boundary", () => {
   it("defaults to the canonical Reef relay", () => {
@@ -80,7 +80,7 @@ describe("Reef configuration boundary", () => {
     const setAutonomy = vi.fn();
     const decide = vi.fn().mockResolvedValue(true);
     const listFriends = vi.fn().mockResolvedValue([]);
-    setActiveReef({
+    createReefRuntimeAuthority().activate({
       flow: { send: flowSend },
       friends: {
         mintCode,

--- a/extensions/reef/src/flow.ts
+++ b/extensions/reef/src/flow.ts
@@ -140,6 +140,7 @@ export class ReefMessageFlow {
       replay: ReplayStore;
       reviews: ReviewApprovalStore;
       delivered: ReefDeliveredStore;
+      authoritySignal?: AbortSignal;
       onIngress: (message: ReefIngressMessage) => Promise<void>;
       onOwnerNotice: (text: string) => Promise<void>;
     },
@@ -157,6 +158,8 @@ export class ReefMessageFlow {
       onPlatformSendDispatch?: () => Promise<void>;
     } = {},
   ): Promise<string> {
+    const signal = this.options.authoritySignal;
+    signal?.throwIfAborted();
     const friend = this.options.trust.get(peer);
     if (
       !friend ||
@@ -185,6 +188,7 @@ export class ReefMessageFlow {
       policyVersion: this.requireGuardConfig().policyVersion,
       reviewGate: (request) => this.options.reviews.request(request),
     });
+    signal?.throwIfAborted();
     // Persist the exact peer/id/body binding before the relay can return a
     // receipt. Only a matching durable record may later authorize a resend turn.
     if (!matchesReefPeerIdentity(this.options.trust.get(peer), recipient)) {
@@ -205,7 +209,9 @@ export class ReefMessageFlow {
     // Guard/review/encryption are local and may reject safely. Mark ambiguity
     // only at the relay boundary so recovery never treats those failures as sent.
     await context.onPlatformSendDispatch?.();
-    await this.options.transport.sendEnvelope(peer, result.envelope);
+    signal?.throwIfAborted();
+    await this.options.transport.sendEnvelope(peer, result.envelope, signal);
+    signal?.throwIfAborted();
     return id;
   }
 

--- a/extensions/reef/src/friends.test.ts
+++ b/extensions/reef/src/friends.test.ts
@@ -132,7 +132,7 @@ describe("ReefFriendManager pairing", () => {
 
     addApproval(store, pairing, pending);
     await expect(manager.reconcile()).resolves.toEqual(["alice"]);
-    expect(relay.respondFriend).toHaveBeenCalledWith(pending, true);
+    expect(relay.respondFriend).toHaveBeenCalledWith(pending, true, undefined);
     expect(store.get("alice")).toMatchObject({
       autonomy: "bounded",
       ed25519PublicKey: pending.ed25519_pub,
@@ -191,6 +191,33 @@ describe("ReefFriendManager pairing", () => {
     const reopened = trust();
     expect(reopened.get("alice")).toMatchObject({ autonomy: "bounded" });
     expect(fs.existsSync(path.join(stateDir, "requested.json"))).toBe(false);
+  });
+
+  it("preserves ambiguous outbound intent when account authority closes during a relay request", async () => {
+    const pending = relayFriend("alice", "pending", generateIdentity(), 1, "me");
+    const requestStarted = deferred<void>();
+    const relayResult = deferred<{ status: string }>();
+    const relay = transport(pending);
+    relay.requestFriend.mockImplementation(async () => {
+      requestStarted.resolve(undefined);
+      return await relayResult.promise;
+    });
+    const store = trust();
+    const authority = new AbortController();
+    const manager = new ReefFriendManager(
+      relay as unknown as ReefTransportClient,
+      store,
+      approvals(),
+      authority.signal,
+    );
+    const request = manager.request("alice");
+    await requestStarted.promise;
+
+    authority.abort();
+    relayResult.resolve({ status: "pending" });
+
+    await expect(request).rejects.toBeInstanceOf(Error);
+    expect(store.hasOutboundRequest("alice")).toBe(true);
   });
 
   it("removes a relay edge created after another process revoked the request", async () => {
@@ -343,7 +370,7 @@ describe("ReefFriendManager pairing", () => {
     addApproval(store, pairing, reapproval);
     await expect(manager.reconcile()).resolves.toEqual(["alice"]);
 
-    expect(relay.respondFriend).toHaveBeenCalledWith(reapproval, true);
+    expect(relay.respondFriend).toHaveBeenCalledWith(reapproval, true, undefined);
     expect(store.get("alice")).toMatchObject({
       autonomy: "extended",
       safetyNumberChanged: false,
@@ -369,7 +396,7 @@ describe("ReefFriendManager pairing", () => {
 
     await expect(manager.reconcile()).resolves.toEqual(["alice"]);
 
-    expect(relay.respondFriend).toHaveBeenCalledWith(pending, true);
+    expect(relay.respondFriend).toHaveBeenCalledWith(pending, true, undefined);
     expect(store.get("alice")).toMatchObject({ autonomy: "extended" });
     expect(pairing.values).toEqual(new Set());
   });
@@ -389,7 +416,7 @@ describe("ReefFriendManager pairing", () => {
 
     await expect(manager.reconcile()).resolves.toEqual([]);
 
-    expect(relay.respondFriend).toHaveBeenCalledWith(pending, true);
+    expect(relay.respondFriend).toHaveBeenCalledWith(pending, true, undefined);
     expect(relay.removeFriend).toHaveBeenCalledWith("alice");
     expect(store.get("alice")).toBeUndefined();
     expect(pairing.values).toEqual(new Set());

--- a/extensions/reef/src/friends.ts
+++ b/extensions/reef/src/friends.ts
@@ -43,14 +43,15 @@ export class ReefFriendManager {
     readonly transport: ReefTransportClient,
     readonly trust: ReefTrustStore,
     readonly pairing: ReefPairingApprovals,
+    private readonly authoritySignal?: AbortSignal,
   ) {}
 
   mintCode() {
-    return this.transport.mintFriendCode();
+    return this.#serialize((signal) => this.transport.mintFriendCode(signal));
   }
 
   request(peer: string, code?: string): Promise<{ status: string }> {
-    return this.#serialize(async () => {
+    return this.#serialize(async (signal) => {
       const normalized = normalizeReefTarget(peer);
       if (!normalized) {
         throw new Error(`Invalid Reef peer handle: ${peer}`);
@@ -60,7 +61,7 @@ export class ReefFriendManager {
       const requestId = this.trust.recordOutboundRequest(normalized);
       let result: { status: string };
       try {
-        result = await this.transport.requestFriend(normalized, code);
+        result = await this.transport.requestFriend(normalized, code, signal);
       } catch (error) {
         const definitiveRejection =
           error instanceof ReefRelayError &&
@@ -97,7 +98,7 @@ export class ReefFriendManager {
       if (!normalized) {
         throw new Error(`Invalid Reef peer handle: ${peer}`);
       }
-      // Local revocation remains fail-closed even when the relay is offline.
+      // Once trust is revoked, finish cleanup even if the account closes.
       this.trust.remove(normalized);
       const results = await Promise.allSettled([
         this.#removePairingApprovalsForPeer(normalized),
@@ -128,8 +129,11 @@ export class ReefFriendManager {
   }
 
   async list(): Promise<ListedReefFriend[]> {
+    const signal = this.authoritySignal;
+    signal?.throwIfAborted();
     const local = new Map(this.trust.list().map((entry) => [entry.peer, entry.trust]));
-    const { friendships } = await this.transport.listFriends();
+    const { friendships } = await this.transport.listFriends(signal);
+    signal?.throwIfAborted();
     const listed: ListedReefFriend[] = [];
     for (const friend of friendships) {
       const autonomy = local.get(friend.peer)?.autonomy;
@@ -142,9 +146,10 @@ export class ReefFriendManager {
     return listed;
   }
 
-  surfacePairingCandidates(issue: PairingChallenge, signal?: AbortSignal): Promise<void> {
-    return this.#serialize(async () => {
+  surfacePairingCandidates(issue: PairingChallenge, lifecycleSignal?: AbortSignal): Promise<void> {
+    return this.#serialize(async (signal) => {
       const { friendships } = await this.transport.listFriends(signal);
+      signal?.throwIfAborted();
       const approvals = await this.#loadPairingApprovals(friendships);
 
       for (const friend of friendships) {
@@ -173,6 +178,7 @@ export class ReefFriendManager {
         if (!inboundPending && !missingLocalApproval && !needsReapproval) {
           continue;
         }
+        signal?.throwIfAborted();
         await issue({
           peer: friend.peer,
           fingerprint: fingerprint(friend.ed25519_pub, friend.x25519_pub),
@@ -180,16 +186,18 @@ export class ReefFriendManager {
           approvalToken: this.trust.createPairingApproval(friend, snapshot.revision),
         });
       }
-    });
+    }, lifecycleSignal);
   }
 
-  reconcile(signal?: AbortSignal): Promise<string[]> {
-    return this.#serialize(async () => {
+  reconcile(lifecycleSignal?: AbortSignal): Promise<string[]> {
+    return this.#serialize(async (signal) => {
       const { friendships } = await this.transport.listFriends(signal);
+      signal?.throwIfAborted();
       const approvals = await this.#loadPairingApprovals(friendships);
       const changed = new Set<string>();
 
       for (const friend of friendships) {
+        signal?.throwIfAborted();
         if (friend.status === "blocked") {
           continue;
         }
@@ -251,9 +259,11 @@ export class ReefFriendManager {
         if (approvalEntry && !(await this.pairing.remove(approvalEntry))) {
           continue;
         }
+        signal?.throwIfAborted();
 
         if (friend.status === "pending" || friend.status === "reapprove_required") {
-          await this.transport.respondFriend(friend, true);
+          await this.transport.respondFriend(friend, true, signal);
+          signal?.throwIfAborted();
         }
 
         const committed = this.trust.commitPeerTrust(friend, {
@@ -280,7 +290,7 @@ export class ReefFriendManager {
       }
 
       return [...changed].toSorted();
-    });
+    }, lifecycleSignal);
   }
 
   async #loadPairingApprovals(
@@ -324,8 +334,20 @@ export class ReefFriendManager {
     this.trust.remove(peer);
   }
 
-  #serialize<T>(operation: () => T | Promise<T>): Promise<T> {
-    const result = this.#mutations.then(operation);
+  #serialize<T>(
+    operation: (signal?: AbortSignal) => T | Promise<T>,
+    lifecycleSignal?: AbortSignal,
+  ): Promise<T> {
+    const signal =
+      lifecycleSignal && this.authoritySignal
+        ? AbortSignal.any([lifecycleSignal, this.authoritySignal])
+        : (lifecycleSignal ?? this.authoritySignal);
+    const result = this.#mutations.then(async () => {
+      signal?.throwIfAborted();
+      const value = await operation(signal);
+      signal?.throwIfAborted();
+      return value;
+    });
     this.#mutations = result.then(
       () => undefined,
       () => undefined,

--- a/extensions/reef/src/outbound.test.ts
+++ b/extensions/reef/src/outbound.test.ts
@@ -1,16 +1,26 @@
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 import {
   canonicalBytes,
+  generateIdentity,
   MemoryAuditStore,
   MemoryReplayStore,
   PipelineError,
   REEF_MAX_PLAINTEXT_BYTES,
 } from "../protocol/index.js";
 import { ReefMessageFlow } from "./flow.js";
-import { allow, config, guard, reefKeys, transport, trust } from "./flow.test-helpers.js";
+import {
+  allow,
+  config,
+  guard,
+  peerTrust,
+  reefKeys,
+  transport,
+  trust,
+} from "./flow.test-helpers.js";
 import { reefMessageAdapter, reefOutboundAdapter } from "./outbound.js";
-import { setActiveReef } from "./runtime.js";
+import { createReefRuntimeAuthority, getActiveReef } from "./runtime.js";
 import type { ReefTransportClient } from "./transport.js";
 
 describe("reefOutboundAdapter", () => {
@@ -51,7 +61,7 @@ describe("reefOutboundAdapter", () => {
     const onPlatformSendDispatch = vi.fn(async () => {
       order.push("dispatch");
     });
-    setActiveReef({ flow: { send }, friends: {}, reviews: {} } as never);
+    createReefRuntimeAuthority().activate({ flow: { send }, friends: {}, reviews: {} } as never);
 
     await expect(
       reefOutboundAdapter.sendText!({
@@ -92,7 +102,7 @@ describe("reefOutboundAdapter", () => {
         return "01JZ0000000000000000000200";
       },
     );
-    setActiveReef({ flow: { send }, friends: {}, reviews: {} } as never);
+    createReefRuntimeAuthority().activate({ flow: { send }, friends: {}, reviews: {} } as never);
 
     await reefMessageAdapter.send.text({
       cfg: {},
@@ -106,12 +116,57 @@ describe("reefOutboundAdapter", () => {
     expect(order).toEqual(["dispatch", "send"]);
   });
 
+  it("revokes a borrowed encrypted flow before a paused guard reaches the replaced relay", async () => {
+    const guardPaused = createDeferred<void>();
+    const firstAuthority = createReefRuntimeAuthority();
+    const classifier = {
+      ...guard(allow),
+      classify: vi.fn(async () => {
+        await guardPaused.promise;
+        return allow;
+      }),
+    };
+    const relay = transport();
+    const flow = new ReefMessageFlow({
+      config: config(),
+      trust: trust({ alice: peerTrust(generateIdentity()) }).store,
+      keys: reefKeys(),
+      transport: relay as unknown as ReefTransportClient,
+      guard: classifier,
+      audit: new MemoryAuditStore(new Uint8Array(32).fill(9)),
+      replay: new MemoryReplayStore(),
+      reviews: {} as never,
+      delivered: {} as never,
+      authoritySignal: firstAuthority.signal,
+      onIngress: async () => {},
+      onOwnerNotice: async () => {},
+    });
+    firstAuthority.activate({ flow, friends: {}, reviews: {} } as never);
+    const stale = reefMessageAdapter.send.text({ cfg: {}, to: "reef:alice", text: "stale" });
+    await vi.waitFor(() => expect(classifier.classify).toHaveBeenCalledOnce());
+
+    const replacementAuthority = createReefRuntimeAuthority();
+    const replacement = { flow: {}, friends: {}, reviews: {} } as never;
+    replacementAuthority.activate(replacement);
+    try {
+      guardPaused.resolve();
+      const staleResult = await stale.catch((error: unknown) => error);
+
+      expect(relay.sendEnvelope).not.toHaveBeenCalled();
+      expect(staleResult).toBeInstanceOf(PlatformMessageNotDispatchedError);
+      expect(getActiveReef()).toBe(replacement);
+    } finally {
+      replacementAuthority.release();
+      firstAuthority.release();
+    }
+  });
+
   it("proves local flow failures happened before platform dispatch", async () => {
     const cause = new Error("guard denied");
     const send = vi.fn(async () => {
       throw cause;
     });
-    setActiveReef({ flow: { send }, friends: {}, reviews: {} } as never);
+    createReefRuntimeAuthority().activate({ flow: { send }, friends: {}, reviews: {} } as never);
 
     const error = await reefMessageAdapter.send
       .text({
@@ -136,7 +191,7 @@ describe("reefOutboundAdapter", () => {
     const send = vi.fn(async () => {
       throw cause;
     });
-    setActiveReef({ flow: { send }, friends: {}, reviews: {} } as never);
+    createReefRuntimeAuthority().activate({ flow: { send }, friends: {}, reviews: {} } as never);
 
     const error = await reefMessageAdapter.send
       .text({ cfg: {}, to: "reef:Alice", text: "hello" })
@@ -160,7 +215,7 @@ describe("reefOutboundAdapter", () => {
       onIngress: async () => {},
       onOwnerNotice: async () => {},
     });
-    setActiveReef({ flow, friends: {}, reviews: {} } as never);
+    createReefRuntimeAuthority().activate({ flow, friends: {}, reviews: {} } as never);
 
     const error = await reefMessageAdapter.send
       .text({ cfg: {}, to: "reef:Alice", text: "hello" })
@@ -187,7 +242,7 @@ describe("reefOutboundAdapter", () => {
     const send = vi.fn(async () => {
       throw cause;
     });
-    setActiveReef({ flow: { send }, friends: {}, reviews: {} } as never);
+    createReefRuntimeAuthority().activate({ flow: { send }, friends: {}, reviews: {} } as never);
 
     const error = await reefMessageAdapter.send
       .text({ cfg: {}, to: "reef:Alice", text: "hello" })
@@ -197,8 +252,9 @@ describe("reefOutboundAdapter", () => {
     expect(error).toMatchObject({ cause, retryable: true });
   });
 
-  it("keeps relay failures ambiguous after platform dispatch starts", async () => {
+  it("keeps published dispatch ambiguous when account authority closes", async () => {
     const cause = new Error("relay outcome unknown");
+    const authority = createReefRuntimeAuthority();
     const send = vi.fn(
       async (
         _peer: string,
@@ -209,8 +265,8 @@ describe("reefOutboundAdapter", () => {
         throw cause;
       },
     );
-    const onPlatformSendDispatch = vi.fn(async () => undefined);
-    setActiveReef({ flow: { send }, friends: {}, reviews: {} } as never);
+    const onPlatformSendDispatch = vi.fn(async () => authority.release());
+    authority.activate({ flow: { send }, friends: {}, reviews: {} } as never);
 
     const error = await reefMessageAdapter.send
       .text({
@@ -260,7 +316,7 @@ describe("reefOutboundAdapter", () => {
       text: rawText,
     });
     const send = vi.fn(async () => "01JZ0000000000000000000200");
-    setActiveReef({ flow: { send }, friends: {}, reviews: {} } as never);
+    createReefRuntimeAuthority().activate({ flow: { send }, friends: {}, reviews: {} } as never);
 
     const error = await reefOutboundAdapter.sendText!({
       cfg: {},

--- a/extensions/reef/src/runtime.test.ts
+++ b/extensions/reef/src/runtime.test.ts
@@ -31,9 +31,20 @@ describe("Reef runtime state", () => {
     const active = { flow: {}, friends: {}, reviews: {} } as never;
 
     first.setReefRuntime(runtime);
-    first.setActiveReef(active);
+    const releaseFirst = first.setActiveReef(active);
 
     expect(second.getReefRuntime()).toBe(runtime);
     expect(second.getActiveReef()).toBe(active);
+
+    const replacement = { flow: {}, friends: {}, reviews: {} } as never;
+    const releaseReplacement = second.setActiveReef(replacement);
+    releaseFirst();
+
+    expect(first.getActiveReef()).toBe(replacement);
+
+    releaseReplacement();
+    releaseReplacement();
+
+    expect(() => first.getActiveReef()).toThrow("Reef channel is not running");
   });
 });

--- a/extensions/reef/src/runtime.test.ts
+++ b/extensions/reef/src/runtime.test.ts
@@ -31,19 +31,26 @@ describe("Reef runtime state", () => {
     const active = { flow: {}, friends: {}, reviews: {} } as never;
 
     first.setReefRuntime(runtime);
-    const releaseFirst = first.setActiveReef(active);
+    const firstAuthority = first.createReefRuntimeAuthority();
+    firstAuthority.activate(active);
 
     expect(second.getReefRuntime()).toBe(runtime);
     expect(second.getActiveReef()).toBe(active);
+    expect(firstAuthority.signal.aborted).toBe(false);
 
     const replacement = { flow: {}, friends: {}, reviews: {} } as never;
-    const releaseReplacement = second.setActiveReef(replacement);
-    releaseFirst();
+    const replacementAuthority = second.createReefRuntimeAuthority();
+    replacementAuthority.activate(replacement);
+    expect(firstAuthority.signal.aborted).toBe(true);
+    expect(replacementAuthority.signal.aborted).toBe(false);
 
+    firstAuthority.release();
     expect(first.getActiveReef()).toBe(replacement);
+    expect(replacementAuthority.signal.aborted).toBe(false);
 
-    releaseReplacement();
-    releaseReplacement();
+    replacementAuthority.release();
+    expect(replacementAuthority.signal.aborted).toBe(true);
+    replacementAuthority.release();
 
     expect(() => first.getActiveReef()).toThrow("Reef channel is not running");
   });

--- a/extensions/reef/src/runtime.ts
+++ b/extensions/reef/src/runtime.ts
@@ -4,9 +4,11 @@ import type { ReefMessageFlow } from "./flow.js";
 import type { ReefFriendManager } from "./friends.js";
 import type { ReviewApprovalStore } from "./state.js";
 
-type ActiveReef =
-  | { flow: ReefMessageFlow; friends: ReefFriendManager; reviews: ReviewApprovalStore }
-  | undefined;
+type ActiveReef = {
+  flow: ReefMessageFlow;
+  friends: ReefFriendManager;
+  reviews: ReviewApprovalStore;
+};
 
 const {
   setRuntime: setReefRuntime,
@@ -17,21 +19,24 @@ const {
   errorMessage: "Reef runtime unavailable",
 });
 
-// Keep the live channel handle in a second named slot: duplicate bundled-plugin
-// module instances must observe the same running Reef instance for outbound sends.
-const activeReefStore = createPluginRuntimeStore<Exclude<ActiveReef, undefined>>({
+const activeReefStore = createPluginRuntimeStore<{ value: ActiveReef }>({
   key: "plugin-runtime:reef:active",
   errorMessage: "Reef channel is not running",
 });
 
 export { getOptionalReefRuntime, getReefRuntime, setReefRuntime };
 
-export function setActiveReef(value: ActiveReef): void {
-  if (value) {
-    activeReefStore.setRuntime(value);
-  } else {
-    activeReefStore.clearRuntime();
-  }
+export function setActiveReef(value: ActiveReef): () => void {
+  const registration = { value };
+  activeReefStore.setRuntime(registration);
+  return () => {
+    // A stopped generation must never clear its replacement, even across module instances.
+    if (activeReefStore.tryGetRuntime() === registration) {
+      activeReefStore.clearRuntime();
+    }
+  };
 }
 
-export const getActiveReef = activeReefStore.getRuntime;
+export function getActiveReef(): ActiveReef {
+  return activeReefStore.getRuntime().value;
+}

--- a/extensions/reef/src/runtime.ts
+++ b/extensions/reef/src/runtime.ts
@@ -19,24 +19,46 @@ const {
   errorMessage: "Reef runtime unavailable",
 });
 
-const activeReefStore = createPluginRuntimeStore<{ value: ActiveReef }>({
+const activeReefStore = createPluginRuntimeStore<{
+  value: ActiveReef;
+  controller: AbortController;
+  signal: AbortSignal;
+}>({
   key: "plugin-runtime:reef:active",
   errorMessage: "Reef channel is not running",
 });
 
 export { getOptionalReefRuntime, getReefRuntime, setReefRuntime };
 
-export function setActiveReef(value: ActiveReef): () => void {
-  const registration = { value };
-  activeReefStore.setRuntime(registration);
-  return () => {
-    // A stopped generation must never clear its replacement, even across module instances.
-    if (activeReefStore.tryGetRuntime() === registration) {
-      activeReefStore.clearRuntime();
-    }
+export function createReefRuntimeAuthority(parentSignal?: AbortSignal) {
+  const controller = new AbortController();
+  const signal = parentSignal
+    ? AbortSignal.any([parentSignal, controller.signal])
+    : controller.signal;
+  let registration: ReturnType<typeof activeReefStore.tryGetRuntime> = null;
+  return {
+    signal,
+    activate(value: ActiveReef): void {
+      signal.throwIfAborted();
+      const predecessor = activeReefStore.tryGetRuntime();
+      registration = { value, controller, signal };
+      activeReefStore.setRuntime(registration);
+      predecessor?.controller.abort();
+    },
+    release(): void {
+      controller.abort();
+      // A stopped generation must never clear its replacement, even across module instances.
+      if (activeReefStore.tryGetRuntime() === registration) {
+        activeReefStore.clearRuntime();
+      }
+    },
   };
 }
 
 export function getActiveReef(): ActiveReef {
-  return activeReefStore.getRuntime().value;
+  const registration = activeReefStore.getRuntime();
+  if (registration.signal.aborted) {
+    throw new Error("Reef channel is not running");
+  }
+  return registration.value;
 }

--- a/extensions/reef/src/state.ts
+++ b/extensions/reef/src/state.ts
@@ -406,7 +406,11 @@ export class ReviewApprovalStore {
   readonly #store: PluginStateSyncKeyedStore<ReefReviewRecord>;
   readonly #maxEntries: number;
 
-  constructor(runtime: PluginRuntime, maxEntries = REEF_REVIEWS_MAX_ENTRIES) {
+  constructor(
+    runtime: PluginRuntime,
+    maxEntries = REEF_REVIEWS_MAX_ENTRIES,
+    private readonly authoritySignal?: AbortSignal,
+  ) {
     this.#maxEntries = maxEntries;
     this.#store = runtime.state.openSyncKeyedStore<ReefReviewRecord>({
       namespace: REEF_REVIEWS_NAMESPACE,
@@ -436,6 +440,7 @@ export class ReviewApprovalStore {
   }
 
   async request(review: ReviewRequest): Promise<ReviewApproval | undefined> {
+    this.authoritySignal?.throwIfAborted();
     const current = this.#store.lookup(review.approvalDigest);
     if (current?.approved !== undefined) {
       return { approved: current.approved, approvalDigest: review.approvalDigest };
@@ -459,6 +464,7 @@ export class ReviewApprovalStore {
       throw new Error("Reef review state requires atomic plugin-state updates");
     }
     let found = false;
+    this.authoritySignal?.throwIfAborted();
     update(digest, (current) => {
       if (!current) {
         return undefined;
@@ -470,6 +476,7 @@ export class ReviewApprovalStore {
   }
 
   async list(): Promise<ReviewRequest[]> {
+    this.authoritySignal?.throwIfAborted();
     return this.#store
       .entries()
       .filter((entry) => entry.value.approved === undefined)
@@ -585,6 +592,7 @@ export function openStores(
     auditMaxEntries?: number;
     replayMaxEntries?: number;
     deliveredMaxEntries?: number;
+    authoritySignal?: AbortSignal;
   } = {},
 ) {
   assertReefIdentityMigrationComplete(runtime);
@@ -596,7 +604,7 @@ export function openStores(
       randomBytes,
       options.replayMaxEntries,
     ),
-    reviews: new ReviewApprovalStore(runtime),
+    reviews: new ReviewApprovalStore(runtime, undefined, options.authoritySignal),
     delivered: new ReefDeliveredStore(runtime, options.deliveredMaxEntries),
   };
 }

--- a/extensions/reef/src/transport.ts
+++ b/extensions/reef/src/transport.ts
@@ -161,31 +161,33 @@ export class ReefTransportClient {
     ]);
   }
 
-  mintFriendCode(): Promise<{ code: string; expires: number }> {
-    return this.signed("POST", "/v1/friend-codes");
+  mintFriendCode(signal?: AbortSignal): Promise<{ code: string; expires: number }> {
+    return this.signed("POST", "/v1/friend-codes", undefined, signal);
   }
-  requestFriend(to: string, code?: string): Promise<{ status: string }> {
+  requestFriend(to: string, code?: string, signal?: AbortSignal): Promise<{ status: string }> {
     return this.signed(
       "POST",
       "/v1/friends/request",
       code ? { to, code } : { to },
-      undefined,
+      signal,
       code ? [code] : [],
     );
   }
   async respondFriend(
     friend: RelayFriend,
     accept: boolean,
+    signal?: AbortSignal,
   ): Promise<{ peer: string; status: "active" | "blocked" }> {
+    const request = {
+      peer: friend.peer,
+      accept,
+      expected_key_epoch: friend.key_epoch,
+      expected_ed25519_pub: friend.ed25519_pub,
+      expected_x25519_pub: friend.x25519_pub,
+    };
     let result: unknown;
     try {
-      result = await this.signed("POST", "/v1/friends/respond", {
-        peer: friend.peer,
-        accept,
-        expected_key_epoch: friend.key_epoch,
-        expected_ed25519_pub: friend.ed25519_pub,
-        expected_x25519_pub: friend.x25519_pub,
-      });
+      result = await this.signed("POST", "/v1/friends/respond", request, signal);
     } catch (error) {
       if (
         error instanceof ReefRelayError &&
@@ -222,11 +224,15 @@ export class ReefTransportClient {
   listFriends(signal?: AbortSignal): Promise<{ friendships: RelayFriend[] }> {
     return this.signed("GET", "/v1/friends", undefined, signal);
   }
-  removeFriend(peer: string): Promise<void> {
-    return this.signed("DELETE", `/v1/friends/${encodeURIComponent(peer)}`);
+  removeFriend(peer: string, signal?: AbortSignal): Promise<void> {
+    return this.signed("DELETE", `/v1/friends/${encodeURIComponent(peer)}`, undefined, signal);
   }
-  sendEnvelope(peer: string, envelope: Envelope): Promise<{ id: string; status: string }> {
-    return this.signed("POST", `/v1/mail/${encodeURIComponent(peer)}`, envelope);
+  sendEnvelope(
+    peer: string,
+    envelope: Envelope,
+    signal?: AbortSignal,
+  ): Promise<{ id: string; status: string }> {
+    return this.signed("POST", `/v1/mail/${encodeURIComponent(peer)}`, envelope, signal);
   }
   acknowledge(peer: string, id: string, receipt: SignedReceipt): Promise<{ result: string }> {
     return this.signed("POST", `/v1/mail/${encodeURIComponent(peer)}/ack`, { id, receipt });


### PR DESCRIPTION
Closes #129063

AI-assisted: Claude Code and Codex.

## What Problem This Solves

Fixes an issue where stopping or replacing a running Reef account left both the retired account's global runtime and already-borrowed outbound, pairing, friendship, and review capabilities usable while shutdown was draining or after it completed.

## Why This Change Was Made

Reef now creates one generation-specific authority before constructing the account-owned flow, friend manager, and review store. Account abort or replacement revokes that authority through the owners themselves, so callers cannot omit or substitute the generation fence. Cleanup clears the global slot only when the retiring generation still owns it.

The same authority reaches final relay I/O, deferred friendship serialization, trust expansion, review decisions, and command reads. Fail-closed friendship tombstones and ambiguous outbound friend-request intent remain durable during cancellation.

## User Impact

Stopped Reef accounts no longer handle outbound messages or privileged Reef commands through stale transport, key, guard, trust, or review state. Work that began before abort is stopped before its final relay or privileged state effect, while a replacement account remains usable even when an earlier generation finishes shutting down late.

## Evidence

- Original pre-fix account-boundary regression failed immediately after abort because `getActiveReef()` still returned the stopped account.
- The first exact-head review found an additional retained-capability race. New RED tests reproduced four failures before the authority fence: stale relay delivery after paused guard work, stale pairing dispatch after paused reconcile, stale command completion after paused lookup, and missing duplicate-module authority revocation.
- `node scripts/run-vitest.mjs extensions/reef/src/channel.test.ts extensions/reef/src/runtime.test.ts extensions/reef/src/outbound.test.ts extensions/reef/src/config-schema.test.ts extensions/reef/src/friends.test.ts` — 69 tests passed on the final owner-bound implementation.
- `node scripts/run-vitest.mjs extensions/reef` — 308 tests passed.
- `node scripts/check-changed.mjs -- extensions/reef/runtime-api.ts extensions/reef/src/channel.test.ts extensions/reef/src/channel.ts extensions/reef/src/config-schema.test.ts extensions/reef/src/flow.ts extensions/reef/src/friends.test.ts extensions/reef/src/friends.ts extensions/reef/src/outbound.test.ts extensions/reef/src/runtime.test.ts extensions/reef/src/runtime.ts extensions/reef/src/state.ts extensions/reef/src/transport.ts` — passed formatting, production/test typechecking, lint, plugin boundaries, dead-code checks, and import-cycle checks. The only advisory is the existing test temp-directory fixture style.
- Fresh structured autoreview reported no accepted or actionable findings after the owner-bound refactor.
- Production delta: +134/-54 (net +80). This is the account-owned authority boundary and cancellation propagation through final relay/trust/review effects; no shared Plugin SDK or config surface was added. Tests: +400/-38.
- Sibling invariant: Buzz and Nostr already retire an account-owned bus only when the retiring generation still owns the active slot. Reef additionally requires owner-bound cancellation because its encrypted flow and friendship operations cross local guard, relay, and durable-state awaits.
- Live relay proof was not used: deterministically proving this race requires holding guard/reconcile work and predecessor shutdown open while replacing the account, which would mutate a real Reef identity and relay friendship state. The real `reefPlugin.gateway.startAccount`, encrypted flow, friend manager, review store, and transport boundaries are exercised with deterministic final-effect assertions instead.
