### PR TITLE
fix(node-host): keep created worker containers alive when status races the start client

### DIFF
--- a/src/node-host/node-worker-container-engine.ts
+++ b/src/node-host/node-worker-container-engine.ts
@@ -340,11 +340,11 @@ export async function inspectNodeWorkerContainer(
   engine: NodeWorkerContainerEngine,
   containerId: string,
   expected?: NodeWorkerContainerExpectedOwner,
-): Promise<"live" | "dead" | "reused" | "unknown"> {
+): Promise<"live" | "created" | "dead" | "reused" | "unknown"> {
   try {
     const format = expected
-      ? `{{.State.Running}}\t{{index .Config.Labels "${HOST_LABEL}"}}\t{{index .Config.Labels "${GATEWAY_LABEL}"}}\t{{index .Config.Labels "${LAUNCH_LABEL}"}}`
-      : "{{.State.Running}}";
+      ? `{{.State.Status}}\t{{index .Config.Labels "${HOST_LABEL}"}}\t{{index .Config.Labels "${GATEWAY_LABEL}"}}\t{{index .Config.Labels "${LAUNCH_LABEL}"}}`
+      : "{{.State.Status}}";
     const state = await runContainerCommand(engine, [
       "inspect",
       "--type",
@@ -353,7 +353,7 @@ export async function inspectNodeWorkerContainer(
       format,
       containerId,
     ]);
-    const [running, owner, gateway, launch, extra] = state.split("\t");
+    const [status, owner, gateway, launch, extra] = state.split("\t");
     if (expected) {
       if (
         extra !== undefined ||
@@ -366,7 +366,28 @@ export async function inspectNodeWorkerContainer(
     } else if (owner !== undefined) {
       return "unknown";
     }
-    return running === "true" ? "live" : running === "false" ? "dead" : "unknown";
+    // "created" is a launch in flight (create finished, start client not yet
+    // through), never a dead workload: reaping it destroys a healthy launch.
+    // Docker states: created/running/paused/restarting/removing/exited/dead;
+    // Podman adds configured/initialized/stopped/stopping.
+    switch (status) {
+      case "running":
+      case "paused":
+      case "restarting":
+      case "stopping":
+        return "live";
+      case "configured":
+      case "initialized":
+      case "created":
+        return "created";
+      case "exited":
+      case "stopped":
+      case "removing":
+      case "dead":
+        return "dead";
+      default:
+        return "unknown";
+    }
   } catch (error) {
     return missingContainer(error) ? "dead" : "unknown";
   }

--- a/src/node-host/node-worker-container-lifecycle.ts
+++ b/src/node-host/node-worker-container-lifecycle.ts
@@ -63,7 +63,7 @@ export class NodeWorkerContainerLifecycle {
   async inspect(
     container: NodeWorkerContainerIdentity,
     owner: NodeWorkerContainerOwner,
-  ): Promise<"live" | "dead" | "reused" | "unknown"> {
+  ): Promise<"live" | "created" | "dead" | "reused" | "unknown"> {
     return await inspectNodeWorkerContainer(
       this.requireMatchingEngine(container),
       container.containerId,

--- a/src/node-host/node-worker-supervisor.container.test.ts
+++ b/src/node-host/node-worker-supervisor.container.test.ts
@@ -67,9 +67,13 @@ const save = (container) => {
 };
 const launchIdFor = (container) =>
   Buffer.from(container.labels["openclaw.node-worker.launch"], "base64url").toString("utf8");
+// null = a successful read proved the row is absent; undefined = the read
+// itself glitched (the live WAL writer's checkpoints can briefly lock out
+// this raw cross-process reader) and proves nothing about the journal.
 const journalState = (launchId) => {
   try {
     const database = new DatabaseSync(path.join(stateRoot, "state", "openclaw.sqlite"), { readOnly: true });
+    database.exec("PRAGMA busy_timeout = 5000;");
     const row = database.prepare("SELECT state FROM node_worker_launches WHERE launch_id = ?").get(launchId);
     const hasContainerTable = database.prepare(
       "SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = 'node_worker_launch_containers'",
@@ -80,7 +84,7 @@ const journalState = (launchId) => {
       ).get(launchId)
       : undefined;
     database.close();
-    return row && { state: row.state, container_json: container?.container_json ?? null };
+    return row ? { state: row.state, container_json: container?.container_json ?? null } : null;
   } catch {
     return undefined;
   }
@@ -147,7 +151,7 @@ if (command === "version") {
   }
   const entry = args.at(-1);
   const image = args.at(-2);
-  const container = { id, labels, env, mounts, image, entry, running: false, pid: null };
+  const container = { id, labels, env, mounts, image, entry, status: "created", pid: null };
   save(container);
   record({ argv: args, container, journal: journalState(launchIdFor(container)) });
   releaseAfterMarker("hold-create", () => process.stdout.write(id + "\n"));
@@ -167,12 +171,18 @@ if (command === "version") {
       process.stderr.write("container worker executed before its exact identity was journaled\n");
       process.exit(67);
     }
+    // Holds the container in "created" so tests can race supervisor calls
+    // against a start client that has not yet transitioned it to running.
+    const startMarker = path.join(engineRoot, "hold-start-running");
+    while (fs.existsSync(startMarker)) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
     const child = spawn(process.execPath, [container.entry], {
       detached: process.platform !== "win32",
       env: container.env,
       stdio: ["pipe", "inherit", "inherit"],
     });
-    container.running = true;
+    container.status = "running";
     container.pid = child.pid;
     save(container);
     child.stdin.end(descriptor);
@@ -183,7 +193,7 @@ if (command === "version") {
     child.once("exit", (code, signal) => {
       if (fs.existsSync(statePath(container.id))) {
         const current = load(container.id);
-        current.running = false;
+        current.status = "exited";
         current.pid = null;
         save(current);
       }
@@ -198,7 +208,7 @@ if (command === "version") {
   record({ argv: args });
   const container = readContainer(id);
   const format = args[args.indexOf("--format") + 1];
-  const columns = [String(container.running)];
+  const columns = [container.status];
   if (format.includes("openclaw.node-worker.host")) {
     columns.push(
       container.labels["openclaw.node-worker.host"] ?? "",
@@ -210,11 +220,11 @@ if (command === "version") {
 } else if (command === "kill") {
   const container = readContainer(args.at(-1));
   record({ argv: args, journal: journalState(launchIdFor(container)) });
-  if (!container.running) {
+  if (container.status !== "running") {
     process.stderr.write("container is not running\n");
     process.exit(1);
   }
-  container.running = false;
+  container.status = "exited";
   save(container);
   if (container.pid) {
     try {
@@ -263,7 +273,7 @@ type FakeContainer = {
   mounts: string[];
   image: string;
   entry: string;
-  running: boolean;
+  status: "created" | "running" | "exited";
   pid: number | null;
 };
 
@@ -351,7 +361,7 @@ function containerFixture(
         mounts: [],
         image: "node:22-slim",
         entry: bundleEntry,
-        running: params.running ?? true,
+        status: (params.running ?? true) ? "running" : "exited",
         pid: null,
       };
       fs.writeFileSync(
@@ -435,7 +445,11 @@ describe("node worker supervisor container isolation", () => {
         },
       });
       const completed = await waitForTerminal(fixture.supervisor, input.launchId);
-      expect(completed?.state).toBe("completed");
+      // Compare state together with errorText so a failed launch prints why.
+      expect({ state: completed?.state, errorText: completed?.errorText }).toEqual({
+        state: "completed",
+        errorText: null,
+      });
       expect(JSON.parse(completed?.resultJson ?? "null")).toEqual({
         status: "completed",
         argv: [],
@@ -494,6 +508,41 @@ describe("node worker supervisor container isolation", () => {
         "node:22-slim",
       );
     } finally {
+      await fixture.supervisor.close();
+    }
+  });
+
+  it("keeps a created container alive when status races the start client", async () => {
+    const fixture = containerFixture();
+    const input = testWorkerLaunchInput(fixture.workspaceDir, "container-created-status-race");
+    const startMarker = path.join(fixture.engineRoot, "hold-start-running");
+    fs.writeFileSync(startMarker, "hold");
+
+    try {
+      const launch = fixture.supervisor.launch(input, endpoint);
+      // The engine records "start" after journaling but before the container
+      // leaves "created" — exactly the window a status() poll used to reap.
+      await vi.waitFor(
+        () => expect(fixture.events().some((event) => event.argv[0] === "start")).toBe(true),
+        { timeout: 5_000 },
+      );
+
+      const observed = await fixture.supervisor.status(input.launchId);
+      expect(observed?.state).toBe("running");
+      expect(fixture.events().some((event) => event.argv[0] === "kill")).toBe(false);
+      expect(fixture.events().some((event) => event.argv[0] === "rm")).toBe(false);
+
+      fs.unlinkSync(startMarker);
+      await expect(launch).resolves.toMatchObject({ state: "running" });
+      const completed = await waitForTerminal(fixture.supervisor, input.launchId);
+      expect({ state: completed?.state, errorText: completed?.errorText }).toEqual({
+        state: "completed",
+        errorText: null,
+      });
+    } finally {
+      if (fs.existsSync(startMarker)) {
+        fs.unlinkSync(startMarker);
+      }
       await fixture.supervisor.close();
     }
   });

--- a/src/node-host/node-worker-supervisor.ts
+++ b/src/node-host/node-worker-supervisor.ts
@@ -217,7 +217,9 @@ class NodeWorkerSupervisor {
         if (inspection === "reused") {
           throw new Error(`node worker launch ${launchId} lost its container ownership`);
         }
-        if (inspection === "live") {
+        // A created container's start client is still in flight; only its own
+        // death may end the launch — reaping here would kill a healthy start.
+        if (inspection === "live" || inspection === "created") {
           const clientState = inspectNodeWorkerProcessIdentity(active.worker);
           if (clientState !== "dead" && clientState !== "reused") {
             return this.store.get(launchId);


### PR DESCRIPTION
## What Problem This Solves

`src/node-host/node-worker-supervisor.container.test.ts > mounts only the admitted bundle and workspace and round-trips the stdio result` flakes CI on unrelated PRs (seen on run 32706072003 for #128614 and run 32708984511 for `fix/br-120962` within the same hour) with `expected 'failed' to be 'completed'`. Reproduced locally at roughly 1-in-3 runs.

The flake is a real production race, not a test artifact: a container in engine state `created` reports `.State.Running=false`, so a concurrent `status()` RPC classified a launch-in-flight container as a dead workload and reaped it (`kill`/`rm`) while `launch()` was still between journaling and the start client transitioning the container to running. The engine's group kill then hit the freshly started worker and the launch terminated `failed` with exit code 137. The same window exists against real Docker: between `docker create` and `docker start --attach` taking effect, any `status()` call destroys a healthy launch.

## Why This Change Was Made

- [node-worker-container-engine.ts](src/node-host/node-worker-container-engine.ts): inspect via `{{.State.Status}}` and return a five-state result. `created`/`configured`/`initialized` classify as `"created"`, never dead; Docker and Podman state vocabularies are both mapped.
- [node-worker-supervisor.ts](src/node-host/node-worker-supervisor.ts): `status()` treats a created container like a live one — only the start client's own death may end the launch.
- Fake engine in the container test now models the real engine contract with `created`/`running`/`exited` tri-state, plus a `hold-start-running` marker so tests can deterministically hold a container in `created`.
- New regression test `keeps a created container alive when status races the start client` pins the exact race; the round-trip assertion now prints `errorText` when a launch fails so any future flake carries its reason (this is how the 137 root cause was found in the first place — the old assertion hid it).

## User Impact

Container-isolated node worker launches no longer fail spuriously when a status poll lands during startup, and the CI flake that hit unrelated PRs is gone.

## Evidence

Before the fix, a bounded local loop failed on iteration 3 with `errorText: "node worker failed with exit code 137"`. After the fix: 25 consecutive runs of the container isolation suite green, full node-host suite green (561 passed / 2 skipped, 40 files), `check-changed` clean, autoreview clean ("patch is correct (0.99)"). The fake-engine journal hardening that landed in #128722 (atomic save, `waitForRunningJournal`) is preserved; this PR fixes the remaining, distinct kill-race.
