### PR TITLE
refactor(agents): deduplicate tool display definitions

### DIFF
--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -17,6 +17,10 @@ type ToolDisplayConfig = {
   tools: Record<string, ToolDisplaySpec>;
 };
 
+function displayAction(label: string, detailKeys?: string[]) {
+  return detailKeys === undefined ? { label } : { label, detailKeys };
+}
+
 /** Static display metadata for known tools plus fallback detail-key selection. */
 export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
   version: 1,
@@ -109,86 +113,36 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       emoji: "🌐",
       title: "Browser",
       actions: {
-        status: {
-          label: "status",
-        },
-        start: {
-          label: "start",
-        },
-        stop: {
-          label: "stop",
-        },
-        tabs: {
-          label: "tabs",
-        },
-        open: {
-          label: "open",
-          detailKeys: ["targetUrl"],
-        },
-        focus: {
-          label: "focus",
-          detailKeys: ["targetId"],
-        },
-        close: {
-          label: "close",
-          detailKeys: ["targetId"],
-        },
-        snapshot: {
-          label: "snapshot",
-          detailKeys: ["targetUrl", "targetId", "ref", "element", "format"],
-        },
-        screenshot: {
-          label: "screenshot",
-          detailKeys: ["targetUrl", "targetId", "ref", "element"],
-        },
-        navigate: {
-          label: "navigate",
-          detailKeys: ["targetUrl", "targetId"],
-        },
-        console: {
-          label: "console",
-          detailKeys: ["level", "targetId"],
-        },
-        pdf: {
-          label: "pdf",
-          detailKeys: ["targetId"],
-        },
-        upload: {
-          label: "upload",
-          detailKeys: ["paths", "ref", "inputRef", "element", "targetId"],
-        },
-        dialog: {
-          label: "dialog",
-          detailKeys: ["accept", "promptText", "targetId"],
-        },
-        act: {
-          label: "act",
-          detailKeys: [
-            "request.kind",
-            "request.ref",
-            "request.selector",
-            "request.text",
-            "request.value",
-          ],
-        },
+        status: displayAction("status"),
+        start: displayAction("start"),
+        stop: displayAction("stop"),
+        tabs: displayAction("tabs"),
+        open: displayAction("open", ["targetUrl"]),
+        focus: displayAction("focus", ["targetId"]),
+        close: displayAction("close", ["targetId"]),
+        snapshot: displayAction("snapshot", ["targetUrl", "targetId", "ref", "element", "format"]),
+        screenshot: displayAction("screenshot", ["targetUrl", "targetId", "ref", "element"]),
+        navigate: displayAction("navigate", ["targetUrl", "targetId"]),
+        console: displayAction("console", ["level", "targetId"]),
+        pdf: displayAction("pdf", ["targetId"]),
+        upload: displayAction("upload", ["paths", "ref", "inputRef", "element", "targetId"]),
+        dialog: displayAction("dialog", ["accept", "promptText", "targetId"]),
+        act: displayAction("act", [
+          "request.kind",
+          "request.ref",
+          "request.selector",
+          "request.text",
+          "request.value",
+        ]),
       },
     },
     canvas: {
       emoji: "🖼️",
       title: "Canvas",
       actions: {
-        present: {
-          label: "present",
-          detailKeys: ["target", "node", "nodeId"],
-        },
-        hide: {
-          label: "hide",
-          detailKeys: ["node", "nodeId"],
-        },
-        navigate: {
-          label: "navigate",
-          detailKeys: ["url", "node", "nodeId"],
-        },
+        present: displayAction("present", ["target", "node", "nodeId"]),
+        hide: displayAction("hide", ["node", "nodeId"]),
+        navigate: displayAction("navigate", ["url", "node", "nodeId"]),
       },
     },
     dashboard: {
@@ -200,88 +154,50 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       emoji: "📱",
       title: "Nodes",
       actions: {
-        status: {
-          label: "status",
-        },
-        describe: {
-          label: "describe",
-          detailKeys: ["node", "nodeId"],
-        },
-        pending: {
-          label: "pending",
-        },
-        approve: {
-          label: "approve",
-          detailKeys: ["requestId"],
-        },
-        reject: {
-          label: "reject",
-          detailKeys: ["requestId"],
-        },
-        notify: {
-          label: "notify",
-          detailKeys: ["node", "nodeId", "title", "body"],
-        },
-        camera_snap: {
-          label: "camera snap",
-          detailKeys: ["node", "nodeId", "facing", "deviceId"],
-        },
-        camera_list: {
-          label: "camera list",
-          detailKeys: ["node", "nodeId"],
-        },
-        camera_clip: {
-          label: "camera clip",
-          detailKeys: ["node", "nodeId", "facing", "duration", "durationMs"],
-        },
-        camera_ptz: {
-          label: "camera PTZ",
-          detailKeys: ["ptzOperation", "node", "nodeId", "deviceId"],
-        },
-        screen_record: {
-          label: "screen record",
-          detailKeys: ["node", "nodeId", "duration", "durationMs", "fps", "screenIndex"],
-        },
-        screen_snapshot: {
-          label: "screen snapshot",
-          detailKeys: ["node", "nodeId", "screenIndex", "maxWidth"],
-        },
+        status: displayAction("status"),
+        describe: displayAction("describe", ["node", "nodeId"]),
+        pending: displayAction("pending"),
+        approve: displayAction("approve", ["requestId"]),
+        reject: displayAction("reject", ["requestId"]),
+        notify: displayAction("notify", ["node", "nodeId", "title", "body"]),
+        camera_snap: displayAction("camera snap", ["node", "nodeId", "facing", "deviceId"]),
+        camera_list: displayAction("camera list", ["node", "nodeId"]),
+        camera_clip: displayAction("camera clip", [
+          "node",
+          "nodeId",
+          "facing",
+          "duration",
+          "durationMs",
+        ]),
+        camera_ptz: displayAction("camera PTZ", ["ptzOperation", "node", "nodeId", "deviceId"]),
+        screen_record: displayAction("screen record", [
+          "node",
+          "nodeId",
+          "duration",
+          "durationMs",
+          "fps",
+          "screenIndex",
+        ]),
+        screen_snapshot: displayAction("screen snapshot", [
+          "node",
+          "nodeId",
+          "screenIndex",
+          "maxWidth",
+        ]),
       },
     },
     cron: {
       emoji: "⏰",
       title: "Cron",
       actions: {
-        status: {
-          label: "status",
-        },
-        list: {
-          label: "list",
-        },
-        add: {
-          label: "add",
-          detailKeys: ["job.name", "job.id", "job.schedule", "job.cron"],
-        },
-        update: {
-          label: "update",
-          detailKeys: ["id"],
-        },
-        remove: {
-          label: "remove",
-          detailKeys: ["id"],
-        },
-        run: {
-          label: "run",
-          detailKeys: ["id"],
-        },
-        runs: {
-          label: "runs",
-          detailKeys: ["id"],
-        },
-        wake: {
-          label: "wake",
-          detailKeys: ["text", "mode"],
-        },
+        status: displayAction("status"),
+        list: displayAction("list"),
+        add: displayAction("add", ["job.name", "job.id", "job.schedule", "job.cron"]),
+        update: displayAction("update", ["id"]),
+        remove: displayAction("remove", ["id"]),
+        run: displayAction("run", ["id"]),
+        runs: displayAction("runs", ["id"]),
+        wake: displayAction("wake", ["text", "mode"]),
       },
     },
     get_goal: {
@@ -368,14 +284,18 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       emoji: "🗂️",
       title: "Session Settings",
       actions: {
-        patch: {
-          label: "update",
-          detailKeys: ["sessionKey", "label", "pinned", "archived", "model", "thinkingLevel"],
-        },
-        group_list: { label: "groups" },
-        group_set: { label: "set groups", detailKeys: ["names"] },
-        group_rename: { label: "rename group", detailKeys: ["name", "to"] },
-        group_delete: { label: "delete group", detailKeys: ["name"] },
+        patch: displayAction("update", [
+          "sessionKey",
+          "label",
+          "pinned",
+          "archived",
+          "model",
+          "thinkingLevel",
+        ]),
+        group_list: displayAction("groups"),
+        group_set: displayAction("set groups", ["names"]),
+        group_rename: displayAction("rename group", ["name", "to"]),
+        group_delete: displayAction("delete group", ["name"]),
       },
     },
     sessions_list: {
@@ -427,33 +347,25 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       emoji: "🎙️",
       title: "Transcripts",
       actions: {
-        start: {
-          label: "start",
-          detailKeys: [
-            "sessionId",
-            "title",
-            "providerId",
-            "accountId",
-            "guildId",
-            "channelId",
-            "meetingUrl",
-          ],
-        },
-        stop: {
-          label: "stop",
-          detailKeys: ["sessionId"],
-        },
-        status: {
-          label: "status",
-        },
-        import: {
-          label: "import",
-          detailKeys: ["sessionId", "title", "providerId", "meetingUrl", "speakerLabel"],
-        },
-        summarize: {
-          label: "summarize",
-          detailKeys: ["sessionId"],
-        },
+        start: displayAction("start", [
+          "sessionId",
+          "title",
+          "providerId",
+          "accountId",
+          "guildId",
+          "channelId",
+          "meetingUrl",
+        ]),
+        stop: displayAction("stop", ["sessionId"]),
+        status: displayAction("status"),
+        import: displayAction("import", [
+          "sessionId",
+          "title",
+          "providerId",
+          "meetingUrl",
+          "speakerLabel",
+        ]),
+        summarize: displayAction("summarize", ["sessionId"]),
       },
     },
     sessions_spawn: {
@@ -467,18 +379,9 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       emoji: "🤖",
       title: "Subagents",
       actions: {
-        list: {
-          label: "list",
-          detailKeys: ["recentMinutes"],
-        },
-        kill: {
-          label: "kill",
-          detailKeys: ["target"],
-        },
-        steer: {
-          label: "steer",
-          detailKeys: ["target"],
-        },
+        list: displayAction("list", ["recentMinutes"]),
+        kill: displayAction("kill", ["target"]),
+        steer: displayAction("steer", ["target"]),
       },
     },
     agents_list: {
@@ -533,50 +436,44 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       emoji: "🎨",
       title: "Image Generation",
       actions: {
-        generate: {
-          label: "generate",
-          detailKeys: ["prompt", "model", "count", "resolution", "aspectRatio"],
-        },
-        list: {
-          label: "list",
-          detailKeys: ["provider", "model"],
-        },
+        generate: displayAction("generate", [
+          "prompt",
+          "model",
+          "count",
+          "resolution",
+          "aspectRatio",
+        ]),
+        list: displayAction("list", ["provider", "model"]),
       },
     },
     music_generate: {
       emoji: "🎵",
       title: "Music Generation",
       actions: {
-        generate: {
-          label: "generate",
-          detailKeys: ["prompt", "model", "durationSeconds", "format", "instrumental"],
-        },
-        list: {
-          label: "list",
-          detailKeys: ["provider", "model"],
-        },
+        generate: displayAction("generate", [
+          "prompt",
+          "model",
+          "durationSeconds",
+          "format",
+          "instrumental",
+        ]),
+        list: displayAction("list", ["provider", "model"]),
       },
     },
     video_generate: {
       emoji: "🎬",
       title: "Video Generation",
       actions: {
-        generate: {
-          label: "generate",
-          detailKeys: [
-            "prompt",
-            "model",
-            "durationSeconds",
-            "resolution",
-            "aspectRatio",
-            "audio",
-            "watermark",
-          ],
-        },
-        list: {
-          label: "list",
-          detailKeys: ["provider", "model"],
-        },
+        generate: displayAction("generate", [
+          "prompt",
+          "model",
+          "durationSeconds",
+          "resolution",
+          "aspectRatio",
+          "audio",
+          "watermark",
+        ]),
+        list: displayAction("list", ["provider", "model"]),
       },
     },
     pdf: {

--- a/src/agents/tool-display-message-config.ts
+++ b/src/agents/tool-display-message-config.ts
@@ -1,133 +1,44 @@
 import type { ToolDisplaySpec } from "./tool-display-common.js";
 
+function displayAction(label: string, detailKeys: string[]) {
+  return { label, detailKeys };
+}
+
 /** Display metadata for the transport-neutral message action surface. */
 export const MESSAGE_TOOL_DISPLAY_SPEC = {
   emoji: "✉️",
   title: "Message",
   actions: {
-    send: {
-      label: "send",
-      detailKeys: ["provider", "to", "media", "replyTo", "threadId"],
-    },
-    poll: {
-      label: "poll",
-      detailKeys: ["provider", "to", "pollQuestion"],
-    },
-    react: {
-      label: "react",
-      detailKeys: ["provider", "to", "messageId", "emoji", "remove"],
-    },
-    reactions: {
-      label: "reactions",
-      detailKeys: ["provider", "to", "messageId", "limit"],
-    },
-    read: {
-      label: "read",
-      detailKeys: ["provider", "to", "limit"],
-    },
-    edit: {
-      label: "edit",
-      detailKeys: ["provider", "to", "messageId"],
-    },
-    delete: {
-      label: "delete",
-      detailKeys: ["provider", "to", "messageId"],
-    },
-    pin: {
-      label: "pin",
-      detailKeys: ["provider", "to", "messageId"],
-    },
-    unpin: {
-      label: "unpin",
-      detailKeys: ["provider", "to", "messageId"],
-    },
-    "list-pins": {
-      label: "list pins",
-      detailKeys: ["provider", "to"],
-    },
-    permissions: {
-      label: "permissions",
-      detailKeys: ["provider", "channelId", "to"],
-    },
-    "thread-create": {
-      label: "thread create",
-      detailKeys: ["provider", "channelId", "threadName"],
-    },
-    "thread-list": {
-      label: "thread list",
-      detailKeys: ["provider", "guildId", "channelId"],
-    },
-    "thread-reply": {
-      label: "thread reply",
-      detailKeys: ["provider", "channelId", "messageId"],
-    },
-    search: {
-      label: "search",
-      detailKeys: ["provider", "guildId", "query"],
-    },
-    sticker: {
-      label: "sticker",
-      detailKeys: ["provider", "to", "stickerId"],
-    },
-    "member-info": {
-      label: "member",
-      detailKeys: ["provider", "guildId", "userId"],
-    },
-    "role-info": {
-      label: "roles",
-      detailKeys: ["provider", "guildId"],
-    },
-    "emoji-list": {
-      label: "emoji list",
-      detailKeys: ["provider", "guildId"],
-    },
-    "emoji-upload": {
-      label: "emoji upload",
-      detailKeys: ["provider", "guildId", "emojiName"],
-    },
-    "sticker-upload": {
-      label: "sticker upload",
-      detailKeys: ["provider", "guildId", "stickerName"],
-    },
-    "role-add": {
-      label: "role add",
-      detailKeys: ["provider", "guildId", "userId", "roleId"],
-    },
-    "role-remove": {
-      label: "role remove",
-      detailKeys: ["provider", "guildId", "userId", "roleId"],
-    },
-    "channel-info": {
-      label: "channel",
-      detailKeys: ["provider", "channelId"],
-    },
-    "channel-list": {
-      label: "channels",
-      detailKeys: ["provider", "guildId"],
-    },
-    "voice-status": {
-      label: "voice",
-      detailKeys: ["provider", "guildId", "userId"],
-    },
-    "event-list": {
-      label: "events",
-      detailKeys: ["provider", "guildId"],
-    },
-    "event-create": {
-      label: "event create",
-      detailKeys: ["provider", "guildId", "eventName"],
-    },
-    timeout: {
-      label: "timeout",
-      detailKeys: ["provider", "guildId", "userId"],
-    },
-    kick: {
-      label: "kick",
-      detailKeys: ["provider", "guildId", "userId"],
-    },
-    ban: {
-      label: "ban",
-      detailKeys: ["provider", "guildId", "userId"],
-    },
+    send: displayAction("send", ["provider", "to", "media", "replyTo", "threadId"]),
+    poll: displayAction("poll", ["provider", "to", "pollQuestion"]),
+    react: displayAction("react", ["provider", "to", "messageId", "emoji", "remove"]),
+    reactions: displayAction("reactions", ["provider", "to", "messageId", "limit"]),
+    read: displayAction("read", ["provider", "to", "limit"]),
+    edit: displayAction("edit", ["provider", "to", "messageId"]),
+    delete: displayAction("delete", ["provider", "to", "messageId"]),
+    pin: displayAction("pin", ["provider", "to", "messageId"]),
+    unpin: displayAction("unpin", ["provider", "to", "messageId"]),
+    "list-pins": displayAction("list pins", ["provider", "to"]),
+    permissions: displayAction("permissions", ["provider", "channelId", "to"]),
+    "thread-create": displayAction("thread create", ["provider", "channelId", "threadName"]),
+    "thread-list": displayAction("thread list", ["provider", "guildId", "channelId"]),
+    "thread-reply": displayAction("thread reply", ["provider", "channelId", "messageId"]),
+    search: displayAction("search", ["provider", "guildId", "query"]),
+    sticker: displayAction("sticker", ["provider", "to", "stickerId"]),
+    "member-info": displayAction("member", ["provider", "guildId", "userId"]),
+    "role-info": displayAction("roles", ["provider", "guildId"]),
+    "emoji-list": displayAction("emoji list", ["provider", "guildId"]),
+    "emoji-upload": displayAction("emoji upload", ["provider", "guildId", "emojiName"]),
+    "sticker-upload": displayAction("sticker upload", ["provider", "guildId", "stickerName"]),
+    "role-add": displayAction("role add", ["provider", "guildId", "userId", "roleId"]),
+    "role-remove": displayAction("role remove", ["provider", "guildId", "userId", "roleId"]),
+    "channel-info": displayAction("channel", ["provider", "channelId"]),
+    "channel-list": displayAction("channels", ["provider", "guildId"]),
+    "voice-status": displayAction("voice", ["provider", "guildId", "userId"]),
+    "event-list": displayAction("events", ["provider", "guildId"]),
+    "event-create": displayAction("event create", ["provider", "guildId", "eventName"]),
+    timeout: displayAction("timeout", ["provider", "guildId", "userId"]),
+    kick: displayAction("kick", ["provider", "guildId", "userId"]),
+    ban: displayAction("ban", ["provider", "guildId", "userId"]),
   },
 } satisfies ToolDisplaySpec & { emoji: string };


### PR DESCRIPTION
## What Problem This Solves

The shipped agent tool-display registry and its message-action owner repeatedly constructed equivalent private descriptor records. Those repetitive definitions made the cross-platform presentation catalog unnecessarily large while requiring exact preservation of every label, action shape, ownership identity, and generated Apple/Android artifact.

## Why This Change Was Made

The two existing private registry owners now use small canonical descriptor factories without changing the exported registry, runtime imports, field presence, object/array identities, or generated platform tool-display catalogs. The change removes duplicate construction while keeping all special tool and message definitions in their original owners.

## User Impact

Agent, channel, web, iOS, and Android tool labels and presentation remain byte-for-byte identical. Every existing action, visible detail, message label, and generated OpenClawKit JSON artifact is unchanged.

## Evidence

- The relevant existing tool-display, formatter, agent, and channel suites passed all 107 cases before and after the refactor.
- Independent source-blind runtime comparisons verified all 62 tools, 88 actions, hundreds of recursive objects and arrays, all own-property descriptors/insertion orders, distinct object and array identities, absent-versus-empty-array fields, and 695 real formatter invocations.
- The canonical cross-platform tool-display generator/check preserved the exact existing 22,968-byte platform JSON and SHA-256 `3402e71f59dd8fe0d938b715af1862e9dbd7eb3f5b7fcbd70faadc4b2d81766f`; no generated files changed.
- Targeted lint, formatting, the repository safety ratchet, `git diff --check`, multiple independent complete source/behavior reviews, and full structured precommit review passed.
- Genuine shipped production delta: 161 added, 353 removed, net **-192**. No tests, generated files, documentation, public APIs, configuration, protocol, or SQLite schemas changed.
