### PR TITLE
fix(ui): preserve confirmed cloud profile deletion across reconnects

### DIFF
--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -507,6 +507,113 @@ suite.define(() => {
     }
   });
 
+  it("rejects a confirmed deletion after same-URL Gateway credentials replace its client", async () => {
+    const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const initialConfig = {
+      cloudWorkers: { profiles: { pending: configuredCloudWorkerProfile() } },
+    };
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["config.patch", "environments.list"],
+      methodResponses: {
+        "config.get": configResponse(initialConfig, "cloud-workers-delete-client-replacement-1"),
+        "config.patch": {
+          ok: true,
+          hash: "cloud-workers-delete-client-replacement-2",
+          config: { cloudWorkers: { profiles: {} } },
+        },
+        "environments.list": { environments: [], profiles: [] },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/cloud-workers`);
+      const pendingRow = page.locator(".settings-row").filter({
+        has: page.locator("code", { hasText: /^pending$/ }),
+      });
+      await pendingRow.getByRole("button", { name: "Delete" }).click();
+      const confirmation = await waitForConfirmModal(page);
+      const socketCount = await gateway.getSocketCount();
+      const configGetCount = (await gateway.getRequests("config.get")).length;
+      const originalGateway = await page.evaluate(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: {
+            context: {
+              gateway: {
+                connection: { gatewayUrl: string };
+                connect: (options: { token: string }) => void;
+                snapshot: { client: { instanceId: string } | null };
+              };
+            };
+          };
+        };
+        const activeGateway = app.runtime?.context.gateway;
+        const client = activeGateway?.snapshot.client;
+        if (!activeGateway || !client) {
+          throw new Error("Expected a connected Gateway client before confirmation");
+        }
+        const identity = {
+          clientInstanceId: client.instanceId,
+          gatewayUrl: activeGateway.connection.gatewayUrl,
+        };
+        activeGateway.connect({ token: "replacement-credential-proof" });
+        return identity;
+      });
+      await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketCount);
+      await expect
+        .poll(async () => (await gateway.getRequests("config.get")).length)
+        .toBeGreaterThan(configGetCount);
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime?: {
+                context: {
+                  gateway: {
+                    connection: { gatewayUrl: string };
+                    snapshot: { client: { instanceId: string } | null; phase: string };
+                  };
+                };
+              };
+            };
+            const activeGateway = app.runtime?.context.gateway;
+            return {
+              clientInstanceId: activeGateway?.snapshot.client?.instanceId,
+              gatewayUrl: activeGateway?.connection.gatewayUrl,
+              phase: activeGateway?.snapshot.phase,
+            };
+          }),
+        )
+        .toMatchObject({ gatewayUrl: originalGateway.gatewayUrl, phase: "connected" });
+      const replacementClientInstanceId = await page.evaluate(() => {
+        const app = document.querySelector("openclaw-app") as HTMLElement & {
+          runtime?: { context: { gateway: { snapshot: { client: { instanceId: string } } } } };
+        };
+        return app.runtime?.context.gateway.snapshot.client.instanceId;
+      });
+      expect(replacementClientInstanceId).not.toBe(originalGateway.clientInstanceId);
+      await expect
+        .poll(() => pendingRow.getByRole("button", { name: "Delete" }).isEnabled())
+        .toBe(true);
+
+      await confirmation.getByRole("button", { name: "Delete", exact: true }).click();
+
+      await expect
+        .poll(async () => ({
+          alerts: await page.getByRole("alert").count(),
+          patches: (await gateway.getRequests("config.patch")).length,
+        }))
+        .not.toEqual({ alerts: 0, patches: 0 });
+      expect(await gateway.getRequests("config.patch")).toHaveLength(0);
+      await expect
+        .poll(async () => page.getByRole("alert").textContent())
+        .toBe("The profile was not deleted. Reload the config and try again.");
+      await pendingRow.waitFor();
+    } finally {
+      await context.close();
+    }
+  });
+
   it("reports a confirmed deletion that cannot run while Gateway config is reconnecting", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();

--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -26,6 +26,19 @@ function configResponse(config: Record<string, unknown>, hash: string) {
   };
 }
 
+function configuredCloudWorkerProfile(backend = "aws") {
+  return {
+    provider: "crabbox",
+    install: "bundle",
+    settings: {
+      provider: backend,
+      class: "standard",
+      ttl: "8h",
+      idleTimeout: "45m",
+    },
+  };
+}
+
 function requestRaw(request: MockGatewayRequest): Record<string, unknown> {
   if (!isRecord(request.params) || typeof request.params.raw !== "string") {
     throw new Error("Expected config.patch params");
@@ -389,17 +402,8 @@ suite.define(() => {
   it("deletes a profile and its project defaults only after confirmation", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
-    const pending = {
-      provider: "crabbox",
-      install: "bundle",
-      settings: {
-        provider: "aws",
-        class: "standard",
-        ttl: "8h",
-        idleTimeout: "45m",
-      },
-    };
-    const retained = { ...pending, settings: { ...pending.settings, provider: "hetzner" } };
+    const pending = configuredCloudWorkerProfile();
+    const retained = configuredCloudWorkerProfile("hetzner");
     const retainedProjectProfiles = { "github.com/acme/retained": "retained" };
     const initialConfig = {
       cloudWorkers: {
@@ -449,6 +453,95 @@ suite.define(() => {
       });
       await expect.poll(() => pendingRow.count()).toBe(0);
       await page.locator(".settings-row code", { hasText: /^retained$/ }).waitFor();
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("deletes a confirmed profile after the Gateway reconnects during confirmation", async () => {
+    const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const pending = configuredCloudWorkerProfile();
+    const initialConfig = { cloudWorkers: { profiles: { pending } } };
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["config.patch", "environments.list"],
+      methodResponses: {
+        "config.get": configResponse(initialConfig, "cloud-workers-delete-reconnect-1"),
+        "config.patch": {
+          ok: true,
+          hash: "cloud-workers-delete-reconnect-3",
+          config: { cloudWorkers: { profiles: {} } },
+        },
+        "environments.list": { environments: [], profiles: [] },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/cloud-workers`);
+      const pendingRow = page.locator(".settings-row").filter({
+        has: page.locator("code", { hasText: /^pending$/ }),
+      });
+      await pendingRow.getByRole("button", { name: "Delete" }).click();
+      const confirmation = await waitForConfirmModal(page);
+      const socketCount = await gateway.getSocketCount();
+      const configGetCount = (await gateway.getRequests("config.get")).length;
+      await gateway.setMethodResponse(
+        "config.get",
+        configResponse(initialConfig, "cloud-workers-delete-reconnect-2"),
+      );
+      await gateway.closeLatest(1012, "cloud worker delete confirmation reconnect proof");
+      await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketCount);
+      await expect
+        .poll(async () => (await gateway.getRequests("config.get")).length)
+        .toBeGreaterThan(configGetCount);
+      await expect
+        .poll(() => pendingRow.getByRole("button", { name: "Delete" }).isEnabled())
+        .toBe(true);
+
+      await confirmation.getByRole("button", { name: "Delete", exact: true }).click();
+
+      await expect.poll(async () => (await gateway.getRequests("config.patch")).length).toBe(1);
+      await expect.poll(() => pendingRow.count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("reports a confirmed deletion that cannot run while Gateway config is reconnecting", async () => {
+    const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const initialConfig = {
+      cloudWorkers: { profiles: { pending: configuredCloudWorkerProfile() } },
+    };
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["config.patch", "environments.list"],
+      methodResponses: {
+        "config.get": configResponse(initialConfig, "cloud-workers-delete-offline-1"),
+        "environments.list": { environments: [], profiles: [] },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/cloud-workers`);
+      const pendingRow = page.locator(".settings-row").filter({
+        has: page.locator("code", { hasText: /^pending$/ }),
+      });
+      await pendingRow.getByRole("button", { name: "Delete" }).click();
+      const confirmation = await waitForConfirmModal(page);
+      const configGetCount = (await gateway.getRequests("config.get")).length;
+      await gateway.deferNext("config.get");
+      await gateway.closeLatest(1012, "cloud worker delete unavailable reconnect proof");
+      await expect
+        .poll(async () => (await gateway.getRequests("config.get")).length)
+        .toBeGreaterThan(configGetCount);
+
+      await confirmation.getByRole("button", { name: "Delete", exact: true }).click();
+
+      await expect
+        .poll(async () => page.getByRole("alert").textContent())
+        .toBe("The profile was not deleted. Reload the config and try again.");
+      expect(await gateway.getRequests("config.patch")).toHaveLength(0);
+      await pendingRow.waitFor();
     } finally {
       await context.close();
     }

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -242,22 +242,33 @@ class CloudWorkersPage extends OpenClawLightDomElement {
   }
 
   private async deleteProfile(profile: ConfiguredCloudWorkerProfile) {
-    const scope = this.gateway.capture();
+    const gateway = this.context.gateway;
+    const gatewayUrl = gateway.connection.gatewayUrl;
     const runtimeConfig = this.context.runtimeConfig;
     if (
-      !scope ||
       !this.canManage() ||
       !(await showConfirmDialog({
         title: t("cloudWorkersPage.deleteTitle"),
         message: t("cloudWorkersPage.deleteConfirm", { profile: profile.id }),
         confirmLabel: t("common.delete"),
         danger: true,
-      })) ||
-      !this.gateway.isCurrent(scope)
+      }))
     ) {
       return;
     }
+    const scope = this.gateway.capture();
+    if (
+      !scope ||
+      this.context.gateway !== gateway ||
+      gateway.connection.gatewayUrl !== gatewayUrl ||
+      this.context.runtimeConfig !== runtimeConfig ||
+      !this.canManage()
+    ) {
+      this.formError = t("cloudWorkersPage.errors.deleteFailed");
+      return;
+    }
     this.busyProfileId = profile.id;
+    this.formError = null;
     this.notice = null;
     const isCurrent = () =>
       this.gateway.isCurrent(scope) && this.context.runtimeConfig === runtimeConfig;
@@ -548,6 +559,9 @@ class CloudWorkersPage extends OpenClawLightDomElement {
           ? html`<div class="callout warning" role="status">
               ${t("cloudWorkersPage.catalogFailed", { error: this.catalogError })}
             </div>`
+          : nothing}
+        ${this.formError && !this.editor
+          ? html`<div class="callout warning" role="alert">${this.formError}</div>`
           : nothing}
         ${this.notice
           ? html`<div class="callout warning" role="status">${this.notice}</div>`

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -243,6 +243,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
 
   private async deleteProfile(profile: ConfiguredCloudWorkerProfile) {
     const gateway = this.context.gateway;
+    const client = gateway.snapshot.client;
     const gatewayUrl = gateway.connection.gatewayUrl;
     const runtimeConfig = this.context.runtimeConfig;
     if (
@@ -259,6 +260,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     const scope = this.gateway.capture();
     if (
       !scope ||
+      scope.client !== client ||
       this.context.gateway !== gateway ||
       gateway.connection.gatewayUrl !== gatewayUrl ||
       this.context.runtimeConfig !== runtimeConfig ||


### PR DESCRIPTION
## What Problem This Solves

Deleting a cloud-worker profile could silently do nothing if the Gateway restarted while its confirmation dialog was open. Another profile change naturally triggers this exact timing: the operator confirms Delete, the dialog closes, but the profile remains because the page rejected its now-stale pre-dialog connection scope without sending a request or reporting an error.

## What Changed

- Capture the authoritative Gateway connection only after the operator confirms the deletion.
- Revalidate the original Gateway identity, exact browser-client identity, runtime-config owner, administrator access, and current configuration before dispatching the destructive operation. Ordinary transport reconnects keep their existing client and remain allowed; replacing credentials at the same URL creates a different client and is rejected before any destructive request.
- Surface an actionable page-level error when reconnection has not completed instead of silently dropping the confirmed action.
- Add real-Chromium regressions for successful same-client reconnects, forbidden same-URL credential/client replacements, and unavailable reconnects that must fail visibly.
- Consolidate repeated cloud-worker profile fixtures in the existing browser suite.

Release note: Cloud-worker profile deletion now survives Gateway reconnects and visibly explains unavailable deletions.

## Evidence

The new reconnect regression failed before the fix with zero `config.patch` requests after the confirmed deletion; it passes after capturing the post-confirmation connection.

The security-boundary regression also failed against the previous PR head: actual Chromium opened the confirmation, invoked the production Gateway store's `connect({ token: replacement })` at the unchanged URL, observed a new client instance and fresh authorized connection, then proved the stale confirmation wrongly dispatched one `config.patch` (`expected length 0 but got 1`). After binding confirmation to the original client, the identical scenario produces zero requests, preserves the profile, and visibly reports that deletion was rejected. A same-client WebSocket reconnect still deletes successfully.

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/cloud-workers-settings.e2e.test.ts ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts ui/src/e2e/new-session-page.places-live.e2e.test.ts ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
# 5 browser files passed; 22 browser tests passed

node scripts/run-vitest.mjs ui/src/pages/cloud-workers/cloud-worker-config.test.ts ui/src/pages/new-session/discovery.test.ts ui/src/pages/new-session/model-control.runtime-placement.test.ts
# 3 files passed; 48 tests passed

node scripts/check-changed.mjs

.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output
# no accepted/actionable findings

pnpm --dir ui test --maxWorkers 3
# 746 files passed; 10,775 tests passed; 1 skipped
```

Separately, a real Chromium browser connected to a real isolated Linux Gateway, opened a profile-delete confirmation, then a second browser tab edited another profile and restarted that Gateway. After the real WebSocket reconnected, confirming the original dialog sent the real `config.patch`, deleted only the selected profile, preserved the other profile, and produced no browser errors. Additional two-tab races proved stale config writes fail visibly, retain their drafts, and succeed after retry.

The patched production UI was rebuilt and served by a separate actual Linux Gateway for the security boundary too. Real Chromium created a profile, opened its confirmation, replaced the Gateway client at the unchanged URL, then confirmed the original dialog. Captured WebSocket frames and visible UI proved `sameGatewayUrl=true`, `replacedClient=true`, `forbiddenPatchRequests=0`, `profileRetained=1`, and the expected visible rejection.

### Before

The confirmed profile remains with no error after the Gateway reconnects:

![Before: confirmed cloud-worker deletion silently leaves both profiles](https://github.com/user-attachments/assets/e9edd67a-451c-4040-b159-0cd10091cafc)

### After

The selected profile is removed after reconnect while the unrelated profile remains:

![After: confirmed deletion succeeds after Gateway reconnect](https://github.com/user-attachments/assets/bc2fdf12-0f9f-4608-b419-c83489760bba)

### Replacement client rejected by the real Gateway UI

The same-URL replacement client cannot reuse the original destructive confirmation: the profile remains, no configuration mutation is sent, and the operator sees the explicit failure.

![Real Gateway: replacement client is visibly rejected before deleting the cloud profile](https://github.com/user-attachments/assets/ce624cf3-d9af-4892-b02d-b111ddab1ceb)

### Real Gateway browser recording

https://github.com/user-attachments/assets/5ff85ecc-4803-4b48-a7e2-28392398a18d
