### PR TITLE
test(outbound): deduplicate delivery fixtures

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -9,6 +9,7 @@ import { onTrustedMessageAuditEventForTest as onTrustedMessageAuditEvent } from 
 import { chunkText } from "../../auto-reply/chunk.js";
 import { createMessageReceiptFromOutboundResults } from "../../channels/message/receipt.js";
 import type {
+  ChannelMessageSendResult,
   ChannelMessageSendMediaContext,
   ChannelMessageSendTextContext,
 } from "../../channels/message/types.js";
@@ -256,23 +257,23 @@ function resolveMatrixSender(deps: DeliverOutboundArgs["deps"]): MatrixSendFn {
   return sender as MatrixSendFn;
 }
 
-function requireMockCallArg(
-  mockFn: { mock: { calls: unknown[][] } },
+function requireMockCallArg<T = Record<string, unknown>>(
+  mockFn: { mock: { calls: Array<[T, ...unknown[]]> } },
   label: string,
   index = 0,
-): Record<string, unknown> {
-  const arg = mockFn.mock.calls[index]?.[0] as Record<string, unknown> | undefined;
+): T {
+  const arg = mockFn.mock.calls[index]?.[0];
   if (!arg) {
     throw new Error(`expected ${label} call #${index + 1}`);
   }
-  return arg;
+  return arg as T;
 }
 
-function requireMockCall(
-  mockFn: { mock: { calls: unknown[][] } },
+function requireMockCall<T extends unknown[] = unknown[]>(
+  mockFn: { mock: { calls: T[] } },
   label: string,
   index = 0,
-): unknown[] {
+): T {
   const call = mockFn.mock.calls[index];
   if (!call) {
     throw new Error(`expected ${label} call #${index + 1}`);
@@ -289,6 +290,10 @@ function withMatrixChannel(result: Awaited<ReturnType<MatrixSendFn>>) {
     channel: "matrix" as const,
     ...result,
   };
+}
+
+function createNetworkError(message: string, code: string, syscall?: string) {
+  return Object.assign(new Error(message), { code, ...(syscall ? { syscall } : {}) });
 }
 
 function setTestPlugin(
@@ -316,6 +321,32 @@ function setTestOutbound(
   setTestPlugin(createOutboundTestPlugin({ id, outbound: createTestOutbound(overrides, id) }));
 }
 
+type OutboundTextSender = NonNullable<ChannelOutboundAdapter["sendText"]>;
+type OutboundPayloadSender = NonNullable<ChannelOutboundAdapter["sendPayload"]>;
+
+function installTextOutbound(
+  send: OutboundTextSender | Awaited<ReturnType<OutboundTextSender>>,
+  overrides: Omit<Partial<ChannelOutboundAdapter>, "sendText"> = {},
+  id: Parameters<typeof createOutboundTestPlugin>[0]["id"] = "matrix",
+) {
+  const implementation: OutboundTextSender = typeof send === "function" ? send : async () => send;
+  const sendText = vi.fn<OutboundTextSender>(implementation);
+  setTestOutbound({ ...overrides, sendText }, id);
+  return sendText;
+}
+
+function installPayloadOutbound(
+  send: OutboundPayloadSender | Awaited<ReturnType<OutboundPayloadSender>>,
+  overrides: Omit<Partial<ChannelOutboundAdapter>, "sendPayload"> = {},
+  id: Parameters<typeof createOutboundTestPlugin>[0]["id"] = "matrix",
+) {
+  const implementation: OutboundPayloadSender =
+    typeof send === "function" ? send : async () => send;
+  const sendPayload = vi.fn<OutboundPayloadSender>(implementation);
+  setTestOutbound({ ...overrides, sendPayload }, id);
+  return sendPayload;
+}
+
 function setMatrixMessageAdapter(
   message: NonNullable<ChannelPlugin["message"]>,
   outbound?: Partial<ChannelOutboundAdapter>,
@@ -328,6 +359,42 @@ function setMatrixMessageAdapter(
         }
       : { id: "matrix", message },
   );
+}
+
+type MatrixMessageAdapter = NonNullable<ChannelPlugin["message"]>;
+type MatrixMessageTextSender = NonNullable<MatrixMessageAdapter["send"]>["text"];
+
+function createMatrixMessageSendResult(
+  messageId: string,
+  kind: "media" | "text" = "text",
+): ChannelMessageSendResult {
+  return {
+    messageId,
+    receipt: createMessageReceiptFromOutboundResults({
+      results: [{ channel: "matrix", messageId }],
+      kind,
+    }),
+  };
+}
+
+function installMatrixTextMessageAdapter(params: {
+  messageId: string;
+  durableFinal?: MatrixMessageAdapter["durableFinal"];
+  lifecycle?: NonNullable<MatrixMessageAdapter["send"]>["lifecycle"];
+  outbound?: Partial<ChannelOutboundAdapter>;
+}) {
+  const messageSendText = vi.fn<MatrixMessageTextSender>(async () =>
+    createMatrixMessageSendResult(params.messageId),
+  );
+  setMatrixMessageAdapter(
+    {
+      id: "matrix",
+      ...(params.durableFinal ? { durableFinal: params.durableFinal } : {}),
+      send: { ...(params.lifecycle ? { lifecycle: params.lifecycle } : {}), text: messageSendText },
+    },
+    params.outbound,
+  );
+  return messageSendText;
 }
 
 const matrixOutboundForTest: ChannelOutboundAdapter = {
@@ -455,39 +522,26 @@ describe("deliverOutboundPayloads", () => {
   beforeEach(() => {
     resetDiagnosticEventsForTest();
     setActivePluginRegistry(defaultRegistry);
-    mocks.appendAssistantMessageToSessionTranscript.mockClear();
-    hookMocks.runner.hasHooks.mockClear();
+    vi.clearAllMocks();
     hookMocks.runner.hasHooks.mockReturnValue(false);
-    hookMocks.runner.runMessageSending.mockClear();
     hookMocks.runner.runMessageSending.mockResolvedValue(undefined);
-    hookMocks.runner.runReplyPayloadSending.mockClear();
     hookMocks.runner.runReplyPayloadSending.mockImplementation(async (event) => ({
       payload: (event as { payload?: unknown }).payload,
     }));
-    hookMocks.runner.runMessageSent.mockClear();
     hookMocks.runner.runMessageSent.mockResolvedValue(undefined);
-    internalHookMocks.createInternalHookEvent.mockClear();
     internalHookMocks.createInternalHookEvent.mockImplementation(createInternalHookEventPayload);
-    internalHookMocks.triggerInternalHook.mockClear();
-    queueMocks.enqueueDelivery.mockClear();
     queueMocks.enqueueDelivery.mockResolvedValue("mock-queue-id");
-    queueMocks.enqueueDeliveryOnce.mockClear();
     queueMocks.enqueueDeliveryOnce.mockImplementation(async (_params, id) => ({
       id,
       created: true,
     }));
-    queueMocks.enqueuePreparedDeliveryOnce.mockClear();
     queueMocks.enqueuePreparedDeliveryOnce.mockImplementation(async (_params, id) => ({
       id,
       created: true,
     }));
-    queueMocks.loadPendingDelivery.mockClear();
     queueMocks.loadPendingDelivery.mockResolvedValue(null);
-    queueMocks.findDeliveryIntentOwner.mockClear();
     queueMocks.findDeliveryIntentOwner.mockReturnValue(null);
-    queueMocks.claimReusableDeliveryPlatformSendAttempt.mockClear();
     queueMocks.claimReusableDeliveryPlatformSendAttempt.mockResolvedValue("mock-producer-claim");
-    queueMocks.renewDeliveryPlatformSendLease.mockClear();
     queueMocks.renewDeliveryPlatformSendLease.mockImplementation(async () => Date.now() + 30_000);
     queueMocks.withStableDeliveryPreparation.mockReset();
     queueMocks.withStableDeliveryPreparation.mockImplementation(
@@ -525,33 +579,18 @@ describe("deliverOutboundPayloads", () => {
         };
       },
     );
-    completionMocks.completeDurableDelivery.mockClear();
-    completionMocks.failDurableDelivery.mockClear();
-    completionMocks.markDurableDeliveryQueued.mockClear();
-    completionMocks.rejectDurableDelivery.mockClear();
-    completionMocks.suppressDurableDelivery.mockClear();
-    queueMocks.ackDelivery.mockClear();
     queueMocks.ackDelivery.mockResolvedValue(undefined);
-    queueMocks.failDelivery.mockClear();
     queueMocks.failDelivery.mockResolvedValue(undefined);
-    queueMocks.failDeliveryAfterPlatformSend.mockClear();
     queueMocks.failDeliveryAfterPlatformSend.mockResolvedValue(undefined);
-    queueMocks.failDeliveryBeforePlatformSend.mockClear();
     queueMocks.failDeliveryBeforePlatformSend.mockResolvedValue(undefined);
-    queueMocks.moveToFailed.mockClear();
     queueMocks.moveToFailed.mockResolvedValue([]);
-    queueMocks.markDeliveryPlatformOutcomeUnknown.mockClear();
     queueMocks.markDeliveryPlatformOutcomeUnknown.mockResolvedValue(undefined);
-    queueMocks.markDeliveryPlatformSendAttemptStarted.mockClear();
     queueMocks.markDeliveryPlatformSendAttemptStarted.mockResolvedValue(undefined);
-    queueMocks.markDeliveryPlatformSendDispatched.mockClear();
     queueMocks.markDeliveryPlatformSendDispatched.mockResolvedValue(undefined);
-    queueMocks.withActiveDeliveryClaim.mockClear();
     queueMocks.withActiveDeliveryClaim.mockImplementation(async (_entryId, fn) => ({
       status: "claimed",
       value: await fn(),
     }));
-    logMocks.warn.mockClear();
   });
 
   afterEach(() => {
@@ -586,35 +625,15 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("uses channel message adapter capabilities for durable final support", async () => {
-    setMatrixMessageAdapter(
-      {
-        id: "matrix",
-        durableFinal: {
-          capabilities: {
-            text: true,
-            silent: true,
-          },
-        },
-        send: {
-          text: async () => ({
-            messageId: "message",
-            receipt: createMessageReceiptFromOutboundResults({
-              results: [{ channel: "matrix", messageId: "message" }],
-              kind: "text",
-            }),
-          }),
-        },
-      },
-      {
+    installMatrixTextMessageAdapter({
+      messageId: "message",
+      durableFinal: { capabilities: { text: true, silent: true } },
+      outbound: {
         deliveryMode: "direct",
         sendText: async () => ({ channel: "matrix", messageId: "outbound" }),
-        deliveryCapabilities: {
-          durableFinal: {
-            text: true,
-          },
-        },
+        deliveryCapabilities: { durableFinal: { text: true } },
       },
-    );
+    });
     await expect(
       resolveOutboundDurableFinalDeliverySupport({
         cfg: {},
@@ -628,30 +647,14 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("requires a real reconciler for required unknown-send recovery support", async () => {
-    setMatrixMessageAdapter(
-      {
-        id: "matrix",
-        durableFinal: {
-          capabilities: {
-            text: true,
-            reconcileUnknownSend: true,
-          },
-        },
-        send: {
-          text: async () => ({
-            messageId: "message",
-            receipt: createMessageReceiptFromOutboundResults({
-              results: [{ channel: "matrix", messageId: "message" }],
-              kind: "text",
-            }),
-          }),
-        },
-      },
-      {
+    installMatrixTextMessageAdapter({
+      messageId: "message",
+      durableFinal: { capabilities: { text: true, reconcileUnknownSend: true } },
+      outbound: {
         deliveryMode: "direct",
         sendText: async () => ({ channel: "matrix", messageId: "outbound" }),
       },
-    );
+    });
 
     await expect(
       resolveOutboundDurableFinalDeliverySupport({
@@ -670,33 +673,18 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("accepts required unknown-send recovery only when the adapter declares and implements it", async () => {
-    setMatrixMessageAdapter(
-      {
-        id: "matrix",
-        durableFinal: {
-          capabilities: {
-            text: true,
-            media: true,
-            reconcileUnknownSend: true,
-          },
-          reconcileUnknownSendKinds: { text: true },
-          reconcileUnknownSend: async () => ({ status: "not_sent" }),
-        },
-        send: {
-          text: async () => ({
-            messageId: "message",
-            receipt: createMessageReceiptFromOutboundResults({
-              results: [{ channel: "matrix", messageId: "message" }],
-              kind: "text",
-            }),
-          }),
-        },
+    installMatrixTextMessageAdapter({
+      messageId: "message",
+      durableFinal: {
+        capabilities: { text: true, media: true, reconcileUnknownSend: true },
+        reconcileUnknownSendKinds: { text: true },
+        reconcileUnknownSend: async () => ({ status: "not_sent" }),
       },
-      {
+      outbound: {
         deliveryMode: "direct",
         sendText: async () => ({ channel: "matrix", messageId: "outbound" }),
       },
-    );
+    });
 
     await expect(
       resolveOutboundDurableFinalDeliverySupport({
@@ -727,20 +715,11 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("preserves global reconciliation declarations when the optional kind map is absent", async () => {
-    setMatrixMessageAdapter({
-      id: "matrix",
+    installMatrixTextMessageAdapter({
+      messageId: "message",
       durableFinal: {
         capabilities: { text: true, reconcileUnknownSend: true },
         reconcileUnknownSend: async () => ({ status: "not_sent" }),
-      },
-      send: {
-        text: async () => ({
-          messageId: "message",
-          receipt: createMessageReceiptFromOutboundResults({
-            results: [{ channel: "matrix", messageId: "message" }],
-            kind: "text",
-          }),
-        }),
       },
     });
     await expect(
@@ -753,21 +732,12 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("requires every concrete reconciliation kind for heterogeneous batches", async () => {
-    setMatrixMessageAdapter({
-      id: "matrix",
+    installMatrixTextMessageAdapter({
+      messageId: "message",
       durableFinal: {
         capabilities: { text: true, media: true, batch: true, reconcileUnknownSend: true },
         reconcileUnknownSendKinds: { media: true, batch: true },
         reconcileUnknownSend: async () => ({ status: "not_sent" }),
-      },
-      send: {
-        text: async () => ({
-          messageId: "message",
-          receipt: createMessageReceiptFromOutboundResults({
-            results: [{ channel: "matrix", messageId: "message" }],
-            kind: "text",
-          }),
-        }),
       },
     });
 
@@ -790,25 +760,15 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("sends text through the channel message adapter when present", async () => {
-    const messageSendText = vi.fn(async () => ({
-      messageId: "message-adapter-1",
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "matrix", messageId: "message-adapter-1" }],
-        kind: "text",
-      }),
-    }));
     const outboundSendText = vi.fn(async () => ({
       channel: "matrix" as const,
       messageId: "outbound-1",
     }));
-    setMatrixMessageAdapter(
-      {
-        id: "matrix",
-        durableFinal: { capabilities: { text: true } },
-        send: { text: messageSendText },
-      },
-      { chunker: chunkText, sendText: outboundSendText },
-    );
+    const messageSendText = installMatrixTextMessageAdapter({
+      messageId: "message-adapter-1",
+      durableFinal: { capabilities: { text: true } },
+      outbound: { chunker: chunkText, sendText: outboundSendText },
+    });
     const results = await deliverMatrix({});
 
     const [sendTextParams] = expectDefined(
@@ -844,13 +804,7 @@ describe("deliverOutboundPayloads", () => {
     const messageSendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
       order.push("send");
       await ctx.onPlatformSendDispatch?.();
-      return {
-        messageId: "message-adapter-1",
-        receipt: createMessageReceiptFromOutboundResults({
-          results: [{ channel: "matrix", messageId: "message-adapter-1" }],
-          kind: "text",
-        }),
-      };
+      return createMatrixMessageSendResult("message-adapter-1");
     });
     const beforeSendAttempt = vi.fn(() => {
       order.push("before");
@@ -947,23 +901,13 @@ describe("deliverOutboundPayloads", () => {
   it("revalidates before direct adapter handoff when the adapter ignores the dispatch callback", async () => {
     const enteredPreflight = createDeferredCore();
     const resumePreflight = createDeferredCore();
-    const messageSendText = vi.fn(async () => ({
+    const messageSendText = installMatrixTextMessageAdapter({
       messageId: "must-not-send",
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "matrix", messageId: "must-not-send" }],
-        kind: "text",
-      }),
-    }));
-    setMatrixMessageAdapter({
-      id: "matrix",
-      send: {
-        lifecycle: {
-          beforeSendAttempt: async () => {
-            enteredPreflight.resolve();
-            await resumePreflight.promise;
-          },
+      lifecycle: {
+        beforeSendAttempt: async () => {
+          enteredPreflight.resolve();
+          await resumePreflight.promise;
         },
-        text: messageSendText,
       },
     });
     const onPlatformSendDispatch = vi.fn(async () => {
@@ -979,17 +923,9 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("fails closed for an unfinished conversation intent without route authority", async () => {
-    const messageSendText = vi.fn(async () => ({
+    const messageSendText = installMatrixTextMessageAdapter({
       messageId: "should-not-send",
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "matrix", messageId: "should-not-send" }],
-        kind: "text",
-      }),
-    }));
-    setMatrixMessageAdapter({
-      id: "matrix",
       durableFinal: { capabilities: { text: true } },
-      send: { text: messageSendText },
     });
 
     await expect(
@@ -1291,13 +1227,7 @@ describe("deliverOutboundPayloads", () => {
     );
     const messageSendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
       await ctx.onPlatformSendDispatch?.();
-      return {
-        messageId: "message-adapter-1",
-        receipt: createMessageReceiptFromOutboundResults({
-          results: [{ channel: "matrix", messageId: "message-adapter-1" }],
-          kind: "text",
-        }),
-      };
+      return createMatrixMessageSendResult("message-adapter-1");
     });
     setMatrixMessageAdapter({
       id: "matrix",
@@ -1317,17 +1247,9 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("does not assign one durable delivery id to multiple payload sends", async () => {
-    const messageSendText = vi.fn(async (_ctx: ChannelMessageSendTextContext) => ({
+    const messageSendText = installMatrixTextMessageAdapter({
       messageId: "message-adapter-1",
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "matrix", messageId: "message-adapter-1" }],
-        kind: "text",
-      }),
-    }));
-    setMatrixMessageAdapter({
-      id: "matrix",
       durableFinal: { capabilities: { text: true } },
-      send: { text: messageSendText },
     });
 
     await deliverMatrix({
@@ -1344,13 +1266,7 @@ describe("deliverOutboundPayloads", () => {
   it("automatically enables provider reconciliation for one supported prepared payload", async () => {
     const messageSendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
       await ctx.onPlatformSendDispatch?.();
-      return {
-        messageId: "message-adapter-1",
-        receipt: createMessageReceiptFromOutboundResults({
-          results: [{ channel: "matrix", messageId: "message-adapter-1" }],
-          kind: "text",
-        }),
-      };
+      return createMatrixMessageSendResult("message-adapter-1");
     });
     setMatrixMessageAdapter({
       id: "matrix",
@@ -1378,22 +1294,14 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("leaves ordinary multi-payload delivery on the existing fail-closed path", async () => {
-    const messageSendText = vi.fn(async (_ctx: ChannelMessageSendTextContext) => ({
+    const messageSendText = installMatrixTextMessageAdapter({
       messageId: "message-adapter-1",
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "matrix", messageId: "message-adapter-1" }],
-        kind: "text",
-      }),
-    }));
-    setMatrixMessageAdapter({
-      id: "matrix",
       durableFinal: {
         automaticUnknownSendReconciliation: true,
         capabilities: { text: true, reconcileUnknownSend: true },
         reconcileUnknownSendKinds: { text: true },
         reconcileUnknownSend: async () => ({ status: "not_sent" }),
       },
-      send: { text: messageSendText },
     });
 
     await deliverMatrix({
@@ -1432,13 +1340,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("keeps ordinary required media sends independent of text-only reconciliation", async () => {
-    const messageSendMedia = vi.fn(async () => ({
-      messageId: "media-1",
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "matrix", messageId: "media-1" }],
-        kind: "media",
-      }),
-    }));
+    const messageSendMedia = vi.fn(async () => createMatrixMessageSendResult("media-1", "media"));
     setMatrixMessageAdapter({
       id: "matrix",
       durableFinal: {
@@ -1459,21 +1361,13 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("keeps delivery directives on a reconciliable text transport", async () => {
-    const messageSendText = vi.fn(async () => ({
+    const messageSendText = installMatrixTextMessageAdapter({
       messageId: "pinned-text",
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "matrix", messageId: "pinned-text" }],
-        kind: "text",
-      }),
-    }));
-    setMatrixMessageAdapter({
-      id: "matrix",
       durableFinal: {
         capabilities: { text: true, reconcileUnknownSend: true },
         reconcileUnknownSendKinds: { text: true },
         reconcileUnknownSend: async () => ({ status: "not_sent" }),
       },
-      send: { text: messageSendText },
     });
 
     await expect(
@@ -1487,13 +1381,9 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("passes stable part indexes to exact multi-media sends", async () => {
-    const messageSendMedia = vi.fn(async (ctx: ChannelMessageSendMediaContext) => ({
-      messageId: `media-${ctx.deliveryPartIndex}`,
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "matrix", messageId: `media-${ctx.deliveryPartIndex}` }],
-        kind: "media",
-      }),
-    }));
+    const messageSendMedia = vi.fn(async (ctx: ChannelMessageSendMediaContext) =>
+      createMatrixMessageSendResult(`media-${ctx.deliveryPartIndex}`, "media"),
+    );
     setMatrixMessageAdapter({
       id: "matrix",
       durableFinal: {
@@ -1529,13 +1419,9 @@ describe("deliverOutboundPayloads", () => {
         mediaUrls: ["https://example.com/first.png", "https://example.com/second.png"],
       },
     });
-    const messageSendMedia = vi.fn(async (ctx: ChannelMessageSendMediaContext) => ({
-      messageId: `prepared-media-${ctx.deliveryPartIndex}`,
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "matrix", messageId: `prepared-media-${ctx.deliveryPartIndex}` }],
-        kind: "media",
-      }),
-    }));
+    const messageSendMedia = vi.fn(async (ctx: ChannelMessageSendMediaContext) =>
+      createMatrixMessageSendResult(`prepared-media-${ctx.deliveryPartIndex}`, "media"),
+    );
     setMatrixMessageAdapter({
       id: "matrix",
       durableFinal: {
@@ -1569,13 +1455,7 @@ describe("deliverOutboundPayloads", () => {
     const messageSendText = vi.fn(async (ctx: ChannelMessageSendTextContext) => {
       await ctx.onPlatformSendDispatch?.();
       platformSend();
-      return {
-        messageId: "message-adapter-1",
-        receipt: createMessageReceiptFromOutboundResults({
-          results: [{ channel: "matrix", messageId: "message-adapter-1" }],
-          kind: "text",
-        }),
-      };
+      return createMatrixMessageSendResult("message-adapter-1");
     });
     setMatrixMessageAdapter({
       id: "matrix",
@@ -1643,13 +1523,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("preserves unsupported send shapes when recovering a best-effort queue entry", async () => {
-    const sendMedia = vi.fn(async () => ({
-      messageId: "media-1",
-      receipt: createMessageReceiptFromOutboundResults({
-        results: [{ channel: "matrix", messageId: "media-1" }],
-        kind: "media",
-      }),
-    }));
+    const sendMedia = vi.fn(async () => createMatrixMessageSendResult("media-1", "media"));
     setMatrixMessageAdapter({
       id: "matrix",
       durableFinal: {
@@ -1802,26 +1676,17 @@ describe("deliverOutboundPayloads", () => {
   it("preserves successful sends when the success hook throws", async () => {
     const afterSendFailure = vi.fn();
     const afterCommit = vi.fn();
-    setMatrixMessageAdapter({
-      id: "matrix",
+    installMatrixTextMessageAdapter({
+      messageId: "message-adapter-1",
       durableFinal: {
         capabilities: { text: true, afterSendSuccess: true, afterCommit: true },
       },
-      send: {
-        lifecycle: {
-          afterSendSuccess: async () => {
-            throw new Error("success hook failed");
-          },
-          afterSendFailure,
-          afterCommit,
+      lifecycle: {
+        afterSendSuccess: async () => {
+          throw new Error("success hook failed");
         },
-        text: async () => ({
-          messageId: "message-adapter-1",
-          receipt: createMessageReceiptFromOutboundResults({
-            results: [{ channel: "matrix", messageId: "message-adapter-1" }],
-            kind: "text",
-          }),
-        }),
+        afterSendFailure,
+        afterCommit,
       },
     });
     const results = await deliverMatrix({
@@ -1928,19 +1793,10 @@ describe("deliverOutboundPayloads", () => {
   it("runs afterCommit hooks after best-effort queue fallback direct sends", async () => {
     queueMocks.enqueueDelivery.mockRejectedValueOnce(new Error("queue offline"));
     const afterCommit = vi.fn();
-    setMatrixMessageAdapter({
-      id: "matrix",
+    installMatrixTextMessageAdapter({
+      messageId: "message-adapter-1",
       durableFinal: { capabilities: { text: true, afterCommit: true } },
-      send: {
-        lifecycle: { afterCommit },
-        text: async () => ({
-          messageId: "message-adapter-1",
-          receipt: createMessageReceiptFromOutboundResults({
-            results: [{ channel: "matrix", messageId: "message-adapter-1" }],
-            kind: "text",
-          }),
-        }),
-      },
+      lifecycle: { afterCommit },
     });
 
     await deliverMatrix({
@@ -2016,10 +1872,7 @@ describe("deliverOutboundPayloads", () => {
   ])(
     "dead-letters the queue entry after a proven pre-connect %s failure",
     async (code, syscall) => {
-      const networkError = Object.assign(new Error(`${syscall ?? "connect"} ${code}`), {
-        code,
-        ...(syscall ? { syscall } : {}),
-      });
+      const networkError = createNetworkError(`${syscall ?? "connect"} ${code}`, code, syscall);
       const sendMatrix = vi.fn().mockRejectedValueOnce(networkError);
 
       await expect(
@@ -2071,10 +1924,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("keeps a reporting-only caller's entry recoverable after a proven pre-connect failure", async () => {
-    const networkError = Object.assign(new Error("connect ECONNREFUSED"), {
-      code: "ECONNREFUSED",
-      syscall: "connect",
-    });
+    const networkError = createNetworkError("connect ECONNREFUSED", "ECONNREFUSED", "connect");
     const sendMatrix = vi.fn().mockRejectedValueOnce(networkError);
 
     await expect(
@@ -2093,10 +1943,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("keeps a durable-completion entry recoverable after a proven pre-connect failure", async () => {
-    const networkError = Object.assign(new Error("connect ECONNREFUSED"), {
-      code: "ECONNREFUSED",
-      syscall: "connect",
-    });
+    const networkError = createNetworkError("connect ECONNREFUSED", "ECONNREFUSED", "connect");
     const sendMatrix = vi.fn().mockRejectedValueOnce(networkError);
 
     await expect(
@@ -2283,10 +2130,11 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("finds a DNS failure in the Slack Web API request-error wrapper", async () => {
-    const networkError = Object.assign(new Error("getaddrinfo EAI_AGAIN slack.com"), {
-      code: "EAI_AGAIN",
-      syscall: "getaddrinfo",
-    });
+    const networkError = createNetworkError(
+      "getaddrinfo EAI_AGAIN slack.com",
+      "EAI_AGAIN",
+      "getaddrinfo",
+    );
     const slackRequestError = Object.assign(new Error("A request error occurred"), {
       code: "slack_webapi_request_error",
       original: networkError,
@@ -2314,10 +2162,7 @@ describe("deliverOutboundPayloads", () => {
     ["ECONNREFUSED", undefined],
     ["ECONNRESET", "connect"],
   ])("retains queued send evidence for ambiguous %s failures", async (code, syscall) => {
-    const networkError = Object.assign(new Error(`${syscall ?? "socket"} ${code}`), {
-      code,
-      ...(syscall ? { syscall } : {}),
-    });
+    const networkError = createNetworkError(`${syscall ?? "socket"} ${code}`, code, syscall);
     const sendMatrix = vi.fn().mockRejectedValueOnce(networkError);
 
     await expect(
@@ -2335,10 +2180,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("clears queued send evidence for a best-effort pre-connect failure", async () => {
-    const networkError = Object.assign(new Error("connect ECONNREFUSED"), {
-      code: "ECONNREFUSED",
-      syscall: "connect",
-    });
+    const networkError = createNetworkError("connect ECONNREFUSED", "ECONNREFUSED", "connect");
     const sendMatrix = vi.fn().mockRejectedValueOnce(networkError);
 
     await expect(
@@ -2460,10 +2302,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("preserves queued send evidence when a marked best-effort batch has an ambiguous failure", async () => {
-    const ambiguousError = Object.assign(new Error("connect ECONNRESET"), {
-      code: "ECONNRESET",
-      syscall: "connect",
-    });
+    const ambiguousError = createNetworkError("connect ECONNRESET", "ECONNRESET", "connect");
     const notDispatchedError = new PlatformMessageNotDispatchedError(
       "upload timed out before completion dispatch",
       { cause: new Error("request timed out") },
@@ -2513,13 +2352,7 @@ describe("deliverOutboundPayloads", () => {
     const afterCommit = vi.fn();
     const messageSendText = vi
       .fn()
-      .mockResolvedValueOnce({
-        messageId: "message-adapter-1",
-        receipt: createMessageReceiptFromOutboundResults({
-          results: [{ channel: "matrix", messageId: "message-adapter-1" }],
-          kind: "text",
-        }),
-      })
+      .mockResolvedValueOnce(createMatrixMessageSendResult("message-adapter-1"))
       .mockRejectedValueOnce(new Error("second send failed"));
     setMatrixMessageAdapter({
       id: "matrix",
@@ -2769,13 +2602,9 @@ describe("deliverOutboundPayloads", () => {
       },
     });
 
-    const [mediaAccessOptions] = requireMockCall(resolveMediaAccessSpy, "media access") as [
-      {
-        messageProvider?: unknown;
-        requesterSenderId?: unknown;
-        sessionKey?: unknown;
-      },
-    ];
+    const [mediaAccessOptions] = requireMockCall<
+      [{ messageProvider?: unknown; requesterSenderId?: unknown; sessionKey?: unknown }]
+    >(resolveMediaAccessSpy, "media access");
     expect(mediaAccessOptions?.sessionKey).toBe("agent:main:matrix:room:ops");
     expect(mediaAccessOptions?.messageProvider).toBeUndefined();
     expect(mediaAccessOptions?.requesterSenderId).toBe("attacker");
@@ -2817,12 +2646,9 @@ describe("deliverOutboundPayloads", () => {
       },
     });
 
-    const [mediaAccessOptions] = requireMockCall(resolveMediaAccessSpy, "media access") as [
-      {
-        requesterSenderId?: unknown;
-        sessionKey?: unknown;
-      },
-    ];
+    const [mediaAccessOptions] = requireMockCall<
+      [{ requesterSenderId?: unknown; sessionKey?: unknown }]
+    >(resolveMediaAccessSpy, "media access");
     expect(mediaAccessOptions?.sessionKey).toBe("agent:main:matrix:group:ops");
     expect(mediaAccessOptions?.requesterSenderId).toBe("attacker");
     const sendOptions = requireMatrixSendCall(sendMatrix)[2] as Record<string, unknown>;
@@ -2852,14 +2678,16 @@ describe("deliverOutboundPayloads", () => {
       },
     });
 
-    const [mediaAccessOptions] = requireMockCall(resolveMediaAccessSpy, "media access") as [
-      {
-        requesterSenderE164?: unknown;
-        requesterSenderId?: unknown;
-        requesterSenderName?: unknown;
-        requesterSenderUsername?: unknown;
-      },
-    ];
+    const [mediaAccessOptions] = requireMockCall<
+      [
+        {
+          requesterSenderE164?: unknown;
+          requesterSenderId?: unknown;
+          requesterSenderName?: unknown;
+          requesterSenderUsername?: unknown;
+        },
+      ]
+    >(resolveMediaAccessSpy, "media access");
     expect(mediaAccessOptions?.requesterSenderId).toBe("id:matrix:123");
     expect(mediaAccessOptions?.requesterSenderName).toBe("Alice");
     expect(mediaAccessOptions?.requesterSenderUsername).toBe("alice_u");
@@ -2885,13 +2713,9 @@ describe("deliverOutboundPayloads", () => {
       },
     });
 
-    const [mediaAccessOptions] = requireMockCall(resolveMediaAccessSpy, "media access") as [
-      {
-        accountId?: unknown;
-        requesterSenderId?: unknown;
-        sessionKey?: unknown;
-      },
-    ];
+    const [mediaAccessOptions] = requireMockCall<
+      [{ accountId?: unknown; requesterSenderId?: unknown; sessionKey?: unknown }]
+    >(resolveMediaAccessSpy, "media access");
     expect(mediaAccessOptions?.sessionKey).toBe("agent:main:matrix:room:ops");
     expect(mediaAccessOptions?.accountId).toBe("source-account");
     expect(mediaAccessOptions?.requesterSenderId).toBe("attacker");
@@ -2950,13 +2774,9 @@ describe("deliverOutboundPayloads", () => {
     });
     unsubscribeAudit();
 
-    const [mediaAccessOptions] = requireMockCall(resolveMediaAccessSpy, "media access") as [
-      {
-        mediaSources?: unknown;
-        requesterSenderId?: unknown;
-        sessionKey?: unknown;
-      },
-    ];
+    const [mediaAccessOptions] = requireMockCall<
+      [{ mediaSources?: unknown; requesterSenderId?: unknown; sessionKey?: unknown }]
+    >(resolveMediaAccessSpy, "media access");
     expect(mediaAccessOptions?.mediaSources).toEqual(["file:///tmp/hook-added.png"]);
     expect(mediaAccessOptions?.sessionKey).toBe("agent:main:matrix:room:ops");
     expect(mediaAccessOptions?.requesterSenderId).toBe("sender-1");
@@ -2969,22 +2789,19 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("chunks direct adapter text and preserves delivery overrides across sends", async () => {
-    const sendText = vi.fn().mockImplementation(async ({ text }: { text: string }) => ({
-      channel: "matrix" as const,
-      messageId: text,
-      roomId: "!room",
-    }));
-    setTestOutbound({
-      textChunkLimit: 2,
-      chunker: (text, limit) => {
-        const chunks: string[] = [];
-        for (let i = 0; i < text.length; i += limit) {
-          chunks.push(text.slice(i, i + limit));
-        }
-        return chunks;
+    const sendText = installTextOutbound(
+      async ({ text }) => ({ channel: "matrix", messageId: text, roomId: "!room" }),
+      {
+        textChunkLimit: 2,
+        chunker: (text, limit) => {
+          const chunks: string[] = [];
+          for (let i = 0; i < text.length; i += limit) {
+            chunks.push(text.slice(i, i + limit));
+          }
+          return chunks;
+        },
       },
-      sendText,
-    });
+    );
 
     const results = await deliverOutboundPayloads({
       cfg: { channels: { matrix: { textChunkLimit: 2 } } } as OpenClawConfig,
@@ -3003,16 +2820,13 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("keeps a prepared transport-id delivery atomic", async () => {
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "prepared-1",
-      roomId: "!room",
-    });
-    setTestOutbound({
-      textChunkLimit: 2,
-      chunker: (text, limit) => [text.slice(0, limit), text.slice(limit)],
-      sendText,
-    });
+    const sendText = installTextOutbound(
+      { channel: "matrix", messageId: "prepared-1", roomId: "!room" },
+      {
+        textChunkLimit: 2,
+        chunker: (text, limit) => [text.slice(0, limit), text.slice(limit)],
+      },
+    );
 
     await deliverOutboundPayloads({
       cfg: { channels: { matrix: { textChunkLimit: 2 } } } as OpenClawConfig,
@@ -3032,22 +2846,19 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("uses replyToId only on the first low-level send for single-use reply modes", async () => {
-    const sendText = vi.fn().mockImplementation(async ({ text }: { text: string }) => ({
-      channel: "matrix" as const,
-      messageId: text,
-      roomId: "!room",
-    }));
-    setTestOutbound({
-      textChunkLimit: 2,
-      chunker: (text, limit) => {
-        const chunks: string[] = [];
-        for (let i = 0; i < text.length; i += limit) {
-          chunks.push(text.slice(i, i + limit));
-        }
-        return chunks;
+    const sendText = installTextOutbound(
+      async ({ text }) => ({ channel: "matrix", messageId: text, roomId: "!room" }),
+      {
+        textChunkLimit: 2,
+        chunker: (text, limit) => {
+          const chunks: string[] = [];
+          for (let i = 0; i < text.length; i += limit) {
+            chunks.push(text.slice(i, i + limit));
+          }
+          return chunks;
+        },
       },
-      sendText,
-    });
+    );
 
     await deliverOutboundPayloads({
       cfg: { channels: { matrix: { textChunkLimit: 2 } } } as OpenClawConfig,
@@ -3065,12 +2876,11 @@ describe("deliverOutboundPayloads", () => {
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "message_sending",
     );
-    const sendText = vi.fn().mockImplementation(async ({ text }: { text: string }) => ({
-      channel: "matrix" as const,
+    const sendText = installTextOutbound(async ({ text }) => ({
+      channel: "matrix",
       messageId: text,
       roomId: "!room",
     }));
-    setTestOutbound({ sendText });
 
     await deliverMatrix({
       to: "!room",
@@ -3094,12 +2904,11 @@ describe("deliverOutboundPayloads", () => {
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "message_sending",
     );
-    const sendText = vi.fn().mockImplementation(async ({ text }: { text: string }) => ({
-      channel: "matrix" as const,
+    const sendText = installTextOutbound(async ({ text }) => ({
+      channel: "matrix",
       messageId: text,
       roomId: "!room",
     }));
-    setTestOutbound({ sendText });
 
     await deliverMatrix({
       to: "!room",
@@ -3124,12 +2933,11 @@ describe("deliverOutboundPayloads", () => {
       (hookName?: string) => hookName === "message_sending",
     );
     hookMocks.runner.runMessageSending.mockResolvedValue({ content: "   " });
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
+    const sendText = installTextOutbound({
+      channel: "matrix",
       messageId: "should-not-send",
       roomId: "!room",
     });
-    setTestOutbound({ sendText });
 
     const results = await deliverMatrix({
       to: "!room",
@@ -3172,12 +2980,11 @@ describe("deliverOutboundPayloads", () => {
       content:
         "<previous_response>null</previous_response><system-reminder>hidden</system-reminder>visible",
     });
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
+    const sendText = installTextOutbound({
+      channel: "matrix",
       messageId: "clean",
       roomId: "!room",
     });
-    setTestOutbound({ sendText });
 
     await deliverMatrix({
       to: "!room",
@@ -3188,12 +2995,11 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("strips complete inline runtime context blocks before channel delivery", async () => {
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
+    const sendText = installTextOutbound({
+      channel: "matrix",
       messageId: "clean-inline-runtime-context",
       roomId: "!room",
     });
-    setTestOutbound({ sendText });
 
     await deliverOutboundPayloads({
       cfg: {},
@@ -3278,19 +3084,16 @@ describe("deliverOutboundPayloads", () => {
     hookMocks.runner.runMessageSending.mockResolvedValue({
       content: "<previous_response>null</previous_response>visible",
     });
-    const sendPayload = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "clean",
-      roomId: "!room",
-    });
-    setTestOutbound({
-      normalizePayload: ({ payload }) => ({
-        ...payload,
-        channelData: { copiedText: payload.text },
-      }),
-      sendMedia: vi.fn(),
-      sendPayload,
-    });
+    const sendPayload = installPayloadOutbound(
+      { channel: "matrix", messageId: "clean", roomId: "!room" },
+      {
+        normalizePayload: ({ payload }) => ({
+          ...payload,
+          channelData: { copiedText: payload.text },
+        }),
+        sendMedia: vi.fn(),
+      },
+    );
 
     await deliverMatrix({
       to: "!room",
@@ -3323,13 +3126,11 @@ describe("deliverOutboundPayloads", () => {
       ...payload,
       channelData: { normalized: true },
     }));
-    const sendPayload = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "context",
-      roomId: "!room",
-    });
     const cfg = { channels: { matrix: { enabled: true } } } as unknown as OpenClawConfig;
-    setTestOutbound({ normalizePayload, sendMedia: vi.fn(), sendPayload });
+    const sendPayload = installPayloadOutbound(
+      { channel: "matrix", messageId: "context", roomId: "!room" },
+      { normalizePayload, sendMedia: vi.fn() },
+    );
 
     await deliverOutboundPayloads({
       cfg,
@@ -3354,15 +3155,10 @@ describe("deliverOutboundPayloads", () => {
       ...payload,
       channelData: { normalized: payload.text },
     }));
-    const sendPayload = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "low-level-normalized",
-      roomId: "!room",
-    });
-    setTestOutbound({
-      normalizePayload: ({ payload }) => normalizePayload(payload),
-      sendPayload,
-    });
+    const sendPayload = installPayloadOutbound(
+      { channel: "matrix", messageId: "low-level-normalized", roomId: "!room" },
+      { normalizePayload: ({ payload }) => normalizePayload(payload) },
+    );
     const payload = { text: "portable" };
 
     await deliverMatrix({
@@ -3387,12 +3183,10 @@ describe("deliverOutboundPayloads", () => {
       },
       null,
     ]);
-    const sendPayload = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "merged",
-      roomId: "!room",
-    });
-    setTestOutbound({ normalizePayloadBatch, sendPayload });
+    const sendPayload = installPayloadOutbound(
+      { channel: "matrix", messageId: "merged", roomId: "!room" },
+      { normalizePayloadBatch },
+    );
 
     await deliverMatrix({
       to: "!room",
@@ -3408,30 +3202,27 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("strips internal runtime scaffolding copied into rendered and normalized nested payloads", async () => {
-    const sendPayload = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "clean-nested",
-      roomId: "!room",
-    });
-    setTestOutbound({
-      renderPresentation: ({ payload }) => ({
-        ...payload,
-        channelData: {
-          renderedText: payload.text,
-          renderedBlocks: [{ text: payload.text }],
-        },
-      }),
-      normalizePayload: ({ payload }) => {
-        const text = payload.text ?? "";
-        return {
+    const sendPayload = installPayloadOutbound(
+      { channel: "matrix", messageId: "clean-nested", roomId: "!room" },
+      {
+        renderPresentation: ({ payload }) => ({
           ...payload,
-          channelData: { ...payload.channelData, normalizedText: text },
-          interactive: { blocks: [{ type: "text", text }] },
-        };
+          channelData: {
+            renderedText: payload.text,
+            renderedBlocks: [{ text: payload.text }],
+          },
+        }),
+        normalizePayload: ({ payload }) => {
+          const text = payload.text ?? "";
+          return {
+            ...payload,
+            channelData: { ...payload.channelData, normalizedText: text },
+            interactive: { blocks: [{ type: "text", text }] },
+          };
+        },
+        sendMedia: vi.fn(),
       },
-      sendMedia: vi.fn(),
-      sendPayload,
-    });
+    );
 
     await deliverMatrix({
       to: "!room",
@@ -3464,18 +3255,15 @@ describe("deliverOutboundPayloads", () => {
   it("prefers the account-aware presentation capability resolver over the static declaration", async () => {
     const renderPresentation = vi.fn(({ payload }) => ({ ...payload, text: "native table" }));
     const resolvePresentationCapabilities = vi.fn(() => ({ supported: true, tables: true }));
-    const sendPayload = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "caps",
-      roomId: "!room",
-    });
-    setTestOutbound({
-      presentationCapabilities: { supported: true, tables: false },
-      resolvePresentationCapabilities,
-      renderPresentation,
-      sendMedia: vi.fn(),
-      sendPayload,
-    });
+    installPayloadOutbound(
+      { channel: "matrix", messageId: "caps", roomId: "!room" },
+      {
+        presentationCapabilities: { supported: true, tables: false },
+        resolvePresentationCapabilities,
+        renderPresentation,
+        sendMedia: vi.fn(),
+      },
+    );
 
     await deliverMatrix({
       to: "!room",
@@ -3510,18 +3298,15 @@ describe("deliverOutboundPayloads", () => {
         tables: params.formatting?.parseMode !== "HTML",
       }),
     );
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "html-fallback",
-      roomId: "!room",
-    });
-    setTestOutbound({
-      presentationCapabilities: { supported: true, tables: true },
-      resolvePresentationCapabilities,
-      renderPresentation,
-      sendMedia: vi.fn(),
-      sendText,
-    });
+    const sendText = installTextOutbound(
+      { channel: "matrix", messageId: "html-fallback", roomId: "!room" },
+      {
+        presentationCapabilities: { supported: true, tables: true },
+        resolvePresentationCapabilities,
+        renderPresentation,
+        sendMedia: vi.fn(),
+      },
+    );
 
     await deliverMatrix({
       to: "!room",
@@ -3551,28 +3336,25 @@ describe("deliverOutboundPayloads", () => {
       ...payload,
       channelData: { rendered: true },
     }));
-    const sendPayload = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "adapted",
-      roomId: "!room",
-    });
-    setTestOutbound({
-      presentationCapabilities: {
-        supported: true,
-        buttons: true,
-        limits: {
-          actions: {
-            maxActions: 1,
-            maxLabelLength: 4,
-            maxValueBytes: 8,
-            supportsStyles: false,
+    installPayloadOutbound(
+      { channel: "matrix", messageId: "adapted", roomId: "!room" },
+      {
+        presentationCapabilities: {
+          supported: true,
+          buttons: true,
+          limits: {
+            actions: {
+              maxActions: 1,
+              maxLabelLength: 4,
+              maxValueBytes: 8,
+              supportsStyles: false,
+            },
           },
         },
+        renderPresentation,
+        sendMedia: vi.fn(),
       },
-      renderPresentation,
-      sendMedia: vi.fn(),
-      sendPayload,
-    });
+    );
 
     await deliverMatrix({
       to: "!room",
@@ -3617,17 +3399,14 @@ describe("deliverOutboundPayloads", () => {
       ...payload,
       channelData: { native: true },
     }));
-    const sendPayload = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "question-card",
-      roomId: "!room",
-    });
-    setTestOutbound({
-      presentationCapabilities: { supported: true, buttons: true },
-      renderPresentation: nativeRender,
-      sendMedia: vi.fn(),
-      sendPayload,
-    });
+    const sendPayload = installPayloadOutbound(
+      { channel: "matrix", messageId: "question-card", roomId: "!room" },
+      {
+        presentationCapabilities: { supported: true, buttons: true },
+        renderPresentation: nativeRender,
+        sendMedia: vi.fn(),
+      },
+    );
 
     await deliverMatrix({
       to: "!room",
@@ -3656,12 +3435,11 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("keeps runtime presentation fallback text exact on button-less channels", async () => {
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
+    const sendText = installTextOutbound({
+      channel: "matrix",
       messageId: "question-text",
       roomId: "!room",
     });
-    setTestOutbound({ sendText });
 
     await deliverMatrix({
       to: "!room",
@@ -3683,25 +3461,22 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("preserves full presentation labels when bounded native rendering declines", async () => {
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "full-labels",
-      roomId: "!room",
-    });
-    setTestOutbound({
-      presentationCapabilities: {
-        supported: true,
-        buttons: true,
-        selects: true,
-        limits: {
-          actions: { maxLabelLength: 4 },
-          selects: { maxLabelLength: 4 },
-          text: { maxLength: 18, encoding: "characters" },
+    const sendText = installTextOutbound(
+      { channel: "matrix", messageId: "full-labels", roomId: "!room" },
+      {
+        presentationCapabilities: {
+          supported: true,
+          buttons: true,
+          selects: true,
+          limits: {
+            actions: { maxLabelLength: 4 },
+            selects: { maxLabelLength: 4 },
+            text: { maxLength: 18, encoding: "characters" },
+          },
         },
+        renderPresentation: vi.fn(() => null),
       },
-      renderPresentation: vi.fn(() => null),
-      sendText,
-    });
+    );
 
     await deliverMatrix({
       to: "!room",
@@ -3730,23 +3505,20 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("reassembles bounded fallback fragments when native presentation rendering succeeds", async () => {
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "joined-labels",
-      roomId: "!room",
-    });
-    setTestOutbound({
-      presentationCapabilities: {
-        supported: true,
-        buttons: false,
-        limits: { text: { maxLength: 18, encoding: "characters" } },
+    const sendText = installTextOutbound(
+      { channel: "matrix", messageId: "joined-labels", roomId: "!room" },
+      {
+        presentationCapabilities: {
+          supported: true,
+          buttons: false,
+          limits: { text: { maxLength: 18, encoding: "characters" } },
+        },
+        renderPresentation: ({ payload, presentation }) => ({
+          ...payload,
+          text: renderMessagePresentationFallbackText({ presentation }),
+        }),
       },
-      renderPresentation: ({ payload, presentation }) => ({
-        ...payload,
-        text: renderMessagePresentationFallbackText({ presentation }),
-      }),
-      sendText,
-    });
+    );
 
     await deliverMatrix({
       to: "!room",
@@ -4147,19 +3919,13 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendMedia).toHaveBeenCalledTimes(1);
-    const sendMediaOptions = (
-      sendMedia.mock.calls as Array<
-        [
-          {
-            accountId?: unknown;
-            audioAsVoice?: unknown;
-            mediaUrl?: unknown;
-            text?: unknown;
-            to?: unknown;
-          },
-        ]
-      >
-    )[0]?.[0];
+    const sendMediaOptions = requireMockCallArg<{
+      accountId?: unknown;
+      audioAsVoice?: unknown;
+      mediaUrl?: unknown;
+      text?: unknown;
+      to?: unknown;
+    }>(sendMedia, "sendMedia");
     expect(sendMediaOptions?.to).toBe("!explicit:example");
     expect(sendMediaOptions?.text).toBe("HEARTBEAT_OK");
     expect(sendMediaOptions?.mediaUrl).toBe("https://example.com/img.png");
@@ -4184,11 +3950,12 @@ describe("deliverOutboundPayloads", () => {
       payloads: [{ text: "voice caption", mediaUrl: "file:///tmp/clip.mp3", audioAsVoice: true }],
     });
 
-    const sendMediaOptions = (
-      sendMedia.mock.calls as unknown as Array<
-        [{ audioAsVoice?: unknown; mediaUrl?: unknown; text?: unknown; to?: unknown }]
-      >
-    )[0]?.[0];
+    const sendMediaOptions = requireMockCallArg<{
+      audioAsVoice?: unknown;
+      mediaUrl?: unknown;
+      text?: unknown;
+      to?: unknown;
+    }>(sendMedia, "sendMedia");
     expect(sendMediaOptions?.to).toBe("room:!room:example");
     expect(sendMediaOptions?.text).toBe("voice caption");
     expect(sendMediaOptions?.mediaUrl).toBe("file:///tmp/clip.mp3");
@@ -4226,11 +3993,11 @@ describe("deliverOutboundPayloads", () => {
     ) as [{ content?: unknown }, { channelId?: unknown }] | undefined;
     expect(sendingCall?.[0]?.content).toBe("original hidden transcript");
     expect(sendingCall?.[1]?.channelId).toBe("matrix");
-    const sendMediaOptions = (
-      sendMedia.mock.calls as unknown as Array<
-        [{ audioAsVoice?: unknown; mediaUrl?: unknown; text?: unknown }]
-      >
-    )[0]?.[0];
+    const sendMediaOptions = requireMockCallArg<{
+      audioAsVoice?: unknown;
+      mediaUrl?: unknown;
+      text?: unknown;
+    }>(sendMedia, "sendMedia");
     expect(sendMediaOptions?.text).toBe("");
     expect(sendMediaOptions?.mediaUrl).toBe("file:///tmp/clip.opus");
     expect(sendMediaOptions?.audioAsVoice).toBe(true);
@@ -4882,28 +4649,20 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(queueMocks.enqueueDelivery).toHaveBeenCalledTimes(1);
-    const queuedDelivery = (
-      queueMocks.enqueueDelivery.mock.calls as unknown as Array<
-        [
-          {
-            preparedBatch?: {
-              entries?: Array<{ payload?: unknown; status?: unknown }>;
-            };
-            renderedBatchPlan?: {
-              items?: Array<{
-                index?: unknown;
-                kinds?: unknown;
-                mediaUrls?: unknown;
-                text?: unknown;
-              }>;
-              mediaCount?: unknown;
-              payloadCount?: unknown;
-              textCount?: unknown;
-            };
-          },
-        ]
-      >
-    )[0]?.[0];
+    const queuedDelivery = requireMockCallArg<{
+      preparedBatch?: { entries?: Array<{ payload?: unknown; status?: unknown }> };
+      renderedBatchPlan?: {
+        items?: Array<{
+          index?: unknown;
+          kinds?: unknown;
+          mediaUrls?: unknown;
+          text?: unknown;
+        }>;
+        mediaCount?: unknown;
+        payloadCount?: unknown;
+        textCount?: unknown;
+      };
+    }>(queueMocks.enqueueDelivery, "enqueueDelivery");
     expect(
       queuedDelivery?.preparedBatch?.entries?.flatMap((entry) =>
         entry.status === "accepted" ? [entry.payload] : [],
@@ -4952,22 +4711,14 @@ describe("deliverOutboundPayloads", () => {
       deps: { matrix: sendMatrix },
     });
 
-    const queuedDelivery = (
-      queueMocks.enqueueDelivery.mock.calls as unknown as Array<
-        [
-          {
-            preparedBatch?: {
-              entries?: Array<{ payload?: unknown; status?: unknown }>;
-            };
-            renderedBatchPlan?: {
-              items?: Array<{ text?: unknown }>;
-              payloadCount?: unknown;
-              textCount?: unknown;
-            };
-          },
-        ]
-      >
-    )[0]?.[0];
+    const queuedDelivery = requireMockCallArg<{
+      preparedBatch?: { entries?: Array<{ payload?: unknown; status?: unknown }> };
+      renderedBatchPlan?: {
+        items?: Array<{ text?: unknown }>;
+        payloadCount?: unknown;
+        textCount?: unknown;
+      };
+    }>(queueMocks.enqueueDelivery, "enqueueDelivery");
     expect(
       queuedDelivery?.preparedBatch?.entries?.flatMap((entry) =>
         entry.status === "accepted" ? [entry.payload] : [],
@@ -5015,9 +4766,10 @@ describe("deliverOutboundPayloads", () => {
       renderedBatchPlan,
     });
 
-    const queuedDelivery = (
-      queueMocks.enqueueDelivery.mock.calls as unknown as Array<[{ renderedBatchPlan?: unknown }]>
-    )[0]?.[0];
+    const queuedDelivery = requireMockCallArg<{ renderedBatchPlan?: unknown }>(
+      queueMocks.enqueueDelivery,
+      "enqueueDelivery",
+    );
     expect(queuedDelivery?.renderedBatchPlan).toEqual(renderedBatchPlan);
   });
 
@@ -5055,17 +4807,11 @@ describe("deliverOutboundPayloads", () => {
         deps: { matrix: sendMatrix },
       });
 
-      const queued = (
-        queueMocks.enqueueDelivery.mock.calls as unknown as Array<
-          [
-            {
-              preparedBatch?: {
-                entries?: Array<{ payload?: { mediaUrl?: string }; status?: string }>;
-              };
-            },
-          ]
-        >
-      )[0]?.[0];
+      const queued = requireMockCallArg<{
+        preparedBatch?: {
+          entries?: Array<{ payload?: { mediaUrl?: string }; status?: string }>;
+        };
+      }>(queueMocks.enqueueDelivery, "enqueueDelivery");
       const queuedMediaUrl = queued?.preparedBatch?.entries?.find(
         (entry) => entry.status === "accepted",
       )?.payload?.mediaUrl;
@@ -5126,17 +4872,11 @@ describe("deliverOutboundPayloads", () => {
         deps: { matrix: sendMatrix },
       });
 
-      const queued = (
-        queueMocks.enqueueDelivery.mock.calls as unknown as Array<
-          [
-            {
-              preparedBatch?: {
-                entries?: Array<{ payload?: { mediaUrl?: string }; status?: string }>;
-              };
-            },
-          ]
-        >
-      )[0]?.[0];
+      const queued = requireMockCallArg<{
+        preparedBatch?: {
+          entries?: Array<{ payload?: { mediaUrl?: string }; status?: string }>;
+        };
+      }>(queueMocks.enqueueDelivery, "enqueueDelivery");
       const queuedMediaUrl = queued?.preparedBatch?.entries?.find(
         (entry) => entry.status === "accepted",
       )?.payload?.mediaUrl;
@@ -5352,11 +5092,11 @@ describe("deliverOutboundPayloads", () => {
       },
     });
 
-    const appendOptions = (
-      mocks.appendAssistantMessageToSessionTranscript.mock.calls as unknown as Array<
-        [{ config?: unknown; idempotencyKey?: unknown; text?: unknown }]
-      >
-    )[0]?.[0];
+    const appendOptions = requireMockCallArg<{
+      config?: unknown;
+      idempotencyKey?: unknown;
+      text?: unknown;
+    }>(mocks.appendAssistantMessageToSessionTranscript, "append transcript");
     expect(appendOptions?.text).toBe("caption\nreport.pdf");
     expect(appendOptions?.idempotencyKey).toBe("idem-deliver-1");
     expect(appendOptions?.config).toBe(cfg);
@@ -5534,12 +5274,7 @@ describe("deliverOutboundPayloads", () => {
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "message_sending",
     );
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "mx-1",
-      roomId: "!room",
-    });
-    setTestOutbound({ sendText });
+    installTextOutbound({ channel: "matrix", messageId: "mx-1", roomId: "!room" });
 
     await deliverMatrix({
       to: "!room",
@@ -5565,12 +5300,7 @@ describe("deliverOutboundPayloads", () => {
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "message_sending",
     );
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "mx-3",
-      roomId: "!room",
-    });
-    setTestOutbound({ sendText });
+    installTextOutbound({ channel: "matrix", messageId: "mx-3", roomId: "!room" });
 
     await deliverMatrix({
       to: "!room",
@@ -5592,12 +5322,7 @@ describe("deliverOutboundPayloads", () => {
     hookMocks.runner.hasHooks.mockImplementation(
       (hookName?: string) => hookName === "message_sending",
     );
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "mx-2",
-      roomId: "!room",
-    });
-    setTestOutbound({ sendText });
+    installTextOutbound({ channel: "matrix", messageId: "mx-2", roomId: "!room" });
 
     await deliverMatrix({
       to: "!room",
@@ -5618,12 +5343,7 @@ describe("deliverOutboundPayloads", () => {
     // test pins `message_sent` to that contract so it cannot diverge
     // from `message_sending` unobserved.
     hookMocks.runner.hasHooks.mockReturnValue(true);
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "mx-sent-1",
-      roomId: "!room",
-    });
-    setTestOutbound({ sendText });
+    installTextOutbound({ channel: "matrix", messageId: "mx-sent-1", roomId: "!room" });
 
     await deliverMatrix({
       to: "!room",
@@ -5643,12 +5363,7 @@ describe("deliverOutboundPayloads", () => {
 
   it("omits sessionKey from the message_sent hook context when session is absent", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
-    const sendText = vi.fn().mockResolvedValue({
-      channel: "matrix" as const,
-      messageId: "mx-sent-2",
-      roomId: "!room",
-    });
-    setTestOutbound({ sendText });
+    installTextOutbound({ channel: "matrix", messageId: "mx-sent-2", roomId: "!room" });
 
     await deliverMatrix({
       to: "!room",
@@ -5702,8 +5417,7 @@ describe("deliverOutboundPayloads", () => {
 
   it("keeps text-only error payloads on the normal text path by default", async () => {
     const sendPayload = vi.fn();
-    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
-    setTestOutbound({ sendPayload, sendText });
+    const sendText = installTextOutbound({ channel: "matrix", messageId: "mx-1" }, { sendPayload });
 
     const results = await deliverMatrix({
       to: "!room:1",
@@ -5716,9 +5430,11 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("routes text-only error payloads through sendPayload when the adapter opts in", async () => {
-    const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
     const sendText = vi.fn();
-    setTestOutbound({ sendPayload, sendText, sendTextOnlyErrorPayloads: true });
+    const sendPayload = installPayloadOutbound(
+      { channel: "matrix", messageId: "mx-1" },
+      { sendText, sendTextOnlyErrorPayloads: true },
+    );
 
     const results = await deliverMatrix({
       to: "!room:1",
@@ -5737,9 +5453,11 @@ describe("deliverOutboundPayloads", () => {
 
   it("does not count no-op sendPayload results as delivered", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
-    const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "" });
     const sendText = vi.fn();
-    setTestOutbound({ sendPayload, sendText, sendTextOnlyErrorPayloads: true });
+    const sendPayload = installPayloadOutbound(
+      { channel: "matrix", messageId: "" },
+      { sendText, sendTextOnlyErrorPayloads: true },
+    );
 
     const results = await deliverMatrix({
       to: "!room:1",
@@ -5795,10 +5513,9 @@ describe("deliverOutboundPayloads", () => {
 
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
-    const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
     const sendText = vi.fn();
     const sendMedia = vi.fn();
-    setTestOutbound({ sendPayload, sendText, sendMedia });
+    installPayloadOutbound({ channel: "matrix", messageId: "mx-1" }, { sendText, sendMedia });
 
     await deliverMatrix({
       to: "!room:1",
@@ -5815,9 +5532,8 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("does not fail successful sends when optional delivery pinning fails", async () => {
-    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
     const pinDeliveredMessage = vi.fn().mockRejectedValue(new Error("pin denied"));
-    setTestOutbound({ sendText, pinDeliveredMessage });
+    installTextOutbound({ channel: "matrix", messageId: "mx-1" }, { pinDeliveredMessage });
 
     const results = await deliverMatrix({
       to: "!room:1",
@@ -5845,9 +5561,8 @@ describe("deliverOutboundPayloads", () => {
     hookMocks.runner.hasHooks.mockImplementation((name?: string) => name === "message_sent");
     const events: TrustedMessageAuditEvent[] = [];
     const unsubscribe = onTrustedMessageAuditEvent((event) => events.push(event));
-    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
     const pinDeliveredMessage = vi.fn().mockRejectedValue(new Error("pin denied"));
-    setTestOutbound({ sendText, pinDeliveredMessage });
+    installTextOutbound({ channel: "matrix", messageId: "mx-1" }, { pinDeliveredMessage });
 
     try {
       await expect(
@@ -5882,8 +5597,7 @@ describe("deliverOutboundPayloads", () => {
   it("keeps adapter side effects unknown when required pinning has no message identity", async () => {
     const events: TrustedMessageAuditEvent[] = [];
     const unsubscribe = onTrustedMessageAuditEvent((event) => events.push(event));
-    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "" });
-    setTestOutbound({ sendText });
+    installTextOutbound({ channel: "matrix", messageId: "" });
 
     try {
       await expect(
@@ -5928,9 +5642,10 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendText).toHaveBeenCalledTimes(2);
-    const pinOptions = (
-      pinDeliveredMessage.mock.calls as unknown as Array<[{ messageId?: unknown }]>
-    )[0]?.[0];
+    const pinOptions = requireMockCallArg<{ messageId?: unknown }>(
+      pinDeliveredMessage,
+      "pin delivered message",
+    );
     expect(pinOptions?.messageId).toBe("mx-1");
   });
 
@@ -5955,9 +5670,10 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendMedia).toHaveBeenCalledTimes(2);
-    const pinOptions = (
-      pinDeliveredMessage.mock.calls as unknown as Array<[{ messageId?: unknown }]>
-    )[0]?.[0];
+    const pinOptions = requireMockCallArg<{ messageId?: unknown }>(
+      pinDeliveredMessage,
+      "pin delivered message",
+    );
     expect(pinOptions?.messageId).toBe("mx-1");
   });
 
@@ -5967,10 +5683,13 @@ describe("deliverOutboundPayloads", () => {
     { name: "a silent JSON action", text: '{"action":"NO_REPLY"}' },
     { name: "a relay status placeholder", text: "No channel reply." },
   ])("delivers channelData-only payloads with $name", async ({ text }) => {
-    const sendPayload = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-1" });
     const sendText = vi.fn();
     const sendMedia = vi.fn();
-    setTestOutbound({ sendPayload, sendText, sendMedia }, "line");
+    const sendPayload = installPayloadOutbound(
+      { channel: "line", messageId: "ln-1" },
+      { sendText, sendMedia },
+      "line",
+    );
 
     const results = await deliverOutboundPayloads({
       cfg: {},
@@ -5989,8 +5708,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("falls back to sendText when plugin outbound omits sendMedia", async () => {
-    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
-    setTestOutbound({ sendText });
+    const sendText = installTextOutbound({ channel: "matrix", messageId: "mx-1" });
 
     const results = await deliverMatrix({
       to: "!room:1",
@@ -6010,8 +5728,7 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("falls back to one sendText call for multi-media payloads when sendMedia is omitted", async () => {
-    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-2" });
-    setTestOutbound({ sendText });
+    const sendText = installTextOutbound({ channel: "matrix", messageId: "mx-2" });
 
     const results = await deliverMatrix({
       to: "!room:1",
@@ -6037,8 +5754,7 @@ describe("deliverOutboundPayloads", () => {
 
   it("fails media-only payloads when plugin outbound omits sendMedia", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
-    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-3" });
-    setTestOutbound({ sendText });
+    const sendText = installTextOutbound({ channel: "matrix", messageId: "mx-3" });
 
     await expect(
       deliverOutboundPayloads({

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -3,7 +3,7 @@
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import type { TrustedMessageAuditEvent } from "../../audit/message-audit-events.js";
 import { onTrustedMessageAuditEventForTest as onTrustedMessageAuditEvent } from "../../audit/message-audit-events.test-support.js";
 import { chunkText } from "../../auto-reply/chunk.js";
@@ -15,7 +15,6 @@ import type {
 } from "../../channels/message/types.js";
 import type { ChannelOutboundAdapter, ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { SessionTranscriptAppendResult } from "../../config/sessions/transcript.js";
 import { renderMessagePresentationFallbackText } from "../../interactive/payload.js";
 import * as mediaCapabilityModule from "../../media/read-capability.js";
 import { createHookRunner } from "../../plugins/hooks.js";
@@ -38,14 +37,35 @@ import { prepareOutboundPayloadBatch } from "./deliver-prepare.js";
 import { PlatformMessageNotDispatchedError } from "./deliver-types.js";
 import { createUnmodifiedPreparedOutboundBatch } from "./prepared-batch.js";
 
+type AppendAssistantTranscript =
+  (typeof import("../../config/sessions/transcript.js"))["appendAssistantMessageToSessionTranscript"];
+
+type EnqueueDeliveryTestParams = Record<string, unknown> & {
+  preparedBatch?: {
+    entries?: Array<{
+      payload?: Record<string, unknown> & { mediaUrl?: string };
+      status?: unknown;
+    }>;
+  };
+  renderedBatchPlan?: {
+    items?: Array<{
+      index?: unknown;
+      kinds?: unknown;
+      mediaUrls?: unknown;
+      text?: unknown;
+    }>;
+    mediaCount?: unknown;
+    payloadCount?: unknown;
+    textCount?: unknown;
+  };
+};
+
 const mocks = vi.hoisted(() => ({
-  appendAssistantMessageToSessionTranscript: vi.fn<() => Promise<SessionTranscriptAppendResult>>(
-    async () => ({
-      ok: true,
-      target: { sessionId: "x", sessionKey: "x", storePath: "/tmp/sessions.json" },
-      messageId: "m",
-    }),
-  ),
+  appendAssistantMessageToSessionTranscript: vi.fn<AppendAssistantTranscript>(async () => ({
+    ok: true,
+    target: { sessionId: "x", sessionKey: "x", storePath: "/tmp/sessions.json" },
+    messageId: "m",
+  })),
 }));
 const hookMocks = vi.hoisted(() => ({
   runner: {
@@ -64,7 +84,9 @@ const internalHookMocks = vi.hoisted(() => ({
   triggerInternalHook: vi.fn(async () => {}),
 }));
 const queueMocks = vi.hoisted(() => ({
-  enqueueDelivery: vi.fn(async (_params: unknown) => "mock-queue-id"),
+  enqueueDelivery: vi.fn<(params: EnqueueDeliveryTestParams) => Promise<string>>(
+    async () => "mock-queue-id",
+  ),
   enqueueDeliveryOnce: vi.fn(async (_params: unknown, id: string) => ({ id, created: true })),
   enqueuePreparedDeliveryOnce: vi.fn(async (_params: unknown, id: string) => ({
     id,
@@ -257,16 +279,16 @@ function resolveMatrixSender(deps: DeliverOutboundArgs["deps"]): MatrixSendFn {
   return sender as MatrixSendFn;
 }
 
-function requireMockCallArg<T = Record<string, unknown>>(
-  mockFn: { mock: { calls: Array<[T, ...unknown[]]> } },
+function requireMockCallArg<TArgs extends unknown[]>(
+  mockFn: { mock: { calls: TArgs[] } },
   label: string,
   index = 0,
-): T {
-  const arg = mockFn.mock.calls[index]?.[0];
-  if (!arg) {
+): TArgs[0] {
+  const call = mockFn.mock.calls[index];
+  if (!call || call.length === 0) {
     throw new Error(`expected ${label} call #${index + 1}`);
   }
-  return arg as T;
+  return call[0];
 }
 
 function requireMockCall<T extends unknown[] = unknown[]>(
@@ -322,27 +344,54 @@ function setTestOutbound(
 }
 
 type OutboundTextSender = NonNullable<ChannelOutboundAdapter["sendText"]>;
+type OutboundMediaSender = NonNullable<ChannelOutboundAdapter["sendMedia"]>;
 type OutboundPayloadSender = NonNullable<ChannelOutboundAdapter["sendPayload"]>;
+type OutboundPinDeliveredMessage = NonNullable<ChannelOutboundAdapter["pinDeliveredMessage"]>;
+type OutboundTextResult = Awaited<ReturnType<OutboundTextSender>>;
+type OutboundPayloadResult = Awaited<ReturnType<OutboundPayloadSender>>;
 
 function installTextOutbound(
-  send: OutboundTextSender | Awaited<ReturnType<OutboundTextSender>>,
+  send: OutboundTextSender,
+  overrides?: Omit<Partial<ChannelOutboundAdapter>, "sendText">,
+  id?: Parameters<typeof createOutboundTestPlugin>[0]["id"],
+): Mock<OutboundTextSender>;
+function installTextOutbound<TResult extends OutboundTextResult>(
+  send: TResult,
+  overrides?: Omit<Partial<ChannelOutboundAdapter>, "sendText">,
+  id?: Parameters<typeof createOutboundTestPlugin>[0]["id"],
+): Mock<(ctx: Parameters<OutboundTextSender>[0]) => Promise<TResult>>;
+function installTextOutbound(
+  send: OutboundTextSender | OutboundTextResult,
   overrides: Omit<Partial<ChannelOutboundAdapter>, "sendText"> = {},
   id: Parameters<typeof createOutboundTestPlugin>[0]["id"] = "matrix",
 ) {
-  const implementation: OutboundTextSender = typeof send === "function" ? send : async () => send;
-  const sendText = vi.fn<OutboundTextSender>(implementation);
+  const sendText =
+    typeof send === "function"
+      ? vi.fn(send)
+      : vi.fn(async (_ctx: Parameters<OutboundTextSender>[0]) => send);
   setTestOutbound({ ...overrides, sendText }, id);
   return sendText;
 }
 
 function installPayloadOutbound(
-  send: OutboundPayloadSender | Awaited<ReturnType<OutboundPayloadSender>>,
+  send: OutboundPayloadSender,
+  overrides?: Omit<Partial<ChannelOutboundAdapter>, "sendPayload">,
+  id?: Parameters<typeof createOutboundTestPlugin>[0]["id"],
+): Mock<OutboundPayloadSender>;
+function installPayloadOutbound<TResult extends OutboundPayloadResult>(
+  send: TResult,
+  overrides?: Omit<Partial<ChannelOutboundAdapter>, "sendPayload">,
+  id?: Parameters<typeof createOutboundTestPlugin>[0]["id"],
+): Mock<(ctx: Parameters<OutboundPayloadSender>[0]) => Promise<TResult>>;
+function installPayloadOutbound(
+  send: OutboundPayloadSender | OutboundPayloadResult,
   overrides: Omit<Partial<ChannelOutboundAdapter>, "sendPayload"> = {},
   id: Parameters<typeof createOutboundTestPlugin>[0]["id"] = "matrix",
 ) {
-  const implementation: OutboundPayloadSender =
-    typeof send === "function" ? send : async () => send;
-  const sendPayload = vi.fn<OutboundPayloadSender>(implementation);
+  const sendPayload =
+    typeof send === "function"
+      ? vi.fn(send)
+      : vi.fn(async (_ctx: Parameters<OutboundPayloadSender>[0]) => send);
   setTestOutbound({ ...overrides, sendPayload }, id);
   return sendPayload;
 }
@@ -362,7 +411,7 @@ function setMatrixMessageAdapter(
 }
 
 type MatrixMessageAdapter = NonNullable<ChannelPlugin["message"]>;
-type MatrixMessageTextSender = NonNullable<MatrixMessageAdapter["send"]>["text"];
+type MatrixMessageTextSender = NonNullable<NonNullable<MatrixMessageAdapter["send"]>["text"]>;
 
 function createMatrixMessageSendResult(
   messageId: string,
@@ -3898,7 +3947,9 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("sends plugin media to an explicit target once instead of fanning out over allowFrom", async () => {
-    const sendMedia = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "m1" });
+    const sendMedia = vi
+      .fn<OutboundMediaSender>()
+      .mockResolvedValue({ channel: "matrix", messageId: "m1" });
     setTestOutbound({
       sendText: vi.fn().mockResolvedValue({ channel: "matrix", messageId: "text-1" }),
       sendMedia,
@@ -3919,13 +3970,7 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendMedia).toHaveBeenCalledTimes(1);
-    const sendMediaOptions = requireMockCallArg<{
-      accountId?: unknown;
-      audioAsVoice?: unknown;
-      mediaUrl?: unknown;
-      text?: unknown;
-      to?: unknown;
-    }>(sendMedia, "sendMedia");
+    const sendMediaOptions = requireMockCallArg(sendMedia, "sendMedia");
     expect(sendMediaOptions?.to).toBe("!explicit:example");
     expect(sendMediaOptions?.text).toBe("HEARTBEAT_OK");
     expect(sendMediaOptions?.mediaUrl).toBe("https://example.com/img.png");
@@ -3933,8 +3978,8 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("forwards audioAsVoice through generic plugin media delivery", async () => {
-    const sendMedia = vi.fn(async () => ({
-      channel: "matrix" as const,
+    const sendMedia = vi.fn(async (_ctx: Parameters<OutboundMediaSender>[0]) => ({
+      channel: "matrix",
       messageId: "mx-1",
       roomId: "!room:example",
     }));
@@ -3950,12 +3995,7 @@ describe("deliverOutboundPayloads", () => {
       payloads: [{ text: "voice caption", mediaUrl: "file:///tmp/clip.mp3", audioAsVoice: true }],
     });
 
-    const sendMediaOptions = requireMockCallArg<{
-      audioAsVoice?: unknown;
-      mediaUrl?: unknown;
-      text?: unknown;
-      to?: unknown;
-    }>(sendMedia, "sendMedia");
+    const sendMediaOptions = requireMockCallArg(sendMedia, "sendMedia");
     expect(sendMediaOptions?.to).toBe("room:!room:example");
     expect(sendMediaOptions?.text).toBe("voice caption");
     expect(sendMediaOptions?.mediaUrl).toBe("file:///tmp/clip.mp3");
@@ -3967,8 +4007,8 @@ describe("deliverOutboundPayloads", () => {
     hookMocks.runner.runMessageSending.mockResolvedValue({
       content: "rewritten hidden transcript",
     });
-    const sendMedia = vi.fn(async () => ({
-      channel: "matrix" as const,
+    const sendMedia = vi.fn(async (_ctx: Parameters<OutboundMediaSender>[0]) => ({
+      channel: "matrix",
       messageId: "mx-voice",
       roomId: "!room:example",
     }));
@@ -3993,11 +4033,7 @@ describe("deliverOutboundPayloads", () => {
     ) as [{ content?: unknown }, { channelId?: unknown }] | undefined;
     expect(sendingCall?.[0]?.content).toBe("original hidden transcript");
     expect(sendingCall?.[1]?.channelId).toBe("matrix");
-    const sendMediaOptions = requireMockCallArg<{
-      audioAsVoice?: unknown;
-      mediaUrl?: unknown;
-      text?: unknown;
-    }>(sendMedia, "sendMedia");
+    const sendMediaOptions = requireMockCallArg(sendMedia, "sendMedia");
     expect(sendMediaOptions?.text).toBe("");
     expect(sendMediaOptions?.mediaUrl).toBe("file:///tmp/clip.opus");
     expect(sendMediaOptions?.audioAsVoice).toBe(true);
@@ -4649,20 +4685,7 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(queueMocks.enqueueDelivery).toHaveBeenCalledTimes(1);
-    const queuedDelivery = requireMockCallArg<{
-      preparedBatch?: { entries?: Array<{ payload?: unknown; status?: unknown }> };
-      renderedBatchPlan?: {
-        items?: Array<{
-          index?: unknown;
-          kinds?: unknown;
-          mediaUrls?: unknown;
-          text?: unknown;
-        }>;
-        mediaCount?: unknown;
-        payloadCount?: unknown;
-        textCount?: unknown;
-      };
-    }>(queueMocks.enqueueDelivery, "enqueueDelivery");
+    const queuedDelivery = requireMockCallArg(queueMocks.enqueueDelivery, "enqueueDelivery");
     expect(
       queuedDelivery?.preparedBatch?.entries?.flatMap((entry) =>
         entry.status === "accepted" ? [entry.payload] : [],
@@ -4711,14 +4734,7 @@ describe("deliverOutboundPayloads", () => {
       deps: { matrix: sendMatrix },
     });
 
-    const queuedDelivery = requireMockCallArg<{
-      preparedBatch?: { entries?: Array<{ payload?: unknown; status?: unknown }> };
-      renderedBatchPlan?: {
-        items?: Array<{ text?: unknown }>;
-        payloadCount?: unknown;
-        textCount?: unknown;
-      };
-    }>(queueMocks.enqueueDelivery, "enqueueDelivery");
+    const queuedDelivery = requireMockCallArg(queueMocks.enqueueDelivery, "enqueueDelivery");
     expect(
       queuedDelivery?.preparedBatch?.entries?.flatMap((entry) =>
         entry.status === "accepted" ? [entry.payload] : [],
@@ -4766,10 +4782,7 @@ describe("deliverOutboundPayloads", () => {
       renderedBatchPlan,
     });
 
-    const queuedDelivery = requireMockCallArg<{ renderedBatchPlan?: unknown }>(
-      queueMocks.enqueueDelivery,
-      "enqueueDelivery",
-    );
+    const queuedDelivery = requireMockCallArg(queueMocks.enqueueDelivery, "enqueueDelivery");
     expect(queuedDelivery?.renderedBatchPlan).toEqual(renderedBatchPlan);
   });
 
@@ -4807,11 +4820,7 @@ describe("deliverOutboundPayloads", () => {
         deps: { matrix: sendMatrix },
       });
 
-      const queued = requireMockCallArg<{
-        preparedBatch?: {
-          entries?: Array<{ payload?: { mediaUrl?: string }; status?: string }>;
-        };
-      }>(queueMocks.enqueueDelivery, "enqueueDelivery");
+      const queued = requireMockCallArg(queueMocks.enqueueDelivery, "enqueueDelivery");
       const queuedMediaUrl = queued?.preparedBatch?.entries?.find(
         (entry) => entry.status === "accepted",
       )?.payload?.mediaUrl;
@@ -4872,11 +4881,7 @@ describe("deliverOutboundPayloads", () => {
         deps: { matrix: sendMatrix },
       });
 
-      const queued = requireMockCallArg<{
-        preparedBatch?: {
-          entries?: Array<{ payload?: { mediaUrl?: string }; status?: string }>;
-        };
-      }>(queueMocks.enqueueDelivery, "enqueueDelivery");
+      const queued = requireMockCallArg(queueMocks.enqueueDelivery, "enqueueDelivery");
       const queuedMediaUrl = queued?.preparedBatch?.entries?.find(
         (entry) => entry.status === "accepted",
       )?.payload?.mediaUrl;
@@ -5092,11 +5097,10 @@ describe("deliverOutboundPayloads", () => {
       },
     });
 
-    const appendOptions = requireMockCallArg<{
-      config?: unknown;
-      idempotencyKey?: unknown;
-      text?: unknown;
-    }>(mocks.appendAssistantMessageToSessionTranscript, "append transcript");
+    const appendOptions = requireMockCallArg(
+      mocks.appendAssistantMessageToSessionTranscript,
+      "append transcript",
+    );
     expect(appendOptions?.text).toBe("caption\nreport.pdf");
     expect(appendOptions?.idempotencyKey).toBe("idem-deliver-1");
     expect(appendOptions?.config).toBe(cfg);
@@ -5532,7 +5536,9 @@ describe("deliverOutboundPayloads", () => {
   });
 
   it("does not fail successful sends when optional delivery pinning fails", async () => {
-    const pinDeliveredMessage = vi.fn().mockRejectedValue(new Error("pin denied"));
+    const pinDeliveredMessage = vi
+      .fn<OutboundPinDeliveredMessage>()
+      .mockRejectedValue(new Error("pin denied"));
     installTextOutbound({ channel: "matrix", messageId: "mx-1" }, { pinDeliveredMessage });
 
     const results = await deliverMatrix({
@@ -5561,7 +5567,9 @@ describe("deliverOutboundPayloads", () => {
     hookMocks.runner.hasHooks.mockImplementation((name?: string) => name === "message_sent");
     const events: TrustedMessageAuditEvent[] = [];
     const unsubscribe = onTrustedMessageAuditEvent((event) => events.push(event));
-    const pinDeliveredMessage = vi.fn().mockRejectedValue(new Error("pin denied"));
+    const pinDeliveredMessage = vi
+      .fn<OutboundPinDeliveredMessage>()
+      .mockRejectedValue(new Error("pin denied"));
     installTextOutbound({ channel: "matrix", messageId: "mx-1" }, { pinDeliveredMessage });
 
     try {
@@ -5627,7 +5635,7 @@ describe("deliverOutboundPayloads", () => {
       .fn()
       .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-1" })
       .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-2" });
-    const pinDeliveredMessage = vi.fn();
+    const pinDeliveredMessage = vi.fn<OutboundPinDeliveredMessage>();
     setTestOutbound({
       chunker: chunkText,
       chunkerMode: "text",
@@ -5642,10 +5650,7 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendText).toHaveBeenCalledTimes(2);
-    const pinOptions = requireMockCallArg<{ messageId?: unknown }>(
-      pinDeliveredMessage,
-      "pin delivered message",
-    );
+    const pinOptions = requireMockCallArg(pinDeliveredMessage, "pin delivered message");
     expect(pinOptions?.messageId).toBe("mx-1");
   });
 
@@ -5655,7 +5660,7 @@ describe("deliverOutboundPayloads", () => {
       .fn()
       .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-1" })
       .mockResolvedValueOnce({ channel: "matrix", messageId: "mx-2" });
-    const pinDeliveredMessage = vi.fn();
+    const pinDeliveredMessage = vi.fn<OutboundPinDeliveredMessage>();
     setTestOutbound({ sendText, sendMedia, pinDeliveredMessage });
 
     await deliverMatrix({
@@ -5670,10 +5675,7 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(sendMedia).toHaveBeenCalledTimes(2);
-    const pinOptions = requireMockCallArg<{ messageId?: unknown }>(
-      pinDeliveredMessage,
-      "pin delivered message",
-    );
+    const pinOptions = requireMockCallArg(pinDeliveredMessage, "pin delivered message");
     expect(pinOptions?.messageId).toBe("mx-1");
   });
 


### PR DESCRIPTION
## What Problem This Solves

Removes duplicated outbound delivery fixtures that repeated Matrix payload, adapter, queue, and result setup throughout the delivery owner suite.

## Why This Change Was Made

The suite now uses narrow typed builders for ordinary delivery boilerplate while keeping authority, custody, retry, receipt, reconciliation, media, session, and terminal-ordering facts explicit in the tests that own them.

Production LOC: +0/-0 (net 0) | Tests: +415/-699 (net -284)

## User Impact

There is no user-visible behavior change. Outbound delivery coverage remains intact while the suite is less repetitive and safer to extend.

## Evidence

- Outbound owner coverage: 189 tests passed.
- Independent sibling coverage: 41 tests passed.
- All 721 complete expectation roots and the queue authority, receipt, reconciliation, session, media, and audit security inventories were preserved.
- Focused typed lint, formatting, and diff validation passed.
