### PR TITLE
fix(reply): keep attachments and actions when reply text was already sent

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -13,6 +13,7 @@ import {
   markReplyPayloadForSourceSuppressionDelivery,
   setReplyPayloadMetadata,
 } from "../reply-payload.js";
+import type { ReplyPayload } from "../types.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import { createBlockReplyContentKey, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { createReplyToModeFilterForChannel } from "./reply-threading.js";
@@ -166,6 +167,83 @@ describe("buildReplyPayloads media filter integration", () => {
         },
       ]),
     );
+  });
+
+  it.each<{
+    name: string;
+    payload: ReplyPayload;
+    sentMediaUrls?: string[];
+    expected?: ReplyPayload[];
+  }>([
+    {
+      name: "unsent media after the legacy media URL was already sent",
+      payload: {
+        text: "already sent",
+        mediaUrl: "file:///tmp/sent.ogg",
+        mediaUrls: ["file:///tmp/unsent-a.ogg", "file:///tmp/unsent-b.ogg"],
+        audioAsVoice: true,
+      },
+      sentMediaUrls: ["file:///tmp/sent.ogg"],
+      expected: [
+        {
+          text: "already sent",
+          mediaUrl: undefined,
+          mediaUrls: ["file:///tmp/unsent-a.ogg", "file:///tmp/unsent-b.ogg"],
+          audioAsVoice: true,
+        },
+      ],
+    },
+    {
+      name: "an unsent portable presentation",
+      payload: {
+        text: "already sent",
+        presentation: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Open", value: "open" }] }],
+        },
+      },
+    },
+    {
+      name: "unsent legacy interactive controls",
+      payload: {
+        text: "already sent",
+        interactive: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Retry", value: "retry" }] }],
+        },
+      },
+    },
+    {
+      name: "unsent channel-specific content",
+      payload: { text: "already sent", channelData: { telegram: { buttons: [] } } },
+    },
+    {
+      name: "an unsent portable location",
+      payload: { text: "already sent", location: { latitude: 1, longitude: 2 } },
+    },
+    {
+      name: "an enabled delivery operation",
+      payload: { text: "already sent", delivery: { pin: true } },
+    },
+    {
+      name: "an enabled configured delivery operation",
+      payload: { text: "already sent", delivery: { pin: { enabled: true } } },
+    },
+    {
+      name: "no unsent content for a disabled delivery operation",
+      payload: { text: "already sent", delivery: { pin: { enabled: false } } },
+      expected: [],
+    },
+  ])("preserves $name when only the reply text was sent", async (testCase) => {
+    const { replyPayloads } = await buildTestReplyPayloads({
+      payloads: [testCase.payload],
+      messagingToolSentTexts: ["already sent"],
+      messagingToolSentMediaUrls: testCase.sentMediaUrls,
+    });
+
+    const expected = testCase.expected ?? [testCase.payload];
+    expect(replyPayloads).toHaveLength(expected.length);
+    for (const [index, payload] of expected.entries()) {
+      expect(replyPayloads[index]).toMatchObject(payload);
+    }
   });
 
   it("shares first-reply threading across staged payload builds", async () => {

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -9,6 +9,7 @@ import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { getLoadedChannelPluginForRead } from "../../channels/plugins/registry-loaded.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { normalizeMediaReferenceForComparison } from "../../media/media-reference-comparison.js";
 import {
   channelRouteTargetsMatchExact,
@@ -34,22 +35,6 @@ type MessagingToolDedupeRouteParams = {
   replyDelivery?: ReplyDeliveryContext;
   accountId?: string;
 };
-
-/** Removes text payloads already sent by message tools. */
-function filterMessagingToolDuplicates(params: {
-  payloads: ReplyPayload[];
-  sentTexts: string[];
-}): ReplyPayload[] {
-  const { payloads, sentTexts } = params;
-  if (sentTexts.length === 0) {
-    return payloads;
-  }
-  return payloads.filter(
-    (payload) =>
-      Boolean(payload.mediaUrl || payload.mediaUrls?.length) ||
-      !isMessagingToolDuplicate(payload.text ?? "", sentTexts),
-  );
-}
 
 /** Removes media payload URLs already sent by message tools. */
 export function filterMessagingToolMediaDuplicates(params: {
@@ -110,12 +95,12 @@ export function filterMessagingToolMediaDuplicates(params: {
     }
 
     const nextMediaUrl = stripSingle ? undefined : mediaUrl;
-    const nextMediaUrls = filteredUrls?.length ? filteredUrls : undefined;
+    const nextMediaUrls = strippedMediaUrls ? filteredUrls : mediaUrls;
     const nextPayload = copyReplyPayloadMetadata(payload, {
       ...payload,
       mediaUrl: nextMediaUrl,
-      mediaUrls: nextMediaUrls,
-      ...(payload.audioAsVoice === true && !nextMediaUrl && !nextMediaUrls
+      mediaUrls: nextMediaUrls?.length ? nextMediaUrls : undefined,
+      ...(payload.audioAsVoice === true && !nextMediaUrl && !nextMediaUrls?.length
         ? { audioAsVoice: undefined }
         : {}),
     });
@@ -422,14 +407,22 @@ export function filterMessagingToolReplyPayload(
     decision.matchingRoute && !decision.useGlobalSentTextEvidenceFallback
       ? decision.routeSentTexts
       : (params.sentTexts ?? []);
-  const filterPayload = (normalizedSentMediaUrls: string[]) =>
-    filterMessagingToolDuplicates({
-      payloads: filterMessagingToolMediaDuplicates({
-        payloads: [params.payload],
-        sentMediaUrls: normalizedSentMediaUrls,
-      }),
-      sentTexts,
+  const filterPayload = (normalizedSentMediaUrls: string[]) => {
+    const payloads = filterMessagingToolMediaDuplicates({
+      payloads: [params.payload],
+      sentMediaUrls: normalizedSentMediaUrls,
     });
+    return sentTexts.length === 0
+      ? payloads
+      : payloads.filter(
+          (payload) =>
+            !isMessagingToolDuplicate(payload.text ?? "", sentTexts) ||
+            hasReplyPayloadContent(
+              { ...payload, text: undefined },
+              { extraContent: hasEnabledDeliveryOperation(payload) || payload.location != null },
+            ),
+        );
+  };
   return params.normalizeSentMediaUrls
     ? params.normalizeSentMediaUrls(sentMediaUrls).then(filterPayload)
     : filterPayload(sentMediaUrls);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where assistant replies silently lost attachments, buttons, portable presentations, channel-specific content, locations, or delivery operations when a messaging tool had already sent the reply text. An already-sent legacy attachment could also erase distinct unsent attachment URLs.

## Why This Change Was Made

The canonical reply-deduplication owner previously decided whether a complete payload was redundant by checking only its text and attachment fields. Reuse the existing authoritative reply-content predicate instead, preserve untouched plural attachment URLs while removing genuinely duplicated media, and delete the obsolete text-only deduplication wrapper.

Production delta: **19 additions / 26 deletions (net -7)**. No configuration, protocol, authentication, persistence, or plugin-SDK changes.

## User Impact

Already-delivered text is still deduplicated, while every remaining unsent attachment, button, location, channel payload, and enabled delivery operation reaches its intended conversation.

## Evidence

- Authentic pre-fix owner-boundary regression: **7 failing cases** for unsent media, presentation, legacy controls, channel data, location, and both enabled pin forms; the disabled-pin control already passed.
- Fixed owner and caller suites: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-payloads.test.ts --reporter=dot` — **112 passed, 1 existing Windows-only skip**.
- Interactive sibling coverage: **45 additional passing tests**.
- Targeted formatter and lint checks passed; changed-file classifier selected only core production and core tests.
- Fresh independent structured review: **clean; no accepted or actionable findings**.
