### PR TITLE
test(clawhub): deduplicate lifecycle fixtures

### DIFF
--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -6,6 +6,10 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ClawHubSkillSecurityVerdictItem,
+  ClawHubSkillVerificationResponse,
+} from "../../infra/clawhub-skills.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 
 const fetchClawHubSkillDetailMock = vi.fn();
@@ -140,6 +144,76 @@ function expectInvalidSlug(result: Awaited<ReturnType<typeof installSkillFromCla
   expect(result.error).toContain("Invalid skill slug");
 }
 
+function installTestSkill(
+  workspaceDir: string,
+  slug: string,
+  params: Omit<Parameters<typeof installSkillFromClawHub>[0], "workspaceDir" | "slug"> = {},
+) {
+  return installSkillFromClawHub({ workspaceDir, slug, ...params });
+}
+
+function updateTestSkill(
+  workspaceDir: string,
+  slug?: string,
+  params: Omit<Parameters<typeof updateSkillsFromClawHub>[0], "workspaceDir" | "slug"> = {},
+) {
+  return updateSkillsFromClawHub({ workspaceDir, ...(slug ? { slug } : {}), ...params });
+}
+
+function mockArchiveInstallResolution(slug: string, version: string, downloadUrl: string) {
+  fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+    ok: true,
+    slug,
+    installKind: "archive",
+    archive: { version, downloadUrl },
+  });
+}
+
+function mockGitHubInstallResolution(params: {
+  slug: string;
+  repo: string;
+  path: string;
+  commit: string;
+  contentHash: string;
+  sourceUrl: string;
+}) {
+  fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+    ok: true,
+    slug: params.slug,
+    installKind: "github",
+    github: {
+      repo: params.repo,
+      path: params.path,
+      commit: params.commit,
+      contentHash: params.contentHash,
+      sourceUrl: params.sourceUrl,
+    },
+  });
+}
+
+function mockSkillSecurityVerdict(item: ClawHubSkillSecurityVerdictItem) {
+  fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
+    schema: "clawhub.skill.security-verdicts.v1",
+    items: [item],
+  });
+}
+
+function mockSkillVerification(response: ClawHubSkillVerificationResponse) {
+  fetchClawHubSkillVerificationMock.mockResolvedValueOnce(response);
+}
+
+function mockInstalledSkillFile(content: string) {
+  installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
+    await fs.mkdir(params.targetDir, { recursive: true });
+    await fs.writeFile(path.join(params.targetDir, "SKILL.md"), content, "utf8");
+    return { ok: true, targetDir: params.targetDir };
+  });
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
+}
+
 async function writeClawHubOriginFixture(params: {
   workspaceDir: string;
   slug: string;
@@ -225,6 +299,14 @@ async function writeClawHubOriginFixture(params: {
     );
   }
   return skillDir;
+}
+
+function writeTrackedSkill(
+  workspaceDir: string,
+  slug: string,
+  params: Omit<Parameters<typeof writeClawHubOriginFixture>[0], "workspaceDir" | "slug"> = {},
+) {
+  return writeClawHubOriginFixture({ workspaceDir, slug, ...params });
 }
 
 describe("skills-clawhub", () => {
@@ -358,10 +440,7 @@ describe("skills-clawhub", () => {
   });
 
   it("installs ClawHub skills from flat-root archives", async () => {
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
-    });
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "agentreceipt",
@@ -425,11 +504,11 @@ describe("skills-clawhub", () => {
       fetchClawHubSkillInstallResolutionMock.mockRejectedValueOnce(requestError);
     }
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "missing-skill",
-      ...(lookup === "detail" ? { version: "1.2.3" } : {}),
-    });
+    const result = await installTestSkill(
+      "/tmp/workspace",
+      "missing-skill",
+      lookup === "detail" ? { version: "1.2.3" } : {},
+    );
 
     expect(result).toEqual({ ok: false, error: expected });
     expect(result.ok ? "" : result.error).not.toContain("/api/v1/");
@@ -463,10 +542,7 @@ describe("skills-clawhub", () => {
       targetDir: "/tmp/workspace/skills/weather",
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: reference,
-    });
+    const result = await installTestSkill("/tmp/workspace", reference);
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "weather",
@@ -523,10 +599,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "skills-sh:openclaw/skills/weather",
-    });
+    const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather");
 
     expect(result.ok).toBe(false);
     expect(result.ok ? "" : result.error).toContain("expected a full 40-character commit SHA");
@@ -543,10 +616,7 @@ describe("skills-clawhub", () => {
     "skills-sh:-owner/repo/slug",
     "skills-sh:owner/../slug",
   ])("rejects invalid skills-sh reference %s before network access", async (reference) => {
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: reference,
-    });
+    const result = await installTestSkill("/tmp/workspace", reference);
 
     expect(result).toMatchObject({
       ok: false,
@@ -557,9 +627,7 @@ describe("skills-clawhub", () => {
   });
 
   it("rejects versions for skills-sh references before network access", async () => {
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "skills-sh:openclaw/skills/weather",
+    const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather", {
       version: "1.2.3",
     });
 
@@ -583,10 +651,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "skills-sh:openclaw/skills/weather",
-    });
+    const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather");
 
     expect(result).toEqual({
       ok: false,
@@ -613,10 +678,7 @@ describe("skills-clawhub", () => {
         },
       });
 
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "skills-sh:openclaw/skills/weather",
-      });
+      const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather");
 
       expect(result).toEqual({
         ok: false,
@@ -660,9 +722,7 @@ describe("skills-clawhub", () => {
       cleanup: archiveCleanupMock,
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
       version: "1.0.0",
       expectedIntegrity: `sha256:${"a".repeat(64)}`,
     });
@@ -689,10 +749,7 @@ describe("skills-clawhub", () => {
     });
     fetchClawHubSkillSecurityVerdictsMock.mockRejectedValueOnce(new Error("should not be called"));
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
-    });
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
@@ -726,10 +783,7 @@ describe("skills-clawhub", () => {
     });
     fetchClawHubSkillSecurityVerdictsMock.mockRejectedValueOnce(new Error("should not be called"));
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "tao-setup-nvidia-gpu-host",
-    });
+    const result = await installTestSkill("/tmp/workspace", "tao-setup-nvidia-gpu-host");
 
     expectInstalledSkill(result, {
       slug: "tao-setup-nvidia-gpu-host",
@@ -749,29 +803,22 @@ describe("skills-clawhub", () => {
 
   it("blocks ClawHub skill installs when release trust is malicious", async () => {
     const warnings: string[] = [];
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: false,
-          decision: "fail",
-          reasons: ["scan:malicious"],
-          requestedSlug: "agentreceipt",
-          requestedVersion: "1.0.0",
-          slug: "agentreceipt",
-          version: "1.0.0",
-          publisherHandle: "acme",
-          security: {
-            status: "malicious",
-            passed: false,
-          },
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: false,
+      decision: "fail",
+      reasons: ["scan:malicious"],
+      requestedSlug: "agentreceipt",
+      requestedVersion: "1.0.0",
+      slug: "agentreceipt",
+      version: "1.0.0",
+      publisherHandle: "acme",
+      security: {
+        status: "malicious",
+        passed: false,
+      },
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "@acme/agentreceipt",
+    const result = await installTestSkill("/tmp/workspace", "@acme/agentreceipt", {
       logger: {
         warn: (message) => warnings.push(message),
       },
@@ -792,31 +839,23 @@ describe("skills-clawhub", () => {
 
   it("requires acknowledgement before installing suspicious ClawHub skill releases", async () => {
     const warnings: string[] = [];
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: false,
-          decision: "fail",
-          reasons: ["security.status_not_clean"],
-          requestedSlug: "agentreceipt",
-          requestedVersion: "1.0.0",
-          slug: "agentreceipt",
-          version: "1.0.0",
-          skillUrl: "https://clawhub.ai/acme/skills/agentreceipt",
-          securityAuditUrl:
-            "https://clawhub.ai/acme/skills/agentreceipt/security-audit?version=1.0.0",
-          security: {
-            status: "suspicious",
-            passed: false,
-          },
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: false,
+      decision: "fail",
+      reasons: ["security.status_not_clean"],
+      requestedSlug: "agentreceipt",
+      requestedVersion: "1.0.0",
+      slug: "agentreceipt",
+      version: "1.0.0",
+      skillUrl: "https://clawhub.ai/acme/skills/agentreceipt",
+      securityAuditUrl: "https://clawhub.ai/acme/skills/agentreceipt/security-audit?version=1.0.0",
+      security: {
+        status: "suspicious",
+        passed: false,
+      },
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
       logger: {
         warn: (message) => warnings.push(message),
       },
@@ -841,29 +880,21 @@ describe("skills-clawhub", () => {
   });
 
   it("returns review-recommended warnings with successful ClawHub skill installs", async () => {
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: true,
-          decision: "pass",
-          reasons: ["scan:pending"],
-          requestedSlug: "agentreceipt",
-          requestedVersion: "1.0.0",
-          slug: "agentreceipt",
-          version: "1.0.0",
-          security: {
-            status: "pending",
-            passed: true,
-          },
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: true,
+      decision: "pass",
+      reasons: ["scan:pending"],
+      requestedSlug: "agentreceipt",
+      requestedVersion: "1.0.0",
+      slug: "agentreceipt",
+      version: "1.0.0",
+      security: {
+        status: "pending",
+        passed: true,
+      },
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
-    });
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
@@ -883,10 +914,7 @@ describe("skills-clawhub", () => {
       new Error("security verdicts unavailable"),
     );
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
-    });
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -905,10 +933,7 @@ describe("skills-clawhub", () => {
       items: [],
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
-    });
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -930,26 +955,18 @@ describe("skills-clawhub", () => {
       verdict: { security: null },
     },
   ])("fails closed when a passing skill verdict has $name", async ({ verdict }) => {
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: true,
-          decision: "pass",
-          reasons: [],
-          requestedSlug: "agentreceipt",
-          requestedVersion: "1.0.0",
-          slug: "agentreceipt",
-          version: "1.0.0",
-          ...verdict,
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      requestedSlug: "agentreceipt",
+      requestedVersion: "1.0.0",
+      slug: "agentreceipt",
+      version: "1.0.0",
+      ...verdict,
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
-    });
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -963,28 +980,21 @@ describe("skills-clawhub", () => {
 
   it("blocks ClawHub skill installs when moderation marks the release as malware-blocked", async () => {
     const warnings: string[] = [];
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: false,
-          decision: "fail",
-          reasons: ["moderation.malware_blocked"],
-          requestedSlug: "agentreceipt",
-          requestedVersion: "1.0.0",
-          slug: "agentreceipt",
-          version: "1.0.0",
-          security: {
-            status: "clean",
-            passed: false,
-          },
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: false,
+      decision: "fail",
+      reasons: ["moderation.malware_blocked"],
+      requestedSlug: "agentreceipt",
+      requestedVersion: "1.0.0",
+      slug: "agentreceipt",
+      version: "1.0.0",
+      security: {
+        status: "clean",
+        passed: false,
+      },
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
       acknowledgeClawHubRisk: true,
       logger: {
         warn: (message) => warnings.push(message),
@@ -1002,29 +1012,21 @@ describe("skills-clawhub", () => {
   });
 
   it("requires acknowledgement when ClawHub returns a failed skill verdict with clean nested scan status", async () => {
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: false,
-          decision: "fail",
-          reasons: [],
-          requestedSlug: "agentreceipt",
-          requestedVersion: "1.0.0",
-          slug: "agentreceipt",
-          version: "1.0.0",
-          security: {
-            status: "clean",
-            passed: false,
-          },
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: false,
+      decision: "fail",
+      reasons: [],
+      requestedSlug: "agentreceipt",
+      requestedVersion: "1.0.0",
+      slug: "agentreceipt",
+      version: "1.0.0",
+      security: {
+        status: "clean",
+        passed: false,
+      },
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
-    });
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1038,29 +1040,22 @@ describe("skills-clawhub", () => {
     const onClawHubRisk = vi.fn<
       NonNullable<Parameters<typeof installSkillFromClawHub>[0]["onClawHubRisk"]>
     >(async () => false);
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: false,
-          decision: "fail",
-          reasons: ["security.status_not_clean"],
-          requestedSlug: "agentreceipt",
-          requestedVersion: "1.0.0",
-          slug: "agentreceipt",
-          version: "1.0.0",
-          publisherHandle: "acme",
-          security: {
-            status: "suspicious",
-            passed: false,
-          },
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: false,
+      decision: "fail",
+      reasons: ["security.status_not_clean"],
+      requestedSlug: "agentreceipt",
+      requestedVersion: "1.0.0",
+      slug: "agentreceipt",
+      version: "1.0.0",
+      publisherHandle: "acme",
+      security: {
+        status: "suspicious",
+        passed: false,
+      },
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "@acme/agentreceipt",
+    const result = await installTestSkill("/tmp/workspace", "@acme/agentreceipt", {
       onClawHubRisk,
     });
 
@@ -1082,28 +1077,21 @@ describe("skills-clawhub", () => {
   });
 
   it("continues after explicit acknowledgement for suspicious ClawHub skill releases", async () => {
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: false,
-          decision: "fail",
-          reasons: ["security.status_not_clean"],
-          requestedSlug: "agentreceipt",
-          requestedVersion: "1.0.0",
-          slug: "agentreceipt",
-          version: "1.0.0",
-          security: {
-            status: "suspicious",
-            passed: false,
-          },
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: false,
+      decision: "fail",
+      reasons: ["security.status_not_clean"],
+      requestedSlug: "agentreceipt",
+      requestedVersion: "1.0.0",
+      slug: "agentreceipt",
+      version: "1.0.0",
+      security: {
+        status: "suspicious",
+        passed: false,
+      },
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
       acknowledgeClawHubRisk: true,
     });
 
@@ -1123,26 +1111,21 @@ describe("skills-clawhub", () => {
 
   it("installs owner-qualified ClawHub skills without using owner as a local path", async () => {
     const workspaceDir = await tempDirs.make("openclaw-owner-skill-");
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: false,
-          decision: "fail",
-          reasons: ["skill.not_found"],
-          requestedSlug: "weather",
-          requestedVersion: "1.0.0",
-          slug: "weather",
-          version: null,
-          security: null,
-          error: {
-            code: "skill_not_found",
-            message: "Skill not found",
-          },
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: false,
+      decision: "fail",
+      reasons: ["skill.not_found"],
+      requestedSlug: "weather",
+      requestedVersion: "1.0.0",
+      slug: "weather",
+      version: null,
+      security: null,
+      error: {
+        code: "skill_not_found",
+        message: "Skill not found",
+      },
     });
-    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+    mockSkillVerification({
       schema: "clawhub.skill.verify.v1",
       ok: true,
       decision: "pass",
@@ -1154,22 +1137,17 @@ describe("skills-clawhub", () => {
       publisherDisplayName: "Demo Owner",
       version: "1.0.0",
       createdAt: 123,
+      skill: { slug: "weather", displayName: "Weather" },
+      publisher: { handle: "demo-owner", displayName: "Demo Owner" },
       card: { available: true, sha256: "card-sha" },
       artifact: { sourceFingerprint: "source-fp" },
       provenance: { source: "unavailable" },
       security: { status: "clean" },
       signature: { status: "unsigned" },
     });
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# Weather\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockInstalledSkillFile("# Weather\n");
 
-    const result = await installSkillFromClawHub({
-      workspaceDir,
-      slug: "@demo-owner/weather",
-    });
+    const result = await installTestSkill(workspaceDir, "@demo-owner/weather");
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "weather",
@@ -1212,20 +1190,17 @@ describe("skills-clawhub", () => {
     });
     await expect(fs.access(path.join(workspaceDir, "skills", "@demo-owner"))).rejects.toThrow();
 
-    const lock = JSON.parse(
-      await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
-    ) as { skills: Record<string, Record<string, unknown>> };
+    const lock = await readJson<{ skills: Record<string, Record<string, unknown>> }>(
+      path.join(workspaceDir, ".clawhub", "lock.json"),
+    );
     expect(lock.skills.weather).toMatchObject({
       version: "1.0.0",
       registry: "https://clawhub.ai",
       ownerHandle: "demo-owner",
     });
-    const origin = JSON.parse(
-      await fs.readFile(
-        path.join(workspaceDir, "skills", "weather", ".clawhub", "origin.json"),
-        "utf8",
-      ),
-    ) as Record<string, unknown>;
+    const origin = await readJson<Record<string, unknown>>(
+      path.join(workspaceDir, "skills", "weather", ".clawhub", "origin.json"),
+    );
     expect(origin).toMatchObject({
       version: 1,
       registry: "https://clawhub.ai",
@@ -1250,26 +1225,21 @@ describe("skills-clawhub", () => {
 
   it("does not require acknowledgement for owner-qualified clean skills missing only cards", async () => {
     const workspaceDir = await tempDirs.make("openclaw-owner-card-missing-");
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: false,
-          decision: "fail",
-          reasons: ["skill.not_found"],
-          requestedSlug: "weather",
-          requestedVersion: "1.0.0",
-          slug: "weather",
-          version: null,
-          security: null,
-          error: {
-            code: "skill_not_found",
-            message: "Skill not found",
-          },
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: false,
+      decision: "fail",
+      reasons: ["skill.not_found"],
+      requestedSlug: "weather",
+      requestedVersion: "1.0.0",
+      slug: "weather",
+      version: null,
+      security: null,
+      error: {
+        code: "skill_not_found",
+        message: "Skill not found",
+      },
     });
-    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+    mockSkillVerification({
       schema: "clawhub.skill.verify.v1",
       ok: false,
       decision: "fail",
@@ -1281,6 +1251,8 @@ describe("skills-clawhub", () => {
       publisherDisplayName: "Demo Owner",
       version: "1.0.0",
       createdAt: 123,
+      skill: { slug: "weather", displayName: "Weather" },
+      publisher: { handle: "demo-owner", displayName: "Demo Owner" },
       card: { available: false },
       artifact: { sourceFingerprint: "source-fp" },
       provenance: { source: "unavailable" },
@@ -1288,15 +1260,9 @@ describe("skills-clawhub", () => {
       signature: { status: "unsigned" },
     });
     const onClawHubRisk = vi.fn(async () => false);
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# Weather\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockInstalledSkillFile("# Weather\n");
 
-    const result = await installSkillFromClawHub({
-      workspaceDir,
-      slug: "@demo-owner/weather",
+    const result = await installTestSkill(workspaceDir, "@demo-owner/weather", {
       onClawHubRisk,
     });
 
@@ -1310,26 +1276,21 @@ describe("skills-clawhub", () => {
   });
 
   it("does not let owner-qualified fallback acknowledgement mask missing exact versions", async () => {
-    fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-      schema: "clawhub.skill.security-verdicts.v1",
-      items: [
-        {
-          ok: false,
-          decision: "fail",
-          reasons: ["skill.not_found"],
-          requestedSlug: "weather",
-          requestedVersion: "1.0.0",
-          slug: "weather",
-          version: null,
-          security: null,
-          error: {
-            code: "skill_not_found",
-            message: "Skill not found",
-          },
-        },
-      ],
+    mockSkillSecurityVerdict({
+      ok: false,
+      decision: "fail",
+      reasons: ["skill.not_found"],
+      requestedSlug: "weather",
+      requestedVersion: "1.0.0",
+      slug: "weather",
+      version: null,
+      security: null,
+      error: {
+        code: "skill_not_found",
+        message: "Skill not found",
+      },
     });
-    fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+    mockSkillVerification({
       schema: "clawhub.skill.verify.v1",
       ok: false,
       decision: "fail",
@@ -1341,6 +1302,8 @@ describe("skills-clawhub", () => {
       publisherDisplayName: "Demo Owner",
       version: null,
       createdAt: 123,
+      skill: { slug: "weather", displayName: "Weather" },
+      publisher: { handle: "demo-owner", displayName: "Demo Owner" },
       card: { available: true, sha256: "card-sha" },
       artifact: { sourceFingerprint: "source-fp" },
       provenance: { source: "unavailable" },
@@ -1348,9 +1311,7 @@ describe("skills-clawhub", () => {
       signature: { status: "unsigned" },
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "@demo-owner/weather",
+    const result = await installTestSkill("/tmp/workspace", "@demo-owner/weather", {
       acknowledgeClawHubRisk: true,
     });
 
@@ -1373,10 +1334,7 @@ describe("skills-clawhub", () => {
       status: 409,
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "weather",
-    });
+    const result = await installTestSkill("/tmp/workspace", "weather");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1388,10 +1346,7 @@ describe("skills-clawhub", () => {
   });
 
   it("rejects malformed owner-qualified ClawHub install refs", async () => {
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "@@demo-owner/weather",
-    });
+    const result = await installTestSkill("/tmp/workspace", "@@demo-owner/weather");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1406,16 +1361,10 @@ describe("skills-clawhub", () => {
     const warn = vi.fn();
     const skillContent = "---\nname: agentreceipt\ndescription: Receipt helper\n---\n";
     const skillSha256 = createHash("sha256").update(skillContent).digest("hex");
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), skillContent, "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockInstalledSkillFile(skillContent);
 
     try {
-      const result = await installSkillFromClawHub({
-        workspaceDir,
-        slug: "agentreceipt",
+      const result = await installTestSkill(workspaceDir, "agentreceipt", {
         logger: { warn },
       });
 
@@ -1430,9 +1379,9 @@ describe("skills-clawhub", () => {
         baseUrl: undefined,
       });
       expect(warn).not.toHaveBeenCalled();
-      const lock = JSON.parse(
-        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
-      ) as { skills: Record<string, Record<string, unknown>> };
+      const lock = await readJson<{ skills: Record<string, Record<string, unknown>> }>(
+        path.join(workspaceDir, ".clawhub", "lock.json"),
+      );
       expect(lock.skills.agentreceipt).toMatchObject({
         version: "1.0.0",
         registry: "https://clawhub.ai",
@@ -1454,12 +1403,9 @@ describe("skills-clawhub", () => {
           security: { status: "clean", signals: { staticScan: { engineVersion: "v2.4.24" } } },
         },
       });
-      const origin = JSON.parse(
-        await fs.readFile(
-          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
-          "utf8",
-        ),
-      ) as Record<string, unknown>;
+      const origin = await readJson<Record<string, unknown>>(
+        path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+      );
       expect(origin).toMatchObject({
         version: 1,
         slug: "agentreceipt",
@@ -1516,16 +1462,10 @@ describe("skills-clawhub", () => {
       security: { status: "clean" },
       signature: { status: "unsigned" },
     });
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockInstalledSkillFile("# AgentReceipt\n");
 
     try {
-      const result = await installSkillFromClawHub({
-        workspaceDir,
-        slug: "agentreceipt",
+      const result = await installTestSkill(workspaceDir, "agentreceipt", {
         version: "1.0.0",
       });
 
@@ -1534,9 +1474,9 @@ describe("skills-clawhub", () => {
         version: "1.0.0",
         targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
       });
-      const lock = JSON.parse(
-        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
-      ) as { skills: Record<string, Record<string, unknown>> };
+      const lock = await readJson<{ skills: Record<string, Record<string, unknown>> }>(
+        path.join(workspaceDir, ".clawhub", "lock.json"),
+      );
       expect(lock.skills.agentreceipt).toMatchObject({
         sourceUrl: verifiedSourceUrl,
         verification: {
@@ -1552,12 +1492,9 @@ describe("skills-clawhub", () => {
           },
         },
       });
-      const origin = JSON.parse(
-        await fs.readFile(
-          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
-          "utf8",
-        ),
-      ) as Record<string, unknown>;
+      const origin = await readJson<Record<string, unknown>>(
+        path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+      );
       expect(origin.sourceUrl).toBe(verifiedSourceUrl);
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
@@ -1610,16 +1547,10 @@ describe("skills-clawhub", () => {
       },
     });
     fetchClawHubSkillVerificationMock.mockRejectedValueOnce(new Error("verification down"));
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockInstalledSkillFile("# AgentReceipt\n");
 
     try {
-      const result = await installSkillFromClawHub({
-        workspaceDir,
-        slug: "agentreceipt",
+      const result = await installTestSkill(workspaceDir, "agentreceipt", {
         version: "1.0.0",
       });
 
@@ -1628,16 +1559,13 @@ describe("skills-clawhub", () => {
         version: "1.0.0",
         targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
       });
-      const lock = JSON.parse(
-        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
-      ) as { skills: Record<string, Record<string, unknown>> };
+      const lock = await readJson<{ skills: Record<string, Record<string, unknown>> }>(
+        path.join(workspaceDir, ".clawhub", "lock.json"),
+      );
       expect(lock.skills.agentreceipt?.sourceUrl).toBeUndefined();
-      const origin = JSON.parse(
-        await fs.readFile(
-          path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
-          "utf8",
-        ),
-      ) as Record<string, unknown>;
+      const origin = await readJson<Record<string, unknown>>(
+        path.join(workspaceDir, "skills", "agentreceipt", ".clawhub", "origin.json"),
+      );
       expect(origin.sourceUrl).toBeUndefined();
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
@@ -1660,16 +1588,10 @@ describe("skills-clawhub", () => {
       security: { status: "clean" },
       signature: { status: "unsigned" },
     });
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# AgentReceipt\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockInstalledSkillFile("# AgentReceipt\n");
 
     try {
-      const result = await installSkillFromClawHub({
-        workspaceDir,
-        slug: "agentreceipt",
+      const result = await installTestSkill(workspaceDir, "agentreceipt", {
         version: "1.0.0",
       });
 
@@ -1678,9 +1600,9 @@ describe("skills-clawhub", () => {
         version: "1.0.0",
         targetDir: path.join(workspaceDir, "skills", "agentreceipt"),
       });
-      const lock = JSON.parse(
-        await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
-      ) as { skills: Record<string, Record<string, unknown>> };
+      const lock = await readJson<{ skills: Record<string, Record<string, unknown>> }>(
+        path.join(workspaceDir, ".clawhub", "lock.json"),
+      );
       expect(lock.skills.agentreceipt?.sourceUrl).toBeUndefined();
       const origin = JSON.parse(
         await fs.readFile(
@@ -1705,9 +1627,7 @@ describe("skills-clawhub", () => {
     });
 
     try {
-      const result = await installSkillFromClawHub({
-        workspaceDir,
-        slug: "agentreceipt",
+      const result = await installTestSkill(workspaceDir, "agentreceipt", {
         logger: { warn },
       });
 
@@ -1732,17 +1652,13 @@ describe("skills-clawhub", () => {
   it("installs GitHub-backed ClawHub skills from the pinned resolver source path", async () => {
     const commit = "b".repeat(40);
     const paddedCommit = `  ${commit.toUpperCase()}\n`;
-    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
-      ok: true,
+    mockGitHubInstallResolution({
       slug: "aiq-deploy",
-      installKind: "github",
-      github: {
-        repo: "NVIDIA/skills",
-        path: "skills/aiq-deploy",
-        commit: paddedCommit,
-        contentHash: "hash-aiq-deploy",
-        sourceUrl: `https://github.com/NVIDIA/skills/tree/${commit}/skills/aiq-deploy`,
-      },
+      repo: "NVIDIA/skills",
+      path: "skills/aiq-deploy",
+      commit: paddedCommit,
+      contentHash: "hash-aiq-deploy",
+      sourceUrl: `https://github.com/NVIDIA/skills/tree/${commit}/skills/aiq-deploy`,
     });
     withExtractedArchiveRootMock.mockImplementationOnce(async (params) => {
       expect(params.rootMarkers).toBeUndefined();
@@ -1753,10 +1669,7 @@ describe("skills-clawhub", () => {
       targetDir: "/tmp/workspace/skills/aiq-deploy",
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "aiq-deploy",
-    });
+    const result = await installTestSkill("/tmp/workspace", "aiq-deploy");
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "aiq-deploy",
@@ -1787,23 +1700,16 @@ describe("skills-clawhub", () => {
   });
 
   it("rejects a mutable GitHub ref before downloading a ClawHub skill", async () => {
-    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
-      ok: true,
+    mockGitHubInstallResolution({
       slug: "aiq-deploy",
-      installKind: "github",
-      github: {
-        repo: "NVIDIA/skills",
-        path: "skills/aiq-deploy",
-        commit: "main",
-        contentHash: "hash-aiq-deploy",
-        sourceUrl: "https://github.com/NVIDIA/skills/tree/main/skills/aiq-deploy",
-      },
+      repo: "NVIDIA/skills",
+      path: "skills/aiq-deploy",
+      commit: "main",
+      contentHash: "hash-aiq-deploy",
+      sourceUrl: "https://github.com/NVIDIA/skills/tree/main/skills/aiq-deploy",
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "aiq-deploy",
-    });
+    const result = await installTestSkill("/tmp/workspace", "aiq-deploy");
 
     expect(result.ok).toBe(false);
     expect(result.ok ? "" : result.error).toContain("expected a full 40-character commit SHA");
@@ -1814,17 +1720,13 @@ describe("skills-clawhub", () => {
 
   it("passes forceInstall to the ClawHub install resolver", async () => {
     const commit = "b".repeat(40);
-    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
-      ok: true,
+    mockGitHubInstallResolution({
       slug: "aiq-deploy",
-      installKind: "github",
-      github: {
-        repo: "NVIDIA/skills",
-        path: "skills/aiq-deploy",
-        commit,
-        contentHash: "hash-aiq-deploy",
-        sourceUrl: `https://github.com/NVIDIA/skills/tree/${commit}/skills/aiq-deploy`,
-      },
+      repo: "NVIDIA/skills",
+      path: "skills/aiq-deploy",
+      commit,
+      contentHash: "hash-aiq-deploy",
+      sourceUrl: `https://github.com/NVIDIA/skills/tree/${commit}/skills/aiq-deploy`,
     });
     withExtractedArchiveRootMock.mockImplementationOnce(async (params) => {
       return await params.onExtracted("/tmp/extracted-github-repo");
@@ -1834,9 +1736,7 @@ describe("skills-clawhub", () => {
       targetDir: "/tmp/workspace/skills/aiq-deploy",
     });
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "aiq-deploy",
+    const result = await installTestSkill("/tmp/workspace", "aiq-deploy", {
       forceInstall: true,
     });
 
@@ -1857,10 +1757,7 @@ describe("skills-clawhub", () => {
   it("keeps ClawHub install telemetry best-effort", async () => {
     reportClawHubSkillInstallTelemetryMock.mockRejectedValueOnce(new Error("telemetry down"));
 
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
-    });
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
@@ -1869,9 +1766,7 @@ describe("skills-clawhub", () => {
   });
 
   it("marks custom ClawHub skill registries as third-party install policy authority", async () => {
-    const result = await installSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
-      slug: "agentreceipt",
+    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
       baseUrl: "https://clawhub.internal.example",
     });
 
@@ -1890,10 +1785,7 @@ describe("skills-clawhub", () => {
     async (marker) => {
       pathExistsMock.mockImplementation(async (input: string) => input.endsWith(marker));
 
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "agentreceipt",
-      });
+      const result = await installTestSkill("/tmp/workspace", "agentreceipt");
 
       expectInstalledSkill(result);
       expectInstallPackageSourceDir("/tmp/extracted-skill");
@@ -1903,9 +1795,7 @@ describe("skills-clawhub", () => {
   it("updates skills.sh installs with the stored reference", async () => {
     const workspaceDir = await tempDirs.make("openclaw-owner-update-");
     const commit = "b".repeat(40);
-    await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "weather",
+    await writeTrackedSkill(workspaceDir, "weather", {
       requestedReference: "skills-sh:openclaw/skills/weather",
       trustState: "not-scanned-by-clawhub",
       registry: "https://private.example.com/clawhub",
@@ -1928,16 +1818,9 @@ describe("skills-clawhub", () => {
     withExtractedArchiveRootMock.mockImplementationOnce(async (params) => {
       return await params.onExtracted("/tmp/extracted-github-repo");
     });
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# Weather\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockInstalledSkillFile("# Weather\n");
 
-    const results = await updateSkillsFromClawHub({
-      workspaceDir,
-      slug: "skills-sh:openclaw/skills/weather",
-    });
+    const results = await updateTestSkill(workspaceDir, "skills-sh:openclaw/skills/weather");
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "weather",
@@ -1972,9 +1855,7 @@ describe("skills-clawhub", () => {
 
   it("reports a tracked skill removed from ClawHub with the same recovery message", async () => {
     const workspaceDir = await tempDirs.make("openclaw-missing-update-");
-    await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "missing-skill",
+    await writeTrackedSkill(workspaceDir, "missing-skill", {
       installedVersion: "0.9.0",
       skillMd: "# Missing skill\n",
     });
@@ -1987,10 +1868,7 @@ describe("skills-clawhub", () => {
       }),
     );
 
-    const results = await updateSkillsFromClawHub({
-      workspaceDir,
-      slug: "missing-skill",
-    });
+    const results = await updateTestSkill(workspaceDir, "missing-skill");
 
     expect(results).toEqual([
       {
@@ -2004,9 +1882,7 @@ describe("skills-clawhub", () => {
 
   it("updates official publisher ClawHub skills without fetching security verdicts", async () => {
     const workspaceDir = await tempDirs.make("openclaw-official-owner-update-");
-    await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "tao-setup-nvidia-gpu-host",
+    await writeTrackedSkill(workspaceDir, "tao-setup-nvidia-gpu-host", {
       ownerHandle: "nvidia",
       registry: "https://clawhub.ai",
       installedVersion: "0.9.0",
@@ -2029,27 +1905,15 @@ describe("skills-clawhub", () => {
         createdAt: 3,
       },
     });
-    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
-      ok: true,
-      slug: "tao-setup-nvidia-gpu-host",
-      installKind: "archive",
-      archive: {
-        version: "1.0.0",
-        downloadUrl:
-          "https://clawhub.ai/api/v1/download?slug=tao-setup-nvidia-gpu-host&ownerHandle=nvidia&version=1.0.0",
-      },
-    });
+    mockArchiveInstallResolution(
+      "tao-setup-nvidia-gpu-host",
+      "1.0.0",
+      "https://clawhub.ai/api/v1/download?slug=tao-setup-nvidia-gpu-host&ownerHandle=nvidia&version=1.0.0",
+    );
     fetchClawHubSkillSecurityVerdictsMock.mockRejectedValueOnce(new Error("should not be called"));
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# NVIDIA\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockInstalledSkillFile("# NVIDIA\n");
 
-    const results = await updateSkillsFromClawHub({
-      workspaceDir,
-      slug: "tao-setup-nvidia-gpu-host",
-    });
+    const results = await updateTestSkill(workspaceDir, "tao-setup-nvidia-gpu-host");
 
     expect(fetchClawHubSkillDetailMock).toHaveBeenCalledWith({
       slug: "tao-setup-nvidia-gpu-host",
@@ -2129,36 +1993,27 @@ describe("skills-clawhub", () => {
       const workspaceDir = path.join(tempRoot, workspaceName);
       const warnings: string[] = [];
       const slug = ownerHandle ? skillRef.slice(skillRef.indexOf("/") + 1) : skillRef;
-      await writeClawHubOriginFixture({
-        workspaceDir,
-        slug,
+      await writeTrackedSkill(workspaceDir, slug, {
         ownerHandle,
         installedVersion: "0.9.0",
         skillMd: "# Fixture\n",
       });
-      fetchClawHubSkillSecurityVerdictsMock.mockResolvedValueOnce({
-        schema: "clawhub.skill.security-verdicts.v1",
-        items: [
-          {
-            ok: false,
-            decision: "fail",
-            reasons: ["scan:malicious"],
-            requestedSlug: slug,
-            requestedVersion: "1.0.0",
-            slug,
-            version: "1.0.0",
-            ...(ownerHandle ? { publisherHandle: ownerHandle } : {}),
-            security: {
-              status: "malicious",
-              passed: false,
-            },
-          },
-        ],
+      mockSkillSecurityVerdict({
+        ok: false,
+        decision: "fail",
+        reasons: ["scan:malicious"],
+        requestedSlug: slug,
+        requestedVersion: "1.0.0",
+        slug,
+        version: "1.0.0",
+        ...(ownerHandle ? { publisherHandle: ownerHandle } : {}),
+        security: {
+          status: "malicious",
+          passed: false,
+        },
       });
 
-      const results = await updateSkillsFromClawHub({
-        workspaceDir,
-        slug: skillRef,
+      const results = await updateTestSkill(workspaceDir, skillRef, {
         logger: {
           warn: (message) => warnings.push(message),
         },
@@ -2206,33 +2061,19 @@ describe("skills-clawhub", () => {
 
   it("updates owner-qualified ClawHub skills when the requested owner matches tracking", async () => {
     const workspaceDir = await tempDirs.make("openclaw-owner-update-request-");
-    await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "weather",
+    await writeTrackedSkill(workspaceDir, "weather", {
       ownerHandle: "demo-owner",
       installedVersion: "0.9.0",
       skillMd: "# Fixture\n",
     });
-    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
-      ok: true,
-      slug: "weather",
-      installKind: "archive",
-      archive: {
-        version: "1.0.0",
-        downloadUrl:
-          "https://clawhub.ai/api/v1/download?slug=weather&ownerHandle=demo-owner&version=1.0.0",
-      },
-    });
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# Weather\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockArchiveInstallResolution(
+      "weather",
+      "1.0.0",
+      "https://clawhub.ai/api/v1/download?slug=weather&ownerHandle=demo-owner&version=1.0.0",
+    );
+    mockInstalledSkillFile("# Weather\n");
 
-    const results = await updateSkillsFromClawHub({
-      workspaceDir,
-      slug: "@demo-owner/weather",
-    });
+    const results = await updateTestSkill(workspaceDir, "@demo-owner/weather");
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "weather",
@@ -2251,9 +2092,7 @@ describe("skills-clawhub", () => {
 
   it("refuses to update a ClawHub skill with local changes unless forced", async () => {
     const workspaceDir = await tempDirs.make("openclaw-local-changes-update-");
-    const skillDir = await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "weather",
+    const skillDir = await writeTrackedSkill(workspaceDir, "weather", {
       installedVersion: "0.9.0",
       skillFile: {
         path: "SKILL.md",
@@ -2266,10 +2105,7 @@ describe("skills-clawhub", () => {
       async (input: string) => input === skillDir || input.endsWith("SKILL.md"),
     );
 
-    const results = await updateSkillsFromClawHub({
-      workspaceDir,
-      slug: "weather",
-    });
+    const results = await updateTestSkill(workspaceDir, "weather");
 
     expect(results).toEqual([
       {
@@ -2289,9 +2125,7 @@ describe("skills-clawhub", () => {
 
   it("refuses to update a ClawHub skill whose SKILL.md is unreadable unless forced", async () => {
     const workspaceDir = await tempDirs.make("openclaw-unreadable-update-");
-    const skillDir = await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "weather",
+    const skillDir = await writeTrackedSkill(workspaceDir, "weather", {
       installedVersion: "0.9.0",
       skillFile: {
         path: "SKILL.md",
@@ -2302,10 +2136,7 @@ describe("skills-clawhub", () => {
     await fs.mkdir(path.join(skillDir, "SKILL.md"), { recursive: true });
     await fs.writeFile(path.join(skillDir, "SKILL.md", "notes.txt"), "local content\n", "utf8");
 
-    const results = await updateSkillsFromClawHub({
-      workspaceDir,
-      slug: "weather",
-    });
+    const results = await updateTestSkill(workspaceDir, "weather");
 
     expect(results).toEqual([
       expect.objectContaining({
@@ -2324,24 +2155,18 @@ describe("skills-clawhub", () => {
 
   it("refuses to replace a ClawHub skill edited while the update was downloading", async () => {
     const workspaceDir = await tempDirs.make("openclaw-concurrent-edit-update-");
-    const skillDir = await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "weather",
+    const skillDir = await writeTrackedSkill(workspaceDir, "weather", {
       installedVersion: "0.9.0",
       skillMd: "# Weather\n",
     });
     pathExistsMock.mockImplementation(
       async (input: string) => input === skillDir || input.endsWith("SKILL.md"),
     );
-    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
-      ok: true,
-      slug: "weather",
-      installKind: "archive",
-      archive: {
-        version: "1.0.0",
-        downloadUrl: "https://clawhub.ai/api/v1/download?slug=weather&version=1.0.0",
-      },
-    });
+    mockArchiveInstallResolution(
+      "weather",
+      "1.0.0",
+      "https://clawhub.ai/api/v1/download?slug=weather&version=1.0.0",
+    );
     downloadClawHubSkillArchiveUrlMock.mockImplementationOnce(async () => {
       await fs.writeFile(
         path.join(skillDir, "SKILL.md"),
@@ -2357,10 +2182,7 @@ describe("skills-clawhub", () => {
       };
     });
 
-    const results = await updateSkillsFromClawHub({
-      workspaceDir,
-      slug: "weather",
-    });
+    const results = await updateTestSkill(workspaceDir, "weather");
 
     expect(results).toEqual([
       {
@@ -2379,9 +2201,7 @@ describe("skills-clawhub", () => {
 
   it("updates a ClawHub skill with local changes when forced", async () => {
     const workspaceDir = await tempDirs.make("openclaw-local-changes-forced-update-");
-    const skillDir = await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "weather",
+    const skillDir = await writeTrackedSkill(workspaceDir, "weather", {
       installedVersion: "0.9.0",
       skillFile: {
         path: "SKILL.md",
@@ -2393,24 +2213,14 @@ describe("skills-clawhub", () => {
     pathExistsMock.mockImplementation(
       async (input: string) => input === skillDir || input.endsWith("SKILL.md"),
     );
-    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
-      ok: true,
-      slug: "weather",
-      installKind: "archive",
-      archive: {
-        version: "1.0.0",
-        downloadUrl: "https://clawhub.ai/api/v1/download?slug=weather&version=1.0.0",
-      },
-    });
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# Weather\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockArchiveInstallResolution(
+      "weather",
+      "1.0.0",
+      "https://clawhub.ai/api/v1/download?slug=weather&version=1.0.0",
+    );
+    mockInstalledSkillFile("# Weather\n");
 
-    const results = await updateSkillsFromClawHub({
-      workspaceDir,
-      slug: "weather",
+    const results = await updateTestSkill(workspaceDir, "weather", {
       force: true,
     });
 
@@ -2427,9 +2237,7 @@ describe("skills-clawhub", () => {
 
   it("requires a one-time force for tracked skills without recorded digests, then verifies digests", async () => {
     const workspaceDir = await tempDirs.make("openclaw-predigest-update-");
-    const skillDir = await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "weather",
+    const skillDir = await writeTrackedSkill(workspaceDir, "weather", {
       installedVersion: "0.9.0",
     });
     await fs.writeFile(path.join(skillDir, "SKILL.md"), "# Weather\n", "utf8");
@@ -2451,7 +2259,7 @@ describe("skills-clawhub", () => {
       return { ok: true, targetDir: params.targetDir };
     });
 
-    const refused = await updateSkillsFromClawHub({ workspaceDir, slug: "weather" });
+    const refused = await updateTestSkill(workspaceDir, "weather");
     expect(refused).toEqual([
       {
         ok: false,
@@ -2461,7 +2269,7 @@ describe("skills-clawhub", () => {
       },
     ]);
 
-    const forced = await updateSkillsFromClawHub({ workspaceDir, slug: "weather", force: true });
+    const forced = await updateTestSkill(workspaceDir, "weather", { force: true });
     expect(forced).toEqual([
       expect.objectContaining({ ok: true, slug: "weather", version: "1.0.0" }),
     ]);
@@ -2471,7 +2279,7 @@ describe("skills-clawhub", () => {
     expect(lock.skills.weather?.skillFile).toMatchObject({ path: "SKILL.md" });
     expect(lock.skills.weather?.fileTreeSha256).toBe(`sha256:${"a".repeat(64)}`);
 
-    const verified = await updateSkillsFromClawHub({ workspaceDir, slug: "weather" });
+    const verified = await updateTestSkill(workspaceDir, "weather");
     expect(verified).toEqual([
       expect.objectContaining({ ok: true, slug: "weather", version: "1.0.0" }),
     ]);
@@ -2480,9 +2288,7 @@ describe("skills-clawhub", () => {
 
   it("updates an unmodified ClawHub skill without requiring force", async () => {
     const workspaceDir = await tempDirs.make("openclaw-clean-update-");
-    const skillDir = await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "weather",
+    const skillDir = await writeTrackedSkill(workspaceDir, "weather", {
       installedVersion: "0.9.0",
       skillFile: {
         path: "SKILL.md",
@@ -2494,25 +2300,14 @@ describe("skills-clawhub", () => {
     pathExistsMock.mockImplementation(
       async (input: string) => input === skillDir || input.endsWith("SKILL.md"),
     );
-    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
-      ok: true,
-      slug: "weather",
-      installKind: "archive",
-      archive: {
-        version: "1.0.0",
-        downloadUrl: "https://clawhub.ai/api/v1/download?slug=weather&version=1.0.0",
-      },
-    });
-    installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
-      await fs.mkdir(params.targetDir, { recursive: true });
-      await fs.writeFile(path.join(params.targetDir, "SKILL.md"), "# Weather\n", "utf8");
-      return { ok: true, targetDir: params.targetDir };
-    });
+    mockArchiveInstallResolution(
+      "weather",
+      "1.0.0",
+      "https://clawhub.ai/api/v1/download?slug=weather&version=1.0.0",
+    );
+    mockInstalledSkillFile("# Weather\n");
 
-    const results = await updateSkillsFromClawHub({
-      workspaceDir,
-      slug: "weather",
-    });
+    const results = await updateTestSkill(workspaceDir, "weather");
 
     expect(results).toEqual([
       expect.objectContaining({
@@ -2527,9 +2322,7 @@ describe("skills-clawhub", () => {
 
   it("rejects owner-qualified ClawHub updates when the requested owner does not match tracking", async () => {
     const workspaceDir = await tempDirs.make("openclaw-owner-update-mismatch-");
-    await writeClawHubOriginFixture({
-      workspaceDir,
-      slug: "weather",
+    await writeTrackedSkill(workspaceDir, "weather", {
       ownerHandle: "other-owner",
       installedVersion: "0.9.0",
     });
@@ -2547,7 +2340,7 @@ describe("skills-clawhub", () => {
 
   describe("legacy tracked slugs remain updatable", () => {
     async function createLegacyTrackedSkillFixture(slug: string) {
-      const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-clawhub-"));
+      const workspaceDir = await tempDirs.make("openclaw-skills-clawhub-");
       const skillDir = path.join(workspaceDir, "skills", slug);
       await fs.mkdir(path.join(skillDir, ".clawhub"), { recursive: true });
       await fs.mkdir(path.join(workspaceDir, ".clawhub"), { recursive: true });
@@ -2614,8 +2407,7 @@ describe("skills-clawhub", () => {
       });
 
       try {
-        const results = await updateSkillsFromClawHub({
-          workspaceDir,
+        const results = await updateTestSkill(workspaceDir, undefined, {
           force: true,
         });
 
@@ -2651,8 +2443,7 @@ describe("skills-clawhub", () => {
       });
 
       try {
-        const results = await updateSkillsFromClawHub({
-          workspaceDir,
+        const results = await updateTestSkill(workspaceDir, undefined, {
           force: true,
           forceInstall: true,
         });
@@ -2670,8 +2461,7 @@ describe("skills-clawhub", () => {
 
     it("does not install configured skills during update all without ClawHub tracking", async () => {
       const workspaceDir = await tempDirs.make("openclaw-configured-update-");
-      const results = await updateSkillsFromClawHub({
-        workspaceDir,
+      const results = await updateTestSkill(workspaceDir, undefined, {
         config: {
           agents: {
             defaults: {
@@ -2689,10 +2479,7 @@ describe("skills-clawhub", () => {
     it("rejects untracked requested updates instead of installing by slug", async () => {
       const workspaceDir = await tempDirs.make("openclaw-untracked-update-");
 
-      const results = await updateSkillsFromClawHub({
-        workspaceDir,
-        slug: "calendar",
-      });
+      const results = await updateTestSkill(workspaceDir, "calendar");
 
       expect(results).toEqual([
         {
@@ -2713,9 +2500,7 @@ describe("skills-clawhub", () => {
       });
 
       try {
-        const results = await updateSkillsFromClawHub({
-          workspaceDir,
-          slug,
+        const results = await updateTestSkill(workspaceDir, slug, {
           force: true,
         });
 
@@ -2743,83 +2528,53 @@ describe("skills-clawhub", () => {
 
   describe("normalizeSlug rejects non-ASCII homograph slugs", () => {
     it("rejects Cyrillic homograph 'а' (U+0430) in slug", async () => {
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "re\u0430ct",
-      });
+      const result = await installTestSkill("/tmp/workspace", "re\u0430ct");
       expectInvalidSlug(result);
     });
 
     it("rejects Cyrillic homograph 'е' (U+0435) in slug", async () => {
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "r\u0435act",
-      });
+      const result = await installTestSkill("/tmp/workspace", "r\u0435act");
       expectInvalidSlug(result);
     });
 
     it("rejects Cyrillic homograph 'о' (U+043E) in slug", async () => {
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "t\u043Edo",
-      });
+      const result = await installTestSkill("/tmp/workspace", "t\u043Edo");
       expectInvalidSlug(result);
     });
 
     it("rejects slug with mixed Unicode and ASCII", async () => {
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "cаlеndаr",
-      });
+      const result = await installTestSkill("/tmp/workspace", "cаlеndаr");
       expectInvalidSlug(result);
     });
 
     it("rejects slug with non-Latin scripts", async () => {
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "技能",
-      });
+      const result = await installTestSkill("/tmp/workspace", "技能");
       expectInvalidSlug(result);
     });
 
     it("rejects Unicode that case-folds to ASCII (Kelvin sign U+212A)", async () => {
       // "\u212A" (Kelvin sign) lowercases to "k" — must be caught before lowercasing
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "\u212Aalendar",
-      });
+      const result = await installTestSkill("/tmp/workspace", "\u212Aalendar");
       expectInvalidSlug(result);
     });
 
     it("rejects slug starting with a hyphen", async () => {
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "-calendar",
-      });
+      const result = await installTestSkill("/tmp/workspace", "-calendar");
       expectInvalidSlug(result);
     });
 
     it("rejects slug ending with a hyphen", async () => {
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "calendar-",
-      });
+      const result = await installTestSkill("/tmp/workspace", "calendar-");
       expectInvalidSlug(result);
     });
 
     it("accepts uppercase ASCII slugs (preserves original casing behavior)", async () => {
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "React",
-      });
+      const result = await installTestSkill("/tmp/workspace", "React");
       expectInstalledSkill(result);
     });
 
     it("accepts valid lowercase ASCII slugs", async () => {
-      const result = await installSkillFromClawHub({
-        workspaceDir: "/tmp/workspace",
-        slug: "calendar-2",
-      });
+      const result = await installTestSkill("/tmp/workspace", "calendar-2");
       expectInstalledSkill(result);
     });
   });
@@ -2828,9 +2583,7 @@ describe("skills-clawhub", () => {
     it("preserves installed skills.sh references for verification", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
-        const skillDir = await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "agentreceipt",
+        const skillDir = await writeTrackedSkill(workspaceDir, "agentreceipt", {
           requestedReference: "skills-sh:openclaw/skills/agentreceipt",
           trustState: "not-scanned-by-clawhub",
           registry: "https://private.example.com/clawhub/",
@@ -2865,9 +2618,7 @@ describe("skills-clawhub", () => {
 
     it("rejects a different installed skills.sh reference before verification", async () => {
       const workspaceDir = await tempDirs.make("openclaw-skill-verify-");
-      await writeClawHubOriginFixture({
-        workspaceDir,
-        slug: "agentreceipt",
+      await writeTrackedSkill(workspaceDir, "agentreceipt", {
         requestedReference: "skills-sh:owner-a/repo-a/agentreceipt",
         trustState: "not-scanned-by-clawhub",
         installedVersion: "a".repeat(40),
@@ -2912,9 +2663,7 @@ describe("skills-clawhub", () => {
       "rejects selectors when an installed skill is tracked from skills.sh",
       async ({ version, tag }) => {
         const workspaceDir = await tempDirs.make("openclaw-skill-verify-");
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "agentreceipt",
+        await writeTrackedSkill(workspaceDir, "agentreceipt", {
           requestedReference: "skills-sh:openclaw/skills/agentreceipt",
           trustState: "not-scanned-by-clawhub",
           installedVersion: "a".repeat(40),
@@ -2937,9 +2686,7 @@ describe("skills-clawhub", () => {
     it("uses installed owner namespace when resolving owner-qualified verification targets", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "weather",
+        await writeTrackedSkill(workspaceDir, "weather", {
           ownerHandle: "demo-owner",
           registry: "https://private.example.com/clawhub",
           installedVersion: "2.0.0",
@@ -2972,9 +2719,7 @@ describe("skills-clawhub", () => {
     it("accepts owner-qualified installed verification targets", async () => {
       const workspaceDir = await tempDirs.make("openclaw-skill-verify-");
       try {
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "weather",
+        await writeTrackedSkill(workspaceDir, "weather", {
           ownerHandle: "demo-owner",
           registry: "https://private.example.com/clawhub",
           installedVersion: "2.0.0",
@@ -3007,9 +2752,7 @@ describe("skills-clawhub", () => {
     it("rejects owner-qualified installed verification when the owner differs", async () => {
       const workspaceDir = await tempDirs.make("openclaw-skill-verify-");
       try {
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "weather",
+        await writeTrackedSkill(workspaceDir, "weather", {
           ownerHandle: "demo-owner",
         });
 
@@ -3032,9 +2775,7 @@ describe("skills-clawhub", () => {
     it("keeps the installed registry when an explicit version overrides the installed version", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "agentreceipt",
+        await writeTrackedSkill(workspaceDir, "agentreceipt", {
           registry: "https://private.example.com/clawhub",
           installedVersion: "2.0.0",
         });
@@ -3067,9 +2808,7 @@ describe("skills-clawhub", () => {
     it("keeps the installed registry when an explicit tag is provided", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "agentreceipt",
+        await writeTrackedSkill(workspaceDir, "agentreceipt", {
           registry: "https://private.example.com/clawhub",
           installedVersion: "2.0.0",
         });
@@ -3102,9 +2841,7 @@ describe("skills-clawhub", () => {
     it("rejects installed owner namespace metadata that does not match lock tracking", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "weather",
+        await writeTrackedSkill(workspaceDir, "weather", {
           ownerHandle: "demo-owner",
         });
         const lockPath = path.join(workspaceDir, ".clawhub", "lock.json");
@@ -3133,9 +2870,7 @@ describe("skills-clawhub", () => {
     it("rejects installed origin metadata without workspace lock tracking", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "agentreceipt",
+        await writeTrackedSkill(workspaceDir, "agentreceipt", {
           writeLock: false,
         });
 
@@ -3157,9 +2892,7 @@ describe("skills-clawhub", () => {
     it("rejects installed origin metadata for a different skill slug", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "agentreceipt",
+        await writeTrackedSkill(workspaceDir, "agentreceipt", {
           originSlug: "trusted-skill",
         });
 
@@ -3181,9 +2914,7 @@ describe("skills-clawhub", () => {
     it("rejects installed origin metadata that does not match lock tracking", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "agentreceipt",
+        await writeTrackedSkill(workspaceDir, "agentreceipt", {
           installedVersion: "2.0.0",
           installedAt: 123,
         });
@@ -3215,9 +2946,7 @@ describe("skills-clawhub", () => {
     it("rejects installed origin metadata when lock registry disagrees", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
-        await writeClawHubOriginFixture({
-          workspaceDir,
-          slug: "agentreceipt",
+        await writeTrackedSkill(workspaceDir, "agentreceipt", {
           registry: "https://origin.example.com/clawhub",
           installedVersion: "2.0.0",
           installedAt: 123,


### PR DESCRIPTION
## What Problem This Solves

Removes duplicated ClawHub lifecycle fixtures that repeated package, ownership, pinning, and registry setup throughout the owner suite.

## Why This Change Was Made

The suite now uses typed owner-local builders for mechanical lifecycle setup while keeping package identity, version pins, ownership, trust, failure, and security inputs explicit at each scenario.

Production LOC: +0/-0 (net 0) | Tests: +410/-687 (net -277)

## User Impact

There is no user-visible behavior change. ClawHub lifecycle coverage remains intact while the suite becomes smaller and easier to audit.

## Evidence

- Owner and independent proofs each passed 118 tests.
- All 265 complete expectations and the pin, owner, trust, and security inventories were preserved.
- Focused typed lint, formatting, and 17 changed-gate phases passed; remaining full-graph diagnostics are unrelated linked dependencies with zero touched-file diagnostics.
