### PR TITLE
perf: per-delta cost grows with concurrent agent count because every delta walks every run's event listeners

### DIFF
--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -17,12 +17,17 @@ type TestSelection = {
 const runtimeConsumers = [
   {
     file: "extensions/qa-lab/src/suite-process-lifecycle.test.ts",
-    config: "test/vitest/vitest.extension-qa.config.ts",
+    configs: ["test/vitest/vitest.extension-qa.config.ts"],
     mode: "private-qa",
   },
   {
     file: "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts",
-    config: "test/vitest/vitest.tooling.config.ts",
+    configs: ["test/vitest/vitest.tooling.config.ts"],
+    mode: "runtime",
+  },
+  {
+    file: "src/gateway/gateway-concurrent-streams.test.ts",
+    configs: ["test/vitest/vitest.gateway-core.config.ts", "test/vitest/vitest.gateway.config.ts"],
     mode: "runtime",
   },
 ] as const;
@@ -30,17 +35,19 @@ const runtimeConsumers = [
 export function resolveVitestPretestBuildMode(
   selections: readonly TestSelection[],
 ): VitestPretestBuildMode | undefined {
-  return runtimeConsumers.find(({ file, config }) =>
+  return runtimeConsumers.find(({ file, configs: consumerConfigs }) =>
     selections.some(({ configs, includePatterns }) =>
       includePatterns
         ? includePatterns.some((pattern) => matchesGlob(file, pattern))
         : configs?.some(
             (selected) =>
-              selected === config ||
+              consumerConfigs.some((config) => selected === config) ||
               selected === "vitest.config.ts" ||
               selected === "test/vitest/vitest.config.ts" ||
               fullSuiteVitestShards.some(
-                (shard) => shard.config === selected && shard.projects.includes(config),
+                (shard) =>
+                  shard.config === selected &&
+                  consumerConfigs.some((config) => shard.projects.includes(config)),
               ),
           ),
     ),

--- a/src/agents/agent-run-approval-wait.ts
+++ b/src/agents/agent-run-approval-wait.ts
@@ -1,4 +1,4 @@
-import { onAgentEvent } from "../infra/agent-events.js";
+import { onAgentEventForRun } from "../infra/agent-events.js";
 
 export type AgentRunApprovalWait = {
   pending: boolean;
@@ -22,13 +22,14 @@ export function observeAgentRunApprovalWait(params: {
       state.onChange = undefined;
     },
   };
-  if (!params.runId) {
+  const runId = params.runId;
+  if (!runId) {
     return state;
   }
   // Lifecycle facts pause scheduling only; the original admitted run retains all authority.
-  unsubscribe = onAgentEvent((event) => {
+  unsubscribe = onAgentEventForRun(runId, (event) => {
     if (
-      event.runId !== params.runId ||
+      event.runId !== runId ||
       event.stream !== "lifecycle" ||
       (params.sessionId && event.sessionId && event.sessionId !== params.sessionId)
     ) {

--- a/src/agents/agent-run-approval-wait.ts
+++ b/src/agents/agent-run-approval-wait.ts
@@ -1,4 +1,4 @@
-import { onAgentEventForRun } from "../infra/agent-events.js";
+import { onAgentEvent } from "../infra/agent-events.js";
 
 export type AgentRunApprovalWait = {
   pending: boolean;
@@ -22,14 +22,13 @@ export function observeAgentRunApprovalWait(params: {
       state.onChange = undefined;
     },
   };
-  const runId = params.runId;
-  if (!runId) {
+  if (!params.runId) {
     return state;
   }
   // Lifecycle facts pause scheduling only; the original admitted run retains all authority.
-  unsubscribe = onAgentEventForRun(runId, (event) => {
+  unsubscribe = onAgentEvent((event) => {
     if (
-      event.runId !== runId ||
+      event.runId !== params.runId ||
       event.stream !== "lifecycle" ||
       (params.sessionId && event.sessionId && event.sessionId !== params.sessionId)
     ) {

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
@@ -12,7 +12,7 @@
  * to run through the CLI backend on plan limits instead.
  */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { onAgentEvent } from "../../infra/agent-events.js";
+import { onAgentEventForRun } from "../../infra/agent-events.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolvePreparedRunAdmission } from "../admitted-run-context.js";
 import { stripOpenClawMcpToolPrefix } from "../cli-runner/tool-policy.js";
@@ -140,7 +140,7 @@ async function runEmbeddedAgentViaCliBackend(
   // CLI tool results arrive as agent events with transport-prefixed MCP
   // names; strip and normalize so observers and transcript records see the
   // same tool names and soft-error signal the native embedded path reports.
-  const unsubscribe = onAgentEvent((evt) => {
+  const unsubscribe = onAgentEventForRun(params.runId, (evt) => {
     if (evt.runId !== params.runId) {
       return;
     }

--- a/src/agents/subagents/spawn/acp-spawn-parent-stream.ts
+++ b/src/agents/subagents/spawn/acp-spawn-parent-stream.ts
@@ -17,7 +17,7 @@ import {
   type StreamingCompatEntry,
 } from "../../../channels/streaming.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { onAgentEvent } from "../../../infra/agent-events.js";
+import { onAgentEventForRun } from "../../../infra/agent-events.js";
 import {
   type EventSessionRoutingPolicy,
   resolveEventSessionKeyForPolicy,
@@ -556,7 +556,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     emitStartNotice();
   }
 
-  const unsubscribe = onAgentEvent((event) => {
+  const unsubscribe = onAgentEventForRun(runId, (event) => {
     if (disposed || event.runId !== runId) {
       return;
     }

--- a/src/auto-reply/reply/agent-event-bridge.test.ts
+++ b/src/auto-reply/reply/agent-event-bridge.test.ts
@@ -41,6 +41,45 @@ describe("agent event delivery bridge", () => {
     expect(deliveredB).toEqual(["b1"]);
   });
 
+  test("keeps stream delivery order when a later global listener emits another event", async () => {
+    registerAgentRunContext("run-nested", { sessionKey: "session-nested" });
+    const delivered: string[] = [];
+    const bridge = textBridge("run-nested", delivered);
+    const stopGlobal = onAgentEvent((evt) => {
+      if (evt.runId === "run-nested" && evt.data.text === "outer") {
+        emitAgentEvent({ runId: "run-nested", stream: "assistant", data: { text: "inner" } });
+      }
+    });
+    try {
+      emitAgentEvent({ runId: "run-nested", stream: "assistant", data: { text: "outer" } });
+      await bridge.drain();
+      expect(delivered).toEqual(["outer", "inner"]);
+    } finally {
+      stopGlobal();
+      bridge.unsubscribe();
+    }
+  });
+
+  test("delivers the current event before a later global listener unsubscribes the bridge", async () => {
+    registerAgentRunContext("run-unsubscribe", { sessionKey: "session-unsubscribe" });
+    const delivered: string[] = [];
+    const bridge = textBridge("run-unsubscribe", delivered);
+    const stopGlobal = onAgentEvent((evt) => {
+      if (evt.runId === "run-unsubscribe") {
+        bridge.unsubscribe();
+      }
+    });
+    try {
+      emitAgentEvent({ runId: "run-unsubscribe", stream: "assistant", data: { text: "first" } });
+      emitAgentEvent({ runId: "run-unsubscribe", stream: "assistant", data: { text: "second" } });
+      await bridge.drain();
+      expect(delivered).toEqual(["first"]);
+    } finally {
+      stopGlobal();
+      bridge.unsubscribe();
+    }
+  });
+
   test("subscribes into its run's bucket rather than the global listener set", () => {
     registerAgentRunContext("run-scope", { sessionKey: "session-scope" });
     const order: string[] = [];

--- a/src/auto-reply/reply/agent-event-bridge.test.ts
+++ b/src/auto-reply/reply/agent-event-bridge.test.ts
@@ -1,0 +1,67 @@
+// Covers the shared CLI delivery bridge's subscription scope. Every concurrent
+// CLI run builds up to eight of these bridges, so a bridge that subscribes
+// globally and discards foreign runs makes per-delta cost grow with agent count.
+import { beforeEach, describe, expect, test } from "vitest";
+import { emitAgentEvent, onAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
+import { registerAgentRunContext } from "../../infra/agent-run-registry.js";
+import { createAgentEventBridge } from "./agent-event-bridge.js";
+
+function textBridge(runId: string, sink: string[]) {
+  return createAgentEventBridge<string>({
+    runId,
+    read: (evt) => (typeof evt.data.text === "string" ? evt.data.text : undefined),
+    deliver: async (text) => {
+      sink.push(text);
+    },
+  });
+}
+
+describe("agent event delivery bridge", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  test("delivers only its own run's events while two CLI runs stream concurrently", async () => {
+    registerAgentRunContext("run-a", { sessionKey: "session-a" });
+    registerAgentRunContext("run-b", { sessionKey: "session-b" });
+    const deliveredA: string[] = [];
+    const deliveredB: string[] = [];
+    const bridgeA = textBridge("run-a", deliveredA);
+    const bridgeB = textBridge("run-b", deliveredB);
+
+    emitAgentEvent({ runId: "run-a", stream: "assistant", data: { text: "a1" } });
+    emitAgentEvent({ runId: "run-b", stream: "assistant", data: { text: "b1" } });
+    emitAgentEvent({ runId: "run-a", stream: "assistant", data: { text: "a2" } });
+    await bridgeA.drain();
+    await bridgeB.drain();
+    bridgeA.unsubscribe();
+    bridgeB.unsubscribe();
+
+    expect(deliveredA).toEqual(["a1", "a2"]);
+    expect(deliveredB).toEqual(["b1"]);
+  });
+
+  test("subscribes into its run's bucket rather than the global listener set", () => {
+    registerAgentRunContext("run-scope", { sessionKey: "session-scope" });
+    const order: string[] = [];
+    // Registered first, so insertion order alone would run the bridge first.
+    // Run-indexed listeners always follow every global listener, so the bridge
+    // trailing here is what proves it is no longer a global subscriber that
+    // every other run's events would still have to walk.
+    const bridge = createAgentEventBridge<string>({
+      runId: "run-scope",
+      read: () => {
+        order.push("bridge");
+        return undefined;
+      },
+      deliver: async () => {},
+    });
+    const stopGlobal = onAgentEvent(() => order.push("global"));
+
+    emitAgentEvent({ runId: "run-scope", stream: "assistant", data: { text: "hi" } });
+    stopGlobal();
+    bridge.unsubscribe();
+
+    expect(order).toEqual(["global", "bridge"]);
+  });
+});

--- a/src/auto-reply/reply/agent-event-bridge.test.ts
+++ b/src/auto-reply/reply/agent-event-bridge.test.ts
@@ -21,25 +21,53 @@ describe("agent event delivery bridge", () => {
     resetAgentEventsForTest();
   });
 
-  test("delivers only its own run's events while two CLI runs stream concurrently", async () => {
-    registerAgentRunContext("run-a", { sessionKey: "session-a" });
-    registerAgentRunContext("run-b", { sessionKey: "session-b" });
-    const deliveredA: string[] = [];
-    const deliveredB: string[] = [];
-    const bridgeA = textBridge("run-a", deliveredA);
-    const bridgeB = textBridge("run-b", deliveredB);
-
-    emitAgentEvent({ runId: "run-a", stream: "assistant", data: { text: "a1" } });
-    emitAgentEvent({ runId: "run-b", stream: "assistant", data: { text: "b1" } });
-    emitAgentEvent({ runId: "run-a", stream: "assistant", data: { text: "a2" } });
-    await bridgeA.drain();
-    await bridgeB.drain();
-    bridgeA.unsubscribe();
-    bridgeB.unsubscribe();
-
-    expect(deliveredA).toEqual(["a1", "a2"]);
-    expect(deliveredB).toEqual(["b1"]);
-  });
+  test.each([1, 4, 16, 64])(
+    "isolates every delivery bridge while %s CLI runs stream interleaved events",
+    async (runs) => {
+      let predicateReads = 0;
+      const bridges = Array.from({ length: runs }, (_, runIndex) => {
+        const runId = `run-${runIndex}`;
+        registerAgentRunContext(runId, { sessionKey: `session-${runIndex}` });
+        return Array.from({ length: 8 }, (_, bridgeIndex) => {
+          const delivered: string[] = [];
+          const bridge = createAgentEventBridge<string>({
+            get runId() {
+              predicateReads++;
+              return runId;
+            },
+            read: (event) => (typeof event.data.text === "string" ? event.data.text : undefined),
+            deliver: async (text) => {
+              delivered.push(text);
+            },
+          });
+          return { ...bridge, delivered, runIndex, bridgeIndex };
+        });
+      }).flat();
+      try {
+        predicateReads = 0;
+        emitAgentEvent({ runId: "run-0", stream: "assistant", data: { text: "a1" } });
+        // Source-pinned work measurement only: hoisting the filter can change this
+        // count without changing dispatch complexity. Output assertions own the test.
+        console.info("bridge predicate-read diagnostic (not latency)", {
+          runs,
+          bridgesPerRun: 8,
+          predicateReads,
+        });
+        emitAgentEvent({ runId: "run-1", stream: "assistant", data: { text: "b1" } });
+        emitAgentEvent({ runId: "run-0", stream: "assistant", data: { text: "a2" } });
+        await Promise.all(bridges.map((bridge) => bridge.drain()));
+        for (const { delivered, runIndex, bridgeIndex } of bridges) {
+          expect(delivered, `run-${runIndex}/bridge-${bridgeIndex}`).toEqual(
+            runIndex === 0 ? ["a1", "a2"] : runIndex === 1 ? ["b1"] : [],
+          );
+        }
+      } finally {
+        for (const bridge of bridges) {
+          bridge.unsubscribe();
+        }
+      }
+    },
+  );
 
   test("keeps stream delivery order when a later global listener emits another event", async () => {
     registerAgentRunContext("run-nested", { sessionKey: "session-nested" });
@@ -80,27 +108,29 @@ describe("agent event delivery bridge", () => {
     }
   });
 
-  test("subscribes into its run's bucket rather than the global listener set", () => {
-    registerAgentRunContext("run-scope", { sessionKey: "session-scope" });
-    const order: string[] = [];
-    // Registered first, so insertion order alone would run the bridge first.
-    // Run-indexed listeners always follow every global listener, so the bridge
-    // trailing here is what proves it is no longer a global subscriber that
-    // every other run's events would still have to walk.
-    const bridge = createAgentEventBridge<string>({
-      runId: "run-scope",
-      read: () => {
-        order.push("bridge");
-        return undefined;
-      },
-      deliver: async () => {},
+  test("routes a changed event identity only to later matching bridges", async () => {
+    registerAgentRunContext("run-a", { sessionKey: "session-a" });
+    registerAgentRunContext("run-b", { sessionKey: "session-b" });
+    const earlierB: string[] = [];
+    const laterB: string[] = [];
+    const laterA: string[] = [];
+    const first = textBridge("run-b", earlierB);
+    const stopGlobal = onAgentEvent((event) => {
+      event.runId = "run-b";
     });
-    const stopGlobal = onAgentEvent(() => order.push("global"));
-
-    emitAgentEvent({ runId: "run-scope", stream: "assistant", data: { text: "hi" } });
-    stopGlobal();
-    bridge.unsubscribe();
-
-    expect(order).toEqual(["global", "bridge"]);
+    const second = textBridge("run-b", laterB);
+    const third = textBridge("run-a", laterA);
+    try {
+      emitAgentEvent({ runId: "run-a", stream: "assistant", data: { text: "changed" } });
+      await Promise.all([first.drain(), second.drain(), third.drain()]);
+      expect(earlierB).toEqual([]);
+      expect(laterB).toEqual(["changed"]);
+      expect(laterA).toEqual([]);
+    } finally {
+      stopGlobal();
+      first.unsubscribe();
+      second.unsubscribe();
+      third.unsubscribe();
+    }
   });
 });

--- a/src/auto-reply/reply/agent-event-bridge.test.ts
+++ b/src/auto-reply/reply/agent-event-bridge.test.ts
@@ -28,7 +28,7 @@ describe("agent event delivery bridge", () => {
       const bridges = Array.from({ length: runs }, (_, runIndex) => {
         const runId = `run-${runIndex}`;
         registerAgentRunContext(runId, { sessionKey: `session-${runIndex}` });
-        return Array.from({ length: 8 }, (_, bridgeIndex) => {
+        return Array.from({ length: 8 }, (_bridge, bridgeIndex) => {
           const delivered: string[] = [];
           const bridge = createAgentEventBridge<string>({
             get runId() {

--- a/src/auto-reply/reply/agent-event-bridge.ts
+++ b/src/auto-reply/reply/agent-event-bridge.ts
@@ -1,6 +1,6 @@
 // Generic agent-event bridge machinery shared by the CLI runner's per-stream
 // delivery bridges (assistant, reasoning, commentary, plan).
-import { type AgentEventPayload, onAgentEvent } from "../../infra/agent-events.js";
+import { type AgentEventPayload, onAgentEventForRun } from "../../infra/agent-events.js";
 
 export type AgentEventDeliveryStartOrder = {
   schedule: (deliver: () => Promise<unknown>) => Promise<void>;
@@ -45,7 +45,7 @@ export function createAgentEventBridge<T>(params: {
   }
   let unsubscribed = false;
   let delivery: Promise<unknown> = Promise.resolve();
-  const rawUnsubscribe = onAgentEvent((evt) => {
+  const rawUnsubscribe = onAgentEventForRun(params.runId, (evt) => {
     if (evt.runId !== params.runId) {
       return;
     }

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -599,6 +599,10 @@ vi.mock("../../infra/agent-events.js", () => ({
   getAgentEventLifecycleGeneration: () => "test-generation",
   isAgentEventLifecycleGenerationCurrent: (generation: string) => generation === "test-generation",
   onAgentEvent: (listener: unknown) => agentEventMocks.onAgentEvent(listener),
+  // Plain stub, not a spy like onAgentEvent above: no test asserts per-run subscription,
+  // and staying out of agentEventMocks keeps the sibling mockReset() calls from clearing
+  // this implementation and handing the CLI bridges an undefined unsubscribe.
+  onAgentEventForRun: () => () => {},
   registerAgentEventLifecycleRotationHandler: vi.fn(),
   runOncePerAgentRun: <T>(_runId: string, _operation: string, run: () => Promise<T>) => run(),
   withAgentRunLifecycleGeneration: <T>(_generation: string, run: () => T) => run(),

--- a/src/gateway/gateway-concurrent-streams.test.ts
+++ b/src/gateway/gateway-concurrent-streams.test.ts
@@ -1,0 +1,259 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { stopChild } from "../../scripts/lib/gateway-bench-child.js";
+import { getFreePort } from "../../scripts/lib/gateway-bench-probes.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { AgentEventPayload } from "../infra/agent-events.js";
+import { resetAgentEventsForTest } from "../infra/agent-events.js";
+import { resetLogger } from "../logging/logger.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
+import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
+
+type StreamFrame = {
+  id?: string;
+  type?: string;
+  delta?: string;
+  choices?: Array<{ delta?: { content?: string }; finish_reason?: string | null }>;
+  response?: { id: string; status: string };
+};
+
+const cases = [
+  {
+    endpoint: "/v1/chat/completions",
+    sessionKey: "agent:main:fanout-alpha",
+    marker: "FANOUT_ALPHA first second",
+  },
+  {
+    endpoint: "/v1/responses",
+    sessionKey: "agent:main:fanout-beta",
+    marker: "FANOUT_BETA first second",
+  },
+] as const;
+
+afterEach(() => {
+  resetAgentEventsForTest({ preserveListeners: true });
+  resetLogger();
+});
+
+describe("Gateway concurrent HTTP streams", () => {
+  it("keeps both streams isolated while global observers retain every run", async () => {
+    const state = await createOpenClawTestState({
+      label: "concurrent-streams",
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
+        OPENCLAW_GATEWAY_STARTUP_TRACE: "1",
+        OPENCLAW_TEST_CONSOLE: "1",
+        OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+      },
+    });
+    // Startup spans use the subsystem logger; discard Vitest's cached silent
+    // settings after entering the isolated fixture so stalled startup is visible.
+    resetLogger();
+    const mockPort = await getFreePort();
+    const controlPath = state.path("response-control.json");
+    const requestLogPath = state.path("provider-requests.jsonl");
+    const provider = buildMockOpenAiResponsesProvider(
+      `http://127.0.0.1:${mockPort}/v1`,
+      "gpt-5.6-luna",
+    );
+    const token = `fanout-${randomUUID()}`;
+    const events: AgentEventPayload[] = [];
+    const abort = new AbortController();
+    let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+    let mock: ChildProcessWithoutNullStreams | undefined;
+    const streams: Array<{
+      item: (typeof cases)[number];
+      settled: Promise<PromiseSettledResult<StreamFrame[]>>;
+    }> = [];
+    const writeControl = async (hold: boolean) => {
+      await fs.writeFile(
+        `${controlPath}.next`,
+        JSON.stringify({
+          scriptVersion: "fanout-proof",
+          hold,
+          responses: cases.map(({ marker }) => ({ text: marker, chunkDelayMs: 100 })),
+        }),
+      );
+      await fs.rename(`${controlPath}.next`, controlPath);
+    };
+    const requestBodies = async () => {
+      const raw = await fs.readFile(requestLogPath, "utf8").catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") {
+          return "";
+        }
+        throw error;
+      });
+      return raw.trim()
+        ? raw.trim().split("\n").map((line) => JSON.parse(line).body as string)
+        : [];
+    };
+    try {
+      await writeControl(true);
+      mock = spawn(process.execPath, ["scripts/e2e/mock-openai-server.mjs"], {
+        cwd: process.cwd(),
+        detached: process.platform !== "win32",
+        env: {
+          PATH: process.env.PATH,
+          MOCK_PORT: String(mockPort),
+          MOCK_RESPONSE_CONTROL: controlPath,
+          MOCK_REQUEST_LOG: requestLogPath,
+        },
+      });
+      mock.stdout.resume();
+      mock.stderr.resume();
+      await vi.waitFor(async () => {
+        expect((await fetch(`http://127.0.0.1:${mockPort}/health`)).status).toBe(200);
+      });
+      const cfg = {
+        gateway: {
+          auth: { mode: "token", token },
+          http: {
+            endpoints: { chatCompletions: { enabled: true }, responses: { enabled: true } },
+          },
+        },
+        agents: {
+          defaults: {
+            workspace: state.workspaceDir,
+            skipBootstrap: true,
+            maxConcurrent: 2,
+            heartbeat: { every: "0m" },
+            model: { primary: provider.modelRef },
+            models: {
+              [provider.modelRef]: {
+                agentRuntime: { id: "openclaw" },
+                params: { transport: "sse", openaiWsWarmup: false },
+              },
+            },
+          },
+        },
+        models: {
+          mode: "replace",
+          providers: {
+            [provider.providerId]: { ...provider.config, request: { allowPrivateNetwork: true } },
+          },
+        },
+        plugins: { slots: { memory: "none" } },
+        tools: { profile: "minimal" },
+      } satisfies OpenClawConfig;
+      gateway = await startGatewayWithClient({
+        cfg,
+        configPath: state.configPath,
+        token,
+        scopes: ["operator.admin", "operator.read", "operator.write"],
+        onEvent: (event) => {
+          if (event.event === "agent") {
+            events.push(event.payload as AgentEventPayload);
+          }
+        },
+      });
+      const { port, client } = gateway;
+      for (const [index, item] of cases.entries()) {
+        await client.request("sessions.messages.subscribe", { key: item.sessionKey });
+        const body = {
+          model: "openclaw:main",
+          stream: true,
+          ...(item.endpoint === "/v1/responses"
+            ? { input: item.marker }
+            : { messages: [{ role: "user", content: item.marker }] }),
+        };
+        const pending = (async () => {
+          const response = await fetch(`http://127.0.0.1:${port}${item.endpoint}`, {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${token}`,
+              "content-type": "application/json",
+              "x-openclaw-session-key": item.sessionKey,
+            },
+            body: JSON.stringify(body),
+            signal: abort.signal,
+          });
+          expect(response.status).toBe(200);
+          const wire = await response.text();
+          expect(wire.match(/^data: \[DONE\]$/gm)).toHaveLength(1);
+          return wire.split("\n").flatMap((line) =>
+            line.startsWith("data: ") && line !== "data: [DONE]"
+              ? [JSON.parse(line.slice(6)) as StreamFrame]
+              : [],
+          );
+        })();
+        streams.push({ item, settled: Promise.allSettled([pending]).then(([result]) => result!) });
+        // Reserve each scripted response in arrival order, but hold both provider
+        // requests open together before either may deliver a delta or terminal.
+        await vi.waitFor(async () => expect(await requestBodies()).toHaveLength(index + 1), {
+          timeout: 30_000,
+        });
+      }
+      const requests = await requestBodies();
+      for (const [index, item] of cases.entries()) {
+        expect(requests[index]).toContain(item.marker);
+      }
+      await writeControl(false);
+      for (const stream of streams) {
+        const { item } = stream;
+        const settled = await stream.settled;
+        if (settled.status === "rejected") {
+          throw settled.reason;
+        }
+        const frames = settled.value;
+        const runId = frames[0]?.id ?? frames[0]?.response?.id;
+        expect(runId).toEqual(expect.any(String));
+        const text = frames
+          .map((frame) => frame.delta ?? frame.choices?.[0]?.delta?.content ?? "")
+          .join("");
+        expect(text).toBe(item.marker);
+        const terminals = frames.filter((frame) =>
+          frame.type === "response.completed" || frame.choices?.[0]?.finish_reason === "stop",
+        );
+        expect(terminals).toHaveLength(1);
+        const result = await client.request<{ status: string }>("agent.wait", {
+          runId,
+          timeoutMs: 10_000,
+        });
+        expect(result.status).toBe("ok");
+        await vi.waitFor(() => {
+          const own = events.filter((event) => event.runId === runId);
+          const lifecycle = own.filter((event) => event.stream === "lifecycle");
+          expect(lifecycle.filter((event) => event.data.phase === "start")).toHaveLength(1);
+          expect(lifecycle.filter((event) => event.data.phase === "end")).toHaveLength(1);
+          const assistant = own.filter((event) => event.stream === "assistant");
+          expect(assistant.at(-1)?.data.text).toBe(item.marker);
+          for (const event of assistant) {
+            expect(item.marker.startsWith(String(event.data.text))).toBe(true);
+          }
+        });
+      }
+    } finally {
+      abort.abort();
+      try {
+        if (gateway) {
+          try {
+            await disconnectGatewayClient(gateway.client);
+          } finally {
+            await gateway.server.close({ reason: "concurrent stream proof cleanup" });
+          }
+        }
+      } finally {
+        try {
+          if (mock) {
+            await stopChild(mock);
+          }
+          await Promise.all(streams.map((stream) => stream.settled));
+        } finally {
+          await state.cleanup();
+        }
+      }
+    }
+  }, 120_000);
+});

--- a/src/gateway/gateway-concurrent-streams.test.ts
+++ b/src/gateway/gateway-concurrent-streams.test.ts
@@ -1,16 +1,20 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { execFileSync, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
 import { stopChild } from "../../scripts/lib/gateway-bench-child.js";
 import { getFreePort } from "../../scripts/lib/gateway-bench-probes.js";
+import { createGatewayWsClient } from "../../scripts/lib/gateway-ws-client.js";
+import {
+  BUILD_STAMP_FILE,
+  RUNTIME_POSTBUILD_STAMP_FILE,
+} from "../../scripts/lib/local-build-metadata-paths.mts";
+import { createOpenClawTestInstance } from "../../test/helpers/openclaw-test-instance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
-import { resetAgentEventsForTest } from "../infra/agent-events.js";
 import { hasErrnoCode } from "../infra/errno.js";
-import { resetLogger } from "../logging/logger.js";
-import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
 import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
 
 type StreamFrame = {
@@ -34,15 +38,27 @@ const cases = [
   },
 ] as const;
 
-afterEach(() => {
-  resetAgentEventsForTest({ preserveListeners: true });
-  resetLogger();
-});
-
 describe("Gateway concurrent HTTP streams", () => {
   it("keeps both streams isolated while global observers retain every run", async () => {
-    const state = await createOpenClawTestState({
-      label: "concurrent-streams",
+    const cwd = process.cwd();
+    const checkoutSha = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd,
+      encoding: "utf8",
+    }).trim();
+    // Require this checkout's complete runtime before the shared helper can
+    // prepare a source fallback. The child must own one coherent built graph.
+    await fs.access(path.join(cwd, "dist/index.js"));
+    for (const stamp of [BUILD_STAMP_FILE, RUNTIME_POSTBUILD_STAMP_FILE]) {
+      const metadata = JSON.parse(await fs.readFile(path.join(cwd, "dist", stamp), "utf8"));
+      expect(metadata.head, stamp).toBe(checkoutSha);
+    }
+    const buildInfo = JSON.parse(await fs.readFile(path.join(cwd, "dist/build-info.json"), "utf8"));
+    expect(buildInfo.commit).toBe(checkoutSha);
+    const token = `fanout-${randomUUID()}`;
+    const gateway = await createOpenClawTestInstance({
+      name: "concurrent-streams",
+      cwd,
+      gatewayToken: token,
       env: {
         OPENCLAW_GATEWAY_TOKEN: undefined,
         OPENCLAW_GATEWAY_PASSWORD: undefined,
@@ -59,20 +75,12 @@ describe("Gateway concurrent HTTP streams", () => {
         OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
       },
     });
-    // Startup spans use the subsystem logger; discard Vitest's cached silent
-    // settings after entering the isolated fixture so stalled startup is visible.
-    resetLogger();
-    const mockPort = await getFreePort();
+    const { state, port } = gateway;
     const controlPath = state.path("response-control.json");
     const requestLogPath = state.path("provider-requests.jsonl");
-    const provider = buildMockOpenAiResponsesProvider(
-      `http://127.0.0.1:${mockPort}/v1`,
-      "gpt-5.6-luna",
-    );
-    const token = `fanout-${randomUUID()}`;
     const events: AgentEventPayload[] = [];
     const abort = new AbortController();
-    let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+    let client: ReturnType<typeof createGatewayWsClient> | undefined;
     let mock: ChildProcessWithoutNullStreams | undefined;
     const streams: Array<{
       item: (typeof cases)[number];
@@ -104,6 +112,12 @@ describe("Gateway concurrent HTTP streams", () => {
         : [];
     };
     try {
+      expect(await gateway.entrypoint()).toEqual(["dist/index.js"]);
+      const mockPort = await getFreePort();
+      const provider = buildMockOpenAiResponsesProvider(
+        `http://127.0.0.1:${mockPort}/v1`,
+        "gpt-5.6-luna",
+      );
       await writeControl(true);
       mock = spawn(process.execPath, ["scripts/e2e/mock-openai-server.mjs"], {
         cwd: process.cwd(),
@@ -122,11 +136,14 @@ describe("Gateway concurrent HTTP streams", () => {
       });
       const cfg = {
         gateway: {
+          port,
           auth: { mode: "token", token },
+          controlUi: { enabled: false },
           http: {
             endpoints: { chatCompletions: { enabled: true }, responses: { enabled: true } },
           },
         },
+        hooks: { enabled: false },
         agents: {
           defaults: {
             workspace: state.workspaceDir,
@@ -151,20 +168,37 @@ describe("Gateway concurrent HTTP streams", () => {
         plugins: { slots: { memory: "none" } },
         tools: { profile: "minimal" },
       } satisfies OpenClawConfig;
-      gateway = await startGatewayWithClient({
-        cfg,
-        configPath: state.configPath,
-        token,
-        scopes: ["operator.admin", "operator.read", "operator.write"],
+      await state.writeConfig(cfg);
+      await gateway.startGateway();
+      client = createGatewayWsClient({
+        url: gateway.url,
         onEvent: (event) => {
           if (event.event === "agent") {
             events.push(event.payload as AgentEventPayload);
           }
         },
       });
-      const { port, client } = gateway;
+      await client.waitOpen();
+      const connected = await client.request("connect", {
+        minProtocol: PROTOCOL_VERSION,
+        maxProtocol: PROTOCOL_VERSION,
+        client: {
+          id: "gateway-client",
+          displayName: "concurrent-stream-proof",
+          version: "dev",
+          platform: process.platform,
+          mode: "backend",
+        },
+        role: "operator",
+        scopes: ["operator.admin", "operator.read", "operator.write"],
+        auth: { token },
+      });
+      expect(connected.ok, JSON.stringify(connected.error)).toBe(true);
       for (const [index, item] of cases.entries()) {
-        await client.request("sessions.messages.subscribe", { key: item.sessionKey });
+        const subscribed = await client.request("sessions.messages.subscribe", {
+          key: item.sessionKey,
+        });
+        expect(subscribed.ok, JSON.stringify(subscribed.error)).toBe(true);
         const body = {
           model: "openclaw:main",
           stream: true,
@@ -224,11 +258,12 @@ describe("Gateway concurrent HTTP streams", () => {
             frame.type === "response.completed" || frame.choices?.[0]?.finish_reason === "stop",
         );
         expect(terminals).toHaveLength(1);
-        const result = await client.request<{ status: string }>("agent.wait", {
+        const result = await client.request("agent.wait", {
           runId,
           timeoutMs: 10_000,
         });
-        expect(result.status).toBe("ok");
+        expect(result.ok, JSON.stringify(result.error)).toBe(true);
+        expect(result.payload).toMatchObject({ status: "ok" });
         await vi.waitFor(() => {
           const own = events.filter((event) => event.runId === runId);
           const lifecycle = own.filter((event) => event.stream === "lifecycle");
@@ -241,16 +276,14 @@ describe("Gateway concurrent HTTP streams", () => {
           }
         });
       }
+    } catch (error) {
+      console.error(gateway.logs());
+      throw error;
     } finally {
       abort.abort();
       try {
-        if (gateway) {
-          try {
-            await disconnectGatewayClient(gateway.client);
-          } finally {
-            await gateway.server.close({ reason: "concurrent stream proof cleanup" });
-          }
-        }
+        client?.close();
+        await gateway.stopGateway();
       } finally {
         try {
           if (mock) {
@@ -258,7 +291,7 @@ describe("Gateway concurrent HTTP streams", () => {
           }
           await Promise.all(streams.map((stream) => stream.settled));
         } finally {
-          await state.cleanup();
+          await gateway.cleanup();
         }
       }
     }

--- a/src/gateway/gateway-concurrent-streams.test.ts
+++ b/src/gateway/gateway-concurrent-streams.test.ts
@@ -7,6 +7,7 @@ import { getFreePort } from "../../scripts/lib/gateway-bench-probes.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentEventPayload } from "../infra/agent-events.js";
 import { resetAgentEventsForTest } from "../infra/agent-events.js";
+import { hasErrnoCode } from "../infra/errno.js";
 import { resetLogger } from "../logging/logger.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
@@ -89,14 +90,17 @@ describe("Gateway concurrent HTTP streams", () => {
       await fs.rename(`${controlPath}.next`, controlPath);
     };
     const requestBodies = async () => {
-      const raw = await fs.readFile(requestLogPath, "utf8").catch((error: NodeJS.ErrnoException) => {
-        if (error.code === "ENOENT") {
+      const raw = await fs.readFile(requestLogPath, "utf8").catch((error: unknown) => {
+        if (hasErrnoCode(error, "ENOENT")) {
           return "";
         }
         throw error;
       });
       return raw.trim()
-        ? raw.trim().split("\n").map((line) => JSON.parse(line).body as string)
+        ? raw
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line).body as string)
         : [];
     };
     try {
@@ -182,11 +186,13 @@ describe("Gateway concurrent HTTP streams", () => {
           expect(response.status).toBe(200);
           const wire = await response.text();
           expect(wire.match(/^data: \[DONE\]$/gm)).toHaveLength(1);
-          return wire.split("\n").flatMap((line) =>
-            line.startsWith("data: ") && line !== "data: [DONE]"
-              ? [JSON.parse(line.slice(6)) as StreamFrame]
-              : [],
-          );
+          return wire
+            .split("\n")
+            .flatMap((line) =>
+              line.startsWith("data: ") && line !== "data: [DONE]"
+                ? [JSON.parse(line.slice(6)) as StreamFrame]
+                : [],
+            );
         })();
         streams.push({ item, settled: Promise.allSettled([pending]).then(([result]) => result!) });
         // Reserve each scripted response in arrival order, but hold both provider
@@ -213,8 +219,9 @@ describe("Gateway concurrent HTTP streams", () => {
           .map((frame) => frame.delta ?? frame.choices?.[0]?.delta?.content ?? "")
           .join("");
         expect(text).toBe(item.marker);
-        const terminals = frames.filter((frame) =>
-          frame.type === "response.completed" || frame.choices?.[0]?.finish_reason === "stop",
+        const terminals = frames.filter(
+          (frame) =>
+            frame.type === "response.completed" || frame.choices?.[0]?.finish_reason === "stop",
         );
         expect(terminals).toHaveLength(1);
         const result = await client.request<{ status: string }>("agent.wait", {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -20,7 +20,7 @@ import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromGatewayIngress } from "../commands/agent.js";
 import { getRuntimeConfig } from "../config/io.js";
 import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.js";
-import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import { emitAgentEvent, onAgentEventForRun } from "../infra/agent-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
 import {
@@ -1233,7 +1233,7 @@ export async function handleOpenAiHttpRequest(
     maybeFinalize();
   };
 
-  const unsubscribe = onAgentEvent((evt) => {
+  const unsubscribe = onAgentEventForRun(runId, (evt) => {
     if (evt.runId !== runId) {
       return;
     }

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -19,7 +19,7 @@ import type { CliDeps } from "../cli/deps.types.js";
 import { agentCommandFromGatewayIngress } from "../commands/agent.js";
 import { getRuntimeConfig } from "../config/io.js";
 import type { GatewayHttpResponsesConfig } from "../config/types.gateway.js";
-import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import { emitAgentEvent, onAgentEventForRun } from "../infra/agent-events.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { logWarn } from "../logger.js";
 import { renderFileContextBlock } from "../media/file-context.js";
@@ -1049,7 +1049,7 @@ export async function handleOpenResponsesHttpRequest(
     part: { type: "output_text", text: "" },
   });
 
-  unsubscribe = onAgentEvent((evt) => {
+  unsubscribe = onAgentEventForRun(responseId, (evt) => {
     if (evt.runId !== responseId) {
       return;
     }

--- a/src/infra/agent-events.run-listeners.test.ts
+++ b/src/infra/agent-events.run-listeners.test.ts
@@ -84,7 +84,6 @@ describe("run-indexed agent event listeners", () => {
       const subscribe = (listener: () => void) =>
         scope === "global" ? onAgentEvent(listener) : onAgentEventForRun("run-live", listener);
       const replaced = () => order.push("re-added");
-      let stopReplaced: () => void;
       onAgentEventForRun("run-live", () => {
         order.push("first");
         stopReplaced();
@@ -92,7 +91,7 @@ describe("run-indexed agent event listeners", () => {
           subscribe(replaced);
         }
       });
-      stopReplaced = subscribe(replaced);
+      const stopReplaced = subscribe(replaced);
       onAgentEvent(() => order.push("middle"));
       emitAgentEvent({ runId: "run-live", stream: "assistant", data: {} });
       expect(order).toEqual(readd ? ["first", "middle", "re-added"] : ["first", "middle"]);

--- a/src/infra/agent-events.run-listeners.test.ts
+++ b/src/infra/agent-events.run-listeners.test.ts
@@ -1,18 +1,19 @@
-// Covers run-indexed agent event delivery: bucket scoping, global-before-bucket
-// ordering, and bucket lifetime. Separate from agent-events.test.ts so neither
-// file needs a max-lines suppression.
-import { beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   emitAgentEvent,
   emitAgentEventForOwner,
   onAgentEvent,
   onAgentEventForRun,
+  onAgentRuntimeEvent,
   resetAgentEventsForTest,
 } from "./agent-events.js";
 import { claimAgentRunContext, registerAgentRunContext } from "./agent-run-registry.js";
 
 describe("run-indexed agent event listeners", () => {
   beforeEach(() => {
+    resetAgentEventsForTest();
+  });
+  afterEach(() => {
     resetAgentEventsForTest();
   });
 
@@ -31,7 +32,7 @@ describe("run-indexed agent event listeners", () => {
     expect(mine).toEqual([1, 2]);
   });
 
-  test("notifies global listeners before run-indexed listeners", () => {
+  test("preserves mixed global and run listener registration order", () => {
     registerAgentRunContext("run-order", { sessionKey: "session-order" });
     const order: string[] = [];
     const stopRun = onAgentEventForRun("run-order", () => order.push("run"));
@@ -45,10 +46,154 @@ describe("run-indexed agent event listeners", () => {
     stopRun();
     stopGlobal();
 
-    // The bucket subscribed first, so insertion order alone would have put it
-    // first. Globals must still win: a global listener may write state that a
-    // run-scoped listener reads.
-    expect(order).toEqual(["global", "run"]);
+    expect(order).toEqual(["run", "global"]);
+  });
+
+  test.each(["global", "run"] as const)(
+    "visits a new %s listener added by the last callback, even when that callback throws",
+    (scope) => {
+      const order: string[] = [];
+      const addLate = () => {
+        order.push("first");
+        if (scope === "global") {
+          onAgentEvent(() => order.push("late"));
+        } else {
+          onAgentEventForRun("run-live", () => order.push("late"));
+        }
+        throw new Error("listener failed after registering its successor");
+      };
+      if (scope === "global") {
+        onAgentEventForRun("run-live", addLate);
+      } else {
+        onAgentEvent(addLate);
+      }
+      emitAgentEvent({ runId: "run-live", stream: "assistant", data: {} });
+      expect(order).toEqual(["first", "late"]);
+    },
+  );
+
+  test.each([
+    ["global", false],
+    ["global", true],
+    ["run", false],
+    ["run", true],
+  ] as const)(
+    "skips a deleted %s callback and appends its replacement (re-add=%s)",
+    (scope, readd) => {
+      const order: string[] = [];
+      const subscribe = (listener: () => void) =>
+        scope === "global" ? onAgentEvent(listener) : onAgentEventForRun("run-live", listener);
+      const replaced = () => order.push("re-added");
+      let stopReplaced: () => void;
+      onAgentEventForRun("run-live", () => {
+        order.push("first");
+        stopReplaced();
+        if (readd) {
+          subscribe(replaced);
+        }
+      });
+      stopReplaced = subscribe(replaced);
+      onAgentEvent(() => order.push("middle"));
+      emitAgentEvent({ runId: "run-live", stream: "assistant", data: {} });
+      expect(order).toEqual(readd ? ["first", "middle", "re-added"] : ["first", "middle"]);
+    },
+  );
+
+  test.each(["global", "run"] as const)(
+    "deduplicates %s callbacks and preserves same-bucket unsubscribe handles",
+    (scope) => {
+      const subscribe = (listener: () => void) =>
+        scope === "global" ? onAgentEvent(listener) : onAgentEventForRun("run-live", listener);
+      const seen: string[] = [];
+      const listener = () => seen.push("event");
+      subscribe(() => {});
+      const stopFirst = subscribe(listener);
+      const stopDuplicate = subscribe(listener);
+      emitAgentEvent({ runId: "run-live", stream: "assistant", data: {} });
+      stopFirst();
+      emitAgentEvent({ runId: "run-live", stream: "assistant", data: {} });
+      subscribe(listener);
+      stopFirst();
+      emitAgentEvent({ runId: "run-live", stream: "assistant", data: {} });
+      stopDuplicate();
+      expect(seen).toEqual(["event"]);
+    },
+  );
+
+  test("shares global callback identity with runtime subscriptions", () => {
+    const seen: string[] = [];
+    const listener = () => seen.push("event");
+    const stop = onAgentEvent(listener);
+    onAgentRuntimeEvent(listener);
+    emitAgentEvent({ runId: "run-live", stream: "assistant", data: {} });
+    stop();
+    emitAgentEvent({ runId: "run-live", stream: "assistant", data: {} });
+    expect(seen).toEqual(["event"]);
+  });
+
+  test.each([false, true])(
+    "keeps reset-during-dispatch live (preserve=%s)",
+    (preserveListeners) => {
+      const order: string[] = [];
+      onAgentEventForRun("run-live", () => {
+        order.push("first");
+        resetAgentEventsForTest({ preserveListeners });
+        onAgentEvent(() => order.push("new-global"));
+        onAgentEventForRun("run-live", () => order.push("new-run"));
+      });
+      onAgentEvent(() => order.push("old-global"));
+      onAgentEventForRun("run-live", () => order.push("old-run"));
+      emitAgentEvent({ runId: "run-live", stream: "assistant", data: {} });
+      expect(order).toEqual(
+        preserveListeners
+          ? ["first", "old-global", "old-run", "new-global", "new-run"]
+          : ["first", "new-global", "new-run"],
+      );
+    },
+  );
+
+  test.each([false, true])(
+    "reselects a mutated run cohort without revisiting earlier positions (pending=%s)",
+    (hasPendingOriginalRun) => {
+      const order: string[] = [];
+      onAgentEventForRun("run-b", () => order.push("earlier-b"));
+      onAgentEventForRun("run-a", () => order.push("first-a"));
+      onAgentEvent((event) => {
+        order.push("global");
+        event.runId = "run-b";
+      });
+      if (hasPendingOriginalRun) {
+        onAgentEventForRun("run-a", () => order.push("later-a"));
+      }
+      onAgentEventForRun("run-b", () => order.push("later-b"));
+      emitAgentEvent({ runId: "run-a", stream: "assistant", data: {} });
+      expect(order).toEqual(["first-a", "global", "later-b"]);
+    },
+  );
+
+  test("retains independent nested cursors while new callbacks join both emissions", () => {
+    const order: string[] = [];
+    onAgentEventForRun("run-live", (event) => {
+      order.push(`first:${String(event.data.text)}`);
+      if (event.data.text === "outer") {
+        emitAgentEvent({ runId: "run-live", stream: "assistant", data: { text: "inner" } });
+      } else {
+        onAgentEventForRun("run-live", (next) => order.push(`new-run:${String(next.data.text)}`));
+        onAgentEvent((next) => order.push(`new-global:${String(next.data.text)}`));
+      }
+    });
+    onAgentEvent((event) => order.push(`global:${String(event.data.text)}`));
+    emitAgentEvent({ runId: "run-live", stream: "assistant", data: { text: "outer" } });
+    expect(order).toEqual([
+      "first:outer",
+      "first:inner",
+      "global:inner",
+      "new-run:inner",
+      "new-global:inner",
+      "global:outer",
+      "new-run:outer",
+      "new-global:outer",
+    ]);
   });
 
   test("keeps sibling subscribers alive and reclaims the bucket only when empty", () => {

--- a/src/infra/agent-events.run-listeners.test.ts
+++ b/src/infra/agent-events.run-listeners.test.ts
@@ -1,0 +1,110 @@
+// Covers run-indexed agent event delivery: bucket scoping, global-before-bucket
+// ordering, and bucket lifetime. Separate from agent-events.test.ts so neither
+// file needs a max-lines suppression.
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  emitAgentEvent,
+  emitAgentEventForOwner,
+  onAgentEvent,
+  onAgentEventForRun,
+  resetAgentEventsForTest,
+} from "./agent-events.js";
+import { claimAgentRunContext, registerAgentRunContext } from "./agent-run-registry.js";
+
+describe("run-indexed agent event listeners", () => {
+  beforeEach(() => {
+    resetAgentEventsForTest();
+  });
+
+  test("delivers only the subscribed run's events", () => {
+    registerAgentRunContext("run-a", { sessionKey: "session-a" });
+    registerAgentRunContext("run-b", { sessionKey: "session-b" });
+    const mine: number[] = [];
+    const unsubscribe = onAgentEventForRun("run-a", (evt) => mine.push(evt.seq));
+
+    emitAgentEvent({ runId: "run-a", stream: "assistant", data: { text: "one" } });
+    emitAgentEvent({ runId: "run-b", stream: "assistant", data: { text: "other run" } });
+    emitAgentEvent({ runId: "run-a", stream: "assistant", data: { text: "two" } });
+    unsubscribe();
+    emitAgentEvent({ runId: "run-a", stream: "assistant", data: { text: "after" } });
+
+    expect(mine).toEqual([1, 2]);
+  });
+
+  test("notifies global listeners before run-indexed listeners", () => {
+    registerAgentRunContext("run-order", { sessionKey: "session-order" });
+    const order: string[] = [];
+    const stopRun = onAgentEventForRun("run-order", () => order.push("run"));
+    const stopGlobal = onAgentEvent((evt) => {
+      if (evt.runId === "run-order") {
+        order.push("global");
+      }
+    });
+
+    emitAgentEvent({ runId: "run-order", stream: "assistant", data: { text: "hi" } });
+    stopRun();
+    stopGlobal();
+
+    // The bucket subscribed first, so insertion order alone would have put it
+    // first. Globals must still win: a global listener may write state that a
+    // run-scoped listener reads.
+    expect(order).toEqual(["global", "run"]);
+  });
+
+  test("keeps sibling subscribers alive and reclaims the bucket only when empty", () => {
+    registerAgentRunContext("run-shared", { sessionKey: "session-shared" });
+    const first: string[] = [];
+    const second: string[] = [];
+    const stopFirst = onAgentEventForRun("run-shared", () => first.push("first"));
+    const stopSecond = onAgentEventForRun("run-shared", () => second.push("second"));
+
+    emitAgentEvent({ runId: "run-shared", stream: "assistant", data: { text: "both" } });
+    stopFirst();
+    // Unsubscribing one subscriber must not drop the bucket the other still uses.
+    emitAgentEvent({ runId: "run-shared", stream: "assistant", data: { text: "still here" } });
+    stopSecond();
+    emitAgentEvent({ runId: "run-shared", stream: "assistant", data: { text: "gone" } });
+
+    expect(first).toEqual(["first"]);
+    expect(second).toEqual(["second", "second"]);
+
+    // A fresh subscription after the bucket was reclaimed still receives events.
+    const revived: string[] = [];
+    const stopRevived = onAgentEventForRun("run-shared", () => revived.push("revived"));
+    emitAgentEvent({ runId: "run-shared", stream: "assistant", data: { text: "again" } });
+    stopRevived();
+    expect(revived).toEqual(["revived"]);
+  });
+
+  test("tolerates a repeated unsubscribe without disturbing a later subscriber", () => {
+    registerAgentRunContext("run-repeat", { sessionKey: "session-repeat" });
+    const stale = onAgentEventForRun("run-repeat", () => {});
+    stale();
+    const seen: string[] = [];
+    const stop = onAgentEventForRun("run-repeat", () => seen.push("seen"));
+    stale();
+
+    emitAgentEvent({ runId: "run-repeat", stream: "assistant", data: { text: "hi" } });
+    stop();
+
+    expect(seen).toEqual(["seen"]);
+  });
+
+  test("routes owner-scoped emissions to run-indexed listeners", () => {
+    const claimId = claimAgentRunContext(
+      "run-owner",
+      { sessionKey: "session-owner" },
+      { exclusive: true, trackOwner: true },
+    )!;
+    const seen: string[] = [];
+    const stop = onAgentEventForRun("run-owner", () => seen.push("seen"));
+
+    emitAgentEventForOwner(
+      { runId: "run-owner", stream: "assistant", data: { text: "owned" } },
+      claimId,
+    );
+    stop();
+
+    expect(seen).toEqual(["seen"]);
+  });
+});

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -82,14 +82,15 @@ export type AgentEventRuntimePayload = AgentEventPayload & {
   readonly projectSessionMessages?: boolean;
 };
 
+type AgentEventListener = (evt: AgentEventRuntimePayload) => void;
+type AgentEventListeners = Map<AgentEventListener, number>;
+
 type AgentEventState = {
   seqByRun: Map<string, number>;
-  listeners: Set<(evt: AgentEventRuntimePayload) => void>;
-  // Run-indexed buckets beside the process-global Set. Subscribers that only
-  // want one run register here so a delta walks its own run's closures instead
-  // of every concurrent run's. Empty buckets are dropped on unsubscribe, so the
-  // map size tracks live subscribed runs, not runs ever seen.
-  runListeners: Map<string, Set<(evt: AgentEventRuntimePayload) => void>>;
+  listeners: AgentEventListeners;
+  runListeners: Map<string, AgentEventListeners>;
+  nextListenerId: number;
+  listenerRevision: number;
   auditListeners: Set<(evt: AgentEventPayload) => void>;
   lifecycleRotationHandlers?: Map<string, (lifecycleGeneration: string) => void>;
 };
@@ -105,8 +106,10 @@ type AgentEventExecutionContext = {
 function getAgentEventState(): AgentEventState {
   return resolveGlobalSingleton<AgentEventState>(AGENT_EVENT_STATE_KEY, () => ({
     seqByRun: new Map<string, number>(),
-    listeners: new Set<(evt: AgentEventRuntimePayload) => void>(),
-    runListeners: new Map<string, Set<(evt: AgentEventRuntimePayload) => void>>(),
+    listeners: new Map(),
+    runListeners: new Map(),
+    nextListenerId: 0,
+    listenerRevision: 0,
     auditListeners: new Set<(evt: AgentEventPayload) => void>(),
   }));
 }
@@ -335,17 +338,33 @@ function enrichAgentEvent(
   return enriched;
 }
 
-function notifyAgentEventListeners(
+function* iterateAgentEventListeners(
   state: AgentEventState,
   enriched: AgentEventRuntimePayload,
-): void {
-  // Global listeners keep their stock insertion ordering and run first, so
-  // moving a subscriber into a run bucket can never reorder it ahead of a
-  // global listener whose state it reads.
-  notifyListeners(state.listeners, enriched);
-  const runListeners = state.runListeners.get(enriched.runId);
-  if (runListeners) {
-    notifyListeners(runListeners, enriched);
+): Generator<AgentEventListener, void> {
+  let lastId = -1;
+  let revision = -1;
+  let runId: string | undefined;
+  let pending: Array<[AgentEventListener, number]> = [];
+  let index = 0;
+  while (true) {
+    const currentRunId = enriched.runId;
+    // Recheck even after the last yield: the original live Set sees additions,
+    // deletions, and re-additions made by a callback. Each nested emit owns its cursor.
+    if (revision !== state.listenerRevision || runId !== currentRunId) {
+      revision = state.listenerRevision;
+      runId = currentRunId;
+      pending = [...state.listeners, ...(state.runListeners.get(runId) ?? [])]
+        .filter(([, id]) => id > lastId)
+        .sort(([, left], [, right]) => left - right);
+      index = 0;
+    }
+    const next = pending[index++];
+    if (!next) {
+      return;
+    }
+    lastId = next[1];
+    yield next[0];
   }
 }
 
@@ -355,7 +374,7 @@ export function emitAgentEventIfCurrent(event: Omit<AgentEventPayload, "seq" | "
   if (!enriched) {
     return false;
   }
-  notifyAgentEventListeners(getAgentEventState(), enriched);
+  notifyListeners(iterateAgentEventListeners(getAgentEventState(), enriched), enriched);
   return true;
 }
 
@@ -370,7 +389,7 @@ export function emitAgentEventForOwner(
 ) {
   const enriched = enrichAgentEvent(event, claimId);
   if (enriched) {
-    notifyAgentEventListeners(getAgentEventState(), enriched);
+    notifyListeners(iterateAgentEventListeners(getAgentEventState(), enriched), enriched);
   }
 }
 
@@ -391,13 +410,12 @@ export function emitAgentAuditEvent(event: Omit<AgentEventPayload, "seq" | "ts">
 
 /** Subscribes to sequenced agent events; returns an unsubscribe callback. */
 export function onAgentEvent(listener: (evt: AgentEventPayload) => void) {
-  const state = getAgentEventState();
-  return registerListener(state.listeners, listener);
+  return registerAgentEventListener(listener);
 }
 
 /** Subscribes Gateway internals that consume non-public ownership and routing metadata. */
 export function onAgentRuntimeEvent(listener: (evt: AgentEventRuntimePayload) => void) {
-  return registerListener(getAgentEventState().listeners, listener);
+  return registerAgentEventListener(listener);
 }
 
 /**
@@ -406,18 +424,27 @@ export function onAgentRuntimeEvent(listener: (evt: AgentEventRuntimePayload) =>
  * listeners otherwise run on every concurrent run's events.
  */
 export function onAgentEventForRun(runId: string, listener: (evt: AgentEventPayload) => void) {
+  return registerAgentEventListener(listener, runId);
+}
+
+function registerAgentEventListener(listener: AgentEventListener, runId?: string) {
   const state = getAgentEventState();
-  const existing = state.runListeners.get(runId);
-  const bucket = existing ?? new Set<(evt: AgentEventRuntimePayload) => void>();
-  if (!existing) {
-    state.runListeners.set(runId, bucket);
+  const bucket: AgentEventListeners =
+    runId === undefined ? state.listeners : (state.runListeners.get(runId) ?? new Map());
+  if (!bucket.has(listener)) {
+    bucket.set(listener, state.nextListenerId++);
+    if (runId !== undefined) {
+      state.runListeners.set(runId, bucket);
+    }
+    state.listenerRevision++;
   }
-  const unsubscribe = registerListener(bucket, listener);
   return () => {
-    unsubscribe();
+    if (bucket.delete(listener)) {
+      state.listenerRevision++;
+    }
     // Only reclaim the bucket this handle registered into; a later subscriber
     // for the same run may already have installed a replacement.
-    if (bucket.size === 0 && state.runListeners.get(runId) === bucket) {
+    if (runId !== undefined && bucket.size === 0 && state.runListeners.get(runId) === bucket) {
       state.runListeners.delete(runId);
     }
   };
@@ -435,7 +462,12 @@ export function resetAgentEventsForTest(options?: { preserveListeners?: boolean 
   resetAgentRunRegistryForTest();
   if (!options?.preserveListeners) {
     state.listeners.clear();
+    for (const bucket of state.runListeners.values()) {
+      bucket.clear();
+    }
     state.runListeners.clear();
     state.auditListeners.clear();
+    // Do not reuse IDs: an active dispatch resumes strictly after its last yield.
+    state.listenerRevision++;
   }
 }

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -356,7 +356,7 @@ function* iterateAgentEventListeners(
       runId = currentRunId;
       pending = [...state.listeners, ...(state.runListeners.get(runId) ?? [])]
         .filter(([, id]) => id > lastId)
-        .sort(([, left], [, right]) => left - right);
+        .toSorted(([, left], [, right]) => left - right);
       index = 0;
     }
     const next = pending[index++];

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -85,6 +85,11 @@ export type AgentEventRuntimePayload = AgentEventPayload & {
 type AgentEventState = {
   seqByRun: Map<string, number>;
   listeners: Set<(evt: AgentEventRuntimePayload) => void>;
+  // Run-indexed buckets beside the process-global Set. Subscribers that only
+  // want one run register here so a delta walks its own run's closures instead
+  // of every concurrent run's. Empty buckets are dropped on unsubscribe, so the
+  // map size tracks live subscribed runs, not runs ever seen.
+  runListeners: Map<string, Set<(evt: AgentEventRuntimePayload) => void>>;
   auditListeners: Set<(evt: AgentEventPayload) => void>;
   lifecycleRotationHandlers?: Map<string, (lifecycleGeneration: string) => void>;
 };
@@ -101,6 +106,7 @@ function getAgentEventState(): AgentEventState {
   return resolveGlobalSingleton<AgentEventState>(AGENT_EVENT_STATE_KEY, () => ({
     seqByRun: new Map<string, number>(),
     listeners: new Set<(evt: AgentEventRuntimePayload) => void>(),
+    runListeners: new Map<string, Set<(evt: AgentEventRuntimePayload) => void>>(),
     auditListeners: new Set<(evt: AgentEventPayload) => void>(),
   }));
 }
@@ -329,13 +335,27 @@ function enrichAgentEvent(
   return enriched;
 }
 
+function notifyAgentEventListeners(
+  state: AgentEventState,
+  enriched: AgentEventRuntimePayload,
+): void {
+  // Global listeners keep their stock insertion ordering and run first, so
+  // moving a subscriber into a run bucket can never reorder it ahead of a
+  // global listener whose state it reads.
+  notifyListeners(state.listeners, enriched);
+  const runListeners = state.runListeners.get(enriched.runId);
+  if (runListeners) {
+    notifyListeners(runListeners, enriched);
+  }
+}
+
 /** Emits an event only when its run ownership is still current. */
 export function emitAgentEventIfCurrent(event: Omit<AgentEventPayload, "seq" | "ts">): boolean {
   const enriched = enrichAgentEvent(event);
   if (!enriched) {
     return false;
   }
-  notifyListeners(getAgentEventState().listeners, enriched);
+  notifyAgentEventListeners(getAgentEventState(), enriched);
   return true;
 }
 
@@ -350,7 +370,7 @@ export function emitAgentEventForOwner(
 ) {
   const enriched = enrichAgentEvent(event, claimId);
   if (enriched) {
-    notifyListeners(getAgentEventState().listeners, enriched);
+    notifyAgentEventListeners(getAgentEventState(), enriched);
   }
 }
 
@@ -380,6 +400,29 @@ export function onAgentRuntimeEvent(listener: (evt: AgentEventRuntimePayload) =>
   return registerListener(getAgentEventState().listeners, listener);
 }
 
+/**
+ * Subscribes to one run's sequenced agent events; returns an unsubscribe callback.
+ * Prefer this over `onAgentEvent` for a listener that discards other runs: those
+ * listeners otherwise run on every concurrent run's events.
+ */
+export function onAgentEventForRun(runId: string, listener: (evt: AgentEventPayload) => void) {
+  const state = getAgentEventState();
+  const existing = state.runListeners.get(runId);
+  const bucket = existing ?? new Set<(evt: AgentEventRuntimePayload) => void>();
+  if (!existing) {
+    state.runListeners.set(runId, bucket);
+  }
+  const unsubscribe = registerListener(bucket, listener);
+  return () => {
+    unsubscribe();
+    // Only reclaim the bucket this handle registered into; a later subscriber
+    // for the same run may already have installed a replacement.
+    if (bucket.size === 0 && state.runListeners.get(runId) === bucket) {
+      state.runListeners.delete(runId);
+    }
+  };
+}
+
 /** Subscribes to private audit-only agent events; returns an unsubscribe callback. */
 export function onAgentAuditEvent(listener: (evt: AgentEventPayload) => void) {
   return registerListener(getAgentEventState().auditListeners, listener);
@@ -392,6 +435,7 @@ export function resetAgentEventsForTest(options?: { preserveListeners?: boolean 
   resetAgentRunRegistryForTest();
   if (!options?.preserveListeners) {
     state.listeners.clear();
+    state.runListeners.clear();
     state.auditListeners.clear();
   }
 }

--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -225,7 +225,7 @@ async function mirrorSystemAgentToolStateFromEvents(params: {
   directiveRef: { current?: SystemAgentTurnDirective };
 }): Promise<() => void> {
   const [
-    { onAgentEvent },
+    { onAgentEventForRun },
     { extractToolResultText },
     { resolveSystemAgentProposalTransition, resolveSystemAgentDirectiveTransition },
   ] = await Promise.all([
@@ -233,7 +233,7 @@ async function mirrorSystemAgentToolStateFromEvents(params: {
     import("../agents/embedded-agent-tool-results.js"),
     import("../agents/tools/system-agent-tool.js"),
   ]);
-  return onAgentEvent((evt) => {
+  return onAgentEventForRun(params.runId, (evt) => {
     if (evt.runId !== params.runId || evt.stream !== "tool" || evt.data.phase !== "result") {
       return;
     }

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -893,7 +893,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         expect(owner?.pretestBuildMode, runtimeTarget).toBe("runtime");
         if (owner && "groups" in owner) {
           expect(
-            owner.groups.find((group) => group.includePatterns?.includes(runtimeTarget))
+            owner.groups?.find((group) => group.includePatterns?.includes(runtimeTarget))
               ?.pretestBuildMode,
             runtimeTarget,
           ).toBe("runtime");

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -871,7 +871,10 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
 
   it("preserves runtime preparation and core-only ownership in full and compact plans", () => {
     const qaConfig = "test/vitest/vitest.extension-qa.config.ts";
-    const runtimeTarget = "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts";
+    const runtimeTargets = [
+      "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts",
+      "src/gateway/gateway-concurrent-streams.test.ts",
+    ];
     for (const shards of [
       createNodeTestShards(),
       createNodeTestShardBundles({ compact: true, compactMode: "pull-request" }),
@@ -881,13 +884,21 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
           "configs" in shard ? shard.configs : shard.groups.flatMap((group) => group.configs),
         ),
       ).not.toContain(qaConfig);
-      expect(
-        shards.find((shard) =>
+      for (const runtimeTarget of runtimeTargets) {
+        const owner = shards.find((shard) =>
           ("configs" in shard ? [shard] : shard.groups).some((group) =>
             group.includePatterns?.includes(runtimeTarget),
           ),
-        )?.pretestBuildMode,
-      ).toBe("runtime");
+        );
+        expect(owner?.pretestBuildMode, runtimeTarget).toBe("runtime");
+        if (owner && "groups" in owner) {
+          expect(
+            owner.groups.find((group) => group.includePatterns?.includes(runtimeTarget))
+              ?.pretestBuildMode,
+            runtimeTarget,
+          ).toBe("runtime");
+        }
+      }
     }
   });
 
@@ -1550,7 +1561,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       requiresDist: false,
       runner: DEFAULT_NODE_TEST_RUNNER,
     });
-    expect(gatewayCoreShards).toEqual(
+    expect(gatewayCoreShards).toMatchObject(
       [1, 2, 3].map((stripe) => ({
         checkName: `checks-node-agentic-gateway-core-${stripe}`,
         shardName: `agentic-gateway-core-${stripe}`,

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -57,6 +57,12 @@ describe("test runtime prerequisites", () => {
       ["test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts"],
       "runtime",
     ],
+    ["concurrent Gateway streams", ["src/gateway/gateway-concurrent-streams.test.ts"], "runtime"],
+    ["Gateway directory", ["src/gateway"], "runtime"],
+    ["Gateway core config", ["test/vitest/vitest.gateway-core.config.ts"], "runtime"],
+    ["Gateway umbrella config", ["test/vitest/vitest.gateway.config.ts"], "runtime"],
+    ["agentic config", ["test/vitest/vitest.full-agentic.config.ts"], "runtime"],
+    ["ordinary Gateway unit test", ["src/gateway/net.test.ts"], undefined],
     ["ordinary QA unit test", ["extensions/qa-lab/src/gateway-child-command.test.ts"], undefined],
     [
       "model reader",


### PR DESCRIPTION
Related: #129173

## What Problem This Solves

Reduces avoidable event-dispatch work when multiple agent runs stream concurrently. A CLI dispatch creates eight run-filtered delivery bridges; the original global subscription set invokes bridges belonging to unrelated runs for each delta.

This is a partial repair of #129173. Approval-wait subscriptions remain global and run-filtered, so the issue stays open for that owner-reviewed surface and complete end-to-end performance proof. No all-fanout O(1) or whole-turn latency improvement is claimed.

## Why This Change Was Made

The canonical event owner now indexes run-specific subscribers. HTTP Chat Completions and Responses, embedded CLI dispatch, system-agent turns, ACP parent streaming, and the shared CLI delivery-bridge factory use the indexed subscription. Existing consumer matching guards remain. Global observers retain every event.

Review and actual CI caught a regression in the first version: delivering all globals before the matching run bucket changed the original mixed registration order. A later global observer could reverse an earlier bridge's outer/inner stream delivery or unsubscribe that bridge before its current event arrived. The emitter-local repair orders global and matching-run listeners by registration position and reselects after subscription or run-ID changes. It preserves live additions, deletions, re-additions, exceptions, nested emission, callback identity and unsubscribe lifecycle. It does not scan unrelated run buckets.

Selection and sorting cost O((G+K)log(G+K)), where G is global listeners and K is matching-run listeners; mutations can trigger reselection. G still includes approval-wait subscribers. Production routing is +95/-19 (net +76), including +32 for preserving observed live ordering while retaining indexing. A single global Set keeps the original fanout cost; global-first and fixed snapshots do not preserve behavior. The existing test-build prerequisite registration is +12/-5, separate from production routing and tests. No persistence schema, authentication mode, public Gateway protocol, or operator configuration surface changes.

Thanks to @quangtran88 for the implementation, regression coverage, and measurements.

## Evidence

The original two ordering scenarios passed on clean baseline `871b18dff5039484e86c76d282699a8defcb1654` using the real emitter and delivery bridge. Exact candidate `10eb01206d0983625612e01312d8724c6c744956` then failed both in [secretless CI](https://github.com/openclaw/openclaw/actions/runs/33162128863/job/98818986689): received `[inner, outer]` instead of `[outer, inner]`, and `[]` instead of `[first]`. That run tested merge `bf6a7a2767bd60ed1328c1ee44af9b981619da03`. Both regressions and the mutable-run identity case now pass on repaired head `15e053097fb858da7154593ecaa535e5a489e180` in the [delivery-bridge job](https://github.com/openclaw/openclaw/actions/runs/33166446389/job/98833279064), testing merge `10bb96a4a8cfe580503b9d68e137b47ca9a1faa5`.

An extended baseline replay also passed the mutable-run identity case and every distinct bridge's interleaved `a1, b1, a2` output at eight bridges/run and 1, 4, 16 and 64 runs. Exact-source predicate reads for the first event were 8, 32, 128 and 512. On repaired head `15e053097fb858da7154593ecaa535e5a489e180`, the same four cohorts record 8, 8, 8 and 8 reads, while every individual bridge's real output sequence and foreign isolation pass. The owning shard reports 49 files and 1,085 tests passed, with one unrelated skipped test. These reads are not a general callback count or performance gate: hoisting a predicate can change them without removing a global scan. No latency claim rests on that metric.

The real Gateway proof uses two simultaneously held local HTTP provider requests, authenticated Chat Completions and Responses streams, exact text and terminal counts, WebSocket agent events and `agent.wait` for the same run IDs. The [previous Gateway job](https://github.com/openclaw/openclaw/actions/runs/33162128863/job/98818983033) built runtime artifacts and loaded all 14 plugin entries natively, but source-host runtime registration still took about 260 seconds and failed the unchanged 120-second test. That is a harness failure, not successful streaming proof.

The test now uses the existing isolated built-Gateway process helper, with strict entrypoint, both build-stamp and build-info checks against the actual checkout SHA before startup. The whole Gateway/runtime graph is built together; no source/dist configuration-owner mixing is introduced. The same plugin selection, provider barriers and assertions remain, without timeout increases or plugin trimming. On repaired head `15e053097fb858da7154593ecaa535e5a489e180`, the [built-Gateway job](https://github.com/openclaw/openclaw/actions/runs/33166446389/job/98833275854) passes the complete concurrent-stream test in 13,149 ms, inside the unchanged 120-second budget. Its Gateway shard passes 144 files and 2,304 tests; the same job's client shard passes another 35 files and 438 tests. Both proof jobs attest read-only repository permissions and no secret source. This is real Gateway behavior with a local mock HTTP provider, not live external-provider or channel proof.

Independent source reviews accepted the ordering repair and built-process fixture, including the mechanical formatting delta. A fresh full-branch-plus-overlay Codex P0/P1/P2 review also found no actionable defects. The `15e053097fb858da7154593ecaa535e5a489e180` CI run completed with all test, type and build jobs passing; only three owned lint findings in two jobs, plus the aggregate gate, failed. Those findings are corrected with `toSorted` on a fresh intermediate array, a const binding initialized before callback invocation, and an unused parameter rename. The exact three-line correction passed separate independent source review and a fresh P0/P1/P2 review without changing assertions or control flow.

Final head `f9fdc4b9bcbd5e4e53cb1b2d1fb6ada18a67b45f` repeats the successful proof in [CI run 33167644535](https://github.com/openclaw/openclaw/actions/runs/33167644535), testing merge `76ba0f7917a3f5f5aff467364504e92c2dac856a` into main `ca5930502984cce275bcb41a02d9d7d999da799d`. The [Gateway job](https://github.com/openclaw/openclaw/actions/runs/33167644535/job/98837253631) passes the complete concurrent-stream test in 19,815 ms, with 144 files/2,305 Gateway tests and 35 files/438 client tests passing. The [bridge job](https://github.com/openclaw/openclaw/actions/runs/33167644535/job/98837256599) passes all seven ordering/isolation cases and again records 8 predicate reads at each of 1/4/16/64 runs; 49 files/1,085 tests pass, with one unrelated skip. Both complete logs attest read-only repository permissions and no secret source. Both corrected lint jobs pass. The entire final-head CI run is now completed successfully, including `openclaw/ci-gate`. Native maintainer preparation and merge verification remain; no merge is claimed. Issue #129173 remains open.

The latest ClawSweeper review (August 28, 11:23 UTC, reviewed head `15e053097fb858da7154593ecaa535e5a489e180`) has no source findings and reports all 19 event-owner tests passing. Its integrated-proof, positive-LOC and refreshed-CI requests are covered above. Native review initialization refreshed the main comparison to `c85129f8550`; affected owners are unchanged except three type-only system-agent substitutions. Main drift alone does not justify changing a behavior-proven patch.

Actual CI entry command for both proof jobs: `node --import tsx scripts/ci-run-node-test-shard.mts`, using the existing matrix groups `agentic-gateway-core-3` and `auto-reply-reply-state-routing`. The Gateway job first ran the canonical full runtime prerequisite build. Local maintainer checks were source review, `git diff --check`, independent P0/P1/P2 review, and native `scripts/pr review-init`, `review-checkout-main`, `review-checkout-pr`, and `review-artifacts-init`; contributor code was not executed locally. Final native preparation uses the hosted-CI gate, not local test substitution.

### Contributor reproduction scripts

The original scripts below are retained as contributor-supplied dispatcher/bridge evidence. Their synthetic subscription counter and direct-emission trace do not exercise a real Gateway or account for approval-wait subscribers; the separate authenticated Gateway proof above covers the integrated streaming path.

<details>
<summary><strong>bench-listener-fanout.mts</strong></summary>

```ts
// Measures per-delta agent-event dispatch cost as concurrent run count grows.
// Runs unmodified against both revisions: it drives the real production CLI
// delivery bridge, so each revision exercises whatever subscription API that
// bridge actually uses. Emits deltas for ONE run while R runs are subscribed,
// which is exactly the claim under test.
import os from "node:os";
import path from "node:path";

const repo = process.argv[2];
if (!repo) {
  throw new Error("usage: bench-listener-fanout.mts <repo-root>");
}
const src = (p: string) => path.join(repo, "src", p);

const events = await import(src("infra/agent-events.js"));
const registry = await import(src("infra/agent-run-registry.js"));
const bridgeMod = await import(src("auto-reply/reply/agent-event-bridge.js"));

const { emitAgentEvent, resetAgentEventsForTest } = events;
const { registerAgentRunContext } = registry;
const { createAgentEventBridge } = bridgeMod;

// The bridge's own subscription entry point on this revision. Detected, not
// assumed, so the "before" revision (no run buckets) needs no separate script.
const hasRunBuckets = typeof events.onAgentEventForRun === "function";
const subscribe = hasRunBuckets
  ? (runId: string, fn: (e: unknown) => void) => events.onAgentEventForRun(runId, fn)
  : (_runId: string, fn: (e: unknown) => void) => events.onAgentEvent(fn);

const BRIDGES_PER_RUN = 8; // one CLI dispatch builds eight bridges from the shared factory
const DELTAS = 20_000;
const WARMUP = 2_000;
const CONCURRENCY = [1, 4, 16, 64];

function buildBridges(runIds: string[]) {
  const teardown: Array<() => void> = [];
  for (const runId of runIds) {
    registerAgentRunContext(runId, { sessionKey: `session-${runId}` });
    for (let b = 0; b < BRIDGES_PER_RUN; b += 1) {
      const bridge = createAgentEventBridge({
        runId,
        read: () => undefined, // no delivery: isolates dispatch fan-out from transport work
        deliver: async () => {},
      });
      teardown.push(() => bridge.unsubscribe());
    }
  }
  return teardown;
}

// Separate pass with a counter ahead of the runId filter. The bridge returns at
// that filter before its read callback, so foreign-run work is invisible from
// inside read -- the count has to be taken at the listener boundary.
function countInvocations(runIds: string[], target: string, deltas: number) {
  resetAgentEventsForTest();
  let invocations = 0;
  const teardown: Array<() => void> = [];
  for (const runId of runIds) {
    registerAgentRunContext(runId, { sessionKey: `session-${runId}` });
    for (let b = 0; b < BRIDGES_PER_RUN; b += 1) {
      teardown.push(
        subscribe(runId, (evt: any) => {
          invocations += 1;
          if (evt.runId !== runId) return;
        }),
      );
    }
  }
  for (let i = 0; i < deltas; i += 1) {
    emitAgentEvent({ runId: target, stream: "assistant", data: { text: "x" } });
  }
  for (const off of teardown) off();
  return invocations;
}

const rows: Array<Record<string, unknown>> = [];
for (const runs of CONCURRENCY) {
  resetAgentEventsForTest();
  const runIds = Array.from({ length: runs }, (_, i) => `run-${i}`);
  const target = runIds[0];
  const teardown = buildBridges(runIds);

  for (let i = 0; i < WARMUP; i += 1) {
    emitAgentEvent({ runId: target, stream: "assistant", data: { text: "w" } });
  }
  const started = process.hrtime.bigint();
  for (let i = 0; i < DELTAS; i += 1) {
    emitAgentEvent({ runId: target, stream: "assistant", data: { text: "x" } });
  }
  const elapsedNs = Number(process.hrtime.bigint() - started);
  for (const off of teardown) off();

  const invocations = countInvocations(runIds, target, DELTAS);
  rows.push({
    runs,
    subscribers: runs * BRIDGES_PER_RUN,
    nsPerDelta: Math.round(elapsedNs / DELTAS),
    totalMs: Math.round(elapsedNs / 1e6),
    callbackInvocations: invocations,
    invocationsPerDelta: invocations / DELTAS,
  });
}

console.log(
  JSON.stringify(
    {
      revision: process.env.BENCH_REV ?? "unknown",
      runBucketsAvailable: hasRunBuckets,
      node: process.version,
      platform: `${os.platform()}-${os.arch()}`,
      cpu: os.cpus()[0]?.model,
      cpus: os.cpus().length,
      deltasPerCase: DELTAS,
      bridgesPerRun: BRIDGES_PER_RUN,
      rows,
    },
    null,
    2,
  ),
);
```

</details>

<details>
<summary><strong>trace-concurrent-runs.mts</strong></summary>

```ts
// Concurrent-run isolation trace against the real production CLI delivery bridge
// and the real dispatcher. Three runs stream interleaved deltas on two streams
// each while a global lifecycle consumer watches, so the output shows both that
// per-run delivery stays isolated and that process-wide consumers still observe
// every run's lifecycle events after the routing change.
import path from "node:path";

const repo = process.argv[2];
const src = (p: string) => path.join(repo, "src", p);
const events = await import(src("infra/agent-events.js"));
const { registerAgentRunContext } = await import(src("infra/agent-run-registry.js"));
const { createAgentEventBridge } = await import(src("auto-reply/reply/agent-event-bridge.js"));
const { emitAgentEvent, onAgentEvent, resetAgentEventsForTest } = events;

resetAgentEventsForTest();
console.log(`runBucketsAvailable=${typeof events.onAgentEventForRun === "function"}`);

const RUNS = ["run-alpha", "run-beta", "run-gamma"];
const delivered = new Map<string, string[]>();
const bridges: Array<{ unsubscribe: () => void; drain: () => Promise<void> }> = [];

// Global lifecycle consumer, the shape gateway/TUI consumers use. It must keep
// seeing every run after single-run consumers move into their buckets.
const lifecycleSeen: string[] = [];
const stopLifecycle = onAgentEvent((evt: any) => {
  if (evt.stream === "lifecycle") lifecycleSeen.push(`${evt.runId}:${evt.data.phase}`);
});

for (const runId of RUNS) {
  registerAgentRunContext(runId, { sessionKey: `session-${runId}` });
  delivered.set(runId, []);
  for (const stream of ["assistant", "reasoning"]) {
    bridges.push(
      createAgentEventBridge<string>({
        runId,
        read: (evt: any) => (evt.stream === stream && typeof evt.data.text === "string" ? evt.data.text : undefined),
        deliver: async (text) => {
          delivered.get(runId)!.push(`${stream}:${text}`);
        },
      }),
    );
  }
}

// startedAt must be a finite number or enrichAgentEvent drops the start event by contract
// (agent-event-lifecycle.ts hasInvalidLifecycleStartTimestamp).
const startedAt = Date.now();
for (const runId of RUNS) {
  emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "start", startedAt } });
}

// Interleaved across runs, so any cross-run leak would land in a foreign sink.
for (let turn = 1; turn <= 3; turn += 1) {
  for (const runId of RUNS) {
    const tag = runId.split("-")[1];
    emitAgentEvent({ runId, stream: "assistant", data: { text: `${tag}-a${turn}` } });
    emitAgentEvent({ runId, stream: "reasoning", data: { text: `${tag}-r${turn}` } });
  }
}
for (const runId of RUNS) emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });

await Promise.all(bridges.map((b) => b.drain()));
for (const b of bridges) b.unsubscribe();
stopLifecycle();

console.log("\n--- per-run delivery (each run must contain only its own tag) ---");
let leaks = 0;
for (const runId of RUNS) {
  const tag = runId.split("-")[1];
  const got = delivered.get(runId)!;
  const foreign = got.filter((entry) => !entry.includes(tag));
  leaks += foreign.length;
  console.log(`${runId}: ${got.join(" ")}`);
  if (foreign.length) console.log(`  !! foreign entries: ${foreign.join(" ")}`);
}
console.log("\n--- global lifecycle consumer ---");
console.log(lifecycleSeen.join(" "));
console.log(`\ncrossRunLeaks=${leaks}`);
console.log(`lifecycleEventsSeen=${lifecycleSeen.length} expected=${RUNS.length * 2}`);
console.log(
  `VERDICT=${leaks === 0 && lifecycleSeen.length === RUNS.length * 2 ? "PASS" : "FAIL"}`,
);
```

</details>

Neither script is added to the repo: they are reviewer-reproducible evidence, not product code, and committing them would add surface this PR does not need.
