### PR TITLE
fix: cloud worker transfers fail after plain workspace results are staged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cloud worker plain workspaces:** keep paired-device workspace transfers working after durable result staging initializes an empty Git repository, while preserving committed Git workspace synchronization.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cloud worker plain workspaces:** keep paired-device workspace transfers working after durable result staging initializes an empty Git repository, while preserving committed Git workspace synchronization.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3116,7 +3116,6 @@ src/gateway/worker-environments/live-event-projection.ts	1
 src/gateway/worker-environments/node-worker-tunnel.ts	6
 src/gateway/worker-environments/node-worker-workspace-fallback.ts	2
 src/gateway/worker-environments/node-workspace-transfer-service.ts	1
-src/gateway/worker-environments/node-workspace-transfer-snapshot.ts	1
 src/gateway/worker-environments/placement-state.ts	3
 src/gateway/worker-environments/placement-store.ts	1
 src/gateway/worker-environments/provider-lifecycle.ts	1

--- a/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-service.test.ts
@@ -7,6 +7,7 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import { NODE_WORKER_WORKSPACE_EXEC_COMMAND } from "../../infra/node-commands.js";
 import { invokeNodeWorkerSupervisorCommand } from "../../node-host/node-worker-supervisor-commands.js";
 import { NodeWorkerWorkspaceRuntime } from "../../node-host/node-worker-workspace.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { createGatewayHttpServer } from "../server-http.js";
 import { createNodeWorkspaceTransferHttpCallback } from "./node-workspace-transfer-http.js";
@@ -113,6 +114,79 @@ function retryOrUploadStatus(retryStarted: Promise<void>, upload: Promise<unknow
 }
 
 describe("node workspace transfer service", () => {
+  it("keeps a plain workspace transferable after durable result staging initializes Git", async () => {
+    const root = tempDirs.make("node-workspace-transfer-unborn-git-");
+    const localPath = path.join(root, "workspace");
+    await fs.mkdir(localPath);
+    await fs.writeFile(path.join(localPath, "input.txt"), "gateway input\n");
+    const service = createNodeWorkspaceTransferService({
+      getOwner: () => ({
+        credential: {
+          ownerEpoch: 1,
+          expiresAtMs: Date.now() + 60_000,
+          sessionId: "session-unborn",
+        },
+        environment: {
+          ownerEpoch: 1,
+          attachedSessionIds: ["session-unborn"],
+          destroyRequestedAtMs: null,
+          state: "attached",
+        },
+      }),
+      temporaryRoot: path.join(root, "transfer-tmp"),
+    });
+    const request = {
+      environmentId: "environment-unborn",
+      ownerEpoch: 1,
+      sessionId: "session-unborn",
+      localPath,
+      isAuthorized: () => true,
+    };
+    const git = async (...args: string[]) => {
+      const result = await runCommandWithTimeout(["git", "-C", localPath, ...args], {
+        timeoutMs: 10_000,
+      });
+      expect(result.code).toBe(0);
+      return result.stdout.trim();
+    };
+    try {
+      const plain = await service.prepareSync({ ...request, generation: 1 });
+      expect(plain.snapshot.manifest.baseCommit).toBeNull();
+
+      await git("init", "--quiet", "--object-format=sha1");
+
+      const staged = await service.prepareSync({ ...request, generation: 2 });
+      expect(staged.snapshot.manifest.baseCommit).toBeNull();
+      expect(staged.snapshot.packPath).toBeUndefined();
+      expect(staged.snapshot.manifestRef).toBe(plain.snapshot.manifestRef);
+      expect(staged.snapshot.manifest.entries).toContainEqual(
+        expect.objectContaining({ path: "input.txt", type: "file" }),
+      );
+
+      await git("add", "input.txt");
+      await git(
+        "-c",
+        "user.name=Worker Transfer Test",
+        "-c",
+        "user.email=worker-transfer@example.invalid",
+        "commit",
+        "--quiet",
+        "-m",
+        "tracked workspace",
+      );
+      const committed = await service.prepareSync({ ...request, generation: 3 });
+      expect(committed.snapshot.manifest.baseCommit).toBe(await git("rev-parse", "HEAD"));
+      expect(committed.snapshot.packPath).toBeDefined();
+
+      await fs.writeFile(path.join(localPath, ".git", "HEAD"), "invalid HEAD\n");
+      await expect(service.prepareSync({ ...request, generation: 4 })).rejects.toThrow(
+        "Worker workspace sync failed",
+      );
+    } finally {
+      await service.closeAll();
+    }
+  });
+
   it("streams a plain workspace to the node and accepts only its changed result blobs", async () => {
     const root = tempDirs.make("node-workspace-transfer-service-");
     const localPath = path.join(root, "gateway-workspace");

--- a/src/gateway/worker-environments/node-workspace-transfer-snapshot.ts
+++ b/src/gateway/worker-environments/node-workspace-transfer-snapshot.ts
@@ -7,6 +7,7 @@ import {
   type WorkerWorkspaceManifest,
 } from "./workspace-manifest.js";
 import { readActualWorkspaceManifest } from "./workspace-reconcile.js";
+import { probeWorkspaceGitMode } from "./workspace-sync-helpers.js";
 import {
   createWorkspaceGitTransferList,
   readWorkspaceTransferPaths,
@@ -23,39 +24,31 @@ export type NodeWorkspaceTransferSnapshot = {
   packPath?: string;
 };
 
-async function successfulGit(root: string, args: string[]): Promise<string> {
-  const result = await runCommandWithTimeout(["git", "-C", root, ...args], {
-    timeoutMs: TRANSFER_TIMEOUT_MS,
-    maxOutputBytes: 256 * 1024,
-    maxCombinedOutputBytes: 512 * 1024,
-    baseEnv: { ...process.env, GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "" },
-  });
-  if (result.termination !== "exit" || result.code !== 0) {
-    throw new Error("Worker workspace Git inspection failed");
-  }
-  return result.stdout.trim();
-}
-
 export async function prepareNodeWorkspaceTransferSnapshot(params: {
   localPath: string;
   temporaryRoot: string;
   signal?: AbortSignal;
 }): Promise<NodeWorkspaceTransferSnapshot> {
   const root = await fsp.realpath(params.localPath);
-  const gitAdmin = await fsp.lstat(path.join(root, ".git")).catch((error: unknown) => {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return undefined;
-    }
-    throw error;
+  const git = await probeWorkspaceGitMode({
+    localPath: root,
+    commandOptions: {
+      timeoutMs: TRANSFER_TIMEOUT_MS,
+      maxOutputBytes: 256 * 1024,
+      maxCombinedOutputBytes: 512 * 1024,
+      baseEnv: { ...process.env, GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "" },
+      signal: params.signal,
+    },
+    runTask: runCommandWithTimeout,
   });
   let baseCommit: string | null = null;
   let includePaths: ReadonlySet<string> | undefined;
-  if (gitAdmin) {
-    const gitRoot = await fsp.realpath(await successfulGit(root, ["rev-parse", "--show-toplevel"]));
+  if (git.mode === "git") {
+    const gitRoot = await fsp.realpath(git.gitRoot);
     if (gitRoot !== root) {
       throw new Error("Worker git workspace sync requires the managed worktree root");
     }
-    baseCommit = await successfulGit(root, ["rev-parse", "--verify", "HEAD"]);
+    baseCommit = git.baseCommit;
     if (!/^[a-f0-9]{40}(?:[a-f0-9]{24})?$/u.test(baseCommit)) {
       throw new Error("Worker workspace Git base is not a commit id");
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users continuing a cloud session on a paired worker could no longer synchronize a plain workspace after an earlier worker result had been staged durably. The next transfer failed with `Worker workspace Git inspection failed`, even though the workspace files and staged result were valid.

## Why This Change Was Made

Durable worker-result staging initializes a Git repository to store its private result refs, but it intentionally does not create a user-facing `HEAD` commit. The node-transfer snapshot owner independently treated any `.git` directory as a committed workspace. Reusing the existing canonical SSH workspace Git-mode probe makes both transports classify unborn repositories as plain, preserves committed Git workspaces and packed history, and continues rejecting corrupt Git metadata. The duplicate Git-inspection path is removed.

## User Impact

Plain cloud-session workspaces remain usable across repeated paired-worker transfers and durable result recovery without changing their contents, requiring users to create a commit, or weakening Git workspace validation.

## Evidence

- Fail-first regression at the actual transfer-service boundary: the first plain transfer succeeded, durable-style `git init` completed, and the second transfer failed with `Worker workspace Git inspection failed` before the fix.
- Passing regression now follows the complete lifecycle: plain workspace, unborn staging repository with the same manifest and no Git pack, committed repository with a real Git pack, and corrupt `HEAD` rejected.
- `node scripts/run-vitest.mjs src/gateway/worker-environments/node-workspace-transfer-service.test.ts src/gateway/worker-environments/node-worker-tunnel.test.ts src/gateway/worker-environments/node-worker-workspace-fallback.test.ts src/gateway/worker-environments/workspace-sync-tunnel.test.ts src/gateway/worker-environments/workspace-sync-inventory.test.ts` — **46 tests passed**.
- Focused formatter, oxlint, and core TypeScript checks passed; structured review reported no actionable findings.
- Production: **+14/-21, net -7 lines**; tests: **+74 lines**.
