### PR TITLE
test(reply): deduplicate reply runner fixtures

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -251,14 +251,6 @@ vi.mock("../../agents/subagents/registry/subagent-registry-read.js", async (impo
   listSubagentRunsForController: () => [],
 }));
 
-vi.mock("../../agents/subagents/registry/subagent-registry-read.js", async (importOriginal) => ({
-  ...(await importOriginal<
-    typeof import("../../agents/subagents/registry/subagent-registry-read.js")
-  >()),
-  getLatestSubagentRunByChildSessionKey: () => null,
-  listSubagentRunsForController: () => [],
-}));
-
 // #85714: keep the real private-final decision but spy the WARN emitter so we
 // can assert it fires only through the substantive text suppression branch.
 const warnPrivateFinalSpy = vi.hoisted(() => vi.fn());
@@ -274,6 +266,82 @@ type RunWithModelFallbackParams = {
   model: string;
   run: (provider: string, model: string) => Promise<unknown>;
 };
+
+type BaseRunOptions = {
+  context?: Parameters<typeof createTestTemplateContext>[0];
+  followup?: Partial<Omit<Parameters<typeof createTestQueuedFollowupRun>[0], "run">>;
+  run?: Parameters<typeof createTestQueuedFollowupRun>[0]["run"];
+  reply?: Partial<
+    Omit<
+      Parameters<typeof runReplyAgent>[0],
+      "followupRun" | "resolvedQueue" | "sessionCtx" | "typing"
+    >
+  >;
+};
+
+function createBaseRun(options: BaseRunOptions = {}) {
+  const sessionKey = options.run?.sessionKey ?? "main";
+  const messageProvider = options.run?.messageProvider ?? "whatsapp";
+  const typing = createMockTypingController();
+  const sessionCtx = createTestTemplateContext(
+    options.context ?? {
+      Provider: "whatsapp",
+      OriginatingTo: "+15550001111",
+      AccountId: "primary",
+      MessageSid: "msg",
+    },
+  );
+  const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
+  const followupRun = createTestQueuedFollowupRun({
+    prompt: "hello",
+    summaryLine: "hello",
+    enqueuedAt: Date.now(),
+    ...options.followup,
+    run: {
+      sessionId: "session",
+      sessionKey,
+      messageProvider,
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {},
+      skillsSnapshot: {},
+      provider: "anthropic",
+      model: "claude",
+      verboseLevel: "off",
+      elevatedLevel: "off",
+      bashElevated: { enabled: false, allowed: false, defaultLevel: "off" },
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+      ...options.run,
+    },
+  });
+  const replyParams = {
+    commandBody: "hello",
+    followupRun,
+    queueKey: "main",
+    resolvedQueue,
+    shouldSteer: false,
+    shouldFollowup: false,
+    isActive: false,
+    typing,
+    sessionCtx,
+    defaultModel: "anthropic/claude-opus-4-6",
+    resolvedVerboseLevel: "off",
+    isNewSession: false,
+    blockStreamingEnabled: false,
+    resolvedBlockStreamingBreak: "message_end",
+    shouldInjectGroupIntro: false,
+    typingMode: "instant",
+    ...options.reply,
+  } satisfies Parameters<typeof runReplyAgent>[0];
+  return {
+    typing,
+    sessionCtx,
+    resolvedQueue,
+    followupRun,
+    run: () => runReplyAgent(replyParams),
+  };
+}
 
 const requireRecord = createRequireRecord("record", "expected-label-object");
 
@@ -373,48 +441,6 @@ describe("runReplyAgent auto-compaction token update", () => {
     );
   }
 
-  function createBaseRun(params: {
-    storePath: string;
-    sessionEntry: Record<string, unknown>;
-    config?: Record<string, unknown>;
-    sessionFile?: string;
-    workspaceDir?: string;
-  }) {
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "whatsapp",
-      OriginatingTo: "+15550001111",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
-      run: {
-        agentId: "main",
-        agentDir: "/tmp/agent",
-        sessionId: "session",
-        sessionKey: "main",
-        messageProvider: "whatsapp",
-        sessionFile: params.sessionFile ?? "/tmp/session.jsonl",
-        workspaceDir: params.workspaceDir ?? "/tmp",
-        config: params.config ?? {},
-        skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
-        reasoningLevel: "on",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: { enabled: false, allowed: false, defaultLevel: "off" },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
-      },
-    });
-    return { typing, sessionCtx, resolvedQueue, followupRun };
-  }
-
   async function runEmptyDirectReply(
     agentResult: Record<string, unknown>,
     options?: {
@@ -453,33 +479,20 @@ describe("runReplyAgent auto-compaction token update", () => {
       };
     });
 
-    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-      storePath: "",
-      sessionEntry,
-      config: options?.config,
-    });
-    return runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      opts: options?.onBlockReply ? { onBlockReply: options.onBlockReply } : undefined,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+    return createBaseRun({
+      run: {
+        agentId: "main",
+        agentDir: "/tmp/agent",
+        config: options?.config ?? {},
+        reasoningLevel: "on",
+      },
+      reply: {
+        opts: options?.onBlockReply ? { onBlockReply: options.onBlockReply } : undefined,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+      },
+    }).run();
   }
 
   async function runBaseReplyWithAgentMeta(params: {
@@ -513,36 +526,24 @@ describe("runReplyAgent auto-compaction token update", () => {
           diagnostics.push(event);
         })
       : undefined;
-    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-      storePath,
-      sessionEntry,
-      config: params.config,
-      workspaceDir: params.workspaceDir,
-    });
-
-    try {
-      await runReplyAgent({
-        commandBody: "hello",
-        followupRun,
-        queueKey: "main",
-        resolvedQueue,
-        shouldSteer: false,
-        shouldFollowup: false,
-        isActive: false,
-        typing,
-        sessionCtx,
+    const baseRun = createBaseRun({
+      run: {
+        agentId: "main",
+        agentDir: "/tmp/agent",
+        config: params.config ?? {},
+        reasoningLevel: "on",
+        workspaceDir: params.workspaceDir ?? "/tmp",
+      },
+      reply: {
         sessionEntry,
         sessionStore: { [sessionKey]: sessionEntry },
         sessionKey,
         storePath,
-        defaultModel: "anthropic/claude-opus-4-6",
-        resolvedVerboseLevel: "off",
-        isNewSession: false,
-        blockStreamingEnabled: false,
-        resolvedBlockStreamingBreak: "message_end",
-        shouldInjectGroupIntro: false,
-        typingMode: "instant",
-      });
+      },
+    });
+
+    try {
+      await baseRun.run();
     } finally {
       unsubscribe?.();
     }
@@ -581,32 +582,16 @@ describe("runReplyAgent auto-compaction token update", () => {
     await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
     compactState.compactEmbeddedAgentSessionMock.mockRejectedValueOnce(new GatewayDrainingError());
 
-    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-      storePath,
-      sessionEntry,
-    });
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+    const result = await createBaseRun({
+      run: { agentId: "main", agentDir: "/tmp/agent", reasoningLevel: "on" },
+      reply: {
+        queueKey: sessionKey,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+        storePath,
+      },
+    }).run();
 
     expect(compactState.compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
     expectReplyText(result, "⚠️ Gateway is restarting. Please wait a few seconds and try again.");
@@ -728,32 +713,15 @@ describe("runReplyAgent auto-compaction token update", () => {
       expect(replyRunRegistry.get(sessionKey)).toBeUndefined();
     });
 
-    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-      storePath: "",
-      sessionEntry,
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+    const result = await createBaseRun({
+      run: { agentId: "main", agentDir: "/tmp/agent", reasoningLevel: "on" },
+      reply: {
+        queueKey: sessionKey,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+      },
+    }).run();
 
     expectReplyText(result, "ok");
     expect(scheduleFollowupDrain).toHaveBeenCalledTimes(1);
@@ -787,40 +755,28 @@ describe("runReplyAgent auto-compaction token update", () => {
         expect(events[0]).toContain("Never skip startup context after compaction.");
       });
 
-      const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-        storePath: "",
-        sessionEntry,
-        workspaceDir,
-        config: {
-          agents: {
-            defaults: {
-              compaction: { postCompactionSections: ["Session Startup", "Red Lines"] },
+      const baseRun = createBaseRun({
+        run: {
+          agentId: "main",
+          agentDir: "/tmp/agent",
+          workspaceDir,
+          reasoningLevel: "on",
+          config: {
+            agents: {
+              defaults: {
+                compaction: { postCompactionSections: ["Session Startup", "Red Lines"] },
+              },
             },
           },
         },
+        reply: {
+          sessionEntry,
+          sessionStore: { [sessionKey]: sessionEntry },
+          sessionKey,
+        },
       });
 
-      await runReplyAgent({
-        commandBody: "hello",
-        followupRun,
-        queueKey: sessionKey,
-        resolvedQueue,
-        shouldSteer: false,
-        shouldFollowup: false,
-        isActive: false,
-        typing,
-        sessionCtx,
-        sessionEntry,
-        sessionStore: { [sessionKey]: sessionEntry },
-        sessionKey,
-        defaultModel: "anthropic/claude-opus-4-6",
-        resolvedVerboseLevel: "off",
-        isNewSession: false,
-        blockStreamingEnabled: false,
-        resolvedBlockStreamingBreak: "message_end",
-        shouldInjectGroupIntro: false,
-        typingMode: "instant",
-      });
+      await baseRun.run();
 
       expect(scheduleFollowupDrain).toHaveBeenCalledTimes(1);
     } finally {
@@ -852,33 +808,16 @@ describe("runReplyAgent auto-compaction token update", () => {
       deliveryOrder.push("followup");
     });
 
-    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-      storePath: "",
-      sessionEntry,
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-      replyOperation,
-    });
+    const result = await createBaseRun({
+      run: { agentId: "main", agentDir: "/tmp/agent", reasoningLevel: "on" },
+      reply: {
+        queueKey: sessionKey,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+        replyOperation,
+      },
+    }).run();
 
     expectReplyText(result, "ok");
     expect(replyRunRegistry.get(sessionKey)).toBe(replyOperation);
@@ -939,35 +878,24 @@ describe("runReplyAgent auto-compaction token update", () => {
           return { result, provider, model };
         },
       );
-      const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
-        storePath: "",
-        sessionEntry,
-      });
-      followupRun.run.sessionKey = sessionKey;
-
-      try {
-        const pending = runReplyAgent({
-          commandBody: "hello",
-          followupRun,
+      const baseRun = createBaseRun({
+        run: {
+          agentId: "main",
+          agentDir: "/tmp/agent",
+          sessionKey,
+          reasoningLevel: "on",
+        },
+        reply: {
           queueKey: sessionKey,
-          resolvedQueue,
-          shouldSteer: false,
-          shouldFollowup: false,
-          isActive: false,
-          typing,
-          sessionCtx,
           sessionEntry,
           sessionStore: { [sessionKey]: sessionEntry },
           sessionKey,
-          defaultModel: "anthropic/claude-opus-4-6",
-          resolvedVerboseLevel: "off",
-          isNewSession: false,
-          blockStreamingEnabled: false,
-          resolvedBlockStreamingBreak: "message_end",
-          shouldInjectGroupIntro: false,
-          typingMode: "instant",
           replyOperation,
-        });
+        },
+      });
+
+      try {
+        const pending = baseRun.run();
         await candidateSettled;
         if (superseded) {
           replyOperation.supersede();
@@ -1128,24 +1056,15 @@ describe("runReplyAgent block streaming", () => {
       };
     });
 
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "discord",
-      OriginatingTo: "channel:C1",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
+    const result = await createBaseRun({
+      context: {
+        Provider: "discord",
+        OriginatingTo: "channel:C1",
+        AccountId: "primary",
+        MessageSid: "msg",
+      },
       run: {
-        sessionId: "session",
-        sessionKey: "main",
         messageProvider: "discord",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
         config: {
           agents: {
             defaults: {
@@ -1157,47 +1076,21 @@ describe("runReplyAgent block streaming", () => {
             },
           },
         },
-        skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
         thinkLevel: "low",
         reasoningLevel: "on",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
         blockReplyBreak: "text_end",
       },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      opts: { onBlockReply },
-      typing,
-      sessionCtx,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: true,
-      blockReplyChunking: {
-        minChars: 1,
-        maxChars: 200,
-        breakPreference: "paragraph",
+      reply: {
+        opts: { onBlockReply },
+        blockStreamingEnabled: true,
+        blockReplyChunking: {
+          minChars: 1,
+          maxChars: 200,
+          breakPreference: "paragraph",
+        },
+        resolvedBlockStreamingBreak: "text_end",
       },
-      resolvedBlockStreamingBreak: "text_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+    }).run();
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
     expect((firstMockCallArg(onBlockReply, "block reply") as { text?: string }).text).toBe("Hello");
@@ -1233,24 +1126,15 @@ describe("runReplyAgent block streaming", () => {
       };
     });
 
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "discord",
-      OriginatingTo: "channel:C1",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
+    const resultPromise = createBaseRun({
+      context: {
+        Provider: "discord",
+        OriginatingTo: "channel:C1",
+        AccountId: "primary",
+        MessageSid: "msg",
+      },
       run: {
-        sessionId: "session",
-        sessionKey: "main",
         messageProvider: "discord",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
         config: {
           agents: {
             defaults: {
@@ -1262,47 +1146,21 @@ describe("runReplyAgent block streaming", () => {
             },
           },
         },
-        skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
         thinkLevel: "low",
         reasoningLevel: "on",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
         blockReplyBreak: "text_end",
       },
-    });
-
-    const resultPromise = runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      opts: { onBlockReply, blockReplyTimeoutMs: 1 },
-      typing,
-      sessionCtx,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: true,
-      blockReplyChunking: {
-        minChars: 1,
-        maxChars: 200,
-        breakPreference: "paragraph",
+      reply: {
+        opts: { onBlockReply, blockReplyTimeoutMs: 1 },
+        blockStreamingEnabled: true,
+        blockReplyChunking: {
+          minChars: 1,
+          maxChars: 200,
+          breakPreference: "paragraph",
+        },
+        resolvedBlockStreamingBreak: "text_end",
       },
-      resolvedBlockStreamingBreak: "text_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+    }).run();
 
     await vi.advanceTimersByTimeAsync(5);
     const result = await resultPromise;
@@ -1336,85 +1194,87 @@ describe("runReplyAgent Active Memory inline debug", () => {
     );
   }
 
-  it("appends inline Active Memory status payload when verbose is enabled", async () => {
+  async function runActiveMemoryDebugCase(sessionEntry: SessionEntry) {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-active-memory-inline-"));
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
+    await replaceSessionEntry({ storePath, sessionKey }, sessionEntry);
+    runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      await writeActiveMemoryDebugEntry({ sessionEntry, sessionKey, storePath });
+      return { payloads: [{ text: "Normal reply" }], meta: {} };
+    });
+    return createBaseRun({
+      context: {
+        Provider: "telegram",
+        OriginatingTo: "chat:1",
+        AccountId: "primary",
+        MessageSid: "msg",
+      },
+      run: {
+        agentId: "main",
+        sessionKey,
+        messageProvider: "telegram",
+        traceAuthorized: true,
+        thinkLevel: "low",
+        verboseLevel: "on",
+      },
+      reply: {
+        queueKey: sessionKey,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+        sessionKey,
+        storePath,
+        resolvedVerboseLevel: "on",
+      },
+    }).run();
+  }
+
+  function runRawTraceCase(params: {
+    commandBody: string;
+    reasoningLevel?: "off" | "on";
+    senderIsOwner?: boolean;
+    sessionEntry: SessionEntry;
+    sessionFile: string;
+    storePath: string;
+    thinkLevel: "low" | "off";
+    traceAuthorized: boolean;
+  }) {
+    const sessionKey = "main";
+    return createBaseRun({
+      context: {
+        Provider: "telegram",
+        OriginatingTo: "chat:1",
+        AccountId: "primary",
+        MessageSid: "msg",
+        CommandBody: params.commandBody,
+      },
+      run: {
+        agentId: "main",
+        sessionKey,
+        messageProvider: "telegram",
+        sessionFile: params.sessionFile,
+        ...(params.senderIsOwner === undefined ? {} : { senderIsOwner: params.senderIsOwner }),
+        traceAuthorized: params.traceAuthorized,
+        thinkLevel: params.thinkLevel,
+        ...(params.reasoningLevel ? { reasoningLevel: params.reasoningLevel } : {}),
+      },
+      reply: {
+        queueKey: sessionKey,
+        sessionEntry: params.sessionEntry,
+        sessionStore: { [sessionKey]: params.sessionEntry },
+        sessionKey,
+        storePath: params.storePath,
+      },
+    }).run();
+  }
+
+  it("appends inline Active Memory status payload when verbose is enabled", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       verboseLevel: "on",
     };
-
-    await replaceSessionEntry({ storePath, sessionKey }, sessionEntry);
-
-    runEmbeddedAgentMock.mockImplementationOnce(async () => {
-      await writeActiveMemoryDebugEntry({ sessionEntry, sessionKey, storePath });
-      return {
-        payloads: [{ text: "Normal reply" }],
-        meta: {},
-      };
-    });
-
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      OriginatingTo: "chat:1",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
-      run: {
-        agentId: "main",
-        sessionId: "session",
-        sessionKey,
-        messageProvider: "telegram",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
-        config: {},
-        skillsSnapshot: {},
-        traceAuthorized: true,
-        provider: "anthropic",
-        model: "claude",
-        thinkLevel: "low",
-        verboseLevel: "on",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
-      },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "on",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+    const result = await runActiveMemoryDebugCase(sessionEntry);
 
     expect(Array.isArray(result)).toBe(true);
     expect((result as { text?: string }[]).map((payload) => payload.text)).toEqual([
@@ -1424,9 +1284,6 @@ describe("runReplyAgent Active Memory inline debug", () => {
   });
 
   it("appends inline Active Memory status and trace payloads when verbose and trace are enabled", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-active-memory-inline-"));
-    const storePath = path.join(tmp, "sessions.json");
-    const sessionKey = "main";
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
@@ -1434,75 +1291,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
       traceLevel: "on",
     };
 
-    await replaceSessionEntry({ storePath, sessionKey }, sessionEntry);
-
-    runEmbeddedAgentMock.mockImplementationOnce(async () => {
-      await writeActiveMemoryDebugEntry({ sessionEntry, sessionKey, storePath });
-      return {
-        payloads: [{ text: "Normal reply" }],
-        meta: {},
-      };
-    });
-
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      OriginatingTo: "chat:1",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
-      run: {
-        agentId: "main",
-        sessionId: "session",
-        sessionKey,
-        messageProvider: "telegram",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
-        config: {},
-        skillsSnapshot: {},
-        traceAuthorized: true,
-        provider: "anthropic",
-        model: "claude",
-        thinkLevel: "low",
-        verboseLevel: "on",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
-      },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "on",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+    const result = await runActiveMemoryDebugCase(sessionEntry);
 
     expect(Array.isArray(result)).toBe(true);
     expect((result as { text?: string }[]).map((payload) => payload.text)).toEqual([
@@ -1512,84 +1301,13 @@ describe("runReplyAgent Active Memory inline debug", () => {
   });
 
   it("appends inline Active Memory trace payload when only trace is enabled", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-active-memory-inline-"));
-    const storePath = path.join(tmp, "sessions.json");
-    const sessionKey = "main";
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       traceLevel: "on",
     };
 
-    await replaceSessionEntry({ storePath, sessionKey }, sessionEntry);
-
-    runEmbeddedAgentMock.mockImplementationOnce(async () => {
-      await writeActiveMemoryDebugEntry({ sessionEntry, sessionKey, storePath });
-      return {
-        payloads: [{ text: "Normal reply" }],
-        meta: {},
-      };
-    });
-
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      OriginatingTo: "chat:1",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
-      run: {
-        agentId: "main",
-        sessionId: "session",
-        sessionKey,
-        messageProvider: "telegram",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
-        config: {},
-        skillsSnapshot: {},
-        traceAuthorized: true,
-        provider: "anthropic",
-        model: "claude",
-        thinkLevel: "low",
-        verboseLevel: "on",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
-      },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
-      storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "on",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+    const result = await runActiveMemoryDebugCase(sessionEntry);
 
     expect(Array.isArray(result)).toBe(true);
     expect((result as { text?: string }[]).map((payload) => payload.text)).toEqual([
@@ -1693,66 +1411,14 @@ describe("runReplyAgent Active Memory inline debug", () => {
       },
     });
 
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      OriginatingTo: "chat:1",
-      AccountId: "primary",
-      MessageSid: "msg",
-      CommandBody: "/trace raw show me everything",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
-      run: {
-        agentId: "main",
-        sessionId: "session",
-        sessionKey,
-        messageProvider: "telegram",
-        sessionFile,
-        workspaceDir: "/tmp",
-        config: {},
-        skillsSnapshot: {},
-        traceAuthorized: true,
-        provider: "anthropic",
-        model: "claude",
-        thinkLevel: "low",
-        reasoningLevel: "on",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
-      },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
+    const result = await runRawTraceCase({
+      commandBody: "/trace raw show me everything",
+      reasoningLevel: "on",
       sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
+      sessionFile,
       storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
+      thinkLevel: "low",
+      traceAuthorized: true,
     });
 
     expect(Array.isArray(result)).toBe(true);
@@ -1863,66 +1529,14 @@ describe("runReplyAgent Active Memory inline debug", () => {
       },
     });
 
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      OriginatingTo: "chat:1",
-      AccountId: "primary",
-      MessageSid: "msg",
-      CommandBody: "show me the answer",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
-      run: {
-        agentId: "main",
-        sessionId: "session",
-        sessionKey,
-        messageProvider: "telegram",
-        sessionFile,
-        workspaceDir: "/tmp",
-        config: {},
-        skillsSnapshot: {},
-        senderIsOwner: false,
-        traceAuthorized: false,
-        provider: "anthropic",
-        model: "claude",
-        thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
-      },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
+    const result = await runRawTraceCase({
+      commandBody: "show me the answer",
+      senderIsOwner: false,
       sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
+      sessionFile,
       storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
+      thinkLevel: "low",
+      traceAuthorized: false,
     });
 
     expectReplyText(result, "Visible reply");
@@ -1969,65 +1583,13 @@ describe("runReplyAgent Active Memory inline debug", () => {
       },
     });
 
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      OriginatingTo: "chat:1",
-      AccountId: "primary",
-      MessageSid: "msg",
-      CommandBody: "/trace raw",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
-      run: {
-        agentId: "main",
-        sessionId: "session",
-        sessionKey,
-        messageProvider: "telegram",
-        sessionFile,
-        workspaceDir: "/tmp",
-        config: {},
-        skillsSnapshot: {},
-        traceAuthorized: true,
-        provider: "anthropic",
-        model: "claude",
-        thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
-      },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
+    const result = await runRawTraceCase({
+      commandBody: "/trace raw",
       sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
+      sessionFile,
       storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
+      thinkLevel: "low",
+      traceAuthorized: true,
     });
 
     const traceText = (Array.isArray(result) ? result[1] : result)?.text ?? "";
@@ -2066,66 +1628,14 @@ describe("runReplyAgent Active Memory inline debug", () => {
       },
     });
 
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      OriginatingTo: "chat:1",
-      AccountId: "primary",
-      MessageSid: "msg",
-      CommandBody: "/trace raw",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
-      run: {
-        agentId: "main",
-        sessionId: "session",
-        sessionKey,
-        messageProvider: "telegram",
-        sessionFile,
-        workspaceDir: "/tmp",
-        config: {},
-        skillsSnapshot: {},
-        traceAuthorized: true,
-        provider: "anthropic",
-        model: "claude",
-        thinkLevel: "off",
-        reasoningLevel: "off",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
-      },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: sessionKey,
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
+    const result = await runRawTraceCase({
+      commandBody: "/trace raw",
+      reasoningLevel: "off",
       sessionEntry,
-      sessionStore: { [sessionKey]: sessionEntry },
-      sessionKey,
+      sessionFile,
       storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
+      thinkLevel: "off",
+      traceAuthorized: true,
     });
 
     const traceText = (result as { text?: string }[])[1]?.text ?? "";
@@ -2136,59 +1646,21 @@ describe("runReplyAgent Active Memory inline debug", () => {
 
 describe("runReplyAgent claude-cli routing", () => {
   function createRun() {
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "webchat",
-      OriginatingTo: "session:1",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
+    return createBaseRun({
+      context: {
+        Provider: "webchat",
+        OriginatingTo: "session:1",
+        AccountId: "primary",
+        MessageSid: "msg",
+      },
       run: {
-        sessionId: "session",
-        sessionKey: "main",
         messageProvider: "webchat",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
-        config: {},
-        skillsSnapshot: {},
         provider: "claude-cli",
         model: "opus-4.5",
         thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
       },
-    });
-
-    return runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      defaultModel: "claude-cli/opus-4.5",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+      reply: { defaultModel: "claude-cli/opus-4.5" },
+    }).run();
   }
 
   it("uses the CLI runner for claude-cli provider", async () => {
@@ -2244,72 +1716,39 @@ describe("runReplyAgent claude-cli routing", () => {
       },
     });
 
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "webchat",
-      OriginatingTo: "session:1",
-      AccountId: "primary",
-      MessageSid: "msg",
-      CommandBody: "secret hitl prompt",
-      RawBody: "secret hitl prompt",
-      BodyForAgent: "secret hitl prompt",
-      Body: "secret hitl prompt",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
     const sessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       traceLevel: "raw",
     } as SessionEntry;
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "secret hitl prompt",
-      summaryLine: "secret hitl prompt",
-      enqueuedAt: Date.now(),
+    const result = await createBaseRun({
+      context: {
+        Provider: "webchat",
+        OriginatingTo: "session:1",
+        AccountId: "primary",
+        MessageSid: "msg",
+        CommandBody: "secret hitl prompt",
+        RawBody: "secret hitl prompt",
+        BodyForAgent: "secret hitl prompt",
+        Body: "secret hitl prompt",
+      },
+      followup: { prompt: "secret hitl prompt", summaryLine: "secret hitl prompt" },
       run: {
         agentId: "main",
-        sessionId: "session",
-        sessionKey: "main",
         messageProvider: "webchat",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
         config: createCliBackendTestConfig(),
-        skillsSnapshot: {},
         traceAuthorized: true,
         provider: "claude-cli",
         model: "opus-4.5",
         thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
       },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "secret hitl prompt",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      defaultModel: "claude-cli/opus-4.5",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+      reply: {
+        commandBody: "secret hitl prompt",
+        sessionEntry,
+        sessionStore: { main: sessionEntry },
+        defaultModel: "claude-cli/opus-4.5",
+      },
+    }).run();
 
     const texts = Array.isArray(result)
       ? result.map((payload) => payload.text ?? "").join("\n")
@@ -2332,28 +1771,19 @@ describe("runReplyAgent claude-cli routing", () => {
       },
     });
 
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "webchat",
-      OriginatingTo: "session:1",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
     const sessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
     } as SessionEntry;
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
+    const result = await createBaseRun({
+      context: {
+        Provider: "webchat",
+        OriginatingTo: "session:1",
+        AccountId: "primary",
+        MessageSid: "msg",
+      },
       run: {
-        sessionId: "session",
-        sessionKey: "main",
         messageProvider: "webchat",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
         config: {
           agents: {
             defaults: {
@@ -2363,41 +1793,12 @@ describe("runReplyAgent claude-cli routing", () => {
             },
           },
         },
-        skillsSnapshot: {},
         provider: "anthropic",
         model: "claude-opus-4-7",
         thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
       },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      defaultModel: "anthropic/claude-opus-4-7",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+      reply: { sessionEntry, defaultModel: "anthropic/claude-opus-4-7" },
+    }).run();
 
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
     expectRecordFields(
@@ -2414,62 +1815,22 @@ describe("runReplyAgent messaging tool dedupe", () => {
     messageProvider = "slack",
     opts: { storePath?: string; sessionKey?: string } = {},
   ) {
-    const typing = createMockTypingController();
     const sessionKey = opts.sessionKey ?? "main";
-    const sessionCtx = createTestTemplateContext({
-      Provider: messageProvider,
-      OriginatingTo: "channel:C1",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
+    return createBaseRun({
+      context: {
+        Provider: messageProvider,
+        OriginatingTo: "channel:C1",
+        AccountId: "primary",
+        MessageSid: "msg",
+      },
       run: {
-        sessionId: "session",
         sessionKey,
         messageProvider,
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
         config: createCliBackendTestConfig(),
-        skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
         thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
       },
-    });
-
-    return runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionKey,
-      storePath: opts.storePath,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+      reply: { queueKey: "main", sessionKey, storePath: opts.storePath },
+    }).run();
   }
 
   it("delivers distinct replies when a messaging tool sent via the same provider + target", async () => {
@@ -2547,61 +1908,21 @@ describe("runReplyAgent messaging tool dedupe", () => {
 
 describe("runReplyAgent reminder commitment guard", () => {
   function createRun(params?: { sessionKey?: string; omitSessionKey?: boolean }) {
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      OriginatingTo: "chat",
-      AccountId: "primary",
-      MessageSid: "msg",
-      Surface: "telegram",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
-      run: {
-        sessionId: "session",
-        sessionKey: "main",
-        messageProvider: "telegram",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
-        config: createCliBackendTestConfig(),
-        skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
-        thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
+    return createBaseRun({
+      context: {
+        Provider: "telegram",
+        OriginatingTo: "chat",
+        AccountId: "primary",
+        MessageSid: "msg",
+        Surface: "telegram",
       },
-    });
-
-    return runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      ...(params?.omitSessionKey ? {} : { sessionKey: params?.sessionKey ?? "main" }),
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+      run: {
+        messageProvider: "telegram",
+        config: createCliBackendTestConfig(),
+        thinkLevel: "low",
+      },
+      reply: params?.omitSessionKey ? {} : { sessionKey: params?.sessionKey ?? "main" },
+    }).run();
   }
 
   it("appends guard note when reminder commitment is not backed by cron.add", async () => {
@@ -2773,63 +2094,16 @@ describe("runReplyAgent fallback reasoning tags", () => {
   };
 
   function createRun(params?: { sessionEntry?: SessionEntry; sessionKey?: string }) {
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "whatsapp",
-      OriginatingTo: "+15550001111",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
     const sessionKey = params?.sessionKey ?? "main";
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
+    return createBaseRun({
       run: {
         agentId: "main",
         agentDir: "/tmp/agent",
-        sessionId: "session",
         sessionKey,
-        messageProvider: "whatsapp",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
         config: createCliBackendTestConfig(),
-        skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
       },
-    });
-
-    return runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry: params?.sessionEntry,
-      sessionKey,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+      reply: { queueKey: "main", sessionEntry: params?.sessionEntry, sessionKey },
+    }).run();
   }
 
   it("enforces <final> when the fallback provider requires reasoning tags", async () => {
@@ -2907,70 +2181,23 @@ describe("runReplyAgent response usage footer", () => {
     provider?: string;
     model?: string;
   }) {
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "whatsapp",
-      OriginatingTo: "+15550001111",
-      AccountId: "primary",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       responseUsage: params.responseUsage,
     };
-
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
+    return createBaseRun({
       run: {
         agentId: "main",
         agentDir: "/tmp/agent",
-        sessionId: "session",
         sessionKey: params.sessionKey,
-        messageProvider: "whatsapp",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
         config: params.config ?? createCliBackendTestConfig(),
-        skillsSnapshot: {},
         provider: params.provider ?? "anthropic",
         model: params.model ?? "claude",
         thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
       },
-    });
-
-    return runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      sessionEntry,
-      sessionKey: params.sessionKey,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+      reply: { queueKey: "main", sessionEntry, sessionKey: params.sessionKey },
+    }).run();
   }
 
   it("uses the built-in compact footer when responseUsage=full", async () => {
@@ -3161,57 +2388,14 @@ describe("runReplyAgent transient HTTP retry", () => {
         meta: {},
       });
 
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
+    const runPromise = createBaseRun({
+      context: { Provider: "telegram", MessageSid: "msg" },
       run: {
-        sessionId: "session",
-        sessionKey: "main",
         messageProvider: "telegram",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
         config: createCliBackendTestConfig(),
-        skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
         thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
       },
-    });
-
-    const runPromise = runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      defaultModel: "anthropic/claude-opus-4-6",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+    }).run();
 
     await vi.advanceTimersByTimeAsync(2_500);
     const result = await runPromise;
@@ -3236,57 +2420,15 @@ describe("runReplyAgent billing error classification", () => {
       new Error("402 Payment Required: request token limit exceeded for this billing plan"),
     );
 
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
+    const result = await createBaseRun({
+      context: { Provider: "telegram", MessageSid: "msg" },
       run: {
-        sessionId: "session",
-        sessionKey: "main",
         messageProvider: "telegram",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
         config: createCliBackendTestConfig(),
-        skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
         thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
       },
-    });
-
-    const result = await runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      defaultModel: "anthropic/claude",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+      reply: { defaultModel: "anthropic/claude" },
+    }).run();
 
     const payload = Array.isArray(result) ? result[0] : result;
     expect(payload?.text).toContain("billing error");
@@ -3296,57 +2438,15 @@ describe("runReplyAgent billing error classification", () => {
 
 describe("runReplyAgent mid-turn rate-limit fallback", () => {
   function createRun() {
-    const typing = createMockTypingController();
-    const sessionCtx = createTestTemplateContext({
-      Provider: "telegram",
-      MessageSid: "msg",
-    });
-    const resolvedQueue = createTestQueueSettings({ mode: "interrupt" });
-    const followupRun = createTestQueuedFollowupRun({
-      prompt: "hello",
-      summaryLine: "hello",
-      enqueuedAt: Date.now(),
+    return createBaseRun({
+      context: { Provider: "telegram", MessageSid: "msg" },
       run: {
-        sessionId: "session",
-        sessionKey: "main",
         messageProvider: "telegram",
-        sessionFile: "/tmp/session.jsonl",
-        workspaceDir: "/tmp",
         config: createCliBackendTestConfig(),
-        skillsSnapshot: {},
-        provider: "anthropic",
-        model: "claude",
         thinkLevel: "low",
-        verboseLevel: "off",
-        elevatedLevel: "off",
-        bashElevated: {
-          enabled: false,
-          allowed: false,
-          defaultLevel: "off",
-        },
-        timeoutMs: 1_000,
-        blockReplyBreak: "message_end",
       },
-    });
-
-    return runReplyAgent({
-      commandBody: "hello",
-      followupRun,
-      queueKey: "main",
-      resolvedQueue,
-      shouldSteer: false,
-      shouldFollowup: false,
-      isActive: false,
-      typing,
-      sessionCtx,
-      defaultModel: "anthropic/claude",
-      resolvedVerboseLevel: "off",
-      isNewSession: false,
-      blockStreamingEnabled: false,
-      resolvedBlockStreamingBreak: "message_end",
-      shouldInjectGroupIntro: false,
-      typingMode: "instant",
-    });
+      reply: { defaultModel: "anthropic/claude" },
+    }).run();
   }
 
   it("surfaces a final error when only reasoning preceded a mid-turn rate limit", async () => {


### PR DESCRIPTION
## Summary

- replace 21 hand-built reply-runner fixtures and six local wrappers with one typed suite-local builder
- preserve explicit queue/session identity, privacy and raw-trace inputs, CLI secrets, block streaming, usage diagnostics, and private-final recovery cases
- remove an accidental duplicate subagent-registry mock

## Verification

- target owner suite: 79/79
- direct-runtime sibling: 12/12
- run-reply-agent E2E: 157/157
- memory sibling: 75/75
- all 234 complete outer expectations, 34 assertion-helper calls, 78 declarations, tables, hooks, comments, and literal inventory preserved exactly
- focused type-aware lint, formatting, and diff checks passed
- independent fresh-main verification passed with no findings
- mandatory isolated review and secret scan completed clean with no actionable findings
- exact reviewed binary diff: `7d33e98b37a11845eb2a9dba5c2b1df812a35c531c977a8ce338cde7d0042e85`

This is test-only: +370/-1270, net -900. No production, API, configuration, schema, migration, security, or documented behavior changes.

Changelog: not required for test-only cleanup.
