### PR TITLE
fix(agents): stored auth profile order is ignored when resolving CLI runtime aliases

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -199,7 +199,7 @@ Notes:
 - `paste-token --expires-in <duration>` stores an absolute token expiry from a relative duration such as `365d` or `12h`.
 - For `openai`, OpenAI API keys and ChatGPT/OAuth token material are different auth shapes. Use `paste-api-key` for `sk-...` OpenAI API keys and `paste-token` only for token auth material.
 - Anthropic: `setup-token`/`paste-token` are supported OpenClaw auth paths for `anthropic`, but OpenClaw prefers reusing the Claude CLI (`claude -p`) on the host when it is available.
-- `auth order get/set/clear` manages a per-agent auth profile order override for one provider, stored in `auth-state.json` (separate from the `auth.order.<provider>` config key). `set` takes one or more profile ids in priority order; `clear` falls back to config/round-robin ordering.
+- `auth order get/set/clear` manages a per-agent auth profile order override for one provider in the SQLite auth store, separate from the `auth.order.<provider>` config key. `set` takes one or more profile ids in priority order. The stored order takes precedence over config for profile selection and CLI runtime routing; `clear` falls back to config/round-robin ordering.
 
 ## Related
 

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -117,6 +117,9 @@ Profiles live in the per-agent `openclaw-agent.sqlite` auth profile store.
 When a provider has multiple profiles, OpenClaw chooses an order like this:
 
 <Steps>
+  <Step title="Stored order override">
+    The per-agent order set with `openclaw models auth order set --provider <id> <profileIds...>`.
+  </Step>
   <Step title="Explicit config">
     `auth.order[provider]` (if set).
   </Step>

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -280,6 +280,55 @@ export type AuthProfileOrderResolution = {
   hasExplicitOrder: boolean;
 };
 
+/**
+ * Resolves which explicit auth order owns selection for a provider.
+ *
+ * The persisted store outranks config, and each source is matched across the
+ * provider auth key and the raw provider key. Shared with CLI runtime alias
+ * routing so profile selection and alias routing cannot disagree on precedence.
+ */
+export function resolveExplicitAuthOrderSelection(params: {
+  storeOrder: AuthProfileStore["order"] | undefined;
+  configuredOrder: Record<string, string[]> | undefined;
+  providerKey: string;
+  providerAuthKey: string;
+}): {
+  openAIOrderAliasProvider: string | undefined;
+  directExplicitOrder: string[] | undefined;
+  aliasExplicitOrder: string[] | undefined;
+  explicitOrderFromStore: boolean;
+} {
+  const { storeOrder, configuredOrder, providerKey, providerAuthKey } = params;
+  const openAIOrderAliasProvider =
+    providerAuthKey === OPENAI_CODEX_PROVIDER_ID || providerKey === OPENAI_CODEX_PROVIDER_ID
+      ? OPENAI_PROVIDER_ID
+      : undefined;
+  const directStoredOrder =
+    resolveAuthOrder(storeOrder, providerAuthKey) ?? resolveAuthOrder(storeOrder, providerKey);
+  const aliasStoredOrder = openAIOrderAliasProvider
+    ? resolveAuthOrder(storeOrder, openAIOrderAliasProvider)
+    : undefined;
+  const directConfiguredOrder =
+    resolveAuthOrder(configuredOrder, providerAuthKey) ??
+    resolveAuthOrder(configuredOrder, providerKey);
+  const aliasConfiguredOrder = openAIOrderAliasProvider
+    ? resolveAuthOrder(configuredOrder, openAIOrderAliasProvider)
+    : undefined;
+  const directExplicitOrder = directStoredOrder ?? directConfiguredOrder;
+  const aliasExplicitOrder = aliasStoredOrder ?? aliasConfiguredOrder;
+  // Stored order repairs are allowed to fall back to live store profiles when
+  // old setup flows persisted profile ids that no longer exist.
+  const explicitOrderFromStore =
+    directStoredOrder !== undefined ||
+    (directExplicitOrder === undefined && aliasStoredOrder !== undefined);
+  return {
+    openAIOrderAliasProvider,
+    directExplicitOrder,
+    aliasExplicitOrder,
+    explicitOrderFromStore,
+  };
+}
+
 /** Resolves ordered usable auth profiles plus whether an explicit order owns selection. */
 export function resolveAuthProfileOrderWithMetadata(
   params: ResolveAuthProfileOrderParams,
@@ -296,28 +345,17 @@ export function resolveAuthProfileOrderWithMetadata(
   // get a fresh error count and are not immediately re-penalized on the
   // next transient failure. See #3604.
   clearExpiredCooldowns(store, now);
-  const openAIOrderAliasProvider =
-    providerAuthKey === OPENAI_CODEX_PROVIDER_ID || providerKey === OPENAI_CODEX_PROVIDER_ID
-      ? OPENAI_PROVIDER_ID
-      : undefined;
-  const directStoredOrder =
-    resolveAuthOrder(store.order, providerAuthKey) ?? resolveAuthOrder(store.order, providerKey);
-  const aliasStoredOrder = openAIOrderAliasProvider
-    ? resolveAuthOrder(store.order, openAIOrderAliasProvider)
-    : undefined;
-  const directConfiguredOrder =
-    resolveAuthOrder(cfg?.auth?.order, providerAuthKey) ??
-    resolveAuthOrder(cfg?.auth?.order, providerKey);
-  const aliasConfiguredOrder = openAIOrderAliasProvider
-    ? resolveAuthOrder(cfg?.auth?.order, openAIOrderAliasProvider)
-    : undefined;
-  const directExplicitOrder = directStoredOrder ?? directConfiguredOrder;
-  const aliasExplicitOrder = aliasStoredOrder ?? aliasConfiguredOrder;
-  // Stored order repairs are allowed to fall back to live store profiles when
-  // old setup flows persisted profile ids that no longer exist.
-  const explicitOrderFromStore =
-    directStoredOrder !== undefined ||
-    (directExplicitOrder === undefined && aliasStoredOrder !== undefined);
+  const {
+    openAIOrderAliasProvider,
+    directExplicitOrder,
+    aliasExplicitOrder,
+    explicitOrderFromStore,
+  } = resolveExplicitAuthOrderSelection({
+    storeOrder: store.order,
+    configuredOrder: cfg?.auth?.order,
+    providerKey,
+    providerAuthKey,
+  });
   const explicitProfiles = cfg?.auth?.profiles
     ? Object.entries(cfg.auth.profiles)
         .filter(([profileId, profile]) =>

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -280,52 +280,26 @@ export type AuthProfileOrderResolution = {
   hasExplicitOrder: boolean;
 };
 
-/**
- * Resolves which explicit auth order owns selection for a provider.
- *
- * The persisted store outranks config, and each source is matched across the
- * provider auth key and the raw provider key. Shared with CLI runtime alias
- * routing so profile selection and alias routing cannot disagree on precedence.
- */
+/** Shares stored-over-config order precedence with CLI runtime selection. */
 export function resolveExplicitAuthOrderSelection(params: {
   storeOrder: AuthProfileStore["order"] | undefined;
   configuredOrder: Record<string, string[]> | undefined;
   providerKey: string;
   providerAuthKey: string;
 }): {
-  openAIOrderAliasProvider: string | undefined;
-  directExplicitOrder: string[] | undefined;
-  aliasExplicitOrder: string[] | undefined;
-  explicitOrderFromStore: boolean;
+  order: string[] | undefined;
+  fromStore: boolean;
 } {
   const { storeOrder, configuredOrder, providerKey, providerAuthKey } = params;
-  const openAIOrderAliasProvider =
-    providerAuthKey === OPENAI_CODEX_PROVIDER_ID || providerKey === OPENAI_CODEX_PROVIDER_ID
-      ? OPENAI_PROVIDER_ID
-      : undefined;
-  const directStoredOrder =
-    resolveAuthOrder(storeOrder, providerAuthKey) ?? resolveAuthOrder(storeOrder, providerKey);
-  const aliasStoredOrder = openAIOrderAliasProvider
-    ? resolveAuthOrder(storeOrder, openAIOrderAliasProvider)
-    : undefined;
-  const directConfiguredOrder =
-    resolveAuthOrder(configuredOrder, providerAuthKey) ??
-    resolveAuthOrder(configuredOrder, providerKey);
-  const aliasConfiguredOrder = openAIOrderAliasProvider
-    ? resolveAuthOrder(configuredOrder, openAIOrderAliasProvider)
-    : undefined;
-  const directExplicitOrder = directStoredOrder ?? directConfiguredOrder;
-  const aliasExplicitOrder = aliasStoredOrder ?? aliasConfiguredOrder;
-  // Stored order repairs are allowed to fall back to live store profiles when
-  // old setup flows persisted profile ids that no longer exist.
-  const explicitOrderFromStore =
-    directStoredOrder !== undefined ||
-    (directExplicitOrder === undefined && aliasStoredOrder !== undefined);
+  const stored =
+    findNormalizedProviderValue(storeOrder, providerAuthKey) ??
+    findNormalizedProviderValue(storeOrder, providerKey);
   return {
-    openAIOrderAliasProvider,
-    directExplicitOrder,
-    aliasExplicitOrder,
-    explicitOrderFromStore,
+    order:
+      stored ??
+      findNormalizedProviderValue(configuredOrder, providerAuthKey) ??
+      findNormalizedProviderValue(configuredOrder, providerKey),
+    fromStore: stored !== undefined,
   };
 }
 
@@ -345,17 +319,13 @@ export function resolveAuthProfileOrderWithMetadata(
   // get a fresh error count and are not immediately re-penalized on the
   // next transient failure. See #3604.
   clearExpiredCooldowns(store, now);
-  const {
-    openAIOrderAliasProvider,
-    directExplicitOrder,
-    aliasExplicitOrder,
-    explicitOrderFromStore,
-  } = resolveExplicitAuthOrderSelection({
-    storeOrder: store.order,
-    configuredOrder: cfg?.auth?.order,
-    providerKey,
-    providerAuthKey,
-  });
+  const { order: explicitOrder, fromStore: explicitOrderFromStore } =
+    resolveExplicitAuthOrderSelection({
+      storeOrder: store.order,
+      configuredOrder: cfg?.auth?.order,
+      providerKey,
+      providerAuthKey,
+    });
   const explicitProfiles = cfg?.auth?.profiles
     ? Object.entries(cfg.auth.profiles)
         .filter(([profileId, profile]) =>
@@ -377,25 +347,6 @@ export function resolveAuthProfileOrderWithMetadata(
     provider,
     providerAuthKey,
   });
-  const nativeStoreProfiles =
-    openAIOrderAliasProvider && providerAuthKey === OPENAI_CODEX_PROVIDER_ID
-      ? storeProfiles.filter((profileId) =>
-          isNativeCredentialProviderCompatibleWithAuthProvider({
-            cfg,
-            authAliasLookupParams: params.authAliasLookupParams,
-            providerAuthKey,
-            credential: store.profiles[profileId],
-          }),
-        )
-      : [];
-  const explicitOrder =
-    directExplicitOrder ??
-    (aliasExplicitOrder
-      ? mergeAliasOrderWithNativeProfiles({
-          aliasOrder: aliasExplicitOrder,
-          nativeProfiles: nativeStoreProfiles,
-        })
-      : undefined);
   const baseOrder =
     explicitOrder ?? (explicitProfiles.length > 0 ? explicitProfiles : storeProfiles);
   if (baseOrder.length === 0) {
@@ -483,43 +434,6 @@ export function resolveAuthProfileOrderWithMetadata(
 /** Resolves ordered usable auth profile ids for a provider. */
 export function resolveAuthProfileOrder(params: ResolveAuthProfileOrderParams): string[] {
   return resolveAuthProfileOrderWithMetadata(params).profileIds;
-}
-
-function resolveAuthOrder(
-  order: Record<string, string[]> | undefined,
-  provider: string,
-): string[] | undefined {
-  return findNormalizedProviderValue(order, provider);
-}
-
-function isNativeCredentialProviderCompatibleWithAuthProvider(params: {
-  cfg?: OpenClawConfig;
-  authAliasLookupParams?: ProviderAuthAliasLookupParams;
-  providerAuthKey: string;
-  credential: AuthProfileCredential | undefined;
-}): boolean {
-  if (!params.credential) {
-    return false;
-  }
-  return (
-    resolveProviderIdForAuth(params.credential.provider, {
-      config: params.cfg,
-      ...params.authAliasLookupParams,
-    }) === params.providerAuthKey
-  );
-}
-
-function mergeAliasOrderWithNativeProfiles(params: {
-  aliasOrder: string[];
-  nativeProfiles: string[];
-}): string[] {
-  const nativeIds = new Set(params.nativeProfiles);
-  const aliasHasNativeProfile = params.aliasOrder.some((profileId) => nativeIds.has(profileId));
-  return dedupeProfileIds(
-    aliasHasNativeProfile
-      ? [...params.aliasOrder, ...params.nativeProfiles]
-      : [...params.nativeProfiles, ...params.aliasOrder],
-  );
 }
 
 function orderProfilesByMode(

--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -1,6 +1,11 @@
 // Verifies CLI runtime alias resolution and runtime model-ref equivalence.
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  setRuntimeAuthProfileStoreSnapshot,
+} from "./auth-profiles/runtime-snapshots.js";
+import type { RuntimeAuthProfileStore } from "./auth-profiles/types.js";
 import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
 import {
   createModelPickerVisibleProviderPredicate,
@@ -39,17 +44,21 @@ function resolveCliRuntimeExecutionProvider(
 
 function createAnthropicAuthConfig(params: {
   order?: string[];
+  orderKey?: string;
+  onlyCliProfile?: boolean;
   models?: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["models"];
 }): OpenClawConfig {
   // Auth order controls whether Anthropic execution is direct API or Claude
   // CLI-backed when no explicit runtime policy overrides it.
   return {
     auth: {
-      order: params.order ? { anthropic: params.order } : undefined,
-      profiles: {
-        "anthropic:api": { provider: "anthropic", mode: "api_key" },
-        "anthropic:claude-cli": { provider: "claude-cli", mode: "oauth" },
-      },
+      order: params.order ? { [params.orderKey ?? "anthropic"]: params.order } : undefined,
+      profiles: params.onlyCliProfile
+        ? { "anthropic:claude-cli": { provider: "claude-cli", mode: "oauth" } }
+        : {
+            "anthropic:api": { provider: "anthropic", mode: "api_key" },
+            "anthropic:claude-cli": { provider: "claude-cli", mode: "oauth" },
+          },
     },
     agents: {
       defaults: {
@@ -83,6 +92,106 @@ describe("resolveCliRuntimeExecutionProvider", () => {
 
   afterEach(() => {
     cliBackendsTesting.resetDepsForTest();
+    clearRuntimeAuthProfileStoreSnapshots();
+  });
+
+  function seedStoredAuthOrder(order: string[], providerKey = "anthropic"): void {
+    setRuntimeAuthProfileStoreSnapshot({
+      profiles: {},
+      order: { [providerKey]: order },
+    } as unknown as RuntimeAuthProfileStore);
+  }
+
+  it("honors a stored auth order when config declares none", () => {
+    // `models auth order set` writes the persisted store, not the config file.
+    // With no config order the resolver used to build an empty ordered list and
+    // fall through to the "exactly one compatible profile" branch, which returns
+    // undefined whenever two profiles share the provider auth key.
+    seedStoredAuthOrder(["anthropic:claude-cli"]);
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({}),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBe("claude-cli");
+  });
+
+  it("matches a stored order key that is not already canonically normalized", () => {
+    // Persisted state only lowercases provider keys, and the canonical resolver
+    // looks the order up through normalized provider matching rather than an exact
+    // key hit, so an un-normalized stored key must still beat the config order.
+    seedStoredAuthOrder(["anthropic:claude-cli"], "Anthropic");
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({ order: ["anthropic:api"] }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBe("claude-cli");
+  });
+
+  it("treats an explicitly empty stored order as authoritative", () => {
+    // An authored empty order owns selection in resolveAuthProfileOrderWithMetadata,
+    // so alias routing must not fall through to the unique-compatible-profile pick.
+    seedStoredAuthOrder([]);
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({ onlyCliProfile: true }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("still picks the sole compatible profile when no stored order was authored", () => {
+    // Control for the case above: without a stored order the fallback must survive.
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({ onlyCliProfile: true }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBe("claude-cli");
+  });
+
+  it("matches a config order key through the same normalized lookup as profile selection", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({ order: ["anthropic:claude-cli"], orderKey: "Anthropic" }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBe("claude-cli");
+  });
+
+  it("inherits the main-agent stored order for an agent with no snapshot of its own", () => {
+    // Named agents inherit auth state from the main agent, and only the main
+    // snapshot may be published. An exact-agent lookup would miss it and fall
+    // back to config, so the order read resolves inheritance the way
+    // getPreparedRuntimeAuthProfileStoreSnapshotCore does.
+    seedStoredAuthOrder(["anthropic:claude-cli"]);
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        agentId: "secondary",
+        cfg: createAnthropicAuthConfig({}),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBe("claude-cli");
+  });
+
+  it("prefers the stored auth order over a conflicting config order", () => {
+    // Same precedence as resolveAuthProfileOrderWithMetadata: stored order wins,
+    // config order is only the fallback.
+    seedStoredAuthOrder(["anthropic:claude-cli"]);
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({ order: ["anthropic:api"] }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBe("claude-cli");
   });
 
   it("routes Anthropic execution to Claude CLI when the selected auth profile is Claude CLI", () => {

--- a/src/agents/model-runtime-aliases.test.ts
+++ b/src/agents/model-runtime-aliases.test.ts
@@ -5,7 +5,7 @@ import {
   clearRuntimeAuthProfileStoreSnapshots,
   setRuntimeAuthProfileStoreSnapshot,
 } from "./auth-profiles/runtime-snapshots.js";
-import type { RuntimeAuthProfileStore } from "./auth-profiles/types.js";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
 import {
   createModelPickerVisibleProviderPredicate,
@@ -95,11 +95,16 @@ describe("resolveCliRuntimeExecutionProvider", () => {
     clearRuntimeAuthProfileStoreSnapshots();
   });
 
-  function seedStoredAuthOrder(order: string[], providerKey = "anthropic"): void {
+  function seedStoredAuthOrder(
+    order: string[],
+    providerKey = "anthropic",
+    profiles: AuthProfileStore["profiles"] = {},
+  ): void {
     setRuntimeAuthProfileStoreSnapshot({
-      profiles: {},
+      version: 1,
+      profiles,
       order: { [providerKey]: order },
-    } as unknown as RuntimeAuthProfileStore);
+    });
   }
 
   it("honors a stored auth order when config declares none", () => {
@@ -117,6 +122,28 @@ describe("resolveCliRuntimeExecutionProvider", () => {
     ).toBe("claude-cli");
   });
 
+  it.each(["order", "pin"])(
+    "routes a stored CLI profile selected by %s without config metadata",
+    (selection) => {
+      seedStoredAuthOrder(selection === "order" ? ["anthropic:claude-cli"] : [], "anthropic", {
+        "anthropic:claude-cli": {
+          type: "oauth",
+          provider: "claude-cli",
+          access: "test-access",
+          refresh: "test-refresh",
+          expires: Date.now() + 60_000,
+        },
+      });
+      expect(
+        resolveCliRuntimeExecutionProvider({
+          provider: "anthropic",
+          modelId: "opus-4.7",
+          authProfileId: selection === "pin" ? "anthropic:claude-cli" : undefined,
+        }),
+      ).toBe("claude-cli");
+    },
+  );
+
   it("matches a stored order key that is not already canonically normalized", () => {
     // Persisted state only lowercases provider keys, and the canonical resolver
     // looks the order up through normalized provider matching rather than an exact
@@ -131,10 +158,45 @@ describe("resolveCliRuntimeExecutionProvider", () => {
     ).toBe("claude-cli");
   });
 
-  it("treats an explicitly empty stored order as authoritative", () => {
-    // An authored empty order owns selection in resolveAuthProfileOrderWithMetadata,
-    // so alias routing must not fall through to the unique-compatible-profile pick.
-    seedStoredAuthOrder([]);
+  it("does not route a provider disabled by an explicitly empty configured order", () => {
+    expect(
+      resolveCliRuntimeExecutionProvider({
+        cfg: createAnthropicAuthConfig({ order: [], onlyCliProfile: true }),
+        provider: "anthropic",
+        modelId: "opus-4.7",
+      }),
+    ).toBeUndefined();
+  });
+
+  it.each(["configured", "stored"])(
+    "repairs a %s order containing only deleted profiles",
+    (source) => {
+      if (source === "stored") {
+        seedStoredAuthOrder(["anthropic:deleted"]);
+      }
+      expect(
+        resolveCliRuntimeExecutionProvider({
+          cfg: createAnthropicAuthConfig({
+            order: source === "configured" ? ["anthropic:deleted"] : undefined,
+            onlyCliProfile: true,
+          }),
+          provider: "anthropic",
+          modelId: "opus-4.7",
+        }),
+      ).toBe("claude-cli");
+    },
+  );
+
+  it.each([
+    { name: "alone", order: ["anthropic:stored-api"] },
+    {
+      name: "before a configured CLI profile",
+      order: ["anthropic:stored-api", "anthropic:claude-cli"],
+    },
+  ])("keeps a stored profile missing from config authoritative $name", ({ order }) => {
+    seedStoredAuthOrder(order, "anthropic", {
+      "anthropic:stored-api": { type: "api_key", provider: "anthropic", key: "test-key" },
+    });
     expect(
       resolveCliRuntimeExecutionProvider({
         cfg: createAnthropicAuthConfig({ onlyCliProfile: true }),

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -5,6 +5,9 @@ import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveAgentDir } from "./agent-scope-config.js";
+import { resolveExplicitAuthOrderSelection } from "./auth-profiles/order.js";
+import { getPreparedRuntimeAuthProfileStoreSnapshotCore } from "./auth-profiles/runtime-snapshots.js";
 import {
   isCliRuntimeModelBackendForProvider,
   listCliRuntimeModelBackendBindings,
@@ -12,6 +15,7 @@ import {
   resolveCliRuntimeCanonicalProvider,
   resolveCliRuntimeModelBackendBinding,
 } from "./cli-backends.js";
+import { resolveLegacyInheritedAuthDir } from "./legacy-inherited-auth-dir.js";
 import { resolveModelRuntimePolicy } from "./model-runtime-policy.js";
 import {
   resolveProviderIdForAuth,
@@ -218,6 +222,7 @@ function resolveCliRuntimeFromAuthProfile(
   params: RuntimeAuthAliasParams & {
     provider: string;
     authProfileId?: string;
+    agentId?: string;
   },
 ): string | undefined {
   if (!params.cfg?.auth?.profiles) {
@@ -233,10 +238,21 @@ function resolveCliRuntimeFromAuthProfile(
 
   const provider = normalizeProviderId(params.provider);
   const providerAuthKey = resolveRuntimeAuthProvider(provider, params);
-  const orderedProfileIds = [
-    ...(params.cfg.auth.order?.[providerAuthKey] ?? []),
-    ...(providerAuthKey === provider ? [] : (params.cfg.auth.order?.[provider] ?? [])),
-  ];
+  // The persisted auth store owns the effective profile order once an operator sets
+  // one (`models auth order set`). Read it from the lifecycle-published snapshot and
+  // resolve precedence through the same helper resolveAuthProfileOrderWithMetadata
+  // uses, so alias routing and profile selection cannot disagree.
+  const store = getPreparedRuntimeAuthProfileStoreSnapshotCore(
+    params.agentId ? resolveAgentDir(params.cfg, params.agentId) : undefined,
+    resolveLegacyInheritedAuthDir(params.cfg),
+  );
+  const selection = resolveExplicitAuthOrderSelection({
+    storeOrder: store?.order,
+    configuredOrder: params.cfg.auth.order,
+    providerKey: provider,
+    providerAuthKey,
+  });
+  const orderedProfileIds = selection.directExplicitOrder ?? selection.aliasExplicitOrder ?? [];
   for (const profileId of orderedProfileIds) {
     const profile = params.cfg.auth.profiles[profileId];
     if (!profile?.provider) {
@@ -251,6 +267,11 @@ function resolveCliRuntimeFromAuthProfile(
       provider,
       profileId,
     });
+  }
+
+  if (selection.explicitOrderFromStore) {
+    // An authored stored order owns selection, including an explicitly empty one.
+    return undefined;
   }
 
   const compatibleProfileIds = Object.entries(params.cfg.auth.profiles)

--- a/src/agents/model-runtime-aliases.ts
+++ b/src/agents/model-runtime-aliases.ts
@@ -191,15 +191,11 @@ function resolveRuntimeAuthProvider(provider: string, params: RuntimeAuthAliasPa
 function resolveProfileRuntimeAlias(
   params: RuntimeAuthAliasParams & {
     provider: string;
-    profileId: string;
+    profileProvider: string | undefined;
   },
 ): string | undefined {
-  const profile = params.cfg?.auth?.profiles?.[params.profileId];
-  if (!profile?.provider) {
-    return undefined;
-  }
   const provider = normalizeProviderId(params.provider);
-  const profileProvider = normalizeProviderId(profile.provider);
+  const profileProvider = normalizeProviderId(params.profileProvider ?? "");
   if (!provider || !profileProvider) {
     return undefined;
   }
@@ -225,36 +221,32 @@ function resolveCliRuntimeFromAuthProfile(
     agentId?: string;
   },
 ): string | undefined {
-  if (!params.cfg?.auth?.profiles) {
-    return undefined;
-  }
+  const configuredProfiles = params.cfg?.auth?.profiles ?? {};
+  // Login and auth-order commands own the credential store, not config metadata.
+  // Reuse its published snapshot without reopening SQLite on a request path.
+  const store = getPreparedRuntimeAuthProfileStoreSnapshotCore(
+    params.agentId ? resolveAgentDir(params.cfg ?? {}, params.agentId) : undefined,
+    resolveLegacyInheritedAuthDir(params.cfg ?? {}),
+  );
   if (params.authProfileId?.trim()) {
+    const profileId = params.authProfileId.trim();
     return resolveProfileRuntimeAlias({
       ...params,
       provider: params.provider,
-      profileId: params.authProfileId.trim(),
+      profileProvider: (configuredProfiles[profileId] ?? store?.profiles[profileId])?.provider,
     });
   }
 
   const provider = normalizeProviderId(params.provider);
   const providerAuthKey = resolveRuntimeAuthProvider(provider, params);
-  // The persisted auth store owns the effective profile order once an operator sets
-  // one (`models auth order set`). Read it from the lifecycle-published snapshot and
-  // resolve precedence through the same helper resolveAuthProfileOrderWithMetadata
-  // uses, so alias routing and profile selection cannot disagree.
-  const store = getPreparedRuntimeAuthProfileStoreSnapshotCore(
-    params.agentId ? resolveAgentDir(params.cfg, params.agentId) : undefined,
-    resolveLegacyInheritedAuthDir(params.cfg),
-  );
   const selection = resolveExplicitAuthOrderSelection({
     storeOrder: store?.order,
-    configuredOrder: params.cfg.auth.order,
+    configuredOrder: params.cfg?.auth?.order,
     providerKey: provider,
     providerAuthKey,
   });
-  const orderedProfileIds = selection.directExplicitOrder ?? selection.aliasExplicitOrder ?? [];
-  for (const profileId of orderedProfileIds) {
-    const profile = params.cfg.auth.profiles[profileId];
+  for (const profileId of selection.order ?? []) {
+    const profile = configuredProfiles[profileId] ?? store?.profiles[profileId];
     if (!profile?.provider) {
       continue;
     }
@@ -265,16 +257,21 @@ function resolveCliRuntimeFromAuthProfile(
     return resolveProfileRuntimeAlias({
       ...params,
       provider,
-      profileId,
+      profileProvider: profile.provider,
     });
   }
 
-  if (selection.explicitOrderFromStore) {
-    // An authored stored order owns selection, including an explicitly empty one.
+  if (
+    selection.order !== undefined &&
+    (selection.order.length === 0 ||
+      selection.order.some((profileId) => store?.profiles[profileId] !== undefined))
+  ) {
+    // Keep empty orders and existing stored profiles authoritative. Only an order
+    // of missing profiles may use the canonical stale-profile repair below.
     return undefined;
   }
 
-  const compatibleProfileIds = Object.entries(params.cfg.auth.profiles)
+  const compatibleProfileIds = Object.entries(configuredProfiles)
     .filter(([, profile]) => {
       if (!profile?.provider) {
         return false;
@@ -290,7 +287,7 @@ function resolveCliRuntimeFromAuthProfile(
     ? resolveProfileRuntimeAlias({
         ...params,
         provider,
-        profileId,
+        profileProvider: configuredProfiles[profileId]?.provider,
       })
     : undefined;
 }


### PR DESCRIPTION
Related: #119946

## What Problem This Solves

Fixes an issue where operators using `openclaw models auth order set` would still get the configured/default execution backend instead of the CLI backend they selected. Stored credentials could also be ignored when login had not created matching `auth.profiles` config metadata.

## Why This Change Was Made

Credential selection and CLI runtime routing now share one stored-over-config order lookup. Runtime routing consumes the lifecycle-published auth snapshot, including the requested agent's inherited auth owner, without reopening SQLite on request paths. Selected profile metadata comes from config or the actual stored credential; explicit model-runtime policy and explicit auth pins retain precedence.

The rewrite preserves the existing repair for orders containing only deleted profiles, honors explicit empty configured orders, and keeps the first existing direct-API profile authoritative. It also removes unreachable OpenAI order-alias merging: both provider constants already identify `openai`, so the alias path could never win. Credential eligibility, cooldowns, and OpenAI API-key versus OAuth handling remain owned by the existing credential selector.

## User Impact

Stored auth order now controls the intended runtime, even when it conflicts with config or the selected credential exists only in the auth store. Clearing the stored order returns selection to configured/automatic behavior. Merely discovering a sole CLI credential does not implicitly select it. No new config option, dependency, database schema, or protocol change.

Documentation now describes stored-order precedence and the SQLite auth store. Production delta: **+67 / −97 (net −30)**; tests: **+176 / −5**; docs: **+4 / −1**. Thanks @masatohoshino for the original fix and production reproduction; contributor credit is retained.

## Evidence

Reviewed candidate: `410a8e8c1be3f9a0bbe7fe3f9bc8b08652e13a56`.

- Before/after regressions: baseline ignored stored-only and conflicting stored order and routed despite an empty configured order. Additional failing-before cases caught stale-profile repair, a first store-only API profile, and stored-only CLI order/pins without config metadata.
- **77 tests passed** across runtime aliases, credential ordering, snapshot lifecycle, external CLI selection, and CLI auth-order commands:

  ```sh
  OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
    src/agents/model-runtime-aliases.test.ts \
    src/agents/auth-profiles/order.test.ts \
    src/agents/auth-profiles/runtime-snapshots.test.ts \
    src/agents/auth-profiles/external-cli-auth-selection.test.ts \
    src/commands/models/auth-order.test.ts
  ```

- **Eight real production-module scenarios passed** on macOS / Node v24.19.0 with isolated synthetic state: actual `setAuthProfileOrder` → SQLite reload → runtime snapshot publication → actual Anthropic plugin discovery → runtime resolution. No mocks or provider requests:

  | Scenario | Observed runtime |
  | --- | --- |
  | Stored order, no config order | CLI |
  | Stored order conflicts with config | CLI |
  | Clear stored order with direct-API config | Direct provider |
  | Config-only CLI order | CLI |
  | Clear order with multiple profiles | Direct provider |
  | Stored CLI order without config profile metadata | CLI |
  | Stored CLI pin without matching config metadata | CLI |
  | Sole stored CLI with no explicit selection | Direct provider |

- Local and complete-branch structured autoreview passed with no actionable findings; separate independent owner-boundary review passed.
- Direct Codex contract inspection: `codex-rs/protocol/src/auth.rs:5-65`, `codex-rs/model-provider/src/auth.rs:197-220`, and `codex-rs/model-provider/src/provider.rs:389-429` at upstream `d47e5cc0e2bb`. These preserve the separate API-key/OAuth shapes; this change does not alter Codex auth.

Proof boundary: the production harness verifies persisted selection and resolver output, not an authenticated turn or Gateway snapshot-refresh lifecycle. The latter remains covered by the unchanged snapshot/auth-order tests and the preceding merged #119946. Callers that do not publish a runtime snapshot retain config-only behavior.

ClawSweeper rank-up: focused resolver tests are complete; required CI must be green on the pushed candidate before landing. The earlier CLI-help probe timed out during a cold build and was not a runtime-routing failure. The prior +59 production-line concern is eliminated by the net-negative owner refactor.
