### PR TITLE
fix: New Session adopts discovered models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI discovered models:** retain authenticated dynamically discovered models and their metadata across Chat and New Session pickers while keeping startup prepared-only and discovering providers only after an explicit picker action. Fixes #124008. Thanks @jalehman.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI discovered models:** retain authenticated dynamically discovered models and their metadata across Chat and New Session pickers while keeping startup prepared-only and discovering providers only after an explicit picker action. Fixes #124008. Thanks @jalehman.
 - **Control UI terminal transcript settlement:** retire live commentary, tool, and streamed reply projections atomically when the matching durable terminal message arrives, preventing duplicated final responses and transient row overlap after steering. Fixes #127209. Thanks @shakkernerd.
 - **Control UI Codex compaction history:** preserve successful native context compactions as durable, model-excluded activity inside completed work traces after the composer status clears or the session reloads. Fixes #127206. Thanks @shakkernerd.
 - **Control UI Codex steering:** preserve pre-steer commentary and tool activity in durable transcript order, keep it visible while active, and collapse it before the steering message after completion. Fixes #126938. Thanks @shakkernerd.

--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -70,6 +70,10 @@ vi.mock("./model.js", () => ({
   resolveModelAsync: resolveModelAsyncMock,
 }));
 
+vi.mock("../provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: () => undefined,
+}));
+
 vi.mock("../harness/runtime-plugin.js", () => ({
   ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
 }));
@@ -138,11 +142,6 @@ vi.mock("../runtime-plan/resolve-auth.js", () => ({
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
   prepareProviderRuntimeAuth: vi.fn(async () => undefined),
-}));
-
-vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: () => ({ plugins: [] }),
-  withPluginMetadataSnapshotScope: (_snapshot: unknown, run: () => unknown) => run(),
 }));
 
 vi.mock("../provider-secret-egress.js", () => ({

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -26,9 +26,9 @@ import {
 import {
   createPreparedModelCatalogWorker,
   createPreparedModelCatalogWorkerInput,
-  getPreparedModelFullCatalogAuth,
 } from "./prepared-model-catalog-worker.js";
 import {
+  getPreparedModelFullCatalogAuth,
   getPreparedModelRuntimeAuthStore,
   loadPreparedModelRuntimeAuth,
   setPreparedModelRuntimeAuthLoader,

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -8,9 +8,10 @@ import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes
 import { cloneAuthProfileStore } from "./auth-profiles/clone.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
-import type {
-  PreparedModelRuntimeAuth,
-  PreparedModelRuntimeAuthScope,
+import {
+  setPreparedModelFullCatalogAuth,
+  type PreparedModelRuntimeAuth,
+  type PreparedModelRuntimeAuthScope,
 } from "./prepared-model-runtime-auth.js";
 import type { PreparedModelRuntimeAgentFacts } from "./prepared-model-runtime.catalog-contract.js";
 import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
@@ -61,22 +62,6 @@ export type PreparedModelWorkerResult =
       authModes: PreparedAgentCredentialModes;
     }>
   | Readonly<{ status: "failed"; requestId: number; error: string }>;
-
-const authByFullCatalog = new WeakMap<
-  object,
-  Readonly<{ authStore: AuthProfileStore; authModes: PreparedAgentCredentialModes }>
->();
-
-function setPreparedModelFullCatalogAuth(
-  modelCatalog: object,
-  auth: Readonly<{ authStore: AuthProfileStore; authModes: PreparedAgentCredentialModes }>,
-): void {
-  authByFullCatalog.set(modelCatalog, auth);
-}
-
-export function getPreparedModelFullCatalogAuth(modelCatalog: object) {
-  return authByFullCatalog.get(modelCatalog);
-}
 
 // Cold source/plugin loading can take well over a minute. Three minutes preserves exact full-view
 // discovery while bounding a wedged provider; expiry rejects and never returns partial results.

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -10,9 +10,6 @@ const mocks = vi.hoisted(() => ({
   loadSnapshot: vi.fn(),
   prepareSnapshot: vi.fn(),
   prepareScopedCatalog: vi.fn(),
-  fullCatalogAuth: undefined as
-    | undefined
-    | { authStore: { version: number; profiles: object }; authModes: object },
   isFullCatalog: vi.fn(),
   releaseSnapshot: vi.fn(),
 }));
@@ -57,10 +54,6 @@ vi.mock("./prepared-model-runtime.full-catalog.js", () => ({
   isPreparedModelCatalogFull: (...args: unknown[]) => mocks.isFullCatalog(...args),
 }));
 
-vi.mock("./prepared-model-catalog-worker.js", () => ({
-  getPreparedModelFullCatalogAuth: () => mocks.fullCatalogAuth,
-}));
-
 vi.mock("./prepared-model-runtime.scoped-catalog.js", () => ({
   prepareScopedReadOnlyModelCatalog: (...args: unknown[]) => mocks.prepareScopedCatalog(...args),
 }));
@@ -77,6 +70,7 @@ import {
 } from "./prepared-model-catalog.js";
 import {
   getPreparedModelRuntimeAuthStore,
+  setPreparedModelFullCatalogAuth,
   setPreparedModelRuntimeAuthStore,
 } from "./prepared-model-runtime-auth.js";
 import { PreparedModelRuntimeOwnerNotPublishedError } from "./prepared-model-runtime.js";
@@ -106,7 +100,6 @@ describe("prepared model catalog access", () => {
     mocks.loadSnapshot.mockReset();
     mocks.prepareSnapshot.mockReset();
     mocks.prepareScopedCatalog.mockReset();
-    mocks.fullCatalogAuth = undefined;
     mocks.isFullCatalog.mockReset();
     mocks.releaseSnapshot.mockReset();
   });
@@ -208,7 +201,7 @@ describe("prepared model catalog access", () => {
       routeVariants: [],
     };
     const { authStore, ...snapshotFacts } = fullSnapshot;
-    mocks.fullCatalogAuth = { authStore, authModes: {} };
+    setPreparedModelFullCatalogAuth(discoveredCatalog, { authStore, authModes: {} });
     const loadFullModelCatalog = vi.fn(async () => discoveredCatalog);
     const snapshot = {
       ...snapshotFacts,

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -10,10 +10,10 @@ import {
 import { resolveLegacyInheritedAuthDir } from "./legacy-inherited-auth-dir.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { resolvePublishedModelCatalogOwner } from "./prepared-model-catalog-owner.js";
-import { getPreparedModelFullCatalogAuth } from "./prepared-model-catalog-worker.js";
 import { PreparedModelCatalogConfigReplacedError } from "./prepared-model-catalog.errors.js";
 import type { ResolvedPublishedModelCatalogOwner } from "./prepared-model-catalog.types.js";
 import {
+  getPreparedModelFullCatalogAuth,
   getPreparedModelRuntimeAuthMaterializations,
   loadPreparedModelRuntimeAuth,
   setPreparedModelRuntimeAuthMaterializations,

--- a/src/agents/prepared-model-runtime-auth.ts
+++ b/src/agents/prepared-model-runtime-auth.ts
@@ -19,6 +19,7 @@ const authLoaderBySnapshot = new WeakMap<
   object,
   (scope: PreparedModelRuntimeAuthScope) => Promise<PreparedModelRuntimeAuth>
 >();
+const authByFullCatalog = new WeakMap<object, PreparedModelRuntimeAuth>();
 
 // Secret-bearing state stays lifecycle-owned without becoming part of the public snapshot shape.
 export function setPreparedModelRuntimeAuthStore(
@@ -30,6 +31,17 @@ export function setPreparedModelRuntimeAuthStore(
 
 export function getPreparedModelRuntimeAuthStore(snapshot: object): AuthProfileStore | undefined {
   return authStoreBySnapshot.get(snapshot);
+}
+
+export function setPreparedModelFullCatalogAuth(
+  snapshot: object,
+  auth: PreparedModelRuntimeAuth,
+): void {
+  authByFullCatalog.set(snapshot, auth);
+}
+
+export function getPreparedModelFullCatalogAuth(snapshot: object) {
+  return authByFullCatalog.get(snapshot);
 }
 
 export function setPreparedModelRuntimeAuthLoader(

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -36,6 +36,7 @@ import {
   createPreparedInboundRegistryLoader,
   preparedModelRuntimeWorkspaceFactsKey,
 } from "./prepared-model-runtime.inbound-registry.js";
+import { notifyPreparedModelRuntimePublication } from "./prepared-model-runtime.publication-events.js";
 import type {
   PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,
@@ -214,6 +215,7 @@ function createFullModelCatalogAccess(params: {
         pending = build
           .then((catalog) => {
             fullCatalog = catalog;
+            notifyPreparedModelRuntimePublication({ phase: "catalog-published" });
             return catalog;
           })
           .finally(() => {

--- a/src/agents/prepared-model-runtime.publication-events.ts
+++ b/src/agents/prepared-model-runtime.publication-events.ts
@@ -3,7 +3,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 const log = createSubsystemLogger("agents/prepared-model-runtime");
 
 type PreparedModelRuntimePublicationEvent =
-  | { phase: "invalidated" | "published" }
+  | { phase: "catalog-published" | "invalidated" | "published" }
   | { phase: "failed"; error: Error };
 
 const publicationListeners = new Set<(event: PreparedModelRuntimePublicationEvent) => void>();

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -209,8 +209,11 @@ vi.mock("../logging/subsystem.js", () => ({
   createSubsystemLogger: () => ({ warn: vi.fn() }),
 }));
 
-const { getPreparedModelRuntimeSnapshot, refreshPreparedModelRuntimeSnapshots } =
-  await import("./prepared-model-runtime.js");
+const {
+  getPreparedModelRuntimeSnapshot,
+  refreshPreparedModelRuntimeSnapshots,
+  registerPreparedModelRuntimePublicationListener,
+} = await import("./prepared-model-runtime.js");
 const { getAvailablePreparedModelCatalogSnapshot } = await import("./prepared-model-catalog.js");
 const { prepareScopedReadOnlyLiveModelCatalog, prepareScopedReadOnlyModelCatalog } =
   await import("./prepared-model-runtime.scoped-catalog.js");
@@ -431,7 +434,12 @@ describe("prepared model runtime Gateway catalog mode", () => {
     expect(snapshot?.pluginRegistry).toBeDefined();
     expect(snapshot?.messageToolCatalog).toBeUndefined();
     expect(snapshot?.mediaCapabilityProviders).toBeDefined();
+    const catalogPublicationEvents: string[] = [];
+    const unregisterCatalogPublication = registerPreparedModelRuntimePublicationListener((event) =>
+      catalogPublicationEvents.push(event.phase),
+    );
     await snapshot?.loadFullModelCatalog?.();
+    expect(catalogPublicationEvents).toEqual(["catalog-published"]);
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
     expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(2);
@@ -452,13 +460,17 @@ describe("prepared model runtime Gateway catalog mode", () => {
       }),
     ).toEqual({ entries: [], routeVariants: [] });
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
+    expect(catalogPublicationEvents).toEqual(["catalog-published"]);
 
     await snapshot?.loadFullModelCatalog?.({ refresh: true });
+    expect(catalogPublicationEvents).toEqual(["catalog-published", "catalog-published"]);
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(2);
     mocks.runPreparedModelCatalogWorker.mockRejectedValueOnce(new Error("refresh failed"));
     await expect(snapshot?.loadFullModelCatalog?.({ refresh: true })).rejects.toThrow(
       "refresh failed",
     );
+    expect(catalogPublicationEvents).toEqual(["catalog-published", "catalog-published"]);
+    unregisterCatalogPublication();
     expect(snapshot?.readFullModelCatalog?.()).toEqual({ entries: [], routeVariants: [] });
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(3);
     expect(mocks.prepareStaticCatalog).toHaveBeenCalledOnce();

--- a/src/gateway/server-chat-metadata-lifecycle.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.test.ts
@@ -178,6 +178,22 @@ describe("gateway chat metadata lifecycle", () => {
     await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(3));
   });
 
+  it("refreshes after the prepared owner publishes a completed full catalog", async () => {
+    const { lifecycle: pendingLifecycle } = createLifecycle(false);
+    const lifecycle = await pendingLifecycle;
+
+    await lifecycle.attachContext(context, []);
+    const modelListener = mocks.registerModelListener.mock.calls[0]?.[0];
+    modelListener({ phase: "published" });
+    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(2));
+    mocks.invalidate.mockClear();
+
+    modelListener({ phase: "catalog-published" });
+
+    expect(mocks.invalidate).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(3));
+  });
+
   it("propagates a failed model publication without starting a refresh", async () => {
     const { lifecycle: pendingLifecycle } = createLifecycle(false);
     const lifecycle = await pendingLifecycle;

--- a/src/gateway/server-chat-metadata-lifecycle.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.test.ts
@@ -197,7 +197,7 @@ describe("gateway chat metadata lifecycle", () => {
   });
 
   it("keeps an owner available when a subordinate catalog publishes during attachment", async () => {
-    const pendingRefresh = createDeferred<void>();
+    const pendingRefresh = createDeferred();
     mocks.refresh.mockReturnValueOnce(pendingRefresh.promise);
     const { lifecycle: pendingLifecycle } = createLifecycle(false);
     const lifecycle = await pendingLifecycle;

--- a/src/gateway/server-chat-metadata-lifecycle.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 
@@ -151,10 +152,11 @@ describe("gateway chat metadata lifecycle", () => {
     expect(skillsListener).toEqual(expect.any(Function));
 
     modelListener({ phase: "invalidated" });
+    modelListener({ phase: "catalog-published" });
     authListener();
     skillsListener();
 
-    expect(mocks.invalidate).toHaveBeenCalledTimes(3);
+    expect(mocks.invalidate).toHaveBeenCalledTimes(4);
     expect(mocks.refresh).toHaveBeenCalledOnce();
     expect(warn).not.toHaveBeenCalled();
 
@@ -192,6 +194,25 @@ describe("gateway chat metadata lifecycle", () => {
 
     expect(mocks.invalidate).toHaveBeenCalledOnce();
     await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(3));
+  });
+
+  it("keeps an owner available when a subordinate catalog publishes during attachment", async () => {
+    const pendingRefresh = createDeferred<void>();
+    mocks.refresh.mockReturnValueOnce(pendingRefresh.promise);
+    const { lifecycle: pendingLifecycle } = createLifecycle(false);
+    const lifecycle = await pendingLifecycle;
+
+    const attachment = lifecycle.attachContext(context, []);
+    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledOnce());
+    const modelListener = mocks.registerModelListener.mock.calls[0]?.[0];
+    modelListener({ phase: "catalog-published" });
+    pendingRefresh.resolve();
+    await attachment;
+
+    const authListener = mocks.registerAuthListener.mock.calls[0]?.[0];
+    authListener();
+
+    await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(2));
   });
 
   it("propagates a failed model publication without starting a refresh", async () => {

--- a/src/gateway/server-chat-metadata-lifecycle.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.ts
@@ -68,6 +68,10 @@ export async function createGatewayChatMetadataLifecycle(params: {
     const unregisterPreparedModelRuntimePublication =
       registerPreparedModelRuntimePublicationListener((event) => {
         preparedModelRuntimeEventVersion += 1;
+        if (event.phase === "catalog-published") {
+          invalidateForSubordinateChange();
+          return;
+        }
         if (event.phase === "invalidated") {
           preparedModelRuntimeAvailable = false;
           runtime.invalidate();

--- a/src/gateway/server-chat-metadata-lifecycle.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.ts
@@ -67,11 +67,11 @@ export async function createGatewayChatMetadataLifecycle(params: {
     ]);
     const unregisterPreparedModelRuntimePublication =
       registerPreparedModelRuntimePublicationListener((event) => {
-        preparedModelRuntimeEventVersion += 1;
         if (event.phase === "catalog-published") {
           invalidateForSubordinateChange();
           return;
         }
+        preparedModelRuntimeEventVersion += 1;
         if (event.phase === "invalidated") {
           preparedModelRuntimeAvailable = false;
           runtime.invalidate();

--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -5,7 +5,7 @@ import {
   type AgentCredentialMap,
 } from "../../agents/agent-auth-credentials.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
-import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import { setPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -80,11 +80,18 @@ function createHarness(
     async ({
       facts,
     }: {
-      facts: { authStore: AuthProfileStore; owner: PreparedModelRuntimeSnapshot };
-    }) => ({
-      modelCatalog: facts.owner.modelCatalog.entries,
-      models: facts.owner.modelCatalog.entries,
-    }),
+      facts: {
+        authStore: AuthProfileStore;
+        modelCatalog: ModelCatalogSnapshot;
+        owner: PreparedModelRuntimeSnapshot;
+      };
+    }) => {
+      const modelCatalog = facts.modelCatalog;
+      return {
+        modelCatalog: modelCatalog.entries,
+        models: modelCatalog.entries,
+      };
+    },
   );
   const context = {
     getRuntimeConfig: () => config,
@@ -479,6 +486,43 @@ describe("gateway chat metadata runtime", () => {
       models: [expect.objectContaining({ id: "gpt-5.6-sol", available: true })],
     });
     expect(loadFullModelCatalog).not.toHaveBeenCalled();
+  });
+
+  test("adopts a completed full catalog from the same prepared generation", async () => {
+    const harness = createHarness();
+    const owner = harness.getPreparedOwner()!;
+    const dynamicModel = { id: "dynamic", name: "dynamic", provider: "dynamic" };
+    const fullCatalog = {
+      ...owner.modelCatalog,
+      entries: [...owner.modelCatalog.entries, dynamicModel],
+      routeVariants: [...owner.modelCatalog.routeVariants, dynamicModel],
+    };
+    let completedCatalog: ModelCatalogSnapshot | undefined;
+    const generationOwner = {
+      ...owner,
+      readFullModelCatalog: () => completedCatalog,
+      loadFullModelCatalog: vi.fn(async () => {
+        completedCatalog = fullCatalog;
+        return fullCatalog;
+      }),
+    };
+    harness.setOwner(generationOwner);
+
+    await harness.runtime.refresh();
+    await expect(harness.runtime.read({ agentId: "main" })).resolves.toMatchObject({
+      models: [expect.objectContaining({ id: "first" })],
+    });
+
+    await generationOwner.loadFullModelCatalog();
+    await harness.runtime.refresh();
+
+    await expect(harness.runtime.read({ agentId: "main" })).resolves.toMatchObject({
+      models: [
+        expect.objectContaining({ id: "first" }),
+        expect.objectContaining({ id: "dynamic" }),
+      ],
+    });
+    expect(generationOwner.loadFullModelCatalog).toHaveBeenCalledOnce();
   });
 
   test("retains a generation while auth store revisions are unchanged", async () => {

--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -6,7 +6,11 @@ import {
 } from "../../agents/agent-auth-credentials.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
-import { setPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
+import {
+  setPreparedModelFullCatalogAuth,
+  setPreparedModelRuntimeAuthStore,
+} from "../../agents/prepared-model-runtime-auth.js";
+import { markPreparedModelCatalogFull } from "../../agents/prepared-model-runtime.full-catalog.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createGatewayChatMetadataRuntime } from "./chat-metadata-runtime.js";
@@ -488,15 +492,52 @@ describe("gateway chat metadata runtime", () => {
     expect(loadFullModelCatalog).not.toHaveBeenCalled();
   });
 
-  test("adopts a completed full catalog from the same prepared generation", async () => {
-    const harness = createHarness();
-    const owner = harness.getPreparedOwner()!;
-    const dynamicModel = { id: "dynamic", name: "dynamic", provider: "dynamic" };
-    const fullCatalog = {
+  test("adopts discovered wildcard models without restarting provider discovery", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.6-sol" },
+          models: { "openai/*": {}, "openai/gpt-5.6-sol": {} },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } satisfies OpenClawConfig;
+    const credentials: AgentCredentialMap = {
+      openai: {
+        type: "oauth",
+        access: "prepared-access",
+        refresh: "prepared-refresh",
+        expires: Date.now() + 30 * 60_000,
+      },
+    };
+    const harness = createHarness(config, { useDefaultProjection: true });
+    const owner = createOwner(
+      config,
+      "gpt-5.6-sol",
+      credentials,
+      "openai",
+      "openai-chatgpt-responses",
+    );
+    const preparedAuthStore: AuthProfileStore = {
+      version: 1,
+      profiles: { "openai:prepared": { ...credentials.openai!, provider: "openai" } },
+    };
+    harness.setAuthStore(preparedAuthStore);
+    const dynamicModel = {
+      id: "gpt-5.6-luna",
+      name: "GPT-5.6 Luna",
+      provider: "openai",
+      api: "openai-chatgpt-responses" as const,
+    };
+    const fullCatalog = markPreparedModelCatalogFull({
       ...owner.modelCatalog,
       entries: [...owner.modelCatalog.entries, dynamicModel],
       routeVariants: [...owner.modelCatalog.routeVariants, dynamicModel],
-    };
+    });
+    setPreparedModelFullCatalogAuth(fullCatalog, {
+      authStore: preparedAuthStore,
+      authModes: owner.authModes,
+    });
     let completedCatalog: ModelCatalogSnapshot | undefined;
     const generationOwner = {
       ...owner,
@@ -510,19 +551,30 @@ describe("gateway chat metadata runtime", () => {
 
     await harness.runtime.refresh();
     await expect(harness.runtime.read({ agentId: "main" })).resolves.toMatchObject({
-      models: [expect.objectContaining({ id: "first" })],
+      models: [expect.objectContaining({ id: "gpt-5.6-sol", available: true })],
     });
 
     await generationOwner.loadFullModelCatalog();
     await harness.runtime.refresh();
 
     await expect(harness.runtime.read({ agentId: "main" })).resolves.toMatchObject({
-      models: [
-        expect.objectContaining({ id: "first" }),
-        expect.objectContaining({ id: "dynamic" }),
-      ],
+      models: expect.arrayContaining([
+        expect.objectContaining({ id: "gpt-5.6-sol", available: true }),
+        expect.objectContaining({ id: "gpt-5.6-luna", available: true }),
+      ]),
     });
     expect(generationOwner.loadFullModelCatalog).toHaveBeenCalledOnce();
+  });
+
+  test("rejects a completed catalog without its matching prepared auth generation", async () => {
+    const harness = createHarness();
+    const owner = harness.getPreparedOwner()!;
+    const unpairedCatalog = markPreparedModelCatalogFull({ ...owner.modelCatalog });
+    harness.setOwner({ ...owner, readFullModelCatalog: () => unpairedCatalog });
+
+    await expect(harness.runtime.refresh()).rejects.toThrow(
+      "prepared full model catalog omitted its auth generation",
+    );
   });
 
   test("retains a generation while auth store revisions are unchanged", async () => {

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -6,12 +6,14 @@ import {
   type AuthProfileStore,
 } from "../../agents/auth-profiles.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
-import { getPreparedModelFullCatalogAuth } from "../../agents/prepared-model-catalog-worker.js";
 import {
   getPublishedPreparedModelCatalogOwnerSnapshot,
   type GetPublishedPreparedModelCatalogOwnerParams,
 } from "../../agents/prepared-model-catalog.js";
-import { getPreparedModelRuntimeAuthMaterializations } from "../../agents/prepared-model-runtime-auth.js";
+import {
+  getPreparedModelFullCatalogAuth,
+  getPreparedModelRuntimeAuthMaterializations,
+} from "../../agents/prepared-model-runtime-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.js";
 import { resolveSwarmConfig } from "../../agents/subagents/swarm/swarm-config.js";
 import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
@@ -138,6 +140,9 @@ function captureGenerationFacts(deps: ChatMetadataRuntimeDeps): PreparedGenerati
     const fullCatalogAuth = fullModelCatalog
       ? getPreparedModelFullCatalogAuth(fullModelCatalog)
       : undefined;
+    if (fullModelCatalog && !fullCatalogAuth) {
+      throw new Error("prepared full model catalog omitted its auth generation");
+    }
     return {
       agentId,
       owner,

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -1,10 +1,12 @@
+import type { PreparedAgentCredentialModes } from "../../agents/agent-auth-credential-modes.js";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import {
   getPreparedRuntimeAuthProfileStoreSnapshot,
   getRuntimeAuthProfileStoreSnapshotRevision,
   type AuthProfileStore,
 } from "../../agents/auth-profiles.js";
-import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import { getPreparedModelFullCatalogAuth } from "../../agents/prepared-model-catalog-worker.js";
 import {
   getPublishedPreparedModelCatalogOwnerSnapshot,
   type GetPublishedPreparedModelCatalogOwnerParams,
@@ -35,7 +37,9 @@ type PreparedAgentFacts = {
   agentId: string;
   owner: PreparedModelRuntimeSnapshot;
   authStore: AuthProfileStore;
+  authModes: PreparedAgentCredentialModes;
   authStoreRevision: string;
+  modelCatalog: ModelCatalogSnapshot;
   skillsVersion: number;
 };
 
@@ -130,14 +134,21 @@ function captureGenerationFacts(deps: ChatMetadataRuntimeDeps): PreparedGenerati
       );
     }
     const workspaceDir = owner.workspaceDir ?? resolveAgentWorkspaceDir(config, agentId);
+    const fullModelCatalog = owner.readFullModelCatalog?.();
+    const fullCatalogAuth = fullModelCatalog
+      ? getPreparedModelFullCatalogAuth(fullModelCatalog)
+      : undefined;
     return {
       agentId,
       owner,
-      authStore: deps.getPreparedAuthStore(owner.agentDir, owner.inheritedAuthDir) ?? {
-        version: 1,
-        profiles: {},
-      },
+      authStore: fullCatalogAuth?.authStore ??
+        deps.getPreparedAuthStore(owner.agentDir, owner.inheritedAuthDir) ?? {
+          version: 1,
+          profiles: {},
+        },
+      authModes: fullCatalogAuth?.authModes ?? owner.authModes,
       authStoreRevision: `${deps.getAuthStoreRevision(owner.agentDir)}:${deps.getAuthStoreRevision(owner.inheritedAuthDir)}`,
+      modelCatalog: fullModelCatalog ?? owner.modelCatalog,
       skillsVersion: deps.getSkillsVersion(workspaceDir),
     };
   });
@@ -166,6 +177,7 @@ function generationFactsMatch(
       candidate?.agentId === agent.agentId &&
       candidate.owner === agent.owner &&
       candidate.authStoreRevision === agent.authStoreRevision &&
+      candidate.modelCatalog === agent.modelCatalog &&
       candidate.skillsVersion === agent.skillsVersion
     );
   });
@@ -220,7 +232,7 @@ async function defaultBuildProjection(params: {
     await import("./models-list-result.js");
   // Chat metadata must stay on process-published facts. Live discovery belongs to explicit
   // models.list control-plane reads so a slow provider cannot delay chat startup.
-  const snapshot = params.facts.owner.modelCatalog;
+  const snapshot = params.facts.modelCatalog;
   const projector = createGatewayAgentModelCatalogProjector({
     cfg: params.facts.owner.config,
     agentId: params.facts.agentId,
@@ -228,7 +240,7 @@ async function defaultBuildProjection(params: {
     metadataSnapshot: params.facts.owner.metadataSnapshot,
     preparedAuthStore: params.facts.authStore,
     // The owner records usable auth at discovery; metadata must share that exact generation fact.
-    preparedRuntimeAuthModes: params.facts.owner.authModes,
+    preparedRuntimeAuthModes: params.facts.authModes,
     preparedRuntimeAuthMaterializations: getPreparedModelRuntimeAuthMaterializations(
       params.facts.owner,
     ),

--- a/src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
+++ b/src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { markPreparedModelCatalogFull } from "../../agents/prepared-model-runtime.full-catalog.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   type PreparedGatewayModelCatalogSnapshot,
@@ -74,7 +75,7 @@ describe("models.list provider catalog outcomes", () => {
       api: "openai-chatgpt-responses" as const,
       baseUrl: "https://chatgpt.com/backend-api/codex",
     };
-    const snapshot = {
+    const snapshot = markPreparedModelCatalogFull({
       entries: [model],
       routeVariants: [model],
       providerOutcomes: [
@@ -84,7 +85,7 @@ describe("models.list provider catalog outcomes", () => {
           status: "auth-rejected" as const,
         },
       ],
-    };
+    });
     const projector = createGatewayAgentModelCatalogProjector({
       cfg: config,
       agentId: "main",
@@ -122,7 +123,7 @@ describe("models.list provider catalog outcomes", () => {
         context,
         agentId: "main",
         params: { view: "configured" },
-        preloadedCatalog: { agentId: "main", config, snapshot, fullyDiscovered: true },
+        preloadedCatalog: { agentId: "main", config, snapshot },
         preloadedOnly: true,
         catalogProjector: projector,
       }),

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -41,6 +41,7 @@ import {
   resolveModelCatalogIdentityKey,
 } from "../../agents/openai-model-routes.js";
 import { publishedModelCatalogOwnerMatchesAgent } from "../../agents/prepared-model-catalog-owner.js";
+import { isPreparedModelCatalogFull } from "../../agents/prepared-model-runtime.full-catalog.js";
 import { preparedModelRuntimeConfigsMatch } from "../../agents/prepared-model-runtime.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getRuntimeConfigSourceSnapshot } from "../../config/config.js";
@@ -441,8 +442,6 @@ type BuildModelsListResultParams = {
     agentId: string;
     config: OpenClawConfig;
     snapshot: ModelCatalogSnapshot;
-    /** The owner already ran full discovery for this exact snapshot. */
-    fullyDiscovered?: boolean;
   };
   catalogProjector?: ReturnType<typeof createGatewayAgentModelCatalogProjector>;
   preloadedOnly?: boolean;
@@ -486,7 +485,8 @@ export async function buildModelsListResult(
       // owner carried the completed-discovery fact with the exact snapshot.
       if (
         preloadedCatalog &&
-        (loadedReadOnly || (params.preloadedOnly && preloadedCatalog.fullyDiscovered === true))
+        (loadedReadOnly ||
+          (params.preloadedOnly && isPreparedModelCatalogFull(preloadedCatalog.snapshot)))
       ) {
         usedPreloadedCatalog = true;
         return preloadedCatalog.snapshot;

--- a/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
@@ -151,14 +151,17 @@ suite.define(() => {
       await page.keyboard.press("Escape");
       await page.locator("openclaw-app-sidebar .sidebar-brand__new-thread").click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
-      await main.locator('[data-chat-model-select="true"]').click();
-      const newSessionModel = main.locator(
+      const newSessionPage = page.locator("openclaw-new-session-page");
+      await newSessionPage.waitFor();
+      const newSessionModelSelect = newSessionPage.locator(
+        '.new-session-page__composer [data-chat-model-select="true"]',
+      );
+      await expect.poll(() => newSessionModelSelect.getAttribute("aria-disabled")).toBe("false");
+      await newSessionModelSelect.click();
+      const newSessionModel = newSessionPage.locator(
         '[data-chat-model-option="omniroute/deepseekv4flash-equivalent"]',
       );
       await expect.poll(() => newSessionModel.textContent()).toContain("262.1k");
-      if (!(await newSessionModel.isVisible())) {
-        await main.locator('[data-chat-model-select="true"]').click();
-      }
       await expect.poll(() => newSessionModel.isVisible()).toBe(true);
       if (dynamicCatalogProofDir) {
         await page.screenshot({

--- a/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
@@ -147,6 +147,25 @@ suite.define(() => {
           path: path.join(dynamicCatalogProofDir, "03-discovered-thinking-levels.png"),
         });
       }
+
+      await page.keyboard.press("Escape");
+      await page.locator("openclaw-app-sidebar .sidebar-brand__new-thread").click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
+      await main.locator('[data-chat-model-select="true"]').click();
+      const newSessionModel = main.locator(
+        '[data-chat-model-option="omniroute/deepseekv4flash-equivalent"]',
+      );
+      await expect.poll(() => newSessionModel.textContent()).toContain("262.1k");
+      if (!(await newSessionModel.isVisible())) {
+        await main.locator('[data-chat-model-select="true"]').click();
+      }
+      await expect.poll(() => newSessionModel.isVisible()).toBe(true);
+      if (dynamicCatalogProofDir) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(dynamicCatalogProofDir, "04-new-session-discovered-context.png"),
+        });
+      }
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -219,7 +219,7 @@ suite.define(() => {
     }
   });
 
-  it("recovers a failed CLI-agent catalog without reloading ready model metadata", async () => {
+  it("recovers a failed CLI-agent catalog without reloading model metadata for its retry", async () => {
     if (captureCatalogRetryProof) {
       await mkdir(catalogRetryProofDir, { recursive: true });
     }
@@ -298,7 +298,7 @@ suite.define(() => {
         ),
       ).toBe("GPT-5.6 Luna");
       expect(await page.getByText("Models unavailable", { exact: true }).count()).toBe(0);
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(1);
+      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
       if (captureCatalogRetryProof) {
         await page.screenshot({
           animations: "disabled",
@@ -336,7 +336,7 @@ suite.define(() => {
           catalogDiscoveryRequests(await gateway.getRequests("sessions.catalog.list")),
         )
         .toHaveLength(3);
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(1);
+      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
       await expect
         .poll(() => page.locator('[data-chat-model-target="anthropic"]').isVisible())
         .toBe(true);

--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -202,15 +202,21 @@ suite.define(() => {
       const modelSelect = page.locator(
         '.new-session-page__composer [data-chat-model-select="true"]',
       );
+      await expect.poll(() => modelSelect.getAttribute("aria-disabled")).toBe("false");
       await modelSelect.click();
       await expect
         .poll(() => page.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').textContent())
         .toContain(recoveredModel.name);
 
-      // Opening the picker consumes the recovered ready snapshot without
-      // revalidating it.
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
+      // Explicit picker discovery refreshes the recovered metadata owner once.
+      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(3);
+      expect(await gateway.getRequests("models.list")).toEqual([
+        expect.objectContaining({
+          params: { view: "configured", agentId: "main", refresh: true },
+        }),
+      ]);
       expect(await gateway.getRequests("chat.metadata")).toEqual([
+        expect.objectContaining({ params: { agentId: "main" } }),
         expect.objectContaining({ params: { agentId: "main" } }),
         expect.objectContaining({ params: { agentId: "main" } }),
       ]);

--- a/ui/src/lib/model-catalog-store.test.ts
+++ b/ui/src/lib/model-catalog-store.test.ts
@@ -1,6 +1,11 @@
 // Control UI tests cover models behavior.
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
+import {
+  peekChatMetadata,
+  rememberChatMetadata,
+  subscribeChatMetadata,
+} from "./chat/chat-metadata-store.ts";
 import { invalidateModelCatalogCache, loadModels } from "./model-catalog-store.ts";
 
 describe("loadModels", () => {
@@ -37,6 +42,41 @@ describe("loadModels", () => {
       agentId: "main",
       preparedOnly: true,
     });
+  });
+
+  it("revalidates existing metadata after explicit account-model discovery", async () => {
+    const prepared = [{ id: "prepared", name: "Prepared", provider: "openai" }];
+    const discovered = [
+      ...prepared,
+      { id: "discovered", name: "Discovered", provider: "openai", contextWindow: 262_144 },
+    ];
+    const request = vi.fn(async (method: string) => ({
+      models: discovered,
+      ...(method === "chat.metadata" ? { commands: [] } : {}),
+    }));
+    const client = { request } as unknown as GatewayBrowserClient;
+    rememberChatMetadata(client, "main", { commands: [], models: prepared });
+    const listener = vi.fn();
+    const unsubscribe = subscribeChatMetadata(client, "main", listener);
+
+    await loadModels(client, { agentId: "main" });
+
+    await vi.waitFor(() => expect(peekChatMetadata(client, "main")?.models).toEqual(discovered));
+    expect(request).toHaveBeenCalledWith("chat.metadata", { agentId: "main" });
+    expect(listener).toHaveBeenCalledOnce();
+    unsubscribe();
+  });
+
+  it("does not revalidate metadata for automatic prepared-only catalog reads", async () => {
+    const models = [{ id: "prepared", name: "Prepared", provider: "openai" }];
+    const request = vi.fn(async () => ({ models }));
+    const client = { request } as unknown as GatewayBrowserClient;
+    rememberChatMetadata(client, "main", { commands: [], models });
+
+    await loadModels(client, { agentId: "main", preparedOnly: true });
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(request).not.toHaveBeenCalledWith("chat.metadata", expect.anything());
   });
 
   it("reuses the configured model list while the cache is fresh", async () => {

--- a/ui/src/lib/model-catalog-store.ts
+++ b/ui/src/lib/model-catalog-store.ts
@@ -1,6 +1,7 @@
 // Control UI model metadata boundary.
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ModelCatalogEntry } from "../api/types.ts";
+import { peekChatMetadata, revalidateChatMetadata } from "./chat/chat-metadata-store.ts";
 
 const MODEL_CATALOG_CACHE_TTL_MS = 60_000;
 // A picker open is an operator signal to revalidate, but full provider discovery can be slow.
@@ -103,6 +104,11 @@ export async function loadModels(
           // An exact catalog supersedes the prepared projection. Reusing it for
           // automatic reads prevents route re-entry from restoring stale data.
           cache.set(preparedCacheKey, entry);
+          if (peekChatMetadata(client, agentId)) {
+            // Metadata owns the per-agent projection; refresh its shared
+            // snapshot after explicit discovery instead of copying catalog rows.
+            void revalidateChatMetadata(client, agentId).catch(() => undefined);
+          }
         }
       }
       return result.models;

--- a/ui/src/pages/new-session/model-control.catalog-targets.test.ts
+++ b/ui/src/pages/new-session/model-control.catalog-targets.test.ts
@@ -54,7 +54,8 @@ describe("new-session CLI-agent model targets", () => {
     picker!.dispatchEvent(new Event("toggle"));
 
     await vi.waitFor(() => {
-      expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(1);
+      expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(2);
+      expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(1);
       expect(catalogCalls(request)).toHaveLength(2);
     });
     await vi.waitFor(() => {

--- a/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
+++ b/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
@@ -8,6 +8,45 @@ import { contextWith, deferred, renderControl } from "./model-control.test-suppo
 import { NewSessionModelControl } from "./model-control.ts";
 
 describe("new-session model metadata lifecycle", () => {
+  it("discovers account models when an operator opens the New Session picker", async () => {
+    const prepared = [{ id: "prepared", name: "Prepared", provider: "openai" }];
+    const discovered = [
+      ...prepared,
+      { id: "discovered", name: "Discovered", provider: "openai", contextWindow: 262_144 },
+    ];
+    const { context, request } = contextWith(prepared);
+    const client = context.gateway.snapshot.client!;
+    rememberChatMetadata(client, "main", { commands: [], models: prepared });
+    request.mockImplementation((method: string) =>
+      Promise.resolve({
+        models: discovered,
+        ...(method === "chat.metadata" ? { commands: [] } : {}),
+      }),
+    );
+    const control = new NewSessionModelControl(() => undefined);
+    control.load(context, "main", true);
+
+    const picker = renderControl(control, context).querySelector<HTMLDetailsElement>(
+      ".chat-controls__model-picker",
+    );
+    picker!.open = true;
+    picker!.dispatchEvent(new Event("toggle"));
+
+    await vi.waitFor(() => {
+      const container = renderControl(control, context);
+      expect(container.querySelector('[data-chat-model-option="openai/prepared"]')).not.toBeNull();
+      expect(
+        container.querySelector('[data-chat-model-option="openai/discovered"]'),
+      ).not.toBeNull();
+    });
+    expect(request).toHaveBeenCalledWith("models.list", {
+      view: "configured",
+      agentId: "main",
+      refresh: true,
+    });
+    expect(request).toHaveBeenCalledWith("chat.metadata", { agentId: "main" });
+  });
+
   it("keeps a ready catalog authoritative across control teardown", async () => {
     const models: ModelCatalogEntry[] = [
       {

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -18,6 +18,7 @@ import {
 import { isChatModelUnavailable } from "../../lib/chat/model-select-state.ts";
 import { normalizeThinkingOptionValue } from "../../lib/chat/thinking.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
+import { loadModels } from "../../lib/model-catalog-store.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import {
   renderChatModelControls,
@@ -327,10 +328,26 @@ export class NewSessionModelControl {
     );
   }
 
-  private retryPickerCatalogs() {
+  private retryPickerCatalogs(refreshReadyMetadata = false) {
     const metadataClient = this.metadataClient;
     if (this.metadataState.status === "error" && metadataClient && this.agentId) {
       this.startMetadataRequest(metadataClient, this.agentId);
+    } else if (
+      refreshReadyMetadata &&
+      this.metadataState.status === "ready" &&
+      metadataClient &&
+      this.agentId
+    ) {
+      const agentId = this.agentId;
+      void loadModels(metadataClient, {
+        agentId,
+        refreshIfDue: true,
+        rejectOnFailure: true,
+      }).catch(() => {
+        if (this.metadataClient === metadataClient && this.agentId === agentId) {
+          this.updateMetadataState({ ...this.metadataState, status: "error" });
+        }
+      });
     }
     const targetDiscovery = this.catalogTargetDiscovery;
     if (
@@ -693,7 +710,7 @@ export class NewSessionModelControl {
         this.notify();
       },
       onModelSetup: () => options.context?.navigate("model-setup"),
-      onModelPickerOpen: () => this.retryPickerCatalogs(),
+      onModelPickerOpen: () => this.retryPickerCatalogs(true),
       onRequestUpdate: this.notify,
     });
   }


### PR DESCRIPTION
Closes #124008

Related: #126013

Thanks @catsonkeyboard for the packaged-runtime report and @ekinnee for investigating the broader catalog convergence problem.

## Root cause

Dynamic provider discovery completed in the prepared model-catalog owner, but the Gateway's cached chat-metadata projection and the browser's independent shared metadata cache both retained their original static snapshots. The original patch also conveyed full-catalog provenance through a manual boolean, imported authentication ownership from the catalog worker, and could misclassify a subordinate catalog publication as a top-level owner transition.

## Architectural repair

- Publish successful full-catalog completion as its own subordinate lifecycle event without claiming that every agent owner is ready.
- Identify completed full catalogs through the existing producer-owned provenance marker, preserve their exact paired authentication generation in the existing auth owner, and fail closed if that pair is missing.
- Rebuild configured wildcard projections from the completed catalog without initiating provider discovery in chat startup or ordinary metadata reads.
- After an operator explicitly requests `models.list`, revalidate the existing per-agent browser metadata owner so Chat and New Session converge without copying rows, adding protocol fields, or introducing a parallel store.
- Opening the New Session model picker now performs the same explicit, cooldown-bounded discovery as the existing Chat picker; background startup remains prepared-only.
- Preserve availability/error behavior, stale-generation rejection, multiple-agent publication ownership, CLI-agent retries, and contributor credit.

The latest ClawSweeper wildcard finding is fixed at the canonical full-catalog provenance boundary and covered with real configured wildcard/auth facts. The old manual discovery flag and worker-owned auth coupling were removed.

## Proof

- Failing-before/passing-after Gateway regression: a configured OAuth-backed wildcard now exposes the newly discovered model rather than returning only its statically prepared sibling.
- Failing-before/passing-after lifecycle regression: catalog publication during owner attachment no longer suppresses later owner refresh.
- Failing-before/passing-after real Chromium flow: Chat discovers a model and its 262k context window, then New Session visibly renders the same discovered option.
- Focused browser regression: both dynamic catalog and New Session CLI-agent recovery scenarios pass.
- Independent structured review of both the maintainer delta and complete contributor branch found no actionable findings.
- Personally inspected upstream Codex contract: `codex-rs/app-server/src/request_processors/catalog_processor.rs:242`, `codex-rs/app-server/src/models.rs:34`, `codex-rs/core/src/thread_manager.rs:782`, and `codex-rs/app-server-protocol/src/protocol/v2/model.rs:89`.

The browser proof uses a real Chromium browser with a mocked Gateway. A combined providers-on, non-minimal real Gateway/browser attempt was also tried twice, including an isolated single-provider bundled root, but Gateway startup exceeded this repository's 120-second test budget before browser navigation (146 seconds/2.44 GiB and 126 seconds/2.49 GiB). That attempt is not represented as live-provider proof.
