### PR TITLE
fix(whatsapp): avoid mentions inside unterminated inline code

### DIFF
--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -16,11 +16,25 @@ describe("resolveWhatsAppOutboundMentions", () => {
     });
   });
 
-  it("rewrites phone-number tokens to LID mention text without device suffixes", () => {
+  it.each([
+    { text: "ping @+5511976136970", expected: "ping @277038292303944" },
+    {
+      text: "literal \\` ping @+5511976136970",
+      expected: "literal \\` ping @277038292303944",
+    },
+    {
+      text: "literal \\\\\\` ping @+5511976136970",
+      expected: "literal \\\\\\` ping @277038292303944",
+    },
+    {
+      text: "inside ``notify ` @+5511976136970`` then @+5511976136970",
+      expected: "inside ``notify ` @+5511976136970`` then @277038292303944",
+    },
+  ])("rewrites visible phone-number mentions to LIDs: $text", ({ text, expected }) => {
     expect(
       resolveWhatsAppOutboundMentions({
         chatJid: "120363000000000000@g.us",
-        text: "ping @+5511976136970",
+        text,
         participants: [
           {
             id: "277038292303944:2@lid",
@@ -29,7 +43,7 @@ describe("resolveWhatsAppOutboundMentions", () => {
         ],
       }),
     ).toEqual({
-      text: "ping @277038292303944",
+      text: expected,
       mentionedJids: ["277038292303944@lid"],
     });
   });
@@ -115,8 +129,14 @@ describe("resolveWhatsAppOutboundMentions", () => {
     });
   });
 
-  it.each(["Run `notify @+5511976136970", "Run `notify\n@+5511976136970"])(
-    "does not rewrite or mention phone numbers inside unterminated inline code: %j",
+  it.each([
+    "Run `notify @+5511976136970",
+    "Run `notify\n@+5511976136970",
+    "Run ``notify ` @+5511976136970",
+    "Run ``notify ` @+5511976136970``",
+    "literal \\\\` inside @+5511976136970",
+  ])(
+    "does not rewrite or mention phone numbers inside balanced or unterminated inline code: %j",
     (text) => {
       expect(
         resolveWhatsAppOutboundMentions({

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -115,6 +115,22 @@ describe("resolveWhatsAppOutboundMentions", () => {
     });
   });
 
+  it("does not rewrite or mention phone numbers inside unterminated inline code", () => {
+    const text = "Run `notify @+5511976136970";
+    expect(
+      resolveWhatsAppOutboundMentions({
+        chatJid: "120363000000000000@g.us",
+        text,
+        participants: [
+          {
+            id: "277038292303944@lid",
+            phoneNumber: "5511976136970@s.whatsapp.net",
+          },
+        ],
+      }),
+    ).toEqual({ text, mentionedJids: [] });
+  });
+
   it("does not mention numeric prefixes inside longer tokens", () => {
     expect(
       resolveWhatsAppOutboundMentions({

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -115,21 +115,23 @@ describe("resolveWhatsAppOutboundMentions", () => {
     });
   });
 
-  it("does not rewrite or mention phone numbers inside unterminated inline code", () => {
-    const text = "Run `notify @+5511976136970";
-    expect(
-      resolveWhatsAppOutboundMentions({
-        chatJid: "120363000000000000@g.us",
-        text,
-        participants: [
-          {
-            id: "277038292303944@lid",
-            phoneNumber: "5511976136970@s.whatsapp.net",
-          },
-        ],
-      }),
-    ).toEqual({ text, mentionedJids: [] });
-  });
+  it.each(["Run `notify @+5511976136970", "Run `notify\n@+5511976136970"])(
+    "does not rewrite or mention phone numbers inside unterminated inline code: %j",
+    (text) => {
+      expect(
+        resolveWhatsAppOutboundMentions({
+          chatJid: "120363000000000000@g.us",
+          text,
+          participants: [
+            {
+              id: "277038292303944@lid",
+              phoneNumber: "5511976136970@s.whatsapp.net",
+            },
+          ],
+        }),
+      ).toEqual({ text, mentionedJids: [] });
+    },
+  );
 
   it("does not mention numeric prefixes inside longer tokens", () => {
     expect(

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -16,7 +16,7 @@ export type WhatsAppOutboundMentionResolution = {
 };
 
 const CODE_FENCE_RE = /```[\s\S]*?```/g;
-const INLINE_CODE_RE = /`[^`\n]+`/g;
+const INLINE_CODE_RE = /`[^`\n]+(?:`|$)/g;
 const OUTBOUND_MENTION_RE = /@(\+?\d+)/g;
 const KNOWN_USER_JID_RE = /^(\d+)(?::\d+)?@(s\.whatsapp\.net|hosted|lid|hosted\.lid|c\.us)$/i;
 const PHONE_JID_DOMAIN_RE = /^(s\.whatsapp\.net|hosted|c\.us)$/i;

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -16,7 +16,7 @@ export type WhatsAppOutboundMentionResolution = {
 };
 
 const CODE_FENCE_RE = /```[\s\S]*?```/g;
-const INLINE_CODE_RE = /`[^`]+(?:`|$)/g;
+const INLINE_CODE_RE = /(?<=(?:^|[^\\])(?:\\\\)*)(`+)[\s\S]*?(?:(?<!`)\1(?!`)|$)/g;
 const OUTBOUND_MENTION_RE = /@(\+?\d+)/g;
 const KNOWN_USER_JID_RE = /^(\d+)(?::\d+)?@(s\.whatsapp\.net|hosted|lid|hosted\.lid|c\.us)$/i;
 const PHONE_JID_DOMAIN_RE = /^(s\.whatsapp\.net|hosted|c\.us)$/i;

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -16,7 +16,7 @@ export type WhatsAppOutboundMentionResolution = {
 };
 
 const CODE_FENCE_RE = /```[\s\S]*?```/g;
-const INLINE_CODE_RE = /`[^`\n]+(?:`|$)/g;
+const INLINE_CODE_RE = /`[^`]+(?:`|$)/g;
 const OUTBOUND_MENTION_RE = /@(\+?\d+)/g;
 const KNOWN_USER_JID_RE = /^(\d+)(?::\d+)?@(s\.whatsapp\.net|hosted|lid|hosted\.lid|c\.us)$/i;
 const PHONE_JID_DOMAIN_RE = /^(s\.whatsapp\.net|hosted|c\.us)$/i;

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -330,9 +330,15 @@ describe("createWebSendApi", () => {
     });
   });
 
-  it.each(["Run `notify @15551234567", "Run `notify\n@15551234567"])(
-    "does not send native mentions for phone numbers inside unterminated inline code: %j",
-    async (messageText) => {
+  it.each([
+    { messageText: "Run `notify @15551234567" },
+    { messageText: "Run `notify\n@15551234567" },
+    { messageText: "Run ``notify ` @15551234567" },
+    { messageText: "literal \\` ping @15551234567", nativeMention: true },
+    { messageText: "literal \\\\` inside @15551234567" },
+  ])(
+    "only sends native mentions for visible phone numbers outside inline code: $messageText",
+    async ({ messageText, nativeMention }) => {
       api = createWebSendApi({
         sock: { sendMessage, sendPresenceUpdate },
         defaultAccountId: "main",
@@ -348,6 +354,7 @@ describe("createWebSendApi", () => {
 
       expect(sendMessage).toHaveBeenCalledWith("120363000000000000@g.us", {
         text: messageText,
+        ...(nativeMention ? { mentions: ["15551234567@s.whatsapp.net"] } : {}),
       });
     },
   );

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -330,27 +330,27 @@ describe("createWebSendApi", () => {
     });
   });
 
-  it("does not send native mentions for phone numbers inside unterminated inline code", async () => {
-    api = createWebSendApi({
-      sock: { sendMessage, sendPresenceUpdate },
-      defaultAccountId: "main",
-      resolveOutboundMentions: ({ jid, text }) =>
-        resolveWhatsAppOutboundMentions({
-          chatJid: jid,
-          text,
-          participants: [{ id: "15551234567@s.whatsapp.net" }],
-        }),
-    });
+  it.each(["Run `notify @15551234567", "Run `notify\n@15551234567"])(
+    "does not send native mentions for phone numbers inside unterminated inline code: %j",
+    async (messageText) => {
+      api = createWebSendApi({
+        sock: { sendMessage, sendPresenceUpdate },
+        defaultAccountId: "main",
+        resolveOutboundMentions: ({ jid, text }) =>
+          resolveWhatsAppOutboundMentions({
+            chatJid: jid,
+            text,
+            participants: [{ id: "15551234567@s.whatsapp.net" }],
+          }),
+      });
 
-    await api.sendMessage(
-      "120363000000000000@g.us",
-      markdownToWhatsApp("Run `notify @15551234567"),
-    );
+      await api.sendMessage("120363000000000000@g.us", markdownToWhatsApp(messageText));
 
-    expect(sendMessage).toHaveBeenCalledWith("120363000000000000@g.us", {
-      text: "Run `notify @15551234567",
-    });
-  });
+      expect(sendMessage).toHaveBeenCalledWith("120363000000000000@g.us", {
+        text: messageText,
+      });
+    },
+  );
 
   it("supports image media with caption", async () => {
     const payload = Buffer.from("img");

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -12,6 +12,7 @@ import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-run
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { prepareWhatsAppOutboundMedia } from "../outbound-media-contract.js";
+import { markdownToWhatsApp } from "../text-runtime.js";
 import { resolveWhatsAppOutboundMentions } from "./outbound-mentions.js";
 import { createWebSendApi } from "./send-api.js";
 import { normalizeWhatsAppSendResult, type WhatsAppSendResult } from "./send-result.js";
@@ -326,6 +327,28 @@ describe("createWebSendApi", () => {
     expect(sendMessage).toHaveBeenCalledWith("120363000000000000@g.us", {
       text: "ping @277038292303944",
       mentions: ["277038292303944@lid"],
+    });
+  });
+
+  it("does not send native mentions for phone numbers inside unterminated inline code", async () => {
+    api = createWebSendApi({
+      sock: { sendMessage, sendPresenceUpdate },
+      defaultAccountId: "main",
+      resolveOutboundMentions: ({ jid, text }) =>
+        resolveWhatsAppOutboundMentions({
+          chatJid: jid,
+          text,
+          participants: [{ id: "15551234567@s.whatsapp.net" }],
+        }),
+    });
+
+    await api.sendMessage(
+      "120363000000000000@g.us",
+      markdownToWhatsApp("Run `notify @15551234567"),
+    );
+
+    expect(sendMessage).toHaveBeenCalledWith("120363000000000000@g.us", {
+      text: "Run `notify @15551234567",
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

WhatsApp turns phone numbers inside unfinished Markdown inline code into native participant mentions, including when the inline code crosses a soft line break or uses multi-backtick delimiters containing embedded shorter backticks. Escaped literal backticks can also incorrectly suppress legitimate intended mentions.

## Why This Change Was Made

The canonical Markdown code-span parser matches equal-length delimiter runs, protects unmatched inline delimiters through the end of the input, permits soft line breaks, and distinguishes escaped literal delimiters. WhatsApp's separate outbound mention scanner originally recognized only closed spans; intermediate fixes missed soft newlines and multi-backtick delimiter runs. The scanner now follows the canonical rules without adding a new Plugin SDK surface.

## User Impact

Phone numbers inside unfinished single-line, multiline, or multi-backtick inline code remain literal instead of sending native WhatsApp mentions. Escaped literal backticks do not suppress legitimate native mentions. Ordinary intended mentions, balanced inline code, fenced code, and other outbound behavior remain unchanged.

## Evidence

- The ClawSweeper-identified multiline, delimiter-run, and escaped-literal owner/actual-Baileys regressions failed before their respective follow-up repairs; the final review pass adds seven authentic adversarial failures.
- `node scripts/run-vitest.mjs extensions/whatsapp/src/inbound/outbound-mentions.test.ts extensions/whatsapp/src/inbound/send-api.test.ts` now passes all 73 tests.
- The complete production formatter-to-fake-Baileys chain suppresses protected native mentions for multiline and multi-backtick code while preserving legitimate mentions after escaped literal backticks.
- Focused type-aware lint, formatting, and both local-change and complete-branch independent structured reviews passed.
- Production delta is net zero: one regular-expression line replaces one line.
- The previously reported ClawSweeper blockers and all requested owner/transport delimiter-run regression cases are addressed at this head without expanding the public Plugin SDK.
