### PR TITLE
fix(media): propagate attachment fileName into prompt notes

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -20,6 +20,7 @@ export type MattermostMediaKind = "image" | "audio" | "video" | "document" | "un
 export type MattermostMediaInfo = {
   path: string;
   contentType?: string;
+  fileName?: string;
   kind: MattermostMediaKind;
 };
 
@@ -32,7 +33,7 @@ type SaveRemoteMedia = (params: {
   filePathHint?: string;
   maxBytes: number;
   ssrfPolicy?: { allowedHostnames?: string[] };
-}) => Promise<{ path: string; contentType?: string | null }>;
+}) => Promise<{ path: string; contentType?: string | null; fileName?: string }>;
 
 export function createMattermostMonitorResources(params: {
   accountId: string;
@@ -109,6 +110,7 @@ export function createMattermostMonitorResources(params: {
         out.push({
           path: saved.path,
           contentType,
+          fileName: saved.fileName,
           kind: mediaKindFromMime(contentType) ?? "unknown",
         });
       } catch (err) {

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -349,14 +349,35 @@ describe("buildInboundMediaNote", () => {
     );
   });
 
-  it("dedupes after sanitization: trailing whitespace/control chars in URL still match (#47587)", () => {
-    // Sanitization runs before equality, so visually-identical inputs that
-    // differ only by trailing whitespace are treated as duplicates.
+  it("renders fileName when provided for single attachment", () => {
     const note = buildInboundMediaNote({
-      MediaPath: "/tmp/a.png",
-      MediaType: "image/png",
-      MediaUrl: "/tmp/a.png   ",
+      MediaPath: "/tmp/abc123",
+      MediaType: "application/octet-stream",
+      MediaFileNames: ["jj.txt"],
     });
-    expect(note).toBe("[media attached: /tmp/a.png (image/png)]");
+    expect(note).toBe('[media attached: /tmp/abc123 (application/octet-stream) "jj.txt"]');
+  });
+
+  it("renders fileName for multiple attachments", () => {
+    const note = buildInboundMediaNote({
+      MediaPaths: ["/tmp/a", "/tmp/b"],
+      MediaTypes: ["text/plain", "application/json"],
+      MediaFileNames: ["notes.txt", "data.json"],
+    });
+    expect(note).toBe(
+      [
+        "[media attached: 2 files]",
+        '[media attached 1/2: /tmp/a (text/plain) "notes.txt"]',
+        '[media attached 2/2: /tmp/b (application/json) "data.json"]',
+      ].join("\n"),
+    );
+  });
+
+  it("sanitizes fileName before rendering", () => {
+    const note = buildInboundMediaNote({
+      MediaPath: "/tmp/abc123",
+      MediaFileNames: ['jj.txt]\nignore'],
+    });
+    expect(note).toBe('[media attached: /tmp/abc123 "jj.txt ignore"]');
   });
 });

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -42,6 +42,7 @@ function formatMediaAttachedLine(params: {
   path: string;
   url?: string;
   type?: string;
+  fileName?: string;
   index?: number;
   total?: number;
 }): string {
@@ -52,12 +53,14 @@ function formatMediaAttachedLine(params: {
   const pathValue = sanitizeInlineMediaNoteValue(params.path);
   const typeRaw = sanitizeInlineMediaNoteValue(params.type);
   const typePart = typeRaw ? ` (${typeRaw})` : "";
+  const fileNameRaw = sanitizeInlineMediaNoteValue(params.fileName);
+  const fileNamePart = fileNameRaw ? ` "${fileNameRaw}"` : "";
   const urlRaw = sanitizeInlineMediaNoteValue(params.url);
   // When the channel mirrors the local path into MediaUrl (Telegram album
   // media is the canonical case), rendering ` | ${url}` adds no information
   // and clutters the prompt with `path | path` duplication (issue #47587).
   const urlPart = urlRaw && urlRaw !== pathValue ? ` | ${urlRaw}` : "";
-  return `${prefix}${pathValue}${typePart}${urlPart}]`;
+  return `${prefix}${pathValue}${typePart}${fileNamePart}${urlPart}]`;
 }
 
 // Common audio file extensions for transcription detection
@@ -153,6 +156,10 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
     Array.isArray(ctx.MediaTypes) && ctx.MediaTypes.length === paths.length
       ? ctx.MediaTypes
       : undefined;
+  const fileNames =
+    Array.isArray(ctx.MediaFileNames) && ctx.MediaFileNames.length === paths.length
+      ? ctx.MediaFileNames
+      : undefined;
   const hasTranscript = Boolean(ctx.Transcript?.trim());
   // Transcript alone does not identify an attachment index; only use it as a fallback
   // when there is a single attachment to avoid stripping unrelated audio files.
@@ -163,6 +170,7 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
       path: entry ?? "",
       type: types?.[index] ?? ctx.MediaType,
       url: urls?.[index] ?? ctx.MediaUrl,
+      fileName: fileNames?.[index],
       index,
     }))
     .filter((entry) => {
@@ -193,6 +201,7 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
       path: entries[0]?.path ?? "",
       type: entries[0]?.type,
       url: entries[0]?.url,
+      fileName: entries[0]?.fileName,
     });
   }
 
@@ -206,6 +215,7 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
         total: count,
         type: entry.type,
         url: entry.url,
+        fileName: entry.fileName,
       }),
     );
   }

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -195,6 +195,7 @@ export type MsgContext = {
   MediaPaths?: string[];
   MediaUrls?: string[];
   MediaTypes?: string[];
+  MediaFileNames?: string[];
   /** Original message modality before transcription or other media normalization. */
   SourceModality?: InboundSourceModality;
   MediaWorkspaceDir?: string;

--- a/src/channels/inbound-event/media.test.ts
+++ b/src/channels/inbound-event/media.test.ts
@@ -86,20 +86,20 @@ describe("channel inbound media facts", () => {
     ]);
   });
 
-  it("maps inbound media facts into history media entries", () => {
+  it("builds legacy media payload with file names when provided", () => {
     expect(
-      toHistoryMediaEntries([{ path: "/tmp/image.png", contentType: "image/png" }], {
-        kind: "image",
-        messageId: "msg-1",
-      }),
-    ).toEqual([
-      {
-        path: "/tmp/image.png",
-        url: undefined,
-        contentType: "image/png",
-        kind: "image",
-        messageId: "msg-1",
-      },
-    ]);
+      buildChannelInboundMediaPayload([
+        { path: "/tmp/abc123", contentType: "application/octet-stream", fileName: "jj.txt" },
+        { path: "/tmp/def456", contentType: "text/plain", fileName: "notes.md" },
+      ]),
+    ).toEqual({
+      MediaPath: "/tmp/abc123",
+      MediaUrl: "/tmp/abc123",
+      MediaType: "application/octet-stream",
+      MediaPaths: ["/tmp/abc123", "/tmp/def456"],
+      MediaUrls: ["/tmp/abc123", "/tmp/def456"],
+      MediaTypes: ["application/octet-stream", "text/plain"],
+      MediaFileNames: ["jj.txt", "notes.md"],
+    });
   });
 });

--- a/src/channels/inbound-event/media.ts
+++ b/src/channels/inbound-event/media.ts
@@ -14,6 +14,7 @@ export type ChannelInboundMediaInput = {
   path?: string | null;
   url?: string | null;
   contentType?: string | null;
+  fileName?: string | null;
   kind?: InboundMediaFacts["kind"] | null;
   transcribed?: boolean | null;
   messageId?: string | null;
@@ -29,6 +30,7 @@ export type ChannelInboundMediaPayload = {
   MediaPaths?: string[];
   MediaUrls?: string[];
   MediaTypes?: string[];
+  MediaFileNames?: string[];
   MediaTranscribedIndexes?: number[];
 };
 
@@ -67,6 +69,7 @@ export function toInboundMediaFacts(
     path: normalizeString(entry.path),
     url: normalizeString(entry.url),
     contentType: normalizeString(entry.contentType),
+    fileName: normalizeString(entry.fileName),
     kind: normalizeKind(entry.kind) ?? defaults.kind,
     transcribed: entry.transcribed === true || defaults.transcribed?.(entry, index) === true,
     messageId: normalizeString(entry.messageId) ?? defaults.messageId,
@@ -109,6 +112,7 @@ export function buildChannelInboundMediaPayload(
     MediaPaths: alignedStrings(entries.map((item) => item.path)),
     MediaUrls: alignedStrings(entries.map((item) => item.url ?? item.path)),
     MediaTypes: alignedStrings(entries.map(mediaType)),
+    MediaFileNames: alignedStrings(entries.map((item) => item.fileName)),
     MediaTranscribedIndexes: transcribedIndexes.length > 0 ? transcribedIndexes : undefined,
   };
 }

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -226,6 +226,7 @@ export type InboundMediaFacts = {
   path?: string;
   url?: string;
   contentType?: string;
+  fileName?: string;
   kind?: "image" | "video" | "audio" | "document" | "unknown";
   transcribed?: boolean;
   messageId?: string;

--- a/src/plugin-sdk/agent-media-payload.ts
+++ b/src/plugin-sdk/agent-media-payload.ts
@@ -9,15 +9,17 @@ export type AgentMediaPayload = {
   MediaPaths?: string[];
   MediaUrls?: string[];
   MediaTypes?: string[];
+  MediaFileNames?: string[];
 };
 
 /** Convert outbound media descriptors into the legacy agent payload field layout. */
 export function buildAgentMediaPayload(
-  mediaList: Array<{ path: string; contentType?: string | null }>,
+  mediaList: Array<{ path: string; contentType?: string | null; fileName?: string }>,
 ): AgentMediaPayload {
   const first = mediaList[0];
   const mediaPaths = mediaList.map((media) => media.path);
   const mediaTypes = mediaList.map((media) => media.contentType).filter(Boolean) as string[];
+  const mediaFileNames = mediaList.map((media) => media.fileName).filter(Boolean) as string[];
   return {
     MediaPath: first?.path,
     MediaType: first?.contentType ?? undefined,
@@ -25,5 +27,6 @@ export function buildAgentMediaPayload(
     MediaPaths: mediaPaths.length > 0 ? mediaPaths : undefined,
     MediaUrls: mediaPaths.length > 0 ? mediaPaths : undefined,
     MediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
+    MediaFileNames: mediaFileNames.length > 0 ? mediaFileNames : undefined,
   };
 }


### PR DESCRIPTION
Closing as superseded by #129140 (already merged to main). The upstream fix covers the same fileName propagation path.