### PR TITLE
fix(acp): honor agent thinkingDefault for ACP bindings instead of forcing adaptive

### DIFF
--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -106,7 +106,13 @@ export async function ensureConfiguredAcpBindingSession(params: {
       sessionKey,
       agent: params.spec.acpAgentId ?? params.spec.agentId,
       mode: params.spec.mode,
-      runtimeOptions: params.spec.model ? { model: params.spec.model } : undefined,
+      runtimeOptions:
+        params.spec.model || params.spec.thinking
+          ? {
+              ...(params.spec.model ? { model: params.spec.model } : {}),
+              ...(params.spec.thinking ? { thinking: params.spec.thinking } : {}),
+            }
+          : undefined,
       cwd: params.spec.cwd,
       backendId: params.spec.backend,
     });

--- a/src/acp/persistent-bindings.types.ts
+++ b/src/acp/persistent-bindings.types.ts
@@ -29,6 +29,8 @@ export type ConfiguredAcpBindingSpec = {
   acpAgentId?: string;
   mode: AcpRuntimeSessionMode;
   model?: string;
+  /** Owner agent thinking policy, carried so ACP sessions honor thinkingDefault. */
+  thinking?: string;
   cwd?: string;
   backend?: string;
   label?: string;
@@ -106,6 +108,7 @@ export function toConfiguredAcpBindingRecord(spec: ConfiguredAcpBindingSpec): Se
       ...(spec.acpAgentId ? { acpAgentId: spec.acpAgentId } : {}),
       label: spec.label,
       ...(spec.model ? { model: spec.model } : {}),
+      ...(spec.thinking ? { thinking: spec.thinking } : {}),
       ...(spec.backend ? { backend: spec.backend } : {}),
       ...(spec.cwd ? { cwd: spec.cwd } : {}),
     },
@@ -164,6 +167,7 @@ export function resolveConfiguredAcpBindingSpecFromRecord(
     acpAgentId: normalizeText(record.metadata?.acpAgentId),
     mode: normalizeMode(record.metadata?.mode),
     model: normalizeText(record.metadata?.model),
+    thinking: normalizeText(record.metadata?.thinking),
     cwd: normalizeText(record.metadata?.cwd),
     backend: normalizeText(record.metadata?.backend),
     label: normalizeText(record.metadata?.label),

--- a/src/channels/plugins/acp-bindings.test.ts
+++ b/src/channels/plugins/acp-bindings.test.ts
@@ -226,6 +226,39 @@ describe("configured binding registry", () => {
     expect(getLoadedChannelPluginMock).not.toHaveBeenCalled();
   });
 
+  it("carries the owner agent thinkingDefault into the ACP binding record", () => {
+    // Regression for #128145: an owner agent's thinkingDefault must reach the ACP session so
+    // models that do not support `adaptive` (e.g. ollama-cloud) are not forced into it.
+    resolveAgentConfigMock.mockReturnValue({ thinkingDefault: "off" });
+    const plugin = createDiscordAcpPlugin();
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
+
+    const resolved = bindingRegistry.resolveConfiguredBindingRecord({
+      cfg: createConfig() as never,
+      channel: "discord",
+      accountId: "default",
+      conversationId: "1479098716916023408",
+    });
+
+    expect(resolved?.record.metadata?.thinking).toBe("off");
+  });
+
+  it("omits thinking from the ACP binding record when no thinking policy applies", () => {
+    // Owner has no thinkingDefault and no explicit model, so the record preserves prior behavior
+    // (no forced thinking level) instead of injecting a default.
+    const plugin = createDiscordAcpPlugin();
+    getLoadedChannelPluginMock.mockReturnValue(plugin);
+
+    const resolved = bindingRegistry.resolveConfiguredBindingRecord({
+      cfg: createConfig() as never,
+      channel: "discord",
+      accountId: "default",
+      conversationId: "1479098716916023408",
+    });
+
+    expect(resolved?.record.metadata?.thinking).toBeUndefined();
+  });
+
   it("uses the current loaded channel plugin on each resolve", () => {
     const firstPlugin = createDiscordAcpPlugin();
     const secondPlugin = createDiscordAcpPlugin();

--- a/src/channels/plugins/acp-configured-binding-consumer.ts
+++ b/src/channels/plugins/acp-configured-binding-consumer.ts
@@ -18,6 +18,8 @@ import {
   resolveAgentExplicitModelPrimary,
   resolveAgentWorkspaceDir,
 } from "../../agents/agent-scope.js";
+import { parseModelRef } from "../../agents/model-selection-normalize.js";
+import { resolveThinkingDefault } from "../../agents/model-thinking-default.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   ConfiguredBindingRuleConfig,
@@ -72,6 +74,7 @@ function buildConfiguredAcpSpec(params: {
   acpAgentId?: string;
   mode: "persistent" | "oneshot";
   model?: string;
+  thinking?: string;
   cwd?: string;
   backend?: string;
   label?: string;
@@ -85,6 +88,7 @@ function buildConfiguredAcpSpec(params: {
     acpAgentId: params.acpAgentId,
     mode: params.mode,
     model: params.model,
+    thinking: params.thinking,
     cwd: params.cwd,
     backend: params.backend,
     label: params.label,
@@ -110,6 +114,22 @@ function buildAcpTargetFactory(params: {
   const mode = normalizeMode(bindingOverrides.mode ?? runtimeDefaults.mode);
   // Every ACP binding uses its owner's explicit model, regardless of the owner's runtime type.
   const model = resolveAgentExplicitModelPrimary(params.cfg, params.agentId);
+  // Resolve the owner agent's thinking policy alongside its model so ACP sessions honor the
+  // agent's thinkingDefault instead of falling back to the runtime's `adaptive` default, which
+  // breaks models that do not support adaptive thinking. Mirrors gateway session resolution:
+  // an explicit per-agent thinkingDefault wins, otherwise the model-family default applies
+  // (which still yields `adaptive` for models that support it).
+  const agentThinkingDefault = resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault;
+  const modelRef = model ? parseModelRef(model, "") : null;
+  const thinking =
+    agentThinkingDefault ??
+    (modelRef
+      ? resolveThinkingDefault({
+          cfg: params.cfg,
+          provider: modelRef.provider,
+          model: modelRef.model,
+        })
+      : undefined);
   const cwd =
     bindingOverrides.cwd ??
     runtimeDefaults.cwd ??
@@ -134,6 +154,7 @@ function buildAcpTargetFactory(params: {
         acpAgentId,
         mode,
         model,
+        thinking,
         cwd,
         backend,
         label,


### PR DESCRIPTION
## What Problem This Solves

Closes #128145.

ACP bindings resolve the owner agent's **model** but never resolve the owner agent's **thinking policy**, so `runtimeOptions.thinking` is never populated. The agent then falls back to the runtime's `adaptive` thinking level, which breaks ACP runs on models that don't support adaptive thinking:

```
AcpRuntimeError: Could not apply ACP runtime mode 'auto':
thinkingLevel 'adaptive' is not supported for ollama-cloud/glm-5.2:cloud (use off)
```

An agent configured with `thinkingDefault: 'off'` is ignored on the ACP path even though the gateway session path already honors it.

## Why This Change Was Made

The fix resolves the owner agent's thinking policy alongside its model at bind time and threads it through the existing binding spec → record → `runtimeOptions.thinking`, reusing OpenClaw's existing config-option delivery channel. It mirrors the gateway's own resolution (`resolveGatewaySessionThinkingDefault`): an explicit per-agent `thinkingDefault` wins, otherwise the model-family default (`resolveThinkingDefault`) applies — which still yields `adaptive` for models that support it, preserving current behavior.

No new plugin/ACPX setting is added, and the acpx adapter is untouched: `acpx@0.13.1`'s `SessionAgentOptions` has no `thinking` field, so thinking correctly flows via the already-wired `session/set_config_option` path (`buildRuntimeConfigOptionPairs` → `applyManagerRuntimeControls`), not via session options.

## User Impact

ACP agents now honor their configured `thinkingDefault` (e.g. `off`), so ACP runs on models without adaptive-thinking support (Ollama Cloud, etc.) no longer error out. Models that support `adaptive` are unaffected.

## Files changed

- `src/channels/plugins/acp-configured-binding-consumer.ts` — resolve owner thinking policy at bind time and pass it into the spec.
- `src/acp/persistent-bindings.types.ts` — carry `thinking` on the binding spec and round-trip it through the persisted record.
- `src/acp/persistent-bindings.lifecycle.ts` — include `thinking` in the ACP session `runtimeOptions`.
- `src/channels/plugins/acp-bindings.test.ts` — regression coverage.

## Evidence

- New regression tests in `acp-bindings.test.ts`:
  - owner `thinkingDefault: 'off'` reaches the ACP binding record (`metadata.thinking === 'off'`);
  - no thinking policy + no explicit model preserves prior behavior (no forced level).
- `vitest run src/channels/plugins/acp-bindings.test.ts` → 9/9 pass.
- Related suites green: `src/acp/persistent-bindings.test.ts` + `src/channels/**` → 1068/1068 pass.
- `oxfmt` clean; `git diff --check` clean.

---

*This change was prepared with AI assistance (Claude Code).*
