### PR TITLE
fix(auth): recover runtime profiles after publication failure

### DIFF
--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -16,6 +16,7 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { withEnvAsync } from "../../test-utils/env.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
 import { testing as externalAuthTesting } from "./external-auth.test-support.js";
+import { resolveApiKeyForProfile } from "./oauth.js";
 import { loadPersistedAuthProfileStore } from "./persisted.js";
 import {
   clearLastGoodProfileWithLock,
@@ -35,7 +36,11 @@ import {
   listRuntimeAuthProfileStoreSnapshots,
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "./runtime-snapshots.js";
-import { resolveAuthProfileDatabasePath, runAuthProfileWriteTransaction } from "./sqlite.js";
+import {
+  resolveAuthProfileDatabasePath,
+  runAuthProfileWriteTransaction,
+  writePersistedAuthProfileStoreRaw,
+} from "./sqlite.js";
 import {
   captureAuthProfileStorePersistenceSnapshot,
   ensureAuthProfileStoreWithoutExternalProfiles,
@@ -330,24 +335,157 @@ describe("promoteAuthProfileInOrder", () => {
     );
   });
 
-  it("clears runtime snapshots when postcommit publication throws", () => {
-    replaceRuntimeAuthProfileStoreSnapshots([
-      {
-        store: {
+  it("isolates postcommit publication failure to the saving owner", async () => {
+    await withAuthProfileTestState(
+      "openclaw-auth-publication-owner-isolation-",
+      async ({ agentDirFor }) => {
+        const savingAgentDir = agentDirFor("saving");
+        const siblingAgentDir = agentDirFor("sibling");
+        const siblingStore: RuntimeAuthProfileStore = {
           version: AUTH_STORE_VERSION,
           profiles: {
-            "openai:default": { type: "api_key", provider: "openai", key: "sk-runtime" },
+            "anthropic:sibling": {
+              type: "api_key",
+              provider: "anthropic",
+              key: "sk-sibling",
+            },
           },
-        },
-      },
-    ]);
+          runtimeLocalProfileIds: ["anthropic:sibling"],
+        };
+        saveAuthProfileStore(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              "openai:saving": { type: "api_key", provider: "openai", key: "sk-old" },
+            },
+          },
+          savingAgentDir,
+        );
+        replaceRuntimeAuthProfileStoreSnapshots([
+          { agentDir: savingAgentDir, store: loadAuthProfileStoreForRuntime(savingAgentDir) },
+          { agentDir: siblingAgentDir, store: siblingStore },
+        ]);
+        storeTesting.setRuntimeSnapshotPublisherForTest((publish) => {
+          publish();
+          throw new Error("postcommit publication failed");
+        });
 
-    expect(
-      storeTesting.publishRuntimeSnapshotsAfterCommit(() => {
-        throw new Error("postcommit publication failed");
-      }),
-    ).toBe(false);
-    expect(getRuntimeAuthProfileStoreSnapshot()).toBeUndefined();
+        saveAuthProfileStore(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              "openai:saving": { type: "api_key", provider: "openai", key: "sk-new" },
+            },
+          },
+          savingAgentDir,
+        );
+
+        expect(getRuntimeAuthProfileStoreSnapshot(savingAgentDir)).toBeUndefined();
+        expect(getRuntimeAuthProfileStoreSnapshot(siblingAgentDir)).toEqual(siblingStore);
+      },
+    );
+  });
+
+  it("converges unreadable derived owners on committed shared credentials", async () => {
+    await withAuthProfileTestState(
+      "openclaw-auth-derived-refresh-convergence-",
+      async ({ agentDirFor }) => {
+        const brokenAgentDir = agentDirFor("broken");
+        const healthyAgentDir = agentDirFor("healthy");
+        const sharedStore = (profileId: string, key: string): AuthProfileStore => ({
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [profileId]: { type: "api_key", provider: "openai", key },
+          },
+        });
+        saveAuthProfileStore(sharedStore("openai:shared", "sk-shared-old"));
+        saveAuthProfileStore(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              "anthropic:broken": {
+                type: "api_key",
+                provider: "anthropic",
+                key: "sk-broken-local",
+              },
+            },
+          },
+          brokenAgentDir,
+        );
+        saveAuthProfileStore(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              "google:healthy": {
+                type: "api_key",
+                provider: "google",
+                key: "sk-healthy-local",
+              },
+            },
+          },
+          healthyAgentDir,
+        );
+        replaceRuntimeAuthProfileStoreSnapshots([
+          { agentDir: brokenAgentDir, store: loadAuthProfileStoreForRuntime(brokenAgentDir) },
+          { agentDir: healthyAgentDir, store: loadAuthProfileStoreForRuntime(healthyAgentDir) },
+        ]);
+        writePersistedAuthProfileStoreRaw(
+          { version: AUTH_STORE_VERSION, profiles: "invalid-profile-map" },
+          brokenAgentDir,
+        );
+
+        saveAuthProfileStore(sharedStore("openai:shared", "sk-shared-new"));
+
+        const brokenAfterRotation = getRuntimeAuthProfileStoreSnapshot(brokenAgentDir);
+        const healthyAfterRotation = getRuntimeAuthProfileStoreSnapshot(healthyAgentDir);
+        expect(brokenAfterRotation).toBeDefined();
+        expect(healthyAfterRotation).toBeDefined();
+        await expect(
+          resolveApiKeyForProfile({
+            cfg: {},
+            store: brokenAfterRotation!,
+            profileId: "openai:shared",
+            agentDir: brokenAgentDir,
+          }),
+        ).resolves.toMatchObject({ apiKey: "sk-shared-new" });
+        await expect(
+          resolveApiKeyForProfile({
+            cfg: {},
+            store: healthyAfterRotation!,
+            profileId: "openai:shared",
+            agentDir: healthyAgentDir,
+          }),
+        ).resolves.toMatchObject({ apiKey: "sk-shared-new" });
+        expect(brokenAfterRotation?.profiles["anthropic:broken"]).toMatchObject({
+          key: "sk-broken-local",
+        });
+        expect(healthyAfterRotation?.profiles["google:healthy"]).toMatchObject({
+          key: "sk-healthy-local",
+        });
+
+        saveAuthProfileStore(sharedStore("openai:replacement", "sk-shared-replacement"));
+
+        const brokenAfterDeletion = getRuntimeAuthProfileStoreSnapshot(brokenAgentDir);
+        expect(brokenAfterDeletion).toBeDefined();
+        await expect(
+          resolveApiKeyForProfile({
+            cfg: {},
+            store: brokenAfterDeletion!,
+            profileId: "openai:shared",
+            agentDir: brokenAgentDir,
+          }),
+        ).resolves.toBeNull();
+        await expect(
+          resolveApiKeyForProfile({
+            cfg: {},
+            store: brokenAfterDeletion!,
+            profileId: "openai:replacement",
+            agentDir: brokenAgentDir,
+          }),
+        ).resolves.toMatchObject({ apiKey: "sk-shared-replacement" });
+      },
+      { clearOAuthDir: true },
+    );
   });
 
   it("keeps a direct save committed when postcommit publication throws", async () => {

--- a/src/agents/auth-profiles/store.test-support.ts
+++ b/src/agents/auth-profiles/store.test-support.ts
@@ -1,7 +1,6 @@
 import "./store.js";
 
 type AuthProfileStoreTestApi = {
-  publishRuntimeSnapshotsAfterCommit(publish: (() => void) | undefined): boolean;
   resetRuntimeSnapshotPublisherForTest(): void;
   setRuntimeSnapshotPublisherForTest(publisher: (publish: () => void) => void): void;
 };
@@ -13,8 +12,6 @@ function getTestApi(): AuthProfileStoreTestApi {
 }
 
 export const testing: AuthProfileStoreTestApi = {
-  publishRuntimeSnapshotsAfterCommit: (publish) =>
-    getTestApi().publishRuntimeSnapshotsAfterCommit(publish),
   resetRuntimeSnapshotPublisherForTest: () => getTestApi().resetRuntimeSnapshotPublisherForTest(),
   setRuntimeSnapshotPublisherForTest: (publisher) =>
     getTestApi().setRuntimeSnapshotPublisherForTest(publisher),

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -49,7 +49,6 @@ import {
 } from "./runtime-external-profile-references.js";
 import {
   clearRuntimeAuthProfileStoreSnapshotCore,
-  clearRuntimeAuthProfileStoreSnapshots,
   getPreparedRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreSnapshotRevision,
@@ -202,19 +201,37 @@ type ExternalCliSyncResult = {
 
 let runtimeSnapshotPublisherForTest: ((publish: () => void) => void) | undefined;
 
-function publishRuntimeSnapshotsAfterCommit(publish: (() => void) | undefined): boolean {
-  if (!publish) {
+type RuntimeSnapshotPublication = {
+  agentDir?: string;
+  databasePath: string;
+  publish: () => boolean;
+};
+
+function publishRuntimeSnapshotsAfterCommit(
+  publication: RuntimeSnapshotPublication | undefined,
+): boolean {
+  if (!publication) {
     return true;
   }
+  // A committed write can no longer roll back, so publication failure must
+  // evict only the exact derived owner that could now be stale.
   try {
+    let converged = false;
+    const publish = () => {
+      converged = publication.publish();
+    };
     if (runtimeSnapshotPublisherForTest) {
       runtimeSnapshotPublisherForTest(publish);
     } else {
       publish();
     }
-    return true;
+    return converged;
   } catch (err) {
-    clearRuntimeAuthProfileStoreSnapshots();
+    replaceRuntimeAuthProfileStoreSnapshot(
+      undefined,
+      publication.agentDir,
+      publication.databasePath,
+    );
     authProfilesLog.warn("auth profile store committed but runtime snapshot publication failed", {
       err,
     });
@@ -223,7 +240,6 @@ function publishRuntimeSnapshotsAfterCommit(publish: (() => void) | undefined): 
 }
 
 const testing = {
-  publishRuntimeSnapshotsAfterCommit,
   resetRuntimeSnapshotPublisherForTest(): void {
     runtimeSnapshotPublisherForTest = undefined;
   },
@@ -409,7 +425,7 @@ function maybeSyncPersistedExternalCliAuthProfiles(params: {
 
   // External CLI sync writes only profiles that still match the loaded
   // baseline, avoiding overwrite of concurrent local auth changes.
-  let publishRuntimeSnapshots: (() => void) | undefined;
+  let publishRuntimeSnapshots: RuntimeSnapshotPublication | undefined;
   let result: ExternalCliSyncResult;
   try {
     result = runAuthProfileWriteTransaction(params.agentDir, (database) => {
@@ -714,6 +730,47 @@ function runtimeStoreInheritsMainState(
   return !isDeepStrictEqual(state(store), state(localStore));
 }
 
+function mergeLocalAuthProfileStoreWithInheritedStore(
+  localStore: AuthProfileStore,
+  inheritedStore: AuthProfileStore,
+): RuntimeAuthProfileStore {
+  // Keep local ownership explicit after merging so later shared-store
+  // publication can reconstruct this owner without retaining inherited rows.
+  const merged = mergeAuthProfileStores(inheritedStore, localStore, {
+    preserveBaseRuntimeExternalProfiles: true,
+  });
+  return setRuntimeLocalProfileMetadata(
+    stripRuntimeExternalProfileMetadata(merged),
+    listRuntimeLocalProfileIds(localStore, inheritedStore),
+    runtimeStoreInheritsMainState(merged, localStore),
+  );
+}
+
+function refreshDerivedRuntimeAuthProfileStoreSnapshot(
+  derived: {
+    databasePath: string;
+    agentDir: string;
+    store: RuntimeAuthProfileStore;
+  },
+  committedSharedStore: AuthProfileStore,
+): boolean {
+  try {
+    rebuildRuntimeAuthProfileStoreSnapshot(
+      derived.agentDir,
+      derived.store,
+      undefined,
+      derived.databasePath,
+      committedSharedStore,
+      derived.store.runtimeLocalProfileIds,
+    );
+    return true;
+  } catch (err) {
+    replaceRuntimeAuthProfileStoreSnapshot(undefined, derived.agentDir, derived.databasePath);
+    authProfilesLog.warn("derived auth profile snapshot convergence failed", { err });
+    return false;
+  }
+}
+
 function listRuntimeLocalProfileIds(
   store: AuthProfileStore,
   mainStore?: AuthProfileStore,
@@ -774,6 +831,16 @@ export function preserveResolvedSecretBackedCredentials(params: {
     }
   }
   return next;
+}
+
+function materializeRuntimeAuthProfileStoreSnapshot(
+  next: AuthProfileStore,
+  existing: AuthProfileStore,
+): AuthProfileStore {
+  return mergeRuntimeExternalProfileReferences({
+    next: preserveResolvedSecretBackedCredentials({ next, existing }),
+    existing,
+  });
 }
 
 function mergeRuntimeExternalProfileState(params: {
@@ -872,7 +939,7 @@ export async function updateAuthProfileStoreWithLock(params: {
   updater: (store: AuthProfileStore) => boolean;
 }): Promise<AuthProfileStore | null> {
   const agentDir = resolveRuntimeAuthProfileAgentDir(params.agentDir);
-  let publishRuntimeSnapshots: (() => void) | undefined;
+  let publishRuntimeSnapshots: RuntimeSnapshotPublication | undefined;
   let store: AuthProfileStore;
   try {
     store = runAuthProfileWriteTransaction(
@@ -1089,14 +1156,7 @@ export function loadAuthProfileStoreWithoutExternalProfiles(
   }
 
   const mainStore = loadAuthProfileStoreForAgent(options.inheritedAuthDir, options);
-  const mergedStore = mergeAuthProfileStores(mainStore, store, {
-    preserveBaseRuntimeExternalProfiles: true,
-  });
-  return setRuntimeLocalProfileMetadata(
-    stripRuntimeExternalProfileMetadata(mergedStore),
-    listRuntimeLocalProfileIds(store, mainStore),
-    runtimeStoreInheritsMainState(mergedStore, store),
-  );
+  return mergeLocalAuthProfileStoreWithInheritedStore(store, mainStore);
 }
 
 /** Ensure an auth store is available, including runtime/external profile overlays. */
@@ -1320,7 +1380,7 @@ function saveAuthProfileStoreInTransaction(
   options: SaveAuthProfileStoreOptions | undefined,
   database: AuthProfileDatabase,
   publishFromSuppliedStore = false,
-): () => void {
+): RuntimeSnapshotPublication {
   // Shared-state rows are global: never scope their persistence or runtime snapshots to an
   // agent, or shared credentials are published and cached as agent-local state.
   const persistenceAgentDir = "agentId" in database ? agentDir : undefined;
@@ -1383,6 +1443,12 @@ function saveAuthProfileStoreInTransaction(
   if (stateChanged) {
     writePersistedAuthProfileStateRaw(statePayload, persistenceAgentDir, database);
   }
+  const committedSharedStore = savesMainStore
+    ? setRuntimeLocalProfileMetadata(
+        markRuntimePersistedProfiles(localStore),
+        listRuntimeLocalProfileIds(localStore),
+      )
+    : undefined;
   const publishRuntimeSnapshots = () => {
     // Main-store publication invalidates derived stores. Capture the latest
     // overlays at the publication edge so post-commit refreshes are retained.
@@ -1402,46 +1468,45 @@ function saveAuthProfileStoreInTransaction(
     if (suppliedRuntimeStore) {
       const existing = getRuntimeAuthProfileStoreSnapshot(persistenceAgentDir);
       if (existing) {
-        const materialized = preserveResolvedSecretBackedCredentials({
-          next: suppliedRuntimeStore,
-          existing,
-        });
         setRuntimeAuthProfileStoreSnapshot(
-          mergeRuntimeExternalProfileReferences({ next: materialized, existing }),
+          materializeRuntimeAuthProfileStoreSnapshot(suppliedRuntimeStore, existing),
           persistenceAgentDir,
         );
       }
       if (savesMainStore && (credentialsChanged || stateChanged)) {
+        let converged = true;
         for (const derived of derivedSnapshots) {
-          const refreshed = loadAuthProfileStoreWithoutExternalProfiles(derived.agentDir);
-          const materialized = preserveResolvedSecretBackedCredentials({
-            next: refreshed,
-            existing: derived.store,
-          });
-          setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
-            mergeRuntimeExternalProfileReferences({ next: materialized, existing: derived.store }),
-            derived.databasePath,
-            derived.agentDir,
-          );
+          converged =
+            refreshDerivedRuntimeAuthProfileStoreSnapshot(derived, committedSharedStore!) &&
+            converged;
         }
+        return converged;
       }
-      return;
+      return true;
     }
-    refreshRuntimeAuthProfileStoreSnapshot(persistenceAgentDir);
+    if (savesMainStore) {
+      const existing = getRuntimeAuthProfileStoreSnapshot(persistenceAgentDir);
+      if (existing) {
+        setRuntimeAuthProfileStoreSnapshot(
+          materializeRuntimeAuthProfileStoreSnapshot(committedSharedStore!, existing),
+          persistenceAgentDir,
+        );
+      }
+    } else {
+      refreshRuntimeAuthProfileStoreSnapshot(persistenceAgentDir);
+    }
+    let converged = true;
     for (const derived of derivedSnapshots) {
-      const refreshed = loadAuthProfileStoreWithoutExternalProfiles(derived.agentDir);
-      const materialized = preserveResolvedSecretBackedCredentials({
-        next: refreshed,
-        existing: derived.store,
-      });
-      setRuntimeAuthProfileStoreSnapshotAtDatabasePath(
-        mergeRuntimeExternalProfileReferences({ next: materialized, existing: derived.store }),
-        derived.databasePath,
-        derived.agentDir,
-      );
+      converged =
+        refreshDerivedRuntimeAuthProfileStoreSnapshot(derived, committedSharedStore!) && converged;
     }
+    return converged;
   };
-  return publishRuntimeSnapshots;
+  return {
+    ...(persistenceAgentDir ? { agentDir: persistenceAgentDir } : {}),
+    databasePath: savedAuthPath,
+    publish: publishRuntimeSnapshots,
+  };
 }
 
 /** Save the auth profile store plus sidecar state, preserving runtime overlay metadata. */
@@ -1469,7 +1534,7 @@ export function saveAuthProfileStore(
     }
     return;
   }
-  let publishRuntimeSnapshots: (() => void) | undefined;
+  let publishRuntimeSnapshots: RuntimeSnapshotPublication | undefined;
   runAuthProfileWriteTransaction(
     effectiveAgentDir,
     (transactionDatabase) => {
@@ -1616,8 +1681,30 @@ function rebuildRuntimeAuthProfileStoreSnapshot(
   existing: AuthProfileStore,
   predecessor?: AuthProfileStore,
   databasePath?: string,
+  inheritedStore?: AuthProfileStore,
+  capturedLocalProfileIds?: Iterable<string>,
 ): void {
-  const refreshed = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
+  let refreshed: AuthProfileStore;
+  try {
+    refreshed = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
+  } catch (err) {
+    if (!inheritedStore) {
+      throw err;
+    }
+    // Persisted shared state is already committed. Recover only local profiles
+    // proven by this snapshot so deleted inherited credentials cannot survive.
+    const localProfileIds = new Set(capturedLocalProfileIds);
+    const localStore = cloneAuthProfileStore(existing);
+    localStore.profiles = Object.fromEntries(
+      Object.entries(localStore.profiles).filter(([profileId]) => localProfileIds.has(profileId)),
+    );
+    pruneAuthProfileStoreReferences(localStore, localProfileIds);
+    refreshed = mergeLocalAuthProfileStoreWithInheritedStore(localStore, inheritedStore);
+    authProfilesLog.warn(
+      "derived auth profile snapshot refresh failed; preserving captured local profiles",
+      { err },
+    );
+  }
   const currentMaterialized = preserveResolvedSecretBackedCredentials({
     next: refreshed,
     existing,
@@ -1667,7 +1754,7 @@ export function saveAuthProfileStoreIfPersistenceSnapshotMatches(params: {
   stateDir?: string;
 }): CommittedAuthProfileStoreSave {
   const agentDir = resolveRuntimeAuthProfileAgentDir(params.agentDir);
-  let publishRuntimeSnapshots: (() => void) | undefined;
+  let publishRuntimeSnapshots: RuntimeSnapshotPublication | undefined;
   const owned: AuthProfileStorePersistenceSnapshot = {
     credentialsRaw: null,
     stateRaw: null,
@@ -1714,28 +1801,38 @@ export function saveAuthProfileStoreIfPersistenceSnapshotMatches(params: {
   );
   return {
     owned,
-    publishRuntimeSnapshots: () =>
-      publishRuntimeSnapshotsAfterCommit(() => {
-        recordRuntimeAuthProfileStorePublicationEdge(
-          owned,
-          captureRuntimeAuthProfileStorePersistenceSnapshot(
-            agentDir,
-            params.stateDir && agentDir === undefined
-              ? resolveSharedAuthPath({ ...process.env, OPENCLAW_STATE_DIR: params.stateDir })
-              : undefined,
-          ),
-        );
-        publishRuntimeSnapshots?.();
-        recordRuntimeAuthProfileStoreOwnership(
-          owned,
-          captureRuntimeAuthProfileStorePersistenceSnapshot(
-            params.agentDir,
-            params.stateDir && params.agentDir === undefined
-              ? resolveSharedAuthPath({ ...process.env, OPENCLAW_STATE_DIR: params.stateDir })
-              : undefined,
-          ),
-        );
-      }),
+    publishRuntimeSnapshots: () => {
+      if (!publishRuntimeSnapshots) {
+        return true;
+      }
+      const publication = publishRuntimeSnapshots;
+      return publishRuntimeSnapshotsAfterCommit({
+        ...(publication.agentDir ? { agentDir: publication.agentDir } : {}),
+        databasePath: publication.databasePath,
+        publish: () => {
+          recordRuntimeAuthProfileStorePublicationEdge(
+            owned,
+            captureRuntimeAuthProfileStorePersistenceSnapshot(
+              agentDir,
+              params.stateDir && agentDir === undefined
+                ? resolveSharedAuthPath({ ...process.env, OPENCLAW_STATE_DIR: params.stateDir })
+                : undefined,
+            ),
+          );
+          const converged = publication.publish();
+          recordRuntimeAuthProfileStoreOwnership(
+            owned,
+            captureRuntimeAuthProfileStorePersistenceSnapshot(
+              params.agentDir,
+              params.stateDir && params.agentDir === undefined
+                ? resolveSharedAuthPath({ ...process.env, OPENCLAW_STATE_DIR: params.stateDir })
+                : undefined,
+            ),
+          );
+          return converged;
+        },
+      });
+    },
   };
 }
 
@@ -1861,7 +1958,7 @@ export function restoreAuthProfileStorePersistenceSnapshot(
   let stateOwned = false;
   let credentialsRestored = false;
   let stateRestored = false;
-  let publishRuntimeSnapshots: (() => void) | undefined;
+  let publishRuntimeSnapshots: RuntimeSnapshotPublication | undefined;
   runAuthProfileWriteTransaction(
     agentDir,
     (database) => {
@@ -1898,39 +1995,45 @@ export function restoreAuthProfileStorePersistenceSnapshot(
       if (stateRestored) {
         writePersistedAuthProfileStateRaw(snapshot.stateRaw, agentDir, database);
       }
-      publishRuntimeSnapshots = () => {
-        // Main credential mutation lineage invalidates derived snapshots. Capture
-        // them first so exact-owned entries can restore and newer entries rebuild.
-        const currentRuntimeStores = listRuntimeAuthProfileStoreSnapshots().map(
-          ({ agentDir: runtimeAgentDir, databasePath, store }) => ({
-            databasePath,
-            agentDir: runtimeAgentDir,
-            store,
-            runtimeRevision: getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(databasePath),
-          }),
-        );
-        const currentRuntimePath = agentDir ? resolveAgentAuthPath(agentDir) : database.path;
-        const currentRuntimeRevision =
-          getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(currentRuntimePath);
-        if (credentialsRestored || stateRestored) {
-          noteRuntimeAuthProfileStorePersistedMutation(agentDir, {
-            credentialsChanged: credentialsRestored,
-            profileSetChanged: credentialsRestored && profileSetChanged,
-            stateChanged: stateRestored,
-            profileIds: credentialsRestored ? changedProfileIds : [],
+      publishRuntimeSnapshots = {
+        ...(agentDir ? { agentDir } : {}),
+        databasePath: agentDir ? resolveAgentAuthPath(agentDir) : database.path,
+        publish: () => {
+          // Main credential mutation lineage invalidates derived snapshots. Capture
+          // them first so exact-owned entries can restore and newer entries rebuild.
+          const currentRuntimeStores = listRuntimeAuthProfileStoreSnapshots().map(
+            ({ agentDir: runtimeAgentDir, databasePath, store }) => ({
+              databasePath,
+              agentDir: runtimeAgentDir,
+              store,
+              runtimeRevision:
+                getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(databasePath),
+            }),
+          );
+          const currentRuntimePath = agentDir ? resolveAgentAuthPath(agentDir) : database.path;
+          const currentRuntimeRevision =
+            getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(currentRuntimePath);
+          if (credentialsRestored || stateRestored) {
+            noteRuntimeAuthProfileStorePersistedMutation(agentDir, {
+              credentialsChanged: credentialsRestored,
+              profileSetChanged: credentialsRestored && profileSetChanged,
+              stateChanged: stateRestored,
+              profileIds: credentialsRestored ? changedProfileIds : [],
+            });
+          }
+          reconcileRuntimeAuthProfileStorePersistenceSnapshot({
+            snapshot,
+            owned,
+            agentDir,
+            credentialsOwned,
+            stateOwned,
+            credentialsRestored,
+            stateRestored,
+            currentRuntimeStores,
+            currentRuntimeRevision,
           });
-        }
-        reconcileRuntimeAuthProfileStorePersistenceSnapshot({
-          snapshot,
-          owned,
-          agentDir,
-          credentialsOwned,
-          stateOwned,
-          credentialsRestored,
-          stateRestored,
-          currentRuntimeStores,
-          currentRuntimeRevision,
-        });
+          return true;
+        },
       };
     },
     options,


### PR DESCRIPTION
Fixes #117209

## What Problem This Solves

Fixes an issue where a committed auth-profile update could leave runtime authentication permanently unreadable when one derived agent snapshot failed to refresh. The failure could erase healthy sibling snapshots and require a Gateway restart even though the shared SQLite store had committed successfully.

## Why This Change Was Made

Post-commit publication now identifies the exact snapshot owner, isolates failures to that owner, and continues refreshing healthy derived owners. When a derived database is unreadable, publication reconstructs that owner from its captured local ownership plus the newly committed shared store, so rotated or deleted inherited credentials cannot survive.

This replacement preserves the core isolation and convergence invariant developed by @vincentkoc in #117258 while reimplementing it against the current shared-state database ownership model. Thanks to @ericcaiwx-star for the production report and to @vincentkoc for the original repair direction.

Production LOC: +206/-103 (net +103) | Tests/test support: +152/-17. The remaining growth is the explicit publication-owner descriptor, per-derived failure boundary, and captured-local reconstruction path; each is required to distinguish the committed shared owner from independently failing derived owners. The old global-clear path and direct test-only publication seam are removed.

## User Impact

Auth-profile updates no longer make unrelated agents lose working credentials when one derived auth store is unreadable. Affected agents converge on newly committed shared credentials without retaining credentials that were rotated or deleted.

AI-assisted; the author reviewed and understands the change.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs src/agents/auth-profiles/profiles.test.ts` produced 33 passes and 2 intended failures: healthy siblings were globally erased, and unreadable derived owners failed to converge.
- Post-fix focused proof: 4 files, 57 tests passed across `profiles.test.ts`, `runtime-snapshots.test.ts`, `upsert-with-lock.sqlite.test.ts`, and `path-resolve.shared-store.test.ts`.
- Blacksmith Testbox real-behavior proof: [run 33027034460](https://github.com/openclaw/openclaw/actions/runs/33027034460) reused lease `tbx_01m109z85yyawwt2y5aw22vxha` for detached base `33e556fe8a23` and head `22c055f956ef`. One real Gateway per revision served real CLI agent turns through mock OpenAI on isolated state and an ephemeral port. Base lost both healthy and faulted runtime owners after the derived publication fault; head kept the healthy sibling usable and recovered the faulted owner from captured runtime-local state, with stable Gateway PID and no restart.
- `pnpm tsgo:core` passed.
- Changed-file gate passed conflict, formatting, ratchet, dependency, plugin-boundary, dead-export, and production type checks. Its core-test type shard remains blocked by the checkout's unrelated missing `pako` declaration at `ui/vite.config.ts:8`; no dependency changes were made.
- Autoreview: clean, no accepted/actionable findings.

No SQLite schema or schema-version changes.
