### PR TITLE
refactor(exa): unify contents validation

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -453,7 +453,7 @@ extensions/duckduckgo/src/config.ts	1
 extensions/duckduckgo/src/ddg-search-provider.ts	1
 extensions/elevenlabs/config-compat.ts	2
 extensions/elevenlabs/speech-provider.ts	3
-extensions/exa/src/exa-web-search-provider.runtime.ts	11
+extensions/exa/src/exa-web-search-provider.runtime.ts	9
 extensions/fal/image-generation-provider.ts	1
 extensions/fal/music-generation-provider.ts	2
 extensions/fal/video-generation-provider.ts	3

--- a/extensions/exa/src/exa-web-search-provider.runtime.ts
+++ b/extensions/exa/src/exa-web-search-provider.runtime.ts
@@ -222,123 +222,61 @@ function parseExaContents(
   }
 
   const parsed: ExaContentsArgs = {};
-
-  const parseText = (
-    value: unknown,
-  ): ExaTextContentsOption | { error: string; message: string; docs: string } => {
-    if (typeof value === "boolean") {
-      return value;
-    }
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
-      return invalidContentsPayload("contents.text must be a boolean or an object.");
-    }
-    const obj = value as Record<string, unknown>;
-    for (const key of Object.keys(obj)) {
-      if (key !== "maxCharacters") {
-        return invalidContentsPayload(
-          `contents.text has unknown field "${key}". Only "maxCharacters" is allowed.`,
-        );
-      }
-    }
-    if ("maxCharacters" in obj && parsePositiveInteger(obj.maxCharacters) === undefined) {
-      return invalidContentsPayload("contents.text.maxCharacters must be a positive integer.");
-    }
-    return parsePositiveInteger(obj.maxCharacters)
-      ? { maxCharacters: parsePositiveInteger(obj.maxCharacters) }
-      : {};
+  const fieldsBySection: Record<string, readonly string[]> = {
+    text: ["maxCharacters"],
+    highlights: ["maxCharacters", "query", "numSentences", "highlightsPerUrl"],
+    summary: ["query"],
   };
 
-  const parseHighlights = (
-    value: unknown,
-  ): ExaHighlightsContentsOption | { error: string; message: string; docs: string } => {
+  for (const section of ["text", "highlights", "summary"] as const) {
+    if (!(section in raw)) {
+      continue;
+    }
+    const value = raw[section];
     if (typeof value === "boolean") {
-      return value;
+      parsed[section] = value;
+      continue;
     }
     if (!value || typeof value !== "object" || Array.isArray(value)) {
-      return invalidContentsPayload("contents.highlights must be a boolean or an object.");
+      return invalidContentsPayload(`contents.${section} must be a boolean or an object.`);
     }
-    const obj = value as Record<string, unknown>;
-    const allowed = new Set(["maxCharacters", "query", "numSentences", "highlightsPerUrl"]);
-    for (const key of Object.keys(obj)) {
-      if (!allowed.has(key)) {
-        return invalidContentsPayload(
-          `contents.highlights has unknown field "${key}". Allowed fields are "maxCharacters", "query", "numSentences", and "highlightsPerUrl".`,
-        );
+
+    const option = value as Record<string, unknown>;
+    const fields = fieldsBySection[section] ?? [];
+    for (const key of Object.keys(option)) {
+      if (!fields.includes(key)) {
+        const allowed =
+          section === "highlights"
+            ? 'Allowed fields are "maxCharacters", "query", "numSentences", and "highlightsPerUrl".'
+            : `Only "${fields[0]}" is allowed.`;
+        return invalidContentsPayload(`contents.${section} has unknown field "${key}". ${allowed}`);
       }
     }
-    if ("maxCharacters" in obj && parsePositiveInteger(obj.maxCharacters) === undefined) {
-      return invalidContentsPayload(
-        "contents.highlights.maxCharacters must be a positive integer.",
-      );
-    }
-    if ("numSentences" in obj && parsePositiveInteger(obj.numSentences) === undefined) {
-      return invalidContentsPayload("contents.highlights.numSentences must be a positive integer.");
-    }
-    if ("highlightsPerUrl" in obj && parsePositiveInteger(obj.highlightsPerUrl) === undefined) {
-      return invalidContentsPayload(
-        "contents.highlights.highlightsPerUrl must be a positive integer.",
-      );
-    }
-    if ("query" in obj && typeof obj.query !== "string") {
-      return invalidContentsPayload("contents.highlights.query must be a string.");
-    }
-    return {
-      ...(parsePositiveInteger(obj.maxCharacters)
-        ? { maxCharacters: parsePositiveInteger(obj.maxCharacters) }
-        : {}),
-      ...(typeof obj.query === "string" ? { query: obj.query } : {}),
-      ...(parsePositiveInteger(obj.numSentences)
-        ? { numSentences: parsePositiveInteger(obj.numSentences) }
-        : {}),
-      ...(parsePositiveInteger(obj.highlightsPerUrl)
-        ? { highlightsPerUrl: parsePositiveInteger(obj.highlightsPerUrl) }
-        : {}),
-    };
-  };
 
-  const parseSummary = (
-    value: unknown,
-  ): ExaSummaryContentsOption | { error: string; message: string; docs: string } => {
-    if (typeof value === "boolean") {
-      return value;
-    }
-    if (!value || typeof value !== "object" || Array.isArray(value)) {
-      return invalidContentsPayload("contents.summary must be a boolean or an object.");
-    }
-    const obj = value as Record<string, unknown>;
-    for (const key of Object.keys(obj)) {
-      if (key !== "query") {
-        return invalidContentsPayload(
-          `contents.summary has unknown field "${key}". Only "query" is allowed.`,
-        );
+    for (const field of fields) {
+      if (
+        field !== "query" &&
+        field in option &&
+        parsePositiveInteger(option[field]) === undefined
+      ) {
+        return invalidContentsPayload(`contents.${section}.${field} must be a positive integer.`);
       }
     }
-    if ("query" in obj && typeof obj.query !== "string") {
-      return invalidContentsPayload("contents.summary.query must be a string.");
+    if (section !== "text" && "query" in option && typeof option.query !== "string") {
+      return invalidContentsPayload(`contents.${section}.query must be a string.`);
     }
-    return typeof obj.query === "string" ? { query: obj.query } : {};
-  };
 
-  if ("text" in raw) {
-    const parsedText = parseText(raw.text);
-    if (isErrorPayload(parsedText)) {
-      return parsedText;
+    const normalized: Record<string, unknown> = {};
+    for (const field of fields) {
+      if (field === "query") {
+        if (typeof option.query === "string") {
+          normalized.query = option.query;
+        }
+      } else if (parsePositiveInteger(option[field])) {
+        normalized[field] = parsePositiveInteger(option[field]);
+      }
     }
-    parsed.text = parsedText;
-  }
-  if ("highlights" in raw) {
-    const parsedHighlights = parseHighlights(raw.highlights);
-    if (isErrorPayload(parsedHighlights)) {
-      return parsedHighlights;
-    }
-    parsed.highlights = parsedHighlights;
-  }
-  if ("summary" in raw) {
-    const parsedSummary = parseSummary(raw.summary);
-    if (isErrorPayload(parsedSummary)) {
-      return parsedSummary;
-    }
-    parsed.summary = parsedSummary;
+    Object.assign(parsed, { [section]: normalized });
   }
 
   return { value: parsed };

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -281,6 +281,25 @@ describe("exa web search provider", () => {
     });
   });
 
+  it.each([
+    { name: "a non-string value", query: { value: 123 } },
+    {
+      name: "a throwing getter",
+      query: {
+        get() {
+          throw new Error("Unrelated inherited contents option was accessed");
+        },
+      },
+    },
+  ])("ignores inherited text query with $name", ({ query }) => {
+    const prototype = Object.defineProperty({}, "query", query);
+    const text = Object.assign(Object.create(prototype), { maxCharacters: 1 });
+
+    expect(testing.parseExaContents({ text })).toEqual({
+      value: { text: { maxCharacters: 1 } },
+    });
+  });
+
   it("rejects invalid Exa contents objects", () => {
     expect(
       testing.parseExaContents({


### PR DESCRIPTION
## What Problem This Solves

The Exa search provider repeatedly validated and normalized the same private contents options across separate input branches. Duplicated owner-local parsing made hostile property access, inherited values, and error ordering harder to keep consistent.

## Why This Change Was Made

The existing private Exa runtime now performs contents validation through one canonical owner while preserving the provider's existing defaults, optional values, validation sequence, error contracts, caching, authentication, network limits, and abort behavior. A real intermediate inherited-query regression was reproduced and repaired; meaningful owner tests now lock down numeric inherited properties and throwing getters.

## User Impact

Exa search requests, credentials, generated provider options, errors, and results remain unchanged. The security-sensitive provider input path contains less duplicate runtime code and two fewer unsafe assertions.

## Evidence

- The existing Exa provider suite passed all 22 owner cases, including new meaningful inherited-property and hostile getter coverage.
- Independent source-blind differential runs exercised 5,845 and 7,053 hostile/ordinary fixtures; the intermediate inherited-query bug was genuinely red against the unsafe change and green after the final repair.
- The full repository assertion-safety ratchet passed across 4,267 files and 13,371 assertions; its sole changed baseline entry shrank this owner's allowance from 11 to 9.
- Targeted lint, formatting, `git diff --check`, three independent source/security owner reviews, and full structured precommit review passed.
- Genuine shipped provider production delta: 41 added, 103 removed, net **-62**. Nineteen meaningful existing-test lines and the single owner-specific assertion-baseline adjustment are excluded from production accounting.
- No public SDK, configuration, protocol, SQLite schema, provider authentication, or user-visible search contract changes.
