### PR TITLE
improve: avoid Gateway setup for pure session-history parser tests

### DIFF
--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -34,20 +34,10 @@ import {
   writeSessionStore,
 } from "./test-helpers.server.js";
 
-installGatewayTestHooks();
-
 const AUTH_HEADER = { Authorization: "Bearer test-gateway-token-1234567890" };
 const READ_SCOPE_HEADER = { "x-openclaw-scopes": "operator.read" };
 const cleanupDirs: string[] = [];
 const requireRecord = createRequireRecord("object", "expected-label");
-
-afterEach(async () => {
-  testState.sessionConfig = undefined;
-  testState.agentsConfig = undefined;
-  await Promise.all(
-    cleanupDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
-  );
-});
 
 const AGENT_ID = "main";
 type SessionHistoryTestDatabase = Pick<
@@ -619,6 +609,16 @@ describe("session history Accept parsing", () => {
 });
 
 describe("session history HTTP endpoints", () => {
+  installGatewayTestHooks();
+
+  afterEach(async () => {
+    testState.sessionConfig = undefined;
+    testState.agentsConfig = undefined;
+    await Promise.all(
+      cleanupDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
   test("uses SSE only for an explicit acceptable event-stream media range", async () => {
     const expectedText = "accept negotiation sentinel";
     await seedSession({ text: expectedText });


### PR DESCRIPTION
## What Problem This Solves

Gateway session-history tests were creating and tearing down a complete isolated Gateway runtime for 41 pure HTTP Accept-header parsing cases. That made an otherwise lightweight developer and CI test surface slower and substantially more memory-intensive.

## Why This Change Was Made

Register the existing Gateway lifecycle and cleanup hooks inside the HTTP endpoint suite that actually owns those resources. Pure parser cases remain outside that suite, while all 47 real HTTP, authentication, session-history, and SSE integration cases retain their existing lifecycle and cleanup ordering.

## User Impact

No production or operator-visible behavior changes. Gateway contributors and CI get faster, lower-memory session-history parser coverage without losing or weakening any tests.

## Evidence

One task-owned Blacksmith Testbox, one Vitest worker, distinct module caches, excluded warmups, exact pre-edit baseline commit, and eight interleaved/order-balanced retained samples:

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Scoped wall time | 4.45 s | 3.68 s | 0.78 s / 17.4% |
| 41-case parser test body | 1.09 s | 0.012 s | 98.9% |
| Peak resident memory | 922,169 KiB | 730,357 KiB | 20.8% |
| User plus system CPU | 6.34 s | 4.73 s | 25.3% |
| Collected tests | 88 | 88 | unchanged |
| Imported modules reported | 10 | 10 | unchanged |

The intentionally injected owner fault (`hasExplicitAcceptableMediaRange` returning false) caused 14 parser cases and the actual SSE HTTP endpoint to fail; restoring the production owner returned the complete file to **88/88 passing**. The full changed-file gate classifies this as `coreTests`, and independent Codex review found no actionable issues.

Testbox proof: https://github.com/openclaw/openclaw/actions/runs/32824816293

Production LOC delta: **0**. Test LOC delta: **+10/-10**. No test, assertion, timeout, integration, lifecycle, authentication, or storage contract was removed or weakened.
