### PR TITLE
fix: return JSON when marketplace listing fails

### DIFF
--- a/src/cli/plugins-cli.marketplace-entries.test.ts
+++ b/src/cli/plugins-cli.marketplace-entries.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExpectedCliError, formatCliJsonFailure } from "./failure-output.js";
 import { createHostedMarketplaceFeedFixture } from "./plugins-marketplace-feed.test-support.js";
 
 const mocks = vi.hoisted(() => {
@@ -374,17 +375,22 @@ describe("plugins marketplace list", () => {
     expect(mocks.defaultRuntime.error).not.toHaveBeenCalled();
   });
 
-  it("preserves remote source failure diagnostics without polluting JSON stdout", async () => {
-    mockMarketplaceListResult({ ok: false, error: "mock git remote unavailable" });
+  it("hands quiet remote source failures to the canonical JSON error renderer", async () => {
+    const message = "mock git remote unavailable";
+    mockMarketplaceListResult({ ok: false, error: message });
     const { runPluginMarketplaceListCommand } = await import("./plugins-cli.runtime.js");
 
-    await expect(runPluginMarketplaceListCommand(source, { json: true })).rejects.toThrow("exit 1");
-
-    expect(mocks.defaultRuntime.log).not.toHaveBeenCalled();
-    expect(mocks.defaultRuntime.error).toHaveBeenCalledExactlyOnceWith(
-      "mock git remote unavailable",
+    const failure = await runPluginMarketplaceListCommand(source, { json: true }).catch(
+      (error: unknown) => error,
     );
-    expect(mocks.defaultRuntime.exit).toHaveBeenCalledExactlyOnceWith(1);
-    expect(mocks.defaultRuntime.writeJson).not.toHaveBeenCalled();
+
+    expect(failure).toBeInstanceOf(ExpectedCliError);
+    expect(formatCliJsonFailure(failure)).toEqual({
+      ok: false,
+      error: { type: "cli_error", message },
+    });
+    expect(mocks.defaultRuntime.log).not.toHaveBeenCalled();
+    expect(mocks.defaultRuntime.error).not.toHaveBeenCalled();
+    expect(mocks.defaultRuntime.exit).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -20,6 +20,7 @@ import { tracePluginLifecyclePhaseAsync } from "../plugins/plugin-lifecycle-trac
 import { defaultRuntime } from "../runtime.js";
 import { shortenHomeInString } from "../utils.js";
 import { formatMissingPluginMessage } from "./error-format.js";
+import { ExpectedCliError } from "./failure-output.js";
 import type {
   PluginDoctorOptions,
   PluginMarketplaceEntriesOptions,
@@ -965,18 +966,17 @@ export async function runPluginMarketplaceListCommand(
     logger: opts.json ? quietPluginJsonLogger : createPluginInstallLogger(),
   });
   if (!result.ok) {
-    defaultRuntime.error(result.error);
-    return defaultRuntime.exit(1);
+    const message = result.error;
+    throw new ExpectedCliError({ message, humanOutput: message, machineOutput: message });
   }
 
   if (opts.json) {
-    defaultRuntime.writeJson({
+    return defaultRuntime.writeJson({
       source: result.sourceLabel,
       name: result.manifest.name,
       version: result.manifest.version,
       plugins: result.manifest.plugins,
     });
-    return;
   }
 
   if (result.manifest.plugins.length === 0) {

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -6,9 +6,14 @@ import { DatabaseSync } from "node:sqlite";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 
-function runBuiltCli(tempHome: string, args: string[], envOverrides: NodeJS.ProcessEnv = {}) {
+function runBuiltCli(
+  tempHome: string,
+  args: string[],
+  envOverrides: NodeJS.ProcessEnv = {},
+  options: { inheritEnvironment?: boolean } = {},
+) {
   const env: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...(options.inheritEnvironment === false ? { PATH: process.env.PATH } : process.env),
     HOME: tempHome,
     USERPROFILE: tempHome,
     OPENCLAW_TEST_FAST: "1",
@@ -2292,6 +2297,98 @@ describe("cli json stdout contract", () => {
         expect(result.stderr).toContain("\u001B[?25h");
       },
       { prefix: "openclaw-plugins-json-tty-failure-e2e-" },
+    );
+  });
+
+  it.each([
+    { name: "a missing local marketplace", source: "local" },
+    {
+      name: "a missing local marketplace through forced Commander",
+      source: "local",
+      commander: true,
+    },
+    { name: "a missing local marketplace with dual TTYs", source: "local", tty: true },
+    { name: "an unavailable Git marketplace", source: "git" },
+    { name: "an unavailable Git marketplace with dual TTYs", source: "git", tty: true },
+    { name: "a missing local marketplace in human mode", source: "local", human: true },
+    { name: "an unavailable Git marketplace in human mode", source: "git", human: true },
+  ])("keeps $name failures on the canonical marketplace output boundary", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const stateDir = path.join(tempHome, "isolated-state");
+        const configPath = path.join(tempHome, "missing-openclaw.json");
+        const source =
+          testCase.source === "git"
+            ? "ssh://marketplace.invalid/openclaw/unavailable.git"
+            : path.join(tempHome, "missing-marketplace");
+        const ttyPreload = Buffer.from(
+          'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true }); Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });',
+        ).toString("base64");
+
+        await expect(fs.stat(stateDir)).rejects.toMatchObject({ code: "ENOENT" });
+
+        const result = runBuiltCli(
+          tempHome,
+          ["plugins", "marketplace", "list", source, ...("human" in testCase ? [] : ["--json"])],
+          {
+            GIT_SSH_COMMAND: `${JSON.stringify(process.execPath)} -e "process.exit(1)"`,
+            GIT_TERMINAL_PROMPT: "0",
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+            OPENCLAW_STATE_DIR: stateDir,
+            ...("commander" in testCase ? { OPENCLAW_DISABLE_ROUTE_FIRST: "1" } : {}),
+            ...("tty" in testCase
+              ? { NODE_OPTIONS: `--import=data:text/javascript;base64,${ttyPreload}` }
+              : {}),
+          },
+          { inheritEnvironment: false },
+        );
+        const expectedMessage =
+          testCase.source === "git"
+            ? `failed to clone marketplace source ${source}:`
+            : `unsupported marketplace source: ${source}`;
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(result.stderr).toContain(expectedMessage);
+
+        if ("human" in testCase) {
+          if (testCase.source === "git") {
+            expect(result.stdout).toContain(`Cloning marketplace source ${source}...`);
+          }
+        } else {
+          expect(result.stdout, result.stderr).not.toMatch(/[\u001B\u0007]/u);
+          expect(result.stdout).not.toContain("Cloning marketplace source");
+          expect(JSON.parse(result.stdout)).toEqual({
+            ok: false,
+            error: {
+              type: "cli_error",
+              message:
+                testCase.source === "git"
+                  ? expect.stringContaining(expectedMessage)
+                  : expectedMessage,
+            },
+          });
+          if ("tty" in testCase) {
+            expect(result.stderr).toContain("\u001B[?25h");
+          }
+        }
+
+        if (testCase.source === "git") {
+          expect(result.stderr).toContain("fatal: Could not read from remote repository.");
+          const clonePath = /Cloning into '([^']+)'\.\.\./u.exec(result.stderr)?.[1];
+          expect(clonePath).toBeDefined();
+          await expect(fs.stat(path.dirname(clonePath as string))).rejects.toMatchObject({
+            code: "ENOENT",
+          });
+        }
+
+        await expect(fs.stat(stateDir)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(fs.stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(fs.stat(path.join(tempHome, ".claude"))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      },
+      { prefix: "openclaw-marketplace-json-failure-e2e-" },
     );
   });
 


### PR DESCRIPTION
Closes #129262

## What Problem This Solves

Fixes an issue where users running `openclaw plugins marketplace list <source> --json` received exit status 1 with empty stdout when the marketplace source was missing or unavailable. Automation therefore had no parseable failure result even though the command advertised JSON output.

## Why This Change Was Made

The marketplace domain already returned a discriminated failure, but the CLI runtime rendered that failure locally to stderr and exited before the root CLI failure renderer could run. The command now throws `ExpectedCliError`, reusing the canonical root-owned JSON envelope while preserving marketplace resolution, clone/cache cleanup, human diagnostics, progress output, and successful JSON payloads.

The built-process regression coverage also gains an opt-in hermetic environment mode so credential-driven startup convergence cannot create unrelated state during no-state assertions. Existing callers continue inheriting the parent environment by default.

## User Impact

Marketplace listing failures now produce exactly one canonical JSON failure document on stdout in JSON mode. Human mode retains the existing actionable error and clone progress, and all failure paths continue to exit nonzero.

## Evidence

- Demonstrated both owner-level and real built-CLI regressions failing before the repair.
- 32 focused marketplace/search/failure-output tests passed.
- 7 focused built-CLI marketplace output-boundary cases passed, covering missing local sources, deterministic Git failures, forced Commander routing, dual TTYs, stdout purity, cleanup, and no persistent state/config/cache artifacts.
- `pnpm build` passed on the rebased head.
- `pnpm check:changed` passed on the rebased head, including formatting, lint, type checks, dead exports, architecture guards, and import-cycle checks.
- Fresh P1 autoreview found no accepted or actionable findings and rated the patch correct at 0.94.
- Production delta: +4/-4 (net zero). Test/support delta: +113/-10.