### PR TITLE
fix(workboard): keep auto-dispatched cards unassigned

### DIFF
--- a/extensions/workboard/src/dispatcher-ownership.test.ts
+++ b/extensions/workboard/src/dispatcher-ownership.test.ts
@@ -47,6 +47,30 @@ describe("Workboard dispatcher ownership", () => {
     });
   });
 
+  it("keeps an automatically dispatched unassigned card ownerless", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Unassigned worker",
+      status: "ready",
+      workspaceAccess: { unrestricted: true },
+    });
+    const run = vi.fn().mockResolvedValue({ runId: "run-unassigned" });
+
+    await dispatchAndStartWorkboardCards({
+      store,
+      subagent: { run },
+      options: { now: 10, maxStarts: 1 },
+    });
+
+    expect(run).toHaveBeenCalledOnce();
+    const persisted = await store.get(card.id);
+    expect(persisted).toMatchObject({
+      status: "running",
+      metadata: { claim: { ownerId: "workboard-dispatcher" } },
+    });
+    expect(persisted?.agentId).toBeUndefined();
+  });
+
   it("falls back to one default owner for persisted blank and unassigned agents", async () => {
     const keyed = createMemoryStore();
     const store = new WorkboardStore(keyed);

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -467,6 +467,7 @@ async function runWorkboardDispatch(
             workspaceAccess: card.metadata?.automation?.workspaceAccess,
           },
           adoptWorkspaceAccess: persistWorkspaceAccess ? workspaceAccess : undefined,
+          preserveUnassignedAgent: true,
         },
       );
       claimValue = claimed.token;

--- a/extensions/workboard/src/store-inputs.ts
+++ b/extensions/workboard/src/store-inputs.ts
@@ -96,6 +96,8 @@ export type WorkboardClaimOptions = {
   };
   /** Trusted legacy-card adoption; applied only while expectedAuthority still matches. */
   adoptWorkspaceAccess?: WorkboardWorkspaceAccess;
+  /** Trusted dispatcher mode; retain an ownerless card while recording its effective claim owner. */
+  preserveUnassignedAgent?: boolean;
 };
 export type WorkboardHeartbeatInput = {
   token?: unknown;

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -143,7 +143,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
             guarded.status === "backlog" || guarded.status === "todo" || guarded.status === "ready"
               ? "running"
               : guarded.status,
-          agentId: guarded.agentId ?? ownerId,
+          agentId: options.preserveUnassignedAgent ? guarded.agentId : (guarded.agentId ?? ownerId),
           ...(options.adoptWorkspaceAccess && !guarded.metadata?.automation?.workspaceAccess
             ? { workspaceAccess: options.adoptWorkspaceAccess }
             : {}),


### PR DESCRIPTION
Closes #128860

## What Problem This Solves

Fixes an issue where Workboard cards without an assigned agent could become persistently assigned to the internal `workboard-dispatcher` sentinel after automatic dispatch. This leaked an internal concurrency owner into `card.agentId` instead of keeping the card unassigned.

## Why This Change Was Made

The dispatcher now uses a trusted claim mode that preserves an unassigned card's `agentId` while still recording the effective dispatcher owner in claim metadata. Normal/direct claims keep their existing assignment behavior.

## User Impact

Automatically dispatched, previously unassigned Workboard cards remain unassigned in persisted card state, while dispatcher ownership and concurrency tracking continue to work through claim metadata. Existing direct claim behavior is unchanged.

## Evidence

- Regression reproduced before the fix: the new ownership test expected `agentId` to stay undefined but received `"workboard-dispatcher"`.
- `node scripts/run-vitest.mjs extensions/workboard/src/dispatcher-ownership.test.ts extensions/workboard/src/store.test.ts` — 169/169 tests passed.
- `node scripts/check-changed.mjs -- extensions/workboard/src/dispatcher.ts extensions/workboard/src/store-workflow.ts extensions/workboard/src/store-inputs.ts extensions/workboard/src/dispatcher-ownership.test.ts` — passed, including format, typecheck, lint, dead-export, boundary, database-first, and import-cycle guards.
- Project `autoreview --mode local` — no accepted/actionable findings; reviewer result: patch correct (0.99 confidence).
- No screenshot attached: this change corrects persisted Workboard ownership state rather than a visual rendering path; the focused dispatcher/store tests exercise the affected contract directly.

AI-assisted: Yes — implementation and review used OpenAI coding tools; the repository autoreview gate was run before opening this PR.
