### PR TITLE
fix(plugins): make marketplace installs transactional

### DIFF
--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -4,13 +4,8 @@ import { assertConfigWriteAllowedInCurrentMode } from "../config/config.js";
 import { reportClawHubPluginInstallTelemetry } from "../infra/clawhub-packages.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { createManagedPluginArtifactConsentHandler } from "../plugins/capability-consent.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "../plugins/clawhub.js";
-import { resolveDefaultPluginExtensionsDir } from "../plugins/install-paths.js";
-import { persistPluginInstall } from "../plugins/install-persistence.js";
-import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import { installManagedPluginSource } from "../plugins/management-service.js";
-import { installPluginFromMarketplace } from "../plugins/marketplace.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { tracePluginLifecyclePhaseAsync } from "../plugins/plugin-lifecycle-trace.js";
 import { defaultRuntime } from "../runtime.js";
@@ -121,23 +116,19 @@ async function runPluginInstallCommandUnlocked(
     ) {
       return runtime.exit(1);
     }
-    const artifactConsent = createManagedPluginArtifactConsentHandler({
-      config: snapshot.config,
-      source: "marketplace",
-      spec: `${raw}@${preflight.marketplace}`,
-      ...(installMode === "update"
-        ? { previousRecords: await loadInstalledPluginIndexInstallRecords() }
-        : {}),
+    const result = await installManagedPluginSource({
+      request: {
+        source: "marketplace",
+        marketplace: preflight.marketplace,
+        plugin: raw,
+        mode: installMode,
+      },
+      snapshot,
       ...capabilityConsent,
-    });
-    const result = await installPluginFromMarketplace({
-      ...safetyOverrides,
-      marketplace: preflight.marketplace,
-      mode: installMode,
-      plugin: raw,
-      extensionsDir: resolveDefaultPluginExtensionsDir(),
+      safetyOverrides,
       logger: createPluginInstallLogger(runtime),
-      onBeforePluginArtifactCommit: artifactConsent.onBeforePluginArtifactCommit,
+      invalidateRuntimeCache,
+      runtime,
     });
     if (!result.ok) {
       if (!isClawHubBlockedCliFailure(result)) {
@@ -145,22 +136,6 @@ async function runPluginInstallCommandUnlocked(
       }
       return runtime.exit(1);
     }
-
-    const install = artifactConsent.applyAcceptedSurface(result.pluginId, {
-      source: "marketplace",
-      installPath: result.targetDir,
-      version: result.version,
-      marketplaceName: result.marketplaceName,
-      marketplaceSource: result.marketplaceSource,
-      marketplacePlugin: result.marketplacePlugin,
-    });
-    await persistPluginInstall({
-      snapshot,
-      pluginId: result.pluginId,
-      install,
-      invalidateRuntimeCache,
-      runtime,
-    });
     return;
   }
 
@@ -251,6 +226,7 @@ async function runPluginInstallCommandUnlocked(
       return runtime.exit(1);
     }
 
+    case "marketplace":
     case "npm-pack":
     case "git": {
       const result = await installManagedPluginSource({

--- a/src/plugins/management-service.install-compensation.test.ts
+++ b/src/plugins/management-service.install-compensation.test.ts
@@ -31,6 +31,9 @@ vi.mock("./install.js", async (importOriginal) => ({
   installPluginFromNpmPackArchive: (...args: unknown[]) => mocks.install(...args),
   installPluginFromPath: (...args: unknown[]) => mocks.install(...args),
 }));
+vi.mock("./marketplace.js", () => ({
+  installPluginFromMarketplace: (...args: unknown[]) => mocks.install(...args),
+}));
 vi.mock("./install-persistence.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./install-persistence.js")>()),
   persistPluginInstall: (...args: unknown[]) => mocks.persist(...args),
@@ -46,6 +49,12 @@ const requests = [
   { source: "npm-pack", archivePath: "/incoming.tgz", mode: "update" },
   { source: "git", spec: "git:example/demo", mode: "update" },
   { source: "clawhub", spec: "clawhub:community/demo", mode: "update" },
+  {
+    source: "marketplace",
+    marketplace: "local/repo",
+    plugin: "demo",
+    mode: "update",
+  },
 ] satisfies ManagedPluginSourceInstallRequest[];
 
 describe("managed plugin install transactions", () => {
@@ -73,6 +82,13 @@ describe("managed plugin install transactions", () => {
           params: Parameters<typeof import("./install-persistence.js").persistPluginInstall>[0],
         ) => {
           expect(params.install.acceptedSurface?.tools).toEqual(["demo.write"]);
+          if (request.source === "marketplace") {
+            expect(params.install).toMatchObject({
+              source: "marketplace",
+              marketplaceSource: request.marketplace,
+              marketplacePlugin: request.plugin,
+            });
+          }
           if (failure === "before-commit") {
             throw conflict;
           }
@@ -115,6 +131,9 @@ describe("managed plugin install transactions", () => {
             targetDir,
             version: "2.0.0",
             extensions: [],
+            marketplaceName: "Local",
+            marketplaceSource: "local/repo",
+            marketplacePlugin: "demo",
             git: { url: "https://example.test/demo.git" },
             packageName: "community/demo",
             clawhub: {

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -94,6 +94,7 @@ import { resolveInstalledPluginPackageOwnership } from "./installed-plugin-packa
 import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
+import { installPluginFromMarketplace } from "./marketplace.js";
 import {
   resolveTrustedOfficialClawHubPackageName,
   resolveTrustedSourceLinkedOfficialClawHubSpec,
@@ -200,6 +201,12 @@ export type ManagedPluginSourceInstallRequest =
       mode: "install" | "update";
     }
   | { source: "git"; spec: string; mode: "install" | "update" }
+  | {
+      source: "marketplace";
+      marketplace: string;
+      plugin: string;
+      mode: "install" | "update";
+    }
   | {
       source: "clawhub";
       spec: string;
@@ -1471,7 +1478,11 @@ async function installResolvedManagedPluginSource(
         config: params.snapshot.config,
         env,
         source,
-        ...("spec" in request ? { spec: request.spec } : {}),
+        ...(request.source === "marketplace"
+          ? { spec: `${request.plugin}@${request.marketplace}` }
+          : "spec" in request
+            ? { spec: request.spec }
+            : {}),
         ...("expectedIntegrity" in request && request.expectedIntegrity
           ? { expectedIntegrity: request.expectedIntegrity }
           : {}),
@@ -1573,6 +1584,27 @@ async function installResolvedManagedPluginSource(
           sourcePath: request.path,
           installPath: installPath ?? result.targetDir,
           version: result.version,
+        }),
+      },
+    );
+  }
+
+  if (request.source === "marketplace") {
+    return await complete(
+      installPluginFromMarketplace({
+        ...common,
+        marketplace: request.marketplace,
+        plugin: request.plugin,
+        mode: request.mode,
+      }),
+      {
+        install: (result) => ({
+          source: "marketplace",
+          installPath: result.targetDir,
+          version: result.version,
+          marketplaceName: result.marketplaceName,
+          marketplaceSource: result.marketplaceSource,
+          marketplacePlugin: result.marketplacePlugin,
         }),
       },
     );


### PR DESCRIPTION
## What Problem This Solves

Marketplace plugin installs still published payload bytes before durable config and install-record persistence. If persistence rejected the replacement, the CLI reported failure while the new marketplace payload remained active.

This is the marketplace remainder of #127244. #122984 landed the stronger canonical transaction owner as `0c313d712839670f3ac60f8fd238af7e308cdc18` for local, npm, npm-pack, Git, and ClawHub sources, and explicitly left marketplace routing as a named follow-up.

## Why This Change Was Made

Route marketplace installs through the existing `installManagedPluginSource` owner introduced by #122984. That owner requests the installer's deferred transaction, records the authoritative persistence commit boundary, rolls back only pre-commit failures, and retains committed payloads after late refresh failures.

The obsolete compensation implementation from this PR's prior head is not retained or replayed. The CLI's duplicate marketplace capability-consent and persistence path is removed.

## User Impact

Failed marketplace replacements restore the previous payload and durable record as one generation. Successful persistence commits the replacement, while a post-commit refresh failure no longer rolls back already-authoritative bytes.

## Evidence

- Pre-fix current-main regression: `node scripts/run-vitest.mjs src/plugins/management-service.install-compensation.test.ts` failed because the marketplace row never invoked the marketplace installer through the transaction owner.
- Post-fix focused proof: `node scripts/run-vitest.mjs src/plugins/management-service.install-compensation.test.ts src/cli/plugins-cli.install.test.ts` — 211 tests passed.
- `node scripts/check-changed.mjs -- src/cli/plugins-install-command.ts src/plugins/management-service.ts src/plugins/management-service.install-compensation.test.ts` — passed.
- Fresh Codex autoreview against `origin/main` — no accepted/actionable findings.
- Production LOC: +45/-37 (net +8). Tests: +19/-0. The production growth adds the marketplace request/owner branch and deletes the CLI's parallel persistence flow.
- Exact-head CI run `33063448628` passed for `f4b2abb59eb06c0dd83f138ad4d49526f7475c30`.
- Blacksmith Testbox run `33063639575` fetched and verified that pushed SHA in a detached worktree, then passed 211/211 tests; lease `tbx_01m11cjd49m1sthpqppz0nd705` was cleaned after success.

Fixes the remaining marketplace path from #127244.
