### PR TITLE
fix(reply): prevent silent assistant turns from streaming private media

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -2,6 +2,9 @@
 // lifecycle events, and deferred reply cleanup.
 import { describe, expect, it, vi } from "vitest";
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
+import type { AgentTurnParams } from "../auto-reply/reply/agent-runner-execution.types.js";
+import { createAgentTurnPresentation } from "../auto-reply/reply/agent-runner-presentation.js";
+import type { ReplyPayload } from "../auto-reply/types.js";
 import { createHookRunner } from "../plugins/hooks.js";
 import { createMockPluginRegistry, TEST_PLUGIN_AGENT_CTX } from "../plugins/hooks.test-fixtures.js";
 import {
@@ -43,7 +46,7 @@ function createContext(
     onAgentEvent?: (event: unknown) => void | Promise<void>;
     onBeforeLifecycleTerminal?: () => void | Promise<void>;
     onBeforeTerminalDelivery?: () => void | Promise<void>;
-    onBlockReply?: ((payload: unknown) => void) | undefined;
+    onBlockReply?: ((payload: unknown) => void | Promise<void>) | undefined;
     onBlockReplyFlush?: () => void | Promise<void>;
     resolveTerminalStopReason?: () => string | undefined;
   },
@@ -950,6 +953,52 @@ describe("handleAgentEnd", () => {
     });
     expect(ctx.state.pendingToolMediaUrls).toStrictEqual([]);
     expect(ctx.state.pendingToolAudioAsVoice).toBe(false);
+  });
+
+  it.each([
+    { name: "ordinary image", mediaUrl: "/tmp/private.png", audioAsVoice: false, deliveries: 0 },
+    { name: "voice exception", mediaUrl: "/tmp/voice.opus", audioAsVoice: true, deliveries: 1 },
+  ])("applies silent-turn policy when lifecycle flushes orphaned $name", async (testCase) => {
+    const delivered = vi.fn(async (_payload: ReplyPayload) => {});
+    const turn = {
+      followupRun: { run: { silentExpected: true } },
+      isHeartbeat: false,
+      opts: { onBlockReply: delivered },
+      sessionCtx: {},
+      applyReplyToMode: (payload: ReplyPayload) => payload,
+      typingSignals: { signalTextDelta: async () => {} },
+      blockStreamingEnabled: true,
+      blockReplyPipeline: null,
+    } as unknown as AgentTurnParams;
+    const presentation = createAgentTurnPresentation({
+      turn,
+      replyMediaContext: { normalizePayload: async (payload) => payload },
+      directlySentBlockKeys: new Set(),
+      directlySentBlockPayloads: [],
+      heartbeatState: { didLogStrip: false },
+    });
+    const ctx = createContext(undefined, {
+      onBlockReply: (payload) => presentation.blockReplyHandler?.(payload as ReplyPayload),
+    });
+    ctx.params.silentExpected = true;
+    ctx.state.pendingToolMediaUrls = [testCase.mediaUrl];
+    ctx.state.pendingToolAudioAsVoice = testCase.audioAsVoice;
+    const lifecycleDelivery = createReplyDelivery({
+      params: ctx.params,
+      state: ctx.state,
+      log: ctx.log,
+    });
+    vi.mocked(ctx.emitBlockReply).mockImplementation(lifecycleDelivery.emitBlockReply);
+
+    await handleAgentEnd(ctx);
+    await Promise.all(lifecycleDelivery.pendingBlockReplyTasks);
+
+    expect(delivered).toHaveBeenCalledTimes(testCase.deliveries);
+    if (testCase.deliveries) {
+      expect(delivered).toHaveBeenCalledWith(
+        expect.objectContaining({ mediaUrls: [testCase.mediaUrl], audioAsVoice: true }),
+      );
+    }
   });
 
   it("preserves orphaned tool media when no block reply callback is configured", async () => {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -33,6 +33,7 @@ import {
   applyReplyThreading,
   isRenderablePayload,
   resolveReplyThreadingPayloads,
+  shouldKeepPayloadDuringSilentTurn,
 } from "./reply-payloads-base.js";
 import { createReplyDeliveryContext } from "./reply-threading.js";
 
@@ -110,13 +111,6 @@ async function normalizeSentMediaUrlsForDedupe(params: {
   }
 
   return normalizedUrls;
-}
-
-function shouldKeepPayloadDuringSilentTurn(payload: ReplyPayload): boolean {
-  if (payload.isError) {
-    return true;
-  }
-  return payload.audioAsVoice === true && resolveSendableOutboundReplyParts(payload).hasMedia;
 }
 
 function sanitizeFinalReplyText(

--- a/src/auto-reply/reply/agent-runner-presentation.test.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.test.ts
@@ -49,11 +49,23 @@ function normalizeStreamingTextReference(
   return sanitized.trim() ? { text: sanitized, skip: false } : { skip: true };
 }
 
-function createPresentation(options: { isHeartbeat?: boolean; silentExpected?: boolean } = {}) {
+function createPresentation(
+  options: {
+    isHeartbeat?: boolean;
+    silentExpected?: boolean;
+    onBlockReply?: (payload: ReplyPayload) => Promise<void>;
+    blockReplyPipeline?: AgentTurnParams["blockReplyPipeline"];
+  } = {},
+) {
   const turn = {
     followupRun: { run: { silentExpected: options.silentExpected === true } },
     isHeartbeat: options.isHeartbeat === true,
-    opts: undefined,
+    opts: options.onBlockReply ? { onBlockReply: options.onBlockReply } : undefined,
+    sessionCtx: {},
+    applyReplyToMode: (payload: ReplyPayload) => payload,
+    typingSignals: { signalTextDelta: async () => {} },
+    blockStreamingEnabled: true,
+    blockReplyPipeline: options.blockReplyPipeline ?? null,
   } as unknown as AgentTurnParams;
   return createAgentTurnPresentation({
     turn,
@@ -121,5 +133,85 @@ describe("agent runner streaming presentation", () => {
       text: "HEARTBEAT_OK details",
       skip: false,
     });
+  });
+
+  it.each<{
+    name: string;
+    payload: ReplyPayload;
+    delivered: boolean;
+  }>([
+    { name: "ordinary text", payload: { text: "private maintenance" }, delivered: false },
+    {
+      name: "orphaned tool image",
+      payload: { mediaUrls: ["file:///tmp/private.png"] },
+      delivered: false,
+    },
+    {
+      name: "portable presentation",
+      payload: {
+        presentation: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Open", value: "open" }] }],
+        },
+      },
+      delivered: false,
+    },
+    {
+      name: "legacy interactive controls",
+      payload: {
+        interactive: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Retry", value: "retry" }] }],
+        },
+      },
+      delivered: false,
+    },
+    {
+      name: "channel-specific action",
+      payload: { channelData: { telegram: { buttons: [{ text: "Open" }] } } },
+      delivered: false,
+    },
+    {
+      name: "portable location",
+      payload: { location: { latitude: 1, longitude: 2 } },
+      delivered: false,
+    },
+    {
+      name: "voice media exception",
+      payload: { mediaUrls: ["file:///tmp/voice.opus"], audioAsVoice: true },
+      delivered: true,
+    },
+    {
+      name: "empty voice marker",
+      payload: { audioAsVoice: true },
+      delivered: false,
+    },
+    {
+      name: "error exception",
+      payload: { text: "maintenance failed", isError: true },
+      delivered: true,
+    },
+  ])("applies the final silent-turn policy to streamed $name", async (testCase) => {
+    for (const usePipeline of [false, true]) {
+      const delivered: ReplyPayload[] = [];
+      const presentation = createPresentation({
+        silentExpected: true,
+        onBlockReply: async (payload) => {
+          delivered.push(payload);
+        },
+        blockReplyPipeline: usePipeline
+          ? ({ enqueue: (payload: ReplyPayload) => delivered.push(payload) } as NonNullable<
+              AgentTurnParams["blockReplyPipeline"]
+            >)
+          : null,
+      });
+
+      await presentation.blockReplyHandler?.(testCase.payload);
+
+      expect(delivered, usePipeline ? "pipeline" : "direct").toHaveLength(
+        testCase.delivered ? 1 : 0,
+      );
+      if (testCase.delivered) {
+        expect(delivered[0]).toMatchObject(testCase.payload);
+      }
+    }
   });
 });

--- a/src/auto-reply/reply/agent-runner-presentation.test.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.test.ts
@@ -13,6 +13,7 @@ import {
 import type { ReplyPayload } from "../types.js";
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
 import { createAgentTurnPresentation } from "./agent-runner-presentation.js";
+import { createBlockReplyPipeline } from "./block-reply-pipeline.js";
 
 function normalizeStreamingTextReference(
   payload: ReplyPayload,
@@ -192,19 +193,24 @@ describe("agent runner streaming presentation", () => {
   ])("applies the final silent-turn policy to streamed $name", async (testCase) => {
     for (const usePipeline of [false, true]) {
       const delivered: ReplyPayload[] = [];
+      const blockReplyPipeline = usePipeline
+        ? createBlockReplyPipeline({
+            onBlockReply: async (payload) => {
+              delivered.push(payload);
+            },
+            timeoutMs: 0,
+          })
+        : null;
       const presentation = createPresentation({
         silentExpected: true,
         onBlockReply: async (payload) => {
           delivered.push(payload);
         },
-        blockReplyPipeline: usePipeline
-          ? ({ enqueue: (payload: ReplyPayload) => delivered.push(payload) } as NonNullable<
-              AgentTurnParams["blockReplyPipeline"]
-            >)
-          : null,
+        blockReplyPipeline,
       });
 
       await presentation.blockReplyHandler?.(testCase.payload);
+      await blockReplyPipeline?.flush({ force: true });
 
       expect(delivered, usePipeline ? "pipeline" : "direct").toHaveLength(
         testCase.delivered ? 1 : 0,

--- a/src/auto-reply/reply/agent-runner-presentation.ts
+++ b/src/auto-reply/reply/agent-runner-presentation.ts
@@ -15,6 +15,7 @@ import type { ReplyPayload } from "../types.js";
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import type { ReplyMediaContext } from "./reply-media-paths.js";
+import { shouldKeepPayloadDuringSilentTurn } from "./reply-payloads-base.js";
 
 type AgentTurnPresentation = {
   classifyStreamingPartial: (payload: ReplyPayload) => { text?: string; skip: boolean };
@@ -38,10 +39,11 @@ export function createAgentTurnPresentation(params: {
   directlySentBlockPayloads: Array<ReplyPayload | undefined>;
   heartbeatState: { didLogStrip: boolean };
 }): AgentTurnPresentation {
+  const silentExpected = params.turn.followupRun.run.silentExpected;
   const classifyStreamingPartial = (payload: ReplyPayload): { text?: string; skip: boolean } => {
     let text = payload.text;
     const reply = resolveSendableOutboundReplyParts(payload);
-    if (params.turn.followupRun.run.silentExpected) {
+    if (silentExpected && !shouldKeepPayloadDuringSilentTurn(payload)) {
       return { skip: true };
     }
     if (!params.turn.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
@@ -124,6 +126,7 @@ export function createAgentTurnPresentation(params: {
         typingSignals: params.turn.typingSignals,
         reasoningPayloadsEnabled: params.turn.opts?.reasoningPayloadsEnabled,
         commentaryPayloadsEnabled: params.turn.opts?.commentaryPayloadsEnabled,
+        silentExpected,
         blockStreamingEnabled: params.turn.blockStreamingEnabled,
         blockReplyPipeline,
         directlySentBlockKeys: params.directlySentBlockKeys,

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -93,6 +93,7 @@ export function createBlockReplyDeliveryHandler(params: {
   typingSignals: TypingSignaler;
   reasoningPayloadsEnabled?: boolean;
   commentaryPayloadsEnabled?: boolean;
+  silentExpected?: boolean;
   blockStreamingEnabled: boolean;
   blockReplyPipeline: BlockReplyPipeline | null;
   directlySentBlockKeys: Set<string>;
@@ -108,7 +109,10 @@ export function createBlockReplyDeliveryHandler(params: {
       return;
     }
     const { text, skip } = params.normalizeStreamingText(payload);
-    if (skip && !hasOutboundReplyContent({ ...payload, text: undefined })) {
+    if (
+      skip &&
+      (params.silentExpected || !hasOutboundReplyContent({ ...payload, text: undefined }))
+    ) {
       return;
     }
 

--- a/src/auto-reply/reply/reply-payloads-base.ts
+++ b/src/auto-reply/reply/reply-payloads-base.ts
@@ -95,6 +95,15 @@ export function isRenderablePayload(payload: ReplyPayload): boolean {
   });
 }
 
+/** Only failures and playable voice messages remain visible during silent turns. */
+export function shouldKeepPayloadDuringSilentTurn(payload: ReplyPayload): boolean {
+  return (
+    payload.isError === true ||
+    (payload.audioAsVoice === true &&
+      hasReplyPayloadContent({ mediaUrl: payload.mediaUrl, mediaUrls: payload.mediaUrls }))
+  );
+}
+
 /** True when a payload should stay internal as reasoning-only output. */
 export function shouldSuppressReasoningPayload(payload: ReplyPayload): boolean {
   return payload.isReasoning === true;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where intentionally silent assistant turns could visibly send private tool-generated images, buttons, locations, or channel actions while simultaneously discarding real error messages. Final replies already enforced the correct policy, but streamed replies bypassed it.

## Why This Change Was Made

Move the existing silent-turn visibility rule into its shared reply-payload owner, then apply that canonical decision consistently to final replies, direct streamed delivery, buffered streamed delivery, and pending tool-media lifecycle flushes. Preserve the existing exceptions for actual voice messages and errors.

Production delta: **19 additions / 9 deletions (net +10)**. The added owner-boundary wiring is necessary to carry the existing visibility decision across separately controlled final and streaming lifecycles; no configuration, protocol, authentication, persistence, plugin-SDK, or dependency changes.

## User Impact

Background turns that are supposed to remain silent no longer leak generated media or other rich content into the conversation. Legitimate errors and intentional voice messages continue to appear.

## Evidence

- Authentic pre-fix regression: six real streaming payload variants failed their intended silent-turn policy, and a real agent-end lifecycle flushed an otherwise private pending image into actual reply delivery.
- Direct production-owner before/after matrix: images, presentations, interactive controls, channel actions, and locations are suppressed; actual voice media and errors remain visible.
- Full owner, final reply, streaming delivery, buffering, and lifecycle sibling coverage: **213 passed; one existing platform-only skip** across six suites.
- Final focused lifecycle and presentation regression rerun: **65 passed**.
- Targeted formatter and typed lint passed; fresh independent structured review was **clean**.
