### PR TITLE
fix(channels): attachment filenames disappear from model context

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -645,6 +645,7 @@ describe("preflightDiscordMessage", () => {
       {
         path: "/tmp/openclaw-discord-test/photo.png",
         contentType: "image/png",
+        fileName: "photo.png",
       },
     ]);
   });

--- a/extensions/discord/src/monitor/message-media.references.test.ts
+++ b/extensions/discord/src/monitor/message-media.references.test.ts
@@ -78,7 +78,9 @@ describe("resolveReferencedReplyMediaList", () => {
       512,
     );
 
-    expect(result).toEqual([{ path: "/tmp/reply-image.png", contentType: "image/png" }]);
+    expect(result).toEqual([
+      { path: "/tmp/reply-image.png", contentType: "image/png", fileName: "reply-image.png" },
+    ]);
     expect(readRemoteMediaBuffer).toHaveBeenCalledWith(
       expect.objectContaining({
         url: attachment.url,

--- a/extensions/discord/src/monitor/message-media.test.ts
+++ b/extensions/discord/src/monitor/message-media.test.ts
@@ -416,6 +416,7 @@ describe("resolveMediaList", () => {
         {
           path: "/tmp/voice.ogg",
           contentType: undefined,
+          fileName: "voice.ogg",
           kind: "audio",
         },
       ]);
@@ -465,6 +466,7 @@ describe("resolveMediaList", () => {
       {
         path: "/tmp/image.png",
         contentType: "image/png",
+        fileName: "image.ogg",
       },
     ]);
   });
@@ -481,6 +483,7 @@ describe("resolveMediaList", () => {
       {
         path: "/tmp/voice",
         contentType: "audio/ogg",
+        fileName: "voice",
         kind: "audio",
       },
     ]);
@@ -516,6 +519,7 @@ describe("resolveMediaList", () => {
       {
         path: "/tmp/image.png",
         contentType: "image/png",
+        fileName: "voice.ogg",
       },
     ]);
   });
@@ -574,6 +578,7 @@ describe("resolveMediaList", () => {
       {
         path: "/tmp/good.png",
         contentType: "image/png",
+        fileName: "good.png",
       },
       {
         contentType: "application/pdf",

--- a/extensions/discord/src/monitor/message-media.test.ts
+++ b/extensions/discord/src/monitor/message-media.test.ts
@@ -154,6 +154,7 @@ function expectSinglePngDownload(params: {
     {
       path: params.expectedPath,
       contentType: "image/png",
+      fileName: params.filePathHint,
       ...(params.kind ? { kind: params.kind } : {}),
     },
   ]);

--- a/extensions/discord/src/monitor/message-media.ts
+++ b/extensions/discord/src/monitor/message-media.ts
@@ -2,6 +2,7 @@
 import { StickerFormatType, type APIAttachment, type APIStickerItem } from "discord-api-types/v10";
 import {
   formatMediaPlaceholderText,
+  type ChannelInboundMediaInput,
   type MediaPlaceholderTextFact,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { getFileExtension, normalizeMimeType } from "openclaw/plugin-sdk/media-mime";
@@ -36,7 +37,10 @@ const AUDIO_ATTACHMENT_EXTENSIONS = new Set([
 
 const DISCORD_STICKER_ASSET_BASE_URL = "https://media.discordapp.net/stickers";
 
-export type DiscordMediaInfo = Pick<MediaPlaceholderTextFact, "contentType" | "kind" | "path">;
+export type DiscordMediaInfo = Pick<
+  ChannelInboundMediaInput,
+  "contentType" | "fileName" | "kind" | "path"
+>;
 
 type DiscordMediaResolveOptions = {
   fetchImpl?: FetchLike;
@@ -350,6 +354,7 @@ async function appendResolvedMediaFromAttachments(params: {
       });
       params.out.push({
         path: saved.path,
+        fileName: attachment.filename,
         ...classification,
       });
     } catch (err) {
@@ -455,6 +460,7 @@ async function appendResolvedMediaFromStickers(params: {
         params.out.push({
           path: saved.path,
           contentType: saved.contentType,
+          fileName: candidate.fileName,
           kind: "sticker",
         });
         lastError = null;

--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -93,6 +93,7 @@ describe("mattermost monitor resources", () => {
     const saveRemoteMedia = vi.fn(async () => ({
       path: "/tmp/file.png",
       contentType: "image/png",
+      fileName: "original screenshot.png",
     }));
 
     const resources = createMattermostMonitorResources({
@@ -113,6 +114,7 @@ describe("mattermost monitor resources", () => {
       {
         path: "/tmp/file.png",
         contentType: "image/png",
+        fileName: "original screenshot.png",
         kind: "image",
       },
     ]);
@@ -166,7 +168,7 @@ describe("mattermost monitor resources", () => {
       .mockRejectedValueOnce(new Error("download failed"));
     const request = vi.fn(async (requestPath: string) => {
       expect(requestPath).toBe("/files/file-audio/info");
-      return { mime_type: "audio/mpeg" };
+      return { mime_type: "audio/mpeg", name: "private-unavailable-recording.mp3" };
     });
     const resources = createMattermostMonitorResources({
       accountId: "default",

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -4,12 +4,13 @@ import {
   formatInboundMediaUnavailableText,
   formatMediaPlaceholderText,
   toInboundMediaFactsWithMetadata,
+  type ChannelInboundMediaInput,
   type ChannelInboundMediaPayload,
   type InboundMediaFacts,
   type MediaPlaceholderTextFact,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
-import type { MediaKind } from "openclaw/plugin-sdk/media-runtime";
+import type { MediaKind, SavedRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -27,7 +28,9 @@ import {
 } from "./client.js";
 import { buildButtonProps, type MattermostInteractionResponse } from "./interactions.js";
 
-type MattermostMediaInfo = Omit<MediaPlaceholderTextFact, "kind" | "url"> & { kind: MediaKind };
+type MattermostMediaInfo = Pick<ChannelInboundMediaInput, "contentType" | "fileName" | "path"> & {
+  kind: MediaKind;
+};
 
 export async function buildMattermostInboundMediaPayload(
   media: readonly MattermostMediaInfo[],
@@ -76,7 +79,7 @@ type SaveRemoteMedia = (params: {
   ssrfPolicy?: { allowedHostnames?: string[] };
   responseHeaderTimeoutMs?: number;
   readIdleTimeoutMs?: number;
-}) => Promise<{ path: string; contentType?: string | null }>;
+}) => Promise<Pick<SavedRemoteMedia, "contentType" | "fileName" | "path">>;
 
 export function createMattermostMonitorResources(params: {
   accountId: string;
@@ -171,6 +174,7 @@ export function createMattermostMonitorResources(params: {
         out.push({
           path: saved.path,
           contentType,
+          ...(saved.fileName ? { fileName: saved.fileName } : {}),
           kind: mediaKindFromMime(contentType) ?? "unknown",
         });
       } catch (err) {

--- a/extensions/slack/src/monitor/media-types.ts
+++ b/extensions/slack/src/monitor/media-types.ts
@@ -2,6 +2,7 @@
 export type SlackMediaResult = {
   path: string;
   contentType?: string;
+  fileName?: string;
   placeholder: string;
 };
 

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -291,7 +291,7 @@ describe("resolveSlackMedia", () => {
     });
     mockFetch.mockResolvedValueOnce(mockResponse);
 
-    await resolveSlackMedia({
+    const result = await resolveSlackMedia({
       files: [
         {
           url_private: "https://files.slack.com/private.jpg",
@@ -304,6 +304,7 @@ describe("resolveSlackMedia", () => {
     });
 
     expectFetchCalledWithUrl(mockFetch, "https://files.slack.com/download.jpg");
+    expect(expectSlackMediaResult(result)[0]?.fileName).toBe("test.jpg");
   });
 
   it("preserves Authorization on same-origin redirects for private downloads", async () => {
@@ -935,8 +936,10 @@ describe("resolveSlackMedia", () => {
     const first = expectDefined(media[0], "first Slack media result");
     const second = expectDefined(media[1], "second Slack media result");
     expect(first.path).toBe("/tmp/a.jpg");
+    expect(first.fileName).toBe("a.jpg");
     expect(first.placeholder).toBe("[Slack file: a.jpg (image/jpeg, 12 bytes, fileId: FA)]");
     expect(second.path).toBe("/tmp/b.png");
+    expect(second.fileName).toBe("b.png");
     expect(second.placeholder).toBe("[Slack file: b.png (image/png, 34 bytes, fileId: FB)]");
   });
 
@@ -1281,6 +1284,7 @@ describe("resolveSlackAttachmentContent", () => {
         {
           path: "/tmp/forwarded.jpg",
           contentType: "image/jpeg",
+          fileName: "forwarded.jpg",
           placeholder: "[Forwarded image: forwarded.jpg]",
         },
       ],

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -290,6 +290,7 @@ async function downloadSlackMediaFile(params: {
   return {
     path: saved.path,
     ...(contentType ? { contentType } : {}),
+    ...(label ? { fileName: label } : {}),
     placeholder: `[Slack file: ${formatSlackFileReference({ ...params.file, name: label })}]`,
   };
 }
@@ -462,6 +463,7 @@ export async function resolveSlackAttachmentContent(params: {
         allMedia.push({
           path: saved.path,
           contentType: saved.contentType,
+          ...(saved.fileName ? { fileName: saved.fileName } : {}),
           placeholder: `[Forwarded image: ${label}]`,
         });
       } catch {

--- a/extensions/telegram/src/bot-handlers.inbound-media.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-media.ts
@@ -364,6 +364,7 @@ export function createTelegramInboundMedia({
           allMedia.push({
             path: media.path,
             contentType: media.contentType,
+            ...(media.fileName ? { fileName: media.fileName } : {}),
             kind: media.kind,
             stickerMetadata: media.stickerMetadata,
             sourceMessageId,

--- a/extensions/telegram/src/bot-handlers.inbound-processing.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-processing.ts
@@ -318,6 +318,7 @@ export function createTelegramInboundProcessing({
             ? {
                 path: media.path,
                 contentType: media.contentType,
+                ...(media.fileName ? { fileName: media.fileName } : {}),
                 kind: media.kind,
                 stickerMetadata: media.stickerMetadata,
               }

--- a/extensions/telegram/src/bot-handlers.message-pipeline.ts
+++ b/extensions/telegram/src/bot-handlers.message-pipeline.ts
@@ -135,6 +135,7 @@ export interface TelegramMessagePipeline {
 
 function resolveRetainedTelegramMedia(params: {
   media?: TelegramResolvedMedia;
+  sourceMessage: Message;
   maxBytes: number;
   ttlHours?: number;
 }): TelegramMediaRef | undefined {
@@ -148,11 +149,17 @@ function resolveRetainedTelegramMedia(params: {
     return undefined;
   }
   const path = resolveTelegramInboundMediaUri(media.id);
+  const fileName =
+    params.sourceMessage.document?.file_name ??
+    params.sourceMessage.audio?.file_name ??
+    params.sourceMessage.video?.file_name ??
+    params.sourceMessage.animation?.file_name;
   return path
     ? {
         path,
         kind: media.kind,
         ...(media.contentType ? { contentType: media.contentType } : {}),
+        ...(fileName ? { fileName } : {}),
         ...(media.stickerMetadata ? { stickerMetadata: media.stickerMetadata } : {}),
       }
     : undefined;
@@ -320,6 +327,7 @@ export function createTelegramMessagePipeline({
           mediaRuntime.abortSignal?.throwIfAborted();
           mediaRef = resolveRetainedTelegramMedia({
             media: node.resolvedMedia,
+            sourceMessage: node.sourceMessage,
             maxBytes: mediaMaxBytes,
             ttlHours: cfg.attachments?.ttlHours,
           });
@@ -338,6 +346,7 @@ export function createTelegramMessagePipeline({
                 path: media.path,
                 kind: media.kind,
                 ...(media.contentType ? { contentType: media.contentType } : {}),
+                ...(media.fileName ? { fileName: media.fileName } : {}),
                 ...(media.stickerMetadata ? { stickerMetadata: media.stickerMetadata } : {}),
               };
               await recordReplyMessageResolvedMedia({

--- a/extensions/telegram/src/bot-message-context.media-carriers.test.ts
+++ b/extensions/telegram/src/bot-message-context.media-carriers.test.ts
@@ -8,6 +8,32 @@ vi.mock("./sticker-vision.runtime.js", () => ({
 }));
 
 describe("buildTelegramMessageContext media carriers", () => {
+  it("carries a successfully downloaded original filename into the current-turn media facts", async () => {
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        chat: { id: 42, type: "private", first_name: "Ada" },
+        text: "Please read quarterly report.pdf",
+        document: {
+          file_id: "file-1",
+          file_unique_id: "file-u1",
+          file_name: "quarterly report.pdf",
+        },
+      },
+      allMedia: [
+        {
+          kind: "document",
+          path: "/tmp/opaque-upload",
+          contentType: "application/pdf",
+          fileName: "quarterly report.pdf",
+        },
+      ],
+    });
+
+    expect(context?.ctxPayload.media).toEqual([
+      expect.objectContaining({ path: "/tmp/opaque-upload", fileName: "quarterly report.pdf" }),
+    ]);
+  });
+
   it("carries direct tool policy into a topic-bound admitted turn", async () => {
     const context = await buildTelegramMessageContextForTest({
       message: {

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -592,6 +592,7 @@ export async function buildTelegramInboundContextPayload(params: {
   const toInboundMedia = (media: TelegramMediaRef, index?: number) => ({
     ...(media.path ? { path: media.path, url: media.path } : {}),
     contentType: media.contentType,
+    ...(media.fileName ? { fileName: media.fileName } : {}),
     kind: media.kind,
     transcribed: index !== undefined && audioTranscribedMediaIndex === index,
   });

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -24,6 +24,7 @@ export type TelegramMediaRef = {
   kind: TelegramMediaKind;
   path?: string;
   contentType?: string;
+  fileName?: string;
   stickerMetadata?: StickerMetadata;
   sourceMessageId?: string;
 };

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -223,9 +223,10 @@ function expectTypeOnlyMediaPayload(kind: string, rawBody = "") {
     media: [expect.objectContaining({ kind })],
     RawBody: rawBody,
   });
-  const media = payload.media as Array<{ path?: string }>;
+  const media = payload.media as Array<{ path?: string; fileName?: string }>;
   expect(media).toHaveLength(1);
   expect(media[0]?.path).toBeUndefined();
+  expect(media[0]?.fileName).toBeUndefined();
 }
 
 function setTelegramIngestGroupConfig(

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -457,6 +457,7 @@ describe("resolveMedia original filename preservation", () => {
     });
     expectResolvedMediaFields(result, "document filename", {
       path: "/tmp/business-plan---uuid.pdf",
+      fileName: "business-plan.pdf",
     });
   });
 

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -467,7 +467,7 @@ export async function resolveMedia(params: {
   trustedLocalFileRoots?: readonly string[];
   dangerouslyAllowPrivateNetwork?: boolean;
   abortSignal?: AbortSignal;
-}): Promise<(TelegramResolvedMedia & { path: string }) | null> {
+}): Promise<(TelegramResolvedMedia & { path: string; fileName?: string }) | null> {
   const {
     ctx,
     maxBytes,
@@ -528,6 +528,7 @@ export async function resolveMedia(params: {
     path: saved.path,
     size: saved.size,
     contentType: saved.contentType,
+    ...(metadata.fileName ? { fileName: metadata.fileName } : {}),
     kind,
     fileUniqueId: m.file_unique_id,
     savedAt: Date.now(),

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -150,21 +150,26 @@ describe("telegram message cache", () => {
     const { bucketKey, entries, store } = createMemoryStore();
     const cache = cacheFor(bucketKey, store);
     await record(cache, message(9000, "Kesava", { photo: photo("photo-1") }));
+    const downloadedMedia = {
+      id: "saved-photo.png",
+      fileUniqueId: "photo-1-unique",
+      size: 4,
+      savedAt: 1_736_380_700_000,
+      kind: "image" as const,
+      contentType: "image/png",
+      path: "/private/user/photos/holiday.png",
+      fileName: "holiday photo.png",
+    };
     await cache.recordResolvedMedia({
       accountId: "default",
       chatId: 7,
       messageId: "9000",
-      media: {
-        id: "saved-photo.png",
-        fileUniqueId: "photo-1-unique",
-        size: 4,
-        savedAt: 1_736_380_700_000,
-        kind: "image",
-        contentType: "image/png",
-      },
+      media: downloadedMedia,
     });
 
     expect(onlyEntry(entries)[1].resolvedMedia?.id).toBe("saved-photo.png");
+    expect(onlyEntry(entries)[1].resolvedMedia).not.toHaveProperty("path");
+    expect(onlyEntry(entries)[1].resolvedMedia).not.toHaveProperty("fileName");
     const reloaded = await reloadGet(bucketKey, store, "9000");
     expect(reloaded?.resolvedMedia).toMatchObject({
       id: "saved-photo.png",

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -69,7 +69,7 @@ type TelegramMessageCache = {
     botUserId?: number;
     chatId: string | number;
     messageId: string;
-    media: TelegramResolvedMedia;
+    media: TelegramResolvedMedia & { path?: string; fileName?: string };
   }) => Promise<void>;
   get: (params: {
     accountId: string;
@@ -720,11 +720,8 @@ export function createTelegramMessageCache(params?: {
       if (fileUniqueId !== media.fileUniqueId) {
         throw new Error(`Telegram message ${messageId} media changed during resolution`);
       }
-      const resolvedMedia = parseTelegramResolvedMedia(media);
-      if (!resolvedMedia) {
-        throw new Error(`Telegram message ${messageId} resolved media is invalid`);
-      }
       // Runtime downloads carry private paths/names; cache only the existing persisted projection.
+      const { path: _path, fileName: _fileName, ...resolvedMedia } = media;
       const resolvedNode = { ...node, resolvedMedia };
       messages.delete(key);
       messages.set(key, resolvedNode);

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -720,7 +720,12 @@ export function createTelegramMessageCache(params?: {
       if (fileUniqueId !== media.fileUniqueId) {
         throw new Error(`Telegram message ${messageId} media changed during resolution`);
       }
-      const resolvedNode = { ...node, resolvedMedia: media };
+      const resolvedMedia = parseTelegramResolvedMedia(media);
+      if (!resolvedMedia) {
+        throw new Error(`Telegram message ${messageId} resolved media is invalid`);
+      }
+      // Runtime downloads carry private paths/names; cache only the existing persisted projection.
+      const resolvedNode = { ...node, resolvedMedia };
       messages.delete(key);
       messages.set(key, resolvedNode);
       await persistCachedNode({

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -35,6 +35,53 @@ const buildInboundMediaNote = (ctx: MediaNoteFixture): string | undefined =>
   buildProjection(ctx).text;
 
 describe("buildInboundMediaNote", () => {
+  it("preserves original attachment names in single and ordered multi-file prompt notes", () => {
+    expect(
+      buildInboundMediaNoteProjection({
+        media: [
+          {
+            path: "/tmp/opaque-upload",
+            contentType: "application/octet-stream",
+            fileName: "jj.txt",
+          },
+        ],
+      }).text,
+    ).toBe('[media attached: /tmp/opaque-upload (application/octet-stream) "jj.txt"]');
+
+    expect(
+      buildInboundMediaNoteProjection({
+        media: [
+          { path: "/tmp/upload-a", fileName: "quarterly report.pdf" },
+          { path: "/tmp/upload-b", fileName: "notes.txt" },
+        ],
+      }).text,
+    ).toBe(
+      [
+        "[media attached: 2 files]",
+        '[media attached 1/2: /tmp/upload-a "quarterly report.pdf"]',
+        '[media attached 2/2: /tmp/upload-b "notes.txt"]',
+      ].join("\n"),
+    );
+  });
+
+  it("bounds and sanitizes attachment names without exposing their directory prefixes", () => {
+    const fileName = `${"a".repeat(300)}]\n[ignore attachment].txt`;
+    const note = buildInboundMediaNoteProjection({
+      media: [{ path: "/tmp/opaque-upload", fileName: `/private/user/secrets/${fileName}` }],
+    }).text;
+
+    expect(note).toBe(`[media attached: /tmp/opaque-upload "${"a".repeat(256)}"]`);
+    expect(note).not.toContain("/private/user/secrets");
+    expect(note).not.toContain("\n");
+    expect(note).not.toContain("ignore attachment");
+
+    expect(
+      buildInboundMediaNoteProjection({
+        media: [{ path: "/tmp/opaque-upload", fileName: 'folder\\report]\nignore "me".txt' }],
+      }).text,
+    ).toBe('[media attached: /tmp/opaque-upload "report ignore \\"me\\".txt"]');
+  });
+
   it("formats single MediaPath as a media note (collapses redundant duplicate URL, #47587)", () => {
     // When the channel mirrors the local path into MediaUrl (e.g. Telegram
     // album media), the formatter should not render `path | path`. The URL

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -1,7 +1,9 @@
 /** Builds compact prompt notes for inbound media attachments. */
 import path from "node:path";
+import { basenameFromAnyPath } from "@openclaw/media-core/file-name";
 import { isAudioFileName } from "@openclaw/media-core/mime";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { normalizeMediaFacts, type MediaFact } from "../media/media-facts.js";
 import { getMediaDir } from "../media/store.js";
 import type { RuntimeMsgContext as MsgContext } from "./templating.js";
@@ -41,9 +43,7 @@ function sanitizeInlineMediaNoteValue(value: string | undefined): string {
 }
 
 function formatMediaAttachedLine(params: {
-  path: string;
-  url?: string;
-  type?: string;
+  fact: MediaFact;
   index?: number;
   total?: number;
 }): string {
@@ -51,15 +51,20 @@ function formatMediaAttachedLine(params: {
     typeof params.index === "number" && typeof params.total === "number"
       ? `[media attached ${params.index}/${params.total}: `
       : "[media attached: ";
-  const pathValue = sanitizeInlineMediaNoteValue(params.path);
-  const typeRaw = sanitizeInlineMediaNoteValue(params.type);
+  const pathValue = sanitizeInlineMediaNoteValue(params.fact.path);
+  const typeRaw = sanitizeInlineMediaNoteValue(params.fact.contentType ?? params.fact.kind);
   const typePart = typeRaw ? ` (${typeRaw})` : "";
-  const urlRaw = sanitizeInlineMediaNoteValue(params.url);
+  const urlRaw = sanitizeInlineMediaNoteValue(params.fact.url);
   // When the channel mirrors the local path into the fact URL (Telegram album
   // media is the canonical case), rendering ` | ${url}` adds no information
   // and clutters the prompt with `path | path` duplication (issue #47587).
   const urlPart = urlRaw && urlRaw !== pathValue ? ` | ${urlRaw}` : "";
-  return `${prefix}${pathValue}${typePart}${urlPart}]`;
+  const fileName = truncateUtf16Safe(
+    sanitizeInlineMediaNoteValue(basenameFromAnyPath(params.fact.fileName ?? "")),
+    256,
+  );
+  const fileNamePart = fileName ? ` ${JSON.stringify(fileName)}` : "";
+  return `${prefix}${pathValue}${typePart}${urlPart}${fileNamePart}]`;
 }
 
 // WebM is ambiguous, while WMA and ALAC do not have canonical extension mappings.
@@ -141,8 +146,6 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
           {
             fact,
             path: mediaPath,
-            type: fact.contentType ?? fact.kind,
-            url: fact.url,
             index,
           },
         ]
@@ -161,7 +164,9 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
   const visibleEntries = entries.filter((entry) => {
     // Strip audio attachments when transcription succeeded - the transcript is already
     // available in the context, raw audio binary would only waste tokens (issue #4197)
-    const normalizedType = normalizeLowercaseStringOrEmpty(entry.type);
+    const normalizedType = normalizeLowercaseStringOrEmpty(
+      entry.fact.contentType ?? entry.fact.kind,
+    );
     const isAudioByMime = normalizedType === "audio" || normalizedType.startsWith("audio/");
     const isAudioEntry = entry.fact.kind === "audio" || isAudioPath(entry.path) || isAudioByMime;
     if (!isAudioEntry) {
@@ -185,13 +190,10 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
     ...(describedImageIndices.has(entry.index) ? { hydrationSuppressed: true } : {}),
   }));
   const mediaIndexes = visibleEntries.map((entry) => entry.index);
-  if (visibleEntries.length === 1) {
+  const firstVisibleEntry = visibleEntries[0];
+  if (visibleEntries.length === 1 && firstVisibleEntry) {
     return {
-      text: formatMediaAttachedLine({
-        path: visibleEntries[0]?.path ?? "",
-        type: visibleEntries[0]?.type,
-        url: visibleEntries[0]?.url,
-      }),
+      text: formatMediaAttachedLine({ fact: firstVisibleEntry.fact }),
       media,
       mediaIndexes,
     };
@@ -202,11 +204,9 @@ export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNo
   for (const [idx, entry] of visibleEntries.entries()) {
     lines.push(
       formatMediaAttachedLine({
-        path: entry.path,
+        fact: entry.fact,
         index: idx + 1,
         total: count,
-        type: entry.type,
-        url: entry.url,
       }),
     );
   }

--- a/src/channels/inbound-event/media.test.ts
+++ b/src/channels/inbound-event/media.test.ts
@@ -416,7 +416,12 @@ describe("channel inbound media facts", () => {
 
   it("normalizes provider media into inbound media facts", () => {
     const input = [
-      { path: " /tmp/image.png ", contentType: " image/png ", messageId: " " },
+      {
+        path: " /tmp/image.png ",
+        contentType: " image/png ",
+        fileName: " original image.png ",
+        messageId: " ",
+      },
       {
         url: "https://example.test/audio.mp3",
         contentType: "audio/mpeg",
@@ -434,6 +439,7 @@ describe("channel inbound media facts", () => {
         url: undefined,
         contentType: "image/png",
         kind: "image",
+        fileName: "original image.png",
         transcribed: false,
         messageId: "msg-1",
       },

--- a/src/channels/inbound-event/media.ts
+++ b/src/channels/inbound-event/media.ts
@@ -19,6 +19,7 @@ export type ChannelInboundMediaInput = {
   path?: string | null;
   url?: string | null;
   contentType?: string | null;
+  fileName?: string | null;
   kind?: InboundMediaFacts["kind"] | null;
   durationMs?: number | null;
   width?: number | null;


### PR DESCRIPTION
Fixes #128956

## What Problem This Solves

Fixes an issue where users sending documents through Discord, Mattermost, Slack, or Telegram would find that their agent could not identify the original attachment filename when inbound files were saved under opaque local names. A related Telegram cache boundary also unintentionally allowed a downloaded file's local host path to enter its stored cache payload.

## Why This Change Was Made

Preserve authoritative filenames only after attachment download succeeds, carry that fact through the shared inbound-media boundary and all relevant Telegram message/reply relays, and render a bounded, sanitized basename in the existing model-visible attachment note. At the Telegram cache owner, project away only the transient filename and previously leaked local host path before storage; preserve all historically accepted partial attachment shapes and retain the existing strict parser exclusively at durable hydration, without changing schemas, history projections, template variables, or persisted canonical fields.

## User Impact

Agents can refer to a successfully received attachment by its real name across all four affected messaging channels. Rejected or failed attachments still disclose no untrusted filename; malicious filenames cannot inject prompt lines, expose path components, or grow the bounded attachment note. Telegram's durable cache keeps only its existing canonical metadata.

## Evidence

Before the fix, the original operator scenario supplied filename `jj.txt` but produced only `[media attached: /tmp/opaque (application/octet-stream)]`. After the fix, the actual shared owner produces `[media attached: /tmp/opaque (application/octet-stream) "jj.txt"]`.

The shared prompt-renderer, inbound-media owner, primary and referenced-reply Discord transport owners, Telegram album and persisted-media owners, retained Telegram reply hydration, and Discord preflight owner pass: **187 tests across eight files**.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/media-note.test.ts src/channels/inbound-event/media.test.ts --maxWorkers=1
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/discord/src/monitor/message-media.test.ts --maxWorkers=1
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/discord/src/monitor/message-media.references.test.ts --maxWorkers=1
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/message-cache.test.ts --maxWorkers=1 -t 'persists resolved media with its source message'
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts --maxWorkers=1
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts --maxWorkers=1 -t 'hydrates allowlisted group reply'
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.preflight.test.ts --maxWorkers=1 -t 'downloads attachments during preflight'
```

A direct source-import scenario exercised the real `createTelegramMessageCache` owner and its actual `persistentStore.register` payload, then verified prompt rendering and hydration:

```json
{"verdict":"PASS","storedKeys":["id","fileUniqueId","size","savedAt","kind","contentType"],"storedLeaksPath":false,"storedLeaksFileName":false,"prompt":"[media attached: media://inbound/saved-report.pdf (application/pdf) \"quarterly-report.pdf\"]","hydratedId":"saved-report.pdf"}
```

Additional regression coverage spans original-name propagation in Discord, Mattermost, Slack, and Telegram; Telegram's direct, album, and reply paths; failed-download suppression; prompt basename sanitization, control-character removal, attachment numbering, and bounded length; and the exact raw persisted Telegram payload. The entire Telegram album-owner suite passes **42/42**; the real allowlisted retained-reply case verifies canonical `media://inbound/` hydration, not a private local host path; the exact Telegram persistent-row owner regression passes **1/1**; and the successful Discord preflight filename case passes **1/1**. An earlier broader Telegram invocation was externally terminated under unrelated host pressure before assertions; all affected named owner paths have since passed genuinely. Exact-head hosted CI must cover the broader affected suites before landing. Live external-channel roundtrips across all four services were infeasible without preconfigured authenticated test-channel sessions; the changed transport-owner and persisted-store boundaries were exercised directly instead.

Production delta: **+56/-26, net +30** across four channel producer boundaries and the canonical privacy-preserving cache projection. Tests: **+114/-13**. Scope: **24 coherent source/test files**. No new dependency, config, breaking public API, template surface, or persistent-store schema.
