### PR TITLE
fix(googlechat): use agent identity in typing status

### DIFF
--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -667,6 +667,73 @@ describe("googlechat monitor inbound space classification", () => {
     });
   });
 
+  it.each([
+    {
+      name: "the agent identity name",
+      accountName: undefined,
+      agent: { identity: { name: "Alvin" } },
+      expectedText: "_Alvin is typing..._",
+    },
+    {
+      name: "the account name before agent names",
+      accountName: "Workspace Bot",
+      agent: { name: "Agent Name", identity: { name: "Identity Name" } },
+      expectedText: "_Workspace Bot is typing..._",
+    },
+    {
+      name: "the agent name before its identity name",
+      accountName: undefined,
+      agent: { name: "Agent Name", identity: { name: "Identity Name" } },
+      expectedText: "_Agent Name is typing..._",
+    },
+    {
+      name: "the generic fallback when names are empty",
+      accountName: " ",
+      agent: { name: " ", identity: { name: " " } },
+      expectedText: "_OpenClaw is typing..._",
+    },
+  ])("uses $name in the typing message", async ({ accountName, agent, expectedText }) => {
+    const { core } = createInboundClassificationHarness();
+    const account = {
+      accountId: "work",
+      config: accountName === undefined ? {} : { name: accountName },
+      credentialSource: "inline",
+    } as ResolvedGoogleChatAccount;
+    const event = {
+      type: "MESSAGE",
+      space: { name: "spaces/IDENTITY", type: "DM" },
+      message: {
+        name: "spaces/IDENTITY/messages/1",
+        text: "hello",
+        sender: { name: "users/alice", displayName: "Alice", type: "HUMAN" },
+      },
+    } satisfies GoogleChatEvent;
+
+    accessMocks.applyGoogleChatInboundAccessPolicy.mockResolvedValue({
+      ok: true,
+      commandAuthorized: undefined,
+      effectiveWasMentioned: undefined,
+      groupBotLoopProtection: undefined,
+      groupSystemPrompt: undefined,
+    });
+
+    await processGoogleChatTestEvent({
+      event,
+      account,
+      config: { agents: { entries: { "agent-1": agent } } },
+      runtime: { error: vi.fn(), log: vi.fn() },
+      core,
+      mediaMaxMb: 10,
+    });
+
+    expect(apiMocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/IDENTITY",
+      text: expectedText,
+      thread: undefined,
+    });
+  });
+
   it("continues delivery in the typing message's canonical fallback thread", async () => {
     const requestedThread = "spaces/CLASSIFY/threads/requested";
     const deliveredThread = "spaces/CLASSIFY/threads/fallback";
@@ -834,75 +901,6 @@ describe("googlechat monitor sender bot status", () => {
 });
 
 describe("googlechat monitor direct messages", () => {
-  it("creates typing messages by default", async () => {
-    const runTurn = vi.fn();
-    const buildContext = vi.fn((payload: unknown) => payload);
-    const core = {
-      logging: { shouldLogVerbose: () => false },
-      channel: {
-        routing: {
-          resolveAgentRoute: () => ({
-            agentId: "agent-1",
-            accountId: "work",
-            sessionKey: "session-1",
-          }),
-        },
-        session: {
-          resolveStorePath: () => "/tmp/openclaw-googlechat-test",
-          readSessionUpdatedAt: () => undefined,
-          recordInboundSession: vi.fn(),
-        },
-        reply: {
-          resolveEnvelopeFormatOptions: () => ({}),
-          formatAgentEnvelope: ({ body }: { body: string }) => body,
-          dispatchReplyWithBufferedBlockDispatcher: vi.fn(),
-        },
-        inbound: { buildContext, run: runTurn },
-      },
-    } as unknown as GoogleChatCoreRuntime;
-    const runtime = { error: vi.fn(), log: vi.fn() } satisfies GoogleChatRuntimeEnv;
-    const account = {
-      accountId: "work",
-      config: {},
-      credentialSource: "inline",
-    } as ResolvedGoogleChatAccount;
-    const event = {
-      type: "MESSAGE",
-      eventTime: "2026-03-22T00:00:00.001Z",
-      space: { name: "spaces/DM", type: "DM" },
-      message: {
-        name: "spaces/DM/messages/2",
-        text: "hello",
-        sender: { name: "users/alice", displayName: "Alice", type: "HUMAN" },
-      },
-    } satisfies GoogleChatEvent;
-
-    accessMocks.applyGoogleChatInboundAccessPolicy.mockResolvedValue({
-      ok: true,
-      commandAuthorized: undefined,
-      effectiveWasMentioned: undefined,
-      groupBotLoopProtection: undefined,
-      groupSystemPrompt: undefined,
-    });
-
-    await processGoogleChatTestEvent({
-      event,
-      account,
-      config: {},
-      runtime,
-      core,
-      mediaMaxMb: 10,
-    });
-
-    expect(apiMocks.sendGoogleChatMessage).toHaveBeenCalledWith({
-      account,
-      space: "spaces/DM",
-      text: "_OpenClaw is typing..._",
-      thread: undefined,
-    });
-    expect(runTurn).toHaveBeenCalledOnce();
-  });
-
   it("omits thread metadata from DM reply context and typing messages", async () => {
     const runTurn = vi.fn();
     const buildContext = vi.fn((payload: unknown) => payload);

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -160,7 +160,7 @@ async function processGoogleChatEvent(
  * Resolve bot display name with fallback chain:
  * 1. Account config name
  * 2. Agent name from config
- * 3. "OpenClaw" as generic fallback
+ * 3. Agent identity name, then "OpenClaw"
  */
 function resolveBotDisplayName(params: {
   accountName?: string;
@@ -175,7 +175,7 @@ function resolveBotDisplayName(params: {
   if (agent?.name?.trim()) {
     return agent.name.trim();
   }
-  return "OpenClaw";
+  return agent?.identity?.name?.trim() || "OpenClaw";
 }
 
 async function processMessageWithPipeline(params: {


### PR DESCRIPTION
Fixes #49350

## What Problem This Solves

Fixes an issue where Google Chat users whose routed agent is named only through `agents.entries.<id>.identity.name` would see the generic `_OpenClaw is typing..._` placeholder.

## Why This Change Was Made

The Google Chat display-name resolver now preserves its existing precedence while consulting the established agent identity name before the generic fallback:

1. Google Chat account name
2. Agent top-level name
3. Agent identity name
4. `OpenClaw`

This is a fresh-main replacement for https://github.com/openclaw/openclaw/pull/49361, whose stale contributor branch cannot be edited. Credit to @zhuowater for the original diagnosis and patch shape; the replacement commit preserves co-author credit and adds current event-pipeline regression coverage.

Issue scope is complete after this PR: https://github.com/openclaw/openclaw/pull/113024 already landed the Google Chat Markdown-rendering repair and its formatter coverage on `main`; this PR resolves the issue's remaining typing-name fallback. `Fixes #49350` is therefore intentional.

## User Impact

Google Chat typing placeholders now use the configured agent identity name without changing account-name or top-level agent-name precedence.

## Evidence

- Base: `db1b8a12ff606930256b1a83735919c20b1d42ad`
- Head: `07cce39bac242ffe57dc34ba71d7d2c222a8dc7e`
- Test-only red on fresh `main`: the identity-only event expected `_Alvin is typing..._` and received `_OpenClaw is typing..._`; the other three precedence rows passed.
- Green after repair: `node scripts/run-vitest.mjs extensions/googlechat/src/monitor.test.ts extensions/googlechat/src/monitor.reply-delivery.test.ts extensions/googlechat/src/monitor.reply-delivery-failure.test.ts extensions/googlechat/src/format.test.ts` (74 passed).
- Full Google Chat source suite: `node scripts/run-vitest.mjs extensions/googlechat/src` (334 passed).
- Exact-head Google Chat Testbox: `tbx_01m0w1y4n62a4kfwv692wknv71`, 334 passed, https://github.com/openclaw/openclaw/actions/runs/32828901481.
- Private-QA build Testbox: `tbx_01m0w2bepcm1sbn651jj64n2sr`, exit 0, https://github.com/openclaw/openclaw/actions/runs/32829546318.
- Existing issue half: https://github.com/openclaw/openclaw/pull/113024 landed the Google Chat Markdown renderer and formatter tests; the typing-name fallback is the only remaining behavior in #49350.
- Changed gates: extension production/test typechecks, strict extension lint, dead-export scan, plugin boundaries, import cycles, database-first, media helper, runtime sidecar, formatting, and repository ratchets passed.
- Autoreview: no accepted or actionable findings at the exact head.
- Production LOC: `+2/-2` (net 0). Tests: `+67/-69` (net -2), consolidating an overlapping default-typing test.

## Mock-Gateway Verdict

```json
{
  "status": "passed",
  "head": "07cce39bac242ffe57dc34ba71d7d2c222a8dc7e",
  "gateway": "ephemeral",
  "provider": "mock-openai",
  "googleChatApi": "guarded loopback mock",
  "agentConfig": {
    "agents.entries.agent-1.identity.name": "Alvin"
  },
  "requests": [
    {
      "method": "POST",
      "path": "/v1/spaces/IDENTITY/messages",
      "body": {
        "text": "_Alvin is typing..._"
      },
      "responseMessage": "spaces/IDENTITY/messages/typing"
    },
    {
      "method": "PATCH",
      "path": "/v1/spaces/IDENTITY/messages/typing?updateMask=text",
      "body": {
        "text": "GOOGLECHAT_IDENTITY_PROOF_OK"
      }
    }
  ],
  "sameMessageUpdated": true,
  "liveWorkspaceRequired": false
}
```
