### PR TITLE
fix(pr): keep older contributor worktree checkouts within OS argument limits

### DIFF
--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -163,13 +163,10 @@ recover_review_transition() {
   fi
 
   validate_review_transition_state "$pr" "$source" "$target" || return 1
-  local paths=()
-  local file
-  while IFS= read -r -d '' file; do
-    paths+=(":(literal)$file")
-  done < <(git diff --name-only --no-renames -z "$source" "$target")
-  if [ "${#paths[@]}" -gt 0 ]; then
-    git restore --source="$target" --staged --worktree -- "${paths[@]}" || return 1
+  if ! git diff --quiet "$source" "$target"; then
+    git diff --name-only --no-renames -z "$source" "$target" |
+      git --literal-pathspecs restore --source="$target" --staged --worktree \
+        --pathspec-from-file=- --pathspec-file-nul || return 1
   fi
   if [ "$(git write-tree)" != "$(git rev-parse "$target^{tree}")" ] || ! git diff --quiet; then
     refuse_review_transition "$pr" "the tracked tree did not reach the journaled target."

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -358,6 +358,8 @@ describePosix("scripts/pr worktree containment", () => {
     for (let index = 0; index < 32; index += 1) {
       writeFileSync(join(fixture.root, `transition-batch-${index}.txt`), `${index}\n`);
     }
+    const literalPath = "transition-[literal]*?.txt";
+    writeFileSync(join(fixture.root, literalPath), "literal path\n");
     git(fixture.root, "add", ".");
     git(fixture.root, "commit", "-m", "add transition batch");
     git(fixture.root, "update-ref", "refs/pull/42/head", "HEAD");
@@ -374,6 +376,10 @@ describePosix("scripts/pr worktree containment", () => {
       [
         "#!/usr/bin/env bash",
         'printf "%s\\n" "$*" >> "$GIT_COMMAND_LOG"',
+        'if [[ ( "${1:-}" == "restore" || "${2:-}" == "restore" ) && "$#" -gt 12 ]]; then',
+        '  printf "%s\\n" "Argument list too long" >&2',
+        "  exit 126",
+        "fi",
         'exec "$REAL_GIT" "$@"',
       ].join("\n"),
     );
@@ -392,6 +398,9 @@ describePosix("scripts/pr worktree containment", () => {
     expect(
       commands.filter((command) => command.startsWith("ls-files --others --ignored ")),
     ).toHaveLength(0);
+    expect(readFileSync(join(fixture.root, ".worktrees", "pr-42", literalPath), "utf8")).toBe(
+      "literal path\n",
+    );
     expectCanonicalCheckoutUnchanged(fixture);
   });
 });


### PR DESCRIPTION
Related: #120114

## What Problem This Solves

Fixes an issue where maintainers reviewing older contributor pull requests could not check out the contributor branch when the intervening changes exceeded the operating system's command-line argument limit. PR #120114 reproduced the failure with 20,667 changed paths and an `Argument list too long` error, leaving its valid review-transition journal unrecoverable through the native maintainer workflow.

## Why This Change Was Made

Keep recovery at its existing journal owner and stream NUL-delimited filenames to Git instead of expanding every filename into the shell argument list. Git's literal-pathspec mode preserves the previous literal-filename contract, and existing foreign-state, ignored-file, reserved-artifact, interrupted-transition, and exact-tree guards remain unchanged.

## User Impact

No end-user product behavior changes. Maintainers can review and land older contributor branches without hitting platform argument limits or weakening worktree-containment safeguards.

## Evidence

- Before the production change, the existing real-Git containment regression failed with `Argument list too long`; after the change, the same regression passes with bounded arguments and a literal wildcard-containing filename.
- `node scripts/run-vitest.mjs test/scripts/pr-worktree-containment.test.ts --run`: 12 passed.
- `pnpm exec oxfmt --check scripts/pr-lib/worktree.sh test/scripts/pr-worktree-containment.test.ts`, `bash -n scripts/pr-lib/worktree.sh`, and `git diff --check` passed.
- Production: +4/-7 (net -3). Tests: +9/-0.
- Full-diff structured review and a separate read-only independent review reported no blocking findings.
