### PR TITLE
fix(cli): unsuccessful message sends report success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Message CLI delivery outcomes:** report suppressed, failed, and partially delivered sends accurately across terminal output, JSON, and exit status while preserving confirmed partial message IDs and successful JSON compatibility.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Message CLI delivery outcomes:** report suppressed, failed, and partially delivered sends accurately across terminal output, JSON, and exit status while preserving confirmed partial message IDs and successful JSON compatibility.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -104,6 +104,11 @@ true}`. `--pin` is shorthand for pinned delivery when the channel supports
 - `--silent` (Telegram, Discord): send without a notification.
 - `--gif-playback` (WhatsApp only): treat video media as GIF playback.
 
+When a send is suppressed by a message hook, fails, or only partially succeeds,
+the command explains the outcome and exits nonzero. Partial delivery keeps any
+confirmed message ID. JSON failures include `ok: false`, `deliveryStatus`, and
+`error`; successful JSON responses retain their existing shape.
+
 ```bash
 openclaw message send --channel discord \
   --target channel:123 --message "Choose:" \

--- a/src/cli/program/message/helpers.test.ts
+++ b/src/cli/program/message/helpers.test.ts
@@ -1,6 +1,8 @@
 // Message program helper tests cover message command helper behavior and mocks.
+import { Command } from "commander";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerMessageSendCommand } from "./register.send.js";
 
 const messageCommandMock = vi.fn(async (): Promise<unknown> => undefined);
 vi.mock("../../../commands/message.js", () => ({
@@ -149,6 +151,66 @@ describe("runMessageAction", () => {
     expect(exitMock).toHaveBeenCalledOnce();
     expect(exitMock).toHaveBeenCalledWith(0);
   });
+
+  it.each([
+    { name: "sent", status: "sent" as const, exitCode: 0 },
+    { name: "suppressed", status: "suppressed" as const, exitCode: 1 },
+    { name: "failed", status: "failed" as const, exitCode: 1 },
+    { name: "partial_failed", status: "partial_failed" as const, exitCode: 1 },
+    { name: "dry-run", status: undefined, dryRun: true, exitCode: 0 },
+  ])(
+    "propagates $name send outcomes through the real CLI parser",
+    async ({ status, dryRun, exitCode }) => {
+      const sendResult = {
+        channel: "discord",
+        to: "channel:123",
+        via: "direct" as const,
+        mediaUrl: null,
+        ...(status ? { deliveryStatus: status } : {}),
+        ...(status === "suppressed"
+          ? { suppressionReason: "cancelled_by_message_sending_hook" as const }
+          : {}),
+        ...(status === "failed" || status === "partial_failed"
+          ? { error: "provider rejected the message" }
+          : {}),
+        ...(status === "partial_failed"
+          ? { sentBeforeError: true as const, result: { channel: "discord", messageId: "part-1" } }
+          : {}),
+      };
+      messageCommandMock.mockResolvedValueOnce({
+        kind: "send",
+        channel: "discord",
+        action: "send",
+        to: "channel:123",
+        handledBy: "core",
+        payload: sendResult,
+        sendResult,
+        dryRun: Boolean(dryRun),
+      });
+      const program = new Command();
+      const message = program.command("message");
+      registerMessageSendCommand(message, createMessageCliHelpers(message, "discord"));
+
+      await expect(
+        program.parseAsync(
+          [
+            "message",
+            "send",
+            "--channel",
+            "discord",
+            "--target",
+            "channel:123",
+            "--message",
+            "hi",
+            ...(dryRun ? ["--dry-run"] : []),
+          ],
+          { from: "user" },
+        ),
+      ).rejects.toThrow("exit");
+
+      expect(exitMock).toHaveBeenCalledWith(exitCode);
+    },
+  );
 
   it("loads configured channel plugins when no target channel is known yet", async () => {
     await runSendAction({ channel: undefined });

--- a/src/cli/program/message/helpers.ts
+++ b/src/cli/program/message/helpers.ts
@@ -15,7 +15,7 @@ import { getRuntimeConfig } from "../../../config/config.js";
 import { danger, setVerbose } from "../../../globals.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { CHANNEL_TARGET_DESCRIPTION } from "../../../infra/outbound/channel-target.js";
-import { isMessageBroadcastSuccessful } from "../../../infra/outbound/message-action-contracts.js";
+import { isMessageActionSuccessful } from "../../../infra/outbound/message-action-contracts.js";
 import { withActivatedPluginIds } from "../../../plugins/activation-context.js";
 import {
   resolveConfiguredChannelPluginIds,
@@ -221,7 +221,7 @@ export function createMessageCliHelpers(
     if (!ACTIONS_WITHOUT_STOP_HOOKS.has(action)) {
       await withPluginRuntimeRegistryScope(pluginRegistry, runPluginStopHooks);
     }
-    failed ||= result?.kind === "broadcast" && !isMessageBroadcastSuccessful(result);
+    failed ||= result !== undefined && !isMessageActionSuccessful(result);
     defaultRuntime.exit(failed ? 1 : 0);
   };
 

--- a/src/commands/message-format.test.ts
+++ b/src/commands/message-format.test.ts
@@ -215,6 +215,58 @@ describe("renderPaginationHint", () => {
   });
 });
 
+describe("formatMessageCliText send results", () => {
+  it.each([
+    {
+      status: "suppressed" as const,
+      suppressionReason: "cancelled_by_message_sending_hook" as const,
+      expected: "Message send suppressed: cancelled_by_message_sending_hook.",
+    },
+    {
+      status: "failed" as const,
+      error: "provider rejected the message",
+      expected: "provider rejected the message",
+    },
+    {
+      status: "partial_failed" as const,
+      error: "second attachment rejected",
+      messageId: "first-part-1",
+      expected: "second attachment rejected",
+    },
+  ])(
+    "reports a $status delivery without claiming success",
+    ({ status, suppressionReason, error, messageId, expected }) => {
+      const result = {
+        kind: "send",
+        action: "send",
+        channel: "directchat",
+        to: "room-1",
+        handledBy: "core",
+        payload: {},
+        dryRun: false,
+        sendResult: {
+          channel: "directchat",
+          to: "room-1",
+          via: "direct",
+          mediaUrl: null,
+          deliveryStatus: status,
+          ...(suppressionReason ? { suppressionReason } : {}),
+          ...(error ? { error } : {}),
+          ...(messageId ? { result: { channel: "directchat", messageId } } : {}),
+        },
+      } satisfies MessageActionResult;
+
+      const output = textJoined(formatMessageCliText(result));
+
+      expect(output).toContain(expected);
+      expect(output).not.toContain("✅ Sent");
+      if (messageId) {
+        expect(output).toContain(`Message ID: ${messageId}`);
+      }
+    },
+  );
+});
+
 describe("formatMessageCliText poll results", () => {
   it("formats direct core poll results as direct deliveries", () => {
     const result = {

--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -8,7 +8,8 @@ import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { OutboundDeliveryResult } from "../infra/outbound/deliver.js";
 import { formatGatewaySummary, formatOutboundDeliverySummary } from "../infra/outbound/format.js";
 import {
-  isMessageBroadcastSuccessful,
+  isMessageActionSuccessful,
+  resolveMessageSendOutcome,
   type MessageActionResult,
 } from "../infra/outbound/message-action-contracts.js";
 import { formatTargetDisplay } from "../infra/outbound/target-resolver.js";
@@ -299,7 +300,7 @@ export function formatMessageCliText(
     }));
     const okCount = results.filter((entry) => entry.ok).length;
     const total = results.length;
-    const successful = isMessageBroadcastSuccessful(result);
+    const successful = isMessageActionSuccessful(result);
     const headingLine = (successful ? ok : fail)(
       `${successful ? "✅ Broadcast complete" : "❌ Broadcast failed"} (${okCount}/${total} succeeded, ${total - okCount} failed)`,
     );
@@ -319,6 +320,11 @@ export function formatMessageCliText(
   }
 
   if (result.kind === "send") {
+    const outcome = resolveMessageSendOutcome(result.sendResult);
+    if (!outcome.ok) {
+      const messageId = result.sendResult?.result?.messageId;
+      return [fail(`❌ ${outcome.error}${messageId ? ` Message ID: ${messageId}` : ""}`)];
+    }
     if (result.handledBy === "core" && result.sendResult) {
       const send = result.sendResult;
       if (send.via === "direct") {

--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -604,7 +604,66 @@ describe("messageCommand", () => {
         channelId: "general",
       },
     });
+    expect(json).not.toHaveProperty("ok");
   });
+
+  it.each([
+    {
+      status: "suppressed" as const,
+      suppressionReason: "cancelled_by_message_sending_hook" as const,
+      expected: "Message send suppressed: cancelled_by_message_sending_hook.",
+    },
+    {
+      status: "failed" as const,
+      error: "provider rejected the message",
+      expected: "provider rejected the message",
+    },
+    {
+      status: "partial_failed" as const,
+      error: "second attachment rejected",
+      messageId: "first-part-1",
+      expected: "second attachment rejected",
+    },
+  ])(
+    "reports $status sends truthfully in JSON output",
+    async ({ status, suppressionReason, error, messageId, expected }) => {
+      const sendResult = {
+        channel: "discord",
+        to: "channel:general",
+        via: "direct" as const,
+        mediaUrl: null,
+        deliveryStatus: status,
+        ...(suppressionReason ? { suppressionReason } : {}),
+        ...(error ? { error } : {}),
+        ...(messageId ? { result: { channel: "discord", messageId } } : {}),
+        ...(status === "partial_failed" ? { sentBeforeError: true as const } : {}),
+      };
+      runMessageActionMock.mockResolvedValueOnce({
+        kind: "send",
+        channel: "discord",
+        action: "send",
+        to: "channel:general",
+        handledBy: "core",
+        payload: sendResult,
+        sendResult,
+        dryRun: false,
+      });
+
+      await runMessageCommand({ channel: "discord", target: "channel:general" });
+
+      const json = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0]));
+      expect(json).toMatchObject({
+        ok: false,
+        deliveryStatus: status,
+        error: { type: "cli_error", message: expected },
+      });
+      expect(json.payload).toEqual(sendResult);
+      if (messageId) {
+        expect(json.messageId).toBe(messageId);
+        expect(json.sentBeforeError).toBe(true);
+      }
+    },
+  );
 
   it("rejects unknown message actions before dispatch", async () => {
     await expect(runMessageCommand({ action: "nope" })).rejects.toThrow("Unknown message action");

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -52,15 +52,15 @@ function extractMessageId(payload: unknown): string | undefined {
 
 function buildMessageCliJson(result: Awaited<ReturnType<typeof runMessageAction>>) {
   const messageId = extractMessageId(result.payload);
-  const sendOutcome =
-    result.kind === "send" ? resolveMessageSendOutcome(result.sendResult) : undefined;
+  const sendResult = result.kind === "send" ? result.sendResult : undefined;
+  const sendOutcome = result.kind === "send" ? resolveMessageSendOutcome(sendResult) : undefined;
   return {
     ...(result.kind === "broadcast"
       ? { ok: isMessageActionSuccessful(result) }
       : sendOutcome && !sendOutcome.ok && !result.dryRun
         ? {
             ...formatCliJsonFailure(sendOutcome.error),
-            deliveryStatus: result.sendResult?.deliveryStatus,
+            deliveryStatus: sendResult?.deliveryStatus,
             ...(sendOutcome.sentBeforeError ? { sentBeforeError: true } : {}),
           }
         : {}),

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -14,6 +14,7 @@ import type { ChannelMessageActionName } from "../channels/plugins/types.public.
 import { resolveCommandConfigWithSecrets } from "../cli/command-config-resolution.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { getScopedChannelsCommandSecretTargets } from "../cli/command-secret-targets.js";
+import { formatCliJsonFailure } from "../cli/failure-output.js";
 import { resolveMessageSecretScope } from "../cli/message-secret-scope.js";
 import { createOutboundSendDeps, type CliDeps } from "../cli/outbound-send-deps.js";
 import { withProgress } from "../cli/progress.js";
@@ -23,7 +24,10 @@ import {
   resolveMessageBroadcastAccountPlan,
   validateExplicitMessageAccountSelection,
 } from "../infra/outbound/message-account-selection.js";
-import { isMessageBroadcastSuccessful } from "../infra/outbound/message-action-contracts.js";
+import {
+  isMessageActionSuccessful,
+  resolveMessageSendOutcome,
+} from "../infra/outbound/message-action-contracts.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 
@@ -48,8 +52,18 @@ function extractMessageId(payload: unknown): string | undefined {
 
 function buildMessageCliJson(result: Awaited<ReturnType<typeof runMessageAction>>) {
   const messageId = extractMessageId(result.payload);
+  const sendOutcome =
+    result.kind === "send" ? resolveMessageSendOutcome(result.sendResult) : undefined;
   return {
-    ...(result.kind === "broadcast" ? { ok: isMessageBroadcastSuccessful(result) } : {}),
+    ...(result.kind === "broadcast"
+      ? { ok: isMessageActionSuccessful(result) }
+      : sendOutcome && !sendOutcome.ok && !result.dryRun
+        ? {
+            ...formatCliJsonFailure(sendOutcome.error),
+            deliveryStatus: result.sendResult?.deliveryStatus,
+            ...(sendOutcome.sentBeforeError ? { sentBeforeError: true } : {}),
+          }
+        : {}),
     action: result.action,
     channel: result.channel,
     dryRun: result.dryRun,

--- a/src/infra/outbound/message-action-contracts.ts
+++ b/src/infra/outbound/message-action-contracts.ts
@@ -178,9 +178,39 @@ export type MessageActionResult =
       dryRun: boolean;
     };
 
-export const isMessageBroadcastSuccessful = (
-  result: Extract<MessageActionResult, { kind: "broadcast" }>,
-): boolean => result.payload.results.every((entry) => entry.ok);
+export function resolveMessageSendOutcome(
+  sendResult: MessageSendResult | undefined,
+  action: "Message" | "Broadcast" = "Message",
+): { ok: true } | { ok: false; error: string; sentBeforeError?: true } {
+  if (
+    !sendResult ||
+    sendResult.deliveryStatus === undefined ||
+    sendResult.deliveryStatus === "sent"
+  ) {
+    return { ok: true };
+  }
+  switch (sendResult.deliveryStatus) {
+    case "suppressed":
+      return {
+        ok: false,
+        error: `${action} send suppressed: ${sendResult.suppressionReason ?? "unknown reason"}.`,
+      };
+    case "failed":
+      return { ok: false, error: sendResult.error ?? `${action} send failed.` };
+    case "partial_failed":
+      return {
+        ok: false,
+        error: sendResult.error ?? `${action} send partially failed.`,
+        sentBeforeError: true,
+      };
+  }
+  return sendResult.deliveryStatus satisfies never;
+}
+
+export const isMessageActionSuccessful = (result: MessageActionResult): boolean =>
+  result.kind === "broadcast"
+    ? result.payload.results.every((entry) => entry.ok)
+    : result.kind !== "send" || result.dryRun || resolveMessageSendOutcome(result.sendResult).ok;
 
 export type ResolvedActionContext = {
   cfg: OpenClawConfig;

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -24,11 +24,12 @@ import {
 } from "./channel-selection.js";
 import { shouldUseInternalSourceReplySink } from "./internal-source-reply.js";
 import { validateExplicitMessageAccountSelection } from "./message-account-selection.js";
-import type {
-  MessageActionInput,
-  MessageActionNormalization,
-  MessageActionResult,
-  ResolvedActionContext,
+import {
+  resolveMessageSendOutcome,
+  type MessageActionInput,
+  type MessageActionNormalization,
+  type MessageActionResult,
+  type ResolvedActionContext,
 } from "./message-action-contracts.js";
 import { MessageActionDeniedError } from "./message-action-denial.js";
 import { executeMessagePlugin, executeMessagePoll } from "./message-action-execution.js";
@@ -63,34 +64,6 @@ function withSendNormalization(
   normalization?: MessageActionNormalization,
 ): MessageActionResult {
   return normalization && result.kind === "send" ? { ...result, normalization } : result;
-}
-
-function deriveBroadcastEntryOutcome(
-  sendResult?: MessageSendResult,
-): { ok: true } | { ok: false; error: string; sentBeforeError?: true } {
-  if (
-    !sendResult ||
-    sendResult.deliveryStatus === undefined ||
-    sendResult.deliveryStatus === "sent"
-  ) {
-    return { ok: true };
-  }
-  switch (sendResult.deliveryStatus) {
-    case "suppressed":
-      return {
-        ok: false,
-        error: `Broadcast send suppressed: ${sendResult.suppressionReason ?? "unknown reason"}.`,
-      };
-    case "failed":
-      return { ok: false, error: sendResult.error ?? "Broadcast send failed." };
-    case "partial_failed":
-      return {
-        ok: false,
-        error: sendResult.error ?? "Broadcast send partially failed.",
-        sentBeforeError: true,
-      };
-  }
-  return sendResult.deliveryStatus satisfies never;
 }
 
 async function handleBroadcastAction(
@@ -195,8 +168,9 @@ async function handleBroadcastAction(
         results.push({
           channel: targetChannel,
           to: resolved.to,
-          ...deriveBroadcastEntryOutcome(
+          ...resolveMessageSendOutcome(
             sendResult.kind === "send" ? sendResult.sendResult : undefined,
+            "Broadcast",
           ),
           payload: sendResult.kind === "send" ? sendResult.payload : undefined,
           result: sendResult.kind === "send" ? sendResult.sendResult : undefined,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw message send` would see a green success message and exit code zero even when a message hook suppressed delivery. Structured failed and partially failed send results also lost their failure details at the same CLI boundary, making automation treat unsuccessful delivery as successful.

## Why This Change Was Made

The durable send owner already records truthful `suppressed`, `failed`, and `partial_failed` outcomes, but the earlier broadcast repair in #125915 classified those outcomes only for broadcast targets. Move that existing classifier into the shared message-action contract and reuse it for single-send presentation, the documented JSON failure envelope, exit status, and unchanged broadcast behavior. Preserve the shipped successful JSON shape, legacy plugin/gateway results without delivery status, dry runs, stop-hook ordering, and platform message IDs for partial delivery.

## User Impact

Intentionally suppressed sends now explain why nothing was delivered and exit nonzero. Failed and partially delivered sends surface the real reason, retain confirmed message IDs, and emit a machine-readable `ok: false` error envelope in JSON mode. Successful sends and existing broadcast results keep their established output.

## Evidence

- Fresh-main pre-fix real Commander parser: suppressed, failed, and partially failed delivery each exited `0` instead of `1`.
- Fresh-main pre-fix formatter and JSON: all three outcomes claimed `✅ Sent` or omitted their failure envelope; six focused regressions failed.
- Final focused owner, broadcast sibling, real parser, formatter, and JSON proof: `node scripts/run-vitest.mjs src/commands/message-format.test.ts src/commands/message.test.ts src/cli/program/message/helpers.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/infra/outbound/message.test.ts` — **120 tests passed across five files and three shards**.
- Formatting, focused lint, `git diff --check`, independent owner-boundary review, and structured Codex autoreview all passed.
- Shipped `v2026.7.1` successful JSON output was inspected and preserved exactly; the failure envelope follows `docs/cli/index.md`.
- Production: +67/-43, net +24; tests: +173/-0; docs: +5/-0; changelog: +1/-0. The production increase provides the documented failure envelope, partial-delivery evidence, and one shared classification owner while deleting the old broadcast-only classifier.
- No authenticated provider request was sent: the bug is deterministic CLI interpretation of an already-recorded delivery outcome, proven through real command parsing and the existing delivery-producer and broadcast-sibling tests.
