### PR TITLE
fix(whatsapp): send read receipts at message receive time

### DIFF
--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -409,6 +409,8 @@ A liveness probe sent to your own number can therefore become agent input with `
 
     Per-account override: `channels.whatsapp.accounts.<id>.sendReadReceipts`. Self-chat safeguards skip read receipts even when globally enabled (see [Self-chat behavior](/channels/whatsapp#personal-number-and-self-chat-behavior)).
 
+    Read receipts fire as soon as the gateway ingests the message — before the agent turn starts — so senders see blue ticks within seconds instead of only once a reply arrives.
+
   </Accordion>
 </AccordionGroup>
 

--- a/extensions/whatsapp/src/inbound/message-debounce.ts
+++ b/extensions/whatsapp/src/inbound/message-debounce.ts
@@ -2,7 +2,7 @@ import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debo
 import { fanInChannelIngressLifecycles } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { getPrimaryIdentityId } from "../identity.js";
 import { requireWhatsAppInboundAdmission } from "./admission.js";
-import type { WhatsAppIngressLifecycle, WhatsAppReadReceiptTarget } from "./durable-receive.js";
+import type { WhatsAppIngressLifecycle } from "./durable-receive.js";
 import { attachWhatsAppIngressLifecycle } from "./ingress-lifecycle.js";
 import type { AdmittedWebInboundCallbackMessage } from "./types.js";
 
@@ -10,7 +10,6 @@ export type WhatsAppQueuedInboundMessage = AdmittedWebInboundCallbackMessage & {
   debounceKey?: string;
   debounceKeyTracked?: boolean;
   turnAdoptionLifecycle?: WhatsAppIngressLifecycle;
-  readReceipt?: WhatsAppReadReceiptTarget;
   receiveOrder?: number;
 };
 
@@ -18,7 +17,6 @@ export function createWhatsAppInboundMessageDebouncer(options: {
   resolveDebounceMs: () => number;
   onMessage: (msg: AdmittedWebInboundCallbackMessage) => Promise<void>;
   shouldDebounce?: (msg: AdmittedWebInboundCallbackMessage) => boolean;
-  markRead: (target: WhatsAppReadReceiptTarget | undefined) => Promise<void>;
   onPendingWorkChanged: () => void;
   onError: (error: unknown) => void;
 }) {
@@ -93,7 +91,6 @@ export function createWhatsAppInboundMessageDebouncer(options: {
             if (orderedEntries.length === 1) {
               await options.onMessage(attachWhatsAppIngressLifecycle(last, admissionLifecycle));
               await settle();
-              await Promise.all(orderedEntries.map((entry) => options.markRead(entry.readReceipt)));
               return;
             }
             const mentioned = new Set<string>();
@@ -134,7 +131,6 @@ export function createWhatsAppInboundMessageDebouncer(options: {
             );
             await options.onMessage(combinedMessage);
             await settle();
-            await Promise.all(orderedEntries.map((entry) => options.markRead(entry.readReceipt)));
           } catch (error) {
             await abandon();
             throw error;

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -194,7 +194,6 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       }),
     onMessage: options.onMessage,
     shouldDebounce: options.shouldDebounce,
-    markRead: maybeMarkInboundAsRead,
     onPendingWorkChanged: publishPendingWorkState,
     onError: (error) => {
       inboundLogger.error({ error: String(error) }, "failed handling inbound web message");
@@ -229,7 +228,6 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
     inbound: WhatsAppNormalizedInboundMessage,
     enriched: WhatsAppEnrichedInboundMessage,
     durable: {
-      readReceipt?: WhatsAppReadReceiptTarget;
       receiveOrder?: number;
       turnAdoptionLifecycle?: WhatsAppIngressLifecycle;
     },
@@ -384,7 +382,6 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
         : undefined,
       group,
       turnAdoptionLifecycle: durable.turnAdoptionLifecycle,
-      readReceipt: durable.readReceipt,
       receiveOrder: durable.receiveOrder,
     };
     if (inboundMessage.event.id) {
@@ -463,10 +460,7 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
     ) {
       return "completed";
     }
-    const readReceipt = buildReadReceiptTarget(inbound);
-    const deliveryReadReceipt = inbound.access.isSelfChat ? undefined : readReceipt;
     if (context.skipStaleAppend === true) {
-      await maybeMarkNonSelfChatReadReceipt(inbound, readReceipt);
       return "completed";
     }
 
@@ -477,13 +471,11 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       logVerbose: (message) => logWhatsAppVerbose(options.verbose, message),
     });
     if (!enriched) {
-      await maybeMarkNonSelfChatReadReceipt(inbound, deliveryReadReceipt);
       return "completed";
     }
 
     recordAcceptedInboundActivity(options.accountId);
     await enqueueInboundMessage(msg, inbound, enriched, {
-      readReceipt: deliveryReadReceipt,
       receiveOrder: context.receiveOrder ?? context.receivedAt,
       turnAdoptionLifecycle: lifecycle,
     });
@@ -607,13 +599,27 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
         if (skipRecentOutboundEcho) {
           finishPreparation(null);
         } else {
+          let acceptedInbound: PreparedInbound | null | undefined;
           try {
-            finishPreparation(await normalizeInboundMessage(msg), true);
+            acceptedInbound = await normalizeInboundMessage(msg);
+            // Publish the prepared identity first so the durable drain never
+            // waits on a stalled receipt ack, then fire the read receipt.
+            finishPreparation(acceptedInbound, true);
           } catch (error) {
             finishPreparation(undefined);
+            acceptedInbound = undefined;
             inboundLogger.warn(
               { error: formatError(error) },
               "failed preparing WhatsApp inbound identity; durable drain will normalize again",
+            );
+          }
+          if (acceptedInbound) {
+            // Read receipts (blue ticks) fire at receive time: the sender sees
+            // the message was read as soon as the gateway ingests it, before
+            // the agent turn starts (issue #128875).
+            await maybeMarkNonSelfChatReadReceipt(
+              acceptedInbound,
+              buildReadReceiptTarget(acceptedInbound),
             );
           }
         }

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -36,6 +36,7 @@ import {
   type WhatsAppNormalizedInboundMessage,
 } from "./message-normalization.js";
 import { addWhatsAppOutboundMentionsToContent } from "./outbound-mentions.js";
+import { createWhatsAppReadReceiptDispatcher } from "./read-receipt-dispatch.js";
 import { normalizeWhatsAppSendResult } from "./send-result.js";
 import type { WhatsAppAttachedSocketSession } from "./socket-session.js";
 import type { WebInboundCallbackMessage } from "./types.js";
@@ -151,83 +152,12 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
         }
       : undefined;
 
-  // One read receipt per transport message id: the receive-time accepted path
-  // fires it, and later redeliveries (pending or completed verdicts) must not
-  // re-send it. Successful receipts and in-flight claims are tracked
-  // separately: a claim is only reserved while the markRead call is running
-  // and is released when it rejects or times out, so a later same-process
-  // redelivery can retry a lost receipt instead of being suppressed forever.
-  // The success memo is bounded like the prepared-inbound map; the in-flight
-  // claims are transient but are also bounded (READ_RECEIPT_INFLIGHT_MAX), so
-  // a stalled socket plus a burst of distinct messages cannot start unbounded
-  // socket work during the operation-timeout window.
-  const READ_RECEIPT_MEMO_MAX = 1000;
-  // Upper bound on concurrently stalled socket acknowledgements. markRead is
-  // bounded by the socket operation timeout (default 60s); while the socket
-  // is stalled, each distinct inbound message would otherwise start one more
-  // socket operation with no cap. When the window is full, new receipts are
-  // skipped without recording success, so a later redelivery can retry them
-  // once capacity frees up. Message admission is never blocked: the skip is
-  // instant and no queue is built.
-  const READ_RECEIPT_INFLIGHT_MAX = 32;
-  const readReceiptsSent = new Set<string>();
-  const readReceiptsInFlight = new Set<string>();
-  const buildReadReceiptDedupeKey = (target: WhatsAppReadReceiptTarget): string =>
-    createHash("sha256").update(`${target.remoteJid}\n${target.id}`).digest("hex");
-
-  const maybeMarkInboundAsRead = async (target: WhatsAppReadReceiptTarget | undefined) => {
-    if (!target || options.sendReadReceipts === false) {
-      return;
-    }
-    const dedupeKey = buildReadReceiptDedupeKey(target);
-    if (readReceiptsSent.has(dedupeKey)) {
-      logWhatsAppVerbose(
-        options.verbose,
-        `Skipping read receipt for already-acknowledged message ${target.id}`,
-      );
-      return;
-    }
-    if (readReceiptsInFlight.has(dedupeKey)) {
-      // A concurrent duplicate delivery is already acknowledging this
-      // message; it must not double-fire.
-      logWhatsAppVerbose(
-        options.verbose,
-        `Skipping read receipt for in-flight acknowledgement of message ${target.id}`,
-      );
-      return;
-    }
-    if (readReceiptsInFlight.size >= READ_RECEIPT_INFLIGHT_MAX) {
-      // The acknowledgement window is full of stalled socket operations.
-      // Skip without recording success so a later redelivery can retry this
-      // receipt once capacity frees up; admission of the message itself is
-      // unaffected.
-      logWhatsAppVerbose(
-        options.verbose,
-        `Read receipt dispatch saturated (${readReceiptsInFlight.size} in flight); deferring acknowledgement for message ${target.id}`,
-      );
-      return;
-    }
-    if (readReceiptsSent.size >= READ_RECEIPT_MEMO_MAX) {
-      const oldest = readReceiptsSent.keys().next().value;
-      if (oldest !== undefined) {
-        readReceiptsSent.delete(oldest);
-      }
-    }
-    readReceiptsInFlight.add(dedupeKey);
-    const { id, remoteJid, participant } = target;
-    try {
-      await socketSession.markRead(target);
-      // Record success only after the call resolves: a rejected or timed-out
-      // attempt releases its reservation below and stays retryable.
-      readReceiptsSent.add(dedupeKey);
-      const suffix = participant ? ` (participant ${participant})` : "";
-      logWhatsAppVerbose(options.verbose, `Marked message ${id} as read for ${remoteJid}${suffix}`);
-    } catch (err) {
-      logWhatsAppVerbose(options.verbose, `Failed to mark message ${id} read: ${String(err)}`);
-    } finally {
-      readReceiptsInFlight.delete(dedupeKey);
-    }
-  };
+  const readReceiptDispatcher = createWhatsAppReadReceiptDispatcher({
+    markRead: (target) => socketSession.markRead(target),
+    sendReadReceipts: options.sendReadReceipts !== false,
+    logVerbose: (message) => logWhatsAppVerbose(options.verbose, message),
+    logger: inboundLogger,
+  });
 
   const maybeLogSkippedSelfChatReadReceipt = (
     inbound: WhatsAppNormalizedInboundMessage,
@@ -247,16 +177,16 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       maybeLogSkippedSelfChatReadReceipt(inbound, target);
       return;
     }
-    await maybeMarkInboundAsRead(target);
+    await readReceiptDispatcher.maybeMarkInboundAsRead(target);
   };
 
   // Fire-and-track dispatch: the sequential upsert loop must never wait on a
   // read-receipt acknowledgement. markRead is bounded by the socket operation
   // timeout (default 60s), so one stalled receipt would otherwise delay the
   // admission of every later message in the same upsert. The dispatch is
-  // awaited nowhere; the dedupe reservation (readReceiptsInFlight) is taken
-  // synchronously when the async call starts and released when it settles,
-  // and errors are logged here so no rejection escapes unhandled.
+  // awaited nowhere; the dedupe reservation and bounded pending queue live in
+  // the read-receipt dispatcher, and errors are logged here so no rejection
+  // escapes unhandled.
   const dispatchReadReceipt = (
     inbound: WhatsAppNormalizedInboundMessage,
     target: WhatsAppReadReceiptTarget | undefined,

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -228,6 +228,25 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
     }
     await maybeMarkInboundAsRead(target);
   };
+
+  // Fire-and-track dispatch: the sequential upsert loop must never wait on a
+  // read-receipt acknowledgement. markRead is bounded by the socket operation
+  // timeout (default 60s), so one stalled receipt would otherwise delay the
+  // admission of every later message in the same upsert. The dispatch is
+  // awaited nowhere; the dedupe reservation (readReceiptsInFlight) is taken
+  // synchronously when the async call starts and released when it settles,
+  // and errors are logged here so no rejection escapes unhandled.
+  const dispatchReadReceipt = (
+    inbound: WhatsAppNormalizedInboundMessage,
+    target: WhatsAppReadReceiptTarget | undefined,
+  ) => {
+    maybeMarkNonSelfChatReadReceipt(inbound, target).catch((error) => {
+      inboundLogger.warn(
+        { error: formatError(error) },
+        "failed dispatching WhatsApp receive-time read receipt",
+      );
+    });
+  };
   const messageDebouncer = createWhatsAppInboundMessageDebouncer({
     resolveDebounceMs: () =>
       resolveInboundDebounceMs({
@@ -636,7 +655,7 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
         finishPreparation(undefined);
         const inbound = await normalizeInboundMessage(msg);
         if (inbound) {
-          await maybeMarkNonSelfChatReadReceipt(inbound, buildReadReceiptTarget(inbound));
+          dispatchReadReceipt(inbound, buildReadReceiptTarget(inbound));
         }
       } else if (result.kind === "durable" && result.queueResult.kind === "accepted") {
         if (skipRecentOutboundEcho) {
@@ -659,11 +678,10 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
           if (acceptedInbound) {
             // Read receipts (blue ticks) fire at receive time: the sender sees
             // the message was read as soon as the gateway ingests it, before
-            // the agent turn starts (issue #128875).
-            await maybeMarkNonSelfChatReadReceipt(
-              acceptedInbound,
-              buildReadReceiptTarget(acceptedInbound),
-            );
+            // the agent turn starts (issue #128875). Fire-and-track only: a
+            // stalled acknowledgement must not delay the admission of later
+            // messages in the same upsert.
+            dispatchReadReceipt(acceptedInbound, buildReadReceiptTarget(acceptedInbound));
           }
         }
       } else {

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -487,6 +487,15 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       return "completed";
     }
 
+    // Cold durable replay (restart recovery) bypasses handleMessagesUpsert,
+    // where every live receipt dispatch lives. Rows the live path admitted
+    // carry a preparation entry, so only rows without one still need the
+    // receive-time retry here; the dispatcher dedupes against any receipt
+    // the live path already sent.
+    if (preparation === undefined) {
+      dispatchReadReceipt(inbound, buildReadReceiptTarget(inbound));
+    }
+
     recordAcceptedInboundActivity(options.accountId);
     await enqueueInboundMessage(msg, inbound, enriched, {
       receiveOrder: context.receiveOrder ?? context.receivedAt,
@@ -638,6 +647,23 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       } else {
         // Pending redelivery leaves the first accepted delivery's preparation in place.
         finishPreparation(undefined);
+        // An active durable duplicate (row still pending or claimed) can carry
+        // a receive-time receipt whose first attempt failed: the admission
+        // verdict has no accepted branch for it, so a replay would otherwise
+        // never re-reach the dispatcher and the blue tick would stay lost.
+        // The dispatcher dedupes across sent/in-flight/pending, so completed
+        // or in-flight acknowledgements stay no-ops, and the agent turn is
+        // never redelivered here (turn dispatch is owned by the ingress drain).
+        if (
+          !skipRecentOutboundEcho &&
+          result.kind === "durable" &&
+          (result.queueResult.kind === "pending" || result.queueResult.kind === "claimed")
+        ) {
+          const inbound = await normalizeInboundMessage(msg);
+          if (inbound) {
+            dispatchReadReceipt(inbound, buildReadReceiptTarget(inbound));
+          }
+        }
       }
     }
   };

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -157,9 +157,19 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
   // separately: a claim is only reserved while the markRead call is running
   // and is released when it rejects or times out, so a later same-process
   // redelivery can retry a lost receipt instead of being suppressed forever.
-  // The success memo is bounded like the prepared-inbound map; in-flight
-  // claims are transient and clear as soon as their call settles.
+  // The success memo is bounded like the prepared-inbound map; the in-flight
+  // claims are transient but are also bounded (READ_RECEIPT_INFLIGHT_MAX), so
+  // a stalled socket plus a burst of distinct messages cannot start unbounded
+  // socket work during the operation-timeout window.
   const READ_RECEIPT_MEMO_MAX = 1000;
+  // Upper bound on concurrently stalled socket acknowledgements. markRead is
+  // bounded by the socket operation timeout (default 60s); while the socket
+  // is stalled, each distinct inbound message would otherwise start one more
+  // socket operation with no cap. When the window is full, new receipts are
+  // skipped without recording success, so a later redelivery can retry them
+  // once capacity frees up. Message admission is never blocked: the skip is
+  // instant and no queue is built.
+  const READ_RECEIPT_INFLIGHT_MAX = 32;
   const readReceiptsSent = new Set<string>();
   const readReceiptsInFlight = new Set<string>();
   const buildReadReceiptDedupeKey = (target: WhatsAppReadReceiptTarget): string =>
@@ -183,6 +193,17 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       logWhatsAppVerbose(
         options.verbose,
         `Skipping read receipt for in-flight acknowledgement of message ${target.id}`,
+      );
+      return;
+    }
+    if (readReceiptsInFlight.size >= READ_RECEIPT_INFLIGHT_MAX) {
+      // The acknowledgement window is full of stalled socket operations.
+      // Skip without recording success so a later redelivery can retry this
+      // receipt once capacity frees up; admission of the message itself is
+      // unaffected.
+      logWhatsAppVerbose(
+        options.verbose,
+        `Read receipt dispatch saturated (${readReceiptsInFlight.size} in flight); deferring acknowledgement for message ${target.id}`,
       );
       return;
     }

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -240,7 +240,7 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
     inbound: WhatsAppNormalizedInboundMessage,
     target: WhatsAppReadReceiptTarget | undefined,
   ) => {
-    maybeMarkNonSelfChatReadReceipt(inbound, target).catch((error) => {
+    maybeMarkNonSelfChatReadReceipt(inbound, target).catch((error: unknown) => {
       inboundLogger.warn(
         { error: formatError(error) },
         "failed dispatching WhatsApp receive-time read receipt",

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -153,11 +153,15 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
 
   // One read receipt per transport message id: the receive-time accepted path
   // fires it, and later redeliveries (pending or completed verdicts) must not
-  // re-send it. The memo is bounded like the prepared-inbound map and claims
-  // the id before awaiting markRead so concurrent duplicate deliveries cannot
-  // double-fire.
+  // re-send it. Successful receipts and in-flight claims are tracked
+  // separately: a claim is only reserved while the markRead call is running
+  // and is released when it rejects or times out, so a later same-process
+  // redelivery can retry a lost receipt instead of being suppressed forever.
+  // The success memo is bounded like the prepared-inbound map; in-flight
+  // claims are transient and clear as soon as their call settles.
   const READ_RECEIPT_MEMO_MAX = 1000;
   const readReceiptsSent = new Set<string>();
+  const readReceiptsInFlight = new Set<string>();
   const buildReadReceiptDedupeKey = (target: WhatsAppReadReceiptTarget): string =>
     createHash("sha256").update(`${target.remoteJid}\n${target.id}`).digest("hex");
 
@@ -173,20 +177,34 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       );
       return;
     }
+    if (readReceiptsInFlight.has(dedupeKey)) {
+      // A concurrent duplicate delivery is already acknowledging this
+      // message; it must not double-fire.
+      logWhatsAppVerbose(
+        options.verbose,
+        `Skipping read receipt for in-flight acknowledgement of message ${target.id}`,
+      );
+      return;
+    }
     if (readReceiptsSent.size >= READ_RECEIPT_MEMO_MAX) {
       const oldest = readReceiptsSent.keys().next().value;
       if (oldest !== undefined) {
         readReceiptsSent.delete(oldest);
       }
     }
-    readReceiptsSent.add(dedupeKey);
+    readReceiptsInFlight.add(dedupeKey);
     const { id, remoteJid, participant } = target;
     try {
       await socketSession.markRead(target);
+      // Record success only after the call resolves: a rejected or timed-out
+      // attempt releases its reservation below and stays retryable.
+      readReceiptsSent.add(dedupeKey);
       const suffix = participant ? ` (participant ${participant})` : "";
       logWhatsAppVerbose(options.verbose, `Marked message ${id} as read for ${remoteJid}${suffix}`);
     } catch (err) {
       logWhatsAppVerbose(options.verbose, `Failed to mark message ${id} read: ${String(err)}`);
+    } finally {
+      readReceiptsInFlight.delete(dedupeKey);
     }
   };
 

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -151,10 +151,35 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
         }
       : undefined;
 
+  // One read receipt per transport message id: the receive-time accepted path
+  // fires it, and later redeliveries (pending or completed verdicts) must not
+  // re-send it. The memo is bounded like the prepared-inbound map and claims
+  // the id before awaiting markRead so concurrent duplicate deliveries cannot
+  // double-fire.
+  const READ_RECEIPT_MEMO_MAX = 1000;
+  const readReceiptsSent = new Set<string>();
+  const buildReadReceiptDedupeKey = (target: WhatsAppReadReceiptTarget): string =>
+    createHash("sha256").update(`${target.remoteJid}\n${target.id}`).digest("hex");
+
   const maybeMarkInboundAsRead = async (target: WhatsAppReadReceiptTarget | undefined) => {
     if (!target || options.sendReadReceipts === false) {
       return;
     }
+    const dedupeKey = buildReadReceiptDedupeKey(target);
+    if (readReceiptsSent.has(dedupeKey)) {
+      logWhatsAppVerbose(
+        options.verbose,
+        `Skipping read receipt for already-acknowledged message ${target.id}`,
+      );
+      return;
+    }
+    if (readReceiptsSent.size >= READ_RECEIPT_MEMO_MAX) {
+      const oldest = readReceiptsSent.keys().next().value;
+      if (oldest !== undefined) {
+        readReceiptsSent.delete(oldest);
+      }
+    }
+    readReceiptsSent.add(dedupeKey);
     const { id, remoteJid, participant } = target;
     try {
       await socketSession.markRead(target);

--- a/extensions/whatsapp/src/inbound/read-receipt-dispatch.ts
+++ b/extensions/whatsapp/src/inbound/read-receipt-dispatch.ts
@@ -1,0 +1,147 @@
+// Bounded, drainable WhatsApp read-receipt dispatch for the inbound
+// delivery coordinator.
+import { createHash } from "node:crypto";
+import { formatError } from "../session.js";
+import type { WhatsAppReadReceiptTarget } from "./durable-receive.js";
+
+export type WhatsAppReadReceiptDispatcherDeps = {
+  /** Transport acknowledgement entry point (bounded by the socket operation timeout). */
+  markRead: (target: WhatsAppReadReceiptTarget) => Promise<unknown>;
+  /** Owner-configured receipt policy; false disables all receipt dispatch. */
+  sendReadReceipts: boolean;
+  logVerbose: (message: string) => void;
+  logger: { warn: (obj: unknown, message: string) => void };
+};
+
+export type WhatsAppReadReceiptDispatcher = {
+  maybeMarkInboundAsRead: (target: WhatsAppReadReceiptTarget | undefined) => Promise<void>;
+};
+
+export function createWhatsAppReadReceiptDispatcher(
+  deps: WhatsAppReadReceiptDispatcherDeps,
+): WhatsAppReadReceiptDispatcher {
+  const { markRead, sendReadReceipts, logVerbose, logger } = deps;
+
+  // One read receipt per transport message id: the receive-time accepted path
+  // fires it, and later redeliveries (pending or completed verdicts) must not
+  // re-send it. Successful receipts and in-flight claims are tracked
+  // separately: a claim is only reserved while the markRead call is running
+  // and is released when it rejects or times out, so a later same-process
+  // redelivery can retry a lost receipt instead of being suppressed forever.
+  // The success memo is bounded like the prepared-inbound map; the in-flight
+  // claims are transient but are also bounded (READ_RECEIPT_INFLIGHT_MAX).
+  // Receipts that arrive while the in-flight window is full are not dropped:
+  // they enter a bounded FIFO pending queue (READ_RECEIPT_PENDING_MAX) and
+  // are dispatched one at a time as each in-flight claim settles, so a
+  // stalled socket cannot silently swallow blue ticks for accepted messages.
+  // Only a burst beyond the pending bound is dropped, with a warn; message
+  // admission is never blocked at any point.
+  const READ_RECEIPT_MEMO_MAX = 1000;
+  // Upper bound on concurrently stalled socket acknowledgements. markRead is
+  // bounded by the socket operation timeout (default 60s); while the socket
+  // is stalled, each distinct inbound message would otherwise start one more
+  // socket operation with no cap.
+  const READ_RECEIPT_INFLIGHT_MAX = 32;
+  // Upper bound on receipt targets waiting for a free in-flight slot. Kept
+  // small (128 entries, roughly four stalled in-flight windows) so memory
+  // stays bounded even during a long socket outage; only a burst beyond this
+  // bound is dropped (with a warn), and those stay retryable via redelivery.
+  const READ_RECEIPT_PENDING_MAX = 128;
+  const readReceiptsSent = new Set<string>();
+  const readReceiptsInFlight = new Set<string>();
+  const readReceiptsPending = new Map<string, WhatsAppReadReceiptTarget>();
+  const buildReadReceiptDedupeKey = (target: WhatsAppReadReceiptTarget): string =>
+    createHash("sha256").update(`${target.remoteJid}\n${target.id}`).digest("hex");
+
+  const startReadReceiptDispatch = async (
+    dedupeKey: string,
+    target: WhatsAppReadReceiptTarget,
+  ): Promise<void> => {
+    if (readReceiptsSent.size >= READ_RECEIPT_MEMO_MAX) {
+      const oldest = readReceiptsSent.keys().next().value;
+      if (oldest !== undefined) {
+        readReceiptsSent.delete(oldest);
+      }
+    }
+    readReceiptsInFlight.add(dedupeKey);
+    const { id, remoteJid, participant } = target;
+    try {
+      await markRead(target);
+      // Record success only after the call resolves: a rejected or timed-out
+      // attempt releases its reservation below and stays retryable.
+      readReceiptsSent.add(dedupeKey);
+      const suffix = participant ? ` (participant ${participant})` : "";
+      logVerbose(`Marked message ${id} as read for ${remoteJid}${suffix}`);
+    } catch (err) {
+      logVerbose(`Failed to mark message ${id} read: ${String(err)}`);
+    } finally {
+      readReceiptsInFlight.delete(dedupeKey);
+      // A slot freed up: drain the oldest queued receipt target (FIFO) so
+      // saturated receipts are eventually delivered instead of dropped.
+      const nextPending = readReceiptsPending.entries().next();
+      if (!nextPending.done) {
+        const [nextKey, nextTarget] = nextPending.value;
+        readReceiptsPending.delete(nextKey);
+        void startReadReceiptDispatch(nextKey, nextTarget).catch((error: unknown) => {
+          logger.warn(
+            { error: formatError(error) },
+            "failed draining queued WhatsApp read receipt",
+          );
+        });
+      }
+    }
+  };
+
+  const maybeMarkInboundAsRead = async (target: WhatsAppReadReceiptTarget | undefined) => {
+    if (!target || !sendReadReceipts) {
+      return;
+    }
+    const dedupeKey = buildReadReceiptDedupeKey(target);
+    if (readReceiptsSent.has(dedupeKey)) {
+      logVerbose(`Skipping read receipt for already-acknowledged message ${target.id}`);
+      return;
+    }
+    if (readReceiptsInFlight.has(dedupeKey)) {
+      // A concurrent duplicate delivery is already acknowledging this
+      // message; it must not double-fire.
+      logVerbose(`Skipping read receipt for in-flight acknowledgement of message ${target.id}`);
+      return;
+    }
+    if (readReceiptsPending.has(dedupeKey)) {
+      // Already queued behind the saturated in-flight window; it must not be
+      // double-queued.
+      logVerbose(`Skipping read receipt for queued acknowledgement of message ${target.id}`);
+      return;
+    }
+    if (readReceiptsInFlight.size >= READ_RECEIPT_INFLIGHT_MAX) {
+      if (readReceiptsPending.size >= READ_RECEIPT_PENDING_MAX) {
+        // Both windows are full: the receipt target cannot be retained.
+        // Warn and drop without recording success so a later redelivery can
+        // retry it once capacity frees up; admission of the message itself
+        // is unaffected.
+        logger.warn(
+          {
+            messageId: target.id,
+            remoteJid: target.remoteJid,
+            inFlight: readReceiptsInFlight.size,
+            pending: readReceiptsPending.size,
+          },
+          "read receipt queues saturated; dropping receipt target for admitted message",
+        );
+        return;
+      }
+      // The acknowledgement window is full of stalled socket operations:
+      // queue the target (FIFO) instead of dropping it. A freed in-flight
+      // slot drains the queue head, so blue ticks are not silently lost
+      // during a socket stall. Admission of the message is unaffected.
+      readReceiptsPending.set(dedupeKey, target);
+      logVerbose(
+        `Read receipt dispatch saturated (${readReceiptsInFlight.size} in flight); queuing acknowledgement for message ${target.id} (pending ${readReceiptsPending.size})`,
+      );
+      return;
+    }
+    await startReadReceiptDispatch(dedupeKey, target);
+  };
+
+  return { maybeMarkInboundAsRead };
+}

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -504,6 +504,76 @@ describe("web monitor inbox delivery and dedupe", () => {
     await listener.close();
   });
 
+  it("delivery coordinator bounds concurrent read-receipt dispatches when the socket stalls", async () => {
+    // Mirrors the production READ_RECEIPT_INFLIGHT_MAX bound in
+    // inbound/message-delivery.ts. Each distinct inbound message normally
+    // starts one socket readMessages operation; when the socket is stalled
+    // (markRead is bounded by the socket operation timeout, default 60s),
+    // a burst of distinct messages would otherwise start unbounded socket
+    // work. The window must cap concurrent acknowledgements without blocking
+    // message admission, and saturated receipts must stay retryable.
+    const INFLIGHT_MAX = 32;
+    const TOTAL = INFLIGHT_MAX + 3;
+    const stalledAcks: Array<() => void> = [];
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 20,
+      socketTiming: {
+        keepAliveIntervalMs: 25_000,
+        connectTimeoutMs: 60_000,
+        defaultQueryTimeoutMs: 60_000,
+      },
+      verbose: true,
+    });
+
+    const messages = Array.from(
+      { length: TOTAL },
+      (_, index) =>
+        buildNotifyMessageUpsert({
+          id: nextMessageId(`receipt-saturation-${index}`),
+          remoteJid: "999@s.whatsapp.net",
+          text: `msg-${index}`,
+          timestamp: 1_700_000_000 + index,
+          pushName: "Tester",
+        }).messages[0],
+    );
+
+    // Every acknowledgement stalls on the socket, so the in-flight window
+    // fills up and stays full.
+    sock.readMessages.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          stalledAcks.push(resolve);
+        }),
+    );
+
+    sock.ev.emit("messages.upsert", { type: "notify", messages });
+
+    // Admission is never blocked by receipt saturation: every message is
+    // delivered even while the acknowledgement window is full.
+    await waitForMessageCalls(onMessage, TOTAL);
+    // Socket work is bounded to the in-flight window size.
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(INFLIGHT_MAX));
+    expect(onMessage).toHaveBeenCalledTimes(TOTAL);
+
+    // Release the stalled acknowledgements; the window frees up again.
+    for (const release of stalledAcks.splice(0)) {
+      release();
+    }
+    await settleInboundWork();
+
+    // A saturated receipt was never recorded as sent: redelivering one of
+    // the skipped messages retries its acknowledgement instead of being
+    // suppressed by the success memo. The delivery itself stays deduped:
+    // the agent still sees each message exactly once.
+    const skippedIndex = INFLIGHT_MAX;
+    sock.ev.emit("messages.upsert", { type: "notify", messages: [messages[skippedIndex]] });
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(INFLIGHT_MAX + 1));
+    expect(onMessage).toHaveBeenCalledTimes(TOTAL);
+
+    await listener.close();
+  });
+
   it("delivery coordinator acknowledges a completed duplicate replayed after restart once", async () => {
     const onMessage = vi.fn(async () => undefined);
     const first = await startInboxMonitor(onMessage as InboxOnMessage);

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -504,14 +504,16 @@ describe("web monitor inbox delivery and dedupe", () => {
     await listener.close();
   });
 
-  it("delivery coordinator bounds concurrent read-receipt dispatches when the socket stalls", async () => {
-    // Mirrors the production READ_RECEIPT_INFLIGHT_MAX bound in
-    // inbound/message-delivery.ts. Each distinct inbound message normally
-    // starts one socket readMessages operation; when the socket is stalled
-    // (markRead is bounded by the socket operation timeout, default 60s),
-    // a burst of distinct messages would otherwise start unbounded socket
-    // work. The window must cap concurrent acknowledgements without blocking
-    // message admission, and saturated receipts must stay retryable.
+  it("delivery coordinator bounds concurrent read-receipt dispatches and drains queued receipts when the socket recovers", async () => {
+    // Mirrors the production READ_RECEIPT_INFLIGHT_MAX /
+    // READ_RECEIPT_PENDING_MAX bounds in inbound/message-delivery.ts. Each
+    // distinct inbound message normally starts one socket readMessages
+    // operation; when the socket is stalled (markRead is bounded by the
+    // socket operation timeout, default 60s), a burst of distinct messages
+    // must not start unbounded socket work, and receipts that arrive while
+    // the in-flight window is full must be retained (queued) and drained
+    // once the socket recovers — never silently dropped — while admission
+    // stays unblocked and every message is acknowledged exactly once.
     const INFLIGHT_MAX = 32;
     const TOTAL = INFLIGHT_MAX + 3;
     const stalledAcks: Array<() => void> = [];
@@ -552,23 +554,109 @@ describe("web monitor inbox delivery and dedupe", () => {
     // Admission is never blocked by receipt saturation: every message is
     // delivered even while the acknowledgement window is full.
     await waitForMessageCalls(onMessage, TOTAL);
-    // Socket work is bounded to the in-flight window size.
+    // Socket work is bounded to the in-flight window size while the socket
+    // is stalled; the excess receipts are queued, not dropped.
     await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(INFLIGHT_MAX));
     expect(onMessage).toHaveBeenCalledTimes(TOTAL);
 
-    // Release the stalled acknowledgements; the window frees up again.
+    // Recover the socket and release the stalled acknowledgements; the
+    // queued receipts must drain automatically as the window frees up.
+    sock.readMessages.mockResolvedValue(undefined);
     for (const release of stalledAcks.splice(0)) {
       release();
     }
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(TOTAL), {
+      timeout: 5_000,
+    });
     await settleInboundWork();
 
-    // A saturated receipt was never recorded as sent: redelivering one of
-    // the skipped messages retries its acknowledgement instead of being
-    // suppressed by the success memo. The delivery itself stays deduped:
-    // the agent still sees each message exactly once.
-    const skippedIndex = INFLIGHT_MAX;
-    sock.ev.emit("messages.upsert", { type: "notify", messages: [messages[skippedIndex]] });
-    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(INFLIGHT_MAX + 1));
+    // Every message is acknowledged exactly once: no receipt was silently
+    // dropped during the stall and none double-fires after the drain.
+    expect(sock.readMessages).toHaveBeenCalledTimes(TOTAL);
+
+    // Redelivering an already-acknowledged message must not re-send its
+    // receipt; the delivery itself stays deduped.
+    sock.ev.emit("messages.upsert", { type: "notify", messages: [messages[INFLIGHT_MAX]] });
+    await settleInboundWork();
+    expect(sock.readMessages).toHaveBeenCalledTimes(TOTAL);
+    expect(onMessage).toHaveBeenCalledTimes(TOTAL);
+
+    await listener.close();
+  });
+
+  it("delivery coordinator bounds the pending receipt queue and keeps overflow retryable", async () => {
+    // Beyond the in-flight window AND the bounded pending queue, a receipt
+    // target can no longer be retained: it is dropped with a warn, but the
+    // message itself is still admitted, and a redelivery retries the receipt
+    // once capacity frees up — the loss is bounded and observable, never a
+    // silent unbounded swallow.
+    const INFLIGHT_MAX = 32;
+    const PENDING_MAX = 128;
+    const TOTAL = INFLIGHT_MAX + PENDING_MAX + 5;
+    const RETAINED = INFLIGHT_MAX + PENDING_MAX;
+    const stalledAcks: Array<() => void> = [];
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 20,
+      socketTiming: {
+        keepAliveIntervalMs: 25_000,
+        connectTimeoutMs: 60_000,
+        defaultQueryTimeoutMs: 60_000,
+      },
+      verbose: true,
+    });
+
+    const messages = Array.from(
+      { length: TOTAL },
+      (_, index) =>
+        buildNotifyMessageUpsert({
+          id: nextMessageId(`receipt-queue-overflow-${index}`),
+          remoteJid: "999@s.whatsapp.net",
+          text: `msg-${index}`,
+          timestamp: 1_700_000_000 + index,
+          pushName: "Tester",
+        }).messages[0],
+    );
+
+    sock.readMessages.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          stalledAcks.push(resolve);
+        }),
+    );
+
+    sock.ev.emit("messages.upsert", { type: "notify", messages });
+
+    // Admission is never blocked: every message is delivered even when both
+    // receipt windows are full. (Custom timeout: 165 messages through the
+    // debounced admission pipeline exceed the shared helper's fixed 5s
+    // window.)
+    await vi.waitFor(() => expect(onMessage).toHaveBeenCalledTimes(TOTAL), {
+      timeout: 20_000,
+    });
+    expect(sock.readMessages).toHaveBeenCalledTimes(INFLIGHT_MAX);
+
+    // Recover the socket: the in-flight window drains, then the bounded
+    // pending queue drains completely; only the beyond-bound overflow is
+    // dropped.
+    sock.readMessages.mockResolvedValue(undefined);
+    for (const release of stalledAcks.splice(0)) {
+      release();
+    }
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(RETAINED), {
+      timeout: 5_000,
+    });
+    await settleInboundWork();
+    expect(sock.readMessages).toHaveBeenCalledTimes(RETAINED);
+
+    // A dropped receipt was never recorded as sent: redelivering one of the
+    // overflow messages retries its acknowledgement. The delivery itself
+    // stays deduped: the agent still sees each message exactly once.
+    const droppedIndex = RETAINED;
+    sock.ev.emit("messages.upsert", { type: "notify", messages: [messages[droppedIndex]] });
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(RETAINED + 1), {
+      timeout: 5_000,
+    });
     expect(onMessage).toHaveBeenCalledTimes(TOTAL);
 
     await listener.close();

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -1,10 +1,13 @@
 // WhatsApp monitor inbox behavior split by ownership.
+import { createHash } from "node:crypto";
+import type { WAMessage } from "baileys";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearWhatsAppApprovalReactionTargetsForTest,
   registerWhatsAppApprovalReactionTarget,
 } from "./approval-reactions.js";
+import { serializeWhatsAppDurableInboundMessage } from "./inbound/durable-payload.js";
 import { createWhatsAppDurableInboundQueue } from "./inbound/durable-receive.js";
 import { resolveWhatsAppIngressLifecycle } from "./inbound/ingress-lifecycle.js";
 import type { WebInboundMessage } from "./inbound/types.js";
@@ -690,6 +693,48 @@ describe("web monitor inbox delivery and dedupe", () => {
     await replay.listener.close();
   });
 
+  it("delivery coordinator sends a read receipt for a cold durable replay drained at startup", async () => {
+    // A stop after durable admission can leave a persisted row for the next
+    // coordinator. Seed that row directly, then start a fresh coordinator:
+    // its startup drain must dispatch the receive-time receipt even though no
+    // new socket upsert ever arrives.
+    const messageId = nextMessageId("cold-replay");
+    const remoteJid = "999@s.whatsapp.net";
+    const upsert = buildNotifyMessageUpsert({
+      id: messageId,
+      remoteJid,
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+    const queue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);
+    await queue.enqueue(
+      createHash("sha256").update(`${remoteJid}\n${messageId}`).digest("hex"),
+      {
+        message: serializeWhatsAppDurableInboundMessage(upsert.messages[0] as unknown as WAMessage),
+        upsertType: "notify",
+        receivedAt: Date.now(),
+      },
+      { laneKey: remoteJid },
+    );
+
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      durableInboundQueue: queue,
+    });
+    await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+    expect(sock.readMessages).toHaveBeenCalledWith([
+      {
+        remoteJid,
+        id: messageId,
+        participant: undefined,
+        fromMe: false,
+      },
+    ]);
+    await listener.close();
+  });
+
   it("delivery coordinator lets a later same-key flush steer during an active turn", async () => {
     let releaseFirst: (() => void) | undefined;
     const firstTurn = new Promise<void>((resolve) => {
@@ -1011,165 +1056,4 @@ describe("web monitor inbox delivery and dedupe", () => {
     );
   });
 
-  it("delivery coordinator deduplicates redelivered messages by id", async () => {
-    const onMessage = vi.fn(async () => {});
-
-    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
-    const upsert = buildNotifyMessageUpsert({
-      id: nextMessageId("dedupe"),
-      remoteJid: "999@s.whatsapp.net",
-      text: "ping",
-      timestamp: 1_700_000_000,
-      pushName: "Tester",
-    });
-
-    sock.ev.emit("messages.upsert", upsert);
-    sock.ev.emit("messages.upsert", upsert);
-    await waitForMessageCalls(onMessage, 1);
-
-    expect(onMessage).toHaveBeenCalledTimes(1);
-
-    await listener.close();
-  });
-
-  it("delivery coordinator dispatches same-content messages with distinct ids in order", async () => {
-    const onMessage = vi.fn(async (_message: WebInboundMessage) => {});
-    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
-
-    for (const [index, id] of ["in-2", "in-3"].entries()) {
-      sock.ev.emit(
-        "messages.upsert",
-        buildNotifyMessageUpsert({
-          id,
-          remoteJid: "999@s.whatsapp.net",
-          text: "Done.",
-          timestamp: 1_700_000_000 + index,
-          pushName: "Tester",
-        }),
-      );
-      await waitForMessageCalls(onMessage, index + 1);
-    }
-
-    expect(onMessage.mock.calls.map(([message]) => message.event.id)).toEqual(["in-2", "in-3"]);
-    await listener.close();
-  });
-
-  it("delivery coordinator automatically retries after an explicit retryable failure", async () => {
-    let attempts = 0;
-    const onMessage = vi.fn(async () => {
-      attempts += 1;
-      if (attempts === 1) {
-        // Any non-permanent error is retryable to the drain classifier.
-        throw new Error("retry me");
-      }
-    });
-
-    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
-    const upsert = buildNotifyMessageUpsert({
-      id: nextMessageId("retryable-dedupe"),
-      remoteJid: "999@s.whatsapp.net",
-      text: "ping",
-      timestamp: 1_700_000_000,
-      pushName: "Tester",
-    });
-
-    sock.ev.emit("messages.upsert", upsert);
-    await waitForMessageCalls(onMessage, 2);
-    await vi.waitFor(() => {
-      expect(sock.readMessages).toHaveBeenCalledTimes(1);
-    });
-
-    sock.ev.emit("messages.upsert", upsert);
-    await waitForMessageCalls(onMessage, 2);
-    await settleInboundWork();
-    // Redelivery of the same message must not re-send the receipt.
-    expect(sock.readMessages).toHaveBeenCalledTimes(1);
-
-    await listener.close();
-  });
-
-  it("delivery coordinator automatically retries after reply session conflicts", async () => {
-    let attempts = 0;
-    const onMessage = vi.fn(async () => {
-      attempts += 1;
-      if (attempts === 1) {
-        throw new Error(
-          "reply session initialization conflicted for agent:main:whatsapp:direct:+15551234567",
-        );
-      }
-    });
-
-    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
-    const upsert = buildNotifyMessageUpsert({
-      id: nextMessageId("session-init-conflict"),
-      remoteJid: "999@s.whatsapp.net",
-      text: "ping",
-      timestamp: 1_700_000_000,
-      pushName: "Tester",
-    });
-
-    sock.ev.emit("messages.upsert", upsert);
-    await waitForMessageCalls(onMessage, 2);
-    await vi.waitFor(() => {
-      expect(sock.readMessages).toHaveBeenCalledTimes(1);
-    });
-
-    sock.ev.emit("messages.upsert", upsert);
-    await waitForMessageCalls(onMessage, 2);
-    await settleInboundWork();
-    // Redelivery of the same message must not re-send the receipt.
-    expect(sock.readMessages).toHaveBeenCalledTimes(1);
-
-    await listener.close();
-  });
-
-  it("delivery coordinator keeps same-lane follow-up pending until turn adoption", async () => {
-    let adoptFirst: (() => void | Promise<void>) | undefined;
-    const onMessage = vi.fn(async (message: WebInboundMessage) => {
-      if (!adoptFirst) {
-        const lifecycle = resolveWhatsAppIngressLifecycle(message);
-        if (!lifecycle) {
-          throw new Error("expected durable ingress lifecycle");
-        }
-        lifecycle.onDeferred();
-        adoptFirst = lifecycle.onAdopted;
-      }
-    });
-
-    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
-    sock.ev.emit("messages.upsert", {
-      type: "notify",
-      messages: [
-        {
-          key: { id: "abc1", fromMe: false, remoteJid: "999@s.whatsapp.net" },
-          message: { conversation: "ping" },
-          messageTimestamp: 1_700_000_000,
-        },
-      ],
-    });
-    await waitForMessageCalls(onMessage, 1);
-
-    sock.ev.emit("messages.upsert", {
-      type: "notify",
-      messages: [
-        {
-          key: { id: "abc2", fromMe: false, remoteJid: "999@s.whatsapp.net" },
-          message: { conversation: "pong" },
-          messageTimestamp: 1_700_000_001,
-        },
-      ],
-    });
-    await settleInboundWork();
-
-    expect(onMessage).toHaveBeenCalledTimes(1);
-    expect(inboundMessage(onMessage).payload.body).toBe("ping");
-
-    if (!adoptFirst) {
-      throw new Error("expected first adoption callback");
-    }
-    await adoptFirst();
-    await waitForMessageCalls(onMessage, 2);
-    expect(inboundMessage(onMessage, 1).payload.body).toBe("pong");
-    await listener.close();
-  });
 });

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -417,6 +417,93 @@ describe("web monitor inbox delivery and dedupe", () => {
     await listener.close();
   });
 
+  it("delivery coordinator does not block later message admission on a stalled read receipt", async () => {
+    let releaseFirstReceipt: (() => void) | undefined;
+    let firstReceiptSettled = false;
+    const firstReceiptGate = new Promise<void>((resolve) => {
+      releaseFirstReceipt = resolve;
+    });
+    void firstReceiptGate.then(() => {
+      firstReceiptSettled = true;
+    });
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 20,
+      // The receive-time receipt for the first message stalls on the socket.
+      // It is bounded by the socket operation timeout, but the admission loop
+      // must not wait for it: the second message in the same upsert has to be
+      // admitted while the first receipt is still in flight.
+      socketTiming: {
+        keepAliveIntervalMs: 25_000,
+        connectTimeoutMs: 60_000,
+        defaultQueryTimeoutMs: 60_000,
+      },
+    });
+    const firstId = nextMessageId("receipt-stall-1");
+    const secondId = nextMessageId("receipt-stall-2");
+    const first = buildNotifyMessageUpsert({
+      id: firstId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "first",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+    const second = buildNotifyMessageUpsert({
+      id: secondId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "second",
+      timestamp: 1_700_000_001,
+      pushName: "Tester",
+    });
+
+    // Only the first receipt stalls; later receipts resolve normally.
+    sock.readMessages.mockImplementationOnce(() => firstReceiptGate);
+
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [...first.messages, ...second.messages],
+    });
+
+    // Both messages are admitted and delivered while the first receipt is
+    // still stalled on the socket.
+    await waitForMessageCalls(onMessage, 2);
+    expect(inboundMessage(onMessage, 0).payload.body).toBe("first");
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("second");
+    expect(sock.readMessages).toHaveBeenCalledWith([
+      {
+        remoteJid: "999@s.whatsapp.net",
+        id: firstId,
+        participant: undefined,
+        fromMe: false,
+      },
+    ]);
+    expect(firstReceiptSettled).toBe(false);
+
+    // Release the stalled receipt; each message must still have exactly one
+    // acknowledgement (no double-fire).
+    releaseFirstReceipt?.();
+    await vi.waitFor(() => expect(firstReceiptSettled).toBe(true));
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(2));
+    expect(sock.readMessages).toHaveBeenNthCalledWith(1, [
+      {
+        remoteJid: "999@s.whatsapp.net",
+        id: firstId,
+        participant: undefined,
+        fromMe: false,
+      },
+    ]);
+    expect(sock.readMessages).toHaveBeenNthCalledWith(2, [
+      {
+        remoteJid: "999@s.whatsapp.net",
+        id: secondId,
+        participant: undefined,
+        fromMe: false,
+      },
+    ]);
+
+    await listener.close();
+  });
+
   it("delivery coordinator acknowledges a completed duplicate replayed after restart once", async () => {
     const onMessage = vi.fn(async () => undefined);
     const first = await startInboxMonitor(onMessage as InboxOnMessage);

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -1055,5 +1055,4 @@ describe("web monitor inbox delivery and dedupe", () => {
       sock.end.mock.invocationCallOrder.at(0),
     );
   });
-
 });

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -164,17 +164,22 @@ describe("web monitor inbox delivery and dedupe", () => {
     await listener.close();
   });
 
-  it("delivery coordinator delays read receipts until inbound handlers complete", async () => {
-    let finishMessage: (() => void) | undefined;
+  it("delivery coordinator sends read receipts when the message is received, not after the agent turn", async () => {
+    let releaseHandler: (() => void) | undefined;
     const handlerGate = new Promise<void>((resolve) => {
-      finishMessage = resolve;
+      releaseHandler = resolve;
+    });
+    let markHandlerFinished: (() => void) | undefined;
+    const handlerFinished = new Promise<void>((resolve) => {
+      markHandlerFinished = resolve;
     });
     const onMessage = vi.fn(async () => {
       await handlerGate;
+      markHandlerFinished?.();
     });
 
     const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
-    const messageId = nextMessageId("delayed-read");
+    const messageId = nextMessageId("immediate-read");
 
     sock.ev.emit(
       "messages.upsert",
@@ -188,18 +193,23 @@ describe("web monitor inbox delivery and dedupe", () => {
     );
     await waitForMessageCalls(onMessage, 1);
 
-    expect(sock.readMessages).not.toHaveBeenCalled();
-    finishMessage?.();
-    await vi.waitFor(() => {
-      expect(sock.readMessages).toHaveBeenCalledWith([
-        {
-          remoteJid: "999@s.whatsapp.net",
-          id: messageId,
-          participant: undefined,
-          fromMe: false,
-        },
-      ]);
-    });
+    // The read receipt (blue tick) must already be on the wire while the
+    // agent turn is still running — the handler gate is still closed.
+    expect(sock.readMessages).toHaveBeenCalledWith([
+      {
+        remoteJid: "999@s.whatsapp.net",
+        id: messageId,
+        participant: undefined,
+        fromMe: false,
+      },
+    ]);
+
+    releaseHandler?.();
+    await handlerFinished;
+    await settleInboundWork();
+
+    // Completing the turn must not send a second receipt.
+    expect(sock.readMessages).toHaveBeenCalledTimes(1);
 
     await listener.close();
   });
@@ -715,6 +725,12 @@ describe("web monitor inbox delivery and dedupe", () => {
       expect(sock.readMessages).toHaveBeenCalledTimes(1);
     });
 
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 2);
+    await settleInboundWork();
+    // Redelivery of the same message must not re-send the receipt.
+    expect(sock.readMessages).toHaveBeenCalledTimes(1);
+
     await listener.close();
   });
 
@@ -743,6 +759,12 @@ describe("web monitor inbox delivery and dedupe", () => {
     await vi.waitFor(() => {
       expect(sock.readMessages).toHaveBeenCalledTimes(1);
     });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 2);
+    await settleInboundWork();
+    // Redelivery of the same message must not re-send the receipt.
+    expect(sock.readMessages).toHaveBeenCalledTimes(1);
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -308,14 +308,19 @@ describe("web monitor inbox delivery and dedupe", () => {
     sock.ev.emit("messages.upsert", upsert);
     await settleInboundWork();
     expect(onMessage).toHaveBeenCalledTimes(1);
+    // The pending redelivery must not re-send the receive-time receipt.
+    expect(sock.readMessages).toHaveBeenCalledTimes(1);
 
     finishMessage?.();
     await listener.close();
   });
 
-  it("delivery coordinator does not redispatch a completed transport-key duplicate", async () => {
+  it("delivery coordinator does not re-send the read receipt for a completed transport-key duplicate", async () => {
     const onMessage = vi.fn(async () => undefined);
-    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const pendingWork = vi.fn<(count: number, at?: number) => void>();
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      onPendingWorkChanged: pendingWork,
+    });
     const upsert = buildNotifyMessageUpsert({
       id: nextMessageId("durable-completed"),
       remoteJid: "999@s.whatsapp.net",
@@ -327,13 +332,47 @@ describe("web monitor inbox delivery and dedupe", () => {
     sock.ev.emit("messages.upsert", upsert);
     await waitForMessageCalls(onMessage, 1);
     await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
-    sock.readMessages.mockClear();
 
+    // Redelivery of the completed transport key must not send a second
+    // receipt: the receive-time receipt already fired on acceptance.
+    const settledBefore = pendingWork.mock.calls.length;
     sock.ev.emit("messages.upsert", upsert);
-    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => {
+      expect(pendingWork.mock.calls.length).toBeGreaterThan(settledBefore);
+      expect(pendingWork.mock.calls.at(-1)?.[0]).toBe(0);
+    });
 
+    expect(sock.readMessages).toHaveBeenCalledTimes(1);
     expect(onMessage).toHaveBeenCalledTimes(1);
     await listener.close();
+  });
+
+  it("delivery coordinator acknowledges a completed duplicate replayed after restart once", async () => {
+    const onMessage = vi.fn(async () => undefined);
+    const first = await startInboxMonitor(onMessage as InboxOnMessage);
+    const sock = first.sock;
+    const upsert = buildNotifyMessageUpsert({
+      id: nextMessageId("durable-replay"),
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+    await first.listener.close();
+
+    // A fresh coordinator (simulated process restart) has no in-memory receipt
+    // memo; the completed replay redelivery still acknowledges the message once.
+    const replayedOnMessage = vi.fn(async () => undefined);
+    const replay = await startInboxMonitor(replayedOnMessage as InboxOnMessage);
+    replay.sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(2));
+    await settleInboundWork();
+    expect(replayedOnMessage).not.toHaveBeenCalled();
+    await replay.listener.close();
   });
 
   it("delivery coordinator lets a later same-key flush steer during an active turn", async () => {

--- a/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts
@@ -347,6 +347,76 @@ describe("web monitor inbox delivery and dedupe", () => {
     await listener.close();
   });
 
+  it("delivery coordinator retries a rejected read receipt when the message is redelivered", async () => {
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const messageId = nextMessageId("receipt-rejection-retry");
+    const upsert = buildNotifyMessageUpsert({
+      id: messageId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    // The receive-time acknowledgement fails on the socket; the failed
+    // attempt must release its reservation instead of claiming the receipt
+    // permanently.
+    sock.readMessages.mockRejectedValueOnce(new Error("connection closed"));
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+
+    // A same-process redelivery of the completed transport key retries the
+    // missing receipt.
+    sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(2));
+
+    // The message itself stays deduped; only the receipt is retried.
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    await listener.close();
+  });
+
+  it("delivery coordinator retries a timed-out read receipt when the message is redelivered", async () => {
+    const onMessage = vi.fn(async () => undefined);
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      socketTiming: {
+        keepAliveIntervalMs: 25_000,
+        connectTimeoutMs: 60_000,
+        defaultQueryTimeoutMs: 100,
+      },
+    });
+    const messageId = nextMessageId("receipt-timeout-retry");
+    const upsert = buildNotifyMessageUpsert({
+      id: messageId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    // The receive-time acknowledgement stalls on the socket and trips the
+    // owned operation timeout.
+    sock.readMessages.mockImplementationOnce(() => new Promise<never>(() => {}));
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+    // Let the operation timeout fire and release the in-flight reservation.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 300);
+    });
+
+    // A same-process redelivery of the completed transport key retries the
+    // missing receipt.
+    sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(2));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    await listener.close();
+  });
+
   it("delivery coordinator acknowledges a completed duplicate replayed after restart once", async () => {
     const onMessage = vi.fn(async () => undefined);
     const first = await startInboxMonitor(onMessage as InboxOnMessage);

--- a/extensions/whatsapp/src/monitor-inbox.receipt-retry.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.receipt-retry.test.ts
@@ -1,0 +1,227 @@
+// WhatsApp receive-time read-receipt retry for active durable duplicates.
+// While a durable row stays pending or claimed, the admission verdict has no
+// accepted branch, so a replay is the only path that can re-reach the receipt
+// dispatcher after a failed first attempt.
+import { describe, expect, it, vi } from "vitest";
+import { nextMessageId } from "./monitor-inbox.streams-inbound-messages.test-support.js";
+import {
+  buildNotifyMessageUpsert,
+  installWebMonitorInboxUnitTestHooks,
+  settleInboundWork,
+  startInboxMonitor,
+  waitForMessageCalls,
+  type InboxOnMessage,
+} from "./monitor-inbox.test-harness.js";
+
+describe("web monitor inbox receipt retry", () => {
+  installWebMonitorInboxUnitTestHooks();
+
+  it("delivery coordinator retries a rejected receipt for a pending durable duplicate without redelivering the turn", async () => {
+    // While the first same-lane turn stays active, the lane stays blocked, so
+    // the second message's durable row remains pending (never claimed). Its
+    // receive-time receipt rejects; a replay of the same transport key must
+    // retry the receipt through the dispatcher even though the durable row is
+    // still pending — and must not redeliver the agent turn.
+    let releaseTurn: (() => void) | undefined;
+    const turnGate = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    const onMessage = vi.fn(async () => {
+      await turnGate;
+    });
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+
+    const blockerId = nextMessageId("receipt-pending-blocker");
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: blockerId,
+        remoteJid: "999@s.whatsapp.net",
+        text: "blocker",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+
+    const messageId = nextMessageId("receipt-pending-reject");
+    const upsert = buildNotifyMessageUpsert({
+      id: messageId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_001,
+      pushName: "Tester",
+    });
+
+    // The receive-time acknowledgement rejects; the failed attempt releases
+    // its dispatcher reservation without recording success.
+    sock.readMessages.mockRejectedValueOnce(new Error("connection closed"));
+
+    sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(2));
+    await settleInboundWork();
+
+    // Replay the same transport key while the durable row is still pending:
+    // the receipt must retry through the dispatcher, and the agent turn must
+    // not redeliver.
+    sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(3));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+
+    releaseTurn?.();
+    await listener.close();
+  });
+
+  it("delivery coordinator retries a rejected receipt for a claimed durable duplicate without redelivering the turn", async () => {
+    let releaseTurn: (() => void) | undefined;
+    const turnGate = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    const onMessage = vi.fn(async () => {
+      await turnGate;
+    });
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const messageId = nextMessageId("receipt-claimed-reject");
+    const upsert = buildNotifyMessageUpsert({
+      id: messageId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    // The receive-time acknowledgement rejects on the socket while the agent
+    // turn is still active, so the durable row stays claimed.
+    sock.readMessages.mockRejectedValueOnce(new Error("connection closed"));
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+    await settleInboundWork();
+
+    // Replay while the original durable row is still claimed: the receipt
+    // must retry through the dispatcher and the turn must not redeliver.
+    sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(2));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+
+    releaseTurn?.();
+    await listener.close();
+  });
+
+  it("delivery coordinator retries a timed-out receipt for a claimed durable duplicate without redelivering the turn", async () => {
+    let releaseTurn: (() => void) | undefined;
+    const turnGate = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    const onMessage = vi.fn(async () => {
+      await turnGate;
+    });
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      socketTiming: {
+        keepAliveIntervalMs: 25_000,
+        connectTimeoutMs: 60_000,
+        defaultQueryTimeoutMs: 100,
+      },
+    });
+    const messageId = nextMessageId("receipt-claimed-timeout");
+    const upsert = buildNotifyMessageUpsert({
+      id: messageId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    // The receive-time acknowledgement stalls on the socket and trips the
+    // owned operation timeout while the agent turn keeps the row claimed.
+    sock.readMessages.mockImplementationOnce(() => new Promise<never>(() => {}));
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+    // Let the operation timeout fire and release the in-flight reservation.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 300);
+    });
+
+    // Replay while the original durable row is still claimed: the receipt
+    // must retry through the dispatcher and the turn must not redeliver.
+    sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(2));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+
+    releaseTurn?.();
+    await listener.close();
+  });
+
+  it("delivery coordinator retries a timed-out receipt for a pending durable duplicate without redelivering the turn", async () => {
+    // Mirrors the pending-duplicate rejection case: the first same-lane turn
+    // keeps the lane blocked, so the second message's durable row remains
+    // pending. Its receive-time receipt times out; a replay must retry the
+    // receipt through the dispatcher without redelivering the agent turn.
+    let releaseTurn: (() => void) | undefined;
+    const turnGate = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    const onMessage = vi.fn(async () => {
+      await turnGate;
+    });
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      socketTiming: {
+        keepAliveIntervalMs: 25_000,
+        connectTimeoutMs: 60_000,
+        defaultQueryTimeoutMs: 100,
+      },
+    });
+
+    const blockerId = nextMessageId("receipt-pending-timeout-blocker");
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: blockerId,
+        remoteJid: "999@s.whatsapp.net",
+        text: "blocker",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(1));
+
+    const messageId = nextMessageId("receipt-pending-timeout");
+    const upsert = buildNotifyMessageUpsert({
+      id: messageId,
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_001,
+      pushName: "Tester",
+    });
+
+    // The receive-time acknowledgement stalls on the socket and trips the
+    // owned operation timeout while the durable row stays pending.
+    sock.readMessages.mockImplementationOnce(() => new Promise<never>(() => {}));
+
+    sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(2));
+    // Let the operation timeout fire and release the in-flight reservation.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 300);
+    });
+
+    // Replay the same transport key while the durable row is still pending:
+    // the receipt must retry through the dispatcher, and the agent turn must
+    // not redeliver.
+    sock.ev.emit("messages.upsert", upsert);
+    await vi.waitFor(() => expect(sock.readMessages).toHaveBeenCalledTimes(3));
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+
+    releaseTurn?.();
+    await listener.close();
+  });
+});

--- a/extensions/whatsapp/src/monitor-inbox.redelivery.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.redelivery.test.ts
@@ -1,0 +1,181 @@
+// WhatsApp monitor inbox redelivery behavior split by ownership.
+import { describe, expect, it, vi } from "vitest";
+import { resolveWhatsAppIngressLifecycle } from "./inbound/ingress-lifecycle.js";
+import type { WebInboundMessage } from "./inbound/types.js";
+import {
+  nextMessageId,
+  inboundMessage,
+  installStreamsInboundMessageHooks,
+} from "./monitor-inbox.streams-inbound-messages.test-support.js";
+import {
+  buildNotifyMessageUpsert,
+  settleInboundWork,
+  startInboxMonitor,
+  waitForMessageCalls,
+  type InboxOnMessage,
+} from "./monitor-inbox.test-harness.js";
+
+describe("web monitor inbox redelivery", () => {
+  installStreamsInboundMessageHooks();
+  it("delivery coordinator deduplicates redelivered messages by id", async () => {
+    const onMessage = vi.fn(async () => {});
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const upsert = buildNotifyMessageUpsert({
+      id: nextMessageId("dedupe"),
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+
+    await listener.close();
+  });
+
+  it("delivery coordinator dispatches same-content messages with distinct ids in order", async () => {
+    const onMessage = vi.fn(async (_message: WebInboundMessage) => {});
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+
+    for (const [index, id] of ["in-2", "in-3"].entries()) {
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id,
+          remoteJid: "999@s.whatsapp.net",
+          text: "Done.",
+          timestamp: 1_700_000_000 + index,
+          pushName: "Tester",
+        }),
+      );
+      await waitForMessageCalls(onMessage, index + 1);
+    }
+
+    expect(onMessage.mock.calls.map(([message]) => message.event.id)).toEqual(["in-2", "in-3"]);
+    await listener.close();
+  });
+
+  it("delivery coordinator automatically retries after an explicit retryable failure", async () => {
+    let attempts = 0;
+    const onMessage = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        // Any non-permanent error is retryable to the drain classifier.
+        throw new Error("retry me");
+      }
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const upsert = buildNotifyMessageUpsert({
+      id: nextMessageId("retryable-dedupe"),
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 2);
+    await vi.waitFor(() => {
+      expect(sock.readMessages).toHaveBeenCalledTimes(1);
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 2);
+    await settleInboundWork();
+    // Redelivery of the same message must not re-send the receipt.
+    expect(sock.readMessages).toHaveBeenCalledTimes(1);
+
+    await listener.close();
+  });
+
+  it("delivery coordinator automatically retries after reply session conflicts", async () => {
+    let attempts = 0;
+    const onMessage = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error(
+          "reply session initialization conflicted for agent:main:whatsapp:direct:+15551234567",
+        );
+      }
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    const upsert = buildNotifyMessageUpsert({
+      id: nextMessageId("session-init-conflict"),
+      remoteJid: "999@s.whatsapp.net",
+      text: "ping",
+      timestamp: 1_700_000_000,
+      pushName: "Tester",
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 2);
+    await vi.waitFor(() => {
+      expect(sock.readMessages).toHaveBeenCalledTimes(1);
+    });
+
+    sock.ev.emit("messages.upsert", upsert);
+    await waitForMessageCalls(onMessage, 2);
+    await settleInboundWork();
+    // Redelivery of the same message must not re-send the receipt.
+    expect(sock.readMessages).toHaveBeenCalledTimes(1);
+
+    await listener.close();
+  });
+
+  it("delivery coordinator keeps same-lane follow-up pending until turn adoption", async () => {
+    let adoptFirst: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (!adoptFirst) {
+        const lifecycle = resolveWhatsAppIngressLifecycle(message);
+        if (!lifecycle) {
+          throw new Error("expected durable ingress lifecycle");
+        }
+        lifecycle.onDeferred();
+        adoptFirst = lifecycle.onAdopted;
+      }
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: { id: "abc1", fromMe: false, remoteJid: "999@s.whatsapp.net" },
+          message: { conversation: "ping" },
+          messageTimestamp: 1_700_000_000,
+        },
+      ],
+    });
+    await waitForMessageCalls(onMessage, 1);
+
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: { id: "abc2", fromMe: false, remoteJid: "999@s.whatsapp.net" },
+          message: { conversation: "pong" },
+          messageTimestamp: 1_700_000_001,
+        },
+      ],
+    });
+    await settleInboundWork();
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(inboundMessage(onMessage).payload.body).toBe("ping");
+
+    if (!adoptFirst) {
+      throw new Error("expected first adoption callback");
+    }
+    await adoptFirst();
+    await waitForMessageCalls(onMessage, 2);
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("pong");
+    await listener.close();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Closes #128875 — WhatsApp read receipts (blue ticks) were only sent after the full agent turn completed (LLM + tools + reply). For long requests (30–120s+) the sender saw gray ticks the entire time, then blue ticks arriving together with the reply — an obvious automation fingerprint, and zero liveness feedback that the gateway actually received the message.

## Why This Change Was Made

The receipt was tied to reply dispatch, not ingestion: the inbound debouncer flush called `markRead` *after* `onMessage()` (the agent turn) resolved, and the durable pump only marked read on its early-exit paths (stale append, enrichment failure). This moves the receipt to receive time.

Fix shape:

- In `handleMessagesUpsert`, the accepted-verdict path now fires the read receipt as soon as the durable admission accepts the message and the inbound identity is normalized — before the turn is routed. `finishPreparation` runs first so the durable drain never waits on a stalled receipt ack (the receipt op stays bounded by the existing socket-operation timeout).
- Removed the post-turn `markRead` calls from the debouncer flush and the pump's stale/enrichment paths, plus the now-dead `readReceipt` plumbing (`WhatsAppQueuedInboundMessage.readReceipt`, debouncer `markRead` option). Redelivery/retry of the same message id no longer re-sends the receipt.
- Receipt dedupe now keeps in-flight and successful states separate (ClawSweeper P2 finding on reviewed head `fa56a69a`): a reservation is only held while the `markRead` call runs and is released on rejection or timeout; success is recorded only after the call resolves — so a later same-process redelivery retries a lost receipt instead of being suppressed forever by a pre-success memo.
- Existing behavior preserved unchanged: `sendReadReceipts` boolean toggle (default on), self-chat skip, blocked-sender skip, per-account override. No new config surface — the issue's optional tri-mode `readReceipts` option was not added; the existing toggle now means "immediate" instead of "on reply", which matches the issue's primary suggested fix.
- Docs (`docs/channels/whatsapp.md`) now state that receipts fire at ingest time.

Production LOC delta: net **+45** across the PR (source +59/−14; docs +2/−0).

## User Impact

- Senders see blue ticks within ~1s of the gateway ingesting the message — the same timing a human reader produces — regardless of how long the agent takes.
- The reply arrives later on its own; the simultaneous "blue ticks + reply" fingerprint is gone.
- No behavior change when `sendReadReceipts: false` or in self-chat mode.
- A read receipt that fails (socket rejection or operation timeout) is now retried on the next same-process redelivery instead of being lost for the lifetime of the coordinator.

## Evidence

- **Root cause of the review finding (head `fa56a69a`)**: `maybeMarkInboundAsRead` added the dedupe key to `readReceiptsSent` before awaiting `socketSession.markRead`, and the catch branch only logged — a rejection/timeout left the key claimed, so any later same-process redelivery returned at the duplicate guard and could never retry the missing blue tick.
- **Fix shape**: the memo is split into `readReceiptsSent` (success only, recorded after the call resolves) and `readReceiptsInFlight` (reservation held only while the call runs, cleared in `finally`); the in-flight guard still stops concurrent duplicates from double-firing.
- **New regression tests** in `extensions/whatsapp/src/monitor-inbox.delivery-and-dedupe.test.ts` (red first, then green):
  - "delivery coordinator retries a rejected read receipt when the message is redelivered" — first `readMessages` call rejects; a redelivery of the completed transport key must issue a second receipt.
  - "delivery coordinator retries a timed-out read receipt when the message is redelivered" — first call stalls and trips the owned socket-operation timeout (100 ms injected via `socketTiming`); a redelivery must retry.
  - RED (pre-fix, head `fa56a69a`): both new tests failed with `expected "vi.fn()" to be called 2 times, but got 1 times` — the duplicate guard suppressed the retry; the 18 pre-existing tests in the file passed.
  - GREEN (post-fix): **20/20 pass** in the file.
- Original timing regression (red before the fix, green after): "delivery coordinator sends read receipts when the message is received, not after the agent turn" asserts the receipt is on the fake transport while the agent handler is still gated, and that completing the turn sends no second receipt. Pre-fix run: 3 rewritten tests failed (`Number of calls: 0`); post-fix: the file passes.
- Retry tests (`...retries redelivery after an explicit retryable failure` and `...after reply session conflicts`) updated to the new contract: receipt fires at receive time even when the first turn attempt fails; redelivery does not re-send.
- `pnpm test extensions/whatsapp` at this head: **1319 passed, 11 skipped, 19 failed** — every failure is in the same 7 files this PR does not touch (inbound/durable-receive EBUSY sqlite temp-file locks on Windows, channel.setup/setup-surface locale-dependent setup-prompt text, session creds atomicity, inbound.media log-redaction sentinels, agent-tools-call, web-auto-reply-utils). For 5 of those files the identical failures were reproduced with the fix stashed (pristine base), proving pre-existing; the remaining 2 fail on environment-local assertions unrelated to the receipt path.
- `pnpm tsgo:extensions:test`: clean. oxfmt and oxlint: clean on all changed files.
- Live WhatsApp proof not feasible from this contributor environment (no linked WhatsApp Web session); the fake-transport harness (`sock.readMessages`) covers the changed receive path end-to-end (upsert → admission → normalize → read receipt), including both failure modes above. The bot's live run of the focused test file stopped at its 30s expect window on an ~40s wall-clock vitest run (transform+import dominate); the same command passes locally at this head.


### Round-8 follow-up: receipt dispatch decoupled from the upsert loop (head ec96d15707f)

- Round-7 [P2] finding ("Avoid serializing a whole upsert behind a stalled receipt", `message-delivery.ts:633-636`): the accepted path awaited `maybeMarkNonSelfChatReadReceipt` inside the sequential upsert loop, so a first receipt stalled on the socket (bounded by the 60s operation timeout) delayed admission of every later message in the same batch.
- Fix: new `dispatchReadReceipt` fire-and-track helper; both call sites (ephemeral and durable accepted paths) now dispatch without awaiting. The `.catch` logs via `inboundLogger.warn`/`formatError` so no rejection escapes unhandled. The self-chat exclusion and the `sendReadReceipts` toggle are unchanged; `readReceiptsInFlight` is reserved synchronously when the async call starts and released in `finally`, so back-to-back dispatches for the same key still dedupe, and success-only memoization (`readReceiptsSent`) is preserved.
- Red→green regression (`delivery coordinator does not block later message admission on a stalled read receipt`): the first receipt is gated on the socket (`readMessages` resolves only on release; socket timeout 60s) while a second message arrives in the same upsert. With the fix stashed (old code): FAIL — the second message is never admitted while the first receipt stalls (`onMessage` called 1 time). With the fix: the second message is admitted and delivered during the stall, and after release each message has exactly one acknowledgement (no double-fire); the full focused file passes 21/21.
- `pnpm tsgo:extensions:test` clean; oxfmt and oxlint clean on both changed files.
### Round-9 follow-up: bounded concurrent receipt dispatch (head fba5916d99f)

The round-9 verdict flagged unbounded concurrent socket work on the fire-and-track path: each distinct inbound message started its own `readMessages` socket operation, and a stalled socket kept `readReceiptsInFlight` occupied for up to the 60s operation timeout.

- `READ_RECEIPT_INFLIGHT_MAX = 32` caps concurrently stalled acknowledgements. When the window is full, new receipts are skipped **without recording success**, so a later redelivery can retry them once capacity frees up. Message admission is never blocked: the skip is instant and no queue is built.
- Saturation is logged through the existing verbose path (`Read receipt dispatch saturated (N in flight); deferring acknowledgement for message <id>`).
- Dedupe semantics unchanged: sent memo check -> in-flight check -> saturation bound -> memo eviction -> reserve.

Regression evidence (TDD, red -> green):

- New test `delivery coordinator bounds concurrent read-receipt dispatches when the socket stalls`: one upsert of 35 distinct messages while every acknowledgement stalls on the socket.
  - Old code (red): `readMessages` called 35 times - unbounded.
  - Fixed (green): all 35 messages admitted and delivered, `readMessages` called exactly 32 times; after releasing the stalled acks, redelivering a skipped message retries its receipt (33rd call) and delivery stays deduped (the agent sees each message exactly once).
- Focused file `monitor-inbox.delivery-and-dedupe.test.ts`: **22/22**.
- `pnpm tsgo:extensions:test` clean; oxfmt and oxlint clean on both changed files.

On the remaining round-9 items: the +63 net production-line delta is the bounded dispatch itself - the cap is what makes the fire-and-track path safe under a stalled socket. The Baileys-typings / GitHub-offline note is a reviewer-environment limitation, not a code defect.


### Round-10 follow-up: drain saturated receipt targets instead of dropping them (head 7968468d7fd)

The round-10 verdict flagged the lossy saturation path: when the 32-entry in-flight window was full, new receipt targets were skipped without being retained or retried, so accepted messages beyond the window could reach the agent with no blue tick unless WhatsApp happened to redeliver them.

- Receipts arriving while the in-flight window is full now enter a bounded FIFO pending queue (`READ_RECEIPT_PENDING_MAX = 128`) and are drained one at a time as each in-flight claim settles (in the dispatch `finally`), so saturated receipts are eventually delivered instead of silently dropped.
- Only a burst beyond both bounds (32 in-flight + 128 pending) is dropped, with a `warn` log and without recording success, so redelivery can still retry it. Message admission is never blocked at any point.
- Dedupe semantics unchanged: sent memo -> in-flight -> pending -> saturation bound -> reserve; each message is acknowledged exactly once.
- The receipt bookkeeping now lives in a dedicated `read-receipt-dispatch.ts` module; `message-delivery.ts` stays within its 700-code-line lint budget.

Regression evidence (TDD, red -> green):

- Rewritten test `delivery coordinator bounds concurrent read-receipt dispatches and drains queued receipts when the socket recovers`: 35 distinct messages while every acknowledgement stalls.
  - Old code (red): after the socket recovers, `readMessages` stops at 32 calls - the 3 excess receipts were dropped.
  - Fixed (green): the queued receipts drain automatically to exactly 35 calls, every message is acknowledged exactly once, and redelivering an acknowledged message does not re-send its receipt.
- New test `delivery coordinator bounds the pending receipt queue and keeps overflow retryable`: 165 messages (beyond 32+128). Exactly 160 receipts are retained and drained; the 5 beyond-bound targets are dropped with a warn, and redelivering one of them retries its receipt (161st call) while delivery stays deduped.
- Focused file `monitor-inbox.delivery-and-dedupe.test.ts`: **23/23**.
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` clean; oxfmt and oxlint clean on all three changed files.

On the remaining items: the [P1] merge-risk finding shares the saturation-loss root and is closed by this change (the +84-line cap machinery is now a dedicated bounded dispatcher instead of an overflow `return`). Real linked-account proof remains unavailable from the contributor side (no linked WhatsApp account in this environment), as stated in earlier rounds; the in-memory harness covers the saturation and recovery behavior deterministically.

---

## Round-11 follow-up (head 3fb842341a5)

Addresses the round-11 review finding: **[P2] Retry failed receipts from active durable duplicates** (`extensions/whatsapp/src/inbound/message-delivery.ts:608`).

**What changed.** A replay of a message whose durable row is still pending or claimed never re-reached the read-receipt dispatcher, so a receive-time acknowledgement that failed on the first attempt (socket rejection or operation timeout) could never be retried and the sender's blue tick stayed lost. The pending/claimed duplicate verdicts now route through the same fire-and-track dispatch path used by the accepted and completed verdicts. The dispatcher dedupes across sent / in-flight / pending, so completed or in-flight acknowledgements remain no-ops, and the agent turn is never redelivered here (turn dispatch stays owned by the ingress drain).

**Tests (red-green).** Four new regressions in `extensions/whatsapp/src/monitor-inbox.receipt-retry.test.ts` cover rejected and timed-out first attempts across both pending and claimed duplicate states, each asserting the receipt retries through the dispatcher while the agent turn is not redelivered. Before the fix, the pending-rejected case failed (`readMessages` called 2 times vs the required 3); after the fix all four pass.

**Verification.**
- `monitor-inbox.receipt-retry.test.ts` 4/4 passed
- `monitor-inbox.delivery-and-dedupe.test.ts` 23/23 passed (regression)
- `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` clean
- `oxfmt --check` and `oxlint` clean on the changed files
