### PR TITLE
fix(cli): recognize OAuth authorization headers regardless of casing

### DIFF
--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -608,6 +608,59 @@ describe("mcp cli", () => {
     });
   });
 
+  it("reports ignored OAuth Authorization headers regardless of casing", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+      readMcpOAuthCredentialsStatus.mockResolvedValue({ state: "authorized" });
+
+      for (const { name, header, oauth } of [
+        { name: "lowercase", header: "authorization", oauth: true },
+        { name: "titlecase", header: "Authorization", oauth: true },
+        { name: "uppercase", header: "AUTHORIZATION", oauth: true },
+        { name: "proxy", header: "Proxy-Authorization", oauth: true },
+        { name: "unrelated", header: "X-Tenant", oauth: true },
+        { name: "without-oauth", header: "AUTHORIZATION", oauth: false },
+      ]) {
+        await runMcpCommand([
+          "mcp",
+          "set",
+          name,
+          JSON.stringify({
+            url: "https://mcp.example.com/mcp",
+            headers: { [header]: "$MCP_HEADER" },
+            ...(oauth ? { auth: "oauth" } : {}),
+          }),
+        ]);
+      }
+      mockLog.mockClear();
+
+      await runMcpCommand(["mcp", "doctor", "--json"]);
+
+      const { servers } = JSON.parse(lastLogLine()) as {
+        servers: Array<{ name: string; issues: Array<{ message: string }> }>;
+      };
+      expect(
+        Object.fromEntries(
+          servers.map(({ name, issues }) => [
+            name,
+            issues.some(
+              ({ message }) =>
+                message === "OAuth is enabled and the static Authorization header is ignored",
+            ),
+          ]),
+        ),
+      ).toEqual({
+        lowercase: true,
+        titlecase: true,
+        uppercase: true,
+        proxy: false,
+        unrelated: false,
+        "without-oauth": false,
+      });
+    });
+  });
+
   it("bounds concurrent MCP doctor server checks", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {
       const workspaceDir = await createWorkspace();

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -331,7 +331,7 @@ async function collectMcpDoctorIssues(params: {
           }
         }
         const headers = asRecord(server.headers);
-        if (headers && "Authorization" in headers) {
+        if (headers && Object.keys(headers).some((key) => key.toLowerCase() === "authorization")) {
           issues.push(
             issue("warning", "OAuth is enabled and the static Authorization header is ignored"),
           );


### PR DESCRIPTION
## Summary

- Make MCP doctor recognize static OAuth `Authorization` headers independently of HTTP header casing.
- Preserve the existing warning that OAuth ignores manually configured authorization headers.
- Exclude similarly named headers and non-OAuth server configurations.

## Root cause

The actual MCP OAuth transport strips authorization headers case-insensitively, but the diagnostic owner previously checked only the exact `Authorization` spelling. Lowercase and uppercase variants therefore disappeared at runtime without the documented operator warning.

## Validation

- Authentic pre-fix doctor regression: lowercase and uppercase headers produced no warning, while title-case did.
- Complete MCP CLI suite: 35 tests passed; existing transport-owner static-header coverage also passed.
- Regression covers lowercase, title-case, uppercase, `Proxy-Authorization`, unrelated headers, and non-OAuth servers.
- Repository formatter, `git diff --check`, changed-lane classification, and fresh independent Codex autoreview passed.
- Production change is one line replaced by one line; OAuth, credentials, transport, and security behavior are unchanged.
