### PR TITLE
fix(release): full validation survives queued parent states

### DIFF
--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -68,13 +68,15 @@ the artifacts and may differ when only one collector needed a retry.
 The helper creates a temporary `release-ci/*` ref pinned to the Tooling SHA,
 passes the Validation SHA as both the candidate ref and `expected_sha`, and
 deletes the temporary ref after successful validation and strict evidence
-verification. If Release Decision reports a blocker while Diagnostic Drain is
-still collecting failures, the helper exits nonzero immediately and keeps both
-temporary refs for reruns and diagnosis. The Validation SHA equals the Code
-SHA for product validation or the Release SHA for changelog-only validation; it
-is not a third release identity. The workflow rejects malformed or mismatched
-expected SHAs before child dispatch. Every child must report the same Tooling
-SHA. Pass
+verification. The helper reads Release Decision artifacts while the parent is
+active so blockers can surface while Diagnostic Drain collects failures. A
+not-yet-created artifact remains an unavailable polling result; terminal
+handling and temporary-ref cleanup wait for the parent to complete with a
+conclusion. Failed validations retain both refs for reruns and diagnosis. The
+Validation SHA equals the Code SHA for product validation or the Release SHA
+for changelog-only validation; it is not a third release identity. The workflow
+rejects malformed or mismatched expected SHAs before child dispatch. Every
+child must report the same Tooling SHA. Pass
 `-f reuse_evidence=false` to force a fresh run. Regular release-branch runs
 require `--workflow-sha` with the recorded full SHA, which must remain reachable
 from current `origin/main`. The helper rejects a pinned Tooling SHA that does

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -627,7 +627,9 @@ export function tryReadReleaseDecision(
     if (result.status !== 0) {
       const stderr = stringValue(result.stderr);
       if (
-        /no valid artifacts found|artifact .* not found|could not find any artifacts/iu.test(stderr)
+        /no valid artifacts found|artifact .* not found|could not find any artifacts|no artifact matches any of the names or patterns provided/iu.test(
+          stderr,
+        )
       ) {
         return undefined;
       }
@@ -716,7 +718,7 @@ function waitForWorkflowRun(parentRunId: string, workflowSha: string) {
         );
       }
     }
-    if (suite?.status === "completed") {
+    if (suite?.status === "completed" && stringValue(suite.conclusion)) {
       if (suite.conclusion === "success") {
         return suite;
       }

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -53,18 +53,30 @@ function runGit(cwd: string, args: string[]): string {
   }).trim();
 }
 
-function createDispatchFixture(options: { workflowSource?: string } = {}) {
+function createDispatchFixture(
+  options: {
+    parentRunStates?: Array<{ conclusion: string | null; status: string }>;
+    workflowSource?: string;
+  } = {},
+) {
   const root = mkdtempSync(join(tmpdir(), "openclaw-release-dispatch-"));
   const origin = join(root, "origin.git");
   const checkout = join(root, "checkout");
   const binDir = join(root, "bin");
   const gitCallsPath = join(root, "git-calls.jsonl");
   const ghCallsPath = join(root, "gh-calls.jsonl");
+  const parentRunIndexPath = join(root, "parent-run-index.txt");
+  const preloadPath = join(root, "immediate-poll.mjs");
   const releaseRef = "release/2026.8.1";
   mkdirSync(checkout);
   mkdirSync(binDir);
   writeFileSync(gitCallsPath, "");
   writeFileSync(ghCallsPath, "");
+  writeFileSync(parentRunIndexPath, "0");
+  writeFileSync(
+    preloadPath,
+    'const wait = Atomics.wait; Atomics.wait = (array, index, value, timeout) => timeout === undefined ? wait(array, index, value) : "timed-out";\n',
+  );
 
   execFileSync("git", ["init", "--bare", origin], { stdio: "ignore" });
   execFileSync("git", ["init", "-b", "main"], { cwd: checkout, stdio: "ignore" });
@@ -149,6 +161,8 @@ process.exit(result.status ?? 1);
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.MOCK_GH_CALLS, JSON.stringify(args) + "\\n");
+const parentRunStates = ${JSON.stringify(options.parentRunStates ?? [{ conclusion: "success", status: "completed" }])};
+const parentRunIndexPath = ${JSON.stringify(parentRunIndexPath)};
 if (args[0] === "workflow" && args[1] === "run") {
   const declaredInputs = new Set(JSON.parse(process.env.MOCK_WORKFLOW_INPUTS));
   for (let index = 0; index < args.length; index += 1) {
@@ -163,9 +177,13 @@ if (args[0] === "workflow" && args[1] === "run") {
   }
   console.log("https://github.com/openclaw/openclaw/actions/runs/123");
 } else if (args[0] === "api" && args.at(-1).endsWith("/actions/runs/123")) {
-  console.log(JSON.stringify({ status: "completed", conclusion: "success", head_sha: process.env.MOCK_WORKFLOW_SHA, run_attempt: 1 }));
+  const index = Number(fs.readFileSync(parentRunIndexPath, "utf8"));
+  const state = parentRunStates[Math.min(index, parentRunStates.length - 1)];
+  fs.writeFileSync(parentRunIndexPath, String(index + 1));
+  console.log(JSON.stringify({ ...state, head_sha: process.env.MOCK_WORKFLOW_SHA, run_attempt: 1 }));
 } else if (args[0] === "run" && args[1] === "download") {
-  console.error("no valid artifacts found");
+  const index = Number(fs.readFileSync(parentRunIndexPath, "utf8")) - 1;
+  console.error(parentRunStates[index]?.status === "queued" ? "no artifact matches any of the names or patterns provided" : "no valid artifacts found");
   process.exit(1);
 } else {
   console.error("unexpected gh call: " + args.join(" "));
@@ -189,6 +207,13 @@ if (args[0] === "workflow" && args[1] === "run") {
         encoding: "utf8",
         env: {
           ...process.env,
+          ...(options.parentRunStates
+            ? {
+                NODE_OPTIONS: [process.env.NODE_OPTIONS, "--import", preloadPath]
+                  .filter(Boolean)
+                  .join(" "),
+              }
+            : {}),
           MOCK_GH_CALLS: ghCallsPath,
           MOCK_GIT_CALLS: gitCallsPath,
           MOCK_REAL_PATH: process.env.PATH,
@@ -573,7 +598,7 @@ describe("full-release-validation-at-sha", () => {
     expect(source).not.toContain("attempt < 480");
   });
 
-  it("binds early release decisions to the exact parent attempt and tooling SHA", () => {
+  it("binds release decisions to the exact parent attempt and tooling SHA", () => {
     const payload = {
       kind: "openclaw.full-release-decision",
       mode: "decision",
@@ -822,6 +847,61 @@ describe("full-release-validation-at-sha", () => {
       expect(runGit(fixture.origin, ["for-each-ref", "--format=%(refname)", "refs/heads"])).toBe(
         "refs/heads/main\nrefs/heads/release/2026.8.1",
       );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("retries an absent decision artifact through a parent status regression", () => {
+    const fixture = createDispatchFixture({
+      parentRunStates: [
+        { conclusion: null, status: "in_progress" },
+        { conclusion: null, status: "queued" },
+        { conclusion: null, status: "in_progress" },
+        { conclusion: "success", status: "completed" },
+      ],
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(0);
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      const parentPolls = calls
+        .map((args, index) => ({ args, index }))
+        .filter(({ args }) => args[0] === "api" && args[1]?.endsWith("/actions/runs/123"));
+      const artifactDownloads = calls
+        .map((args, index) => ({ args, index }))
+        .filter(({ args }) => args[0] === "run" && args[1] === "download");
+      expect(parentPolls).toHaveLength(4);
+      expect(artifactDownloads).toHaveLength(4);
+      expect(artifactDownloads[1]?.index).toBeGreaterThan(parentPolls[1]?.index ?? Infinity);
+      expect(artifactDownloads[1]?.index).toBeLessThan(parentPolls[2]?.index ?? -Infinity);
+      expect(result.stdout).toContain("Parent run status: queued/pending");
+      expect(runGit(fixture.origin, ["for-each-ref", "--format=%(refname)", "refs/heads"])).toBe(
+        "refs/heads/main\nrefs/heads/release/2026.8.1",
+      );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("waits for a terminal conclusion across every nonterminal parent state", () => {
+    const fixture = createDispatchFixture({
+      parentRunStates: [
+        { conclusion: null, status: "requested" },
+        { conclusion: null, status: "waiting" },
+        { conclusion: null, status: "pending" },
+        { conclusion: null, status: "completed" },
+        { conclusion: "success", status: "completed" },
+      ],
+    });
+    try {
+      const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
+      expect(result.status, result.stderr).toBe(0);
+      const calls = fixture.readCalls(fixture.ghCallsPath);
+      expect(
+        calls.filter((args) => args[0] === "api" && args[1]?.endsWith("/actions/runs/123")),
+      ).toHaveLength(5);
+      expect(calls.filter((args) => args[0] === "run" && args[1] === "download")).toHaveLength(5);
     } finally {
       fixture.cleanup();
     }


### PR DESCRIPTION
Closes #129104

## What Problem This Solves

Fixes an issue where the SHA-pinned Full Release Validation helper could abandon a still-running validation when GitHub transiently reported the parent as queued and the Release Decision artifact had not been created yet.

## Why This Change Was Made

The helper now recognizes GitHub CLI's current named-artifact absence message as a retryable polling result. It preserves intentional early Release Decision handling so blockers can still surface while Diagnostic Drain runs, and it waits for both a completed parent status and a terminal conclusion before terminal cleanup.

The regression fixture exercises an in-progress to queued to in-progress to completed transition, verifies the missing artifact is retried rather than treated as fatal, and covers a completed parent response whose conclusion is still absent. The operator documentation now states both the early-decision and terminal-cleanup boundaries. This change is AI-assisted and was reviewed against the full affected helper, tests, docs, history, and live failure evidence.

## User Impact

Release operators keep one controller attached to an expensive validation run instead of receiving a false local failure and potentially dispatching duplicate work. Early blocker visibility remains unchanged, and failed validations still retain their immutable temporary refs for diagnosis and reruns.

## Evidence

- Live failure: https://github.com/openclaw/openclaw/actions/runs/32819785885 continued running after the helper exited on `no artifact matches any of the names or patterns provided`.
- Pre-fix regression proof: the focused queued-transition test failed with that exact artifact error and exit code 1.
- Post-fix focused proof: the same regression passed, including all four parent polls and four early artifact polls.
- Rebased helper regressions: 2 passed, 29 skipped.
- Full helper suite: 31 passed.
- `node scripts/check-changed.mjs -- docs/reference/full-release-validation.md scripts/full-release-validation-at-sha.mts test/scripts/full-release-validation-at-sha.test.ts`
- `pnpm docs:list`
- `git diff --check`
- Mandatory uncommitted autoreview: clean, no accepted/actionable findings.
- Delta: tooling +4/-2, tests +84/-4, docs +9/-7.
