### PR TITLE
fix(telegram): preserve exact whitespace in selected reply quotes

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1960,19 +1960,35 @@ describe("handleTelegramAction", () => {
       expectedOptions: { mediaUrl: "https://example.com/image.jpg" },
     },
     {
-      name: "quoteText",
+      name: "quoteText preserving exact whitespace",
       params: {
         action: "sendMessage",
         to: "123456",
         content: "Replying now",
         replyToMessageId: 144,
-        quoteText: "The text you want to quote",
+        quoteText: "  The text you want to quote\n  ",
       },
       expectedTo: "123456",
       expectedContent: "Replying now",
       expectedOptions: {
         replyToMessageId: 144,
-        quoteText: "The text you want to quote",
+        quoteText: "  The text you want to quote\n  ",
+      },
+    },
+    {
+      name: "snake-case quoteText preserving exact whitespace",
+      params: {
+        action: "sendMessage",
+        to: "123456",
+        content: "Replying now",
+        replyToMessageId: 144,
+        quote_text: " \nThe text you want to quote  ",
+      },
+      expectedTo: "123456",
+      expectedContent: "Replying now",
+      expectedOptions: {
+        replyToMessageId: 144,
+        quoteText: " \nThe text you want to quote  ",
       },
     },
     {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -673,7 +673,7 @@ export async function handleTelegramAction(
     // Optional threading parameters for forum topics and reply chains
     const replyToMessageId = readTelegramReplyToMessageId(params);
     const messageThreadId = readTelegramThreadId(params);
-    const quoteText = readStringParam(params, "quoteText");
+    const quoteText = readStringParam(params, "quoteText", { trim: false });
     const token = resolveTelegramToken(cfg, { accountId }).token;
     if (!token) {
       throw new Error(

--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -262,7 +262,7 @@ describe("telegram actions contract", () => {
           channel: "telegram",
           action: "send",
           cfg: {} as OpenClawConfig,
-          params: { quoteText: "  original message  " },
+          params: { quoteText: "  original message\n  " },
         },
         to: "123456",
         payload: {
@@ -277,7 +277,7 @@ describe("telegram actions contract", () => {
       channelData: {
         telegram: {
           parseMode: "MarkdownV2",
-          quoteText: "original message",
+          quoteText: "  original message\n  ",
         },
       },
     });
@@ -299,7 +299,7 @@ describe("telegram actions contract", () => {
           channel: "telegram",
           action: "send",
           cfg: {} as OpenClawConfig,
-          params: { quote_text: "  snake case quote  " },
+          params: { quote_text: " \nsnake case quote  " },
         },
         to: "123456",
         payload: { text: "Chart", presentation },
@@ -307,7 +307,7 @@ describe("telegram actions contract", () => {
     ).toEqual({
       text: "Chart",
       presentation,
-      channelData: { telegram: { quoteText: "snake case quote" } },
+      channelData: { telegram: { quoteText: " \nsnake case quote  " } },
     });
   });
 

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -84,7 +84,7 @@ async function prepareTelegramSendPayload({
   ) {
     return null;
   }
-  const quoteText = readStringParam(ctx.params, "quoteText");
+  const quoteText = readStringParam(ctx.params, "quoteText", { trim: false });
   if (!quoteText) {
     return payload;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram selected replies could quote the wrong passage or fail to send when the selected text began or ended with spaces, tabs, or newlines.

## Why This Change Was Made

Telegram requires a quote to be an exact substring of the original message, but both OpenClaw action-ingress owners trimmed it before the existing Telegram sender received the value. Preserve the exact quote bytes through both direct actions and durable channel payloads while retaining the sender's existing whitespace-only rejection.

Production delta: **2 additions / 2 deletions (net 0)**. No configuration, protocol, authentication, persistence, plugin-SDK, or dependency changes.

## User Impact

Telegram reply quotes now match the text the user or agent actually selected, including meaningful leading/trailing whitespace and newlines, for both standard and snake-case action parameters.

## Evidence

- Direct installed Telegram dependency contract states that a quote must be an exact substring or the message fails to send.
- Authentic pre-fix direct-action and durable-payload regressions failed for both camel-case and snake-case quoted text.
- Focused action, durable contract, and provider reply-parameter suites: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/channel-actions.contract.test.ts extensions/telegram/src/reply-parameters.test.ts --reporter=dot` — **149 passed**.
- Real Telegram sender-path regression and rejected-native-quote fallback: **2 additional passing tests**.
- Scoped type-aware lint and formatting passed; fresh independent structured review was **clean**.
