### PR TITLE
fix(cli): honor reaction listing limits

### DIFF
--- a/src/commands/message-format.test.ts
+++ b/src/commands/message-format.test.ts
@@ -99,6 +99,33 @@ describe("formatMessageCliText displayLimit", () => {
     expect(out).not.toContain("search-15");
   });
 
+  it.each([
+    { displayLimit: 1, expectedRows: 1 },
+    { displayLimit: 75, expectedRows: 75 },
+    { displayLimit: undefined, expectedRows: 50 },
+  ])(
+    "renders $expectedRows reaction rows for displayLimit $displayLimit",
+    ({ displayLimit, expectedRows }) => {
+      const reactions = Array.from({ length: 80 }, (_, index) => ({
+        name: `reaction-${String(index).padStart(2, "0")}`,
+        count: index + 1,
+      }));
+      const result = {
+        kind: "action",
+        channel: "matrix",
+        action: "reactions",
+        handledBy: "plugin",
+        payload: { reactions },
+        dryRun: false,
+      } satisfies MessageActionResult;
+
+      const output = textJoined(formatMessageCliText(result, { displayLimit }));
+
+      expect(output).toContain(`reaction-${String(expectedRows - 1).padStart(2, "0")}`);
+      expect(output).not.toContain(`reaction-${String(expectedRows).padStart(2, "0")}`);
+    },
+  );
+
   it.each([0, 1])(
     "renders an explicit outcome for a search with no results (total: %i)",
     (totalResults) => {

--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -192,7 +192,7 @@ function renderReactions(payload: unknown, opts: FormatOpts): string[] | null {
     return null;
   }
 
-  const rows = reactions.slice(0, 50).map((r) => {
+  const rows = reactions.slice(0, opts.displayLimit ?? 50).map((r) => {
     const entry = r as Record<string, unknown>;
     const emojiObj = entry.emoji as Record<string, unknown> | undefined;
     const emoji =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users listing message reactions with `openclaw message reactions --limit N` would always see at most 50 reactions, regardless of whether they requested fewer or more.

## Why This Change Was Made

Reaction rendering now uses the same existing display-limit option already honored by message reads, pinned messages, and searches. The historical 50-reaction default remains unchanged when `--limit` is omitted, and channel-specific fetching behavior is untouched.

## User Impact

Operators can reliably control how many reaction rows appear for Discord, Matrix, Microsoft Teams, and Slack; for example, `--limit 1` displays one row and `--limit 75` can display 75 available rows.

## Evidence

- Added one table-driven owner-boundary regression covering limits 1, 75, and the unchanged omitted-limit default of 50.
- Before the fix: the explicit-limit cases both failed while the default and existing sibling cases passed.
- After the fix: 97 tests pass across the message formatter, message command, shared CLI numeric validation, and message command registration suites.
- Formatting, conflict-marker, max-lines, and assertion-safety ratchets passed; independent review and authenticated structured Codex review found no actionable issues.
- Production size: +1/-1 lines (net zero); regression coverage: +27 lines.
