### PR TITLE
fix(reply): deduplicate rendered side-question replies correctly

### DIFF
--- a/src/auto-reply/reply/followup-delivery.channel.test.ts
+++ b/src/auto-reply/reply/followup-delivery.channel.test.ts
@@ -203,6 +203,31 @@ describe("follow-up delivery channel boundary", () => {
     ).toEqual([{ text: "first answer", replyToId: "111.000" }]);
   });
 
+  it("delivers an unsent BTW question when its answer was already tool-sent", async () => {
+    const text = "The image is ready for review";
+    const payloads = resolveFollowupDeliveryPayloads({
+      cfg: {},
+      payloads: [{ text, btw: { question: "What changed?" } }],
+      originatingChannel: "slack",
+      originatingTo: "channel:C1",
+      sentTexts: [text],
+      sentTargets: [{ tool: "message", provider: "slack", to: "channel:C1", text }],
+    });
+
+    await deliverBatch({
+      messageProvider: "discord",
+      originatingChannel: "slack",
+      outcomes: ["delivered"],
+      payloads,
+    });
+
+    expect(channelState.deliver).toHaveBeenCalledOnce();
+    expect(channelState.deliver.mock.calls[0]?.[0]).toMatchObject({
+      channel: "slack",
+      payloads: [{ text: "BTW\nQuestion: What changed?\n\nThe image is ready for review" }],
+    });
+  });
+
   it("emits one safe cross-channel error when a terminal payload fails after status delivery", async () => {
     const onBlockReply = await deliverBatch({
       messageProvider: "discord",

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -155,6 +155,43 @@ describe("resolveFollowupDeliveryPayloads", () => {
     ).toStrictEqual([]);
   });
 
+  it.each([
+    {
+      name: "keeps an unsent BTW question when its answer is most of the rendered reply",
+      text: "The image is ready for review",
+      sentText: "The image is ready for review",
+      delivered: true,
+    },
+    {
+      name: "keeps a short BTW question even when its long answer was already sent",
+      text: "The image is ready for review and the complete report is attached.",
+      sentText: "The image is ready for review and the complete report is attached.",
+      delivered: true,
+    },
+    {
+      name: "drops an already-delivered rendered BTW reply",
+      text: "The image is ready for review",
+      sentText: "BTW\nQuestion: What changed?\n\nThe image is ready for review",
+      delivered: false,
+    },
+    {
+      name: "preserves fuzzy matching for rendered BTW replies",
+      text: "The image is ready for review",
+      sentText: "btw\nquestion: WHAT CHANGED?\n\nThe image is ready for review 🌍",
+      delivered: false,
+    },
+  ])("$name", ({ text, sentText, delivered }) => {
+    const payload = { text, btw: { question: "What changed?" } };
+
+    expect(
+      resolveFollowupDeliveryPayloads({
+        cfg: baseConfig,
+        payloads: [payload],
+        sentTexts: [sentText],
+      }),
+    ).toEqual(delivered ? [payload] : []);
+  });
+
   it("drops media payloads already sent via messaging tool", () => {
     expect(
       resolveFollowupDeliveryPayloads({

--- a/src/auto-reply/reply/reply-payloads-dedupe.ts
+++ b/src/auto-reply/reply/reply-payloads-dedupe.ts
@@ -3,7 +3,10 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { isMessagingToolDuplicate } from "../../agents/embedded-agent-helpers.js";
+import {
+  isMessagingToolDuplicate,
+  normalizeTextForComparison,
+} from "../../agents/embedded-agent-helpers.js";
 import type { MessagingToolSend } from "../../agents/embedded-agent-messaging.types.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { getLoadedChannelPluginForRead } from "../../channels/plugins/registry-loaded.js";
@@ -23,6 +26,7 @@ import {
   type ReplyDeliveryContext,
 } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
+import { formatBtwTextForExternalDelivery } from "./reply-payloads-base.js";
 
 type MessagingToolDedupeRouteParams = {
   config?: OpenClawConfig;
@@ -414,14 +418,22 @@ export function filterMessagingToolReplyPayload(
     });
     return sentTexts.length === 0
       ? payloads
-      : payloads.filter(
-          (payload) =>
-            !isMessagingToolDuplicate(payload.text ?? "", sentTexts) ||
+      : payloads.filter((payload) => {
+          const duplicate = payload.btw?.question
+            ? sentTexts.some(
+                (sentText) =>
+                  normalizeTextForComparison(sentText) ===
+                  normalizeTextForComparison(formatBtwTextForExternalDelivery(payload) ?? ""),
+              )
+            : isMessagingToolDuplicate(payload.text ?? "", sentTexts);
+          return (
+            !duplicate ||
             hasReplyPayloadContent(
               { ...payload, text: undefined },
               { extraContent: hasEnabledDeliveryOperation(payload) || payload.location != null },
-            ),
-        );
+            )
+          );
+        });
   };
   return params.normalizeSentMediaUrls
     ? params.normalizeSentMediaUrls(sentMediaUrls).then(filterPayload)


### PR DESCRIPTION
## Summary

- Compare the user-visible rendered `/btw` reply before suppressing already-sent follow-up text.
- Preserve genuinely new side questions even when their ordinary base text was previously sent by a message tool.
- Keep existing fuzzy duplicate matching and the previously repaired pin, location, interactive, and presentation contracts intact.

## Root cause

The shared auto-reply/follow-up deduplication owner compared only raw base text, while `/btw` prepends a separately visible question and answer. It could therefore suppress a brand-new side question entirely, or fail to recognize already-rendered `/btw` output. The existing command-delivery sibling already uses the canonical externally rendered representation.

## Validation

- Authentic production follow-up through the actual channel/durable-outbound boundary previously recorded zero deliveries for a new `/btw` side question.
- Additional regressions cover already-rendered exact and fuzzy duplicates and preserve ordinary text, required operations, media, locations, and interactive replies.
- Six focused reply/follow-up/channel/command sibling suites: 281 tests passed with one preexisting skipped case.
- Focused type-aware lint, repository formatter, changed-lane classification, `git diff --check`, and fresh independent Codex autoreview must pass on the final exact diff.
- Production growth is limited to importing the existing canonical renderer; no protocol, config, persistence, or security changes.
