### PR TITLE
fix(reply): preserve every mixed explicit and parsed attachment

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4549,9 +4549,10 @@ describe("deliverOutboundPayloads", () => {
       extractMarkdownImages: true,
     },
   ])("delivers explicit attachments and every extracted $name", async (testCase) => {
-    const sendMedia = vi.fn<NonNullable<ChannelOutboundAdapter["sendMedia"]>>(
-      async ({ mediaUrl }) => ({ channel: "matrix", messageId: mediaUrl }),
-    );
+    const sendMedia = vi.fn<NonNullable<ChannelOutboundAdapter["sendMedia"]>>(async () => ({
+      channel: "matrix",
+      messageId: "sent",
+    }));
     setTestOutbound({
       ...matrixOutboundForTest,
       sendMedia,

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -4537,6 +4537,46 @@ describe("deliverOutboundPayloads", () => {
     expect(sendMatrixOptions?.mediaUrl).toBe("https://example.com/chart.png");
   });
 
+  it.each([
+    {
+      name: "MEDIA directives",
+      text: "Caption\nMEDIA:https://example.com/one.png\nMEDIA:https://example.com/two.png",
+      extractMarkdownImages: false,
+    },
+    {
+      name: "Markdown images",
+      text: "Caption ![one](https://example.com/one.png) ![two](https://example.com/two.png)",
+      extractMarkdownImages: true,
+    },
+  ])("delivers explicit attachments and every extracted $name", async (testCase) => {
+    const sendMedia = vi.fn<NonNullable<ChannelOutboundAdapter["sendMedia"]>>(
+      async ({ mediaUrl }) => ({ channel: "matrix", messageId: mediaUrl }),
+    );
+    setTestOutbound({
+      ...matrixOutboundForTest,
+      sendMedia,
+      extractMarkdownImages: testCase.extractMarkdownImages,
+    });
+
+    await deliverMatrix({
+      cfg: matrixChunkConfig,
+      payloads: [
+        {
+          text: testCase.text,
+          mediaUrl: "https://example.com/primary.png",
+          mediaUrls: ["https://example.com/explicit.png", "https://example.com/one.png"],
+        },
+      ],
+    });
+
+    expect(sendMedia.mock.calls.map(([params]) => params.mediaUrl)).toEqual([
+      "https://example.com/explicit.png",
+      "https://example.com/one.png",
+      "https://example.com/primary.png",
+      "https://example.com/two.png",
+    ]);
+  });
+
   it("continues on errors when bestEffort is enabled", async () => {
     const { sendMatrix, onError, results } = await runBestEffortPartialFailureDelivery();
 

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -408,6 +408,7 @@ describe("sendMessage", () => {
       name: string;
       content: string;
       mediaUrl?: string;
+      mediaUrls?: string[];
       expectedPayloads: Array<{
         text: string;
         mediaUrl: string | null;
@@ -431,6 +432,33 @@ describe("sendMessage", () => {
         expectedMirror: {
           text: "Here",
           mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+        },
+      },
+      {
+        name: "explicit attachments and extracted MEDIA directives",
+        content: "Here\nMEDIA:https://example.com/a.png\nMEDIA:https://example.com/b.png",
+        mediaUrl: "https://example.com/primary.png",
+        mediaUrls: ["https://example.com/explicit.png", "https://example.com/a.png"],
+        expectedPayloads: [
+          {
+            text: "Here",
+            mediaUrl: null,
+            mediaUrls: [
+              "https://example.com/explicit.png",
+              "https://example.com/a.png",
+              "https://example.com/primary.png",
+              "https://example.com/b.png",
+            ],
+          },
+        ],
+        expectedMirror: {
+          text: "Here",
+          mediaUrls: [
+            "https://example.com/explicit.png",
+            "https://example.com/a.png",
+            "https://example.com/primary.png",
+            "https://example.com/b.png",
+          ],
         },
       },
       {
@@ -478,6 +506,7 @@ describe("sendMessage", () => {
         to: "123456",
         content: entry.content,
         ...(entry.mediaUrl ? { mediaUrl: entry.mediaUrl } : {}),
+        ...(entry.mediaUrls ? { mediaUrls: entry.mediaUrls } : {}),
         mirror: {
           sessionKey: "agent:main:forum:dm:123456",
         },

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -54,6 +54,81 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ]);
   });
 
+  it.each([
+    {
+      name: "MEDIA directives",
+      text: "Caption\nMEDIA:https://x.test/one.png\nMEDIA:https://x.test/two.png",
+      extractMarkdownImages: false,
+    },
+    {
+      name: "Markdown images",
+      text: "Caption ![one](https://x.test/one.png) ![two](https://x.test/two.png)",
+      extractMarkdownImages: true,
+    },
+  ])("merges every explicit attachment and extracted $name in source order", (testCase) => {
+    const plan = createOutboundPayloadPlan(
+      [
+        {
+          text: testCase.text,
+          mediaUrl: "https://x.test/primary.png",
+          mediaUrls: ["https://x.test/explicit.png", "https://x.test/one.png"],
+        },
+      ],
+      { extractMarkdownImages: testCase.extractMarkdownImages },
+    );
+    const mediaUrls = [
+      "https://x.test/explicit.png",
+      "https://x.test/one.png",
+      "https://x.test/primary.png",
+      "https://x.test/two.png",
+    ];
+
+    expect(projectOutboundPayloadPlanForDelivery(plan)).toMatchObject([
+      { text: "Caption", mediaUrl: undefined, mediaUrls },
+    ]);
+    expect(projectOutboundPayloadPlanForOutbound(plan)).toMatchObject([
+      { text: "Caption", mediaUrls },
+    ]);
+    expect(projectOutboundPayloadPlanForJson(plan)).toMatchObject([
+      { text: "Caption", mediaUrl: null, mediaUrls },
+    ]);
+    expect(projectOutboundPayloadPlanForMirror(plan)).toEqual({ text: "Caption", mediaUrls });
+  });
+
+  it("keeps parsed attachment order before an explicit singular attachment", () => {
+    const [payload] = normalizeReplyPayloadsForDelivery([
+      {
+        text: "MEDIA:https://x.test/one.png\nMEDIA:https://x.test/two.png",
+        mediaUrl: "https://x.test/primary.png",
+      },
+    ]);
+
+    expect(payload).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: ["https://x.test/one.png", "https://x.test/two.png", "https://x.test/primary.png"],
+    });
+  });
+
+  it("keeps parsed attachments when explicit list and singular sources override the first", () => {
+    const [payload] = normalizeReplyPayloadsForDelivery([
+      {
+        text: "MEDIA:https://x.test/one.png\nMEDIA:https://x.test/two.png",
+        mediaUrl: "https://x.test/primary.png",
+        mediaUrls: ["https://x.test/explicit.png"],
+      },
+    ]);
+
+    expect(payload).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: [
+        "https://x.test/explicit.png",
+        "https://x.test/primary.png",
+        "https://x.test/one.png",
+        "https://x.test/two.png",
+      ],
+    });
+  });
+
   it("strips leading echoed inbound metadata before parsing reply directives", () => {
     const text = [
       markInboundContextLabel("Location:"),

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -225,14 +225,14 @@ function createOutboundPayloadPlanEntry(
   const mergedMedia = mergeMediaUrls(
     explicitMediaUrls,
     explicitMediaUrl ? [explicitMediaUrl] : undefined,
+    parsed.mediaUrls,
   );
   const strippedText = stripUnsupportedCitationControlMarkers(parsed.text ?? "");
   const strippedParsed =
     strippedText === (parsed.text ?? "") ? parsed : parseReplyDirectives(strippedText);
   const parsedText = strippedParsed.text ?? "";
   const suppressedText = strippedParsed.isSilent || isSuppressedRelayStatusText(parsedText);
-  const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
-  const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
+  const resolvedMediaUrl = mergedMedia.length > 1 ? undefined : explicitMediaUrl;
   const normalizedPayload: ReplyPayload = {
     ...payload,
     text:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where attachments silently disappeared when a reply combined explicit media URLs with multiple `MEDIA:` directives or extracted Markdown image URLs.

## Why This Change Was Made

Merge every explicit and parsed attachment source in the existing canonical outbound payload owner, preserving stable order, deduplication, and the correct singular-versus-multiple media representation.

## User Impact

All requested attachments now reach actual channel delivery, structured payload projections, and message mirrors instead of silently losing parsed images after an explicit attachment.

## Evidence

- Five authentic pre-fix regressions reproduced attachment loss across the outbound owner, Markdown extraction, two real outbound adapter paths, and the message/mirror caller.
- Focused payload, media parser, actual delivery, message, and reply sibling suites pass all 568 tests.
- Formatting, lint, independent owner-boundary review, and structured review are clean. Production additions and deletions balance exactly: zero net production growth.
