### PR TITLE
refactor(agents): unify generated media reference handling

### DIFF
--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -30,15 +30,9 @@ import {
   resolveConfiguredMediaMaxBytes,
   resolveGeneratedMediaMaxBytes,
 } from "../../media/configured-max-bytes.js";
-import {
-  classifyMediaReferenceSource,
-  normalizeMediaReferenceSource,
-} from "../../media/media-reference.js";
 import { getImageMetadata } from "../../media/media-services.js";
 import { saveMediaBuffer } from "../../media/store.js";
-import { loadWebMedia } from "../../media/web-media.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
-import { resolveUserPath } from "../../utils.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import {
@@ -61,7 +55,6 @@ import {
   createImageGenerateListActionResult,
   createImageGenerateStatusActionResult,
 } from "./image-generate-tool.actions.js";
-import { decodeDataUrl } from "./image-tool.helpers.js";
 import {
   createDefaultMediaGenerateBackgroundScheduler,
   type MediaGenerateAsyncStartCallback,
@@ -73,18 +66,17 @@ import {
   type ImageGenerationTaskHandle,
 } from "./media-generate-background.js";
 import {
-  applyImageGenerationModelConfigDefaults,
+  applyAgentDefaultModelConfig,
   buildMediaReferenceDetails,
   buildTaskRunDetails,
   createCapabilityProviderRuntimeDeps,
   hasGenerationToolAvailability,
+  loadMediaToolReferences,
   normalizeMediaReferenceInputs,
   readGenerationTimeoutMs,
-  REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
   resolveRemoteMediaSsrfPolicy,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
-  resolveMediaToolReferenceAccess,
   resolveSelectedCapabilityProvider,
 } from "./media-tool-shared.js";
 import {
@@ -92,12 +84,7 @@ import {
   hasToolModelConfig,
   type ToolModelConfig,
 } from "./model-config.helpers.js";
-import {
-  createSandboxBridgeReadFile,
-  type AnyAgentTool,
-  type SandboxFsBridge,
-  type ToolFsPolicy,
-} from "./tool-runtime.helpers.js";
+import type { AnyAgentTool, SandboxFsBridge, ToolFsPolicy } from "./tool-runtime.helpers.js";
 
 const DEFAULT_COUNT = 1;
 const MAX_COUNT = 4;
@@ -563,87 +550,29 @@ async function loadReferenceImages(params: {
     rewrittenFrom?: string;
   }>
 > {
-  const loaded: Array<{
-    sourceImage: ImageGenerationSourceImage;
-    resolvedImage: string;
-    rewrittenFrom?: string;
-  }> = [];
-
-  for (const imageRawInput of params.imageInputs) {
-    params.signal?.throwIfAborted();
-    const trimmed = imageRawInput.trim();
-    const imageRaw = normalizeMediaReferenceSource(
-      trimmed.startsWith("@") ? trimmed.slice(1).trim() : trimmed,
-    );
-    if (!imageRaw) {
-      throw new ToolInputError("image required (empty string in array)");
-    }
-    const refInfo = classifyMediaReferenceSource(imageRaw);
-    const { isDataUrl, isHttpUrl } = refInfo;
-    if (refInfo.hasUnsupportedScheme) {
-      throw new ToolInputError(
-        `Unsupported image reference: ${imageRawInput}. Use a file path, a file:// URL, a data: URL, or an http(s) URL.`,
-      );
-    }
-    if (params.sandboxConfig && isHttpUrl) {
-      throw new ToolInputError("Sandboxed image_generate does not allow remote URLs.");
-    }
-
-    const resolvedImage = (() => {
-      if (params.sandboxConfig) {
-        return imageRaw;
-      }
-      if (imageRaw.startsWith("~")) {
-        return resolveUserPath(imageRaw);
-      }
-      return imageRaw;
-    })();
-
-    const { resolvedPath, localRoots, rewrittenFrom } = await resolveMediaToolReferenceAccess({
-      input: resolvedImage,
-      isDataUrl,
-      workspaceDir: params.workspaceDir,
-      sandbox: params.sandboxConfig,
-    });
-    params.signal?.throwIfAborted();
-
-    const media = isDataUrl
-      ? decodeDataUrl(resolvedImage, { maxBytes: params.maxBytes })
-      : params.sandboxConfig
-        ? await loadWebMedia(resolvedPath ?? resolvedImage, {
-            maxBytes: params.maxBytes,
-            sandboxValidated: true,
-            readFile: createSandboxBridgeReadFile({ sandbox: params.sandboxConfig }),
-            ...(params.signal ? { requestInit: { signal: params.signal } } : {}),
-          })
-        : await loadWebMedia(resolvedPath ?? resolvedImage, {
-            maxBytes: params.maxBytes,
-            localRoots,
-            ssrfPolicy: params.ssrfPolicy,
-            ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
-            ...(params.signal ? { requestInit: { signal: params.signal } } : {}),
-          });
-    params.signal?.throwIfAborted();
-    if (media.kind !== "image") {
-      throw new ToolInputError(`Unsupported media type: ${media.kind}`);
-    }
-
-    const mimeType =
-      ("contentType" in media && media.contentType) ||
-      ("mimeType" in media && media.mimeType) ||
-      "image/png";
-
-    loaded.push({
-      sourceImage: {
-        buffer: media.buffer,
-        mimeType,
-      },
-      resolvedImage,
-      ...(rewrittenFrom ? { rewrittenFrom } : {}),
-    });
-  }
-
-  return loaded;
+  const loaded = await loadMediaToolReferences<ImageGenerationSourceImage>({
+    inputs: params.imageInputs,
+    toolName: "image_generate",
+    expectedKind: "image",
+    sandbox: params.sandboxConfig,
+    workspaceDir: params.workspaceDir,
+    maxBytes: params.maxBytes,
+    ssrfPolicy: params.ssrfPolicy,
+    signal: params.signal,
+    mapMedia: (media) => ({
+      buffer: media.buffer,
+      mimeType:
+        ("contentType" in media && media.contentType) ||
+        ("mimeType" in media && media.mimeType) ||
+        "image/png",
+    }),
+  });
+  return loaded.map(({ source, resolvedInput, rewrittenFrom }) =>
+    Object.assign(
+      { sourceImage: source, resolvedImage: resolvedInput },
+      rewrittenFrom ? { rewrittenFrom } : {},
+    ),
+  );
 }
 
 async function inferResolutionFromInputImages(
@@ -933,7 +862,7 @@ export function createImageGenerateTool(options?: {
       }
       const explicitModelConfig = hasExplicitImageGenerationModelConfig(cfg);
       const effectiveCfg =
-        applyImageGenerationModelConfigDefaults(cfg, imageGenerationModelConfig) ?? cfg;
+        applyAgentDefaultModelConfig(cfg, "image", imageGenerationModelConfig) ?? cfg;
       const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
       const prompt = readToolStringParam(params, "prompt", { required: true });
 

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -22,7 +22,7 @@ import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
 } from "../../media/media-reference.js";
-import { loadWebMedia, type WebMediaResult } from "../../media/web-media.js";
+import type { WebMediaResult } from "../../media/web-media.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { loadCapabilityManifestSnapshot } from "../../plugins/capability-provider-runtime.js";
 import { listAvailableManifestContractValues } from "../../plugins/manifest-contract-eligibility.js";
@@ -40,7 +40,7 @@ import {
   readStringArrayParam,
   readToolStringParam,
 } from "./common.js";
-import { decodeDataUrl, type ImageModelConfig } from "./image-tool.helpers.js";
+import type { decodeDataUrl, ImageModelConfig } from "./image-tool.helpers.js";
 import {
   getCurrentCapabilityMetadataSnapshot,
   hasSnapshotCapabilityAvailability,
@@ -133,22 +133,15 @@ export function applyAgentDefaultModelConfig(
   if (!cfg) {
     return undefined;
   }
-  if (key === "imageModel") {
-    return {
-      ...cfg,
-      agents: {
-        ...cfg.agents,
-        defaults: { ...cfg.agents?.defaults, imageModel: modelConfig },
-      },
-    };
-  }
   return {
     ...cfg,
     agents: {
       ...cfg.agents,
       defaults: {
         ...cfg.agents?.defaults,
-        mediaModels: { ...cfg.agents?.defaults?.mediaModels, [key]: modelConfig },
+        ...(key === "imageModel"
+          ? { imageModel: modelConfig }
+          : { mediaModels: { ...cfg.agents?.defaults?.mediaModels, [key]: modelConfig } }),
       },
     },
   };
@@ -666,39 +659,45 @@ export async function loadMediaToolReferences<T>(params: {
         `${params.expectedKind} data: URLs are not supported for ${params.toolName}.`,
       );
     }
-    const timeout =
-      params.toolName === "music_generate" && !params.sandbox && !reference.isDataUrl
-        ? buildTimeoutAbortSignal({
-            timeoutMs: params.timeoutMs ?? 30_000,
-            operation: "music-generate.reference-fetch",
-            ...(params.signal ? { signal: params.signal } : {}),
-            ...(reference.isHttpUrl ? { url: resolvedPath ?? resolvedInput } : {}),
-          })
-        : undefined;
     let media: LoadedToolReferenceMedia;
-    try {
-      media = reference.isDataUrl
-        ? decodeDataUrl(
-            resolvedInput,
-            params.toolName === "image_generate" ? { maxBytes: params.maxBytes } : undefined,
-          )
-        : await loadWebMedia(resolvedPath ?? resolvedInput, {
-            ...(params.toolName === "music_generate" ? {} : { maxBytes: params.maxBytes }),
-            ...(params.sandbox
-              ? {
-                  sandboxValidated: true,
-                  readFile: createSandboxBridgeReadFile({ sandbox: params.sandbox }),
-                }
-              : { localRoots, ssrfPolicy: params.ssrfPolicy }),
-            ...(params.toolName === "image_generate" && reference.isHttpUrl
-              ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS }
-              : {}),
-            ...(timeout?.signal || params.signal
-              ? { requestInit: { signal: timeout?.signal ?? params.signal } }
-              : {}),
-          });
-    } finally {
-      timeout?.cleanup();
+    if (reference.isDataUrl) {
+      const { decodeDataUrl } = await import("./image-tool.helpers.js");
+      params.signal?.throwIfAborted();
+      media = decodeDataUrl(
+        resolvedInput,
+        params.toolName === "image_generate" ? { maxBytes: params.maxBytes } : undefined,
+      );
+    } else {
+      const { loadWebMedia } = await import("../../media/web-media.js");
+      params.signal?.throwIfAborted();
+      const timeout =
+        params.toolName === "music_generate" && !params.sandbox
+          ? buildTimeoutAbortSignal({
+              timeoutMs: params.timeoutMs ?? 30_000,
+              operation: "music-generate.reference-fetch",
+              ...(params.signal ? { signal: params.signal } : {}),
+              ...(reference.isHttpUrl ? { url: resolvedPath ?? resolvedInput } : {}),
+            })
+          : undefined;
+      try {
+        media = await loadWebMedia(resolvedPath ?? resolvedInput, {
+          ...(params.toolName === "music_generate" ? {} : { maxBytes: params.maxBytes }),
+          ...(params.sandbox
+            ? {
+                sandboxValidated: true,
+                readFile: createSandboxBridgeReadFile({ sandbox: params.sandbox }),
+              }
+            : { localRoots, ssrfPolicy: params.ssrfPolicy }),
+          ...(params.toolName === "image_generate" && reference.isHttpUrl
+            ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS }
+            : {}),
+          ...(timeout?.signal || params.signal
+            ? { requestInit: { signal: timeout?.signal ?? params.signal } }
+            : {}),
+        });
+      } finally {
+        timeout?.cleanup();
+      }
     }
     params.signal?.throwIfAborted();
     if (media.kind !== params.expectedKind) {

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -18,12 +18,19 @@ import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import type { Model } from "../../llm/types.js";
 import { resolveChannelInboundAttachmentRootsForChannel } from "../../media/channel-inbound-roots.js";
 import { getDefaultLocalRootsCore } from "../../media/local-media-access.js";
-import { classifyMediaReferenceSource } from "../../media/media-reference.js";
+import {
+  classifyMediaReferenceSource,
+  normalizeMediaReferenceSource,
+} from "../../media/media-reference.js";
+import { loadWebMedia, type WebMediaResult } from "../../media/web-media.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { loadCapabilityManifestSnapshot } from "../../plugins/capability-provider-runtime.js";
 import { listAvailableManifestContractValues } from "../../plugins/manifest-contract-eligibility.js";
+import { resolveUserPath } from "../../utils.js";
+import { buildTimeoutAbortSignal } from "../../utils/fetch-timeout.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import {
+  createSandboxBridgeReadFile,
   resolveSandboxedBridgeMediaPath,
   type SandboxedBridgeMediaPathConfig,
 } from "../sandbox-media-paths.js";
@@ -33,7 +40,7 @@ import {
   readStringArrayParam,
   readToolStringParam,
 } from "./common.js";
-import type { ImageModelConfig } from "./image-tool.helpers.js";
+import { decodeDataUrl, type ImageModelConfig } from "./image-tool.helpers.js";
 import {
   getCurrentCapabilityMetadataSnapshot,
   hasSnapshotCapabilityAvailability,
@@ -101,36 +108,6 @@ export function applyImageModelConfigDefaults(
 }
 
 /**
- * Applies an image-generation model as the agent default for downstream tool calls.
- */
-export function applyImageGenerationModelConfigDefaults(
-  cfg: OpenClawConfig | undefined,
-  imageGenerationModelConfig: ToolModelConfig,
-): OpenClawConfig | undefined {
-  return applyAgentDefaultModelConfig(cfg, "image", imageGenerationModelConfig);
-}
-
-/**
- * Applies a video-generation model as the agent default for downstream tool calls.
- */
-export function applyVideoGenerationModelConfigDefaults(
-  cfg: OpenClawConfig | undefined,
-  videoGenerationModelConfig: ToolModelConfig,
-): OpenClawConfig | undefined {
-  return applyAgentDefaultModelConfig(cfg, "video", videoGenerationModelConfig);
-}
-
-/**
- * Applies a music-generation model as the agent default for downstream tool calls.
- */
-export function applyMusicGenerationModelConfigDefaults(
-  cfg: OpenClawConfig | undefined,
-  musicGenerationModelConfig: ToolModelConfig,
-): OpenClawConfig | undefined {
-  return applyAgentDefaultModelConfig(cfg, "music", musicGenerationModelConfig);
-}
-
-/**
  * Reads an optional generation timeout while preserving common tool parameter validation.
  */
 export function readGenerationTimeoutMs(args: Record<string, unknown>): number | undefined {
@@ -148,7 +125,7 @@ export function resolveRemoteMediaSsrfPolicy(
   return cfg?.tools?.web?.fetch?.ssrfPolicy;
 }
 
-function applyAgentDefaultModelConfig(
+export function applyAgentDefaultModelConfig(
   cfg: OpenClawConfig | undefined,
   key: "imageModel" | "image" | "video" | "music",
   modelConfig: ToolModelConfig,
@@ -637,6 +614,101 @@ export async function resolveMediaToolReferenceAccess(params: {
     localRoots: resolveMediaToolLocalRoots(params.workspaceDir, rootOptions),
     ...(pathInfo.rewrittenFrom ? { rewrittenFrom: pathInfo.rewrittenFrom } : {}),
   };
+}
+
+type LoadedToolReferenceMedia = WebMediaResult | ReturnType<typeof decodeDataUrl>;
+
+/** Loads generation references while retaining each tool's distinct transport and sandbox policy. */
+export async function loadMediaToolReferences<T>(params: {
+  inputs: string[];
+  toolName: "image_generate" | "video_generate" | "music_generate";
+  expectedKind: "image" | "video" | "audio";
+  sandbox: SandboxedBridgeMediaPathConfig | null;
+  workspaceDir?: string;
+  maxBytes?: number;
+  ssrfPolicy?: SsrFPolicy;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  mapMedia: (media: LoadedToolReferenceMedia) => T;
+  mapRemote?: (url: string) => T;
+}): Promise<Array<{ source: T; resolvedInput: string; rewrittenFrom?: string }>> {
+  const loaded: Array<{ source: T; resolvedInput: string; rewrittenFrom?: string }> = [];
+  for (const rawInput of params.inputs) {
+    params.signal?.throwIfAborted();
+    const input = normalizeMediaReferenceSource(rawInput.trim().replace(/^@\s*/, ""));
+    if (!input) {
+      throw new ToolInputError(`${params.expectedKind} required (empty string in array)`);
+    }
+    const reference = classifyMediaReferenceSource(input);
+    if (reference.hasUnsupportedScheme) {
+      throw new ToolInputError(
+        `Unsupported ${params.expectedKind} reference: ${rawInput}. Use a file path, a file:// URL, a data: URL, or an http(s) URL.`,
+      );
+    }
+    if (params.sandbox && reference.isHttpUrl) {
+      const label = params.toolName === "image_generate" ? "" : `${params.expectedKind} `;
+      throw new ToolInputError(`Sandboxed ${params.toolName} does not allow remote ${label}URLs.`);
+    }
+    const resolvedInput = !params.sandbox && input.startsWith("~") ? resolveUserPath(input) : input;
+    if (reference.isHttpUrl && params.mapRemote) {
+      loaded.push({ source: params.mapRemote(resolvedInput), resolvedInput });
+      continue;
+    }
+    const { resolvedPath, localRoots, rewrittenFrom } = await resolveMediaToolReferenceAccess({
+      input: resolvedInput,
+      isDataUrl: reference.isDataUrl,
+      workspaceDir: params.workspaceDir,
+      sandbox: params.sandbox,
+    });
+    params.signal?.throwIfAborted();
+    if (reference.isDataUrl && params.expectedKind !== "image") {
+      throw new ToolInputError(
+        `${params.expectedKind} data: URLs are not supported for ${params.toolName}.`,
+      );
+    }
+    const timeout =
+      params.toolName === "music_generate" && !params.sandbox && !reference.isDataUrl
+        ? buildTimeoutAbortSignal({
+            timeoutMs: params.timeoutMs ?? 30_000,
+            operation: "music-generate.reference-fetch",
+            ...(params.signal ? { signal: params.signal } : {}),
+            ...(reference.isHttpUrl ? { url: resolvedPath ?? resolvedInput } : {}),
+          })
+        : undefined;
+    let media: LoadedToolReferenceMedia;
+    try {
+      media = reference.isDataUrl
+        ? decodeDataUrl(
+            resolvedInput,
+            params.toolName === "image_generate" ? { maxBytes: params.maxBytes } : undefined,
+          )
+        : await loadWebMedia(resolvedPath ?? resolvedInput, {
+            ...(params.toolName === "music_generate" ? {} : { maxBytes: params.maxBytes }),
+            ...(params.sandbox
+              ? {
+                  sandboxValidated: true,
+                  readFile: createSandboxBridgeReadFile({ sandbox: params.sandbox }),
+                }
+              : { localRoots, ssrfPolicy: params.ssrfPolicy }),
+            ...(params.toolName === "image_generate" && reference.isHttpUrl
+              ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS }
+              : {}),
+            ...(timeout?.signal || params.signal
+              ? { requestInit: { signal: timeout?.signal ?? params.signal } }
+              : {}),
+          });
+    } finally {
+      timeout?.cleanup();
+    }
+    params.signal?.throwIfAborted();
+    if (media.kind !== params.expectedKind) {
+      const kind = params.toolName === "image_generate" ? media.kind : (media.kind ?? "unknown");
+      throw new ToolInputError(`Unsupported media type: ${kind}`);
+    }
+    const loadedReference = { source: params.mapMedia(media), resolvedInput };
+    loaded.push(rewrittenFrom ? { ...loadedReference, rewrittenFrom } : loadedReference);
+  }
+  return loaded;
 }
 
 /**

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -8,12 +8,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseMusicGenerationModelRef } from "../../media-generation/model-ref.js";
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { probeMediaFilesWithinBudget } from "../../media/media-probe.js";
-import {
-  classifyMediaReferenceSource,
-  normalizeMediaReferenceSource,
-} from "../../media/media-reference.js";
 import { saveMediaBuffer } from "../../media/store.js";
-import { loadWebMedia } from "../../media/web-media.js";
 import { resolveMusicGenerationModeCapabilities } from "../../music-generation/capabilities.js";
 import {
   generateMusic,
@@ -25,9 +20,7 @@ import type {
   MusicGenerationSourceImage,
 } from "../../music-generation/types.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
-import { resolveUserPath } from "../../utils.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
-import { buildTimeoutAbortSignal } from "../../utils/fetch-timeout.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import {
   formatGeneratedAttachmentLines,
@@ -38,7 +31,6 @@ import { buildMediaGenerationRequestKey } from "../media-generation-task-status-
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { ToolInputError, readNumberParam, readToolStringParam } from "./common.js";
 import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
-import { decodeDataUrl } from "./image-tool.helpers.js";
 import {
   createDefaultMediaGenerateBackgroundScheduler,
   type MediaGenerateAsyncStartCallback,
@@ -50,16 +42,16 @@ import {
   type MusicGenerationTaskHandle,
 } from "./media-generate-background.js";
 import {
-  applyMusicGenerationModelConfigDefaults,
+  applyAgentDefaultModelConfig,
   buildMediaReferenceDetails,
   buildTaskRunDetails,
   createCapabilityProviderRuntimeDeps,
   hasGenerationToolAvailability,
+  loadMediaToolReferences,
   normalizeMediaReferenceInputs,
   readBooleanToolParam,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
-  resolveMediaToolReferenceAccess,
   resolveRemoteMediaSsrfPolicy,
   resolveSelectedCapabilityProvider,
 } from "./media-tool-shared.js";
@@ -73,18 +65,12 @@ import {
   createMusicGenerateListActionResult,
   createMusicGenerateStatusActionResult,
 } from "./music-generate-tool.actions.js";
-import {
-  createSandboxBridgeReadFile,
-  type AnyAgentTool,
-  type SandboxFsBridge,
-  type ToolFsPolicy,
-} from "./tool-runtime.helpers.js";
+import type { AnyAgentTool, SandboxFsBridge, ToolFsPolicy } from "./tool-runtime.helpers.js";
 
 const log = createSubsystemLogger("agents/tools/music-generate");
 const MAX_INPUT_IMAGES = 10;
 const GENERATED_MUSIC_MEDIA_SUBDIR = "tool-music-generation";
 const SUPPORTED_OUTPUT_FORMATS = new Set<MusicGenerationOutputFormat>(["mp3", "wav"]);
-const DEFAULT_REFERENCE_FETCH_TIMEOUT_MS = 30_000;
 const DEFAULT_MUSIC_GENERATION_TIMEOUT_MS = 300_000;
 const MIN_MUSIC_GENERATION_TIMEOUT_MS = 120_000;
 const GENERATED_MUSIC_PROBE_BUDGET_MS = 3000;
@@ -301,89 +287,24 @@ async function loadReferenceImages(params: {
     rewrittenFrom?: string;
   }>
 > {
-  const loaded: Array<{
-    sourceImage: MusicGenerationSourceImage;
-    resolvedInput: string;
-    rewrittenFrom?: string;
-  }> = [];
-
-  for (const rawInput of params.inputs) {
-    params.signal?.throwIfAborted();
-    const trimmed = rawInput.trim();
-    const inputRaw = normalizeMediaReferenceSource(
-      trimmed.startsWith("@") ? trimmed.slice(1).trim() : trimmed,
-    );
-    if (!inputRaw) {
-      throw new ToolInputError("image required (empty string in array)");
-    }
-    const refInfo = classifyMediaReferenceSource(inputRaw);
-    const { isDataUrl, isHttpUrl } = refInfo;
-    if (refInfo.hasUnsupportedScheme) {
-      throw new ToolInputError(
-        `Unsupported image reference: ${rawInput}. Use a file path, a file:// URL, a data: URL, or an http(s) URL.`,
-      );
-    }
-    if (params.sandboxConfig && isHttpUrl) {
-      throw new ToolInputError("Sandboxed music_generate does not allow remote image URLs.");
-    }
-
-    const resolvedInput = params.sandboxConfig
-      ? inputRaw
-      : inputRaw.startsWith("~")
-        ? resolveUserPath(inputRaw)
-        : inputRaw;
-    const { resolvedPath, localRoots, rewrittenFrom } = await resolveMediaToolReferenceAccess({
-      input: resolvedInput,
-      isDataUrl,
-      workspaceDir: params.workspaceDir,
-      sandbox: params.sandboxConfig,
-    });
-    params.signal?.throwIfAborted();
-    const media = isDataUrl
-      ? decodeDataUrl(resolvedInput)
-      : params.sandboxConfig
-        ? await loadWebMedia(resolvedPath ?? resolvedInput, {
-            sandboxValidated: true,
-            readFile: createSandboxBridgeReadFile({ sandbox: params.sandboxConfig }),
-            ...(params.signal ? { requestInit: { signal: params.signal } } : {}),
-          })
-        : await (async () => {
-            const referenceTarget = resolvedPath ?? resolvedInput;
-            const isRemoteReference = /^https?:\/\//i.test(referenceTarget);
-            const { signal, cleanup } = buildTimeoutAbortSignal({
-              timeoutMs: params.timeoutMs ?? DEFAULT_REFERENCE_FETCH_TIMEOUT_MS,
-              operation: "music-generate.reference-fetch",
-              ...(params.signal ? { signal: params.signal } : {}),
-              ...(isRemoteReference ? { url: referenceTarget } : {}),
-            });
-            try {
-              return await loadWebMedia(resolvedPath ?? resolvedInput, {
-                localRoots,
-                requestInit: signal ? { signal } : undefined,
-                ssrfPolicy: params.ssrfPolicy,
-              });
-            } finally {
-              cleanup();
-            }
-          })();
-    params.signal?.throwIfAborted();
-    if (media.kind !== "image") {
-      throw new ToolInputError(`Unsupported media type: ${media.kind ?? "unknown"}`);
-    }
-    const mimeType = "mimeType" in media ? media.mimeType : media.contentType;
-    const fileName = "fileName" in media ? media.fileName : undefined;
-    loaded.push({
-      sourceImage: {
-        buffer: media.buffer,
-        mimeType,
-        fileName,
-      },
-      resolvedInput,
-      ...(rewrittenFrom ? { rewrittenFrom } : {}),
-    });
-  }
-
-  return loaded;
+  const loaded = await loadMediaToolReferences<MusicGenerationSourceImage>({
+    inputs: params.inputs,
+    toolName: "music_generate",
+    expectedKind: "image",
+    sandbox: params.sandboxConfig,
+    workspaceDir: params.workspaceDir,
+    ssrfPolicy: params.ssrfPolicy,
+    timeoutMs: params.timeoutMs,
+    signal: params.signal,
+    mapMedia: (media) => ({
+      buffer: media.buffer,
+      mimeType: "mimeType" in media ? media.mimeType : media.contentType,
+      fileName: "fileName" in media ? media.fileName : undefined,
+    }),
+  });
+  return loaded.map(({ source, resolvedInput, rewrittenFrom }) =>
+    Object.assign({ sourceImage: source, resolvedInput }, rewrittenFrom ? { rewrittenFrom } : {}),
+  );
 }
 
 type LoadedReferenceImage = Awaited<ReturnType<typeof loadReferenceImages>>[number];
@@ -675,7 +596,7 @@ export function createMusicGenerateTool(options?: {
       }
       const explicitModelConfig = hasExplicitMusicGenerationModelConfig(cfg);
       const effectiveCfg =
-        applyMusicGenerationModelConfigDefaults(cfg, musicGenerationModelConfig) ?? cfg;
+        applyAgentDefaultModelConfig(cfg, "music", musicGenerationModelConfig) ?? cfg;
       const prompt = readToolStringParam(args, "prompt", { required: true });
 
       const activeDuplicateGuardResult = createMusicGenerateDuplicateGuardResult(

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -7,16 +7,10 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseVideoGenerationModelRef } from "../../media-generation/model-ref.js";
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
 import { probeMediaFilesWithinBudget } from "../../media/media-probe.js";
-import {
-  classifyMediaReferenceSource,
-  normalizeMediaReferenceSource,
-} from "../../media/media-reference.js";
 import { saveMediaBuffer } from "../../media/store.js";
-import { loadWebMedia } from "../../media/web-media.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
-import { resolveUserPath } from "../../utils.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import {
   generateVideo,
@@ -40,7 +34,6 @@ import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js"
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { ToolInputError, readNumberParam, readToolStringParam } from "./common.js";
 import { persistGeneratedMediaBatch } from "./generated-media-batch-persistence.js";
-import { decodeDataUrl } from "./image-tool.helpers.js";
 import {
   hasSnapshotCapabilityProviderAvailability,
   loadCapabilityMetadataSnapshot,
@@ -56,17 +49,17 @@ import {
   type VideoGenerationTaskHandle,
 } from "./media-generate-background.js";
 import {
-  applyVideoGenerationModelConfigDefaults,
+  applyAgentDefaultModelConfig,
   buildMediaReferenceDetails,
   buildTaskRunDetails,
   createCapabilityProviderRuntimeDeps,
   hasGenerationToolAvailability,
+  loadMediaToolReferences,
   normalizeMediaReferenceInputs,
   readBooleanToolParam,
   readGenerationTimeoutMs,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
-  resolveMediaToolReferenceAccess,
   resolveRemoteMediaSsrfPolicy,
   resolveSelectedCapabilityProvider,
 } from "./media-tool-shared.js";
@@ -76,12 +69,7 @@ import {
   hasToolModelConfig,
   type ToolModelConfig,
 } from "./model-config.helpers.js";
-import {
-  createSandboxBridgeReadFile,
-  type AnyAgentTool,
-  type SandboxFsBridge,
-  type ToolFsPolicy,
-} from "./tool-runtime.helpers.js";
+import type { AnyAgentTool, SandboxFsBridge, ToolFsPolicy } from "./tool-runtime.helpers.js";
 import {
   createVideoGenerateDuplicateGuardResult,
   createVideoGenerateListActionResult,
@@ -474,98 +462,25 @@ async function loadReferenceAssets(params: {
     rewrittenFrom?: string;
   }>
 > {
-  const loaded: Array<{
-    sourceAsset: VideoGenerationSourceAsset;
-    resolvedInput: string;
-    rewrittenFrom?: string;
-  }> = [];
-
-  for (const rawInput of params.inputs) {
-    params.signal?.throwIfAborted();
-    const trimmed = rawInput.trim();
-    const inputRaw = normalizeMediaReferenceSource(
-      trimmed.startsWith("@") ? trimmed.slice(1).trim() : trimmed,
-    );
-    if (!inputRaw) {
-      throw new ToolInputError(`${params.expectedKind} required (empty string in array)`);
-    }
-    const refInfo = classifyMediaReferenceSource(inputRaw);
-    const { isDataUrl, isHttpUrl } = refInfo;
-    if (refInfo.hasUnsupportedScheme) {
-      throw new ToolInputError(
-        `Unsupported ${params.expectedKind} reference: ${rawInput}. Use a file path, a file:// URL, a data: URL, or an http(s) URL.`,
-      );
-    }
-    if (params.sandboxConfig && isHttpUrl) {
-      throw new ToolInputError(
-        `Sandboxed video_generate does not allow remote ${params.expectedKind} URLs.`,
-      );
-    }
-
-    const resolvedInput = (() => {
-      if (params.sandboxConfig) {
-        return inputRaw;
-      }
-      if (inputRaw.startsWith("~")) {
-        return resolveUserPath(inputRaw);
-      }
-      return inputRaw;
-    })();
-
-    if (isHttpUrl && !params.sandboxConfig) {
-      loaded.push({
-        sourceAsset: { url: resolvedInput },
-        resolvedInput,
-      });
-      continue;
-    }
-
-    const { resolvedPath, localRoots, rewrittenFrom } = await resolveMediaToolReferenceAccess({
-      input: resolvedInput,
-      isDataUrl,
-      workspaceDir: params.workspaceDir,
-      sandbox: params.sandboxConfig,
-    });
-    params.signal?.throwIfAborted();
-    const media = isDataUrl
-      ? params.expectedKind === "image"
-        ? decodeDataUrl(resolvedInput)
-        : (() => {
-            throw new ToolInputError(
-              `${params.expectedKind} data: URLs are not supported for video_generate.`,
-            );
-          })()
-      : params.sandboxConfig
-        ? await loadWebMedia(resolvedPath ?? resolvedInput, {
-            maxBytes: params.maxBytes,
-            sandboxValidated: true,
-            readFile: createSandboxBridgeReadFile({ sandbox: params.sandboxConfig }),
-            ...(params.signal ? { requestInit: { signal: params.signal } } : {}),
-          })
-        : await loadWebMedia(resolvedPath ?? resolvedInput, {
-            maxBytes: params.maxBytes,
-            localRoots,
-            ssrfPolicy: params.ssrfPolicy,
-            ...(params.signal ? { requestInit: { signal: params.signal } } : {}),
-          });
-    params.signal?.throwIfAborted();
-    if (media.kind !== params.expectedKind) {
-      throw new ToolInputError(`Unsupported media type: ${media.kind ?? "unknown"}`);
-    }
-    const mimeType = "mimeType" in media ? media.mimeType : media.contentType;
-    const fileName = "fileName" in media ? media.fileName : undefined;
-    loaded.push({
-      sourceAsset: {
-        buffer: media.buffer,
-        mimeType,
-        fileName,
-      },
-      resolvedInput,
-      ...(rewrittenFrom ? { rewrittenFrom } : {}),
-    });
-  }
-
-  return loaded;
+  const loaded = await loadMediaToolReferences<VideoGenerationSourceAsset>({
+    inputs: params.inputs,
+    toolName: "video_generate",
+    expectedKind: params.expectedKind,
+    sandbox: params.sandboxConfig,
+    workspaceDir: params.workspaceDir,
+    maxBytes: params.maxBytes,
+    ssrfPolicy: params.ssrfPolicy,
+    signal: params.signal,
+    mapMedia: (media) => ({
+      buffer: media.buffer,
+      mimeType: "mimeType" in media ? media.mimeType : media.contentType,
+      fileName: "fileName" in media ? media.fileName : undefined,
+    }),
+    mapRemote: (url) => ({ url }),
+  });
+  return loaded.map(({ source, resolvedInput, rewrittenFrom }) =>
+    Object.assign({ sourceAsset: source, resolvedInput }, rewrittenFrom ? { rewrittenFrom } : {}),
+  );
 }
 
 type LoadedReferenceAsset = Awaited<ReturnType<typeof loadReferenceAssets>>[number];
@@ -967,7 +882,7 @@ export function createVideoGenerateTool(options?: {
       }
       const explicitModelConfig = hasExplicitVideoGenerationModelConfig(cfg);
       const effectiveCfg =
-        applyVideoGenerationModelConfigDefaults(cfg, videoGenerationModelConfig) ?? cfg;
+        applyAgentDefaultModelConfig(cfg, "video", videoGenerationModelConfig) ?? cfg;
       const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
       const prompt = readToolStringParam(args, "prompt", { required: true });
 


### PR DESCRIPTION
## What Problem This Solves

The shipped image, video, and music generation tools each maintained separate versions of the same media-reference classification, sandbox access, and provider-facing input preparation. Repeated security-sensitive branches made the three tool families harder to keep aligned while obscuring their genuinely different size, timeout, and provider contracts.

## Why This Change Was Made

The existing shared media-tool runtime now owns canonical reference normalization and guarded media access. The image, video, and music tools consume that existing owner while retaining their intentional individual limits, remote-video handling, MIME restrictions, cancellation behavior, sandbox roots, and provider-specific timeouts.

## User Impact

Image, video, and music generation continue accepting the same inputs and returning the same behavior. Existing sandbox and SSRF protections remain fail-closed, and public tool/configuration contracts are unchanged.

## Evidence

- The relevant existing image, video, music, sandbox, cancellation, provider, and security suites passed 145 tests before the change and all 145 tests again afterward.
- The real assertion-safety and maximum-lines ratchets passed; targeted lint, formatting, import-cycle checks, and `git diff --check` passed.
- Separate primary and secondary complete security/owner-boundary source reviews accepted all four runtime owners, and the full structured precommit review finished cleanly.
- Verified asymmetric image/video/music byte limits, image-only idle timeout, remote video URL pass-through, fail-closed sandbox bridge and roots, SSRF protection, music-specific abort timeout and cleanup, data MIME restrictions, and existing provider/model defaults.
- Genuine shipped production delta: 177 added, 340 removed, net **-163**. No tests, documentation, generated files, lockfiles, metadata, public APIs, or SQLite schemas changed.
