### PR TITLE
fix(plugins): report update failures on stderr

### DIFF
--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -1722,7 +1722,19 @@ describe("plugins cli update", () => {
       nextConfig,
       [
         { pluginId: "alpha", status: "updated", message: "Updated alpha -> 1.1.0" },
-        { pluginId: "beta", status: "error", message: "Failed to update beta: registry timeout" },
+        {
+          pluginId: "beta",
+          status: "error",
+          message: "Failed to update beta: registry timeout",
+          channelFallback: {
+            requestedSpec: "@openclaw/beta@beta",
+            usedSpec: "@openclaw/beta@latest",
+            requestedLabel: "beta",
+            usedLabel: "latest",
+            reason: "failed",
+            message: "Beta channel unavailable; tried latest.",
+          },
+        },
       ],
       true,
     );
@@ -1740,7 +1752,10 @@ describe("plugins cli update", () => {
       installRecords: nextConfig.plugins?.installs,
       reason: "source-changed",
     });
-    expect(pluginsCliRuntimeLogs).toContain("Failed to update beta: registry timeout");
+    expect(runtimeErrors).toContain("Failed to update beta: registry timeout");
+    expect(pluginsCliRuntimeLogs).toContain("Updated alpha -> 1.1.0");
+    expect(pluginsCliRuntimeLogs).toContain("Beta channel unavailable; tried latest.");
+    expect(pluginsCliRuntimeLogs).not.toContain("Failed to update beta: registry timeout");
   });
 
   it("exits non-zero when a ClawHub update is skipped for missing risk acknowledgement", async () => {
@@ -1800,7 +1815,8 @@ describe("plugins cli update", () => {
     );
 
     expect(configWriteMock).not.toHaveBeenCalled();
-    expect(pluginsCliRuntimeLogs).toContain(
+    expect(runtimeErrors).toContain('Failed to update hook pack "demo-hooks": registry timeout');
+    expect(pluginsCliRuntimeLogs).not.toContain(
       'Failed to update hook pack "demo-hooks": registry timeout',
     );
   });

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -588,7 +588,8 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
 
     const outcomeSummary = logPluginUpdateOutcomes({
       outcomes: [...pluginResult.outcomes, ...hookResult.outcomes],
-      log: (message) => defaultRuntime.log(message),
+      log: defaultRuntime.log,
+      error: defaultRuntime.error,
     });
     if (outcomeSummary.hasErrors) {
       defaultRuntime.exit(1);

--- a/src/cli/plugins-update-outcomes.ts
+++ b/src/cli/plugins-update-outcomes.ts
@@ -15,28 +15,21 @@ type PluginUpdateCliOutcome = {
 export function logPluginUpdateOutcomes(params: {
   outcomes: readonly PluginUpdateCliOutcome[];
   log: (message: string) => void;
+  error: (message: string) => void;
 }): { hasErrors: boolean } {
   let hasErrors = false;
   for (const outcome of params.outcomes) {
     if (outcome.status === "error") {
       hasErrors = true;
-      params.log(theme.error(outcome.message));
-      if (outcome.channelFallback) {
-        params.log(theme.warn(outcome.channelFallback.message));
-      }
-      continue;
-    }
-    if (outcome.status === "skipped") {
+      params.error(theme.error(outcome.message));
+    } else if (outcome.status === "skipped") {
       if (isClawHubTrustSkippedOutcome(outcome)) {
         hasErrors = true;
       }
       params.log(theme.warn(outcome.message));
-      if (outcome.channelFallback) {
-        params.log(theme.warn(outcome.channelFallback.message));
-      }
-      continue;
+    } else {
+      params.log(outcome.message);
     }
-    params.log(outcome.message);
     if (outcome.channelFallback) {
       params.log(theme.warn(outcome.channelFallback.message));
     }


### PR DESCRIPTION
## What Problem This Solves

Actual plugin and hook-pack update failures were printed to standard output even though `openclaw plugins update` already exited nonzero. Operators and scripts that capture standard error therefore missed failed update diagnostics, while standard output mixed successful updates with fatal failures. The same shared update owner also serves the deprecated `openclaw hooks update` alias.

## Why This Change Was Made

Route actual `status: "error"` outcomes through the existing runtime error stream at the canonical update-outcome owner. Consolidate the previously triplicated channel-fallback warning emission, preserving successful and skipped outcomes plus fallback notices on standard output. Keep existing nonzero exits, partial-success persistence, restart notices, warning handling, and update selection unchanged.

## User Impact

Failed plugin and hook-pack updates now appear on standard error where operators and shell scripts expect them. Successful updates, ordinary and trust-related skipped warnings, fallback notices, and command exit codes retain their existing behavior. Update commands do not expose JSON output, and neighboring JSON-capable plugin commands are unchanged. Production code decreases by six lines.

## Evidence

- Authentic pre-fix Commander-parser regressions failed for both a mixed-success plugin update and a hook-pack update because the captured error stream was empty; the same cases pass after the owner-level repair.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/plugins-cli.update.test.ts -t 'exits non-zero when a (plugin|hook pack) update reports an error'`: 2 passing regression tests.
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/cli/plugins-cli.update.test.ts src/cli/plugins-update-selection.test.ts src/cli/hooks-cli.test.ts`: 91 passing tests across the update owner, selection siblings, and deprecated hook alias.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/plugins-cli.update.test.ts src/cli/plugins-update-command.ts src/cli/plugins-update-outcomes.ts`: passed.
- `./node_modules/.bin/oxfmt --check src/cli/plugins-update-outcomes.ts src/cli/plugins-update-command.ts src/cli/plugins-cli.update.test.ts` and `git diff --check`: passed.
- Independent owner-boundary review and structured Codex review found no actionable issues.
- No external package installation or live operator configuration mutation was performed; proof runs the actual Commander parser with deterministic package-update outcomes.
