### PR TITLE
perf(sessions): defer transcript index rebuilds to the reconcile worker

### DIFF
--- a/src/commands/doctor-session-transcript-headers.test.ts
+++ b/src/commands/doctor-session-transcript-headers.test.ts
@@ -7,6 +7,7 @@ import {
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import { readTranscriptStorageRows } from "../config/sessions/session-accessor.sqlite-read.js";
+import { waitForSessionTranscriptIndexReconcile } from "../config/sessions/session-transcript-reconcile.js";
 import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -61,6 +62,7 @@ describe("doctor SQLite session transcript header repair", () => {
   });
 
   afterEach(async () => {
+    await waitForSessionTranscriptIndexReconcile({ agentId: AGENT_ID, env: state.env });
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     await state.cleanup();
@@ -168,6 +170,7 @@ describe("doctor SQLite session transcript header repair", () => {
       { event_id: "user-1", parent_id: "model-1", seq: 2 },
       { event_id: "leaf-1", parent_id: "user-1", seq: 3 },
     ]);
+    await waitForSessionTranscriptIndexReconcile(databaseOptions);
     expect(
       database.db
         .prepare(

--- a/src/commands/doctor-session-transcript-labels.test.ts
+++ b/src/commands/doctor-session-transcript-labels.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../config/sessions/session-accessor.sqlite-read.js";
 import { appendTranscriptEventsInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import { waitForSessionTranscriptIndexReconcile } from "../config/sessions/session-transcript-reconcile.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -211,6 +212,7 @@ describe("doctor SQLite session transcript label migration", () => {
   });
 
   afterEach(async () => {
+    await waitForSessionTranscriptIndexReconcile({ agentId: AGENT_ID, env: state.env });
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     await state.cleanup();
@@ -536,8 +538,9 @@ describe("doctor SQLite session transcript label migration", () => {
       );
 
     await runTranscriptLabelHealth(state, true);
+    await waitForSessionTranscriptIndexReconcile(databaseOptions);
 
-    // The rebuild (delete+reconcile) must re-derive the FTS timestamp from the row's own created_at,
+    // The deferred rebuild must re-derive the FTS timestamp from the row's own created_at,
     // NOT stamp Date.now(); otherwise every timestamp-less event's search recency resets on repair.
     expect(readFtsTimestamp()).toBe(OLD_CREATED_AT);
   });

--- a/src/commands/doctor-session-transcript-labels.ts
+++ b/src/commands/doctor-session-transcript-labels.ts
@@ -226,12 +226,14 @@ export async function noteSessionTranscriptLabelHealth(params: {
         // Build per-row change list keyed by seq. Parse each row individually so unparseable
         // rows (with corrupted eventJson) don't break the whole session.
         const updates: Array<{ seq: number; eventJson: string }> = [];
+        let hasMalformedRow = false;
         for (const row of readResult.rows) {
           let event: TranscriptEvent;
           try {
             event = JSON.parse(row.eventJson) as TranscriptEvent;
           } catch {
-            // Skip rows with unparseable eventJson (corrupted data).
+            // A malformed sibling cannot produce a valid deferred projection after repair.
+            hasMalformedRow = true;
             continue;
           }
           if (normalizeLegacyInboundContextLabels(event)) {
@@ -249,6 +251,9 @@ export async function noteSessionTranscriptLabelHealth(params: {
         // REPAIR PHASE (if --fix): process immediately, don't buffer.
         if (params.shouldRepair) {
           try {
+            if (hasMalformedRow) {
+              throw new Error(`transcript contains malformed event JSON for ${sessionId}`);
+            }
             runOpenClawAgentWriteTransaction(
               (writeDatabase) => {
                 // Use rows-only guard (tolerant of malformed JSON in sibling rows).

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
@@ -53,6 +53,7 @@ describe("SQLite transcript archive worker", () => {
     // A deferred projection reconcile worker may still hold the agent DB open;
     // Windows cannot unlink open files, so settle it before removing tempDir.
     await waitForSessionTranscriptIndexReconcile({
+      agentId: "main",
       path: resolveSqliteTargetFromSessionStorePath(storePath).path,
     });
     closeOpenClawAgentDatabasesForTest();

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
@@ -30,6 +30,7 @@ import {
 import { touchTranscriptMutationInTransaction } from "./session-accessor.sqlite-transcript-state.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import { waitForSessionTranscriptProjection } from "./session-transcript-reconcile.js";
 
 type TestTranscriptEvent = {
   id: string;
@@ -426,6 +427,7 @@ describe("SQLite transcript archive worker", () => {
         db.selectFrom("session_windows").select("session_id").where("session_id", "=", sessionId),
       ).rows.length,
     });
+    await waitForSessionTranscriptProjection(scope);
     const before = readLifecycleCounts();
 
     await expect(

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
@@ -30,7 +30,10 @@ import {
 import { touchTranscriptMutationInTransaction } from "./session-accessor.sqlite-transcript-state.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
-import { waitForSessionTranscriptProjection } from "./session-transcript-reconcile.js";
+import {
+  waitForSessionTranscriptIndexReconcile,
+  waitForSessionTranscriptProjection,
+} from "./session-transcript-reconcile.js";
 
 type TestTranscriptEvent = {
   id: string;
@@ -46,7 +49,12 @@ describe("SQLite transcript archive worker", () => {
     storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // A deferred projection reconcile worker may still hold the agent DB open;
+    // Windows cannot unlink open files, so settle it before removing tempDir.
+    await waitForSessionTranscriptIndexReconcile({
+      path: resolveSqliteTargetFromSessionStorePath(storePath).path,
+    });
     closeOpenClawAgentDatabasesForTest();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });

--- a/src/config/sessions/session-accessor.sqlite-canonical-repair.ts
+++ b/src/config/sessions/session-accessor.sqlite-canonical-repair.ts
@@ -469,7 +469,7 @@ function copySqliteSessionOwnedStateForRepair(params: {
     if (!replaced) {
       continue;
     }
-    // Search and active-event tables are derived from transcript_events; force their canonical rebuild.
+    // Doctor repair runs outside gateway requests and must atomically finish copied projections.
     deleteSessionTranscriptIndexInTransaction(params.destination.db, sessionId);
     reconcileSessionTranscriptIndexInTransaction(params.destination.db, sessionId);
     publishSessionEntryCacheInvalidation(params.destination);

--- a/src/config/sessions/session-accessor.sqlite-import.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.ts
@@ -152,6 +152,7 @@ function importSqliteSessionRowsInTransaction(
         );
       }
       transcriptEvents = exactTranscriptRows.length;
+      // Doctor imports run outside gateway requests and must finish with a complete projection.
       reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
       publishSessionEntryCacheInvalidation(database);
     }
@@ -180,6 +181,7 @@ function importSqliteSessionRowsInTransaction(
         transcriptEvents += 1;
       }
     }
+    // Doctor imports run outside gateway requests and must finish with a complete projection.
     reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
     publishSessionEntryCacheInvalidation(database);
   }

--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -24,6 +24,7 @@ import {
   updateSessionEntry,
   upsertSessionEntryCore,
 } from "./session-accessor.js";
+import { SYNC_REBUILD_MAX_BYTES } from "./session-transcript-index.js";
 import { waitForSessionTranscriptProjection } from "./session-transcript-reconcile.js";
 import type { InternalSessionEntry } from "./types.js";
 
@@ -424,12 +425,6 @@ describe("SQLite session message cuts", () => {
     if (result.status !== "created") {
       throw new Error("expected branch switch result");
     }
-    await waitForSessionTranscriptProjection({
-      agentId,
-      env,
-      sessionId: result.entry.sessionId,
-      sessionKey,
-    });
     const activeEventIds = readSessionTranscriptMessageEvents({
       agentId,
       env,
@@ -486,12 +481,6 @@ describe("SQLite session message cuts", () => {
     if (result.status !== "created") {
       throw new Error("expected rewind result");
     }
-    await waitForSessionTranscriptProjection({
-      agentId,
-      env,
-      sessionId: result.entry.sessionId,
-      sessionKey,
-    });
     expect(
       readSessionTranscriptMessageEventPage(
         { agentId, env, sessionId: result.entry.sessionId },
@@ -518,6 +507,31 @@ describe("SQLite session message cuts", () => {
       to: "chat-123",
       accountId: undefined,
     });
+  });
+
+  it("defers an oversized rewind projection until the reconcile worker finishes", async () => {
+    const { env, scope } = await createSession();
+    await appendTranscriptEvent(scope, {
+      type: "oversized-padding",
+      padding: "x".repeat(SYNC_REBUILD_MAX_BYTES),
+    });
+
+    const result = await rewindSessionToMessage({
+      agentId,
+      env,
+      entryId: "user-2",
+      sessionKey,
+    });
+    if (result.status !== "created") {
+      throw new Error("expected oversized rewind result");
+    }
+    const targetScope = { agentId, env, sessionId: result.entry.sessionId, sessionKey };
+    expect(() => readSessionTranscriptMessageEvents(targetScope)).toThrow(
+      /projection is rebuilding/,
+    );
+
+    await waitForSessionTranscriptProjection(targetScope);
+    expect(readSessionTranscriptMessageEvents(targetScope)).toHaveLength(2);
   });
 
   it("omits editor attachments for a text-only message", async () => {

--- a/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.test.ts
@@ -24,6 +24,7 @@ import {
   updateSessionEntry,
   upsertSessionEntryCore,
 } from "./session-accessor.js";
+import { waitForSessionTranscriptProjection } from "./session-transcript-reconcile.js";
 import type { InternalSessionEntry } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -423,6 +424,12 @@ describe("SQLite session message cuts", () => {
     if (result.status !== "created") {
       throw new Error("expected branch switch result");
     }
+    await waitForSessionTranscriptProjection({
+      agentId,
+      env,
+      sessionId: result.entry.sessionId,
+      sessionKey,
+    });
     const activeEventIds = readSessionTranscriptMessageEvents({
       agentId,
       env,
@@ -479,6 +486,12 @@ describe("SQLite session message cuts", () => {
     if (result.status !== "created") {
       throw new Error("expected rewind result");
     }
+    await waitForSessionTranscriptProjection({
+      agentId,
+      env,
+      sessionId: result.entry.sessionId,
+      sessionKey,
+    });
     expect(
       readSessionTranscriptMessageEventPage(
         { agentId, env, sessionId: result.entry.sessionId },

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -39,7 +39,12 @@ import type {
 } from "./session-accessor.types.js";
 import { buildSessionCreationStamp } from "./session-entry-provenance.js";
 import { inheritSessionSelection } from "./session-entry-selection.js";
-import { markSessionTranscriptIndexDirtyInTransaction } from "./session-transcript-index.js";
+import {
+  markSessionTranscriptIndexDirtyInTransaction,
+  reconcileSessionTranscriptIndexInTransaction,
+  SYNC_REBUILD_MAX_BYTES,
+  SYNC_REBUILD_MAX_ROWS,
+} from "./session-transcript-index.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   isSessionTranscriptLeafControl,
@@ -326,11 +331,22 @@ function mutateSqliteSessionAtMessageInTransaction(
             targetId: params.mode === "switch" ? params.entryId : (cut?.parentId ?? null),
           },
         ];
-  if (params.mode !== "fork") {
+  let copiedBytes = 0;
+  const rebuildSynchronously =
+    params.mode !== "fork" &&
+    nextEvents.length <= SYNC_REBUILD_MAX_ROWS &&
+    nextEvents.every((event) => {
+      copiedBytes += JSON.stringify(event).length;
+      return copiedBytes <= SYNC_REBUILD_MAX_BYTES;
+    });
+  if (params.mode !== "fork" && !rebuildSynchronously) {
     ensureTranscriptSessionRoot(database, targetScope, Date.parse(header.timestamp));
     markSessionTranscriptIndexDirtyInTransaction(database.db, nextSessionId);
   }
   appendTranscriptEventsInTransaction(database, targetScope, nextEvents);
+  if (rebuildSynchronously) {
+    reconcileSessionTranscriptIndexInTransaction(database.db, nextSessionId);
+  }
 
   // Rotating transcript identity fences stale live managers: later snapshot-replace writes
   // target the old session and cannot erase this leaf repoint from the active session.

--- a/src/config/sessions/session-accessor.sqlite-message-cut.ts
+++ b/src/config/sessions/session-accessor.sqlite-message-cut.ts
@@ -26,6 +26,7 @@ import {
   toDatabaseOptions,
   type ResolvedSqliteScope,
 } from "./session-accessor.sqlite-scope.js";
+import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcript-state.js";
 import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
 import type {
   SessionBranchListParams,
@@ -38,7 +39,7 @@ import type {
 } from "./session-accessor.types.js";
 import { buildSessionCreationStamp } from "./session-entry-provenance.js";
 import { inheritSessionSelection } from "./session-entry-selection.js";
-import { reconcileSessionTranscriptIndexInTransaction } from "./session-transcript-index.js";
+import { markSessionTranscriptIndexDirtyInTransaction } from "./session-transcript-index.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   isSessionTranscriptLeafControl,
@@ -325,10 +326,11 @@ function mutateSqliteSessionAtMessageInTransaction(
             targetId: params.mode === "switch" ? params.entryId : (cut?.parentId ?? null),
           },
         ];
-  appendTranscriptEventsInTransaction(database, targetScope, nextEvents);
   if (params.mode !== "fork") {
-    reconcileSessionTranscriptIndexInTransaction(database.db, nextSessionId);
+    ensureTranscriptSessionRoot(database, targetScope, Date.parse(header.timestamp));
+    markSessionTranscriptIndexDirtyInTransaction(database.db, nextSessionId);
   }
+  appendTranscriptEventsInTransaction(database, targetScope, nextEvents);
 
   // Rotating transcript identity fences stale live managers: later snapshot-replace writes
   // target the old session and cannot erase this leaf repoint from the active session.

--- a/src/config/sessions/session-accessor.sqlite-transcript-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-state.ts
@@ -14,7 +14,6 @@ import {
   assertCanonicalSessionKeyWriteMatchesDatabase,
   canonicalSessionKeyMigrationRequiredError,
 } from "./session-canonical-key.js";
-import { deleteSessionTranscriptIndexInTransaction } from "./session-transcript-index.js";
 import {
   foldedSessionKeyAliasCandidates,
   normalizeStoreSessionKey,
@@ -290,7 +289,5 @@ export function deleteTranscriptEventsInTransaction(
     database.db,
     db.deleteFrom("transcript_events").where("session_id", "=", sessionId),
   );
-  // FTS rows have no FK onto transcript_events; clear them in this transaction.
-  deleteSessionTranscriptIndexInTransaction(database.db, sessionId);
   return (result.numAffectedRows ?? 0n) > 0n;
 }

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -36,6 +36,8 @@ import {
   deleteSessionTranscriptIndexInTransaction,
   indexAppendedTranscriptEventInTransaction,
   markSessionTranscriptIndexDirtyInTransaction,
+  reconcileSessionTranscriptIndexInTransaction,
+  shouldRebuildSessionTranscriptIndexSynchronously,
 } from "./session-transcript-index.js";
 import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
@@ -336,6 +338,9 @@ export function replaceSqliteTranscriptEventsInTransaction(
     preserveSessionWindowRecency?: boolean;
   } = {},
 ): void {
+  const rebuildSynchronously =
+    events.length > 0 &&
+    shouldRebuildSessionTranscriptIndexSynchronously(database.db, resolved.sessionId, events);
   const preservedTranscriptUpdatedAt =
     options.preserveSessionWindowRecency === true
       ? readTranscriptMutationStateInTransaction(database, resolved.sessionId).updatedAt
@@ -362,8 +367,12 @@ export function replaceSqliteTranscriptEventsInTransaction(
   } else {
     ensureTranscriptGenerationInTransaction(database, resolved.sessionId);
   }
-  // Preserve old FTS rows; the dirty watermark hides them and prevents replacement-row indexing.
-  markSessionTranscriptIndexDirtyInTransaction(database.db, resolved.sessionId);
+  if (rebuildSynchronously) {
+    deleteSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+  } else {
+    // Preserve large old FTS rows; the dirty watermark hides them until worker reconciliation.
+    markSessionTranscriptIndexDirtyInTransaction(database.db, resolved.sessionId);
+  }
   let seq = 0;
   const seenEventIds = new Set<string>();
   const seenMessageIdempotencyKeys = new Set<string>();
@@ -386,7 +395,11 @@ export function replaceSqliteTranscriptEventsInTransaction(
   }
   if (deleted || seq > 0) {
     recordTranscriptReplacementMutation(database, resolved.sessionId, preservedTranscriptUpdatedAt);
-    scheduleTranscriptProjectionReconcile(database, resolved.sessionId, true, {});
+    if (rebuildSynchronously) {
+      reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+    } else {
+      scheduleTranscriptProjectionReconcile(database, resolved.sessionId, true, {});
+    }
   }
 }
 
@@ -419,6 +432,10 @@ export function rewriteSqliteTranscriptEventRowsInTransaction(
   if (rows.length === 0) {
     return;
   }
+  const rebuildSynchronously = shouldRebuildSessionTranscriptIndexSynchronously(
+    database.db,
+    resolved.sessionId,
+  );
   const db = getSessionKysely(database.db);
   for (const row of rows) {
     const persistedEvent = canonicalizeTranscriptEventMedia(row.event);
@@ -439,13 +456,18 @@ export function rewriteSqliteTranscriptEventRowsInTransaction(
   }
   rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
   touchTranscriptMutationInTransaction(database, resolved.sessionId);
-  markSessionTranscriptIndexDirtyInTransaction(database.db, resolved.sessionId);
-  scheduleTranscriptProjectionReconcile(database, resolved.sessionId, true, {});
+  if (rebuildSynchronously) {
+    deleteSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+    reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+  } else {
+    markSessionTranscriptIndexDirtyInTransaction(database.db, resolved.sessionId);
+    scheduleTranscriptProjectionReconcile(database, resolved.sessionId, true, {});
+  }
 }
 
 // Text-only transcript repair: rewrites event_json for specific rows in place.
 // Preserves seq, created_at, session_key, and session activity recency; rotates the transcript
-// generation and marks the index dirty so readers/search pick up the new text after reconciliation.
+// generation and rebuilds bounded projections immediately or defers large projections.
 export function updateSqliteTranscriptEventJsonInTransaction(
   database: OpenClawAgentDatabase,
   sessionId: string,
@@ -454,6 +476,10 @@ export function updateSqliteTranscriptEventJsonInTransaction(
   if (updates.length === 0) {
     return;
   }
+  const rebuildSynchronously = shouldRebuildSessionTranscriptIndexSynchronously(
+    database.db,
+    sessionId,
+  );
   const db = getSessionKysely(database.db);
   for (const { seq, eventJson } of updates) {
     executeSqliteQuerySync(
@@ -466,7 +492,12 @@ export function updateSqliteTranscriptEventJsonInTransaction(
     );
   }
   rotateTranscriptGenerationInTransaction(database, sessionId);
-  markSessionTranscriptIndexDirtyInTransaction(database.db, sessionId);
+  if (rebuildSynchronously) {
+    deleteSessionTranscriptIndexInTransaction(database.db, sessionId);
+    reconcileSessionTranscriptIndexInTransaction(database.db, sessionId);
+  } else {
+    markSessionTranscriptIndexDirtyInTransaction(database.db, sessionId);
+  }
   // Minimally advance transcript_updated_at (prev+1), NOT to now. This is a one-time maintenance
   // rewrite: bumping to now would reorder legacy sessions to the top of every recency view
   // (sqlite-history.ts orders by transcript_updated_at). But the watermark must still change,
@@ -482,7 +513,7 @@ export function updateSqliteTranscriptEventJsonInTransaction(
       strictly: true,
     });
   }
-  scheduleTranscriptProjectionReconcile(database, sessionId, true, {});
+  scheduleTranscriptProjectionReconcile(database, sessionId, !rebuildSynchronously, {});
 }
 
 export function readTranscriptIdentityByEventId(

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -6,7 +6,10 @@ import {
 } from "../../infra/kysely-sync.js";
 import { redactSecrets } from "../../logging/redact.js";
 import { canonicalizePersistedUserMessageMedia } from "../../media/media-facts.js";
-import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import {
+  deferOpenClawAgentPostCommitPublication,
+  type OpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
 import type {
   TranscriptEvent,
   TranscriptMessageAppendOptions,
@@ -32,7 +35,7 @@ import {
 import {
   deleteSessionTranscriptIndexInTransaction,
   indexAppendedTranscriptEventInTransaction,
-  reconcileSessionTranscriptIndexInTransaction,
+  markSessionTranscriptIndexDirtyInTransaction,
 } from "./session-transcript-index.js";
 import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
@@ -100,7 +103,12 @@ export function appendTranscriptEventInTransaction(
     options.onProjectionReconcileNeeded?.();
   }
   if (!identity) {
-    scheduleTranscriptProjectionReconcile(database, scope, projectionNeedsRebuild, options);
+    scheduleTranscriptProjectionReconcile(
+      database,
+      scope.sessionId,
+      projectionNeedsRebuild,
+      options,
+    );
     return true;
   }
   // Caller-checked appends may retain a duplicate key in the payload, but the
@@ -130,26 +138,27 @@ export function appendTranscriptEventInTransaction(
       })
       .onConflict((conflict) => conflict.columns(["session_id", "event_id"]).doNothing()),
   );
-  scheduleTranscriptProjectionReconcile(database, scope, projectionNeedsRebuild, options);
+  scheduleTranscriptProjectionReconcile(database, scope.sessionId, projectionNeedsRebuild, options);
   return true;
 }
 
 function scheduleTranscriptProjectionReconcile(
   database: OpenClawAgentDatabase,
-  scope: ResolvedTranscriptScope,
+  sessionId: string,
   projectionNeedsRebuild: boolean,
   options: { scheduleProjectionReconcile?: boolean },
 ): void {
   if (!projectionNeedsRebuild || options.scheduleProjectionReconcile === false) {
     return;
   }
-  // setImmediate in the reconcile owner runs only after this synchronous
-  // SQLite transaction commits, keeping full-tree work off the writer stack.
-  startSessionTranscriptIndexReconcile({
-    agentId: scope.agentId,
-    path: database.path,
-    preferredSessionId: scope.sessionId,
-  });
+  // Dirty state is durable: a missed post-commit kick is recovered by startup/search reconciliation.
+  deferOpenClawAgentPostCommitPublication(database, () =>
+    startSessionTranscriptIndexReconcile({
+      agentId: database.agentId,
+      path: database.path,
+      preferredSessionId: sessionId,
+    }),
+  );
 }
 
 export function appendTranscriptEventsInTransaction(
@@ -174,7 +183,7 @@ export function appendTranscriptEventsInTransaction(
   }
   if (appended > 0) {
     touchTranscriptMutationInTransaction(database, scope.sessionId);
-    scheduleTranscriptProjectionReconcile(database, scope, projectionNeedsRebuild, {});
+    scheduleTranscriptProjectionReconcile(database, scope.sessionId, projectionNeedsRebuild, {});
   }
   return appended;
 }
@@ -334,6 +343,7 @@ export function replaceSqliteTranscriptEventsInTransaction(
   const previousGeneration = readTranscriptGenerationInTransaction(database, resolved.sessionId);
   const deleted = deleteTranscriptEventsInTransaction(database, resolved.sessionId);
   if (events.length === 0) {
+    deleteSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
     if (deleted || previousGeneration) {
       rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
       recordTranscriptReplacementMutation(
@@ -352,6 +362,8 @@ export function replaceSqliteTranscriptEventsInTransaction(
   } else {
     ensureTranscriptGenerationInTransaction(database, resolved.sessionId);
   }
+  // Preserve old FTS rows; the dirty watermark hides them and prevents replacement-row indexing.
+  markSessionTranscriptIndexDirtyInTransaction(database.db, resolved.sessionId);
   let seq = 0;
   const seenEventIds = new Set<string>();
   const seenMessageIdempotencyKeys = new Set<string>();
@@ -374,7 +386,7 @@ export function replaceSqliteTranscriptEventsInTransaction(
   }
   if (deleted || seq > 0) {
     recordTranscriptReplacementMutation(database, resolved.sessionId, preservedTranscriptUpdatedAt);
-    reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+    scheduleTranscriptProjectionReconcile(database, resolved.sessionId, true, {});
   }
 }
 
@@ -427,12 +439,13 @@ export function rewriteSqliteTranscriptEventRowsInTransaction(
   }
   rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
   touchTranscriptMutationInTransaction(database, resolved.sessionId);
-  reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+  markSessionTranscriptIndexDirtyInTransaction(database.db, resolved.sessionId);
+  scheduleTranscriptProjectionReconcile(database, resolved.sessionId, true, {});
 }
 
 // Text-only transcript repair: rewrites event_json for specific rows in place.
 // Preserves seq, created_at, session_key, and session activity recency; rotates the transcript
-// generation and rebuilds the index so readers/search pick up the new text.
+// generation and marks the index dirty so readers/search pick up the new text after reconciliation.
 export function updateSqliteTranscriptEventJsonInTransaction(
   database: OpenClawAgentDatabase,
   sessionId: string,
@@ -453,8 +466,7 @@ export function updateSqliteTranscriptEventJsonInTransaction(
     );
   }
   rotateTranscriptGenerationInTransaction(database, sessionId);
-  deleteSessionTranscriptIndexInTransaction(database.db, sessionId);
-  reconcileSessionTranscriptIndexInTransaction(database.db, sessionId);
+  markSessionTranscriptIndexDirtyInTransaction(database.db, sessionId);
   // Minimally advance transcript_updated_at (prev+1), NOT to now. This is a one-time maintenance
   // rewrite: bumping to now would reorder legacy sessions to the top of every recency view
   // (sqlite-history.ts orders by transcript_updated_at). But the watermark must still change,
@@ -470,6 +482,7 @@ export function updateSqliteTranscriptEventJsonInTransaction(
       strictly: true,
     });
   }
+  scheduleTranscriptProjectionReconcile(database, sessionId, true, {});
 }
 
 export function readTranscriptIdentityByEventId(

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -90,6 +90,7 @@ import {
   trimTranscriptForManualCompact,
 } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import { waitForSessionTranscriptProjection } from "./session-transcript-reconcile.js";
 import {
   SessionTranscriptWriterClaimReboundError,
   withOwnedSessionTranscriptWrites,
@@ -3292,6 +3293,13 @@ describe("session accessor seam", () => {
           appendParentId: "existing-message",
         },
       ]);
+      // Replace defers the projection rebuild to the reconcile worker; committed
+      // cursors are provable only once the projection converges.
+      await waitForSessionTranscriptProjection({
+        agentId: scope.agentId,
+        sessionId: scope.sessionId,
+        storePath,
+      });
 
       const updates: Array<{
         target: unknown;

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -90,7 +90,6 @@ import {
   trimTranscriptForManualCompact,
 } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
-import { waitForSessionTranscriptProjection } from "./session-transcript-reconcile.js";
 import {
   SessionTranscriptWriterClaimReboundError,
   withOwnedSessionTranscriptWrites,
@@ -3293,13 +3292,6 @@ describe("session accessor seam", () => {
           appendParentId: "existing-message",
         },
       ]);
-      // Replace defers the projection rebuild to the reconcile worker; committed
-      // cursors are provable only once the projection converges.
-      await waitForSessionTranscriptProjection({
-        agentId: scope.agentId,
-        sessionId: scope.sessionId,
-        storePath,
-      });
 
       const updates: Array<{
         target: unknown;

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -310,7 +310,10 @@ function applyForwardIndex(
 }
 
 /** Marks one session for lazy rebuild without touching its FTS rows. */
-function markSessionTranscriptIndexDirtyInTransaction(db: DatabaseSync, sessionId: string): void {
+export function markSessionTranscriptIndexDirtyInTransaction(
+  db: DatabaseSync,
+  sessionId: string,
+): void {
   const now = Date.now();
   const watermark = readSessionTranscriptProjectionState(db, sessionId);
   writeWatermark(

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -55,8 +55,48 @@ export type SessionTranscriptProjectionState = {
   needsRebuild: boolean;
 };
 
+// FTS rebuilds cost about 60 ms per 1,000 events/1 MiB on dev hardware; cap synchronous
+// work near a 250 ms event-loop stall and leave larger projections to the reconcile worker.
+export const SYNC_REBUILD_MAX_ROWS = 4_000;
+export const SYNC_REBUILD_MAX_BYTES = 4 * 1024 * 1024;
+
 function getIndexKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<TranscriptIndexDatabase>(db);
+}
+
+/** Size the old projection and incoming rows before their owning transaction mutates either. */
+export function shouldRebuildSessionTranscriptIndexSynchronously(
+  db: DatabaseSync,
+  sessionId: string,
+  events: readonly unknown[] = [],
+): boolean {
+  if (events.length > SYNC_REBUILD_MAX_ROWS) {
+    return false;
+  }
+  const stored = executeSqliteQueryTakeFirstSync(
+    db,
+    getIndexKysely(db)
+      .selectFrom("transcript_events")
+      .select((eb) => [
+        eb.fn.countAll<number>().as("event_count"),
+        eb.fn.sum<number>(eb.fn<number>("length", ["event_json"])).as("event_bytes"),
+      ])
+      .where("session_id", "=", sessionId),
+  );
+  if ((stored?.event_count ?? 0) + events.length > SYNC_REBUILD_MAX_ROWS) {
+    return false;
+  }
+  let bytes = stored?.event_bytes ?? 0;
+  if (bytes > SYNC_REBUILD_MAX_BYTES) {
+    return false;
+  }
+  for (const event of events) {
+    bytes += JSON.stringify(event).length;
+    if (bytes > SYNC_REBUILD_MAX_BYTES) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function readSessionTranscriptProjectionState(

--- a/src/config/sessions/session-transcript-reconcile.ts
+++ b/src/config/sessions/session-transcript-reconcile.ts
@@ -247,29 +247,27 @@ export async function reconcileSessionTranscriptIndexes(
     let doneReceived = false;
     let reconciledSessions = 0;
     let settled = false;
-    const settle = (finish: () => void, terminate: boolean) => {
+    const settle = (finish: () => void) => {
       if (settled) {
         return;
       }
       settled = true;
       worker.removeAllListeners();
-      if (terminate) {
-        void worker.terminate();
-      }
-      finish();
+      // Finish only after the worker thread has stopped: waiters may delete
+      // the database file next, and the thread's open SQLite handle must be
+      // released first (Windows fails the unlink with EBUSY otherwise).
+      // terminate() on an already-exited worker resolves immediately.
+      void worker.terminate().then(finish, finish);
     };
     const handleMessage = async (message: SessionTranscriptReconcileWorkerMessage) => {
       if (message.type === "failed") {
-        settle(() => reject(new Error(message.error)), false);
+        settle(() => reject(new Error(message.error)));
         return;
       }
       if (message.type === "done") {
         doneReceived = true;
         if (active) {
-          settle(
-            () => reject(new Error("session transcript reconcile worker ended mid-plan")),
-            true,
-          );
+          settle(() => reject(new Error("session transcript reconcile worker ended mid-plan")));
           return;
         }
         try {
@@ -279,10 +277,10 @@ export async function reconcileSessionTranscriptIndexes(
             (database) => deleteOrphanedTranscriptIndexRowsInTransaction(database.db),
           );
         } catch (error) {
-          settle(() => reject(toStringifiedError(error)), true);
+          settle(() => reject(toStringifiedError(error)));
           return;
         }
-        settle(() => resolve({ reconciledSessions }), false);
+        settle(() => resolve({ reconciledSessions }));
         return;
       }
       try {
@@ -318,22 +316,21 @@ export async function reconcileSessionTranscriptIndexes(
         }
         continueProjectionWorker(worker, owned);
       } catch (error) {
-        settle(() => reject(toStringifiedError(error)), true);
+        settle(() => reject(toStringifiedError(error)));
       }
     };
     worker.on("message", (message: SessionTranscriptReconcileWorkerMessage) => {
       void handleMessage(message);
     });
     worker.once("error", (error) => {
-      settle(() => reject(toStringifiedError(error)), true);
+      settle(() => reject(toStringifiedError(error)));
     });
     worker.once("exit", (code) => {
       if (doneReceived && code === 0) {
         return;
       }
-      settle(
-        () => reject(new Error(`session transcript reconcile worker exited with code ${code}`)),
-        false,
+      settle(() =>
+        reject(new Error(`session transcript reconcile worker exited with code ${code}`)),
       );
     });
   });

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -16,7 +16,10 @@ import {
   appendTranscriptMessage,
   replaceTranscriptEvents,
 } from "./session-accessor.sqlite-transcript-write.js";
-import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
+import {
+  listSessionsNeedingTranscriptIndexReconcile,
+  SYNC_REBUILD_MAX_BYTES,
+} from "./session-transcript-index.js";
 import {
   isSessionTranscriptIndexReconcileRunning,
   waitForSessionTranscriptIndexReconcile,
@@ -182,6 +185,7 @@ describe("searchSessionTranscripts", () => {
         id: "m-new",
         parentId: null,
         message: { role: "user", content: [{ type: "text", text: "replacement text" }] },
+        padding: "x".repeat(SYNC_REBUILD_MAX_BYTES),
         timestamp: 1720000000000,
       } as unknown as TranscriptEvent,
     ]);

--- a/src/config/sessions/session-transcript-search.test.ts
+++ b/src/config/sessions/session-transcript-search.test.ts
@@ -17,6 +17,10 @@ import {
   replaceTranscriptEvents,
 } from "./session-accessor.sqlite-transcript-write.js";
 import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
+import {
+  isSessionTranscriptIndexReconcileRunning,
+  waitForSessionTranscriptIndexReconcile,
+} from "./session-transcript-reconcile.js";
 import { searchSessionTranscripts } from "./session-transcript-search.js";
 
 vi.mock("../config.js", async () => ({
@@ -157,8 +161,21 @@ describe("searchSessionTranscripts", () => {
     expect(() => search("x".repeat(4097))).toThrow(/must not exceed/);
   });
 
-  it("reindexes synchronously when a linear transcript is replaced", async () => {
+  it("preserves stale FTS rows until a replaced transcript is reconciled after commit", async () => {
     await appendUserMessage("session-1", "agent:main:main", "obsolete branch text");
+    const { db, kysely } = agentKysely();
+    const indexedRows = () =>
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .selectFrom("session_transcript_fts")
+          .select(["message_id", "text"])
+          .where("session_id", "=", "session-1"),
+      ).rows;
+    const originalIndexedRows = indexedRows();
+    expect(originalIndexedRows).toEqual([
+      expect.objectContaining({ text: "obsolete branch text" }),
+    ]);
     await replaceTranscriptEvents(transcriptScope("session-1", "agent:main:main"), [
       {
         type: "message",
@@ -168,6 +185,22 @@ describe("searchSessionTranscripts", () => {
         timestamp: 1720000000000,
       } as unknown as TranscriptEvent,
     ]);
+
+    expect(indexedRows()).toEqual(originalIndexedRows);
+    expect(
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .selectFrom("session_transcript_index_state")
+          .select("needs_rebuild")
+          .where("session_id", "=", "session-1"),
+      ).rows,
+    ).toEqual([{ needs_rebuild: 1 }]);
+    expect(isSessionTranscriptIndexReconcileRunning({ agentId: "main", env: env() })).toBe(true);
+    expect(search("obsolete")).toMatchObject({ hits: [], indexing: true });
+    expect(search("replacement")).toMatchObject({ hits: [], indexing: true });
+
+    await waitForSessionTranscriptIndexReconcile({ agentId: "main", env: env() });
 
     expect(search("obsolete").hits).toHaveLength(0);
     const result = search("replacement");

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -26,7 +26,10 @@ import {
   replaceSessionEntry,
   withTranscriptWriteLock,
 } from "../config/sessions/session-accessor.js";
-import { waitForSessionTranscriptIndexReconcile } from "../config/sessions/session-transcript-reconcile.js";
+import {
+  waitForSessionTranscriptIndexReconcile,
+  waitForSessionTranscriptProjection,
+} from "../config/sessions/session-transcript-reconcile.js";
 import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
@@ -329,6 +332,13 @@ async function writeMainSessionTranscript(
     },
     transcriptEvents,
   );
+  // Oversized fixture transcripts take the deferred rebuild path; history
+  // reads need the projection converged before the case under test runs.
+  await waitForSessionTranscriptProjection({
+    agentId: opts?.agentId ?? "main",
+    sessionId,
+    storePath,
+  });
 }
 
 async function withDirectChatSession(


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #129135. The remaining whole-gateway stall source on busy hosts: transcript replacement/rewrite paths rebuilt the full FTS + active-event projection **inside their synchronous SQLite write transactions** on the gateway main thread (`reconcileSessionTranscriptIndexInTransaction`, src/config/sessions/session-transcript-index.ts). FTS5 deletion retokenizes every removed row, so compacting or repairing a large session blocked the event loop for O(transcript bytes) — the best match for the ~11s synchronized-stall windows observed live on the team host.

The chunked, claim-guarded off-thread rebuild machinery already existed (`session-transcript-reconcile.worker.ts` + `session-transcript-projection-rebuild.ts`, header: "request paths may only schedule it and return a bounded retryable response") — the write paths just never adopted it. Consumers are already lag-tolerant: history readers throw the retryable `SessionTranscriptProjectionUnavailableError` (#129114 contract) which gateway handlers map to retryable responses, FTS search schedules the worker for dirty sessions and reports `indexing=true`, and transcript mirror-facts fall back to raw rows.

## Why This Change Was Made

Transcript replace (compaction), exact rewrite, text repair, and message-cut are now **size-gated**: transcripts within `SYNC_REBUILD_MAX_ROWS = 4_000` / `SYNC_REBUILD_MAX_BYTES = 4 MiB` keep the original synchronous in-transaction rebuild (measured ~60ms per 1k events/1MiB, so ≤~250ms — no reader dirty window, semantics identical to today for the vast majority of sessions). Larger transcripts mark the projection dirty in-transaction (`markSessionTranscriptIndexDirtyInTransaction`, which also invalidates in-flight worker claims) and schedule the worker-owned reconcile after commit through the existing `deferOpenClawAgentPostCommitPublication` seam — discarded on rollback, with durable `needs_rebuild` making a missed kick recoverable by startup/search reconciliation. Old FTS rows are preserved on the deferred path (the dirty watermark hides them from search) instead of paying the synchronous O(bytes) FTS mass-delete. Doctor import and canonical repair intentionally stay synchronous (maintenance contexts that must finish with a complete projection; commented in place).

Accepted tradeoff on the deferred (large-transcript) path only: reads during the ~1–2s convergence window get the designed retryable/`indexing=true` responses, and the first appended turn publishes the cursor-invalidation fallback. Small sessions see no behavior change at all.

## User Impact

Compaction and transcript repair of large sessions no longer freeze every session on the gateway. Small-session behavior is unchanged. No schema, worker-protocol, or config changes.

## Evidence

A/B stall probe through the real accessor path (`replaceTranscriptEvents` with compaction-shaped replacement + event-loop lag sampler):
- 60k events (~66MB), deferred path: max event-loop stall **3197ms → 639ms**; immediately after, search returns `indexing=true`, and after off-thread convergence (~1.6s) FTS search returns the correct post-compaction rows.
- 2k events, sync path: 95ms replace, search current immediately with `indexing=false` — no dirty window.

Tests: full `src/config/sessions` suite green (86 files, 947 tests), plus the gateway suites that exercise replace-then-read seeding: `session-transcript-readers(.markers)`, `server.chat-history-cursor`, `server.chat.gateway-server-chat`, `chat.directive-tags` (312 tests) and `ui/src/pages/chat/chat-pane-terminal.test.ts`. New regressions: deferred path forced via an over-4MiB event proves search dirty-window exclusion + convergence; an oversized-rewind regression covers message-cut's deferred path; the deferred-FTS regression was confirmed failing on pre-fix code. `pnpm check:changed` green (import cycles, database-first, storage guards). Codex autoreview clean.

Production LOC +109 net vs main (tests +64): the growth is the size gate + post-commit scheduling seam, justified by the bounded-latency capability (stall budget enforced at the projection owner) while preserving small-session synchronous semantics.