### PR TITLE
refactor(browser): unify browser mutation routes

### DIFF
--- a/extensions/browser/src/browser/routes/agent.storage.device.test.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.device.test.ts
@@ -3,8 +3,10 @@ import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helper
 import type { BrowserRequest } from "./types.js";
 
 const routeState = vi.hoisted(() => ({
+  cookiesGetViaPlaywright: vi.fn(async () => ({ cookies: [] })),
   cookiesSetManyViaPlaywright: vi.fn(async () => ({ added: 2 })),
   setDeviceViaPlaywright: vi.fn(async () => {}),
+  setHttpCredentialsViaPlaywright: vi.fn(async () => {}),
   withPlaywrightRouteContext: vi.fn(),
 }));
 
@@ -25,8 +27,10 @@ type PlaywrightRouteParams = {
     tab: { targetId: string };
     signal: AbortSignal;
     pw: {
+      cookiesGetViaPlaywright: typeof routeState.cookiesGetViaPlaywright;
       cookiesSetManyViaPlaywright: typeof routeState.cookiesSetManyViaPlaywright;
       setDeviceViaPlaywright: typeof routeState.setDeviceViaPlaywright;
+      setHttpCredentialsViaPlaywright: typeof routeState.setHttpCredentialsViaPlaywright;
     };
   }) => Promise<unknown>;
 };
@@ -39,25 +43,21 @@ function getPostHandler(route: string) {
   return handler;
 }
 
-describe("browser device route", () => {
-  beforeEach(() => {
-    routeState.cookiesSetManyViaPlaywright.mockClear();
-    routeState.setDeviceViaPlaywright.mockClear();
-    routeState.withPlaywrightRouteContext
-      .mockReset()
-      .mockImplementation(async (params: PlaywrightRouteParams) => {
-        await params.run({
-          cdpUrl: "http://127.0.0.1:18800",
-          tab: { targetId: "tab-1" },
-          signal: params.req.signal ?? new AbortController().signal,
-          pw: {
-            cookiesSetManyViaPlaywright: routeState.cookiesSetManyViaPlaywright,
-            setDeviceViaPlaywright: routeState.setDeviceViaPlaywright,
-          },
-        });
+beforeEach(() => {
+  vi.clearAllMocks();
+  routeState.withPlaywrightRouteContext
+    .mockReset()
+    .mockImplementation(async (params: PlaywrightRouteParams) => {
+      await params.run({
+        cdpUrl: "http://127.0.0.1:18800",
+        tab: { targetId: "tab-1" },
+        signal: params.req.signal ?? new AbortController().signal,
+        pw: routeState,
       });
-  });
+    });
+});
 
+describe("browser device route", () => {
   it("forwards the route lease signal into the atomic device transition", async () => {
     const controller = new AbortController();
     const response = createBrowserRouteResponse();
@@ -79,27 +79,36 @@ describe("browser device route", () => {
       signal: controller.signal,
     });
     expect(response.body).toEqual({ ok: true, targetId: "tab-1" });
+    expect(routeState.withPlaywrightRouteContext).toHaveBeenCalledWith(
+      expect.objectContaining({ feature: "device emulation" }),
+    );
+    expect(routeState.withPlaywrightRouteContext.mock.calls[0]?.[0]).not.toHaveProperty(
+      "enforceCurrentUrlAllowed",
+    );
+  });
+
+  it("never publishes a successful mutation after its route lease is canceled", async () => {
+    const controller = new AbortController();
+    const response = createBrowserRouteResponse();
+    routeState.setDeviceViaPlaywright.mockImplementationOnce(async () => controller.abort());
+
+    await expect(
+      getPostHandler("/set/device")?.(
+        {
+          params: {},
+          query: {},
+          body: { name: "iPhone 14" },
+          signal: controller.signal,
+        },
+        response.res,
+      ),
+    ).rejects.toThrow();
+
+    expect(response.body).toBeUndefined();
   });
 });
 
 describe("browser cookie batch route", () => {
-  beforeEach(() => {
-    routeState.cookiesSetManyViaPlaywright.mockClear();
-    routeState.withPlaywrightRouteContext
-      .mockReset()
-      .mockImplementation(async (params: PlaywrightRouteParams) => {
-        await params.run({
-          cdpUrl: "http://127.0.0.1:18800",
-          tab: { targetId: "tab-1" },
-          signal: params.req.signal ?? new AbortController().signal,
-          pw: {
-            cookiesSetManyViaPlaywright: routeState.cookiesSetManyViaPlaywright,
-            setDeviceViaPlaywright: routeState.setDeviceViaPlaywright,
-          },
-        });
-      });
-  });
-
   it("parses and injects a non-empty cookie batch", async () => {
     const controller = new AbortController();
     const response = createBrowserRouteResponse();
@@ -148,5 +157,45 @@ describe("browser cookie batch route", () => {
     expect(response.statusCode).toBe(400);
     expect(routeState.withPlaywrightRouteContext).not.toHaveBeenCalled();
     expect(routeState.cookiesSetManyViaPlaywright).not.toHaveBeenCalled();
+  });
+});
+
+describe("browser storage route boundaries", () => {
+  it("keeps cookie reads behind the current-tab URL guard", async () => {
+    const { app, getHandlers } = createBrowserRouteApp();
+    registerBrowserAgentStorageRoutes(app, {} as never);
+    const response = createBrowserRouteResponse();
+
+    await getHandlers.get("/cookies")?.({ params: {}, query: {} }, response.res);
+
+    expect(routeState.withPlaywrightRouteContext).toHaveBeenCalledWith(
+      expect.objectContaining({ feature: "cookies", enforceCurrentUrlAllowed: true }),
+    );
+    expect(response.body).toEqual({ ok: true, targetId: "tab-1", cookies: [] });
+  });
+
+  it("applies HTTP credentials without ever returning the password", async () => {
+    const response = createBrowserRouteResponse();
+
+    await getPostHandler("/set/credentials")?.(
+      {
+        params: {},
+        query: {},
+        body: { username: "browser-user", password: "sensitive-browser-password" },
+      },
+      response.res,
+    );
+
+    expect(routeState.setHttpCredentialsViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18800",
+      targetId: "tab-1",
+      username: "browser-user",
+      password: "sensitive-browser-password",
+      clear: false,
+    });
+    expect(response.body).toEqual({ ok: true, targetId: "tab-1" });
+    expect(routeState.withPlaywrightRouteContext).toHaveBeenCalledWith(
+      expect.objectContaining({ feature: "http credentials" }),
+    );
   });
 });

--- a/extensions/browser/src/browser/routes/agent.storage.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.ts
@@ -43,6 +43,10 @@ type CookieSetOptions = {
   sameSite?: "Lax" | "None" | "Strict";
 };
 
+type PlaywrightStorageMutationContext = Parameters<
+  Parameters<typeof withPlaywrightRouteContext>[0]["run"]
+>[0];
+
 /** Parse the supported browser storage bucket names. */
 function parseStorageKind(raw: string): StorageKind | null {
   if (raw === "local" || raw === "session") {
@@ -178,6 +182,28 @@ export function registerBrowserAgentStorageRoutes(
   app: BrowserRouteRegistrar,
   ctx: BrowserRouteContext,
 ) {
+  const runMutation = async (
+    req: BrowserRequest,
+    res: BrowserResponse,
+    targetId: string | undefined,
+    feature: string,
+    run: (context: PlaywrightStorageMutationContext) => Promise<void | Record<string, unknown>>,
+  ) => {
+    // Mutations intentionally do not apply the tab-scoped read/export URL guard.
+    await withPlaywrightRouteContext({
+      req,
+      res,
+      ctx,
+      targetId,
+      feature,
+      run: async (context) => {
+        const result = await run(context);
+        context.signal.throwIfAborted();
+        res.json({ ok: true, targetId: context.tab.targetId, ...result });
+      },
+    });
+  };
+
   app.get("/cookies", async (req, res) => {
     const targetId = resolveTargetIdFromQuery(req.query);
     await withPlaywrightRouteContext({
@@ -212,22 +238,12 @@ export function registerBrowserAgentStorageRoutes(
       return jsonError(res, 400, formatErrorMessage(err));
     }
 
-    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-    await withPlaywrightRouteContext({
-      req,
-      res,
-      ctx,
-      targetId,
-      feature: "cookies set",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
-        await pw.cookiesSetViaPlaywright({
-          cdpUrl,
-          targetId: tab.targetId,
-          cookie: parsedCookie,
-        });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
-      },
+    await runMutation(req, res, targetId, "cookies set", async ({ cdpUrl, tab, pw }) => {
+      await pw.cookiesSetViaPlaywright({
+        cdpUrl,
+        targetId: tab.targetId,
+        cookie: parsedCookie,
+      });
     });
   });
 
@@ -252,45 +268,32 @@ export function registerBrowserAgentStorageRoutes(
       return jsonError(res, 400, formatErrorMessage(err));
     }
 
-    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-    await withPlaywrightRouteContext({
+    await runMutation(
       req,
       res,
-      ctx,
       targetId,
-      feature: "cookies set-many",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
-        const result = await pw.cookiesSetManyViaPlaywright({
+      "cookies set-many",
+      async ({ cdpUrl, tab, pw, signal }) => {
+        const { added } = await pw.cookiesSetManyViaPlaywright({
           cdpUrl,
           targetId: tab.targetId,
           cookies,
           signal,
         });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId, added: result.added });
+        return { added };
       },
-    });
+    );
   });
 
   app.post("/cookies/clear", async (req, res) => {
     const body = readBody(req);
     const targetId = resolveTargetIdFromBody(body);
 
-    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-    await withPlaywrightRouteContext({
-      req,
-      res,
-      ctx,
-      targetId,
-      feature: "cookies clear",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
-        await pw.cookiesClearViaPlaywright({
-          cdpUrl,
-          targetId: tab.targetId,
-        });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
-      },
+    await runMutation(req, res, targetId, "cookies clear", async ({ cdpUrl, tab, pw }) => {
+      await pw.cookiesClearViaPlaywright({
+        cdpUrl,
+        targetId: tab.targetId,
+      });
     });
   });
 
@@ -333,14 +336,12 @@ export function registerBrowserAgentStorageRoutes(
     }
     const value = typeof mutation.body.value === "string" ? mutation.body.value : "";
 
-    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-    await withPlaywrightRouteContext({
+    await runMutation(
       req,
       res,
-      ctx,
-      targetId: mutation.parsed.targetId,
-      feature: "storage set",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
+      mutation.parsed.targetId,
+      "storage set",
+      async ({ cdpUrl, tab, pw }) => {
         await pw.storageSetViaPlaywright({
           cdpUrl,
           targetId: tab.targetId,
@@ -348,10 +349,8 @@ export function registerBrowserAgentStorageRoutes(
           key,
           value,
         });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
       },
-    });
+    );
   });
 
   app.post("/storage/:kind/clear", async (req, res) => {
@@ -360,23 +359,19 @@ export function registerBrowserAgentStorageRoutes(
       return;
     }
 
-    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-    await withPlaywrightRouteContext({
+    await runMutation(
       req,
       res,
-      ctx,
-      targetId: mutation.parsed.targetId,
-      feature: "storage clear",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
+      mutation.parsed.targetId,
+      "storage clear",
+      async ({ cdpUrl, tab, pw }) => {
         await pw.storageClearViaPlaywright({
           cdpUrl,
           targetId: tab.targetId,
           kind: mutation.parsed.kind,
         });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
       },
-    });
+    );
   });
 
   app.post("/set/offline", async (req, res) => {
@@ -387,22 +382,12 @@ export function registerBrowserAgentStorageRoutes(
       return jsonError(res, 400, "offline is required");
     }
 
-    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-    await withPlaywrightRouteContext({
-      req,
-      res,
-      ctx,
-      targetId,
-      feature: "offline",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
-        await pw.setOfflineViaPlaywright({
-          cdpUrl,
-          targetId: tab.targetId,
-          offline,
-        });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
-      },
+    await runMutation(req, res, targetId, "offline", async ({ cdpUrl, tab, pw }) => {
+      await pw.setOfflineViaPlaywright({
+        cdpUrl,
+        targetId: tab.targetId,
+        offline,
+      });
     });
   });
 
@@ -424,22 +409,12 @@ export function registerBrowserAgentStorageRoutes(
       }
     }
 
-    // Intentional: mutation routes are outside the tab-scoped read/export guard scope.
-    await withPlaywrightRouteContext({
-      req,
-      res,
-      ctx,
-      targetId,
-      feature: "headers",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
-        await pw.setExtraHTTPHeadersViaPlaywright({
-          cdpUrl,
-          targetId: tab.targetId,
-          headers: parsed,
-        });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
-      },
+    await runMutation(req, res, targetId, "headers", async ({ cdpUrl, tab, pw }) => {
+      await pw.setExtraHTTPHeadersViaPlaywright({
+        cdpUrl,
+        targetId: tab.targetId,
+        headers: parsed,
+      });
     });
   });
 
@@ -450,23 +425,14 @@ export function registerBrowserAgentStorageRoutes(
     const username = toStringOrEmpty(body.username) || undefined;
     const password = readStringValue(body.password);
 
-    await withPlaywrightRouteContext({
-      req,
-      res,
-      ctx,
-      targetId,
-      feature: "http credentials",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
-        await pw.setHttpCredentialsViaPlaywright({
-          cdpUrl,
-          targetId: tab.targetId,
-          username,
-          password,
-          clear,
-        });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
-      },
+    await runMutation(req, res, targetId, "http credentials", async ({ cdpUrl, tab, pw }) => {
+      await pw.setHttpCredentialsViaPlaywright({
+        cdpUrl,
+        targetId: tab.targetId,
+        username,
+        password,
+        clear,
+      });
     });
   });
 
@@ -480,21 +446,12 @@ export function registerBrowserAgentStorageRoutes(
       return jsonError(res, 400, formatErrorMessage(err));
     }
 
-    await withPlaywrightRouteContext({
-      req,
-      res,
-      ctx,
-      targetId,
-      feature: "geolocation",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
-        await pw.setGeolocationViaPlaywright({
-          cdpUrl,
-          targetId: tab.targetId,
-          ...geolocation,
-        });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
-      },
+    await runMutation(req, res, targetId, "geolocation", async ({ cdpUrl, tab, pw }) => {
+      await pw.setGeolocationViaPlaywright({
+        cdpUrl,
+        targetId: tab.targetId,
+        ...geolocation,
+      });
     });
   });
 
@@ -512,21 +469,12 @@ export function registerBrowserAgentStorageRoutes(
       return jsonError(res, 400, "colorScheme must be dark|light|no-preference|none");
     }
 
-    await withPlaywrightRouteContext({
-      req,
-      res,
-      ctx,
-      targetId,
-      feature: "media emulation",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
-        await pw.emulateMediaViaPlaywright({
-          cdpUrl,
-          targetId: tab.targetId,
-          colorScheme,
-        });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
-      },
+    await runMutation(req, res, targetId, "media emulation", async ({ cdpUrl, tab, pw }) => {
+      await pw.emulateMediaViaPlaywright({
+        cdpUrl,
+        targetId: tab.targetId,
+        colorScheme,
+      });
     });
   });
 
@@ -538,21 +486,12 @@ export function registerBrowserAgentStorageRoutes(
       return jsonError(res, 400, "timezoneId is required");
     }
 
-    await withPlaywrightRouteContext({
-      req,
-      res,
-      ctx,
-      targetId,
-      feature: "timezone",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
-        await pw.setTimezoneViaPlaywright({
-          cdpUrl,
-          targetId: tab.targetId,
-          timezoneId,
-        });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
-      },
+    await runMutation(req, res, targetId, "timezone", async ({ cdpUrl, tab, pw }) => {
+      await pw.setTimezoneViaPlaywright({
+        cdpUrl,
+        targetId: tab.targetId,
+        timezoneId,
+      });
     });
   });
 
@@ -564,21 +503,12 @@ export function registerBrowserAgentStorageRoutes(
       return jsonError(res, 400, "locale is required");
     }
 
-    await withPlaywrightRouteContext({
-      req,
-      res,
-      ctx,
-      targetId,
-      feature: "locale",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
-        await pw.setLocaleViaPlaywright({
-          cdpUrl,
-          targetId: tab.targetId,
-          locale,
-        });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
-      },
+    await runMutation(req, res, targetId, "locale", async ({ cdpUrl, tab, pw }) => {
+      await pw.setLocaleViaPlaywright({
+        cdpUrl,
+        targetId: tab.targetId,
+        locale,
+      });
     });
   });
 
@@ -590,22 +520,19 @@ export function registerBrowserAgentStorageRoutes(
       return jsonError(res, 400, "name is required");
     }
 
-    await withPlaywrightRouteContext({
+    await runMutation(
       req,
       res,
-      ctx,
       targetId,
-      feature: "device emulation",
-      run: async ({ cdpUrl, tab, pw, signal }) => {
+      "device emulation",
+      async ({ cdpUrl, tab, pw, signal }) => {
         await pw.setDeviceViaPlaywright({
           cdpUrl,
           targetId: tab.targetId,
           name,
           signal,
         });
-        signal.throwIfAborted();
-        res.json({ ok: true, targetId: tab.targetId });
       },
-    });
+    );
   });
 }


### PR DESCRIPTION
## What Problem This Solves

The shipped Browser storage/device HTTP owner duplicated common guarded mutation scaffolding across its cookies, storage, credentials, emulation, and related action routes. Repeated handlers obscured the intentionally different security policies for current-tab reads versus explicit mutations.

## Why This Change Was Made

The existing private Browser route owner now shares one canonical mutation-registration flow while preserving all 15 HTTP route identities, features, leases, abort signals, validation, credentials redaction, cookie result shapes, and separate SSRF guard policies. The existing route test gains direct security and lifecycle coverage instead of replacing real behavior with mocks.

## User Impact

Authenticated browser storage and device commands behave exactly as before. Current-tab cookie/storage reads continue rejecting private navigation, while intentionally allowed mutations keep their original policy. Credential secrets are never echoed, and cancellation does not destroy the selected browser tab.

## Evidence

- A real isolated Chrome 151 session and authenticated Browser/CDP bridge executed 26 actual HTTP requests across all 13 mutation families and both read routes.
- Live strict localhost policy returned HTTP 400 for both guarded GET cookie/storage reads while the intentionally distinct mutation path returned HTTP 200; unauthorized requests returned HTTP 401.
- The same real browser run proved credentials are not echoed, cookie batches report exactly two added items, and a genuine AbortError cancellation preserves the active tab.
- Seven actual route, browser, authorization, and lifecycle suites passed all 103 tests; the max-lines ratchet, targeted lint, formatting, and `git diff --check` passed.
- Three independent source/security/real-behavior reviews and full structured precommit review completed without findings.
- Genuine shipped Browser production delta: 101 added, 174 deleted, net **-73**. Meaningful existing route tests changed +83/-34, net +49, and are excluded from production accounting.
- No public SDK, configuration, protocol, SQLite schema, authentication, or documented Browser command contract changes.
