### PR TITLE
fix(ollama): protect local credentials on all loopback addresses

### DIFF
--- a/extensions/ollama/src/discovery-shared.test.ts
+++ b/extensions/ollama/src/discovery-shared.test.ts
@@ -14,6 +14,8 @@ describe("isLocalOllamaBaseUrl", () => {
     "",
     "http://localhost:11434",
     "http://127.0.0.1:11434",
+    "http://127.0.0.2:11434",
+    "http://127.1.2.3:11434",
     "http://0.0.0.0:11434",
     "http://[::1]:11434",
     "http://10.0.0.5:11434",
@@ -331,6 +333,29 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
     expect(providerCalled).toBe(false);
     expect(result?.provider.models).toEqual([cloudModel]);
   });
+
+  it.each(["localhost", "127.0.0.1", "127.0.0.2", "127.1.2.3", "10.0.0.5"])(
+    "keeps ambient cloud credentials away from the local endpoint %s",
+    async (hostname) => {
+      const provider = {
+        baseUrl: `http://${hostname}:11434`,
+        api: "ollama" as const,
+        models: [cloudModel],
+      };
+      const result = await resolveOllamaDiscoveryResult({
+        ctx: {
+          config: { models: { providers: { ollama: provider } } },
+          env: { OLLAMA_API_KEY: "ambient-cloud-credential" },
+          resolveProviderApiKey: () => ({}),
+        },
+        pluginConfig: {},
+        buildProvider: buildMockProvider,
+      });
+
+      expect(result?.provider.apiKey).toBe("ollama-local");
+      expect(shouldUseSyntheticOllamaAuth(provider)).toBe(true);
+    },
+  );
 
   it("does not call buildProvider for remote base URL without explicit models", async () => {
     let providerCalled = false;

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -104,7 +104,6 @@ function shouldSkipAmbientOllamaDiscovery(env: NodeJS.ProcessEnv): boolean {
 
 const LOCAL_OLLAMA_HOSTNAMES = new Set([
   "localhost",
-  "127.0.0.1",
   "0.0.0.0",
   "::1",
   "::",
@@ -161,6 +160,7 @@ export function isLocalOllamaBaseUrl(baseUrl: string | undefined | null): boolea
   }
   return (
     LOCAL_OLLAMA_HOSTNAMES.has(host) ||
+    isIpv4Loopback(host) ||
     host.endsWith(".local") ||
     isIpv4PrivateRange(host) ||
     isIpv6LocalRange(host) ||


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Ollama on a loopback alias such as `127.0.0.2` or `127.1.2.3` would lose synthetic local authentication and could forward their ambient Ollama Cloud credential to that local server. The public Ollama documentation explicitly promises that `127.0.0.2` remains local.

## Why This Change Was Made

The Ollama plugin already had a canonical full-`127/8` IPv4 loopback detector, but its local-auth classifier only recognized `127.0.0.1`. Reuse the existing detector at the provider-owned classification boundary and remove the now-redundant exact-address entry. Production LOC is net zero.

## User Impact

Every IPv4 loopback Ollama endpoint now receives synthetic local authentication instead of an unrelated ambient cloud credential. Existing localhost, standard loopback, private-network, IPv6, and external-host behavior remains unchanged.

## Evidence

- Before the fix, the owner regression failed in four cases: `127.0.0.2` and `127.1.2.3` were classified as remote and each incorrectly selected an ambient fixture credential instead of the local marker.
- After the fix, eight focused Ollama discovery, authentication, SSRF, timeout, header-redaction, and import-boundary test files passed: **151 tests**.
- Regression controls cover `localhost`, `127.0.0.1`, both alternate loopback addresses, and a private-network endpoint; existing external-host cases remain green.
- Focused formatting and direct scoped lint passed; two independent reviews and mandatory structured review reported no actionable findings.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/ollama/src/discovery-shared.test.ts extensions/ollama/provider-discovery.test.ts extensions/ollama/provider-discovery.import-guard.test.ts extensions/ollama/src/provider-models.test.ts extensions/ollama/src/provider-models.ssrf.test.ts extensions/ollama/src/provider-models.preflight-timeout.test.ts extensions/ollama/src/setup.non-interactive-auth.test.ts extensions/ollama/src/request-header-redaction.test.ts
node_modules/.bin/oxfmt --check extensions/ollama/src/discovery-shared.ts extensions/ollama/src/discovery-shared.test.ts
node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/ollama/src/discovery-shared.test.ts extensions/ollama/src/discovery-shared.ts
git diff --check
```
