### PR TITLE
fix(doctor): run health checks for the installed Codex plugin

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -38,6 +38,7 @@ const repositoryScriptEntries = [
   "scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs!",
   "scripts/e2e/lib/codex-media-path/write-config.mjs!",
   "scripts/e2e/lib/codex-npm-plugin-live/followthrough-turn.mjs!",
+  "scripts/e2e/lib/codex-on-demand/doctor-checks.mjs!",
   "scripts/e2e/lib/config-reload/assert-log.mjs!",
   "scripts/e2e/lib/config-reload/mutate-metadata.mjs!",
   "scripts/e2e/lib/docker-artifact-proof/write-identities.ts!",

--- a/scripts/e2e/codex-on-demand-docker.sh
+++ b/scripts/e2e/codex-on-demand-docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Installs a prepared OpenClaw npm tarball in Docker, runs OpenAI onboarding,
-# and verifies the Codex plugin plus @openai/codex dependency are downloaded on demand.
+# Installs OpenClaw and Codex from npm artifacts with explicit capability consent,
+# then verifies OpenAI onboarding, managed dependencies, and doctor in Docker.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -98,6 +98,7 @@ dump_debug_logs() {
   echo "Codex on-demand scenario failed with exit code $status" >&2
   openclaw_e2e_dump_logs \
     /tmp/openclaw-install.log \
+    /tmp/openclaw-codex-plugin-install.log \
     /tmp/openclaw-codex-registry/server.log \
     /tmp/openclaw-onboard.json \
     /tmp/openclaw-plugins-list.json \
@@ -128,7 +129,17 @@ openclaw_e2e_assert_dep_absent "@openai/codex" "$HOME/.openclaw" "$NPM_CONFIG_PR
 
 configure_plugin_registry
 
-echo "Running non-interactive OpenAI onboarding; Codex should install on demand..."
+# Non-interactive onboarding cannot grant capabilities. Use the shared fixture
+# consent flow and the exact companion when testing an unpublished candidate.
+codex_install_args=("@openclaw/codex")
+if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
+  codex_install_args=("npm:@openclaw/codex@${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION:?missing candidate version}" --pin)
+fi
+echo "Installing Codex on demand with explicit capability consent..."
+openclaw_e2e_fixture_plugin_command openclaw -- plugins install "${codex_install_args[@]}" \
+  >/tmp/openclaw-codex-plugin-install.log 2>&1
+
+echo "Running non-interactive OpenAI onboarding with the accepted Codex plugin..."
 openclaw onboard --non-interactive --accept-risk \
   --mode local \
   --auth-choice openai-api-key \
@@ -143,6 +154,7 @@ openclaw onboard --non-interactive --accept-risk \
 openclaw plugins list --json >/tmp/openclaw-plugins-list.json
 openclaw plugins inspect codex --runtime --json >/tmp/openclaw-codex-inspect.json
 node scripts/e2e/lib/codex-on-demand/assertions.mjs
+node scripts/e2e/lib/codex-on-demand/doctor-checks.mjs
 
 echo "Codex on-demand Docker E2E passed"
 EOF
@@ -150,4 +162,5 @@ EOF
   exit 1
 fi
 
+docker_e2e_print_log "$run_log"
 echo "Codex on-demand Docker E2E passed"

--- a/scripts/e2e/lib/codex-on-demand/assertions.mjs
+++ b/scripts/e2e/lib/codex-on-demand/assertions.mjs
@@ -1,4 +1,5 @@
 // Assertions for Codex on-demand plugin E2E scenarios.
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {
@@ -112,3 +113,28 @@ assertOpenAiEnvAuthProfileStore(authRaw, {
   rawKeyMessage: "auth profile persisted the raw OpenAI test key",
   rawKeyNeedle: "sk-openclaw-codex-on-demand-e2e",
 });
+
+// Use the installed CLI after normal onboarding; a source-tree API would hide missing package surfaces.
+for (const only of [undefined, "codex/managed-app-server"]) {
+  const args = ["doctor", "--lint", "--json", ...(only ? ["--only", only] : [])];
+  const result = spawnSync("openclaw", args, { encoding: "utf8", timeout: 120_000 });
+  if (result.error || (result.status !== 0 && result.status !== 1)) {
+    throw new Error(
+      `doctor failed before producing findings: ${result.error?.message ?? result.stderr}`,
+    );
+  }
+  const report = JSON.parse(result.stdout);
+  if (only) {
+    if (
+      result.status !== 0 ||
+      report.ok !== true ||
+      report.checksRun !== 1 ||
+      report.findings.length !== 0
+    ) {
+      throw new Error(`managed Codex doctor check failed: ${JSON.stringify(report)}`);
+    }
+  } else if (report.checksRun <= 1) {
+    throw new Error(`ordinary doctor did not reach health checks: ${JSON.stringify(report)}`);
+  }
+  process.stdout.write(`[codex-doctor] ${only ?? "default"}: ${JSON.stringify(report)}\n`);
+}

--- a/scripts/e2e/lib/codex-on-demand/assertions.mjs
+++ b/scripts/e2e/lib/codex-on-demand/assertions.mjs
@@ -1,5 +1,4 @@
 // Assertions for Codex on-demand plugin E2E scenarios.
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {
@@ -113,28 +112,3 @@ assertOpenAiEnvAuthProfileStore(authRaw, {
   rawKeyMessage: "auth profile persisted the raw OpenAI test key",
   rawKeyNeedle: "sk-openclaw-codex-on-demand-e2e",
 });
-
-// Use the installed CLI after normal onboarding; a source-tree API would hide missing package surfaces.
-for (const only of [undefined, "codex/managed-app-server"]) {
-  const args = ["doctor", "--lint", "--json", ...(only ? ["--only", only] : [])];
-  const result = spawnSync("openclaw", args, { encoding: "utf8", timeout: 120_000 });
-  if (result.error || (result.status !== 0 && result.status !== 1)) {
-    throw new Error(
-      `doctor failed before producing findings: ${result.error?.message ?? result.stderr}`,
-    );
-  }
-  const report = JSON.parse(result.stdout);
-  if (only) {
-    if (
-      result.status !== 0 ||
-      report.ok !== true ||
-      report.checksRun !== 1 ||
-      report.findings.length !== 0
-    ) {
-      throw new Error(`managed Codex doctor check failed: ${JSON.stringify(report)}`);
-    }
-  } else if (report.checksRun <= 1) {
-    throw new Error(`ordinary doctor did not reach health checks: ${JSON.stringify(report)}`);
-  }
-  process.stdout.write(`[codex-doctor] ${only ?? "default"}: ${JSON.stringify(report)}\n`);
-}

--- a/scripts/e2e/lib/codex-on-demand/doctor-checks.mjs
+++ b/scripts/e2e/lib/codex-on-demand/doctor-checks.mjs
@@ -1,0 +1,26 @@
+import { spawnSync } from "node:child_process";
+
+// Use the installed CLI after normal onboarding; a source-tree API would hide missing package surfaces.
+for (const only of [undefined, "codex/managed-app-server"]) {
+  const args = ["doctor", "--lint", "--json", ...(only ? ["--only", only] : [])];
+  const result = spawnSync("openclaw", args, { encoding: "utf8", timeout: 120_000 });
+  if (result.error || (result.status !== 0 && result.status !== 1)) {
+    throw new Error(
+      `doctor failed before producing findings: ${result.error?.message ?? result.stderr}`,
+    );
+  }
+  const report = JSON.parse(result.stdout);
+  if (only) {
+    if (
+      result.status !== 0 ||
+      report.ok !== true ||
+      report.checksRun !== 1 ||
+      report.findings.length !== 0
+    ) {
+      throw new Error(`managed Codex doctor check failed: ${JSON.stringify(report)}`);
+    }
+  } else if (report.checksRun <= 1) {
+    throw new Error(`ordinary doctor did not reach health checks: ${JSON.stringify(report)}`);
+  }
+  process.stdout.write(`[codex-doctor] ${only ?? "default"}: ${JSON.stringify(report)}\n`);
+}

--- a/src/flows/bundled-health-checks.test.ts
+++ b/src/flows/bundled-health-checks.test.ts
@@ -1,19 +1,24 @@
 // Bundled health check tests cover built-in doctor checks and repair advice.
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { linkSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { MissingPublicSurfaceError } from "../plugin-sdk/facade-loader.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { ProviderPolicySurface } from "../plugins/provider-policy-surface.js";
 import {
   registerBundledHealthChecks,
   resolveBundledHealthCheckPluginStateMode,
 } from "./bundled-health-checks.js";
+import { clearHealthChecksForTest, getHealthCheck } from "./health-check-registry.js";
 
 const STATE_DEFERRED_CHECK_ID = "memory-core/managed-local-embedding-setup";
 
 const mocks = vi.hoisted(() => ({
-  registerCodexManagedAppServerDoctorChecks: vi.fn(),
+  registerCodexManagedAppServerDoctorChecks: vi.fn(() => {
+    throw new Error("Unable to resolve bundled plugin public surface codex/api.js");
+  }),
   inspectEmbeddingProviderSetup: vi.fn(),
   loadBundledPluginManifestRegistry: vi.fn(
     (): PluginManifestRegistry => ({
@@ -21,10 +26,12 @@ const mocks = vi.hoisted(() => ({
       diagnostics: [],
     }),
   ),
-  loadPluginManifestRegistryForPluginRegistry: vi.fn(() => ({
-    plugins: [],
-    diagnostics: [],
-  })),
+  loadPluginManifestRegistryForPluginRegistry: vi.fn(
+    (): PluginManifestRegistry => ({
+      plugins: [],
+      diagnostics: [],
+    }),
+  ),
   registerCuaDriverDoctorChecks: vi.fn(),
   registerMemoryCoreDoctorChecks: vi.fn(),
   registerPolicyDoctorChecks: vi.fn(),
@@ -44,10 +51,7 @@ const mocks = vi.hoisted(() => ({
       : dirName === "cua-computer"
         ? { registerCuaDriverDoctorChecks: mocks.registerCuaDriverDoctorChecks }
         : dirName === "codex"
-          ? {
-              registerCodexManagedAppServerDoctorChecks:
-                mocks.registerCodexManagedAppServerDoctorChecks,
-            }
+          ? mocks.registerCodexManagedAppServerDoctorChecks()
           : { registerPolicyDoctorChecks: mocks.registerPolicyDoctorChecks },
   ),
   resolveProviderPolicySurface: vi.fn((): ProviderPolicySurface | null => ({
@@ -65,7 +69,8 @@ vi.mock("../plugins/manifest-registry.js", async (importOriginal) => ({
 vi.mock("../plugins/provider-public-artifacts.js", () => ({
   resolveProviderPolicySurface: mocks.resolveProviderPolicySurface,
 }));
-vi.mock("../plugins/public-surface-loader.js", () => ({
+vi.mock("../plugins/public-surface-loader.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/public-surface-loader.js")>()),
   loadBundledPluginPublicArtifactModuleFromCandidatesSync:
     mocks.loadBundledPluginPublicArtifactModuleFromCandidatesSync,
   loadBundledPluginPublicArtifactModuleSync: mocks.loadBundledPluginPublicArtifactModuleSync,
@@ -76,11 +81,17 @@ let workspaceDir: string;
 describe("registerBundledHealthChecks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
     workspaceDir = join(tmpdir(), `bundled-health-${process.pid}-${Date.now()}`);
     mkdirSync(workspaceDir, { recursive: true });
+    workspaceDir = realpathSync(workspaceDir);
   });
 
   afterEach(() => {
+    clearHealthChecksForTest();
     rmSync(workspaceDir, { recursive: true, force: true });
   });
 
@@ -354,62 +365,136 @@ describe("registerBundledHealthChecks", () => {
     expect(mocks.registerWorkerProviderDoctorChecks).not.toHaveBeenCalled();
   });
 
-  it("loads managed Codex health when an effective model route selects Codex", () => {
+  const codexConfig: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: { primary: "openai/gpt-5.6-sol" },
+        models: { "openai/gpt-5.6-sol": { agentRuntime: { id: "codex" } } },
+      },
+    },
+  };
+
+  function codexRecord(origin: "bundled" | "global", trustedOfficialInstall?: boolean) {
+    return {
+      id: "codex",
+      origin,
+      trustedOfficialInstall,
+      rootDir: workspaceDir,
+      source: join(workspaceDir, "index.js"),
+      manifestPath: join(workspaceDir, "openclaw.plugin.json"),
+      channels: [],
+      providers: [],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      contracts: {},
+    } satisfies PluginManifestRegistry["plugins"][number];
+  }
+
+  it.each(["bundled", "global"] as const)(
+    "registers and runs health from the selected %s Codex public artifact",
+    async (origin) => {
+      mkdirSync(join(workspaceDir, "dist"));
+      writeFileSync(
+        join(workspaceDir, "dist", "api.js"),
+        `
+        module.exports.registerCodexManagedAppServerDoctorChecks = (host) => {
+          if (!host.getHealthCheck("codex/managed-app-server")) {
+            host.registerHealthCheck({
+              id: "codex/managed-app-server", kind: "plugin", source: "codex",
+              description: "Selected artifact check", detect: async () => [],
+            });
+          }
+        };
+      `,
+      );
+      if (origin === "bundled") {
+        linkSync(join(workspaceDir, "dist", "api.js"), join(workspaceDir, "api-copy.js"));
+      }
+      mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+        plugins: [codexRecord(origin, origin === "global")],
+        diagnostics: [],
+      });
+      const env = { ...process.env, OPENCLAW_STATE_DIR: join(workspaceDir, "state") };
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        registerBundledHealthChecks({ cfg: codexConfig, cwd: workspaceDir, env });
+      }
+      const check = getHealthCheck("codex/managed-app-server");
+      expect(check?.description).toBe("Selected artifact check");
+      await expect(
+        check?.detect({
+          cfg: codexConfig,
+          env,
+          mode: "lint",
+          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        }),
+      ).resolves.toEqual([]);
+      expect(mocks.loadPluginManifestRegistryForPluginRegistry).toHaveBeenCalledWith({
+        config: codexConfig,
+        workspaceDir,
+        env,
+        pluginIds: ["codex"],
+      });
+      expect(mocks.registerCodexManagedAppServerDoctorChecks).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["missing", "untrusted", "missing-api", "missing-export", "broken-api"])(
+    "fails visibly for a selected Codex install with %s state",
+    (state) => {
+      mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+        plugins: state === "missing" ? [] : [codexRecord("global", state !== "untrusted")],
+        diagnostics: [],
+      });
+      if (state === "untrusted") {
+        writeFileSync(
+          join(workspaceDir, "api.js"),
+          'throw new Error("untrusted artifact executed");',
+        );
+      }
+      if (state === "missing-export") {
+        writeFileSync(join(workspaceDir, "api.js"), "module.exports = {};");
+      }
+      if (state === "broken-api") {
+        writeFileSync(join(workspaceDir, "api.js"), 'throw new Error("selected artifact failed");');
+      }
+      expect(() => registerBundledHealthChecks({ cfg: codexConfig, cwd: workspaceDir })).toThrow(
+        state === "broken-api"
+          ? "selected artifact failed"
+          : state === "missing-export"
+            ? TypeError
+            : MissingPublicSurfaceError,
+      );
+      expect(getHealthCheck("codex/managed-app-server")).toBeUndefined();
+      expect(mocks.registerCodexManagedAppServerDoctorChecks).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { enabled: false },
+    { entries: { codex: { enabled: false } } },
+    { deny: ["codex"] },
+    { allow: ["telegram"] },
+  ])("preserves Codex owner policy without loading plugin code: %j", (plugins) => {
+    registerBundledHealthChecks({ cfg: { ...codexConfig, plugins }, cwd: workspaceDir });
+    expect(mocks.loadPluginManifestRegistryForPluginRegistry).not.toHaveBeenCalled();
+    expect(mocks.registerCodexManagedAppServerDoctorChecks).not.toHaveBeenCalled();
+  });
+
+  it("does not load managed Codex health for an OpenClaw route", () => {
     registerBundledHealthChecks({
       cfg: {
         agents: {
           defaults: {
             model: { primary: "openai/gpt-5.6-sol" },
-            models: {
-              "openai/gpt-5.6-sol": { agentRuntime: { id: "codex" } },
-            },
+            models: { "openai/gpt-5.6-sol": { agentRuntime: { id: "openclaw" } } },
           },
         },
       },
       cwd: workspaceDir,
     });
-
-    expect(mocks.loadBundledPluginPublicArtifactModuleSync).toHaveBeenCalledWith({
-      dirName: "codex",
-      artifactBasename: "api.js",
-    });
-    expect(mocks.registerCodexManagedAppServerDoctorChecks).toHaveBeenCalledWith({
-      getHealthCheck: expect.any(Function),
-      registerHealthCheck: expect.any(Function),
-    });
-  });
-
-  it("does not load managed Codex health for OpenClaw routes or disabled Codex", () => {
-    for (const cfg of [
-      {
-        agents: {
-          defaults: {
-            model: { primary: "openai/gpt-5.6-sol" },
-            models: {
-              "openai/gpt-5.6-sol": { agentRuntime: { id: "openclaw" } },
-            },
-          },
-        },
-      },
-      {
-        agents: {
-          defaults: {
-            model: { primary: "openai/gpt-5.6-sol" },
-            models: {
-              "openai/gpt-5.6-sol": { agentRuntime: { id: "codex" } },
-            },
-          },
-        },
-        plugins: { entries: { codex: { enabled: false } } },
-      },
-    ]) {
-      vi.clearAllMocks();
-      registerBundledHealthChecks({ cfg, cwd: workspaceDir });
-      expect(mocks.loadBundledPluginPublicArtifactModuleSync).not.toHaveBeenCalledWith({
-        dirName: "codex",
-        artifactBasename: "api.js",
-      });
-    }
+    expect(mocks.loadPluginManifestRegistryForPluginRegistry).not.toHaveBeenCalled();
+    expect(mocks.registerCodexManagedAppServerDoctorChecks).not.toHaveBeenCalled();
   });
 
   it("does not use policy.jsonc existence as extension activation", () => {

--- a/src/flows/bundled-health-checks.ts
+++ b/src/flows/bundled-health-checks.ts
@@ -2,6 +2,7 @@
 import { asOptionalObjectRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { collectConfiguredAgentHarnessRuntimes } from "../agents/harness-runtimes.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { MissingPublicSurfaceError } from "../plugin-sdk/facade-loader.js";
 import { normalizePluginId, normalizePluginsConfig } from "../plugins/config-state.js";
 import { passesManifestOwnerBasePolicy } from "../plugins/manifest-owner-policy.js";
 import {
@@ -14,6 +15,7 @@ import { resolveProviderPolicySurface } from "../plugins/provider-public-artifac
 import {
   loadBundledPluginPublicArtifactModuleFromCandidatesSync,
   loadBundledPluginPublicArtifactModuleSync,
+  loadPluginPublicArtifactModuleSync,
 } from "../plugins/public-surface-loader.js";
 import { collectConfiguredWorkerProviderIds } from "../plugins/worker-provider-config.js";
 import { listBundledWorkerProviderOwners } from "../plugins/worker-provider-manifest.js";
@@ -126,10 +128,27 @@ export function registerBundledHealthChecks(params: {
     memoryCoreActive: isMemoryCoreActive(params.cfg),
   });
   if (shouldRegisterCodexManagedHealth(params.cfg)) {
-    loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({
-      dirName: "codex",
+    const registry = loadPluginManifestRegistryForPluginRegistry({
+      config: params.cfg,
+      workspaceDir: params.cwd,
+      env,
+      pluginIds: ["codex"],
+    });
+    const owner = registry.plugins.find((plugin) => plugin.id === "codex");
+    // Doctor must inspect the selected runtime's artifact, including official external installs.
+    // A bundled-first lookup can inspect a different version or bypass the selected owner's trust.
+    if (!owner || (owner.origin !== "bundled" && owner.trustedOfficialInstall !== true)) {
+      throw new MissingPublicSurfaceError(
+        "Unable to resolve Codex doctor health API: install the official Codex plugin with openclaw plugins install @openclaw/codex",
+      );
+    }
+    loadPluginPublicArtifactModuleSync<
+      Required<Pick<BundledHealthApi, "registerCodexManagedAppServerDoctorChecks">>
+    >({
+      pluginRoot: owner.rootDir,
       artifactBasename: "api.js",
-    }).registerCodexManagedAppServerDoctorChecks?.({ getHealthCheck, registerHealthCheck });
+      origin: owner.origin === "bundled" ? "bundled" : "global",
+    }).registerCodexManagedAppServerDoctorChecks({ getHealthCheck, registerHealthCheck });
   }
   if (shouldRegisterPolicyHealth(params)) {
     loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({
@@ -168,9 +187,6 @@ function registerBundledWorkerProviderHealthChecks(
 
 function shouldRegisterCodexManagedHealth(cfg: OpenClawConfig): boolean {
   if (!collectConfiguredAgentHarnessRuntimes(cfg).includes("codex")) {
-    return false;
-  }
-  if (cfg.plugins?.entries?.codex?.enabled === false) {
     return false;
   }
   return passesManifestOwnerBasePolicy({

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -132,6 +132,7 @@ export function loadBundledPluginPublicArtifactModuleSync<T extends object>(para
 export function loadPluginPublicArtifactModuleSync<T extends object>(params: {
   pluginRoot: string;
   artifactBasename: string;
+  origin?: "bundled" | "global";
 }): T {
   const root = getPluginCacheRoot(params.pluginRoot);
   const key = `public:${params.artifactBasename}`;
@@ -150,7 +151,7 @@ export function loadPluginPublicArtifactModuleSync<T extends object>(params: {
     ...location,
     boundaryLabel: "plugin root",
     surfaceLabel: `plugin public surface ${params.artifactBasename}`,
-    origin: "global",
+    origin: params.origin ?? "global",
   }) as T;
 }
 

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -767,7 +767,7 @@ describe("Codex install helpers", () => {
 
     const result = runCodexOnDemandAssertions(root);
 
-    expect(result.status).toBe(0);
+    expect(result.status, result.stderr).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain(`[codex-release] packageVersion=${CODEX_VERSION}`);
     expect(result.stdout).toContain(`[codex-release] cliVersion=${CODEX_VERSION}`);


### PR DESCRIPTION
Closes #128826

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers remains enabled. This refresh preserves Finn763's original contribution and commit credit.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw doctor --lint --json` or `openclaw doctor --only codex/managed-app-server --json` would receive `MissingPublicSurfaceError` before any checks ran when the official Codex plugin was installed separately from core. A working Gateway turn did not imply that doctor could load the plugin's health check.

## Why This Change Was Made

Doctor now resolves the canonical selected manifest and loads the public API from that plugin's root. Core intentionally excludes the external Codex plugin from its bundled distribution, so searching only core's bundled directory was the wrong ownership boundary. Registration supplies both current callbacks, `getHealthCheck` and `registerHealthCheck`.

Existing owner policy still decides whether Codex checks apply. Only bundled or explicitly trusted official installations can supply this surface, and the selected origin preserves the existing hardlink policy. Missing or broken APIs remain visible errors. There is no bundled-first fallback, catch-and-skip path, or automatic trust grant.

The canonical package scenario now uses its shared setup helper to explicitly accept the documented capabilities before non-interactive onboarding. This acceptance is confined to the test fixture; product consent behavior is unchanged. Real doctor execution assertions are separated from package metadata assertions so fixture-only metadata tests do not require a CLI binary.

## User Impact

Operators with the selected trusted external Codex plugin can run ordinary lint and the targeted managed-app-server check. Disabled, missing, untrusted, and non-Codex cases retain their intended behavior. No configuration option, dependency version, release selector, schema, or protocol changes are included.

## Evidence

- The original installed beta.3 reproduction failed before checks for both doctor commands. Focused regression tests failed against the old loader and passed with the selected-root change; coverage includes owner policy, missing/untrusted plugins, hardlinks, current registration callbacks, and non-Codex paths.
- Clean remote verification passed 103 production-focused tests, the full build, and core/core-test/scripts type lanes. Packaged execution checked the real Codex 0.150.1 launcher and managed native `--version` invocation, plus negative cases.
- The complete canonical package/on-demand scenario first failed at explicit capability consent. After the bounded fixture setup repair, [clean package run run_3400b5ca4215](https://crabbox.openclaw.ai/portal/runs/run_3400b5ca4215) completed with exit 0, including the new doctor assertions, 120 focused tests, and the staged changed-files gate. Ordinary lint reached 30 checks (two expected fixture warnings); targeted doctor returned `ok: true`, `checksRun: 1`, and no findings. No manual mid-scenario workaround was used.
- At the earlier UI refresh, the two reviewed commits were mechanically refreshed onto main containing the independently merged UI startup-budget correction #132124. `range-diff` and all six changed-file hashes match the previously verified doctor source. The UI repair is not part of this PR's delta. The first refreshed CI run33214281203 failed only because Knip did not know the new shell-launched doctor check was executable. A third commit registers that exact file in the existing executable-root inventory, without suppressing findings. The complete production and full-tree unused-file scans and formatting then passed on clean Blacksmith Testbox ([run33215965337](https://github.com/openclaw/openclaw/actions/runs/33215965337)). Final corrected-head CI is still required.
- Direct upstream inspection used Codex tag `rust-v0.150.1` (peeled commit `90854393966b21e9ebfd21b122334eb09a20c93d`), including `codex-cli/bin/codex.js:80` (native launcher selection) and `codex-rs/cli/src/main.rs:104` (CLI version declaration).

Production LOC: +24/-7 (net +17); analyzer tooling: +1/-0. Unit tests: +143/-58; E2E support: +42/-3. Production growth carries the canonical selected manifest/root and its trust/origin policy into the existing public-surface loader; the redundant disabled branch is removed. The metadata assertions file has no net change from the reviewed baseline.

ClawSweeper rank-up disposition: exact registry tarball readback verified `@openclaw/codex@2026.8.1-beta.3` and `2026.9.1-beta.1` both export the public API, but their registration callback contract is older than this candidate. Stable `2026.7.1-1` has no `api.js`. The exact candidate cohort is unpublished. Matching published-cohort update convergence therefore remains post-publication release proof and is deliberately skipped here; this PR does not publish packages or claim old/new callback compatibility. The complete candidate package scenario above is the relevant pre-merge artifact proof. Full release verification remains separate.

## Current main integration

The prior corrected head `f511217c24e51cd9dca20b848189f263b04f92cc` failed the unrelated Linux QA cleanup gate. That owner defect is now fixed and merged in #132230. This branch is refreshed onto its actual main commit `80944da38fc8049ccafacb86d1860be85ab071ea`; the new head is `6c16ea6e3c8bc0ee7ae0fd586fc8f4f3b6f2e308`. Finn763's verified coauthor trailer remains in all three commits.

The doctor logic, registration tests and package harness bytes are unchanged. Main's #132166 public-loader repair is preserved: source artifacts use the canonical module loader, while built JavaScript keeps its existing loading path. Clean Linux integration [run 33224709816](https://github.com/openclaw/openclaw/actions/runs/33224709816) passed 140 tests across eight owner/sibling files, including the new main source-artifact/import-only/lifecycle regression, plus formatting and script syntax checks. The exact full tracked tree `4ab84f08a368c75a2f26c81cabe15af145693825` matched before/after; canonical dependencies were installed, the command exited 0, and its Testbox was stopped. Fresh isolated complete-PR P0 review found no actionable P0 findings.

This is focused proof of the main integration, not a rerun or relabeling of the complete earlier candidate package proof. [Exact refreshed-head CI33224992862](https://github.com/openclaw/openclaw/actions/runs/33224992862) completed successfully, including the required gate. Native landing gates are next. The matching published-cohort limitation above is unchanged.
