### PR TITLE
fix: skill reviews recover after runtime config changes

### DIFF
--- a/src/skills/workshop/experience-review.test.ts
+++ b/src/skills/workshop/experience-review.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getPreparedModelRuntimePluginGeneration,
+  withPreparedModelRuntimePluginGenerationScope,
+} from "../../agents/prepared-model-runtime-generation-scope.js";
+import type { PreparedModelRuntimePluginGeneration } from "../../agents/prepared-model-runtime.types.js";
 import { buildSkillExperienceReviewPrompt } from "./experience-review-prompt.js";
 import {
   createSkillExperienceReviewScheduler,
@@ -60,6 +65,42 @@ async function flushMicrotasks(): Promise<void> {
 afterEach(() => vi.useRealTimers());
 
 describe("skill experience review scheduler", () => {
+  it("runs detached review work outside the foreground prepared generation", async () => {
+    const generation: PreparedModelRuntimePluginGeneration = {
+      configuredCatalogEntries: [],
+      inlineProviderModels: [],
+      pluginMetadataSnapshot: {} as never,
+    };
+    const observedGenerations: Array<PreparedModelRuntimePluginGeneration | undefined> = [];
+    let finishReview: (() => void) | undefined;
+    const reviewFinished = new Promise<void>((resolve) => {
+      finishReview = resolve;
+    });
+    const scheduler = createSkillExperienceReviewScheduler({
+      isSystemActive: () => {
+        observedGenerations.push(getPreparedModelRuntimePluginGeneration());
+        return false;
+      },
+      prepareReview: async (candidate) => {
+        observedGenerations.push(getPreparedModelRuntimePluginGeneration());
+        return candidate;
+      },
+      runReview: async () => {
+        observedGenerations.push(getPreparedModelRuntimePluginGeneration());
+        finishReview?.();
+      },
+      setTimer: (callback) => setTimeout(callback, 0),
+    });
+
+    withPreparedModelRuntimePluginGenerationScope(generation, () => {
+      scheduler.schedule(completedRun());
+    });
+    await reviewFinished;
+
+    expect(observedGenerations).toEqual([undefined, undefined, undefined]);
+    scheduler.clear();
+  });
+
   it("runs one deep turn after the idle window", async () => {
     vi.useFakeTimers();
     const runReview = vi.fn().mockResolvedValue(undefined);

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { prepareSystemAgentRunAdmission } from "../../agents/admitted-run-context.js";
+import { runOutsidePreparedModelRuntimePluginGenerationScope } from "../../agents/prepared-model-runtime-generation-scope.js";
 import { resolveAgentRunSessionTarget } from "../../agents/run-session-target.js";
 import { SessionManager } from "../../agents/sessions/index.js";
 import { getCanonicalSkillWorkspace } from "../../agents/skill-workshop-workspace-context.js";
@@ -210,7 +211,7 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
       clearTimer(pending.timer);
     }
     const generation = ++pending.generation;
-    const timer = setTimer(() => {
+    const timerCallback = () => {
       if (pendingBySession.get(sessionKey) !== pending || pending.generation !== generation) {
         return;
       }
@@ -254,7 +255,12 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
             pendingBySession.delete(sessionKey);
           }
         });
-    }, delayMs);
+    };
+    // This timer outlives the foreground turn that armed it. Create its async
+    // resource outside the parent scope so review work admits on the current generation.
+    const timer = runOutsidePreparedModelRuntimePluginGenerationScope(() =>
+      setTimer(timerCallback, delayMs),
+    );
     pending.timer = timer;
     timer.unref?.();
   };


### PR DESCRIPTION
Related: #128515

## What Problem This Solves

Fixes an issue where a delayed Skill Workshop review would inherit the completed foreground turn's prepared-runtime generation after config publication, then fail every 30 seconds with `prepared model runtime plugin generation was superseded` instead of running.

The `/models` symptom from the same report was fixed separately by #128608. This change addresses the remaining `skill-workshop-review` background lane reported by @Marvinthebored.

## Why This Change Was Made

The review timer is detached work with independent Gateway admission, so its async resource must not retain the foreground turn's generation scope. The scheduler now creates that timer outside the prepared-generation scope, matching the existing detached queue-drain lifecycle boundary; nested foreground work remains generation-pinned.

## User Impact

Background Skill Workshop reviews can recover after runtime config publication instead of repeatedly failing on a retired generation until the Gateway restarts.

## Evidence

- Regression before fix: focused test observed the retired foreground generation in the activity probe, candidate preparation, and review callback.
- Regression after fix: `node scripts/run-vitest.mjs src/skills/workshop/experience-review.test.ts` — 41 passed.
- `node scripts/check-changed.mjs --dry-run -- ...` classified the change as core production + core test.
- Changed-file gates passed through core typecheck; local core-test typecheck was blocked by the isolated worktree's shared dependency tree missing the existing `pako` declaration (`ui/vite.config.ts:8`), unrelated to these files.
- Exact-head CI on `a2078f6c2156222925f80c165b81bf5475a0c7ec`: 297 checks completed, zero failures.
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings.
- Judged LOC: +6 production, +41 test; the existing timer callback body is unchanged.


## Maintainer rebase (2026-08-25)

Rebased onto `main` after #129282 rewrote the scheduler: the retry-on-error branch this patch touched no longer exists (a failed review is now recorded and dropped), so the change reduces to wrapping the timer creation in `runOutsidePreparedModelRuntimePluginGenerationScope`. The regression test was ported into the rewritten `experience-review.test.ts` unchanged.

- `node scripts/run-vitest.mjs src/skills/workshop/experience-review.test.ts` — 24 passed on the rebased head; with `experience-review.ts` reverted to `main`, the ported test fails (observed generations are the foreground generation, not `undefined`).
- `scripts/run-oxlint.mjs` + `oxfmt` on both files — clean.
- Judged LOC on the rebased head: +6 production, +41 test.
- Local ClawSweeper review (`gpt-5.6-terra`, high) on `faf630bb8`: patch correct, 0 findings, security cleared. Rank-up move "redacted exact-head Gateway trace across a config publication" skipped: the regression test asserts the same three observation points (activity probe, candidate preparation, review callback) run with no inherited generation, which is the exact condition the lease checks.

Unrelated CI on `faf630b`: `check-lint-core-3` fails on `src/commands/doctor-auth.profile-health.test.ts:179` (`require-array-sort-compare`, from #129375) and fails identically on `main` `d53ea9cf4`; `checks-node-compact-small-31` and the `checks-node-compact` shards are the known `main` auth-resolution failures from #129052. This PR touches only `src/skills/workshop/experience-review.ts` and its test.
