### PR TITLE
fix(whatsapp): preserve text when Markdown formatting returns no chunks

### DIFF
--- a/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.test.ts
@@ -296,6 +296,29 @@ describe("deliverWebReply", () => {
     });
   });
 
+  it.each([
+    {
+      name: "an image without alt text",
+      text: "![](https://example.com/diagram.png)",
+      expected: "![](https://example.com/diagram.png)",
+    },
+    {
+      name: "an image with visible alt text",
+      text: "![Diagram](https://example.com/diagram.png)",
+      expected: "Diagram",
+    },
+  ])("delivers $name instead of silently dropping the auto-reply", async ({ text, expected }) => {
+    const { msg, params } = createDelivery({ text });
+
+    const delivery = await deliverWebReply(params);
+
+    expect(msg.platform.reply).toHaveBeenCalledExactlyOnceWith(expected, undefined);
+    expect(delivery).toMatchObject({
+      providerAccepted: true,
+      results: [{ messageId: "reply-sent-1" }],
+    });
+  });
+
   it("retains an accepted auto-reply receipt when outbound activity bookkeeping fails", async () => {
     hoisted.recordChannelActivity.mockClear();
     const activityError = new Error("auto-reply activity bookkeeping disconnected");

--- a/extensions/whatsapp/src/auto-reply/deliver-reply.ts
+++ b/extensions/whatsapp/src/auto-reply/deliver-reply.ts
@@ -9,6 +9,7 @@ import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import type { ChunkMode, ReplyPayload } from "openclaw/plugin-sdk/reply-chunking";
 import {
   isReasoningReplyPayload,
+  resolveTextChunksWithFallback,
   sendMediaWithLeadingCaption,
 } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -203,11 +204,10 @@ async function deliverWebReplyInActivityScope(
     normalizeWhatsAppOutboundPayload(replyResult, {
       normalizeText: normalizeWhatsAppPayloadTextPreservingIndentation,
     });
-  const textChunks = markdownToWhatsAppChunks(
-    normalizedReply.text ?? "",
-    textLimit,
-    tableMode,
-    chunkMode,
+  const text = normalizedReply.text ?? "";
+  const textChunks = resolveTextChunksWithFallback(
+    text,
+    markdownToWhatsAppChunks(text, textLimit, tableMode, chunkMode),
   );
   const mediaList = normalizedReply.mediaUrls ?? [];
 

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -148,6 +148,28 @@ describe("web outbound", () => {
   });
 
   it.each([
+    {
+      name: "an image without alt text",
+      text: "![](https://example.com/diagram.png)",
+      expected: "![](https://example.com/diagram.png)",
+    },
+    {
+      name: "an image with visible alt text",
+      text: "![Diagram](https://example.com/diagram.png)",
+      expected: "Diagram",
+    },
+  ])("delivers $name instead of reporting an unsent success", async ({ text, expected }) => {
+    await expect(
+      sendMessageWhatsApp("+1555", text, {
+        verbose: false,
+        cfg: WHATSAPP_TEST_CFG,
+      }),
+    ).resolves.toEqual({ messageId: "msg123", toJid: "1555@s.whatsapp.net" });
+
+    expect(sendMessage).toHaveBeenCalledExactlyOnceWith("+1555", expected, undefined, undefined);
+  });
+
+  it.each([
     { kind: "text", mediaUrl: undefined, contentType: undefined },
     { kind: "image", mediaUrl: "/tmp/pic.png", contentType: "image/png" },
     { kind: "document", mediaUrl: "/tmp/report.pdf", contentType: "application/pdf" },

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -208,7 +208,7 @@ async function sendMessageWhatsAppInActivityScope(
     tableMode,
     resolveChunkMode(cfg, "whatsapp", accountIdForFormatting),
   );
-  text = textChunks.shift() ?? "";
+  text = textChunks.shift() ?? text;
   if (!text && !hasMedia) {
     return { messageId: "", toJid: jid };
   }


### PR DESCRIPTION
## Summary

- Preserve nonempty WhatsApp reply text when Markdown formatting produces zero chunks.
- Repair both direct sends and automatic reply delivery at their respective canonical owners.
- Reuse the existing shared text-chunk fallback for automatic replies; keep ordinary formatting, empty-message handling, and media behavior unchanged.

## Root cause

The real WhatsApp Markdown formatter removes an image token that has no visible alt text, yielding an empty chunk array for otherwise nonempty input. The direct sender replaced the original input with an empty string and returned a fake successful empty message ID. Automatic replies independently attempted zero sends and returned an empty result. Both paths silently lost a legitimate requested delivery.

## Validation

- Captured authentic failing regressions against both actual delivery owners; the fake in-memory WhatsApp transport received zero calls before the fix.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/whatsapp/src/send.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.test.ts extensions/whatsapp/src/text-runtime.test.ts extensions/whatsapp/src/send.voice-delivery.test.ts extensions/whatsapp/src/auto-reply/deliver-reply.filename-media.test.ts` — 180 tests passed.
- Existing labeled-image, empty-input, voice, image/document-caption, chunking, receipt, and reasoning-reply behavior remains covered.
- Type-aware plugin lint, repository formatter, `git diff --check`, and fresh independent Codex autoreview passed.
- Production lines added equal production lines removed; no configuration, protocol, auth, or persistence changes.
