### PR TITLE
refactor(qa): consolidate runtime fixtures

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -275,6 +275,58 @@ describe("qa cli runtime", () => {
   let telegramArtifactsDir: string;
   let telegramSummaryPath: string;
 
+  async function writeSuiteSummary(summary: unknown, summaryPath = suiteSummaryPath) {
+    await fs.writeFile(summaryPath, JSON.stringify(summary), "utf8");
+  }
+
+  function mockSuiteRuntimeResult(
+    executionKind: "flow" | "suite",
+    params: { evidencePath?: string; scenarios?: unknown[] } = {},
+  ) {
+    const paths = {
+      reportPath: suiteReportPath,
+      summaryPath: suiteSummaryPath,
+      ...(params.scenarios ? { scenarios: params.scenarios } : {}),
+    };
+    return executionKind === "flow"
+      ? flowSuiteRuntimeResult(paths)
+      : unifiedSuiteRuntimeResult({
+          ...paths,
+          outputDir: suiteArtifactsDir,
+          evidencePath: params.evidencePath ?? suiteEvidencePath,
+        });
+  }
+
+  async function withMultipassSummary(summary: unknown, run: () => Promise<void>) {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
+    const summaryPath = path.join(repoRoot, "qa-suite-summary.json");
+    if (summary !== undefined) {
+      await fs.writeFile(
+        summaryPath,
+        typeof summary === "string" ? summary : JSON.stringify(summary),
+        "utf8",
+      );
+    }
+    runQaMultipass.mockResolvedValueOnce({
+      outputDir: repoRoot,
+      reportPath: path.join(repoRoot, "qa-suite-report.md"),
+      summaryPath,
+      hostLogPath: path.join(repoRoot, "multipass-host.log"),
+      bootstrapLogPath: path.join(repoRoot, "multipass-guest-bootstrap.log"),
+      guestScriptPath: path.join(repoRoot, "multipass-guest-run.sh"),
+      vmName: "openclaw-qa-test",
+      scenarioIds: ["channel-chat-baseline"],
+    });
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await run();
+    } finally {
+      process.exitCode = priorExitCode;
+      await fs.rm(repoRoot, { recursive: true, force: true });
+    }
+  }
+
   beforeEach(async () => {
     suiteArtifactsDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-suite-runtime-"));
     suiteEvidencePath = path.join(suiteArtifactsDir, "qa-evidence.json");
@@ -486,23 +538,13 @@ describe("qa cli runtime", () => {
       status: "skip" as const,
       details: "image_generate mock provider report-only: tool unavailable",
     };
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
-        scenarios: [optionalScenario],
-      }),
-      "utf8",
-    );
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+      scenarios: [optionalScenario],
+    });
     runQaSuite.mockResolvedValueOnce(
-      unifiedSuiteRuntimeResult({
-        outputDir: suiteArtifactsDir,
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-        evidencePath: suiteEvidencePath,
-        scenarios: [optionalScenario],
-      }),
+      mockSuiteRuntimeResult("suite", { scenarios: [optionalScenario] }),
     );
 
     await expect(runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" })).rejects.toThrow(
@@ -511,23 +553,12 @@ describe("qa cli runtime", () => {
   });
 
   it("rejects a direct suite summary with unaccounted outcomes", async () => {
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { total: 2, passed: 1, failed: 0, skipped: 0 },
-        scenarios: [{ status: "pass" }],
-      }),
-      "utf8",
-    );
-    runQaSuite.mockResolvedValueOnce(
-      unifiedSuiteRuntimeResult({
-        outputDir: suiteArtifactsDir,
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-        evidencePath: suiteEvidencePath,
-      }),
-    );
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 2, passed: 1, failed: 0, skipped: 0 },
+      scenarios: [{ status: "pass" }],
+    });
+    runQaSuite.mockResolvedValueOnce(mockSuiteRuntimeResult("suite"));
 
     await expect(runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" })).rejects.toMatchObject({
       code: "summary_counts_invalid",
@@ -535,24 +566,13 @@ describe("qa cli runtime", () => {
   });
 
   it("rejects a direct suite summary whose canonical evidence contradicts its counts", async () => {
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
-        scenarios: [{ status: "pass" }],
-        evidence: { entries: [{ result: { status: "fail" } }] },
-      }),
-      "utf8",
-    );
-    runQaSuite.mockResolvedValueOnce(
-      unifiedSuiteRuntimeResult({
-        outputDir: suiteArtifactsDir,
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-        evidencePath: suiteEvidencePath,
-      }),
-    );
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
+      scenarios: [{ status: "pass" }],
+      evidence: { entries: [{ result: { status: "fail" } }] },
+    });
+    runQaSuite.mockResolvedValueOnce(mockSuiteRuntimeResult("suite"));
 
     await expect(runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" })).rejects.toMatchObject({
       code: "summary_counts_invalid",
@@ -562,26 +582,15 @@ describe("qa cli runtime", () => {
   it("accepts a passing scenario with lower-level blocked and passing producer checks", async () => {
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
-        scenarios: [{ status: "pass" }],
-        evidence: {
-          entries: [{ result: { status: "blocked" } }, { result: { status: "pass" } }],
-        },
-      }),
-      "utf8",
-    );
-    runQaSuite.mockResolvedValueOnce(
-      unifiedSuiteRuntimeResult({
-        outputDir: suiteArtifactsDir,
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-        evidencePath: suiteEvidencePath,
-      }),
-    );
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
+      scenarios: [{ status: "pass" }],
+      evidence: {
+        entries: [{ result: { status: "blocked" } }, { result: { status: "pass" } }],
+      },
+    });
+    runQaSuite.mockResolvedValueOnce(mockSuiteRuntimeResult("suite"));
 
     try {
       await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" });
@@ -599,24 +608,13 @@ describe("qa cli runtime", () => {
       status: "skip" as const,
       details: "image_generate mock provider report-only: tool unavailable",
     };
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { total: 2, passed: 1, failed: 0, skipped: 1 },
-        scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
-      }),
-      "utf8",
-    );
-    runQaSuite.mockResolvedValueOnce(
-      unifiedSuiteRuntimeResult({
-        outputDir: suiteArtifactsDir,
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-        evidencePath: suiteEvidencePath,
-        scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
-      }),
-    );
+    const scenarios = [QA_PASSING_SUITE_SCENARIO, optionalScenario];
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 2, passed: 1, failed: 0, skipped: 1 },
+      scenarios,
+    });
+    runQaSuite.mockResolvedValueOnce(mockSuiteRuntimeResult("suite", { scenarios }));
 
     try {
       await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" });
@@ -632,23 +630,13 @@ describe("qa cli runtime", () => {
       status: "skip" as const,
       details: "image_generate mock provider report-only: tool unavailable",
     };
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
-        scenarios: [optionalScenario],
-      }),
-      "utf8",
-    );
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+      scenarios: [optionalScenario],
+    });
     runQaSuite.mockResolvedValueOnce(
-      unifiedSuiteRuntimeResult({
-        outputDir: suiteArtifactsDir,
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-        evidencePath: suiteEvidencePath,
-        scenarios: [optionalScenario],
-      }),
+      mockSuiteRuntimeResult("suite", { scenarios: [optionalScenario] }),
     );
 
     await expect(
@@ -698,48 +686,30 @@ describe("qa cli runtime", () => {
       } else if (summary === "malformed") {
         await fs.writeFile(suiteSummaryPath, "{not-json", "utf8");
       } else if (summary === "zero-work") {
-        await fs.writeFile(
-          suiteSummaryPath,
-          JSON.stringify({
-            run: { status: "completed" },
-            counts: { total: 0, passed: 0, failed: 0, skipped: 0 },
-            scenarios: [],
-          }),
-          "utf8",
-        );
+        await writeSuiteSummary({
+          run: { status: "completed" },
+          counts: { total: 0, passed: 0, failed: 0, skipped: 0 },
+          scenarios: [],
+        });
       } else {
-        await fs.writeFile(
-          suiteSummaryPath,
-          JSON.stringify({
-            run: { status: "completed" },
-            counts:
-              summary === "required-skip"
-                ? { total: 1, passed: 0, failed: 0, skipped: 1 }
-                : { total: 1 },
-            scenarios: [
-              {
-                name: "Required channel scenario",
-                status: summary === "required-skip" ? "skip" : "blocked",
-                details: "Required transport unavailable",
-              },
-            ],
-          }),
-          "utf8",
-        );
+        await writeSuiteSummary({
+          run: { status: "completed" },
+          counts:
+            summary === "required-skip"
+              ? { total: 1, passed: 0, failed: 0, skipped: 1 }
+              : { total: 1 },
+          scenarios: [
+            {
+              name: "Required channel scenario",
+              status: summary === "required-skip" ? "skip" : "blocked",
+              details: "Required transport unavailable",
+            },
+          ],
+        });
       }
       if (runner === "host" || runner === "flow") {
         runQaSuite.mockResolvedValueOnce(
-          runner === "flow"
-            ? flowSuiteRuntimeResult({
-                reportPath: suiteReportPath,
-                summaryPath: suiteSummaryPath,
-              })
-            : unifiedSuiteRuntimeResult({
-                outputDir: suiteArtifactsDir,
-                reportPath: suiteReportPath,
-                summaryPath: suiteSummaryPath,
-                evidencePath: suiteEvidencePath,
-              }),
+          mockSuiteRuntimeResult(runner === "flow" ? "flow" : "suite"),
         );
       }
 
@@ -1864,25 +1834,12 @@ describe("qa cli runtime", () => {
   it("sets a failing exit code when host suite scenarios fail", async () => {
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: {
-          total: 1,
-          passed: 0,
-          failed: 1,
-        },
-        scenarios: [{ name: "channel chat baseline", status: "fail" }],
-      }),
-      "utf8",
-    );
-    runQaSuite.mockResolvedValueOnce(
-      flowSuiteRuntimeResult({
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-      }),
-    );
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 1, passed: 0, failed: 1 },
+      scenarios: [{ name: "channel chat baseline", status: "fail" }],
+    });
+    runQaSuite.mockResolvedValueOnce(mockSuiteRuntimeResult("flow"));
 
     try {
       await runQaSuiteCommand({
@@ -1897,27 +1854,18 @@ describe("qa cli runtime", () => {
   it("rejects a full host suite containing only report-only optional tool skips", async () => {
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
-        scenarios: [
-          {
-            name: "Runtime tool fixture — image_generate",
-            status: "skip",
-            details: "image_generate mock provider report-only: tool unavailable",
-          },
-        ],
-      }),
-      "utf8",
-    );
-    runQaSuite.mockResolvedValueOnce(
-      flowSuiteRuntimeResult({
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-      }),
-    );
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+      scenarios: [
+        {
+          name: "Runtime tool fixture — image_generate",
+          status: "skip",
+          details: "image_generate mock provider report-only: tool unavailable",
+        },
+      ],
+    });
+    runQaSuite.mockResolvedValueOnce(mockSuiteRuntimeResult("flow"));
 
     try {
       await expect(runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" })).rejects.toThrow(
@@ -1937,22 +1885,13 @@ describe("qa cli runtime", () => {
       status: "skip" as const,
       details: "image_generate mock provider report-only: tool unavailable",
     };
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { total: 2, passed: 1, failed: 0, skipped: 1 },
-        scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
-      }),
-      "utf8",
-    );
-    runQaSuite.mockResolvedValueOnce(
-      flowSuiteRuntimeResult({
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-        scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
-      }),
-    );
+    const scenarios = [QA_PASSING_SUITE_SCENARIO, optionalScenario];
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 2, passed: 1, failed: 0, skipped: 1 },
+      scenarios,
+    });
+    runQaSuite.mockResolvedValueOnce(mockSuiteRuntimeResult("flow", { scenarios }));
 
     try {
       await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" });
@@ -1965,27 +1904,18 @@ describe("qa cli runtime", () => {
   it("keeps explicitly selected optional tool skips blocking", async () => {
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
-        scenarios: [
-          {
-            name: "Runtime tool fixture — image_generate",
-            status: "skip",
-            details: "image_generate mock provider report-only: tool unavailable",
-          },
-        ],
-      }),
-      "utf8",
-    );
-    runQaSuite.mockResolvedValueOnce(
-      flowSuiteRuntimeResult({
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-      }),
-    );
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+      scenarios: [
+        {
+          name: "Runtime tool fixture — image_generate",
+          status: "skip",
+          details: "image_generate mock provider report-only: tool unavailable",
+        },
+      ],
+    });
+    runQaSuite.mockResolvedValueOnce(mockSuiteRuntimeResult("flow"));
 
     try {
       await runQaSuiteCommand({
@@ -2001,26 +1931,12 @@ describe("qa cli runtime", () => {
   it("sets a failing exit code when host suite scenarios are skipped", async () => {
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: {
-          total: 1,
-          passed: 0,
-          failed: 0,
-          skipped: 1,
-        },
-        scenarios: [{ name: "channel chat baseline", status: "skip" }],
-      }),
-      "utf8",
-    );
-    runQaSuite.mockResolvedValueOnce(
-      flowSuiteRuntimeResult({
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-      }),
-    );
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
+      scenarios: [{ name: "channel chat baseline", status: "skip" }],
+    });
+    runQaSuite.mockResolvedValueOnce(mockSuiteRuntimeResult("flow"));
 
     try {
       await runQaSuiteCommand({
@@ -2035,30 +1951,14 @@ describe("qa cli runtime", () => {
   it("keeps host suite exit code clear when --allow-failures is set", async () => {
     const priorExitCode = process.exitCode;
     process.exitCode = undefined;
-    await fs.writeFile(
-      suiteSummaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: {
-          total: 1,
-          passed: 0,
-          failed: 1,
-        },
-        scenarios: [{ name: "channel chat baseline", status: "fail" }],
-      }),
-      "utf8",
-    );
+    await writeSuiteSummary({
+      run: { status: "completed" },
+      counts: { total: 1, passed: 0, failed: 1 },
+      scenarios: [{ name: "channel chat baseline", status: "fail" }],
+    });
     runQaSuite.mockResolvedValueOnce(
-      flowSuiteRuntimeResult({
-        reportPath: suiteReportPath,
-        summaryPath: suiteSummaryPath,
-        scenarios: [
-          {
-            name: "channel chat baseline",
-            status: "fail",
-            steps: [],
-          },
-        ],
+      mockSuiteRuntimeResult("flow", {
+        scenarios: [{ name: "channel chat baseline", status: "fail", steps: [] }],
       }),
     );
 
@@ -3109,243 +3009,99 @@ describe("qa cli runtime", () => {
   });
 
   it("sets a failing exit code when multipass summary reports failed scenarios", async () => {
-    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
-    const summaryPath = path.join(repoRoot, "qa-suite-summary.json");
-    await fs.writeFile(
-      summaryPath,
-      JSON.stringify({
+    await withMultipassSummary(
+      {
         run: { status: "completed" },
-        counts: {
-          total: 2,
-          passed: 1,
-          failed: 1,
-        },
-      }),
-      "utf8",
+        counts: { total: 2, passed: 1, failed: 1 },
+      },
+      async () => {
+        await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo", runner: "multipass" });
+        expect(process.exitCode).toBe(1);
+      },
     );
-    runQaMultipass.mockResolvedValueOnce({
-      outputDir: repoRoot,
-      reportPath: path.join(repoRoot, "qa-suite-report.md"),
-      summaryPath,
-      hostLogPath: path.join(repoRoot, "multipass-host.log"),
-      bootstrapLogPath: path.join(repoRoot, "multipass-guest-bootstrap.log"),
-      guestScriptPath: path.join(repoRoot, "multipass-guest-run.sh"),
-      vmName: "openclaw-qa-test",
-      scenarioIds: ["channel-chat-baseline"],
-    });
-    const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
-
-    try {
-      await runQaSuiteCommand({
-        repoRoot: "/tmp/openclaw-repo",
-        runner: "multipass",
-      });
-      expect(process.exitCode).toBe(1);
-    } finally {
-      process.exitCode = priorExitCode;
-      await fs.rm(repoRoot, { recursive: true, force: true });
-    }
   });
 
   it("sets a failing exit code when multipass summary reports skipped scenarios", async () => {
-    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
-    const summaryPath = path.join(repoRoot, "qa-suite-summary.json");
-    await fs.writeFile(
-      summaryPath,
-      JSON.stringify({
+    await withMultipassSummary(
+      {
         run: { status: "completed" },
-        counts: {
-          total: 2,
-          passed: 1,
-          failed: 0,
-          skipped: 1,
-        },
-      }),
-      "utf8",
+        counts: { total: 2, passed: 1, failed: 0, skipped: 1 },
+      },
+      async () => {
+        await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo", runner: "multipass" });
+        expect(process.exitCode).toBe(1);
+      },
     );
-    runQaMultipass.mockResolvedValueOnce({
-      outputDir: repoRoot,
-      reportPath: path.join(repoRoot, "qa-suite-report.md"),
-      summaryPath,
-      hostLogPath: path.join(repoRoot, "multipass-host.log"),
-      bootstrapLogPath: path.join(repoRoot, "multipass-guest-bootstrap.log"),
-      guestScriptPath: path.join(repoRoot, "multipass-guest-run.sh"),
-      vmName: "openclaw-qa-test",
-      scenarioIds: ["channel-chat-baseline"],
-    });
-    const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
-
-    try {
-      await runQaSuiteCommand({
-        repoRoot: "/tmp/openclaw-repo",
-        runner: "multipass",
-      });
-      expect(process.exitCode).toBe(1);
-    } finally {
-      process.exitCode = priorExitCode;
-      await fs.rm(repoRoot, { recursive: true, force: true });
-    }
   });
 
   it("rejects a running multipass summary", async () => {
-    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
-    const summaryPath = path.join(repoRoot, "qa-suite-summary.json");
-    await fs.writeFile(
-      summaryPath,
-      JSON.stringify({
+    await withMultipassSummary(
+      {
         run: { status: "running" },
         counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
         scenarios: [{ status: "pass" }],
-      }),
-      "utf8",
+      },
+      async () => {
+        await expect(
+          runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo", runner: "multipass" }),
+        ).rejects.toMatchObject({ code: "summary_not_completed" });
+      },
     );
-    runQaMultipass.mockResolvedValueOnce({
-      outputDir: repoRoot,
-      reportPath: path.join(repoRoot, "qa-suite-report.md"),
-      summaryPath,
-      hostLogPath: path.join(repoRoot, "multipass-host.log"),
-      bootstrapLogPath: path.join(repoRoot, "multipass-guest-bootstrap.log"),
-      guestScriptPath: path.join(repoRoot, "multipass-guest-run.sh"),
-      vmName: "openclaw-qa-test",
-      scenarioIds: ["channel-chat-baseline"],
-    });
-
-    try {
-      await expect(
-        runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo", runner: "multipass" }),
-      ).rejects.toMatchObject({ code: "summary_not_completed" });
-    } finally {
-      await fs.rm(repoRoot, { recursive: true, force: true });
-    }
   });
 
   it("rejects malformed multipass summary JSON", async () => {
-    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
-    const summaryPath = path.join(repoRoot, "qa-suite-summary.json");
-    await fs.writeFile(summaryPath, "{not-json", "utf8");
-    runQaMultipass.mockResolvedValueOnce({
-      outputDir: repoRoot,
-      reportPath: path.join(repoRoot, "qa-suite-report.md"),
-      summaryPath,
-      hostLogPath: path.join(repoRoot, "multipass-host.log"),
-      bootstrapLogPath: path.join(repoRoot, "multipass-guest-bootstrap.log"),
-      guestScriptPath: path.join(repoRoot, "multipass-guest-run.sh"),
-      vmName: "openclaw-qa-test",
-      scenarioIds: ["channel-chat-baseline"],
-    });
-
-    try {
+    await withMultipassSummary("{not-json", async () => {
       await expect(
         runQaSuiteCommand({
           repoRoot: "/tmp/openclaw-repo",
           runner: "multipass",
         }),
       ).rejects.toThrow("Could not parse QA summary JSON");
-    } finally {
-      await fs.rm(repoRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it("rejects unreadable multipass summary JSON with read/parse wording", async () => {
-    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
-    const summaryPath = path.join(repoRoot, "qa-suite-summary.json");
-    runQaMultipass.mockResolvedValueOnce({
-      outputDir: repoRoot,
-      reportPath: path.join(repoRoot, "qa-suite-report.md"),
-      summaryPath,
-      hostLogPath: path.join(repoRoot, "multipass-host.log"),
-      bootstrapLogPath: path.join(repoRoot, "multipass-guest-bootstrap.log"),
-      guestScriptPath: path.join(repoRoot, "multipass-guest-run.sh"),
-      vmName: "openclaw-qa-test",
-      scenarioIds: ["channel-chat-baseline"],
-    });
-
-    try {
+    await withMultipassSummary(undefined, async () => {
       await expect(
         runQaSuiteCommand({
           repoRoot: "/tmp/openclaw-repo",
           runner: "multipass",
         }),
       ).rejects.toThrow("Could not read QA summary JSON");
-    } finally {
-      await fs.rm(repoRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it("rejects partial multipass summary JSON without failure fields", async () => {
-    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
-    const summaryPath = path.join(repoRoot, "qa-suite-summary.json");
-    await fs.writeFile(
-      summaryPath,
-      JSON.stringify({ run: { status: "completed" }, counts: { total: 2, passed: 2 } }),
-      "utf8",
+    await withMultipassSummary(
+      { run: { status: "completed" }, counts: { total: 2, passed: 2 } },
+      async () => {
+        await expect(
+          runQaSuiteCommand({
+            repoRoot: "/tmp/openclaw-repo",
+            runner: "multipass",
+          }),
+        ).rejects.toThrow(
+          "did not include counts.failed, counts.skipped, scenarios[].status, or entries[].result.status",
+        );
+      },
     );
-    runQaMultipass.mockResolvedValueOnce({
-      outputDir: repoRoot,
-      reportPath: path.join(repoRoot, "qa-suite-report.md"),
-      summaryPath,
-      hostLogPath: path.join(repoRoot, "multipass-host.log"),
-      bootstrapLogPath: path.join(repoRoot, "multipass-guest-bootstrap.log"),
-      guestScriptPath: path.join(repoRoot, "multipass-guest-run.sh"),
-      vmName: "openclaw-qa-test",
-      scenarioIds: ["channel-chat-baseline"],
-    });
-
-    try {
-      await expect(
-        runQaSuiteCommand({
-          repoRoot: "/tmp/openclaw-repo",
-          runner: "multipass",
-        }),
-      ).rejects.toThrow(
-        "did not include counts.failed, counts.skipped, scenarios[].status, or entries[].result.status",
-      );
-    } finally {
-      await fs.rm(repoRoot, { recursive: true, force: true });
-    }
   });
 
   it("keeps multipass exit code clear when --allow-failures is set", async () => {
-    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
-    const summaryPath = path.join(repoRoot, "qa-suite-summary.json");
-    await fs.writeFile(
-      summaryPath,
-      JSON.stringify({
+    await withMultipassSummary(
+      {
         run: { status: "completed" },
-        counts: {
-          total: 2,
-          passed: 1,
-          failed: 1,
-        },
-      }),
-      "utf8",
+        counts: { total: 2, passed: 1, failed: 1 },
+      },
+      async () => {
+        await runQaSuiteCommand({
+          repoRoot: "/tmp/openclaw-repo",
+          runner: "multipass",
+          allowFailures: true,
+        });
+        expect(process.exitCode).toBeUndefined();
+      },
     );
-    runQaMultipass.mockResolvedValueOnce({
-      outputDir: repoRoot,
-      reportPath: path.join(repoRoot, "qa-suite-report.md"),
-      summaryPath,
-      hostLogPath: path.join(repoRoot, "multipass-host.log"),
-      bootstrapLogPath: path.join(repoRoot, "multipass-guest-bootstrap.log"),
-      guestScriptPath: path.join(repoRoot, "multipass-guest-run.sh"),
-      vmName: "openclaw-qa-test",
-      scenarioIds: ["channel-chat-baseline"],
-    });
-    const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
-
-    try {
-      await runQaSuiteCommand({
-        repoRoot: "/tmp/openclaw-repo",
-        runner: "multipass",
-        allowFailures: true,
-      });
-      expect(process.exitCode).toBeUndefined();
-    } finally {
-      process.exitCode = priorExitCode;
-      await fs.rm(repoRoot, { recursive: true, force: true });
-    }
   });
 
   it("passes provider-qualified mock parity suite selection through to the host runner", async () => {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -1067,58 +1067,31 @@ export async function runQaSuiteCommand(opts: QaSuiteCommandOptions) {
         : {}),
     ...(runtimePair ? { runtimePair } : {}),
   });
-  switch (runtimeResult.executionKind) {
-    case "suite": {
-      const result = runtimeResult.result;
-      process.stdout.write(`QA suite report: ${result.reportPath}\n`);
-      process.stdout.write(`QA suite evidence: ${result.evidencePath}\n`);
-      process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
-      const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
-        result.summaryPath,
-        {
-          optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
-            scenarioIds,
-            explicitScenarioSelection: opts.explicitScenarioSelection,
-          }),
-          requireExecutedScenario: allowFailures,
-        },
-      );
-      if (!allowFailures && blockingScenarioCount > 0) {
-        process.exitCode = 1;
-      }
-      return {
-        ...result,
-        expectedCells: runtimeResult.expectedCells,
-        observedCells: runtimeResult.observedCells,
-      };
-    }
-    case "flow": {
-      const result = runtimeResult.result;
-      process.stdout.write(`QA suite watch: ${result.watchUrl}\n`);
-      process.stdout.write(`QA suite report: ${result.reportPath}\n`);
-      process.stdout.write(`QA suite evidence: ${result.evidencePath}\n`);
-      process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
-      const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
-        result.summaryPath,
-        {
-          optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
-            scenarioIds,
-            explicitScenarioSelection: opts.explicitScenarioSelection,
-          }),
-          requireExecutedScenario: allowFailures,
-        },
-      );
-      if (!allowFailures && blockingScenarioCount > 0) {
-        process.exitCode = 1;
-      }
-      return {
-        ...result,
-        expectedCells: runtimeResult.expectedCells,
-        observedCells: runtimeResult.observedCells,
-      };
-    }
+  const result = runtimeResult.result;
+  if (runtimeResult.executionKind === "flow") {
+    process.stdout.write(`QA suite watch: ${runtimeResult.result.watchUrl}\n`);
   }
-  return undefined;
+  process.stdout.write(`QA suite report: ${result.reportPath}\n`);
+  process.stdout.write(`QA suite evidence: ${result.evidencePath}\n`);
+  process.stdout.write(`QA suite summary: ${result.summaryPath}\n`);
+  const blockingScenarioCount = await readQaSuiteFailedOrSkippedScenarioCountFromFile(
+    result.summaryPath,
+    {
+      optionalScenarioNames: resolveQaReportOnlyOptionalScenarioNames({
+        scenarioIds,
+        explicitScenarioSelection: opts.explicitScenarioSelection,
+      }),
+      requireExecutedScenario: allowFailures,
+    },
+  );
+  if (!allowFailures && blockingScenarioCount > 0) {
+    process.exitCode = 1;
+  }
+  return {
+    ...result,
+    expectedCells: runtimeResult.expectedCells,
+    observedCells: runtimeResult.observedCells,
+  };
 }
 
 export async function runQaParityReportCommand(opts: {

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -7,7 +7,7 @@ import type { QaLabServerHandle } from "./lab-server.types.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 import { writeQaSuiteArtifacts } from "./suite-artifacts.js";
 import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
-import type { QaSuiteScenarioResult } from "./suite.js";
+import type { QaSuiteRunParams, QaSuiteScenarioResult } from "./suite.js";
 import { throwQaSuiteCleanupErrors } from "./suite.js";
 import type {
   QaTestFileScenario,
@@ -87,11 +87,64 @@ function createDeferred() {
   return { promise, resolve };
 }
 
-function trackMaxActiveFlowRuns() {
-  const run = runQaFlowSuite.getMockImplementation();
-  if (!run) {
+function requireDefaultQaFlowSuiteImplementation() {
+  const implementation = runQaFlowSuite.getMockImplementation();
+  if (!implementation) {
     throw new Error("expected default QA flow suite mock implementation");
   }
+  return implementation;
+}
+
+function requireDefaultQaTestFileImplementation() {
+  const implementation = runQaTestFileScenarios.getMockImplementation();
+  if (!implementation) {
+    throw new Error("expected default QA test-file mock implementation");
+  }
+  return implementation;
+}
+
+function blockNextQaFlowSuite() {
+  const implementation = requireDefaultQaFlowSuiteImplementation();
+  const started = createDeferred();
+  const blocked = createDeferred();
+  runQaFlowSuite.mockImplementationOnce(async (params) => {
+    started.resolve();
+    await blocked.promise;
+    return await implementation(params);
+  });
+  return { started: started.promise, release: blocked.resolve };
+}
+
+function blockNextQaTestFileRun() {
+  const implementation = requireDefaultQaTestFileImplementation();
+  const started = createDeferred();
+  const blocked = createDeferred();
+  runQaTestFileScenarios.mockImplementationOnce(async (params) => {
+    started.resolve();
+    await blocked.promise;
+    return await implementation(params);
+  });
+  return { started: started.promise, release: blocked.resolve };
+}
+
+async function runFailFastQaSuite(label: string, overrides: QaSuiteRunParams = {}) {
+  return await runQaSuite({
+    repoRoot: await makeTempRepo(`qa-suite-${label}-`),
+    outputDir: `.artifacts/qa-e2e/${label}`,
+    concurrency: 8,
+    failFast: true,
+    scenarioIds: [
+      "dm-chat-baseline",
+      "group-visible-reply-tool",
+      "control-ui-chat-flow-playwright",
+      "docker-npm-onboard-channel-agent",
+    ],
+    ...overrides,
+  });
+}
+
+function trackMaxActiveFlowRuns() {
+  const run = requireDefaultQaFlowSuiteImplementation();
   let active = 0;
   let maxActive = 0;
   runQaFlowSuite.mockImplementation(async (params) => {
@@ -110,10 +163,7 @@ function trackMaxActiveFlowRuns() {
 }
 
 function mockFlowPartitionFailures(failuresByScenarioId: ReadonlyMap<string, readonly Error[]>) {
-  const run = runQaFlowSuite.getMockImplementation();
-  if (!run) {
-    throw new Error("expected default QA flow suite mock implementation");
-  }
+  const run = requireDefaultQaFlowSuiteImplementation();
   const attempts = new Map<string, number>();
   runQaFlowSuite.mockImplementation(async (params) => {
     const scenarioId = params?.scenarioIds?.[0];
@@ -437,10 +487,7 @@ describe("qa suite runtime launcher", () => {
 
   it("expands profile scenarios across every eligible pluggable channel", async () => {
     const repoRoot = await makeTempRepo("qa-suite-pluggable-channels-");
-    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
-    if (!defaultFlowImplementation) {
-      throw new Error("expected default QA flow suite mock implementation");
-    }
+    const defaultFlowImplementation = requireDefaultQaFlowSuiteImplementation();
     runQaFlowSuite.mockImplementation(async (params) => {
       const result = await defaultFlowImplementation(params);
       if (params?.channelId === "matrix" && params.scenarioIds?.includes("thread-isolation")) {
@@ -948,10 +995,7 @@ describe("qa suite runtime launcher", () => {
 
   it("partitions mixed Crabline flow channels into one aggregate suite", async () => {
     const repoRoot = await makeTempRepo("qa-suite-crabline-channels-");
-    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
-    if (!defaultFlowImplementation) {
-      throw new Error("expected default QA flow suite mock implementation");
-    }
+    const defaultFlowImplementation = requireDefaultQaFlowSuiteImplementation();
     runQaFlowSuite.mockImplementation(async (params) => {
       const result = await defaultFlowImplementation(params);
       const scenarioIds: readonly string[] = params?.scenarioIds ?? [];
@@ -1182,10 +1226,7 @@ describe("qa suite runtime launcher", () => {
 
   it("projects a skipped native producer as a skipped unified scenario", async () => {
     const repoRoot = await makeTempRepo("qa-suite-native-skip-");
-    const defaultImplementation = runQaTestFileScenarios.getMockImplementation();
-    if (!defaultImplementation) {
-      throw new Error("expected default QA test-file scenario mock implementation");
-    }
+    const defaultImplementation = requireDefaultQaTestFileImplementation();
     runQaTestFileScenarios.mockImplementationOnce(async (params) => {
       const result = await defaultImplementation(params);
       return {
@@ -1216,40 +1257,7 @@ describe("qa suite runtime launcher", () => {
 
   it("serializes test-file runner partitions in one checkout", async () => {
     const repoRoot = await makeTempRepo("qa-suite-test-file-serial-");
-    let releaseVitest!: () => void;
-    let markVitestStarted!: () => void;
-    const vitestStarted = new Promise<void>((resolve) => {
-      markVitestStarted = resolve;
-    });
-    const vitestBlocked = new Promise<void>((resolve) => {
-      releaseVitest = resolve;
-    });
-    runQaTestFileScenarios.mockImplementationOnce(
-      async (params: {
-        outputDir: string;
-        scenarios: Array<{ id: string; execution: { kind: "script" | "vitest" | "playwright" } }>;
-      }) => {
-        markVitestStarted();
-        await vitestBlocked;
-        const evidencePath = path.join(params.outputDir, "qa-evidence.json");
-        await writeEvidence(evidencePath);
-        const scenario = params.scenarios[0];
-        if (!scenario) {
-          throw new Error("expected scenario");
-        }
-        return {
-          outputDir: params.outputDir,
-          executionKind: scenario.execution.kind,
-          evidencePath,
-          results: params.scenarios.map((scenarioItem) => ({
-            durationMs: 1,
-            logPath: path.join(params.outputDir, `${scenarioItem.id}.log`),
-            scenario: scenarioItem,
-            status: "pass",
-          })),
-        };
-      },
-    );
+    const vitest = blockNextQaTestFileRun();
 
     const runPromise = runQaSuite({
       repoRoot,
@@ -1257,12 +1265,12 @@ describe("qa suite runtime launcher", () => {
       concurrency: 8,
       scenarioIds: ["gateway-smoke", "control-ui-chat-flow-playwright"],
     });
-    await vitestStarted;
+    await vitest.started;
     await Promise.resolve();
 
     expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
 
-    releaseVitest();
+    vitest.release();
     await runPromise;
 
     expect(runQaTestFileScenarios).toHaveBeenCalledTimes(2);
@@ -1375,10 +1383,7 @@ describe("qa suite runtime launcher", () => {
       state: {} as QaLabServerHandle["state"],
       stop: vi.fn(),
     } satisfies QaLabServerHandle;
-    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
-    if (!defaultFlowImplementation) {
-      throw new Error("expected default QA flow suite mock implementation");
-    }
+    const defaultFlowImplementation = requireDefaultQaFlowSuiteImplementation();
     runQaFlowSuite.mockImplementationOnce(async (params) => {
       params?.lab?.setScenarioRun({
         kind: "suite",
@@ -1480,10 +1485,7 @@ describe("qa suite runtime launcher", () => {
 
   it("serializes channel-driver isolated flow workers under explicit concurrency", async () => {
     const repoRoot = await makeTempRepo("qa-suite-crabline-isolated-");
-    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
-    if (!defaultFlowImplementation) {
-      throw new Error("expected default QA flow suite mock implementation");
-    }
+    const defaultFlowImplementation = requireDefaultQaFlowSuiteImplementation();
     const isolatedScenarioIds = new Set([
       "runtime-tool-image-generate",
       "runtime-inventory-drift-check",
@@ -1566,37 +1568,7 @@ describe("qa suite runtime launcher", () => {
 
   it("respects serial concurrency across unified suite partitions", async () => {
     const repoRoot = await makeTempRepo("qa-suite-serial-");
-    let releaseFlow!: () => void;
-    let markFlowStarted!: () => void;
-    const flowStarted = new Promise<void>((resolve) => {
-      markFlowStarted = resolve;
-    });
-    const flowBlocked = new Promise<void>((resolve) => {
-      releaseFlow = resolve;
-    });
-    runQaFlowSuite.mockImplementationOnce(
-      async (params: { outputDir?: string; scenarioIds?: string[] } | undefined) => {
-        markFlowStarted();
-        await flowBlocked;
-        const outputDir = params?.outputDir ?? "/tmp/qa-flow";
-        const evidencePath = path.join(outputDir, "qa-evidence.json");
-        await writeEvidence(evidencePath);
-        const scenarioIds = params?.scenarioIds ?? ["channel-chat-baseline"];
-        return {
-          outputDir,
-          evidencePath,
-          reportPath: path.join(outputDir, "qa-suite-report.md"),
-          summaryPath: path.join(outputDir, "qa-suite-summary.json"),
-          report: "# QA Suite Report\n",
-          scenarios: scenarioIds.map((scenarioId) => ({
-            name: scenarioId,
-            status: "pass",
-            steps: [],
-          })),
-          watchUrl: "http://127.0.0.1:43124",
-        };
-      },
-    );
+    const flow = blockNextQaFlowSuite();
 
     const runPromise = runQaSuite({
       repoRoot,
@@ -1608,13 +1580,13 @@ describe("qa suite runtime launcher", () => {
         "control-ui-chat-flow-playwright",
       ],
     });
-    await flowStarted;
+    await flow.started;
     await Promise.resolve();
 
     expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
     expect(runQaTestFileScenarios).not.toHaveBeenCalled();
 
-    releaseFlow();
+    flow.release();
     await runPromise;
 
     expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
@@ -1622,7 +1594,6 @@ describe("qa suite runtime launcher", () => {
   });
 
   it("stops unified suite partitions after the first failed flow scenario", async () => {
-    const repoRoot = await makeTempRepo("qa-suite-fail-fast-flow-");
     const scenarioRuns: Array<Parameters<QaLabServerHandle["setScenarioRun"]>[0]> = [];
     const lab = {
       baseUrl: "http://127.0.0.1:43124",
@@ -1634,10 +1605,7 @@ describe("qa suite runtime launcher", () => {
       state: {} as QaLabServerHandle["state"],
       stop: vi.fn(),
     } satisfies QaLabServerHandle;
-    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
-    if (!defaultFlowImplementation) {
-      throw new Error("expected default QA flow suite mock implementation");
-    }
+    const defaultFlowImplementation = requireDefaultQaFlowSuiteImplementation();
     runQaFlowSuite.mockImplementationOnce(async (params) => {
       const result = await defaultFlowImplementation(params);
       return {
@@ -1651,19 +1619,7 @@ describe("qa suite runtime launcher", () => {
       };
     });
 
-    const result = await runQaSuite({
-      lab,
-      repoRoot,
-      outputDir: ".artifacts/qa-e2e/fail-fast-flow",
-      concurrency: 8,
-      failFast: true,
-      scenarioIds: [
-        "dm-chat-baseline",
-        "group-visible-reply-tool",
-        "control-ui-chat-flow-playwright",
-        "docker-npm-onboard-channel-agent",
-      ],
-    });
+    const result = await runFailFastQaSuite("fail-fast-flow", { lab });
 
     expect(result.executionKind).toBe("suite");
     if (result.executionKind !== "suite") {
@@ -1705,11 +1661,7 @@ describe("qa suite runtime launcher", () => {
   });
 
   it("stops pending flow and script partitions after a native scenario fails", async () => {
-    const repoRoot = await makeTempRepo("qa-suite-fail-fast-native-");
-    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
-    if (!defaultTestFileImplementation) {
-      throw new Error("expected default QA test-file scenario mock implementation");
-    }
+    const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
     runQaTestFileScenarios.mockImplementationOnce(async (params) => {
       const result = await defaultTestFileImplementation(params);
       return {
@@ -1723,18 +1675,7 @@ describe("qa suite runtime launcher", () => {
       };
     });
 
-    const result = await runQaSuite({
-      repoRoot,
-      outputDir: ".artifacts/qa-e2e/fail-fast-native",
-      concurrency: 8,
-      failFast: true,
-      scenarioIds: [
-        "dm-chat-baseline",
-        "group-visible-reply-tool",
-        "control-ui-chat-flow-playwright",
-        "docker-npm-onboard-channel-agent",
-      ],
-    });
+    const result = await runFailFastQaSuite("fail-fast-native");
 
     expect(result.executionKind).toBe("suite");
     if (result.executionKind !== "suite") {
@@ -1755,28 +1696,13 @@ describe("qa suite runtime launcher", () => {
   });
 
   it("fails and stops when a started flow partition omits its scenario result", async () => {
-    const repoRoot = await makeTempRepo("qa-suite-fail-fast-missing-flow-");
-    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
-    if (!defaultFlowImplementation) {
-      throw new Error("expected default QA flow suite mock implementation");
-    }
+    const defaultFlowImplementation = requireDefaultQaFlowSuiteImplementation();
     runQaFlowSuite.mockImplementationOnce(async (params) => ({
       ...(await defaultFlowImplementation(params)),
       scenarios: [],
     }));
 
-    const result = await runQaSuite({
-      repoRoot,
-      outputDir: ".artifacts/qa-e2e/fail-fast-missing-flow",
-      concurrency: 8,
-      failFast: true,
-      scenarioIds: [
-        "dm-chat-baseline",
-        "group-visible-reply-tool",
-        "control-ui-chat-flow-playwright",
-        "docker-npm-onboard-channel-agent",
-      ],
-    });
+    const result = await runFailFastQaSuite("fail-fast-missing-flow");
 
     expect(result.executionKind).toBe("suite");
     if (result.executionKind !== "suite") {
@@ -1819,28 +1745,13 @@ describe("qa suite runtime launcher", () => {
   });
 
   it("fails and stops when a started native partition omits its scenario result", async () => {
-    const repoRoot = await makeTempRepo("qa-suite-fail-fast-missing-native-");
-    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
-    if (!defaultTestFileImplementation) {
-      throw new Error("expected default QA test-file scenario mock implementation");
-    }
+    const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
     runQaTestFileScenarios.mockImplementationOnce(async (params) => ({
       ...(await defaultTestFileImplementation(params)),
       results: [],
     }));
 
-    const result = await runQaSuite({
-      repoRoot,
-      outputDir: ".artifacts/qa-e2e/fail-fast-missing-native",
-      concurrency: 8,
-      failFast: true,
-      scenarioIds: [
-        "dm-chat-baseline",
-        "group-visible-reply-tool",
-        "control-ui-chat-flow-playwright",
-        "docker-npm-onboard-channel-agent",
-      ],
-    });
+    const result = await runFailFastQaSuite("fail-fast-missing-native");
 
     expect(result.executionKind).toBe("suite");
     if (result.executionKind !== "suite") {
@@ -1874,11 +1785,7 @@ describe("qa suite runtime launcher", () => {
   });
 
   it("stops later native execution kinds after a started kind omits its result", async () => {
-    const repoRoot = await makeTempRepo("qa-suite-fail-fast-missing-native-kind-");
-    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
-    if (!defaultTestFileImplementation) {
-      throw new Error("expected default QA test-file scenario mock implementation");
-    }
+    const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
     runQaTestFileScenarios.mockImplementationOnce(async (params) => ({
       ...(await defaultTestFileImplementation(params)),
       results: [],
@@ -1890,13 +1797,7 @@ describe("qa suite runtime launcher", () => {
       "control-ui-chat-flow-playwright",
       "docker-npm-onboard-channel-agent",
     ];
-    const result = await runQaSuite({
-      repoRoot,
-      outputDir: ".artifacts/qa-e2e/fail-fast-missing-native-kind",
-      concurrency: 8,
-      failFast: true,
-      scenarioIds,
-    });
+    const result = await runFailFastQaSuite("fail-fast-missing-native-kind", { scenarioIds });
 
     expect(result.executionKind).toBe("suite");
     if (result.executionKind !== "suite") {
@@ -2010,10 +1911,7 @@ describe("qa suite runtime launcher", () => {
 
   it("continues every unified partition after a failure when fail-fast is disabled", async () => {
     const repoRoot = await makeTempRepo("qa-suite-continue-after-failure-");
-    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
-    if (!defaultFlowImplementation) {
-      throw new Error("expected default QA flow suite mock implementation");
-    }
+    const defaultFlowImplementation = requireDefaultQaFlowSuiteImplementation();
     runQaFlowSuite.mockImplementationOnce(async (params) => {
       const result = await defaultFlowImplementation(params);
       return {
@@ -2054,37 +1952,7 @@ describe("qa suite runtime launcher", () => {
 
   it("runs script scenarios after flow Gateways stop without serializing Playwright", async () => {
     const repoRoot = await makeTempRepo("qa-suite-script-isolation-");
-    let releaseFlow!: () => void;
-    let markFlowStarted!: () => void;
-    const flowStarted = new Promise<void>((resolve) => {
-      markFlowStarted = resolve;
-    });
-    const flowBlocked = new Promise<void>((resolve) => {
-      releaseFlow = resolve;
-    });
-    runQaFlowSuite.mockImplementationOnce(
-      async (params: { outputDir?: string; scenarioIds?: string[] } | undefined) => {
-        markFlowStarted();
-        await flowBlocked;
-        const outputDir = params?.outputDir ?? "/tmp/qa-flow";
-        const evidencePath = path.join(outputDir, "qa-evidence.json");
-        await writeEvidence(evidencePath);
-        const scenarioIds = params?.scenarioIds ?? ["channel-chat-baseline"];
-        return {
-          outputDir,
-          evidencePath,
-          reportPath: path.join(outputDir, "qa-suite-report.md"),
-          summaryPath: path.join(outputDir, "qa-suite-summary.json"),
-          report: "# QA Suite Report\n",
-          scenarios: scenarioIds.map((scenarioId) => ({
-            name: scenarioId,
-            status: "pass",
-            steps: [],
-          })),
-          watchUrl: "http://127.0.0.1:43124",
-        };
-      },
-    );
+    const flow = blockNextQaFlowSuite();
 
     const runPromise = runQaSuite({
       repoRoot,
@@ -2096,7 +1964,7 @@ describe("qa suite runtime launcher", () => {
         "docker-npm-onboard-channel-agent",
       ],
     });
-    await flowStarted;
+    await flow.started;
     await vi.waitFor(() => {
       expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
     });
@@ -2110,7 +1978,7 @@ describe("qa suite runtime launcher", () => {
       }),
     );
 
-    releaseFlow();
+    flow.release();
     await runPromise;
 
     expect(runQaTestFileScenarios).toHaveBeenCalledTimes(2);
@@ -2126,11 +1994,8 @@ describe("qa suite runtime launcher", () => {
 
   it("settles flow and native work, then runs serial scripts before a bounded parallel tail", async () => {
     const repoRoot = await makeTempRepo("qa-suite-parallel-scripts-");
-    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
-    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
-    if (!defaultFlowImplementation || !defaultTestFileImplementation) {
-      throw new Error("expected default QA suite mock implementations");
-    }
+    const defaultFlowImplementation = requireDefaultQaFlowSuiteImplementation();
+    const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
     const flow = createDeferred();
     const native = createDeferred();
     const serial = createDeferred();
@@ -2238,10 +2103,7 @@ describe("qa suite runtime launcher", () => {
   it("reuses the prepared Docker env object when a script partition retries", async () => {
     const repoRoot = await makeTempRepo("qa-suite-docker-prep-retry-");
     const preparedEnv = Object.freeze({ OPENCLAW_CURRENT_PACKAGE_TGZ: "/tmp/candidate.tgz" });
-    const defaultImplementation = runQaTestFileScenarios.getMockImplementation();
-    if (!defaultImplementation) {
-      throw new Error("expected default QA test-file mock implementation");
-    }
+    const defaultImplementation = requireDefaultQaTestFileImplementation();
     prepareDockerE2eEnvironment.mockResolvedValueOnce(preparedEnv);
     runQaTestFileScenarios
       .mockRejectedValueOnce(new QaSuiteInfraError("transport_ready_timeout", "retry"))
@@ -2279,10 +2141,7 @@ describe("qa suite runtime launcher", () => {
 
   it("keeps selected evidence order and successful siblings when a parallel script rejects", async () => {
     const repoRoot = await makeTempRepo("qa-suite-parallel-script-rejection-");
-    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
-    if (!defaultTestFileImplementation) {
-      throw new Error("expected default QA test-file mock implementation");
-    }
+    const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
     const first = createDeferred();
     runQaTestFileScenarios.mockImplementation(async (params) => {
       const scenario = params.scenarios[0] as QaTestFileScenario | undefined;
@@ -2346,10 +2205,7 @@ describe("qa suite runtime launcher", () => {
 
   it("serializes every fail-fast script and stops before post-failure work", async () => {
     const repoRoot = await makeTempRepo("qa-suite-fail-fast-scripts-");
-    const defaultTestFileImplementation = runQaTestFileScenarios.getMockImplementation();
-    if (!defaultTestFileImplementation) {
-      throw new Error("expected default QA test-file mock implementation");
-    }
+    const defaultTestFileImplementation = requireDefaultQaTestFileImplementation();
     const first = createDeferred();
     const preparedEnv = Object.freeze({ OPENCLAW_CURRENT_PACKAGE_TGZ: "/tmp/candidate.tgz" });
     const started: string[] = [];
@@ -2447,37 +2303,7 @@ describe("qa suite runtime launcher", () => {
 
   it("accounts for isolated flow worker weight in unified suite concurrency", async () => {
     const repoRoot = await makeTempRepo("qa-suite-weighted-");
-    let releaseShared!: () => void;
-    let markSharedStarted!: () => void;
-    const sharedStarted = new Promise<void>((resolve) => {
-      markSharedStarted = resolve;
-    });
-    const sharedBlocked = new Promise<void>((resolve) => {
-      releaseShared = resolve;
-    });
-    runQaFlowSuite.mockImplementationOnce(
-      async (params: { outputDir?: string; scenarioIds?: string[] } | undefined) => {
-        markSharedStarted();
-        await sharedBlocked;
-        const outputDir = params?.outputDir ?? "/tmp/qa-flow";
-        const evidencePath = path.join(outputDir, "qa-evidence.json");
-        await writeEvidence(evidencePath);
-        const scenarioIds = params?.scenarioIds ?? ["channel-chat-baseline"];
-        return {
-          outputDir,
-          evidencePath,
-          reportPath: path.join(outputDir, "qa-suite-report.md"),
-          summaryPath: path.join(outputDir, "qa-suite-summary.json"),
-          report: "# QA Suite Report\n",
-          scenarios: scenarioIds.map((scenarioId) => ({
-            name: scenarioId,
-            status: "pass",
-            steps: [],
-          })),
-          watchUrl: "http://127.0.0.1:43124",
-        };
-      },
-    );
+    const shared = blockNextQaFlowSuite();
 
     const runPromise = runQaSuite({
       repoRoot,
@@ -2489,7 +2315,7 @@ describe("qa suite runtime launcher", () => {
         "control-ui-chat-flow-playwright",
       ],
     });
-    await sharedStarted;
+    await shared.started;
     await Promise.resolve();
 
     expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
@@ -2497,7 +2323,7 @@ describe("qa suite runtime launcher", () => {
       expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
     });
 
-    releaseShared();
+    shared.release();
     await runPromise;
 
     expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
@@ -2506,67 +2332,8 @@ describe("qa suite runtime launcher", () => {
 
   it("starts native suite proof before isolated flow work fills the weighted queue", async () => {
     const repoRoot = await makeTempRepo("qa-suite-native-before-isolated-");
-    let releaseShared!: () => void;
-    let markSharedStarted!: () => void;
-    const sharedStarted = new Promise<void>((resolve) => {
-      markSharedStarted = resolve;
-    });
-    const sharedBlocked = new Promise<void>((resolve) => {
-      releaseShared = resolve;
-    });
-    let releaseTestFile!: () => void;
-    let markTestFileStarted!: () => void;
-    const testFileStarted = new Promise<void>((resolve) => {
-      markTestFileStarted = resolve;
-    });
-    const testFileBlocked = new Promise<void>((resolve) => {
-      releaseTestFile = resolve;
-    });
-    runQaFlowSuite.mockImplementationOnce(
-      async (params: { outputDir?: string; scenarioIds?: string[] } | undefined) => {
-        markSharedStarted();
-        await sharedBlocked;
-        const outputDir = params?.outputDir ?? "/tmp/qa-flow";
-        const evidencePath = path.join(outputDir, "qa-evidence.json");
-        await writeEvidence(evidencePath);
-        const scenarioIds = params?.scenarioIds ?? ["channel-chat-baseline"];
-        return {
-          outputDir,
-          evidencePath,
-          reportPath: path.join(outputDir, "qa-suite-report.md"),
-          summaryPath: path.join(outputDir, "qa-suite-summary.json"),
-          report: "# QA Suite Report\n",
-          scenarios: scenarioIds.map((scenarioId) => ({
-            name: scenarioId,
-            status: "pass",
-            steps: [],
-          })),
-          watchUrl: "http://127.0.0.1:43124",
-        };
-      },
-    );
-    runQaTestFileScenarios.mockImplementationOnce(
-      async (params: {
-        outputDir: string;
-        scenarios: Array<{ id: string; execution: { kind: "script" | "vitest" | "playwright" } }>;
-      }) => {
-        markTestFileStarted();
-        await testFileBlocked;
-        const evidencePath = path.join(params.outputDir, "qa-evidence.json");
-        await writeEvidence(evidencePath);
-        return {
-          outputDir: params.outputDir,
-          executionKind: params.scenarios[0]?.execution.kind ?? "playwright",
-          evidencePath,
-          results: params.scenarios.map((scenarioItem) => ({
-            durationMs: 1,
-            logPath: path.join(params.outputDir, `${scenarioItem.id}.log`),
-            scenario: scenarioItem,
-            status: "pass",
-          })),
-        };
-      },
-    );
+    const shared = blockNextQaFlowSuite();
+    const testFile = blockNextQaTestFileRun();
 
     const runPromise = runQaSuite({
       repoRoot,
@@ -2578,15 +2345,15 @@ describe("qa suite runtime launcher", () => {
         "control-ui-chat-flow-playwright",
       ],
     });
-    await sharedStarted;
-    await testFileStarted;
+    await shared.started;
+    await testFile.started;
     await Promise.resolve();
 
     expect(runQaFlowSuite).toHaveBeenCalledTimes(1);
     expect(runQaTestFileScenarios).toHaveBeenCalledTimes(1);
 
-    releaseTestFile();
-    releaseShared();
+    testFile.release();
+    shared.release();
     await runPromise;
 
     expect(runQaFlowSuite).toHaveBeenCalledTimes(2);
@@ -2604,14 +2371,7 @@ describe("qa suite runtime launcher", () => {
     await Promise.all(
       priorArtifactPaths.map((artifactPath) => fs.writeFile(artifactPath, "stale")),
     );
-    let releaseTestFile!: () => void;
-    let markTestFileStarted!: () => void;
-    const testFileStarted = new Promise<void>((resolve) => {
-      markTestFileStarted = resolve;
-    });
-    const testFileBlocked = new Promise<void>((resolve) => {
-      releaseTestFile = resolve;
-    });
+    const testFile = blockNextQaTestFileRun();
     runQaFlowSuite.mockRejectedValueOnce(
       new Error("flow partition failed", {
         cause: Object.assign(new Error("unrelated capacity failure"), {
@@ -2619,29 +2379,6 @@ describe("qa suite runtime launcher", () => {
         }),
       }),
     );
-    runQaTestFileScenarios.mockImplementationOnce(
-      async (params: {
-        outputDir: string;
-        scenarios: Array<{ id: string; execution: { kind: "script" | "vitest" | "playwright" } }>;
-      }) => {
-        markTestFileStarted();
-        await testFileBlocked;
-        const evidencePath = path.join(params.outputDir, "qa-evidence.json");
-        await writeEvidence(evidencePath);
-        return {
-          outputDir: params.outputDir,
-          executionKind: params.scenarios[0]?.execution.kind ?? "playwright",
-          evidencePath,
-          results: params.scenarios.map((scenarioItem) => ({
-            durationMs: 1,
-            logPath: path.join(params.outputDir, `${scenarioItem.id}.log`),
-            scenario: scenarioItem,
-            status: "pass",
-          })),
-        };
-      },
-    );
-
     const runPromise = runQaSuite({
       repoRoot,
       outputDir: ".artifacts/qa-e2e/reject-settle",
@@ -2652,7 +2389,7 @@ describe("qa suite runtime launcher", () => {
     void runPromise.then(() => {
       completed = true;
     });
-    await testFileStarted;
+    await testFile.started;
     await Promise.resolve();
 
     expect(completed).toBe(false);
@@ -2660,7 +2397,7 @@ describe("qa suite runtime launcher", () => {
       await expect(fs.access(artifactPath)).rejects.toMatchObject({ code: "ENOENT" });
     }
 
-    releaseTestFile();
+    testFile.release();
     const result = await runPromise;
     expect(completed).toBe(true);
     expect(result.executionKind).toBe("suite");

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -418,15 +418,7 @@ async function runQaTestFileSuiteFromRuntime(params: {
   scenarios: readonly QaTestFileScenario[];
 }): Promise<QaTestFileScenarioRunResult> {
   const runParams = params.runParams;
-  if (runParams?.runtimePair) {
-    throw new Error("--runtime-pair requires execution.kind: flow scenarios.");
-  }
-  if (runParams?.forcedRuntime) {
-    throw new Error("forced runtime execution requires execution.kind: flow scenarios.");
-  }
-  if (runParams?.captureRuntimeParityCell) {
-    throw new Error("runtime parity capture requires execution.kind: flow scenarios.");
-  }
+  rejectFlowOnlySuiteOptionsForUnifiedRun(runParams);
   const repoRoot = path.resolve(runParams?.repoRoot ?? process.cwd());
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, runParams?.outputDir);
   const providerMode = normalizeQaProviderMode(runParams?.providerMode ?? DEFAULT_QA_PROVIDER_MODE);


### PR DESCRIPTION
## What Problem This Solves

Removes duplicated QA runtime fixture and launch-payload assembly across the CLI and suite-launch paths, where parallel representations made option and security behavior harder to keep aligned.

## Why This Change Was Made

The QA runtime now uses the same canonical payload construction at its CLI and suite-launch boundaries, while the tests share typed fixtures that preserve every behavior-defining override and assertion.

Production LOC: +25/-60 (net -35) | Tests: +315/-822 (net -507)

## User Impact

There is no intended behavior change. QA Lab runtime launches retain the same configuration, isolation, and provider boundaries with less duplicated production and test code.

## Evidence

- Local owner coverage: 269/271 tests passed.
- The two local failures reproduce identically on the clean baseline and come from the linked checkout exposing Crabline 0.1.11 while the repository pins 0.1.17; they are not changed-path regressions.
- Complete assertion, title, hook, security, and runtime contract inventories were preserved in independent review.
- Exact-head CI on clean repository dependencies is the authoritative full 271-test and full-tree gate; this PR will not land unless all required checks are green.
