### PR TITLE
fix(ui): allow manual runs for paused automations

### DIFF
--- a/ui/src/pages/agents/panels-status-files.test.ts
+++ b/ui/src/pages/agents/panels-status-files.test.ts
@@ -1,0 +1,56 @@
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { CronJob } from "../../api/types.ts";
+import { createAgentViewTestProps } from "./agents-view.test-helpers.ts";
+import { renderAgents } from "./view.ts";
+
+describe("agent automation actions", () => {
+  it.each([
+    { name: "enabled job", enabled: true, canRunCron: true, canRun: true },
+    { name: "paused job", enabled: false, canRunCron: true, canRun: true },
+    { name: "job without cron access", enabled: true, canRunCron: false, canRun: false },
+    { name: "paused job without cron access", enabled: false, canRunCron: false, canRun: false },
+  ])("gates manual execution of a $name on operator access", ({ enabled, canRunCron, canRun }) => {
+    const job: CronJob = {
+      id: "manual-run",
+      name: "Scheduled job",
+      enabled,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule: { kind: "cron", expr: "0 9 * * *" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "ping" },
+      state: {},
+    };
+    const defaults = createAgentViewTestProps();
+    const onCronRunNow = vi.fn();
+    const container = document.createElement("div");
+
+    render(
+      renderAgents(
+        createAgentViewTestProps({
+          activePanel: "cron",
+          access: { ...defaults.access, canRunCron },
+          cron: { ...defaults.cron, jobs: [job], jobsTotal: 1, scopedTotal: 1 },
+          onCronRunNow,
+        }),
+      ),
+      container,
+    );
+
+    const jobRow = Array.from(container.querySelectorAll(".settings-row")).find(
+      (row) => row.querySelector(".settings-row__title")?.textContent === job.name,
+    );
+    const runNow = jobRow?.querySelector<HTMLButtonElement>("button");
+    expect(runNow).toBeInstanceOf(HTMLButtonElement);
+    expect(runNow?.disabled).toBe(!canRun);
+
+    runNow?.click();
+    if (canRun) {
+      expect(onCronRunNow).toHaveBeenCalledWith(job.id);
+    } else {
+      expect(onCronRunNow).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/ui/src/pages/agents/panels-status-files.ts
+++ b/ui/src/pages/agents/panels-status-files.ts
@@ -375,7 +375,7 @@ export function renderAgentCron(params: {
                   })}
                   <button
                     class="btn btn--sm"
-                    ?disabled=${!params.canRunNow || !job.enabled}
+                    ?disabled=${!params.canRunNow}
                     @click=${() => params.onRunNow(job.id)}
                   >
                     ${t("agents.cronPanel.runNow")}


### PR DESCRIPTION
## What Problem This Solves

Fixes the disabled Run Now button for paused automations in the Agents panel.

## User Impact

Authorized operators can run a paused automation once without enabling its schedule. Operators without run permission still cannot start it.

## Why This Change Was Made

The existing handler requests a forced run, which the scheduler already supports for paused jobs. Remove the panel's extra enabled-state condition and extend the existing rendered-view test to cover enabled/paused jobs with and without permission. Preserve the shared Edit link and existing dispatch-time permission checks.

## Evidence

- The rendered regression fails only for an authorized paused job before the repair; the other three permission/state cases pass. All nine selected UI cases pass after the repair.
- Five existing scheduler admission cases pass, including a job disabled before forced-run reservation.
- Before/after builds served through the bundled UI and synthetic mock Gateway prove one `cron.run` request with `mode: "force"`, one history read, and queued feedback. The job remains paused; there are no enable/config writes or page errors.
- All 21 selected checks passed, including UI/core-test typechecks, formatting, lint, localization, and three dead-export scans. Independent P2 review found no actionable issues.

Inspected synthetic before/after screenshots are attached below. Exact-head CI is pending. This proof uses a synthetic mock Gateway; it does not claim a live Gateway execution.

**Paused automation — before and after**

![Paused automation before](https://github.com/user-attachments/assets/8d8192b1-c521-49aa-a1d6-0fbb48b11d82)

![Paused automation after](https://github.com/user-attachments/assets/99518c00-b6e6-46ad-a55d-b7a891b5f4f7)

