### PR TITLE
fix(qa): OpenClaw harness planning check fails after progress-card migration

### DIFF
--- a/extensions/qa-lab/src/scenario-flow-runner.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test.ts
@@ -231,10 +231,10 @@ function createPlanningEvidenceFixture(
     return {
       scenario,
       outboundText: `Built ${artifactFile}`,
-      failureMessage: "missing OpenClaw update_plan signal",
+      failureMessage: "missing OpenClaw progress_card signal",
       currentSummary: {
         eventCursor: 9,
-        successfulToolCallCounts: { update_plan: 1 },
+        successfulToolCallCounts: { progress_card: 1 },
       },
     };
   }
@@ -254,7 +254,7 @@ function runPlanningEvidenceFixture(
         { identity: "old-turn:plan", text: "Codex plan:\nQA_INTERNAL_PLAN_DO_NOT_SEND" },
         { identity: "old-turn:assistant", text: fixture.outboundText },
       ],
-      successfulToolCallCounts: { update_plan: 1 },
+      successfulToolCallCounts: { progress_card: 1 },
     },
     currentSummary,
   ];

--- a/qa/scenarios/workspace/medium-game-plan-openclaw-harness.yaml
+++ b/qa/scenarios/workspace/medium-game-plan-openclaw-harness.yaml
@@ -12,7 +12,7 @@ scenario:
   successCriteria:
     - A live-frontier run fails fast unless the selected primary model is openai/gpt-5.6-luna.
     - The scenario forces the embedded OpenClaw harness before the build turn.
-    - The OpenClaw harness records a successful `update_plan` tool call before the artifact assertion passes.
+    - The OpenClaw harness records a successful `progress_card` tool call before the artifact assertion passes.
     - The agent writes a self-contained HTML game with a canvas loop, controls, scoring, waves, pause, and restart.
   docsRefs:
     - docs/plugins/sdk-agent-harness.md
@@ -35,7 +35,7 @@ scenario:
       gameTitle: Star Garden Defenders
       minBytes: 5000
       buildPrompt: |-
-        Call update_plan with a short implementation plan before editing.
+        Call progress_card with a short implementation plan before editing.
 
         Then build a medium-complex, self-contained browser game at ./star-garden-defenders-openclaw.html.
 
@@ -108,8 +108,8 @@ flow:
             - afterEventCursor:
                 expr: transcriptBefore.eventCursor
         - assert:
-            expr: "(transcript.successfulToolCallCounts.update_plan ?? 0) > 0"
-            message: missing OpenClaw update_plan signal
+            expr: "(transcript.successfulToolCallCounts.progress_card ?? 0) > 0"
+            message: missing OpenClaw progress_card signal
         - set: artifactPath
           value:
             expr: "path.join(env.gateway.workspaceDir, config.artifactFile)"
@@ -150,4 +150,4 @@ flow:
             expr: "outbound.text.includes(config.artifactFile)"
             message:
               expr: "`final reply did not mention ${config.artifactFile}: ${outbound.text}`"
-      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${config.harnessRuntime} agentRun=${turn.started.runId} appServerTurn=n/a planSignal=update_plan:success:${transcript.successfulToolCallCounts.update_plan ?? 0} artifact=${artifactPath} bytes=${artifact.length} visibleReply=${JSON.stringify(outbound.text)}`"
+      detailsExpr: "`provider=${selected?.provider} model=${selected?.model} runtime=${config.harnessRuntime} agentRun=${turn.started.runId} appServerTurn=n/a planSignal=progress_card:success:${transcript.successfulToolCallCounts.progress_card ?? 0} artifact=${artifactPath} bytes=${artifact.length} visibleReply=${JSON.stringify(outbound.text)}`"


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the canonical live OpenClaw harness QA scenario completed its requested game but still failed after the planning tool migrated from `update_plan` to `progress_card`.

## Why This Change Was Made

Updates the existing OpenClaw scenario and its current-attempt/stale-attempt fixture to require the canonical `progress_card` signal. The runtime and production tool surfaces are unchanged.

The regression was made visible by #125125, which replaced the OpenClaw planning tool without migrating this live scenario. The original fail-closed planning scenario came from #109282.

## User Impact

No end-user runtime behavior changes. Maintainers regain a trustworthy live dual-harness gate for OpenAI GPT-5.6 Luna.

## Evidence

- Before: live pair at `02a5be389240` — Codex passed; OpenClaw built the artifact but failed with `missing OpenClaw update_plan signal`.
- Exact-head live OpenAI pair at `ca57f4bd9d5`:
  - 2 total, 2 passed, 0 failed, 0 skipped
  - Codex runtime recorded a real App Server plan mirror and produced a 12,083-byte game.
  - OpenClaw runtime recorded three successful `progress_card` calls and produced a 14,754-byte game.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-flow-runner.test.ts` — 22 passed.
- `node scripts/check-changed.mjs -- <changed files>` — full fail-safe changed-file gate passed, including all typechecks, lint, dead-export scan, and import-cycle checks.
- `git diff --check origin/main...HEAD` — passed.

AI-assisted. The change and live evidence were reviewed by the PR author; the isolated `autoreview` credential scan passed, but standalone Codex review could not authenticate to the upstream Responses endpoint in the orb, so repo-native review artifacts and exact-head CI remain required before merge.
