### PR TITLE
fix(telegram): honor explicit replies when implicit threading is off

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -801,7 +801,9 @@ export async function deliverReplies(params: {
     const reactionEmoji =
       typeof telegramData?.reaction?.emoji === "string" ? telegramData.reaction.emoji : undefined;
     const replyToId =
-      params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
+      params.replyToMode === "off" && !reply.replyToTag && !reply.replyToCurrent
+        ? undefined
+        : resolveTelegramReplyId(reply.replyToId);
     if (reactionEmoji && typeof replyToId !== "number") {
       params.runtime.error?.(danger("Telegram reaction requires a reply target"));
       continue;

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -2925,6 +2925,44 @@ describe("deliverReplies", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "an explicit current-message reply",
+      reply: { text: "current", replyToId: "700", replyToCurrent: true },
+      expectedReplyTo: 700,
+    },
+    {
+      name: "an explicit reply tag",
+      reply: { text: "tagged", replyToId: "701", replyToTag: true },
+      expectedReplyTo: 701,
+    },
+    {
+      name: "an implicit reply",
+      reply: { text: "implicit", replyToId: "702" },
+      expectedReplyTo: undefined,
+    },
+    {
+      name: "a status notice whose target was stripped upstream",
+      reply: { text: "status", replyToCurrent: true, isStatusNotice: true },
+      expectedReplyTo: undefined,
+    },
+    {
+      name: "an explicit tag without a target",
+      reply: { text: "untargeted", replyToTag: true },
+      expectedReplyTo: undefined,
+    },
+  ])("replyToMode 'off' handles $name", async ({ reply, expectedReplyTo }) => {
+    const { runtime, sendMessage, bot } = createSendMessageHarness();
+
+    await deliverWith({ replies: [reply], runtime, bot });
+
+    expect(mockCallArg(sendMessage, 0, 2)).toEqual(
+      expectedReplyTo === undefined
+        ? expect.not.objectContaining({ reply_to_message_id: expect.anything() })
+        : expect.objectContaining({ reply_to_message_id: expectedReplyTo }),
+    );
+  });
+
   it("replyToMode 'first' keeps native reply-to for a single text chunk", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/channel.gateway.test.ts
+++ b/extensions/telegram/src/channel.gateway.test.ts
@@ -2,9 +2,13 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { deliverInboundReplyWithMessageSendContext } from "openclaw/plugin-sdk/channel-outbound";
 import {
   createPluginRuntimeMock,
   createStartAccountContext,
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -743,6 +747,68 @@ describe("telegramPlugin gateway startup", () => {
 });
 
 describe("telegramPlugin outbound attachments", () => {
+  it.each([
+    {
+      name: "an explicit current-message reply",
+      payload: { text: "current", replyToCurrent: true },
+      replyToId: "700",
+      expectedReplyTo: 700,
+    },
+    {
+      name: "an explicit reply tag",
+      payload: { text: "tagged", replyToTag: true },
+      replyToId: "701",
+      expectedReplyTo: 701,
+    },
+    {
+      name: "an implicit reply",
+      payload: { text: "implicit" },
+      replyToId: "702",
+      expectedReplyTo: undefined,
+    },
+    {
+      name: "a compaction notice",
+      payload: { text: "compacting", replyToCurrent: true, isCompactionNotice: true },
+      replyToId: "703",
+      expectedReplyTo: undefined,
+    },
+  ])("threads $name correctly through durable Telegram delivery", async (testCase) => {
+    await useTempStateDir();
+    installTelegramRuntime();
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
+    );
+    sendMessageTelegram.mockResolvedValue({ messageId: "tg-durable", chatId: "12345" });
+
+    try {
+      const result = await deliverInboundReplyWithMessageSendContext({
+        cfg: createTelegramConfig(),
+        channel: "telegram",
+        accountId: "default",
+        agentId: "main",
+        info: { kind: "final" },
+        payload: testCase.payload,
+        replyToId: testCase.replyToId,
+        replyToMode: "off",
+        ctxPayload: {
+          CommandAuthorized: true,
+          CommandTurn: { kind: "normal", source: "message", authorized: false },
+          OriginatingTo: "telegram:12345",
+        },
+        deps: { sendTelegram: sendMessageTelegram },
+      });
+
+      expect(result.status).toBe("handled_visible");
+      expect(sendMessageTelegram).toHaveBeenCalledTimes(1);
+      expect(sendMessageOptionsAt(0).replyToMessageId).toBe(testCase.expectedReplyTo);
+      expect(sendMessageOptionsAt(0).replyToIdSource).toBe(
+        testCase.expectedReplyTo === undefined ? undefined : "explicit",
+      );
+    } finally {
+      resetPluginRuntimeStateForTest();
+    }
+  });
+
   it("preserves default markdown rendering unless a parse mode is explicit", async () => {
     installTelegramRuntime();
     sendMessageTelegram.mockResolvedValue({ messageId: "tg-1", chatId: "12345" });

--- a/src/channels/turn/durable-delivery.test.ts
+++ b/src/channels/turn/durable-delivery.test.ts
@@ -34,6 +34,9 @@ type SendDurableMessageBatchRequest = {
   cfg?: unknown;
   channel?: string;
   to?: string;
+  reply?: { source: "explicit" | "implicit"; replyToId: string };
+  replyToId?: string | null;
+  replyToMode?: string;
   threadId?: string | number | null;
   durability?: string;
   requireUnknownSendReconciliation?: boolean;
@@ -114,6 +117,49 @@ describe("durable inbound reply delivery", () => {
     expect(request.threadId).toBeNull();
     expect(request.durability).toBe("best_effort");
     expect(request.gatewayClientScopes).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: "an explicit current-message reply",
+      payload: { text: "current", replyToCurrent: true },
+      replyToId: "700",
+      expectedReply: { source: "explicit", replyToId: "700" },
+    },
+    {
+      name: "an explicit reply tag",
+      payload: { text: "tagged", replyToTag: true },
+      replyToId: "701",
+      expectedReply: { source: "explicit", replyToId: "701" },
+    },
+    {
+      name: "an implicit reply",
+      payload: { text: "implicit" },
+      replyToId: "702",
+      expectedReply: undefined,
+    },
+    {
+      name: "a compaction notice",
+      payload: { text: "compacting", replyToCurrent: true, isCompactionNotice: true },
+      replyToId: "703",
+      expectedReply: undefined,
+    },
+  ])("keeps $name explicit when durable implicit replies are off", async (testCase) => {
+    await deliverInboundReplyWithMessageSendContextCore({
+      cfg: {},
+      channel: "telegram",
+      agentId: "main",
+      info: { kind: "final" },
+      payload: testCase.payload,
+      replyToId: testCase.replyToId,
+      replyToMode: "off",
+      ctxPayload: ctxPayload({ OriginatingTo: "chat-1" }),
+    });
+
+    const request = latestSendDurableMessageBatchRequest();
+    expect(request.reply).toEqual(testCase.expectedReply);
+    expect(request.replyToId).toBe(testCase.replyToId);
+    expect(request.replyToMode).toBe("off");
   });
 
   it("does not require unknown-send reconciliation for the default best-effort final path", async () => {

--- a/src/channels/turn/durable-delivery.ts
+++ b/src/channels/turn/durable-delivery.ts
@@ -1,7 +1,7 @@
 // Durable final-reply delivery for inbound channel turns.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
-import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import { isReplyPayloadStatusNotice, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeDeliverableOutboundChannel } from "../../infra/outbound/channel-resolution.js";
@@ -85,15 +85,6 @@ function resolveDurableInboundReplyToId(
   );
 }
 
-function resolveDurableInboundReplyThreadId(
-  params: DurableInboundReplyDeliveryParams,
-): string | number | null | undefined {
-  if ("threadId" in params) {
-    return params.threadId;
-  }
-  return params.ctxPayload.MessageThreadId;
-}
-
 function stringifyThreadId(value: string | number | null | undefined): string | undefined {
   return value == null ? undefined : String(value);
 }
@@ -166,7 +157,7 @@ export async function deliverInboundReplyWithMessageSendContextCore(
   }
 
   const replyToId = resolveDurableInboundReplyToId(params);
-  const threadId = resolveDurableInboundReplyThreadId(params);
+  const threadId = "threadId" in params ? params.threadId : params.ctxPayload.MessageThreadId;
   const requiredCapabilities =
     params.requiredCapabilities ??
     deriveDurableFinalDeliveryRequirements({
@@ -222,6 +213,12 @@ export async function deliverInboundReplyWithMessageSendContextCore(
         }
       : {}),
     threadId,
+    reply:
+      replyToId &&
+      !isReplyPayloadStatusNotice(params.payload) &&
+      (params.payload.replyToTag || params.payload.replyToCurrent)
+        ? { source: "explicit", replyToId }
+        : undefined,
     replyToId,
     replyToMode: params.replyToMode,
     formatting: params.formatting,


### PR DESCRIPTION
## Summary

- Preserve explicitly requested reply targets through both the default durable-delivery owner and Telegram's legacy direct sender when implicit reply threading is disabled.
- Honor both current-message reply tags and explicit message-ID tags while keeping ordinary replies and status/compaction notices unthreaded.
- Carry the existing typed explicit-reply fact across the shared owner boundary; remove an obsolete one-use thread helper.

## Root cause

The earlier version of this PR repaired Telegram's legacy direct sender only. Actual final replies normally take the shared durable delivery path, where the canonical owner carried a resolved reply ID separately from the payload but omitted its existing typed explicit provenance. Downstream reply normalization therefore legitimately discarded that ID when `replyToMode` was `off`. The default operator-visible path remained broken despite passing legacy-path tests.

The durable owner now passes the existing `{ source: "explicit", replyToId }` fact only for explicitly tagged ordinary reply payloads. Telegram's direct sender independently preserves the same documented contract. No Plugin SDK shape, configuration, protocol, authentication, or other channel policy is changed.

## Validation

- Authentic pre-fix failures: two shared durable-owner cases and two full public-SDK -> durable queue -> real registered Telegram adapter -> injected provider cases failed for explicit-current and explicit-ID replies; implicit replies and status notices remained passing controls.
- After repair, 231 focused owner, canonical reply-policy, Telegram gateway, dispatch, direct-delivery, and outbound-adapter tests passed.
- Actual registered-adapter proof observes Telegram reply IDs `700` and `701` for explicit tags and no reply parameter for implicit/status-notice controls. The final Telegram API sender is injected; this is not a live Telegram send.
- Type-aware core and plugin lint, formatting, changed-scope classification, and fresh independent complete-branch autoreview passed.
- Entire PR production delta: +11/-12, net -1. Tests are counted separately.
