### PR TITLE
fix(workers): preserve workspace reconciliation failures

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -832,6 +832,11 @@ describe("failover-error", () => {
     it.each([
       ["availability", "WorkerRunnerUnavailableError", "The device runner is offline"],
       ["capacity", "WorkerRunnerCapacityError", "device worker capacity remained full"],
+      [
+        "workspace reconciliation",
+        "WorkerWorkspaceReconciliationError",
+        "cloud worker workspace result could not be reconciled",
+      ],
     ])("returns true for direct and nested runner %s failures", (_label, name, message) => {
       const coordination = new Error(message);
       coordination.name = name;

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -493,9 +493,11 @@ function hasGatewayDrainingFailure(err: unknown): boolean {
 }
 
 function hasWorkerRunnerCoordinationFailure(err: unknown): boolean {
-  return ["WorkerRunnerUnavailableError", "WorkerRunnerCapacityError"].some((name) =>
-    errorGraphHasName(err, name),
-  );
+  return [
+    "WorkerRunnerUnavailableError",
+    "WorkerRunnerCapacityError",
+    "WorkerWorkspaceReconciliationError",
+  ].some((name) => errorGraphHasName(err, name));
 }
 
 function hasDirectProviderFailureIdentity(err: unknown): boolean {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2265,7 +2265,23 @@ describe("runWithModelFallback", () => {
           }),
         }),
     ],
-  ])("aborts fallback on %s device capacity failures", async (_label, makeError) => {
+    [
+      "workspace reconciliation",
+      () =>
+        Object.assign(new Error("cloud worker workspace result could not be reconciled"), {
+          name: "WorkerWorkspaceReconciliationError",
+        }),
+    ],
+    [
+      "wrapped workspace reconciliation",
+      () =>
+        new Error("worker turn failed", {
+          cause: Object.assign(new Error("cloud worker workspace result could not be reconciled"), {
+            name: "WorkerWorkspaceReconciliationError",
+          }),
+        }),
+    ],
+  ])("aborts fallback on %s worker coordination failures", async (_label, makeError) => {
     const error = makeError();
     const run = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce("too late");
     const onError = vi.fn();

--- a/src/gateway/worker-environments/worker-turn-launcher-terminal-results.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-terminal-results.test.ts
@@ -110,6 +110,7 @@ describe("worker turn launcher terminal results", () => {
         async () => ({ meta: { durationMs: 1 } }),
       ),
     ).rejects.toMatchObject({
+      name: "WorkerWorkspaceReconciliationError",
       message:
         "Cloud worker finished, but its workspace result could not be reconciled: workspace-transfer-failed: gateway TLS fingerprint mismatch",
     });

--- a/src/gateway/worker-environments/workspace-result-finalize.ts
+++ b/src/gateway/worker-environments/workspace-result-finalize.ts
@@ -34,7 +34,9 @@ type ActiveWorkerPlacement = Extract<WorkerSessionPlacementRecord, { state: "act
 type OwnedWorkerPlacement = Extract<WorkerSessionPlacementRecord, { state: "active" | "draining" }>;
 type RemoteExecEnvironmentService = Pick<WorkerEnvironmentService, "get" | "startTunnel">;
 
-export class WorkerWorkspaceReconciliationError extends Error {}
+export class WorkerWorkspaceReconciliationError extends Error {
+  override name = "WorkerWorkspaceReconciliationError";
+}
 
 type WorkspaceConflictReport = {
   paths: string[];


### PR DESCRIPTION
## What Problem This Solves

Cloud-worker workspace reconciliation failures were misclassified as provider failures. The model-fallback loop immediately retried the same admitted run while its durable workspace-result claim was still fenced, replacing the actionable original failure with `Session ... already has an active turn claim`.

The producer's `WorkerWorkspaceReconciliationError` inherited the generic `Error` name, so the existing worker-coordination classifier could not distinguish it from an unknown model error. Give that producer-owned error its stable identity and recognize it alongside existing offline/capacity coordination failures, preserving the original error and preventing an unsafe fallback attempt. The workspace quiescence root-user security boundary and durable claim lifecycle remain unchanged.

## Evidence

- Fail-first owner regressions independently proved the missing producer identity, incorrect direct/wrapped classification, and fallback incorrectly executing a second model candidate.
- `node scripts/run-vitest.mjs src/agents/failover-error.test.ts src/agents/model-fallback.test.ts src/gateway/worker-environments/worker-turn-launcher-terminal-results.test.ts src/gateway/worker-environments/worker-turn-launcher-claim-admission.test.ts` — 228 tests passed across three Vitest shards.
- A real isolated Linux Gateway with a signed paired-node worker reproduced the original root-owned workspace failure. Before the fix its visible result was `already has an active turn claim`; after the fix the original `workspace quiescence refuses root-owned worker sessions` failure remains visible and no fallback runs.
- The same real worker-generation stress scenario passed as an unprivileged user after the fix: six turns preserved provider credential generations `A,B,C,C,C,D`, hot-published without replacing the Gateway process, retained queued-turn ownership, and persisted each worker reply exactly once.
- Real cloud-worker disappearance proof passed across three Gateway replacements with independent per-session terminal errors and preserved orphan diagnostics.
- Changed-file formatting, focused lint, architectural guards, dead-code scan, production TypeScript checking, and independent structured review passed. Full local core-test typechecking additionally encounters an unrelated pre-existing shared dependency issue: `ui/vite.config.ts` cannot find declarations for `pako`; exact-head hosted CI uses a clean dependency installation.

## Risk and Release Note

Low risk: two production-owner changes, no SQLite schema/store change, no weakened root or turn-claim fencing, and no changed successful-provider fallback behavior. Cloud-worker workspace synchronization errors now remain visible instead of being hidden by an unnecessary model fallback.
