### PR TITLE
fix(ui): bound tool title background state

### DIFF
--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -194,4 +194,212 @@ describe("title fetch batching", () => {
       expect.objectContaining({ sessionKey: "agent:b:main", agentId: "b" }),
     ]);
   });
+
+  it("bounds one owner's queue and drains retained batches without another debounce", async () => {
+    vi.useFakeTimers();
+    const requestedInputs: string[] = [];
+    const requestTimes: number[] = [];
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      const items = (params as { items: Array<{ input: string }> }).items;
+      requestedInputs.push(...items.map((item) => item.input));
+      requestTimes.push(Date.now());
+      return { titles: {} };
+    });
+    configureToolTitleFetcher({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+      onTitlesChanged: null,
+    });
+
+    for (let index = 0; index < 240; index += 1) {
+      getToolCallTitle("bash", { command: `printf retained-command-${index}` });
+    }
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(request).toHaveBeenCalledTimes(4);
+    expect(requestedInputs).toHaveLength(96);
+    expect(requestedInputs[0]).toBe("printf retained-command-144");
+    expect(requestedInputs.at(-1)).toBe("printf retained-command-239");
+    expect(new Set(requestTimes).size).toBe(1);
+  });
+
+  it("bounds the queue across owners", async () => {
+    vi.useFakeTimers();
+    const requestedSessions: string[] = [];
+    const client = {
+      request: vi.fn(async (_method: string, params: unknown) => {
+        requestedSessions.push((params as { sessionKey: string }).sessionKey);
+        return { titles: {} };
+      }),
+    } as unknown as GatewayBrowserClient;
+
+    for (const sessionKey of ["owner-a", "owner-b", "owner-c"]) {
+      configureToolTitleFetcher({ client, sessionKey, onTitlesChanged: null });
+      for (let index = 0; index < 96; index += 1) {
+        getToolCallTitle("bash", { command: `printf ${sessionKey}-command-${index}` });
+      }
+    }
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(requestedSessions).toHaveLength(8);
+    expect(requestedSessions).not.toContain("owner-a");
+    expect(new Set(requestedSessions)).toEqual(new Set(["owner-b", "owner-c"]));
+  });
+
+  it("bounds retained failures even before their retry time", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn(async () => ({ titles: {} }));
+    configureToolTitleFetcher({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+      onTitlesChanged: null,
+    });
+    const argsFor = (index: number) => ({ command: `printf failed-command-${index}` });
+
+    for (let start = 0; start < 501; start += 96) {
+      for (let index = start; index < Math.min(start + 96, 501); index += 1) {
+        getToolCallTitle("bash", argsFor(index));
+      }
+      await vi.advanceTimersByTimeAsync(250);
+    }
+    getToolCallTitle("bash", argsFor(0));
+    getToolCallTitle("bash", argsFor(500));
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(request).toHaveBeenCalledTimes(22);
+  });
+
+  it("retries transient failures after their bounded retention expires", async () => {
+    vi.useFakeTimers();
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValue({ titles: {} });
+    configureToolTitleFetcher({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+      onTitlesChanged: null,
+    });
+    const args = { command: "pnpm test ui transient title retry" };
+
+    getToolCallTitle("bash", args);
+    await vi.advanceTimersByTimeAsync(250);
+    getToolCallTitle("bash", args);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    getToolCallTitle("bash", args);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not publish a title after its client lifecycle is cleared", async () => {
+    vi.useFakeTimers();
+    let resolveRequest: ((value: { titles: Record<string, string> }) => void) | undefined;
+    const request = vi.fn(
+      async () =>
+        await new Promise<{ titles: Record<string, string> }>((resolve) => {
+          resolveRequest = resolve;
+        }),
+    );
+    const notify = vi.fn();
+    const args = { command: "pnpm test ui stale title owner" };
+    configureToolTitleFetcher({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+      onTitlesChanged: notify,
+    });
+
+    getToolCallTitle("bash", args);
+    await vi.advanceTimersByTimeAsync(250);
+    const params = requireFirstRequestParams(request) as { items: Array<{ id: string }> };
+    const id = params.items[0]?.id;
+    if (!id || !resolveRequest) {
+      throw new Error("expected pending tool title request");
+    }
+    const replacementRequest = vi.fn(async () => ({ titles: {} }));
+    configureToolTitleFetcher({
+      client: { request: replacementRequest } as unknown as GatewayBrowserClient,
+      sessionKey: "replacement-session",
+      onTitlesChanged: null,
+    });
+    resolveRequest({ titles: { [id]: "Stale title" } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(getToolCallTitle("bash", args)).toBeUndefined();
+    expect(replacementRequest).not.toHaveBeenCalled();
+  });
+
+  it("times out a hung owner before continuing another owner", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn(
+      async (
+        _method: string,
+        params: unknown,
+        options?: { timeoutMs?: number },
+      ): Promise<{ titles: Record<string, string> }> => {
+        if ((params as { sessionKey: string }).sessionKey === "new-session") {
+          return { titles: {} };
+        }
+        return await new Promise((_, reject) => {
+          setTimeout(() => reject(new Error("request timed out")), options?.timeoutMs);
+        });
+      },
+    );
+    const client = { request } as unknown as GatewayBrowserClient;
+    configureToolTitleFetcher({
+      client,
+      sessionKey: "old-session",
+      onTitlesChanged: null,
+    });
+    getToolCallTitle("bash", { command: "pnpm test ui obsolete title owner" });
+    await vi.advanceTimersByTimeAsync(250);
+
+    configureToolTitleFetcher({
+      client,
+      sessionKey: "new-session",
+      onTitlesChanged: null,
+    });
+    getToolCallTitle("bash", { command: "pnpm test ui replacement title owner" });
+    await vi.advanceTimersByTimeAsync(250);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(29_750);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls[0]?.[2]).toEqual({ timeoutMs: 30_000 });
+    expect(request.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({ sessionKey: "new-session" }),
+    );
+  });
+
+  it("evicts least-recently-used successful titles", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn(async (_method: string, params: unknown) => {
+      const items = (params as { items: Array<{ id: string; input: string }> }).items;
+      return { titles: Object.fromEntries(items.map((item) => [item.id, item.input])) };
+    });
+    configureToolTitleFetcher({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessionKey: "main",
+      onTitlesChanged: null,
+    });
+    const argsFor = (index: number) => ({ command: `printf cached-command-${index}` });
+
+    for (let start = 0; start < 500; start += 96) {
+      for (let index = start; index < Math.min(start + 96, 500); index += 1) {
+        getToolCallTitle("bash", argsFor(index));
+      }
+      await vi.advanceTimersByTimeAsync(1_000);
+    }
+    expect(getToolCallTitle("bash", argsFor(0))).toBe("printf cached-command-0");
+    getToolCallTitle("bash", argsFor(500));
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(getToolCallTitle("bash", argsFor(0))).toBe("printf cached-command-0");
+    expect(getToolCallTitle("bash", argsFor(1))).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(request).toHaveBeenCalledTimes(23);
+  });
 });

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -16,13 +16,21 @@ import { fnv1aUtf16 } from "../../lib/fnv1a.ts";
 
 const MAX_TITLE_INPUT_CHARS = 2_000;
 const MAX_ITEMS_PER_REQUEST = 24;
+// Titles/failures retain only small digests and strings. Queue caps additionally
+// bound raw tool input to below 400k UTF-16 code units across split panes.
+const MAX_CACHED_TITLES = 500;
+const MAX_FAILED_TITLES = 500;
+const MAX_QUEUED_ITEMS_PER_OWNER = 96;
+const MAX_QUEUED_ITEMS = 192;
+const FAILURE_RETRY_MS = 60_000;
+const REQUEST_TIMEOUT_MS = 30_000;
 const REQUEST_DEBOUNCE_MS = 250;
 const MIN_COMMAND_CHARS_FOR_TITLE = 12;
 const MIN_GENERIC_INPUT_CHARS_FOR_TITLE = 120;
 
 const titlesByKey = new Map<string, string>();
 const pendingKeys = new Set<string>();
-const failedKeys = new Set<string>();
+const failedAtByKey = new Map<string, number>();
 // Bumped whenever titles land; chat threads include it in their lit guard()
 // dependencies so cached row subtrees repaint with the new titles.
 let titlesVersion = 0;
@@ -50,6 +58,8 @@ type ToolTitlesResult = { titles?: Record<string, string>; disabled?: boolean };
 let titlesDisabledByGateway = false;
 let queue = new Map<string, PendingItem>();
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
+let activeFlush: object | null = null;
+let generation = 0;
 let activeClient: GatewayBrowserClient | null = null;
 let activeSessionKey: string | null = null;
 let activeAgentId: string | null = null;
@@ -59,6 +69,75 @@ let notifyUpdate: (() => void) | null = null;
 function digest(name: string, input: string): string {
   const source = `${name}\u0000${input}`;
   return `t${fnv1aUtf16(source).toString(36)}${source.length.toString(36)}`;
+}
+
+function deleteOldest<K, V>(map: Map<K, V>): void {
+  const oldest = map.keys().next();
+  if (!oldest.done) {
+    map.delete(oldest.value);
+  }
+}
+
+function setBoundedMap<K, V>(map: Map<K, V>, key: K, value: V, maxEntries: number): void {
+  map.delete(key);
+  map.set(key, value);
+  if (map.size > maxEntries) {
+    deleteOldest(map);
+  }
+}
+
+function hasRecentFailure(key: string): boolean {
+  const failedAt = failedAtByKey.get(key);
+  if (failedAt === undefined) {
+    return false;
+  }
+  if (Date.now() - failedAt < FAILURE_RETRY_MS) {
+    return true;
+  }
+  failedAtByKey.delete(key);
+  return false;
+}
+
+function recordFailure(key: string): void {
+  setBoundedMap(failedAtByKey, key, Date.now(), MAX_FAILED_TITLES);
+}
+
+function sameOwner(left: PendingItem, right: PendingItem): boolean {
+  return (
+    left.client === right.client &&
+    left.sessionKey === right.sessionKey &&
+    left.agentId === right.agentId
+  );
+}
+
+function trimQueue(newest: PendingItem): void {
+  let ownerCount = 0;
+  let oldestOwnerKey: string | null = null;
+  for (const [key, item] of queue) {
+    if (sameOwner(item, newest)) {
+      ownerCount += 1;
+      oldestOwnerKey ??= key;
+    }
+  }
+  if (ownerCount > MAX_QUEUED_ITEMS_PER_OWNER && oldestOwnerKey) {
+    queue.delete(oldestOwnerKey);
+  }
+  if (queue.size > MAX_QUEUED_ITEMS) {
+    deleteOldest(queue);
+  }
+}
+
+function resetToolTitleState(): void {
+  titlesDisabledByGateway = false;
+  generation += 1;
+  titlesByKey.clear();
+  pendingKeys.clear();
+  failedAtByKey.clear();
+  queue = new Map();
+  if (flushTimer) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
 }
 
 function serializeArgs(args: unknown): string | null {
@@ -112,6 +191,10 @@ export function getToolCallTitle(name: string, args: unknown): string | undefine
   }
   const cached = titlesByKey.get(request.key);
   if (cached) {
+    // Map insertion order is the LRU order; frequently visible rows survive
+    // transcript churn while old decorative titles fall back safely.
+    titlesByKey.delete(request.key);
+    titlesByKey.set(request.key, cached);
     return cached;
   }
   scheduleTitleRequest(name, request);
@@ -125,19 +208,8 @@ export function configureToolTitleFetcher(params: {
   agentId?: string | null;
   onTitlesChanged: (() => void) | null;
 }): void {
-  if (!params.client) {
-    titlesDisabledByGateway = false;
-    titlesByKey.clear();
-    pendingKeys.clear();
-    failedKeys.clear();
-    queue = new Map();
-    if (flushTimer) {
-      clearTimeout(flushTimer);
-      flushTimer = null;
-    }
-  }
-  if (params.client !== activeClient) {
-    titlesDisabledByGateway = false;
+  if (!params.client || params.client !== activeClient) {
+    resetToolTitleState();
   }
   activeClient = params.client;
   activeSessionKey = params.sessionKey;
@@ -152,12 +224,12 @@ function scheduleTitleRequest(name: string, request: { key: string; input: strin
     !activeSessionKey ||
     titlesByKey.has(request.key) ||
     pendingKeys.has(request.key) ||
-    failedKeys.has(request.key) ||
+    hasRecentFailure(request.key) ||
     queue.has(request.key)
   ) {
     return;
   }
-  queue.set(request.key, {
+  const item: PendingItem = {
     key: request.key,
     name,
     input: request.input,
@@ -165,7 +237,14 @@ function scheduleTitleRequest(name: string, request: { key: string; input: strin
     agentId: activeAgentId,
     client: activeClient,
     notify: notifyUpdate,
-  });
+  };
+  queue.set(request.key, item);
+  // Prefer newly rendered rows and bound retained callbacks/tool input per
+  // owner as well as across split panes.
+  trimQueue(item);
+  if (activeFlush) {
+    return;
+  }
   flushTimer ??= setTimeout(() => {
     flushTimer = null;
     void flushTitleQueue();
@@ -173,6 +252,9 @@ function scheduleTitleRequest(name: string, request: { key: string; input: strin
 }
 
 async function flushTitleQueue(): Promise<void> {
+  if (activeFlush) {
+    return;
+  }
   // One request per scheduling pane (client + session + agent); other panes'
   // items stay queued for the follow-up flush.
   const head = queue.values().next().value;
@@ -180,6 +262,9 @@ async function flushTitleQueue(): Promise<void> {
     queue = new Map();
     return;
   }
+  const flushToken = {};
+  const flushGeneration = generation;
+  activeFlush = flushToken;
   const batch: PendingItem[] = [];
   for (const item of queue.values()) {
     if (
@@ -195,13 +280,19 @@ async function flushTitleQueue(): Promise<void> {
     queue.delete(item.key);
     pendingKeys.add(item.key);
   }
-  const hasBacklog = queue.size > 0;
   try {
-    const result = await head.client.request<ToolTitlesResult>("chat.toolTitles", {
-      sessionKey: head.sessionKey,
-      ...(head.agentId ? { agentId: head.agentId } : {}),
-      items: batch.map((item) => ({ id: item.key, name: item.name, input: item.input })),
-    });
+    const result = await head.client.request<ToolTitlesResult>(
+      "chat.toolTitles",
+      {
+        sessionKey: head.sessionKey,
+        ...(head.agentId ? { agentId: head.agentId } : {}),
+        items: batch.map((item) => ({ id: item.key, name: item.name, input: item.input })),
+      },
+      { timeoutMs: REQUEST_TIMEOUT_MS },
+    );
+    if (flushGeneration !== generation) {
+      return;
+    }
     if (result?.disabled === true) {
       titlesDisabledByGateway = true;
       queue = new Map();
@@ -213,10 +304,10 @@ async function flushTitleQueue(): Promise<void> {
       const rawTitle = titles[item.key];
       const title = typeof rawTitle === "string" ? rawTitle.trim() : "";
       if (title) {
-        titlesByKey.set(item.key, title);
+        setBoundedMap(titlesByKey, item.key, title, MAX_CACHED_TITLES);
         changed = true;
       } else {
-        failedKeys.add(item.key);
+        recordFailure(item.key);
       }
     }
     if (changed) {
@@ -234,18 +325,28 @@ async function flushTitleQueue(): Promise<void> {
   } catch {
     // Gateway without the method, no usable cheap model, transient errors:
     // titles are decorative, so fail closed and keep deterministic labels.
-    for (const item of batch) {
-      failedKeys.add(item.key);
+    if (flushGeneration === generation) {
+      for (const item of batch) {
+        recordFailure(item.key);
+      }
     }
   } finally {
-    for (const item of batch) {
-      pendingKeys.delete(item.key);
+    if (flushGeneration === generation) {
+      for (const item of batch) {
+        pendingKeys.delete(item.key);
+      }
     }
-    if (hasBacklog && !flushTimer) {
-      flushTimer = setTimeout(() => {
-        flushTimer = null;
+    if (activeFlush === flushToken) {
+      activeFlush = null;
+      // The debounce coalesces a new burst once. Existing backlog drains
+      // serially without adding 250 ms between already queued batches.
+      if (queue.size > 0) {
+        if (flushTimer) {
+          clearTimeout(flushTimer);
+          flushTimer = null;
+        }
         void flushTitleQueue();
-      }, REQUEST_DEBOUNCE_MS);
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #129225

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where long-lived Control UI sessions retained every generated or failed tool title and could queue unbounded serialized tool input. Large transcripts also waited another 250 ms between every 24-item follow-up batch, delaying newly visible titles and extending background work.

## Why This Change Was Made

The Control UI title-state owner now keeps successful titles in a 500-entry LRU, retains at most 500 failures for one minute before retrying, and caps queued work at 96 items per client/session/agent owner and 192 items globally. It preserves the existing 24-item protocol limit, captured pane routing, deterministic fallback labels, and one initial debounce, then drains retained batches serially without repeated debounce pauses.

Title requests now use the Gateway client's existing 30-second request deadline. Client lifecycle changes retire queued/cached browser state and prevent stale responses from publishing into the replacement lifecycle.

This is a UI-only repair: it adds no dependency, config, protocol, public API, or persistent-store change.

## User Impact

Long-lived Control UI sessions have predictable browser memory and queued-input bounds. Temporary title-generation failures recover after one minute, current transcript rows are preferred when a queue overflows, and large retained backlogs begin all follow-up batches without an extra 250 ms per batch. Evicted, dropped, timed-out, or failed decorative titles continue to use the existing deterministic labels.

## Evidence

- Pre-fix focused regression: 3 new cases failed on unmodified production code (unbounded/repeatedly delayed queue, permanent failure suppression, and non-evicting success cache).
- `node scripts/run-vitest.mjs ui/src/pages/chat/tool-titles.test.ts` — 15/15 passed after the repair and again after rebasing onto current `origin/main`.
- `pnpm check:changed -- ui/src/pages/chat/tool-titles.ts ui/src/pages/chat/tool-titles.test.ts` — passed the repository-classified core-test and UI lanes, including typechecks, formatting, lint, dead exports, policy ratchets, and UI i18n verification.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings, with TruffleHog clean.
- Production: +134/-33 (net +101). Tests: +208/-0. The production growth owns the missing LRU, failure TTL/cap, queue bounds, serial request deadline, and lifecycle-generation contracts.
- Visual before/after proof is not applicable: title rendering and deterministic fallbacks are intentionally unchanged, while the defect is browser retention and RPC scheduling measured by the fake-timer regressions.

## Open questions

- A client-side request deadline retires local pending state but cannot cancel model work already dispatched inside the Gateway. The serialized UI owner does not start the next batch before settlement/deadline; propagating cancellation through the Gateway handler would be a separate protocol/server contract.
- The Gateway also persists generated titles in its per-agent SQLite cache. This issue describes browser-process state, and changing persistent retention policy requires a separate maintainer-approved storage decision, so this PR does not alter it.

## AI Assistance

AI-assisted. I reviewed the full title-generation lifecycle and repository history, validated the failing regressions before changing production code, addressed the independent critic's lifecycle findings, and ran the repository's required autoreview workflow.
