### PR TITLE
fix(openai): preserve embedding index across proxy key rotation

### DIFF
--- a/extensions/openai/memory-embedding-adapter.test.ts
+++ b/extensions/openai/memory-embedding-adapter.test.ts
@@ -105,8 +105,12 @@ describe("OpenAI memory embedding adapter", () => {
     expect(JSON.stringify(current.cacheKeyData)).not.toContain("fixture-secret");
   });
 
-  it("preserves custom endpoint tenant and version-like cache identity headers", async () => {
-    const createForTenant = async (tenant: string) => {
+  it("keeps rotated proxy credentials out of tenant-specific embedding cache identity", async () => {
+    const createForTenant = async (
+      tenant: string,
+      proxyApiKey: string,
+      proxyHeaderName = "X-Api-Key",
+    ) => {
       const client = await resolveRemoteEmbeddingBearerClient({
         provider: "bailian-embedding",
         defaultBaseUrl: "https://embeddings.example/v1",
@@ -116,12 +120,19 @@ describe("OpenAI memory embedding adapter", () => {
           remote: {
             apiKey: "fixture-secret",
             headers: {
+              [proxyHeaderName]: proxyApiKey,
+              "X-Deployment": tenant,
               "X-Tenant": tenant,
               version: "tenant-api-v2",
               "User-Agent": "tenant-client/2",
             },
           },
         },
+      });
+      expect(client.headers).toMatchObject({
+        Authorization: "Bearer fixture-secret",
+        [proxyHeaderName]: proxyApiKey,
+        "X-Deployment": tenant,
       });
       mocks.createOpenAiEmbeddingProvider.mockResolvedValueOnce({
         provider,
@@ -135,19 +146,26 @@ describe("OpenAI memory embedding adapter", () => {
       });
     };
 
-    const first = await createForTenant("tenant-a");
-    const second = await createForTenant("tenant-b");
+    const first = await createForTenant("tenant-a", "proxy-key-before-rotation");
+    const rotated = await createForTenant("tenant-a", "proxy-key-after-rotation", "x-aPI-kEY");
+    const second = await createForTenant("tenant-b", "proxy-key-after-rotation");
     const headers = first.runtime?.cacheKeyData?.headers;
 
     expect(headers).toEqual(
       expect.arrayContaining([
+        ["X-Deployment", "tenant-a"],
         ["X-Tenant", "tenant-a"],
         ["version", "tenant-api-v2"],
         ["User-Agent", "tenant-client/2"],
       ]),
     );
+    expect(first.runtime?.cacheKeyData).toEqual(rotated.runtime?.cacheKeyData);
+    expect(hashText(JSON.stringify(first.runtime?.cacheKeyData))).toBe(
+      hashText(JSON.stringify(rotated.runtime?.cacheKeyData)),
+    );
     expect(first.runtime?.cacheKeyData).not.toEqual(second.runtime?.cacheKeyData);
     expect(JSON.stringify(first.runtime?.cacheKeyData)).not.toContain("fixture-secret");
+    expect(JSON.stringify(first.runtime?.cacheKeyData)).not.toContain("proxy-key-before-rotation");
   });
 
   it("sends document input_type in OpenAI batch embedding requests", async () => {

--- a/extensions/openai/memory-embedding-adapter.ts
+++ b/extensions/openai/memory-embedding-adapter.ts
@@ -12,7 +12,7 @@ import {
 } from "./embedding-provider.js";
 
 function resolveEmbeddingCacheExcludedHeaders(providerId: string, baseUrl: string): string[] {
-  const excludedHeaders = ["authorization"];
+  const excludedHeaders = ["authorization", "x-api-key"];
   if (providerId !== "openai") {
     return excludedHeaders;
   }


### PR DESCRIPTION
## What Problem This Solves

OpenAI-compatible embedding endpoints can authenticate requests with an `X-Api-Key` header. The OpenAI provider adapter included that credential in durable memory-index identity, so rotating an otherwise unrelated proxy key invalidated the index and paused semantic recall. The same credential-independent identity invariant was recently repaired for LM Studio in #129076.

## Why This Change Was Made

Exclude `X-Api-Key` alongside `Authorization` at the owning OpenAI embedding adapter boundary. Header comparison remains case-insensitive, outbound authentication headers are unchanged, and deployment/tenant headers still distinguish genuinely different embedding indexes. Production lines are net-neutral.

## User Impact

Future proxy API-key rotations preserve the existing memory index instead of requiring unnecessary reindexing. Ordinary OpenAI configurations retain their exact previous index identity.

Existing configurations that explicitly supplied an `X-Api-Key` header have one intentional identity transition because their old identity incorrectly included that key. Rebuild once with `openclaw memory index --force --agent <id>`; subsequent rotations do not invalidate the index.

## Evidence

- Regression captured red before the production fix: the same endpoint, model, and tenant produced distinct index identities solely because the mixed-case `X-Api-Key` value rotated.
- Regression passed after the fix, including changed header casing, preserved outbound `Authorization`/`X-Api-Key`, unchanged ordinary identity, and distinct deployment/tenant identities.
- Focused Google-adjacent provider/SDK coverage: 81 tests across five files and three Vitest shards:
  `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-openai-identity-final OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --configLoader runner extensions/openai/memory-embedding-adapter.test.ts extensions/openai/embedding-provider.test.ts extensions/lmstudio/src/embedding-provider.test.ts extensions/ollama/src/embedding-provider.test.ts packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.test.ts`
- Scoped lint: `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/openai/memory-embedding-adapter.ts extensions/openai/memory-embedding-adapter.test.ts`.
- Formatting and whitespace: `node_modules/.bin/oxfmt --check extensions/openai/memory-embedding-adapter.ts extensions/openai/memory-embedding-adapter.test.ts` and `git diff --check`.
- Fresh Codex autoreview: clean, with no accepted or actionable findings.
- Production delta: +1/-1; regression-test delta: +22/-4.
