### PR TITLE
fix(android): preserve photo orientation in chat images

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CameraCaptureManager.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.Matrix
 import android.hardware.camera2.CameraCharacteristics
 import android.util.Base64
 import androidx.camera.camera2.interop.Camera2CameraInfo
@@ -172,7 +171,7 @@ class CameraCaptureManager(
       val decoded =
         BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
           ?: throw IllegalStateException("UNAVAILABLE: failed to decode captured image")
-      val rotated = rotateBitmapByExif(decoded, orientation)
+      val rotated = JpegSizeLimiter.normalizeOrientation(decoded, orientation)
       val scaled =
         if (maxWidth > 0 && rotated.width > maxWidth) {
           val h =
@@ -313,35 +312,6 @@ class CameraCaptureManager(
         )
       }
     }
-
-  private fun rotateBitmapByExif(
-    bitmap: Bitmap,
-    orientation: Int,
-  ): Bitmap {
-    val matrix = Matrix()
-    // CameraX JPEG bytes keep sensor orientation in EXIF; normalize before resizing/encoding.
-    when (orientation) {
-      ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
-      ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
-      ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
-      ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.postScale(-1f, 1f)
-      ExifInterface.ORIENTATION_FLIP_VERTICAL -> matrix.postScale(1f, -1f)
-      ExifInterface.ORIENTATION_TRANSPOSE -> {
-        matrix.postRotate(90f)
-        matrix.postScale(-1f, 1f)
-      }
-      ExifInterface.ORIENTATION_TRANSVERSE -> {
-        matrix.postRotate(-90f)
-        matrix.postScale(-1f, 1f)
-      }
-      else -> return bitmap
-    }
-    val rotated = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
-    if (rotated !== bitmap) {
-      bitmap.recycle()
-    }
-    return rotated
-  }
 
   private fun parseFacing(params: JsonObject?): String? {
     val value = parseJsonString(params, "facing")?.trim()?.lowercase() ?: return null

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/JpegSizeLimiter.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/JpegSizeLimiter.kt
@@ -1,5 +1,8 @@
 package ai.openclaw.app.node
 
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import androidx.exifinterface.media.ExifInterface
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -18,6 +21,33 @@ internal data class JpegSizeLimiterResult(
  * Utility that searches quality/scale combinations until a JPEG fits a byte budget.
  */
 internal object JpegSizeLimiter {
+  /** Applies camera/gallery orientation before resize, display, or metadata-stripping JPEG encoding. */
+  fun normalizeOrientation(
+    bitmap: Bitmap,
+    orientation: Int,
+  ): Bitmap {
+    val matrix = Matrix()
+    when (orientation) {
+      ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
+      ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
+      ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+      ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.postScale(-1f, 1f)
+      ExifInterface.ORIENTATION_FLIP_VERTICAL -> matrix.postScale(1f, -1f)
+      ExifInterface.ORIENTATION_TRANSPOSE -> {
+        matrix.postRotate(90f)
+        matrix.postScale(-1f, 1f)
+      }
+      ExifInterface.ORIENTATION_TRANSVERSE -> {
+        matrix.postRotate(-90f)
+        matrix.postScale(-1f, 1f)
+      }
+      else -> return bitmap
+    }
+    return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true).also { oriented ->
+      if (oriented !== bitmap) bitmap.recycle()
+    }
+  }
+
   /** Compresses with the caller-provided encoder, reducing quality before image dimensions. */
   fun compressToLimit(
     initialWidth: Int,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
@@ -17,7 +17,10 @@ import android.provider.OpenableColumns
 import android.util.Base64
 import android.util.LruCache
 import androidx.core.graphics.scale
+import androidx.exifinterface.media.ExifInterface
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -248,8 +251,9 @@ internal fun decodeImageBytes(
       },
     ) ?: return null
 
-  decodedBitmapCache.put(cacheKey, bitmap)
-  return bitmap
+  val oriented = JpegSizeLimiter.normalizeOrientation(bitmap, imageOrientation { ByteArrayInputStream(bytes) })
+  decodedBitmapCache.put(cacheKey, oriented)
+  return oriented
 }
 
 /** Computes Android's power-of-two bitmap sampling size for bounded decode. */
@@ -302,15 +306,25 @@ private fun decodeScaledBitmap(
       )
     } ?: return null
 
-  val longestEdge = max(decoded.width, decoded.height)
-  if (longestEdge <= maxDimension) return decoded
+  val oriented = JpegSizeLimiter.normalizeOrientation(decoded, imageOrientation { resolver.openInputStream(uri) })
+  val longestEdge = max(oriented.width, oriented.height)
+  if (longestEdge <= maxDimension) return oriented
 
   val scale = maxDimension.toDouble() / longestEdge.toDouble()
-  val targetWidth = max(1, (decoded.width * scale).roundToInt())
-  val targetHeight = max(1, (decoded.height * scale).roundToInt())
-  val scaled = decoded.scale(targetWidth, targetHeight, true)
-  if (scaled !== decoded) {
-    decoded.recycle()
+  val targetWidth = max(1, (oriented.width * scale).roundToInt())
+  val targetHeight = max(1, (oriented.height * scale).roundToInt())
+  val scaled = oriented.scale(targetWidth, targetHeight, true)
+  if (scaled !== oriented) {
+    oriented.recycle()
   }
   return scaled
 }
+
+private fun imageOrientation(open: () -> InputStream?): Int =
+  try {
+    open()?.use { stream ->
+      ExifInterface(stream).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+    } ?: ExifInterface.ORIENTATION_NORMAL
+  } catch (_: Exception) {
+    ExifInterface.ORIENTATION_NORMAL
+  }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatImageCodecTest.kt
@@ -1,11 +1,35 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.CHAT_IMAGE_MAX_BASE64_CHARS
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import android.net.Uri
+import android.util.Base64
+import androidx.exifinterface.media.ExifInterface
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.GraphicsMode
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
 
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
 class ChatImageCodecTest {
+  private val temporaryImages = mutableListOf<File>()
+
+  @After
+  fun deleteTemporaryImages() {
+    temporaryImages.forEach(File::delete)
+  }
+
   @Test
   fun computeInSampleSizeCapsLongestEdge() {
     assertEquals(4, computeInSampleSize(width = 4032, height = 3024, maxDimension = 1600))
@@ -21,5 +45,170 @@ class ChatImageCodecTest {
   @Test
   fun decodeBase64BitmapRejectsOversizedInputBeforeDecode() {
     assertNull(decodeBase64Bitmap("A".repeat(CHAT_IMAGE_MAX_BASE64_CHARS + 1)))
+  }
+
+  @Test
+  fun managedImageDecoderAppliesEveryExifOrientation() {
+    val cases =
+      listOf(
+        OrientationCase(ExifInterface.ORIENTATION_NORMAL, RED, GREEN, BLUE, YELLOW),
+        OrientationCase(ExifInterface.ORIENTATION_FLIP_HORIZONTAL, GREEN, RED, YELLOW, BLUE),
+        OrientationCase(ExifInterface.ORIENTATION_ROTATE_180, YELLOW, BLUE, GREEN, RED),
+        OrientationCase(ExifInterface.ORIENTATION_FLIP_VERTICAL, BLUE, YELLOW, RED, GREEN),
+        OrientationCase(ExifInterface.ORIENTATION_TRANSPOSE, RED, BLUE, GREEN, YELLOW, transposed = true),
+        OrientationCase(ExifInterface.ORIENTATION_ROTATE_90, BLUE, RED, YELLOW, GREEN, transposed = true),
+        OrientationCase(ExifInterface.ORIENTATION_TRANSVERSE, YELLOW, GREEN, BLUE, RED, transposed = true),
+        OrientationCase(ExifInterface.ORIENTATION_ROTATE_270, GREEN, YELLOW, RED, BLUE, transposed = true),
+      )
+
+    cases.forEach { expected ->
+      val bytes = createTaggedImage(expected.orientation).readBytes()
+      val decoded = requireNotNull(decodeImageBytes(bytes))
+
+      assertOrientedPixels(decoded, expected)
+    }
+  }
+
+  @Test
+  fun inlineImageDecoderAppliesExifOrientation() {
+    val bytes = createTaggedImage(ExifInterface.ORIENTATION_ROTATE_270).readBytes()
+
+    val decoded = requireNotNull(decodeBase64Bitmap(Base64.encodeToString(bytes, Base64.NO_WRAP)))
+
+    assertOrientedPixels(
+      decoded,
+      OrientationCase(ExifInterface.ORIENTATION_ROTATE_270, GREEN, YELLOW, RED, BLUE, transposed = true),
+    )
+  }
+
+  @Test
+  fun pickedImageIsNormalizedBeforeJpegUpload() {
+    val image = createTaggedImage(ExifInterface.ORIENTATION_ROTATE_90)
+    val resolver = RuntimeEnvironment.getApplication().contentResolver
+
+    val attachment = loadSizedImageAttachment(resolver, Uri.fromFile(image))
+    val encoded = Base64.decode(attachment.base64, Base64.DEFAULT)
+    val decoded = requireNotNull(BitmapFactory.decodeByteArray(encoded, 0, encoded.size))
+
+    assertEquals("image/jpeg", attachment.mimeType)
+    val outputOrientation =
+      ExifInterface(ByteArrayInputStream(encoded)).getAttributeInt(
+        ExifInterface.TAG_ORIENTATION,
+        ExifInterface.ORIENTATION_UNDEFINED,
+      )
+    assertTrue(
+      "re-encoded JPEG must not require an orientation transform",
+      outputOrientation == ExifInterface.ORIENTATION_UNDEFINED || outputOrientation == ExifInterface.ORIENTATION_NORMAL,
+    )
+    assertOrientedPixels(
+      decoded,
+      OrientationCase(ExifInterface.ORIENTATION_ROTATE_90, BLUE, RED, YELLOW, GREEN, transposed = true),
+    )
+  }
+
+  @Test
+  fun pickedImagePreservesMirroredExifOrientation() {
+    val image = createTaggedImage(ExifInterface.ORIENTATION_FLIP_HORIZONTAL)
+    val resolver = RuntimeEnvironment.getApplication().contentResolver
+
+    val attachment = loadSizedImageAttachment(resolver, Uri.fromFile(image))
+    val encoded = Base64.decode(attachment.base64, Base64.DEFAULT)
+    val decoded = requireNotNull(BitmapFactory.decodeByteArray(encoded, 0, encoded.size))
+
+    assertOrientedPixels(
+      decoded,
+      OrientationCase(ExifInterface.ORIENTATION_FLIP_HORIZONTAL, GREEN, RED, YELLOW, BLUE),
+    )
+  }
+
+  @Test
+  fun imageDecoderPreservesImagesWithoutExifMetadata() {
+    val bitmap = createAsymmetricBitmap()
+    val bytes =
+      ByteArrayOutputStream().use { output ->
+        assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, output))
+        output.toByteArray()
+      }
+    bitmap.recycle()
+
+    val decoded = requireNotNull(decodeImageBytes(bytes))
+
+    assertOrientedPixels(
+      decoded,
+      OrientationCase(ExifInterface.ORIENTATION_NORMAL, RED, GREEN, BLUE, YELLOW),
+    )
+  }
+
+  private fun createTaggedImage(orientation: Int): File {
+    val image = File.createTempFile("chat-image-orientation-", ".jpg", RuntimeEnvironment.getApplication().cacheDir)
+    temporaryImages += image
+    val bitmap = createAsymmetricBitmap()
+    image.outputStream().use { output -> assertTrue(bitmap.compress(Bitmap.CompressFormat.JPEG, 100, output)) }
+    bitmap.recycle()
+    ExifInterface(image.absolutePath).apply {
+      setAttribute(ExifInterface.TAG_ORIENTATION, orientation.toString())
+      saveAttributes()
+    }
+    return image
+  }
+
+  private fun createAsymmetricBitmap(): Bitmap =
+    Bitmap.createBitmap(IMAGE_WIDTH, IMAGE_HEIGHT, Bitmap.Config.ARGB_8888).apply {
+      for (y in 0 until height) {
+        for (x in 0 until width) {
+          setPixel(
+            x,
+            y,
+            when {
+              x < width / 2 && y < height / 2 -> RED
+              x >= width / 2 && y < height / 2 -> GREEN
+              x < width / 2 -> BLUE
+              else -> YELLOW
+            },
+          )
+        }
+      }
+    }
+
+  private fun assertOrientedPixels(
+    bitmap: Bitmap,
+    expected: OrientationCase,
+  ) {
+    val expectedWidth = if (expected.transposed) IMAGE_HEIGHT else IMAGE_WIDTH
+    val expectedHeight = if (expected.transposed) IMAGE_WIDTH else IMAGE_HEIGHT
+    assertEquals("orientation ${expected.orientation} width", expectedWidth, bitmap.width)
+    assertEquals("orientation ${expected.orientation} height", expectedHeight, bitmap.height)
+    assertPixel(expected, bitmap.getPixel(bitmap.width / 4, bitmap.height / 4), expected.topLeft)
+    assertPixel(expected, bitmap.getPixel(bitmap.width * 3 / 4, bitmap.height / 4), expected.topRight)
+    assertPixel(expected, bitmap.getPixel(bitmap.width / 4, bitmap.height * 3 / 4), expected.bottomLeft)
+    assertPixel(expected, bitmap.getPixel(bitmap.width * 3 / 4, bitmap.height * 3 / 4), expected.bottomRight)
+  }
+
+  private fun assertPixel(
+    orientation: OrientationCase,
+    actual: Int,
+    expected: Int,
+  ) {
+    assertTrue("orientation ${orientation.orientation} red", kotlin.math.abs(Color.red(actual) - Color.red(expected)) <= 40)
+    assertTrue("orientation ${orientation.orientation} green", kotlin.math.abs(Color.green(actual) - Color.green(expected)) <= 40)
+    assertTrue("orientation ${orientation.orientation} blue", kotlin.math.abs(Color.blue(actual) - Color.blue(expected)) <= 40)
+  }
+
+  private data class OrientationCase(
+    val orientation: Int,
+    val topLeft: Int,
+    val topRight: Int,
+    val bottomLeft: Int,
+    val bottomRight: Int,
+    val transposed: Boolean = false,
+  )
+
+  private companion object {
+    const val IMAGE_WIDTH = 120
+    const val IMAGE_HEIGHT = 80
+    val RED = Color.rgb(255, 0, 0)
+    val GREEN = Color.rgb(0, 255, 0)
+    val BLUE = Color.rgb(0, 0, 255)
+    val YELLOW = Color.rgb(255, 255, 0)
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Android chat decoded camera/gallery JPEG pixels without applying their EXIF orientation. Uploading a portrait photo then re-encoded the original sideways pixels while discarding the orientation metadata, and incoming inline or managed images were displayed sideways as well. Rotations and mirrored camera orientations were both affected even though the existing Android camera-capture path already normalized them correctly.

## What Changed

- Move the existing camera implementation's complete eight-orientation bitmap transform into the JPEG utility already shared by camera capture and chat.
- Apply that same canonical transform to picked/shared chat images before resizing and JPEG encoding, and to incoming image bytes before caching or rendering.
- Preserve camera behavior, image bounds, bitmap recycling, PNG/non-EXIF compatibility, and the existing dependency surface. Unsupported metadata is handled without swallowing VM errors.
- Production change is +14 lines after moving the existing transform; the growth owns the two previously missing inbound/outbound metadata-read boundaries.

## Evidence

- Fail-first on unchanged main: the final native-graphics regression suite failed four real rotation/mirroring cases while its four existing/non-EXIF controls passed.
- Fixed: 21/21 focused tests passed, including every EXIF rotation/reflection with asymmetric four-quadrant pixel assertions, the existing camera suite, and the existing JPEG utility suite.
- All four hosted Android Kotlin formatting checks passed: app, benchmark, wear, and wear-shared.
- Real Android 36 app-owned MediaStore `content://` input: the same tagged photo changed from an incorrect 320x160 red-first upload to the correct 160x320 blue-first normalized upload.
- Real production Android Compose `ChatBase64Image`: the same image changed from visibly sideways to upright; the fixed screenshot contains a measured 159x313 portrait color raster.
- Before and after captures contain only synthetic test imagery.

### Before

![Before: Android chat displays an EXIF-rotated photo sideways](https://github.com/user-attachments/assets/f4d2d4a0-f6f7-44fd-aed1-936128249bcc)

### After

![After: Android chat displays the same photo upright](https://github.com/user-attachments/assets/04ab8d84-6022-4634-9fe0-3941695a3a61)
