### PR TITLE
fix(cron): scheduled delivery failures are shown as success

### DIFF
--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -394,6 +394,70 @@ describe("printCronList", () => {
     expect(singleLine).not.toContain("(1x)");
   });
 
+  it.each([
+    { label: "required", bestEffort: false },
+    { label: "best-effort", bestEffort: true },
+    { label: "default", bestEffort: undefined },
+  ])(
+    "makes $label undelivered automation output visible without changing JSON status",
+    ({ bestEffort }) => {
+      const job = createBaseJob({
+        id: "undelivered-job",
+        delivery: {
+          mode: "announce",
+          ...(bestEffort === undefined ? {} : { bestEffort }),
+        },
+        state: {
+          lastRunStatus: "ok",
+          lastDeliveryStatus: "not-delivered",
+          lastDeliveryError: "primary route rejected",
+        },
+      });
+
+      const list = createRuntimeLogCapture();
+      printCronList([job], list.runtime);
+      expectLogsToInclude(list.logs, "ok (not delivered)");
+
+      const show = createRuntimeLogCapture();
+      printCronShow(job, show.runtime);
+      expectLogsToInclude(show.logs, "status: ok (not delivered)");
+      expectLogsToInclude(show.logs, "last delivery error: primary route rejected");
+
+      expect(enrichCronJsonWithStatus(job)).toMatchObject({
+        status: "ok",
+        state: { lastRunStatus: "ok", lastDeliveryStatus: "not-delivered" },
+      });
+      expect(enrichCronJsonWithStatus({ jobs: [job] })).toMatchObject({
+        jobs: [{ status: "ok" }],
+      });
+    },
+  );
+
+  it.each([
+    { label: "disabled", enabled: false, runStatus: "ok" as const, expectedStatus: "disabled" },
+    { label: "running", enabled: true, runStatus: "ok" as const, expectedStatus: "running" },
+    { label: "failed", enabled: true, runStatus: "error" as const, expectedStatus: "error" },
+  ])(
+    "does not let prior non-delivery override a $label automation",
+    ({ enabled, runStatus, expectedStatus }) => {
+      const job = createBaseJob({
+        enabled,
+        state: {
+          lastRunStatus: runStatus,
+          lastDeliveryStatus: "not-delivered",
+          ...(expectedStatus === "running" ? { runningAtMs: Date.now() } : {}),
+        },
+      });
+
+      const show = createRuntimeLogCapture();
+      printCronShow(job, show.runtime);
+
+      expectLogsToInclude(show.logs, `status: ${expectedStatus}`);
+      expect(show.logs.join("\n")).not.toContain("ok (not delivered)");
+      expect(enrichCronJsonWithStatus(job)).toMatchObject({ status: expectedStatus });
+    },
+  );
+
   it("shows why the scheduler auto-disabled a job without changing JSON status", () => {
     const runFailures = createBaseJob({
       id: "auto-disabled-runs",

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -198,12 +198,16 @@ function decorateStatusWithFailures(status: string, consecutiveErrors: number | 
 
 function formatCronStatusForDisplay(job: CronJob): string {
   const state = job.state ?? {};
-  if (computeStatus(job) === "disabled" && state.autoDisabled) {
+  const status = computeStatus(job);
+  if (status === "disabled" && state.autoDisabled) {
     return state.autoDisabled.reason === "schedule-errors"
       ? "disabled (schedule)"
       : `disabled (${state.autoDisabled.consecutiveErrors}x)`;
   }
-  return decorateStatusWithFailures(computeStatus(job), state.consecutiveErrors);
+  if (status === "ok" && state.lastDeliveryStatus === "not-delivered") {
+    return "ok (not delivered)";
+  }
+  return decorateStatusWithFailures(status, state.consecutiveErrors);
 }
 
 export function handleCronCliError(err: unknown) {
@@ -513,13 +517,13 @@ export function printCronList(
     );
 
     const coloredStatus = (() => {
-      if (statusRaw === "ok") {
+      if (statusRaw === "ok" && state.lastDeliveryStatus !== "not-delivered") {
         return colorize(rich, theme.success, statusLabel);
       }
       if (statusRaw === "error") {
         return colorize(rich, theme.error, statusLabel);
       }
-      if (statusRaw === "running") {
+      if (statusRaw === "running" || statusRaw === "ok") {
         return colorize(rich, theme.warn, statusLabel);
       }
       if (statusRaw === "skipped") {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cron jobs whose execution succeeded but whose reply delivery failed appeared as green successful jobs in cron list and detail output.

## Why This Change Was Made

Decorate the existing human-readable cron status with the already-recorded delivery outcome, producing `ok (not delivered)` for both required and best-effort failed deliveries without changing execution status or inferring policy from mutable configuration.

## User Impact

Operators immediately see when a scheduled task ran successfully but did not deliver its expected response; raw JSON status, disabled/running/error precedence, and persisted cron state remain unchanged.

## Evidence

- Three authentic pre-fix CLI regressions failed across required, best-effort, and default failed-delivery records.
- Focused cron CLI and simple-command sibling suites pass 118 tests; intentionally interrupted broader E2E startup is not counted as completed proof.
- Formatting, independent owner-boundary review, and structured review pass; focused local lint was deliberately stopped during severe host contention, so the required exact-head hosted lint check is authoritative.
