### PR TITLE
fix(plugins): keep healthy CLI commands when another plugin fails

### DIFF
--- a/src/plugins/cli-root-descriptors.ts
+++ b/src/plugins/cli-root-descriptors.ts
@@ -25,6 +25,7 @@ export async function getPluginCliCommandDescriptors(
   env?: NodeJS.ProcessEnv,
   loaderOptions?: PluginCliLoaderOptions,
 ): Promise<OpenClawPluginCliRootCommandDescriptor[]> {
+  const descriptorGroups: OpenClawPluginCliRootCommandDescriptor[][] = [];
   try {
     const context = resolvePluginRuntimeLoadContext({ config: cfg, env, logger: quietLogger });
     const snapshot = context.metadataSnapshot;
@@ -32,7 +33,6 @@ export async function getPluginCliCommandDescriptors(
       return [];
     }
     const legacyExternalPluginIds: string[] = [];
-    const descriptorGroups: OpenClawPluginCliRootCommandDescriptor[][] = [];
     const seenPluginIds = new Set<string>();
     let selectedMemoryPluginId: string | null = null;
     const memorySlot = context.config.plugins?.slots?.memory;
@@ -91,6 +91,6 @@ export async function getPluginCliCommandDescriptors(
     }
     return collectUniqueCommandDescriptors(descriptorGroups);
   } catch {
-    return [];
+    return collectUniqueCommandDescriptors(descriptorGroups);
   }
 }

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -385,6 +385,49 @@ describe("registerPluginCliCommands", () => {
     expect(stderrWrite).not.toHaveBeenCalled();
   });
 
+  it("preserves manifest-backed root help when an unrelated legacy CLI plugin fails", async () => {
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((() => true) as unknown as typeof process.stderr.write);
+    const healthySnapshot = createCliMetadataSnapshot();
+    const legacySnapshot = createLegacyExternalCliMetadataSnapshot();
+    const plugins = [
+      ...healthySnapshot.plugins.map((plugin) => ({
+        ...plugin,
+        cliCommands: [...plugin.cliCommands, ...plugin.cliCommands],
+      })),
+      ...legacySnapshot.plugins,
+    ];
+    mocks.resolvePluginMetadataSnapshot.mockReturnValue({
+      ...healthySnapshot,
+      index: {
+        ...healthySnapshot.index,
+        plugins: [...healthySnapshot.index.plugins, ...legacySnapshot.index.plugins],
+      },
+      manifestRegistry: { plugins, diagnostics: [] },
+      plugins,
+      byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
+    });
+    mocks.loadOpenClawPluginCliRegistry.mockRejectedValue(new Error("broken legacy CLI plugin"));
+    const config = {
+      plugins: { entries: { "legacy-cli": { enabled: true } } },
+    } as OpenClawConfig;
+
+    await expect(getPluginCliCommandDescriptors(config)).resolves.toEqual([
+      {
+        name: "matrix",
+        description: "Matrix channel utilities",
+        hasSubcommands: true,
+      },
+    ]);
+    const { renderRootHelpText } = await import("../cli/program/root-help.js");
+    await expect(renderRootHelpText({ config })).resolves.toContain("matrix *");
+    expect(stderrWrite).not.toHaveBeenCalled();
+    expect(getMockCallObject(mocks.loadOpenClawPluginCliRegistry).onlyPluginIds).toEqual([
+      "legacy-cli",
+    ]);
+  });
+
   it("preserves root help for external plugins without manifest CLI descriptors", async () => {
     const config = {
       plugins: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a single broken legacy plugin caused every healthy plugin command to disappear from `openclaw --help`, even when those healthy commands were already available from validated plugin manifests.

## Why This Change Was Made

Keep the already-collected manifest-backed command descriptors at their existing owner boundary when an unrelated legacy CLI registry fails. Reuse the same canonical command-deduplication helper on both successful and failed registry paths; preserve quiet failures and lazy plugin loading.

Production delta: **2 additions / 2 deletions (net 0)**. No configuration, protocol, authentication, persistence, plugin-SDK, or dependency changes.

## User Impact

Healthy plugin commands remain discoverable in root CLI help when another older plugin fails to load. Duplicate commands remain suppressed, and failing optional plugins do not emit new noisy warnings.

## Evidence

- Authentic pre-fix regression: the actual plugin descriptor owner returned an empty command list when a healthy manifest-backed Matrix command and an unrelated throwing legacy plugin were both present.
- Regression verifies the actual rendered root-help text, deduplicated Matrix command, silent error behavior, and that only the legacy plugin is loaded.
- Focused plugin owner, canonical descriptor, and root-help renderer suites: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/cli.test.ts src/cli/program/command-descriptor-utils.test.ts src/cli/program/root-help.test.ts --reporter=dot` — **34 passed**.
- Targeted formatter and lint passed; fresh independent structured review was **clean**.
