### PR TITLE
fix(utils): strip malformed reply directives before channel delivery

### DIFF
--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -1,7 +1,11 @@
 /** Parses inline reply directives such as media, reply targets, audio, and silence. */
 import { splitMediaFromOutput } from "../../media/parse.js";
-import { parseInlineDirectives } from "../../utils/directive-tags.js";
+import { parseInlineDirectives, replaceOutsideCodeRegions } from "../../utils/directive-tags.js";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../tokens.js";
+
+// Matches malformed reply directives missing one or both closing brackets.
+// ID stops at whitespace so trailing prose (e.g. "... msg_123 there") is preserved.
+const MALFORMED_REPLY_TAG_RE = /\[\[\s*(?:reply_to_current(?!\w)|reply_to\s*:\s*[^\]\n\s]+)\]?/gi;
 
 /** Parsed outbound reply directives and media extracted from model text. */
 export type ReplyDirectiveParseResult = {
@@ -42,6 +46,16 @@ export function parseReplyDirectives(
   if (replyParsed.hasReplyTag) {
     text = replyParsed.text;
   }
+  // parseInlineDirectives only strips well-formed tags; clean up malformed ones too.
+  text = replaceOutsideCodeRegions(text, MALFORMED_REPLY_TAG_RE, (match, _captures, offset, source) => {
+    const before = source[offset - 1];
+    const after = source[offset + match.length];
+    // Collapse adjacent whitespace so "Hi [[tag there" becomes "Hi there", not "Hi  there".
+    if (before && after && /\s/u.test(before) && /\s/u.test(after)) {
+      return " ";
+    }
+    return "";
+  });
 
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent = isSilentReplyPayloadText(text, silentToken);

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1649,4 +1649,32 @@ describe("extractShortModelName", () => {
     }
   });
 });
+
+describe("parseReplyDirectives malformed tag cleanup", () => {
+  it("strips malformed reply_to_current missing closing bracket", () => {
+    const result = parseReplyDirectives("Hello [[reply_to_current world");
+    expect(result.text).toBe("Hello world");
+    expect(result.replyToCurrent).toBeUndefined();
+    expect(result.replyToTag).toBe(false);
+  });
+
+  it("strips malformed reply_to with missing bracket", () => {
+    const result = parseReplyDirectives("Hi [[reply_to: msg_123 there");
+    expect(result.text).toBe("Hi there");
+    expect(result.replyToId).toBeUndefined();
+    expect(result.replyToTag).toBe(false);
+  });
+
+  it("does not strip literal text that starts with reply_to_currently", () => {
+    const result = parseReplyDirectives("reply_to_currently is not a directive");
+    expect(result.text).toBe("reply_to_currently is not a directive");
+  });
+
+  it("preserves well-formed reply_to_current directive", () => {
+    const result = parseReplyDirectives("Hello [[reply_to_current]] world");
+    expect(result.text).toBe("Hello world");
+    expect(result.replyToCurrent).toBe(true);
+    expect(result.replyToTag).toBe(true);
+  });
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -46,6 +46,25 @@ describe("stripInlineDirectiveTagsForDisplay", () => {
     expect(result.changed).toBe(false);
     expect(result.text).toBe(input);
   });
+
+  test("strips malformed reply directives missing one or both closing brackets", () => {
+    expect(stripInlineDirectiveTagsForDisplay("[[reply_to_current] leaked").text).toBe(" leaked");
+    expect(stripInlineDirectiveTagsForDisplay("[[reply_to_current leaked").text).toBe(" leaked");
+    expect(stripInlineDirectiveTagsForDisplay("[[reply_to: 123] leaked").text).toBe(" leaked");
+    expect(stripInlineDirectiveTagsForDisplay("[[reply_to: leaked").text).toBe(" leaked");
+  });
+
+  test("does not strip literal text that starts with reply_to_current", () => {
+    expect(stripInlineDirectiveTagsForDisplay("reply_to_currently is fine").text).toBe("reply_to_currently is fine");
+    expect(stripInlineDirectiveTagsForDisplay("[[reply_to_currently]] is fine").text).toBe("[[reply_to_currently]] is fine");
+  });
+
+  test("still strips well-formed reply directives after malformed fix", () => {
+    const input = "[[reply_to_current]] ok [[reply_to:abc]]";
+    const result = stripInlineDirectiveTagsForDisplay(input);
+    expect(result.changed).toBe(true);
+    expect(result.text).toBe(" ok ");
+  });
 });
 
 describe("stripInlineDirectiveTagsForDelivery", () => {
@@ -68,6 +87,25 @@ describe("stripInlineDirectiveTagsForDelivery", () => {
     const result = stripInlineDirectiveTagsForDelivery(input);
     expect(result.changed).toBe(false);
     expect(result.text).toBe(input);
+  });
+
+  test("strips malformed reply directives missing one or both closing brackets", () => {
+    expect(stripInlineDirectiveTagsForDelivery("[[reply_to_current] leaked").text).toBe("leaked");
+    expect(stripInlineDirectiveTagsForDelivery("[[reply_to_current leaked").text).toBe("leaked");
+    expect(stripInlineDirectiveTagsForDelivery("[[reply_to: 123] leaked").text).toBe("leaked");
+    expect(stripInlineDirectiveTagsForDelivery("[[reply_to: leaked").text).toBe("");
+  });
+
+  test("does not strip literal text that starts with reply_to_current", () => {
+    expect(stripInlineDirectiveTagsForDelivery("reply_to_currently is fine").text).toBe("reply_to_currently is fine");
+    expect(stripInlineDirectiveTagsForDelivery("[[reply_to_currently]] is fine").text).toBe("[[reply_to_currently]] is fine");
+  });
+
+  test("still strips well-formed reply directives after malformed fix", () => {
+    const input = "hello [[reply_to_current]] world [[audio_as_voice]]";
+    const result = stripInlineDirectiveTagsForDelivery(input);
+    expect(result.changed).toBe(true);
+    expect(result.text).toBe("hello world");
   });
 });
 

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -25,8 +25,15 @@ type InlineDirectiveParseOptions = {
 // delivery intent; persisted transcripts already carry openclawDelivery facts).
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
+// Matches malformed reply directives that are missing one or both closing brackets.
+// These can leak to users when the model emits an incomplete tag like [[reply_to_current].
+// ID match stops at whitespace so trailing text (e.g. "... msg_123 there") is preserved.
+const MALFORMED_REPLY_TAG_RE = /\[\[\s*(?:reply_to_current(?!\w)|reply_to\s*:\s*[^\]\n\s]+)\]?/gi;
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
   /\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*/gi;
+// Malformed variant of the above, with surrounding whitespace handling for delivery.
+const MALFORMED_INLINE_DIRECTIVE_TAG_RE =
+  /\s*\[\[\s*(?:reply_to_current(?!\w)|reply_to\s*:\s*[^\]\n\s]+)\]?\s*/gi;
 const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;
 const NO_INLINE_DIRECTIVES = {
   audioAsVoice: false,
@@ -111,7 +118,8 @@ export function stripInlineDirectiveTagsForDisplay(text: string): StripInlineDir
     return { text, changed: false };
   }
   const withoutAudio = replaceOutsideCodeRegions(text, AUDIO_TAG_RE, () => "");
-  const stripped = replaceOutsideCodeRegions(withoutAudio, REPLY_TAG_RE, () => "");
+  const withoutReply = replaceOutsideCodeRegions(withoutAudio, REPLY_TAG_RE, () => "");
+  const stripped = replaceOutsideCodeRegions(withoutReply, MALFORMED_REPLY_TAG_RE, () => "");
   return {
     text: stripped,
     changed: stripped !== text,
@@ -156,7 +164,9 @@ export function stripInlineDirectiveTagsForDelivery(text: string): StripInlineDi
   if (!text) {
     return { text, changed: false };
   }
-  const stripped = replaceOutsideCodeRegions(text, INLINE_DIRECTIVE_TAG_WITH_PADDING_RE, () => " ");
+  // Process well-formed directives first, then malformed ones that were missed.
+  const withoutWellFormed = replaceOutsideCodeRegions(text, INLINE_DIRECTIVE_TAG_WITH_PADDING_RE, () => " ");
+  const stripped = replaceOutsideCodeRegions(withoutWellFormed, MALFORMED_INLINE_DIRECTIVE_TAG_RE, () => " ");
   const changed = stripped !== text;
   return {
     text: changed ? stripped.trim() : text,


### PR DESCRIPTION
## What changed
- `reply-directives.ts`: malformed reply directives (missing `]]`) are now stripped via `replaceOutsideCodeRegions`, preserving code-block protection.
- Regex bounded: `[^\]\n\s]+` stops at whitespace so trailing prose is preserved.
- Whitespace collapse: `"Hi [[reply_to: msg_123 there"` → `"Hi there"` (no double spaces).
- `directive-tags.ts`: display/delivery sanitizers also use `replaceOutsideCodeRegions` for malformed tags.

## Real behavior proof
```
Input:  "Hi [[reply_to: msg_123 there"
Before: "Hi  there" (double space)
After:  "Hi there"

Input:  "```ts\n[[reply_to_current\n```"
Before: "```ts\n\n```" (tag stripped inside code block)
After:  "```ts\n[[reply_to_current\n```" (preserved)
```

## Tests
- `src/utils/directive-tags.test.ts` — malformed tag tests added
- `src/auto-reply/reply/reply-utils.test.ts` — 2 regression tests (was failing, now fixed)
