### PR TITLE
fix(health): activated plugin failures are silently omitted

### DIFF
--- a/src/commands/health-format.test.ts
+++ b/src/commands/health-format.test.ts
@@ -197,6 +197,54 @@ describe("formatHealthChannelLines", () => {
     ]);
   });
 
+  it("surfaces activated plugin failures without promoting inactive load errors", () => {
+    const summary = createHealthSummary({ channels: {}, channelOrder: [], channelLabels: {} });
+    summary.plugins = {
+      loaded: ["calendar"],
+      errors: [
+        {
+          id: "calendar",
+          origin: "workspace",
+          activated: true,
+          failurePhase: "service",
+          error: "service scheduler: address already in use",
+        },
+        {
+          id: "inactive",
+          origin: "workspace",
+          activated: false,
+          failurePhase: "load",
+          error: "inactive plugin load failed",
+        },
+      ],
+    };
+
+    expect(formatHealthChannelLines(summary)).toStrictEqual([
+      "Plugin calendar: failed - service scheduler: address already in use; run openclaw doctor",
+    ]);
+  });
+
+  it("bounds activated plugin failure details and summarizes omitted failures", () => {
+    const summary = createHealthSummary({ channels: {}, channelOrder: [], channelLabels: {} });
+    summary.plugins = {
+      loaded: [],
+      errors: Array.from({ length: 22 }, (_, index) => ({
+        id: `plugin-${index}`,
+        origin: "workspace",
+        activated: true,
+        error: "x".repeat(600),
+      })),
+    };
+
+    const lines = formatHealthChannelLines(summary);
+
+    expect(lines).toHaveLength(21);
+    expect(lines[0]).toBe(`Plugin plugin-0: failed - ${"x".repeat(500)}; run openclaw doctor`);
+    expect(lines.at(-1)).toBe(
+      "Plugins: failed - 2 additional activated failures; run openclaw doctor",
+    );
+  });
+
   it("formats iMessage probe failures as failed health lines", () => {
     const summary = createHealthSummary({
       channels: {

--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -140,7 +140,7 @@ const isProbeFailure = (summary: ChannelAccountHealthSummary): boolean => {
   return ok === false;
 };
 
-/** Formats one terse health line per channel, optionally including every account. */
+/** Formats terse channel and activated-plugin health lines for shared CLI surfaces. */
 export const formatHealthChannelLines = (
   summary: HealthSummary,
   opts: {
@@ -256,6 +256,17 @@ export const formatHealthChannelLines = (
             ? "configured"
             : "unknown";
     lines.push(`${label}: ${passiveState}`);
+  }
+  const failedPlugins = (summary.plugins?.errors ?? []).filter((plugin) => plugin.activated);
+  for (const plugin of failedPlugins.slice(0, 20)) {
+    const id = sanitizeTerminalText(plugin.id).slice(0, 120);
+    const error = sanitizeTerminalText(plugin.error).slice(0, 500);
+    lines.push(`Plugin ${id}: failed - ${error}; run openclaw doctor`);
+  }
+  if (failedPlugins.length > 20) {
+    lines.push(
+      `Plugins: failed - ${failedPlugins.length - 20} additional activated failures; run openclaw doctor`,
+    );
   }
   return lines;
 };

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -166,7 +166,7 @@ describe("healthCommand", () => {
     probeGatewayStatusMock.mockReset();
   });
 
-  it("renders the gateway session path identically in JSON and text", async () => {
+  it("preserves plugin health in JSON while surfacing activated failures in text", async () => {
     const agentSessions = {
       path: "/tmp/sessions.json",
       count: 1,
@@ -190,6 +190,24 @@ describe("healthCommand", () => {
       },
       sessions: agentSessions,
     });
+    snapshot.plugins = {
+      loaded: ["calendar"],
+      errors: [
+        {
+          id: "calendar",
+          origin: "workspace",
+          activated: true,
+          failurePhase: "service",
+          error: "service scheduler: address already in use",
+        },
+        {
+          id: "inactive",
+          origin: "workspace",
+          activated: false,
+          error: "inactive plugin load failed",
+        },
+      ],
+    };
     callGatewayMock.mockResolvedValueOnce(snapshot);
 
     await healthCommand({ json: true, timeoutMs: 5000, config: {} }, runtime as never);
@@ -200,6 +218,7 @@ describe("healthCommand", () => {
     expect(parsed.channels.whatsapp?.linked).toBe(true);
     expect(parsed.channels.telegram?.configured).toBe(true);
     expect(parsed.sessions.count).toBe(1);
+    expect(parsed.plugins).toEqual(snapshot.plugins);
 
     runtime.log.mockClear();
     callGatewayMock.mockResolvedValueOnce(snapshot);
@@ -207,6 +226,10 @@ describe("healthCommand", () => {
 
     const output = stripAnsi(runtime.log.mock.calls.map((call) => String(call[0])).join("\n"));
     expect(output).toContain(`Session store (main): ${parsed.sessions.path}`);
+    expect(output).toContain(
+      "Plugin calendar: failed - service scheduler: address already in use; run openclaw doctor",
+    );
+    expect(output).not.toContain("inactive plugin load failed");
   });
 
   it("prints the gateway probe duration in text output", async () => {

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -293,8 +293,14 @@ describe("status.command-sections", () => {
   });
 
   it("marks activated plugin service failures as warnings in deep health rows", () => {
-    const health = {
+    const health: HealthSummary = {
+      ok: true,
+      ts: 0,
       durationMs: 42,
+      heartbeatSeconds: 60,
+      defaultAgentId: "main",
+      agents: [],
+      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
       channels: {},
       channelOrder: [],
       channelLabels: {},
@@ -310,7 +316,7 @@ describe("status.command-sections", () => {
           },
         ],
       },
-    } as HealthSummary;
+    };
     const rows = buildStatusHealthRows({
       health,
       formatHealthChannelLines,

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -1,5 +1,6 @@
 // Status command section tests cover footer, health, and report section rendering.
 import { describe, expect, it } from "vitest";
+import { formatHealthChannelLines } from "./health-format.js";
 import type { HealthSummary } from "./health.js";
 import {
   buildStatusFooterLines,
@@ -289,6 +290,40 @@ describe("status.command-sections", () => {
       { Item: "Matrix", Status: "ok(LINKED)", Detail: "linked" },
       { Item: "Pager", Status: "warn(UNLINKED)", Detail: "not linked" },
     ]);
+  });
+
+  it("marks activated plugin service failures as warnings in deep health rows", () => {
+    const health = {
+      durationMs: 42,
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+      plugins: {
+        loaded: ["calendar"],
+        errors: [
+          {
+            id: "calendar",
+            origin: "workspace",
+            activated: true,
+            failurePhase: "service",
+            error: "service scheduler: address already in use",
+          },
+        ],
+      },
+    } as HealthSummary;
+    const rows = buildStatusHealthRows({
+      health,
+      formatHealthChannelLines,
+      ok: (value) => `ok(${value})`,
+      warn: (value) => `warn(${value})`,
+      muted: (value) => `muted(${value})`,
+    });
+
+    expect(rows).toContainEqual({
+      Item: "Plugin calendar",
+      Status: "warn(WARN)",
+      Detail: "failed - service scheduler: address already in use; run openclaw doctor",
+    });
   });
 
   it("adds degraded event-loop health to status rows", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ordinary health commands and deep status silently reported healthy output even though an activated plugin or background plugin service had already failed to load or start.

## Why This Change Was Made

Render the Gateway's existing authoritative activated-plugin failure records in the shared human-readable health formatter so ordinary health, gateway health, and deep status consistently surface bounded actionable diagnostics.

## User Impact

Operators see activated plugin and service failures together with a concrete `openclaw doctor` next step. Inactive or unavailable plugins remain excluded from these alarms, and existing JSON, persistence, configuration, and protocol contracts stay unchanged.

## Evidence

- Four authentic pre-fix regressions reproduced missing failures in the shared formatter, deep status, and the real health command.
- The full health formatter owner suite passes all 19 tests; the exact real health-command regression also passes while preserving JSON output.
- Focused formatting, direct lint, independent owner-boundary review, and structured review are clean.
