### PR TITLE
fix(telegram): preserve rich message chunk limits

### DIFF
--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -10,7 +10,10 @@ import {
   createAttachedChannelResultAdapter,
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
-import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
+import {
+  resolveTextChunkLimit,
+  chunkMarkdownTextWithMode,
+} from "openclaw/plugin-sdk/reply-chunking";
 import {
   resolveSendableOutboundReplyParts,
   sendPayloadMediaSequenceOrFallback,
@@ -33,6 +36,7 @@ import {
   resolveTelegramPromptContextSource,
 } from "./prompt-context-projection.js";
 import { registerTelegramQuestionDelivery } from "./question-finalization.js";
+import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
 import { loadTelegramSendModule, type TelegramSendModule } from "./send-runtime.js";
 import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
 
@@ -572,8 +576,18 @@ export function createTelegramOutboundAdapter(
         gatewayClientScopes,
       });
     },
-    resolveEffectiveTextChunkLimit: ({ fallbackLimit }) =>
-      typeof fallbackLimit === "number" ? Math.min(fallbackLimit, 4096) : 4096,
+    resolveEffectiveTextChunkLimit: ({ cfg, accountId }) => {
+      const richMessages =
+        mergeTelegramAccountConfig(cfg, accountId ?? resolveDefaultTelegramAccountId(cfg))
+          .richMessages === true;
+      const platformLimit = richMessages ? TELEGRAM_RICH_TEXT_LIMIT : TELEGRAM_TEXT_CHUNK_LIMIT;
+      return Math.min(
+        resolveTextChunkLimit(cfg, "telegram", accountId ?? undefined, {
+          fallbackLimit: platformLimit,
+        }),
+        platformLimit,
+      );
+    },
     pollMaxOptions: TELEGRAM_POLL_OPTION_LIMIT,
     supportsPollDurationSeconds: true,
     supportsAnonymousPolls: true,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -574,8 +574,8 @@ export function createTelegramOutboundAdapter(
         gatewayClientScopes,
       });
     },
-    resolveEffectiveTextChunkLimit: ({ cfg, accountId }) =>
-      resolveTelegramTextChunkLimit({ cfg, accountId }),
+    resolveEffectiveTextChunkLimit: ({ cfg, accountId, formatting }) =>
+      resolveTelegramTextChunkLimit({ cfg, accountId, formatting }),
     pollMaxOptions: TELEGRAM_POLL_OPTION_LIMIT,
     supportsPollDurationSeconds: true,
     supportsAnonymousPolls: true,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -10,10 +10,7 @@ import {
   createAttachedChannelResultAdapter,
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
-import {
-  resolveTextChunkLimit,
-  chunkMarkdownTextWithMode,
-} from "openclaw/plugin-sdk/reply-chunking";
+import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import {
   resolveSendableOutboundReplyParts,
   sendPayloadMediaSequenceOrFallback,
@@ -36,11 +33,12 @@ import {
   resolveTelegramPromptContextSource,
 } from "./prompt-context-projection.js";
 import { registerTelegramQuestionDelivery } from "./question-finalization.js";
-import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
 import { loadTelegramSendModule, type TelegramSendModule } from "./send-runtime.js";
 import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
+import { resolveTelegramTextChunkLimit, TELEGRAM_TEXT_CHUNK_LIMIT } from "./text-chunk-limit.js";
 
-export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
+export { TELEGRAM_TEXT_CHUNK_LIMIT } from "./text-chunk-limit.js";
+
 const TELEGRAM_POLL_OPTION_LIMIT = 12;
 
 type TelegramSendFn = typeof import("./send.js").sendMessageTelegram;
@@ -576,18 +574,8 @@ export function createTelegramOutboundAdapter(
         gatewayClientScopes,
       });
     },
-    resolveEffectiveTextChunkLimit: ({ cfg, accountId }) => {
-      const richMessages =
-        mergeTelegramAccountConfig(cfg, accountId ?? resolveDefaultTelegramAccountId(cfg))
-          .richMessages === true;
-      const platformLimit = richMessages ? TELEGRAM_RICH_TEXT_LIMIT : TELEGRAM_TEXT_CHUNK_LIMIT;
-      return Math.min(
-        resolveTextChunkLimit(cfg, "telegram", accountId ?? undefined, {
-          fallbackLimit: platformLimit,
-        }),
-        platformLimit,
-      );
-    },
+    resolveEffectiveTextChunkLimit: ({ cfg, accountId }) =>
+      resolveTelegramTextChunkLimit({ cfg, accountId }),
     pollMaxOptions: TELEGRAM_POLL_OPTION_LIMIT,
     supportsPollDurationSeconds: true,
     supportsAnonymousPolls: true,

--- a/extensions/telegram/src/send-message-text.ts
+++ b/extensions/telegram/src/send-message-text.ts
@@ -1,6 +1,5 @@
 import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
-import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedTelegramAccount } from "./accounts.js";
@@ -11,7 +10,6 @@ import type { TelegramOutboundPromptContextMessage as TelegramMessageLike } from
 import {
   getTelegramRichRawApi,
   removeTelegramRichNativeQuoteParam,
-  TELEGRAM_RICH_TEXT_LIMIT,
   toTelegramRichMessageContextParams,
   type TelegramRichMessageContextParams,
 } from "./rich-message.js";
@@ -37,6 +35,7 @@ import {
   deliverTelegramTextPage,
   planTelegramTextDeliveryPages,
 } from "./telegram-text-delivery.js";
+import { resolveTelegramTextChunkLimit } from "./text-chunk-limit.js";
 
 type SendTextOptions = {
   replyToAlreadyUsed?: boolean;
@@ -366,12 +365,7 @@ export function createTelegramTextSender(config: {
     });
     const alreadyUsed = options.replyToAlreadyUsed === true;
     const maxChars = useRichMessages
-      ? Math.min(
-          resolveTextChunkLimit(cfg, "telegram", account.accountId, {
-            fallbackLimit: TELEGRAM_RICH_TEXT_LIMIT,
-          }),
-          TELEGRAM_RICH_TEXT_LIMIT,
-        )
+      ? resolveTelegramTextChunkLimit({ cfg, accountId: account.accountId })
       : 4000;
     const pages = planTelegramTextDeliveryPages({
       text: textMode === "html" ? renderHtmlText(rawText) : rawText,

--- a/extensions/telegram/src/telegram-outbound.test.ts
+++ b/extensions/telegram/src/telegram-outbound.test.ts
@@ -33,6 +33,29 @@ describe("telegramPlugin outbound", () => {
     expect(telegramOutbound.pollMaxOptions).toBe(12);
   });
 
+  it("uses the rich-message limit before the shared outbound chunker", () => {
+    const resolveLimit = telegramOutbound.resolveEffectiveTextChunkLimit;
+    expect(resolveLimit?.({ cfg: {}, accountId: "default", fallbackLimit: 4000 })).toBe(4000);
+    expect(
+      resolveLimit?.({
+        cfg: { channels: { telegram: { richMessages: true } } },
+        accountId: "default",
+        fallbackLimit: 4000,
+      }),
+    ).toBe(32768);
+  });
+
+  it("preserves an explicitly configured lower rich-message limit", () => {
+    expect(
+      telegramOutbound.resolveEffectiveTextChunkLimit?.({
+        cfg: {
+          channels: { telegram: { richMessages: true, textChunkLimit: 1200 } },
+        },
+        accountId: "default",
+        fallbackLimit: 4000,
+      }),
+    ).toBe(1200);
+  });
   it("strips assistant-visible tool traces before outbound delivery", () => {
     clearTelegramRuntime();
     const text = 'Done.\n⚠️ 🛠️ `search "Pipeline" in ~/.openclaw/workspace-* (agent)` failed';

--- a/extensions/telegram/src/telegram-outbound.test.ts
+++ b/extensions/telegram/src/telegram-outbound.test.ts
@@ -56,6 +56,39 @@ describe("telegramPlugin outbound", () => {
       }),
     ).toBe(1200);
   });
+
+  it("uses the selected account's rich-message limit", () => {
+    expect(
+      telegramOutbound.resolveEffectiveTextChunkLimit?.({
+        cfg: {
+          channels: {
+            telegram: {
+              richMessages: false,
+              accounts: { rich: { richMessages: true } },
+            },
+          },
+        },
+        accountId: "rich",
+        fallbackLimit: 4000,
+      }),
+    ).toBe(32768);
+  });
+
+  it("preserves a selected account's lower rich-message limit", () => {
+    expect(
+      telegramOutbound.resolveEffectiveTextChunkLimit?.({
+        cfg: {
+          channels: {
+            telegram: {
+              accounts: { rich: { richMessages: true, textChunkLimit: 1200 } },
+            },
+          },
+        },
+        accountId: "rich",
+        fallbackLimit: 4000,
+      }),
+    ).toBe(1200);
+  });
   it("strips assistant-visible tool traces before outbound delivery", () => {
     clearTelegramRuntime();
     const text = 'Done.\n⚠️ 🛠️ `search "Pipeline" in ~/.openclaw/workspace-* (agent)` failed';

--- a/extensions/telegram/src/telegram-outbound.test.ts
+++ b/extensions/telegram/src/telegram-outbound.test.ts
@@ -57,6 +57,17 @@ describe("telegramPlugin outbound", () => {
     ).toBe(1200);
   });
 
+  it("keeps rich-account legacy HTML at the Telegram text limit", () => {
+    expect(
+      telegramOutbound.resolveEffectiveTextChunkLimit?.({
+        cfg: { channels: { telegram: { richMessages: true } } },
+        accountId: "default",
+        fallbackLimit: 4000,
+        formatting: { parseMode: "HTML" },
+      }),
+    ).toBe(4000);
+  });
+
   it("uses the selected account's rich-message limit", () => {
     expect(
       telegramOutbound.resolveEffectiveTextChunkLimit?.({
@@ -147,6 +158,28 @@ describe("telegramPlugin outbound", () => {
       "first<b>second</b>",
       expect.objectContaining({ textMode: "html" }),
     );
+  });
+
+  it("keeps rich-account legacy HTML chunks within Telegram's text limit", async () => {
+    clearTelegramRuntime();
+    const text = "x".repeat(4_001);
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-1", chatId: "12345" });
+
+    await sendTextMediaPayload({
+      channel: "telegram",
+      ctx: {
+        cfg: { channels: { telegram: { richMessages: true } } },
+        to: "12345",
+        text: "",
+        payload: { text },
+        formatting: { parseMode: "HTML" },
+        deps: { sendTelegram },
+      },
+      adapter: telegramOutbound,
+    });
+
+    expect(sendTelegram.mock.calls.map((call) => call[1])).toEqual(["x".repeat(4_000), "x"]);
+    expect(sendTelegram.mock.calls.every((call) => call[2]?.textMode === "html")).toBe(true);
   });
 
   it("keeps astral characters whole at positive configured chunk limits", () => {

--- a/extensions/telegram/src/text-chunk-limit.ts
+++ b/extensions/telegram/src/text-chunk-limit.ts
@@ -1,4 +1,7 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  OpenClawConfig,
+  OutboundDeliveryFormattingOptions,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { mergeTelegramAccountConfig, resolveDefaultTelegramAccountId } from "./accounts.js";
 import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
@@ -8,13 +11,17 @@ export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
 export function resolveTelegramTextChunkLimit(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
+  formatting?: OutboundDeliveryFormattingOptions;
 }): number {
   const richMessages =
     mergeTelegramAccountConfig(
       params.cfg,
       params.accountId ?? resolveDefaultTelegramAccountId(params.cfg),
     ).richMessages === true;
-  const platformLimit = richMessages ? TELEGRAM_RICH_TEXT_LIMIT : TELEGRAM_TEXT_CHUNK_LIMIT;
+  const platformLimit =
+    richMessages && params.formatting?.parseMode !== "HTML"
+      ? TELEGRAM_RICH_TEXT_LIMIT
+      : TELEGRAM_TEXT_CHUNK_LIMIT;
   return Math.min(
     resolveTextChunkLimit(params.cfg, "telegram", params.accountId ?? undefined, {
       fallbackLimit: platformLimit,

--- a/extensions/telegram/src/text-chunk-limit.ts
+++ b/extensions/telegram/src/text-chunk-limit.ts
@@ -1,7 +1,5 @@
-import type {
-  OpenClawConfig,
-  OutboundDeliveryFormattingOptions,
-} from "openclaw/plugin-sdk/channel-outbound";
+import type { OutboundDeliveryFormattingOptions } from "openclaw/plugin-sdk/channel-outbound";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { mergeTelegramAccountConfig, resolveDefaultTelegramAccountId } from "./accounts.js";
 import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";

--- a/extensions/telegram/src/text-chunk-limit.ts
+++ b/extensions/telegram/src/text-chunk-limit.ts
@@ -1,0 +1,24 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
+import { mergeTelegramAccountConfig, resolveDefaultTelegramAccountId } from "./accounts.js";
+import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
+
+export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
+
+export function resolveTelegramTextChunkLimit(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): number {
+  const richMessages =
+    mergeTelegramAccountConfig(
+      params.cfg,
+      params.accountId ?? resolveDefaultTelegramAccountId(params.cfg),
+    ).richMessages === true;
+  const platformLimit = richMessages ? TELEGRAM_RICH_TEXT_LIMIT : TELEGRAM_TEXT_CHUNK_LIMIT;
+  return Math.min(
+    resolveTextChunkLimit(params.cfg, "telegram", params.accountId ?? undefined, {
+      fallbackLimit: platformLimit,
+    }),
+    platformLimit,
+  );
+}

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -210,6 +210,7 @@ export type ChannelOutboundAdapter = {
     cfg: OpenClawConfig;
     accountId?: string | null;
     fallbackLimit?: number;
+    formatting?: OutboundDeliveryFormattingOptions;
   }) => number | undefined;
   shouldSuppressLocalPayloadPrompt?: (params: {
     cfg: OpenClawConfig;

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -402,11 +402,12 @@ function createPluginHandler(
       ? (payload) => outbound.shouldSkipPlainTextSanitization!({ payload })
       : undefined,
     resolveEffectiveTextChunkLimit: outbound?.resolveEffectiveTextChunkLimit
-      ? (fallbackLimit) =>
+      ? ({ fallbackLimit, formatting }) =>
           outbound.resolveEffectiveTextChunkLimit!({
             cfg: params.cfg,
             accountId: params.accountId ?? undefined,
             fallbackLimit,
+            formatting,
           })
       : undefined,
     sendPayload:

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -97,7 +97,10 @@ export type ChannelHandler = {
   }) => { threadId: string | number } | null | undefined;
   buildTargetRef: (overrides?: { threadId?: string | number | null }) => ChannelOutboundTargetRef;
   shouldSkipPlainTextSanitization?: (payload: ReplyPayload) => boolean;
-  resolveEffectiveTextChunkLimit?: (fallbackLimit?: number) => number | undefined;
+  resolveEffectiveTextChunkLimit?: (params: {
+    fallbackLimit?: number;
+    formatting?: OutboundDeliveryFormattingOptions;
+  }) => number | undefined;
   sendPayload?: (
     payload: ReplyPayload,
     overrides?: OutboundMessageSendOverrides,

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -140,7 +140,10 @@ export async function deliverOutboundPayloadsCore(
   const textLimit =
     params.formatting?.textLimit ??
     (handler.resolveEffectiveTextChunkLimit
-      ? handler.resolveEffectiveTextChunkLimit(configuredTextLimit)
+      ? handler.resolveEffectiveTextChunkLimit({
+          fallbackLimit: configuredTextLimit,
+          formatting: params.formatting,
+        })
       : configuredTextLimit);
   const chunkMode = handler.chunker
     ? (params.formatting?.chunkMode ?? resolveChunkMode(cfg, channel, accountId))


### PR DESCRIPTION
Closes #128993

## What Problem This Solves

Telegram rich messages were still pre-chunked at the plain-text 4,000-character limit before the rich block planner received the document. A long rich response containing media blocks, headings, or lists could therefore be split inside the rich document and lose later content.

## Summary

The outbound adapter now resolves the effective limit from the account's `richMessages` setting:

- plain Telegram messages retain the 4,000-character limit;
- rich messages use the existing 32,768-character rich-text limit before block planning;
- an explicitly configured lower `textChunkLimit` remains authoritative;
- the platform limit still caps overly large configured values.

## Evidence

- Added focused adapter contract tests for plain, rich, and explicitly lower configured limits.
- `extensions/telegram/src/telegram-outbound.test.ts`: 16 passed.
- Telegram send coverage and shared outbound delivery coverage: 262 tests passed.
- `pnpm check:changed -- extensions/telegram/src/outbound-adapter.ts extensions/telegram/src/telegram-outbound.test.ts`: exit 0.
- Extension production and test typechecks passed.
- No live Telegram credentials or private channel data were used; the regression is deterministic at the shared outbound pre-chunk boundary.

AI-assisted disclosure: implementation and tests were developed with AI assistance and reviewed against the repository's local guidance and existing Telegram rich-message contracts.
