### PR TITLE
fix(discord): honor explicit names for new forum posts

### DIFF
--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -258,7 +258,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
         return jsonResult(
           await appendDiscordThreadRenameResult(ctx, {
             payload: { ok: true, result, components: true },
-            target: to,
+            target: result.receipt?.threadId ?? to,
             threadName,
           }),
         );
@@ -309,7 +309,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
       return jsonResult(
         await appendDiscordThreadRenameResult(ctx, {
           payload: { ok: true, result },
-          target: to,
+          target: result.receipt?.threadId ?? to,
           threadName,
         }),
       );

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -2364,6 +2364,55 @@ describe("handleDiscordMessagingAction", () => {
     });
   });
 
+  it.each([
+    { label: "forum message", parentType: ChannelType.GuildForum, components: false },
+    { label: "media message", parentType: ChannelType.GuildMedia, components: false },
+    { label: "forum component media", parentType: ChannelType.GuildForum, components: true },
+    { label: "media component media", parentType: ChannelType.GuildMedia, components: true },
+  ])("renames the newly created $label thread", async ({ parentType, components }) => {
+    const sender = components ? sendDiscordComponentMessage : sendMessageDiscord;
+    sender.mockResolvedValueOnce({
+      messageId: "M1",
+      channelId: "T1",
+      receipt: { threadId: "T1" },
+    });
+    fetchChannelInfoDiscord.mockImplementation(async (channelId) => ({
+      id: channelId,
+      type: channelId === "P1" ? parentType : ChannelType.PublicThread,
+    }));
+    editChannelDiscord.mockResolvedValueOnce({
+      id: "T1",
+      name: "chosen-thread",
+    });
+
+    const result = await handleMessagingAction(
+      "sendMessage",
+      {
+        to: "channel:P1",
+        content: "A generated thread title",
+        threadName: "chosen-thread",
+        ...(components
+          ? {
+              components: { blocks: [{ type: "text", text: "A generated thread title" }] },
+              mediaUrl: "/tmp/image.png",
+            }
+          : {}),
+      },
+      enableAllActions,
+    );
+
+    expect(fetchChannelInfoDiscord).toHaveBeenCalledWith("T1", { cfg: DISCORD_TEST_CFG });
+    expect(editChannelDiscord).toHaveBeenCalledWith(
+      { channelId: "T1", name: "chosen-thread" },
+      { cfg: DISCORD_TEST_CFG },
+    );
+    expect(result.details).toMatchObject({
+      ok: true,
+      result: { channelId: "T1", receipt: { threadId: "T1" } },
+      threadRename: { ok: true, channelId: "T1", name: "chosen-thread" },
+    });
+  });
+
   it("forwards sendMessage suppressEmbeds overrides", async () => {
     sendMessageDiscord.mockClear();
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a message with an explicit thread name to a Discord forum or media channel would receive a post titled after the message content instead of the requested name. The same issue affected media messages expressed as classic Discord component payloads.

## Why This Change Was Made

Discord automatically creates a child thread when a message is sent to a forum or media parent. The send owner already records that child thread in its delivery receipt, but both message-action rename paths inspected the original parent and incorrectly concluded that it was not a thread. Rename the authoritative delivered child thread when the receipt identifies one, preserving the original destination for existing threads, direct messages, and senders without a thread receipt.

## User Impact

Explicit thread names now apply to newly created Discord forum and media posts for both ordinary messages and classic component-with-media sends. Existing thread renames, unsupported interactive forum components, direct-message warnings, voice sends, disabled channel management, and partial-delivery warnings keep their existing behavior.

## Evidence

- Tests-first regression reproduced four failures before the fix: ordinary forum, ordinary media, classic-component forum, and classic-component media sends each inspected parent `P1` instead of delivered thread `T1`.
- Focused Discord action, forum-thread producer, outbound adapter, and component suites: **4 files, 278 tests passed**.
- Existing component suite separately verifies that truly interactive components remain rejected for forum parents.
- Formatter, targeted oxlint, max-lines ratchet, and assertion-safety ratchet pass.
- Independent source/dependency review and fresh authenticated structured Codex review report no actionable findings.
- Production: **+2/-2, net 0**. Tests: **+49/-0**.
- Live Discord proof was not run because no disposable authenticated forum/media channel was available; owner-boundary RED→GREEN coverage and the existing Discord REST producer/component suites exercise the exact changed paths.
