### PR TITLE
refactor(cli): centralize Claws output formatting

### DIFF
--- a/src/cli/claws-cli-output.ts
+++ b/src/cli/claws-cli-output.ts
@@ -1,6 +1,20 @@
+import type { ClawDiagnostic } from "../claws/types.js";
 import type { ClawUpdatePlan } from "../claws/update-plan.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import type { RuntimeEnv } from "../runtime.js";
+
+export function formatClawDiagnostics(diagnostics: readonly ClawDiagnostic[]): string {
+  return diagnostics
+    .map(
+      (diagnostic) =>
+        `${diagnostic.level.toUpperCase()} ${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`,
+    )
+    .join("\n");
+}
+
+export function logClawExperimentalWarning(runtime: RuntimeEnv): void {
+  runtime.log("Experimental: Claws contracts may change while RFC 0016 is under review.");
+}
 
 export function logClawUpdatePlanSummary(plan: ClawUpdatePlan, runtime: RuntimeEnv): void {
   runtime.log(`Agent: ${plan.agentId}`);
@@ -32,13 +46,6 @@ export function logClawUpdatePlanSummary(plan: ClawUpdatePlan, runtime: RuntimeE
     }
   }
   if (plan.blockers.length > 0) {
-    runtime.error(
-      plan.blockers
-        .map(
-          (diagnostic) =>
-            `${diagnostic.level.toUpperCase()} ${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`,
-        )
-        .join("\n"),
-    );
+    runtime.error(formatClawDiagnostics(plan.blockers));
   }
 }

--- a/src/cli/claws-cli-update-output.test.ts
+++ b/src/cli/claws-cli-update-output.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { makeEmptyClawUpdatePlan } from "../claws/update-plan-empty.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { logClawUpdatePlanSummary } from "./claws-cli-update-output.js";
+import { logClawUpdatePlanSummary } from "./claws-cli-output.js";
 
 describe("logClawUpdatePlanSummary", () => {
   it("prints plugin setup prerequisites", () => {

--- a/src/cli/claws-cli.project.ts
+++ b/src/cli/claws-cli.project.ts
@@ -16,10 +16,11 @@ import {
   validateClawProject,
 } from "../claws/project.js";
 import { readClawManifestFile } from "../claws/reader.js";
-import { CLAW_OUTPUT_STABILITY, type ClawAddPlan, type ClawDiagnostic } from "../claws/types.js";
+import { CLAW_OUTPUT_STABILITY, type ClawAddPlan } from "../claws/types.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import { normalizeConfiguredMcpServers } from "../config/mcp-config-normalize.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
+import { formatClawDiagnostics, logClawExperimentalWarning } from "./claws-cli-output.js";
 import type {
   ClawsBuildOptions,
   ClawsCreateOptions,
@@ -33,16 +34,6 @@ type PreparedDev = {
 };
 
 const CLAW_DEV_RESULT_SCHEMA_VERSION = "openclaw.clawDev.v1" as const;
-
-function formatDiagnostics(diagnostics: ClawDiagnostic[]): string {
-  return diagnostics
-    .map((item) => `${item.level.toUpperCase()} ${item.code} ${item.path}: ${item.message}`)
-    .join("\n");
-}
-
-function logExperimentalWarning(runtime: RuntimeEnv): void {
-  runtime.log("Experimental: Claws contracts may change while RFC 0016 is under review.");
-}
 
 function reportProjectError(
   error: unknown,
@@ -87,7 +78,7 @@ async function prepareDev(projectPath: string, opts: ClawsDevOptions): Promise<P
       if (!result.ok) {
         throw new ClawProjectError(
           "artifact_verification_failed",
-          formatDiagnostics(result.diagnostics),
+          formatClawDiagnostics(result.diagnostics),
         );
       }
       const configSnapshot = await readConfigFileSnapshot({
@@ -155,7 +146,7 @@ export async function runClawsCreateCommand(
       });
       return;
     }
-    logExperimentalWarning(runtime);
+    logClawExperimentalWarning(runtime);
     runtime.log(`Created Claw project: ${result.root}`);
     runtime.log(`Package: ${result.packageJson.name}@${result.packageJson.version}`);
   } catch (error) {
@@ -186,7 +177,7 @@ export async function runClawsValidateCommand(
         diagnostics: result.diagnostics,
       });
     } else {
-      runtime.error(formatDiagnostics(result.diagnostics));
+      runtime.error(formatClawDiagnostics(result.diagnostics));
     }
     runtime.exit(1);
     return;
@@ -205,7 +196,7 @@ export async function runClawsValidateCommand(
     });
     return;
   }
-  logExperimentalWarning(runtime);
+  logClawExperimentalWarning(runtime);
   runtime.log(`Valid Claw project: ${result.root}`);
   runtime.log(`Package: ${result.packageJson.name}@${result.packageJson.version}`);
   for (const path of result.excludedPaths) {
@@ -225,7 +216,7 @@ export async function runClawsBuildCommand(
       writeRuntimeJson(runtime, { ...result, stability: CLAW_OUTPUT_STABILITY, ok: true });
       return;
     }
-    logExperimentalWarning(runtime);
+    logClawExperimentalWarning(runtime);
     runtime.log(`Built Claw: ${result.claw.name}@${result.claw.version}`);
     runtime.log(`Artifact: ${result.artifact}`);
     runtime.log(`Integrity: ${result.integrity}`);
@@ -277,12 +268,12 @@ export async function runClawsDevCommand(
       plan,
     });
   } else {
-    logExperimentalWarning(runtime);
+    logClawExperimentalWarning(runtime);
     runtime.log(`Claw dev preview: ${build.claw.name}@${build.claw.version}`);
     runtime.log(`Artifact integrity: ${build.integrity}`);
     logDevPlanSummary(plan, runtime);
     if (plan.blockers.length > 0) {
-      runtime.error(formatDiagnostics(plan.blockers));
+      runtime.error(formatClawDiagnostics(plan.blockers));
     }
   }
   if (plan.blockers.length > 0) {

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -58,6 +58,7 @@ import {
 import { redactSensitiveText } from "../logging/redact.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
 import { authorizeLegacyV1Resume } from "./claws-cli-legacy-resume.js";
+import { formatClawDiagnostics, logClawExperimentalWarning } from "./claws-cli-output.js";
 import { waitUntilGatewayConfigApplied } from "./claws-cli.gateway-readiness.js";
 import type {
   ClawsAddOptions,
@@ -68,21 +69,6 @@ import type {
 } from "./claws-cli.js";
 import { listCronJobsFromGateway } from "./cron-cli/list-jobs.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
-
-type DiagnosticLike = { level: string; code: string; path: string; message: string };
-
-function formatDiagnostics(diagnostics: DiagnosticLike[]): string {
-  return diagnostics
-    .map(
-      (diagnostic) =>
-        `${diagnostic.level.toUpperCase()} ${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`,
-    )
-    .join("\n");
-}
-
-function logExperimentalWarning(runtime: RuntimeEnv): void {
-  runtime.log("Experimental: Claws contracts may change while RFC 0016 is under review.");
-}
 
 function logClawAddPlanSummary(plan: ClawAddPlan, runtime: RuntimeEnv): void {
   runtime.log(`Agent: ${plan.agent.finalId}`);
@@ -215,7 +201,7 @@ export async function runClawsInspectCommand(
         diagnostics: result.diagnostics,
       });
     } else {
-      runtime.error(formatDiagnostics(result.diagnostics));
+      runtime.error(formatClawDiagnostics(result.diagnostics));
     }
     runtime.exit(1);
     return;
@@ -253,7 +239,7 @@ export async function runClawsInspectCommand(
     }
     return;
   }
-  logExperimentalWarning(runtime);
+  logClawExperimentalWarning(runtime);
   runtime.log(`Claw: ${result.source.name}@${result.source.version}`);
   runtime.log(`Agent: ${result.manifest.agent.name ?? result.manifest.agent.id}`);
   runtime.log(`Packages: ${result.manifest.packages.length}`);
@@ -266,7 +252,7 @@ export async function runClawsInspectCommand(
   runtime.log(`MCP servers: ${Object.keys(result.manifest.mcpServers).length}`);
   runtime.log(`Cron jobs: ${result.manifest.cronJobs.length}`);
   if (!valid) {
-    runtime.error(formatDiagnostics(diagnostics));
+    runtime.error(formatClawDiagnostics(diagnostics));
     runtime.exit(1);
   }
 }
@@ -296,7 +282,7 @@ export async function runClawsAddCommand(
         diagnostics: result.diagnostics,
       });
     } else {
-      runtime.error(formatDiagnostics(result.diagnostics));
+      runtime.error(formatClawDiagnostics(result.diagnostics));
     }
     runtime.exit(1);
     return;
@@ -460,9 +446,9 @@ export async function runClawsAddCommand(
     if (opts.json) {
       writeRuntimeJson(runtime, plan);
     } else {
-      logExperimentalWarning(runtime);
+      logClawExperimentalWarning(runtime);
       logClawAddPlanSummary(plan, runtime);
-      runtime.error(formatDiagnostics(plan.blockers));
+      runtime.error(formatClawDiagnostics(plan.blockers));
     }
     runtime.exit(1);
     return;
@@ -472,7 +458,7 @@ export async function runClawsAddCommand(
     if (opts.json) {
       writeRuntimeJson(runtime, plan);
     } else {
-      logExperimentalWarning(runtime);
+      logClawExperimentalWarning(runtime);
       runtime.log(`Claw add plan: ${plan.claw.name}@${plan.claw.version}`);
       logClawAddPlanSummary(plan, runtime);
     }
@@ -499,7 +485,7 @@ export async function runClawsAddCommand(
 
   let addResult;
   if (!opts.json) {
-    logExperimentalWarning(runtime);
+    logClawExperimentalWarning(runtime);
   }
   try {
     addResult = await applyClawAddPlan(plan, {
@@ -553,7 +539,7 @@ export async function runClawsStatusCommand(
   if (opts.json) {
     writeRuntimeJson(runtime, status);
   } else {
-    logExperimentalWarning(runtime);
+    logClawExperimentalWarning(runtime);
     runtime.log(`Installed Claws: ${status.summary.claws}`);
     for (const record of status.records) {
       runtime.log(
@@ -605,7 +591,7 @@ export async function runClawsRemoveCommand(
     if (opts.json) {
       writeRuntimeJson(runtime, plan);
     } else {
-      logExperimentalWarning(runtime);
+      logClawExperimentalWarning(runtime);
       runtime.log(`Remove actions: ${plan.actions.length}`);
       runtime.log(`Plan integrity: ${plan.planIntegrity}`);
       for (const action of plan.actions.filter((candidate) => candidate.kind === "packageRef")) {
@@ -639,7 +625,7 @@ export async function runClawsRemoveCommand(
     if (opts.json) {
       writeRuntimeJson(runtime, result);
     } else {
-      logExperimentalWarning(runtime);
+      logClawExperimentalWarning(runtime);
       runtime.log(`Removed agent: ${result.agentId}`);
       runtime.log(`Status: ${result.status}`);
       for (const pkg of result.packages) {
@@ -689,7 +675,7 @@ export async function runClawsExportCommand(
       writeRuntimeJson(runtime, result);
       return;
     }
-    logExperimentalWarning(runtime);
+    logClawExperimentalWarning(runtime);
     runtime.log(`Exported agent: ${result.agentId}`);
     runtime.log(`Package directory: ${result.outputDirectory}`);
     runtime.log(

--- a/src/cli/claws-update-cli.runtime.ts
+++ b/src/cli/claws-update-cli.runtime.ts
@@ -12,24 +12,13 @@ import { buildClawUpdatePlan, CLAW_UPDATE_PLAN_SCHEMA_VERSION } from "../claws/u
 import { listConfiguredMcpServers } from "../config/mcp-config.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
 import { openExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db.js";
-import { logClawUpdatePlanSummary } from "./claws-cli-update-output.js";
+import {
+  formatClawDiagnostics,
+  logClawExperimentalWarning,
+  logClawUpdatePlanSummary,
+} from "./claws-cli-output.js";
 import type { ClawsUpdateOptions } from "./claws-cli.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
-
-type DiagnosticLike = { level: string; code: string; path: string; message: string };
-
-function formatDiagnostics(diagnostics: DiagnosticLike[]): string {
-  return diagnostics
-    .map(
-      (diagnostic) =>
-        `${diagnostic.level.toUpperCase()} ${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`,
-    )
-    .join("\n");
-}
-
-function logExperimentalWarning(runtime: RuntimeEnv): void {
-  runtime.log("Experimental: Claws contracts may change while RFC 0016 is under review.");
-}
 
 export async function runClawsUpdateCommand(
   target: string,
@@ -162,7 +151,7 @@ export async function runClawsUpdateCommand(
         diagnostics,
       });
     } else {
-      runtime.error(formatDiagnostics(diagnostics));
+      runtime.error(formatClawDiagnostics(diagnostics));
     }
     runtime.exit(1);
     return;
@@ -183,7 +172,7 @@ export async function runClawsUpdateCommand(
     if (opts.json) {
       writeRuntimeJson(runtime, plan);
     } else {
-      logExperimentalWarning(runtime);
+      logClawExperimentalWarning(runtime);
       runtime.log(
         `Claw update plan: ${plan.currentClaw?.name ?? target} ${plan.currentClaw?.version ?? "unknown"} -> ${plan.targetClaw?.version ?? "unknown"}`,
       );
@@ -222,7 +211,7 @@ export async function runClawsUpdateCommand(
       writeRuntimeJson(runtime, result);
       return;
     }
-    logExperimentalWarning(runtime);
+    logClawExperimentalWarning(runtime);
     runtime.log(`Updated agent: ${result.agentId}`);
     runtime.log(`Claw version: ${result.previousClaw.version} -> ${result.targetClaw.version}`);
   } catch (error) {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Claws commands evolved separate copies of the same human-readable diagnostic renderer and experimental warning. Keeping those output policies in multiple command modules adds drift risk whenever the CLI wording or diagnostic format changes.

## Why This Change Was Made

Rename the existing update-specific output owner to the generic Claws CLI output owner and route inspect, project, and update flows through its canonical diagnostic and warning helpers. Exact output and command behavior stay unchanged; adding another wrapper or compatibility alias was rejected because it would preserve rather than remove the duplicate ownership. This change was developed with AI assistance.

## User Impact

No user-visible behavior changes. Claws CLI human-readable warnings and diagnostics now have one canonical implementation, reducing future formatting drift.

## Evidence

- Exact pushed head: `081641f55a03577c0f9ef9f22550ce3b55fdecb3`
- Production LOC: +45/−72 (net −27); tests: +1/−1 (net 0)
- `node scripts/run-vitest.mjs src/cli/claws-cli-update-output.test.ts src/cli/claws-cli.project.test.ts src/cli/claws-cli.test.ts src/cli/claws-cli.inspect.test.ts` — 4 files, 42 tests passed
- `node scripts/check-changed.mjs` — passed, including formatting, dead-export scans, core/core-test typechecks, lint, import-cycle, and repository guards
- Deslop pass — no actionable slop
- `autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings
- Independent read-only Codex review of the exact frozen head — `CLEAN`
- Exact-head GitHub CI: green — run `32826668058` on `081641f55a03577c0f9ef9f22550ce3b55fdecb3`

