### PR TITLE
fix(mac): prevent network discovery crashes on addressless interfaces

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/NetworkInterfaceIPv4.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/NetworkInterfaceIPv4.swift
@@ -17,14 +17,14 @@ public enum NetworkInterfaceIPv4 {
             let flags = Int32(ptr.pointee.ifa_flags)
             let isUp = (flags & IFF_UP) != 0
             let isLoopback = (flags & IFF_LOOPBACK) != 0
-            let family = ptr.pointee.ifa_addr.pointee.sa_family
-            if !isUp || isLoopback || family != UInt8(AF_INET) { continue }
+            guard isUp, !isLoopback, let addrPtr = ptr.pointee.ifa_addr,
+                  addrPtr.pointee.sa_family == UInt8(AF_INET) else { continue }
 
-            var addr = ptr.pointee.ifa_addr.pointee
+            var addr = addrPtr.pointee
             var buffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
             let result = getnameinfo(
                 &addr,
-                socklen_t(ptr.pointee.ifa_addr.pointee.sa_len),
+                socklen_t(addrPtr.pointee.sa_len),
                 &buffer,
                 socklen_t(buffer.count),
                 nil,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS application could crash while discovering network interfaces when Darwin returned a valid interface record that temporarily had no assigned address.

## Why This Change Was Made

Darwin documents that `getifaddrs` may return a null `ifa_addr`. The existing iOS sibling already checks that contract, while the shared macOS networking owner unconditionally dereferenced it. Guard the pointer before reading the address family and reuse the verified pointer for the remaining address operations.

Production delta: **4 additions / 4 deletions (net 0)**. No public API, configuration, protocol, authentication, persistence, or dependency changes.

## User Impact

Network discovery, presence reporting, Mac connection flows, and Tailscale integration no longer crash when a VPN, virtual adapter, or transitioning interface temporarily has no assigned address.

## Evidence

- Direct local Darwin `getifaddrs` documentation explicitly permits `ifa_addr == NULL`.
- Deterministic compiled actual-owner fixture supplied an up, non-loopback, addressless interface followed by a valid IPv4 interface: **before**, process crashed with exit 133; **after**, it skipped the null entry and returned the valid `192.0.2.23` address.
- `swiftc -typecheck` passed for both the shared IPv4 owner and its public caller.
- Repository-configured SwiftFormat lint passed with zero formatting changes; `git diff --check` passed.
- Full SwiftPM suite intentionally not run because this isolated worktree lacks its package build cache and would require remote dependency resolution; the actual-owner compiled crash regression directly verifies the changed OS boundary.
- Fresh independent structured review was **clean**.
