### PR TITLE
improve: validate built CLI with Bun 1.4

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -321,7 +321,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        npm install -g bun@1.3.14
+        npm install -g bun@1.4.0
 
     - name: Runtime versions
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1346,7 +1346,7 @@ jobs:
         uses: ./.ci-harness/.github/actions/setup-node-env
         with:
           cache-mode: ${{ needs.preflight.outputs.cache_mode }}
-          install-bun: "false"
+          install-bun: "true"
           node-compile-cache: "true"
           node-compile-cache-scope: "build"
           # Same-repo Blacksmith runs restore the dependency cache published by
@@ -1427,6 +1427,11 @@ jobs:
 
       - name: Smoke test CLI launcher status json
         run: node openclaw.mjs status --json --timeout 1
+
+      - name: Smoke test built CLI with Bun
+        run: |
+          bun openclaw.mjs --help
+          bun openclaw.mjs status --json --timeout 1
 
       # Doctor index proof, singleton smoke, and startup-memory check are
       # independent dist readers; Blacksmith runners have the cores to overlap

--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -1449,7 +1449,7 @@ jobs:
             --source-archive-sha256 "$SOURCE_ARCHIVE_SHA256"
 
       - name: Install Bun for global smoke
-        run: npm install -g bun@1.3.14
+        run: npm install -g bun@1.4.0
 
       - name: Run Bun global install candidate-payload smoke
         working-directory: .release-harness

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE="docker.io/library/node:24-bookworm-slim@s
 ARG OPENCLAW_NODE_BOOKWORM_SLIM_DIGEST="sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03"
 # Keep in sync with .github/actions/setup-node-env/action.yml bun-version.
 # To update: docker buildx imagetools inspect docker.io/oven/bun:<version> and use the manifest-list digest.
-ARG OPENCLAW_BUN_IMAGE="docker.io/oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4"
+ARG OPENCLAW_BUN_IMAGE="docker.io/oven/bun:1.4.0@sha256:5ff609364c049b54eb0ff560ec96319729a972078ef2c755d758f0c6ef89c2d6"
 
 # Base images are pinned to SHA256 digests for reproducible builds.
 # Dependabot refreshes these blessed digests; release builds consume the

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -275,7 +275,7 @@ const jsRuntimeEntrypoints = new Set([
 ]);
 const awsMacosCorepackEntrypoints = new Set(["pnpm", "yarn", "corepack"]);
 const awsMacosBunEntrypoints = new Set(["bun", "bunx"]);
-const awsMacosBunVersion = "1.3.14";
+const awsMacosBunVersion = "1.4.0";
 const awsMacosSwiftEntrypoints = new Set(["swift", "xcodebuild"]);
 const awsMacosSwiftScriptTargets = new Set([
   "mac:package",

--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -147,8 +147,8 @@ main() {
   export NO_COLOR=1
   mkdir -p "$HOME" "$BUN_INSTALL/bin" "$BUN_INSTALL/install/global" "$XDG_CACHE_HOME"
   export PATH="$BUN_INSTALL/bin:$(dirname "$(command -v node)"):$PATH"
-  # Release publishes @openclaw/ai first. Bun 1.3.14 ignores bundled deps in
-  # local tarballs, so resolve that one package from the exact candidate bytes.
+  # Release publishes @openclaw/ai first. Pin the local tarball install to
+  # exact candidate bytes instead of allowing public-registry resolution.
   node --input-type=module - \
     "$BUN_INSTALL/install/global/package.json" \
     "$AI_PACKAGE_TGZ" <<'NODE'

--- a/scripts/e2e/docker-package-install.sh
+++ b/scripts/e2e/docker-package-install.sh
@@ -86,7 +86,7 @@ DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run -d \
   "$IMAGE_NAME" \
   bash -lc '
     set -euo pipefail
-    npm install -g --prefix /tmp/bun-runtime bun@1.3.14 --no-fund --no-audit
+    npm install -g --prefix /tmp/bun-runtime bun@1.4.0 --no-fund --no-audit
     cd /repo
     BUN_BIN=/tmp/bun-runtime/bin/bun \
       OPENCLAW_BUN_GLOBAL_SMOKE_HOST_BUILD=0 \

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -148,6 +148,7 @@ async function runIsolatedGatewayCli(params: {
   stateDir: string;
   configPath: string;
   env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
 }): Promise<{
   code: number | null;
   signal: NodeJS.Signals | null;
@@ -185,7 +186,7 @@ async function runIsolatedGatewayCli(params: {
         },
         encoding: "utf8",
         killSignal: "SIGKILL",
-        timeout: 20_000,
+        timeout: params.timeoutMs ?? 20_000,
       },
     );
     return { code: 0, signal: null, stdout: result.stdout, stderr: result.stderr };
@@ -235,6 +236,9 @@ describe("gateway-backed CLI process exit", () => {
         root,
         stateDir,
         configPath,
+        // The first source child cold-loads the CLI graph and can contend with
+        // neighboring CI shards before it reaches the Gateway turn.
+        timeoutMs: 45_000,
       });
 
       expect(result, result.stderr).toMatchObject({ code: exitCode, signal: null, stderr: "" });
@@ -244,7 +248,7 @@ describe("gateway-backed CLI process exit", () => {
         result: { payloads: [{ text }] },
       });
     },
-    30_000,
+    60_000,
   );
 
   it.each([

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -85,7 +85,7 @@ describe("Dockerfile", () => {
       'ARG OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE="docker.io/library/node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03"',
     );
     expect(dockerfile).toContain(
-      'ARG OPENCLAW_BUN_IMAGE="docker.io/oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4"',
+      'ARG OPENCLAW_BUN_IMAGE="docker.io/oven/bun:1.4.0@sha256:5ff609364c049b54eb0ff560ec96319729a972078ef2c755d758f0c6ef89c2d6"',
     );
     expect(dockerfile).toContain("FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS workspace-deps");
     expect(dockerfile).toContain("FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS build");

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -7405,13 +7405,26 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(realGatewayRunContract).not.toContain("--testTimeout");
   });
 
-  it("does not rebuild Control UI after build:ci-artifacts", () => {
+  it("builds artifacts once and smoke-tests the built CLI with Node and Bun", () => {
     const workflow = readCiWorkflow();
     const buildArtifactSteps = workflow.jobs["build-artifacts"].steps;
+    const setupStep = buildArtifactSteps.find(
+      (step: WorkflowStep) => step.name === "Setup Node environment",
+    );
     const buildDistStep = buildArtifactSteps.find(
       (step: WorkflowStep) => step.name === "Build dist",
     );
+    const nodeHelpSmoke = buildArtifactSteps.find(
+      (step: WorkflowStep) => step.name === "Smoke test CLI launcher help",
+    );
+    const nodeStatusSmoke = buildArtifactSteps.find(
+      (step: WorkflowStep) => step.name === "Smoke test CLI launcher status json",
+    );
+    const bunSmoke = buildArtifactSteps.find(
+      (step: WorkflowStep) => step.name === "Smoke test built CLI with Bun",
+    );
 
+    expect(setupStep.with["install-bun"]).toBe("true");
     expect(buildDistStep.run).toBe("pnpm build:ci-artifacts");
     expect(buildArtifactSteps.map((step: WorkflowStep) => step.name)).not.toContain(
       "Build Control UI",
@@ -7419,6 +7432,10 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(buildArtifactSteps.some((step: WorkflowStep) => step.run === "pnpm ui:build")).toBe(
       false,
     );
+    expect(nodeHelpSmoke.run).toBe("node openclaw.mjs --help");
+    expect(nodeStatusSmoke.run).toBe("node openclaw.mjs status --json --timeout 1");
+    expect(bunSmoke.run).toContain("bun openclaw.mjs --help");
+    expect(bunSmoke.run).toContain("bun openclaw.mjs status --json --timeout 1");
   });
 
   it("keeps source-only Control UI locale drift advisory", () => {

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -2575,7 +2575,7 @@ describe("scripts/crabbox-wrapper", () => {
     expect(output.args).toContain("--shell");
     expect(result.stderr).toContain("Node/Corepack/pnpm/Bun");
     expect(remoteCommand).toContain("openclaw_crabbox_bootstrap_macos_js");
-    expect(remoteCommand).toContain("bun_version=1.3.14");
+    expect(remoteCommand).toContain("bun_version=1.4.0");
     expect(remoteCommand).toContain('bun_root="$tool_root/bun-v${bun_version}"');
     expect(remoteCommand).toContain(
       'npm install --global --prefix "$bun_root" --fetch-timeout=120000 --fetch-retries=2 --fetch-retry-mintimeout=2000 --fetch-retry-maxtimeout=15000 "bun@${bun_version}"',
@@ -2871,7 +2871,7 @@ describe("scripts/crabbox-wrapper", () => {
   it("bootstraps Bun for AWS macOS script-stdin bun shebangs", () => {
     const script = ["#!/usr/bin/env bun", "console.log(Bun.version);"].join("\n");
     const { output } = runSuccessfulMacosScript(script);
-    expect(output.scriptContent).toContain("bun_version=1.3.14");
+    expect(output.scriptContent).toContain("bun_version=1.4.0");
     expect(output.scriptContent).toContain(
       'npm install --global --prefix "$bun_root" --fetch-timeout=120000 --fetch-retries=2 --fetch-retry-mintimeout=2000 --fetch-retry-maxtimeout=15000 "bun@${bun_version}"',
     );

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -4520,7 +4520,7 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
       "npm install -g --prefix /tmp/openclaw-proof",
       "corepack prepare pnpm@11.22.0 --activate",
       "pnpm add --global --allow-build=openclaw",
-      "bun@1.3.14",
+      "bun@1.4.0",
       'test "$(command -v openclaw)" = "/tmp/openclaw-proof/bin/openclaw"',
       'test "$(command -v openclaw)" = "$PNPM_HOME/openclaw"',
       "OPENCLAW_BUN_GLOBAL_SMOKE_PROOF_PATH",

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -543,7 +543,7 @@ describe("install smoke no-push root image transport", () => {
     expect(bunVerify.run).toContain("install-smoke-candidate-payload.mts verify");
     expect(bunVerify.run).toContain('--run-id "$PRODUCER_RUN_ID"');
     expect(bunVerify.run).toContain('--run-attempt "$PRODUCER_RUN_ATTEMPT"');
-    expect(step(bunConsumer, "Install Bun for global smoke").run).toBe("npm install -g bun@1.3.14");
+    expect(step(bunConsumer, "Install Bun for global smoke").run).toBe("npm install -g bun@1.4.0");
     expect(step(bunConsumer, "Run Bun global install candidate-payload smoke")).toMatchObject({
       "working-directory": ".release-harness",
       env: {

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2171,7 +2171,7 @@ chmod +x "$BUN_INSTALL/bin/openclaw"
     expect(workflow).toContain("bun_global_install_smoke:");
     expect(workflow).toContain("Setup trusted release harness for Bun smoke");
     expect(workflow).toContain("uses: ./.release-harness/.github/actions/setup-release-harness");
-    expect(workflow).toContain("npm install -g bun@1.3.14");
+    expect(workflow).toContain("npm install -g bun@1.4.0");
     expect(workflow).toContain('install-bun: "false"');
     expect(workflow).toContain("Run Bun global install candidate-payload smoke");
     expect(workflow).toContain("working-directory: .release-harness");


### PR DESCRIPTION
Closes #129164

## What Problem This Solves

OpenClaw's Bun compatibility checks did not execute the built CLI under the currently supported Bun runtime. Operational setup, install-smoke, Docker, and Crabbox paths still pinned Bun 1.3.14, while the existing fixture lane and global-install smoke did not prove that the built runtime could load and run commands under Bun.

## Why This Change Was Made

Update the operational Bun pins coherently to stable Bun 1.4.0, including the digest-pinned multi-arch Docker image, and add an explicit built-CLI Bun smoke to the existing artifact build job. Node/pnpm still install dependencies, build artifacts, run the primary tests, and execute the first CLI smokes; Bun remains a secondary CLI runtime verifier. Intentional old-Bun fixtures remain unchanged.

The Bun install smoke's `@openclaw/ai` override is retained as candidate-byte integrity policy rather than attributed to a Bun 1.3-only behavior.

Exact-head CI also exposed an existing cold-start deadline in the first gateway-backed CLI process test: Node + TSX startup exceeded its fixed 20-second kill timer by 139 ms while every sibling case passed. The agent-turn cases now use the repository's established 45-second cold-start allowance; all other cases retain the 20-second guard.

## User Impact

Users who explicitly run the OpenClaw CLI with Bun get continuous compatibility coverage against Bun 1.4. Managed services, default package-manager behavior, Node engine support, and release behavior are unchanged; Node remains the primary and recommended runtime.

## Evidence

- `pnpm test test/scripts/ci-workflow-guards.test.ts test/scripts/docker-build-helper.test.ts test/scripts/install-smoke-no-push-workflow.test.ts test/scripts/test-install-sh-docker.test.ts test/scripts/crabbox-wrapper.test.ts` — 666 tests passed on the rebased head.
- `OPENCLAW_E2E_SKIP_BUILD=1 OPENCLAW_TEST_BUN_LAUNCHER=1 BUN_BIN=/tmp/openclaw-bun140/node_modules/.bin/bun pnpm test test/openclaw-launcher.e2e.test.ts` — 40 tests passed with Bun 1.4.0.
- `pnpm check:changed` — formatting, guards, full typecheck, lint, and import-cycle checks passed.
- `pnpm test src/cli/gateway-backed-exit.process.test.ts` — all 32 CLI process tests passed; the two agent-turn regressions also passed in 3 consecutive focused runs.
- `pnpm build` — built all runtime and Control UI artifacts successfully.
- Bun 1.4.0 directly ran the built `openclaw.mjs --help` and `status --json --timeout 1`; the same Node smoke passed first.
- `scripts/e2e/bun-global-install-smoke.sh` passed with Bun 1.4.0 against locally built candidate tarballs, including all 9 image providers.
- Docker's Bun image now uses the registry-verified multi-arch manifest digest `sha256:5ff609364c049b54eb0ff560ec96319729a972078ef2c755d758f0c6ef89c2d6`.
- Structured Codex autoreview: clean, patch correct, 0.98 confidence on the final branch diff.
