### PR TITLE
fix: restore usage for prepared provider credentials

### DIFF
--- a/src/infra/provider-usage.auth.plugin.test.ts
+++ b/src/infra/provider-usage.auth.plugin.test.ts
@@ -478,6 +478,78 @@ describe("resolveProviderAuths plugin boundary", () => {
     expect(resolveProviderUsageAuthWithPluginMock).not.toHaveBeenCalled();
   });
 
+  it("uses a caller-provided auth store for credential gating", async () => {
+    const store = {
+      profiles: {
+        "anthropic:external": {
+          type: "oauth",
+          provider: "anthropic",
+          access: "external-access",
+          refresh: "external-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    resolveAuthProfileOrderMock.mockReturnValue(["anthropic:external"]);
+    resolveApiKeyForProfileMock.mockResolvedValue({
+      apiKey: "external-access",
+      provider: "anthropic",
+    });
+    resolveProviderUsageAuthWithPluginMock.mockImplementationOnce(async (rawParams) => {
+      const params = rawParams as {
+        context: { resolveOAuthToken: () => Promise<{ token: string } | null> };
+      };
+      return params.context.resolveOAuthToken();
+    });
+
+    await expect(
+      resolveProviderAuthsForTest({
+        providers: ["anthropic"],
+        store: store as never,
+      }),
+    ).resolves.toEqual([{ provider: "anthropic", token: "external-access" }]);
+
+    expect(ensureAuthProfileStoreWithoutExternalProfilesMock).not.toHaveBeenCalled();
+    expect(ensureAuthProfileStoreMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves a caller-provided lazy auth store once for credential gating", async () => {
+    const store = {
+      profiles: {
+        "anthropic:external": {
+          type: "oauth",
+          provider: "anthropic",
+          access: "external-access",
+          refresh: "external-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    const getStore = vi.fn(() => store as never);
+    resolveAuthProfileOrderMock.mockReturnValue(["anthropic:external"]);
+    resolveApiKeyForProfileMock.mockResolvedValue({
+      apiKey: "external-access",
+      provider: "anthropic",
+    });
+    resolveProviderUsageAuthWithPluginMock.mockImplementationOnce(async (rawParams) => {
+      const params = rawParams as {
+        context: { resolveOAuthToken: () => Promise<{ token: string } | null> };
+      };
+      return params.context.resolveOAuthToken();
+    });
+
+    await expect(
+      resolveProviderAuthsForTest({
+        providers: ["anthropic"],
+        getStore,
+      }),
+    ).resolves.toEqual([{ provider: "anthropic", token: "external-access" }]);
+
+    expect(getStore).toHaveBeenCalledOnce();
+    expect(ensureAuthProfileStoreWithoutExternalProfilesMock).not.toHaveBeenCalled();
+    expect(ensureAuthProfileStoreMock).not.toHaveBeenCalled();
+  });
+
   it("does not fall back to standard Anthropic API keys for usage auth", async () => {
     resolveProviderUsageAuthWithPluginMock.mockResolvedValueOnce({ handled: true });
     await withTempHome(async (homeDir) => {

--- a/src/infra/provider-usage.auth.ts
+++ b/src/infra/provider-usage.auth.ts
@@ -456,9 +456,11 @@ function hasAuthProfileCredentialSource(params: {
   state: UsageAuthState;
   providerIds: string[];
 }): boolean {
-  const store = ensureAuthProfileStoreWithoutExternalProfiles(params.state.agentDir, {
-    allowKeychainPrompt: false,
-  });
+  const store = (params.state.store ??=
+    params.state.getStore?.() ??
+    ensureAuthProfileStoreWithoutExternalProfiles(params.state.agentDir, {
+      allowKeychainPrompt: false,
+    }));
   for (const provider of params.providerIds) {
     const order = resolveAuthProfileOrder({
       cfg: params.state.cfg,
@@ -549,10 +551,8 @@ export async function resolveProviderAuths(params: {
             providerIds: credentialProviderIds,
           }));
       const state: UsageAuthState = {
-        ...stateBase,
+        ...authProfileSourceState,
         allowAuthProfileStore,
-        getStore: params.getStore,
-        store: params.store,
       };
       const hasPluginCredentialSource = hasDirectCredentialSource || allowAuthProfileStore;
 

--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -32,6 +32,9 @@ suite.define(() => {
     await expect
       .poll(async () => {
         const state = await textarea.evaluate((element) => {
+          if (!(element instanceof HTMLTextAreaElement)) {
+            throw new TypeError("capabilities prompt target must be a textarea");
+          }
           const inputElement = element.closest<HTMLElement>(".agent-chat__input");
           const style = inputElement ? getComputedStyle(inputElement) : null;
           return {


### PR DESCRIPTION
Fixes #128917

Reported by @aniruddhaadak80.

## What Problem This Solves

Fixes an issue where users whose provider credentials came from a prepared in-memory auth store, including external CLI overlays, would see provider usage disappear because the credential gate checked a separate stripped disk view instead.

## Why This Change Was Made

Caller-provided `store` and `getStore` values are now authoritative for both credential gating and plugin auth resolution. The resolved store is carried forward once across the provider flow; the stripped disk probe remains the fallback only when the caller supplied neither source.

## User Impact

Provider usage and quota windows remain available when authentication exists only in a caller-prepared store. Existing credential-less providers still avoid loading plugin runtime.

## Evidence

- Focused owner-boundary tests after rebase: 35/35 passed across `provider-usage.auth.plugin.test.ts`, `provider-usage.load.plugin.test.ts`, and `prepared-model-catalog-worker.integration.test.ts`.
- Current-main CI repair: the capabilities composer locator now verifies its runtime textarea contract before reading `.value`; the affected UI E2E test passes 6/6.
- Scoped changed gate passed formatting, guards, production typecheck, dead-code, dependency-pin, boundary, and ratchet checks. Core-test typecheck reached an unrelated linked-worktree shared-install error: the main checkout lacks the `pako` declaration currently required by `ui/vite.config.ts`; exact-head CI provides the clean-install result.
- Fresh exact-head autoreview: clean, no accepted/actionable findings (0.99 confidence).
- Production LOC: 6 added / 6 removed (net zero). Tests: 75 added.

### Exact-head real-behavior proof

- Provider: Blacksmith Testbox (`blacksmith-testbox`)
- Lease: `tbx_01m11edxnvrkw001720fz68xnr` (`swift-crab`)
- Run: https://github.com/openclaw/openclaw/actions/runs/33065970961
- Exact base: `ea552dff2c26fc8b7074a8b1275d527d3579f92f`
- Exact pushed head: `67774406c456703d49016a50592c4aebeee17f98`
- Scenario: created isolated base and head worktrees, loaded the real OpenAI plugin, resolved the hydrated Codex CLI credential into a caller-prepared in-memory auth store, explicitly unset `OPENAI_API_KEY` and `OPENAI_BASE_URL`, then called the real provider-usage loader.
- Base result: one prepared external profile, but no OpenAI usage result and zero quota windows.
- Head result: the same prepared external profile resolved OpenAI usage with two quota windows and no provider error.
- Result: pass. This reproduces the stripped-disk-store defect on the base and proves the prepared-store path on the exact rebased PR head.
- Isolation and cleanup: fresh isolated state directories; no Gateway or port 18789; lease stopped successfully after proof.

No credential values were printed or persisted in PR evidence.

AI-assisted; the implementation and validation evidence were reviewed by the submitting maintainer.
