### PR TITLE
fix(gateway): protect concurrent cloud session placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cloud worker placement retries:** revalidate each operator joining an in-flight dispatch or move, and reject conflicting paired-device command or capacity requirements instead of sharing the wrong placement.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Cloud worker placement retries:** revalidate each operator joining an in-flight dispatch or move, and reject conflicting paired-device command or capacity requirements instead of sharing the wrong placement.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
@@ -82,10 +82,16 @@ describe("worker placement dispatch coordinator", () => {
     const modeConflict = expect(
       coordinated.dispatch({ ...REQUEST, executionMode: "remote-exec" }),
     ).rejects.toThrow(`Session ${REQUEST.sessionKey} is already dispatching another request`);
+    const devicePlacementConflict = expect(
+      coordinated.dispatch({
+        ...REQUEST,
+        devicePlacement: { requiredNodeCommands: ["system.run"], consumesWorkerSlot: true },
+      }),
+    ).rejects.toThrow(`Session ${REQUEST.sessionKey} is already dispatching another request`);
     const retry = coordinated.dispatch(REQUEST);
     releaseDispatch.resolve();
 
-    await modeConflict;
+    await Promise.all([modeConflict, devicePlacementConflict]);
     const [firstResult, retryResult] = await Promise.all([first, retry]);
     expect(retryResult).toBe(firstResult);
     expect(dispatch).toHaveBeenCalledOnce();
@@ -93,6 +99,60 @@ describe("worker placement dispatch coordinator", () => {
     await coordinated.dispatch({ ...REQUEST, profileId: "another-profile" });
     expect(dispatch).toHaveBeenCalledTimes(2);
   });
+
+  it.each([
+    { kind: "dispatch", revokedBeforeJoining: true },
+    { kind: "dispatch", revokedBeforeJoining: false },
+    { kind: "move", revokedBeforeJoining: true },
+    { kind: "move", revokedBeforeJoining: false },
+  ] as const)(
+    "rejects a joined $kind when its authority is revoked (before joining: $revokedBeforeJoining)",
+    async ({ kind, revokedBeforeJoining }) => {
+      const ownerStarted = createDeferredCore();
+      const releaseOwner = createDeferredCore();
+      const expectedResult = { state: kind === "dispatch" ? "active" : "local" };
+      const operation = vi.fn(async () => {
+        ownerStarted.resolve();
+        await releaseOwner.promise;
+        return expectedResult;
+      });
+      const service = {
+        dispatch: kind === "dispatch" ? operation : vi.fn(),
+        forceDestroyEnvironment: vi.fn(),
+        move: kind === "move" ? operation : vi.fn(),
+        reclaim: vi.fn(),
+        reconcile: vi.fn(),
+        reconcileActive: vi.fn(),
+      } as unknown as DispatchService;
+      const coordinated = coordinateWorkerPlacementDispatch(service);
+      const invoke = (authorize?: () => void) =>
+        kind === "dispatch"
+          ? coordinated.dispatch(REQUEST, undefined, authorize)
+          : coordinated.move(MOVE_REQUEST, undefined, authorize);
+      const owner = invoke();
+      await ownerStarted.promise;
+
+      let revoked = revokedBeforeJoining;
+      const observedAuthorizationStates: boolean[] = [];
+      const authorize = () => {
+        observedAuthorizationStates.push(revoked);
+        if (revoked) {
+          throw new Error("session access revoked");
+        }
+      };
+      const joined = invoke(authorize);
+      revoked = true;
+      const outcomes = Promise.allSettled([owner, joined]);
+      releaseOwner.resolve();
+
+      await expect(outcomes).resolves.toEqual([
+        { status: "fulfilled", value: expectedResult },
+        { status: "rejected", reason: new Error("session access revoked") },
+      ]);
+      expect(observedAuthorizationStates).toEqual(revokedBeforeJoining ? [true] : [false, true]);
+      expect(operation).toHaveBeenCalledOnce();
+    },
+  );
 
   it("joins a retry before a queued reconciliation after dispatch failure", async () => {
     const dispatchStarted = createDeferredCore();

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -119,23 +119,21 @@ export function coordinateWorkerPlacementDispatch(
       operation: ReturnType<WorkerPlacementDispatchService["move"]>;
     }
   >();
+  const joinOperation = async <T>(operation: Promise<T>, authorize?: () => void): Promise<T> => {
+    // Shared placement work must never inherit another caller's authority across an await.
+    authorize?.();
+    const result = await operation;
+    authorize?.();
+    return result;
+  };
   return {
     dispatch: async (request, onTransition, authorize) => {
       const inFlight = dispatchInFlight.get(request.sessionId);
       if (inFlight) {
-        if (
-          inFlight.request.sessionKey !== request.sessionKey ||
-          inFlight.request.agentId !== request.agentId ||
-          inFlight.request.profileId !== request.profileId ||
-          inFlight.request.executionMode !== request.executionMode ||
-          inFlight.request.idempotencyKey !== request.idempotencyKey ||
-          inFlight.request.deviceId !== request.deviceId ||
-          inFlight.request.machineClass !== request.machineClass ||
-          !isDeepStrictEqual(inFlight.request.inheritedProfile, request.inheritedProfile)
-        ) {
+        if (!isDeepStrictEqual(inFlight.request, request)) {
           throw new Error(`Session ${request.sessionKey} is already dispatching another request`);
         }
-        return await inFlight.operation;
+        return await joinOperation(inFlight.operation, authorize);
       }
       const operation = runPlacementOperation(() =>
         service.dispatch(request, onTransition, authorize),
@@ -159,7 +157,7 @@ export function coordinateWorkerPlacementDispatch(
         if (!isDeepStrictEqual(inFlight.request, request)) {
           throw new Error(`Session ${request.sessionKey} is already moving to another target`);
         }
-        return await inFlight.operation;
+        return await joinOperation(inFlight.operation, authorize);
       }
       const operation = runExclusivePlacementOperation(() =>
         service.move(request, onTransition, authorize),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators starting or moving the same cloud session concurrently could receive a successful placement after their own session access was revoked. Concurrent paired-device requests with different required node commands or worker-slot requirements could also incorrectly share the first request's placement.

## Why This Change Was Made

The placement coordinator now compares the complete dispatch request, matching the existing move contract, and revalidates each joining caller's existing session authority immediately before and after awaiting shared dispatch or move work. This preserves one provider operation for truly identical authorized requests without changing protocols, storage, operator scopes, or provider behavior.

The original coalescing paths predate per-request placement authority, added in #125787; paired-device requirements were subsequently added in #127202 without extending the hand-maintained dispatch comparison. Replacing that comparison with the existing whole-request equality primitive removes the incomplete policy instead of adding another field-specific workaround.

## User Impact

Cloud-session dispatch and moves consistently respect each operator's current session access, and paired-device placement cannot silently reuse a concurrent request with incompatible command permissions or capacity needs.

## Evidence

- Fail-first proof against the unchanged production coordinator: all five new regressions failed (four revoked-authority cases across dispatch/move and before/during joining; one mismatched paired-device requirement).
- After the fix: `node scripts/run-vitest.mjs src/gateway/worker-environments/placement-dispatch-coordinator.test.ts` passes **21/21** tests.
- Full affected owner, caller, sibling, reclaim, startup, and provisioning-recovery matrix passes **226/226 tests across 12 files**, including device dispatch, move abandonment, reclaim, enrollment replay, shutdown recovery, Gateway startup, and session-dispatch authorization.
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 node scripts/check-changed.mjs -- src/gateway/worker-environments/placement-dispatch-coordinator.ts src/gateway/worker-environments/placement-dispatch-coordinator.test.ts CHANGELOG.md` passes every changed-file guard plus production and test typechecks; the complete dead-export scan also passed separately before an isolated-worktree dependency-link correction.
- Structured pre-commit review: clean, no accepted/actionable findings.
- Production LOC: **+10/-12 (net -2)**. Tests: **+61/-1**. User-facing changelog: **+1**.
- No SQLite, protocol, configuration, protected authentication-file, or security-ownership surface changes.
