### PR TITLE
fix(agents): preserve timeout and termination details in process logs

### DIFF
--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -690,41 +690,90 @@ test.each([
   }
 });
 
-test("process poll exposes finished-session termination metadata", async () => {
-  const sessionId = "sess-signal";
-  const { processTool, session } = createProcessSessionHarness(sessionId);
+test.each([
+  {
+    name: "overall timeout after a zero exit",
+    exitCode: 0,
+    exitSignal: null,
+    status: "failed",
+    exitReason: "overall-timeout",
+    noOutputTimedOut: false,
+    timedOut: true,
+  },
+  {
+    name: "no-output timeout",
+    exitCode: null,
+    exitSignal: "SIGKILL",
+    status: "failed",
+    exitReason: "no-output-timeout",
+    noOutputTimedOut: true,
+    timedOut: true,
+  },
+  {
+    name: "nonzero exit",
+    exitCode: 7,
+    exitSignal: null,
+    status: "completed",
+    exitReason: "exit",
+    timedOut: false,
+  },
+  {
+    name: "successful exit",
+    exitCode: 0,
+    exitSignal: null,
+    status: "completed",
+    exitReason: "exit",
+    timedOut: false,
+  },
+  {
+    name: "manual cancellation",
+    exitCode: null,
+    exitSignal: "SIGTERM",
+    status: "failed",
+    exitReason: "manual-cancel",
+    timedOut: false,
+  },
+] as const)(
+  "process log and poll preserve authoritative $name without log consuming the completion",
+  async ({ name, exitCode, exitSignal, status, exitReason, timedOut, ...optional }) => {
+    const sessionId = `sess-terminal-${name.replaceAll(" ", "-")}`;
+    const { processTool, session } = createProcessSessionHarness(sessionId);
+    const remove = vi.fn(() => true);
 
-  appendOutput(session, "stderr", "terminated\n");
-  markExited(session, null, "SIGKILL", "failed", "no-output-timeout", true);
+    appendOutput(session, "stderr", "terminal output\n");
+    markExited(session, exitCode, exitSignal, status, exitReason, optional.noOutputTimedOut);
+    recordNotifyOnExitRemoval(session, remove);
 
-  const poll = await pollSession(processTool, "toolcall-signal", sessionId);
-  const details = poll.details as {
-    status?: string;
-    exitCode?: number | null;
-    exitSignal?: NodeJS.Signals | number | null;
-    exitReason?: string;
-    timedOut?: boolean;
-    noOutputTimedOut?: boolean;
-    aggregated?: string;
-  };
+    const log = await processTool.execute("toolcall-terminal-log", {
+      action: "log",
+      sessionId,
+    });
+    expect(log.details).toMatchObject({
+      status,
+      sessionId,
+      exitCode: exitCode ?? undefined,
+      exitReason,
+      timedOut,
+      ...optional,
+    });
+    const logText = log.content[0]?.type === "text" ? log.content[0].text : "";
+    expect(logText).toContain("terminal output");
+    expect(logText.includes("Verify the resulting state before retrying")).toBe(timedOut);
+    expect(remove).not.toHaveBeenCalled();
 
-  expect(details.status).toBe("failed");
-  expect(details.exitCode).toBeUndefined();
-  expect(details.exitSignal).toBe("SIGKILL");
-  expect(details.exitReason).toBe("no-output-timeout");
-  expect(details.timedOut).toBe(true);
-  expect(details.noOutputTimedOut).toBe(true);
-  expect(details.aggregated).toContain("terminated");
-  expect(poll.content[0]).toMatchObject({
-    type: "text",
-    text: expect.stringContaining("external side effects may already have completed"),
-  });
-  expect(poll.content[0]).toMatchObject({
-    type: "text",
-    text: expect.stringContaining("Verify the resulting state before retrying"),
-  });
-  expect(poll.content[0]).toMatchObject({
-    type: "text",
-    text: expect.stringContaining("Do not automatically rerun non-idempotent commands"),
-  });
-});
+    const poll = await pollSession(processTool, "toolcall-terminal-poll", sessionId);
+    expect(poll.details).toMatchObject({
+      status,
+      sessionId,
+      exitCode: exitCode ?? undefined,
+      exitReason,
+      timedOut,
+      aggregated: "terminal output\n",
+      ...optional,
+    });
+    const pollText = poll.content[0]?.type === "text" ? poll.content[0].text : "";
+    expect(pollText).toContain("terminal output");
+    expect(pollText.includes("Verify the resulting state before retrying")).toBe(timedOut);
+    expect(remove).toHaveBeenCalledOnce();
+  },
+);

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -165,6 +165,27 @@ function resetPollRetrySuggestion(sessionId: string): void {
 
 type FinishedSession = NonNullable<ReturnType<typeof getFinishedSession>>;
 
+function finishedSessionDetails(sessionId: string, finished: FinishedSession) {
+  return {
+    status: finished.status === "completed" ? "completed" : "failed",
+    sessionId,
+    exitCode: finished.exitCode ?? undefined,
+    ...(finished.exitSignal != null ? { exitSignal: finished.exitSignal } : {}),
+    ...(finished.exitReason
+      ? {
+          exitReason: finished.exitReason,
+          timedOut:
+            finished.exitReason === "overall-timeout" ||
+            finished.exitReason === "no-output-timeout",
+        }
+      : {}),
+    ...(finished.noOutputTimedOut !== undefined
+      ? { noOutputTimedOut: finished.noOutputTimedOut }
+      : {}),
+    name: deriveSessionName(finished.command),
+  };
+}
+
 function finishedPollResult(
   sessionId: string,
   finished: FinishedSession,
@@ -194,23 +215,8 @@ function finishedPollResult(
       },
     ],
     details: {
-      status: finished.status === "completed" ? "completed" : "failed",
-      sessionId,
-      exitCode: finished.exitCode ?? undefined,
-      ...(finished.exitSignal != null ? { exitSignal: finished.exitSignal } : {}),
-      ...(finished.exitReason
-        ? {
-            exitReason: finished.exitReason,
-            timedOut:
-              finished.exitReason === "overall-timeout" ||
-              finished.exitReason === "no-output-timeout",
-          }
-        : {}),
-      ...(finished.noOutputTimedOut !== undefined
-        ? { noOutputTimedOut: finished.noOutputTimedOut }
-        : {}),
+      ...finishedSessionDetails(sessionId, finished),
       aggregated: finished.aggregated,
-      name: deriveSessionName(finished.command),
     },
   };
 }
@@ -474,13 +480,11 @@ export function createProcessTool(
             content: [
               {
                 type: "text",
-                text: appendExecTimeoutRetryGuidance(
+                text:
                   (output || "(no new output)") +
-                    aggregateOutputNote +
-                    retainedOutputNote +
-                    (buildInputWaitHint(runtime) || "\n\nProcess still running."),
-                  undefined,
-                ),
+                  aggregateOutputNote +
+                  retainedOutputNote +
+                  (buildInputWaitHint(runtime) || "\n\nProcess still running."),
               },
             ],
             details: {
@@ -545,28 +549,24 @@ export function createProcessTool(
               window.effectiveOffset,
               window.effectiveLimit,
             );
-            const status = scopedFinished.status === "completed" ? "completed" : "failed";
-            const logDefaultTailNote = defaultTailNote(totalLines, window.usingDefaultTail);
             return {
               content: [
                 {
                   type: "text",
-                  text:
+                  text: appendExecTimeoutRetryGuidance(
                     (slice || "(no output recorded)") +
-                    logDefaultTailNote +
-                    retentionCapNote(scopedFinished),
+                      defaultTailNote(totalLines, window.usingDefaultTail) +
+                      retentionCapNote(scopedFinished),
+                    scopedFinished.exitReason,
+                  ),
                 },
               ],
               details: {
-                status,
-                sessionId: params.sessionId,
+                ...finishedSessionDetails(params.sessionId, scopedFinished),
                 total: totalLines,
                 totalLines,
                 totalChars,
                 truncated: scopedFinished.truncated,
-                exitCode: scopedFinished.exitCode ?? undefined,
-                exitSignal: scopedFinished.exitSignal ?? undefined,
-                name: deriveSessionName(scopedFinished.command),
               },
             };
           }

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -20,6 +20,9 @@ import {
   buildAdjustedParamsKey,
   recordToolExecutionTracked,
 } from "./agent-tools.before-tool-call.state.js";
+import { addSession, deleteSession, markExited } from "./bash-process-registry.js";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { createProcessTool } from "./bash-tools.process.js";
 import { projectEmbeddedMessageDeliveryFact } from "./embedded-agent-message-delivery.js";
 import type { MessagingToolSend } from "./embedded-agent-messaging.types.js";
 import { buildEmbeddedRunPayloads } from "./embedded-agent-runner/run/payloads.js";
@@ -2267,19 +2270,42 @@ describe("handleToolExecutionEnd timeout metadata", () => {
   }
 
   it.each(["poll", "log"])(
-    "projects a structured terminal process diagnostic from %s",
+    "projects a structured diagnostic from the real terminal process %s result",
     async (action) => {
       const { ctx } = createTestContext();
-      await executeProcessResult(ctx, { action, details: { exitCode: 7 } });
-
-      expect(ctx.state.lastToolError).toMatchObject({
-        toolName: "process",
-        terminalDiagnostic: {
-          kind: "process",
-          sessionId: "wild-lagoon",
-          reason: { kind: "exit", exitCode: 7 },
-        },
+      const sessionId = `wild-lagoon-${action}`;
+      const session = createProcessSessionFixture({
+        id: sessionId,
+        command: "test",
+        backgrounded: true,
       });
+      addSession(session);
+      markExited(session, 0, null, "failed", "overall-timeout", false);
+
+      try {
+        const args = { action, sessionId } as Parameters<
+          ReturnType<typeof createProcessTool>["execute"]
+        >[1];
+        const result = await createProcessTool().execute(`tool-real-process-${action}`, args);
+        await executeTool(ctx, {
+          toolName: "process",
+          toolCallId: `tool-process-${action}`,
+          args,
+          isError: false,
+          result,
+        });
+
+        expect(ctx.state.lastToolError).toMatchObject({
+          toolName: "process",
+          terminalDiagnostic: {
+            kind: "process",
+            sessionId,
+            reason: { kind: "timeout", timeoutKind: "overall-timeout" },
+          },
+        });
+      } finally {
+        deleteSession(sessionId);
+      }
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents inspecting a finished background command with `process(action="log")` lost its timeout or termination reason, received no warning before retrying a potentially non-idempotent command, and could not produce the structured process-failure diagnostic that the equivalent `poll` action already supplied.

## Why This Change Was Made

Both finished-process observation actions now derive their terminal status, exit reason, timeout facts, signal, and command identity from the same lifecycle-owned projection. Finished logs reuse the existing timeout retry guidance without consuming unread output, acknowledging completion notifications, or changing log pagination; an obsolete no-op guidance call on running polls is removed.

## User Impact

Agents can distinguish overall timeouts, no-output timeouts, cancellations, successful exits, and ordinary nonzero exits when reading finished process logs. Timeout logs explicitly warn that external side effects may already have happened, and a subsequent poll still receives the complete unread output and owns completion acknowledgment.

## Evidence

- Before the fix: **6 regressions fail**—five actual finished log lifecycle states omit terminal provenance, and the real registry → process log → agent subscriber path loses its structured timeout diagnostic.
- After the fix: **250 tests pass across 6 focused suites**, including real lifecycle-owner → tool → subscriber integration, overall timeout with exit code zero, no-output timeout, ordinary nonzero exit retaining its `completed` status, successful exit, manual cancellation, preserved unread output, and deferred completion acknowledgment.
- Independent review and fresh authenticated Codex structured review: no actionable findings.
- Formatting, assertion-safety ratchet, and max-lines ratchet pass; the grandfathered process owner stays exactly 766 lines.
- Production: **+32/-32 (net zero)**. Tests: **+122/-47**.
- Reviewed commit: `dd89e7519a4f77fa3107b086650359c60c7b4f02`.
