### PR TITLE
fix(cli): keep plugin update recovery hints inside the active container

### DIFF
--- a/src/cli/command-format.ts
+++ b/src/cli/command-format.ts
@@ -6,7 +6,7 @@ const CLI_PREFIX_RE = /^(?:pnpm|npm|bunx|npx)\s+openclaw\b|^openclaw\b/;
 const CONTAINER_FLAG_RE = /(?:^|\s)--container(?:\s|=|$)/;
 const PROFILE_FLAG_RE = /(?:^|\s)--profile(?:\s|=|$)/;
 const DEV_FLAG_RE = /(?:^|\s)--dev(?:\s|$)/;
-const UPDATE_COMMAND_RE = /^(?:(?:pnpm|npm|bunx|npx)\s+openclaw|openclaw)\b.*\supdate(?:\s|$)/;
+const UPDATE_RE = /^(?:\s+--(?:dev|no-color|(?:profile|log-level)[=\s]+\S+))*\s+update(?:\s|$)/;
 const CONTAINER_HINT_RE = /^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,127}$/;
 
 /** Add active root options to a displayed command without duplicating explicit flags. */
@@ -29,7 +29,7 @@ export function formatCliCommand(
   if (
     container &&
     !CONTAINER_FLAG_RE.test(normalizedCommand) &&
-    !UPDATE_COMMAND_RE.test(normalizedCommand)
+    !UPDATE_RE.test(normalizedCommand.replace(CLI_PREFIX_RE, ""))
   ) {
     additions.push(`--container ${container}`);
   }

--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -664,12 +664,44 @@ describe("formatCliCommand", () => {
     ).toBe("openclaw --container demo doctor");
   });
 
-  it("does not prepend --container for update commands", () => {
-    expect(formatCliCommand("openclaw update", { OPENCLAW_CONTAINER_HINT: "demo" })).toBe(
-      "openclaw update",
-    );
+  it.each([
+    "openclaw update",
+    "pnpm openclaw update --channel beta",
+    "npm openclaw update",
+    "bunx openclaw update",
+    "npx openclaw update",
+    "openclaw --profile work update",
+    "openclaw --profile=work update",
+    "openclaw --log-level debug update",
+    "openclaw --log-level=debug update",
+    "openclaw --dev update",
+    "openclaw --no-color update",
+    "openclaw --no-color --profile work --log-level=debug update",
+    "openclaw --profile update update",
+    "pnpm openclaw --profile work update --channel beta",
+  ])("does not prepend --container to root update: %s", (command) => {
     expect(
-      formatCliCommand("pnpm openclaw update --channel beta", { OPENCLAW_CONTAINER_HINT: "demo" }),
-    ).toBe("pnpm openclaw update --channel beta");
+      formatCliCommand(command, { OPENCLAW_CONTAINER_HINT: "demo", OPENCLAW_PROFILE: "work" }),
+    ).toBe(command);
+  });
+
+  it.each([
+    ["openclaw", "plugins update telegram"],
+    ["openclaw", "hooks update webhook"],
+    ["openclaw", "skills update summarize"],
+    ["pnpm openclaw", "plugins update telegram"],
+    ["openclaw", "--profile work plugins update telegram"],
+    ["openclaw", "--log-level=debug plugins update telegram"],
+    ["openclaw", "--profile update plugins list"],
+    ["openclaw", "--log-level update plugins list"],
+    ["openclaw", "config set action update"],
+    ["openclaw", "gateway status --name update"],
+  ])("preserves the active container for non-root update: %s %s", (prefix, command) => {
+    expect(
+      formatCliCommand(`${prefix} ${command}`, {
+        OPENCLAW_CONTAINER_HINT: "demo",
+        OPENCLAW_PROFILE: "work",
+      }),
+    ).toBe(`${prefix} --container demo ${command}`);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators following recovery hints for plugin, hook, or skill updates would accidentally run the command against the host instead of the active container whenever the command contained the word `update`.

## Why This Change Was Made

The shared command formatter exempted any command containing a later `update` token from container scoping. Match only the actual root self-update command after supported root flags, while preserving existing package-manager wrappers and container-over-profile precedence.

Production delta: **2 additions / 2 deletions (net 0)**. No configuration, protocol, authentication, persistence, or plugin-SDK changes.

## User Impact

Plugin, hook, and skill update hints consistently retain their active `--container` target. Root self-update commands continue to run outside the container exactly as before.

## Evidence

- Authentic pre-fix regression: **10 independently failing cases**, including nested plugin/hook/skill updates, wrapped commands, root-option values, and positional values named `update`.
- Fixed owner and root-option suites: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/profile.test.ts src/infra/cli-root-options.test.ts --reporter=dot` — **94 passed**.
- Actual operator-facing plugin recovery formatter now preserves the active container for install, update, and uninstall suggestions; 14 root-update, wrapper, and root-option forms remain unchanged.
- Targeted formatter and lint checks passed; changed-file classifier selected only core production and core tests.
- Fresh independent structured review: **clean; no accepted or actionable findings**.
