### PR TITLE
fix(audio): discover installed Windows transcription tools with mixed-case Path

### DIFF
--- a/src/media-understanding/local-audio.test.ts
+++ b/src/media-understanding/local-audio.test.ts
@@ -111,6 +111,30 @@ describe("local audio selection", () => {
     });
   });
 
+  it("discovers Windows commands through case-insensitive PATH and PATHEXT values", async () => {
+    const availableDirectory = "/virtual/audio-tools";
+    const commandPath = path.join(availableDirectory, "whisper.AUDIO");
+    const inspect = (env: NodeJS.ProcessEnv) =>
+      inspectLocalAudioSelection({
+        env,
+        platform: "win32",
+        arch: "x64",
+        checkExecutable: async (filePath) => filePath === commandPath,
+        listDirectory: async () => [],
+      });
+
+    for (const env of [
+      { Path: "/virtual/missing-tools", pAtHeXt: ".AUDIO" },
+      { Path: availableDirectory, pAtHeXt: ".MISSING" },
+    ]) {
+      expect((await inspect(env)).selected).toBeUndefined();
+    }
+
+    expect((await inspect({ Path: availableDirectory, pAtHeXt: ".AUDIO" })).selected).toMatchObject(
+      { id: "whisper", resolvedCommand: commandPath },
+    );
+  });
+
   it("retries binary inspection after a transient failure", async () => {
     const tempDir = tempDirs.make("openclaw-local-audio-");
     const modelPath = path.join(tempDir, "whisper.bin");

--- a/src/media-understanding/local-audio.ts
+++ b/src/media-understanding/local-audio.ts
@@ -2,6 +2,7 @@ import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { MediaUnderstandingModelConfig } from "../config/types.tools.js";
+import { resolveEnvironmentValue } from "../infra/process-env.js";
 import { runExec } from "../process/exec.js";
 import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { optionalPathExists } from "./fs.js";
@@ -168,11 +169,11 @@ async function isExecutable(filePath: string, platform: NodeJS.Platform): Promis
   }
 }
 
-function binaryNames(name: string, platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string[] {
+function binaryNames(name: string, platform: NodeJS.Platform, pathExtensions?: string): string[] {
   if (platform !== "win32" || path.extname(name)) {
     return [name];
   }
-  const extensions = (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+  const extensions = (pathExtensions ?? ".EXE;.CMD;.BAT;.COM")
     .split(";")
     .map((extension) => extension.trim())
     .filter(Boolean);
@@ -196,13 +197,15 @@ async function findBinary(
   platform: NodeJS.Platform,
   checkExecutable: (filePath: string, platform: NodeJS.Platform) => Promise<boolean> = isExecutable,
 ): Promise<string | null> {
-  const key = `${platform}\0${env.PATH ?? ""}\0${env.PATHEXT ?? ""}\0${name}`;
+  const pathValue = resolveEnvironmentValue(env, "PATH", platform) ?? "";
+  const pathExtensions = resolveEnvironmentValue(env, "PATHEXT", platform);
+  const key = `${platform}\0${pathValue}\0${pathExtensions ?? ""}\0${name}`;
   return await getOrCreatePromise(
     binaryCache,
     key,
     async () => {
       const direct = name.trim();
-      const candidates = binaryNames(direct, platform, env);
+      const candidates = binaryNames(direct, platform, pathExtensions);
       if (direct.includes("/") || direct.includes("\\")) {
         for (const candidate of candidates) {
           const expanded =
@@ -215,7 +218,7 @@ async function findBinary(
         }
         return null;
       }
-      for (const directory of (env.PATH ?? "").split(path.delimiter)) {
+      for (const directory of pathValue.split(path.delimiter)) {
         const expandedDirectory = expandHomeDir(directory, env);
         if (!expandedDirectory) {
           continue;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows users with an installed local transcription tool would see audio understanding report no available executable when Windows exposed its ordinary environment variables as mixed-case `Path` or `pAtHeXt`.

## Why This Change Was Made

The local-audio executable owner read Windows process variables case-sensitively even though the repository already provides a canonical Windows-aware process-environment reader. Resolve `PATH` and `PATHEXT` once with that existing owner, then reuse the authoritative values for executable lookup, extension expansion, and cache identity.

Production delta: **8 additions / 5 deletions (net +3)** for shared prepared lookup facts. No configuration, protocol, authentication, persistence, plugin-SDK, or dependency changes.

## User Impact

Installed local transcription tools are discovered reliably on Windows regardless of environment-variable casing, restoring automatic audio understanding, capability listings, and doctor diagnostics.

## Evidence

- Authentic pre-fix owner regression: a real Windows-mode executable inspection with `Path` and mixed-case `pAtHeXt` incorrectly selected no installed transcription tool.
- Regression primes independent negative cache entries for both directory and executable-extension changes, then verifies the actual installed transcription executable is selected.
- Focused owner and canonical process-environment sibling suites: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/media-understanding/local-audio.test.ts src/infra/process-env.test.ts --reporter=dot` — **17 passed**.
- Targeted formatter, lint, and diff checks passed; the existing prohibition on probing the current working directory remains unchanged.
- Fresh independent structured review: **clean; no accepted or actionable findings**.
