### PR TITLE
fix(reply): preserve location and video presentation in delivery identity

### DIFF
--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -206,6 +206,18 @@ describe("createBlockReplyPipeline dedup with threading", () => {
         { location: { latitude: 3, longitude: 4 } },
       ],
     },
+    {
+      name: "normal and round videos sharing the same media",
+      payloads: [
+        { mediaUrl: "file:///reply.mp4" },
+        { mediaUrl: "file:///reply.mp4", videoAsNote: false },
+        { mediaUrl: "file:///reply.mp4", videoAsNote: true },
+      ],
+      expected: [
+        { mediaUrl: "file:///reply.mp4" },
+        { mediaUrl: "file:///reply.mp4", videoAsNote: true },
+      ],
+    },
   ])("preserves streamed delivery order for $name", async ({ payloads, expected }) => {
     const sent: ReplyPayload[] = [];
     const pipeline = createBlockReplyPipeline({
@@ -233,12 +245,16 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     expect(sent).toHaveLength(expected.length);
     expect(sent).toMatchObject(expected);
     expect(pipeline.getSentMediaUrls()).toEqual(
-      expected.flatMap((payload) =>
-        "mediaUrls" in payload
-          ? payload.mediaUrls
-          : "mediaUrl" in payload
-            ? [payload.mediaUrl]
-            : [],
+      Array.from(
+        new Set(
+          expected.flatMap((payload) =>
+            "mediaUrls" in payload
+              ? payload.mediaUrls
+              : "mediaUrl" in payload
+                ? [payload.mediaUrl]
+                : [],
+          ),
+        ),
       ),
     );
   });

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -63,6 +63,7 @@ function createBlockReplyContentIdentity(payload: ReplyPayload) {
     interactive: payload.interactive ?? null,
     channelData: payload.channelData ?? null,
     location: payload.location ?? null,
+    videoAsNote: payload.videoAsNote === true,
   };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.payloads.ts
+++ b/src/auto-reply/reply/dispatch-from-config.payloads.ts
@@ -86,6 +86,8 @@ export function createFinalDispatchPayloadDedupeKey(payload: ReplyPayload): stri
       replyToTag: payload.replyToTag,
       replyToCurrent: payload.replyToCurrent,
       audioAsVoice: payload.audioAsVoice,
+      videoAsNote: payload.videoAsNote === true,
+      location: payload.location,
       spokenText: payload.spokenText,
       ttsSupplement: payload.ttsSupplement,
       isError: payload.isError,

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -894,7 +894,7 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     }
   });
 
-  it("dedupes byte-identical non-streaming final payload entries for one turn", async () => {
+  it("dedupes equivalent non-streaming final payload entries for one turn", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(false);
     const dispatcher = createDispatcher();
     const replyPayload = {
@@ -907,7 +907,11 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
       ctx: createHookCtx(),
       cfg: emptyConfig,
       dispatcher,
-      replyResolver: async () => [replyPayload, { ...replyPayload }],
+      replyResolver: async () => [
+        replyPayload,
+        { ...replyPayload },
+        { ...replyPayload, videoAsNote: false },
+      ],
     });
 
     expect(result.queuedFinal).toBe(true);
@@ -915,87 +919,68 @@ describe("dispatchReplyFromConfig reply_dispatch hook", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(replyPayload);
   });
 
-  it("preserves same-content final payloads with distinct route metadata", async () => {
-    hookMocks.runner.hasHooks.mockReturnValue(false);
-    const dispatcher = createDispatcher();
-    const firstReply = setReplyPayloadMetadata(
-      { text: "same visible reply" } satisfies ReplyPayload,
-      {
-        replyDelivery: { chatType: "channel", replyToMode: "off" },
-        replyDeliverySource: { channel: "slack", accountId: "primary" },
-      },
-    );
-    const secondReply = setReplyPayloadMetadata(
-      { text: "same visible reply" } satisfies ReplyPayload,
-      {
-        replyDelivery: { chatType: "channel", replyToMode: "off" },
-        replyDeliverySource: { channel: "slack", accountId: "secondary" },
-      },
-    );
+  it.each([
+    {
+      name: "different native locations",
+      replies: [
+        { location: { latitude: 1, longitude: 2 } },
+        { location: { latitude: 3, longitude: 4 } },
+      ],
+    },
+    {
+      name: "normal and round videos sharing the same media",
+      replies: [
+        { mediaUrl: "file:///tmp/reply.mp4" },
+        { mediaUrl: "file:///tmp/reply.mp4", videoAsNote: true },
+      ],
+    },
+    {
+      name: "distinct route metadata",
+      replies: ["primary", "secondary"].map((accountId) =>
+        setReplyPayloadMetadata(
+          { text: "same visible reply" },
+          {
+            replyDelivery: { chatType: "channel", replyToMode: "off" },
+            replyDeliverySource: { channel: "slack", accountId },
+          },
+        ),
+      ),
+    },
+    {
+      name: "distinct reply-threading identity",
+      replies: [
+        { text: "same threaded reply", replyToId: "message-1" },
+        setReplyPayloadMetadata(
+          { text: "same threaded reply", replyToId: "message-1" },
+          { replyToIdExplicit: true },
+        ),
+      ],
+    },
+    {
+      name: "distinct assistant messages",
+      replies: [1, 2].map((assistantMessageIndex) =>
+        setReplyPayloadMetadata({ text: "intentional repeat" }, { assistantMessageIndex }),
+      ),
+    },
+  ] satisfies Array<{ name: string; replies: ReplyPayload[] }>)(
+    "preserves final payloads with $name",
+    async ({ replies }) => {
+      hookMocks.runner.hasHooks.mockReturnValue(false);
+      const dispatcher = createDispatcher();
 
-    const result = await dispatchReplyFromConfig({
-      ctx: createHookCtx(),
-      cfg: emptyConfig,
-      dispatcher,
-      replyResolver: async () => [firstReply, secondReply],
-    });
+      const result = await dispatchReplyFromConfig({
+        ctx: createHookCtx(),
+        cfg: emptyConfig,
+        dispatcher,
+        replyResolver: async () => replies,
+      });
 
-    expect(result.queuedFinal).toBe(true);
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(2);
-    expect(dispatcher.sendFinalReply).toHaveBeenNthCalledWith(1, firstReply);
-    expect(dispatcher.sendFinalReply).toHaveBeenNthCalledWith(2, secondReply);
-  });
-
-  it("preserves same-content final payloads with distinct reply-threading identity", async () => {
-    hookMocks.runner.hasHooks.mockReturnValue(false);
-    const dispatcher = createDispatcher();
-    const implicitReply = {
-      text: "same threaded reply",
-      replyToId: "message-1",
-    } satisfies ReplyPayload;
-    const explicitReply = setReplyPayloadMetadata(
-      {
-        text: "same threaded reply",
-        replyToId: "message-1",
-      } satisfies ReplyPayload,
-      { replyToIdExplicit: true },
-    );
-
-    await dispatchReplyFromConfig({
-      ctx: createHookCtx(),
-      cfg: emptyConfig,
-      dispatcher,
-      replyResolver: async () => [implicitReply, explicitReply],
-    });
-
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(2);
-    expect(dispatcher.sendFinalReply).toHaveBeenNthCalledWith(1, implicitReply);
-    expect(dispatcher.sendFinalReply).toHaveBeenNthCalledWith(2, explicitReply);
-  });
-
-  it("preserves same-content final payloads from distinct assistant messages", async () => {
-    hookMocks.runner.hasHooks.mockReturnValue(false);
-    const dispatcher = createDispatcher();
-    const firstReply = setReplyPayloadMetadata(
-      { text: "intentional repeat" } satisfies ReplyPayload,
-      { assistantMessageIndex: 1 },
-    );
-    const secondReply = setReplyPayloadMetadata(
-      { text: "intentional repeat" } satisfies ReplyPayload,
-      { assistantMessageIndex: 2 },
-    );
-
-    await dispatchReplyFromConfig({
-      ctx: createHookCtx(),
-      cfg: emptyConfig,
-      dispatcher,
-      replyResolver: async () => [firstReply, secondReply],
-    });
-
-    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(2);
-    expect(dispatcher.sendFinalReply).toHaveBeenNthCalledWith(1, firstReply);
-    expect(dispatcher.sendFinalReply).toHaveBeenNthCalledWith(2, secondReply);
-  });
+      expect(result.queuedFinal).toBe(true);
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(2);
+      expect(dispatcher.sendFinalReply).toHaveBeenNthCalledWith(1, replies[0]);
+      expect(dispatcher.sendFinalReply).toHaveBeenNthCalledWith(2, replies[1]);
+    },
+  );
 
   it("clears the reply lane but defers follow-up admission until final delivery settles", async () => {
     const deliveryOrder: string[] = [];


### PR DESCRIPTION
## Summary

- Preserve distinct portable locations during final reply deduplication.
- Keep normal video and round-video presentations distinct in both final and streamed reply identities.
- Normalize omitted and explicitly false round-video markers identically so ordinary duplicate suppression remains stable.

## Root cause

Final reply identity omitted the location coordinates entirely, causing two distinct destinations to collapse into one delivered reply. Both final and streamed identity owners also omitted whether the same video should be sent as a normal video or round video. Existing streamed-location handling covered only one sibling and left these delivery identities incomplete.

## Validation

- Authentic pre-fix failures used actual final reply dispatch and the actual streaming pipeline; each silently delivered one message instead of two.
- Additional regressions caught the tempting but incorrect distinction between omitted and explicitly false video markers.
- Real reply-owner to Telegram transport proof delivered both distinct locations, normal video, and round video while suppressing one actual duplicate.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/block-reply-pipeline.test.ts src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts extensions/telegram/src/outbound-adapter.test.ts --reporter=dot` — 91 tests passed.
- Focused type-aware lint, formatting, changed-scope dry run, and fresh independent Codex autoreview passed.
- Three necessary production identity fields; consolidated existing duplicate tests so the complete change adds only four lines overall.
