### PR TITLE
fix(plugins): keep channels authoritative after activation rollback

### DIFF
--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -39,7 +39,7 @@ import type { PluginRecord, PluginRegistry } from "./registry.js";
 import {
   captureActivePluginRegistrySnapshot,
   commitStagedPluginRegistry,
-  restoreActivePluginRegistrySnapshot,
+  rollbackStagedPluginRegistry,
   stageActivePluginRegistry,
 } from "./runtime.js";
 import { validateJsonSchemaValue } from "./schema-validator.js";
@@ -374,7 +374,7 @@ export function activatePluginRegistry(
     activateContextEngineRegistrations(registry);
     commitStagedPluginRegistry(activeSnapshot.activeRegistry, registry);
   } catch (error) {
-    restoreActivePluginRegistrySnapshot(activeSnapshot);
+    rollbackStagedPluginRegistry(activeSnapshot);
     if (previousHookRegistry) {
       initializeGlobalHookRunner(previousHookRegistry);
     } else {

--- a/src/plugins/loader.registration.test-utils.ts
+++ b/src/plugins/loader.registration.test-utils.ts
@@ -63,7 +63,11 @@ import {
   registerMemoryPromptSupplement,
   resolveMemoryFlushPlan,
 } from "./memory-state.test-fixtures.js";
-import { isPluginRegistryRetired } from "./registry-lifecycle.js";
+import {
+  activatePluginRecordLifecycleEpoch,
+  isPluginRecordLifecycleEpochActive,
+  isPluginRegistryRetired,
+} from "./registry-lifecycle.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 import {
   getActivePluginRegistry,
@@ -393,6 +397,10 @@ describe("loadOpenClawPlugins", () => {
     const priorKey = getActivePluginRegistryKey();
     const priorMode = getActivePluginRuntimeSubagentMode();
     const priorWorkspaceDir = getActivePluginRegistryWorkspaceDir();
+    const priorRecord = priorRegistry.plugins.find((entry) => entry.id === "activation-prior");
+    expect(priorRecord).toBeDefined();
+    const priorEpoch = activatePluginRecordLifecycleEpoch(priorRegistry, priorRecord!);
+    expect(priorEpoch).toBeDefined();
 
     const replacement = writePlugin({
       id: "activation-replacement",
@@ -437,10 +445,14 @@ describe("loadOpenClawPlugins", () => {
     expect(getActivePluginRuntimeSubagentMode()).toBe(priorMode);
     expect(getActivePluginRegistryWorkspaceDir()).toBe(priorWorkspaceDir);
     expect(getPluginCommandSpecs().map((command) => command.name)).toEqual(["prior"]);
+    expect(isPluginRecordLifecycleEpochActive(priorRegistry, priorRecord!, priorEpoch!)).toBe(true);
 
     const activated = loadOpenClawPlugins(replacementOptions);
     expect(activated.commands.map((entry) => entry.command.name)).toEqual(["replacement"]);
     expect(getPluginCommandSpecs().map((command) => command.name)).toEqual(["replacement"]);
+    expect(isPluginRecordLifecycleEpochActive(priorRegistry, priorRecord!, priorEpoch!)).toBe(
+      false,
+    );
   });
 
   it("fails plugin registration when a hook is missing its required name", () => {

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -200,16 +200,34 @@ export function restoreActivePluginRegistrySnapshot(
   });
 }
 
+/** Rolls back a staged registry without reactivating the prior committed generation. */
+export function rollbackStagedPluginRegistry(
+  snapshot: ReturnType<typeof captureActivePluginRegistrySnapshot>,
+): void {
+  installActivePluginRegistry({
+    registry: snapshot.activeRegistry,
+    key: snapshot.key,
+    runtimeSubagentMode: snapshot.runtimeSubagentMode,
+    workspaceDir: snapshot.workspaceDir,
+    // Staging never retired the prior registry. Reactivating it here would mint a
+    // new epoch and revoke closures that remained authoritative through rollback.
+    activateRegistry: false,
+  });
+}
+
 function installActivePluginRegistry(params: {
   registry: PluginRegistry | null;
   key: string | null;
   runtimeSubagentMode: RegistryState["runtimeSubagentMode"];
   workspaceDir: string | null;
   retirePrevious?: boolean;
+  activateRegistry?: boolean;
 }): void {
   const previousRegistry = asPluginRegistry(state.activeRegistry);
   state.activeRegistry = params.registry;
-  markPluginRegistryActive(params.registry);
+  if (params.activateRegistry !== false) {
+    markPluginRegistryActive(params.registry);
+  }
   state.activeVersion += 1;
   if (params.registry) {
     settlePreparedMessageToolCatalog(params.registry, state.activeVersion);


### PR DESCRIPTION
Closes #127393

## What Problem This Solves

Fixes an issue where running bundled channels lost trusted ingress and invoker provenance after a candidate plugin registry failed to activate. Although OpenClaw restored the prior registry object, its existing channel runtimes were no longer recognized as live until restart recovery.

## Why This Change Was Made

Failed pre-commit activation now uses a rollback-specific registry operation that preserves the prior committed lifecycle epoch because staging never retired it. Successful replacement and genuine later reactivation retain their existing behavior: they retire old authority and mint a fresh epoch.

This adds no config, protocol, plugin SDK, or database surface.

## User Impact

Running bundled channels remain authoritative through a failed plugin activation rollback instead of temporarily degrading provenance to unknown. A later successful replacement still revokes the old channel authority.

## Evidence

- Regression failed before the fix: the restored prior epoch was inactive (`expected false to be true`).
- `mise exec -- node scripts/run-vitest.mjs src/plugins/loader.test.ts src/plugins/registry-runtime.channel-ingress.test.ts`
  - loader: 183 passed
  - channel ingress: 25 passed
- Blacksmith Testbox `tbx_01m0w5h6w9axgfr8kxjje3v13c`: `pnpm build` passed in 6m20s ([run](https://github.com/openclaw/openclaw/actions/runs/32834531341)).
- Changed-file gate passed policy, formatting, boundaries, dead-export, and production typecheck lanes locally and remotely. The clean remote run stalled without output in core-test typechecking and was explicitly stopped after more than ten minutes ([run](https://github.com/openclaw/openclaw/actions/runs/32835152256)); focused core tests and the complete clean build passed separately.
- Autoreview: clean, no actionable findings.
- LOC: production +21/-3 (net +18); test +13/-1 (net +12). Production growth is the named rollback lifecycle operation and its explicit epoch-preservation boundary.
- Post-merge same-lease real-behavior proof on Blacksmith Testbox `tbx_01m10a0a1s8j0hdt80rr3ss6d3`: detached baseline `33e556fe8a2331d2deff610508b45c1d28df5a01` degraded retained channel ingress/invoker authority from `present` to `unknown` after failed activation; detached merged head `2056b13ace89cbfa993ff7427b9b00f56ce50ade` kept both `present`, including a subsequent real QA-channel turn, while successful replacement revoked both to `unknown`. Both scenarios passed through real ephemeral Gateways and operator CLI calls; isolated state, detached worktrees, and remote artifacts were cleaned ([run](https://github.com/openclaw/openclaw/actions/runs/33027071317)).
