### PR TITLE
fix(heartbeat): preserve cron wakes across clock jumps and handler replacement

### DIFF
--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -229,7 +229,10 @@ describe("plugin-owned CLI execution host boundary", () => {
       runId: "plugin-user-input",
       nativeTools: ["AskUserQuestion"],
     });
-    const onBlockReply = vi.fn(async () => {});
+    let promptDelivered = createDeferred();
+    const onBlockReply = vi.fn(async () => {
+      promptDelivered.resolve();
+    });
     context.params.onBlockReply = onBlockReply;
     const requests = new Map<string, { questions: Array<{ questionId: string }> }>();
     mockCallGatewayTool.mockImplementation(async (method, _opts, rawParams) => {
@@ -240,9 +243,8 @@ describe("plugin-owned CLI execution host boundary", () => {
       }
       if (method === "question.waitAnswer") {
         const request = requests.get(params.id);
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 5);
-        });
+        await promptDelivered.promise;
+        promptDelivered = createDeferred();
         return {
           status: "answered",
           answers: {

--- a/src/infra/heartbeat-wake-lifecycle.ts
+++ b/src/infra/heartbeat-wake-lifecycle.ts
@@ -22,6 +22,7 @@ export async function runAbortableHeartbeatWake(
   wake: HeartbeatWakeRequest,
   signal: AbortSignal,
 ): Promise<HeartbeatRunResult> {
+  signal.throwIfAborted();
   let abortListener: (() => void) | undefined;
   const aborted = new Promise<never>((_resolve, reject) => {
     abortListener = () => {
@@ -30,10 +31,6 @@ export async function runAbortableHeartbeatWake(
         abortReason instanceof Error ? abortReason : new Error("Heartbeat handler was replaced"),
       );
     };
-    if (signal.aborted) {
-      abortListener();
-      return;
-    }
     signal.addEventListener("abort", abortListener, { once: true });
   });
   try {

--- a/src/infra/heartbeat-wake.preemption.test.ts
+++ b/src/infra/heartbeat-wake.preemption.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js";
+import {
+  resetGatewayWorkAdmission,
+  tryBeginGatewaySuspendAdmission,
+} from "../process/gateway-work-admission.js";
 import {
   HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
   requestHeartbeat,
@@ -39,6 +42,82 @@ describe("heartbeat wake preemption retry", () => {
     disposeHandler = undefined;
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it.each([-86_400_000, 86_400_000])(
+    "dispatches a coalesced wake after the wall clock changes by %i ms",
+    async (clockChangeMs) => {
+      vi.setSystemTime(2_000_000_000_000);
+      const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+      setHeartbeatWakeHandler(handler);
+
+      requestHeartbeat(wake("manual", { coalesceMs: 250 }));
+      vi.setSystemTime(Date.now() + clockChangeMs);
+      await vi.advanceTimersByTimeAsync(249);
+      expect(handler).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(handler).toHaveBeenCalledExactlyOnceWith(wake("manual"));
+    },
+  );
+
+  it("dispatches an urgent wake after the wall clock changes forward", async () => {
+    vi.setSystemTime(2_000_000_000_000);
+    const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeat(wake("interval", { agentId: "slow", coalesceMs: 60_000 }));
+    vi.setSystemTime(Date.now() + 3_600_000);
+    requestHeartbeat(wake("manual", { agentId: "urgent", coalesceMs: 0 }));
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(handler).toHaveBeenCalledExactlyOnceWith(wake("manual", { agentId: "urgent" }));
+  });
+
+  it("retries a retained wake on time after the wall clock changes", async () => {
+    vi.setSystemTime(2_000_000_000_000);
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "skipped",
+        reason: "min-spacing",
+        retryAtMs: Date.now() + 1_000,
+      })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeat(wake("exec-event", { coalesceMs: 0 }));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledOnce();
+    vi.setSystemTime(Date.now() - 86_400_000);
+    await vi.advanceTimersByTimeAsync(998);
+    expect(handler).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("hands a suspended wake to the replacement without running the retired handler", async () => {
+    const retiredHandler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const replacementHandler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(retiredHandler);
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    expect(suspension?.commit()).toBe(true);
+
+    const pendingWake = {
+      source: "cron" as const,
+      intent: "event" as const,
+      reason: "cron:retired-generation",
+      agentId: "main",
+    };
+    requestHeartbeat({ ...pendingWake, coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(1);
+    setHeartbeatWakeHandler(replacementHandler);
+    expect(suspension?.release()).toBe(true);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(retiredHandler).not.toHaveBeenCalled();
+    expect(replacementHandler).toHaveBeenCalledExactlyOnceWith(pendingWake);
   });
 
   it("gives scheduled requests-in-flight a 60-second idle grace", async () => {

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -218,7 +218,7 @@ function mergePendingWakeReasons(
   return merged;
 }
 
-function takePendingWakeBatch(maxGroups: number, now = Date.now()): ReadyWakeGroup[] {
+function takePendingWakeBatch(maxGroups: number, now = performance.now()): ReadyWakeGroup[] {
   if (maxGroups <= 0) {
     return [];
   }
@@ -362,7 +362,7 @@ function queuePendingWakeReason(params: {
   blockTargetUntilMs?: number;
   retainedWork?: boolean;
 }) {
-  const requestedAt = params.requestedAt ?? Date.now();
+  const requestedAt = params.requestedAt ?? performance.now();
   const enqueueSequence = params.enqueueSequence ?? ++wakeEnqueueSequence;
   const normalizedReason = normalizeWakeReason(params.reason);
   const normalizedAgentId = normalizeHeartbeatWakeTarget(params.agentId);
@@ -443,7 +443,7 @@ function retryPendingWake(
 ) {
   // A thrown or busy wake owns only its target; replaying the whole batch
   // duplicates completed reminders and stalls unrelated agents.
-  const retryAtMs = Date.now() + retrySchedule.delayMs;
+  const retryAtMs = performance.now() + retrySchedule.delayMs;
   queuePendingWakeReason({
     source: pendingWake.source,
     intent: pendingWake.intent,
@@ -546,24 +546,8 @@ async function dispatchPendingWakeGroup(params: {
           pendingWake.intent === "immediate")
       ) {
         // Retain real task/event work until its spacing guard allows a retry.
-        const retryAtMs = Math.max(Date.now(), result.retryAtMs ?? Date.now() + DEFAULT_RETRY_MS);
-        queuePendingWakeReason({
-          source: pendingWake.source,
-          intent: pendingWake.intent,
-          reason: pendingWake.reason ?? "retry",
-          agentId: pendingWake.agentId,
-          sessionKey: pendingWake.sessionKey,
-          heartbeat: pendingWake.heartbeat,
-          tasks: pendingWake.tasks,
-          scheduledEveryMs: pendingWake.scheduledEveryMs,
-          scheduledAnchorMs: pendingWake.scheduledAnchorMs,
-          requestedAt: pendingWake.requestedAt,
-          enqueueSequence: pendingWake.enqueueSequence,
-          immediateBarrierSequence: pendingWake.immediateBarrierSequence,
-          notBeforeMs: retryAtMs,
-          retainedWork: true,
-        });
-        schedule(retryAtMs - Date.now());
+        const { delayMs } = resolveHeartbeatRetrySchedule(pendingWake, result);
+        retryPendingWake(pendingWake, { delayMs, deferWakeOnly: true });
       }
     }
   } finally {
@@ -581,7 +565,7 @@ async function dispatchPendingWakeGroup(params: {
 
 function schedule(coalesceMs: number) {
   const delay = resolveTimerTimeoutMs(coalesceMs, DEFAULT_COALESCE_MS, 0);
-  const dueAt = Date.now() + delay;
+  const dueAt = performance.now() + delay;
   if (timer) {
     // If existing timer fires sooner or at the same time, keep it.
     if (typeof timerDueAt === "number" && timerDueAt <= dueAt) {
@@ -633,7 +617,7 @@ function schedulePendingWakes(readyDelayMs: number) {
     // would spin zero-delay timers while every provider slot remains busy.
     return;
   }
-  const now = Date.now();
+  const now = performance.now();
   if (
     activeWakeTargets.has(GLOBAL_HEARTBEAT_WAKE_TARGET_KEY) ||
     (activeWakeTargets.size > 0 &&
@@ -764,7 +748,7 @@ export function requestHeartbeat(opts: {
   scheduledAnchorMs?: number;
   tasks?: readonly HeartbeatScheduledTask[];
 }) {
-  const requestedAt = Date.now();
+  const requestedAt = performance.now();
   const { coalesceMs: requestedCoalesceMs, ...wake } = opts;
   const coalesceMs = requestedCoalesceMs ?? DEFAULT_COALESCE_MS;
   // Wake timers outlive the attempt that requested them. Do not let their

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -4196,6 +4196,7 @@ describe("task-registry", () => {
         "Background task ready for review: ACP background task (run run-quie). Next: parent will review/verify before calling it done.",
       ]);
       relay.dispose();
+      await vi.runOnlyPendingTimersAsync();
       vi.useRealTimers();
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users relying on scheduled cron runs, manual heartbeat requests, or immediate wakeups could see work silently stall after the system clock changed. Resolves a second issue where a cron wake queued while Gateway admission was suspended could run on a retired handler and never reach its replacement.

## Why This Change Was Made

Private heartbeat coalescing, retry, target-backoff, and timer-preemption deadlines now share the same monotonic clock as their native timers; the public wall-clock retry deadline and persisted schedule anchor remain unchanged. Guard retries reuse the existing canonical retry owner, and lifecycle cancellation is checked before an already-retired handler can execute.

## User Impact

Scheduled jobs, explicit heartbeat requests, and retained retries continue to run on time across forward or backward system-clock changes. Cron work queued during Gateway suspension follows the replacement handler exactly once instead of executing stale work and disappearing.

## Evidence

- Exact current-main production owner, backward 24-hour wall-clock jump: before the fix the expired wake ran **0** times and a subsequent immediate wake also ran **0** times; after the fix those same real owner calls ran **1**, then **2** times.
- Exact production Gateway admission flow (`suspend -> queue cron wake -> replace handler -> reopen`): before the fix `retiredCalls=1, replacementCalls=0`; after the fix `retiredCalls=0, replacementCalls=1`.
- Demonstrated failing-before/passing-after owner regressions for backward clock jumps, forward-clock urgent-wake starvation, retained wall-clock retry deadlines, and suspended handler replacement.
- Hosted CI also exposed an existing task-test cleanup bug: an ACP test discarded fake timers with a heartbeat still queued. The exact failing test was reproduced locally, then fixed by draining pending test timers before restoring the real clock; no production workaround or assertion changes were needed.
- A second existing test flake was reproduced deterministically: its mock answered a plugin question before the intentionally raced prompt could render. The test now waits for the actual prompt-delivery event with the existing deferred helper, preserving every original assertion without timing guesses.
- Complete original-order suites pass **130/130 task-registry tests**, **95/95 heartbeat owner/sibling tests**, and **29/29 plugin execution tests**: **254 passing tests**. Both real isolated Gateway-backed CLI success/error subprocess cases also pass.
- Production and test type checks, changed-file lint/format, fresh structured independent review, and the complete five-file repository changed-files gate pass. Production change: **+9/-28 (net -19 lines)**; tests: **+87/-5**.
