### PR TITLE
fix(release): verify focused candidate checkout

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -292,8 +292,10 @@ jobs:
             --source-digest "${PRODUCER_WORKFLOW_SHA}" \
             --source-ref "${PRODUCER_WORKFLOW_FULL_REF}" \
             --deny-self-hosted-runners
-          node .release-harness/scripts/validate-authorized-beta-focused-evidence.mts verify \
-            --candidate-root . \
+          node .release-harness/scripts/verify-authorized-beta-focused-candidate.mjs \
+            --repository-root . \
+            --validator .release-harness/scripts/validate-authorized-beta-focused-evidence.mts \
+            --policy .release-harness/scripts/authorized-beta-focused-policy.json \
             --artifact "${evidence}" \
             --producer-run-id "${FOCUSED_RELEASE_EVIDENCE_RUN_ID}" \
             --producer-run-attempt "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" \

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -535,6 +535,8 @@ jobs:
             --jq .content | base64 --decode > "${tooling_dir}/plugin-sdk-api-release-evidence.mjs"
           gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/validate-authorized-beta-focused-evidence.mts?ref=${WORKFLOW_SHA}" \
             --jq .content | base64 --decode > "${tooling_dir}/validate-authorized-beta-focused-evidence.mts"
+          gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/verify-authorized-beta-focused-candidate.mjs?ref=${WORKFLOW_SHA}" \
+            --jq .content | base64 --decode > "${tooling_dir}/verify-authorized-beta-focused-candidate.mjs"
           gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/authorized-beta-focused-policy.json?ref=${WORKFLOW_SHA}" \
             --jq .content | base64 --decode > "${tooling_dir}/authorized-beta-focused-policy.json"
           gh api "repos/${GITHUB_REPOSITORY}/contents/scripts/lib/record-shared.mjs?ref=${WORKFLOW_SHA}" \
@@ -814,8 +816,11 @@ jobs:
             --source-digest "${PRODUCER_WORKFLOW_SHA}" \
             --source-ref "${PRODUCER_WORKFLOW_FULL_REF}" \
             --deny-self-hosted-runners
-          node "${RUNNER_TEMP}/release-validation-tooling/validate-authorized-beta-focused-evidence.mts" verify \
-            --candidate-root . \
+          tooling_dir="${RUNNER_TEMP}/release-validation-tooling"
+          node "${tooling_dir}/verify-authorized-beta-focused-candidate.mjs" \
+            --repository-root . \
+            --validator "${tooling_dir}/validate-authorized-beta-focused-evidence.mts" \
+            --policy "${tooling_dir}/authorized-beta-focused-policy.json" \
             --artifact "${evidence}" \
             --producer-run-id "${FOCUSED_RELEASE_EVIDENCE_RUN_ID}" \
             --producer-run-attempt "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" \
@@ -950,8 +955,10 @@ jobs:
             --source-digest "${PRODUCER_WORKFLOW_SHA}" \
             --source-ref "${PRODUCER_WORKFLOW_FULL_REF}" \
             --deny-self-hosted-runners
-          node .release-harness/scripts/validate-authorized-beta-focused-evidence.mts verify \
-            --candidate-root . \
+          node .release-harness/scripts/verify-authorized-beta-focused-candidate.mjs \
+            --repository-root . \
+            --validator .release-harness/scripts/validate-authorized-beta-focused-evidence.mts \
+            --policy .release-harness/scripts/authorized-beta-focused-policy.json \
             --artifact "${evidence}" \
             --producer-run-id "${FOCUSED_RELEASE_EVIDENCE_RUN_ID}" \
             --producer-run-attempt "${FOCUSED_RELEASE_EVIDENCE_RUN_ATTEMPT}" \

--- a/scripts/validate-authorized-beta-focused-evidence.mts
+++ b/scripts/validate-authorized-beta-focused-evidence.mts
@@ -350,13 +350,18 @@ function requireHistoricalExecutionPlan(policy: AuthorizedBetaFocusedPolicy) {
       fail("historical execution plan children must be an array");
     }
     const childRuns = new Map(
-      plan.children.map((entry: unknown) => {
+      plan.children.flatMap((entry: unknown) => {
         if (!isRecord(entry)) {
           fail("historical execution plan child must be an object");
         }
+        if (entry.selected !== true) {
+          return [];
+        }
         return [
-          exactString(entry.key, "historical execution plan child key"),
-          exactJsonId(entry.runId, "historical execution plan child run id"),
+          [
+            exactString(entry.key, "historical execution plan child key"),
+            exactJsonId(entry.runId, "historical execution plan child run id"),
+          ],
         ];
       }),
     );

--- a/scripts/verify-authorized-beta-focused-candidate.mjs
+++ b/scripts/verify-authorized-beta-focused-candidate.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const FORWARDED_OPTIONS = new Set([
+  "--artifact",
+  "--producer-run-id",
+  "--producer-run-attempt",
+  "--producer-workflow-full-ref",
+  "--producer-workflow-sha",
+]);
+
+function main() {
+  const [rootFlag, root, validatorFlag, validator, policyFlag, policyFile, ...forwarded] =
+    process.argv.slice(2);
+  if (
+    rootFlag !== "--repository-root" ||
+    !root ||
+    validatorFlag !== "--validator" ||
+    !validator ||
+    policyFlag !== "--policy" ||
+    !policyFile
+  ) {
+    throw new Error("expected --repository-root <path> --validator <path> --policy <path>");
+  }
+  const seen = new Set();
+  for (let index = 0; index < forwarded.length; index += 2) {
+    const option = forwarded[index];
+    const value = forwarded[index + 1];
+    if (!FORWARDED_OPTIONS.has(option) || seen.has(option) || !value || value.startsWith("--")) {
+      throw new Error(`invalid focused evidence verifier option: ${option ?? "<missing>"}`);
+    }
+    seen.add(option);
+  }
+
+  const repositoryRoot = resolve(root);
+  const validatorPath = resolve(validator);
+  const policyPath = resolve(policyFile);
+  if (policyPath !== join(dirname(validatorPath), "authorized-beta-focused-policy.json")) {
+    throw new Error("focused evidence policy must be the trusted validator's adjacent policy");
+  }
+  const policy = JSON.parse(readFileSync(policyPath, "utf8"));
+  if (
+    policy === null ||
+    typeof policy !== "object" ||
+    Array.isArray(policy) ||
+    policy.schema !== "openclaw.authorized-beta-focused-policy.v1" ||
+    policy.mode !== "authorized-beta-focused-v1" ||
+    typeof policy.candidateSha !== "string" ||
+    !/^[a-f0-9]{40}$/u.test(policy.candidateSha)
+  ) {
+    throw new Error("invalid trusted focused evidence policy or candidate SHA");
+  }
+
+  const candidateSha = policy.candidateSha;
+  const git = (args, options = {}) =>
+    execFileSync("git", ["-C", repositoryRoot, ...args], { stdio: "inherit", ...options });
+  const hasCandidate = () =>
+    spawnSync("git", ["-C", repositoryRoot, "cat-file", "-e", `${candidateSha}^{commit}`], {
+      stdio: "ignore",
+    }).status === 0;
+  if (!hasCandidate()) {
+    git(["fetch", "--no-tags", "origin", candidateSha], { timeout: 120_000 });
+    if (!hasCandidate()) {
+      throw new Error(`trusted focused evidence candidate is unavailable: ${candidateSha}`);
+    }
+  }
+
+  const directory = mkdtempSync(join(tmpdir(), "authorized-beta-focused-candidate-"));
+  const candidateRoot = join(directory, "candidate");
+  let worktreeAdded = false;
+  try {
+    // Verification reads Git objects only; no checkout also prevents candidate checkout hooks.
+    git(["worktree", "add", "--detach", "--no-checkout", candidateRoot, candidateSha]);
+    worktreeAdded = true;
+    execFileSync(
+      process.execPath,
+      [validatorPath, "verify", "--candidate-root", candidateRoot, ...forwarded],
+      { cwd: repositoryRoot, stdio: "inherit" },
+    );
+  } finally {
+    try {
+      if (worktreeAdded) {
+        git(["worktree", "remove", "--force", candidateRoot]);
+      }
+    } finally {
+      try {
+        rmSync(directory, { force: true, recursive: true });
+      } finally {
+        git(["worktree", "prune", "--expire", "now"]);
+      }
+    }
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : "unknown error");
+  console.error("[authorized-beta-focused-candidate] FAILED (exit 1)");
+  process.exitCode = 1;
+}

--- a/test/scripts/authorized-beta-focused-evidence.test.ts
+++ b/test/scripts/authorized-beta-focused-evidence.test.ts
@@ -434,6 +434,92 @@ describe("authorized beta focused evidence", () => {
     });
   });
 
+  it("accepts skipped historical release-plan children without run identities", () => {
+    const { policy, root } = fixturePolicy();
+    const trustedRoot = tempDirs.make("authorized-beta-focused-historical-plan-");
+    const validatorPath = stageValidatorClosure(trustedRoot, false);
+    writeFileSync(join(trustedRoot, "authorized-beta-focused-policy.json"), JSON.stringify(policy));
+
+    const producerSha = "a".repeat(40);
+    const producerRef = "release-publish/aaaaaaaaaaaa-1";
+    const historical = policy.historicalFrv;
+    const plan = {
+      parentRunId: historical.runId,
+      parentRunAttempt: historical.runAttempt,
+      workflowRef: historical.workflowRef,
+      workflowSha: policy.historicalToolingSha,
+      targetSha: historical.targetSha,
+      releaseProfile: "beta",
+      rerunGroup: "all",
+      children: [
+        { key: "normalCi", selected: true, runId: historical.ciRunId },
+        { key: "pluginPrerelease", selected: true, runId: historical.pluginRunId },
+        { key: "releaseChecks", selected: true, runId: historical.releaseChecksRunId },
+        { key: "npmTelegram", selected: false, runId: "" },
+        { key: "productPerformance", selected: true, runId: historical.performanceRunId },
+      ],
+    };
+    const producerRun = {
+      id: 123,
+      run_attempt: 1,
+      name: "Authorized Beta Focused Validation",
+      path: ".github/workflows/authorized-beta-focused-validation.yml",
+      event: "workflow_dispatch",
+      status: "completed",
+      conclusion: "success",
+      head_branch: producerRef,
+      head_sha: producerSha,
+    };
+    writeFileSync(
+      join(trustedRoot, "gh"),
+      [
+        "#!/usr/bin/env node",
+        'import { writeFileSync } from "node:fs";',
+        'import { join } from "node:path";',
+        "const [command, route, ...args] = process.argv.slice(2);",
+        'if (command === "api" && route.endsWith("/actions/runs/123")) {',
+        `  process.stdout.write(JSON.stringify(${JSON.stringify(producerRun)}));`,
+        '} else if (command === "api" && route.includes("/git/ref/tags/")) {',
+        `  process.stdout.write(JSON.stringify({ object: { type: "commit", sha: ${JSON.stringify(producerSha)} } }));`,
+        '} else if (command === "run" && route === "download") {',
+        '  const directory = args[args.indexOf("--dir") + 1];',
+        `  writeFileSync(join(directory, "full-release-execution-plan.json"), JSON.stringify(${JSON.stringify(plan)}));`,
+        "} else {",
+        '  console.error("historical execution plan child identities accepted");',
+        "  process.exitCode = 1;",
+        "}",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        validatorPath,
+        "verify",
+        "--candidate-root",
+        root,
+        "--artifact",
+        join(trustedRoot, "unused-evidence.json"),
+        "--producer-run-id",
+        "123",
+        "--producer-run-attempt",
+        "1",
+        "--producer-workflow-full-ref",
+        `refs/tags/${producerRef}`,
+        "--producer-workflow-sha",
+        producerSha,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${trustedRoot}:${process.env.PATH ?? ""}` },
+      },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("historical execution plan child identities accepted");
+    expect(result.stderr).not.toContain("historical execution plan child run id");
+  });
+
   it("binds the direct-child tree, exact diff, and unchanged published projection", () => {
     const { policy, root } = fixturePolicy();
     const changedPath = policy.changedPaths[0];

--- a/test/scripts/authorized-beta-focused-evidence.test.ts
+++ b/test/scripts/authorized-beta-focused-evidence.test.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
@@ -50,6 +50,7 @@ const VALIDATOR_CLOSURE = [
   "scripts/authorized-beta-focused-policy.json",
   "scripts/lib/record-shared.mjs",
   "scripts/validate-authorized-beta-focused-evidence.mts",
+  "scripts/verify-authorized-beta-focused-candidate.mjs",
 ] as const;
 
 function stageValidatorClosure(root: string, scriptsDirectory: boolean): string {
@@ -131,6 +132,57 @@ function fixturePolicy(): { policy: AuthorizedBetaFocusedPolicy; root: string } 
       ],
     },
   };
+}
+
+function stageCandidateVerifier(policy: AuthorizedBetaFocusedPolicy, shouldFail = false) {
+  const trustedRoot = tempDirs.make("authorized-beta-focused-trusted-");
+  const validatorPath = stageValidatorClosure(trustedRoot, false);
+  const policyPath = join(trustedRoot, "authorized-beta-focused-policy.json");
+  const markerPath = join(trustedRoot, "candidate-verifier.json");
+  writeFileSync(policyPath, JSON.stringify(policy));
+  const fixtureValidatorPath = join(trustedRoot, "candidate-verifier.mjs");
+  writeFileSync(
+    fixtureValidatorPath,
+    [
+      `import { readdirSync, writeFileSync } from "node:fs";`,
+      `import { assertAuthorizedBetaFocusedCandidate, readAuthorizedBetaFocusedPolicy } from ${JSON.stringify(pathToFileURL(validatorPath).href)};`,
+      `const args = process.argv.slice(2);`,
+      `const candidateRoot = args[args.indexOf("--candidate-root") + 1];`,
+      `assertAuthorizedBetaFocusedCandidate(readAuthorizedBetaFocusedPolicy(), candidateRoot);`,
+      `writeFileSync(${JSON.stringify(markerPath)}, JSON.stringify({ args, candidateRoot, entries: readdirSync(candidateRoot) }));`,
+      shouldFail ? `throw new Error("trusted fixture verifier rejected evidence");` : "",
+    ].join("\n"),
+  );
+  return {
+    fixtureValidatorPath,
+    helperPath: join(trustedRoot, "verify-authorized-beta-focused-candidate.mjs"),
+    markerPath,
+    policyPath,
+    validatorPath,
+  };
+}
+
+function runCandidateVerifier(params: {
+  helperPath?: string;
+  policyPath: string;
+  repositoryRoot: string;
+  validatorPath: string;
+  verifierArgs?: string[];
+}) {
+  return spawnSync(
+    process.execPath,
+    [
+      params.helperPath ?? join(REPO_ROOT, "scripts/verify-authorized-beta-focused-candidate.mjs"),
+      "--repository-root",
+      params.repositoryRoot,
+      "--validator",
+      params.validatorPath,
+      "--policy",
+      params.policyPath,
+      ...(params.verifierArgs ?? []),
+    ],
+    { encoding: "utf8" },
+  );
 }
 
 function resolveFocusedProducer(
@@ -336,6 +388,16 @@ describe("authorized beta focused evidence", () => {
     expect(revalidation).toBeLessThan(download);
     expect(download).toBeLessThan(verification);
     expect(verification).toBeLessThan(provenance);
+    const verifyStep = namedStep(
+      docker,
+      "resolve_build_provenance",
+      "Verify focused release evidence after Docker approval",
+    );
+    expect(verifyStep.run).toContain("verify-authorized-beta-focused-candidate.mjs");
+    expect(verifyStep.run).not.toContain("--candidate-root .");
+    expect(verifyStep.run?.indexOf("gh attestation verify")).toBeLessThan(
+      verifyStep.run?.indexOf("verify-authorized-beta-focused-candidate.mjs") ?? -1,
+    );
 
     for (const jobName of ["build-amd64", "build-arm64"]) {
       expect(docker.jobs?.[jobName]?.needs).toContain("resolve_build_provenance");
@@ -388,6 +450,229 @@ describe("authorized beta focused evidence", () => {
         root,
       ),
     ).toThrow("candidate diff does not match authorized path");
+  });
+
+  it("verifies the policy candidate when the release checkout has diverged", () => {
+    const { policy, root } = fixturePolicy();
+    git(root, ["checkout", "--quiet", "--detach", policy.baseCandidateSha]);
+    writeFileSync(join(root, "published.txt"), "divergent release\n");
+    const releaseSha = commit(root, "divergent release");
+    const ancestry = spawnSync(
+      "git",
+      ["merge-base", "--is-ancestor", policy.candidateSha, releaseSha],
+      { cwd: root },
+    );
+    expect(ancestry.status).toBe(1);
+
+    const staged = stageCandidateVerifier(policy);
+    const checkoutHookMarker = join(root, "checkout-hook-ran");
+    writeFileSync(
+      join(root, ".git", "hooks", "post-checkout"),
+      `#!/bin/sh\n: > ${JSON.stringify(checkoutHookMarker)}\n`,
+      { mode: 0o755 },
+    );
+    const producerSha = "a".repeat(40);
+    const verifierArgs = [
+      "--artifact",
+      join(root, "evidence.json"),
+      "--producer-run-id",
+      "123",
+      "--producer-run-attempt",
+      "1",
+      "--producer-workflow-full-ref",
+      "refs/tags/release-publish/aaaaaaaaaaaa-1",
+      "--producer-workflow-sha",
+      producerSha,
+    ];
+    const direct = spawnSync(
+      process.execPath,
+      [staged.validatorPath, "verify", "--candidate-root", root, ...verifierArgs],
+      { encoding: "utf8" },
+    );
+    expect(direct.status).toBe(1);
+    expect(direct.stderr).toContain(
+      `candidate checkout must be ${policy.candidateSha}, got ${releaseSha}`,
+    );
+
+    const originalWorktrees = git(root, ["worktree", "list", "--porcelain"]);
+    const stagedResult = runCandidateVerifier({
+      helperPath: staged.helperPath,
+      policyPath: staged.policyPath,
+      repositoryRoot: root,
+      validatorPath: staged.fixtureValidatorPath,
+      verifierArgs,
+    });
+    expect(stagedResult.status).toBe(0);
+    const invocation = JSON.parse(readFileSync(staged.markerPath, "utf8")) as {
+      args: string[];
+      candidateRoot: string;
+      entries: string[];
+    };
+    expect(invocation.args).toEqual([
+      "verify",
+      "--candidate-root",
+      invocation.candidateRoot,
+      ...verifierArgs,
+    ]);
+    expect(invocation.entries).toEqual([".git"]);
+    expect(existsSync(checkoutHookMarker)).toBe(false);
+    expect(existsSync(invocation.candidateRoot)).toBe(false);
+    expect(git(root, ["worktree", "list", "--porcelain"])).toBe(originalWorktrees);
+    expect(git(root, ["rev-parse", "HEAD"])).toBe(releaseSha);
+  });
+
+  it.each([
+    { name: "null policy", policy: null },
+    { name: "array policy", policy: [] },
+    {
+      name: "wrong policy schema",
+      policy: { schema: "other", mode: "authorized-beta-focused-v1", candidateSha: "a".repeat(40) },
+    },
+    {
+      name: "wrong policy mode",
+      policy: {
+        schema: "openclaw.authorized-beta-focused-policy.v1",
+        mode: "other",
+        candidateSha: "a".repeat(40),
+      },
+    },
+    {
+      name: "missing candidate",
+      policy: {
+        schema: "openclaw.authorized-beta-focused-policy.v1",
+        mode: "authorized-beta-focused-v1",
+      },
+    },
+    {
+      name: "short candidate",
+      policy: {
+        schema: "openclaw.authorized-beta-focused-policy.v1",
+        mode: "authorized-beta-focused-v1",
+        candidateSha: "abc",
+      },
+    },
+    {
+      name: "uppercase candidate",
+      policy: {
+        schema: "openclaw.authorized-beta-focused-policy.v1",
+        mode: "authorized-beta-focused-v1",
+        candidateSha: "A".repeat(40),
+      },
+    },
+  ])("rejects $name before touching the repository or verifier", ({ policy }) => {
+    const trustedRoot = tempDirs.make("authorized-beta-focused-invalid-");
+    const policyPath = join(trustedRoot, "authorized-beta-focused-policy.json");
+    writeFileSync(policyPath, JSON.stringify(policy));
+    const result = runCandidateVerifier({
+      policyPath,
+      repositoryRoot: join(trustedRoot, "missing-repository"),
+      validatorPath: join(trustedRoot, "missing-verifier.mjs"),
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("invalid trusted focused evidence policy");
+    expect(result.stderr).not.toContain("missing-repository");
+  });
+
+  it("rejects a policy that is not adjacent to the trusted verifier", () => {
+    const { policy, root } = fixturePolicy();
+    const staged = stageCandidateVerifier(policy);
+    const otherRoot = tempDirs.make("authorized-beta-focused-other-policy-");
+    const policyPath = join(otherRoot, "authorized-beta-focused-policy.json");
+    writeFileSync(policyPath, JSON.stringify(policy));
+    const result = runCandidateVerifier({
+      policyPath,
+      repositoryRoot: root,
+      validatorPath: staged.fixtureValidatorPath,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("trusted validator's adjacent policy");
+    expect(existsSync(staged.markerPath)).toBe(false);
+  });
+
+  it("rejects an unavailable policy candidate without invoking the verifier", () => {
+    const { policy, root } = fixturePolicy();
+    git(root, ["remote", "add", "origin", root]);
+    const staged = stageCandidateVerifier({ ...policy, candidateSha: "f".repeat(40) });
+    const originalWorktrees = git(root, ["worktree", "list", "--porcelain"]);
+    const result = runCandidateVerifier({
+      policyPath: staged.policyPath,
+      repositoryRoot: root,
+      validatorPath: staged.fixtureValidatorPath,
+    });
+    expect(result.status).toBe(1);
+    expect(existsSync(staged.markerPath)).toBe(false);
+    expect(git(root, ["worktree", "list", "--porcelain"])).toBe(originalWorktrees);
+  });
+
+  it("fetches only the exact policy candidate when the release clone does not contain it", () => {
+    const { policy, root } = fixturePolicy();
+    git(root, ["checkout", "--quiet", "--detach", policy.baseCandidateSha]);
+    writeFileSync(join(root, "published.txt"), "divergent release\n");
+    const releaseSha = commit(root, "divergent release");
+    git(root, ["branch", "release-candidate", releaseSha]);
+    const releaseRoot = tempDirs.make("authorized-beta-focused-release-clone-");
+    execFileSync("git", [
+      "clone",
+      "--quiet",
+      "--no-local",
+      "--depth",
+      "1",
+      "--branch",
+      "release-candidate",
+      root,
+      releaseRoot,
+    ]);
+    expect(
+      spawnSync("git", ["cat-file", "-e", `${policy.candidateSha}^{commit}`], {
+        cwd: releaseRoot,
+      }).status,
+    ).not.toBe(0);
+
+    const staged = stageCandidateVerifier(policy);
+    const originalWorktrees = git(releaseRoot, ["worktree", "list", "--porcelain"]);
+    const result = runCandidateVerifier({
+      policyPath: staged.policyPath,
+      repositoryRoot: releaseRoot,
+      validatorPath: staged.fixtureValidatorPath,
+    });
+    expect(result.status).toBe(0);
+    expect(existsSync(staged.markerPath)).toBe(true);
+    expect(git(releaseRoot, ["rev-parse", "HEAD"])).toBe(releaseSha);
+    expect(git(releaseRoot, ["worktree", "list", "--porcelain"])).toBe(originalWorktrees);
+  });
+
+  it("rejects candidate-root overrides before staging a trusted candidate", () => {
+    const { policy, root } = fixturePolicy();
+    const staged = stageCandidateVerifier(policy);
+    const originalWorktrees = git(root, ["worktree", "list", "--porcelain"]);
+    const result = runCandidateVerifier({
+      policyPath: staged.policyPath,
+      repositoryRoot: root,
+      validatorPath: staged.fixtureValidatorPath,
+      verifierArgs: ["--candidate-root", root],
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("invalid focused evidence verifier option: --candidate-root");
+    expect(existsSync(staged.markerPath)).toBe(false);
+    expect(git(root, ["worktree", "list", "--porcelain"])).toBe(originalWorktrees);
+  });
+
+  it("removes and prunes the candidate worktree when trusted verification fails", () => {
+    const { policy, root } = fixturePolicy();
+    const staged = stageCandidateVerifier(policy, true);
+    const originalWorktrees = git(root, ["worktree", "list", "--porcelain"]);
+    const result = runCandidateVerifier({
+      policyPath: staged.policyPath,
+      repositoryRoot: root,
+      validatorPath: staged.fixtureValidatorPath,
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("trusted fixture verifier rejected evidence");
+    const invocation = JSON.parse(readFileSync(staged.markerPath, "utf8")) as {
+      candidateRoot: string;
+    };
+    expect(existsSync(invocation.candidateRoot)).toBe(false);
+    expect(git(root, ["worktree", "list", "--porcelain"])).toBe(originalWorktrees);
   });
 
   it("hashes sorted unique package inventories and rejects duplicates", () => {
@@ -598,6 +883,12 @@ describe("authorized beta focused evidence", () => {
         '--producer-workflow-full-ref "${PRODUCER_WORKFLOW_FULL_REF}"',
       );
       expect(verifyStep.run).toContain('--producer-workflow-sha "${PRODUCER_WORKFLOW_SHA}"');
+      expect(verifyStep.run).toContain("verify-authorized-beta-focused-candidate.mjs");
+      expect(verifyStep.run).toContain("--repository-root .");
+      expect(verifyStep.run).not.toContain("--candidate-root .");
+      expect(verifyStep.run?.indexOf("gh attestation verify")).toBeLessThan(
+        verifyStep.run?.indexOf("verify-authorized-beta-focused-candidate.mjs") ?? -1,
+      );
     }
     const publishSteps = parentWorkflow.jobs?.publish?.steps ?? [];
     const publishStepNames = publishSteps.map((step) => step.name);


### PR DESCRIPTION
## What Problem This Solves

The Docker-only recovery for `v2026.8.1-beta.3` now accepts the original focused-evidence producer identity, but verification still runs against the release-tag checkout. That evidence intentionally describes a separate historical candidate pinned by trusted policy, so recovery fails before Docker publication with a candidate-checkout mismatch.

## Why This Change Was Made

Add one trusted helper that reads the fixed policy's candidate SHA, stages that exact commit as a temporary detached no-checkout worktree, invokes the existing focused-evidence verifier there, and always removes/prunes the worktree. All existing producer-run, protected-tag, attestation, npm preflight, approval, and Docker registry gates remain unchanged.

## User Impact

Docker-only recovery can verify the historical focused candidate without confusing it with the independently validated release tag. This unblocks publication of the missing `2026.8.1-beta.3` default, slim, and browser images.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/authorized-beta-focused-evidence.test.ts test/scripts/release-no-push-workflow.test.ts test/scripts/docker-release-policy.test.ts` — 154 passed
- `node scripts/check-changed.mjs -- .github/workflows/openclaw-release-publish.yml .github/workflows/docker-release.yml scripts/verify-authorized-beta-focused-candidate.mjs test/scripts/authorized-beta-focused-evidence.test.ts` — passed
- `actionlint .github/workflows/openclaw-release-publish.yml .github/workflows/docker-release.yml` — passed
- `node --check scripts/verify-authorized-beta-focused-candidate.mjs` — passed
- Fresh Codex autoreview — no accepted/actionable findings

Production/tooling LOC: +119/-6 (net +113) | Tests: +292/-1. The helper is the single canonical owner for trusted candidate staging, exact-SHA fetch, verifier invocation, and cleanup across all three release gates.
