### PR TITLE
fix(telegram): resolve default account without default agent

### DIFF
--- a/extensions/telegram/src/account-selection.ts
+++ b/extensions/telegram/src/account-selection.ts
@@ -9,7 +9,7 @@ import {
   normalizeAccountId,
   normalizeOptionalAccountId,
 } from "openclaw/plugin-sdk/account-id";
-import { listAgentIds, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
+import { listAgentIds, tryResolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -53,7 +53,10 @@ function resolveDefaultAgentBoundAccountId(cfg: OpenClawConfig, channelId: strin
   if (cfg.agents?.ownership === "explicit" && listAgentIds(cfg).length !== 1) {
     return null;
   }
-  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const defaultAgentId = tryResolveDefaultAgentId(cfg);
+  if (!defaultAgentId) {
+    return null;
+  }
   for (const binding of cfg.bindings ?? []) {
     const resolved = resolveBindingAccount({ binding, channelId });
     if (resolved?.agentId === defaultAgentId) {

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -268,6 +268,22 @@ describe("resolveDefaultTelegramAccountId", () => {
     );
   });
 
+  it("falls back to the configured default account without a default agent", () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "hex" }, { id: "quill" }] },
+      channels: {
+        telegram: {
+          accounts: { default: { botToken: "tok-default" }, coding: { botToken: "tok-coding" } },
+        },
+      },
+      bindings: [
+        { agentId: "quill", match: { channel: "telegram", accountId: "default" } },
+        { agentId: "hex", match: { channel: "telegram", accountId: "coding" } },
+      ],
+    };
+
+    expect(resolveDefaultTelegramAccountId(cfg)).toBe("default");
+  });
   it("does not warn when accounts.default exists", () => {
     const cfg: OpenClawConfig = {
       channels: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Telegram setup with a configured accounts.default could fail during account selection when multiple agents are configured but none is the default agent. The channel then could not start even though the configured default bot account was valid.

## Why This Change Was Made

Telegram first attempts to select an account bound to the default agent. That optional selection must not use the strict agent resolver when no default agent exists. The repair uses the optional resolver and falls through to the established configured-account selection path when there is no default agent.

## User Impact

Multi-agent Telegram configurations can start the configured default bot account without adding an unrelated default-agent setting. Explicit agent bindings and explicit ownership behavior remain unchanged.

## Evidence

- Pre-fix regression: the added focused test failed on clean upstream main with AgentSelectionRequiredError from strict default-agent resolution.
- Post-fix: node scripts/run-vitest.mjs extensions/telegram/src/accounts.test.ts passed 39 of 39 tests.
- Changed-file gate: node scripts/check-changed.mjs --base upstream/main -- extensions/telegram/src/account-selection.ts extensions/telegram/src/accounts.test.ts.
- Package build: pnpm build.
- Local Telegram verification: the Gateway started the configured accounts and the affected Telegram agents replied successfully.

Production LOC: +5/-2. Tests: +16/-0.