### PR TITLE
refactor(discord): unify approval lifecycle rendering

### DIFF
--- a/extensions/discord/src/approval-handler.runtime.test.ts
+++ b/extensions/discord/src/approval-handler.runtime.test.ts
@@ -1,6 +1,7 @@
 // Discord tests cover approval handler plugin behavior.
 import { describe, expect, it } from "vitest";
 import { discordApprovalNativeRuntime } from "./approval-handler.runtime.js";
+import { serializePayload } from "./internal/discord.js";
 
 async function buildExecApprovalPayloadText(commandText: string): Promise<string> {
   const pending = await discordApprovalNativeRuntime.presentation.buildPendingPayload({
@@ -48,7 +49,11 @@ async function buildExecApprovalPayloadText(commandText: string): Promise<string
   return JSON.stringify(pending);
 }
 
-async function buildPluginApprovalPayloadText(): Promise<string> {
+async function buildPluginApprovalPayloadText(params?: {
+  severity?: "info" | "warning" | "critical";
+  expiresAtMs?: number;
+}): Promise<string> {
+  const expiresAtMs = params?.expiresAtMs ?? 1_000;
   const pending = await discordApprovalNativeRuntime.presentation.buildPendingPayload({
     cfg: {} as never,
     accountId: "main",
@@ -63,7 +68,7 @@ async function buildPluginApprovalPayloadText(): Promise<string> {
         description: "Approve the requested plugin",
       },
       createdAtMs: 0,
-      expiresAtMs: 1_000,
+      expiresAtMs,
     },
     approvalKind: "plugin",
     nowMs: 0,
@@ -73,7 +78,7 @@ async function buildPluginApprovalPayloadText(): Promise<string> {
       approvalId: "plain-plugin-id",
       title: "Install plugin",
       description: "Approve the requested plugin",
-      severity: "warning",
+      severity: params?.severity ?? "warning",
       pluginId: "example-plugin",
       toolName: "plugin.install",
       metadata: [],
@@ -91,7 +96,7 @@ async function buildPluginApprovalPayloadText(): Promise<string> {
           },
         },
       ],
-      expiresAtMs: 1_000,
+      expiresAtMs,
     },
   } as never);
   return JSON.stringify(pending);
@@ -136,6 +141,127 @@ describe("discordApprovalNativeRuntime", () => {
       "execapproval:kind=plugin;id=plain-plugin-id;action=deny",
     );
   });
+
+  it.each([
+    { severity: "info" as const, accentColor: 0x5865f2 },
+    { severity: "warning" as const, accentColor: 0xfaa61a },
+    { severity: "critical" as const, accentColor: 0xed4245 },
+  ])("preserves $severity plugin approval styling and clamps expiry", async (params) => {
+    const payload = await buildPluginApprovalPayloadText({
+      severity: params.severity,
+      expiresAtMs: -1,
+    });
+
+    expect(payload).toContain(`"accent_color":${params.accentColor}`);
+    expect(payload).toContain("Expires <t:0:R>");
+  });
+
+  it.each([
+    {
+      approvalKind: "exec",
+      phase: "resolved",
+      decision: "allow-once",
+      label: "Allowed (once)",
+      accentColor: 0x57f287,
+    },
+    {
+      approvalKind: "exec",
+      phase: "resolved",
+      decision: "allow-always",
+      label: "Allowed (always)",
+      accentColor: 0x5865f2,
+    },
+    {
+      approvalKind: "exec",
+      phase: "resolved",
+      decision: "deny",
+      label: "Denied",
+      accentColor: 0xed4245,
+    },
+    {
+      approvalKind: "plugin",
+      phase: "resolved",
+      decision: "allow-once",
+      label: "Allowed (once)",
+      accentColor: 0x57f287,
+    },
+    {
+      approvalKind: "plugin",
+      phase: "resolved",
+      decision: "allow-always",
+      label: "Allowed (always)",
+      accentColor: 0x5865f2,
+    },
+    {
+      approvalKind: "plugin",
+      phase: "resolved",
+      decision: "deny",
+      label: "Denied",
+      accentColor: 0xed4245,
+    },
+    { approvalKind: "exec", phase: "expired", label: "Expired", accentColor: 0x99aab5 },
+    { approvalKind: "plugin", phase: "expired", label: "Expired", accentColor: 0x99aab5 },
+  ] as const)(
+    "preserves $approvalKind $phase approval components and terminal preview limits ($label)",
+    async (scenario) => {
+      const plugin = scenario.approvalKind === "plugin";
+      const commandLimit = plugin ? 700 : 500;
+      const secondaryLimit = plugin ? 1_000 : 300;
+      const command = `${"x".repeat(commandLimit)}😀`;
+      const secondary = `${"y".repeat(secondaryLimit)}😀`;
+      const view = {
+        approvalId: "approval-<@123>",
+        approvalKind: scenario.approvalKind,
+        phase: scenario.phase,
+        title: plugin ? command : "Exec Approval Required",
+        metadata: [{ label: "agent", value: "crew" }],
+        ...(plugin
+          ? { description: secondary, severity: "critical" }
+          : { commandText: command, commandPreview: secondary }),
+        ...(scenario.phase === "resolved"
+          ? { decision: scenario.decision, resolvedBy: "<@456>" }
+          : {}),
+      };
+      const args = {
+        cfg: {} as never,
+        accountId: "main",
+        context: { token: "discord-token", config: {} as never },
+        view,
+      };
+      const result =
+        scenario.phase === "resolved"
+          ? await discordApprovalNativeRuntime.presentation.buildResolvedResult(args as never)
+          : await discordApprovalNativeRuntime.presentation.buildExpiredResult(args as never);
+
+      expect(result.kind).toBe("update");
+      if (result.kind !== "update") {
+        return;
+      }
+      const payload = serializePayload({ components: [result.payload] });
+      const [container] = payload.components ?? [];
+      expect(container).toMatchObject({
+        accent_color: scenario.accentColor,
+        components: expect.arrayContaining([
+          { content: `## ${plugin ? "Plugin" : "Exec"} Approval: ${scenario.label}`, type: 10 },
+          { content: `### Command\n\`\`\`\n${"x".repeat(commandLimit)}...\n\`\`\``, type: 10 },
+          {
+            content: `### Shell Preview\n\`\`\`\n${"y".repeat(secondaryLimit)}...\n\`\`\``,
+            type: 10,
+          },
+          { content: "- agent: crew", type: 10 },
+          { content: "-# ID: approval\\-\\<@123\\>", type: 10 },
+          {
+            content:
+              scenario.phase === "resolved"
+                ? "Resolved by \\<@456\\>"
+                : "This approval request has expired.",
+            type: 10,
+          },
+        ]),
+      });
+      expect(JSON.stringify(payload)).not.toContain("custom_id");
+    },
+  );
 
   it("does not split emoji graphemes when truncating exec command previews", async () => {
     const prefix = "a".repeat(999);

--- a/extensions/discord/src/approval-handler.runtime.test.ts
+++ b/extensions/discord/src/approval-handler.runtime.test.ts
@@ -1,7 +1,7 @@
 // Discord tests cover approval handler plugin behavior.
 import { describe, expect, it } from "vitest";
 import { discordApprovalNativeRuntime } from "./approval-handler.runtime.js";
-import { serializePayload } from "./internal/discord.js";
+import { DiscordUiContainer } from "./ui.js";
 
 async function buildExecApprovalPayloadText(commandText: string): Promise<string> {
   const pending = await discordApprovalNativeRuntime.presentation.buildPendingPayload({
@@ -237,8 +237,11 @@ describe("discordApprovalNativeRuntime", () => {
       if (result.kind !== "update") {
         return;
       }
-      const payload = serializePayload({ components: [result.payload] });
-      const [container] = payload.components ?? [];
+      expect(result.payload).toBeInstanceOf(DiscordUiContainer);
+      if (!(result.payload instanceof DiscordUiContainer)) {
+        return;
+      }
+      const container = result.payload.serialize();
       expect(container).toMatchObject({
         accent_color: scenario.accentColor,
         components: expect.arrayContaining([
@@ -259,7 +262,7 @@ describe("discordApprovalNativeRuntime", () => {
           },
         ]),
       });
-      expect(JSON.stringify(payload)).not.toContain("custom_id");
+      expect(JSON.stringify(container)).not.toContain("custom_id");
     },
   );
 

--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -1,14 +1,9 @@
 // Discord plugin module implements approval handler behavior.
 import { ButtonStyle } from "discord-api-types/v10";
 import type {
+  ApprovalViewModel,
   ChannelApprovalCapabilityHandlerContext,
-  ExecApprovalExpiredView,
-  ExecApprovalPendingView,
-  ExecApprovalResolvedView,
   PendingApprovalView,
-  PluginApprovalExpiredView,
-  PluginApprovalPendingView,
-  PluginApprovalResolvedView,
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import type { ExecApprovalActionDescriptor } from "openclaw/plugin-sdk/approval-reply-runtime";
@@ -243,169 +238,79 @@ function resolveCommandPreviews(
   };
 }
 
-function createExecApprovalRequestContainer(params: {
-  view: ExecApprovalPendingView;
+function createApprovalContainer(params: {
+  view: ApprovalViewModel;
   cfg: OpenClawConfig;
   accountId: string;
   actionRow?: Row<Button>;
 }): ExecApprovalContainer {
-  const { commandPreview, commandSecondaryPreview } = resolveCommandPreviews(
-    params.view.commandText,
-    params.view.commandPreview,
-    1000,
-    500,
-  );
-  const expiresAtSeconds = Math.max(0, Math.floor(params.view.expiresAtMs / 1000));
-
-  return new ExecApprovalContainer({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    title: "Exec Approval Required",
-    description: "A command needs your approval.",
-    commandPreview,
-    commandSecondaryPreview,
-    metadataLines: buildApprovalMetadataLines(params.view.metadata),
-    actionRow: params.actionRow,
-    footer: `Expires <t:${expiresAtSeconds}:R> · ID: ${formatDiscordApprovalDisplayValue(params.view.approvalId)}`,
-    accentColor: "#FFA500",
-  });
-}
-
-function createPluginApprovalRequestContainer(params: {
-  view: PluginApprovalPendingView;
-  cfg: OpenClawConfig;
-  accountId: string;
-  actionRow?: Row<Button>;
-}): ExecApprovalContainer {
-  const expiresAtSeconds = Math.max(0, Math.floor(params.view.expiresAtMs / 1000));
-  const severity = params.view.severity;
-  const accentColor =
-    severity === "critical" ? "#ED4245" : severity === "info" ? "#5865F2" : "#FAA61A";
-  return new ExecApprovalContainer({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    title: "Plugin Approval Required",
-    description: "A plugin action needs your approval.",
-    commandPreview: formatCommandPreview(params.view.title, 700),
-    commandSecondaryPreview: formatOptionalCommandPreview(params.view.description, 1000),
-    metadataLines: buildApprovalMetadataLines(params.view.metadata),
-    actionRow: params.actionRow,
-    footer: `Expires <t:${expiresAtSeconds}:R> · ID: ${formatDiscordApprovalDisplayValue(params.view.approvalId)}`,
-    accentColor,
-  });
-}
-
-function createExecResolvedContainer(params: {
-  view: ExecApprovalResolvedView;
-  cfg: OpenClawConfig;
-  accountId: string;
-}): ExecApprovalContainer {
-  const { commandPreview, commandSecondaryPreview } = resolveCommandPreviews(
-    params.view.commandText,
-    params.view.commandPreview,
-    500,
-    300,
-  );
+  const { view } = params;
+  const plugin = view.approvalKind === "plugin";
+  const pending = view.phase === "pending";
+  const approvalLabel = plugin ? "Plugin" : "Exec";
+  const { commandPreview, commandSecondaryPreview } = plugin
+    ? {
+        commandPreview: formatCommandPreview(view.title, 700),
+        commandSecondaryPreview: formatOptionalCommandPreview(view.description, 1000),
+      }
+    : resolveCommandPreviews(
+        view.commandText,
+        view.commandPreview,
+        pending ? 1000 : 500,
+        pending ? 500 : 300,
+      );
   const decisionLabel =
-    params.view.decision === "allow-once"
-      ? "Allowed (once)"
-      : params.view.decision === "allow-always"
-        ? "Allowed (always)"
-        : "Denied";
+    view.phase !== "resolved"
+      ? undefined
+      : view.decision === "allow-once"
+        ? "Allowed (once)"
+        : view.decision === "allow-always"
+          ? "Allowed (always)"
+          : "Denied";
+  const title = pending
+    ? `${approvalLabel} Approval Required`
+    : `${approvalLabel} Approval: ${view.phase === "expired" ? "Expired" : decisionLabel}`;
+  const description = pending
+    ? plugin
+      ? "A plugin action needs your approval."
+      : "A command needs your approval."
+    : view.phase === "expired"
+      ? "This approval request has expired."
+      : view.resolvedBy
+        ? `Resolved by ${formatDiscordApprovalDisplayValue(view.resolvedBy)}`
+        : "Resolved";
   const accentColor =
-    params.view.decision === "deny"
-      ? "#ED4245"
-      : params.view.decision === "allow-always"
-        ? "#5865F2"
-        : "#57F287";
+    view.phase === "expired"
+      ? "#99AAB5"
+      : view.phase === "resolved"
+        ? view.decision === "deny"
+          ? "#ED4245"
+          : view.decision === "allow-always"
+            ? "#5865F2"
+            : "#57F287"
+        : plugin
+          ? view.severity === "critical"
+            ? "#ED4245"
+            : view.severity === "info"
+              ? "#5865F2"
+              : "#FAA61A"
+          : "#FFA500";
+  const approvalId = formatDiscordApprovalDisplayValue(view.approvalId);
+  const footer = pending
+    ? `Expires <t:${Math.max(0, Math.floor(view.expiresAtMs / 1000))}:R> · ID: ${approvalId}`
+    : `ID: ${approvalId}`;
 
   return new ExecApprovalContainer({
     cfg: params.cfg,
     accountId: params.accountId,
-    title: `Exec Approval: ${decisionLabel}`,
-    description: params.view.resolvedBy
-      ? `Resolved by ${formatDiscordApprovalDisplayValue(params.view.resolvedBy)}`
-      : "Resolved",
+    title,
+    description,
     commandPreview,
     commandSecondaryPreview,
-    metadataLines: buildApprovalMetadataLines(params.view.metadata),
-    footer: `ID: ${formatDiscordApprovalDisplayValue(params.view.approvalId)}`,
+    metadataLines: buildApprovalMetadataLines(view.metadata),
+    actionRow: params.actionRow,
+    footer,
     accentColor,
-  });
-}
-
-function createPluginResolvedContainer(params: {
-  view: PluginApprovalResolvedView;
-  cfg: OpenClawConfig;
-  accountId: string;
-}): ExecApprovalContainer {
-  const decisionLabel =
-    params.view.decision === "allow-once"
-      ? "Allowed (once)"
-      : params.view.decision === "allow-always"
-        ? "Allowed (always)"
-        : "Denied";
-  const accentColor =
-    params.view.decision === "deny"
-      ? "#ED4245"
-      : params.view.decision === "allow-always"
-        ? "#5865F2"
-        : "#57F287";
-
-  return new ExecApprovalContainer({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    title: `Plugin Approval: ${decisionLabel}`,
-    description: params.view.resolvedBy
-      ? `Resolved by ${formatDiscordApprovalDisplayValue(params.view.resolvedBy)}`
-      : "Resolved",
-    commandPreview: formatCommandPreview(params.view.title, 700),
-    commandSecondaryPreview: formatOptionalCommandPreview(params.view.description, 1000),
-    metadataLines: buildApprovalMetadataLines(params.view.metadata),
-    footer: `ID: ${formatDiscordApprovalDisplayValue(params.view.approvalId)}`,
-    accentColor,
-  });
-}
-
-function createExecExpiredContainer(params: {
-  view: ExecApprovalExpiredView;
-  cfg: OpenClawConfig;
-  accountId: string;
-}): ExecApprovalContainer {
-  const { commandPreview, commandSecondaryPreview } = resolveCommandPreviews(
-    params.view.commandText,
-    params.view.commandPreview,
-    500,
-    300,
-  );
-  return new ExecApprovalContainer({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    title: "Exec Approval: Expired",
-    description: "This approval request has expired.",
-    commandPreview,
-    commandSecondaryPreview,
-    metadataLines: buildApprovalMetadataLines(params.view.metadata),
-    footer: `ID: ${formatDiscordApprovalDisplayValue(params.view.approvalId)}`,
-    accentColor: "#99AAB5",
-  });
-}
-
-function createPluginExpiredContainer(params: {
-  view: PluginApprovalExpiredView;
-  cfg: OpenClawConfig;
-  accountId: string;
-}): ExecApprovalContainer {
-  return new ExecApprovalContainer({
-    cfg: params.cfg,
-    accountId: params.accountId,
-    title: "Plugin Approval: Expired",
-    description: "This approval request has expired.",
-    commandPreview: formatCommandPreview(params.view.title, 700),
-    commandSecondaryPreview: formatOptionalCommandPreview(params.view.description, 1000),
-    metadataLines: buildApprovalMetadataLines(params.view.metadata),
-    footer: `ID: ${formatDiscordApprovalDisplayValue(params.view.approvalId)}`,
-    accentColor: "#99AAB5",
   });
 }
 
@@ -501,21 +406,12 @@ export const discordApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
       if (!resolved) {
         return { body: {} };
       }
-      const actionRow = createApprovalActionRow(view);
-      const container =
-        view.approvalKind === "plugin"
-          ? createPluginApprovalRequestContainer({
-              view,
-              cfg,
-              accountId: resolved.accountId,
-              actionRow,
-            })
-          : createExecApprovalRequestContainer({
-              view,
-              cfg,
-              accountId: resolved.accountId,
-              actionRow,
-            });
+      const container = createApprovalContainer({
+        view,
+        cfg,
+        accountId: resolved.accountId,
+        actionRow: createApprovalActionRow(view),
+      });
       return {
         body: stripUndefinedFields(serializePayload(buildExecApprovalPayload(container))),
       };
@@ -525,18 +421,11 @@ export const discordApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
       if (!resolvedContext) {
         return { kind: "delete" } as const;
       }
-      const container =
-        view.approvalKind === "plugin"
-          ? createPluginResolvedContainer({
-              view,
-              cfg,
-              accountId: resolvedContext.accountId,
-            })
-          : createExecResolvedContainer({
-              view,
-              cfg,
-              accountId: resolvedContext.accountId,
-            });
+      const container = createApprovalContainer({
+        view,
+        cfg,
+        accountId: resolvedContext.accountId,
+      });
       return { kind: "update", payload: container } as const;
     },
     buildExpiredResult: ({ cfg, accountId, context, view }) => {
@@ -544,18 +433,11 @@ export const discordApprovalNativeRuntime = createChannelApprovalNativeRuntimeAd
       if (!resolvedContext) {
         return { kind: "delete" } as const;
       }
-      const container =
-        view.approvalKind === "plugin"
-          ? createPluginExpiredContainer({
-              view,
-              cfg,
-              accountId: resolvedContext.accountId,
-            })
-          : createExecExpiredContainer({
-              view,
-              cfg,
-              accountId: resolvedContext.accountId,
-            });
+      const container = createApprovalContainer({
+        view,
+        cfg,
+        accountId: resolvedContext.accountId,
+      });
       return { kind: "update", payload: container } as const;
     },
   },


### PR DESCRIPTION
## What Problem This Solves

Discord approval presentation repeated the same lifecycle-rendering decisions across its separate pending, resolved, expired, and failure paths. The duplication made security-sensitive approval metadata, component visibility, and message content harder to maintain consistently.

## Why This Change Was Made

The existing Discord approval owner now renders those lifecycle variants through one canonical private flow. Existing public interfaces, approval identity and authority, actor restrictions, native Discord payload limits, transport behavior, and intentional differences between pending and terminal approval presentations remain unchanged.

## User Impact

Discord operators see the same approval messages, controls, and terminal outcomes. Future approval rendering changes have one security-sensitive owner instead of duplicated lifecycle branches.

## Evidence

- The unchanged baseline approval-owner cases passed before editing; the final relevant Discord owner and sibling suites passed 99 real tests, including meaningful approval lifecycle and security coverage.
- The existing assertion-safety ratchet, directly scoped lint, formatting, and `git diff --check` all passed.
- Both independent complete source reviews accepted the owner-boundary change, and the full structured precommit review completed cleanly.
- Genuine shipped runtime production delta: 77 added, 195 deleted, net **-118**. Existing meaningful approval tests gained independent lifecycle coverage and are excluded from the production accounting.
- No public Plugin SDK contract, configuration surface, schema, protocol, or changelog changes.
