### PR TITLE
perf(gateway): fix event-loop convoys from per-session hot paths under concurrent sessions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3385,7 +3385,7 @@ src/logging/diagnostic.ts	2
 src/logging/json-console-line.ts	2
 src/logging/levels.ts	2
 src/logging/log-file-shared.ts	1
-src/logging/logger.ts	13
+src/logging/logger.ts	14
 src/logging/node-require.ts	2
 src/logging/parse-log-line.ts	1
 src/logging/redact-internal-state.ts	1
@@ -3791,7 +3791,6 @@ src/skills/loading/workspace-skill-sync.runtime.ts	1
 src/skills/runtime/refresh.ts	3
 src/skills/runtime/remote-probe-utils.ts	2
 src/skills/runtime/remote-skills.ts	1
-src/skills/runtime/session-snapshot.ts	1
 src/skills/security/clawhub-verdicts.ts	2
 src/skills/workshop/experience-review.ts	2
 src/skills/workshop/history-scan.ts	2

--- a/src/gateway/control-ui-session-pr-subscriptions.test.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.test.ts
@@ -117,6 +117,38 @@ describe("control UI session PR subscriptions", () => {
     ).toEqual(["only-a", "only-b", "shared"]);
   });
 
+  it("limits initial hydration and polling to four simultaneous session loads", async () => {
+    vi.useFakeTimers();
+    const releases: Array<() => void> = [];
+    const load = vi.fn(
+      async () =>
+        await new Promise<ControlUiSessionPullRequests>((resolve) => {
+          releases.push(() => resolve(READY));
+        }),
+    );
+    active = createControlUiSessionPullRequestSubscriptions({
+      broadcastToConnIds: vi.fn(),
+      load,
+    });
+    const sessionKeys = Array.from({ length: 6 }, (_value, index) => `session-${index}`);
+
+    const finishLimitedLoads = async (operation: Promise<void>) => {
+      await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(4));
+      for (const release of releases.splice(0)) {
+        release();
+      }
+      await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(6));
+      for (const release of releases.splice(0)) {
+        release();
+      }
+      await operation;
+    };
+
+    await finishLimitedLoads(active.replace("conn-a", sessionKeys));
+    load.mockClear();
+    await finishLimitedLoads(active.pollNow());
+  });
+
   it("hydrates and broadcasts only newly added keys across replacement sets", async () => {
     vi.useFakeTimers();
     const load = vi.fn(async () => READY);
@@ -200,7 +232,7 @@ describe("control UI session PR subscriptions", () => {
 
     const poll = active.pollNow();
     const refresh = active.replace("conn-a", ["session"], new Set(["session"]));
-    expect(load).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
     resolveNormal({ pullRequests: [], rateLimited: true });
     await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(3));
     resolveForced(READY);
@@ -275,13 +307,19 @@ describe("control UI session PR subscriptions", () => {
       resolveBlocked = resolve;
     });
     const load = vi.fn(async ({ sessionKey }: { sessionKey: string }) =>
-      sessionKey === "blocked" ? await blocked : READY,
+      sessionKey.startsWith("blocked") ? await blocked : READY,
     );
     const broadcastToConnIds = vi.fn();
     active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
 
-    const oldReplace = active.replace("conn-a", ["blocked", "shared"]);
-    await vi.waitFor(() => expect(load).toHaveBeenCalledWith({ sessionKey: "blocked" }));
+    const oldReplace = active.replace("conn-a", [
+      "blocked-1",
+      "blocked-2",
+      "blocked-3",
+      "blocked-4",
+      "shared",
+    ]);
+    await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(4));
     await active.replace("conn-b", ["shared"]);
     broadcastToConnIds.mockClear();
 
@@ -289,7 +327,7 @@ describe("control UI session PR subscriptions", () => {
     resolveBlocked(READY);
     await oldReplace;
 
-    expect(load).toHaveBeenCalledTimes(2);
+    expect(load).toHaveBeenCalledTimes(5);
     expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
       CHANGED_EVENT,
       { sessions: { shared: { ...READY, status: "ready" } } },

--- a/src/gateway/control-ui-session-pr-subscriptions.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.ts
@@ -1,3 +1,4 @@
+import pLimit from "p-limit";
 import { CHAT_SEND_SESSION_KEY_MAX_LENGTH } from "../../packages/gateway-protocol/src/schema/primitives.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import type {
@@ -13,6 +14,7 @@ import type { ControlUiSessionPullRequestsParams } from "./control-ui-session-pr
 import type { GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
 
 const CONTROL_UI_SESSION_PR_POLL_INTERVAL_MS = 60_000;
+const CONTROL_UI_SESSION_PR_LOAD_CONCURRENCY = 4;
 
 type LoadSessionPullRequests = (
   params: ControlUiSessionPullRequestsParams,
@@ -225,30 +227,38 @@ export function createControlUiSessionPullRequestSubscriptions(
     timer.unref?.();
   };
 
+  const loadKeysInParallel = async (
+    sessionKeys: Iterable<string>,
+    loadKey: (sessionKey: string) => Promise<void>,
+  ) => {
+    const limit = pLimit(CONTROL_UI_SESSION_PR_LOAD_CONCURRENCY);
+    await Promise.all(Array.from(sessionKeys, (sessionKey) => limit(() => loadKey(sessionKey))));
+  };
+
   const pollNow = async () => {
     if (stopped) {
       return;
     }
     // One union pass owns each key once; the loader retains its failure and
     // rate-limit cache, so the poller never creates a second quota policy.
-    for (const sessionKey of watchedKeys()) {
-      if (stopped) {
-        break;
+    await loadKeysInParallel(watchedKeys(), async (sessionKey) => {
+      if (stopped || subscribersForKey(sessionKey).size === 0) {
+        return;
       }
       const snapshot = await loadSnapshot(sessionKey);
       const connIds = subscribersForKey(sessionKey);
       if (connIds.size === 0) {
-        continue;
+        return;
       }
       const hash = snapshotHash(snapshot);
       if (snapshots.get(sessionKey)?.hash === hash) {
-        continue;
+        return;
       }
       snapshots.set(sessionKey, { hash, snapshot });
-      // Publish before awaiting another key; cross-key batching can otherwise
-      // deliver an older poll result after a newer forced refresh.
+      // Publish immediately after each key resolves: cross-key batching can
+      // otherwise deliver an older poll result after a forced refresh.
       push(connIds, sessionKey, snapshot);
-    }
+    });
   };
 
   const replace = async (
@@ -285,27 +295,35 @@ export function createControlUiSessionPullRequestSubscriptions(
     pruneOrphans();
     schedulePoll();
 
+    const pendingKeys: string[] = [];
     for (const sessionKey of next) {
-      if (stopped) {
-        break;
-      }
       const previous = snapshots.get(sessionKey);
       const refresh = refreshSessionKeys.has(sessionKey);
       const cached = refresh ? undefined : previous?.snapshot;
       // A shared cached snapshot does not prove this connection received it.
-      if (cached && delivered.has(sessionKey)) {
+      if (cached) {
+        if (!delivered.has(sessionKey)) {
+          push(new Set([normalizedConnId]), sessionKey, cached);
+        }
         continue;
       }
-      const snapshot = cached ?? (await loadSnapshot(sessionKey, refresh));
+      pendingKeys.push(sessionKey);
+    }
+
+    await loadKeysInParallel(pendingKeys, async (sessionKey) => {
+      if (stopped || replacementTokens.get(normalizedConnId) !== replacementToken) {
+        return;
+      }
+      const previous = snapshots.get(sessionKey);
+      const refresh = refreshSessionKeys.has(sessionKey);
+      const snapshot = await loadSnapshot(sessionKey, refresh);
       // A later replace-set owns the connection immediately; an older async
       // initial load must never publish keys after that ownership changed.
       if (replacementTokens.get(normalizedConnId) !== replacementToken) {
         return;
       }
       const hash = snapshotHash(snapshot);
-      if (!cached) {
-        snapshots.set(sessionKey, { hash, snapshot });
-      }
+      snapshots.set(sessionKey, { hash, snapshot });
       if (refresh && previous?.hash !== hash) {
         push(subscribersForKey(sessionKey), sessionKey, snapshot);
       } else {
@@ -313,7 +331,7 @@ export function createControlUiSessionPullRequestSubscriptions(
         // delay an old cached value past a concurrent refresh.
         push(new Set([normalizedConnId]), sessionKey, snapshot);
       }
-    }
+    });
   };
 
   const unsubscribe = (connId: string) => {

--- a/src/gateway/control-ui-session-prs-local-git.ts
+++ b/src/gateway/control-ui-session-prs-local-git.ts
@@ -7,7 +7,7 @@ import {
 } from "./control-ui-session-prs-landing.js";
 import { parseGitHubRemoteUrl } from "./github-remote.js";
 
-const LOCAL_GIT_CACHE_MS = 10_000;
+const LOCAL_GIT_CACHE_MS = 75_000;
 const LOCAL_GIT_CACHE_LIMIT = 100;
 
 /** GitHub repo + branch resolved from a session's git checkout. */
@@ -51,8 +51,8 @@ function createLocalGitCache<T>() {
   };
 }
 
-// Process-local and bounded: ten seconds keeps sidebar checkout/tree facts
-// responsive; removing this freshness window respawns Git for every row.
+// Outlive the 60-second subscription poll so unchanged rows do not respawn
+// Git every cycle; explicit structural refreshes still bypass both caches.
 const cachedGitContext = createLocalGitCache<SessionPullRequestGitContext | null>();
 const cachedBranchFacts = createLocalGitCache<SessionPullRequestBranchFacts | undefined>();
 

--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -180,6 +180,20 @@ describe("loadControlUiSessionPullRequests", () => {
       },
     ]);
     expect(fetchImpl.mock.calls).toHaveLength(1);
+
+    vi.advanceTimersByTime(60_000);
+    await loadControlUiSessionPullRequests(
+      { sessionKey: "agent:main:main" },
+      { fetchImpl, resolveGitContext },
+    );
+    expect(fetchImpl.mock.calls).toHaveLength(1);
+
+    vi.advanceTimersByTime(30_001);
+    await loadControlUiSessionPullRequests(
+      { sessionKey: "agent:main:main" },
+      { fetchImpl, resolveGitContext },
+    );
+    expect(fetchImpl.mock.calls).toHaveLength(2);
   });
 
   it("marks in-flight checks pending and failed conclusions failing", async () => {
@@ -298,7 +312,7 @@ describe("loadControlUiSessionPullRequests", () => {
     expect(fresh.rateLimited).toBe(false);
 
     limited = true;
-    vi.advanceTimersByTime(61_000);
+    vi.advanceTimersByTime(91_000);
     const stale = await loadControlUiSessionPullRequests(
       { sessionKey: "agent:main:main" },
       { fetchImpl, resolveGitContext },
@@ -389,14 +403,19 @@ describe("loadControlUiSessionPullRequests", () => {
     await expect(load("/repo/other-context")).rejects.toBeInstanceOf(Error);
     expect(gitOutputImpl).toHaveBeenCalledTimes(6);
 
-    vi.advanceTimersByTime(10_001);
+    vi.advanceTimersByTime(60_000);
+    await expect(load()).rejects.toBeInstanceOf(Error);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(6);
+    expect(fetchImpl.mock.calls).toHaveLength(2);
+
+    vi.advanceTimersByTime(15_001);
     await expect(load()).rejects.toBeInstanceOf(Error);
     expect(gitOutputImpl).toHaveBeenCalledTimes(9);
-    // The longer GitHub failure cache remains independent of local Git expiry.
-    expect(fetchImpl.mock.calls).toHaveLength(1);
+    // GitHub's shorter failure backoff stays independent of local Git expiry.
+    expect(fetchImpl.mock.calls).toHaveLength(2);
   });
 
-  it("keeps normal local facts cached while forced refresh bypasses them", async () => {
+  it("caches local facts across a poll while forced refresh bypasses them", async () => {
     let pulls: Record<string, unknown>[] = [];
     const fetchImpl = routedFetch([
       { match: "/pulls?head=", response: () => githubJson(pulls) },
@@ -457,7 +476,16 @@ describe("loadControlUiSessionPullRequests", () => {
     expect(runGitImpl).toHaveBeenCalledTimes(3);
     expect(gitOutputImpl).toHaveBeenCalledTimes(6);
 
-    vi.advanceTimersByTime(10_001);
+    const githubRequests = fetchImpl.mock.calls.length;
+    vi.advanceTimersByTime(60_000);
+    additions = 5;
+    expect((await load("agent:main:a")).branch?.additions).toBe(4);
+    expect(resolveBranchLanding).toHaveBeenCalledTimes(3);
+    expect(runGitImpl).toHaveBeenCalledTimes(3);
+    expect(gitOutputImpl).toHaveBeenCalledTimes(6);
+    expect(fetchImpl.mock.calls).toHaveLength(githubRequests);
+
+    vi.advanceTimersByTime(15_001);
     additions = 5;
     expect((await load("agent:main:a")).branch?.additions).toBe(5);
     expect(resolveBranchLanding).toHaveBeenCalledTimes(4);

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -35,7 +35,7 @@ import {
 import { resolveGitHubForkParent } from "./github-repository-target.js";
 import { loadGatewaySessionEntryReadOnly } from "./session-utils.js";
 
-const SUCCESS_CACHE_MS = 60_000;
+const SUCCESS_CACHE_MS = 90_000;
 // Back off refetches while GitHub reports quota exhaustion; the UI keeps
 // showing the last-known chips with the stale warning during this window.
 const RATE_LIMIT_CACHE_MS = 5 * 60_000;
@@ -611,8 +611,8 @@ export async function loadControlUiSessionPullRequests(
   if (!context) {
     return { pullRequests: [], rateLimited: false };
   }
-  // Normal polling keeps the short local-Git TTL; forced structural refreshes
-  // must observe the replacement checkout before publishing its branch facts.
+  // Normal polling reuses local Git facts across a poll cycle; forced
+  // structural refreshes observe the replacement checkout immediately.
   const { mergedHeads, ...snapshot } = await cachedBranchPullRequests(
     context,
     deps,

--- a/src/gateway/server-methods/chat-message-get-handler.ts
+++ b/src/gateway/server-methods/chat-message-get-handler.ts
@@ -13,10 +13,8 @@ import {
 } from "../chat-display-projection.js";
 import { resolveCurrentUserProfileDisplay } from "../current-user-profile-display.js";
 import { MAX_PAYLOAD_BYTES } from "../server-constants.js";
-import {
-  readSessionMessageByIdAsync,
-  readSessionMessagesAsync,
-} from "../session-transcript-readers.js";
+import { readSessionMessagesAroundIdWithStatsAsync } from "../session-transcript-anchor-reader.js";
+import { readSessionMessageByIdAsync } from "../session-transcript-readers.js";
 import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
 import { readChatHistoryMessageId } from "./chat-history-pages.js";
 import { resolveRequestedChatAgentId, validateChatSelectedAgent } from "./chat-origin-routing.js";
@@ -37,7 +35,9 @@ async function isChatMessageIdVisibleAfterHistoryFilters(params: {
   if (params.sessionStartedAt === undefined) {
     return true;
   }
-  const messages = await readSessionMessagesAsync(
+  // The anchored reader includes the immediately preceding row, which is the
+  // complete context needed to hide a stale announce and its paired reply.
+  const { messages } = await readSessionMessagesAroundIdWithStatsAsync(
     {
       agentId: params.agentId,
       sessionEntry: params.sessionEntry,
@@ -46,8 +46,8 @@ async function isChatMessageIdVisibleAfterHistoryFilters(params: {
       storePath: params.storePath,
     },
     {
-      mode: "full",
-      reason: "chat.message.get visibility",
+      maxMessages: 1,
+      messageId: params.messageId,
       ...(params.allowResetArchiveFallback === true ? { allowResetArchiveFallback: true } : {}),
     },
   );

--- a/src/gateway/server-methods/control-ui.test.ts
+++ b/src/gateway/server-methods/control-ui.test.ts
@@ -229,6 +229,31 @@ describe("controlUi.sessionPullRequests.subscribe", () => {
     expect(respond).toHaveBeenCalledWith(true, { subscribed: true }, undefined);
   });
 
+  it("acknowledges a subscription before its cold snapshots finish loading", async () => {
+    let finishHydration!: () => void;
+    const hydration = new Promise<void>((resolve) => {
+      finishHydration = resolve;
+    });
+    const replace = vi.fn(() => hydration);
+    const handlers = createControlUiHandlers(vi.fn());
+    const respond = vi.fn<RespondFn>();
+
+    const request = expectDefined(
+      handlers["controlUi.sessionPullRequests.subscribe"],
+      'handlers["controlUi.sessionPullRequests.subscribe"] test invariant',
+    )(
+      requestOptions({ sessionKeys: ["agent:main:cold"] }, respond, {
+        client: { connId: "conn-control-ui" },
+        context: { controlUiSessionPullRequests: { replace } },
+      }),
+    );
+
+    expect(replace).toHaveBeenCalledWith("conn-control-ui", ["agent:main:cold"]);
+    expect(respond).toHaveBeenCalledWith(true, { subscribed: true }, undefined);
+    finishHydration();
+    await request;
+  });
+
   it("accepts an empty replace-set as unsubscribe", async () => {
     const replace = vi.fn().mockResolvedValue(undefined);
     const handlers = createControlUiHandlers(vi.fn());

--- a/src/gateway/server-methods/control-ui.ts
+++ b/src/gateway/server-methods/control-ui.ts
@@ -188,7 +188,7 @@ export function createControlUiHandlers(
         );
       }
     },
-    "controlUi.sessionPullRequests.subscribe": async ({ params, client, context, respond }) => {
+    "controlUi.sessionPullRequests.subscribe": ({ params, client, context, respond }) => {
       const parsed = parseControlUiSessionPullRequestsSubscribeParams(params);
       if (!parsed) {
         respond(
@@ -212,9 +212,9 @@ export function createControlUiHandlers(
         return;
       }
       if (parsed.refreshSessionKeys.length > 0) {
-        await subscriptions.replace(connId, parsed.sessionKeys, new Set(parsed.refreshSessionKeys));
+        void subscriptions.replace(connId, parsed.sessionKeys, new Set(parsed.refreshSessionKeys));
       } else {
-        await subscriptions.replace(connId, parsed.sessionKeys);
+        void subscriptions.replace(connId, parsed.sessionKeys);
       }
       respond(true, { subscribed: parsed.sessionKeys.length > 0 }, undefined);
     },

--- a/src/gateway/server-methods/sessions-files.touched-files.test.ts
+++ b/src/gateway/server-methods/sessions-files.touched-files.test.ts
@@ -155,6 +155,40 @@ describe("sessions.files touched-file folds", () => {
     });
   });
 
+  it("retains incremental cursors across more than 16 concurrently viewed sessions", async () => {
+    hoisted.resolveAgentWorkspaceDir.mockReturnValue(undefined);
+    const storePath = path.join(workspaceRoot, "visible-sessions.sqlite");
+    hoisted.loadSessionEntry.mockImplementation((sessionKey: string) => {
+      const sessionId = sessionKey.split(":").at(-1)!;
+      return {
+        agentId: "main",
+        canonicalKey: sessionKey,
+        cfg: {},
+        storePath,
+        entry: { sessionId, sessionFile: `sqlite:main:${sessionId}:${storePath}` },
+      };
+    });
+    hoisted.readSessionTranscriptVisibleMessageDeltaCore.mockImplementation((scope) => ({
+      kind: "page",
+      cursor: `${scope.sessionId}-cursor`,
+      events: [],
+      hasMore: false,
+      serializedBytes: 100,
+    }));
+
+    const sessionKeys = Array.from({ length: 24 }, (_, index) => `agent:main:visible-${index}`);
+    for (const sessionKey of sessionKeys) {
+      expectOkPayload(await invokeSessionFilesHandler("sessions.files.list", { sessionKey }));
+    }
+    expectOkPayload(
+      await invokeSessionFilesHandler("sessions.files.list", { sessionKey: sessionKeys[0] }),
+    );
+
+    expect(hoisted.readSessionTranscriptVisibleMessageDeltaCore.mock.lastCall?.[1]).toMatchObject({
+      cursor: "visible-0-cursor",
+    });
+  });
+
   it("yields between SQLite pages and shares one concurrent fold per session", async () => {
     useSqliteSession(hoisted.loadSessionEntry, workspaceRoot, "sess-touched-singleflight");
     let otherWorkRan = false;

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { resolveToCwd as resolveSessionToolPathToCwd } from "../../agents/sessions/tools/path-utils.js";
-import { runGit } from "../../agents/worktrees/git.js";
+import { insideGitCheckout } from "../../agents/worktrees/git.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { FsSafeError } from "../../infra/fs-safe.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
@@ -48,6 +48,7 @@ import {
   decodeUtf8Strict,
   listWorkspacePath,
   normalizeRelativePath,
+  openWorkspaceRoot,
   readWorkspaceFile,
   readWorkspaceFilePrefix,
   resolveWorkspacePath,
@@ -60,6 +61,7 @@ import {
   workspaceStatKind,
   type WorkspaceDirEntry,
   type WorkspaceFileUpdateResult,
+  type WorkspaceRoot,
 } from "./workspace-fs.js";
 
 type FileKind = "modified" | "read";
@@ -85,7 +87,9 @@ const MAX_PREVIEW_BYTES = WORKSPACE_PREVIEW_MAX_BYTES;
 const MAX_BROWSER_ENTRIES = 250;
 const MAX_SEARCH_ENTRIES = 500;
 const MAX_SEARCH_VISITED_ENTRIES = 5_000;
-const TOUCHED_FILES_CACHE_LIMIT = 16;
+// Control UI requests fan out per visible session; keep enough folds to avoid
+// eviction and full-transcript reparsing across realistic concurrent viewers.
+const TOUCHED_FILES_CACHE_LIMIT = 256;
 const TOUCHED_FILES_DELTA_MAX_MESSAGES = 1_000;
 const TOUCHED_FILES_DELTA_MAX_BYTES = 1_000_000;
 // Matches file-type's documented default buffer sample while keeping metadata
@@ -459,7 +463,7 @@ async function toSessionFileEntry(
   touched: TouchedFile,
   root: string | undefined,
   fileRoot: string | undefined,
-  opts: { includeContent?: boolean } = {},
+  opts: { includeContent?: boolean; workspaceRoot?: WorkspaceRoot } = {},
 ): Promise<SessionFileEntry> {
   const resolved = resolveTouchedFilePath({ root, fileRoot, filePath: touched.path });
   const base = {
@@ -471,7 +475,7 @@ async function toSessionFileEntry(
     return { ...base, missing: true };
   }
   const browserPath = toDisplayPath(root!, resolved);
-  const stat = await statWorkspacePath(root!, browserPath);
+  const stat = await statWorkspacePath(opts.workspaceRoot ?? root!, browserPath);
   if (!stat || workspaceStatKind(stat) !== "file") {
     return { ...base, missing: true };
   }
@@ -603,7 +607,7 @@ function matchesSearch(entryPath: string, name: string, query: string): boolean 
 }
 
 async function searchBrowserEntries(params: {
-  root: string;
+  root: string | WorkspaceRoot;
   query: string;
   relevance: ReadonlyMap<string, SessionFileRelevance>;
 }): Promise<{ entries: SessionFileBrowserEntry[]; truncated?: boolean }> {
@@ -648,6 +652,7 @@ async function searchBrowserEntries(params: {
 
 async function buildBrowserResult(params: {
   root: string | undefined;
+  workspaceRoot?: WorkspaceRoot;
   fileRoot: string | undefined;
   path?: string;
   search?: string;
@@ -660,7 +665,7 @@ async function buildBrowserResult(params: {
   const relevance = buildSessionRelevanceMap(params.files, params.root, params.fileRoot);
   if (search) {
     const result = await searchBrowserEntries({
-      root: params.root,
+      root: params.workspaceRoot ?? params.root,
       query: search,
       relevance,
     });
@@ -676,11 +681,11 @@ async function buildBrowserResult(params: {
   if (!resolved) {
     return undefined;
   }
-  const stat = await statWorkspacePath(params.root, browserPath);
+  const stat = await statWorkspacePath(params.workspaceRoot ?? params.root, browserPath);
   if (!stat || workspaceStatKind(stat) !== "directory") {
     return undefined;
   }
-  const dirents = await listWorkspacePath(params.root, browserPath);
+  const dirents = await listWorkspacePath(params.workspaceRoot ?? params.root, browserPath);
   if (!dirents) {
     return undefined;
   }
@@ -752,25 +757,21 @@ async function buildListResult(params: {
 }> {
   const loaded = await loadSessionFiles(params);
   const root = loaded.root;
-  let gitCheckout: boolean | undefined;
-  if (loaded.diffCwd) {
-    try {
-      const result = await runGit(loaded.diffCwd, ["rev-parse", "--show-toplevel"]);
-      gitCheckout = result.code === 0 && Boolean(result.stdout.trim());
-    } catch {
-      gitCheckout = false;
-    }
-  }
+  const gitCheckout = loaded.diffCwd ? insideGitCheckout(loaded.diffCwd) : undefined;
+  const workspaceRoot = root ? await openWorkspaceRoot(root) : undefined;
   const workspaceFiles = root
     ? loaded.files.filter((file) =>
         Boolean(resolveTouchedFilePath({ root, fileRoot: loaded.fileRoot, filePath: file.path })),
       )
     : loaded.files;
   const files = await Promise.all(
-    workspaceFiles.map((file) => toSessionFileEntry(file, loaded.root, loaded.fileRoot)),
+    workspaceFiles.map((file) =>
+      toSessionFileEntry(file, loaded.root, loaded.fileRoot, { workspaceRoot }),
+    ),
   );
   const browser = await buildBrowserResult({
     root,
+    workspaceRoot,
     fileRoot: loaded.fileRoot,
     path: params.path,
     search: params.search,

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -1,4 +1,5 @@
 // Read-only session queries.
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
@@ -536,21 +537,16 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatErrorMessage(error)));
     }
   },
-  "sessions.preview": ({ params, respond, context, client }) => {
+  "sessions.preview": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateSessionsPreviewParams, "sessions.preview", respond)) {
       return;
     }
-    const p = params;
-    const keys = (Array.isArray(p.keys) ? p.keys : [])
+    const keys = (Array.isArray(params.keys) ? params.keys : [])
       .map((key) => normalizeOptionalString(key ?? ""))
       .filter((key): key is string => Boolean(key))
       .slice(0, 64);
-    const limit =
-      typeof p.limit === "number" && Number.isFinite(p.limit) ? Math.max(1, p.limit) : 12;
-    const maxChars =
-      typeof p.maxChars === "number" && Number.isFinite(p.maxChars)
-        ? Math.max(20, p.maxChars)
-        : 240;
+    const limit = params.limit ?? 12;
+    const maxChars = params.maxChars ?? 240;
 
     if (keys.length === 0) {
       respond(true, { ts: Date.now(), previews: [] } satisfies SessionsPreviewResult, undefined);
@@ -565,6 +561,9 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
     const previews: SessionsPreviewEntry[] = [];
 
     for (const key of keys) {
+      if (previews.length > 0) {
+        await yieldToEventLoop();
+      }
       const requestedAgent = resolveRequestedGlobalAgentId(cfg, key);
       if (!requestedAgent.ok) {
         respond(false, undefined, requestedAgent.error);

--- a/src/gateway/server-methods/workspace-fs.ts
+++ b/src/gateway/server-methods/workspace-fs.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { readFileWindowFully } from "../../infra/file-read.js";
 import { root as fsSafeRoot, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
 
-type WorkspaceRoot = Awaited<ReturnType<typeof fsSafeRoot>>;
+export type WorkspaceRoot = Awaited<ReturnType<typeof fsSafeRoot>>;
 type WorkspacePathStat = Awaited<ReturnType<WorkspaceRoot["stat"]>>;
 export type WorkspaceDirEntry = WorkspacePathStat & { name: string };
 type WorkspaceFileReadResult = ReadResult & { canonicalPath: string };
@@ -17,7 +17,7 @@ export const WORKSPACE_PREVIEW_MAX_BYTES = 256 * 1024;
 
 let workspaceFileUpdateQueue: Promise<void> = Promise.resolve();
 
-async function openWorkspaceRoot(rootDir: string): Promise<WorkspaceRoot | undefined> {
+export async function openWorkspaceRoot(rootDir: string): Promise<WorkspaceRoot | undefined> {
   try {
     return await fsSafeRoot(rootDir, {
       hardlinks: "reject",
@@ -31,10 +31,10 @@ async function openWorkspaceRoot(rootDir: string): Promise<WorkspaceRoot | undef
 }
 
 export async function statWorkspacePath(
-  rootDir: string,
+  rootDir: string | WorkspaceRoot,
   browserPath: string,
 ): Promise<WorkspacePathStat | undefined> {
-  const workspaceRoot = await openWorkspaceRoot(rootDir);
+  const workspaceRoot = typeof rootDir === "string" ? await openWorkspaceRoot(rootDir) : rootDir;
   if (!workspaceRoot) {
     return undefined;
   }
@@ -46,10 +46,10 @@ export async function statWorkspacePath(
 }
 
 export async function listWorkspacePath(
-  rootDir: string,
+  rootDir: string | WorkspaceRoot,
   browserPath: string,
 ): Promise<WorkspaceDirEntry[] | undefined> {
-  const workspaceRoot = await openWorkspaceRoot(rootDir);
+  const workspaceRoot = typeof rootDir === "string" ? await openWorkspaceRoot(rootDir) : rootDir;
   if (!workspaceRoot) {
     return undefined;
   }

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -6608,6 +6608,10 @@ describe("gateway server chat", () => {
       expect(hidden.ok).toBe(false);
       expect(hidden.unavailableReason).toBe("not_found");
 
+      const announce = await fetchChatMessage(ws, makeMainMessageParams("msg-announce"));
+      expect(announce.ok).toBe(false);
+      expect(announce.unavailableReason).toBe("not_found");
+
       const visible = await fetchChatMessage(ws, makeMainMessageParams("msg-visible-assistant"));
       expect(visible.ok).toBe(true);
       expect(JSON.stringify(visible.message)).toContain("visible reply");

--- a/src/gateway/server.sessions.preview-resolve.test.ts
+++ b/src/gateway/server.sessions.preview-resolve.test.ts
@@ -1,7 +1,9 @@
 /**
  * Gateway session preview resolve tests.
  */
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
+import * as sessionHistoryEvents from "../config/sessions/session-accessor.sqlite-history-events.js";
 import type { GatewayClient } from "./server-methods/types.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
 import { rpcReq, writeSessionStore } from "./test-helpers.js";
@@ -13,6 +15,23 @@ import {
 } from "./test/server-sessions.test-helpers.js";
 
 const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
+
+async function seedPreviewTail(
+  sessionId: string,
+  messages: Array<{ role: string; content: string }>,
+): Promise<void> {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: { "agent:main:main": sessionStoreEntry(sessionId) },
+  });
+  await sessionAccessor.persistSessionTranscriptTurn(
+    { agentId: "main", sessionId, sessionKey: "agent:main:main", storePath },
+    {
+      messages: messages.map((message) => ({ message })),
+      touchSessionEntry: false,
+    },
+  );
+}
 
 function identifiedClient(profileId: string, scopes: string[] = ["operator.read"]): GatewayClient {
   return {
@@ -111,6 +130,74 @@ test("sessions.preview honors maxChars up to the shared cap", async () => {
   expect(capped.payload?.previews[0]?.items).toEqual([
     { role: "assistant", text: `${"a".repeat(maxChars - 3)}...` },
   ]);
+});
+
+test("sessions.preview reads only a bounded tail from a large transcript", async () => {
+  await seedPreviewTail(
+    "sess-preview-bounded-tail",
+    Array.from({ length: 1024 }, (_, index) => ({
+      role: "assistant",
+      content: `message ${String(index)}`,
+    })),
+  );
+  const fullRead = vi.spyOn(sessionAccessor, "readSessionTranscriptMessageEvents");
+  const tailRead = vi.spyOn(sessionHistoryEvents, "readRecentSessionTranscriptHistoryEvents");
+
+  try {
+    const preview = await directSessionReq<{
+      previews: Array<{ items: Array<{ role: string; text: string }> }>;
+    }>("sessions.preview", { keys: ["main"], limit: 12, maxChars: 120 });
+
+    expect(preview.ok).toBe(true);
+    expect(preview.payload?.previews[0]?.items).toEqual(
+      Array.from({ length: 12 }, (_, index) => ({
+        role: "assistant",
+        text: `message ${String(1012 + index)}`,
+      })),
+    );
+    expect(fullRead).not.toHaveBeenCalled();
+    expect(tailRead).toHaveBeenCalledOnce();
+    expect(tailRead.mock.results[0]).toMatchObject({
+      type: "return",
+      value: { events: { length: 64 }, totalMessages: 1024 },
+    });
+  } finally {
+    fullRead.mockRestore();
+    tailRead.mockRestore();
+  }
+});
+
+test("sessions.preview widens its bounded tail past filtered tool-result rows", async () => {
+  await seedPreviewTail("sess-preview-sparse-tail", [
+    ...Array.from({ length: 12 }, (_, index) => ({
+      role: "assistant",
+      content: `visible ${String(index)}`,
+    })),
+    ...Array.from({ length: 320 }, (_, index) => ({
+      role: "toolResult",
+      content: `tool ${String(index)}`,
+    })),
+  ]);
+  const tailRead = vi.spyOn(sessionHistoryEvents, "readRecentSessionTranscriptHistoryEvents");
+
+  try {
+    const preview = await directSessionReq<{
+      previews: Array<{ items: Array<{ role: string; text: string }> }>;
+    }>("sessions.preview", { keys: ["main"], limit: 12, maxChars: 120 });
+
+    expect(preview.payload?.previews[0]?.items).toEqual(
+      Array.from({ length: 12 }, (_, index) => ({
+        role: "assistant",
+        text: `visible ${String(index)}`,
+      })),
+    );
+    expect(tailRead.mock.calls.map(([, options]) => options)).toEqual([
+      { maxBytes: 1024 * 1024, maxLines: 64, maxMessages: 64 },
+      { maxBytes: 8 * 1024 * 1024, maxLines: 1024, maxMessages: 1024 },
+    ]);
+  } finally {
+    tailRead.mockRestore();
+  }
 });
 
 test("sessions.resolve by sessionId ignores fuzzy-search list limits and returns the exact match", async () => {

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -252,7 +252,33 @@ function buildSqlitePreviewItems(
   maxItems: number,
   maxChars: number,
 ): SessionPreviewItem[] {
-  return buildSessionPreviewItems(readSqliteMessagesSync(target), maxItems, maxChars);
+  // Tool-only and suppressed rows need headroom; cap even the recovery scan so previews
+  // never materialize an entire large transcript or monopolize the Gateway thread.
+  const initialMaxEvents = Math.min(256, Math.max(64, Math.ceil(maxItems) * 4));
+  const readPreviewPage = (maxEvents: number, maxBytes: number) => {
+    const page = readRecentSessionTranscriptHistoryEvents(toTranscriptReadScope(target), {
+      maxBytes,
+      maxLines: maxEvents,
+      maxMessages: maxEvents,
+    });
+    return {
+      items: buildSessionPreviewItems(
+        extractMessageRecordsFromEventEntries(page.events).map(sqliteRecordMessageWithSeq),
+        maxItems,
+        maxChars,
+      ),
+      hasOlderEvents: page.totalMessages > page.events.length,
+    };
+  };
+  const preview = readPreviewPage(initialMaxEvents, 1024 * 1024);
+  if (preview.items.length >= maxItems || !preview.hasOlderEvents) {
+    return preview.items;
+  }
+  const recoveryMaxEvents = Math.min(
+    2048,
+    Math.max(1024, initialMaxEvents * 8, Math.ceil(maxItems)),
+  );
+  return readPreviewPage(recoveryMaxEvents, 8 * 1024 * 1024).items;
 }
 
 /** Reads display messages asynchronously through the reader seam. */

--- a/src/skills/loading/agents-directory.test.ts
+++ b/src/skills/loading/agents-directory.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { setTestEnvValue } from "../../test-utils/env.js";
+import { bumpSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import {
   restoreMockSkillsHomeEnv,
@@ -73,6 +74,7 @@ describe("buildWorkspaceSkillsPrompt — .agents/skills/ directories", () => {
       name: "shared-skill",
       description: "Workspace version",
     });
+    bumpSkillsSnapshotVersion({ workspaceDir, reason: "watch" });
 
     const prompt2 = buildSkillsPrompt(workspaceDir, managedDir, bundledDir);
     expect(prompt2).toContain("Workspace version");
@@ -104,6 +106,7 @@ describe("buildWorkspaceSkillsPrompt — .agents/skills/ directories", () => {
       name: "shared-skill",
       description: "Project agents version",
     });
+    bumpSkillsSnapshotVersion({ workspaceDir, reason: "watch" });
 
     const prompt2 = buildSkillsPrompt(workspaceDir, managedDir, bundledDir);
     expect(prompt2).toContain("Project agents version");

--- a/src/skills/loading/workspace-precedence.test.ts
+++ b/src/skills/loading/workspace-precedence.test.ts
@@ -6,6 +6,7 @@ import { resetLogger, setLoggerOverride } from "../../logging/logger.js";
 import { loggingState } from "../../logging/state.js";
 import { withEnv } from "../../test-utils/env.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
+import { bumpSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
 import type { OpenClawSkillMetadata, SkillEntry } from "../types.js";
 import { createSyntheticSourceInfo } from "./skill-contract.js";
@@ -174,13 +175,14 @@ describe("buildWorkspaceSkillsPrompt", () => {
     });
     const warn = captureJsonWarningLogger();
 
-    const entries = loadMergedWorkspaceSkills({
+    const loadOptions = {
       agentWorkspaceDir,
       executionSkillsDir: path.join(executionWorkspaceDir, "skills"),
       managedSkillsDir: path.join(agentWorkspaceDir, ".managed"),
       bundledSkillsDir: "",
       pluginSkillsDir: path.join(agentWorkspaceDir, ".plugin-skills"),
-    });
+    };
+    const entries = loadMergedWorkspaceSkills(loadOptions);
     const warning = JSON.parse(String(warn.mock.calls[0]?.[0])) as Record<string, unknown>;
 
     expect(entries.find((entry) => entry.skill.name === "demo-skill")?.skill.description).toBe(
@@ -192,6 +194,13 @@ describe("buildWorkspaceSkillsPrompt", () => {
       winnerPath: workspaceSkillFile,
       loserPath: executionSkillFile,
     });
+
+    loadMergedWorkspaceSkills(loadOptions);
+    expect(warn).toHaveBeenCalledOnce();
+
+    bumpSkillsSnapshotVersion({ workspaceDir: agentWorkspaceDir, reason: "watch" });
+    loadMergedWorkspaceSkills(loadOptions);
+    expect(warn).toHaveBeenCalledTimes(2);
   });
 
   it("does not report execution-directory collisions for the same canonical skill file", async () => {

--- a/src/skills/loading/workspace-skill-loader.test.ts
+++ b/src/skills/loading/workspace-skill-loader.test.ts
@@ -13,6 +13,7 @@ import type {
   PluginManifestRegistry,
 } from "../../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
+import { bumpSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { writeSkill, writeWorkspaceSkills } from "../test-support/e2e-test-helpers.js";
 import {
   restoreMockSkillsHomeEnv,
@@ -226,6 +227,60 @@ async function setupWorkspaceSkillPlugin() {
 }
 
 describe("loadWorkspaceSkills", () => {
+  it("reuses unfiltered skill discovery until the workspace snapshot version changes", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "cached-skill"),
+      name: "cached-skill",
+      description: "Cached skill",
+    });
+    const config: OpenClawConfig = {};
+    const options = {
+      config,
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: "",
+      pluginSkillsDir: path.join(workspaceDir, ".plugin-skills"),
+      pluginMetadataSnapshot: createWorkspacePluginMetadataSnapshot({
+        workspaceDir,
+        config,
+        manifestRegistry: createWorkspacePluginRegistry(workspaceDir),
+      }),
+    };
+    const directoryReads = vi.spyOn(fsSync, "readdirSync");
+
+    try {
+      const first = loadWorkspaceSkills(workspaceDir, options);
+      const initialReadCount = directoryReads.mock.calls.length;
+      expect(initialReadCount).toBeGreaterThan(0);
+
+      const filtered = loadWorkspaceSkills(workspaceDir, {
+        ...options,
+        skillFilter: ["cached-skill"],
+      });
+      expect(filtered[0]).toBe(first[0]);
+      expect(directoryReads).toHaveBeenCalledTimes(initialReadCount);
+
+      await writeSkill({
+        dir: path.join(workspaceDir, "skills", "fresh-skill"),
+        name: "fresh-skill",
+        description: "Fresh skill",
+      });
+      expect(loadWorkspaceSkills(workspaceDir, options).map((entry) => entry.skill.name)).toEqual([
+        "cached-skill",
+      ]);
+      expect(directoryReads).toHaveBeenCalledTimes(initialReadCount);
+
+      bumpSkillsSnapshotVersion({ workspaceDir, reason: "watch" });
+      expect(loadWorkspaceSkills(workspaceDir, options).map((entry) => entry.skill.name)).toEqual([
+        "cached-skill",
+        "fresh-skill",
+      ]);
+      expect(directoryReads.mock.calls.length).toBeGreaterThan(initialReadCount);
+    } finally {
+      directoryReads.mockRestore();
+    }
+  });
+
   it("filters plugin-shipped skills through plugin config", async () => {
     const { workspaceDir, managedDir } = await setupWorkspaceSkillPlugin();
 

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -7,6 +7,7 @@ import { tryResolveAmbientOwnerAgentId } from "../../agents/agent-scope-config.j
 import { canonicalizePath } from "../../agents/utils/paths.js";
 import { isDefaultStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
@@ -17,7 +18,9 @@ import {
   resolveEffectiveAgentSkillFilter,
 } from "../discovery/agent-filter.js";
 import { normalizeSkillFilter } from "../discovery/filter.js";
+import { getSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { mergeRemoteNodeSkillEntries } from "../runtime/remote-skills.js";
+import { fingerprintSkillSnapshotConfig } from "../runtime/snapshot-config-fingerprint.js";
 import type {
   OpenClawSkillMetadata,
   ParsedSkillFrontmatter,
@@ -54,6 +57,9 @@ const skillsLogger = createSubsystemLogger("skills");
 const CUSTODIAN_SKILLS_DIR_NAME = "custodian-skills";
 const SKILL_SOURCE_ORIGIN_RELATIVE_PATH = path.join(".openclaw", "source-origin.json");
 const MAX_SKILL_SOURCE_ORIGIN_BYTES = 16 * 1024;
+const MAX_SKILL_ENTRY_CACHE_SIZE = 64;
+const skillEntryCache = new Map<string, SkillEntry[]>();
+const reportedSkillCollisions = new Map<string, true>();
 
 type LoadedSkillRecord = {
   skill: Skill;
@@ -110,13 +116,27 @@ function warnInvalidSkill(source: string, diagnostic: LocalSkillLoadDiagnostic):
 
 // Shared by both merge paths so a dropped skill is never silent: the by-name merge in
 // loadSkillEntries and the execution-directory filter in loadMergedWorkspaceSkills.
-function warnSkillPrecedenceCollision(winner: Skill, loser: Skill): void {
+function warnSkillPrecedenceCollision(winner: Skill, loser: Skill, workspaceDir: string): void {
+  const collisionKey = JSON.stringify([
+    workspaceDir,
+    getSkillsSnapshotVersion(workspaceDir),
+    winner.name,
+    winner.source,
+    winner.filePath,
+    loser.source,
+    loser.filePath,
+  ]);
+  if (reportedSkillCollisions.has(collisionKey)) {
+    return;
+  }
   // One file reachable through two roots is not a collision. normalizeWorkspaceSkillRoots only
   // rejects the literal <agentWorkspaceDir>/skills path, so a symlinked execution dir still
   // arrives here with both sides naming the same skill.
   if (canonicalizePath(winner.filePath) === canonicalizePath(loser.filePath)) {
     return;
   }
+  reportedSkillCollisions.set(collisionKey, true);
+  pruneMapToMaxSize(reportedSkillCollisions, MAX_SKILL_ENTRY_CACHE_SIZE * 4);
   const collisionName = winner.name.slice(0, 128);
   skillsLogger.warn("Skill precedence collision resolved.", {
     skill: collisionName,
@@ -348,14 +368,44 @@ function loadSkillEntries(
     pluginMetadataSnapshot?: PluginMetadataSnapshot;
   },
 ): SkillEntry[] {
+  const workspaceOnly = opts?.workspaceOnly === true;
+  const workspaceSkillsDir = opts?.workspaceSkillsDir ?? path.resolve(workspaceDir, "skills");
+  const configuredCustodianAgentId = opts?.config
+    ? tryResolveAmbientOwnerAgentId(opts.config)
+    : undefined;
+  const custodianAgentId =
+    !workspaceOnly &&
+    opts?.agentId &&
+    configuredCustodianAgentId &&
+    normalizeAgentId(opts.agentId) === configuredCustodianAgentId
+      ? configuredCustodianAgentId
+      : undefined;
+  const osHomeDir = resolveSkillsUserHomeDir();
+  // Snapshot versions are the watcher-owned invalidation boundary; cache hits must do no IO.
+  const cacheKey = JSON.stringify([
+    workspaceDir,
+    workspaceSkillsDir,
+    workspaceOnly,
+    custodianAgentId,
+    opts?.managedSkillsDir,
+    opts?.bundledSkillsDir,
+    opts?.pluginSkillsDir,
+    opts?.includeArchived === true,
+    opts?.config ? fingerprintSkillSnapshotConfig(opts.config) : undefined,
+    osHomeDir,
+    process.env.OPENCLAW_STATE_DIR,
+    getSkillsSnapshotVersion(workspaceDir),
+  ]);
+  const cachedEntries = skillEntryCache.get(cacheKey);
+  if (cachedEntries) {
+    return cachedEntries;
+  }
+
   const limits = resolveSkillDiscoveryLimits(opts?.config);
   const allowedSymlinkTargetRealPaths = resolveAllowedSkillSymlinkTargetRealPaths(opts?.config);
   const loadSkills = (params: { dir: string; source: string }): LoadedSkillRecord[] =>
     loadDiscoveredSkillRecords({ ...params, limits, allowedSymlinkTargetRealPaths });
-
-  const workspaceOnly = opts?.workspaceOnly === true;
   const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
-  const workspaceSkillsDir = opts?.workspaceSkillsDir ?? path.resolve(workspaceDir, "skills");
   const bundledSkillsDir = workspaceOnly
     ? undefined
     : (opts?.bundledSkillsDir ?? resolveBundledSkillsDir());
@@ -377,12 +427,8 @@ function loadSkillEntries(
   const bundledSkills = bundledSkillsDir
     ? loadSkills({ dir: bundledSkillsDir, source: "openclaw-bundled" })
     : [];
-  const custodianAgentId = opts?.config ? tryResolveAmbientOwnerAgentId(opts.config) : undefined;
   const custodianSkillsDir =
-    bundledSkillsDir &&
-    opts?.agentId &&
-    custodianAgentId &&
-    normalizeAgentId(opts.agentId) === custodianAgentId
+    bundledSkillsDir && custodianAgentId
       ? path.join(path.dirname(bundledSkillsDir), CUSTODIAN_SKILLS_DIR_NAME)
       : undefined;
   const custodianSkills = custodianSkillsDir
@@ -402,7 +448,6 @@ function loadSkillEntries(
   const managedSkills = workspaceOnly
     ? []
     : loadSkills({ dir: managedSkillsDir, source: "openclaw-managed" });
-  const osHomeDir = resolveSkillsUserHomeDir();
   const personalAgentsSkillsDir = osHomeDir
     ? path.resolve(osHomeDir, ".agents", "skills")
     : path.resolve(".agents", "skills");
@@ -424,7 +469,7 @@ function loadSkillEntries(
     }
     const replaced = merged.get(record.skill.name);
     if (replaced) {
-      warnSkillPrecedenceCollision(record.skill, replaced.skill);
+      warnSkillPrecedenceCollision(record.skill, replaced.skill, workspaceDir);
     }
     merged.set(record.skill.name, record);
   };
@@ -454,7 +499,7 @@ function loadSkillEntries(
     mergeRecord(record);
   }
 
-  return Array.from(merged.values())
+  const entries = Array.from(merged.values())
     .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name, "en"))
     .map((record) => {
       const skill = record.skill;
@@ -486,6 +531,9 @@ function loadSkillEntries(
       }
       return entry;
     });
+  skillEntryCache.set(cacheKey, entries);
+  pruneMapToMaxSize(skillEntryCache, MAX_SKILL_ENTRY_CACHE_SIZE);
+  return entries;
 }
 
 function filterArchivedSkillEntries(entries: SkillEntry[]): SkillEntry[] {
@@ -589,7 +637,7 @@ export function loadMergedWorkspaceSkills(
     if (!agentEntry) {
       return true;
     }
-    warnSkillPrecedenceCollision(agentEntry.skill, entry.skill);
+    warnSkillPrecedenceCollision(agentEntry.skill, entry.skill, agentWorkspaceDir);
     return false;
   });
   const effectiveSkillFilter = resolveEffectiveWorkspaceSkillFilter(params);

--- a/src/skills/runtime/session-snapshot.test.ts
+++ b/src/skills/runtime/session-snapshot.test.ts
@@ -94,6 +94,28 @@ describe("resolveReusableWorkspaceSkillSnapshot", () => {
     );
   });
 
+  it("reuses complete cached snapshots for fresh sessions until the snapshot version changes", () => {
+    buildWorkspaceSkillSnapshotMock.mockReturnValue({
+      prompt: "cached skills prompt",
+      skills: [{ name: "cached-skill" }],
+      resolvedSkills: [{ name: "cached-skill" }],
+    });
+    const params = { workspaceDir: TEST_WORKSPACE_DIR, config: {} };
+
+    const first = resolveReusableWorkspaceSkillSnapshot(params);
+    const second = resolveReusableWorkspaceSkillSnapshot(params);
+
+    expect(second.snapshot).toBe(first.snapshot);
+    expect(second.snapshot.prompt).toBe("cached skills prompt");
+    expect(second.snapshot.skills).toEqual([{ name: "cached-skill" }]);
+    expect(second.snapshot.resolvedSkills).toEqual([{ name: "cached-skill" }]);
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledOnce();
+
+    getSkillsSnapshotVersionMock.mockReturnValue(2);
+    resolveReusableWorkspaceSkillSnapshot(params);
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(2);
+  });
+
   it("reuses cached resolvedSkills across calls with the same workspace, version, and filter", () => {
     const snapshot = strippedSnapshot();
 

--- a/src/skills/runtime/session-snapshot.ts
+++ b/src/skills/runtime/session-snapshot.ts
@@ -16,10 +16,9 @@ import { ensureSkillsWatcher } from "./refresh.js";
 import { fingerprintSkillSnapshotConfig } from "./snapshot-config-fingerprint.js";
 import { hydrateResolvedSkills } from "./snapshot-hydration.js";
 
-// The resolved index is gateway-process state. Mutation RPCs and watcher events
-// must bump that same process's version so a new-session key cannot reuse it.
-const resolvedSkillsCache = new Map<string, SkillSnapshot["resolvedSkills"]>();
-const RESOLVED_SKILLS_CACHE_MAX = 10;
+// Full snapshots let fresh sessions and runtime-only hydration share one versioned rebuild.
+const skillSnapshotCache = new Map<string, SkillSnapshot>();
+const SKILL_SNAPSHOT_CACHE_MAX = 10;
 
 /** Inputs that make a resolved skill snapshot reusable within a process. */
 type ReusableSkillSnapshotParams = {
@@ -43,9 +42,9 @@ type ReusableSkillSnapshotResult = {
   snapshotVersion: number;
 };
 
-function cacheResolvedSkills(cacheKey: string, snapshot: SkillSnapshot): SkillSnapshot {
-  resolvedSkillsCache.set(cacheKey, snapshot.resolvedSkills);
-  pruneMapToMaxSize(resolvedSkillsCache, RESOLVED_SKILLS_CACHE_MAX);
+function cacheSkillSnapshot(cacheKey: string, snapshot: SkillSnapshot): SkillSnapshot {
+  skillSnapshotCache.set(cacheKey, snapshot);
+  pruneMapToMaxSize(skillSnapshotCache, SKILL_SNAPSHOT_CACHE_MAX);
   return snapshot;
 }
 
@@ -133,15 +132,16 @@ export function resolveReusableWorkspaceSkillSnapshot(
     ]);
 
   const cachedRebuild = (snapshotCacheKey = buildSnapshotCacheKey()): SkillSnapshot => {
-    if (resolvedSkillsCache.has(snapshotCacheKey)) {
-      return { resolvedSkills: resolvedSkillsCache.get(snapshotCacheKey) } as SkillSnapshot;
+    const cachedSnapshot = skillSnapshotCache.get(snapshotCacheKey);
+    if (cachedSnapshot) {
+      return cachedSnapshot;
     }
-    return cacheResolvedSkills(snapshotCacheKey, buildSnapshot());
+    return cacheSkillSnapshot(snapshotCacheKey, buildSnapshot());
   };
 
   const snapshot =
     !params.existingSnapshot || shouldRefresh
-      ? cacheResolvedSkills(buildSnapshotCacheKey(), buildSnapshot())
+      ? cachedRebuild()
       : params.hydrateExisting === false
         ? params.existingSnapshot
         : hydrateResolvedSkills(params.existingSnapshot, cachedRebuild);

--- a/src/skills/workshop/collection-restore.test.ts
+++ b/src/skills/workshop/collection-restore.test.ts
@@ -13,7 +13,7 @@ import {
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
-import { getSkillsSnapshotVersion } from "../runtime/refresh-state.js";
+import { bumpSkillsSnapshotVersion, getSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { writeWorkspaceSkills } from "../test-support/e2e-test-helpers.js";
 import { resolveSkillCollectionBackupRoot } from "./collection-paths.js";
 import {
@@ -208,6 +208,7 @@ describe("skill collection backup and restore", () => {
     await writeWorkspaceSkills(workspaceDir, [
       { name: "external", description: "Operator procedure", body: "# External original\n" },
     ]);
+    bumpSkillsSnapshotVersion({ workspaceDir, reason: "watch" });
     await reconcileSkillCollection({
       workspaceDir,
       env: testState.env,
@@ -270,6 +271,7 @@ describe("skill collection backup and restore", () => {
     await writeWorkspaceSkills(workspaceDir, [
       { name: "created", description: "Operator procedure", body: "# Operator\n" },
     ]);
+    bumpSkillsSnapshotVersion({ workspaceDir, reason: "watch" });
     expect(listWritableSkillCollection(workspaceDir, { env: testState.env })).toEqual([
       expect.objectContaining({ name: "created", workshopOwned: false }),
       expect.objectContaining({ name: "dropped", workshopOwned: true }),
@@ -352,6 +354,7 @@ describe("skill collection backup and restore", () => {
     await writeWorkspaceSkills(workspaceDir, [
       { name: "external", description: "Operator procedure", body: "# External original\n" },
     ]);
+    bumpSkillsSnapshotVersion({ workspaceDir, reason: "watch" });
     const result = await reconcileSkillCollection({
       workspaceDir,
       env: testState.env,


### PR DESCRIPTION
## What Problem This Solves

On busy gateways (observed live on the team host, 20+ concurrent Control UI sessions and several active codex runs), the whole gateway degrades: WS methods that normally answer in milliseconds take 8–20s in bursts, and there are ~11s windows where *every* in-flight method completes at the same instant — a whole-event-loop stall. Live log analysis (43MB gateway log, one day) plus code tracing found four independent per-session hot paths that either block the event loop with synchronous full-transcript work or serially spawn subprocess/network batteries per watched session:

1. **`sessions.files.list`** (536 calls/day, 32% >2s): cold touched-files folds re-parse entire 30–80MB transcripts synchronously; the process-wide LRU held only **16** entries, so >16 viewed sessions thrash it and concurrent cold folds convoy (each request observes the *sum* of all concurrent folds' CPU). Every call also spawned `git rev-parse --show-toplevel` just to compute a boolean, and re-opened/realpathed the fs-safe workspace root per touched file.
2. **`controlUi.sessionPullRequests.subscribe`** (2,527 calls/day, p50 1.9s, max 45s): the RPC awaited serial cold loads (~10–18 git spawns + 1–3 serial GitHub fetches with 8s timeouts, per session key, up to 200 keys). Worse, the cache TTLs were inverted: local-git caches lasted 10s against a 60s poll, and the GitHub success cache expired at exactly the poll interval (stamped at load *start*) — so every poll re-ran the full battery for every watched session, every minute.
3. **Skill loading**: full synchronous rescans of every skill root (~94 SKILL.md files on the affected host, readFileSync + frontmatter parse each) ran 4–6× per inbound message on the event loop; the snapshot cache was written but never read for fresh sessions. Symptom: 8,964 "Skill precedence collision resolved" warnings per day for a static configuration fact.
4. **`sessions.preview` / `chat.message.get`**: preview batches (≤64 keys) synchronously loaded *every* message event per session to keep the last 12 items, with no yields between keys; message-get loaded the full projected transcript to check one messageId. Together with the folds above this drove repeated `memory pressure: level=critical reason=rss_growth` events (heap oscillating 0.75→3.1+ GiB).

## Why This Change Was Made

The shared invariant violation: request paths answered small questions by synchronously materializing entire transcripts or re-running full discovery batteries, instead of bounded reads and caches sized/invalidated correctly. Fixes stay at the owning boundaries:

- **sessions-files**: touched-files cache 16→256 (entries are a cursor + small Map; 256 covers realistic concurrent viewed sessions so warm calls do cursor-delta reads); in-process `insideGitCheckout` replaces the per-call git spawn; one prepared fs-safe workspace root per request instead of per-file realpath round trips.
- **PR subscriptions**: the subscribe RPC now registers the replace-set, pushes cached snapshots, kicks cold loads in the background (replacement-token ordering preserved) and responds immediately; hydration and polling process at most 4 keys concurrently; local-git caches 10s→75s and GitHub success cache 60s→90s so the 60s poll hits warm caches; failure/rate-limit semantics unchanged.
- **skills**: `loadSkillEntries` is memoized (bounded 64-entry cache) keyed on the existing chokidar snapshot-version seam plus config fingerprint/roots; the session snapshot cache now serves fresh sessions read-through; collision warnings fire once per snapshot version.
- **preview/message-get**: preview reads a bounded recent tail (64–256 events / 1MiB, one escalation to 2,048 events / 8MiB if filtered messages starve the 12-item preview) and yields between batch keys; message-get uses the existing message-ID-anchored reader (message + predecessor) preserving active-branch filtering, archive fallback, and hidden announce/reply semantics.

## User Impact

Control UI stays responsive with many sessions active: sidebar/file-panel/PR-indicator refreshes no longer convoy behind full transcript re-parses or per-session git/GitHub batteries, subscribe RPCs return immediately, and the gateway's background load drops from ~N×15 git spawns + N×2–9 GitHub calls per minute to near-zero for unchanged repos. Heap churn from preview/message-get paths shrinks accordingly. No config surface, schema, or protocol changes; no behavior changes beyond latency/logging (collision warning now deduped per snapshot version).

## Evidence

Live diagnosis on team.openclaw.ai (gateway 2026.8.1): per-method latency distribution extracted from the gateway JSONL log — `sessions.files.list` 536 calls/172 >2s; `controlUi.sessionPullRequests.subscribe` 2,527 calls, p50 1,873ms; a synchronized ~11.18s completion cluster across 8 unrelated methods at 00:39:12 (event-loop stall); 26 critical rss_growth memory-pressure events; 8,964 skill-collision warnings. Subprocess sampling over 30s showed the PR poller's `git diff --shortstat` battery cycling across all watched worktrees.

Local verification: targeted Vitest for all touched surfaces green — gateway shard (7 files, 117 tests), skills + workshop suites (57 files, 815 tests incl. new regressions), preview/chat shard. New regression coverage: cursor retention across 24 viewed sessions; subscribe responds without awaiting cold loads; no re-scan within a snapshot version and rescan after version bump; collision warning once per version; 1,024-message transcript preview reads only 64 events; hidden announce messages remain inaccessible via message-get. `pnpm check:changed` green (assertion-safety baseline shrink included). Production LOC delta: +184/−93 (bounded-parallelism helper, memoization, and bounded-read logic); tests +323/−15.