### PR TITLE
perf(test): await one-shot CLI exit completion directly

### DIFF
--- a/src/cli/one-shot-exit.test.ts
+++ b/src/cli/one-shot-exit.test.ts
@@ -1,10 +1,26 @@
 import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import { defaultRuntime } from "../runtime.js";
 import { requestExitAfterOneShotOutput, runCliWithExitFinalization } from "./one-shot-exit.js";
 
 const successfulRun = async () => {};
 const ignoreError = () => {};
+
+function spyOnExit(onExit?: (code: number) => void) {
+  const exited = createDeferred();
+  const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
+    onExit?.(code);
+    exited.resolve();
+  });
+  return {
+    exit,
+    waitForExit: async (code: number) => {
+      await withTestTimeout(exited.promise, 1_000, "one-shot CLI did not exit");
+      expect(exit).toHaveBeenCalledWith(code);
+    },
+  };
+}
 
 describe("one-shot CLI exit", () => {
   afterEach(() => {
@@ -21,7 +37,7 @@ describe("one-shot CLI exit", () => {
     "exits after macOS system CA command completion from %s",
     async (_label, env, execArgv) => {
       const previousExitCode = process.exitCode;
-      const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+      const { waitForExit } = spyOnExit();
       try {
         process.exitCode = 3;
         await runCliWithExitFinalization({
@@ -32,7 +48,7 @@ describe("one-shot CLI exit", () => {
           platform: "darwin",
           markers: {},
         });
-        await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(3));
+        await waitForExit(3);
       } finally {
         process.exitCode = previousExitCode;
       }
@@ -61,7 +77,7 @@ describe("one-shot CLI exit", () => {
   });
 
   it("does not finalize a long-lived command until its run promise settles", async () => {
-    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+    const { exit, waitForExit } = spyOnExit();
     let finishRun: (() => void) | undefined;
     const runPromise = runCliWithExitFinalization({
       run: async () =>
@@ -82,13 +98,13 @@ describe("one-shot CLI exit", () => {
 
     finishRun?.();
     await runPromise;
-    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+    await waitForExit(0);
   });
 
   it("reports failures and replaces a pending successful exit before draining", async () => {
     const previousExitCode = process.exitCode;
     const order: string[] = [];
-    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation((code) => {
+    const { waitForExit } = spyOnExit((code) => {
       order.push(`exit:${String(code)}`);
     });
 
@@ -112,7 +128,7 @@ describe("one-shot CLI exit", () => {
         markers: {},
       });
 
-      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(6));
+      await waitForExit(6);
       expect(order).toEqual(["reported", "exit:6"]);
     } finally {
       process.exitCode = previousExitCode;
@@ -127,7 +143,7 @@ describe("one-shot CLI exit", () => {
     "preserves the final process outcome for $name",
     async ({ processExitCode, expectedExitCode }) => {
       const previousExitCode = process.exitCode;
-      const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+      const { waitForExit } = spyOnExit();
 
       try {
         process.exitCode = undefined;
@@ -143,7 +159,7 @@ describe("one-shot CLI exit", () => {
           markers: {},
         });
 
-        await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(expectedExitCode));
+        await waitForExit(expectedExitCode);
       } finally {
         process.exitCode = previousExitCode;
       }
@@ -152,7 +168,7 @@ describe("one-shot CLI exit", () => {
 
   it.each([0, 7])("preserves an explicit exit override of %i", async (requestedExitCode) => {
     const previousExitCode = process.exitCode;
-    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+    const { waitForExit } = spyOnExit();
 
     try {
       process.exitCode = 9;
@@ -166,7 +182,7 @@ describe("one-shot CLI exit", () => {
         markers: {},
       });
 
-      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(requestedExitCode));
+      await waitForExit(requestedExitCode);
     } finally {
       process.exitCode = previousExitCode;
     }
@@ -174,7 +190,7 @@ describe("one-shot CLI exit", () => {
 
   it("normalizes a Node integer-string process exit code", async () => {
     const previousExitCode = process.exitCode;
-    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+    const { waitForExit } = spyOnExit();
 
     try {
       process.exitCode = "9";
@@ -186,14 +202,14 @@ describe("one-shot CLI exit", () => {
         platform: "darwin",
         markers: {},
       });
-      await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(9));
+      await waitForExit(9);
     } finally {
       process.exitCode = previousExitCode;
     }
   });
 
   it("preserves a command-specific exit code when system CA completion also requests exit", async () => {
-    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+    const { waitForExit } = spyOnExit();
 
     requestExitAfterOneShotOutput(defaultRuntime, 7);
     await runCliWithExitFinalization({
@@ -205,11 +221,11 @@ describe("one-shot CLI exit", () => {
       markers: {},
     });
 
-    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(7));
+    await waitForExit(7);
   });
 
   it("defers a requested exit until the outer finalizer", async () => {
-    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+    const { exit, waitForExit } = spyOnExit();
 
     expect(requestExitAfterOneShotOutput(defaultRuntime, 2)).toBe(true);
     await new Promise<void>((resolve) => {
@@ -225,7 +241,7 @@ describe("one-shot CLI exit", () => {
       platform: "linux",
       markers: {},
     });
-    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(2));
+    await waitForExit(2);
   });
 
   it("does not request exits for embedded custom runtimes", async () => {
@@ -249,7 +265,7 @@ describe("one-shot CLI exit", () => {
   });
 
   it("suppresses exits inside Vitest workers but not spawned CLI children", async () => {
-    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined);
+    const { exit, waitForExit } = spyOnExit();
     const inheritedTestEnv = { VITEST: "1", VITEST_WORKER_ID: "1" } as NodeJS.ProcessEnv;
 
     requestExitAfterOneShotOutput(defaultRuntime);
@@ -272,7 +288,7 @@ describe("one-shot CLI exit", () => {
       platform: "linux",
       markers: {},
     });
-    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+    await waitForExit(0);
   });
 
   it("waits for stream callbacks even when writableLength is zero", async () => {


### PR DESCRIPTION
## What Problem This Solves

One-shot CLI finalization tests repeatedly waited for Vitest's default 50 ms polling interval after the real runtime exit had already completed. Sixteen affected cases slowed a process-heavy CLI suite without adding synchronization or coverage.

## Why This Change Was Made

Resolve the existing exit spy through the shared deferred-promise helper and await that authoritative owner completion signal. Preserve the original one-second failure deadline, exact exit-code assertions, error-report ordering, stream-drain lifecycle, fake-timer fallback, and every real subprocess case.

## User Impact

No production or operator-visible behavior changes. Developers and CI get faster deterministic CLI-finalization coverage while keeping real proxy command, JSON/TTY output, stdout-drain, MCP, and agent exit proof.

## Evidence

One task-owned Blacksmith Testbox, one Vitest worker, distinct filesystem module caches, excluded warmups, exact unchanged baseline contents, and eight interleaved/order-balanced retained samples (`baseline, candidate, candidate, baseline, candidate, baseline, baseline, candidate`):

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Scoped wall time | 14.9375 s | 13.3875 s | -1.55 s / -10.38% |
| Vitest duration | 11.485 s | 9.825 s | -1.66 s / -14.45% |
| Test body | 10.58 s | 8.8225 s | -1.7575 s / -16.61% |
| Peak resident memory | 499,684 KiB | 496,144 KiB | -0.71% |
| Collected tests | 31 | 31 | unchanged |
| Reported imports | 10 | 10 | unchanged |

The original affected cases took approximately 50-52 ms each; direct owner completion takes approximately 0-1 ms. All 59 tests pass across the finalization owner, one-shot agent command registration, and real MCP process boundary. Reversible production-owner faults independently failed three exact exit-code cases and the stream-drain ordering case before the owner was restored. The complete `coreTests` changed gate and independent structured review passed.

Blacksmith validation: https://github.com/openclaw/openclaw/actions/runs/32832270069

Production LOC: **0**. Test LOC: **+34/-18**. No subprocess, timeout, fake timer, assertion, readiness, stream, output, or exit-status contract was removed or weakened.
