### PR TITLE
fix(docker): correction-release images report their full version

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -203,6 +203,7 @@ jobs:
       contents: read
     outputs:
       built_at: ${{ steps.build_provenance.outputs.built_at }}
+      release_version: ${{ needs.resolve_release_policy.outputs.version }}
       source_sha: ${{ steps.build_provenance.outputs.source_sha }}
     steps:
       - name: Checkout selected source
@@ -448,6 +449,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_DOCKER_BUILD_VERSION=${{ needs.resolve_build_provenance.outputs.release_version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
@@ -470,6 +472,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_DOCKER_BUILD_VERSION=${{ needs.resolve_build_provenance.outputs.release_version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
             OPENCLAW_INSTALL_BROWSER=1
           tags: ${{ steps.tags.outputs.browser }}
@@ -657,6 +660,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_DOCKER_BUILD_VERSION=${{ needs.resolve_build_provenance.outputs.release_version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
@@ -679,6 +683,7 @@ jobs:
           build-args: |
             GIT_COMMIT=${{ needs.resolve_build_provenance.outputs.source_sha }}
             OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}
+            OPENCLAW_DOCKER_BUILD_VERSION=${{ needs.resolve_build_provenance.outputs.release_version }}
             OPENCLAW_EXTENSIONS=diagnostics-otel,codex
             OPENCLAW_INSTALL_BROWSER=1
           tags: ${{ steps.tags.outputs.browser }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ RUN sh scripts/docker/verify-native-addons.sh
 # these after the dependency layer so a new timestamp does not invalidate install.
 ARG GIT_COMMIT=""
 ARG OPENCLAW_BUILD_TIMESTAMP=""
+ARG OPENCLAW_DOCKER_BUILD_VERSION=""
 ENV GIT_COMMIT=${GIT_COMMIT} \
     OPENCLAW_BUILD_TIMESTAMP=${OPENCLAW_BUILD_TIMESTAMP}
 
@@ -148,8 +149,13 @@ RUN pnpm_config_verify_deps_before_run=false pnpm canvas:a2ui:bundle || \
      rm -rf vendor/a2ui apps/shared/OpenClawKit/Tools/CanvasA2UI)
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
+# Correction-release sources keep the base package version; official images
+# stamp the complete release version before generating their build metadata.
 RUN set -eu; \
     selected_plugin_dirs="$(cat /tmp/openclaw-selected-plugin-dirs)"; \
+    if [ -n "$OPENCLAW_DOCKER_BUILD_VERSION" ]; then \
+      pnpm pkg set "version=$OPENCLAW_DOCKER_BUILD_VERSION"; \
+    fi; \
     if [ -z "$OPENCLAW_BUILD_TIMESTAMP" ]; then \
       OPENCLAW_BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
       export OPENCLAW_BUILD_TIMESTAMP; \
@@ -174,6 +180,9 @@ ARG OPENCLAW_BUNDLED_PLUGIN_DIR
 RUN rm -rf node_modules ui/node_modules && \
     find packages "${OPENCLAW_BUNDLED_PLUGIN_DIR}" -name node_modules -prune -exec rm -rf {} +
 COPY --from=production-deps /app/ ./
+# Production dependencies carry the base source version. Restore the release
+# manifest so every runtime surface keeps the version used during the build.
+COPY --from=build /app/package.json ./package.json
 
 # Prune omitted plugins and build metadata. Keep SDK-native binaries only for
 # selected plugins that explicitly require them.
@@ -263,6 +272,14 @@ COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR}
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
 COPY --from=runtime-assets --chown=node:node /app/qa ./qa
+
+# Validate the three version surfaces in every release-built runtime variant.
+ARG OPENCLAW_DOCKER_BUILD_VERSION
+RUN if [ -n "$OPENCLAW_DOCKER_BUILD_VERSION" ]; then \
+      test "$(node -p "require(\"/app/package.json\").version")" = "$OPENCLAW_DOCKER_BUILD_VERSION"; \
+      test "$(node -p "require(\"/app/dist/build-info.json\").version")" = "$OPENCLAW_DOCKER_BUILD_VERSION"; \
+      test "$(node /app/openclaw.mjs --version | cut -d ' ' -f 2)" = "$OPENCLAW_DOCKER_BUILD_VERSION"; \
+    fi
 
 # Keep pnpm available in the runtime image for container-local workflows.
 # Use a shared Corepack home so the non-root `node` user does not need a

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -546,11 +546,18 @@ describe("Dockerfile", () => {
     expect(workflow).not.toContain("OPENCLAW_EXTENSIONS=diagnostics-otel\n");
   });
 
-  it("uses one source commit and timestamp for every official Docker artifact", async () => {
-    const workflow = await readFile(dockerReleaseWorkflowPath, "utf8");
+  it("uses one release identity for every official Docker artifact", async () => {
+    const [rawDockerfile, workflow] = await Promise.all([
+      readFile(dockerfilePath, "utf8"),
+      readFile(dockerReleaseWorkflowPath, "utf8"),
+    ]);
+    const dockerfile = collapseDockerContinuations(rawDockerfile);
 
     expect(workflow).toContain("resolve_build_provenance:");
     expect(workflow).toContain("built_at: ${{ steps.build_provenance.outputs.built_at }}");
+    expect(workflow).toContain(
+      "release_version: ${{ needs.resolve_release_policy.outputs.version }}",
+    );
     expect(workflow).toContain("source_sha: ${{ steps.build_provenance.outputs.source_sha }}");
     expect(workflow.match(/date -u \+%Y-%m-%dT%H:%M:%SZ/gu)).toHaveLength(1);
     expect(
@@ -569,6 +576,30 @@ describe("Dockerfile", () => {
         "OPENCLAW_BUILD_TIMESTAMP=${{ needs.resolve_build_provenance.outputs.built_at }}",
       ).length - 1,
     ).toBe(4);
+    expect(
+      workflow.split(
+        "OPENCLAW_DOCKER_BUILD_VERSION=${{ needs.resolve_build_provenance.outputs.release_version }}",
+      ).length - 1,
+    ).toBe(4);
+
+    const stampIndex = dockerfile.indexOf('pnpm pkg set "version=$OPENCLAW_DOCKER_BUILD_VERSION"');
+    const buildIndex = dockerfile.indexOf("pnpm build:docker");
+    const productionDepsIndex = dockerfile.indexOf("COPY --from=production-deps /app/ ./");
+    const restoreVersionIndex = dockerfile.indexOf(
+      "COPY --from=build /app/package.json ./package.json",
+    );
+    expect(stampIndex).toBeGreaterThan(dockerfile.indexOf("COPY . ."));
+    expect(stampIndex).toBeLessThan(buildIndex);
+    expect(restoreVersionIndex).toBeGreaterThan(productionDepsIndex);
+    expect(dockerfile).toContain(
+      'test "$(node -p "require(\\"/app/package.json\\").version")" = "$OPENCLAW_DOCKER_BUILD_VERSION"',
+    );
+    expect(dockerfile).toContain(
+      'test "$(node -p "require(\\"/app/dist/build-info.json\\").version")" = "$OPENCLAW_DOCKER_BUILD_VERSION"',
+    );
+    expect(dockerfile).toContain(
+      'test "$(node /app/openclaw.mjs --version | cut -d \' \' -f 2)" = "$OPENCLAW_DOCKER_BUILD_VERSION"',
+    );
   });
 
   it("publishes official Docker browser images with baked Chromium", async () => {


### PR DESCRIPTION
Closes #121958

## What Problem This Solves

Correction-release images such as `2026.7.1-2` reported the base version `2026.7.1` through the CLI, Gateway, and Control UI. The public registry then made the running image appear outdated and showed a false update action.

## Root Cause

Release preparation intentionally keeps correction-release source manifests at the base version. The Docker release workflow resolved the full tag, but dropped it before the four image builds. The Docker build therefore generated every runtime version surface from the base manifest.

## Fix

The Docker release workflow now carries the resolved version through shared build provenance into the default and browser image builds for both architectures. The Dockerfile stamps that version after dependency installation, restores the stamped manifest after the production-dependency overlay, and fails the image build unless package metadata, build metadata, and CLI output agree.

## Evidence

- Exact-main red: a disposable `2026.7.1-2` image from `1ab7b7533318a264be37d29dae33d7bb3aff92b0` reported `2026.7.1`; its live Updates page showed `Update available v2026.7.1-2`.
- Exact-head green: the final image from `fa9e86774937d5ed71ae771acd3cf8dc289412b5` reported `2026.7.1-2` from `/app/package.json`, `dist/build-info.json`, `openclaw --version`, the Gateway handshake, and the Control UI; its Updates page showed `Up to date`.
- Anti-cheat: both runtime records contain their exact full source SHA, and both screenshots display the matching short commit from the connected Gateway.
- Regression: the owner test fails on pre-fix `main` at the missing release-version output and passes all 37 Dockerfile tests on the repaired head.
- Checks: focused Vitest, Oxfmt, repository ratchets, full lint, `git diff --check`, and branch autoreview passed. Hosted CI owns type checking.

## Change Size

- Production and release tooling: `+22` lines. The build argument, cache-preserving manifest restore, and final-image invariant are the smallest closed owner flow found.
- Tests: `+33/-2` lines. The existing shared provenance test now covers release identity without YAML parsing or step-name coupling.
