### PR TITLE
chore: remove duplicate Anthropic Vertex policy tests

### DIFF
--- a/extensions/anthropic-vertex/provider-policy-api.test.ts
+++ b/extensions/anthropic-vertex/provider-policy-api.test.ts
@@ -3,26 +3,7 @@ import { describe, expect, it } from "vitest";
 import { resolveThinkingProfile } from "./provider-policy-api.js";
 
 describe("anthropic-vertex provider-policy-api", () => {
-  it("leaves Claude Opus 4.8 thinking off by default with max effort support", () => {
-    const profile = resolveThinkingProfile({
-      provider: "anthropic-vertex",
-      modelId: "claude-opus-4-8",
-    });
-
-    expect(profile?.defaultLevel).toBe("off");
-    expect(profile?.levels.map((level) => level.id)).toContain("max");
-  });
-
-  it("keeps Claude Opus 4.7 thinking off by default", () => {
-    const profile = resolveThinkingProfile({
-      provider: "anthropic-vertex",
-      modelId: "claude-opus-4-7",
-    });
-
-    expect(profile?.defaultLevel).toBe("off");
-  });
-
-  it("exposes native max without xhigh for Claude Sonnet 4.6", () => {
+  it("adds Vertex-native max without xhigh for Claude Sonnet 4.6", () => {
     const profile = resolveThinkingProfile({
       provider: "anthropic-vertex",
       modelId: "claude-sonnet-4-6",
@@ -30,31 +11,6 @@ describe("anthropic-vertex provider-policy-api", () => {
 
     expect(profile?.levels.map((level) => level.id)).toContain("max");
     expect(profile?.levels.map((level) => level.id)).not.toContain("xhigh");
-  });
-
-  it.each(["claude-fable-5", "claude-mythos-5"])(
-    "inherits %s's provider-agnostic thinking contract",
-    (modelId) => {
-      const profile = resolveThinkingProfile({
-        provider: "anthropic-vertex",
-        modelId,
-      });
-
-      expect(profile?.defaultLevel).toBe("high");
-      expect(profile?.preserveWhenCatalogReasoningFalse).toBe(true);
-      expect(profile?.levels.map((level) => level.id)).toContain("max");
-    },
-  );
-
-  it("resolves deployment aliases from canonical model metadata", () => {
-    const profile = resolveThinkingProfile({
-      provider: "anthropic-vertex",
-      modelId: "production-claude",
-      params: { canonicalModelId: "claude-fable-5" },
-    });
-
-    expect(profile?.defaultLevel).toBe("high");
-    expect(profile?.preserveWhenCatalogReasoningFalse).toBe(true);
   });
 
   it("ignores other providers", () => {


### PR DESCRIPTION
## What Problem This Solves

The Anthropic Vertex public policy suite replayed shared Claude model-profile cases already owned by the shared policy suite and the plugin registration boundary. This made provider policy changes slower and noisier without protecting an independent contract.

## Why This Change Was Made

Remove the five duplicated model/alias cases while retaining the two provider-local contracts: filtering non-Vertex providers and enabling Vertex's native `max` effort override for adaptive Sonnet models. Shared Claude model semantics remain covered in `src/plugin-sdk/provider-model-shared.test.ts`, and registered Anthropic Vertex policy remains covered in `extensions/anthropic-vertex/index.test.ts`.

AI-assisted test audit requested by the maintainer.

## User Impact

No user-visible behavior changes. The test suite has less duplicate coverage while preserving the provider boundary and Vertex-specific override assertions.

## Evidence

- `node scripts/run-vitest.mjs extensions/anthropic-vertex/provider-policy-api.test.ts extensions/anthropic-vertex/index.test.ts src/plugin-sdk/provider-model-shared.test.ts` — 73 tests passed after cleanup.
- `node scripts/check-changed.mjs -- extensions/anthropic-vertex/provider-policy-api.test.ts` — passed, including extension test typecheck and lint.
- `git diff --check origin/main...HEAD` — passed.
- Fresh autoreview reported no actionable findings; correctness confidence 0.99.
- Production LOC: +0/-0. Test LOC: +1/-45.
