### PR TITLE
fix(qa): scope restart sentinel checks to scenario logs

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-causality.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-causality.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createQaBusState } from "./bus-state.js";
+import { assertNoGatewayLogSentinels } from "./gateway-log-sentinel.js";
 import { readQaScenarioById, readQaScenarioExecutionConfig } from "./scenario-catalog.js";
 import { readFlowAssertExpression, requireFlowScenario } from "./scenario-catalog.test-utils.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
@@ -246,6 +247,35 @@ describe("qa scenario catalog causality", () => {
     });
     expect(actions.some((action) => (action as { call?: string }).call === "sleep")).toBe(false);
   });
+
+  it.each(["gateway-restart-inflight-run", "gateway-restart-multi-live"] as const)(
+    "ignores pre-scenario gateway sentinel logs during %s recovery",
+    async (scenarioId) => {
+      const scenario = requireFlowScenario(readQaScenarioById(scenarioId));
+      const actions = scenario.execution.flow?.steps.flatMap((step) => step.actions) ?? [];
+      const gatewayActions = actions.filter(
+        (action) =>
+          (action as { set?: string }).set === "gatewayLogCursor" ||
+          (action as { call?: string }).call === "assertNoGatewayLogSentinels",
+      );
+      expect(gatewayActions).toHaveLength(2);
+      const priorLogs = "codex_app_server progress stalled before this scenario\n";
+
+      await expect(
+        runLoadedScenarioFlow(scenarioId, {
+          flow: {
+            steps: [{ name: "ignores prior sentinels", actions: gatewayActions }],
+          },
+          api: {
+            markGatewayLogCursor: () => priorLogs.length,
+            assertNoGatewayLogSentinels: (
+              options?: Parameters<typeof assertNoGatewayLogSentinels>[1],
+            ) => assertNoGatewayLogSentinels(`${priorLogs}gateway recovered cleanly`, options),
+          },
+        }),
+      ).resolves.toMatchObject({ status: "pass" });
+    },
+  );
 
   it("scopes prompt diagnostics to requests after each scenario cursor", () => {
     for (const scenarioId of [

--- a/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
+++ b/qa/scenarios/runtime/gateway-restart-inflight-run.yaml
@@ -311,6 +311,6 @@ flow:
             message: replay-safe QA checkpoint tool was removed before Code Mode catalog construction
         - call: assertNoGatewayLogSentinels
           args:
-            - sinceIndex:
+            - since:
                 ref: gatewayLogCursor
       detailsExpr: "`inboundMessageId=${inbound.id} session=${sessionKey} restarts=3 execs=${finalTranscript.assistantToolCallCounts.exec ?? 0} waits=${finalTranscript.assistantToolCallCounts.wait ?? 0} deliveryRunIds=${checkpointDeliveryRunIds.join(',')} auditAnchorRunId=${auditAnchorIdentity.runId} recoveryDispatches=${recoveryDispatches} retainedPolicies=${retainedPolicies} finalDeliveries=${finalMatches.length} resendNotices=${restartNotices.length}\n${outbound.text}`"

--- a/qa/scenarios/runtime/gateway-restart-multi-live.yaml
+++ b/qa/scenarios/runtime/gateway-restart-multi-live.yaml
@@ -281,6 +281,6 @@ flow:
             message: replay-safe QA checkpoint tool was removed before Code Mode catalog construction
         - call: assertNoGatewayLogSentinels
           args:
-            - sinceIndex:
+            - since:
                 ref: gatewayLogCursor
       detailsExpr: "`inboundMessageId=${inbound.id} session=${sessionKey} restarts=3 execs=${finalTranscript.assistantToolCallCounts.exec ?? 0} waits=${finalTranscript.assistantToolCallCounts.wait ?? 0} recoveryDispatches=${recoveryDispatches} retainedPolicies=${retainedPolicies} finalDeliveries=${finalMatches.length} resendNotices=${restartNotices.length}\n${outbound.text}`"


### PR DESCRIPTION
## Summary

- Repair both gateway-restart QA scenarios that passed the nonexistent `sinceIndex` option to the shared log-sentinel owner.
- Use the existing canonical `since` cursor so diagnostics from before the scenario cannot falsely fail an otherwise clean restart.
- Cover the actual parsed YAML actions and real sentinel implementation for both scenarios.

## Root cause

The scenario action payload diverged from `assertNoGatewayLogSentinels`' existing option contract. The sentinel therefore scanned the entire gateway log instead of beginning at the cursor captured by each scenario.

## Validation

- Authentic pre-fix regression: a pre-scenario `codex_app_server progress stalled` log falsely failed each real parsed restart scenario.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run extensions/qa-lab/src/scenario-catalog-causality.test.ts extensions/qa-lab/src/gateway-log-sentinel.test.ts` — 20 tests passed.
- Repository formatter, `git diff --check`, and independent Codex autoreview passed.
- No production TypeScript, gateway protocol, configuration, or persistence changes.
