### PR TITLE
test(node-host): deduplicate system run fixtures

### DIFF
--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -430,7 +430,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   function createPolicyMutationCommit(
     mutate: (current: ReturnType<typeof loadExecApprovals>) => void,
-  ): Mock<HandleSystemRunInvokeOptions["commitExecAuthorization"]> {
+  ): Mock<NonNullable<HandleSystemRunInvokeOptions["commitExecAuthorization"]>> {
     return vi.fn(async (params) => {
       const current = loadExecApprovals();
       mutate(current);

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -21,7 +21,7 @@ import {
 } from "../config/runtime-snapshot.js";
 import { deleteExecApprovalsConfigRow } from "../infra/exec-approvals-sqlite.js";
 import { testing as execApprovalsStoreTesting } from "../infra/exec-approvals-store.test-support.js";
-import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
+import type { ExecAsk, ExecSecurity, SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 import {
   commitExecAuthorizationLocked,
   createExecApprovalPolicySnapshot,
@@ -51,6 +51,29 @@ type MockedRunViaMacAppExecHost = Mock<HandleSystemRunInvokeOptions["runViaMacAp
 type MockedSendInvokeResult = Mock<HandleSystemRunInvokeOptions["sendInvokeResult"]>;
 type MockedSendExecFinishedEvent = Mock<HandleSystemRunInvokeOptions["sendExecFinishedEvent"]>;
 type MockedSendNodeEvent = Mock<HandleSystemRunInvokeOptions["sendNodeEvent"]>;
+type InvokeSpies = {
+  runCommand: MockedRunCommand;
+  runViaMacAppExecHost: MockedRunViaMacAppExecHost;
+  sendInvokeResult: MockedSendInvokeResult;
+  sendExecFinishedEvent: MockedSendExecFinishedEvent;
+  sendNodeEvent: MockedSendNodeEvent;
+};
+type InvokeResult = {
+  ok?: boolean;
+  payloadJSON?: string;
+  error?: { code?: string; message?: string };
+};
+type MacExecHostCall = {
+  approvals?: { agent?: { security?: string; ask?: string } };
+  request?: {
+    command?: string[];
+    rawCommand?: string;
+    cwd?: string;
+    approvalDecision?: string | null;
+    approvalSource?: string | null;
+    policySnapshot?: unknown;
+  };
+};
 
 describe("handleSystemRunInvoke mac app exec host routing", () => {
   let sharedFixtureRoot = "";
@@ -115,9 +138,9 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     };
   }
 
-  function createTempExecutable(params: { dir: string; name: string }): string {
-    const fileName = process.platform === "win32" ? `${params.name}.exe` : params.name;
-    const executablePath = path.join(params.dir, fileName);
+  function createTempExecutable(dir: string, name: string): string {
+    const fileName = process.platform === "win32" ? `${name}.exe` : name;
+    const executablePath = path.join(dir, fileName);
     fs.writeFileSync(executablePath, "");
     fs.chmodSync(executablePath, 0o755);
     return executablePath;
@@ -125,13 +148,13 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   function createStrictInlineEvalApprovalPlan(prefix: string): SystemRunApprovalPlan {
     const tempDir = createFixtureDir(prefix);
-    const executablePath = createTempExecutable({ dir: tempDir, name: "gawk" });
+    const executablePath = createTempExecutable(tempDir, "gawk");
     const scriptPath = path.join(tempDir, "library.awk");
     fs.writeFileSync(scriptPath, "{ print }\n");
-    const prepared = buildSystemRunApprovalPlan({
-      command: [executablePath, "-f", scriptPath, '--source=BEGIN{print "safe"}'],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(
+      [executablePath, "-f", scriptPath, '--source=BEGIN{print "safe"}'],
+      "agent:main:main",
+    );
     if (!prepared.ok) {
       throw new Error(prepared.message);
     }
@@ -151,10 +174,29 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     };
   }
 
-  function expectInvokeOk(
-    sendInvokeResult: MockedSendInvokeResult,
-    params?: { payloadContains?: string },
-  ) {
+  function requireApprovalPlan(
+    prepared: ReturnType<typeof buildSystemRunApprovalPlan>,
+    message: string,
+  ): asserts prepared is Extract<ReturnType<typeof buildSystemRunApprovalPlan>, { ok: true }> {
+    if (!prepared.ok) {
+      throw new Error(message);
+    }
+  }
+
+  function buildSessionApprovalPlan(command: string[], sessionKey: string) {
+    return buildSystemRunApprovalPlan({ command, sessionKey });
+  }
+
+  function buildCwdApprovalPlan(command: string[], cwd: string) {
+    return buildSystemRunApprovalPlan({ command, cwd });
+  }
+
+  function buildCwdSessionApprovalPlan(command: string[], cwd: string, sessionKey: string) {
+    return buildSystemRunApprovalPlan({ command, cwd, sessionKey });
+  }
+
+  function expectInvokeOk(sendInvokeResult: MockedSendInvokeResult, payloadContains?: string) {
+    const params = payloadContains === undefined ? undefined : { payloadContains };
     const result = requireInvokeResult(sendInvokeResult);
     expect(result.ok).toBe(true);
     if (params?.payloadContains) {
@@ -164,8 +206,10 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   function expectInvokeErrorMessage(
     sendInvokeResult: MockedSendInvokeResult,
-    params: { message: string; exact?: boolean },
+    expectedMessage: string,
+    exact = false,
   ) {
+    const params = { message: expectedMessage, exact };
     const result = requireInvokeResult(sendInvokeResult);
     expect(result.ok).toBe(false);
     const message = result.error?.message;
@@ -176,46 +220,20 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     }
   }
 
-  function requireInvokeResult(sendInvokeResult: MockedSendInvokeResult): {
-    ok?: boolean;
-    payloadJSON?: string;
-    error?: { code?: string; message?: string };
-  } {
+  function requireInvokeResult(sendInvokeResult: MockedSendInvokeResult): InvokeResult {
     const result = firstMockCallArg(sendInvokeResult, "sendInvokeResult", 0);
-    return result as {
-      ok?: boolean;
-      payloadJSON?: string;
-      error?: { code?: string; message?: string };
-    };
+    return result as InvokeResult;
   }
 
   function requireFirstRunCommandArgs(runCommand: MockedRunCommand): string[] {
     return firstMockCallArg(vi.mocked(runCommand), "runCommand", 0) as string[];
   }
 
-  function requireMacExecHostCall(runViaMacAppExecHost: MockedRunViaMacAppExecHost): {
-    approvals?: { agent?: { security?: string; ask?: string } };
-    request?: {
-      command?: string[];
-      rawCommand?: string;
-      cwd?: string;
-      approvalDecision?: string | null;
-      approvalSource?: string | null;
-      policySnapshot?: unknown;
-    };
-  } {
+  function requireMacExecHostCall(
+    runViaMacAppExecHost: MockedRunViaMacAppExecHost,
+  ): MacExecHostCall {
     const call = firstMockCallArg(runViaMacAppExecHost, "runViaMacAppExecHost", 0);
-    return call as {
-      approvals?: { agent?: { security?: string; ask?: string } };
-      request?: {
-        command?: string[];
-        rawCommand?: string;
-        cwd?: string;
-        approvalDecision?: string | null;
-        approvalSource?: string | null;
-        policySnapshot?: unknown;
-      };
-    };
+    return call as MacExecHostCall;
   }
 
   function firstMockCallArg(
@@ -242,15 +260,13 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     expect((call[2] as { reason?: string }).reason).toBe(reason);
   }
 
-  function expectApprovalRequiredDenied(params: {
-    sendNodeEvent: MockedSendNodeEvent;
-    sendInvokeResult: MockedSendInvokeResult;
-  }) {
+  function expectApprovalRequiredDenied(
+    sendNodeEvent: MockedSendNodeEvent,
+    sendInvokeResult: MockedSendInvokeResult,
+  ) {
+    const params = { sendNodeEvent, sendInvokeResult };
     expectExecDeniedEvent(params.sendNodeEvent);
-    expectInvokeErrorMessage(params.sendInvokeResult, {
-      message: "SYSTEM_RUN_DENIED: approval required",
-      exact: true,
-    });
+    expectInvokeErrorMessage(params.sendInvokeResult, "SYSTEM_RUN_DENIED: approval required", true);
   }
 
   function expectApprovalStateWriteDenied(params: {
@@ -291,19 +307,19 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     };
   }
 
-  function createRuntimeScriptOperandFixture(params: {
-    tmp: string;
-    runtime: "bun" | "deno" | "jiti" | "tsx";
-  }): {
+  function createRuntimeScriptOperandFixture(
+    tmp: string,
+    runtime: "bun" | "deno" | "jiti" | "tsx",
+  ): {
     command: string[];
     scriptPath: string;
     initialBody: string;
     changedBody: string;
   } {
-    const scriptPath = path.join(params.tmp, "run.ts");
+    const scriptPath = path.join(tmp, "run.ts");
     const initialBody = 'console.log("SAFE");\n';
     const changedBody = 'console.log("PWNED");\n';
-    switch (params.runtime) {
+    switch (runtime) {
       case "bun":
         return {
           command: ["bun", "run", "./run.ts"],
@@ -333,7 +349,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           changedBody,
         };
     }
-    const unsupportedRuntime: never = params.runtime;
+    const unsupportedRuntime: never = runtime;
     throw new Error(`unsupported runtime fixture: ${String(unsupportedRuntime)}`);
   }
 
@@ -371,6 +387,23 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     };
   }
 
+  function createApprovals(
+    security: ExecSecurity,
+    ask: ExecAsk,
+    askFallback: ExecSecurity,
+    agents?: Parameters<typeof saveExecApprovals>[0]["agents"],
+  ): Parameters<typeof saveExecApprovals>[0] {
+    return {
+      version: 1,
+      defaults: { security, ask, askFallback },
+      ...(agents === undefined ? {} : { agents }),
+    };
+  }
+
+  function createExactCommandPattern(commandText: string): string {
+    return `=command:${crypto.createHash("sha256").update(commandText).digest("hex").slice(0, 16)}`;
+  }
+
   function resolveProductionExecSecurity(value?: string): "deny" | "allowlist" | "full" {
     return value === "deny" || value === "allowlist" || value === "full" ? value : "allowlist";
   }
@@ -379,73 +412,89 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     return value === "off" || value === "on-miss" || value === "always" ? value : "on-miss";
   }
 
-  function createInvokeSpies(params?: { runCommand?: MockedRunCommand }): {
-    runCommand: MockedRunCommand;
-    sendInvokeResult: MockedSendInvokeResult;
-    sendNodeEvent: MockedSendNodeEvent;
-  } {
+  function createInvokeSpies(params?: {
+    runCommand?: HandleSystemRunInvokeOptions["runCommand"];
+    runViaMacAppExecHost?: HandleSystemRunInvokeOptions["runViaMacAppExecHost"];
+    sendInvokeResult?: HandleSystemRunInvokeOptions["sendInvokeResult"];
+    sendExecFinishedEvent?: HandleSystemRunInvokeOptions["sendExecFinishedEvent"];
+    sendNodeEvent?: HandleSystemRunInvokeOptions["sendNodeEvent"];
+  }): InvokeSpies {
     return {
-      runCommand: params?.runCommand ?? vi.fn(async () => createLocalRunResult()),
-      sendInvokeResult: vi.fn(async () => {}),
-      sendNodeEvent: vi.fn(async () => {}),
+      runCommand: vi.fn(params?.runCommand ?? (async () => createLocalRunResult())),
+      runViaMacAppExecHost: vi.fn(params?.runViaMacAppExecHost ?? (async () => null)),
+      sendInvokeResult: vi.fn(params?.sendInvokeResult ?? (async () => {})),
+      sendExecFinishedEvent: vi.fn(params?.sendExecFinishedEvent ?? (async () => {})),
+      sendNodeEvent: vi.fn(params?.sendNodeEvent ?? (async () => {})),
     };
   }
 
-  async function withTempApprovalsHome<T>(params: {
-    approvals: Parameters<typeof saveExecApprovals>[0];
-    run: (ctx: { tempHome: string }) => Promise<T>;
-  }): Promise<T> {
-    const tempHome = sharedOpenClawHome;
-    return await withEnvAsync({ OPENCLAW_HOME: tempHome }, async () => {
-      saveExecApprovals(params.approvals);
-      return await params.run({ tempHome });
+  function createPolicyMutationCommit(
+    mutate: (current: ReturnType<typeof loadExecApprovals>) => void,
+  ): Mock<HandleSystemRunInvokeOptions["commitExecAuthorization"]> {
+    return vi.fn(async (params) => {
+      const current = loadExecApprovals();
+      mutate(current);
+      saveExecApprovals(current);
+      await commitExecAuthorizationLocked(params);
     });
   }
 
-  async function withPathTokenCommand<T>(params: {
-    tmpPrefix: string;
-    run: (ctx: { link: string; expected: string }) => Promise<T>;
-  }): Promise<T> {
-    const tmp = createFixtureDir(params.tmpPrefix);
+  async function withTempApprovalsHome<T>(
+    approvals: Parameters<typeof saveExecApprovals>[0],
+    run: (ctx: { tempHome: string }) => Promise<T>,
+  ): Promise<T> {
+    const tempHome = sharedOpenClawHome;
+    return await withEnvAsync({ OPENCLAW_HOME: tempHome }, async () => {
+      saveExecApprovals(approvals);
+      return await run({ tempHome });
+    });
+  }
+
+  async function withPathTokenCommand<T>(
+    tmpPrefix: string,
+    run: (ctx: { link: string; expected: string }) => Promise<T>,
+  ): Promise<T> {
+    const tmp = createFixtureDir(tmpPrefix);
     const binDir = path.join(tmp, "bin");
     fs.mkdirSync(binDir, { recursive: true });
     const link = path.join(binDir, "poccmd");
     fs.symlinkSync("/bin/echo", link);
     const expected = fs.realpathSync(link);
     return await withEnvAsync({ PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` }, () =>
-      params.run({ link, expected }),
+      run({ link, expected }),
     );
   }
 
-  async function withFakeRuntimeOnPath<T>(params: {
-    runtime: "bun" | "deno" | "jiti" | "tsx";
-    run: () => Promise<T>;
-  }): Promise<T> {
-    if (!sharedRuntimeBins.has(params.runtime)) {
+  async function withFakeRuntimeOnPath<T>(
+    runtime: "bun" | "deno" | "jiti" | "tsx",
+    run: () => Promise<T>,
+  ): Promise<T> {
+    if (!sharedRuntimeBins.has(runtime)) {
       const runtimePath =
         process.platform === "win32"
-          ? path.join(sharedRuntimeBinDir, `${params.runtime}.cmd`)
-          : path.join(sharedRuntimeBinDir, params.runtime);
+          ? path.join(sharedRuntimeBinDir, `${runtime}.cmd`)
+          : path.join(sharedRuntimeBinDir, runtime);
       const runtimeBody =
         process.platform === "win32" ? "@echo off\r\nexit /b 0\r\n" : "#!/bin/sh\nexit 0\n";
       fs.writeFileSync(runtimePath, runtimeBody, { mode: 0o755 });
       if (process.platform !== "win32") {
         fs.chmodSync(runtimePath, 0o755);
       }
-      sharedRuntimeBins.add(params.runtime);
+      sharedRuntimeBins.add(runtime);
     }
     return await withEnvAsync(
       { PATH: `${sharedRuntimeBinDir}${path.delimiter}${process.env.PATH ?? ""}` },
-      () => params.run(),
+      run,
     );
   }
 
-  function expectCommandPinnedToCanonicalPath(params: {
-    runCommand: MockedRunCommand;
-    expected: string;
-    commandTail: string[];
-    cwd?: string;
-  }) {
+  function expectCommandPinnedToCanonicalPath(
+    runCommand: MockedRunCommand,
+    expected: string,
+    commandTail: string[],
+    cwd?: string,
+  ) {
+    const params = { runCommand, expected, commandTail, cwd };
     expect(params.runCommand).toHaveBeenCalledWith(
       [params.expected, ...params.commandTail],
       params.cwd,
@@ -503,6 +552,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     env?: Record<string, string>;
     rawCommand?: string | null;
     systemRunPlan?: SystemRunApprovalPlan | null;
+    preparedPlan?: SystemRunApprovalPlan;
     cwd?: string;
     agentId?: string;
     security?: "full" | "allowlist";
@@ -526,48 +576,25 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     commitExecAuthorization?: HandleSystemRunInvokeOptions["commitExecAuthorization"];
     prepareDelayedApprovalPlan?: boolean;
     signal?: AbortSignal;
-  }): Promise<{
-    runCommand: MockedRunCommand;
-    runViaMacAppExecHost: MockedRunViaMacAppExecHost;
-    sendInvokeResult: MockedSendInvokeResult;
-    sendNodeEvent: MockedSendNodeEvent;
-    sendExecFinishedEvent: MockedSendExecFinishedEvent;
-  }> {
-    const runCommand: MockedRunCommand = vi.fn<HandleSystemRunInvokeOptions["runCommand"]>(
-      async () => createLocalRunResult(),
-    );
-    const runViaMacAppExecHost: MockedRunViaMacAppExecHost = vi.fn<
-      HandleSystemRunInvokeOptions["runViaMacAppExecHost"]
-    >(async () => params.runViaResponse ?? null);
-    const sendInvokeResult: MockedSendInvokeResult = vi.fn<
-      HandleSystemRunInvokeOptions["sendInvokeResult"]
-    >(async () => {});
-    const sendNodeEvent: MockedSendNodeEvent = vi.fn<HandleSystemRunInvokeOptions["sendNodeEvent"]>(
-      async () => {},
-    );
-    const sendExecFinishedEvent: MockedSendExecFinishedEvent = vi.fn<
-      HandleSystemRunInvokeOptions["sendExecFinishedEvent"]
-    >(async () => {});
+  }): Promise<InvokeSpies> {
+    const {
+      runCommand,
+      runViaMacAppExecHost,
+      sendInvokeResult,
+      sendExecFinishedEvent,
+      sendNodeEvent,
+    } = createInvokeSpies({
+      runCommand: params.runCommand,
+      runViaMacAppExecHost:
+        params.runViaMacAppExecHost ?? (async () => params.runViaResponse ?? null),
+      sendInvokeResult: params.sendInvokeResult,
+      sendExecFinishedEvent: params.sendExecFinishedEvent,
+      sendNodeEvent: params.sendNodeEvent,
+    });
 
-    if (params.runCommand !== undefined) {
-      runCommand.mockImplementation(params.runCommand);
-    }
-    if (params.runViaMacAppExecHost !== undefined) {
-      runViaMacAppExecHost.mockImplementation(params.runViaMacAppExecHost);
-    }
-    if (params.sendInvokeResult !== undefined) {
-      sendInvokeResult.mockImplementation(params.sendInvokeResult);
-    }
-    if (params.sendNodeEvent !== undefined) {
-      sendNodeEvent.mockImplementation(params.sendNodeEvent);
-    }
-    if (params.sendExecFinishedEvent !== undefined) {
-      sendExecFinishedEvent.mockImplementation(params.sendExecFinishedEvent);
-    }
-
-    const command = params.command ?? ["echo", "ok"];
+    const command = params.command ?? params.preparedPlan?.argv ?? ["echo", "ok"];
     let dispatchCommand = command;
-    let dispatchRawCommand = params.rawCommand;
+    let dispatchRawCommand = params.rawCommand ?? params.preparedPlan?.commandText;
     let dispatchCwd = params.cwd;
     let dispatchAgentId: string | undefined = params.agentId ?? "main";
     const forwardsDelayedApproval =
@@ -576,11 +603,12 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       params.approvalDecision === "allow" ||
       params.approvalDecision === "allow-once" ||
       params.approvalDecision === "allow-always";
-    let systemRunPlan: SystemRunApprovalPlan | undefined = params.systemRunPlan
+    const providedPlan = params.preparedPlan ?? params.systemRunPlan ?? undefined;
+    let systemRunPlan: SystemRunApprovalPlan | undefined = providedPlan
       ? {
-          ...params.systemRunPlan,
-          agentId: params.systemRunPlan.agentId ?? dispatchAgentId,
-          sessionKey: params.systemRunPlan.sessionKey ?? "agent:main:main",
+          ...providedPlan,
+          agentId: providedPlan.agentId ?? dispatchAgentId,
+          sessionKey: providedPlan.sessionKey ?? "agent:main:main",
         }
       : undefined;
     if (forwardsDelayedApproval && params.prepareDelayedApprovalPlan !== false) {
@@ -651,12 +679,44 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     };
   }
 
+  type SystemInvokeFixtureParams = Parameters<typeof runSystemInvoke>[0];
+
+  async function runLocalSystemInvoke(
+    params: Omit<SystemInvokeFixtureParams, "preferMacAppExecHost"> = {},
+  ) {
+    return await runSystemInvoke({ ...params, preferMacAppExecHost: false });
+  }
+
+  async function runMacSystemInvoke(
+    params: Omit<SystemInvokeFixtureParams, "preferMacAppExecHost"> = {},
+  ) {
+    return await runSystemInvoke({ ...params, preferMacAppExecHost: true });
+  }
+
+  type ExplicitSystemInvokePolicy = {
+    security: NonNullable<SystemInvokeFixtureParams["security"]>;
+    ask: NonNullable<SystemInvokeFixtureParams["ask"]>;
+  };
+
+  async function runLocalSystemInvokeWithPolicy(
+    security: ExplicitSystemInvokePolicy["security"],
+    ask: ExplicitSystemInvokePolicy["ask"],
+    params: Omit<SystemInvokeFixtureParams, "preferMacAppExecHost" | "security" | "ask"> = {},
+  ) {
+    return await runLocalSystemInvoke({ ...params, security, ask });
+  }
+
+  async function runMacSystemInvokeWithPolicy(
+    security: ExplicitSystemInvokePolicy["security"],
+    ask: ExplicitSystemInvokePolicy["ask"],
+    params: Omit<SystemInvokeFixtureParams, "preferMacAppExecHost" | "security" | "ask"> = {},
+  ) {
+    return await runMacSystemInvoke({ ...params, security, ask });
+  }
+
   it("forwards cancellation to locally spawned node commands", async () => {
     const controller = new AbortController();
-    const result = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      signal: controller.signal,
-    });
+    const result = await runLocalSystemInvoke({ signal: controller.signal });
 
     expect(result.runCommand.mock.calls[0]?.[4]).toBe(controller.signal);
   });
@@ -665,10 +725,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     const controller = new AbortController();
     controller.abort();
 
-    const result = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      signal: controller.signal,
-    });
+    const result = await runLocalSystemInvoke({ signal: controller.signal });
 
     expect(result.runCommand).not.toHaveBeenCalled();
     expect(result.runViaMacAppExecHost).not.toHaveBeenCalled();
@@ -676,8 +733,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   it("does not publish a cancelled local command completion", async () => {
     const controller = new AbortController();
-    const result = await runSystemInvoke({
-      preferMacAppExecHost: false,
+    const result = await runLocalSystemInvoke({
       signal: controller.signal,
       runCommand: async () => {
         controller.abort();
@@ -692,8 +748,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   it("does not publish a cancelled Mac exec-host completion", async () => {
     const controller = new AbortController();
-    const result = await runSystemInvoke({
-      preferMacAppExecHost: true,
+    const result = await runMacSystemInvoke({
       signal: controller.signal,
       runViaMacAppExecHost: async () => {
         controller.abort();
@@ -707,28 +762,22 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("routes local, mac host, and canonical shell-wrapper requests", async () => {
-    const localInvoke = await runSystemInvoke({
-      preferMacAppExecHost: false,
-    });
+    const localInvoke = await runLocalSystemInvoke({});
 
     expect(localInvoke.runViaMacAppExecHost).not.toHaveBeenCalled();
     expect(localInvoke.runCommand).toHaveBeenCalledTimes(1);
-    expectInvokeOk(localInvoke.sendInvokeResult, { payloadContains: "local-ok" });
+    expectInvokeOk(localInvoke.sendInvokeResult, "local-ok");
 
-    const macHostInvoke = await runSystemInvoke({
-      preferMacAppExecHost: true,
-      runViaResponse: createMacExecHostSuccess(),
-    });
+    const macHostInvoke = await runMacSystemInvoke({ runViaResponse: createMacExecHostSuccess() });
 
     const macHostCall = requireMacExecHostCall(macHostInvoke.runViaMacAppExecHost);
     expect(macHostCall.approvals?.agent?.security).toBe("full");
     expect(macHostCall.approvals?.agent?.ask).toBe("off");
     expect(macHostCall.request?.command).toEqual(["echo", "ok"]);
     expect(macHostInvoke.runCommand).not.toHaveBeenCalled();
-    expectInvokeOk(macHostInvoke.sendInvokeResult, { payloadContains: "app-ok" });
+    expectInvokeOk(macHostInvoke.sendInvokeResult, "app-ok");
 
-    const shellWrapperInvoke = await runSystemInvoke({
-      preferMacAppExecHost: true,
+    const shellWrapperInvoke = await runMacSystemInvoke({
       command: ["/bin/sh", "-lc", '$0 "$1"', "/usr/bin/touch", "/tmp/marker"],
       runViaResponse: createMacExecHostSuccess(),
     });
@@ -751,7 +800,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   it("uses auto reviewer for system.run approval misses when exec mode is auto", async () => {
     const tmp = createFixtureDir("openclaw-system-run-auto-review-");
-    const executablePath = createTempExecutable({ dir: tmp, name: "read-info" });
+    const executablePath = createTempExecutable(tmp, "read-info");
     setRuntimeConfigSnapshot({
       tools: {
         exec: {
@@ -767,16 +816,10 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       }));
       const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
       const runCommand = vi.fn(async () => createLocalRunResult("auto-reviewed"));
-      const prepared = buildSystemRunApprovalPlan({
-        command: [executablePath],
-        cwd: tmp,
-      });
+      const prepared = buildCwdApprovalPlan([executablePath], tmp);
       expect(prepared.ok).toBe(true);
-      if (!prepared.ok) {
-        throw new Error("unreachable");
-      }
-      const invoke = await runSystemInvoke({
-        preferMacAppExecHost: false,
+      requireApprovalPlan(prepared, "unreachable");
+      const invoke = await runLocalSystemInvoke({
         command: prepared.plan.argv,
         cwd: prepared.plan.cwd ?? tmp,
         systemRunPlan: prepared.plan,
@@ -808,10 +851,9 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           authorization: expect.objectContaining({ source: "auto-review" }),
         }),
       );
-      expectInvokeOk(invoke.sendInvokeResult, { payloadContains: "auto-reviewed" });
+      expectInvokeOk(invoke.sendInvokeResult, "auto-reviewed");
 
-      const macInvoke = await runSystemInvoke({
-        preferMacAppExecHost: true,
+      const macInvoke = await runMacSystemInvoke({
         runViaResponse: createMacExecHostSuccess(),
         command: prepared.plan.argv,
         cwd: prepared.plan.cwd ?? tmp,
@@ -827,7 +869,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         createExecApprovalPolicySnapshot({ file: loadExecApprovals(), agentId: undefined }),
       );
       expect(macInvoke.runCommand).not.toHaveBeenCalled();
-      expectInvokeOk(macInvoke.sendInvokeResult, { payloadContains: "app-ok" });
+      expectInvokeOk(macInvoke.sendInvokeResult, "app-ok");
     } finally {
       clearRuntimeConfigSnapshot();
     }
@@ -835,7 +877,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   it("does not auto-review direct system.run approval misses without an approval plan", async () => {
     const tmp = createFixtureDir("openclaw-system-run-auto-review-no-plan-");
-    const executablePath = createTempExecutable({ dir: tmp, name: "read-info" });
+    const executablePath = createTempExecutable(tmp, "read-info");
     setRuntimeConfigSnapshot({
       tools: {
         exec: {
@@ -850,8 +892,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         risk: "low",
       }));
       const runCommand = vi.fn(async () => createLocalRunResult("should-not-run"));
-      const invoke = await runSystemInvoke({
-        preferMacAppExecHost: false,
+      const invoke = await runLocalSystemInvoke({
         command: [executablePath],
         cwd: tmp,
         runCommand,
@@ -862,9 +903,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
       expect(autoReviewer).not.toHaveBeenCalled();
       expect(runCommand).not.toHaveBeenCalled();
-      expectInvokeErrorMessage(invoke.sendInvokeResult, {
-        message: "SYSTEM_RUN_DENIED: approval required",
-      });
+      expectInvokeErrorMessage(invoke.sendInvokeResult, "SYSTEM_RUN_DENIED: approval required");
     } finally {
       clearRuntimeConfigSnapshot();
     }
@@ -885,18 +924,15 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     },
   ])("denies direct system.run when its reviewer $name", async ({ reviewer }) => {
     const tmp = createFixtureDir("openclaw-system-run-auto-review-failure-");
-    const executablePath = createTempExecutable({ dir: tmp, name: "read-info" });
+    const executablePath = createTempExecutable(tmp, "read-info");
     setRuntimeConfigSnapshot({ tools: { exec: { mode: "auto" } } });
     const autoReviewer = vi.fn<ExecAutoReviewer>(reviewer);
     const runCommand = vi.fn(async () => createLocalRunResult("should-not-run"));
-    const prepared = buildSystemRunApprovalPlan({ command: [executablePath], cwd: tmp });
+    const prepared = buildCwdApprovalPlan([executablePath], tmp);
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("expected a bound system.run approval plan");
-    }
+    requireApprovalPlan(prepared, "expected a bound system.run approval plan");
 
-    const invoke = await runSystemInvoke({
-      preferMacAppExecHost: false,
+    const invoke = await runLocalSystemInvoke({
       command: prepared.plan.argv,
       cwd: prepared.plan.cwd ?? tmp,
       systemRunPlan: prepared.plan,
@@ -908,10 +944,10 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
     expect(autoReviewer).toHaveBeenCalledTimes(1);
     expect(runCommand).not.toHaveBeenCalled();
-    expectInvokeErrorMessage(invoke.sendInvokeResult, {
-      message:
-        "exec auto-review deferred to human approval: exec reviewer failed: provider\\nfailed",
-    });
+    expectInvokeErrorMessage(
+      invoke.sendInvokeResult,
+      "exec auto-review deferred to human approval: exec reviewer failed: provider\\nfailed",
+    );
   });
 
   it.runIf(process.platform !== "win32").each(["bash", "sh", "/bin/sh"])(
@@ -937,8 +973,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           sessionKey: "agent:main:main",
         } satisfies SystemRunApprovalPlan;
 
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
+        const invoke = await runLocalSystemInvoke({
           command,
           rawCommand: approvalPlan.commandText,
           cwd: tmp,
@@ -950,9 +985,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
         expect(autoReviewer).not.toHaveBeenCalled();
         expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectInvokeErrorMessage(invoke.sendInvokeResult, {
-          message: "SYSTEM_RUN_DENIED: approval required",
-        });
+        expectInvokeErrorMessage(invoke.sendInvokeResult, "SYSTEM_RUN_DENIED: approval required");
       } finally {
         clearRuntimeConfigSnapshot();
       }
@@ -961,7 +994,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   it("does not auto-review direct system.run security audit suppression edits", async () => {
     const tmp = createFixtureDir("openclaw-system-run-auto-review-suppression-");
-    const executablePath = createTempExecutable({ dir: tmp, name: "openclaw" });
+    const executablePath = createTempExecutable(tmp, "openclaw");
     setRuntimeConfigSnapshot({
       tools: {
         exec: {
@@ -976,16 +1009,13 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         risk: "low",
       }));
       const runCommand = vi.fn(async () => createLocalRunResult("should-not-run"));
-      const prepared = buildSystemRunApprovalPlan({
-        command: [executablePath, "config", "set", "security.audit.suppressions", "[]"],
-        cwd: tmp,
-      });
+      const prepared = buildCwdApprovalPlan(
+        [executablePath, "config", "set", "security.audit.suppressions", "[]"],
+        tmp,
+      );
       expect(prepared.ok).toBe(true);
-      if (!prepared.ok) {
-        throw new Error("unreachable");
-      }
-      const invoke = await runSystemInvoke({
-        preferMacAppExecHost: false,
+      requireApprovalPlan(prepared, "unreachable");
+      const invoke = await runLocalSystemInvoke({
         command: prepared.plan.argv,
         cwd: prepared.plan.cwd ?? tmp,
         systemRunPlan: prepared.plan,
@@ -997,9 +1027,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
       expect(autoReviewer).not.toHaveBeenCalled();
       expect(runCommand).not.toHaveBeenCalled();
-      expectInvokeErrorMessage(invoke.sendInvokeResult, {
-        message: "SYSTEM_RUN_DENIED: approval required",
-      });
+      expectInvokeErrorMessage(invoke.sendInvokeResult, "SYSTEM_RUN_DENIED: approval required");
     } finally {
       clearRuntimeConfigSnapshot();
     }
@@ -1007,7 +1035,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   it("defers to human approval when system.run auto reviewer asks", async () => {
     const tmp = createFixtureDir("openclaw-system-run-auto-review-ask-");
-    const executablePath = createTempExecutable({ dir: tmp, name: "read-info" });
+    const executablePath = createTempExecutable(tmp, "read-info");
     setRuntimeConfigSnapshot({
       tools: {
         exec: {
@@ -1022,16 +1050,10 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         risk: "medium",
       }));
       const runCommand = vi.fn(async () => createLocalRunResult("should-not-run"));
-      const prepared = buildSystemRunApprovalPlan({
-        command: [executablePath],
-        cwd: tmp,
-      });
+      const prepared = buildCwdApprovalPlan([executablePath], tmp);
       expect(prepared.ok).toBe(true);
-      if (!prepared.ok) {
-        throw new Error("unreachable");
-      }
-      const invoke = await runSystemInvoke({
-        preferMacAppExecHost: false,
+      requireApprovalPlan(prepared, "unreachable");
+      const invoke = await runLocalSystemInvoke({
         command: prepared.plan.argv,
         cwd: prepared.plan.cwd ?? tmp,
         systemRunPlan: prepared.plan,
@@ -1043,9 +1065,10 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
       expect(autoReviewer).toHaveBeenCalledTimes(1);
       expect(runCommand).not.toHaveBeenCalled();
-      expectInvokeErrorMessage(invoke.sendInvokeResult, {
-        message: "exec auto-review deferred to human approval",
-      });
+      expectInvokeErrorMessage(
+        invoke.sendInvokeResult,
+        "exec auto-review deferred to human approval",
+      );
     } finally {
       clearRuntimeConfigSnapshot();
     }
@@ -1117,7 +1140,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           expect(macHostCall.request?.policySnapshot).toEqual(
             createExecApprovalPolicySnapshot({ file: loadExecApprovals(), agentId: undefined }),
           );
-          expectInvokeOk(invoke.sendInvokeResult, { payloadContains: "app-ok" });
+          expectInvokeOk(invoke.sendInvokeResult, "app-ok");
           continue;
         }
 
@@ -1139,14 +1162,13 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       process.env.PATH = "/usr/bin:/bin";
     }
     try {
-      const transparent = await runSystemInvoke({
-        preferMacAppExecHost: false,
+      const transparent = await runLocalSystemInvoke({
         security: "allowlist",
         command: ["env", "tr", "a", "b"],
       });
       if (process.platform === "win32") {
         expect(transparent.runCommand).not.toHaveBeenCalled();
-        expectInvokeErrorMessage(transparent.sendInvokeResult, { message: "allowlist miss" });
+        expectInvokeErrorMessage(transparent.sendInvokeResult, "allowlist miss");
       } else {
         const expectedTrPath = fs.realpathSync(
           fs.existsSync("/usr/bin/tr") ? "/usr/bin/tr" : "/bin/tr",
@@ -1159,13 +1181,12 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         expectInvokeOk(transparent.sendInvokeResult);
       }
 
-      const semantic = await runSystemInvoke({
-        preferMacAppExecHost: false,
+      const semantic = await runLocalSystemInvoke({
         security: "allowlist",
         command: ["env", "FOO=bar", "tr", "a", "b"],
       });
       expect(semantic.runCommand).not.toHaveBeenCalled();
-      expectInvokeErrorMessage(semantic.sendInvokeResult, { message: "allowlist miss" });
+      expectInvokeErrorMessage(semantic.sendInvokeResult, "allowlist miss");
     } finally {
       if (oldPath === undefined) {
         delete process.env.PATH;
@@ -1221,17 +1242,16 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     ];
 
     for (const testCase of shellPayloadCases) {
-      const { runCommand, sendInvokeResult, sendNodeEvent } = await runSystemInvoke({
-        preferMacAppExecHost: false,
-        security: "allowlist",
-        ask: testCase.ask ?? "on-miss",
-        command: testCase.command,
-      });
+      const { runCommand, sendInvokeResult, sendNodeEvent } = await runLocalSystemInvokeWithPolicy(
+        "allowlist",
+        testCase.ask ?? "on-miss",
+        { command: testCase.command },
+      );
       expect(runCommand, testCase.label).not.toHaveBeenCalled();
       if (testCase.approvalRequired) {
-        expectApprovalRequiredDenied({ sendNodeEvent, sendInvokeResult });
+        expectApprovalRequiredDenied(sendNodeEvent, sendInvokeResult);
       } else if ("message" in testCase) {
-        expectInvokeErrorMessage(sendInvokeResult, { message: testCase.message });
+        expectInvokeErrorMessage(sendInvokeResult, testCase.message);
       }
     }
   });
@@ -1239,16 +1259,17 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   it.runIf(process.platform !== "win32")(
     "denies safe-bin shell expansion carriers in allowlist mode",
     async () => {
-      const { runCommand, sendInvokeResult } = await runSystemInvoke({
-        preferMacAppExecHost: false,
-        security: "allowlist",
-        ask: "off",
-        command: ["/bin/sh", "-lc", "head -c${IFS}16${IFS}${OPENCLAW_CONFIG_PATH}"],
-        rawCommand: "head -c${IFS}16${IFS}${OPENCLAW_CONFIG_PATH}",
-      });
+      const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy(
+        "allowlist",
+        "off",
+        {
+          command: ["/bin/sh", "-lc", "head -c${IFS}16${IFS}${OPENCLAW_CONFIG_PATH}"],
+          rawCommand: "head -c${IFS}16${IFS}${OPENCLAW_CONFIG_PATH}",
+        },
+      );
 
       expect(runCommand).not.toHaveBeenCalled();
-      expectInvokeErrorMessage(sendInvokeResult, { message: "allowlist miss" });
+      expectInvokeErrorMessage(sendInvokeResult, "allowlist miss");
     },
   );
 
@@ -1261,13 +1282,11 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         const expectedHeadPath = fs.realpathSync(
           fs.existsSync("/usr/bin/head") ? "/usr/bin/head" : "/bin/head",
         );
-        const { runCommand, sendInvokeResult } = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          security: "allowlist",
-          ask: "off",
-          command: ["/bin/sh", "-lc", "head -c 16"],
-          rawCommand: "head -c 16",
-        });
+        const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy(
+          "allowlist",
+          "off",
+          { command: ["/bin/sh", "-lc", "head -c 16"], rawCommand: "head -c 16" },
+        );
 
         expect(requireFirstRunCommandArgs(runCommand)).toEqual([
           "/bin/sh",
@@ -1297,13 +1316,14 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         const expectedHeadPath = fs.realpathSync(
           fs.existsSync("/usr/bin/head") ? "/usr/bin/head" : "/bin/head",
         );
-        const { runCommand, sendInvokeResult } = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          security: "allowlist",
-          ask: "off",
-          command: ["/bin/sh", "-lc", "sh -c 'tr a b && head -c 16'"],
-          rawCommand: "sh -c 'tr a b && head -c 16'",
-        });
+        const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy(
+          "allowlist",
+          "off",
+          {
+            command: ["/bin/sh", "-lc", "sh -c 'tr a b && head -c 16'"],
+            rawCommand: "sh -c 'tr a b && head -c 16'",
+          },
+        );
 
         const payload = requireFirstRunCommandArgs(runCommand)[2] ?? "";
         expect(payload).not.toContain("tr a b && head -c 16");
@@ -1326,12 +1346,11 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       const oldPath = process.env.PATH;
       process.env.PATH = "/usr/bin:/bin";
       try {
-        const { runCommand, sendInvokeResult } = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          security: "allowlist",
-          ask: "off",
-          command: ["pwsh", "-Command", "head -c 16"],
-        });
+        const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy(
+          "allowlist",
+          "off",
+          { command: ["pwsh", "-Command", "head -c 16"] },
+        );
 
         expect(requireFirstRunCommandArgs(runCommand)).toEqual(["pwsh", "-Command", "head -c 16"]);
         expectInvokeOk(sendInvokeResult);
@@ -1347,73 +1366,59 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   it("denies abbreviated PowerShell encoded payloads even when the wrapper is allowlisted", async () => {
     const binDir = createFixtureDir("openclaw-pwsh-allowlist-");
-    const executablePath = createTempExecutable({ dir: binDir, name: "pwsh" });
-    await withTempApprovalsHome({
-      approvals: createAllowlistOnMissApprovals({
+    const executablePath = createTempExecutable(binDir, "pwsh");
+    await withTempApprovalsHome(
+      createAllowlistOnMissApprovals({
         agents: {
           main: {
             allowlist: [{ pattern: executablePath }],
           },
         },
       }),
-      run: async () => {
-        const { runCommand, sendInvokeResult, sendNodeEvent } = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          security: "allowlist",
-          ask: "on-miss",
-          command: [
-            executablePath,
-            "-win",
-            "hidden",
-            "-if",
-            "XML",
-            "-config",
-            "SomeConfig",
-            "/NoProfile",
-            "/ec",
-            "VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIABoAGkA",
-          ],
-        });
+      async () => {
+        const { runCommand, sendInvokeResult, sendNodeEvent } =
+          await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
+            command: [
+              executablePath,
+              "-win",
+              "hidden",
+              "-if",
+              "XML",
+              "-config",
+              "SomeConfig",
+              "/NoProfile",
+              "/ec",
+              "VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIABoAGkA",
+            ],
+          });
 
         expect(runCommand).not.toHaveBeenCalled();
-        expectApprovalRequiredDenied({ sendNodeEvent, sendInvokeResult });
+        expectApprovalRequiredDenied(sendNodeEvent, sendInvokeResult);
 
-        const commandWithArgs = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          security: "allowlist",
-          ask: "on-miss",
+        const commandWithArgs = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
           command: [executablePath, "-cwa", "Write-Output", "hi"],
         });
 
         expect(commandWithArgs.runCommand).not.toHaveBeenCalled();
-        expectApprovalRequiredDenied({
-          sendNodeEvent: commandWithArgs.sendNodeEvent,
-          sendInvokeResult: commandWithArgs.sendInvokeResult,
-        });
+        expectApprovalRequiredDenied(
+          commandWithArgs.sendNodeEvent,
+          commandWithArgs.sendInvokeResult,
+        );
       },
-    });
+    );
   });
 
   it.runIf(process.platform !== "win32")(
     "pins PATH-token executable to canonical path",
     async () => {
-      await withPathTokenCommand({
-        tmpPrefix: "openclaw-approval-path-pin-",
-        run: async ({ expected }) => {
-          const { runCommand, sendInvokeResult } = await runSystemInvoke({
-            preferMacAppExecHost: false,
-            command: ["poccmd", "-n", "SAFE"],
-            approved: true,
-            security: "full",
-            ask: "off",
-          });
-          expectCommandPinnedToCanonicalPath({
-            runCommand,
-            expected,
-            commandTail: ["-n", "SAFE"],
-          });
-          expectInvokeOk(sendInvokeResult);
-        },
+      await withPathTokenCommand("openclaw-approval-path-pin-", async ({ expected }) => {
+        const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy(
+          "full",
+          "off",
+          { command: ["poccmd", "-n", "SAFE"], approved: true },
+        );
+        expectCommandPinnedToCanonicalPath(runCommand, expected, ["-n", "SAFE"]);
+        expectInvokeOk(sendInvokeResult);
       });
     },
   );
@@ -1425,42 +1430,27 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         ...createLocalRunResult(),
       }));
       const sendInvokeResult = vi.fn(async () => {});
-      await withPathTokenCommand({
-        tmpPrefix: "openclaw-allowlist-path-pin-",
-        run: async ({ link: _link, expected }) => {
-          await withTempApprovalsHome({
-            approvals: {
-              version: 1,
-              defaults: {
-                security: "allowlist",
-                ask: "off",
-                askFallback: "deny",
+      await withPathTokenCommand(
+        "openclaw-allowlist-path-pin-",
+        async ({ link: _link, expected }) => {
+          await withTempApprovalsHome(
+            createApprovals("allowlist", "off", "deny", {
+              main: {
+                allowlist: [{ pattern: expected }],
               },
-              agents: {
-                main: {
-                  allowlist: [{ pattern: expected }],
-                },
-              },
-            },
-            run: async () => {
-              await runSystemInvoke({
-                preferMacAppExecHost: false,
+            }),
+            async () => {
+              await runLocalSystemInvokeWithPolicy("allowlist", "off", {
                 command: ["poccmd", "-n", "SAFE"],
-                security: "allowlist",
-                ask: "off",
                 runCommand,
                 sendInvokeResult,
               });
             },
-          });
-          expectCommandPinnedToCanonicalPath({
-            runCommand,
-            expected,
-            commandTail: ["-n", "SAFE"],
-          });
+          );
+          expectCommandPinnedToCanonicalPath(runCommand, expected, ["-n", "SAFE"]);
           expectInvokeOk(sendInvokeResult);
         },
-      });
+      );
     },
   );
 
@@ -1519,28 +1509,26 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     const script = path.join(tmp, "run.sh");
     fs.writeFileSync(script, "#!/bin/sh\necho SAFE\n");
     fs.chmodSync(script, 0o755);
-    const { runCommand, sendInvokeResult } = await runSystemInvoke({
-      preferMacAppExecHost: false,
+    const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy("full", "off", {
       command: ["./run.sh", "--flag"],
       cwd: tmp,
       approved: true,
-      security: "full",
-      ask: "off",
     });
     if (process.platform === "win32") {
       expect(runCommand).not.toHaveBeenCalled();
-      expectInvokeErrorMessage(sendInvokeResult, {
-        message: "SYSTEM_RUN_DENIED: approval requires a stable executable path",
-        exact: true,
-      });
+      expectInvokeErrorMessage(
+        sendInvokeResult,
+        "SYSTEM_RUN_DENIED: approval requires a stable executable path",
+        true,
+      );
       return;
     }
-    expectCommandPinnedToCanonicalPath({
+    expectCommandPinnedToCanonicalPath(
       runCommand,
-      expected: fs.realpathSync(script),
-      commandTail: ["--flag"],
-      cwd: fs.realpathSync(tmp),
-    });
+      fs.realpathSync(script),
+      ["--flag"],
+      fs.realpathSync(tmp),
+    );
     expectInvokeOk(sendInvokeResult);
   });
 
@@ -1551,41 +1539,32 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     fs.writeFileSync(script, "#!/bin/sh\necho SAFE\n");
     fs.chmodSync(script, 0o755);
     const canonicalCwd = fs.realpathSync(tmp);
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["./run.sh"],
-      cwd: tmp,
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildCwdSessionApprovalPlan(["./run.sh"], tmp, "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
+    requireApprovalPlan(prepared, "unreachable");
     await withMockedCwdIdentityDrift({
       canonicalCwd,
       driftDir: fallback,
       run: async () => {
-        const { runCommand, sendInvokeResult } = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          cwd: prepared.plan.cwd ?? tmp,
-          approved: true,
-          security: "full",
-          ask: "off",
-        });
+        const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy(
+          "full",
+          "off",
+          { preparedPlan: prepared.plan, cwd: prepared.plan.cwd ?? tmp, approved: true },
+        );
         expect(runCommand).not.toHaveBeenCalled();
         if (process.platform === "win32") {
-          expectInvokeErrorMessage(sendInvokeResult, {
-            message: "SYSTEM_RUN_DENIED: approval requires a stable executable path",
-            exact: true,
-          });
+          expectInvokeErrorMessage(
+            sendInvokeResult,
+            "SYSTEM_RUN_DENIED: approval requires a stable executable path",
+            true,
+          );
           return;
         }
-        expectInvokeErrorMessage(sendInvokeResult, {
-          message: "SYSTEM_RUN_DENIED: approval cwd changed before execution",
-          exact: true,
-        });
+        expectInvokeErrorMessage(
+          sendInvokeResult,
+          "SYSTEM_RUN_DENIED: approval cwd changed before execution",
+          true,
+        );
       },
     });
   });
@@ -1600,35 +1579,26 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       if (process.platform !== "win32") {
         fs.chmodSync(fixture.scriptPath, 0o755);
       }
-      const prepared = buildSystemRunApprovalPlan({
-        command: fixture.command,
-        cwd: tmp,
-      });
+      const prepared = buildCwdApprovalPlan(fixture.command, tmp);
       expect(prepared.ok).toBe(true);
-      if (!prepared.ok) {
-        throw new Error("unreachable");
-      }
+      requireApprovalPlan(prepared, "unreachable");
 
       if (mutate) {
         fs.writeFileSync(fixture.scriptPath, fixture.changedBody);
       }
-      const { runCommand, sendInvokeResult } = await runSystemInvoke({
-        preferMacAppExecHost: false,
-        command: prepared.plan.argv,
-        rawCommand: prepared.plan.commandText,
-        systemRunPlan: prepared.plan,
+      const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy("full", "off", {
+        preparedPlan: prepared.plan,
         cwd: prepared.plan.cwd ?? tmp,
         approved: true,
-        security: "full",
-        ask: "off",
       });
 
       if (mutate) {
         expect(runCommand).not.toHaveBeenCalled();
-        expectInvokeErrorMessage(sendInvokeResult, {
-          message: "SYSTEM_RUN_DENIED: approval script operand changed before execution",
-          exact: true,
-        });
+        expectInvokeErrorMessage(
+          sendInvokeResult,
+          "SYSTEM_RUN_DENIED: approval script operand changed before execution",
+          true,
+        );
       } else {
         expect(runCommand).toHaveBeenCalledTimes(1);
         expectInvokeOk(sendInvokeResult);
@@ -1653,21 +1623,19 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         fs.writeFileSync(path.join(tmp, "run.sh"), "#!/bin/sh\necho CHANGED\n", { mode: 0o755 });
       };
 
-      const invoke = await runSystemInvoke({
-        preferMacAppExecHost: false,
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "off", {
         command: ["./run.sh"],
         cwd: tmp,
         approved: true,
-        security: "full",
-        ask: "off",
         commitExecAuthorization: commitAuthorization,
       });
 
       expect(invoke.runCommand).not.toHaveBeenCalled();
-      expectInvokeErrorMessage(invoke.sendInvokeResult, {
-        message: "SYSTEM_RUN_DENIED: approval cwd changed before execution",
-        exact: true,
-      });
+      expectInvokeErrorMessage(
+        invoke.sendInvokeResult,
+        "SYSTEM_RUN_DENIED: approval cwd changed before execution",
+        true,
+      );
     },
   );
 
@@ -1678,11 +1646,9 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     if (process.platform !== "win32") {
       fs.chmodSync(fixture.scriptPath, 0o755);
     }
-    const prepared = buildSystemRunApprovalPlan({ command: fixture.command, cwd: tmp });
+    const prepared = buildCwdApprovalPlan(fixture.command, tmp);
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
+    requireApprovalPlan(prepared, "unreachable");
     const commitAuthorization: HandleSystemRunInvokeOptions["commitExecAuthorization"] = async (
       params,
     ) => {
@@ -1690,92 +1656,69 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       fs.writeFileSync(fixture.scriptPath, fixture.changedBody);
     };
 
-    const invoke = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      command: prepared.plan.argv,
-      rawCommand: prepared.plan.commandText,
-      systemRunPlan: prepared.plan,
+    const invoke = await runLocalSystemInvokeWithPolicy("full", "off", {
+      preparedPlan: prepared.plan,
       cwd: prepared.plan.cwd ?? tmp,
       approved: true,
-      security: "full",
-      ask: "off",
       commitExecAuthorization: commitAuthorization,
     });
 
     expect(invoke.runCommand).not.toHaveBeenCalled();
-    expectInvokeErrorMessage(invoke.sendInvokeResult, {
-      message: "SYSTEM_RUN_DENIED: approval script operand changed before execution",
-      exact: true,
-    });
+    expectInvokeErrorMessage(
+      invoke.sendInvokeResult,
+      "SYSTEM_RUN_DENIED: approval script operand changed before execution",
+      true,
+    );
   });
 
   it("validates approved runtime script operand bindings at dispatch", async () => {
-    await withFakeRuntimeOnPath({
-      runtime: "tsx",
-      run: async () => {
-        const tmp = createFixtureDir("openclaw-approval-tsx-script-drift-");
-        const fixture = createRuntimeScriptOperandFixture({ tmp, runtime: "tsx" });
-        fs.writeFileSync(fixture.scriptPath, fixture.initialBody);
-        const prepared = buildSystemRunApprovalPlan({
-          command: fixture.command,
-          cwd: tmp,
-        });
-        expect(prepared.ok).toBe(true);
-        if (!prepared.ok) {
-          throw new Error("unreachable");
-        }
+    await withFakeRuntimeOnPath("tsx", async () => {
+      const tmp = createFixtureDir("openclaw-approval-tsx-script-drift-");
+      const fixture = createRuntimeScriptOperandFixture(tmp, "tsx");
+      fs.writeFileSync(fixture.scriptPath, fixture.initialBody);
+      const prepared = buildCwdApprovalPlan(fixture.command, tmp);
+      expect(prepared.ok).toBe(true);
+      requireApprovalPlan(prepared, "unreachable");
 
-        fs.writeFileSync(fixture.scriptPath, fixture.changedBody);
-        const { runCommand, sendInvokeResult } = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          cwd: prepared.plan.cwd ?? tmp,
-          approved: true,
-          security: "full",
-          ask: "off",
-        });
+      fs.writeFileSync(fixture.scriptPath, fixture.changedBody);
+      const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy("full", "off", {
+        preparedPlan: prepared.plan,
+        cwd: prepared.plan.cwd ?? tmp,
+        approved: true,
+      });
 
-        expect(runCommand).not.toHaveBeenCalled();
-        expectInvokeErrorMessage(sendInvokeResult, {
-          message: "SYSTEM_RUN_DENIED: approval script operand changed before execution",
-          exact: true,
-        });
-        const missingBindingTmp = createFixtureDir("openclaw-approval-tsx-missing-binding-");
-        const missingBindingFixture = createRuntimeScriptOperandFixture({
-          tmp: missingBindingTmp,
-          runtime: "tsx",
-        });
-        fs.writeFileSync(missingBindingFixture.scriptPath, missingBindingFixture.initialBody);
-        const missingBindingPrepared = buildSystemRunApprovalPlan({
-          command: missingBindingFixture.command,
-          cwd: missingBindingTmp,
-        });
-        expect(missingBindingPrepared.ok).toBe(true);
-        if (!missingBindingPrepared.ok) {
-          throw new Error("unreachable");
-        }
+      expect(runCommand).not.toHaveBeenCalled();
+      expectInvokeErrorMessage(
+        sendInvokeResult,
+        "SYSTEM_RUN_DENIED: approval script operand changed before execution",
+        true,
+      );
+      const missingBindingTmp = createFixtureDir("openclaw-approval-tsx-missing-binding-");
+      const missingBindingFixture = createRuntimeScriptOperandFixture(missingBindingTmp, "tsx");
+      fs.writeFileSync(missingBindingFixture.scriptPath, missingBindingFixture.initialBody);
+      const missingBindingPrepared = buildCwdApprovalPlan(
+        missingBindingFixture.command,
+        missingBindingTmp,
+      );
+      expect(missingBindingPrepared.ok).toBe(true);
+      if (!missingBindingPrepared.ok) {
+        throw new Error("unreachable");
+      }
 
-        const planWithoutBinding = { ...missingBindingPrepared.plan };
-        delete planWithoutBinding.mutableFileOperand;
-        const missingBindingRun = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: missingBindingPrepared.plan.argv,
-          rawCommand: missingBindingPrepared.plan.commandText,
-          systemRunPlan: planWithoutBinding,
-          cwd: missingBindingPrepared.plan.cwd ?? missingBindingTmp,
-          approved: true,
-          security: "full",
-          ask: "off",
-        });
+      const planWithoutBinding = { ...missingBindingPrepared.plan };
+      delete planWithoutBinding.mutableFileOperand;
+      const missingBindingRun = await runLocalSystemInvokeWithPolicy("full", "off", {
+        preparedPlan: planWithoutBinding,
+        cwd: missingBindingPrepared.plan.cwd ?? missingBindingTmp,
+        approved: true,
+      });
 
-        expect(missingBindingRun.runCommand).not.toHaveBeenCalled();
-        expectInvokeErrorMessage(missingBindingRun.sendInvokeResult, {
-          message: "SYSTEM_RUN_DENIED: approval missing script operand binding",
-          exact: true,
-        });
-      },
+      expect(missingBindingRun.runCommand).not.toHaveBeenCalled();
+      expectInvokeErrorMessage(
+        missingBindingRun.sendInvokeResult,
+        "SYSTEM_RUN_DENIED: approval missing script operand binding",
+        true,
+      );
     });
   });
 
@@ -1788,11 +1731,8 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     const sendInvokeResult = vi.fn(async () => {});
     const sendNodeEvent = vi.fn(async () => {});
 
-    await runSystemInvoke({
-      preferMacAppExecHost: false,
+    await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
       command: ["./sh", "-lc", "/bin/echo approved-only"],
-      security: "allowlist",
-      ask: "on-miss",
       runCommand,
       sendInvokeResult,
       sendNodeEvent,
@@ -1800,7 +1740,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
     expect(runCommand).not.toHaveBeenCalled();
     expect(fs.existsSync(marker)).toBe(false);
-    expectApprovalRequiredDenied({ sendNodeEvent, sendInvokeResult });
+    expectApprovalRequiredDenied(sendNodeEvent, sendInvokeResult);
     try {
       fs.unlinkSync(marker);
     } catch {
@@ -1811,28 +1751,25 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   it("denies ./skill-bin even when autoAllowSkills trust entry exists", async () => {
     const { runCommand, sendInvokeResult, sendNodeEvent } = createInvokeSpies();
 
-    await withTempApprovalsHome({
-      approvals: createAllowlistOnMissApprovals({ autoAllowSkills: true }),
-      run: async ({ tempHome }) => {
+    await withTempApprovalsHome(
+      createAllowlistOnMissApprovals({ autoAllowSkills: true }),
+      async ({ tempHome }) => {
         const skillBinPath = path.join(tempHome, "skill-bin");
         fs.writeFileSync(skillBinPath, "#!/bin/sh\necho should-not-run\n", { mode: 0o755 });
         fs.chmodSync(skillBinPath, 0o755);
-        await runSystemInvoke({
-          preferMacAppExecHost: false,
+        await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
           command: ["./skill-bin", "--help"],
           cwd: tempHome,
-          security: "allowlist",
-          ask: "on-miss",
           skillBinsCurrent: async () => [{ name: "skill-bin", resolvedPath: skillBinPath }],
           runCommand,
           sendInvokeResult,
           sendNodeEvent,
         });
       },
-    });
+    );
 
     expect(runCommand).not.toHaveBeenCalled();
-    expectApprovalRequiredDenied({ sendNodeEvent, sendInvokeResult });
+    expectApprovalRequiredDenied(sendNodeEvent, sendInvokeResult);
   });
 
   it("rejects unsafe environment inputs before execution", async () => {
@@ -1878,29 +1815,21 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     ];
 
     for (const testCase of cases) {
-      const { runCommand, sendInvokeResult } = await runSystemInvoke({
-        preferMacAppExecHost: false,
-        security: "full",
-        ask: "off",
+      const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy("full", "off", {
         command: testCase.command,
         env: testCase.env,
       });
 
       expect(runCommand, testCase.label).not.toHaveBeenCalled();
-      expectInvokeErrorMessage(sendInvokeResult, {
-        message: testCase.message,
-      });
+      expectInvokeErrorMessage(sendInvokeResult, testCase.message);
       for (const detail of testCase.details) {
-        expectInvokeErrorMessage(sendInvokeResult, { message: detail });
+        expectInvokeErrorMessage(sendInvokeResult, detail);
       }
     }
   });
 
   it("applies shell-wrapper env allowlist for shell executable commands without inline payload", async () => {
-    const { runCommand, sendInvokeResult } = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      security: "full",
-      ask: "off",
+    const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy("full", "off", {
       command: ["/bin/sh", "./script.sh"],
       env: {
         OPENCLAW_TEST: "1",
@@ -1930,34 +1859,31 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       }),
     });
 
-    await withTempApprovalsHome({
-      approvals: createAllowlistOnMissApprovals({
+    await withTempApprovalsHome(
+      createAllowlistOnMissApprovals({
         agents: {
           main: {
             allowlist: [{ pattern: "/usr/bin/env" }],
           },
         },
       }),
-      run: async ({ tempHome }) => {
+      async ({ tempHome }) => {
         const marker = path.join(tempHome, params.markerName);
-        await runSystemInvoke({
-          preferMacAppExecHost: false,
+        await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
           command: buildNestedEnvShellCommand({
             depth: params.depth,
             payload: `echo PWNED > ${marker}`,
           }),
-          security: "allowlist",
-          ask: "on-miss",
           runCommand,
           sendInvokeResult,
           sendNodeEvent,
         });
         expect(fs.existsSync(marker)).toBe(false);
       },
-    });
+    );
 
     expect(runCommand).not.toHaveBeenCalled();
-    expectApprovalRequiredDenied({ sendNodeEvent, sendInvokeResult });
+    expectApprovalRequiredDenied(sendNodeEvent, sendInvokeResult);
   }
 
   it("denies env-wrapped shell payloads at and past the dispatch depth boundary", async () => {
@@ -2002,18 +1928,12 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     });
     try {
       for (const testCase of cases) {
-        const { runCommand, sendInvokeResult, sendNodeEvent } = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: [...testCase.command],
-          security: "full",
-          ask: "off",
-        });
+        const { runCommand, sendInvokeResult, sendNodeEvent } =
+          await runLocalSystemInvokeWithPolicy("full", "off", { command: [...testCase.command] });
 
         expect(runCommand, testCase.command.join(" ")).not.toHaveBeenCalled();
         expectExecDeniedEvent(sendNodeEvent);
-        expectInvokeErrorMessage(sendInvokeResult, {
-          message: testCase.expected,
-        });
+        expectInvokeErrorMessage(sendInvokeResult, testCase.expected);
       }
     } finally {
       clearRuntimeConfigSnapshot();
@@ -2029,55 +1949,49 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       },
     });
     try {
-      const { runCommand, sendInvokeResult, sendNodeEvent } = await runSystemInvoke({
-        preferMacAppExecHost: false,
-        command: ["awk", 'BEGIN{system("id")}', "/dev/null"],
-        security: "allowlist",
-        ask: "on-miss",
-      });
+      const { runCommand, sendInvokeResult, sendNodeEvent } = await runLocalSystemInvokeWithPolicy(
+        "allowlist",
+        "on-miss",
+        { command: ["awk", 'BEGIN{system("id")}', "/dev/null"] },
+      );
 
       expect(runCommand).not.toHaveBeenCalled();
       expectExecDeniedEvent(sendNodeEvent);
-      expectInvokeErrorMessage(sendInvokeResult, {
-        message: "awk inline program requires explicit approval in strictInlineEval mode",
-      });
+      expectInvokeErrorMessage(
+        sendInvokeResult,
+        "awk inline program requires explicit approval in strictInlineEval mode",
+      );
     } finally {
       clearRuntimeConfigSnapshot();
     }
   });
 
   it("fails closed when allow-always approval persistence fails", async () => {
-    await withTempApprovalsHome({
-      approvals: createAllowlistOnMissApprovals(),
-      run: async () => {
-        const tempDir = createFixtureDir("openclaw-allow-always-write-failure-");
-        const executablePath = createTempExecutable({ dir: tempDir, name: "approved-tool" });
-        const commitAuthorization = vi.fn(async () => {
-          throw new Error("approval lock unavailable");
-        });
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: [executablePath],
-          security: "allowlist",
-          ask: "on-miss",
-          approvalDecision: "allow-always",
-          approved: true,
-          commitExecAuthorization: commitAuthorization,
-        });
+    await withTempApprovalsHome(createAllowlistOnMissApprovals(), async () => {
+      const tempDir = createFixtureDir("openclaw-allow-always-write-failure-");
+      const executablePath = createTempExecutable(tempDir, "approved-tool");
+      const commitAuthorization = vi.fn(async () => {
+        throw new Error("approval lock unavailable");
+      });
+      const invoke = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
+        command: [executablePath],
+        approvalDecision: "allow-always",
+        approved: true,
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(commitAuthorization).toHaveBeenCalledWith(
-          expect.objectContaining({ allowAlwaysDecision: expect.any(Object) }),
-        );
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expect(invoke.sendExecFinishedEvent).not.toHaveBeenCalled();
-        expectApprovalStateWriteDenied(invoke);
-      },
+      expect(commitAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({ allowAlwaysDecision: expect.any(Object) }),
+      );
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expect(invoke.sendExecFinishedEvent).not.toHaveBeenCalled();
+      expectApprovalStateWriteDenied(invoke);
     });
   });
 
   it("does not restore a revoked allowlist rule during explicit allow-always persistence", async () => {
     const tempDir = createFixtureDir("openclaw-allow-always-revoked-rule-");
-    const executablePath = createTempExecutable({ dir: tempDir, name: "approved-tool" });
+    const executablePath = createTempExecutable(tempDir, "approved-tool");
     const matchedEntry = { pattern: fs.realpathSync(executablePath) };
     const expectedPolicySnapshot = {
       security: "allowlist" as const,
@@ -2087,13 +2001,9 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       allowlistRules: [matchedEntry],
     };
 
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "allowlist", ask: "always", askFallback: "deny" },
-        agents: { main: { allowlist: [matchedEntry] } },
-      },
-      run: async () => {
+    await withTempApprovalsHome(
+      createApprovals("allowlist", "always", "deny", { main: { allowlist: [matchedEntry] } }),
+      async () => {
         let capturedAuthorization:
           | Parameters<typeof commitExecAuthorizationLocked>[0]["authorization"]
           | undefined;
@@ -2113,11 +2023,8 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           },
         );
 
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
+        const invoke = await runLocalSystemInvokeWithPolicy("allowlist", "always", {
           command: [executablePath],
-          security: "allowlist",
-          ask: "always",
           approvalDecision: "allow-always",
           approved: true,
           commitExecAuthorization: commitAuthorization,
@@ -2144,29 +2051,26 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
         expectApprovalStateWriteDenied(invoke);
       },
-    });
+    );
   });
 
   it("fails closed when allowlist usage persistence fails", async () => {
     const tempDir = createFixtureDir("openclaw-allowlist-usage-write-failure-");
-    const executablePath = createTempExecutable({ dir: tempDir, name: "allowlisted-tool" });
-    await withTempApprovalsHome({
-      approvals: createAllowlistOnMissApprovals({
+    const executablePath = createTempExecutable(tempDir, "allowlisted-tool");
+    await withTempApprovalsHome(
+      createAllowlistOnMissApprovals({
         agents: {
           main: {
             allowlist: [{ pattern: fs.realpathSync(executablePath) }],
           },
         },
       }),
-      run: async () => {
+      async () => {
         const commitAuthorization = vi.fn(async () => {
           throw new Error("approval lock unavailable");
         });
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
+        const invoke = await runLocalSystemInvokeWithPolicy("allowlist", "off", {
           command: [executablePath],
-          security: "allowlist",
-          ask: "off",
           commitExecAuthorization: commitAuthorization,
         });
 
@@ -2182,405 +2086,237 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         );
         expectApprovalStateWriteDenied(invoke);
       },
-    });
+    );
   });
 
   it("revalidates unprompted full policy before local execution", async () => {
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "off", askFallback: "deny" },
-      },
-      run: async () => {
-        const commitAuthorization = vi.fn(
-          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
-            const current = loadExecApprovals();
-            current.defaults = { ...current.defaults, security: "deny" };
-            saveExecApprovals(current);
-            await commitExecAuthorizationLocked(params);
-          },
-        );
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          security: "full",
-          ask: "off",
-          commitExecAuthorization: commitAuthorization,
-        });
+    await withTempApprovalsHome(createApprovals("full", "off", "deny"), async () => {
+      const commitAuthorization = createPolicyMutationCommit((current) => {
+        current.defaults = { ...current.defaults, security: "deny" };
+      });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "off", {
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(commitAuthorization).toHaveBeenCalledWith(
-          expect.objectContaining({
-            authorization: expect.objectContaining({ source: "current-policy" }),
-          }),
-        );
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectApprovalStateWriteDenied(invoke);
-      },
+      expect(commitAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorization: expect.objectContaining({ source: "current-policy" }),
+        }),
+      );
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectApprovalStateWriteDenied(invoke);
     });
   });
 
   it("rejects unprompted full execution after ask policy tightens", async () => {
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "off", askFallback: "deny" },
-      },
-      run: async () => {
-        const commitAuthorization: HandleSystemRunInvokeOptions["commitExecAuthorization"] = async (
-          params,
-        ) => {
-          const current = loadExecApprovals();
-          current.defaults = { ...current.defaults, ask: "on-miss" };
-          saveExecApprovals(current);
-          await commitExecAuthorizationLocked(params);
-        };
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          security: "full",
-          ask: "off",
-          commitExecAuthorization: commitAuthorization,
-        });
+    await withTempApprovalsHome(createApprovals("full", "off", "deny"), async () => {
+      const commitAuthorization = createPolicyMutationCommit((current) => {
+        current.defaults = { ...current.defaults, ask: "on-miss" };
+      });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "off", {
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectApprovalStateWriteDenied(invoke);
-      },
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectApprovalStateWriteDenied(invoke);
     });
   });
 
   it("revalidates explicit approval against a current deny policy", async () => {
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "always", askFallback: "deny" },
-      },
-      run: async () => {
-        const commitAuthorization = vi.fn(
-          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
-            const current = loadExecApprovals();
-            current.defaults = { ...current.defaults, security: "deny" };
-            saveExecApprovals(current);
-            await commitExecAuthorizationLocked(params);
-          },
-        );
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          security: "full",
-          ask: "always",
-          approvalDecision: "allow-once",
-          approved: true,
-          commitExecAuthorization: commitAuthorization,
-        });
+    await withTempApprovalsHome(createApprovals("full", "always", "deny"), async () => {
+      const commitAuthorization = createPolicyMutationCommit((current) => {
+        current.defaults = { ...current.defaults, security: "deny" };
+      });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
+        approvalDecision: "allow-once",
+        approved: true,
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(commitAuthorization).toHaveBeenCalledWith(
-          expect.objectContaining({
-            authorization: expect.objectContaining({ source: "explicit-approval" }),
-          }),
-        );
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectApprovalStateWriteDenied(invoke);
-      },
+      expect(commitAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorization: expect.objectContaining({ source: "explicit-approval" }),
+        }),
+      );
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectApprovalStateWriteDenied(invoke);
     });
   });
 
   it("rejects explicit allow-once when persisted security tightens to allowlist", async () => {
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "always", askFallback: "deny" },
-      },
-      run: async () => {
-        const commitAuthorization = vi.fn(
-          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
-            const current = loadExecApprovals();
-            current.defaults = { ...current.defaults, security: "allowlist" };
-            saveExecApprovals(current);
-            await commitExecAuthorizationLocked(params);
-          },
-        );
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          security: "full",
-          ask: "always",
-          approvalDecision: "allow-once",
-          approved: true,
-          commitExecAuthorization: commitAuthorization,
-        });
+    await withTempApprovalsHome(createApprovals("full", "always", "deny"), async () => {
+      const commitAuthorization = createPolicyMutationCommit((current) => {
+        current.defaults = { ...current.defaults, security: "allowlist" };
+      });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
+        approvalDecision: "allow-once",
+        approved: true,
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(commitAuthorization).toHaveBeenCalledWith(
-          expect.objectContaining({
-            authorization: expect.objectContaining({
-              source: "explicit-approval",
-              policySnapshot: expect.any(Object),
-            }),
+      expect(commitAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorization: expect.objectContaining({
+            source: "explicit-approval",
+            policySnapshot: expect.any(Object),
           }),
-        );
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectApprovalStateWriteDenied(invoke);
-      },
+        }),
+      );
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectApprovalStateWriteDenied(invoke);
     });
   });
 
   it("treats authenticated auto-review provenance as marker-only one-shot authority", async () => {
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["echo", "ok"],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "on-miss", askFallback: "deny" },
-      },
-      run: async () => {
-        const autoReviewer = vi.fn<ExecAutoReviewer>(() => ({
-          decision: "ask",
-          rationale: "must not be called for forwarded provenance",
-          risk: "medium",
-        }));
-        const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          security: "full",
-          ask: "on-miss",
-          approvalSource: "auto-review",
-          autoReviewer,
-          commitExecAuthorization: commitAuthorization,
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "on-miss", "deny"), async () => {
+      const autoReviewer = vi.fn<ExecAutoReviewer>(() => ({
+        decision: "ask",
+        rationale: "must not be called for forwarded provenance",
+        risk: "medium",
+      }));
+      const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "on-miss", {
+        preparedPlan: prepared.plan,
+        approvalSource: "auto-review",
+        autoReviewer,
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(autoReviewer).not.toHaveBeenCalled();
-        expect(commitAuthorization).toHaveBeenCalledWith(
-          expect.objectContaining({
-            authorization: expect.objectContaining({ source: "auto-review" }),
-          }),
-        );
-        expect(invoke.runCommand).toHaveBeenCalledTimes(1);
-        expectInvokeOk(invoke.sendInvokeResult);
-      },
+      expect(autoReviewer).not.toHaveBeenCalled();
+      expect(commitAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorization: expect.objectContaining({ source: "auto-review" }),
+        }),
+      );
+      expect(invoke.runCommand).toHaveBeenCalledTimes(1);
+      expectInvokeOk(invoke.sendInvokeResult);
     });
   });
 
   it("rejects forwarded auto-review when current ask policy tightens to always", async () => {
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["echo", "ok"],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "on-miss", askFallback: "deny" },
-      },
-      run: async () => {
-        const commitAuthorization = vi.fn(
-          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
-            const current = loadExecApprovals();
-            current.defaults = { ...current.defaults, ask: "always" };
-            saveExecApprovals(current);
-            await commitExecAuthorizationLocked(params);
-          },
-        );
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          security: "full",
-          ask: "on-miss",
-          approvalSource: "auto-review",
-          commitExecAuthorization: commitAuthorization,
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "on-miss", "deny"), async () => {
+      const commitAuthorization = createPolicyMutationCommit((current) => {
+        current.defaults = { ...current.defaults, ask: "always" };
+      });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "on-miss", {
+        preparedPlan: prepared.plan,
+        approvalSource: "auto-review",
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(commitAuthorization).toHaveBeenCalledWith(
-          expect.objectContaining({
-            authorization: expect.objectContaining({ source: "auto-review" }),
-          }),
-        );
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectApprovalStateWriteDenied(invoke);
-      },
+      expect(commitAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorization: expect.objectContaining({ source: "auto-review" }),
+        }),
+      );
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectApprovalStateWriteDenied(invoke);
     });
   });
 
   it("rejects forwarded auto-review when persisted security tightens to allowlist", async () => {
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["echo", "ok"],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "on-miss", askFallback: "deny" },
-      },
-      run: async () => {
-        const commitAuthorization = vi.fn(
-          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
-            const current = loadExecApprovals();
-            current.defaults = { ...current.defaults, security: "allowlist" };
-            saveExecApprovals(current);
-            await commitExecAuthorizationLocked(params);
-          },
-        );
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          security: "full",
-          ask: "on-miss",
-          approvalSource: "auto-review",
-          commitExecAuthorization: commitAuthorization,
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "on-miss", "deny"), async () => {
+      const commitAuthorization = createPolicyMutationCommit((current) => {
+        current.defaults = { ...current.defaults, security: "allowlist" };
+      });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "on-miss", {
+        preparedPlan: prepared.plan,
+        approvalSource: "auto-review",
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(commitAuthorization).toHaveBeenCalledWith(
-          expect.objectContaining({
-            authorization: expect.objectContaining({
-              source: "auto-review",
-              policySnapshot: expect.any(Object),
-            }),
+      expect(commitAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorization: expect.objectContaining({
+            source: "auto-review",
+            policySnapshot: expect.any(Object),
           }),
-        );
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectApprovalStateWriteDenied(invoke);
-      },
+        }),
+      );
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectApprovalStateWriteDenied(invoke);
     });
   });
 
   it("rejects forwarded auto-review when persisted ask tightens from off to on-miss", async () => {
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["echo", "ok"],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "off", askFallback: "deny" },
-      },
-      run: async () => {
-        const commitAuthorization = vi.fn(
-          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
-            const current = loadExecApprovals();
-            current.defaults = { ...current.defaults, ask: "on-miss" };
-            saveExecApprovals(current);
-            await commitExecAuthorizationLocked(params);
-          },
-        );
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          security: "full",
-          ask: "off",
-          approvalSource: "auto-review",
-          commitExecAuthorization: commitAuthorization,
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "off", "deny"), async () => {
+      const commitAuthorization = createPolicyMutationCommit((current) => {
+        current.defaults = { ...current.defaults, ask: "on-miss" };
+      });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "off", {
+        preparedPlan: prepared.plan,
+        approvalSource: "auto-review",
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(commitAuthorization).toHaveBeenCalledWith(
-          expect.objectContaining({
-            authorization: expect.objectContaining({
-              source: "auto-review",
-              policySnapshot: expect.any(Object),
-            }),
+      expect(commitAuthorization).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorization: expect.objectContaining({
+            source: "auto-review",
+            policySnapshot: expect.any(Object),
           }),
-        );
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectApprovalStateWriteDenied(invoke);
-      },
+        }),
+      );
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectApprovalStateWriteDenied(invoke);
     });
   });
 
   it("rejects forwarded auto-review when current security policy tightens to deny", async () => {
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["echo", "ok"],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "on-miss", askFallback: "deny" },
-      },
-      run: async () => {
-        const commitAuthorization: HandleSystemRunInvokeOptions["commitExecAuthorization"] = async (
-          params,
-        ) => {
-          const current = loadExecApprovals();
-          current.defaults = { ...current.defaults, security: "deny" };
-          saveExecApprovals(current);
-          await commitExecAuthorizationLocked(params);
-        };
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          security: "full",
-          ask: "on-miss",
-          approvalSource: "auto-review",
-          commitExecAuthorization: commitAuthorization,
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "on-miss", "deny"), async () => {
+      const commitAuthorization = createPolicyMutationCommit((current) => {
+        current.defaults = { ...current.defaults, security: "deny" };
+      });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "on-miss", {
+        preparedPlan: prepared.plan,
+        approvalSource: "auto-review",
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectApprovalStateWriteDenied(invoke);
-      },
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectApprovalStateWriteDenied(invoke);
     });
   });
 
   it("does not let forwarded auto-review authorize security audit suppression edits", async () => {
     const tmp = createFixtureDir("openclaw-forwarded-auto-review-suppression-");
-    const executablePath = createTempExecutable({ dir: tmp, name: "openclaw" });
-    const prepared = buildSystemRunApprovalPlan({
-      command: [executablePath, "config", "set", "security.audit.suppressions", "[]"],
-      cwd: tmp,
-      sessionKey: "agent:main:main",
-    });
+    const executablePath = createTempExecutable(tmp, "openclaw");
+    const prepared = buildCwdSessionApprovalPlan(
+      [executablePath, "config", "set", "security.audit.suppressions", "[]"],
+      tmp,
+      "agent:main:main",
+    );
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "on-miss", askFallback: "deny" },
-      },
-      run: async () => {
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          cwd: tmp,
-          security: "full",
-          ask: "on-miss",
-          approvalSource: "auto-review",
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "on-miss", "deny"), async () => {
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "on-miss", {
+        preparedPlan: prepared.plan,
+        cwd: tmp,
+        approvalSource: "auto-review",
+      });
 
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectExecDeniedEvent(invoke.sendNodeEvent);
-        expectInvokeErrorMessage(invoke.sendInvokeResult, {
-          message: "SYSTEM_RUN_DENIED: explicit approval required",
-          exact: true,
-        });
-      },
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectExecDeniedEvent(invoke.sendNodeEvent);
+      expectInvokeErrorMessage(
+        invoke.sendInvokeResult,
+        "SYSTEM_RUN_DENIED: explicit approval required",
+        true,
+      );
     });
   });
 
@@ -2588,32 +2324,21 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     const plan = createStrictInlineEvalApprovalPlan("openclaw-forwarded-inline-");
     setRuntimeConfigSnapshot({ tools: { exec: { strictInlineEval: true } } });
     try {
-      await withTempApprovalsHome({
-        approvals: {
-          version: 1,
-          defaults: { security: "full", ask: "on-miss", askFallback: "deny" },
-        },
-        run: async () => {
-          const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
-          const invoke = await runSystemInvoke({
-            preferMacAppExecHost: false,
-            command: plan.argv,
-            rawCommand: plan.commandText,
-            systemRunPlan: plan,
-            security: "full",
-            ask: "on-miss",
-            approvalSource: "auto-review",
-            commitExecAuthorization: commitAuthorization,
-          });
+      await withTempApprovalsHome(createApprovals("full", "on-miss", "deny"), async () => {
+        const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
+        const invoke = await runLocalSystemInvokeWithPolicy("full", "on-miss", {
+          preparedPlan: plan,
+          approvalSource: "auto-review",
+          commitExecAuthorization: commitAuthorization,
+        });
 
-          expect(commitAuthorization).toHaveBeenCalledWith(
-            expect.objectContaining({
-              authorization: expect.objectContaining({ source: "auto-review" }),
-            }),
-          );
-          expect(invoke.runCommand).toHaveBeenCalledTimes(1);
-          expectInvokeOk(invoke.sendInvokeResult);
-        },
+        expect(commitAuthorization).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authorization: expect.objectContaining({ source: "auto-review" }),
+          }),
+        );
+        expect(invoke.runCommand).toHaveBeenCalledTimes(1);
+        expectInvokeOk(invoke.sendInvokeResult);
       });
     } finally {
       clearRuntimeConfigSnapshot();
@@ -2621,272 +2346,185 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
   });
 
   it("does not commit allow-always state when local screen recording is unavailable", async () => {
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "always", askFallback: "deny" },
-      },
-      run: async () => {
-        const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          security: "full",
-          ask: "always",
-          approvalDecision: "allow-always",
-          approved: true,
-          needsScreenRecording: true,
-          commitExecAuthorization: commitAuthorization,
-        });
+    await withTempApprovalsHome(createApprovals("full", "always", "deny"), async () => {
+      const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
+        approvalDecision: "allow-always",
+        approved: true,
+        needsScreenRecording: true,
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(commitAuthorization).not.toHaveBeenCalled();
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
-        expect(invoke.sendNodeEvent).toHaveBeenCalledWith(
-          expect.anything(),
-          "exec.denied",
-          expect.objectContaining({ reason: "permission:screenRecording" }),
-        );
-      },
+      expect(commitAuthorization).not.toHaveBeenCalled();
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
+      expect(invoke.sendNodeEvent).toHaveBeenCalledWith(
+        expect.anything(),
+        "exec.denied",
+        expect.objectContaining({ reason: "permission:screenRecording" }),
+      );
     });
   });
 
   it("revalidates timeout fallback against the current askFallback policy", async () => {
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["echo", "ok"],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "always", askFallback: "full" },
-        agents: {},
-      },
-      run: async () => {
-        const commitAuthorization: HandleSystemRunInvokeOptions["commitExecAuthorization"] = async (
-          params,
-        ) => {
-          const current = loadExecApprovals();
-          current.defaults = { ...current.defaults, askFallback: "deny" };
-          saveExecApprovals(current);
-          await commitExecAuthorizationLocked(params);
-        };
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          cwd: prepared.plan.cwd ?? undefined,
-          security: "full",
-          ask: "always",
-          approvalSource: "ask-fallback",
-          commitExecAuthorization: commitAuthorization,
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "always", "full", {}), async () => {
+      const commitAuthorization = createPolicyMutationCommit((current) => {
+        current.defaults = { ...current.defaults, askFallback: "deny" };
+      });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
+        preparedPlan: prepared.plan,
+        cwd: prepared.plan.cwd ?? undefined,
+        approvalSource: "ask-fallback",
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expect(invoke.sendExecFinishedEvent).not.toHaveBeenCalled();
-        expectApprovalStateWriteDenied(invoke);
-      },
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expect(invoke.sendExecFinishedEvent).not.toHaveBeenCalled();
+      expectApprovalStateWriteDenied(invoke);
     });
   });
 
   it("requires a canonical plan for timeout fallback provenance", async () => {
-    const invoke = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      security: "full",
-      ask: "always",
+    const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
       approvalSource: "ask-fallback",
     });
 
     expect(invoke.runCommand).not.toHaveBeenCalled();
-    expectInvokeErrorMessage(invoke.sendInvokeResult, {
-      message: "approvalSource requires matching systemRunPlan",
-      exact: true,
-    });
+    expectInvokeErrorMessage(
+      invoke.sendInvokeResult,
+      "approvalSource requires matching systemRunPlan",
+      true,
+    );
   });
 
   it("requires a canonical plan for forwarded auto-review provenance", async () => {
-    const invoke = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      security: "full",
-      ask: "on-miss",
+    const invoke = await runLocalSystemInvokeWithPolicy("full", "on-miss", {
       approvalSource: "auto-review",
       prepareDelayedApprovalPlan: false,
     });
 
     expect(invoke.runCommand).not.toHaveBeenCalled();
-    expectInvokeErrorMessage(invoke.sendInvokeResult, {
-      message: "approvalSource requires matching systemRunPlan",
-      exact: true,
-    });
+    expectInvokeErrorMessage(
+      invoke.sendInvokeResult,
+      "approvalSource requires matching systemRunPlan",
+      true,
+    );
   });
 
   it("requires a canonical plan for explicit approval provenance", async () => {
-    const invoke = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      security: "full",
-      ask: "always",
+    const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
       approvalDecision: "allow-once",
       approved: true,
       prepareDelayedApprovalPlan: false,
     });
 
     expect(invoke.runCommand).not.toHaveBeenCalled();
-    expectInvokeErrorMessage(invoke.sendInvokeResult, {
-      message: "explicit approval requires matching systemRunPlan",
-      exact: true,
-    });
+    expectInvokeErrorMessage(
+      invoke.sendInvokeResult,
+      "explicit approval requires matching systemRunPlan",
+      true,
+    );
   });
 
   it("requires a prepared policy snapshot for forwarded delayed approval", async () => {
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["echo", "ok"],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    const invoke = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      command: prepared.plan.argv,
-      rawCommand: prepared.plan.commandText,
-      systemRunPlan: prepared.plan,
-      security: "full",
-      ask: "on-miss",
+    requireApprovalPlan(prepared, "unreachable");
+    const invoke = await runLocalSystemInvokeWithPolicy("full", "on-miss", {
+      preparedPlan: prepared.plan,
       approvalSource: "auto-review",
       prepareDelayedApprovalPlan: false,
     });
 
     expect(invoke.runCommand).not.toHaveBeenCalled();
-    expectInvokeErrorMessage(invoke.sendInvokeResult, {
-      message: "delayed approval requires a prepared policy snapshot",
-      exact: true,
-    });
+    expectInvokeErrorMessage(
+      invoke.sendInvokeResult,
+      "delayed approval requires a prepared policy snapshot",
+      true,
+    );
   });
 
   it("rejects explicit approval when policy tightens after prepare", async () => {
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "always", askFallback: "deny" },
-      },
-      run: async () => {
-        const prepared = buildSystemRunApprovalPlan({
-          command: ["echo", "ok"],
-          sessionKey: "agent:main:main",
-        });
-        expect(prepared.ok).toBe(true);
-        if (!prepared.ok) {
-          throw new Error("unreachable");
-        }
-        const policyBoundPlan = bindCurrentPolicyToPlan(prepared.plan);
-        const current = loadExecApprovals();
-        current.defaults = { ...current.defaults, security: "allowlist" };
-        saveExecApprovals(current);
-        const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
+    await withTempApprovalsHome(createApprovals("full", "always", "deny"), async () => {
+      const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
+      expect(prepared.ok).toBe(true);
+      requireApprovalPlan(prepared, "unreachable");
+      const policyBoundPlan = bindCurrentPolicyToPlan(prepared.plan);
+      const current = loadExecApprovals();
+      current.defaults = { ...current.defaults, security: "allowlist" };
+      saveExecApprovals(current);
+      const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
 
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: policyBoundPlan.argv,
-          rawCommand: policyBoundPlan.commandText,
-          systemRunPlan: policyBoundPlan,
-          security: "full",
-          ask: "always",
-          approvalDecision: "allow-once",
-          approved: true,
-          prepareDelayedApprovalPlan: false,
-          commitExecAuthorization: commitAuthorization,
-        });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
+        preparedPlan: policyBoundPlan,
+        approvalDecision: "allow-once",
+        approved: true,
+        prepareDelayedApprovalPlan: false,
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(commitAuthorization).not.toHaveBeenCalled();
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectInvokeErrorMessage(invoke.sendInvokeResult, {
-          message: "exec approval policy changed; request approval again",
-        });
-      },
+      expect(commitAuthorization).not.toHaveBeenCalled();
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectInvokeErrorMessage(
+        invoke.sendInvokeResult,
+        "exec approval policy changed; request approval again",
+      );
     });
   });
 
   it("rejects forwarded auto-review when ask tightens after prepare", async () => {
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "off", askFallback: "deny" },
-      },
-      run: async () => {
-        const prepared = buildSystemRunApprovalPlan({
-          command: ["echo", "ok"],
-          sessionKey: "agent:main:main",
-        });
-        expect(prepared.ok).toBe(true);
-        if (!prepared.ok) {
-          throw new Error("unreachable");
-        }
-        const policyBoundPlan = bindCurrentPolicyToPlan(prepared.plan);
-        const current = loadExecApprovals();
-        current.defaults = { ...current.defaults, ask: "on-miss" };
-        saveExecApprovals(current);
-        const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
+    await withTempApprovalsHome(createApprovals("full", "off", "deny"), async () => {
+      const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
+      expect(prepared.ok).toBe(true);
+      requireApprovalPlan(prepared, "unreachable");
+      const policyBoundPlan = bindCurrentPolicyToPlan(prepared.plan);
+      const current = loadExecApprovals();
+      current.defaults = { ...current.defaults, ask: "on-miss" };
+      saveExecApprovals(current);
+      const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
 
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: policyBoundPlan.argv,
-          rawCommand: policyBoundPlan.commandText,
-          systemRunPlan: policyBoundPlan,
-          security: "full",
-          ask: "off",
-          approvalSource: "auto-review",
-          prepareDelayedApprovalPlan: false,
-          commitExecAuthorization: commitAuthorization,
-        });
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "off", {
+        preparedPlan: policyBoundPlan,
+        approvalSource: "auto-review",
+        prepareDelayedApprovalPlan: false,
+        commitExecAuthorization: commitAuthorization,
+      });
 
-        expect(commitAuthorization).not.toHaveBeenCalled();
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectInvokeErrorMessage(invoke.sendInvokeResult, {
-          message: "exec approval policy changed; request approval again",
-        });
-      },
+      expect(commitAuthorization).not.toHaveBeenCalled();
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectInvokeErrorMessage(
+        invoke.sendInvokeResult,
+        "exec approval policy changed; request approval again",
+      );
     });
   });
 
   it("rejects explicit approval when an allowlist rule is revoked after prepare", async () => {
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "allowlist", ask: "always", askFallback: "deny" },
-        agents: {
-          main: {
-            allowlist: [{ id: "rule-1", pattern: "/usr/bin/echo" }],
-          },
+    await withTempApprovalsHome(
+      createApprovals("allowlist", "always", "deny", {
+        main: {
+          allowlist: [{ id: "rule-1", pattern: "/usr/bin/echo" }],
         },
-      },
-      run: async () => {
+      }),
+      async () => {
         const prepared = buildSystemRunApprovalPlan({
           command: ["echo", "ok"],
           agentId: "main",
           sessionKey: "agent:main:main",
         });
         expect(prepared.ok).toBe(true);
-        if (!prepared.ok) {
-          throw new Error("unreachable");
-        }
+        requireApprovalPlan(prepared, "unreachable");
         const policyBoundPlan = bindCurrentPolicyToPlan(prepared.plan);
         const current = loadExecApprovals();
         current.agents = { ...current.agents, main: { allowlist: [] } };
         saveExecApprovals(current);
         const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
 
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: policyBoundPlan.argv,
-          rawCommand: policyBoundPlan.commandText,
-          systemRunPlan: policyBoundPlan,
-          security: "allowlist",
-          ask: "always",
+        const invoke = await runLocalSystemInvokeWithPolicy("allowlist", "always", {
+          preparedPlan: policyBoundPlan,
           agentId: "main",
           approvalDecision: "allow-once",
           approved: true,
@@ -2896,80 +2534,60 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
         expect(commitAuthorization).not.toHaveBeenCalled();
         expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectInvokeErrorMessage(invoke.sendInvokeResult, {
-          message: "exec approval policy changed; request approval again",
-        });
+        expectInvokeErrorMessage(
+          invoke.sendInvokeResult,
+          "exec approval policy changed; request approval again",
+        );
       },
-    });
+    );
   });
 
   it("rejects timeout fallback provenance mixed with explicit approval", async () => {
-    const invoke = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      security: "full",
-      ask: "always",
+    const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
       approvalDecision: "allow-once",
       approvalSource: "ask-fallback",
     });
 
     expect(invoke.runCommand).not.toHaveBeenCalled();
-    expectInvokeErrorMessage(invoke.sendInvokeResult, {
-      message: "approvalSource cannot be combined with explicit approval",
-      exact: true,
-    });
+    expectInvokeErrorMessage(
+      invoke.sendInvokeResult,
+      "approvalSource cannot be combined with explicit approval",
+      true,
+    );
   });
 
   it("rejects forwarded auto-review provenance mixed with explicit approval", async () => {
-    const invoke = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      security: "full",
-      ask: "on-miss",
+    const invoke = await runLocalSystemInvokeWithPolicy("full", "on-miss", {
       approved: true,
       approvalDecision: "allow-once",
       approvalSource: "auto-review",
     });
 
     expect(invoke.runCommand).not.toHaveBeenCalled();
-    expectInvokeErrorMessage(invoke.sendInvokeResult, {
-      message: "approvalSource cannot be combined with explicit approval",
-      exact: true,
-    });
+    expectInvokeErrorMessage(
+      invoke.sendInvokeResult,
+      "approvalSource cannot be combined with explicit approval",
+      true,
+    );
   });
 
   it("applies marker-only full timeout fallback without another prompt", async () => {
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["echo", "ok"],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "always", askFallback: "full" },
-        agents: {},
-      },
-      run: async () => {
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          security: "full",
-          ask: "always",
-          approvalSource: "ask-fallback",
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "always", "full", {}), async () => {
+      const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
+        preparedPlan: prepared.plan,
+        approvalSource: "ask-fallback",
+      });
 
-        expect(invoke.runCommand).toHaveBeenCalledWith(
-          prepared.plan.argv,
-          undefined,
-          undefined,
-          undefined,
-        );
-        expectInvokeOk(invoke.sendInvokeResult);
-      },
+      expect(invoke.runCommand).toHaveBeenCalledWith(
+        prepared.plan.argv,
+        undefined,
+        undefined,
+        undefined,
+      );
+      expectInvokeOk(invoke.sendInvokeResult);
     });
   });
 
@@ -2977,38 +2595,23 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     "permits a durable exact-command approval under allowlist timeout fallback",
     async () => {
       const tempDir = createFixtureDir("openclaw-fallback-durable-");
-      const prepared = buildSystemRunApprovalPlan({
-        command: ["/bin/sh", "-c", "/bin/ls"],
-        cwd: tempDir,
-        sessionKey: "agent:main:main",
-      });
+      const prepared = buildCwdSessionApprovalPlan(
+        ["/bin/sh", "-c", "/bin/ls"],
+        tempDir,
+        "agent:main:main",
+      );
       expect(prepared.ok).toBe(true);
-      if (!prepared.ok) {
-        throw new Error("unreachable");
-      }
-      const commandPattern = `=command:${crypto
-        .createHash("sha256")
-        .update(prepared.plan.commandText)
-        .digest("hex")
-        .slice(0, 16)}`;
-      await withTempApprovalsHome({
-        approvals: {
-          version: 1,
-          defaults: { security: "full", ask: "always", askFallback: "allowlist" },
-          agents: {
-            main: { allowlist: [{ pattern: commandPattern, source: "allow-always" }] },
-          },
-        },
-        run: async () => {
+      requireApprovalPlan(prepared, "unreachable");
+      const commandPattern = createExactCommandPattern(prepared.plan.commandText);
+      await withTempApprovalsHome(
+        createApprovals("full", "always", "allowlist", {
+          main: { allowlist: [{ pattern: commandPattern, source: "allow-always" }] },
+        }),
+        async () => {
           const commitAuthorization = vi.fn(commitExecAuthorizationLocked);
-          const invoke = await runSystemInvoke({
-            preferMacAppExecHost: false,
-            command: prepared.plan.argv,
-            rawCommand: prepared.plan.commandText,
-            systemRunPlan: prepared.plan,
+          const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
+            preparedPlan: prepared.plan,
             cwd: prepared.plan.cwd ?? tempDir,
-            security: "full",
-            ask: "always",
             approvalSource: "ask-fallback",
             commitExecAuthorization: commitAuthorization,
           });
@@ -3024,7 +2627,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           expect(invoke.runCommand).toHaveBeenCalledTimes(1);
           expectInvokeOk(invoke.sendInvokeResult);
         },
-      });
+      );
     },
   );
 
@@ -3032,48 +2635,28 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     "rejects allowlist timeout fallback when its durable source is removed before commit",
     async () => {
       const tempDir = createFixtureDir("openclaw-fallback-durable-revoked-");
-      const prepared = buildSystemRunApprovalPlan({
-        command: ["/bin/sh", "-c", "/bin/ls"],
-        cwd: tempDir,
-        sessionKey: "agent:main:main",
-      });
+      const prepared = buildCwdSessionApprovalPlan(
+        ["/bin/sh", "-c", "/bin/ls"],
+        tempDir,
+        "agent:main:main",
+      );
       expect(prepared.ok).toBe(true);
-      if (!prepared.ok) {
-        throw new Error("unreachable");
-      }
-      const commandPattern = `=command:${crypto
-        .createHash("sha256")
-        .update(prepared.plan.commandText)
-        .digest("hex")
-        .slice(0, 16)}`;
-      await withTempApprovalsHome({
-        approvals: {
-          version: 1,
-          defaults: { security: "full", ask: "always", askFallback: "allowlist" },
-          agents: {
-            main: { allowlist: [{ pattern: commandPattern, source: "allow-always" }] },
-          },
-        },
-        run: async () => {
-          const commitAuthorization = vi.fn(
-            async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
-              const current = loadExecApprovals();
-              current.agents = {
-                ...current.agents,
-                main: { allowlist: [{ pattern: commandPattern }] },
-              };
-              saveExecApprovals(current);
-              await commitExecAuthorizationLocked(params);
-            },
-          );
-          const invoke = await runSystemInvoke({
-            preferMacAppExecHost: false,
-            command: prepared.plan.argv,
-            rawCommand: prepared.plan.commandText,
-            systemRunPlan: prepared.plan,
+      requireApprovalPlan(prepared, "unreachable");
+      const commandPattern = createExactCommandPattern(prepared.plan.commandText);
+      await withTempApprovalsHome(
+        createApprovals("full", "always", "allowlist", {
+          main: { allowlist: [{ pattern: commandPattern, source: "allow-always" }] },
+        }),
+        async () => {
+          const commitAuthorization = createPolicyMutationCommit((current) => {
+            current.agents = {
+              ...current.agents,
+              main: { allowlist: [{ pattern: commandPattern }] },
+            };
+          });
+          const invoke = await runLocalSystemInvokeWithPolicy("full", "always", {
+            preparedPlan: prepared.plan,
             cwd: prepared.plan.cwd ?? tempDir,
-            security: "full",
-            ask: "always",
             approvalSource: "ask-fallback",
             commitExecAuthorization: commitAuthorization,
           });
@@ -3089,81 +2672,48 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           expect(invoke.runCommand).not.toHaveBeenCalled();
           expectApprovalStateWriteDenied(invoke);
         },
-      });
+      );
     },
   );
 
   it("preserves source-only fallback across the authenticated Mac app bridge", async () => {
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["echo", "ok"],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "always", askFallback: "full" },
-        agents: {},
-      },
-      run: async () => {
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: true,
-          runViaResponse: createMacExecHostSuccess(),
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          security: "full",
-          ask: "always",
-          approvalSource: "ask-fallback",
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "always", "full", {}), async () => {
+      const invoke = await runMacSystemInvokeWithPolicy("full", "always", {
+        runViaResponse: createMacExecHostSuccess(),
+        preparedPlan: prepared.plan,
+        approvalSource: "ask-fallback",
+      });
 
-        const call = requireMacExecHostCall(invoke.runViaMacAppExecHost);
-        expect(call.request?.approvalSource).toBe("ask-fallback");
-        expect(call.request?.approvalDecision).toBeNull();
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectInvokeOk(invoke.sendInvokeResult, { payloadContains: "app-ok" });
-      },
+      const call = requireMacExecHostCall(invoke.runViaMacAppExecHost);
+      expect(call.request?.approvalSource).toBe("ask-fallback");
+      expect(call.request?.approvalDecision).toBeNull();
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectInvokeOk(invoke.sendInvokeResult, "app-ok");
     });
   });
 
   it("preserves marker-only auto-review across the authenticated Mac app bridge", async () => {
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["echo", "ok"],
-      sessionKey: "agent:main:main",
-    });
+    const prepared = buildSessionApprovalPlan(["echo", "ok"], "agent:main:main");
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "on-miss", askFallback: "deny" },
-      },
-      run: async () => {
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: true,
-          runViaResponse: createMacExecHostSuccess(),
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          security: "full",
-          ask: "on-miss",
-          approvalSource: "auto-review",
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "on-miss", "deny"), async () => {
+      const invoke = await runMacSystemInvokeWithPolicy("full", "on-miss", {
+        runViaResponse: createMacExecHostSuccess(),
+        preparedPlan: prepared.plan,
+        approvalSource: "auto-review",
+      });
 
-        const call = requireMacExecHostCall(invoke.runViaMacAppExecHost);
-        expect(call.request?.approvalSource).toBe("auto-review");
-        expect(call.request?.approvalDecision).toBeNull();
-        expect(call.request?.policySnapshot).toEqual(
-          createExecApprovalPolicySnapshot({ file: loadExecApprovals(), agentId: undefined }),
-        );
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectInvokeOk(invoke.sendInvokeResult, { payloadContains: "app-ok" });
-      },
+      const call = requireMacExecHostCall(invoke.runViaMacAppExecHost);
+      expect(call.request?.approvalSource).toBe("auto-review");
+      expect(call.request?.approvalDecision).toBeNull();
+      expect(call.request?.policySnapshot).toEqual(
+        createExecApprovalPolicySnapshot({ file: loadExecApprovals(), agentId: undefined }),
+      );
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectInvokeOk(invoke.sendInvokeResult, "app-ok");
     });
   });
 
@@ -3171,26 +2721,17 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     const plan = createStrictInlineEvalApprovalPlan("openclaw-fallback-inline-");
     setRuntimeConfigSnapshot({ tools: { exec: { strictInlineEval: true } } });
     try {
-      await withTempApprovalsHome({
-        approvals: {
-          version: 1,
-          defaults: { security: "full", ask: "always", askFallback: "full" },
-          agents: {},
-        },
-        run: async () => {
-          const invoke = await runSystemInvoke({
-            preferMacAppExecHost: false,
-            command: plan.argv,
-            rawCommand: plan.commandText,
-            systemRunPlan: plan,
-            approvalSource: "ask-fallback",
-          });
+      await withTempApprovalsHome(createApprovals("full", "always", "full", {}), async () => {
+        const invoke = await runLocalSystemInvoke({
+          preparedPlan: plan,
+          approvalSource: "ask-fallback",
+        });
 
-          expect(invoke.runCommand).not.toHaveBeenCalled();
-          expectInvokeErrorMessage(invoke.sendInvokeResult, {
-            message: "requires explicit approval in strictInlineEval mode",
-          });
-        },
+        expect(invoke.runCommand).not.toHaveBeenCalled();
+        expectInvokeErrorMessage(
+          invoke.sendInvokeResult,
+          "requires explicit approval in strictInlineEval mode",
+        );
       });
     } finally {
       clearRuntimeConfigSnapshot();
@@ -3199,97 +2740,62 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
 
   it("does not let timeout fallback authorize security audit suppression edits", async () => {
     const tmp = createFixtureDir("openclaw-timeout-fallback-suppression-");
-    const executablePath = createTempExecutable({ dir: tmp, name: "openclaw" });
-    const prepared = buildSystemRunApprovalPlan({
-      command: [executablePath, "config", "set", "security.audit.suppressions", "[]"],
-      cwd: tmp,
-      sessionKey: "agent:main:main",
-    });
+    const executablePath = createTempExecutable(tmp, "openclaw");
+    const prepared = buildCwdSessionApprovalPlan(
+      [executablePath, "config", "set", "security.audit.suppressions", "[]"],
+      tmp,
+      "agent:main:main",
+    );
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "always", askFallback: "full" },
-        agents: {},
-      },
-      run: async () => {
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
-          cwd: tmp,
-          approvalSource: "ask-fallback",
-        });
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(createApprovals("full", "always", "full", {}), async () => {
+      const invoke = await runLocalSystemInvoke({
+        preparedPlan: prepared.plan,
+        cwd: tmp,
+        approvalSource: "ask-fallback",
+      });
 
-        expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectApprovalRequiredDenied({
-          sendNodeEvent: invoke.sendNodeEvent,
-          sendInvokeResult: invoke.sendInvokeResult,
-        });
-      },
+      expect(invoke.runCommand).not.toHaveBeenCalled();
+      expectApprovalRequiredDenied(invoke.sendNodeEvent, invoke.sendInvokeResult);
     });
   });
 
   it("keeps audit suppression edits approval-gated under allowlist fallback from full/off", async () => {
     const tmp = createFixtureDir("openclaw-timeout-fallback-full-off-suppression-");
-    const executablePath = createTempExecutable({ dir: tmp, name: "openclaw" });
-    const prepared = buildSystemRunApprovalPlan({
-      command: [executablePath, "config", "set", "security.audit.suppressions", "[]"],
-      cwd: tmp,
-      sessionKey: "agent:main:main",
-    });
+    const executablePath = createTempExecutable(tmp, "openclaw");
+    const prepared = buildCwdSessionApprovalPlan(
+      [executablePath, "config", "set", "security.audit.suppressions", "[]"],
+      tmp,
+      "agent:main:main",
+    );
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "full", ask: "off", askFallback: "allowlist" },
-        agents: {
-          main: { allowlist: [{ pattern: fs.realpathSync(executablePath) }] },
-        },
-      },
-      run: async () => {
-        const invoke = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
+    requireApprovalPlan(prepared, "unreachable");
+    await withTempApprovalsHome(
+      createApprovals("full", "off", "allowlist", {
+        main: { allowlist: [{ pattern: fs.realpathSync(executablePath) }] },
+      }),
+      async () => {
+        const invoke = await runLocalSystemInvokeWithPolicy("full", "off", {
+          preparedPlan: prepared.plan,
           cwd: tmp,
-          security: "full",
-          ask: "off",
           approvalSource: "ask-fallback",
         });
 
         expect(invoke.runCommand).not.toHaveBeenCalled();
-        expectApprovalRequiredDenied({
-          sendNodeEvent: invoke.sendNodeEvent,
-          sendInvokeResult: invoke.sendInvokeResult,
-        });
+        expectApprovalRequiredDenied(invoke.sendNodeEvent, invoke.sendInvokeResult);
       },
-    });
+    );
   });
 
   it("rejects unknown approval provenance", async () => {
-    const invoke = await runSystemInvoke({
-      preferMacAppExecHost: false,
-      security: "full",
-      ask: "off",
+    const invoke = await runLocalSystemInvokeWithPolicy("full", "off", {
       approved: true,
       approvalDecision: "allow-once",
       approvalSource: "explicit",
     });
 
     expect(invoke.runCommand).not.toHaveBeenCalled();
-    expectInvokeErrorMessage(invoke.sendInvokeResult, {
-      message: "approvalSource invalid",
-      exact: true,
-    });
+    expectInvokeErrorMessage(invoke.sendInvokeResult, "approvalSource invalid", true);
   });
 
   it("rejects unbindable strict inline-eval carriers before delayed approval", async () => {
@@ -3301,25 +2807,19 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       },
     });
     try {
-      await withTempApprovalsHome({
-        approvals: createAllowlistOnMissApprovals(),
-        run: async () => {
-          const tempDir = createFixtureDir("openclaw-inline-eval-bin-");
-          const executablePath = createTempExecutable({
-            dir: tempDir,
-            name: "python3.13",
-          });
-          const prepared = buildSystemRunApprovalPlan({
-            command: [executablePath, "-c", "print('hi')"],
-          });
+      await withTempApprovalsHome(createAllowlistOnMissApprovals(), async () => {
+        const tempDir = createFixtureDir("openclaw-inline-eval-bin-");
+        const executablePath = createTempExecutable(tempDir, "python3.13");
+        const prepared = buildSystemRunApprovalPlan({
+          command: [executablePath, "-c", "print('hi')"],
+        });
 
-          expect(prepared).toEqual({
-            ok: false,
-            message:
-              "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
-          });
-          expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
-        },
+        expect(prepared).toEqual({
+          ok: false,
+          message:
+            "SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command",
+        });
+        expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
       });
     } finally {
       clearRuntimeConfigSnapshot();
@@ -3335,61 +2835,48 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       },
     });
     try {
-      await withTempApprovalsHome({
-        approvals: createAllowlistOnMissApprovals(),
-        run: async () => {
-          const tempDir = createFixtureDir("openclaw-inline-eval-awk-");
-          const executablePath = createTempExecutable({
-            dir: tempDir,
-            name: "gawk",
-          });
-          fs.writeFileSync(path.join(tempDir, "script.awk"), "{ print }\n");
-          const benign = await runSystemInvoke({
-            preferMacAppExecHost: false,
-            command: [executablePath, "-F", ",", "-f", "script.awk"],
-            cwd: tempDir,
-            security: "allowlist",
-            ask: "on-miss",
-            approvalDecision: "allow-always",
-            approved: true,
-            runCommand: vi.fn(async () => createLocalRunResult("awk-ok")),
-          });
+      await withTempApprovalsHome(createAllowlistOnMissApprovals(), async () => {
+        const tempDir = createFixtureDir("openclaw-inline-eval-awk-");
+        const executablePath = createTempExecutable(tempDir, "gawk");
+        fs.writeFileSync(path.join(tempDir, "script.awk"), "{ print }\n");
+        const benign = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
+          command: [executablePath, "-F", ",", "-f", "script.awk"],
+          cwd: tempDir,
+          approvalDecision: "allow-always",
+          approved: true,
+          runCommand: vi.fn(async () => createLocalRunResult("awk-ok")),
+        });
 
-          expect(benign.runCommand).toHaveBeenCalledTimes(1);
-          expectInvokeOk(benign.sendInvokeResult, { payloadContains: "awk-ok" });
-          const allowlist = loadExecApprovals().agents?.main?.allowlist ?? [];
-          expect(allowlist).toHaveLength(2);
-          expect(allowlist[0]?.pattern).toBe(fs.realpathSync(executablePath));
-          expect(allowlist[0]?.lastUsedCommand).toBeUndefined();
-          expect(allowlist[1]?.pattern).toMatch(/^=node-command:[0-9a-f]{16}$/);
-          expect(allowlist[1]?.lastUsedCommand).toBeUndefined();
+        expect(benign.runCommand).toHaveBeenCalledTimes(1);
+        expectInvokeOk(benign.sendInvokeResult, "awk-ok");
+        const allowlist = loadExecApprovals().agents?.main?.allowlist ?? [];
+        expect(allowlist).toHaveLength(2);
+        expect(allowlist[0]?.pattern).toBe(fs.realpathSync(executablePath));
+        expect(allowlist[0]?.lastUsedCommand).toBeUndefined();
+        expect(allowlist[1]?.pattern).toMatch(/^=node-command:[0-9a-f]{16}$/);
+        expect(allowlist[1]?.lastUsedCommand).toBeUndefined();
 
-          const malicious = await runSystemInvoke({
-            preferMacAppExecHost: false,
-            command: [executablePath, 'BEGIN{system("id")}', "/dev/null"],
-            cwd: tempDir,
-            security: "allowlist",
-            ask: "on-miss",
-          });
+        const malicious = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
+          command: [executablePath, 'BEGIN{system("id")}', "/dev/null"],
+          cwd: tempDir,
+        });
 
-          expect(malicious.runCommand).not.toHaveBeenCalled();
-          expectInvokeErrorMessage(malicious.sendInvokeResult, {
-            message: "awk inline program requires explicit approval in strictInlineEval mode",
-          });
+        expect(malicious.runCommand).not.toHaveBeenCalled();
+        expectInvokeErrorMessage(
+          malicious.sendInvokeResult,
+          "awk inline program requires explicit approval in strictInlineEval mode",
+        );
 
-          const abbreviated = await runSystemInvoke({
-            preferMacAppExecHost: false,
-            command: [executablePath, '--s=BEGIN{system("id")}', "/dev/null"],
-            cwd: tempDir,
-            security: "allowlist",
-            ask: "on-miss",
-          });
+        const abbreviated = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
+          command: [executablePath, '--s=BEGIN{system("id")}', "/dev/null"],
+          cwd: tempDir,
+        });
 
-          expect(abbreviated.runCommand).not.toHaveBeenCalled();
-          expectInvokeErrorMessage(abbreviated.sendInvokeResult, {
-            message: "gawk --source requires explicit approval in strictInlineEval mode",
-          });
-        },
+        expect(abbreviated.runCommand).not.toHaveBeenCalled();
+        expectInvokeErrorMessage(
+          abbreviated.sendInvokeResult,
+          "gawk --source requires explicit approval in strictInlineEval mode",
+        );
       });
     } finally {
       clearRuntimeConfigSnapshot();
@@ -3405,42 +2892,30 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       },
     });
     try {
-      await withTempApprovalsHome({
-        approvals: createAllowlistOnMissApprovals(),
-        run: async () => {
-          const tempDir = createFixtureDir("openclaw-inline-eval-make-");
-          const executablePath = createTempExecutable({
-            dir: tempDir,
-            name: "make",
-          });
-          const makefilePath = path.join(tempDir, "Makefile");
-          fs.writeFileSync(makefilePath, "all:\n\t@echo inline-eval-ok\n");
-          const prepared = buildSystemRunApprovalPlan({
-            command: [executablePath, "-f", makefilePath],
-            cwd: tempDir,
-          });
-          expect(prepared.ok).toBe(true);
-          if (!prepared.ok) {
-            throw new Error("unreachable");
-          }
+      await withTempApprovalsHome(createAllowlistOnMissApprovals(), async () => {
+        const tempDir = createFixtureDir("openclaw-inline-eval-make-");
+        const executablePath = createTempExecutable(tempDir, "make");
+        const makefilePath = path.join(tempDir, "Makefile");
+        fs.writeFileSync(makefilePath, "all:\n\t@echo inline-eval-ok\n");
+        const prepared = buildCwdApprovalPlan([executablePath, "-f", makefilePath], tempDir);
+        expect(prepared.ok).toBe(true);
+        requireApprovalPlan(prepared, "unreachable");
 
-          const { runCommand, sendInvokeResult } = await runSystemInvoke({
-            preferMacAppExecHost: false,
-            command: prepared.plan.argv,
-            rawCommand: prepared.plan.commandText,
-            systemRunPlan: prepared.plan,
+        const { runCommand, sendInvokeResult } = await runLocalSystemInvokeWithPolicy(
+          "allowlist",
+          "on-miss",
+          {
+            preparedPlan: prepared.plan,
             cwd: prepared.plan.cwd ?? tempDir,
-            security: "allowlist",
-            ask: "on-miss",
             approvalDecision: "allow-always",
             approved: true,
             runCommand: vi.fn(async () => createLocalRunResult("inline-eval-ok")),
-          });
+          },
+        );
 
-          expect(runCommand).toHaveBeenCalledTimes(1);
-          expectInvokeOk(sendInvokeResult, { payloadContains: "inline-eval-ok" });
-          expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
-        },
+        expect(runCommand).toHaveBeenCalledTimes(1);
+        expectInvokeOk(sendInvokeResult, "inline-eval-ok");
+        expect(loadExecApprovals().agents?.main?.allowlist ?? []).toStrictEqual([]);
       });
     } finally {
       clearRuntimeConfigSnapshot();
@@ -3457,31 +2932,26 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       fs.writeFileSync(scriptPath, "#!/bin/sh\necho ok\n");
       fs.chmodSync(scriptPath, 0o755);
 
-      await withTempApprovalsHome({
-        approvals: createAllowlistOnMissApprovals({
+      await withTempApprovalsHome(
+        createAllowlistOnMissApprovals({
           agents: {
             main: {
               allowlist: [{ pattern: fs.realpathSync(scriptPath) }],
             },
           },
         }),
-        run: async () => {
-          const invoke = await runSystemInvoke({
-            preferMacAppExecHost: false,
+        async () => {
+          const invoke = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
             command: ["/bin/sh", "-lc", "./scripts/check_mail.sh --limit 5"],
             rawCommand: '/bin/sh -lc "./scripts/check_mail.sh --limit 5"',
             cwd: tempDir,
-            security: "allowlist",
-            ask: "on-miss",
             runCommand: vi.fn(async () => createLocalRunResult("shell-wrapper-inner-ok")),
           });
 
           expect(invoke.runCommand).toHaveBeenCalledTimes(1);
-          expectInvokeOk(invoke.sendInvokeResult, {
-            payloadContains: "shell-wrapper-inner-ok",
-          });
+          expectInvokeOk(invoke.sendInvokeResult, "shell-wrapper-inner-ok");
         },
-      });
+      );
     },
   );
 
@@ -3499,22 +2969,19 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         fs.writeFileSync(scriptPath, "@echo off\r\necho ok\r\n");
         const command = [...testCase.commandPrefix, `${scriptPath} --limit 5`];
 
-        await withTempApprovalsHome({
-          approvals: createAllowlistOnMissApprovals({
+        await withTempApprovalsHome(
+          createAllowlistOnMissApprovals({
             agents: {
               main: {
                 allowlist: [{ pattern: scriptPath }],
               },
             },
           }),
-          run: async () => {
+          async () => {
             const seenArgv: string[][] = [];
-            const invoke = await runSystemInvoke({
-              preferMacAppExecHost: false,
+            const invoke = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
               command,
               cwd: tempDir,
-              security: "allowlist",
-              ask: "on-miss",
               isCmdExeInvocation: (argv) => {
                 seenArgv.push([...argv]);
                 const token = argv[0]?.trim();
@@ -3530,12 +2997,9 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
               ["cmd.exe", "/d", "/s", "/c", `${scriptPath} --limit 5`],
             ]);
             expect(invoke.runCommand, testCase.name).not.toHaveBeenCalled();
-            expectApprovalRequiredDenied({
-              sendNodeEvent: invoke.sendNodeEvent,
-              sendInvokeResult: invoke.sendInvokeResult,
-            });
+            expectApprovalRequiredDenied(invoke.sendNodeEvent, invoke.sendInvokeResult);
           },
-        });
+        );
       }
     } finally {
       platformSpy.mockRestore();
@@ -3551,17 +3015,11 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       const ordinaryPattern = "*";
       const prepared = buildSystemRunApprovalPlan({ command, cwd: tempDir });
       expect(prepared.ok).toBe(true);
-      if (!prepared.ok) {
-        throw new Error("unreachable");
-      }
-      const commandPattern = `=command:${crypto
-        .createHash("sha256")
-        .update(prepared.plan.commandText)
-        .digest("hex")
-        .slice(0, 16)}`;
+      requireApprovalPlan(prepared, "unreachable");
+      const commandPattern = createExactCommandPattern(prepared.plan.commandText);
 
-      await withTempApprovalsHome({
-        approvals: createAllowlistOnMissApprovals({
+      await withTempApprovalsHome(
+        createAllowlistOnMissApprovals({
           agents: {
             main: {
               allowlist: [
@@ -3571,28 +3029,18 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
             },
           },
         }),
-        run: async () => {
-          const commitAuthorization = vi.fn(
-            async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
-              const current = loadExecApprovals();
-              current.agents = {
-                ...current.agents,
-                main: {
-                  allowlist: [{ pattern: ordinaryPattern }, { pattern: commandPattern }],
-                },
-              };
-              saveExecApprovals(current);
-              await commitExecAuthorizationLocked(params);
-            },
-          );
-          const invoke = await runSystemInvoke({
-            preferMacAppExecHost: false,
-            command: prepared.plan.argv,
-            rawCommand: prepared.plan.commandText,
-            systemRunPlan: prepared.plan,
+        async () => {
+          const commitAuthorization = createPolicyMutationCommit((current) => {
+            current.agents = {
+              ...current.agents,
+              main: {
+                allowlist: [{ pattern: ordinaryPattern }, { pattern: commandPattern }],
+              },
+            };
+          });
+          const invoke = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
+            preparedPlan: prepared.plan,
             cwd: prepared.plan.cwd ?? tempDir,
-            security: "allowlist",
-            ask: "on-miss",
             isCmdExeInvocation: (argv) => {
               const token = argv[0]?.trim();
               if (!token) {
@@ -3616,7 +3064,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           expect(invoke.sendExecFinishedEvent).not.toHaveBeenCalled();
           expectApprovalStateWriteDenied(invoke);
         },
-      });
+      );
     } finally {
       platformSpy.mockRestore();
     }
@@ -3628,50 +3076,36 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     }
 
     const tempDir = createFixtureDir("openclaw-shell-wrapper-allow-");
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["/bin/sh", "-c", "/bin/ls"],
-      cwd: tempDir,
-    });
+    const prepared = buildCwdApprovalPlan(["/bin/sh", "-c", "/bin/ls"], tempDir);
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
+    requireApprovalPlan(prepared, "unreachable");
 
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "allowlist", ask: "on-miss", askFallback: "full" },
-        agents: {
-          main: {
-            allowlist: [
-              {
-                pattern: `=command:${crypto
-                  .createHash("sha256")
-                  .update(prepared.plan.commandText)
-                  .digest("hex")
-                  .slice(0, 16)}`,
-                source: "allow-always",
-              },
-            ],
-          },
+    await withTempApprovalsHome(
+      createApprovals("allowlist", "on-miss", "full", {
+        main: {
+          allowlist: [
+            {
+              pattern: `=command:${crypto
+                .createHash("sha256")
+                .update(prepared.plan.commandText)
+                .digest("hex")
+                .slice(0, 16)}`,
+              source: "allow-always",
+            },
+          ],
         },
-      },
-      run: async () => {
-        const rerun = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
+      }),
+      async () => {
+        const rerun = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
+          preparedPlan: prepared.plan,
           cwd: prepared.plan.cwd ?? tempDir,
-          security: "allowlist",
-          ask: "on-miss",
           runCommand: vi.fn(async () => createLocalRunResult("shell-wrapper-reused")),
         });
 
         expect(rerun.runCommand).toHaveBeenCalledTimes(1);
-        expectInvokeOk(rerun.sendInvokeResult, { payloadContains: "shell-wrapper-reused" });
+        expectInvokeOk(rerun.sendInvokeResult, "shell-wrapper-reused");
       },
-    });
+    );
   });
 
   it("does not bind safe builtin policy to a redundant exact-command grant", async () => {
@@ -3680,47 +3114,24 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     }
 
     const tempDir = createFixtureDir("openclaw-shell-wrapper-redundant-grant-");
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["/bin/sh", "-c", "cd ."],
-      cwd: tempDir,
-    });
+    const prepared = buildCwdApprovalPlan(["/bin/sh", "-c", "cd ."], tempDir);
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    const commandPattern = `=command:${crypto
-      .createHash("sha256")
-      .update(prepared.plan.commandText)
-      .digest("hex")
-      .slice(0, 16)}`;
+    requireApprovalPlan(prepared, "unreachable");
+    const commandPattern = createExactCommandPattern(prepared.plan.commandText);
 
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "allowlist", ask: "on-miss", askFallback: "full" },
-        agents: {
-          main: {
-            allowlist: [{ pattern: commandPattern, source: "allow-always" }],
-          },
+    await withTempApprovalsHome(
+      createApprovals("allowlist", "on-miss", "full", {
+        main: {
+          allowlist: [{ pattern: commandPattern, source: "allow-always" }],
         },
-      },
-      run: async () => {
-        const commitAuthorization = vi.fn(
-          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
-            const current = loadExecApprovals();
-            current.agents = { ...current.agents, main: { allowlist: [] } };
-            saveExecApprovals(current);
-            await commitExecAuthorizationLocked(params);
-          },
-        );
-        const rerun = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
+      }),
+      async () => {
+        const commitAuthorization = createPolicyMutationCommit((current) => {
+          current.agents = { ...current.agents, main: { allowlist: [] } };
+        });
+        const rerun = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
+          preparedPlan: prepared.plan,
           cwd: prepared.plan.cwd ?? tempDir,
-          security: "allowlist",
-          ask: "on-miss",
           commitExecAuthorization: commitAuthorization,
           runCommand: vi.fn(async () => createLocalRunResult("safe-builtin-ok")),
         });
@@ -3735,9 +3146,9 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
           }),
         );
         expect(rerun.runCommand).toHaveBeenCalledTimes(1);
-        expectInvokeOk(rerun.sendInvokeResult, { payloadContains: "safe-builtin-ok" });
+        expectInvokeOk(rerun.sendInvokeResult, "safe-builtin-ok");
       },
-    });
+    );
   });
 
   it("fails closed when an exact-command grant is revoked before execution", async () => {
@@ -3746,47 +3157,24 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     }
 
     const tempDir = createFixtureDir("openclaw-shell-wrapper-revoked-");
-    const prepared = buildSystemRunApprovalPlan({
-      command: ["/bin/sh", "-c", "/bin/ls"],
-      cwd: tempDir,
-    });
+    const prepared = buildCwdApprovalPlan(["/bin/sh", "-c", "/bin/ls"], tempDir);
     expect(prepared.ok).toBe(true);
-    if (!prepared.ok) {
-      throw new Error("unreachable");
-    }
-    const commandPattern = `=command:${crypto
-      .createHash("sha256")
-      .update(prepared.plan.commandText)
-      .digest("hex")
-      .slice(0, 16)}`;
+    requireApprovalPlan(prepared, "unreachable");
+    const commandPattern = createExactCommandPattern(prepared.plan.commandText);
 
-    await withTempApprovalsHome({
-      approvals: {
-        version: 1,
-        defaults: { security: "allowlist", ask: "on-miss", askFallback: "full" },
-        agents: {
-          main: {
-            allowlist: [{ pattern: commandPattern, source: "allow-always" }],
-          },
+    await withTempApprovalsHome(
+      createApprovals("allowlist", "on-miss", "full", {
+        main: {
+          allowlist: [{ pattern: commandPattern, source: "allow-always" }],
         },
-      },
-      run: async () => {
-        const commitAuthorization = vi.fn(
-          async (params: Parameters<typeof commitExecAuthorizationLocked>[0]) => {
-            const current = loadExecApprovals();
-            current.agents = { ...current.agents, main: { allowlist: [] } };
-            saveExecApprovals(current);
-            await commitExecAuthorizationLocked(params);
-          },
-        );
-        const rerun = await runSystemInvoke({
-          preferMacAppExecHost: false,
-          command: prepared.plan.argv,
-          rawCommand: prepared.plan.commandText,
-          systemRunPlan: prepared.plan,
+      }),
+      async () => {
+        const commitAuthorization = createPolicyMutationCommit((current) => {
+          current.agents = { ...current.agents, main: { allowlist: [] } };
+        });
+        const rerun = await runLocalSystemInvokeWithPolicy("allowlist", "on-miss", {
+          preparedPlan: prepared.plan,
           cwd: prepared.plan.cwd ?? tempDir,
-          security: "allowlist",
-          ask: "on-miss",
           commitExecAuthorization: commitAuthorization,
         });
 
@@ -3802,7 +3190,7 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
         expect(rerun.sendExecFinishedEvent).not.toHaveBeenCalled();
         expectApprovalStateWriteDenied(rerun);
       },
-    });
+    );
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Removes duplicated NodeHost system-run fixtures that repeated invocation, approval, environment, and result setup across the owner suite.

## Why This Change Was Made

The suite now uses typed owner-local builders for mechanical run and response construction while keeping approval identity, command authority, environment, failure, and security-sensitive inputs explicit in each scenario.

Production LOC: +0/-0 (net 0) | Tests: +1075/-1687 (net -612)

## User Impact

There is no user-visible behavior change. NodeHost invocation coverage remains intact while the suite is smaller and easier to audit.

## Evidence

- Owner and independent proofs each passed 111 tests with one unchanged existing skip.
- All 207 normalized complete expectations and the title, table, hook, comment, approval-identity, and security inventories were preserved.
- The changed gate completed 17 phases; remaining local full-graph diagnostics come from unrelated linked dependencies with zero touched-file diagnostics.
