### PR TITLE
fix(cli): make managed Gateway and Node recovery hints actionable

### DIFF
--- a/src/cli/daemon-cli/response.test.ts
+++ b/src/cli/daemon-cli/response.test.ts
@@ -52,6 +52,22 @@ describe("daemon action JSON hints", () => {
       }),
     );
   });
+
+  it.each([
+    "openclaw --profile work gateway install",
+    "openclaw --container demo gateway install",
+    "openclaw node install",
+    "openclaw --profile work node install",
+    "openclaw --container demo node install",
+  ])("classifies scoped Gateway and node service install hints: %s", (hint) => {
+    const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+
+    createDaemonActionContext({ action: "start", json: true }).emit({ ok: false, hints: [hint] });
+
+    expect(writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({ hintItems: [{ kind: "install", text: hint }] }),
+    );
+  });
 });
 
 describe("daemon install verification", () => {

--- a/src/cli/daemon-cli/response.ts
+++ b/src/cli/daemon-cli/response.ts
@@ -51,7 +51,7 @@ function emitDaemonActionJson(payload: DaemonActionResponse) {
 }
 
 function classifyDaemonHintText(text: string): DaemonHintKind {
-  if (text.includes("openclaw gateway install") || text.startsWith("Service not installed. Run:")) {
+  if (/\b(gateway|node) install\b/u.test(text) || text.startsWith("Service not installed. Run:")) {
     return "install";
   }
   if (text.startsWith("Restart the container or the service that manages it for ")) {

--- a/src/cli/daemon-cli/shared.test.ts
+++ b/src/cli/daemon-cli/shared.test.ts
@@ -35,6 +35,23 @@ describe("parsePortFromArgs", () => {
 });
 
 describe("renderGatewayServiceStartHints", () => {
+  it.each([
+    {
+      name: "the default profile",
+      env: {},
+      installCommand: "openclaw gateway install",
+      startCommand: "openclaw gateway start",
+    },
+    {
+      name: "a named profile",
+      env: { OPENCLAW_PROFILE: "work" },
+      installCommand: "openclaw --profile work gateway install",
+      startCommand: "openclaw --profile work gateway start",
+    },
+  ])("recommends managed service commands for $name", ({ env, installCommand, startCommand }) => {
+    expect(renderGatewayServiceStartHints(env).slice(0, 2)).toEqual([installCommand, startCommand]);
+  });
+
   it("uses GUI session wording for installed LaunchAgents that cannot access gui/$UID", () => {
     expect(
       renderRuntimeHints(
@@ -71,10 +88,11 @@ describe("renderGatewayServiceStartHints", () => {
     expect(
       renderGatewayServiceStartHints({
         OPENCLAW_CONTAINER_HINT: "openclaw-demo-container",
+        OPENCLAW_PROFILE: "work",
       } as NodeJS.ProcessEnv),
-    ).toContain(
+    ).toEqual([
       "Restart the container or the service that manages it for openclaw-demo-container.",
-    );
+    ]);
   });
 });
 

--- a/src/cli/daemon-cli/shared.ts
+++ b/src/cli/daemon-cli/shared.ts
@@ -205,7 +205,7 @@ export function renderGatewayServiceStartHints(env: NodeJS.ProcessEnv = process.
   const container = resolveDaemonContainerContext(env);
   const hints = buildPlatformServiceStartHints({
     installCommand: formatCliCommand("openclaw gateway install", env),
-    startCommand: formatCliCommand("openclaw gateway", env),
+    startCommand: formatCliCommand("openclaw gateway start", env),
     launchAgentPlistPath: `~/Library/LaunchAgents/${resolveGatewayLaunchAgentLabel(profile)}.plist`,
     systemdServiceName: resolveGatewaySystemdServiceName(profile),
     windowsTaskName: resolveGatewayWindowsTaskName(profile),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators recovering a failed managed Gateway were instructed to start a foreground process instead of the managed service. Structured recovery output also mislabeled scoped Gateway installations and all Node-service installations as generic suggestions.

## Why This Change Was Made

Use the already-registered managed-service start command in the shared recovery owner and recognize existing Gateway/Node installation hints after root profile or container flags. Both fixes preserve canonical active-profile formatting and container-only recovery behavior.

Production delta: **2 additions / 2 deletions (net 0)**. No configuration, protocol, authentication, persistence, or plugin-SDK changes.

## User Impact

Gateway recovery instructions now actually restart the managed service. Automation consuming structured JSON can correctly identify both Gateway and Node installation remedies, including named-profile and container-scoped commands.

## Evidence

- Authentic pre-fix owner regressions: two incorrect managed-service commands and five incorrectly classified scoped Gateway/Node installation hints.
- Focused recovery owner, structured response, and real lifecycle-consumer suites: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/daemon-cli/shared.test.ts src/cli/daemon-cli/response.test.ts src/cli/daemon-cli/lifecycle-core.test.ts --reporter=dot` — **62 passed**.
- Additional platform-hint sibling coverage passed, for **65 total focused tests**.
- Default and named-profile commands preserve their existing profile; a container remains limited to its existing container-restart instruction.
- Targeted formatter/lint passed; fresh independent structured review was **clean**.
