### PR TITLE
test(daemon): deduplicate service fixtures

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -146,6 +146,40 @@ function createDefaultLaunchdEnv(): Record<string, string | undefined> {
   };
 }
 
+function createLaunchdEnvWithGatewayPort(port: string): Record<string, string | undefined> {
+  return { ...createDefaultLaunchdEnv(), OPENCLAW_GATEWAY_PORT: port };
+}
+
+function capturePassThroughOutput(
+  append: (text: string) => void,
+  encoding?: BufferEncoding,
+): PassThrough {
+  const stdout = new PassThrough();
+  stdout.on("data", (chunk: Buffer) => append(chunk.toString(encoding)));
+  return stdout;
+}
+
+function setLegacyGatewayLaunchAgentPlist(plistPath: string, extraLines: string[]): void {
+  state.files.set(
+    plistPath,
+    [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<plist version="1.0">',
+      "  <dict>",
+      "    <key>Label</key>",
+      "    <string>ai.openclaw.gateway</string>",
+      "    <key>ProgramArguments</key>",
+      "    <array>",
+      "      <string>node</string>",
+      "      <string>gateway.js</string>",
+      "    </array>",
+      ...extraLines,
+      "  </dict>",
+      "</plist>",
+    ].join("\n"),
+  );
+}
+
 async function installLaunchAgent(
   args: Parameters<typeof installLaunchAgentImpl>[0],
 ): ReturnType<typeof installLaunchAgentImpl> {
@@ -197,16 +231,46 @@ function createTestLaunchAgentPlist(params: {
   ].join("\n");
 }
 
-function setLaunchAgentPlist(params: {
-  env: Record<string, string | undefined>;
-  label: string;
-  programArguments: string[];
-  environment?: Record<string, string>;
-}): void {
+function setLaunchAgentPlist(
+  env: Record<string, string | undefined>,
+  label: string,
+  programArguments: string[],
+  environment?: Record<string, string>,
+): void {
   state.files.set(
-    `${params.env.HOME}/Library/LaunchAgents/${params.label}.plist`,
-    createTestLaunchAgentPlist(params),
+    `${env.HOME}/Library/LaunchAgents/${label}.plist`,
+    createTestLaunchAgentPlist({ label, programArguments, environment }),
   );
+}
+
+type LaunchAgentInstallFixture = Parameters<typeof installLaunchAgentImpl>[0];
+type LaunchAgentInstallOverrides = Omit<
+  LaunchAgentInstallFixture,
+  "env" | "stdout" | "programArguments"
+>;
+
+function launchAgentFixture(
+  env: LaunchAgentInstallFixture["env"],
+  programArguments: string[],
+  overrides: LaunchAgentInstallOverrides = {},
+): LaunchAgentInstallFixture {
+  return { env, stdout: new PassThrough(), programArguments, ...overrides };
+}
+
+function defaultLaunchAgentFixture(
+  env: LaunchAgentInstallFixture["env"],
+  overrides: LaunchAgentInstallOverrides = {},
+): LaunchAgentInstallFixture {
+  return launchAgentFixture(env, defaultProgramArguments, overrides);
+}
+
+type LaunchAgentControlFixture = Parameters<typeof stopLaunchAgent>[0];
+
+function launchAgentControlFixture(
+  env: LaunchAgentControlFixture["env"],
+  overrides: Omit<LaunchAgentControlFixture, "env" | "stdout"> = {},
+): LaunchAgentControlFixture {
+  return { env, stdout: new PassThrough(), ...overrides };
 }
 
 async function withProcessEnv<T>(
@@ -921,26 +985,19 @@ describe("launchctl list detection", () => {
         `2468 0 ${nonOpenClawLabel}`,
         `1357 0 ${prefixedCliLabel}`,
       ].join("\n");
-      setLaunchAgentPlist({
-        env,
-        label: updaterLabel,
-        programArguments: ["/opt/homebrew/bin/openclaw", "update", "--yes", "--json"],
-      });
-      setLaunchAgentPlist({
-        env,
-        label: gatewayLikeLabel,
-        programArguments: ["/opt/homebrew/bin/openclaw", "gateway", "run"],
-      });
-      setLaunchAgentPlist({
-        env,
-        label: nonOpenClawLabel,
-        programArguments: ["/bin/echo", "update", "--yes"],
-      });
-      setLaunchAgentPlist({
-        env,
-        label: prefixedCliLabel,
-        programArguments: ["/usr/local/bin/openclaw-helper", "update", "--yes"],
-      });
+      setLaunchAgentPlist(env, updaterLabel, [
+        "/opt/homebrew/bin/openclaw",
+        "update",
+        "--yes",
+        "--json",
+      ]);
+      setLaunchAgentPlist(env, gatewayLikeLabel, ["/opt/homebrew/bin/openclaw", "gateway", "run"]);
+      setLaunchAgentPlist(env, nonOpenClawLabel, ["/bin/echo", "update", "--yes"]);
+      setLaunchAgentPlist(env, prefixedCliLabel, [
+        "/usr/local/bin/openclaw-helper",
+        "update",
+        "--yes",
+      ]);
 
       const jobs = await findStaleOpenClawUpdateLaunchdJobs(env as NodeJS.ProcessEnv);
 
@@ -960,11 +1017,8 @@ describe("launchctl list detection", () => {
       const env = createDefaultLaunchdEnv();
       const updaterLabel = "ai.openclaw.tayoun.update.20260625T201026-0400";
       state.listOutput = `4321 0 ${updaterLabel}`;
-      setLaunchAgentPlist({
-        env,
-        label: updaterLabel,
-        programArguments: ["/opt/homebrew/bin/openclaw", "gateway", "run"],
-        environment: { OPENCLAW_UPDATE_RUN_HANDOFF: "1" },
+      setLaunchAgentPlist(env, updaterLabel, ["/opt/homebrew/bin/openclaw", "gateway", "run"], {
+        OPENCLAW_UPDATE_RUN_HANDOFF: "1",
       });
 
       const jobs = await findStaleOpenClawUpdateLaunchdJobs(env as NodeJS.ProcessEnv);
@@ -989,18 +1043,14 @@ describe("launchctl list detection", () => {
       const envFilePath = `${envDir}/${label}.env`;
       state.listOutput = `4321 0 ${label}`;
       state.files.set(envFilePath, "export PATH='/opt/homebrew/bin:/usr/bin'\n");
-      setLaunchAgentPlist({
-        env,
-        label,
-        programArguments: [
-          LAUNCH_AGENT_ENV_WRAPPER_SHELL,
-          wrapperPath,
-          envFilePath,
-          "/opt/homebrew/bin/openclaw",
-          "update",
-          "--yes",
-        ],
-      });
+      setLaunchAgentPlist(env, label, [
+        LAUNCH_AGENT_ENV_WRAPPER_SHELL,
+        wrapperPath,
+        envFilePath,
+        "/opt/homebrew/bin/openclaw",
+        "update",
+        "--yes",
+      ]);
 
       const jobs = await findStaleOpenClawUpdateLaunchdJobs(env as NodeJS.ProcessEnv);
 
@@ -1024,18 +1074,14 @@ describe("launchctl list detection", () => {
       const envFilePath = `${envDir}/${label}.env`;
       state.listOutput = `4321 0 ${label}`;
       state.files.set(envFilePath, "export OPENCLAW_UPDATE_RUN_HANDOFF='1'\n");
-      setLaunchAgentPlist({
-        env,
-        label,
-        programArguments: [
-          LAUNCH_AGENT_ENV_WRAPPER_SHELL,
-          wrapperPath,
-          envFilePath,
-          "/opt/homebrew/bin/openclaw",
-          "gateway",
-          "run",
-        ],
-      });
+      setLaunchAgentPlist(env, label, [
+        LAUNCH_AGENT_ENV_WRAPPER_SHELL,
+        wrapperPath,
+        envFilePath,
+        "/opt/homebrew/bin/openclaw",
+        "gateway",
+        "run",
+      ]);
 
       const jobs = await findStaleOpenClawUpdateLaunchdJobs(env as NodeJS.ProcessEnv);
 
@@ -1058,11 +1104,7 @@ describe("launchctl list detection", () => {
       };
       const gatewayLikeLabel = "ai.openclaw.dev.team.update.20260625T201026-0400";
       state.listOutput = `9876 0 ${gatewayLikeLabel}`;
-      setLaunchAgentPlist({
-        env,
-        label: gatewayLikeLabel,
-        programArguments: ["/opt/homebrew/bin/openclaw", "gateway", "run"],
-      });
+      setLaunchAgentPlist(env, gatewayLikeLabel, ["/opt/homebrew/bin/openclaw", "gateway", "run"]);
 
       const jobs = await findStaleOpenClawUpdateLaunchdJobs(env as NodeJS.ProcessEnv);
 
@@ -1212,11 +1254,12 @@ describe("launchctl list detection", () => {
     async () => {
       const env = createDefaultLaunchdEnv();
       const label = "ai.openclaw.tayoun.update.20260625T201026-0400";
-      setLaunchAgentPlist({
-        env,
-        label,
-        programArguments: ["/usr/local/bin/node", "/opt/openclaw/openclaw.mjs", "update", "--yes"],
-      });
+      setLaunchAgentPlist(env, label, [
+        "/usr/local/bin/node",
+        "/opt/openclaw/openclaw.mjs",
+        "update",
+        "--yes",
+      ]);
 
       await expect(
         disableCurrentOpenClawUpdateLaunchdJob({
@@ -1254,11 +1297,7 @@ describe("launchctl list detection", () => {
     async () => {
       const env = createDefaultLaunchdEnv();
       const label = "ai.openclaw.dev.team.update.20260625T201026-0400";
-      setLaunchAgentPlist({
-        env,
-        label,
-        programArguments: ["/opt/homebrew/bin/openclaw", "gateway", "run"],
-      });
+      setLaunchAgentPlist(env, label, ["/opt/homebrew/bin/openclaw", "gateway", "run"]);
 
       await expect(
         disableCurrentOpenClawUpdateLaunchdJob({
@@ -1277,11 +1316,7 @@ describe("launchctl list detection", () => {
     async () => {
       const env = createDefaultLaunchdEnv();
       const label = "ai.openclaw.tayoun.update.20260625T201026-0400";
-      setLaunchAgentPlist({
-        env,
-        label,
-        programArguments: ["/opt/homebrew/bin/openclaw", "update", "--yes"],
-      });
+      setLaunchAgentPlist(env, label, ["/opt/homebrew/bin/openclaw", "update", "--yes"]);
 
       await expect(
         disableCurrentOpenClawUpdateLaunchdJob({
@@ -1301,11 +1336,7 @@ describe("launchctl list detection", () => {
     async () => {
       const env = createDefaultLaunchdEnv();
       const label = "ai.openclaw.tayoun.update.20260625T201026-0400";
-      setLaunchAgentPlist({
-        env,
-        label,
-        programArguments: ["/opt/homebrew/bin/openclaw", "gateway", "run"],
-      });
+      setLaunchAgentPlist(env, label, ["/opt/homebrew/bin/openclaw", "gateway", "run"]);
 
       await expect(
         disableCurrentOpenClawUpdateLaunchdJob({
@@ -1581,7 +1612,7 @@ describe("launchd uninstall", () => {
       }),
     );
 
-    const uninstall = uninstallLaunchAgent({ env, stdout: new PassThrough() });
+    const uninstall = uninstallLaunchAgent(launchAgentControlFixture(env));
 
     await expect(uninstall).rejects.toThrow("LaunchAgent removal failed (EACCES)");
     await expect(uninstall).rejects.not.toThrow(plistPath);
@@ -1609,7 +1640,7 @@ describe("launchd uninstall", () => {
       }),
     );
 
-    const uninstall = uninstallLaunchAgent({ env, stdout: new PassThrough() });
+    const uninstall = uninstallLaunchAgent(launchAgentControlFixture(env));
 
     await expect(uninstall).rejects.toThrow("LaunchAgent removal failed (EACCES)");
     await expect(uninstall).rejects.not.toThrow(plistPath);
@@ -1667,7 +1698,7 @@ describe("launchd uninstall", () => {
       }),
     );
 
-    const uninstall = uninstallLaunchAgent({ env, stdout: new PassThrough() });
+    const uninstall = uninstallLaunchAgent(launchAgentControlFixture(env));
 
     await expect(uninstall).rejects.toThrow("LaunchAgent removal failed (ENOENT)");
     await expect(uninstall).rejects.not.toThrow(plistPath);
@@ -1774,11 +1805,7 @@ describe("launchd install", () => {
     launchdConstantsState.legacyGatewayLabels.push(legacyLabel);
     state.files.set(legacyPlistPath, previousLegacy);
 
-    await stageLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-    });
+    await stageLaunchAgent(defaultLaunchAgentFixture(env));
 
     expect(state.files.get(legacyPlistPath)).toBe(previousLegacy);
     expect(state.files.has(resolveLaunchAgentPlistPath(env))).toBe(true);
@@ -1867,12 +1894,11 @@ describe("launchd install", () => {
     state.bootoutError = "Boot-out failed: 5: Input/output error";
     state.bootoutCode = 5;
 
-    const error = await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: { OPENCLAW_GATEWAY_PORT: "19000" },
-    }).catch((caught: unknown) => caught);
+    const error = await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: { OPENCLAW_GATEWAY_PORT: "19000" },
+      }),
+    ).catch((caught: unknown) => caught);
 
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toBe("launchctl bootstrap failed: Operation not permitted");
@@ -1890,11 +1916,9 @@ describe("launchd install", () => {
     state.printFailuresRemaining = 1;
     state.bootstrapError = "Operation not permitted";
 
-    const error = await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-    }).catch((caught: unknown) => caught);
+    const error = await installLaunchAgent(defaultLaunchAgentFixture(env)).catch(
+      (caught: unknown) => caught,
+    );
 
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain(
@@ -2049,11 +2073,7 @@ describe("launchd install", () => {
     async ({ env, label, programArguments }) => {
       state.bootoutError = "Boot-out failed: 5: Input/output error";
       state.bootoutCode = 5;
-      await installLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-        programArguments,
-      });
+      await installLaunchAgent(launchAgentFixture(env, programArguments));
 
       const plist = state.files.get(resolveLaunchAgentPlistPath(env)) ?? "";
       expect(plist).not.toContain("OPENCLAW_SERVICE_VERSION");
@@ -2097,12 +2117,11 @@ describe("launchd install", () => {
       HOME: "/Users/test",
       OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.node",
     };
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: ["node", "node-host.js"],
-      description: "OpenClaw Node Host",
-    });
+    await installLaunchAgent(
+      launchAgentFixture(env, ["node", "node-host.js"], {
+        description: "OpenClaw Node Host",
+      }),
+    );
 
     const plist = state.files.get(resolveLaunchAgentPlistPath(env)) ?? "";
     expect(plist).toContain("<key>Comment</key>\n    <string>OpenClaw Node Host</string>");
@@ -2113,12 +2132,11 @@ describe("launchd install", () => {
     const env = createDefaultLaunchdEnv();
     const tmpDir = "/Users/test/.openclaw/tmp";
     const apiKey = "secret-api-key";
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: { TMPDIR: tmpDir, OPENAI_API_KEY: apiKey },
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: { TMPDIR: tmpDir, OPENAI_API_KEY: apiKey },
+      }),
+    );
 
     const plistPath = resolveLaunchAgentPlistPath(env);
     const envFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
@@ -2153,24 +2171,22 @@ describe("launchd install", () => {
     const envFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
     const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
 
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: { NODE_EXTRA_CA_CERTS: extraCaCerts },
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: { NODE_EXTRA_CA_CERTS: extraCaCerts },
+      }),
+    );
 
     const installedCommand = await readLaunchAgentProgramArguments(env);
     expect(installedCommand?.environment?.NODE_EXTRA_CA_CERTS).toBe(extraCaCerts);
     expect(installedCommand?.environmentValueSources?.NODE_EXTRA_CA_CERTS).toBe("file");
     const initialEnvWrites = countMatching(state.fileWrites, ({ path }) => path === envFilePath);
 
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: installedCommand?.environment,
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: installedCommand?.environment,
+      }),
+    );
 
     const refreshedCommand = await readLaunchAgentProgramArguments(env);
     expect(refreshedCommand?.environment?.NODE_EXTRA_CA_CERTS).toBe(extraCaCerts);
@@ -2188,12 +2204,11 @@ describe("launchd install", () => {
   it("warns before overwriting a customized generated LaunchAgent env wrapper", async () => {
     const env = createDefaultLaunchdEnv();
     const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: { OPENCLAW_GATEWAY_PORT: "18789" },
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+      }),
+    );
     const generatedWrapper = state.files.get(wrapperPath);
     if (!generatedWrapper) {
       throw new Error("expected generated wrapper");
@@ -2203,11 +2218,8 @@ describe("launchd install", () => {
       generatedWrapper.replace('exec "$@"', 'echo "custom-secret-provider-marker"\nexec "$@"'),
     );
 
-    const stdout = new PassThrough();
     let output = "";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString("utf8");
-    });
+    const stdout = capturePassThroughOutput((text) => (output += text), "utf8");
 
     await installLaunchAgent({
       env,
@@ -2226,12 +2238,11 @@ describe("launchd install", () => {
   it("warns before overwriting a customized generated LaunchAgent env wrapper during restart rewrite", async () => {
     const env = createDefaultLaunchdEnv();
     const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: { OPENCLAW_GATEWAY_PORT: "18789" },
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+      }),
+    );
     const generatedWrapper = state.files.get(wrapperPath);
     if (!generatedWrapper) {
       throw new Error("expected generated wrapper");
@@ -2242,11 +2253,8 @@ describe("launchd install", () => {
     );
     state.launchctlCalls.length = 0;
 
-    const stdout = new PassThrough();
     let output = "";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString("utf8");
-    });
+    const stdout = capturePassThroughOutput((text) => (output += text), "utf8");
 
     await restartLaunchAgent({
       env,
@@ -2264,12 +2272,11 @@ describe("launchd install", () => {
     const env = createDefaultLaunchdEnv();
     const envFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
     const wrapperPath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: { OPENCLAW_GATEWAY_PORT: "19007" },
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: { OPENCLAW_GATEWAY_PORT: "19007" },
+      }),
+    );
 
     const plistPath = resolveLaunchAgentPlistPath(env);
     const legacyPlist = (state.files.get(plistPath) ?? "").replace(
@@ -2288,10 +2295,7 @@ describe("launchd install", () => {
     state.files.set(plistPath, legacyPlist);
     state.launchctlCalls.length = 0;
 
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    await restartLaunchAgent(launchAgentControlFixture(env));
 
     const rewritten = state.files.get(plistPath) ?? "";
     expect(readPlistProgramArgumentStrings(rewritten)).toEqual([
@@ -2314,15 +2318,14 @@ describe("launchd install", () => {
       ...callerEnv,
       OPENCLAW_STATE_DIR: "/Users/test/service-env/custom-state",
     };
-    await installLaunchAgent({
-      env: serviceEnv,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: {
-        OPENCLAW_GATEWAY_PORT: "18789",
-        OPENCLAW_STATE_DIR: serviceEnv.OPENCLAW_STATE_DIR,
-      },
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(serviceEnv, {
+        environment: {
+          OPENCLAW_GATEWAY_PORT: "18789",
+          OPENCLAW_STATE_DIR: serviceEnv.OPENCLAW_STATE_DIR,
+        },
+      }),
+    );
 
     const plistPath = resolveLaunchAgentPlistPath(callerEnv);
     const envFilePath = "/Users/test/service-env/custom-state/service-env/ai.openclaw.gateway.env";
@@ -2348,10 +2351,7 @@ describe("launchd install", () => {
     expect(command?.environment?.OPENCLAW_STATE_DIR).toBe(serviceEnv.OPENCLAW_STATE_DIR);
     expect(command?.environmentValueSources?.OPENCLAW_GATEWAY_PORT).toBe("file");
 
-    await restartLaunchAgent({
-      env: callerEnv,
-      stdout: new PassThrough(),
-    });
+    await restartLaunchAgent(launchAgentControlFixture(callerEnv));
 
     const rewritten = state.files.get(plistPath) ?? "";
     expect(readPlistProgramArgumentStrings(rewritten)).toEqual([
@@ -2372,12 +2372,11 @@ describe("launchd install", () => {
   it("creates the LaunchAgent TMPDIR before bootstrap", async () => {
     const env = createDefaultLaunchdEnv();
     const tmpDir = "/Users/test/.openclaw/tmp";
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: { TMPDIR: tmpDir },
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: { TMPDIR: tmpDir },
+      }),
+    );
 
     expect(state.dirs.has(tmpDir)).toBe(true);
     expect(state.dirModes.get(tmpDir)).toBe(0o700);
@@ -2385,11 +2384,7 @@ describe("launchd install", () => {
 
   it("writes KeepAlive=true policy with shutdown and throttle limits", async () => {
     const env = createDefaultLaunchdEnv();
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-    });
+    await installLaunchAgent(defaultLaunchAgentFixture(env));
 
     const plistPath = resolveLaunchAgentPlistPath(env);
     const plist = state.files.get(plistPath) ?? "";
@@ -2416,33 +2411,15 @@ describe("launchd install", () => {
     state.serviceLoaded = false;
     state.kickstartError = "Could not find service";
     state.kickstartFailuresRemaining = 1;
-    state.files.set(
-      plistPath,
-      [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        '<plist version="1.0">',
-        "  <dict>",
-        "    <key>Label</key>",
-        "    <string>ai.openclaw.gateway</string>",
-        "    <key>ProgramArguments</key>",
-        "    <array>",
-        "      <string>node</string>",
-        "      <string>gateway.js</string>",
-        "    </array>",
-        "    <key>EnvironmentVariables</key>",
-        "    <dict>",
-        "      <key>OPENCLAW_SERVICE_VERSION</key>",
-        "      <string>2026.4.24</string>",
-        "    </dict>",
-        "  </dict>",
-        "</plist>",
-      ].join("\n"),
-    );
+    setLegacyGatewayLaunchAgentPlist(plistPath, [
+      "    <key>EnvironmentVariables</key>",
+      "    <dict>",
+      "      <key>OPENCLAW_SERVICE_VERSION</key>",
+      "      <string>2026.4.24</string>",
+      "    </dict>",
+    ]);
 
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    await restartLaunchAgent(launchAgentControlFixture(env));
 
     const plist = state.files.get(plistPath) ?? "";
     expect(plist).toContain("<key>StandardInPath</key>");
@@ -2467,11 +2444,7 @@ describe("launchd install", () => {
     state.dirs.add("/Users/test/Library");
     state.dirModes.set("/Users/test/Library", 0o777);
 
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-    });
+    await installLaunchAgent(defaultLaunchAgentFixture(env));
 
     const plistPath = resolveLaunchAgentPlistPath(env);
     expect(state.dirModes.get(env.HOME!)).toBe(0o755);
@@ -2482,11 +2455,8 @@ describe("launchd install", () => {
 
   it("stops LaunchAgent via bootout by default, preserving KeepAlive for future crashes", async () => {
     const env = createDefaultLaunchdEnv();
-    const stdout = new PassThrough();
     let output = "";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
+    const stdout = capturePassThroughOutput((text) => (output += text));
 
     await stopLaunchAgent({ env, stdout });
 
@@ -2610,11 +2580,8 @@ describe("launchd install", () => {
       ...createDefaultLaunchdEnv(),
       OPENCLAW_LAUNCHD_LABEL: "com.example.openclaw.gateway",
     };
-    const stdout = new PassThrough();
     let output = "";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
+    const stdout = capturePassThroughOutput((text) => (output += text));
 
     await withProcessEnv(
       {
@@ -2637,15 +2604,9 @@ describe("launchd install", () => {
   });
 
   it("verifies the configured gateway port is released before reporting stop success", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "19003",
-    };
-    const stdout = new PassThrough();
+    const env = createLaunchdEnvWithGatewayPort("19003");
     let output = "";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
+    const stdout = capturePassThroughOutput((text) => (output += text));
 
     await stopLaunchAgent({ env, stdout });
 
@@ -2657,10 +2618,7 @@ describe("launchd install", () => {
   });
 
   it("waits for the configured gateway port to finish releasing after bootout", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "19009",
-    };
+    const env = createLaunchdEnvWithGatewayPort("19009");
     inspectPortUsage.mockResolvedValueOnce({
       port: 19009,
       status: "busy",
@@ -2668,17 +2626,14 @@ describe("launchd install", () => {
       hints: [],
     });
 
-    await runStopLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() });
+    await runStopLaunchAgentWithFakeTimers(launchAgentControlFixture(env));
 
     expect(inspectPortUsage).toHaveBeenCalledTimes(1);
     expect(probePortUsage).toHaveBeenCalledWith(19009, ["127.0.0.1"]);
   });
 
   it("waits on the configured non-loopback host before reporting the port released", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "19011",
-    };
+    const env = createLaunchdEnvWithGatewayPort("19011");
     resolveGatewayServiceProbeHosts.mockResolvedValue(["192.0.2.40"]);
     inspectPortUsage.mockResolvedValueOnce({
       port: 19011,
@@ -2687,7 +2642,7 @@ describe("launchd install", () => {
       hints: [],
     });
 
-    await runStopLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() });
+    await runStopLaunchAgentWithFakeTimers(launchAgentControlFixture(env));
 
     expect(inspectPortUsage).toHaveBeenCalledWith(19011, {
       probeHosts: ["192.0.2.40"],
@@ -2696,10 +2651,7 @@ describe("launchd install", () => {
   });
 
   it("keeps waiting until a bind probe explicitly confirms port release", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "19010",
-    };
+    const env = createLaunchdEnvWithGatewayPort("19010");
     inspectPortUsage.mockResolvedValueOnce({
       port: 19010,
       status: "busy",
@@ -2708,22 +2660,21 @@ describe("launchd install", () => {
     });
     probePortUsage.mockResolvedValueOnce("busy").mockResolvedValueOnce("unknown");
 
-    await runStopLaunchAgentWithFakeTimers({ env, stdout: new PassThrough() });
+    await runStopLaunchAgentWithFakeTimers(launchAgentControlFixture(env));
 
     expect(probePortUsage).toHaveBeenCalledTimes(3);
   });
 
   it("resolves the stop postcondition port from the stored LaunchAgent environment", async () => {
     const env = createDefaultLaunchdEnv();
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: { OPENCLAW_GATEWAY_PORT: "19006" },
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: { OPENCLAW_GATEWAY_PORT: "19006" },
+      }),
+    );
     state.launchctlCalls.length = 0;
 
-    await stopLaunchAgent({ env, stdout: new PassThrough() });
+    await stopLaunchAgent(launchAgentControlFixture(env));
 
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19006);
     expect(inspectPortUsage).toHaveBeenCalledWith(19006, {
@@ -2732,16 +2683,10 @@ describe("launchd install", () => {
   });
 
   it("fails stop when the verified gateway port remains busy after cleanup", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "19004",
-    };
-    const stdout = new PassThrough();
+    const env = createLaunchdEnvWithGatewayPort("19004");
+    const stdout = capturePassThroughOutput((text) => (output += text));
     const onMutation = vi.fn();
     let output = "";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
     inspectPortUsage.mockResolvedValue({
       port: 19004,
       status: "busy",
@@ -2770,16 +2715,17 @@ describe("launchd install", () => {
       OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.node",
       OPENCLAW_GATEWAY_PORT: "18789",
     };
-    setLaunchAgentPlist({
-      env,
-      label: "ai.openclaw.node",
-      programArguments: ["node", "node", "run", "--host", "127.0.0.1", "--port", "18789"],
-    });
-    const stdout = new PassThrough();
+    setLaunchAgentPlist(env, "ai.openclaw.node", [
+      "node",
+      "node",
+      "run",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "18789",
+    ]);
     let output = "";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
+    const stdout = capturePassThroughOutput((text) => (output += text));
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
@@ -2809,11 +2755,8 @@ describe("launchd install", () => {
 
   it("stops LaunchAgent with disable+stop when --disable is passed", async () => {
     const env = createDefaultLaunchdEnv();
-    const stdout = new PassThrough();
     let output = "";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
+    const stdout = capturePassThroughOutput((text) => (output += text));
 
     await stopLaunchAgent({ env, stdout, disable: true });
 
@@ -2828,15 +2771,9 @@ describe("launchd install", () => {
   });
 
   it("verifies the configured gateway port is released before reporting disable stop success", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "19005",
-    };
-    const stdout = new PassThrough();
+    const env = createLaunchdEnvWithGatewayPort("19005");
     let output = "";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
+    const stdout = capturePassThroughOutput((text) => (output += text));
 
     await stopLaunchAgent({ env, stdout, disable: true });
 
@@ -2868,15 +2805,12 @@ describe("launchd install", () => {
 
   it("treats already-unloaded services as successfully stopped without bootout fallback (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
-    const stdout = new PassThrough();
+    const stdout = capturePassThroughOutput((text) => (output += text));
     let output = "";
     state.serviceLoaded = false;
     state.serviceRunning = false;
     state.stopError = "Could not find service";
     state.stopCode = 113;
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
 
     await stopLaunchAgent({ env, stdout, disable: true });
 
@@ -2894,13 +2828,10 @@ describe("launchd install", () => {
 
   it("treats already-unloaded services as successfully stopped in default bootout path", async () => {
     const env = createDefaultLaunchdEnv();
-    const stdout = new PassThrough();
+    const stdout = capturePassThroughOutput((text) => (output += text));
     let output = "";
     state.serviceLoaded = false;
     state.serviceRunning = false;
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
 
     await stopLaunchAgent({ env, stdout });
 
@@ -2911,12 +2842,9 @@ describe("launchd install", () => {
 
   it("falls back to bootout when disable fails so stop remains authoritative (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
-    const stdout = new PassThrough();
+    const stdout = capturePassThroughOutput((text) => (output += text));
     let output = "";
     state.disableError = "Operation not permitted";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
 
     await stopLaunchAgent({ env, stdout, disable: true });
 
@@ -2927,17 +2855,11 @@ describe("launchd install", () => {
   });
 
   it("does not report degraded stop success when fallback cleanup leaves the port busy", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "19008",
-    };
-    const stdout = new PassThrough();
+    const env = createLaunchdEnvWithGatewayPort("19008");
+    const stdout = capturePassThroughOutput((text) => (output += text));
     const onMutation = vi.fn();
     let output = "";
     state.disableError = "Operation not permitted";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
     inspectPortUsage.mockResolvedValue({
       port: 19008,
       status: "busy",
@@ -2961,12 +2883,9 @@ describe("launchd install", () => {
 
   it("falls back to bootout when stop does not fully stop the service (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
-    const stdout = new PassThrough();
+    const stdout = capturePassThroughOutput((text) => (output += text));
     let output = "";
     state.stopLeavesRunning = true;
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
 
     await runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true });
 
@@ -2978,13 +2897,10 @@ describe("launchd install", () => {
 
   it("treats launchctl print state=running as running even when pid is missing (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
-    const stdout = new PassThrough();
+    const stdout = capturePassThroughOutput((text) => (output += text));
     let output = "";
     state.stopLeavesRunning = true;
     state.printOutput = "state = running\n";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
 
     await runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true });
 
@@ -2995,12 +2911,9 @@ describe("launchd install", () => {
 
   it("falls back to bootout when launchctl stop itself errors (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
-    const stdout = new PassThrough();
+    const stdout = capturePassThroughOutput((text) => (output += text));
     let output = "";
     state.stopError = "stop failed due to transient launchd error";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
 
     await stopLaunchAgent({ env, stdout, disable: true });
 
@@ -3011,13 +2924,10 @@ describe("launchd install", () => {
 
   it("falls back to bootout when launchctl print cannot confirm the stop state (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
-    const stdout = new PassThrough();
+    const stdout = capturePassThroughOutput((text) => (output += text));
     let output = "";
     state.printError = "launchctl print permission denied";
     state.printFailuresRemaining = 10;
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
 
     await runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true });
 
@@ -3068,12 +2978,9 @@ describe("launchd install", () => {
 
   it("sanitizes launchctl details before writing warnings (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
-    const stdout = new PassThrough();
+    const stdout = capturePassThroughOutput((text) => (output += text));
     let output = "";
     state.disableError = "boom\n\u001b[31mred\u001b[0m\tmsg";
-    stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
-    });
 
     await stopLaunchAgent({ env, stdout, disable: true });
 
@@ -3100,16 +3007,13 @@ describe("launchd install", () => {
   });
 
   it("restarts LaunchAgent with kickstart and no bootout", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "18789",
-    };
+    const env = createLaunchdEnvWithGatewayPort("18789");
     const onMutation = vi.fn();
-    const result = await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      onMutation,
-    });
+    const result = await restartLaunchAgent(
+      launchAgentControlFixture(env, {
+        onMutation,
+      }),
+    );
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
@@ -3166,7 +3070,11 @@ describe("launchd install", () => {
     state.kickstartError = "Could not find service";
     state.kickstartFailuresRemaining = 1;
 
-    await startLaunchAgent({ env, stdout: new PassThrough(), onMutation });
+    await startLaunchAgent(
+      launchAgentControlFixture(env, {
+        onMutation,
+      }),
+    );
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const serviceId = `${domain}/ai.openclaw.gateway`;
@@ -3214,10 +3122,7 @@ describe("launchd install", () => {
   });
 
   it("audits kickstart before a later output failure", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "18789",
-    };
+    const env = createLaunchdEnvWithGatewayPort("18789");
     const onMutation = vi.fn();
     const stdout = {
       write: vi.fn(() => {
@@ -3231,37 +3136,19 @@ describe("launchd install", () => {
   });
 
   it("reloads launchd after rewriting an existing plist", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "18789",
-    };
+    const env = createLaunchdEnvWithGatewayPort("18789");
     const plistPath = resolveLaunchAgentPlistPath(env);
-    state.files.set(
-      plistPath,
-      [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        '<plist version="1.0">',
-        "  <dict>",
-        "    <key>Label</key>",
-        "    <string>ai.openclaw.gateway</string>",
-        "    <key>ProgramArguments</key>",
-        "    <array>",
-        "      <string>node</string>",
-        "      <string>gateway.js</string>",
-        "    </array>",
-        "    <key>StandardOutPath</key>",
-        "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
-        "  </dict>",
-        "</plist>",
-      ].join("\n"),
-    );
+    setLegacyGatewayLaunchAgentPlist(plistPath, [
+      "    <key>StandardOutPath</key>",
+      "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
+    ]);
 
     const onMutation = vi.fn();
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      onMutation,
-    });
+    await restartLaunchAgent(
+      launchAgentControlFixture(env, {
+        onMutation,
+      }),
+    );
 
     const plist = state.files.get(plistPath) ?? "";
     expect(plist).toContain("<key>StandardInPath</key>");
@@ -3278,15 +3165,8 @@ describe("launchd install", () => {
   });
 
   it("audits reload bootout before a later bootstrap failure", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "18789",
-    };
-    setLaunchAgentPlist({
-      env,
-      label: "ai.openclaw.gateway",
-      programArguments: ["node", "gateway.js"],
-    });
+    const env = createLaunchdEnvWithGatewayPort("18789");
+    setLaunchAgentPlist(env, "ai.openclaw.gateway", ["node", "gateway.js"]);
     state.bootstrapError = "Operation not permitted";
     state.bootstrapCode = 5;
     const onMutation = vi.fn();
@@ -3307,26 +3187,19 @@ describe("launchd install", () => {
   });
 
   it("reloads the LaunchAgent through a transient reload bootstrap failure", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "18789",
-    };
-    setLaunchAgentPlist({
-      env,
-      label: "ai.openclaw.gateway",
-      programArguments: ["node", "gateway.js"],
-    });
+    const env = createLaunchdEnvWithGatewayPort("18789");
+    setLaunchAgentPlist(env, "ai.openclaw.gateway", ["node", "gateway.js"]);
     // launchd answers EIO while the just-booted-out job is still tearing down.
     state.bootstrapError = "Bootstrap failed: 5: Input/output error";
     state.bootstrapCode = 5;
     state.bootstrapTransient = true;
     const onMutation = vi.fn();
 
-    const result = await runRestartLaunchAgentWithFakeTimers({
-      env,
-      stdout: new PassThrough(),
-      onMutation,
-    });
+    const result = await runRestartLaunchAgentWithFakeTimers(
+      launchAgentControlFixture(env, {
+        onMutation,
+      }),
+    );
 
     // Teardown is transient, so the retry must land a real bootstrap rather than
     // surfacing an error the operator has to recover from by hand.
@@ -3336,24 +3209,16 @@ describe("launchd install", () => {
   });
 
   it("reports the LaunchAgent as unloaded when bootstrap teardown never clears", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "18789",
-    };
-    setLaunchAgentPlist({
-      env,
-      label: "ai.openclaw.gateway",
-      programArguments: ["node", "gateway.js"],
-    });
+    const env = createLaunchdEnvWithGatewayPort("18789");
+    setLaunchAgentPlist(env, "ai.openclaw.gateway", ["node", "gateway.js"]);
     // EIO that never clears must stay bounded instead of retrying forever, and
     // the restore attempt fails with it, so the label really does stay absent.
     state.bootstrapError = "Bootstrap failed: 5: Input/output error";
     state.bootstrapCode = 5;
 
-    const error = await runRestartLaunchAgentWithFakeTimers({
-      env,
-      stdout: new PassThrough(),
-    }).catch((caught: unknown) => caught);
+    const error = await runRestartLaunchAgentWithFakeTimers(launchAgentControlFixture(env)).catch(
+      (caught: unknown) => caught,
+    );
 
     // bootout already removed the job, so the operator has to learn both why the
     // bootstrap failed and that nothing is left for KeepAlive to respawn.
@@ -3370,15 +3235,8 @@ describe("launchd install", () => {
   });
 
   it("does not wait out the teardown deadline when the reload bootstrap reports already-loaded", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "18789",
-    };
-    setLaunchAgentPlist({
-      env,
-      label: "ai.openclaw.gateway",
-      programArguments: ["node", "gateway.js"],
-    });
+    const env = createLaunchdEnvWithGatewayPort("18789");
+    setLaunchAgentPlist(env, "ai.openclaw.gateway", ["node", "gateway.js"]);
     // Same EIO code as a pending teardown, but the label is still registered
     // rather than draining, so there is nothing to wait for. Real timers here:
     // a retry loop would blow the test timeout instead of quietly passing.
@@ -3387,7 +3245,7 @@ describe("launchd install", () => {
     state.bootstrapCode = 5;
     state.bootstrapLoadsServiceOnFailure = true;
 
-    const error = await restartLaunchAgent({ env, stdout: new PassThrough() }).catch(
+    const error = await restartLaunchAgent(launchAgentControlFixture(env)).catch(
       (caught: unknown) => caught,
     );
 
@@ -3403,15 +3261,8 @@ describe("launchd install", () => {
   });
 
   it("completes reload when the mutation observer fails after bootout", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "18789",
-    };
-    setLaunchAgentPlist({
-      env,
-      label: "ai.openclaw.gateway",
-      programArguments: ["node", "gateway.js"],
-    });
+    const env = createLaunchdEnvWithGatewayPort("18789");
+    setLaunchAgentPlist(env, "ai.openclaw.gateway", ["node", "gateway.js"]);
     const onMutation = vi.fn(({ mode }: { mode: string }) => {
       if (mode === "bootout") {
         throw new Error("audit failed");
@@ -3428,38 +3279,17 @@ describe("launchd install", () => {
   });
 
   it("treats a concurrent launchd bootstrap as success when the service is loaded", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "18789",
-    };
+    const env = createLaunchdEnvWithGatewayPort("18789");
     const plistPath = resolveLaunchAgentPlistPath(env);
-    state.files.set(
-      plistPath,
-      [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        '<plist version="1.0">',
-        "  <dict>",
-        "    <key>Label</key>",
-        "    <string>ai.openclaw.gateway</string>",
-        "    <key>ProgramArguments</key>",
-        "    <array>",
-        "      <string>node</string>",
-        "      <string>gateway.js</string>",
-        "    </array>",
-        "    <key>StandardOutPath</key>",
-        "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
-        "  </dict>",
-        "</plist>",
-      ].join("\n"),
-    );
+    setLegacyGatewayLaunchAgentPlist(plistPath, [
+      "    <key>StandardOutPath</key>",
+      "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
+    ]);
     state.bootstrapError = "Bootstrap failed: 37: Operation already in progress";
     state.bootstrapCode = 5;
     state.bootstrapLoadsServiceOnFailure = true;
 
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    await restartLaunchAgent(launchAgentControlFixture(env));
 
     expect(launchctlCommandNames()).toEqual([
       "print",
@@ -3473,15 +3303,9 @@ describe("launchd install", () => {
   });
 
   it("uses the configured gateway port for stale cleanup", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "19001",
-    };
+    const env = createLaunchdEnvWithGatewayPort("19001");
 
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    await restartLaunchAgent(launchAgentControlFixture(env));
 
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(
       19001,
@@ -3492,16 +3316,10 @@ describe("launchd install", () => {
   });
 
   it("ignores invalid configured gateway ports for stale cleanup", async () => {
-    const env = {
-      ...createDefaultLaunchdEnv(),
-      OPENCLAW_GATEWAY_PORT: "65536",
-    };
+    const env = createLaunchdEnvWithGatewayPort("65536");
     state.files.clear();
 
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    await restartLaunchAgent(launchAgentControlFixture(env));
 
     expect(cleanStaleGatewayProcessesSync).not.toHaveBeenCalled();
     expect(inspectPortUsage).not.toHaveBeenCalled();
@@ -3509,18 +3327,14 @@ describe("launchd install", () => {
 
   it("uses the stored LaunchAgent environment port for restart stale cleanup", async () => {
     const env = createDefaultLaunchdEnv();
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: { OPENCLAW_GATEWAY_PORT: "19007" },
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: { OPENCLAW_GATEWAY_PORT: "19007" },
+      }),
+    );
     state.launchctlCalls.length = 0;
 
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    await restartLaunchAgent(launchAgentControlFixture(env));
 
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(
       19007,
@@ -3535,18 +3349,14 @@ describe("launchd install", () => {
 
   it("uses the final repeated LaunchAgent port flag for restart stale cleanup", async () => {
     const env = createDefaultLaunchdEnv();
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: [...defaultProgramArguments, "--port", "18789", "--port=19008"],
-      environment: {},
-    });
+    await installLaunchAgent(
+      launchAgentFixture(env, [...defaultProgramArguments, "--port", "18789", "--port=19008"], {
+        environment: {},
+      }),
+    );
     state.launchctlCalls.length = 0;
 
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    await restartLaunchAgent(launchAgentControlFixture(env));
 
     expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(
       19008,
@@ -3561,18 +3371,14 @@ describe("launchd install", () => {
 
   it("ignores invalid stored LaunchAgent environment ports for stale cleanup", async () => {
     const env = createDefaultLaunchdEnv();
-    await installLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-      programArguments: defaultProgramArguments,
-      environment: { OPENCLAW_GATEWAY_PORT: "65536" },
-    });
+    await installLaunchAgent(
+      defaultLaunchAgentFixture(env, {
+        environment: { OPENCLAW_GATEWAY_PORT: "65536" },
+      }),
+    );
     state.launchctlCalls.length = 0;
 
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    await restartLaunchAgent(launchAgentControlFixture(env));
 
     expect(cleanStaleGatewayProcessesSync).not.toHaveBeenCalled();
     expect(inspectPortUsage).not.toHaveBeenCalled();
@@ -3599,10 +3405,7 @@ describe("launchd install", () => {
   }>)(
     "protects the current service and allows $name",
     async ({ managedPidAfterCleanup, listeners }) => {
-      const env = {
-        ...createDefaultLaunchdEnv(),
-        OPENCLAW_GATEWAY_PORT: "19002",
-      };
+      const env = createLaunchdEnvWithGatewayPort("19002");
       if (managedPidAfterCleanup !== 4242) {
         state.printOutput = ["state = running", `pid = ${managedPidAfterCleanup}`].join("\n");
       }
@@ -3613,7 +3416,7 @@ describe("launchd install", () => {
         hints: [],
       });
 
-      const result = await restartLaunchAgent({ env, stdout: new PassThrough() });
+      const result = await restartLaunchAgent(launchAgentControlFixture(env));
 
       const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
       const serviceId = `${domain}/ai.openclaw.gateway`;
@@ -3658,15 +3461,8 @@ describe("launchd install", () => {
   ] satisfies Array<{ name: string; listeners: PortListener[] }>)(
     "rejects $name gateway port ownership before mutating launchd",
     async ({ listeners }) => {
-      const env = {
-        ...createDefaultLaunchdEnv(),
-        OPENCLAW_GATEWAY_PORT: "19002",
-      };
-      setLaunchAgentPlist({
-        env,
-        label: "ai.openclaw.gateway",
-        programArguments: ["node", "gateway.js"],
-      });
+      const env = createLaunchdEnvWithGatewayPort("19002");
+      setLaunchAgentPlist(env, "ai.openclaw.gateway", ["node", "gateway.js"]);
       const plistPath = resolveLaunchAgentPlistPath(env);
       const originalPlist = state.files.get(plistPath);
       inspectPortUsage.mockResolvedValue({
@@ -3716,11 +3512,15 @@ describe("launchd install", () => {
       OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.node",
       OPENCLAW_GATEWAY_PORT: "18789",
     };
-    setLaunchAgentPlist({
-      env,
-      label: "ai.openclaw.node",
-      programArguments: ["node", "node", "run", "--host", "127.0.0.1", "--port", "18789"],
-    });
+    setLaunchAgentPlist(env, "ai.openclaw.node", [
+      "node",
+      "node",
+      "run",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      "18789",
+    ]);
     inspectPortUsage.mockResolvedValue({
       port: 18789,
       status: "busy",
@@ -3728,10 +3528,7 @@ describe("launchd install", () => {
       hints: [],
     });
 
-    const result = await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    const result = await restartLaunchAgent(launchAgentControlFixture(env));
 
     expect(result).toEqual({ outcome: "completed" });
     expect(cleanStaleGatewayProcessesSync).not.toHaveBeenCalled();
@@ -3742,10 +3539,7 @@ describe("launchd install", () => {
     const env = createDefaultLaunchdEnv();
     state.files.clear();
 
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    await restartLaunchAgent(launchAgentControlFixture(env));
 
     expect(cleanStaleGatewayProcessesSync).not.toHaveBeenCalled();
   });
@@ -3755,10 +3549,7 @@ describe("launchd install", () => {
     state.kickstartError = "Could not find service";
     state.kickstartFailuresRemaining = 1;
 
-    const result = await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
+    const result = await restartLaunchAgent(launchAgentControlFixture(env));
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const serviceId = `${domain}/ai.openclaw.gateway`;
@@ -3800,10 +3591,7 @@ describe("launchd install", () => {
     const env = createDefaultLaunchdEnv();
 
     const result = await withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
-      restartLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-      }),
+      restartLaunchAgent(launchAgentControlFixture(env)),
     );
 
     expect(result).toEqual({ outcome: "scheduled" });
@@ -3818,31 +3606,13 @@ describe("launchd install", () => {
   it("hands plist reload off when current LaunchAgent needs rewritten paths", async () => {
     const env = createDefaultLaunchdEnv();
     const plistPath = resolveLaunchAgentPlistPath(env);
-    state.files.set(
-      plistPath,
-      [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        '<plist version="1.0">',
-        "  <dict>",
-        "    <key>Label</key>",
-        "    <string>ai.openclaw.gateway</string>",
-        "    <key>ProgramArguments</key>",
-        "    <array>",
-        "      <string>node</string>",
-        "      <string>gateway.js</string>",
-        "    </array>",
-        "    <key>StandardOutPath</key>",
-        "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
-        "  </dict>",
-        "</plist>",
-      ].join("\n"),
-    );
+    setLegacyGatewayLaunchAgentPlist(plistPath, [
+      "    <key>StandardOutPath</key>",
+      "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
+    ]);
 
     const result = await withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
-      restartLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-      }),
+      restartLaunchAgent(launchAgentControlFixture(env)),
     );
 
     expect(result).toEqual({ outcome: "scheduled" });
@@ -3884,11 +3654,7 @@ describe("launchd install", () => {
         OPENCLAW_SERVICE_KIND: "gateway",
         OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
       },
-      async () =>
-        restartLaunchAgent({
-          env,
-          stdout: new PassThrough(),
-        }),
+      async () => restartLaunchAgent(launchAgentControlFixture(env)),
     );
 
     expect(result).toEqual({ outcome: "scheduled" });
@@ -3912,11 +3678,7 @@ describe("launchd install", () => {
         OPENCLAW_SERVICE_KIND: undefined,
         OPENCLAW_LAUNCHD_LABEL: undefined,
       },
-      async () =>
-        restartLaunchAgent({
-          env,
-          stdout: new PassThrough(),
-        }),
+      async () => restartLaunchAgent(launchAgentControlFixture(env)),
     );
 
     expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).not.toHaveBeenCalled();
@@ -3928,11 +3690,7 @@ describe("launchd install", () => {
     const env = createDefaultLaunchdEnv();
     let message = "";
     try {
-      await installLaunchAgent({
-        env,
-        stdout: new PassThrough(),
-        programArguments: defaultProgramArguments,
-      });
+      await installLaunchAgent(defaultLaunchAgentFixture(env));
     } catch (error) {
       message = String(error);
     }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -264,7 +264,8 @@ function defaultLaunchAgentFixture(
   return launchAgentFixture(env, defaultProgramArguments, overrides);
 }
 
-type LaunchAgentControlFixture = Parameters<typeof stopLaunchAgent>[0];
+type LaunchAgentControlFixture = Parameters<typeof stopLaunchAgent>[0] &
+  Parameters<typeof uninstallLaunchAgent>[0];
 
 function launchAgentControlFixture(
   env: LaunchAgentControlFixture["env"],

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -134,6 +134,47 @@ const createWritableStreamMock = (write = vi.fn()) => {
   };
 };
 
+type SystemdServiceFixture = Parameters<typeof stageSystemdService>[0];
+type SystemdServiceFixtureOverrides = Omit<
+  SystemdServiceFixture,
+  "env" | "stdout" | "programArguments"
+>;
+
+function systemdServiceFixture(
+  env: SystemdServiceFixture["env"],
+  programArguments: string[],
+  overrides: SystemdServiceFixtureOverrides = {},
+): SystemdServiceFixture {
+  return { env, stdout: createWritableStreamMock().stdout, programArguments, ...overrides };
+}
+
+function gatewaySystemdServiceFixture(
+  env: SystemdServiceFixture["env"],
+  overrides: Omit<SystemdServiceFixtureOverrides, "workingDirectory"> = {},
+): SystemdServiceFixture {
+  return systemdServiceFixture(env, ["/usr/bin/openclaw", "gateway", "run"], {
+    workingDirectory: "/tmp",
+    ...overrides,
+  });
+}
+
+function nodeSystemdServiceFixture(
+  env: SystemdServiceFixture["env"],
+  overrides: Omit<SystemdServiceFixtureOverrides, "workingDirectory"> = {},
+): SystemdServiceFixture {
+  return systemdServiceFixture(env, ["/usr/bin/openclaw", "node", "run"], {
+    workingDirectory: "/tmp",
+    ...overrides,
+  });
+}
+
+function gatewayPortSystemdServiceFixture(
+  env: SystemdServiceFixture["env"],
+  port: string,
+): SystemdServiceFixture {
+  return gatewaySystemdServiceFixture(env, { environment: { OPENCLAW_GATEWAY_PORT: port } });
+}
+
 function requireFirstWrite(write: ReturnType<typeof vi.fn>): string {
   const [call] = write.mock.calls;
   if (!call) {
@@ -165,6 +206,72 @@ function assertUserSystemctlArgs(args: string[], ...command: string[]) {
 
 function assertMachineUserSystemctlArgs(args: string[], user: string, ...command: string[]) {
   expect(args).toEqual(["--machine", `${user}@`, "--user", ...command]);
+}
+
+function systemctlUserSuccess(...command: string[]): ExecFileMock {
+  return (_cmd, args, _opts, cb) => {
+    assertUserSystemctlArgs(args, ...command);
+    cb(null, "", "");
+  };
+}
+
+function systemctlMachineUserSuccess(user: string, ...command: string[]): ExecFileMock {
+  return (_cmd, args, _opts, cb) => {
+    assertMachineUserSystemctlArgs(args, user, ...command);
+    cb(null, "", "");
+  };
+}
+
+function execFileSuccess(): ExecFileMock {
+  return (_cmd, _args, _opts, cb) => cb(null, "", "");
+}
+
+type ExecFileResult = [error: ExecFileError | null, stdout: string, stderr: string];
+
+function systemctlUserResult(result: ExecFileResult, ...command: string[]): ExecFileMock {
+  return (_cmd, args, _opts, cb) => {
+    assertUserSystemctlArgs(args, ...command);
+    cb(...result);
+  };
+}
+
+function systemctlMachineUserResult(
+  result: ExecFileResult,
+  user: string,
+  ...command: string[]
+): ExecFileMock {
+  return (_cmd, args, _opts, cb) => {
+    assertMachineUserSystemctlArgs(args, user, ...command);
+    cb(...result);
+  };
+}
+
+function execFileResult(...result: ExecFileResult): ExecFileMock {
+  return (_cmd, _args, _opts, cb) => cb(...result);
+}
+
+function mockNodeInstallNoMediumFailure(machineUser?: string): void {
+  execFileMock
+    .mockImplementationOnce(systemctlUserSuccess("status"))
+    .mockImplementationOnce(systemctlUserSuccess("daemon-reload"))
+    .mockImplementationOnce(
+      systemctlUserResult(
+        [
+          createExecFileError("Failed to connect to bus: No medium found", {
+            stderr: "Failed to connect to bus: No medium found",
+          }),
+          "",
+          "",
+        ],
+        "enable",
+        NODE_SERVICE,
+      ),
+    );
+  if (machineUser) {
+    execFileMock
+      .mockImplementationOnce(systemctlMachineUserSuccess(machineUser, "enable", NODE_SERVICE))
+      .mockImplementationOnce(systemctlUserSuccess("restart", NODE_SERVICE));
+  }
 }
 
 function mockEffectiveUid(uid: number) {
@@ -289,9 +396,7 @@ describe("systemd availability", () => {
   });
 
   it("returns true when systemctl --user succeeds", async () => {
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
-      cb(null, "", "");
-    });
+    execFileMock.mockImplementation(execFileResult(null, "", ""));
     await expect(isSystemdUserServiceAvailable()).resolves.toBe(true);
   });
 
@@ -331,9 +436,13 @@ describe("systemd availability", () => {
   });
 
   it("returns true when systemd is degraded but still reachable", async () => {
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
-      cb(createExecFileError("degraded", { stderr: "degraded\nsome-unit.service failed" }), "", "");
-    });
+    execFileMock.mockImplementation(
+      execFileResult(
+        createExecFileError("degraded", { stderr: "degraded\nsome-unit.service failed" }),
+        "",
+        "",
+      ),
+    );
 
     await expect(isSystemdUserServiceAvailable()).resolves.toBe(true);
   });
@@ -375,17 +484,20 @@ describe("systemd availability", () => {
 
   it("does not fall back to direct --user when machine scope fails under sudo", async () => {
     mockEffectiveUid(0);
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      assertMachineUserSystemctlArgs(args, "ai", "status");
-      cb(
-        createExecFileError("Failed to connect to bus: No such file or directory", {
-          stderr: "Failed to connect to bus: No such file or directory",
-          code: 1,
-        }),
-        "",
-        "",
-      );
-    });
+    execFileMock.mockImplementationOnce(
+      systemctlMachineUserResult(
+        [
+          createExecFileError("Failed to connect to bus: No such file or directory", {
+            stderr: "Failed to connect to bus: No such file or directory",
+            code: 1,
+          }),
+          "",
+          "",
+        ],
+        "ai",
+        "status",
+      ),
+    );
 
     await expect(isSystemdUserServiceAvailable({ SUDO_USER: "ai" })).resolves.toBe(false);
     expect(execFileMock).toHaveBeenCalledTimes(1);
@@ -393,10 +505,7 @@ describe("systemd availability", () => {
 
   it("does not let preserved USER suppress sudo-to-root machine scope", async () => {
     mockEffectiveUid(0);
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      assertMachineUserSystemctlArgs(args, "debian", "status");
-      cb(null, "", "");
-    });
+    execFileMock.mockImplementationOnce(systemctlMachineUserSuccess("debian", "status"));
 
     await expect(
       isSystemdUserServiceAvailable({
@@ -429,10 +538,7 @@ describe("systemd availability", () => {
 
   it("keeps root user scope when stale SUDO_USER is paired with root bus environment", async () => {
     mockEffectiveUid(0);
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      assertUserSystemctlArgs(args, "status");
-      cb(null, "", "");
-    });
+    execFileMock.mockImplementationOnce(systemctlUserSuccess("status"));
 
     await expect(
       isSystemdUserServiceAvailable({
@@ -471,10 +577,7 @@ describe("systemd availability", () => {
 
   it("does not let stale SUDO_USER override a sudo-u target user scope", async () => {
     mockEffectiveUid(1000);
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      assertUserSystemctlArgs(args, "status");
-      cb(null, "", "");
-    });
+    execFileMock.mockImplementationOnce(systemctlUserSuccess("status"));
 
     await expect(
       isSystemdUserServiceAvailable({ USER: "openclaw", SUDO_USER: "admin" }),
@@ -527,10 +630,9 @@ describe("isSystemdServiceEnabled", () => {
   });
 
   it("calls systemctl is-enabled when systemctl is present", async () => {
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      assertUserSystemctlArgs(args, "is-enabled", GATEWAY_SERVICE);
-      cb(null, "enabled", "");
-    });
+    execFileMock.mockImplementationOnce(
+      systemctlUserResult([null, "enabled", ""], "is-enabled", GATEWAY_SERVICE),
+    );
     const result = await readManagedServiceEnabled();
     expect(result).toBe(true);
   });
@@ -564,14 +666,17 @@ describe("isSystemdServiceEnabled", () => {
     vi.spyOn(os, "userInfo").mockImplementationOnce(() => {
       throw new Error("no user info");
     });
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      assertUserSystemctlArgs(args, "is-enabled", GATEWAY_SERVICE);
-      cb(
-        createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
-        "",
-        "",
-      );
-    });
+    execFileMock.mockImplementationOnce(
+      systemctlUserResult(
+        [
+          createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
+          "",
+          "",
+        ],
+        "is-enabled",
+        GATEWAY_SERVICE,
+      ),
+    );
 
     await expect(
       readManagedServiceEnabled({ HOME: TEST_MANAGED_HOME, USER: "", LOGNAME: "" }),
@@ -580,25 +685,32 @@ describe("isSystemdServiceEnabled", () => {
 
   it("returns false when both direct and machine-scope is-enabled checks report bus unavailability", async () => {
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "is-enabled", GATEWAY_SERVICE);
-        cb(
-          createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
-          "",
-          "",
-        );
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertMachineUserSystemctlArgs(args, "debian", "is-enabled", GATEWAY_SERVICE);
-        cb(
-          createExecFileError("Failed to connect to user scope bus via local transport", {
-            stderr:
-              "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
-          }),
-          "",
-          "",
-        );
-      });
+      .mockImplementationOnce(
+        systemctlUserResult(
+          [
+            createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
+            "",
+            "",
+          ],
+          "is-enabled",
+          GATEWAY_SERVICE,
+        ),
+      )
+      .mockImplementationOnce(
+        systemctlMachineUserResult(
+          [
+            createExecFileError("Failed to connect to user scope bus via local transport", {
+              stderr:
+                "Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined",
+            }),
+            "",
+            "",
+          ],
+          "debian",
+          "is-enabled",
+          GATEWAY_SERVICE,
+        ),
+      );
 
     await expect(
       readManagedServiceEnabled({ HOME: TEST_MANAGED_HOME, USER: "debian" }),
@@ -667,10 +779,9 @@ describe("isSystemdUnitActive", () => {
   });
 
   it("checks user-scoped units through the user systemd manager", async () => {
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      assertUserSystemctlArgs(args, "is-active", "--quiet", GATEWAY_SERVICE);
-      cb(null, "", "");
-    });
+    execFileMock.mockImplementationOnce(
+      systemctlUserSuccess("is-active", "--quiet", GATEWAY_SERVICE),
+    );
 
     await expect(isSystemdUnitActive({ HOME: TEST_MANAGED_HOME }, GATEWAY_SERVICE)).resolves.toBe(
       true,
@@ -1046,10 +1157,7 @@ describe("readSystemdServiceRuntime", () => {
   async function readRuntimeFromShowOutput(output: string) {
     execFileMock.mockReset();
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "status");
-        cb(null, "", "");
-      })
+      .mockImplementationOnce(systemctlUserSuccess("status"))
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args[0]).toBe("--user");
         expect(args[1]).toBe("show");
@@ -1079,10 +1187,7 @@ describe("readSystemdServiceRuntime", () => {
 
   it("reports a missing unit without surfacing routine systemctl stderr", async () => {
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "status");
-        cb(null, "", "");
-      })
+      .mockImplementationOnce(systemctlUserSuccess("status"))
       .mockImplementationOnce((_cmd, _args, _opts, cb) => {
         const detail = "Unit openclaw-gateway.service could not be found.";
         cb(createExecFileError(detail, { stderr: detail }), "", detail);
@@ -1096,10 +1201,7 @@ describe("readSystemdServiceRuntime", () => {
 
   it("keeps unexpected systemctl failures visible", async () => {
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "status");
-        cb(null, "", "");
-      })
+      .mockImplementationOnce(systemctlUserSuccess("status"))
       .mockImplementationOnce((_cmd, _args, _opts, cb) => {
         const detail = "Permission denied while reading systemd state";
         cb(createExecFileError(detail, { stderr: detail }), "", detail);
@@ -1202,35 +1304,31 @@ describe("readSystemdServiceRuntime", () => {
 
   it("surfaces systemd cgroup metrics and KillMode", async () => {
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "status");
-        cb(null, "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(
-          args,
+      .mockImplementationOnce(systemctlUserSuccess("status"))
+      .mockImplementationOnce(
+        systemctlUserResult(
+          [
+            null,
+            [
+              "Id=openclaw-gateway.service",
+              "ActiveState=active",
+              "SubState=running",
+              "MainPID=1234",
+              "ExecMainStatus=0",
+              "ExecMainCode=running",
+              "KillMode=process",
+              "TasksCurrent=807",
+              "MemoryCurrent=11918534246",
+            ].join("\n"),
+            "",
+          ],
           "show",
           GATEWAY_SERVICE,
           "--no-page",
           "--property",
           "Id,ActiveState,SubState,Result,NRestarts,StartLimitBurst,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent",
-        );
-        cb(
-          null,
-          [
-            "Id=openclaw-gateway.service",
-            "ActiveState=active",
-            "SubState=running",
-            "MainPID=1234",
-            "ExecMainStatus=0",
-            "ExecMainCode=running",
-            "KillMode=process",
-            "TasksCurrent=807",
-            "MemoryCurrent=11918534246",
-          ].join("\n"),
-          "",
-        );
-      });
+        ),
+      );
     const runtime = await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME });
     expect(runtime).toEqual({
       status: "running",
@@ -1252,7 +1350,7 @@ describe("readSystemdServiceRuntime", () => {
   // wedged systemd socket cannot hang `openclaw status` (which advertises --timeout).
   it("passes a kill-backed timeout to systemctl when a read deadline is set", async () => {
     execFileMock.mockReset();
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => cb(null, "", ""));
+    execFileMock.mockImplementation(execFileResult(null, "", ""));
     await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME }, { timeoutMs: 1234 });
     expect(execFileMock).toHaveBeenCalled();
     for (const call of execFileMock.mock.calls) {
@@ -1264,7 +1362,7 @@ describe("readSystemdServiceRuntime", () => {
 
   it("leaves systemctl unbounded when no read deadline is set", async () => {
     execFileMock.mockReset();
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => cb(null, "", ""));
+    execFileMock.mockImplementation(execFileResult(null, "", ""));
     await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME });
     expect(execFileMock).toHaveBeenCalled();
     for (const call of execFileMock.mock.calls) {
@@ -1276,12 +1374,9 @@ describe("readSystemdServiceRuntime", () => {
 
   it("carries the supervision counters through a crash-looped failed unit", async () => {
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "status");
-        cb(null, "", "");
-      })
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
-        cb(
+      .mockImplementationOnce(systemctlUserSuccess("status"))
+      .mockImplementationOnce(
+        execFileResult(
           null,
           [
             "Id=openclaw-gateway.service",
@@ -1295,8 +1390,8 @@ describe("readSystemdServiceRuntime", () => {
             "ExecMainCode=exited",
           ].join("\n"),
           "",
-        );
-      });
+        ),
+      );
     const runtime = await readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME });
     // ActiveState=failed collapses to the generic "stopped" status, so the raw
     // state + restart counters are what let callers detect the crash-loop give-up.
@@ -1990,10 +2085,7 @@ describe("stageSystemdService", () => {
   }
 
   function mockSystemctlStatusOk(): void {
-    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
-      assertUserSystemctlArgs(args, "status");
-      cb(null, "", "");
-    });
+    execFileMock.mockImplementationOnce(systemctlUserSuccess("status"));
   }
 
   beforeEach(() => {
@@ -2163,13 +2255,7 @@ describe("stageSystemdService", () => {
     };
     try {
       mockSystemctlStatusOk();
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
-      });
+      await stageSystemdService(gatewayPortSystemdServiceFixture(env, "18789"));
       expect(assertNoSystemSystemdOwnershipMock).toHaveBeenCalledWith(
         "openclaw-gateway-work.service",
       );
@@ -2213,17 +2299,15 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: {
-          OPENCLAW_GATEWAY_TOKEN: "dotenv-token",
-          LLM_API_KEY: "dotenv-key",
-          OPENCLAW_GATEWAY_PORT: "18789",
-        },
-      });
+      await stageSystemdService(
+        gatewaySystemdServiceFixture(env, {
+          environment: {
+            OPENCLAW_GATEWAY_TOKEN: "dotenv-token",
+            LLM_API_KEY: "dotenv-key",
+            OPENCLAW_GATEWAY_PORT: "18789",
+          },
+        }),
+      );
 
       const unit = await fs.readFile(unitPath, "utf8");
 
@@ -2259,13 +2343,12 @@ describe("stageSystemdService", () => {
       );
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: [wrapperPath, "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
-      });
+      await stageSystemdService(
+        systemdServiceFixture(env, [wrapperPath, "gateway", "run"], {
+          workingDirectory: "/tmp",
+          environment: { OPENCLAW_GATEWAY_PORT: "18789" },
+        }),
+      );
 
       expect(await fs.readFile(envFilePath, "utf8")).toBe("OPERATOR_API_KEY=operator-owned\n");
       expect(await fs.readFile(unitPath, "utf8")).toContain(`EnvironmentFile=-${envFilePath}`);
@@ -2407,20 +2490,18 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "node", "run"],
-        workingDirectory: "/tmp",
-        environment: {
-          OPENCLAW_GATEWAY_TOKEN: "fresh-file-token",
-          OPENCLAW_GATEWAY_PORT: "18789",
-          OPENCLAW_SERVICE_KIND: "node",
-        },
-        environmentValueSources: {
-          OPENCLAW_GATEWAY_TOKEN: "file",
-        },
-      });
+      await stageSystemdService(
+        nodeSystemdServiceFixture(env, {
+          environment: {
+            OPENCLAW_GATEWAY_TOKEN: "fresh-file-token",
+            OPENCLAW_GATEWAY_PORT: "18789",
+            OPENCLAW_SERVICE_KIND: "node",
+          },
+          environmentValueSources: {
+            OPENCLAW_GATEWAY_TOKEN: "file",
+          },
+        }),
+      );
 
       const [unit, nodeEnvFile, gatewayEnvFile] = await Promise.all([
         fs.readFile(unitPath, "utf8"),
@@ -2450,19 +2531,17 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "node", "run"],
-        workingDirectory: "/tmp",
-        environment: {
-          OPENCLAW_GATEWAY_PORT: "18789",
-          OPENCLAW_SERVICE_KIND: "node",
-        },
-        environmentValueSources: {
-          OPENCLAW_GATEWAY_TOKEN: "file",
-        },
-      });
+      await stageSystemdService(
+        nodeSystemdServiceFixture(env, {
+          environment: {
+            OPENCLAW_GATEWAY_PORT: "18789",
+            OPENCLAW_SERVICE_KIND: "node",
+          },
+          environmentValueSources: {
+            OPENCLAW_GATEWAY_TOKEN: "file",
+          },
+        }),
+      );
 
       const unit = await fs.readFile(unitPath, "utf8");
 
@@ -2483,19 +2562,17 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: {
-          LLM_API_KEY: "$SECRET_FROM_SHELL",
-          OPENCLAW_GATEWAY_PORT: "18789",
-        },
-        environmentValueSources: {
-          LLM_API_KEY: "inline-and-file",
-        },
-      });
+      await stageSystemdService(
+        gatewaySystemdServiceFixture(env, {
+          environment: {
+            LLM_API_KEY: "$SECRET_FROM_SHELL",
+            OPENCLAW_GATEWAY_PORT: "18789",
+          },
+          environmentValueSources: {
+            LLM_API_KEY: "inline-and-file",
+          },
+        }),
+      );
 
       const unit = await fs.readFile(unitPath, "utf8");
       expect(unit).not.toContain("EnvironmentFile=");
@@ -2524,20 +2601,18 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "node", "run"],
-        workingDirectory: "/tmp",
-        environment: {
-          OPENCLAW_GATEWAY_TOKEN: "fresh-token",
-          OPENCLAW_GATEWAY_PORT: "18789",
-          OPENCLAW_SERVICE_KIND: "node",
-        },
-        environmentValueSources: {
-          OPENCLAW_GATEWAY_TOKEN: "file",
-        },
-      });
+      await stageSystemdService(
+        nodeSystemdServiceFixture(env, {
+          environment: {
+            OPENCLAW_GATEWAY_TOKEN: "fresh-token",
+            OPENCLAW_GATEWAY_PORT: "18789",
+            OPENCLAW_SERVICE_KIND: "node",
+          },
+          environmentValueSources: {
+            OPENCLAW_GATEWAY_TOKEN: "file",
+          },
+        }),
+      );
 
       const [unit, backupUnit, backupStat] = await Promise.all([
         fs.readFile(unitPath, "utf8"),
@@ -2566,16 +2641,14 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: {
-          OPENCLAW_GATEWAY_TOKEN: "fresh-token",
-          LLM_API_KEY: "dotenv-key",
-        },
-      });
+      await stageSystemdService(
+        gatewaySystemdServiceFixture(env, {
+          environment: {
+            OPENCLAW_GATEWAY_TOKEN: "fresh-token",
+            LLM_API_KEY: "dotenv-key",
+          },
+        }),
+      );
 
       const unit = await fs.readFile(unitPath, "utf8");
 
@@ -2649,13 +2722,7 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
-      });
+      await stageSystemdService(gatewayPortSystemdServiceFixture(env, "18789"));
 
       const envFile = await fs.readFile(envFilePath, "utf8");
       // Operator-only secret must survive even when no dotenv vars are staged.
@@ -2681,13 +2748,11 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: { LLM_API_KEY: "new-value" },
-      });
+      await stageSystemdService(
+        gatewaySystemdServiceFixture(env, {
+          environment: { LLM_API_KEY: "new-value" },
+        }),
+      );
 
       const envFile = await fs.readFile(envFilePath, "utf8");
       // Operator secrets survive; the state-dir key is loaded directly by Gateway startup.
@@ -2712,13 +2777,7 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
-      });
+      await stageSystemdService(gatewayPortSystemdServiceFixture(env, "18789"));
 
       const envFile = await fs.readFile(envFilePath, "utf8");
       expect(envFile).toContain('OPENROUTER_API_KEY="\\$SECRET_FROM_SHELL"');
@@ -2744,13 +2803,7 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
-      });
+      await stageSystemdService(gatewayPortSystemdServiceFixture(env, "18789"));
 
       const envFile = await fs.readFile(envFilePath, "utf8");
       // The stale literal reference for the skipped managed key is dropped...
@@ -2771,13 +2824,7 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
-      });
+      await stageSystemdService(gatewayPortSystemdServiceFixture(env, "18789"));
 
       const envFile = await fs.readFile(envFilePath, "utf8");
       expect(envFile).not.toContain("LLM_API_KEY");
@@ -2805,13 +2852,7 @@ describe("stageSystemdService", () => {
 
       mockSystemctlStatusOk();
 
-      await stageSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "gateway", "run"],
-        workingDirectory: "/tmp",
-        environment: { OPENCLAW_GATEWAY_PORT: "18789" },
-      });
+      await stageSystemdService(gatewayPortSystemdServiceFixture(env, "18789"));
 
       const envFile = await fs.readFile(envFilePath, "utf8");
       expect(envFile).toContain("ANTHROPIC_API_KEY=sk-ant-operator-secret");
@@ -2858,33 +2899,19 @@ describe("systemd service install and uninstall", () => {
   it("activates the OPENCLAW_SYSTEMD_UNIT override during install", async () => {
     await withNodeSystemdFixture(async ({ env, unitPath }) => {
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "daemon-reload");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "enable", NODE_SERVICE);
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "restart", NODE_SERVICE);
-          cb(null, "", "");
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlUserSuccess("daemon-reload"))
+        .mockImplementationOnce(systemctlUserSuccess("enable", NODE_SERVICE))
+        .mockImplementationOnce(systemctlUserSuccess("restart", NODE_SERVICE));
 
-      await installSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "node", "run"],
-        workingDirectory: "/tmp",
-        description: "OpenClaw Node Host",
-        environment: {
-          OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
-        },
-      });
+      await installSystemdService(
+        nodeSystemdServiceFixture(env, {
+          description: "OpenClaw Node Host",
+          environment: {
+            OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
+          },
+        }),
+      );
 
       const unit = await fs.readFile(unitPath, "utf8");
       expect(unitPath).toMatch(/openclaw-node\.service$/);
@@ -2930,14 +2957,12 @@ describe("systemd service install and uninstall", () => {
         });
         const warn = vi.fn();
 
-        await installSystemdService({
-          env,
-          stdout: createWritableStreamMock().stdout,
-          warn,
-          programArguments: ["/usr/bin/openclaw", "node", "run"],
-          workingDirectory: "/tmp",
-          environment: { OPENCLAW_SYSTEMD_UNIT: "openclaw-node" },
-        });
+        await installSystemdService(
+          nodeSystemdServiceFixture(env, {
+            warn,
+            environment: { OPENCLAW_SYSTEMD_UNIT: "openclaw-node" },
+          }),
+        );
 
         if (shouldWarn) {
           expect(warn).toHaveBeenCalledWith(
@@ -2953,44 +2978,30 @@ describe("systemd service install and uninstall", () => {
   it("retries enable after reloading again when systemd cannot see the written unit yet", async () => {
     await withNodeSystemdFixture(async ({ env }) => {
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "daemon-reload");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "enable", NODE_SERVICE);
-          cb(
-            createExecFileError("enable failed"),
-            "",
-            "Unit file openclaw-node.service does not exist.",
-          );
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "daemon-reload");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "enable", NODE_SERVICE);
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "restart", NODE_SERVICE);
-          cb(null, "", "");
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlUserSuccess("daemon-reload"))
+        .mockImplementationOnce(
+          systemctlUserResult(
+            [
+              createExecFileError("enable failed"),
+              "",
+              "Unit file openclaw-node.service does not exist.",
+            ],
+            "enable",
+            NODE_SERVICE,
+          ),
+        )
+        .mockImplementationOnce(systemctlUserSuccess("daemon-reload"))
+        .mockImplementationOnce(systemctlUserSuccess("enable", NODE_SERVICE))
+        .mockImplementationOnce(systemctlUserSuccess("restart", NODE_SERVICE));
 
-      await installSystemdService({
-        env,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "node", "run"],
-        workingDirectory: "/tmp",
-        environment: {
-          OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
-        },
-      });
+      await installSystemdService(
+        nodeSystemdServiceFixture(env, {
+          environment: {
+            OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
+          },
+        }),
+      );
 
       expect(execFileMock).toHaveBeenCalledTimes(6);
     });
@@ -2999,43 +3010,15 @@ describe("systemd service install and uninstall", () => {
   it("falls back to machine user scope when install activation hits a no-medium user bus failure", async () => {
     await withNodeSystemdFixture(async ({ env }) => {
       const installEnv = { ...env, USER: "debian" };
-      execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "daemon-reload");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "enable", NODE_SERVICE);
-          cb(
-            createExecFileError("Failed to connect to bus: No medium found", {
-              stderr: "Failed to connect to bus: No medium found",
-            }),
-            "",
-            "",
-          );
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertMachineUserSystemctlArgs(args, "debian", "enable", NODE_SERVICE);
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "restart", NODE_SERVICE);
-          cb(null, "", "");
-        });
+      mockNodeInstallNoMediumFailure("debian");
 
-      await installSystemdService({
-        env: installEnv,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "node", "run"],
-        workingDirectory: "/tmp",
-        environment: {
-          OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
-        },
-      });
+      await installSystemdService(
+        nodeSystemdServiceFixture(installEnv, {
+          environment: {
+            OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
+          },
+        }),
+      );
 
       expect(execFileMock).toHaveBeenCalledTimes(5);
     });
@@ -3045,43 +3028,15 @@ describe("systemd service install and uninstall", () => {
     await withNodeSystemdFixture(async ({ env }) => {
       mockEffectiveUid(1000);
       const installEnv = { ...env, USER: "openclaw", SUDO_USER: "admin" };
-      execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "daemon-reload");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "enable", NODE_SERVICE);
-          cb(
-            createExecFileError("Failed to connect to bus: No medium found", {
-              stderr: "Failed to connect to bus: No medium found",
-            }),
-            "",
-            "",
-          );
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertMachineUserSystemctlArgs(args, "openclaw", "enable", NODE_SERVICE);
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "restart", NODE_SERVICE);
-          cb(null, "", "");
-        });
+      mockNodeInstallNoMediumFailure("openclaw");
 
-      await installSystemdService({
-        env: installEnv,
-        stdout: createWritableStreamMock().stdout,
-        programArguments: ["/usr/bin/openclaw", "node", "run"],
-        workingDirectory: "/tmp",
-        environment: {
-          OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
-        },
-      });
+      await installSystemdService(
+        nodeSystemdServiceFixture(installEnv, {
+          environment: {
+            OPENCLAW_SYSTEMD_UNIT: "openclaw-node",
+          },
+        }),
+      );
 
       expect(execFileMock).toHaveBeenCalledTimes(5);
     });
@@ -3092,25 +3047,7 @@ describe("systemd service install and uninstall", () => {
       vi.spyOn(os, "userInfo").mockImplementation(() => {
         throw new Error("no user info");
       });
-      execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "daemon-reload");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "enable", NODE_SERVICE);
-          cb(
-            createExecFileError("Failed to connect to bus: No medium found", {
-              stderr: "Failed to connect to bus: No medium found",
-            }),
-            "",
-            "",
-          );
-        });
+      mockNodeInstallNoMediumFailure();
 
       await expect(
         installSystemdService({
@@ -3141,14 +3078,15 @@ describe("systemd service install and uninstall", () => {
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Node\n", "utf8");
       await fs.writeFile(nodeEnvFilePath, "OPENCLAW_GATEWAY_TOKEN=preserved-token\n", "utf8");
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "disable", "--now", NODE_SERVICE);
-          cb(createExecFileError(detail), "", detail);
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(
+          systemctlUserResult(
+            [createExecFileError(detail), "", detail],
+            "disable",
+            "--now",
+            NODE_SERVICE,
+          ),
+        );
 
       const { stdout } = createWritableStreamMock();
 
@@ -3169,14 +3107,15 @@ describe("systemd service install and uninstall", () => {
   ])("keeps missing or inactive systemd unit removal idempotent: %s", async (detail) => {
     await withNodeSystemdFixture(async ({ env }) => {
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "disable", "--now", NODE_SERVICE);
-          cb(createExecFileError(detail), "", detail);
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(
+          systemctlUserResult(
+            [createExecFileError(detail), "", detail],
+            "disable",
+            "--now",
+            NODE_SERVICE,
+          ),
+        );
 
       const { write, stdout } = createWritableStreamMock();
 
@@ -3204,14 +3143,8 @@ describe("systemd service install and uninstall", () => {
       );
 
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "disable", "--now", NODE_SERVICE);
-          cb(null, "", "");
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlUserSuccess("disable", "--now", NODE_SERVICE));
 
       const { write, stdout } = createWritableStreamMock();
       await uninstallSystemdService({ env, stdout });
@@ -3246,14 +3179,8 @@ describe("systemd service install and uninstall", () => {
       });
 
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "disable", "--now", NODE_SERVICE);
-          cb(null, "", "");
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlUserSuccess("disable", "--now", NODE_SERVICE));
 
       const { stdout } = createWritableStreamMock();
       await uninstallSystemdService({ env, stdout });
@@ -3274,14 +3201,8 @@ describe("systemd service install and uninstall", () => {
       );
 
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "disable", "--now", NODE_SERVICE);
-          cb(null, "", "");
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlUserSuccess("disable", "--now", NODE_SERVICE));
 
       const unlinkError = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
       unlinkError.code = "EACCES";
@@ -3321,9 +3242,9 @@ describe("isSystemUnitActiveAndEnabled", () => {
 
   it("returns false for an enabled unit that is not running", async () => {
     // Deleting the user unit here would leave no gateway until the next boot.
-    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
-      cb(createExecFileError("inactive", { code: 3 }), "", "");
-    });
+    execFileMock.mockImplementationOnce(
+      execFileResult(createExecFileError("inactive", { code: 3 }), "", ""),
+    );
     await expect(isSystemUnitActiveAndEnabled({}, GATEWAY_SERVICE)).resolves.toBe(false);
     expect(execFileMock).toHaveBeenCalledTimes(1);
   });
@@ -3331,18 +3252,14 @@ describe("isSystemUnitActiveAndEnabled", () => {
   it("returns false for a running unit that is not enabled at boot", async () => {
     // Deleting the user unit here would leave no gateway after a reboot.
     execFileMock
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
-        cb(null, "", "");
-      })
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
-        cb(createExecFileError("disabled", { code: 1 }), "", "");
-      });
+      .mockImplementationOnce(execFileResult(null, "", ""))
+      .mockImplementationOnce(execFileResult(createExecFileError("disabled", { code: 1 }), "", ""));
     await expect(isSystemUnitActiveAndEnabled({}, GATEWAY_SERVICE)).resolves.toBe(false);
   });
 
   it("returns false when systemctl is unavailable", async () => {
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
-      cb(createExecFileError("spawn systemctl ENOENT", { code: "ENOENT" }), "", ""),
+    execFileMock.mockImplementation(
+      execFileResult(createExecFileError("spawn systemctl ENOENT", { code: "ENOENT" }), "", ""),
     );
     await expect(isSystemUnitActiveAndEnabled({}, GATEWAY_SERVICE)).resolves.toBe(false);
   });
@@ -3353,12 +3270,8 @@ describe("isSystemUnitActiveAndEnabled", () => {
     "returns false for the non-persistent is-enabled state %s",
     async (state) => {
       execFileMock
-        .mockImplementationOnce((_cmd, _args, _opts, cb) => {
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, _args, _opts, cb) => {
-          cb(null, `${state}\n`, "");
-        });
+        .mockImplementationOnce(execFileResult(null, "", ""))
+        .mockImplementationOnce(execFileResult(null, `${state}\n`, ""));
       await expect(isSystemUnitActiveAndEnabled({}, GATEWAY_SERVICE)).resolves.toBe(false);
     },
   );
@@ -3378,22 +3291,19 @@ describe("uninstallLegacySystemdUnits", () => {
       await fs.mkdir(path.dirname(unitPath), { recursive: true });
       await fs.writeFile(unitPath, "[Unit]\nDescription=Clawdbot Gateway\n", "utf8");
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "is-enabled", "clawdbot-gateway.service");
-          cb(null, "enabled\n", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "disable", "--now", "clawdbot-gateway.service");
-          cb(createExecFileError("permission denied", { code: 1 }), "", "Permission denied");
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(
+          systemctlUserResult([null, "enabled\n", ""], "is-enabled", "clawdbot-gateway.service"),
+        )
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(
+          systemctlUserResult(
+            [createExecFileError("permission denied", { code: 1 }), "", "Permission denied"],
+            "disable",
+            "--now",
+            "clawdbot-gateway.service",
+          ),
+        );
 
       const { stdout } = createWritableStreamMock();
       await expect(uninstallLegacySystemdUnits({ env, stdout })).rejects.toThrow(
@@ -3431,19 +3341,10 @@ describe("uninstallUserSystemdGatewayUnit", () => {
     await withUserUnitFixture(async ({ env, unitPath }) => {
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Gateway\n", "utf8");
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "disable", "--now", GATEWAY_SERVICE);
-          cb(null, "", "");
-        })
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlUserSuccess("disable", "--now", GATEWAY_SERVICE))
         // A deleted unit stays loaded until the manager reloads.
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "daemon-reload");
-          cb(null, "", "");
-        });
+        .mockImplementationOnce(systemctlUserSuccess("daemon-reload"));
 
       const { write, stdout } = createWritableStreamMock();
       const result = await uninstallUserSystemdGatewayUnit({ env, stdout });
@@ -3459,14 +3360,8 @@ describe("uninstallUserSystemdGatewayUnit", () => {
   it("reports removed:false without throwing when the unit file is already absent", async () => {
     await withUserUnitFixture(async ({ env }) => {
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "disable", "--now", GATEWAY_SERVICE);
-          cb(null, "", "");
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlUserSuccess("disable", "--now", GATEWAY_SERVICE));
 
       const { write, stdout } = createWritableStreamMock();
       const result = await uninstallUserSystemdGatewayUnit({ env, stdout });
@@ -3479,8 +3374,8 @@ describe("uninstallUserSystemdGatewayUnit", () => {
   it("removes the unit file only when systemctl is unavailable", async () => {
     await withUserUnitFixture(async ({ env, unitPath }) => {
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Gateway\n", "utf8");
-      execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
-        cb(createExecFileError("spawn systemctl ENOENT", { code: "ENOENT" }), "", ""),
+      execFileMock.mockImplementation(
+        execFileResult(createExecFileError("spawn systemctl ENOENT", { code: "ENOENT" }), "", ""),
       );
 
       const { write, stdout } = createWritableStreamMock();
@@ -3500,14 +3395,15 @@ describe("uninstallUserSystemdGatewayUnit", () => {
     await withUserUnitFixture(async ({ env, unitPath }) => {
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Gateway\n", "utf8");
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "disable", "--now", GATEWAY_SERVICE);
-          cb(createExecFileError("permission denied", { code: 1 }), "", "Permission denied");
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(
+          systemctlUserResult(
+            [createExecFileError("permission denied", { code: 1 }), "", "Permission denied"],
+            "disable",
+            "--now",
+            GATEWAY_SERVICE,
+          ),
+        );
 
       const { stdout } = createWritableStreamMock();
       await expect(uninstallUserSystemdGatewayUnit({ env, stdout })).rejects.toThrow(
@@ -3522,18 +3418,14 @@ describe("uninstallUserSystemdGatewayUnit", () => {
     await withUserUnitFixture(async ({ env, unitPath }) => {
       await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Gateway\n", "utf8");
       execFileMock
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "status");
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "disable", "--now", GATEWAY_SERVICE);
-          cb(null, "", "");
-        })
-        .mockImplementationOnce((_cmd, args, _opts, cb) => {
-          assertUserSystemctlArgs(args, "daemon-reload");
-          cb(createExecFileError("bus unavailable", { code: 1 }), "", "Bus unavailable");
-        });
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce(systemctlUserSuccess("disable", "--now", GATEWAY_SERVICE))
+        .mockImplementationOnce(
+          systemctlUserResult(
+            [createExecFileError("bus unavailable", { code: 1 }), "", "Bus unavailable"],
+            "daemon-reload",
+          ),
+        );
 
       const { stdout } = createWritableStreamMock();
       await expect(uninstallUserSystemdGatewayUnit({ env, stdout })).rejects.toThrow(
@@ -3565,7 +3457,7 @@ describe("systemd service control", () => {
     assertNoSystemSystemdOwnershipMock.mockRejectedValueOnce(
       new Error("same-name system ownership"),
     );
-    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""));
+    execFileMock.mockImplementationOnce(execFileSuccess());
 
     await expect(
       startSystemdService({
@@ -3580,7 +3472,7 @@ describe("systemd service control", () => {
   it("starts the resolved user unit and ignores audit observer failures", async () => {
     const sequence: string[] = [];
     execFileMock
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce(execFileSuccess())
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
         sequence.push(args[1] ?? "");
@@ -3615,7 +3507,7 @@ describe("systemd service control", () => {
   it("still starts when reset-failed cannot resolve an unloaded user unit", async () => {
     const sequence: string[] = [];
     execFileMock
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce(execFileSuccess())
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
         sequence.push(args[1] ?? "");
@@ -3643,7 +3535,7 @@ describe("systemd service control", () => {
   it("stops the resolved user unit", async () => {
     const sequence: string[] = [];
     execFileMock
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce(execFileSuccess())
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "stop", GATEWAY_SERVICE);
         sequence.push(args[1] ?? "");
@@ -3669,11 +3561,8 @@ describe("systemd service control", () => {
 
   it("audits a successful stop before a later output failure", async () => {
     execFileMock
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "stop", GATEWAY_SERVICE);
-        cb(null, "", "");
-      });
+      .mockImplementationOnce(execFileSuccess())
+      .mockImplementationOnce(systemctlUserSuccess("stop", GATEWAY_SERVICE));
     const onMutation = vi.fn();
     const write = vi.fn(() => {
       throw new Error("output failed");
@@ -3689,17 +3578,14 @@ describe("systemd service control", () => {
 
   it("allows stop when systemd status is degraded but available", async () => {
     execFileMock
-      .mockImplementationOnce((_cmd, _args, _opts, cb) =>
-        cb(
+      .mockImplementationOnce(
+        execFileResult(
           createExecFileError("degraded", { stderr: "degraded\nsome-unit.service failed" }),
           "",
           "",
         ),
       )
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "stop", GATEWAY_SERVICE);
-        cb(null, "", "");
-      });
+      .mockImplementationOnce(systemctlUserSuccess("stop", GATEWAY_SERVICE));
 
     await stopSystemdService({
       stdout: createWritableStreamMock().stdout,
@@ -3710,7 +3596,7 @@ describe("systemd service control", () => {
   it("runs reset-failed before restarting a profile-specific user unit", async () => {
     const restartSequence: string[] = [];
     execFileMock
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce(execFileSuccess())
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "reset-failed", "openclaw-gateway-work.service");
         // args[0] is the "--user" scope flag; the systemctl verb is args[1].
@@ -3730,7 +3616,7 @@ describe("systemd service control", () => {
 
   it("surfaces stop failures with systemctl detail", async () => {
     execFileMock
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => cb(null, "", ""))
+      .mockImplementationOnce(execFileSuccess())
       .mockImplementationOnce((_cmd, _args, _opts, cb) => {
         const err = new Error("stop failed") as Error & { code?: number };
         err.code = 1;
@@ -3749,13 +3635,13 @@ describe("systemd service control", () => {
     vi.spyOn(os, "userInfo").mockImplementationOnce(() => {
       throw new Error("no user info");
     });
-    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
-      cb(
+    execFileMock.mockImplementationOnce(
+      execFileResult(
         createExecFileError("Failed to connect to bus", { stderr: "Failed to connect to bus" }),
         "",
         "",
-      );
-    });
+      ),
+    );
 
     await expect(
       stopSystemdService({
@@ -3768,14 +3654,10 @@ describe("systemd service control", () => {
   it("targets the sudo caller's user scope when SUDO_USER is set", async () => {
     mockEffectiveUid(0);
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertMachineUserSystemctlArgs(args, "debian", "status");
-        cb(null, "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertMachineUserSystemctlArgs(args, "debian", "reset-failed", GATEWAY_SERVICE);
-        cb(null, "", "");
-      })
+      .mockImplementationOnce(systemctlMachineUserSuccess("debian", "status"))
+      .mockImplementationOnce(
+        systemctlMachineUserSuccess("debian", "reset-failed", GATEWAY_SERVICE),
+      )
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertMachineRestartArgs(args);
         cb(null, "", "");
@@ -3786,18 +3668,9 @@ describe("systemd service control", () => {
   it("restarts root user services directly when stale SUDO_USER is paired with root bus environment", async () => {
     mockEffectiveUid(0);
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "status");
-        cb(null, "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
-        cb(null, "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "restart", GATEWAY_SERVICE);
-        cb(null, "", "");
-      });
+      .mockImplementationOnce(systemctlUserSuccess("status"))
+      .mockImplementationOnce(systemctlUserSuccess("reset-failed", GATEWAY_SERVICE))
+      .mockImplementationOnce(systemctlUserSuccess("restart", GATEWAY_SERVICE));
     await assertRestartSuccess({
       HOME: "/root",
       USER: "root",
@@ -3810,18 +3683,9 @@ describe("systemd service control", () => {
 
   it("keeps direct --user scope when SUDO_USER is root", async () => {
     execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "status");
-        cb(null, "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
-        cb(null, "", "");
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "restart", GATEWAY_SERVICE);
-        cb(null, "", "");
-      });
+      .mockImplementationOnce(systemctlUserSuccess("status"))
+      .mockImplementationOnce(systemctlUserSuccess("reset-failed", GATEWAY_SERVICE))
+      .mockImplementationOnce(systemctlUserSuccess("restart", GATEWAY_SERVICE));
     await assertRestartSuccess({ SUDO_USER: "root", USER: "root" });
   });
 
@@ -3835,10 +3699,7 @@ describe("systemd service control", () => {
         });
         cb(err, "", "");
       })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertMachineUserSystemctlArgs(args, "debian", "status");
-        cb(null, "", "");
-      })
+      .mockImplementationOnce(systemctlMachineUserSuccess("debian", "status"))
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "reset-failed", GATEWAY_SERVICE);
         const err = createExecFileError("Failed to connect to user scope bus", {
@@ -3846,10 +3707,9 @@ describe("systemd service control", () => {
         });
         cb(err, "", "");
       })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertMachineUserSystemctlArgs(args, "debian", "reset-failed", GATEWAY_SERVICE);
-        cb(null, "", "");
-      })
+      .mockImplementationOnce(
+        systemctlMachineUserSuccess("debian", "reset-failed", GATEWAY_SERVICE),
+      )
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         assertUserSystemctlArgs(args, "restart", GATEWAY_SERVICE);
         const err = createExecFileError("Failed to connect to user scope bus", {


### PR DESCRIPTION
## What Problem This Solves

Removes duplicated launchd and systemd fixtures that repeated service definitions, environment setup, and assertions across the daemon test suites.

## Why This Change Was Made

Both platform suites now use typed, owner-local builders for their mechanical service setup while keeping platform-specific commands, paths, permissions, environment values, and failure cases explicit at each test.

Production LOC: +0/-0 (net 0) | Tests: +768/-1150 (net -382)

## User Impact

There is no user-visible behavior change. Daemon installation and lifecycle coverage remains intact while the platform suites are easier to review and extend.

## Evidence

- Daemon owner coverage: 329 tests passed.
- Independent sibling coverage: 147 tests passed.
- Complete expectation and security-sensitive path, permission, command, and environment inventories were preserved.
- Focused typed lint, formatting, and diff validation passed.
