### PR TITLE
fix(agent-core): close tool batches at the launch boundary

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -218,6 +218,97 @@ describe("agentLoop EventStream failures", () => {
   });
 });
 
+describe("public runner context isolation", () => {
+  function createAssistantReplyStream(): ReturnType<StreamFn> {
+    const stream = createAssistantMessageEventStream();
+    queueMicrotask(() => {
+      stream.push({
+        type: "done",
+        reason: "stop",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "new reply" }],
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage: TEST_USAGE,
+          stopReason: "stop",
+          timestamp: 2,
+        },
+      });
+      stream.end();
+    });
+    return stream;
+  }
+
+  async function expectCallerMessagesUnchanged(
+    context: AgentContext,
+    run: (emit: (event: AgentEvent) => void) => Promise<AgentMessage[]>,
+  ): Promise<void> {
+    const originalMessages = context.messages;
+    const originalSnapshot = structuredClone(context.messages);
+    const events: AgentEvent[] = [];
+
+    const messages = await run((event) => {
+      events.push(event);
+    });
+
+    expect(context.messages).toBe(originalMessages);
+    expect(context.messages).toEqual(originalSnapshot);
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        content: [{ type: "text", text: "new reply" }],
+      }),
+    ]);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "message_end",
+          message: expect.objectContaining({
+            role: "assistant",
+            content: [{ type: "text", text: "new reply" }],
+          }),
+        }),
+      ]),
+    );
+  }
+
+  it("keeps caller messages isolated for empty-prompt runs", async () => {
+    const context: AgentContext = {
+      systemPrompt: "",
+      messages: [{ role: "user", content: "existing prompt", timestamp: 1 }],
+    };
+
+    await expectCallerMessagesUnchanged(context, (emit) =>
+      runAgentLoop([], context, config, emit, undefined, async () => createAssistantReplyStream()),
+    );
+  });
+
+  it("keeps caller messages isolated for continuations", async () => {
+    const context: AgentContext = {
+      systemPrompt: "",
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call-ready",
+          toolName: "read",
+          content: [{ type: "text", text: "ready" }],
+          details: {},
+          isError: false,
+          timestamp: 1,
+        },
+      ],
+    };
+
+    await expectCallerMessagesUnchanged(context, (emit) =>
+      runAgentLoopContinue(context, config, emit, undefined, async () =>
+        createAssistantReplyStream(),
+      ),
+    );
+  });
+});
+
 describe("agentLoop continuation guards", () => {
   const assistantTailContext: AgentContext = {
     systemPrompt: "",
@@ -1643,44 +1734,223 @@ describe("agentLoop tool termination", () => {
     expect(releaseSkippedCalls).not.toHaveBeenCalled();
   });
 
-  it("does not launch prepared tools when the admission commit fails", async () => {
-    const execute = vi.fn(async () => ({ content: [], details: {} }));
-    const streamFn = createTurnSequenceStream(
-      [[{ type: "toolCall", id: "commit-failure", name: "side-effect", arguments: {} }]],
-      [],
-    );
+  it.each(["sequential", "parallel"] as const)(
+    "pairs every tool lifecycle before rejecting a %s admission commit failure",
+    async (toolExecution) => {
+      const firstExecute = vi.fn(async () => ({ content: [], details: { executed: "first" } }));
+      const secondExecute = vi.fn(async () => ({ content: [], details: { executed: "second" } }));
+      const thirdExecute = vi.fn(async () => ({ content: [], details: { executed: "third" } }));
+      const commitError = new Error("private admission details must not reach tool results");
+      const releaseSkippedCalls = vi.fn();
+      const afterToolOutcome = vi.fn(async () => undefined);
+      const events: AgentEvent[] = [];
+
+      await expect(
+        runAgentLoop(
+          [{ role: "user", content: "run", timestamp: 1 }],
+          {
+            systemPrompt: "",
+            messages: [],
+            tools: [
+              { ...makeTool("first", []), execute: firstExecute },
+              { ...makeTool("second", []), execute: secondExecute },
+              { ...makeTool("third", []), execute: thirdExecute },
+            ],
+          },
+          {
+            ...config,
+            toolExecution,
+            afterToolOutcome,
+            beforeToolBatch: async () =>
+              attachInternalToolBatchLifecycle(
+                {},
+                {
+                  commitReadyCalls: (calls) => {
+                    if (calls.some((call) => call.toolCallId === "commit-second")) {
+                      throw commitError;
+                    }
+                  },
+                  releaseSkippedCalls,
+                },
+              ),
+          },
+          (event) => {
+            events.push(event);
+          },
+          undefined,
+          createTurnSequenceStream([
+            [
+              { type: "toolCall", id: "commit-first", name: "first", arguments: {} },
+              { type: "toolCall", id: "commit-second", name: "second", arguments: {} },
+              { type: "toolCall", id: "commit-third", name: "third", arguments: {} },
+            ],
+          ]),
+        ),
+      ).rejects.toBe(commitError);
+
+      expect(firstExecute).toHaveBeenCalledOnce();
+      expect(secondExecute).not.toHaveBeenCalled();
+      expect(thirdExecute).not.toHaveBeenCalled();
+      expect(releaseSkippedCalls).toHaveBeenCalledExactlyOnceWith([
+        "commit-second",
+        "commit-third",
+      ]);
+      expect(
+        events
+          .filter((event) => event.type === "tool_execution_start")
+          .map((event) => event.toolCallId),
+      ).toEqual(["commit-first", "commit-second", "commit-third"]);
+      const toolEnds = events
+        .filter((event) => event.type === "tool_execution_end")
+        .map((event) => ({ id: event.toolCallId, started: event.executionStarted }));
+      expect(toolEnds).toHaveLength(3);
+      expect(toolEnds).toEqual(
+        expect.arrayContaining([
+          { id: "commit-first", started: true },
+          { id: "commit-second", started: false },
+          { id: "commit-third", started: false },
+        ]),
+      );
+      const toolResults = events
+        .filter(
+          (
+            event,
+          ): event is Extract<AgentEvent, { type: "message_end" }> & {
+            message: { role: "toolResult" };
+          } => event.type === "message_end" && event.message.role === "toolResult",
+        )
+        .map((event) => event.message);
+      expect(toolResults.map((message) => message.toolCallId)).toEqual([
+        "commit-first",
+        "commit-second",
+        "commit-third",
+      ]);
+      for (const toolResult of toolResults.slice(1)) {
+        expect(toolResult).toMatchObject({
+          isError: true,
+          content: [{ type: "text", text: "Tool execution was blocked before launch." }],
+          details: { status: "blocked", deniedReason: "tool-admission" },
+        });
+        expect(JSON.stringify(toolResult)).not.toContain(commitError.message);
+      }
+      expect(afterToolOutcome).toHaveBeenCalledTimes(3);
+      for (const toolCallId of ["commit-second", "commit-third"]) {
+        expect(afterToolOutcome).toHaveBeenCalledWith(
+          expect.objectContaining({
+            executionStarted: false,
+            toolCall: expect.objectContaining({ id: toolCallId }),
+          }),
+          undefined,
+        );
+      }
+      expect(events.filter((event) => event.type === "turn_end")).toEqual([
+        expect.objectContaining({
+          message: expect.objectContaining({ role: "assistant", stopReason: "toolUse" }),
+          toolResults,
+        }),
+      ]);
+    },
+  );
+
+  it("keeps Agent active until started parallel work settles after a later commit failure", async () => {
+    const firstStarted = createDeferred();
+    const releaseFirst = createDeferred();
+    const secondCommitAttempted = createDeferred();
+    const secondExecute = vi.fn(async () => ({ content: [], details: {} }));
     const commitError = new Error("admission commit failed");
     const releaseSkippedCalls = vi.fn();
-
-    await expect(
-      runAgentLoop(
-        [{ role: "user", content: "run", timestamp: 1 }],
-        {
-          systemPrompt: "",
-          messages: [],
-          tools: [{ ...makeTool("side-effect", []), execute }],
+    const events: AgentEvent[] = [];
+    let providerCalls = 0;
+    let agentEnded = false;
+    const agent = new Agent({
+      initialState: {
+        model,
+        tools: [
+          {
+            ...makeTool("first", []),
+            execute: async () => {
+              firstStarted.resolve();
+              await releaseFirst.promise;
+              return { content: [], details: { executed: "first" } };
+            },
+          },
+          { ...makeTool("second", []), execute: secondExecute },
+        ],
+      },
+      toolExecution: "parallel",
+      streamFn: createTurnSequenceStream(
+        [
+          [
+            { type: "toolCall", id: "idle-first", name: "first", arguments: {} },
+            { type: "toolCall", id: "idle-second", name: "second", arguments: {} },
+          ],
+        ],
+        [],
+        () => {
+          providerCalls += 1;
         },
-        {
-          ...config,
-          toolExecution: "parallel",
-          beforeToolBatch: async () =>
-            attachInternalToolBatchLifecycle(
-              {},
-              {
-                commitReadyCalls: () => {
-                  throw commitError;
-                },
-                releaseSkippedCalls,
-              },
-            ),
-        },
-        () => {},
-        undefined,
-        streamFn,
       ),
-    ).rejects.toBe(commitError);
-    expect(execute).not.toHaveBeenCalled();
-    expect(releaseSkippedCalls).not.toHaveBeenCalled();
+    });
+    setInternalBeforeToolBatch(agent, async () =>
+      attachInternalToolBatchLifecycle(
+        {},
+        {
+          commitReadyCalls: (calls) => {
+            if (calls.some((call) => call.toolCallId === "idle-second")) {
+              secondCommitAttempted.resolve();
+              throw commitError;
+            }
+          },
+          releaseSkippedCalls,
+        },
+      ),
+    );
+    agent.subscribe((event) => {
+      events.push(event);
+      agentEnded ||= event.type === "agent_end";
+    });
+
+    const prompt = agent.prompt("run");
+    await firstStarted.promise;
+    await secondCommitAttempted.promise;
+    try {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      expect(agentEnded).toBe(false);
+      expect(agent.state.isStreaming).toBe(true);
+    } finally {
+      releaseFirst.resolve();
+    }
+    await prompt;
+
+    expect(providerCalls).toBe(1);
+    expect(secondExecute).not.toHaveBeenCalled();
+    expect(releaseSkippedCalls).toHaveBeenCalledWith(["idle-second"]);
+    expect(agent.state.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "toolResult",
+      "assistant",
+    ]);
+    const toolUseTurnEnd = events.findIndex(
+      (event) =>
+        event.type === "turn_end" &&
+        event.message.role === "assistant" &&
+        event.message.stopReason === "toolUse",
+    );
+    const failureTurnEnd = events.findIndex(
+      (event) =>
+        event.type === "turn_end" &&
+        event.message.role === "assistant" &&
+        event.message.stopReason === "error",
+    );
+    const agentEnd = events.findIndex((event) => event.type === "agent_end");
+    expect(toolUseTurnEnd).toBeGreaterThanOrEqual(0);
+    expect(failureTurnEnd).toBeGreaterThan(toolUseTurnEnd);
+    expect(agentEnd).toBeGreaterThan(failureTurnEnd);
+    expect(events.slice(agentEnd + 1)).toEqual([]);
   });
 
   it("gives the model one recovery turn with the normal tool catalog", async () => {

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -72,6 +72,11 @@ type AssistantMessageUpdateEvent = Extract<
 const TOOL_LOOP_RECOVERY_TERMINATED_MESSAGE =
   "OpenClaw stopped this run because tool-loop recovery encountered another critical loop. No blocked tool action was executed.";
 const STEERING_TOOL_SKIP_MESSAGE = "Skipped due to queued user message.";
+const TOOL_ADMISSION_FAILURE_MESSAGE = "Tool execution was blocked before launch.";
+const TOOL_ADMISSION_FAILURE_DETAILS = {
+  status: "blocked",
+  deniedReason: "tool-admission",
+} as const;
 
 function getSteeringAtCheckpoint(
   config: AgentLoopConfig,
@@ -140,27 +145,11 @@ export function agentLoop(
   streamFn?: StreamFn,
   runtime?: AgentCoreStreamRuntimeDeps,
 ): EventStream<AgentEvent, AgentMessage[]> {
-  const stream = createAgentStream();
-
-  void runAgentLoop(
-    prompts,
-    context,
+  return streamAgentRun(
+    (emit) => runAgentLoop(prompts, context, config, emit, signal, streamFn, runtime),
     config,
-    async (event) => {
-      stream.push(event);
-    },
     signal,
-    streamFn,
-    runtime,
-  )
-    .then((messages) => {
-      stream.end(messages);
-    })
-    .catch((error: unknown) => {
-      pushLoopFailure(stream, config, error, signal);
-    });
-
-  return stream;
+  );
 }
 
 /**
@@ -178,35 +167,12 @@ export function agentLoopContinue(
   streamFn?: StreamFn,
   runtime?: AgentCoreStreamRuntimeDeps,
 ): EventStream<AgentEvent, AgentMessage[]> {
-  const lastMessage = context.messages.at(-1);
-  if (!lastMessage) {
-    throw new Error("Cannot continue: no messages in context");
-  }
-
-  if (lastMessage.role === "assistant") {
-    throw new TranscriptNotContinuableError(lastMessage.role);
-  }
-
-  const stream = createAgentStream();
-
-  void runAgentLoopContinue(
-    context,
+  assertContinuableContext(context);
+  return streamAgentRun(
+    (emit) => runAgentLoopContinue(context, config, emit, signal, streamFn, runtime),
     config,
-    async (event) => {
-      stream.push(event);
-    },
     signal,
-    streamFn,
-    runtime,
-  )
-    .then((messages) => {
-      stream.end(messages);
-    })
-    .catch((error: unknown) => {
-      pushLoopFailure(stream, config, error, signal);
-    });
-
-  return stream;
+  );
 }
 
 /** Run a prompt-started loop and emit events through a caller-owned sink. */
@@ -219,21 +185,7 @@ export async function runAgentLoop(
   streamFn?: StreamFn,
   runtime?: AgentCoreStreamRuntimeDeps,
 ): Promise<AgentMessage[]> {
-  const newMessages: AgentMessage[] = [...prompts];
-  const currentContext: AgentContext = {
-    ...context,
-    messages: [...context.messages, ...prompts],
-  };
-
-  await emit({ type: "agent_start" });
-  await emit({ type: "turn_start" });
-  for (const prompt of prompts) {
-    await emit({ type: "message_start", message: prompt });
-    await emit({ type: "message_end", message: prompt });
-  }
-
-  await runLoop(currentContext, newMessages, config, signal, emit, streamFn, runtime);
-  return newMessages;
+  return runAgentLoopCore(prompts, context, config, emit, signal, streamFn, runtime);
 }
 
 /** Continue an existing loop context and emit only newly produced messages. */
@@ -245,21 +197,49 @@ export async function runAgentLoopContinue(
   streamFn?: StreamFn,
   runtime?: AgentCoreStreamRuntimeDeps,
 ): Promise<AgentMessage[]> {
+  assertContinuableContext(context);
+  return runAgentLoopCore([], context, config, emit, signal, streamFn, runtime);
+}
+
+function assertContinuableContext(context: AgentContext): void {
   const lastMessage = context.messages.at(-1);
   if (!lastMessage) {
     throw new Error("Cannot continue: no messages in context");
   }
-
   if (lastMessage.role === "assistant") {
     throw new TranscriptNotContinuableError(lastMessage.role);
   }
+}
 
-  const newMessages: AgentMessage[] = [];
-  const currentContext: AgentContext = { ...context };
+function streamAgentRun(
+  run: (emit: AgentEventSink) => Promise<AgentMessage[]>,
+  config: AgentLoopConfig,
+  signal?: AbortSignal,
+): EventStream<AgentEvent, AgentMessage[]> {
+  const stream = createAgentStream();
+  void run((event) => stream.push(event))
+    .then((messages) => stream.end(messages))
+    .catch((error: unknown) => pushLoopFailure(stream, config, error, signal));
+  return stream;
+}
 
+async function runAgentLoopCore(
+  prompts: AgentMessage[],
+  context: AgentContext,
+  config: AgentLoopConfig,
+  emit: AgentEventSink,
+  signal?: AbortSignal,
+  streamFn?: StreamFn,
+  runtime?: AgentCoreStreamRuntimeDeps,
+): Promise<AgentMessage[]> {
+  const newMessages = [...prompts];
+  const currentContext = { ...context, messages: [...context.messages, ...prompts] };
   await emit({ type: "agent_start" });
   await emit({ type: "turn_start" });
-
+  for (const prompt of prompts) {
+    await emit({ type: "message_start", message: prompt });
+    await emit({ type: "message_end", message: prompt });
+  }
   await runLoop(currentContext, newMessages, config, signal, emit, streamFn, runtime);
   return newMessages;
 }
@@ -410,6 +390,7 @@ async function runLoop(
       const toolResults: ToolResultMessage[] = [];
       hasMoreToolCalls = false;
       let terminateRun = false;
+      let fatalToolBatch: ExecutedToolCallBatch["fatal"];
       if (message.stopReason === "toolUse" && toolCalls.length > 0) {
         const executedToolBatch = await executeToolCalls(
           currentContext,
@@ -427,6 +408,7 @@ async function runLoop(
           toolLoopRecoveryState.criticalToolLoopSeen = true;
         }
         terminateRun = executedToolBatch.terminateRun;
+        fatalToolBatch = executedToolBatch.fatal;
 
         for (const result of toolResults) {
           currentContext.messages.push(result);
@@ -436,6 +418,9 @@ async function runLoop(
 
       await emit({ type: "turn_end", message, toolResults });
       turnOpen = false;
+      if (fatalToolBatch) {
+        throw fatalToolBatch.error;
+      }
       if (await stopIfAborted()) {
         return;
       }
@@ -639,9 +624,15 @@ async function executeToolCalls(
   criticalToolLoopSeen: boolean,
 ): Promise<ExecutedToolCallBatch> {
   const toolCalls = assistantMessage.content.filter((c) => c.type === "toolCall");
-  const resolvedToolCalls = new Map<AgentToolCall, ResolvedToolCallOutcome>();
-  const validatedToolCalls = new Map<AgentToolCall, ValidatedToolCallOutcome>();
-  let batchLifecycle: InternalToolBatchLifecycle | undefined;
+  const batch: ToolBatchContext = {
+    currentContext,
+    assistantMessage,
+    config,
+    signal,
+    emit,
+    resolved: new Map(),
+    validated: new Map(),
+  };
   if (config.beforeToolBatch) {
     for (const toolCall of toolCalls) {
       if (signal?.aborted) {
@@ -650,20 +641,10 @@ async function executeToolCalls(
         // through the executors' normal aborted-call lifecycle.
         break;
       }
-      validatedToolCalls.set(
-        toolCall,
-        await validateToolCallForBatchAdmission(
-          currentContext,
-          assistantMessage,
-          toolCall,
-          config,
-          signal,
-          resolvedToolCalls,
-        ),
-      );
+      batch.validated.set(toolCall, await validateToolCallForBatchAdmission(batch, toolCall));
     }
     const calls = toolCalls.flatMap((toolCall) => {
-      const validation = validatedToolCalls.get(toolCall);
+      const validation = batch.validated.get(toolCall);
       return validation?.kind === "validated"
         ? [{ toolCall, args: validation.prepared.args, tool: validation.prepared.tool }]
         : [];
@@ -674,20 +655,13 @@ async function executeToolCalls(
         signal,
       );
       if (admission?.intervention) {
-        return await completeToolLoopInterventionBatch({
-          currentContext,
-          assistantMessage,
+        return await completeToolLoopInterventionBatch(batch, {
           toolCalls,
-          resolvedToolCalls,
-          validatedToolCalls,
-          config,
-          signal,
-          emit,
           intervention: admission.intervention,
           terminal: criticalToolLoopSeen,
         });
       }
-      batchLifecycle = admission ? takeInternalToolBatchLifecycle(admission) : undefined;
+      batch.lifecycle = admission ? takeInternalToolBatchLifecycle(admission) : undefined;
     }
   }
   let hasSequentialToolCall = false;
@@ -696,14 +670,7 @@ async function executeToolCalls(
       if (signal?.aborted) {
         break;
       }
-      const resolution = await resolveToolCallTool(
-        currentContext,
-        assistantMessage,
-        toolCall,
-        config,
-        signal,
-        resolvedToolCalls,
-      );
+      const resolution = await resolveToolCallTool(batch, toolCall);
       if (resolution.kind === "resolved" && resolution.tool?.executionMode === "sequential") {
         hasSequentialToolCall = true;
         break;
@@ -711,29 +678,9 @@ async function executeToolCalls(
     }
   }
   if (config.toolExecution === "sequential" || hasSequentialToolCall) {
-    return executeToolCallsSequential(
-      currentContext,
-      assistantMessage,
-      toolCalls,
-      resolvedToolCalls,
-      validatedToolCalls,
-      batchLifecycle,
-      config,
-      signal,
-      emit,
-    );
+    return executeToolCallsSequential(batch, toolCalls);
   }
-  return executeToolCallsParallel(
-    currentContext,
-    assistantMessage,
-    toolCalls,
-    resolvedToolCalls,
-    validatedToolCalls,
-    batchLifecycle,
-    config,
-    signal,
-    emit,
-  );
+  return executeToolCallsParallel(batch, toolCalls);
 }
 
 type ExecutedToolCallBatch = {
@@ -742,6 +689,18 @@ type ExecutedToolCallBatch = {
   terminate: boolean;
   terminateRun: boolean;
   intervention?: ToolLoopIntervention;
+  fatal?: { error: unknown };
+};
+
+type ToolBatchContext = {
+  currentContext: AgentContext;
+  assistantMessage: AssistantMessage;
+  config: AgentLoopConfig;
+  signal: AbortSignal | undefined;
+  emit: AgentEventSink;
+  resolved: Map<AgentToolCall, ResolvedToolCallOutcome>;
+  validated: Map<AgentToolCall, ValidatedToolCallOutcome>;
+  lifecycle?: InternalToolBatchLifecycle;
 };
 
 type ResolvedToolCallOutcome =
@@ -761,128 +720,90 @@ function hidesToolCallFromChannelProgress(
   return tool?.hideFromChannelProgress === true;
 }
 
+function validatedToolCallIds(batch: ToolBatchContext, calls: AgentToolCall[]): string[] {
+  return calls
+    .filter((call) => batch.validated.get(call)?.kind === "validated")
+    .map((call) => call.id);
+}
+
 async function executeToolCallsSequential(
-  currentContext: AgentContext,
-  assistantMessage: AssistantMessage,
+  batch: ToolBatchContext,
   toolCalls: AgentToolCall[],
-  resolvedToolCalls: Map<AgentToolCall, ResolvedToolCallOutcome>,
-  validatedToolCalls: Map<AgentToolCall, ValidatedToolCallOutcome>,
-  batchLifecycle: InternalToolBatchLifecycle | undefined,
-  config: AgentLoopConfig,
-  signal: AbortSignal | undefined,
-  emit: AgentEventSink,
 ): Promise<ExecutedToolCallBatch> {
   const finalizedCalls: FinalizedToolCallOutcome[] = [];
   const messages: ToolResultMessage[] = [];
   let steeringMessages: AgentMessage[] = [];
   let skippedReady: { args: unknown; startEmitted: true } | undefined;
   let skippedStartIndex = toolCalls.length;
+  let fatal: ExecutedToolCallBatch["fatal"];
 
   for (let callIndex = 0; callIndex < toolCalls.length; callIndex++) {
     const toolCall = toolCalls[callIndex];
     if (!toolCall) {
       continue;
     }
-    if (!signal?.aborted) {
-      const steering = getSteeringAtCheckpoint(config);
+    if (!batch.signal?.aborted) {
+      const steering = getSteeringAtCheckpoint(batch.config);
       steeringMessages = Array.isArray(steering) ? steering : await steering;
     }
     if (steeringMessages.length > 0) {
       skippedStartIndex = callIndex;
       break;
     }
-    const hideFromChannelProgress = hidesToolCallFromChannelProgress(
-      currentContext,
-      toolCall,
-      resolvedToolCalls,
-    );
-    await emit({
-      type: "tool_execution_start",
-      toolCallId: toolCall.id,
-      toolName: toolCall.name,
-      args: toolCall.arguments,
-      ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
-    });
-
-    const preparation = await prepareToolCall(
-      currentContext,
-      assistantMessage,
-      toolCall,
-      config,
-      signal,
-      resolvedToolCalls,
-      validatedToolCalls,
-    );
+    const entry = await prepareToolCallEntry(batch, toolCall);
     let finalized: FinalizedToolCallOutcome;
-    if (preparation.kind === "immediate") {
-      finalized = await finalizeToolCallOutcome(
-        currentContext,
-        assistantMessage,
-        {
-          toolCall,
-          result: preparation.result,
-          isError: preparation.isError,
-          executionStarted: false,
-          ...(preparation.errorKind ? { errorKind: preparation.errorKind } : {}),
-          ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
-        },
-        toolCall.arguments,
-        config,
-        signal,
-      );
+    if (!("kind" in entry)) {
+      finalized = entry;
     } else {
-      const execution = await prepareToolCallExecution(
-        preparation,
-        { assistantMessage, toolCall: preparation.toolCall },
-        signal,
-        emit,
-      );
-      if (execution.kind === "immediate") {
-        finalized = await finalizeExecutedToolCall(
-          currentContext,
-          assistantMessage,
-          preparation,
-          execution.outcome,
-          preparation.args,
-          config,
-          signal,
-        );
-      } else {
-        try {
-          if (!signal?.aborted) {
-            const steering = getSteeringAtCheckpoint(config);
-            steeringMessages = Array.isArray(steering) ? steering : await steering;
-          }
-          if (steeringMessages.length > 0) {
-            skippedReady = { args: execution.args, startEmitted: true };
-            skippedStartIndex = callIndex;
-            break;
-          }
-          const executed = await execution.execute(() =>
-            batchLifecycle?.commitReadyCalls([{ toolCallId: toolCall.id, args: execution.args }]),
-          );
-          finalized = await finalizeExecutedToolCall(
-            currentContext,
-            assistantMessage,
-            preparation,
-            executed,
-            execution.args,
-            config,
-            signal,
-          );
-        } finally {
-          execution.dispose();
+      try {
+        if (!batch.signal?.aborted) {
+          const steering = getSteeringAtCheckpoint(batch.config);
+          steeringMessages = Array.isArray(steering) ? steering : await steering;
         }
+        if (steeringMessages.length > 0) {
+          skippedReady = { args: entry.execution.args, startEmitted: true };
+          skippedStartIndex = callIndex;
+          break;
+        }
+        const launches = await launchParallelToolCalls([entry], batch.lifecycle);
+        if (launches.rejected) {
+          fatal = { error: launches.rejected.error };
+          batch.lifecycle?.releaseSkippedCalls(
+            validatedToolCallIds(batch, toolCalls.slice(callIndex)),
+          );
+          const completed = await completeUnstartedToolCall(batch, toolCall, {
+            args: entry.execution.args,
+            details: TOOL_ADMISSION_FAILURE_DETAILS,
+            message: TOOL_ADMISSION_FAILURE_MESSAGE,
+            startEmitted: true,
+          });
+          await emitToolResultMessage(completed.message, batch.emit);
+          finalizedCalls.push(completed.finalized);
+          messages.push(completed.message);
+          skippedStartIndex = callIndex + 1;
+          break;
+        }
+        let executed = launches.completed[0]?.outcome;
+        if (!executed) {
+          const startedOutcome = launches.started[0]?.outcome;
+          if (!startedOutcome) {
+            throw new Error("Tool launch finished without an outcome");
+          }
+          executed = await startedOutcome;
+        }
+        finalized = await finalizeExecutedToolCall(batch, entry, executed, entry.execution.args);
+      } finally {
+        entry.execution.dispose();
       }
     }
 
-    await emitToolExecutionEnd(finalized, emit);
+    await emitToolExecutionEnd(finalized, batch.emit);
     const toolResultMessage = createToolResultMessage(finalized);
-    await emitToolResultMessage(toolResultMessage, emit);
+    await emitToolResultMessage(toolResultMessage, batch.emit);
     finalizedCalls.push(finalized);
     messages.push(toolResultMessage);
 
-    if (signal?.aborted) {
+    if (batch.signal?.aborted) {
       skippedStartIndex = callIndex + 1;
       break;
     }
@@ -890,19 +811,21 @@ async function executeToolCallsSequential(
 
   // A steer accepted during the final call's awaited preflight or execution
   // must outrank shouldStopAfterTurn even when there is no remaining tail.
-  if (!signal?.aborted && steeringMessages.length === 0 && skippedStartIndex === toolCalls.length) {
-    const steering = getSteeringAtCheckpoint(config);
+  if (
+    !fatal &&
+    !batch.signal?.aborted &&
+    steeringMessages.length === 0 &&
+    skippedStartIndex === toolCalls.length
+  ) {
+    const steering = getSteeringAtCheckpoint(batch.config);
     steeringMessages = Array.isArray(steering) ? steering : await steering;
   }
 
   // Complete the unstarted tail through one lifecycle path so committed tool
   // calls remain paired and outcome hooks observe every synthetic result.
   if (steeringMessages.length > 0) {
-    batchLifecycle?.releaseSkippedCalls(
-      toolCalls
-        .slice(skippedStartIndex)
-        .filter((toolCall) => validatedToolCalls.get(toolCall)?.kind === "validated")
-        .map((toolCall) => toolCall.id),
+    batch.lifecycle?.releaseSkippedCalls(
+      validatedToolCallIds(batch, toolCalls.slice(skippedStartIndex)),
     );
   }
   for (let i = skippedStartIndex; i < toolCalls.length; i++) {
@@ -911,25 +834,21 @@ async function executeToolCallsSequential(
       continue;
     }
     const isSteeringSkip = steeringMessages.length > 0;
-    const completed = await completeUnstartedToolCall(
-      currentContext,
-      assistantMessage,
-      skippedToolCall,
-      resolvedToolCalls,
-      config,
-      signal,
-      emit,
-      {
-        ...(i === skippedStartIndex && skippedReady ? skippedReady : {}),
-        ...(isSteeringSkip
+    const completed = await completeUnstartedToolCall(batch, skippedToolCall, {
+      ...(i === skippedStartIndex && skippedReady ? skippedReady : {}),
+      ...(fatal
+        ? {
+            details: TOOL_ADMISSION_FAILURE_DETAILS,
+            message: TOOL_ADMISSION_FAILURE_MESSAGE,
+          }
+        : isSteeringSkip
           ? {
               details: { status: "skipped", deniedReason: "steering" },
               message: STEERING_TOOL_SKIP_MESSAGE,
             }
           : {}),
-      },
-    );
-    await emitToolResultMessage(completed.message, emit);
+    });
+    await emitToolResultMessage(completed.message, batch.emit);
     finalizedCalls.push(completed.finalized);
     messages.push(completed.message);
   }
@@ -939,198 +858,143 @@ async function executeToolCallsSequential(
     steeringMessages,
     terminate: shouldTerminateToolBatch(finalizedCalls),
     terminateRun: false,
+    ...(fatal ? { fatal } : {}),
   };
 }
 
 async function executeToolCallsParallel(
-  currentContext: AgentContext,
-  assistantMessage: AssistantMessage,
+  batch: ToolBatchContext,
   toolCalls: AgentToolCall[],
-  resolvedToolCalls: Map<AgentToolCall, ResolvedToolCallOutcome>,
-  validatedToolCalls: Map<AgentToolCall, ValidatedToolCallOutcome>,
-  batchLifecycle: InternalToolBatchLifecycle | undefined,
-  config: AgentLoopConfig,
-  signal: AbortSignal | undefined,
-  emit: AgentEventSink,
 ): Promise<ExecutedToolCallBatch> {
-  const finalizedCalls: FinalizedToolCallEntry[] = [];
-  const pendingExecutions = new Set<ReadyToolCallExecution>();
+  const entries: FinalizedToolCallEntry[] = [];
 
   try {
     for (const toolCall of toolCalls) {
-      const hideFromChannelProgress = hidesToolCallFromChannelProgress(
-        currentContext,
-        toolCall,
-        resolvedToolCalls,
-      );
-      await emit({
-        type: "tool_execution_start",
-        toolCallId: toolCall.id,
-        toolName: toolCall.name,
-        args: toolCall.arguments,
-        ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
-      });
-
-      const preparation = await prepareToolCall(
-        currentContext,
-        assistantMessage,
-        toolCall,
-        config,
-        signal,
-        resolvedToolCalls,
-        validatedToolCalls,
-      );
-      if (preparation.kind === "immediate") {
-        const finalized = await finalizeToolCallOutcome(
-          currentContext,
-          assistantMessage,
-          {
-            toolCall,
-            result: preparation.result,
-            isError: preparation.isError,
-            executionStarted: false,
-            ...(preparation.errorKind ? { errorKind: preparation.errorKind } : {}),
-            ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
-          },
-          toolCall.arguments,
-          config,
-          signal,
-        );
-        await emitToolExecutionEnd(finalized, emit);
-        finalizedCalls.push(finalized);
-        if (signal?.aborted) {
-          break;
-        }
-        continue;
+      const entry = await prepareToolCallEntry(batch, toolCall);
+      entries.push(entry);
+      if (!("kind" in entry)) {
+        await emitToolExecutionEnd(entry, batch.emit);
       }
-
-      const execution = await prepareToolCallExecution(
-        preparation,
-        { assistantMessage, toolCall: preparation.toolCall },
-        signal,
-        emit,
-      );
-      if (execution.kind === "immediate") {
-        const finalized = await finalizeExecutedToolCall(
-          currentContext,
-          assistantMessage,
-          preparation,
-          execution.outcome,
-          preparation.args,
-          config,
-          signal,
-        );
-        await emitToolExecutionEnd(finalized, emit);
-        finalizedCalls.push(finalized);
-        if (signal?.aborted) {
-          break;
-        }
-        continue;
-      }
-
-      pendingExecutions.add(execution);
-      finalizedCalls.push({ ...preparation, execution });
-      if (signal?.aborted) {
+      if (batch.signal?.aborted) {
         break;
       }
     }
 
-    const steering = signal?.aborted ? [] : getSteeringAtCheckpoint(config);
+    const steering = batch.signal?.aborted ? [] : getSteeringAtCheckpoint(batch.config);
     const steeringMessages = Array.isArray(steering) ? steering : await steering;
     const skippedToolCallIds = [
       ...(steeringMessages.length > 0
-        ? finalizedCalls.flatMap((entry) => ("kind" in entry ? [entry.toolCall.id] : []))
+        ? entries.flatMap((entry) => ("kind" in entry ? [entry.toolCall.id] : []))
         : []),
       ...(steeringMessages.length > 0
-        ? toolCalls.slice(finalizedCalls.length).map((toolCall) => toolCall.id)
+        ? toolCalls.slice(entries.length).map((toolCall) => toolCall.id)
         : []),
     ];
     if (skippedToolCallIds.length > 0) {
-      batchLifecycle?.releaseSkippedCalls(skippedToolCallIds);
+      batch.lifecycle?.releaseSkippedCalls(skippedToolCallIds);
     }
-    const orderedFinalizedCalls: FinalizedToolCallOutcome[] = [];
+    const orderedFinalizedCalls: Array<FinalizedToolCallOutcome | undefined> = entries.map(
+      (entry) => ("kind" in entry ? undefined : entry),
+    );
+    let fatal: ExecutedToolCallBatch["fatal"];
     if (steeringMessages.length > 0) {
-      for (const entry of finalizedCalls) {
+      for (const [index, entry] of entries.entries()) {
         if (!("kind" in entry)) {
-          orderedFinalizedCalls.push(entry);
           continue;
         }
         entry.execution.dispose();
-        pendingExecutions.delete(entry.execution);
-        const completed = await completeUnstartedToolCall(
-          currentContext,
-          assistantMessage,
-          entry.toolCall,
-          resolvedToolCalls,
-          config,
-          signal,
-          emit,
-          {
-            args: entry.execution.args,
-            details: { status: "skipped", deniedReason: "steering" },
-            message: STEERING_TOOL_SKIP_MESSAGE,
-            startEmitted: true,
-          },
-        );
-        orderedFinalizedCalls.push(completed.finalized);
+        const completed = await completeUnstartedToolCall(batch, entry.toolCall, {
+          args: entry.execution.args,
+          details: { status: "skipped", deniedReason: "steering" },
+          message: STEERING_TOOL_SKIP_MESSAGE,
+          startEmitted: true,
+        });
+        orderedFinalizedCalls[index] = completed.finalized;
       }
     } else {
-      orderedFinalizedCalls.push(
-        ...(await Promise.all(
-          finalizedCalls.map(async (entry) => {
-            if (!("kind" in entry)) {
-              return entry;
-            }
-            try {
-              const executed = await entry.execution.execute(() =>
-                batchLifecycle?.commitReadyCalls([
-                  { toolCallId: entry.toolCall.id, args: entry.execution.args },
-                ]),
-              );
-              const finalized = await finalizeExecutedToolCall(
-                currentContext,
-                assistantMessage,
-                entry,
-                executed,
-                entry.execution.args,
-                config,
-                signal,
-              );
-              await emitToolExecutionEnd(finalized, emit);
-              return finalized;
-            } finally {
-              entry.execution.dispose();
-              pendingExecutions.delete(entry.execution);
-            }
-          }),
-        )),
+      const launched = await launchParallelToolCalls(entries, batch.lifecycle);
+      for (const { index, entry, outcome } of launched.completed) {
+        const finalized = await finalizeExecutedToolCall(
+          batch,
+          entry,
+          outcome,
+          entry.execution.args,
+        );
+        await emitToolExecutionEnd(finalized, batch.emit);
+        orderedFinalizedCalls[index] = finalized;
+        entry.execution.dispose();
+      }
+      const rejectedIndex = launched.rejected?.index ?? -1;
+      fatal = launched.rejected ? { error: launched.rejected.error } : undefined;
+      if (fatal) {
+        const unstartedIds = entries
+          .slice(rejectedIndex)
+          .flatMap((entry) => ("kind" in entry ? [entry.toolCall.id] : []));
+        batch.lifecycle?.releaseSkippedCalls([
+          ...unstartedIds,
+          ...validatedToolCallIds(batch, toolCalls.slice(entries.length)),
+        ]);
+        for (let index = rejectedIndex; index < entries.length; index++) {
+          const entry = entries[index];
+          if (!entry || !("kind" in entry)) {
+            continue;
+          }
+          entry.execution.dispose();
+          const completed = await completeUnstartedToolCall(batch, entry.toolCall, {
+            args: entry.execution.args,
+            details: TOOL_ADMISSION_FAILURE_DETAILS,
+            message: TOOL_ADMISSION_FAILURE_MESSAGE,
+            startEmitted: true,
+          });
+          orderedFinalizedCalls[index] = completed.finalized;
+        }
+      }
+      await Promise.all(
+        launched.started.map(async ({ index, entry, outcome }) => {
+          try {
+            const finalized = await finalizeExecutedToolCall(
+              batch,
+              entry,
+              await outcome,
+              entry.execution.args,
+            );
+            await emitToolExecutionEnd(finalized, batch.emit);
+            orderedFinalizedCalls[index] = finalized;
+          } finally {
+            entry.execution.dispose();
+          }
+        }),
       );
     }
     const messages: ToolResultMessage[] = [];
     for (const finalized of orderedFinalizedCalls) {
+      if (!finalized) {
+        continue;
+      }
       const toolResultMessage = createToolResultMessage(finalized);
-      await emitToolResultMessage(toolResultMessage, emit);
+      await emitToolResultMessage(toolResultMessage, batch.emit);
       messages.push(toolResultMessage);
     }
 
     // Complete calls skipped before queueing through the same lifecycle contract
     // as the sequential path.
-    if (signal?.aborted && orderedFinalizedCalls.length < toolCalls.length) {
-      for (let i = orderedFinalizedCalls.length; i < toolCalls.length; i++) {
+    if ((batch.signal?.aborted || fatal) && entries.length < toolCalls.length) {
+      for (let i = entries.length; i < toolCalls.length; i++) {
         const skippedToolCall = toolCalls[i];
         if (!skippedToolCall) {
           continue;
         }
         const completed = await completeUnstartedToolCall(
-          currentContext,
-          assistantMessage,
+          batch,
           skippedToolCall,
-          resolvedToolCalls,
-          config,
-          signal,
-          emit,
+          fatal
+            ? {
+                details: TOOL_ADMISSION_FAILURE_DETAILS,
+                message: TOOL_ADMISSION_FAILURE_MESSAGE,
+              }
+            : undefined,
         );
-        await emitToolResultMessage(completed.message, emit);
+        await emitToolResultMessage(completed.message, batch.emit);
         orderedFinalizedCalls.push(completed.finalized);
         messages.push(completed.message);
       }
@@ -1139,12 +1003,19 @@ async function executeToolCallsParallel(
     return {
       messages,
       steeringMessages,
-      terminate: shouldTerminateToolBatch(orderedFinalizedCalls),
+      terminate: shouldTerminateToolBatch(
+        orderedFinalizedCalls.filter(
+          (entry): entry is FinalizedToolCallOutcome => entry !== undefined,
+        ),
+      ),
       terminateRun: false,
+      ...(fatal ? { fatal } : {}),
     };
   } finally {
-    for (const execution of pendingExecutions) {
-      execution.dispose();
+    for (const entry of entries) {
+      if ("kind" in entry) {
+        entry.execution.dispose();
+      }
     }
   }
 }
@@ -1199,6 +1070,130 @@ type FinalizedToolCallOutcome = {
 
 type FinalizedToolCallEntry = FinalizedToolCallOutcome | ReadyPreparedToolCall;
 
+type StartedToolCall = {
+  index: number;
+  entry: ReadyPreparedToolCall;
+  outcome: Promise<ExecutedToolCallOutcome>;
+};
+
+type ParallelToolCallLaunches = {
+  started: StartedToolCall[];
+  completed: Array<Omit<StartedToolCall, "outcome"> & { outcome: ExecutedToolCallOutcome }>;
+  rejected?: { index: number; error: unknown };
+};
+
+async function prepareToolCallEntry(
+  batch: ToolBatchContext,
+  toolCall: AgentToolCall,
+): Promise<FinalizedToolCallEntry> {
+  const hideFromChannelProgress = hidesToolCallFromChannelProgress(
+    batch.currentContext,
+    toolCall,
+    batch.resolved,
+  );
+  await batch.emit({
+    type: "tool_execution_start",
+    toolCallId: toolCall.id,
+    toolName: toolCall.name,
+    args: toolCall.arguments,
+    ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
+  });
+  const preparation = await prepareToolCall(batch, toolCall);
+  if (preparation.kind === "immediate") {
+    return await finalizeToolCallOutcome(
+      batch,
+      {
+        toolCall,
+        result: preparation.result,
+        isError: preparation.isError,
+        executionStarted: false,
+        ...(preparation.errorKind ? { errorKind: preparation.errorKind } : {}),
+        ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
+      },
+      toolCall.arguments,
+    );
+  }
+  const execution = await prepareToolCallExecution(
+    preparation,
+    { assistantMessage: batch.assistantMessage, toolCall: preparation.toolCall },
+    batch.signal,
+    batch.emit,
+  );
+  return execution.kind === "immediate"
+    ? await finalizeExecutedToolCall(batch, preparation, execution.outcome, preparation.args)
+    : { ...preparation, execution };
+}
+
+async function launchParallelToolCalls(
+  entries: FinalizedToolCallEntry[],
+  batchLifecycle: InternalToolBatchLifecycle | undefined,
+): Promise<ParallelToolCallLaunches> {
+  const ready = entries.flatMap((entry, index) => ("kind" in entry ? [{ entry, index }] : []));
+  const result: ParallelToolCallLaunches = { started: [], completed: [] };
+  let cursor = 0;
+  let finish!: () => void;
+  let finished = false;
+  const done = new Promise<void>((resolve) => {
+    finish = () => {
+      if (!finished) {
+        finished = true;
+        resolve();
+      }
+    };
+  });
+  const launchNext = () => {
+    const current = ready[cursor++];
+    if (!current) {
+      finish();
+      return;
+    }
+    const launchState: { outcome?: Promise<ExecutedToolCallOutcome> } = {};
+    let started = false;
+    let rejected = false;
+    const onStart = () => {
+      try {
+        batchLifecycle?.commitReadyCalls([
+          { toolCallId: current.entry.toolCall.id, args: current.entry.execution.args },
+        ]);
+      } catch (error) {
+        rejected = true;
+        result.rejected = { index: current.index, error };
+        finish();
+        throw error;
+      }
+      started = true;
+      if (launchState.outcome) {
+        result.started.push({ ...current, outcome: launchState.outcome });
+      }
+      // Advance only from the final source-start callback so guard → commit → implementation stays
+      // adjacent while started bodies overlap; pre-source completion advances below without commit.
+      queueMicrotask(launchNext);
+    };
+    const outcome = current.entry.execution.execute(onStart);
+    launchState.outcome = outcome;
+    if (started) {
+      result.started.push({ ...current, outcome });
+    }
+    void outcome.then(
+      (completed) => {
+        if (!started && !rejected) {
+          result.completed.push({ ...current, outcome: completed });
+          queueMicrotask(launchNext);
+        }
+      },
+      (error: unknown) => {
+        if (!rejected) {
+          result.rejected = { index: current.index, error };
+          finish();
+        }
+      },
+    );
+  };
+  launchNext();
+  await done;
+  return result;
+}
+
 function shouldTerminateToolBatch(finalizedCalls: FinalizedToolCallOutcome[]): boolean {
   return (
     finalizedCalls.length > 0 &&
@@ -1221,28 +1216,24 @@ function prepareToolCallArguments(tool: AgentTool, toolCall: AgentToolCall): Age
 }
 
 async function resolveToolCallTool(
-  currentContext: AgentContext,
-  assistantMessage: AssistantMessage,
+  batch: ToolBatchContext,
   toolCall: AgentToolCall,
-  config: AgentLoopConfig,
-  signal: AbortSignal | undefined,
-  resolvedToolCalls?: Map<AgentToolCall, ResolvedToolCallOutcome>,
 ): Promise<ResolvedToolCallOutcome> {
-  const cached = resolvedToolCalls?.get(toolCall);
+  const cached = batch.resolved.get(toolCall);
   if (cached) {
     return cached;
   }
   let resolution: ResolvedToolCallOutcome;
   try {
-    let tool = currentContext.tools?.find((t) => t.name === toolCall.name);
+    let tool = batch.currentContext.tools?.find((t) => t.name === toolCall.name);
     if (!tool) {
-      const resolvedTool = await config.resolveDeferredTool?.(
+      const resolvedTool = await batch.config.resolveDeferredTool?.(
         {
-          assistantMessage,
+          assistantMessage: batch.assistantMessage,
           toolCall,
-          context: currentContext,
+          context: batch.currentContext,
         },
-        signal,
+        batch.signal,
       );
       // Keep execution and lifecycle/audit identity aligned with the original model call.
       if (resolvedTool && resolvedTool.name !== toolCall.name) {
@@ -1253,28 +1244,23 @@ async function resolveToolCallTool(
       tool = resolvedTool;
       if (tool) {
         // Make the recovered tool visible to later provider continuations in this run.
-        currentContext.tools = [...(currentContext.tools ?? []), tool];
+        batch.currentContext.tools = [...(batch.currentContext.tools ?? []), tool];
       }
     }
     resolution = { kind: "resolved", ...(tool ? { tool } : {}) };
   } catch (error) {
     resolution = { kind: "error", error };
   }
-  resolvedToolCalls?.set(toolCall, resolution);
+  batch.resolved.set(toolCall, resolution);
   return resolution;
 }
 
 async function prepareToolCall(
-  currentContext: AgentContext,
-  assistantMessage: AssistantMessage,
+  batch: ToolBatchContext,
   toolCall: AgentToolCall,
-  config: AgentLoopConfig,
-  signal: AbortSignal | undefined,
-  resolvedToolCalls: Map<AgentToolCall, ResolvedToolCallOutcome>,
-  validatedToolCalls: Map<AgentToolCall, ValidatedToolCallOutcome>,
 ): Promise<PreparedToolCall | ImmediateToolCallOutcome> {
-  const cachedValidation = validatedToolCalls.get(toolCall);
-  if (signal?.aborted && !cachedValidation) {
+  const cachedValidation = batch.validated.get(toolCall);
+  if (batch.signal?.aborted && !cachedValidation) {
     // Execution cannot start after cancellation, so never begin validation
     // work (including deferred tool resolvers) for an uncached call.
     return {
@@ -1283,33 +1269,24 @@ async function prepareToolCall(
       isError: true,
     };
   }
-  const validation =
-    cachedValidation ??
-    (await validateToolCallForBatchAdmission(
-      currentContext,
-      assistantMessage,
-      toolCall,
-      config,
-      signal,
-      resolvedToolCalls,
-    ));
+  const validation = cachedValidation ?? (await validateToolCallForBatchAdmission(batch, toolCall));
   if (validation.kind === "immediate") {
     return validation.outcome;
   }
   const { args: validatedArgs } = validation.prepared;
 
   try {
-    if (config.beforeToolCall) {
-      const beforeResult = await config.beforeToolCall(
+    if (batch.config.beforeToolCall) {
+      const beforeResult = await batch.config.beforeToolCall(
         {
-          assistantMessage,
+          assistantMessage: batch.assistantMessage,
           toolCall,
           args: validatedArgs,
-          context: currentContext,
+          context: batch.currentContext,
         },
-        signal,
+        batch.signal,
       );
-      if (signal?.aborted) {
+      if (batch.signal?.aborted) {
         return {
           kind: "immediate",
           result: createErrorToolResult("Operation aborted"),
@@ -1324,7 +1301,7 @@ async function prepareToolCall(
         };
       }
     }
-    if (signal?.aborted) {
+    if (batch.signal?.aborted) {
       return {
         kind: "immediate",
         result: createErrorToolResult("Operation aborted"),
@@ -1342,28 +1319,17 @@ async function prepareToolCall(
 }
 
 async function validateToolCallForBatchAdmission(
-  currentContext: AgentContext,
-  assistantMessage: AssistantMessage,
+  batch: ToolBatchContext,
   toolCall: AgentToolCall,
-  config: AgentLoopConfig,
-  signal: AbortSignal | undefined,
-  resolvedToolCalls: Map<AgentToolCall, ResolvedToolCallOutcome>,
 ): Promise<ValidatedToolCallOutcome> {
-  const resolution = await resolveToolCallTool(
-    currentContext,
-    assistantMessage,
-    toolCall,
-    config,
-    signal,
-    resolvedToolCalls,
-  );
+  const resolution = await resolveToolCallTool(batch, toolCall);
   if (resolution.kind === "error") {
     return {
       kind: "immediate",
       outcome: {
         kind: "immediate",
         result: createErrorToolResult(
-          signal?.aborted ? "Operation aborted" : coerceErrorMessage(resolution.error),
+          batch.signal?.aborted ? "Operation aborted" : coerceErrorMessage(resolution.error),
         ),
         isError: true,
       },
@@ -1475,46 +1441,45 @@ async function prepareToolCallExecution(
       args,
       dispose,
       async execute(onImplementationStart) {
-        if (signal?.aborted) {
-          dispose();
-          await finishUpdates();
-          return {
-            result: createErrorToolResult("Operation aborted"),
-            isError: true,
-            executionStarted: false,
-          };
-        }
         let executionStarted = false;
         let implementationStartError: { error: unknown } | undefined;
         try {
-          const result = await run(() => {
-            try {
-              onImplementationStart?.();
-            } catch (error) {
-              implementationStartError = { error };
-              throw error;
+          if (signal?.aborted) {
+            return {
+              result: createErrorToolResult("Operation aborted"),
+              isError: true,
+              executionStarted: false,
+            };
+          }
+          try {
+            const result = await run(() => {
+              try {
+                onImplementationStart?.();
+              } catch (error) {
+                implementationStartError = { error };
+                throw error;
+              }
+              executionStarted = true;
+            });
+            if (implementationStartError) {
+              throw implementationStartError.error;
             }
-            executionStarted = true;
-          });
-          if (implementationStartError) {
-            throw implementationStartError.error;
+            return { result, isError: false, executionStarted };
+          } catch (error) {
+            if (implementationStartError) {
+              throw implementationStartError.error;
+            }
+            return {
+              result: createErrorToolResult(coerceErrorMessage(error)),
+              isError: true,
+              executionStarted,
+              ...(executionStarted && signal?.aborted && error === signal.reason
+                ? { callerCancelled: true }
+                : {}),
+            };
           }
-          await finishUpdates();
-          return { result, isError: false, executionStarted };
-        } catch (error) {
-          await finishUpdates();
-          if (implementationStartError) {
-            throw implementationStartError.error;
-          }
-          return {
-            result: createErrorToolResult(coerceErrorMessage(error)),
-            isError: true,
-            executionStarted,
-            ...(executionStarted && signal?.aborted && error === signal.reason
-              ? { callerCancelled: true }
-              : {}),
-          };
         } finally {
+          await finishUpdates();
           dispose();
         }
       },
@@ -1556,23 +1521,20 @@ async function prepareToolCallExecution(
   if (internalPreparation.kind === "immediate") {
     internalPreparation.dispose();
     await finishUpdates();
-    if (internalPreparation.outcome.kind === "result") {
-      return {
-        kind: "immediate",
-        outcome: {
-          result: internalPreparation.outcome.result,
-          isError: internalPreparation.outcome.isError,
-          executionStarted: false,
-        },
-      };
-    }
     return {
       kind: "immediate",
-      outcome: {
-        result: createErrorToolResult(coerceErrorMessage(internalPreparation.outcome.error)),
-        isError: true,
-        executionStarted: false,
-      },
+      outcome:
+        internalPreparation.outcome.kind === "result"
+          ? {
+              result: internalPreparation.outcome.result,
+              isError: internalPreparation.outcome.isError,
+              executionStarted: false,
+            }
+          : {
+              result: createErrorToolResult(coerceErrorMessage(internalPreparation.outcome.error)),
+              isError: true,
+              executionStarted: false,
+            },
     };
   }
 
@@ -1588,29 +1550,26 @@ async function prepareToolCallExecution(
 }
 
 async function finalizeExecutedToolCall(
-  currentContext: AgentContext,
-  assistantMessage: AssistantMessage,
+  batch: ToolBatchContext,
   prepared: PreparedToolCall,
   executed: ExecutedToolCallOutcome,
   finalArgs: unknown,
-  config: AgentLoopConfig,
-  signal: AbortSignal | undefined,
 ): Promise<FinalizedToolCallOutcome> {
   let result = executed.result;
   let isError = executed.isError;
 
-  if (executed.executionStarted && config.afterToolCall) {
+  if (executed.executionStarted && batch.config.afterToolCall) {
     try {
-      const afterResult = await config.afterToolCall(
+      const afterResult = await batch.config.afterToolCall(
         {
-          assistantMessage,
+          assistantMessage: batch.assistantMessage,
           toolCall: prepared.toolCall,
           args: finalArgs,
           result,
           isError,
-          context: currentContext,
+          context: batch.currentContext,
         },
-        signal,
+        batch.signal,
       );
       if (afterResult) {
         result = {
@@ -1628,8 +1587,7 @@ async function finalizeExecutedToolCall(
   }
 
   return await finalizeToolCallOutcome(
-    currentContext,
-    assistantMessage,
+    batch,
     {
       toolCall: prepared.toolCall,
       result,
@@ -1643,35 +1601,30 @@ async function finalizeExecutedToolCall(
         : {}),
     },
     finalArgs,
-    config,
-    signal,
   );
 }
 
 async function finalizeToolCallOutcome(
-  currentContext: AgentContext,
-  assistantMessage: AssistantMessage,
+  batch: ToolBatchContext,
   finalized: FinalizedToolCallOutcome,
   args: unknown,
-  config: AgentLoopConfig,
-  signal: AbortSignal | undefined,
 ): Promise<FinalizedToolCallOutcome> {
-  if (!config.afterToolOutcome) {
+  if (!batch.config.afterToolOutcome) {
     return finalized;
   }
   try {
-    const afterResult = await config.afterToolOutcome(
+    const afterResult = await batch.config.afterToolOutcome(
       {
-        assistantMessage,
+        assistantMessage: batch.assistantMessage,
         toolCall: finalized.toolCall,
         args,
         result: finalized.result,
         isError: finalized.isError,
         executionStarted: finalized.executionStarted,
         ...(finalized.errorKind ? { errorKind: finalized.errorKind } : {}),
-        context: currentContext,
+        context: batch.currentContext,
       },
-      signal,
+      batch.signal,
     );
     if (!afterResult) {
       return finalized;
@@ -1701,27 +1654,23 @@ async function finalizeToolCallOutcome(
   }
 }
 
-async function completeToolLoopInterventionBatch(params: {
-  currentContext: AgentContext;
-  assistantMessage: AssistantMessage;
-  toolCalls: AgentToolCall[];
-  resolvedToolCalls: Map<AgentToolCall, ResolvedToolCallOutcome>;
-  validatedToolCalls: Map<AgentToolCall, ValidatedToolCallOutcome>;
-  config: AgentLoopConfig;
-  signal: AbortSignal | undefined;
-  emit: AgentEventSink;
-  intervention: ToolLoopIntervention;
-  terminal: boolean;
-}): Promise<ExecutedToolCallBatch> {
+async function completeToolLoopInterventionBatch(
+  batch: ToolBatchContext,
+  params: {
+    toolCalls: AgentToolCall[];
+    intervention: ToolLoopIntervention;
+    terminal: boolean;
+  },
+): Promise<ExecutedToolCallBatch> {
   const messages: ToolResultMessage[] = [];
   const finalizedCalls: FinalizedToolCallOutcome[] = [];
   for (const toolCall of params.toolCalls) {
     const hideFromChannelProgress = hidesToolCallFromChannelProgress(
-      params.currentContext,
+      batch.currentContext,
       toolCall,
-      params.resolvedToolCalls,
+      batch.resolved,
     );
-    await params.emit({
+    await batch.emit({
       type: "tool_execution_start",
       toolCallId: toolCall.id,
       toolName: toolCall.name,
@@ -1736,13 +1685,12 @@ async function completeToolLoopInterventionBatch(params: {
       : isTrigger
         ? `${params.intervention.reason}\n\nDo not repeat this exact tool action. Reassess the task. You may answer the user, ask for clarification, or continue with a different tool or different arguments.`
         : "This tool was not executed because another call in the batch triggered critical tool-loop recovery. Reassess the task before choosing the next action.";
-    const validation = params.validatedToolCalls.get(toolCall);
+    const validation = batch.validated.get(toolCall);
     // Rejected calls never start executing, so they must not inherit the
     // resolved tool's result content source; that metadata is only truthful
     // after execution starts and would otherwise taint the recovery turn.
     const finalized = await finalizeToolCallOutcome(
-      params.currentContext,
-      params.assistantMessage,
+      batch,
       {
         toolCall,
         result: {
@@ -1759,12 +1707,10 @@ async function completeToolLoopInterventionBatch(params: {
         ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
       },
       validation?.kind === "validated" ? validation.prepared.args : toolCall.arguments,
-      params.config,
-      params.signal,
     );
-    await emitToolExecutionEnd(finalized, params.emit);
+    await emitToolExecutionEnd(finalized, batch.emit);
     const message = createToolResultMessage(finalized);
-    await emitToolResultMessage(message, params.emit);
+    await emitToolResultMessage(message, batch.emit);
     messages.push(message);
     finalizedCalls.push(finalized);
   }
@@ -1781,13 +1727,8 @@ async function completeToolLoopInterventionBatch(params: {
 }
 
 async function completeUnstartedToolCall(
-  currentContext: AgentContext,
-  assistantMessage: AssistantMessage,
+  batch: ToolBatchContext,
   toolCall: AgentToolCall,
-  resolvedToolCalls: Map<AgentToolCall, ResolvedToolCallOutcome>,
-  config: AgentLoopConfig,
-  signal: AbortSignal | undefined,
-  emit: AgentEventSink,
   options: {
     args?: unknown;
     details?: unknown;
@@ -1796,12 +1737,12 @@ async function completeUnstartedToolCall(
   } = {},
 ): Promise<{ finalized: FinalizedToolCallOutcome; message: ToolResultMessage }> {
   const hideFromChannelProgress = hidesToolCallFromChannelProgress(
-    currentContext,
+    batch.currentContext,
     toolCall,
-    resolvedToolCalls,
+    batch.resolved,
   );
   if (!options.startEmitted) {
-    await emit({
+    await batch.emit({
       type: "tool_execution_start",
       toolCallId: toolCall.id,
       toolName: toolCall.name,
@@ -1810,8 +1751,7 @@ async function completeUnstartedToolCall(
     });
   }
   const finalized = await finalizeToolCallOutcome(
-    currentContext,
-    assistantMessage,
+    batch,
     {
       toolCall,
       result: createErrorToolResult(options.message ?? "Operation aborted", options.details),
@@ -1820,10 +1760,8 @@ async function completeUnstartedToolCall(
       ...(hideFromChannelProgress ? { hideFromChannelProgress: true } : {}),
     },
     "args" in options ? options.args : toolCall.arguments,
-    config,
-    signal,
   );
-  await emitToolExecutionEnd(finalized, emit);
+  await emitToolExecutionEnd(finalized, batch.emit);
   const message = createToolResultMessage(finalized);
   return { finalized, message };
 }

--- a/packages/agent-core/src/internal-hooks.ts
+++ b/packages/agent-core/src/internal-hooks.ts
@@ -19,7 +19,7 @@ type InternalReadyToolCall = { toolCallId: string; args: unknown };
 export type InternalToolBatchLifecycle = {
   /** Commit admitted calls whose tool implementations are about to start. May throw before launch. */
   commitReadyCalls: (calls: readonly InternalReadyToolCall[]) => void;
-  /** Release admission state for admitted prepared calls suppressed by steering. */
+  /** Release admission state for admitted prepared calls that will not launch. */
   releaseSkippedCalls: (toolCallIds: readonly string[]) => void;
 };
 


### PR DESCRIPTION
## Summary

- Close tool-batch launch authority at the canonical agent-loop boundary so an idle or stale run cannot start prepared side effects.
- Preserve paired lifecycle, rejection, result, and turn events through one batch owner.
- Clone caller-owned message context unconditionally, including empty-prompt runs, so exported loop APIs never mutate the supplied transcript.

## Root cause

Tool execution admission and lifecycle settlement were spread across launch and result paths, allowing stale run state to reach a prepared tool. During consolidation, the empty-prompt path also reused the caller's messages array while the loop appends assistant and tool-result messages, violating the existing public context-isolation contract.

The current-main reconstruction keeps all intervening owner changes, centralizes launch admission, and restores an unconditional context clone before the loop mutates its working transcript.

## User impact

- Delayed tool side effects cannot start after the owning turn becomes idle.
- Lifecycle events remain paired for observers and recovery logic.
- Empty-prompt callers retain an unchanged input transcript.
- No new public API, configuration, persistence, or fallback behavior is introduced.

## Verification

- Two caller-context regressions failed before the correction and pass afterward.
- Agent-core owner, lifecycle, rejection-contract, and stale-authority coverage passed on the current-main reconstruction.
- Independent final verification and both mandatory local and committed-branch reviews completed without findings.

## Surface

- Three agent-core source/test files.
- Production: net -62 lines.
- Tests cover lifecycle admission and caller-context isolation at the exported loop boundary.
