### PR TITLE
refactor(ui): use canonical sessions usage request

### DIFF
--- a/ui/src/lib/sessions/usage.test.ts
+++ b/ui/src/lib/sessions/usage.test.ts
@@ -27,44 +27,45 @@ describe("buildSessionUsageDateParams", () => {
   });
 });
 
-describe("requestSessionUsage legacy timeZone retry", () => {
-  const query = {
-    startDate: "2026-07-01",
-    endDate: "2026-07-28",
-    scope: "instance",
-    timeZone: "local",
-  } as const;
-
-  it("retries older gateways with the legacy UTC offset", async () => {
+describe("requestSessionUsage", () => {
+  it("requests canonical family grouping", async () => {
     const result = { sessions: [] };
-    const request = vi
-      .fn()
-      .mockRejectedValueOnce(
-        new GatewayRequestError({
-          code: "INVALID_REQUEST",
-          message: "invalid sessions.usage params: at root: unexpected property 'timeZone'",
-        }),
-      )
-      .mockResolvedValueOnce(result);
+    const request = vi.fn().mockResolvedValue(result);
 
-    await expect(requestSessionUsage({ request } as never, query)).resolves.toBe(result);
-    expect(request).toHaveBeenCalledTimes(2);
-    const [, firstParams] = request.mock.calls[0] as [string, Record<string, unknown>];
-    const [, retryParams] = request.mock.calls[1] as [string, Record<string, unknown>];
-    expect(typeof firstParams.timeZone).toBe("string");
-    expect(typeof firstParams.utcOffset).toBe("string");
-    const { timeZone: _dropped, ...withoutTimeZone } = firstParams;
-    expect(retryParams).toEqual(withoutTimeZone);
+    await expect(
+      requestSessionUsage({ request } as never, {
+        startDate: "2026-07-01",
+        endDate: "2026-07-28",
+        scope: "family",
+        timeZone: "utc",
+      }),
+    ).resolves.toBe(result);
+    expect(request).toHaveBeenCalledWith("sessions.usage", {
+      startDate: "2026-07-01",
+      endDate: "2026-07-28",
+      agentScope: "all",
+      mode: "utc",
+      groupBy: "family",
+      limit: 1000,
+      includeContextWeight: true,
+    });
   });
 
-  it("does not retry unrelated invalid usage parameters", async () => {
+  it("surfaces a rejected request without retrying an older Gateway shape", async () => {
     const error = new GatewayRequestError({
       code: "INVALID_REQUEST",
-      message: "invalid sessions.usage params: invalid IANA timeZone",
+      message: "invalid sessions.usage params: at root: unexpected property 'timeZone'",
     });
     const request = vi.fn().mockRejectedValue(error);
 
-    await expect(requestSessionUsage({ request } as never, query)).rejects.toBe(error);
+    await expect(
+      requestSessionUsage({ request } as never, {
+        startDate: "2026-07-01",
+        endDate: "2026-07-28",
+        scope: "instance",
+        timeZone: "local",
+      }),
+    ).rejects.toBe(error);
     expect(request).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/lib/sessions/usage.ts
+++ b/ui/src/lib/sessions/usage.ts
@@ -1,6 +1,6 @@
 import type { SessionUsageTimeSeries } from "../../../../src/shared/session-usage-timeseries-types.js";
 import type { SessionsUsageResult } from "../../../../src/shared/usage-types.js";
-import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 
 type SessionRequestClient = Pick<GatewayBrowserClient, "request">;
 
@@ -40,49 +40,16 @@ function buildSessionUsageParams(query: SessionUsageQuery): Record<string, unkno
     ...(query.agentId ? { agentId: query.agentId } : { agentScope: "all" }),
     ...buildSessionUsageDateParams(query.timeZone),
     groupBy: query.scope,
-    includeHistorical: query.scope === "family",
     limit: 1000,
     includeContextWeight: true,
   };
-}
-
-function isOlderGatewayWithoutUsageTimeZone(
-  error: unknown,
-  params: Record<string, unknown>,
-): boolean {
-  return (
-    typeof params.timeZone === "string" &&
-    typeof params.utcOffset === "string" &&
-    error instanceof GatewayRequestError &&
-    error.gatewayCode === "INVALID_REQUEST" &&
-    error.message.includes("invalid sessions.usage params:") &&
-    error.message.includes("unexpected property 'timeZone'")
-  );
-}
-
-async function requestSessionsUsage(
-  client: SessionRequestClient,
-  params: Record<string, unknown>,
-): Promise<SessionsUsageResult> {
-  try {
-    return await client.request<SessionsUsageResult>("sessions.usage", params);
-  } catch (error) {
-    if (!isOlderGatewayWithoutUsageTimeZone(error, params)) {
-      throw error;
-    }
-    // Protocol v4 gateways predating timeZone reject the additive field.
-    // Retry with the accompanying fixed offset for mixed-version clients.
-    const legacyParams = { ...params };
-    delete legacyParams.timeZone;
-    return await client.request<SessionsUsageResult>("sessions.usage", legacyParams);
-  }
 }
 
 export function requestSessionUsage(
   client: SessionRequestClient,
   query: SessionUsageQuery,
 ): Promise<SessionsUsageResult> {
-  return requestSessionsUsage(client, buildSessionUsageParams(query));
+  return client.request<SessionsUsageResult>("sessions.usage", buildSessionUsageParams(query));
 }
 
 export function requestSessionUsageTimeSeries(


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Related: #124971

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Control UI usage loading still carried an old-Gateway retry path even though the Control UI and Gateway ship as one version. A rejected `timeZone` request was parsed by error-message text and retried with a second request shape, while every supported deployment accepts the canonical parameters.

## Why This Change Was Made

Send one canonical `sessions.usage` request with `timeZone`, `utcOffset`, and `groupBy`; remove the stale parser/retry and the deprecated duplicate `includeHistorical` flag. `utcOffset` stays because a same-version browser and Gateway can have different timezone databases, so it remains a current fallback rather than version-skew compatibility.

## User Impact

No user-visible behavior changes on supported same-version deployments. Unsupported UI/Gateway skew now surfaces the Gateway's first rejection instead of silently retrying; maintainers get one request/control path with 33 fewer production lines.

## Evidence

Exact reviewed head: `c91a83b31473713afa97b90cdf26da922423c87a`

- Production LOC: +2/−35 (net −33); tests: +30/−29 (net +1); total: +32/−64.
- Baseline regression proof against the pre-change code:
  - canonical-family request-shape test failed because `includeHistorical: true` was still sent;
  - no-retry regression failed because the old handler called `request` twice.
- Focused unit/route proof:
  - `node scripts/run-vitest.mjs ui/src/lib/sessions/usage.test.ts ui/src/pages/usage/route.test.ts ui/src/pages/model-providers/load.test.ts`
  - 3 files, 12 tests passed.
- Browser DOM/accessibility proof:
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/usage-cost-analysis.e2e.test.ts`
  - 4/4 passed across provider-error and empty states, local/UTC filtering, pending/cached rows, request mode, role-based controls, tooltip focus/hover/click/Escape behavior, cost/provider cards, and filtered-empty output.
- Changed-file gate:
  - `node scripts/check-changed.mjs -- ui/src/lib/sessions/usage.ts ui/src/lib/sessions/usage.test.ts`
  - passed selected guards, i18n, core-test/UI typechecks, formatting, dead exports, and oxlint.
- `git diff --check` passed.
- No targeted open issue/PR overlap for the legacy retry or canonical request path; history traced the retry to #103097 and the current one-version policy to #124971.
- Deslop pass: clean. Branch autoreview: no actionable findings, patch correctness 0.99. Independent exact-head review: prior no-retry test gap resolved; no remaining actionable findings.
- No screenshot: rendering is intentionally unchanged; the executed browser DOM/accessibility flow covers the representative UI states affected by this data request.

AI-assisted: yes