### PR TITLE
fix(cron): send completion webhooks for failed automation runs

### DIFF
--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -431,7 +431,24 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     ).rejects.toThrow("channel unavailable");
   });
 
-  it("delivers a failed cron webhook even when the run produced no summary", async () => {
+  it.each([
+    {
+      name: "execution failure",
+      event: { status: "error", error: "provider unavailable" },
+    },
+    {
+      name: "required delivery failure",
+      event: {
+        status: "ok",
+        deliveryStatus: "not-delivered",
+        deliveryError: "channel unavailable",
+      },
+    },
+    {
+      name: "skipped run",
+      event: { status: "skipped", error: "trigger condition not met" },
+    },
+  ] as const)("delivers a failed $name completion webhook without a summary", async ({ event }) => {
     const logger = { warn: vi.fn() };
     const job = createCompletionWebhookJob();
 
@@ -439,8 +456,8 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       evt: {
         jobId: job.id,
         action: "finished",
-        status: "error",
-        error: "provider unavailable",
+        completionStatus: "failed",
+        ...event,
       },
       job,
       deps: {} as CliDeps,
@@ -454,11 +471,33 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     expect(webhookRequestBody()).toMatchObject({
       jobId: job.id,
       action: "finished",
-      status: "error",
-      error: "provider unavailable",
+      completionStatus: "failed",
+      ...event,
     });
     expect(logger.warn).not.toHaveBeenCalled();
   });
+
+  it.each([undefined, "succeeded", "unknown"] as const)(
+    "keeps a successful completion without a summary silent (%s)",
+    (completionStatus) => {
+      const job = createCompletionWebhookJob();
+
+      dispatchGatewayCronFinishedNotifications({
+        evt: {
+          jobId: job.id,
+          action: "finished",
+          status: "ok",
+          ...(completionStatus ? { completionStatus } : {}),
+        },
+        job,
+        deps: {} as CliDeps,
+        logger: { warn: vi.fn() },
+        resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+      });
+
+      expect(mocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
+    },
+  );
 
   it("applies the webhook timeout to guarded network preflight", async () => {
     const job = createCompletionWebhookJob();
@@ -476,39 +515,6 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
         expect.objectContaining({ timeoutMs: 10_000 }),
       ),
     );
-  });
-
-  it("delivers a failed completion-destination webhook without a summary", async () => {
-    const logger = { warn: vi.fn() };
-    const job = createWebhookJob({
-      mode: "announce",
-      completionDestination: {
-        mode: "webhook",
-        to: "https://example.invalid/completion",
-      },
-    });
-
-    dispatchGatewayCronFinishedNotifications({
-      evt: {
-        jobId: job.id,
-        action: "finished",
-        status: "error",
-        error: "provider unavailable",
-      },
-      job,
-      deps: {} as CliDeps,
-      logger,
-      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
-    });
-
-    await waitForFast(() => expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledOnce());
-    expect(webhookRequestBody()).toMatchObject({
-      jobId: job.id,
-      action: "finished",
-      status: "error",
-      error: "provider unavailable",
-    });
-    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("independently admits scheduler-authorized failure alerts", async () => {

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -440,7 +440,7 @@ export function dispatchGatewayCronFinishedNotifications(params: {
 
   // Script notify is carried as the completion summary, so its absence uses
   // the same silent-summary suppression path as NO_REPLY output.
-  if (completionWebhookUrl && (completionSummary || params.evt.status === "error")) {
+  if (completionWebhookUrl && (completionSummary || params.evt.completionStatus === "failed")) {
     const payload = buildCronFinishedWebhookPayload(redactedWebhookEvent);
     dispatchDetachedCronNotification({
       jobId: params.evt.jobId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators configuring completion webhooks would receive no notification when an automation finished without a summary after required delivery failed or its run was skipped.

## Why This Change Was Made

The scheduler already authors one authoritative whole-run completion outcome after execution and required delivery settle, but Gateway completion webhook dispatch was consulting only the narrower execution status. Use the existing authored failed completion fact directly, preserve silent successful/unknown outcomes, and consolidate duplicate execution-failure tests into one owner-boundary behavior table.

## User Impact

Configured completion webhooks now fire for summary-less execution failures, required delivery failures, and skipped runs. Successful or unknown summary-less completions remain silent; existing URL validation, SSRF policy, token ownership, admission, and command-redaction boundaries are unchanged.

## Evidence

- Regression-first proof: the unchanged production owner failed exactly two new cases because both required-delivery failure and skipped execution made zero webhook requests; existing execution failures and silent-success controls remained correct.
- Fixed owner plus scheduler and Gateway siblings: four focused files passed, **36 tests** total.
- Explicit coverage includes execution failure, required delivery failure with successful execution, skipped run, and omitted/succeeded/unknown summary-less outcomes; duplicate obsolete execution-failure coverage was removed.
- Both max-lines and assertion-safety ratchets passed; targeted formatting and diff checks passed.
- An independent owner-boundary review and fresh authenticated Codex autoreview both returned no actionable findings.
- Production change: **+1/-1, net zero lines**. Tests: **+44/-38**.
- Live external webhook infrastructure is not required for this deterministic internal owner boundary; the focused suite verifies the real guarded fetch request and serialized webhook payload.
