### PR TITLE
fix(plugins): block retired callbacks from changing run context

### DIFF
--- a/src/plugins/contracts/run-context-lifecycle.contract.test.ts
+++ b/src/plugins/contracts/run-context-lifecycle.contract.test.ts
@@ -294,6 +294,100 @@ describe("plugin run context lifecycle", () => {
     ]);
   });
 
+  it("fences retired agent-event callbacks from successor run context", async () => {
+    let releasePriorHandler: (() => void) | undefined;
+    let markPriorHandlerStarted: (() => void) | undefined;
+    let retiredHandlerSawContext: unknown;
+    const priorHandlerStarted = new Promise<void>((resolve) => {
+      markPriorHandlerStarted = resolve;
+    });
+    const priorHandlerRelease = new Promise<void>((resolve) => {
+      releasePriorHandler = resolve;
+    });
+    const prior = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry: prior.registry,
+      config: prior.config,
+      record: createPluginRecord({
+        id: "agent-event-generation",
+        name: "Agent Event Generation",
+      }),
+      register(api) {
+        api.registerAgentEventSubscription({
+          id: "prior",
+          streams: ["tool"],
+          async handle(event, ctx) {
+            if (event.data.name !== "hold") {
+              return;
+            }
+            markPriorHandlerStarted?.();
+            await priorHandlerRelease;
+            retiredHandlerSawContext = ctx.getRunContext("state");
+            ctx.setRunContext("state", { generation: "A" });
+            ctx.clearRunContext("preserved");
+          },
+        });
+      },
+    });
+    const successor = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry: successor.registry,
+      config: successor.config,
+      record: createPluginRecord({
+        id: "agent-event-generation",
+        name: "Agent Event Generation",
+      }),
+      register(api) {
+        api.registerAgentEventSubscription({
+          id: "successor",
+          streams: ["tool"],
+          handle(event, ctx) {
+            if (event.data.name !== "successor") {
+              return;
+            }
+            ctx.setRunContext("state", { generation: "B" });
+            ctx.setRunContext("preserved", { generation: "B" });
+          },
+        });
+      },
+    });
+
+    setActivePluginRegistry(prior.registry.registry);
+    emitAgentEvent({
+      runId: "run-agent-event-generation",
+      stream: "tool",
+      data: { name: "hold" },
+    });
+    await priorHandlerStarted;
+
+    setActivePluginRegistry(successor.registry.registry);
+    emitAgentEvent({
+      runId: "run-agent-event-generation",
+      stream: "tool",
+      data: { name: "successor" },
+    });
+    await waitForPluginEventHandlers();
+
+    // Restoring the same registry object must not revive callbacks admitted before cutover.
+    setActivePluginRegistry(prior.registry.registry);
+    releasePriorHandler?.();
+    await waitForPluginEventHandlers();
+
+    expect(retiredHandlerSawContext).toBeUndefined();
+    expect(
+      getPluginRunContext({
+        pluginId: "agent-event-generation",
+        get: { runId: "run-agent-event-generation", namespace: "state" },
+      }),
+    ).toEqual({ generation: "B" });
+    expect(
+      getPluginRunContext({
+        pluginId: "agent-event-generation",
+        get: { runId: "run-agent-event-generation", namespace: "preserved" },
+      }),
+    ).toEqual({ generation: "B" });
+  });
+
   it("does not let delayed non-terminal subscriptions resurrect closed run context", async () => {
     let releaseToolHandler: (() => void) | undefined;
     let delayedToolHandlerSawContext: unknown;
@@ -894,6 +988,7 @@ describe("plugin run context lifecycle", () => {
     ).toBe(true);
     dispatchPluginAgentEventSubscriptions({
       registry: createEmptyPluginRegistry(),
+      isLive: () => true,
       event: {
         runId: "run-closed",
         seq: 1,

--- a/src/plugins/host-hook-runtime.ts
+++ b/src/plugins/host-hook-runtime.ts
@@ -292,6 +292,7 @@ function logAgentEventSubscriptionFailure(params: {
 export function dispatchPluginAgentEventSubscriptions(params: {
   registry: PluginRegistry | null | undefined;
   event: AgentEventPayload;
+  isLive: () => boolean;
 }): void {
   const subscriptions = params.registry?.agentEventSubscriptions ?? [];
   const pendingHandlers: Promise<void>[] = [];
@@ -306,11 +307,16 @@ export function dispatchPluginAgentEventSubscriptions(params: {
     let handlerActive = true;
     const ctx: PluginAgentEventSubscriptionContext = {
       getRunContext: ((namespace: string) =>
-        getPluginRunContext({
-          pluginId,
-          get: { runId, namespace },
-        })) as PluginAgentEventSubscriptionContext["getRunContext"],
+        params.isLive()
+          ? getPluginRunContext({
+              pluginId,
+              get: { runId, namespace },
+            })
+          : undefined) as PluginAgentEventSubscriptionContext["getRunContext"],
       setRunContext: (namespace: string, value: PluginJsonValue) => {
+        if (!params.isLive()) {
+          return;
+        }
         setPluginRunContext({
           pluginId,
           patch: { runId, namespace, value },
@@ -318,6 +324,9 @@ export function dispatchPluginAgentEventSubscriptions(params: {
         });
       },
       clearRunContext: (namespace?: string) => {
+        if (!params.isLive()) {
+          return;
+        }
         clearPluginRunContext({ pluginId, runId, namespace });
       },
     };

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -126,14 +126,19 @@ function retirePluginRegistryIfUnused(registry: PluginRegistry | null): boolean 
 function syncPluginAgentEventBridge(): void {
   state.agentEventBridgeUnsubscribe?.();
   state.agentEventBridgeUnsubscribe = undefined;
-  if (!state.activeRegistry) {
+  const registry = asPluginRegistry(state.activeRegistry);
+  if (!registry) {
     return;
   }
+  const version = state.activeVersion;
   state.agentEventBridgeUnsubscribe = onAgentEvent((event) => {
-    const registry = asPluginRegistry(state.activeRegistry);
-    if (registry) {
-      dispatchPluginAgentEventSubscriptions({ registry, event });
-    }
+    dispatchPluginAgentEventSubscriptions({
+      registry,
+      event,
+      // The registry object can become active again after rollback. Its version
+      // keeps already-dispatched callback authority bound to this exact cutover.
+      isLive: () => state.activeRegistry === registry && state.activeVersion === version,
+    });
   });
 }
 


### PR DESCRIPTION
Closes #127537

## What Problem This Solves

Fixes an issue where an async plugin agent-event callback that started before hot reload could resume afterward and read, overwrite, or clear run context now owned by the replacement plugin generation.

## Why This Change Was Made

Agent-event dispatch now carries a closure-bound claim for the exact active registry object and activation version. Every callback-context read, write, and clear checks that claim immediately, so a retired callback loses run-context authority while same-generation async callbacks continue normally.

The version check is intentional: restoring the same registry object must not revive callbacks admitted before the cutover. This complements #129232, which preserves channel-record authority across failed pre-commit rollback while still incrementing the runtime activation version to fence already-running callbacks.

This adds no config, protocol, Plugin SDK shape, or database surface.

## User Impact

Slow plugin monitors and workflows can no longer corrupt continuing-run state produced by their live replacement after hot reload. Restart context remains available to the successor generation.

## Evidence

- Regression failed before the fix: generation A resumed after B wrote `{ generation: "B" }` and read B's value instead of `undefined`; the same test also attempts overwrite and clear after restoring the exact A registry object.
- `mise exec -- node scripts/run-vitest.mjs src/plugins/contracts/run-context-lifecycle.contract.test.ts src/plugins/runtime.test.ts`
  - lifecycle contract: 17 passed
  - plugin runtime: 9 passed
- Autoreview: clean, no actionable findings (0.99 confidence).
- Blacksmith Testbox `tbx_01m0w7tav5sp1xacgjphamze70` changed-file gate passed conflict, policy, formatting, dependency, plugin-boundary, dead-export, test-temp, and production-typecheck lanes. Core-test typechecking then produced no output past the bounded ten-minute window, so the owned lease was explicitly stopped ([run](https://github.com/openclaw/openclaw/actions/runs/32837978165)). Exact-head CI provides the complete clean-run gate.
- LOC: production +23/-9 (net +14); test +95/-0. Production growth is the required dispatch-claim seam and per-operation authority checks.


- Real CLI/Gateway/plugin lifecycle proof on Blacksmith Testbox `tbx_01m10a0a1bjyarsjr15e357p9j` ([run](https://github.com/openclaw/openclaw/actions/runs/33027071485)): `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --id tbx_01m10a0a1bjyarsjr15e357p9j --timing-json -- OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 bash scripts/pr-129250-crabbox-proof.sh 452e734022214f5f00bdd44cae675cc467c3cd85 bb7b135523de78e976193108bbb4eb59c6bf982d`. On the parent SHA, a retired generation-A callback read successor state B, overwrote it with A, and cleared B's preserved value while the live callback worked. On the PR head, the same retired callback read `undefined`; its overwrite and clear were ignored; successor state and preserved value remained B; the live callback still completed read/set/clear. Both cases ran in one Gateway process per SHA on isolated non-default ports; detached worktrees, Gateways, and isolated state were removed. Exit 0 in 11m 7s.
