### PR TITLE
refactor(podman): share rootless security helpers

### DIFF
--- a/scripts/podman/common.sh
+++ b/scripts/podman/common.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+validate_single_line_value() {
+  local label="$1"
+  local value="$2"
+  if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
+    fail "Invalid $label: control characters are not allowed."
+  fi
+}
+
+validate_absolute_path() {
+  local label="$1"
+  local value="$2"
+  validate_single_line_value "$label" "$value"
+  [[ "$value" == /* ]] || fail "Invalid $label: expected an absolute path."
+  [[ "$value" != *"//"* ]] || fail "Invalid $label: repeated slashes are not allowed."
+  [[ "$value" != *"/./"* && "$value" != */. && "$value" != *"/../"* && "$value" != */.. ]] ||
+    fail "Invalid $label: dot path segments are not allowed."
+}
+
+validate_mount_source_path() {
+  local label="$1"
+  local value="$2"
+  validate_absolute_path "$label" "$value"
+  [[ "$value" != *:* ]] || fail "Invalid $label: ':' is not allowed in Podman bind-mount source paths."
+}
+
+ensure_safe_existing_dir() {
+  local label="$1"
+  local dir="$2"
+  validate_absolute_path "$label" "$dir"
+  [[ -d "$dir" ]] || fail "Missing $label: $dir"
+  [[ ! -L "$dir" ]] || fail "Unsafe $label: symlinks are not allowed ($dir)"
+}
+
+stat_uid() {
+  local path="$1"
+  if stat -f '%u' "$path" >/dev/null 2>&1; then
+    stat -f '%u' "$path"
+  else
+    stat -Lc '%u' "$path"
+  fi
+}
+
+stat_mode() {
+  local path="$1"
+  if stat -f '%Lp' "$path" >/dev/null 2>&1; then
+    stat -f '%Lp' "$path"
+  else
+    stat -Lc '%a' "$path"
+  fi
+}
+
+ensure_private_existing_dir_owned_by_user() {
+  local label="$1"
+  local dir="$2"
+  local uid=""
+  local mode=""
+  ensure_safe_existing_dir "$label" "$dir"
+  uid="$(stat_uid "$dir")"
+  [[ "$uid" == "$(id -u)" ]] || fail "Unsafe $label: not owned by current user ($dir)"
+  mode="$(stat_mode "$dir")"
+  (( (8#$mode & 0022) == 0 )) || fail "Unsafe $label: group/other writable ($dir)"
+}
+
+ensure_safe_write_file_path() {
+  local label="$1"
+  local file="$2"
+  local dir
+  validate_absolute_path "$label" "$file"
+  if [[ -e "$file" ]]; then
+    [[ ! -L "$file" ]] || fail "Unsafe $label: symlinks are not allowed ($file)"
+    [[ -f "$file" ]] || fail "Unsafe $label: expected a regular file ($file)"
+  fi
+  dir="$(dirname "$file")"
+  ensure_safe_existing_dir "${label} parent directory" "$dir"
+}
+
+write_file_atomically() {
+  local file="$1"
+  local mode="$2"
+  local dir=""
+  local tmp=""
+  ensure_safe_write_file_path "output file" "$file"
+  dir="$(dirname "$file")"
+  tmp="$(mktemp "$dir/.tmp.XXXXXX")"
+  cat >"$tmp"
+  chmod "$mode" "$tmp"
+  mv -f "$tmp" "$file"
+}
+
+validate_port() {
+  local label="$1"
+  local value="$2"
+  local numeric=""
+  [[ "$value" =~ ^[0-9]{1,5}$ ]] || fail "Invalid $label: must be numeric."
+  numeric=$((10#$value))
+  (( numeric >= 1 && numeric <= 65535 )) || fail "Invalid $label: out of range."
+}
+
+resolve_user_home() {
+  local user="$1"
+  local home=""
+  if command -v getent >/dev/null 2>&1; then
+    home="$(getent passwd "$user" 2>/dev/null | cut -d: -f6 || true)"
+  fi
+  if [[ -z "$home" && -f /etc/passwd ]]; then
+    home="$(awk -F: -v u="$user" '$1==u {print $6}' /etc/passwd 2>/dev/null || true)"
+  fi
+  if [[ -z "$home" ]]; then
+    home="/home/$user"
+  fi
+  printf '%s' "$home"
+}
+
+generate_token_hex_32() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+    return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+    return 0
+  fi
+  if command -v od >/dev/null 2>&1; then
+    od -An -N32 -tx1 /dev/urandom | tr -d " \n"
+    return 0
+  fi
+  echo "Missing dependency: need openssl or python3 (or od) to generate OPENCLAW_GATEWAY_TOKEN." >&2
+  exit 1
+}
+
+upsert_env_var() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  local tmp
+  local dir
+  ensure_safe_write_file_path "env file" "$file"
+  dir="$(dirname "$file")"
+  tmp="$(mktemp "$dir/.env.tmp.XXXXXX")"
+  if [[ -f "$file" ]]; then
+    awk -v k="$key" -v v="$value" '
+      BEGIN { found = 0 }
+      $0 ~ ("^" k "=") { print k "=" v; found = 1; next }
+      { print }
+      END { if (!found) print k "=" v }
+    ' "$file" >"$tmp"
+  else
+    printf '%s=%s\n' "$key" "$value" >"$tmp"
+  fi
+  mv "$tmp" "$file"
+  chmod 600 "$file" 2>/dev/null || true
+}

--- a/scripts/podman/setup.sh
+++ b/scripts/podman/setup.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 REPO_PATH="${OPENCLAW_REPO_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 source "$REPO_PATH/scripts/lib/build-metadata.sh"
 source "$REPO_PATH/scripts/lib/host-timeout.sh"
+# shellcheck source=scripts/podman/common.sh
+source "$REPO_PATH/scripts/podman/common.sh"
 RUN_SCRIPT_SRC="$REPO_PATH/scripts/run-openclaw-podman.sh"
 QUADLET_TEMPLATE="$REPO_PATH/scripts/podman/openclaw.container.in"
 OPENCLAW_USER="$(id -un)"
@@ -42,11 +44,6 @@ require_cmd() {
 
 is_root() { [[ "$(id -u)" -eq 0 ]]; }
 
-fail() {
-  echo "$*" >&2
-  exit 1
-}
-
 run_podman_pull() {
   local image="$1"
   openclaw_host_timeout_cmd "$PODMAN_PULL_TIMEOUT" podman pull "$image"
@@ -54,31 +51,6 @@ run_podman_pull() {
 
 run_podman_build() {
   openclaw_host_timeout_cmd "$PODMAN_BUILD_TIMEOUT" podman build "$@"
-}
-
-validate_single_line_value() {
-  local label="$1"
-  local value="$2"
-  if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
-    fail "Invalid $label: control characters are not allowed."
-  fi
-}
-
-validate_absolute_path() {
-  local label="$1"
-  local value="$2"
-  validate_single_line_value "$label" "$value"
-  [[ "$value" == /* ]] || fail "Invalid $label: expected an absolute path."
-  [[ "$value" != *"//"* ]] || fail "Invalid $label: repeated slashes are not allowed."
-  [[ "$value" != *"/./"* && "$value" != */. && "$value" != *"/../"* && "$value" != */.. ]] ||
-    fail "Invalid $label: dot path segments are not allowed."
-}
-
-validate_mount_source_path() {
-  local label="$1"
-  local value="$2"
-  validate_absolute_path "$label" "$value"
-  [[ "$value" != *:* ]] || fail "Invalid $label: ':' is not allowed in Podman bind-mount source paths."
 }
 
 validate_container_name() {
@@ -100,116 +72,8 @@ validate_image_name() {
     fail "Invalid image name: $value"
 }
 
-ensure_safe_existing_dir() {
-  local label="$1"
-  local dir="$2"
-  validate_absolute_path "$label" "$dir"
-  [[ -d "$dir" ]] || fail "Missing $label: $dir"
-  [[ ! -L "$dir" ]] || fail "Unsafe $label: symlinks are not allowed ($dir)"
-}
-
-stat_uid() {
-  local path="$1"
-  if stat -f '%u' "$path" >/dev/null 2>&1; then
-    stat -f '%u' "$path"
-  else
-    stat -Lc '%u' "$path"
-  fi
-}
-
-stat_mode() {
-  local path="$1"
-  if stat -f '%Lp' "$path" >/dev/null 2>&1; then
-    stat -f '%Lp' "$path"
-  else
-    stat -Lc '%a' "$path"
-  fi
-}
-
-ensure_private_existing_dir_owned_by_user() {
-  local label="$1"
-  local dir="$2"
-  local uid=""
-  local mode=""
-  ensure_safe_existing_dir "$label" "$dir"
-  uid="$(stat_uid "$dir")"
-  [[ "$uid" == "$(id -u)" ]] || fail "Unsafe $label: not owned by current user ($dir)"
-  mode="$(stat_mode "$dir")"
-  (( (8#$mode & 0022) == 0 )) || fail "Unsafe $label: group/other writable ($dir)"
-}
-
-ensure_safe_write_file_path() {
-  local label="$1"
-  local file="$2"
-  local dir
-  validate_absolute_path "$label" "$file"
-  if [[ -e "$file" ]]; then
-    [[ ! -L "$file" ]] || fail "Unsafe $label: symlinks are not allowed ($file)"
-    [[ -f "$file" ]] || fail "Unsafe $label: expected a regular file ($file)"
-  fi
-  dir="$(dirname "$file")"
-  ensure_safe_existing_dir "${label} parent directory" "$dir"
-}
-
-write_file_atomically() {
-  local file="$1"
-  local mode="$2"
-  local dir=""
-  local tmp=""
-  ensure_safe_write_file_path "output file" "$file"
-  dir="$(dirname "$file")"
-  tmp="$(mktemp "$dir/.tmp.XXXXXX")"
-  cat >"$tmp"
-  chmod "$mode" "$tmp"
-  mv -f "$tmp" "$file"
-}
-
-validate_port() {
-  local label="$1"
-  local value="$2"
-  local numeric=""
-  [[ "$value" =~ ^[0-9]{1,5}$ ]] || fail "Invalid $label: must be numeric."
-  numeric=$((10#$value))
-  (( numeric >= 1 && numeric <= 65535 )) || fail "Invalid $label: out of range."
-}
-
 escape_sed_replacement_pipe_delim() {
   printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
-}
-
-resolve_user_home() {
-  local user="$1"
-  local home=""
-  if command -v getent >/dev/null 2>&1; then
-    home="$(getent passwd "$user" 2>/dev/null | cut -d: -f6 || true)"
-  fi
-  if [[ -z "$home" && -f /etc/passwd ]]; then
-    home="$(awk -F: -v u="$user" '$1==u {print $6}' /etc/passwd 2>/dev/null || true)"
-  fi
-  if [[ -z "$home" ]]; then
-    home="/home/$user"
-  fi
-  printf '%s' "$home"
-}
-
-generate_token_hex_32() {
-  if command -v openssl >/dev/null 2>&1; then
-    openssl rand -hex 32
-    return 0
-  fi
-  if command -v python3 >/dev/null 2>&1; then
-    python3 - <<'PY'
-import secrets
-print(secrets.token_hex(32))
-PY
-    return 0
-  fi
-  if command -v od >/dev/null 2>&1; then
-    od -An -N32 -tx1 /dev/urandom | tr -d " \n"
-    return 0
-  fi
-  echo "Missing dependency: need openssl or python3 (or od) to generate OPENCLAW_GATEWAY_TOKEN." >&2
-  exit 1
 }
 
 seed_local_control_ui_origins() {
@@ -285,29 +149,6 @@ PY
   }
   chmod 600 "$tmp" 2>/dev/null || true
   mv -f "$tmp" "$file"
-}
-
-upsert_env_var() {
-  local file="$1"
-  local key="$2"
-  local value="$3"
-  local tmp
-  local dir
-  ensure_safe_write_file_path "env file" "$file"
-  dir="$(dirname "$file")"
-  tmp="$(mktemp "$dir/.env.tmp.XXXXXX")"
-  if [[ -f "$file" ]]; then
-    awk -v k="$key" -v v="$value" '
-      BEGIN { found = 0 }
-      $0 ~ ("^" k "=") { print k "=" v; found = 1; next }
-      { print }
-      END { if (!found) print k "=" v }
-    ' "$file" >"$tmp"
-  else
-    printf '%s=%s\n' "$key" "$value" >"$tmp"
-  fi
-  mv "$tmp" "$file"
-  chmod 600 "$file" 2>/dev/null || true
 }
 
 INSTALL_QUADLET=false

--- a/scripts/run-openclaw-podman.sh
+++ b/scripts/run-openclaw-podman.sh
@@ -17,55 +17,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/lib/host-timeout.sh
 source "$SCRIPT_DIR/lib/host-timeout.sh"
+# shellcheck source=scripts/podman/common.sh
+source "$SCRIPT_DIR/podman/common.sh"
 PLATFORM_NAME="$(uname -s 2>/dev/null || echo unknown)"
-
-resolve_user_home() {
-  local user="$1"
-  local home=""
-  if command -v getent >/dev/null 2>&1; then
-    home="$(getent passwd "$user" 2>/dev/null | cut -d: -f6 || true)"
-  fi
-  if [[ -z "$home" && -f /etc/passwd ]]; then
-    home="$(awk -F: -v u="$user" '$1==u {print $6}' /etc/passwd 2>/dev/null || true)"
-  fi
-  if [[ -z "$home" ]]; then
-    home="/home/$user"
-  fi
-  printf '%s' "$home"
-}
-
-fail() {
-  echo "$*" >&2
-  exit 1
-}
 
 run_podman_detached() {
   openclaw_host_timeout_cmd "$PODMAN_RUN_TIMEOUT" podman run "$@"
-}
-
-validate_single_line_value() {
-  local label="$1"
-  local value="$2"
-  if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
-    fail "Invalid $label: control characters are not allowed."
-  fi
-}
-
-validate_absolute_path() {
-  local label="$1"
-  local value="$2"
-  validate_single_line_value "$label" "$value"
-  [[ "$value" == /* ]] || fail "Invalid $label: expected an absolute path."
-  [[ "$value" != *"//"* ]] || fail "Invalid $label: repeated slashes are not allowed."
-  [[ "$value" != *"/./"* && "$value" != */. && "$value" != *"/../"* && "$value" != */.. ]] ||
-    fail "Invalid $label: dot path segments are not allowed."
-}
-
-validate_mount_source_path() {
-  local label="$1"
-  local value="$2"
-  validate_absolute_path "$label" "$value"
-  [[ "$value" != *:* ]] || fail "Invalid $label: ':' is not allowed in Podman bind-mount source paths."
 }
 
 ensure_safe_existing_regular_file() {
@@ -75,44 +32,6 @@ ensure_safe_existing_regular_file() {
   [[ -e "$file" ]] || fail "Missing $label: $file"
   [[ ! -L "$file" ]] || fail "Unsafe $label: symlinks are not allowed ($file)"
   [[ -f "$file" ]] || fail "Unsafe $label: expected a regular file ($file)"
-}
-
-ensure_safe_existing_dir() {
-  local label="$1"
-  local dir="$2"
-  validate_absolute_path "$label" "$dir"
-  [[ -d "$dir" ]] || fail "Missing $label: $dir"
-  [[ ! -L "$dir" ]] || fail "Unsafe $label: symlinks are not allowed ($dir)"
-}
-
-stat_uid() {
-  local path="$1"
-  if stat -f '%u' "$path" >/dev/null 2>&1; then
-    stat -f '%u' "$path"
-  else
-    stat -Lc '%u' "$path"
-  fi
-}
-
-stat_mode() {
-  local path="$1"
-  if stat -f '%Lp' "$path" >/dev/null 2>&1; then
-    stat -f '%Lp' "$path"
-  else
-    stat -Lc '%a' "$path"
-  fi
-}
-
-ensure_private_existing_dir_owned_by_user() {
-  local label="$1"
-  local dir="$2"
-  local uid=""
-  local mode=""
-  ensure_safe_existing_dir "$label" "$dir"
-  uid="$(stat_uid "$dir")"
-  [[ "$uid" == "$(id -u)" ]] || fail "Unsafe $label: not owned by current user ($dir)"
-  mode="$(stat_mode "$dir")"
-  (( (8#$mode & 0022) == 0 )) || fail "Unsafe $label: group/other writable ($dir)"
 }
 
 ensure_private_existing_regular_file_owned_by_user() {
@@ -125,32 +44,6 @@ ensure_private_existing_regular_file_owned_by_user() {
   [[ "$uid" == "$(id -u)" ]] || fail "Unsafe $label: not owned by current user ($file)"
   mode="$(stat_mode "$file")"
   (( (8#$mode & 0077) == 0 )) || fail "Unsafe $label: expected owner-only permissions ($file)"
-}
-
-ensure_safe_write_file_path() {
-  local label="$1"
-  local file="$2"
-  local dir
-  validate_absolute_path "$label" "$file"
-  if [[ -e "$file" ]]; then
-    [[ ! -L "$file" ]] || fail "Unsafe $label: symlinks are not allowed ($file)"
-    [[ -f "$file" ]] || fail "Unsafe $label: expected a regular file ($file)"
-  fi
-  dir="$(dirname "$file")"
-  ensure_safe_existing_dir "${label} parent directory" "$dir"
-}
-
-write_file_atomically() {
-  local file="$1"
-  local mode="$2"
-  local dir=""
-  local tmp=""
-  ensure_safe_write_file_path "output file" "$file"
-  dir="$(dirname "$file")"
-  tmp="$(mktemp "$dir/.tmp.XXXXXX")"
-  cat >"$tmp"
-  chmod "$mode" "$tmp"
-  mv -f "$tmp" "$file"
 }
 
 load_podman_env_file() {
@@ -187,15 +80,6 @@ load_podman_env_file() {
     export "$key"
   done
   exec 9<&-
-}
-
-validate_port() {
-  local label="$1"
-  local value="$2"
-  local numeric=""
-  [[ "$value" =~ ^[0-9]{1,5}$ ]] || fail "Invalid $label: must be numeric."
-  numeric=$((10#$value))
-  (( numeric >= 1 && numeric <= 65535 )) || fail "Invalid $label: out of range."
 }
 
 EFFECTIVE_USER="$(id -un)"
@@ -284,49 +168,6 @@ resolve_config_gateway_bind() {
 # OPENCLAW_GATEWAY_BIND first, then gateway.bind in local config.
 CONFIG_GATEWAY_BIND="$(resolve_config_gateway_bind "$CONFIG_DIR")"
 GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-${CONFIG_GATEWAY_BIND:-lan}}"
-
-upsert_env_var() {
-  local file="$1"
-  local key="$2"
-  local value="$3"
-  local tmp
-  local dir
-  ensure_safe_write_file_path "env file" "$file"
-  dir="$(dirname "$file")"
-  tmp="$(mktemp "$dir/.env.tmp.XXXXXX")"
-  if [[ -f "$file" ]]; then
-    awk -v k="$key" -v v="$value" '
-      BEGIN { found = 0 }
-      $0 ~ ("^" k "=") { print k "=" v; found = 1; next }
-      { print }
-      END { if (!found) print k "=" v }
-    ' "$file" >"$tmp"
-  else
-    printf '%s=%s\n' "$key" "$value" >"$tmp"
-  fi
-  mv "$tmp" "$file"
-  chmod 600 "$file" 2>/dev/null || true
-}
-
-generate_token_hex_32() {
-  if command -v openssl >/dev/null 2>&1; then
-    openssl rand -hex 32
-    return 0
-  fi
-  if command -v python3 >/dev/null 2>&1; then
-    python3 - <<'PY'
-import secrets
-print(secrets.token_hex(32))
-PY
-    return 0
-  fi
-  if command -v od >/dev/null 2>&1; then
-    od -An -N32 -tx1 /dev/urandom | tr -d " \n"
-    return 0
-  fi
-  echo "Missing dependency: need openssl or python3 (or od) to generate OPENCLAW_GATEWAY_TOKEN." >&2
-  exit 1
-}
 
 create_token_env_file() {
   local file="$1"


### PR DESCRIPTION
## What Problem This Solves

Rootless Podman installation and container startup each maintained their own complete copies of the same path, permissions, token, environment-file, and network-port safeguards. Keeping security-sensitive setup and launch policies synchronized made changes unnecessarily difficult and invited future drift.

## Why This Change Was Made

Both documented, repo-local Podman entrypoints now source one shared owner for their 14 identical security and runtime helpers. The helper bodies are unchanged; setup, launch, rootless ownership requirements, Quadlet handling, environment allowlisting, atomic private files, token generation, and port validation retain their existing behavior. This removes 156 genuine operational production lines without changing public commands, tests, or configuration.

## User Impact

Existing Podman operators continue using `./scripts/podman/setup.sh --container` and `./scripts/run-openclaw-podman.sh launch` unchanged. Installation and startup now enforce the same canonical security policy.

## Evidence

- Executed both documented setup and launch commands end to end against an isolated fake Podman binary; 52 executable assertions covered rootless ownership, symlink/world-writable rejection, absolute-path/control-character/colon/dot-segment guards, numeric port bounds and leading zeros, atomic 0600 writes, private config directories, generated-token shape, container arguments, absence of token leakage, and temporary-token cleanup.
- Existing Podman install/launcher coverage: 6 passed, 82 unrelated cases skipped with the focused `Podman` filter.
- All three shell files pass `bash -n`; all three pass `shellcheck --severity=error`; `git diff --check` is clean.
- Production delta: 166 added, 322 removed, net **-156**; no tests, generated files, docs, or metadata are included in that accounting.
- The unfocused install suite has seven pre-existing local sandbox failures because unrelated cases request `/var/folders/...` temporary directories unavailable to this managed checkout; exact-head hosted CI and the native isolated Testbox validation provide the complete clean-machine gate.
