### PR TITLE
fix(reply): preserve explicit routing through block coalescing

### DIFF
--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -26,14 +26,7 @@ export function createBlockReplyCoalescer(params: {
   const flushOnEnqueue = config.flushOnEnqueue === true;
 
   let bufferText = "";
-  let bufferReplyToId: ReplyPayload["replyToId"];
-  let bufferAudioAsVoice: ReplyPayload["audioAsVoice"];
-  let bufferIsReasoning: ReplyPayload["isReasoning"];
-  let bufferIsCommentary: ReplyPayload["isCommentary"];
-  let bufferIsCompactionNotice: ReplyPayload["isCompactionNotice"];
-  let bufferIsFallbackNotice: ReplyPayload["isFallbackNotice"];
-  let bufferIsStatusNotice: ReplyPayload["isStatusNotice"];
-  let bufferMetadataSource: ReplyPayload | undefined;
+  let bufferedPayload: ReplyPayload | undefined;
   let idleTimer: NodeJS.Timeout | undefined;
 
   const clearIdleTimer = () => {
@@ -46,25 +39,7 @@ export function createBlockReplyCoalescer(params: {
 
   const resetBuffer = () => {
     bufferText = "";
-    bufferReplyToId = undefined;
-    bufferAudioAsVoice = undefined;
-    bufferIsReasoning = undefined;
-    bufferIsCommentary = undefined;
-    bufferIsCompactionNotice = undefined;
-    bufferIsFallbackNotice = undefined;
-    bufferIsStatusNotice = undefined;
-    bufferMetadataSource = undefined;
-  };
-
-  const startBufferFromPayload = (payload: ReplyPayload) => {
-    bufferReplyToId = payload.replyToId;
-    bufferAudioAsVoice = payload.audioAsVoice;
-    bufferIsReasoning = payload.isReasoning;
-    bufferIsCommentary = payload.isCommentary;
-    bufferIsCompactionNotice = payload.isCompactionNotice;
-    bufferIsFallbackNotice = payload.isFallbackNotice;
-    bufferIsStatusNotice = payload.isStatusNotice;
-    bufferMetadataSource = payload;
+    bufferedPayload = undefined;
   };
 
   const scheduleIdleFlush = () => {
@@ -83,55 +58,48 @@ export function createBlockReplyCoalescer(params: {
       resetBuffer();
       return;
     }
-    if (!bufferText) {
+    if (!bufferText || !bufferedPayload) {
       return;
     }
     if (!options?.force && !flushOnEnqueue && bufferText.length < minChars) {
       scheduleIdleFlush();
       return;
     }
-    const payload: ReplyPayload = {
+    const payload = copyReplyPayloadMetadata(bufferedPayload, {
+      ...bufferedPayload,
       text: bufferText,
-      replyToId: bufferReplyToId,
-      audioAsVoice: bufferAudioAsVoice,
-      isReasoning: bufferIsReasoning,
-      isCommentary: bufferIsCommentary,
-      isCompactionNotice: bufferIsCompactionNotice,
-      isFallbackNotice: bufferIsFallbackNotice,
-      isStatusNotice: bufferIsStatusNotice,
-    };
-    const payloadWithMetadata = copyReplyPayloadMetadata(bufferMetadataSource ?? payload, payload);
+    });
     resetBuffer();
-    await onFlush(payloadWithMetadata);
+    await onFlush(payload);
   };
 
   const canMergeBufferedTextWithMedia = (payload: ReplyPayload) =>
     Boolean(bufferText) &&
+    bufferedPayload !== undefined &&
     !flushOnEnqueue &&
-    !bufferAudioAsVoice &&
+    !bufferedPayload.audioAsVoice &&
     !payload.audioAsVoice &&
     !payload.isReasoning &&
     !payload.isCommentary &&
     !isReplyPayloadStatusNotice(payload) &&
-    !bufferIsReasoning &&
-    !bufferIsCommentary &&
-    !isReplyPayloadStatusNotice({
-      isCompactionNotice: bufferIsCompactionNotice,
-      isFallbackNotice: bufferIsFallbackNotice,
-      isStatusNotice: bufferIsStatusNotice,
-    }) &&
-    (!payload.replyToId || bufferReplyToId === payload.replyToId);
+    !bufferedPayload.isReasoning &&
+    !bufferedPayload.isCommentary &&
+    !isReplyPayloadStatusNotice(bufferedPayload) &&
+    (!payload.replyToId || bufferedPayload.replyToId === payload.replyToId);
 
   /** Merges buffered text into a media payload without changing media metadata. */
   const mergeBufferedTextWithMedia = (payload: ReplyPayload, text: string): ReplyPayload => {
     const mergedText = text ? `${bufferText}${joiner}${text}` : bufferText;
     const mergedPayload: ReplyPayload = {
+      ...bufferedPayload,
       ...payload,
       text: mergedText,
-      replyToId: payload.replyToId ?? bufferReplyToId,
+      replyToId: payload.replyToId ?? bufferedPayload?.replyToId,
+      replyToCurrent: payload.replyToCurrent || bufferedPayload?.replyToCurrent,
+      replyToTag: payload.replyToTag || bufferedPayload?.replyToTag,
     };
     const metadataMergedPayload = copyReplyPayloadMetadata(
-      bufferMetadataSource ?? mergedPayload,
+      bufferedPayload ?? mergedPayload,
       mergedPayload,
     );
     resetBuffer();
@@ -165,7 +133,7 @@ export function createBlockReplyCoalescer(params: {
       if (bufferText) {
         void flush({ force: true });
       }
-      startBufferFromPayload(payload);
+      bufferedPayload = payload;
       bufferText = text;
       void flush({ force: true });
       return;
@@ -174,36 +142,34 @@ export function createBlockReplyCoalescer(params: {
     const replyToConflict = Boolean(
       bufferText &&
       payload.replyToId &&
-      (!bufferReplyToId || bufferReplyToId !== payload.replyToId),
+      (!bufferedPayload?.replyToId || bufferedPayload.replyToId !== payload.replyToId),
     );
     const visibilityConflict =
       bufferText &&
-      (bufferIsReasoning !== payload.isReasoning ||
-        bufferIsCommentary !== payload.isCommentary ||
-        bufferIsCompactionNotice !== payload.isCompactionNotice ||
-        bufferIsFallbackNotice !== payload.isFallbackNotice ||
-        isReplyPayloadStatusNotice({
-          isCompactionNotice: bufferIsCompactionNotice,
-          isFallbackNotice: bufferIsFallbackNotice,
-          isStatusNotice: bufferIsStatusNotice,
-        }) !== isReplyPayloadStatusNotice(payload));
+      (bufferedPayload?.isReasoning !== payload.isReasoning ||
+        bufferedPayload.isCommentary !== payload.isCommentary ||
+        bufferedPayload.isCompactionNotice !== payload.isCompactionNotice ||
+        bufferedPayload.isFallbackNotice !== payload.isFallbackNotice ||
+        isReplyPayloadStatusNotice(bufferedPayload) !== isReplyPayloadStatusNotice(payload));
     // Flush before changing reply target, audio mode, or visibility class.
     if (
       bufferText &&
-      (replyToConflict || bufferAudioAsVoice !== payload.audioAsVoice || visibilityConflict)
+      (replyToConflict ||
+        bufferedPayload?.audioAsVoice !== payload.audioAsVoice ||
+        visibilityConflict)
     ) {
       void flush({ force: true });
     }
 
     if (!bufferText) {
-      startBufferFromPayload(payload);
+      bufferedPayload = payload;
     }
 
     const nextText = bufferText ? `${bufferText}${joiner}${text}` : text;
     if (nextText.length > maxChars) {
       if (bufferText) {
         void flush({ force: true });
-        startBufferFromPayload(payload);
+        bufferedPayload = payload;
         if (text.length >= maxChars) {
           void onFlush(payload);
           return;

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -146,7 +146,8 @@ export function createBlockReplyCoalescer(params: {
     );
     const visibilityConflict =
       bufferText &&
-      (bufferedPayload?.isReasoning !== payload.isReasoning ||
+      bufferedPayload &&
+      (bufferedPayload.isReasoning !== payload.isReasoning ||
         bufferedPayload.isCommentary !== payload.isCommentary ||
         bufferedPayload.isCompactionNotice !== payload.isCompactionNotice ||
         bufferedPayload.isFallbackNotice !== payload.isFallbackNotice ||

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -317,6 +317,61 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(pipeline.hasSentPayload({ text: "Preview below" })).toBe(true);
   });
 
+  it.each([
+    { name: "reply-to-current text", routing: { replyToCurrent: true }, media: false },
+    { name: "explicit-tag text", routing: { replyToTag: true }, media: false },
+    { name: "reply-to-current media", routing: { replyToCurrent: true }, media: true },
+    { name: "explicit-tag media", routing: { replyToTag: true }, media: true },
+  ] as const)(
+    "preserves explicit reply routing and metadata for $name",
+    async ({ routing, media }) => {
+      const sent: ReplyPayload[] = [];
+      const pipeline = createBlockReplyPipeline({
+        onBlockReply: async (payload) => {
+          sent.push(payload);
+        },
+        timeoutMs: 5000,
+        coalescing: { minChars: 1, maxChars: 200, idleMs: 0, joiner: " " },
+      });
+
+      pipeline.enqueue(
+        setReplyPayloadMetadata(
+          { text: "Explicit answer", replyToId: "100", ...routing },
+          { assistantMessageIndex: 7, replyToIdExplicit: true },
+        ),
+      );
+      if (media) {
+        pipeline.enqueue(
+          setReplyPayloadMetadata(
+            {
+              mediaUrls: ["file:///photo.png"],
+              replyToId: "100",
+              replyToCurrent: undefined,
+              replyToTag: undefined,
+            },
+            { assistantMessageIndex: 7, assistantTranscriptMediaUrls: ["file:///photo.png"] },
+          ),
+        );
+      }
+      await pipeline.flush({ force: true });
+
+      expect(sent).toHaveLength(1);
+      expect(sent[0]).toMatchObject({
+        text: "Explicit answer",
+        replyToId: "100",
+        ...routing,
+        ...(media ? { mediaUrls: ["file:///photo.png"] } : {}),
+      });
+      expect(sent.map(getReplyPayloadMetadata)).toEqual([
+        expect.objectContaining({
+          assistantMessageIndex: 7,
+          replyToIdExplicit: true,
+          ...(media ? { assistantTranscriptMediaUrls: ["file:///photo.png"] } : {}),
+        }),
+      ]);
+    },
+  );
+
   it("keeps media separate across assistant message boundaries", async () => {
     const sent: Array<{ text?: string; mediaUrls?: string[] }> = [];
     const pipeline = createBlockReplyPipeline({


### PR DESCRIPTION
## Summary

- Preserve the complete original reply payload while streaming text blocks are coalesced.
- Carry explicit current-message/tag reply intent and authoritative reply metadata through both plain-text and text-plus-media flushes.
- Delete the lossy field-by-field reconstruction and its duplicate buffered state.

## Root cause

The block coalescer decomposed a `ReplyPayload` into a small hand-maintained list of properties, then rebuilt a new payload. Explicit routing flags were absent from that list, so downstream Telegram delivery could mistake intentional replies for implicit replies and route them to the wrong message. The media merge also lost the buffered routing intent when a later media payload omitted it.

## Validation

- Authentic production pipeline-to-Telegram-owner reproduction: explicit replies previously targeted quoted message `42` instead of the requested message `100`; both text and media now retain target `100`.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run src/auto-reply/reply/block-reply-pipeline.test.ts src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts` — 33 tests passed.
- Broader owner/channel verification previously passed 173 tests.
- Repository formatter, `git diff --check`, type-aware lint, and independent Codex autoreview passed.
- Production change removes 34 lines and introduces no configuration, protocol, or persistence surface.
