### PR TITLE
fix(plugins): normal disablement is reported as an error

### DIFF
--- a/src/cli/plugins-cli.inspect.test.ts
+++ b/src/cli/plugins-cli.inspect.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginRecord } from "../plugins/status.test-fixtures.js";
+import {
+  buildPluginDiagnosticsReportMock,
+  buildPluginInspectReportMock,
+  buildPluginSnapshotReportMock,
+  pluginCliConfigMock,
+  pluginsCliRuntimeLogs,
+  resetPluginsCliTestState,
+  runPluginsCommand,
+  runtimeErrors,
+  setInstalledPluginIndexInstallRecords,
+} from "./plugins-cli-test-helpers.js";
+
+const workshopMocks = vi.hoisted(() => ({
+  detectToolPolicyDiagnostic: vi.fn(),
+}));
+
+vi.mock("../skills/workshop/tool-policy-diagnostic.js", () => ({
+  detectSkillWorkshopToolPolicyDiagnostic: workshopMocks.detectToolPolicyDiagnostic,
+}));
+
+describe("plugins cli inspect", () => {
+  beforeEach(() => {
+    resetPluginsCliTestState();
+    workshopMocks.detectToolPolicyDiagnostic.mockReset();
+  });
+
+  it("keeps inspect on the static snapshot and distinguishes disabled reasons from errors", async () => {
+    setInstalledPluginIndexInstallRecords({
+      "openclaw-mem0": {
+        source: "clawhub",
+        spec: "clawhub:openclaw-mem0",
+        installPath: "/plugins/openclaw-mem0",
+        version: "2026.5.1",
+        clawhubPackage: "openclaw-mem0",
+        clawhubChannel: "official",
+        artifactKind: "npm-pack",
+        artifactFormat: "tgz",
+        npmIntegrity: "sha512-clawpack",
+        npmShasum: "1".repeat(40),
+        npmTarballName: "openclaw-mem0-2026.5.1.tgz",
+        clawpackSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        clawpackSpecVersion: 1,
+        clawpackManifestSha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        clawpackSize: 4096,
+      },
+    });
+    buildPluginSnapshotReportMock.mockReturnValue({
+      plugins: [createPluginRecord({ id: "openclaw-mem0", name: "Mem0" })],
+      diagnostics: [],
+    });
+    const inspectReport = {
+      workspaceDir: "/workspace",
+      plugin: createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
+      shape: "hook-only",
+      capabilityMode: "plain",
+      capabilityCount: 1,
+      capabilities: [],
+      typedHooks: [{ name: "agent_end" }],
+      customHooks: [],
+      tools: [],
+      commands: [],
+      cliCommands: [],
+      services: [],
+      gatewayDiscoveryServices: [],
+      mcpServers: [
+        { name: "local", hasStdioTransport: true },
+        { name: "remote", hasStdioTransport: false },
+        { name: "broken", hasStdioTransport: false, unsupported: true },
+      ],
+      lspServers: [],
+      httpRouteCount: 0,
+      bundleCapabilities: [],
+      diagnostics: [],
+      policy: {
+        allowConversationAccess: true,
+        allowedModels: [],
+        hasAllowedModelsConfig: false,
+      },
+      usesLegacyBeforeAgentStart: false,
+      compatibility: [],
+    };
+    buildPluginInspectReportMock.mockReturnValue(inspectReport);
+
+    await runPluginsCommand(["plugins", "inspect", "openclaw-mem0"]);
+
+    expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Policy");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("allowConversationAccess: true");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawHub package: openclaw-mem0");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Artifact kind: npm-pack");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Npm integrity: sha512-clawpack");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain(
+      "ClawPack sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawPack spec: 1");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawPack size: 4096 bytes");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("remote");
+    expect(pluginsCliRuntimeLogs.join("\n")).not.toContain("remote (unsupported transport)");
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain("broken (unsupported transport)");
+
+    for (const { id, status, detail, label } of [
+      {
+        id: "workspace-disabled",
+        status: "disabled" as const,
+        detail: "workspace plugin (disabled by default)",
+        label: "Reason",
+      },
+      { id: "broken", status: "error" as const, detail: "missing plugin module", label: "Error" },
+    ]) {
+      const plugin = createPluginRecord({
+        id,
+        enabled: status !== "disabled",
+        status,
+        error: detail,
+        ...(status === "disabled" ? { activationReason: detail } : {}),
+      });
+      buildPluginSnapshotReportMock.mockReturnValue({ plugins: [plugin], diagnostics: [] });
+      buildPluginInspectReportMock.mockReturnValue({ ...inspectReport, plugin });
+
+      await runPluginsCommand(["plugins", "inspect", id]);
+
+      const inspectOutput = pluginsCliRuntimeLogs.at(-1) ?? "";
+      expect(inspectOutput).toContain(`Status: ${status}`);
+      expect(inspectOutput).toContain(`${label}: ${detail}`);
+      expect(inspectOutput).not.toContain(`${label === "Reason" ? "Error" : "Reason"}: ${detail}`);
+
+      if (status === "disabled") {
+        await runPluginsCommand(["plugins", "inspect", id, "--json"]);
+        expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null").plugin).toMatchObject({
+          status: "disabled",
+          error: detail,
+          activationReason: detail,
+        });
+      }
+    }
+  });
+
+  it("runtime-inspects exact plugin ids and display names without repairing deps", async () => {
+    buildPluginSnapshotReportMock.mockReturnValue({
+      plugins: [
+        createPluginRecord({ id: "unrelated-plugin", name: "openclaw-mem0" }),
+        createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
+      ],
+      diagnostics: [],
+    });
+    buildPluginInspectReportMock.mockReturnValue({
+      workspaceDir: "/workspace",
+      plugin: createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
+      shape: "hook-only",
+      capabilityMode: "plain",
+      capabilityCount: 1,
+      capabilities: [],
+      typedHooks: [],
+      customHooks: [],
+      tools: [],
+      commands: [],
+      cliCommands: [],
+      services: [],
+      gatewayDiscoveryServices: [],
+      mcpServers: [],
+      lspServers: [],
+      httpRouteCount: 0,
+      bundleCapabilities: [],
+      diagnostics: [],
+      policy: {
+        allowedModels: [],
+        hasAllowedModelsConfig: false,
+      },
+      usesLegacyBeforeAgentStart: false,
+      compatibility: [],
+    });
+
+    for (const selector of ["openclaw-mem0", "Mem0"]) {
+      await runPluginsCommand(["plugins", "inspect", selector, "--runtime"]);
+      expect(buildPluginDiagnosticsReportMock).toHaveBeenLastCalledWith({
+        config: {},
+        onlyPluginIds: ["openclaw-mem0"],
+      });
+    }
+  });
+
+  it("does not runtime-load plugins when inspect target is missing", async () => {
+    buildPluginSnapshotReportMock.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
+
+    await expect(runPluginsCommand(["plugins", "inspect", "missing-plugin"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(buildPluginSnapshotReportMock).toHaveBeenCalledWith({ config: {} });
+    expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
+    expect(runtimeErrors.at(-1)).toContain("Plugin not found: missing-plugin");
+  });
+
+  it("explains a policy-hidden built-in Skill Workshop at the legacy inspect surface", async () => {
+    const config: OpenClawConfig = {
+      tools: { profile: "messaging" },
+    };
+    pluginCliConfigMock.mockReturnValue(config);
+    workshopMocks.detectToolPolicyDiagnostic.mockReturnValue({
+      agentId: "main",
+      source: "tools.profile",
+      detail: 'tools.profile: "messaging" does not include "skill_workshop".',
+      fix: 'Add tools.alsoAllow: ["skill_workshop"].',
+      message:
+        'Skill Workshop is active, but "skill_workshop" is hidden for agent "main": tools.profile: "messaging" does not include "skill_workshop". Add tools.alsoAllow: ["skill_workshop"].',
+    });
+    buildPluginSnapshotReportMock.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
+
+    await expect(runPluginsCommand(["plugins", "inspect", "skill-workshop"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(runtimeErrors.at(-1)).toContain(
+      "Skill Workshop is built into OpenClaw, not a plugin; configure it under skills.workshop.",
+    );
+    expect(workshopMocks.detectToolPolicyDiagnostic).toHaveBeenCalledWith({
+      config,
+      workshopEnabled: true,
+    });
+    expect(runtimeErrors.at(-1)).toContain(
+      'tools.profile: "messaging" does not include "skill_workshop".',
+    );
+    expect(runtimeErrors.at(-1)).toContain('Add tools.alsoAllow: ["skill_workshop"].');
+  });
+});

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -73,7 +73,8 @@ describe("plugins cli list", () => {
     workshopMocks.detectToolPolicyDiagnostic.mockReset();
   });
 
-  it("shows plugin load errors and healthy descriptions in the default list", async () => {
+  it("distinguishes plugin load errors from disabled reasons across list formats", async () => {
+    const disabledReason = "workspace plugin (disabled by default)";
     buildPluginRegistrySnapshotReportMock.mockReturnValue({
       workspaceDir: "/workspace",
       registrySource: "persisted",
@@ -91,7 +92,8 @@ describe("plugins cli list", () => {
           description: "Disabled plugin description",
           enabled: false,
           status: "disabled",
-          error: "workspace plugin (disabled by default)",
+          error: disabledReason,
+          activationReason: disabledReason,
         }),
       ],
       diagnostics: [],
@@ -103,6 +105,13 @@ describe("plugins cli list", () => {
     expect(output).toContain("missing plugin module");
     expect(output).toContain("Healthy plugin");
     expect(output).toContain("Disabled plugin description");
+
+    await runPluginsCommand(["plugins", "list", "--verbose"]);
+
+    const verboseOutput = pluginsCliRuntimeLogs.at(-1) ?? "";
+    expect(verboseOutput).toContain(`activation reason: ${disabledReason}`);
+    expect(verboseOutput).not.toContain(`error: ${disabledReason}`);
+    expect(verboseOutput).toContain("error: missing plugin module");
   });
 
   it.each([
@@ -876,7 +885,7 @@ describe("plugins cli list", () => {
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("Plugin registry refreshed: 1/2 enabled");
   });
 
-  it("keeps inspect on the static snapshot by default", async () => {
+  it("keeps inspect on the static snapshot and distinguishes disabled reasons from errors", async () => {
     setInstalledPluginIndexInstallRecords({
       "openclaw-mem0": {
         source: "clawhub",
@@ -900,7 +909,7 @@ describe("plugins cli list", () => {
       plugins: [createPluginRecord({ id: "openclaw-mem0", name: "Mem0" })],
       diagnostics: [],
     });
-    buildPluginInspectReportMock.mockReturnValue({
+    const inspectReport = {
       workspaceDir: "/workspace",
       plugin: createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
       shape: "hook-only",
@@ -930,7 +939,8 @@ describe("plugins cli list", () => {
       },
       usesLegacyBeforeAgentStart: false,
       compatibility: [],
-    });
+    };
+    buildPluginInspectReportMock.mockReturnValue(inspectReport);
 
     await runPluginsCommand(["plugins", "inspect", "openclaw-mem0"]);
 
@@ -948,6 +958,42 @@ describe("plugins cli list", () => {
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("remote");
     expect(pluginsCliRuntimeLogs.join("\n")).not.toContain("remote (unsupported transport)");
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("broken (unsupported transport)");
+
+    for (const { id, status, detail, label } of [
+      {
+        id: "workspace-disabled",
+        status: "disabled" as const,
+        detail: "workspace plugin (disabled by default)",
+        label: "Reason",
+      },
+      { id: "broken", status: "error" as const, detail: "missing plugin module", label: "Error" },
+    ]) {
+      const plugin = createPluginRecord({
+        id,
+        enabled: status !== "disabled",
+        status,
+        error: detail,
+        ...(status === "disabled" ? { activationReason: detail } : {}),
+      });
+      buildPluginSnapshotReportMock.mockReturnValue({ plugins: [plugin], diagnostics: [] });
+      buildPluginInspectReportMock.mockReturnValue({ ...inspectReport, plugin });
+
+      await runPluginsCommand(["plugins", "inspect", id]);
+
+      const inspectOutput = pluginsCliRuntimeLogs.at(-1) ?? "";
+      expect(inspectOutput).toContain(`Status: ${status}`);
+      expect(inspectOutput).toContain(`${label}: ${detail}`);
+      expect(inspectOutput).not.toContain(`${label === "Reason" ? "Error" : "Reason"}: ${detail}`);
+
+      if (status === "disabled") {
+        await runPluginsCommand(["plugins", "inspect", id, "--json"]);
+        expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null").plugin).toMatchObject({
+          status: "disabled",
+          error: detail,
+          activationReason: detail,
+        });
+      }
+    }
   });
 
   it("runtime-inspects exact plugin ids and display names without repairing deps", async () => {

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -1,5 +1,5 @@
 // Plugins CLI list tests cover plugin listing output and installed-state formatting.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type {
   ConfigFileSnapshot,
   ConfigValidationIssue,
@@ -9,9 +9,7 @@ import { createPluginRecord } from "../plugins/status.test-fixtures.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   buildPluginDiagnosticsReportMock,
-  buildPluginInspectReportMock,
   buildPluginRegistrySnapshotReportMock,
-  buildPluginSnapshotReportMock,
   inspectPluginRegistryMock,
   pluginCliConfigMock,
   loadPluginManifestRegistryMock,
@@ -21,12 +19,7 @@ import {
   runPluginsCommand,
   runtimeErrors,
   pluginsCliRuntimeLogs,
-  setInstalledPluginIndexInstallRecords,
 } from "./plugins-cli-test-helpers.js";
-
-const workshopMocks = vi.hoisted(() => ({
-  detectToolPolicyDiagnostic: vi.fn(),
-}));
 
 const cleanDoctorMessage =
   "Plugin discovery, module loading, compatibility, and configuration checks passed. " +
@@ -63,14 +56,9 @@ async function mockPluginDoctorValidationWarnings(warnings: ConfigValidationIssu
   });
 }
 
-vi.mock("../skills/workshop/tool-policy-diagnostic.js", () => ({
-  detectSkillWorkshopToolPolicyDiagnostic: workshopMocks.detectToolPolicyDiagnostic,
-}));
-
 describe("plugins cli list", () => {
   beforeEach(() => {
     resetPluginsCliTestState();
-    workshopMocks.detectToolPolicyDiagnostic.mockReset();
   });
 
   it("distinguishes plugin load errors from disabled reasons across list formats", async () => {
@@ -883,210 +871,5 @@ describe("plugins cli list", () => {
     });
     expect(inspectPluginRegistryMock).not.toHaveBeenCalled();
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("Plugin registry refreshed: 1/2 enabled");
-  });
-
-  it("keeps inspect on the static snapshot and distinguishes disabled reasons from errors", async () => {
-    setInstalledPluginIndexInstallRecords({
-      "openclaw-mem0": {
-        source: "clawhub",
-        spec: "clawhub:openclaw-mem0",
-        installPath: "/plugins/openclaw-mem0",
-        version: "2026.5.1",
-        clawhubPackage: "openclaw-mem0",
-        clawhubChannel: "official",
-        artifactKind: "npm-pack",
-        artifactFormat: "tgz",
-        npmIntegrity: "sha512-clawpack",
-        npmShasum: "1".repeat(40),
-        npmTarballName: "openclaw-mem0-2026.5.1.tgz",
-        clawpackSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        clawpackSpecVersion: 1,
-        clawpackManifestSha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        clawpackSize: 4096,
-      },
-    });
-    buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [createPluginRecord({ id: "openclaw-mem0", name: "Mem0" })],
-      diagnostics: [],
-    });
-    const inspectReport = {
-      workspaceDir: "/workspace",
-      plugin: createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
-      shape: "hook-only",
-      capabilityMode: "plain",
-      capabilityCount: 1,
-      capabilities: [],
-      typedHooks: [{ name: "agent_end" }],
-      customHooks: [],
-      tools: [],
-      commands: [],
-      cliCommands: [],
-      services: [],
-      gatewayDiscoveryServices: [],
-      mcpServers: [
-        { name: "local", hasStdioTransport: true },
-        { name: "remote", hasStdioTransport: false },
-        { name: "broken", hasStdioTransport: false, unsupported: true },
-      ],
-      lspServers: [],
-      httpRouteCount: 0,
-      bundleCapabilities: [],
-      diagnostics: [],
-      policy: {
-        allowConversationAccess: true,
-        allowedModels: [],
-        hasAllowedModelsConfig: false,
-      },
-      usesLegacyBeforeAgentStart: false,
-      compatibility: [],
-    };
-    buildPluginInspectReportMock.mockReturnValue(inspectReport);
-
-    await runPluginsCommand(["plugins", "inspect", "openclaw-mem0"]);
-
-    expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Policy");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("allowConversationAccess: true");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawHub package: openclaw-mem0");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Artifact kind: npm-pack");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("Npm integrity: sha512-clawpack");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain(
-      "ClawPack sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    );
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawPack spec: 1");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("ClawPack size: 4096 bytes");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("remote");
-    expect(pluginsCliRuntimeLogs.join("\n")).not.toContain("remote (unsupported transport)");
-    expect(pluginsCliRuntimeLogs.join("\n")).toContain("broken (unsupported transport)");
-
-    for (const { id, status, detail, label } of [
-      {
-        id: "workspace-disabled",
-        status: "disabled" as const,
-        detail: "workspace plugin (disabled by default)",
-        label: "Reason",
-      },
-      { id: "broken", status: "error" as const, detail: "missing plugin module", label: "Error" },
-    ]) {
-      const plugin = createPluginRecord({
-        id,
-        enabled: status !== "disabled",
-        status,
-        error: detail,
-        ...(status === "disabled" ? { activationReason: detail } : {}),
-      });
-      buildPluginSnapshotReportMock.mockReturnValue({ plugins: [plugin], diagnostics: [] });
-      buildPluginInspectReportMock.mockReturnValue({ ...inspectReport, plugin });
-
-      await runPluginsCommand(["plugins", "inspect", id]);
-
-      const inspectOutput = pluginsCliRuntimeLogs.at(-1) ?? "";
-      expect(inspectOutput).toContain(`Status: ${status}`);
-      expect(inspectOutput).toContain(`${label}: ${detail}`);
-      expect(inspectOutput).not.toContain(`${label === "Reason" ? "Error" : "Reason"}: ${detail}`);
-
-      if (status === "disabled") {
-        await runPluginsCommand(["plugins", "inspect", id, "--json"]);
-        expect(JSON.parse(pluginsCliRuntimeLogs.at(-1) ?? "null").plugin).toMatchObject({
-          status: "disabled",
-          error: detail,
-          activationReason: detail,
-        });
-      }
-    }
-  });
-
-  it("runtime-inspects exact plugin ids and display names without repairing deps", async () => {
-    buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [
-        createPluginRecord({ id: "unrelated-plugin", name: "openclaw-mem0" }),
-        createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
-      ],
-      diagnostics: [],
-    });
-    buildPluginInspectReportMock.mockReturnValue({
-      workspaceDir: "/workspace",
-      plugin: createPluginRecord({ id: "openclaw-mem0", name: "Mem0" }),
-      shape: "hook-only",
-      capabilityMode: "plain",
-      capabilityCount: 1,
-      capabilities: [],
-      typedHooks: [],
-      customHooks: [],
-      tools: [],
-      commands: [],
-      cliCommands: [],
-      services: [],
-      gatewayDiscoveryServices: [],
-      mcpServers: [],
-      lspServers: [],
-      httpRouteCount: 0,
-      bundleCapabilities: [],
-      diagnostics: [],
-      policy: {
-        allowedModels: [],
-        hasAllowedModelsConfig: false,
-      },
-      usesLegacyBeforeAgentStart: false,
-      compatibility: [],
-    });
-
-    for (const selector of ["openclaw-mem0", "Mem0"]) {
-      await runPluginsCommand(["plugins", "inspect", selector, "--runtime"]);
-      expect(buildPluginDiagnosticsReportMock).toHaveBeenLastCalledWith({
-        config: {},
-        onlyPluginIds: ["openclaw-mem0"],
-      });
-    }
-  });
-
-  it("does not runtime-load plugins when inspect target is missing", async () => {
-    buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [],
-      diagnostics: [],
-    });
-
-    await expect(runPluginsCommand(["plugins", "inspect", "missing-plugin"])).rejects.toThrow(
-      "__exit__:1",
-    );
-
-    expect(buildPluginSnapshotReportMock).toHaveBeenCalledWith({ config: {} });
-    expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
-    expect(runtimeErrors.at(-1)).toContain("Plugin not found: missing-plugin");
-  });
-
-  it("explains a policy-hidden built-in Skill Workshop at the legacy inspect surface", async () => {
-    const config: OpenClawConfig = {
-      tools: { profile: "messaging" },
-    };
-    pluginCliConfigMock.mockReturnValue(config);
-    workshopMocks.detectToolPolicyDiagnostic.mockReturnValue({
-      agentId: "main",
-      source: "tools.profile",
-      detail: 'tools.profile: "messaging" does not include "skill_workshop".',
-      fix: 'Add tools.alsoAllow: ["skill_workshop"].',
-      message:
-        'Skill Workshop is active, but "skill_workshop" is hidden for agent "main": tools.profile: "messaging" does not include "skill_workshop". Add tools.alsoAllow: ["skill_workshop"].',
-    });
-    buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [],
-      diagnostics: [],
-    });
-
-    await expect(runPluginsCommand(["plugins", "inspect", "skill-workshop"])).rejects.toThrow(
-      "__exit__:1",
-    );
-
-    expect(runtimeErrors.at(-1)).toContain(
-      "Skill Workshop is built into OpenClaw, not a plugin; configure it under skills.workshop.",
-    );
-    expect(workshopMocks.detectToolPolicyDiagnostic).toHaveBeenCalledWith({
-      config,
-      workshopEnabled: true,
-    });
-    expect(runtimeErrors.at(-1)).toContain(
-      'tools.profile: "messaging" does not include "skill_workshop".',
-    );
-    expect(runtimeErrors.at(-1)).toContain('Add tools.alsoAllow: ["skill_workshop"].');
   });
 });

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -415,7 +415,9 @@ export async function runPluginsInspectCommand(
   );
   lines.push(...formatInspectSection("Install", formatInstallLines(install)));
   if (inspect.plugin.error) {
-    lines.push("", `${theme.error("Error:")} ${inspect.plugin.error}`);
+    const label =
+      inspect.plugin.status === "error" ? theme.error("Error:") : theme.muted("Reason:");
+    lines.push("", `${label} ${inspect.plugin.error}`);
   }
   defaultRuntime.log(lines.join("\n"));
 }

--- a/src/cli/plugins-list-format.ts
+++ b/src/cli/plugins-list-format.ts
@@ -69,7 +69,7 @@ export function formatPluginLine(plugin: PluginRecord, verbose = false): string 
         : (plugin.activationSource ?? (plugin.activated ? "active" : "inactive"));
     parts.push(`  activation: ${activationSummary}`);
   }
-  if (plugin.error) {
+  if (plugin.status === "error" && plugin.error) {
     parts.push(theme.error(`  error: ${plugin.error}`));
   }
   return parts.join("\n");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where inspecting an intentionally disabled plugin displayed its ordinary disablement reason as a red failure, despite the plugin being disabled normally rather than broken.

## Why This Change Was Made

Classify plugin error text using the existing authoritative plugin status at both human inspection and verbose formatting boundaries. Genuine failed plugins keep their error presentation, while intentionally disabled plugins retain their useful explanation under a neutral reason label.

## User Impact

Operators can distinguish real plugin failures from normal disablement and still see why an intentional disablement occurred. Plugin JSON output, raw loader metadata, and enabled plugin behavior remain unchanged.

## Evidence

- Two authentic real CLI regressions failed before the fix: verbose formatting displayed a bogus error for ordinary disablement, and inspection displayed the disablement reason as `Error:` instead of `Reason:`.
- Completed formatter and real CLI suites pass 63 tests; a broader unrelated plugin shard was deliberately interrupted under severe host load and is not claimed as passing.
- Focused direct lint, formatting, independent owner-boundary review, and structured review are clean.
