### PR TITLE
fix(channels): keep title-only cards visible and media counts accurate

### DIFF
--- a/src/channels/message/rendered-batch.test.ts
+++ b/src/channels/message/rendered-batch.test.ts
@@ -19,4 +19,36 @@ describe("createRenderedMessageBatchPlan", () => {
       audioAsVoice: true,
     });
   });
+
+  it("recognizes a presentation heading even when it has no blocks", () => {
+    const plan = createRenderedMessageBatchPlan([
+      { presentation: { title: "Delivery failed: action required", blocks: [] } },
+    ]);
+
+    expect(plan.presentationCount).toBe(1);
+    expect(plan.items[0]).toMatchObject({ kinds: ["presentation"], mediaUrls: [] });
+  });
+
+  it.each([
+    {
+      name: "a single attachment repeated in its media alias",
+      payload: { mediaUrl: "/tmp/image.png", mediaUrls: ["/tmp/image.png"] },
+      expected: ["/tmp/image.png"],
+    },
+    {
+      name: "distinct attachments across both media fields",
+      payload: { mediaUrl: "/tmp/first.png", mediaUrls: ["/tmp/second.png"] },
+      expected: ["/tmp/first.png", "/tmp/second.png"],
+    },
+    {
+      name: "intentional repeated attachments in the ordered media list",
+      payload: { mediaUrl: "/tmp/image.png", mediaUrls: ["/tmp/image.png", "/tmp/image.png"] },
+      expected: ["/tmp/image.png", "/tmp/image.png"],
+    },
+  ])("accounts for $name", ({ payload, expected }) => {
+    const plan = createRenderedMessageBatchPlan([payload]);
+
+    expect(plan.mediaCount).toBe(expected.length);
+    expect(plan.items[0]?.mediaUrls).toEqual(expected);
+  });
 });

--- a/src/channels/message/rendered-batch.ts
+++ b/src/channels/message/rendered-batch.ts
@@ -3,6 +3,7 @@
  *
  * Summarizes reply payloads so delivery can pick adapter paths and recovery metadata.
  */
+import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type {
   RenderedMessageBatch,
@@ -11,14 +12,10 @@ import type {
   RenderedMessageBatchPlanKind,
 } from "./types.js";
 
-function countMedia(payload: ReplyPayload): number {
-  return collectMediaUrls(payload).length;
-}
-
 function collectMediaUrls(payload: ReplyPayload): string[] {
-  return [payload.mediaUrl, ...(payload.mediaUrls ?? [])]
-    .map((url) => url?.trim())
-    .filter((url): url is string => Boolean(url));
+  const mediaUrls = normalizeTrimmedStringList(payload.mediaUrls);
+  const mediaUrl = payload.mediaUrl?.trim();
+  return mediaUrl && !mediaUrls.includes(mediaUrl) ? [mediaUrl, ...mediaUrls] : mediaUrls;
 }
 
 function createRenderedMessageBatchPlanItem(
@@ -35,7 +32,7 @@ function createRenderedMessageBatchPlanItem(
   if (mediaUrls.length > 0) {
     kinds.push(payload.audioAsVoice ? "voice" : "media");
   }
-  if (presentationBlockCount > 0) {
+  if (presentationBlockCount > 0 || payload.presentation?.title?.trim()) {
     kinds.push("presentation");
   }
   if (payload.interactive) {
@@ -61,21 +58,17 @@ export function createRenderedMessageBatchPlan(
   payloads: readonly ReplyPayload[],
 ): RenderedMessageBatchPlan {
   const items = payloads.map(createRenderedMessageBatchPlanItem);
-  return payloads.reduce<RenderedMessageBatchPlan>(
-    (plan, payload) => {
-      const text = payload.text?.trim();
-      const mediaCount = countMedia(payload);
-      return {
-        payloadCount: plan.payloadCount + 1,
-        textCount: plan.textCount + (text ? 1 : 0),
-        mediaCount: plan.mediaCount + mediaCount,
-        voiceCount: plan.voiceCount + (payload.audioAsVoice && mediaCount > 0 ? 1 : 0),
-        presentationCount: plan.presentationCount + (payload.presentation?.blocks?.length ? 1 : 0),
-        interactiveCount: plan.interactiveCount + (payload.interactive ? 1 : 0),
-        channelDataCount: plan.channelDataCount + (payload.channelData || payload.location ? 1 : 0),
-        items: plan.items,
-      };
-    },
+  return items.reduce<RenderedMessageBatchPlan>(
+    (plan, item) => ({
+      payloadCount: plan.payloadCount + 1,
+      textCount: plan.textCount + (item.text ? 1 : 0),
+      mediaCount: plan.mediaCount + item.mediaUrls.length,
+      voiceCount: plan.voiceCount + (item.audioAsVoice ? 1 : 0),
+      presentationCount: plan.presentationCount + (item.kinds.includes("presentation") ? 1 : 0),
+      interactiveCount: plan.interactiveCount + (item.hasInteractive ? 1 : 0),
+      channelDataCount: plan.channelDataCount + (item.hasChannelData ? 1 : 0),
+      items: plan.items,
+    }),
     {
       payloadCount: 0,
       textCount: 0,

--- a/src/channels/message/send.test.ts
+++ b/src/channels/message/send.test.ts
@@ -218,6 +218,28 @@ describe("withDurableMessageSendContext", () => {
     });
   });
 
+  it.each([
+    {
+      name: "title-only presentations",
+      payload: { presentation: { title: "Delivery failed: action required", blocks: [] } },
+      expected: { presentationCount: 1, items: [{ kinds: ["presentation"] }] },
+    },
+    {
+      name: "single attachments mirrored by the media alias",
+      payload: { mediaUrl: "/tmp/image.png", mediaUrls: ["/tmp/image.png"] },
+      expected: { mediaCount: 1, items: [{ mediaUrls: ["/tmp/image.png"] }] },
+    },
+  ])("keeps $name visible in durable live previews", async ({ payload, expected }) => {
+    await withDurableMessageSendContext(
+      { cfg, channel: "telegram", to: "chat-1", payloads: [payload] },
+      async (ctx) => {
+        const rendered = await ctx.render();
+        expect(rendered.plan).toMatchObject(expected);
+        expect((await ctx.previewUpdate(rendered)).lastRendered?.plan).toMatchObject(expected);
+      },
+    );
+  });
+
   it("forwards the durable send context signal to outbound delivery", async () => {
     const abortController = new AbortController();
     deliverOutboundPayloads.mockImplementationOnce(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a presentation that contains only a heading would have a genuinely visible card recorded as an empty message in durable send and live-preview metadata. Ordinary message-tool media sends also recorded one attachment twice because the payload producer mirrors its primary attachment in both supported media fields.

## Why This Change Was Made

The rendered-batch owner now recognizes presentation headings, merges the overlapping single-media alias without collapsing deliberately repeated ordered attachments, and derives every aggregate from the same normalized render-plan items. This removes the duplicate raw-payload counting path and preserves distinct attachments supplied through both fields.

## User Impact

Title-only cards stay visible to durable delivery and live-preview consumers, and generated-image or other media sends report the number of attachments that will actually be delivered. Existing voice, location, multi-attachment, distinct legacy-media, and intentionally repeated-attachment behavior remains unchanged.

## Evidence

- Authentic pre-fix producer proof: the real message-action payload builder accepted a title-only presentation, while the real rendered-batch owner labeled it `empty`; the same builder produced one attachment in both `mediaUrl` and `mediaUrls`, while the owner incorrectly counted two.
- Authentic pre-fix regression results: rendered-batch owner suite failed three new cases; the actual durable-send/live-preview boundary failed both new presentation and media cases.
- Post-fix focused owner, caller, sibling bridge, real message-action producer, and media compatibility proof: `node scripts/run-vitest.mjs src/channels/message/rendered-batch.test.ts src/channels/message/send.test.ts src/channels/message/outbound-bridge.test.ts src/media/media-retirement-non-goals.test.ts src/infra/outbound/message-action-send.test.ts` — **57 tests passed across five files and three Vitest shards**.
- Targeted formatting, lint, diff checks, independent owner-boundary review, and structured Codex review all passed. Production code shrank by seven lines.
- Live-channel execution was not performed: this deterministic generic render-plan metadata repair is fully exercised through the actual message-action producer and durable live-preview owner without accessing an operator-owned channel or live credentials.
