### PR TITLE
fix(ai): enforce Anthropic stream completion by provider ownership

### DIFF
--- a/packages/ai/src/providers/anthropic.sse-parse-error.test.ts
+++ b/packages/ai/src/providers/anthropic.sse-parse-error.test.ts
@@ -1,5 +1,6 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import Anthropic from "@anthropic-ai/sdk";
 import { describe, expect, it } from "vitest";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type { Context, Model } from "../types.js";
@@ -103,5 +104,78 @@ describe("Anthropic malformed SSE frames", () => {
 
     expect(result.stopReason).toBe("stop");
     expect(result.errorMessage).toBeUndefined();
+  });
+
+  it.each([
+    {
+      label: "rejects an empty first-party stream",
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      frames: [],
+      stopReason: "error",
+    },
+    {
+      label: "rejects a ping-only first-party stream",
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      frames: [["ping", '{"type":"ping"}']] as const,
+      stopReason: "error",
+    },
+    {
+      label: "still rejects a started first-party stream without message_stop",
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      frames: WELL_FORMED_FRAMES.slice(0, -1),
+      stopReason: "error",
+    },
+    {
+      label: "still accepts an empty compatible provider stream",
+      provider: "openrouter",
+      baseUrl: "https://proxy.example.com/v1",
+      frames: [],
+      stopReason: "stop",
+    },
+    {
+      label: "still accepts a ping-only Anthropic-compatible custom endpoint",
+      provider: "anthropic",
+      baseUrl: "https://proxy.example.com/v1",
+      frames: [["ping", '{"type":"ping"}']] as const,
+      stopReason: "stop",
+    },
+    {
+      label: "accepts a complete compatible provider stream without message_stop",
+      provider: "openrouter",
+      baseUrl: "https://proxy.example.com/v1",
+      frames: WELL_FORMED_FRAMES.slice(0, -1),
+      stopReason: "stop",
+    },
+  ])("$label", async ({ provider, baseUrl, frames, stopReason }) => {
+    const client = new Anthropic({
+      apiKey: "test-api-key",
+      baseURL: baseUrl,
+      fetch: async () =>
+        new Response(frames.map(([event, data]) => `event: ${event}\ndata: ${data}\n\n`).join(""), {
+          headers: { "content-type": "text/event-stream" },
+        }),
+    });
+    const stream = streamAnthropic({ ...makeModel(baseUrl), provider }, context, {
+      apiKey: "test-api-key",
+      client,
+      maxRetries: 0,
+    });
+    const eventTypes: string[] = [];
+    for await (const event of stream) {
+      eventTypes.push(event.type);
+    }
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe(stopReason);
+    expect(eventTypes.at(-1)).toBe(stopReason === "error" ? "error" : "done");
+    expect(result.errorMessage).toBe(
+      stopReason === "error" ? "Anthropic stream ended before message_stop" : undefined,
+    );
+    if (frames.length > 1 && stopReason === "stop") {
+      expect(result.content).toEqual([expect.objectContaining({ type: "text", text: "ok" })]);
+    }
   });
 });

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -291,7 +291,6 @@ async function* iterateAnthropicEvents(
     throw new Error("Attempted to iterate over an Anthropic response with no body");
   }
 
-  let sawMessageStart = false;
   let sawMessageEnd = false;
 
   for await (const sse of Stream.rawEvents(response)) {
@@ -305,9 +304,7 @@ async function* iterateAnthropicEvents(
 
     try {
       const event = parseJsonWithRepair(sse.data) as RawMessageStreamEvent;
-      if (event.type === "message_start") {
-        sawMessageStart = true;
-      } else if (event.type === "message_stop") {
+      if (event.type === "message_stop") {
         sawMessageEnd = true;
       }
       yield event;
@@ -321,7 +318,7 @@ async function* iterateAnthropicEvents(
     }
   }
 
-  if ((sawMessageStart || requireMessageStop) && !sawMessageEnd) {
+  if (requireMessageStop && !sawMessageEnd) {
     throw new Error("Anthropic stream ended before message_stop");
   }
 }
@@ -447,8 +444,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicComp
         contentIndex: number;
       }> = [];
       const compactionCapture = createCompactionCapture(output, model, requestOptions);
+      const requireMessageStop =
+        refusalBuffer !== undefined ||
+        (model.provider === "anthropic" && isAnthropicPublicEndpoint(model.baseUrl));
 
-      for await (const event of iterateAnthropicEvents(response, refusalBuffer !== undefined)) {
+      for await (const event of iterateAnthropicEvents(response, requireMessageStop)) {
         if (event.type === "message_start") {
           output.responseId = event.message.id;
           output.responseModel = event.message.model;


### PR DESCRIPTION
## Summary

- Reject empty or ping-only first-party Anthropic streams instead of recording successful empty assistant turns.
- Accept fully completed compatible-provider responses that legitimately omit the Anthropic-only `message_stop` event.
- Apply the same first-party/refusal terminal-frame contract already enforced by the sibling managed transport.

## Root cause

The built-in SDK stream owner tied terminal-frame strictness to whether a start frame happened to arrive. This both accepted empty first-party SSE responses as successful empty messages and rejected otherwise complete proxy responses carrying text plus their terminal `end_turn` event. A previous transport repair implemented the correct endpoint-owned distinction only for the managed sibling, leaving the default SDK path inconsistent.

## Validation

- Authentic pre-fix actual installed Anthropic SDK regressions reproduced both direct empty/ping false success and complete OpenRouter-compatible response false failure without any external network access.
- First-party direct streams now fail visibly; complete proxy streams retain their text; refusal-capable streams remain strict.
- Three focused provider/SDK/managed-transport suites: 235 tests passed.
- Direct focused type-aware lint, repository formatter, changed-lane classification, `git diff --check`, and fresh independent Codex autoreview are required before landing.
- Production diff adds and removes six lines; no model configuration, credentials, protocol, or persistence changes.
