### PR TITLE
fix(cli): start under Bun 1.4 without warning filter

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -298,7 +298,9 @@ const isDirectModuleNotFoundError = (err, specifier) => {
     message.includes(`Cannot find module "${specifier}"`);
   const launcherPath = fileURLToPath(import.meta.url);
   const bunLauncherImporterMiss =
-    message.includes(` from '${launcherPath}'`) || message.includes(` from "${launcherPath}"`);
+    message.includes(` from '${launcherPath}'`) ||
+    message.includes(` from "${launcherPath}"`) ||
+    message.includes(` imported from ${launcherPath}`);
 
   const expectedUrl = new URL(specifier, import.meta.url);
   const expectedPath = fileURLToPath(expectedUrl);


### PR DESCRIPTION
Closes #129139

## What Problem This Solves

Fixes an issue where users running OpenClaw with Bun 1.4.0 would see the CLI exit before startup when the optional warning-filter bundle was absent.

## Why This Change Was Made

Bun 1.4 changed direct dynamic-import diagnostics from a quoted `from '<launcher>'` suffix to an unquoted `imported from <launcher>` suffix. The launcher now recognizes that exact direct-import shape while retaining the existing specifier and launcher-path checks, so transitive module failures are still surfaced.

Node remains the primary runtime and its launcher behavior is unchanged.

## User Impact

Users can run the OpenClaw CLI under Bun 1.4.0 without the launcher rejecting an absent optional warning-filter module.

## Evidence

Reproduced before the fix with Bun 1.4.0:

```text
FAIL ... gates the real Bun runtime on node:sqlite availability
AssertionError: expected 1 to be +0
error: Cannot find module './dist/warning-filter.js' from '/tmp/.../openclaw.mjs'
```

Passing after the fix:

- `OPENCLAW_E2E_SKIP_BUILD=1 OPENCLAW_TEST_BUN_LAUNCHER=1 BUN_BIN=/tmp/openclaw-bun140/node_modules/.bin/bun pnpm test test/openclaw-launcher.e2e.test.ts` — 40 passed
- `pnpm check:changed` — passed all selected checks, typechecks, lint, and cycle guard
- `pnpm build` — passed
- `bun openclaw.mjs --version` — `OpenClaw 2026.8.1 (4c829ed)`
- `bun openclaw.mjs --help` — exited 0 with root help
- Exact-head CI run `32824702686`, attempt 2 — passed; the retry cleared an unrelated Microsoft Teams ephemeral-port collision from attempt 1

Structured Codex autoreview (`gpt-5.6-sol`, high reasoning) reported no accepted/actionable findings and judged the patch correct at 0.99 confidence.

ClawSweeper's optional rank-up move requested a current-main refresh plus the exact-head Bun 1.4 E2E. The Bun 1.4 E2E already passed at `4c829eda6a6b44dcfbc81258a5cbff92f3beb4b4`. I am not rebasing solely for review freshness because current main has no conflicting or material launcher change; the native merge guard will revalidate current main before merge.
