### PR TITLE
fix(sandbox): resolve bare upload handles to staged inbound media

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -201,6 +201,7 @@ type OpenClawCodingToolsOptions = {
   /** Opaque host-issued capability for current-turn channel message actions. */
   messageActionTurnCapability?: string;
   sandbox?: SandboxContext | null;
+  stagedMediaPaths?: ReadonlyMap<string, string>;
   sessionKey?: string;
   /**
    * The durable store session key for the live run when it differs from the
@@ -849,6 +850,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             sandboxRoot,
             sandboxContainerWorkdir: sandbox?.containerWorkdir,
             sandboxFsBridge,
+            stagedMediaPaths: options?.stagedMediaPaths,
             sandboxWorkspaceMediaReadAllowed,
             fsPolicy,
             workspaceDir: workspaceRoot,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -8,6 +8,7 @@ import {
   isCodeModeDiagnosticEnabled,
   logCodeModeDiagnostic,
 } from "../../../logging/code-mode-diagnostic.js";
+import { resolveStagedInputMediaPaths } from "../../../media/staged-inputs.js";
 import { extractModelCompat } from "../../../plugins/provider-model-compat.js";
 import { getPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
@@ -261,6 +262,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
             elevated: attempt.bashElevated,
           },
           sandbox: params.sandbox,
+          stagedMediaPaths: resolveStagedInputMediaPaths(attempt.media),
           sessionPermissionPolicy: params.sessionPermissionPolicy,
           messageProvider: resolveAttemptToolPolicyMessageProvider(attempt),
           agentAccountId: attempt.agentAccountId,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -125,7 +125,11 @@ export function createOpenClawTools(options?: OpenClawToolsOptions): AnyAgentToo
   const runtimeWebTools = getActiveRuntimeWebToolsMetadataFromState();
   const sandbox =
     options?.sandboxRoot && options?.sandboxFsBridge
-      ? { root: options.sandboxRoot, bridge: options.sandboxFsBridge }
+      ? {
+          root: options.sandboxRoot,
+          bridge: options.sandboxFsBridge,
+          stagedMediaPaths: options.stagedMediaPaths,
+        }
       : undefined;
   const optionalMediaTools = resolveOptionalMediaToolFactoryPlan({
     config: availabilityConfig ?? resolvedConfig,

--- a/src/agents/openclaw-tools.types.ts
+++ b/src/agents/openclaw-tools.types.ts
@@ -51,6 +51,8 @@ export type OpenClawToolsOptions = {
   sandboxRoot?: string;
   sandboxContainerWorkdir?: string;
   sandboxFsBridge?: SandboxFsBridge;
+  /** Producer-authored bare upload handles mapped to exact sandbox paths. */
+  stagedMediaPaths?: ReadonlyMap<string, string>;
   /** Prepared effective read authorization for exporting sandbox workspace media. */
   sandboxWorkspaceMediaReadAllowed?: boolean;
   fsPolicy?: ToolFsPolicy;

--- a/src/agents/sandbox-media-paths.ts
+++ b/src/agents/sandbox-media-paths.ts
@@ -16,6 +16,7 @@ export type SandboxedBridgeMediaPathConfig = {
   root: string;
   bridge: SandboxFsBridge;
   workspaceOnly?: boolean;
+  stagedMediaPaths?: ReadonlyMap<string, string>;
 };
 
 export function createSandboxBridgeReadFile(params: {
@@ -39,10 +40,24 @@ export async function resolveSandboxedBridgeMediaPath(params: {
   const mediaPathInfo = params.inboundFallbackDir
     ? resolveMediaReferenceSandboxPath(params.mediaPath, params.inboundFallbackDir)
     : { resolved: params.mediaPath };
-  const filePath = /^file:/iu.test(mediaPathInfo.resolved)
+  let filePath = /^file:/iu.test(mediaPathInfo.resolved)
     ? safeFileURLToPath(mediaPathInfo.resolved, "linux")
     : mediaPathInfo.resolved;
-  const rewrittenFrom = mediaPathInfo.rewrittenFrom;
+  let rewrittenFrom = mediaPathInfo.rewrittenFrom;
+  const stagedMediaPath = rewrittenFrom
+    ? undefined
+    : params.sandbox.stagedMediaPaths?.get(filePath);
+  if (stagedMediaPath) {
+    // A real workspace entry remains authoritative over the producer's staged alias.
+    const directStat = await params.sandbox.bridge.stat({
+      filePath,
+      cwd: params.sandbox.root,
+    });
+    if (!directStat) {
+      rewrittenFrom = filePath;
+      filePath = stagedMediaPath;
+    }
+  }
   if (rewrittenFrom) {
     const stat = await params.sandbox.bridge.stat({
       filePath,

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -72,13 +72,15 @@ import {
   loadMediaToolReferences,
   normalizeMediaReferenceInputs,
   readGenerationTimeoutMs,
+  resolveMediaToolSandboxConfig,
   resolveRemoteMediaSsrfPolicy,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
   resolveSelectedCapabilityProvider,
+  type MediaToolSandbox,
 } from "./media-tool-shared.js";
 import type { ToolModelConfig } from "./model-config.helpers.js";
-import type { AnyAgentTool, SandboxFsBridge, ToolFsPolicy } from "./tool-runtime.helpers.js";
+import type { AnyAgentTool, ToolFsPolicy } from "./tool-runtime.helpers.js";
 
 const DEFAULT_COUNT = 1;
 const MAX_COUNT = 4;
@@ -515,16 +517,13 @@ function validateImageGenerationCapabilities(params: {
   }
 }
 
-type ImageGenerateSandboxConfig = {
-  root: string;
-  bridge: SandboxFsBridge;
-};
+type ImageGenerateSandboxConfig = MediaToolSandbox;
 
 async function loadReferenceImages(params: {
   imageInputs: string[];
   maxBytes: number;
   workspaceDir?: string;
-  sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
+  sandboxConfig: ReturnType<typeof resolveMediaToolSandboxConfig>;
   ssrfPolicy?: SsrFPolicy;
   signal?: AbortSignal;
 }): Promise<
@@ -795,14 +794,10 @@ export function createImageGenerateTool(options?: {
   ) {
     return null;
   }
-  const sandboxConfig =
-    options?.sandbox && options.sandbox.root.trim()
-      ? {
-          root: options.sandbox.root.trim(),
-          bridge: options.sandbox.bridge,
-          workspaceOnly: options.fsPolicy?.workspaceOnly === true,
-        }
-      : null;
+  const sandboxConfig = resolveMediaToolSandboxConfig(
+    options?.sandbox,
+    options?.fsPolicy?.workspaceOnly,
+  );
   const scheduleBackgroundWork =
     options?.scheduleBackgroundWork ?? defaultScheduleImageGenerateBackgroundWork;
 

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -2525,6 +2525,43 @@ describe("image tool implicit imageModel config", () => {
       expect((res.details as { rewrittenFrom?: string }).rewrittenFrom).toContain("photo.png");
     });
   });
+
+  it("resolves a producer-staged bare upload handle", async () => {
+    await withTempSandboxState(async ({ agentDir, sandboxRoot }) => {
+      const stagedPath = "media/inbound/openclaw-staged-proof/input-file_upload.png";
+      await fs.mkdir(path.dirname(path.join(sandboxRoot, stagedPath)), { recursive: true });
+      await fs.writeFile(
+        path.join(sandboxRoot, stagedPath),
+        Buffer.from(ONE_PIXEL_PNG_B64, "base64"),
+      );
+
+      const fetch = stubMinimaxOkFetch();
+      const sandbox = {
+        root: sandboxRoot,
+        bridge: createHostSandboxFsBridge(sandboxRoot),
+        stagedMediaPaths: new Map([["file_upload", stagedPath]]),
+      };
+      const tool = createRequiredImageTool({
+        config: createMinimaxImageConfig(),
+        agentDir,
+        sandbox,
+      });
+
+      const res = await tool.execute("t1", { path: "file_upload" });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(res.details).toMatchObject({ rewrittenFrom: "file_upload" });
+
+      await fs.writeFile(
+        path.join(sandboxRoot, "file_upload"),
+        Buffer.from(ONE_PIXEL_PNG_B64, "base64"),
+      );
+      const direct = await tool.execute("t2", { path: "file_upload" });
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(direct.details).not.toHaveProperty("rewrittenFrom");
+    });
+  });
 });
 
 describe("image tool data URL support", () => {

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -62,10 +62,12 @@ import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
   REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
+  resolveMediaToolSandboxConfig,
   resolveMediaToolInboundRoots,
   resolveMediaToolReferenceAccess,
   resolveRemoteMediaSsrfPolicy,
   resolvePromptAndModelOverride,
+  type MediaToolSandbox,
 } from "./media-tool-shared.js";
 import {
   buildToolModelConfigFromCandidates,
@@ -77,8 +79,6 @@ import {
   createSandboxBridgeReadFile,
   runWithImageModelFallback,
   type AnyAgentTool,
-  type SandboxedBridgeMediaPathConfig,
-  type SandboxFsBridge,
   type ToolFsPolicy,
 } from "./tool-runtime.helpers.js";
 
@@ -659,10 +659,7 @@ function resolveImageToolTimeoutMs(params: {
   );
 }
 
-type ImageSandboxConfig = {
-  root: string;
-  bridge: SandboxFsBridge;
-};
+type ImageSandboxConfig = MediaToolSandbox;
 
 async function runImagePrompt(params: {
   cfg?: OpenClawConfig;
@@ -995,14 +992,10 @@ export function createImageTool(options?: {
       }
       const imageCompression =
         imageRoute.kind === "fallback" ? imageRoute.imageCompression : undefined;
-      const sandboxConfig: SandboxedBridgeMediaPathConfig | null =
-        options?.sandbox && options?.sandbox.root.trim()
-          ? {
-              root: options.sandbox.root.trim(),
-              bridge: options.sandbox.bridge,
-              workspaceOnly: options.fsPolicy?.workspaceOnly === true,
-            }
-          : null;
+      const sandboxConfig = resolveMediaToolSandboxConfig(
+        options?.sandbox,
+        options?.fsPolicy?.workspaceOnly,
+      );
 
       // MARK: - Load and resolve each image
       const loadedImages: LoadedImageForTool[] = [];

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -1,18 +1,25 @@
 // Shared media tool tests cover root separation, provider availability, and
 // model-registry normalization for generation/understanding tools.
+import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import { createHostSandboxFsBridge } from "../test-helpers/host-sandbox-fs-bridge.js";
 import {
   hasGenerationToolAvailability,
   isCapabilityProviderConfigured,
+  loadMediaToolReferences,
   resolveGenerateAction,
   resolveMediaToolInboundRoots,
   resolveCapabilityModelConfigForTool,
   resolveMediaToolReferenceAccess,
+  resolveMediaToolSandboxConfig,
 } from "./media-tool-shared.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 // Keep media-tool-shared tests focused on root separation; channel-inbound
 // tests cover the real bundled contract loader.
@@ -186,6 +193,45 @@ describe("resolveMediaToolReferenceAccess", () => {
       }),
     ).rejects.toThrow(expected);
   });
+
+  it.each(["image_generate", "video_generate", "music_generate"] as const)(
+    "loads a producer-staged bare handle for %s references",
+    async (toolName) => {
+      const root = tempDirs.make("openclaw-media-tool-staged-");
+      const stagedPath = "media/inbound/openclaw-staged-proof/input-file_upload.png";
+      const fullPath = path.join(root, stagedPath);
+      await fs.mkdir(path.dirname(fullPath), { recursive: true });
+      await fs.writeFile(
+        fullPath,
+        Buffer.from(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2f7z8AAAAASUVORK5CYII=",
+          "base64",
+        ),
+      );
+      const sandbox = resolveMediaToolSandboxConfig(
+        {
+          root,
+          bridge: createHostSandboxFsBridge(root),
+          stagedMediaPaths: new Map([["file_upload", stagedPath]]),
+        },
+        true,
+      );
+
+      const loaded = await loadMediaToolReferences({
+        inputs: ["file_upload"],
+        toolName,
+        expectedKind: "image",
+        sandbox,
+        workspaceDir: root,
+        maxBytes: 1024,
+        mapMedia: (media) => media.buffer,
+      });
+
+      expect(loaded).toMatchObject([
+        { resolvedInput: "file_upload", rewrittenFrom: "file_upload" },
+      ]);
+    },
+  );
 });
 
 describe("hasGenerationToolAvailability", () => {

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -594,6 +594,22 @@ export async function resolveMediaToolReferenceAccess(params: {
 
 type LoadedToolReferenceMedia = WebMediaResult | ReturnType<typeof decodeDataUrl>;
 
+export type MediaToolSandbox = Pick<
+  SandboxedBridgeMediaPathConfig,
+  "root" | "bridge" | "stagedMediaPaths"
+>;
+
+export function resolveMediaToolSandboxConfig(
+  sandbox: MediaToolSandbox | null | undefined,
+  workspaceOnly: boolean | undefined,
+): SandboxedBridgeMediaPathConfig | null {
+  if (!sandbox) {
+    return null;
+  }
+  const root = sandbox.root.trim();
+  return root ? { ...sandbox, root, workspaceOnly: workspaceOnly === true } : null;
+}
+
 /** Loads generation references while retaining each tool's distinct transport and sandbox policy. */
 export async function loadMediaToolReferences<T>(params: {
   inputs: string[];

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -51,10 +51,12 @@ import {
   hasGenerationToolAvailability,
   loadMediaToolReferences,
   normalizeMediaReferenceInputs,
+  resolveMediaToolSandboxConfig,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
   resolveRemoteMediaSsrfPolicy,
   resolveSelectedCapabilityProvider,
+  type MediaToolSandbox,
 } from "./media-tool-shared.js";
 import type { ToolModelConfig } from "./model-config.helpers.js";
 import {
@@ -62,7 +64,7 @@ import {
   createMusicGenerateListActionResult,
   createMusicGenerateStatusActionResult,
 } from "./music-generate-tool.actions.js";
-import type { AnyAgentTool, SandboxFsBridge, ToolFsPolicy } from "./tool-runtime.helpers.js";
+import type { AnyAgentTool, ToolFsPolicy } from "./tool-runtime.helpers.js";
 
 const log = createSubsystemLogger("agents/tools/music-generate");
 const MAX_INPUT_IMAGES = 10;
@@ -214,10 +216,7 @@ function validateMusicGenerationCapabilities(params: {
   }
 }
 
-type MusicGenerateSandboxConfig = {
-  root: string;
-  bridge: SandboxFsBridge;
-};
+type MusicGenerateSandboxConfig = MediaToolSandbox;
 
 type MusicGenerationTimeoutNormalization = {
   requested: number;
@@ -264,7 +263,7 @@ async function loadReferenceImages(params: {
   inputs: string[];
   maxBytes: number;
   workspaceDir?: string;
-  sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
+  sandboxConfig: ReturnType<typeof resolveMediaToolSandboxConfig>;
   ssrfPolicy?: SsrFPolicy;
   timeoutMs?: number;
   signal?: AbortSignal;
@@ -538,13 +537,10 @@ export function createMusicGenerateTool(options?: {
     return null;
   }
 
-  const sandboxConfig = options?.sandbox
-    ? {
-        root: options.sandbox.root,
-        bridge: options.sandbox.bridge,
-        workspaceOnly: options.fsPolicy?.workspaceOnly === true,
-      }
-    : null;
+  const sandboxConfig = resolveMediaToolSandboxConfig(
+    options?.sandbox,
+    options?.fsPolicy?.workspaceOnly,
+  );
   const scheduleBackgroundWork =
     options?.scheduleBackgroundWork ?? defaultScheduleMusicGenerateBackgroundWork;
 

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as pdfExtractModule from "../../media/pdf-extract.js";
 import * as webMedia from "../../media/web-media.js";
@@ -22,6 +23,7 @@ import {
 
 const completeMock = vi.hoisted(() => vi.fn());
 const registerProviderStreamForModelMock = vi.hoisted(() => vi.fn());
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("../../llm/stream.js", async () => {
   const actual = await vi.importActual<typeof import("../../llm/stream.js")>("../../llm/stream.js");
@@ -476,6 +478,39 @@ describe("createPdfTool", () => {
       });
     },
   );
+
+  it("resolves a producer-staged bare PDF handle", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      const workspaceDir = tempDirs.make("openclaw-pdf-sandbox-");
+      const stagedPath = "media/inbound/openclaw-staged-proof/input-file_upload.pdf";
+      await fs.mkdir(path.dirname(path.join(workspaceDir, stagedPath)), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, stagedPath), FAKE_PDF_MEDIA.buffer);
+      await stubPdfToolInfra(agentDir, {
+        mockLoad: false,
+        provider: "anthropic",
+        input: ["text", "document"],
+      });
+      vi.spyOn(pdfNativeProviders, "anthropicAnalyzePdf").mockResolvedValue("native summary");
+      const tool = requirePdfTool(
+        (await loadCreatePdfTool())({
+          config: withPdfModel(ANTHROPIC_PDF_MODEL),
+          agentDir,
+          workspaceDir,
+          sandbox: {
+            root: workspaceDir,
+            bridge: createContainerWorkspaceSandboxFsBridge(workspaceDir),
+            stagedMediaPaths: new Map([["file_upload", stagedPath]]),
+          },
+          fsPolicy: { workspaceOnly: true },
+        }),
+      );
+
+      const result = await tool.execute("t1", { prompt: "summarize", pdf: "file_upload" });
+
+      expect(result.content).toEqual([{ type: "text", text: "native summary" }]);
+      expect(result.details).toMatchObject({ rewrittenFrom: "file_upload" });
+    });
+  });
 
   it("passes web_fetch SSRF policy when loading remote PDFs", async () => {
     await withTempPdfAgentDir(async (agentDir) => {

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -37,10 +37,12 @@ import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
   REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
+  resolveMediaToolSandboxConfig,
   resolveMediaToolReferenceAccess,
   resolveModelRuntimeApiKey,
   resolvePromptAndModelOverride,
   resolveRemoteMediaSsrfPolicy,
+  type MediaToolSandbox,
 } from "./media-tool-shared.js";
 import { hasToolModelConfig } from "./model-config.helpers.js";
 import { anthropicAnalyzePdf, geminiAnalyzePdf } from "./pdf-native-providers.js";
@@ -57,8 +59,6 @@ import {
   createSandboxBridgeReadFile,
   runWithImageModelFallback,
   type AnyAgentTool,
-  type SandboxedBridgeMediaPathConfig,
-  type SandboxFsBridge,
   type ToolFsPolicy,
 } from "./tool-runtime.helpers.js";
 
@@ -138,10 +138,7 @@ function buildPdfExtractionContext(
 // Run PDF prompt with model fallback
 // ---------------------------------------------------------------------------
 
-type PdfSandboxConfig = {
-  root: string;
-  bridge: SandboxFsBridge;
-};
+type PdfSandboxConfig = MediaToolSandbox;
 
 async function runPdfPrompt(params: {
   cfg?: OpenClawConfig;
@@ -486,14 +483,10 @@ export function createPdfTool(options?: {
         throw new ToolInputError("No PDF model configured.");
       }
 
-      const sandboxConfig: SandboxedBridgeMediaPathConfig | null =
-        options?.sandbox && options.sandbox.root.trim()
-          ? {
-              root: options.sandbox.root.trim(),
-              bridge: options.sandbox.bridge,
-              workspaceOnly: options.fsPolicy?.workspaceOnly === true,
-            }
-          : null;
+      const sandboxConfig = resolveMediaToolSandboxConfig(
+        options?.sandbox,
+        options?.fsPolicy?.workspaceOnly,
+      );
 
       // MARK: - Load each PDF
       const loadedPdfs: Array<{

--- a/src/agents/tools/tool-runtime.helpers.ts
+++ b/src/agents/tools/tool-runtime.helpers.ts
@@ -6,11 +6,7 @@
  */
 export { getApiKeyForModelCore, requireApiKey } from "../model-auth.js";
 export { runWithImageModelFallback } from "../model-fallback-image.js";
-export {
-  createSandboxBridgeReadFile,
-  type SandboxedBridgeMediaPathConfig,
-} from "../sandbox-media-paths.js";
-export type { SandboxFsBridge } from "../sandbox/fs-bridge.js";
+export { createSandboxBridgeReadFile } from "../sandbox-media-paths.js";
 export type { ToolFsPolicy } from "../tool-fs-policy.js";
 export { normalizeWorkspaceDir } from "../workspace-dir.js";
 export type { AnyAgentTool } from "./common.js";

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -59,17 +59,19 @@ import {
   loadMediaToolReferences,
   normalizeMediaReferenceInputs,
   readGenerationTimeoutMs,
+  resolveMediaToolSandboxConfig,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
   resolveRemoteMediaSsrfPolicy,
   resolveSelectedCapabilityProvider,
+  type MediaToolSandbox,
 } from "./media-tool-shared.js";
 import {
   hasAuthForProvider,
   coerceToolModelConfig,
   type ToolModelConfig,
 } from "./model-config.helpers.js";
-import type { AnyAgentTool, SandboxFsBridge, ToolFsPolicy } from "./tool-runtime.helpers.js";
+import type { AnyAgentTool, ToolFsPolicy } from "./tool-runtime.helpers.js";
 import {
   createVideoGenerateDuplicateGuardResult,
   createVideoGenerateListActionResult,
@@ -427,10 +429,7 @@ function formatIgnoredVideoGenerationOverride(override: VideoGenerationIgnoredOv
   return `${sanitizeGeneratedMediaDisplayText(override.key)}=${sanitizeGeneratedMediaDisplayText(String(override.value))}`;
 }
 
-type VideoGenerateSandboxConfig = {
-  root: string;
-  bridge: SandboxFsBridge;
-};
+type VideoGenerateSandboxConfig = MediaToolSandbox;
 
 const defaultScheduleVideoGenerateBackgroundWork = createDefaultMediaGenerateBackgroundScheduler({
   toolName: "video_generate",
@@ -442,7 +441,7 @@ async function loadReferenceAssets(params: {
   expectedKind: "image" | "video" | "audio";
   maxBytes: number;
   workspaceDir?: string;
-  sandboxConfig: { root: string; bridge: SandboxFsBridge; workspaceOnly: boolean } | null;
+  sandboxConfig: ReturnType<typeof resolveMediaToolSandboxConfig>;
   ssrfPolicy?: SsrFPolicy;
   signal?: AbortSignal;
 }): Promise<
@@ -817,13 +816,10 @@ export function createVideoGenerateTool(options?: {
     return null;
   }
 
-  const sandboxConfig = options?.sandbox
-    ? {
-        root: options.sandbox.root,
-        bridge: options.sandbox.bridge,
-        workspaceOnly: options.fsPolicy?.workspaceOnly === true,
-      }
-    : null;
+  const sandboxConfig = resolveMediaToolSandboxConfig(
+    options?.sandbox,
+    options?.fsPolicy?.workspaceOnly,
+  );
   const scheduleBackgroundWork =
     options?.scheduleBackgroundWork ?? defaultScheduleVideoGenerateBackgroundWork;
   const includeAudioReferences = shouldExposeVideoReferenceAudioParams({

--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path, { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveStagedInputMediaPaths } from "../media/staged-inputs.js";
 import { MEDIA_MAX_BYTES } from "../media/store.js";
 import { SANDBOX_MEDIA_MAX_BYTES, stageSandboxMedia } from "./reply/stage-sandbox-media.js";
 import {
@@ -104,8 +105,35 @@ describe("stageSandboxMedia", () => {
       expect(ctx.media?.[0]?.url).toBe(stagedPath);
       expect(sessionCtx.media?.[0]?.url).toBe(stagedPath);
       expect(ctx.media?.[0]).toMatchObject({ path: stagedPath, workspaceDir: sandboxDir });
+      expect(ctx.media?.[0]?.staged).toBe(true);
       expect(sessionCtx.media?.[0]).toMatchObject({ path: stagedPath, workspaceDir: sandboxDir });
       await expect(fs.readFile(join(sandboxDir, stagedPath), "utf8")).resolves.toBe("pdf-bytes");
+    });
+  });
+
+  it("maps a staged upload handle to its exact private input path", async () => {
+    await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
+      const { cfg, workspaceDir } = await setupSandboxWorkspace(home);
+      const fileName = "file_upload.jpg";
+      await writeInboundMedia(home, fileName, "jpeg-bytes");
+      const mediaUri = `media://inbound/${fileName}`;
+      const { ctx, sessionCtx } = createSandboxMediaContexts(mediaUri);
+
+      const result = await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      });
+
+      const stagedPath = result.staged.get(0)!;
+      expect(resolveStagedInputMediaPaths(ctx.media)).toEqual(
+        new Map([
+          ["file_upload.jpg", stagedPath],
+          ["file_upload", stagedPath],
+        ]),
+      );
     });
   });
 

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -170,6 +170,7 @@ export async function stageSandboxMedia(params: {
         path: stagedPath,
         ...(stagedUrlAliases.has(index) ? { url: stagedPath } : {}),
         workspaceDir: effectiveWorkspaceDir,
+        staged: true,
       };
     }
   }

--- a/src/media/staged-inputs.ts
+++ b/src/media/staged-inputs.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
 import { root as fsRoot, sanitizeUntrustedFileName, type Root } from "../infra/fs-safe.js";
+import type { MediaFact } from "./media-facts.js";
 
 const STAGED_INPUT_DIRECTORY_PREFIX = "media/inbound/openclaw-staged-";
 export const STAGED_INPUT_GIT_PATHSPEC = `:(glob)${STAGED_INPUT_DIRECTORY_PREFIX}*/**`;
@@ -87,6 +89,44 @@ export function stagedInputDirectory(identity: string): string {
 export function stagedInputFileName(name: string): string {
   // A generic prefix keeps uploaded Git control filenames ordinary input files.
   return sanitizeUntrustedFileName(`input-${name}`, "input-attachment");
+}
+
+/** Maps producer-stamped upload handles to exact private paths for the current turn. */
+export function resolveStagedInputMediaPaths(
+  media: readonly MediaFact[] | undefined,
+): ReadonlyMap<string, string> {
+  const paths = new Map<string, string>();
+  const ambiguous = new Set<string>();
+  for (const fact of media ?? []) {
+    if (fact.staged !== true || !fact.path) {
+      continue;
+    }
+    const directory = stagedInputPathDirectory(fact.path);
+    const prefix = directory ? `${directory}/input-` : undefined;
+    if (!prefix || !fact.path.startsWith(prefix)) {
+      continue;
+    }
+    const fileName = fact.path.slice(prefix.length);
+    if (!/^file_[^/\\]+$/u.test(fileName)) {
+      continue;
+    }
+    const extension = path.posix.extname(fileName);
+    const aliases = extension ? [fileName, fileName.slice(0, -extension.length)] : [fileName];
+    for (const alias of aliases) {
+      if (ambiguous.has(alias)) {
+        continue;
+      }
+      const existing = paths.get(alias);
+      if (existing && existing !== fact.path) {
+        // A duplicate alias has no authoritative target; input order must not select one.
+        paths.delete(alias);
+        ambiguous.add(alias);
+      } else {
+        paths.set(alias, fact.path);
+      }
+    }
+  }
+  return paths;
 }
 
 export async function ensureStagedInputDirectory(


### PR DESCRIPTION
## What Problem This Solves

Sandboxed agents could not inspect an uploaded image when the model used its bare `file_<id>` handle. The image tool resolved that handle at the workspace root and returned `ENOENT`, even though inbound staging had copied the image into the private sandbox input directory.

PR #122031 established the contract: managed inbound media references remain available for later inspection.

## Root cause

The staging producer knew the exact private path, but tool construction discarded that mapping. The stale patch scanned a former flat `media/inbound` layout and added directory-listing APIs. Current staging uses marker-owned `media/inbound/openclaw-staged-<id>/input-<name>` directories, so that scan could not own the mapping.

## Fix

- Mark producer-staged media facts explicitly.
- Build one bounded alias-to-path map from those facts during attempt preparation.
- Carry the map into sandbox media tools.
- Resolve only exact `file_` aliases, reject ambiguous aliases, and keep an existing workspace file authoritative.
- Keep canonical `media://inbound/...` handling unchanged.

No directory scan, extension allowlist, filesystem bridge API, config change, or documented behavior change is added.

## Evidence

- Exact-main red at `0320297d7a1573c08cfaab781f93bd57dc4a694b`: a real Docker sandbox staged a 519-byte JPEG, `view_image("file_proof")` returned `ENOENT`, and the exact staged path read with JPEG signature `ffd8ff`.
- Exact-head green at `aa4a2f88049a37af4814d68ab87f52b3f0ac2f7c`: the same Docker and image-tool flow loaded the 519-byte JPEG from the producer path through the bare handle.
- Focused suites: 494 tests passed across staging, tool assembly, sandbox path resolution, native image hydration, `view_image`, PDF, and media-generation references.
- All permitted changed-scope checks passed. Hosted CI owns the required TypeScript checks for this host.

## Scope

- Production: +127/−76 lines, net +51. One shared sandbox-media configuration replaces five duplicate tool-specific builders and carries the producer-owned mapping.
- Tests: +147/−1 lines, net +146. The image regression failed on pre-fix code for the expected workspace-root `ENOENT`; PDF and generation references cover the shared sibling path.

Closes #129084
