### PR TITLE
Control UI: parallelize session roster loads

### DIFF
--- a/ui/src/e2e/session-owner-first.e2e.test.ts
+++ b/ui/src/e2e/session-owner-first.e2e.test.ts
@@ -63,7 +63,7 @@ suite.define(() => {
       sessions: sharedRoster.sessions.slice(0, 1),
     };
     const gateway = await installMockGateway(page, {
-      deferredMethods: ["sessions.list"],
+      deferredMethods: ["sessions.list", "sessions.list"],
       presenceUsers: [{ self: true, id: "profile-ada", name: "Ada" }],
       sessionKey: "agent:main:ada",
       methodResponses: {
@@ -79,23 +79,20 @@ suite.define(() => {
     try {
       await page.goto(`${suite.server?.baseUrl ?? ""}chat`);
       await expect
-        .poll(async () =>
-          (await gateway.getRequests("sessions.list")).some(
-            (request) =>
-              (request.params as { ownerId?: unknown } | undefined)?.ownerId === "profile-ada",
-          ),
-        )
-        .toBe(true);
-      await gateway.deferNext("sessions.list", { agentId: "main", limit: 60 });
+        .poll(async () => (await gateway.getRequests("sessions.list")).length)
+        .toBeGreaterThanOrEqual(2);
+      expect(
+        (await gateway.getRequests("sessions.list")).some(
+          (request) =>
+            (request.params as { ownerId?: unknown } | undefined)?.ownerId === "profile-ada",
+        ),
+      ).toBe(true);
       await gateway.resolveDeferred("sessions.list", ownerRoster);
 
       const adaRow = page.locator('[data-session-key="agent:main:ada"]');
       const bobRow = page.locator('[data-session-key="agent:main:bob"]');
       await adaRow.waitFor();
       await expect.poll(() => bobRow.count()).toBe(0);
-      await expect
-        .poll(async () => (await gateway.getRequests("sessions.list")).length)
-        .toBeGreaterThanOrEqual(2);
       await captureSidebar(page, "owner-first-roster.png");
 
       await gateway.resolveDeferred("sessions.list", sharedRoster);

--- a/ui/src/lib/sessions/connection-hydration.test.ts
+++ b/ui/src/lib/sessions/connection-hydration.test.ts
@@ -191,19 +191,19 @@ describe("session connection hydration", () => {
         expect.objectContaining({ ownerId: "operator", limit: 60 }),
       ),
     );
-    expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(1);
-    const queuedRefresh = sessions.refresh({ agentId: "other", search: "queued", force: true });
-
-    ownerList.resolve(ownerResult);
-    await waitForFast(() => expect(sessions.state.result).toBe(ownerResult));
     await waitForFast(() =>
       expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(2),
     );
-    expect(sessions.state.loading).toBe(false);
+    expect(sessions.state.result).toBeNull();
     expect(request.mock.calls.at(-1)?.[1]).toEqual(
       expect.objectContaining({ agentId: "main", limit: 60 }),
     );
     expect(request.mock.calls.at(-1)?.[1]).not.toHaveProperty("ownerId");
+    const queuedRefresh = sessions.refresh({ agentId: "other", search: "queued", force: true });
+
+    ownerList.resolve(ownerResult);
+    await waitForFast(() => expect(sessions.state.result).toBe(ownerResult));
+    expect(sessions.state.loading).toBe(false);
 
     sharedList.resolve(sharedResult);
     await waitForFast(() =>

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -231,7 +231,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     }
   };
 
-  const load = async (options: SessionRosterLoadOptions) => {
+  const load = async (options: SessionRosterLoadOptions, publishAfter?: Promise<void>) => {
     const scope = host.connection.capture();
     if (!scope) {
       return;
@@ -265,7 +265,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       );
     }
     try {
-      const result = await requestSessionList(scope.client, requestOptions);
+      const request = requestSessionList(scope.client, requestOptions);
+      await Promise.allSettled([request, publishAfter]);
+      const result = await request;
       if (!host.connection.isCurrent(scope)) {
         return;
       }
@@ -386,10 +388,10 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     return { ...lastListOptions, force: true };
   };
 
-  const refreshPlan = (options: SessionRefreshOptions): SessionRosterLoadOptions[] => {
+  const refreshPlan = (options: SessionRefreshOptions) => {
     const ownerId = host.snapshot().selfUser?.id.trim();
     if (!ownerId || options.append === true || !isPrimarySessionListQuery(options)) {
-      return [options];
+      return { initial: options, shared: undefined };
     }
     const sharedLimit = Math.max(
       OWNER_FIRST_SESSION_LIST_LIMIT,
@@ -399,19 +401,19 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     );
     // Keep owner-first and shared loads atomic in the existing refresh queue.
     // Only the shared phase advances canonical membership and durable options.
-    return [
-      {
+    return {
+      initial: {
         ...options,
         ownerId,
         limit: OWNER_FIRST_SESSION_LIST_LIMIT,
         provisional: true,
       },
-      {
+      shared: {
         ...options,
         limit: sharedLimit,
         mergeExisting: true,
       },
-    ];
+    };
   };
 
   const drainRefreshQueue = async (options: SessionRefreshOptions) => {
@@ -421,11 +423,11 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     }
     let next: SessionRefreshOptions | null = options;
     while (next) {
-      for (const loadOptions of refreshPlan(next)) {
-        await load(loadOptions);
-        if (!host.connection.isCurrent(scope)) {
-          return;
-        }
+      const { initial, shared } = refreshPlan(next);
+      const initialLoad = load(initial);
+      await (shared ? load(shared, initialLoad) : initialLoad);
+      if (!host.connection.isCurrent(scope)) {
+        return;
       }
       next = takeNextQueuedRefresh();
     }


### PR DESCRIPTION
## What Problem This Solves

The signed-in Control UI roster loaded its owner-only and shared session pages serially. On a normal Gateway connection, users paid both RPC round trips before the complete session roster was ready, making startup and reconnect hydration slower as session counts grew.

## Why This Change Was Made

The canonical roster owner now starts the owner-only and shared `sessions.list` requests together. The shared request still waits for the provisional owner publication before it may publish, preserving the existing owner-first visual ordering, canonical membership rules, connection fencing, queued refresh ordering, pagination, and retained-pane behavior.

Non-primary queries and append requests remain single-load. This adds no protocol, config, polling, persistence, or compatibility surface.

## User Impact

Signed-in roster request latency changes from approximately `owner RTT + shared RTT` to `max(owner RTT, shared RTT)`. The owner roster still appears first, then the shared rows merge into it; repeated session switching and reconnect hydration retain their current behavior.

Control UI production delta is +15/-13 lines. Test/E2E delta is +15/-18 lines. The complete PR is +30/-31 lines (net -1), and the built startup bundle is 379 bytes below the committed gzip baseline.

## Evidence

Focused verification on exact head `71f994f356695a56efda196035b5d28f923f7f5f`:

- `node scripts/run-vitest.mjs run ui/src/lib/sessions/connection-hydration.test.ts` — 18/18 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-owner-first.e2e.test.ts ui/src/e2e/chat-retained-pane-hydration.e2e.test.ts` — 2/2 passed, including concurrent dispatch with owner-first publication and reconnect hydration of a retained pane.
- `pnpm tsgo:ui` — passed.
- Focused `oxlint` and `oxfmt --check` — passed.
- `pnpm ui:build` — all bundle budgets passed; startup JS 332.0 KiB gzip, 379 B below baseline.
- Codex autoreview (`gpt-5.6-sol`, high) — clean, no accepted or actionable findings.

Live proof used an isolated non-default Gateway, the freshly built Control UI, and real OpenAI API credentials:

- 18 sessions total: 12 OpenClaw proof sessions, 5 Codex-harness sessions, and the default session.
- A real `openai/gpt-5.6-sol` OpenClaw turn returned its expected nonce.
- Four `openai/gpt-5.6-luna` Codex sessions ran concurrently; every turn returned its unique nonce, reported `agentHarnessId: "codex"`, and used a distinct session ID.
- Chromium repeatedly switched across all 12 Performance sessions and both OpenClaw and Codex groups on the exact built head.
- The served hashed entry asset matched `dist/control-ui` byte-for-byte.
- The inspected 16.7-second video and final screenshot are published in the [live proof comment](https://github.com/openclaw/openclaw/pull/129175#issuecomment-5408020879); neither contains credentials or errors.

Codex contract inspection used sibling source at `d52478c52ef09f001142a4b82339467c3880877f`: app-server dispatches start and resume separately ([`codex-rs/app-server/src/message_processor.rs:1116-1149`](https://github.com/openai/codex/blob/d52478c52ef09f001142a4b82339467c3880877f/codex-rs/app-server/src/message_processor.rs#L1116-L1149)); fresh threads receive generated IDs and are rejected rather than aliased on collision ([`codex-rs/core/src/thread_manager.rs:128-155`](https://github.com/openai/codex/blob/d52478c52ef09f001142a4b82339467c3880877f/codex-rs/core/src/thread_manager.rs#L128-L155), [`codex-rs/core/src/thread_manager.rs:2008-2050`](https://github.com/openai/codex/blob/d52478c52ef09f001142a4b82339467c3880877f/codex-rs/core/src/thread_manager.rs#L2008-L2050)); resume preserves the requested stored thread identity and auto-attaches its listener ([`codex-rs/app-server/src/request_processors/thread_processor.rs:3519-3637`](https://github.com/openai/codex/blob/d52478c52ef09f001142a4b82339467c3880877f/codex-rs/app-server/src/request_processors/thread_processor.rs#L3519-L3637), [`thread_processor.rs:3780-3825`](https://github.com/openai/codex/blob/d52478c52ef09f001142a4b82339467c3880877f/codex-rs/app-server/src/request_processors/thread_processor.rs#L3780-L3825)); and each live thread owns an event loop whose translated notifications retain that thread ID, so events from concurrent threads can be demultiplexed after interleaving ([`codex-rs/app-server/src/request_processors/thread_lifecycle.rs:221-384`](https://github.com/openai/codex/blob/d52478c52ef09f001142a4b82339467c3880877f/codex-rs/app-server/src/request_processors/thread_lifecycle.rs#L221-L384), [`codex-rs/app-server/src/bespoke_event_handling.rs:143-187`](https://github.com/openai/codex/blob/d52478c52ef09f001142a4b82339467c3880877f/codex-rs/app-server/src/bespoke_event_handling.rs#L143-L187)).

Known harness note: the repository's separate isolated Codex Vitest live wrapper stopped before provider admission because its temporary prepared runtime omitted bundled plugin registration. The production Gateway proof above exercised the Codex harness successfully; the wrapper setup remains a separate test-infrastructure follow-up.
