### PR TITLE
fix(claude-live): include runId and error detail in failTurn() log

### DIFF
--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -411,8 +411,11 @@ function failTurn(session: ClaudeLiveSession, error: unknown): void {
     return;
   }
   const errorKind = error instanceof Error ? error.name : typeof error;
+  const runId = turn.diagnosticRefs?.runId;
   cliBackendLog.warn(
-    `claude live session turn failed: provider=${session.providerId} model=${session.modelId} durationMs=${Date.now() - turn.startedAtMs} error=${errorKind}`,
+    `claude live session turn failed: provider=${session.providerId} model=${session.modelId} ` +
+    `durationMs=${Date.now() - turn.startedAtMs}${runId ? ` runId=${runId}` : ""} ` +
+    `error=${errorKind} detail=${formatErrorMessage(error)}`,
   );
   failActiveClaudeLiveTools(turn, error);
   clearTurnTimers(turn);


### PR DESCRIPTION
Closing this PR because upstream has removed/refactored  (the file no longer exists on current main). The  logging path has been moved or eliminated. If the diagnostic gap still exists in the new code location, I will open a fresh PR.