### PR TITLE
fix(telemetry): suppress reporting from automated environments

### DIFF
--- a/docs/gateway/telemetry.md
+++ b/docs/gateway/telemetry.md
@@ -165,6 +165,19 @@ even when `telemetry.enabled` is `true`. `DO_NOT_TRACK` does not disable the
 daily update check: OpenClaw sends the update-only `GET` request without a
 feature-statistics body.
 
+## Automated environments
+
+OpenClaw sends nothing when it detects an automated environment, meaning the
+`CI` environment variable is set to a truthy value. Continuous integration jobs
+are not installations: they would outnumber real operators by orders of
+magnitude and make version and platform counts meaningless, and your pipeline
+should not report to us on every job.
+
+This applies to both tiers, so a CI job sends no update check and no feature
+statistics. Setting `OPENCLAW_TELEMETRY_ENDPOINT` overrides the suppression,
+because a configured endpoint means the run is deliberately exercising this
+path.
+
 ## Disable every automatic update request
 
 To go fully dark, disable the existing startup update check:

--- a/src/cli/telemetry-cli.ts
+++ b/src/cli/telemetry-cli.ts
@@ -10,6 +10,7 @@ import { runCommandWithRuntime } from "./cli-utils.js";
 
 const TELEMETRY_REASON_LABELS = {
   enabled: "enabled in configuration",
+  "automated-environment": "disabled in an automated environment (CI is set)",
   "do-not-track": "disabled by DO_NOT_TRACK",
   "config-disabled": "disabled in configuration",
   "never-asked": "consent has not been requested",

--- a/src/infra/telemetry.test.ts
+++ b/src/infra/telemetry.test.ts
@@ -12,7 +12,11 @@ import {
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
 import { VERSION } from "../version.js";
-import { buildTelemetryPayload, checkTelemetryUpdate } from "./telemetry.js";
+import {
+  buildTelemetryPayload,
+  checkTelemetryUpdate,
+  resolveTelemetryStatus,
+} from "./telemetry.js";
 
 const NOW = Date.parse("2026-08-23T12:00:00.000Z");
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -86,6 +90,7 @@ describe("anonymous telemetry", () => {
       layout: "state-only",
       prefix: "openclaw-telemetry-",
       env: {
+        CI: undefined,
         DO_NOT_TRACK: undefined,
         OPENCLAW_NIX_MODE: undefined,
         OPENCLAW_NO_AUTO_UPDATE: undefined,
@@ -358,6 +363,35 @@ describe("anonymous telemetry", () => {
 
     expect(mockHttp.requests()).toHaveLength(0);
     expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toBeUndefined();
+  });
+
+  it("never sends a request from an automated environment", async () => {
+    setTestEnvValue("CI", "true");
+
+    await expect(
+      checkTelemetryUpdate(createFeatureConfig(), {
+        surface: "gateway",
+        fetchImpl: globalThis.fetch,
+        nowMs: NOW,
+      }),
+    ).resolves.toBeNull();
+
+    expect(mockHttp.requests()).toHaveLength(0);
+    expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toBeUndefined();
+    expect(resolveTelemetryStatus(createFeatureConfig()).reason).toBe("automated-environment");
+  });
+
+  it("still reports from an automated environment when an endpoint is configured for it", async () => {
+    const customEndpoint = "https://telemetry.example.invalid/api/latest-version";
+    setTestEnvValue("CI", "true");
+    setTestEnvValue("OPENCLAW_TELEMETRY_ENDPOINT", customEndpoint);
+    mockHttp.intercept({ url: customEndpoint, reply: { json: { version: "2026.8.24" } } });
+
+    await expect(
+      checkTelemetryUpdate({}, { surface: "gateway", fetchImpl: globalThis.fetch, nowMs: NOW }),
+    ).resolves.toEqual({ version: "2026.8.24" });
+
+    expect(mockHttp.requests()).toHaveLength(1);
   });
 
   it("never sends a request for Nix-managed installations", async () => {

--- a/src/infra/telemetry.ts
+++ b/src/infra/telemetry.ts
@@ -54,6 +54,7 @@ type TelemetryPayload = {
 
 type TelemetryStatusReason =
   | "enabled"
+  | "automated-environment"
   | "do-not-track"
   | "config-disabled"
   | "never-asked"
@@ -73,10 +74,24 @@ const TelemetryResponseSchema = z.object({
 let lastFailedAttempt: { at: number; endpoint: string; stateDirectory?: string } | undefined;
 let inFlightUpdate: Promise<TelemetryUpdate | null> | undefined;
 
+/**
+ * CI jobs are not installs. Left unchecked they outnumber operators by orders of
+ * magnitude and make version and platform counts meaningless, and someone else's
+ * pipeline should not report to us on every job either. A configured endpoint
+ * means the caller is deliberately exercising this path, so it still reports.
+ */
+function isAutomatedEnvironment(): boolean {
+  if (process.env.OPENCLAW_TELEMETRY_ENDPOINT?.trim()) {
+    return false;
+  }
+  return isTruthyEnvValue(process.env.CI);
+}
+
 function isUpdateCheckDisabled(config: OpenClawConfig): boolean {
   return (
     config.update?.checkOnStart === false ||
     isTruthyEnvValue(process.env.OPENCLAW_NO_AUTO_UPDATE) ||
+    isAutomatedEnvironment() ||
     resolveIsNixMode()
   );
 }
@@ -132,7 +147,9 @@ export function resolveTelemetryStatus(config: OpenClawConfig): {
   lastPingAt?: number;
 } {
   let reason: TelemetryStatusReason;
-  if (isUpdateCheckDisabled(config)) {
+  if (isAutomatedEnvironment()) {
+    reason = "automated-environment";
+  } else if (isUpdateCheckDisabled(config)) {
     reason = "update-disabled";
   } else if (isDoNotTrackEnabled()) {
     reason = "do-not-track";


### PR DESCRIPTION
Follow-up to #128476 and #128603.

## What Problem This Solves

Telemetry is live on `main` and working, but the numbers it produces are currently meaningless.

Over the last 7 days the deployed service recorded **27,270 pings**, of which **27,034 came from Linux and 180 from macOS**. That 150:1 ratio does not describe this project's users; it describes our own Docker E2E lanes. The confirming detail is that there are **zero pings from `2026.7.1-2`**, the current npm `latest` — every ping comes from unreleased builds, because telemetry has not shipped in a release yet. So today's dataset is CI plus a handful of developers running `main`.

CI runs the real CLI and gateway across install-smoke, package-acceptance, npm E2E, upgrade-survivor, and multi-node-update lanes, and none of them disable update checks. Left alone, CI volume would permanently dwarf real installs and make version and platform distribution useless after release too.

There is a second reason beyond our own data hygiene: a *user's* CI pipeline running OpenClaw should not report to us on every job either.

## Why This Change Was Made

A detected automated environment now sends nothing. `isAutomatedEnvironment()` treats a truthy `CI` environment variable as automation and feeds the existing "no request at all" gate, so it suppresses **both** tiers: no update check and no feature statistics.

Setting `OPENCLAW_TELEMETRY_ENDPOINT` overrides the suppression. A configured endpoint means the run is deliberately exercising this path, so E2E lanes that test update behavior keep working without special-casing anything.

`resolveTelemetryStatus` reports a distinct `automated-environment` reason rather than folding into `update-disabled`, so `openclaw telemetry show` explains precisely why nothing is sent instead of looking like a silent failure.

## User Impact

CI jobs stop making update-check requests, which is also marginally faster for them. No change for interactive installs. Existing polluted rows age out on their own, since the public aggregates only look back 7 days.

## Evidence

Live data motivating the change is quoted above from `https://telemetry.openclaw.ai/api/stats`.

New tests:
- `never sends a request from an automated environment` — asserts zero requests, no successful-ping stamp, and the `automated-environment` status reason.
- `still reports from an automated environment when an endpoint is configured for it` — asserts the override path still performs exactly one request.

`CI: undefined` was added to this suite's environment reset list. Without it, setting `CI` in one test leaked into six later tests and broke them depending on execution order.

Green locally: `pnpm check:changed`, `pnpm test src/infra/telemetry.test.ts src/cli/telemetry-cli.test.ts`, `pnpm tsgo:core`. Codex autoreview: clean, no actionable findings.

Note for reviewers: an initial `pnpm tsgo:core` run reported errors in `packages/ai` and `packages/markdown-core` about `markdown-it` exports and a missing `FinishReason` member. Those files are untouched here; the cause was stale worktree dependencies after `main` advanced, and `pnpm install` cleared them.

**LOC delta:** production +19/-1, tests +36/-1, docs +13/-0.
