### PR TITLE
refactor(plugins): deduplicate install security scan contracts

### DIFF
--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -18,6 +18,10 @@ import { isPathInside } from "../security/scan-paths.js";
 import { getGlobalHookRunner } from "./hook-runner-global.js";
 import { createBeforeInstallHookPayload } from "./install-policy-context.js";
 import type {
+  InstallSecurityScanResult,
+  SkillInstallSpecMetadata,
+} from "./install-security-scan.js";
+import type {
   InstallPolicyWarningDetails,
   InstallSafetyOverrides,
 } from "./install-security-scan.types.js";
@@ -90,30 +94,6 @@ type PackageTraversalLimits = {
 type InstalledPackageScanRoot = {
   packageDir: string;
   realPath: string;
-};
-
-type SkillInstallSpec = {
-  id?: string;
-  kind: "brew" | "node" | "go" | "uv" | "download";
-  label?: string;
-  bins?: string[];
-  os?: string[];
-  formula?: string;
-  package?: string;
-  module?: string;
-  url?: string;
-  archive?: string;
-  extract?: boolean;
-  stripComponents?: number;
-  targetDir?: string;
-};
-
-export type InstallSecurityScanResult = {
-  blocked?: {
-    code?: "security_scan_blocked" | "security_scan_failed";
-    reason: string;
-    installPolicyWarning?: InstallPolicyWarningDetails;
-  };
 };
 
 function failOversizedInstallPolicyWarning(params: {
@@ -582,7 +562,7 @@ async function runBeforeInstallHook(params: {
   requestedSpecifier?: string;
   skill?: {
     installId: string;
-    installSpec?: SkillInstallSpec;
+    installSpec?: SkillInstallSpecMetadata;
   };
   plugin?: {
     contentType: "bundle" | "package" | "file";
@@ -733,7 +713,7 @@ async function runOperatorInstallPolicy(params: {
   requestedSpecifier?: string;
   skill?: {
     installId: string;
-    installSpec?: SkillInstallSpec;
+    installSpec?: SkillInstallSpecMetadata;
   };
   plugin?: {
     contentType: "bundle" | "package" | "file" | "dependency-tree";
@@ -1246,7 +1226,7 @@ export async function preflightPluginGitInstallPolicyRuntime(params: {
 export async function evaluateSkillInstallPolicyRuntime(params: {
   config?: OpenClawConfig;
   installId: string;
-  installSpec?: SkillInstallSpec;
+  installSpec?: SkillInstallSpecMetadata;
   logger: InstallScanLogger;
   mode?: "install" | "update";
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];

--- a/src/plugins/install-security-scan.ts
+++ b/src/plugins/install-security-scan.ts
@@ -1,19 +1,6 @@
 // Runs security checks over plugin install candidates before activation.
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type {
-  InstallPolicyOrigin,
-  InstallPolicyRequestKind,
-  InstallPolicySource,
-} from "../security/install-policy.js";
-import type {
-  InstallPolicyWarningDetails,
-  InstallSafetyOverrides,
-} from "./install-security-scan.types.js";
+import type { InstallPolicyWarningDetails } from "./install-security-scan.types.js";
 export type { InstallSafetyOverrides } from "./install-security-scan.types.js";
-
-type InstallScanLogger = {
-  warn?: (message: string) => void;
-};
 
 /** Result returned by plugin/skill install security policy checks. */
 export type InstallSecurityScanResult = {
@@ -23,9 +10,6 @@ export type InstallSecurityScanResult = {
     installPolicyWarning?: InstallPolicyWarningDetails;
   };
 };
-
-/** Plugin install request kinds that share install policy without skill install semantics. */
-type PluginInstallRequestKind = Exclude<InstallPolicyRequestKind, "skill-install">;
 
 /** Skill install metadata shape passed into shared install policy evaluation. */
 export type SkillInstallSpecMetadata = {
@@ -51,17 +35,9 @@ async function loadInstallSecurityScanRuntime() {
 
 /** Scans an unpacked bundle source before plugin install/update. */
 export async function scanBundleInstallSource(
-  params: InstallSafetyOverrides & {
-    config?: OpenClawConfig;
-    logger: InstallScanLogger;
-    pluginId: string;
-    sourceDir: string;
-    requestKind?: PluginInstallRequestKind;
-    requestedSpecifier?: string;
-    mode?: "install" | "update";
-    version?: string;
-    source?: InstallPolicySource;
-  },
+  params: Parameters<
+    typeof import("./install-security-scan.runtime.js").scanBundleInstallSourceRuntime
+  >[0],
 ): Promise<InstallSecurityScanResult | undefined> {
   const { scanBundleInstallSourceRuntime } = await loadInstallSecurityScanRuntime();
   return await scanBundleInstallSourceRuntime(params);
@@ -69,42 +45,20 @@ export async function scanBundleInstallSource(
 
 /** Scans a package source directory and executable metadata before install/update. */
 export async function scanPackageInstallSource(
-  params: InstallSafetyOverrides & {
-    config?: OpenClawConfig;
-    extensions: string[];
-    logger: InstallScanLogger;
-    packageDir: string;
-    pluginId: string;
-    requestKind?: PluginInstallRequestKind;
-    requestedSpecifier?: string;
-    mode?: "install" | "update";
-    packageName?: string;
-    manifestId?: string;
-    version?: string;
-    source?: InstallPolicySource;
-    trustedSourceLinkedOfficialInstall?: boolean;
-  },
+  params: Parameters<
+    typeof import("./install-security-scan.runtime.js").scanPackageInstallSourceRuntime
+  >[0],
 ): Promise<InstallSecurityScanResult | undefined> {
   const { scanPackageInstallSourceRuntime } = await loadInstallSecurityScanRuntime();
   return await scanPackageInstallSourceRuntime(params);
 }
 
 /** Scans the installed package dependency tree after npm resolution. */
-export async function scanInstalledPackageDependencyTree(params: {
-  additionalPackageDirs?: string[];
-  allowManagedNpmRootPackagePeerSymlinks?: boolean;
-  config?: OpenClawConfig;
-  dependencyScanRootDir?: string;
-  logger: InstallScanLogger;
-  mode?: "install" | "update";
-  onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
-  packageDir: string;
-  pluginId: string;
-  requestKind?: PluginInstallRequestKind;
-  requestedSpecifier?: string;
-  source?: InstallPolicySource;
-  trustedSourceLinkedOfficialInstall?: boolean;
-}): Promise<InstallSecurityScanResult | undefined> {
+export async function scanInstalledPackageDependencyTree(
+  params: Parameters<
+    typeof import("./install-security-scan.runtime.js").scanInstalledPackageDependencyTreeRuntime
+  >[0],
+): Promise<InstallSecurityScanResult | undefined> {
   const { scanInstalledPackageDependencyTreeRuntime } = await loadInstallSecurityScanRuntime();
   return await scanInstalledPackageDependencyTreeRuntime(params);
 }
@@ -114,68 +68,40 @@ export async function scanInstalledPackageDependencyTree(params: {
  * Remove only with the matching runtime-postbuild legacy alias cleanup.
  */
 export async function scanFileInstallSource(
-  params: InstallSafetyOverrides & {
-    config?: OpenClawConfig;
-    filePath: string;
-    logger: InstallScanLogger;
-    mode?: "install" | "update";
-    pluginId: string;
-    requestedSpecifier?: string;
-    source?: InstallPolicySource;
-  },
+  params: Parameters<
+    typeof import("./install-security-scan.runtime.js").scanFileInstallSourceRuntime
+  >[0],
 ): Promise<InstallSecurityScanResult | undefined> {
   const { scanFileInstallSourceRuntime } = await loadInstallSecurityScanRuntime();
   return await scanFileInstallSourceRuntime(params);
 }
 
 /** Runs npm install policy checks before package install side effects. */
-export async function preflightPluginNpmInstallPolicy(params: {
-  config?: OpenClawConfig;
-  dangerouslyForceUnsafeInstall?: boolean;
-  logger: InstallScanLogger;
-  mode?: "install" | "update";
-  onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
-  packageName: string;
-  pluginId?: string;
-  requestedSpecifier?: string;
-  source?: InstallPolicySource;
-  sourcePath: string;
-  sourcePathKind: "file" | "directory";
-}): Promise<InstallSecurityScanResult | undefined> {
+export async function preflightPluginNpmInstallPolicy(
+  params: Parameters<
+    typeof import("./install-security-scan.runtime.js").preflightPluginNpmInstallPolicyRuntime
+  >[0],
+): Promise<InstallSecurityScanResult | undefined> {
   const { preflightPluginNpmInstallPolicyRuntime } = await loadInstallSecurityScanRuntime();
   return await preflightPluginNpmInstallPolicyRuntime(params);
 }
 
 /** Runs git install policy checks before plugin install side effects. */
-export async function preflightPluginGitInstallPolicy(params: {
-  config?: OpenClawConfig;
-  dangerouslyForceUnsafeInstall?: boolean;
-  logger: InstallScanLogger;
-  mode?: "install" | "update";
-  onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
-  pluginId: string;
-  requestedSpecifier?: string;
-  source?: InstallPolicySource;
-  sourcePath: string;
-}): Promise<InstallSecurityScanResult | undefined> {
+export async function preflightPluginGitInstallPolicy(
+  params: Parameters<
+    typeof import("./install-security-scan.runtime.js").preflightPluginGitInstallPolicyRuntime
+  >[0],
+): Promise<InstallSecurityScanResult | undefined> {
   const { preflightPluginGitInstallPolicyRuntime } = await loadInstallSecurityScanRuntime();
   return await preflightPluginGitInstallPolicyRuntime(params);
 }
 
 /** Evaluates shared install policy for skill-managed dependency installs. */
-export async function evaluateSkillInstallPolicy(params: {
-  config?: OpenClawConfig;
-  installId: string;
-  installSpec?: SkillInstallSpecMetadata;
-  logger: InstallScanLogger;
-  mode?: "install" | "update";
-  onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
-  origin: InstallPolicyOrigin;
-  requestedSpecifier?: string;
-  source?: InstallPolicySource;
-  skillName: string;
-  sourceDir: string;
-}): Promise<InstallSecurityScanResult | undefined> {
+export async function evaluateSkillInstallPolicy(
+  params: Parameters<
+    typeof import("./install-security-scan.runtime.js").evaluateSkillInstallPolicyRuntime
+  >[0],
+): Promise<InstallSecurityScanResult | undefined> {
   const { evaluateSkillInstallPolicyRuntime } = await loadInstallSecurityScanRuntime();
   return await evaluateSkillInstallPolicyRuntime(params);
 }


### PR DESCRIPTION
## What Problem This Solves

The shipped plugin-install security scanner repeated the same private scan contracts across its lazy public-facing facade and runtime owner. Those duplicated structural types and wrapper annotations added maintenance surface without affecting any security decision or emitted JavaScript.

## Why This Change Was Made

The existing install-security runtime and facade now share their canonical private contract while preserving both named facade types, all seven lazy asynchronous wrappers, the existing legacy alias, and every runtime policy. Type-only references erase completely; independently transpiling both changed owners produces byte-for-byte identical JavaScript before and after the cleanup.

## User Impact

Plugin installation, security scanning, lifecycle hooks, approval policy, and all existing exported facade signatures behave exactly as before. No private runtime type leaks into the published Plugin SDK.

## Evidence

- Existing install, plugin security, skills, and postbuild suites passed 302 meaningful tests, and the import-cycle guard reported zero cycles.
- Independent baseline/candidate transpilation proves identical emitted JavaScript for both production owners; AST inspection verifies all seven async wrappers, both named facade types, the original dynamic import, and the existing scan alias.
- The declaration generator emitted both changed scanner declarations and 462 public Plugin SDK declaration files; no public SDK declaration references the private scanner runtime.
- Targeted formatting, diff checks, two independent complete security/owner reviews, and full structured precommit review passed.
- Full local build/declaration commands also encounter 11 unrelated existing errors because the shared canonical dependencies are stale: installed `pi-tui` 0.82.1 versus locked 0.84.2, `markdown-it` 14 versus locked 15, and existing Google provider declarations. No edited scanner file has a diagnostic. Exact-head hosted clean-environment build, SDK declarations, and native isolated Testbox validation are mandatory before merge.
- Genuine shipped production delta: 37 added, 131 removed, net **-94**. No tests, documentation, configuration, generated files, public SDK exports, or SQLite schemas changed.
